### PR TITLE
Actually begin render passes

### DIFF
--- a/examples/hello_triangle_c/main.c
+++ b/examples/hello_triangle_c/main.c
@@ -122,8 +122,8 @@ int main()
         .stages = stages,
         .stages_length = STAGES_LENGTH,
         .primitive_topology = WGPUPrimitiveTopology_TriangleList,
-        .blend_state = blend_state,
-        .blend_state_length = BLEND_STATE_LENGTH,
+        .blend_states = blend_state,
+        .blend_states_length = BLEND_STATE_LENGTH,
         .depth_stencil_state = depth_stencil_state,
         .attachment_state = attachment_state,
     };

--- a/examples/hello_triangle_rust/main.rs
+++ b/examples/hello_triangle_rust/main.rs
@@ -43,7 +43,7 @@ fn main() {
             },
         ],
         primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-        blend_state: &[
+        blend_states: &[
             &blend_state0,
         ],
         depth_stencil_state: &depth_stencil_state,

--- a/wgpu-bindings/wgpu.h
+++ b/wgpu-bindings/wgpu.h
@@ -219,8 +219,8 @@ typedef struct {
   const WGPUPipelineStageDescriptor *stages;
   uintptr_t stages_length;
   WGPUPrimitiveTopology primitive_topology;
-  const WGPUBlendStateId *blend_state;
-  uintptr_t blend_state_length;
+  const WGPUBlendStateId *blend_states;
+  uintptr_t blend_states_length;
   WGPUDepthStencilStateId depth_stencil_state;
   WGPUAttachmentStateId attachment_state;
 } WGPURenderPipelineDescriptor;
@@ -304,7 +304,7 @@ WGPUDeviceId wgpu_adapter_create_device(WGPUAdapterId adapter_id,
 WGPUComputePassId wgpu_command_buffer_begin_compute_pass(WGPUCommandBufferId command_buffer_id);
 
 WGPURenderPassId wgpu_command_buffer_begin_render_pass(WGPUCommandBufferId command_buffer_id,
-                                                       WGPURenderPassDescriptor_WGPUTextureViewId _descriptor);
+                                                       WGPURenderPassDescriptor_WGPUTextureViewId desc);
 
 WGPUCommandBufferId wgpu_compute_pass_end_pass(WGPUComputePassId pass_id);
 

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -6,15 +6,17 @@ pub use self::allocator::CommandAllocator;
 pub use self::compute::*;
 pub use self::render::*;
 
-use hal;
+use hal::{self, Device};
 
 use {
     Color, Origin3d, Stored,
     BufferId, CommandBufferId, ComputePassId, DeviceId, RenderPassId, TextureId, TextureViewId,
 };
+use conv;
 use registry::{HUB, Items, Registry};
 use track::{BufferTracker, TextureTracker};
 
+use std::iter;
 use std::thread::ThreadId;
 
 
@@ -88,17 +90,72 @@ pub struct CommandBufferDescriptor {}
 #[no_mangle]
 pub extern "C" fn wgpu_command_buffer_begin_render_pass(
     command_buffer_id: CommandBufferId,
-    _descriptor: RenderPassDescriptor<TextureViewId>,
+    desc: RenderPassDescriptor<TextureViewId>,
 ) -> RenderPassId {
     let mut cmb_guard = HUB.command_buffers.lock();
     let cmb = cmb_guard.get_mut(command_buffer_id);
-
     let device_guard = HUB.devices.lock();
     let device = device_guard.get(cmb.device_id.0);
 
     let current_comb = device.com_allocator.extend(cmb);
 
-    //let render_pass = device.create_render_pass();
+    let render_pass = {
+        let tracker = &mut cmb.texture_tracker;
+        let view_guard = HUB.texture_views.lock();
+
+        let depth_stencil_attachment = match desc.depth_stencil_attachment {
+            Some(ref at) => {
+                let view = view_guard.get(at.attachment);
+                let query = tracker.query(view.source_id.0);
+                let (_, layout) = conv::map_texture_state(
+                    query.usage,
+                    hal::format::Aspects::DEPTH | hal::format::Aspects::STENCIL,
+                );
+                Some(hal::pass::Attachment {
+                    format: Some(conv::map_texture_format(view.format)),
+                    samples: view.samples,
+                    ops: conv::map_load_store_ops(at.depth_load_op, at.depth_store_op),
+                    stencil_ops: conv::map_load_store_ops(at.stencil_load_op, at.stencil_store_op),
+                    layouts: layout .. layout,
+                })
+            }
+            None => None,
+        };
+        let color_attachments = desc.color_attachments
+            .iter()
+            .map(|at| {
+                let view = view_guard.get(at.attachment);
+                let query = tracker.query(view.source_id.0);
+                let (_, layout) = conv::map_texture_state(query.usage, hal::format::Aspects::COLOR);
+                hal::pass::Attachment {
+                    format: Some(conv::map_texture_format(view.format)),
+                    samples: view.samples,
+                    ops: conv::map_load_store_ops(at.load_op, at.store_op),
+                    stencil_ops: hal::pass::AttachmentOps::DONT_CARE,
+                    layouts: layout .. layout,
+                }
+            });
+        let attachments = color_attachments.chain(depth_stencil_attachment);
+
+        //TODO: retain the storage
+        let color_refs = (0 .. desc.color_attachments.len())
+            .map(|i| {
+                (i, hal::image::Layout::ColorAttachmentOptimal)
+            })
+            .collect::<Vec<_>>();
+        let ds_ref = desc.depth_stencil_attachment.as_ref().map(|_| {
+            (desc.color_attachments.len(), hal::image::Layout::DepthStencilAttachmentOptimal)
+        });
+        let subpass = hal::pass::SubpassDesc {
+            colors: &color_refs,
+            depth_stencil: ds_ref.as_ref(),
+            inputs: &[],
+            resolves: &[],
+            preserves: &[],
+        };
+
+        device.raw.create_render_pass(attachments, iter::once(subpass), &[])
+    };
     //let framebuffer = device.create_framebuffer();
 
     /*TODO:

--- a/wgpu-native/src/conv.rs
+++ b/wgpu-native/src/conv.rs
@@ -1,6 +1,6 @@
 use hal;
 
-use {Extent3d, binding_model, pipeline, resource};
+use {Extent3d, binding_model, command, pipeline, resource};
 
 
 pub fn map_buffer_usage(
@@ -357,4 +357,16 @@ pub fn map_texture_state(
     }
 
     (access, layout)
+}
+
+pub fn map_load_store_ops(load: command::LoadOp, store: command::StoreOp) -> hal::pass::AttachmentOps {
+    hal::pass::AttachmentOps {
+        load: match load {
+            command::LoadOp::Clear => hal::pass::AttachmentLoadOp::Clear,
+            command::LoadOp::Load => hal::pass::AttachmentLoadOp::Load,
+        },
+        store: match store {
+            command::StoreOp::Store => hal::pass::AttachmentStoreOp::Store,
+        },
+    }
 }

--- a/wgpu-native/src/conv.rs
+++ b/wgpu-native/src/conv.rs
@@ -1,6 +1,6 @@
 use hal;
 
-use {Extent3d, binding_model, command, pipeline, resource};
+use {Color, Extent3d, binding_model, command, pipeline, resource};
 
 
 pub fn map_buffer_usage(
@@ -369,4 +369,8 @@ pub fn map_load_store_ops(load: command::LoadOp, store: command::StoreOp) -> hal
             command::StoreOp::Store => hal::pass::AttachmentStoreOp::Store,
         },
     }
+}
+
+pub fn map_color(color: Color) -> hal::pso::ColorValue {
+    [color.r, color.g, color.b, color.a]
 }

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -1,6 +1,6 @@
 use {back, binding_model, command, conv, pipeline, resource};
 use registry::{HUB, Items, Registry};
-use track::{BufferTracker, TextureTracker, TrackPermit};
+use track::{BufferTracker, TextureTracker};
 use {
     AttachmentStateId, BindGroupLayoutId, BlendStateId, CommandBufferId, DepthStencilStateId,
     DeviceId, PipelineLayoutId, QueueId, RenderPipelineId, ShaderModuleId, TextureId,
@@ -115,11 +115,11 @@ pub extern "C" fn wgpu_device_create_texture(
             raw: bound_image,
             aspects,
         });
-    device.texture_tracker
+    let query = device.texture_tracker
         .lock()
         .unwrap()
-        .track(id, resource::TextureUsageFlags::empty(), TrackPermit::empty())
-        .expect("Resource somehow is already registered");
+        .query(id);
+    assert!(query.initialized);
 
     id
 }

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -423,14 +423,14 @@ pub extern "C" fn wgpu_device_create_render_pipeline(
     };
 
     let blend_state_guard = HUB.blend_states.lock();
-    let blend_state = unsafe { slice::from_raw_parts(desc.blend_state, desc.blend_state_length) }
+    let blend_states = unsafe { slice::from_raw_parts(desc.blend_states, desc.blend_states_length) }
         .iter()
         .map(|id| blend_state_guard.get(id.clone()).raw)
         .collect();
 
     let blender = hal::pso::BlendDesc {
         logic_op: None, // TODO
-        targets: blend_state,
+        targets: blend_states,
     };
 
     let depth_stencil_state_guard = HUB.depth_stencil_states.lock();

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -100,6 +100,7 @@ type BufferHandle = Buffer<B>;
 
 // Resource
 pub type TextureViewId = Id;
+type TextureViewHandle = TextureView<B>;
 pub type TextureId = Id;
 type TextureHandle = Texture<B>;
 pub type SamplerId = Id;

--- a/wgpu-native/src/pipeline.rs
+++ b/wgpu-native/src/pipeline.rs
@@ -247,8 +247,8 @@ pub struct RenderPipelineDescriptor {
     pub stages: *const PipelineStageDescriptor,
     pub stages_length: usize,
     pub primitive_topology: PrimitiveTopology,
-    pub blend_state: *const BlendStateId,
-    pub blend_state_length: usize,
+    pub blend_states: *const BlendStateId,
+    pub blend_states_length: usize,
     pub depth_stencil_state: DepthStencilStateId,
     pub attachment_state: AttachmentStateId,
 }

--- a/wgpu-native/src/registry/mod.rs
+++ b/wgpu-native/src/registry/mod.rs
@@ -13,7 +13,7 @@ use {
     BlendStateHandle, CommandBufferHandle, DepthStencilStateHandle, DeviceHandle, InstanceHandle,
     RenderPassHandle, ComputePassHandle,
     PipelineLayoutHandle, RenderPipelineHandle, ComputePipelineHandle, ShaderModuleHandle,
-    BufferHandle, TextureHandle,
+    BufferHandle, TextureHandle, TextureViewHandle,
 };
 
 
@@ -50,6 +50,7 @@ pub struct Hub {
     pub(crate) compute_passes: ConcreteRegistry<ComputePassHandle>,
     pub(crate) buffers: ConcreteRegistry<BufferHandle>,
     pub(crate) textures: ConcreteRegistry<TextureHandle>,
+    pub(crate) texture_views: ConcreteRegistry<TextureViewHandle>,
 }
 
 lazy_static! {

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -82,6 +82,7 @@ pub(crate) struct TextureView<B: hal::Backend> {
     pub raw: B::ImageView,
     pub source_id: Stored<TextureId>,
     pub format: TextureFormat,
+    pub extent: hal::image::Extent,
     pub samples: hal::image::NumSamples,
 }
 

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -1,4 +1,4 @@
-use {Extent3d};
+use {Extent3d, Stored, TextureId};
 
 use hal;
 
@@ -32,9 +32,6 @@ pub(crate) struct Buffer<B: hal::Backend> {
     // TODO: mapping, unmap()
 }
 
-pub struct TextureView {
-    // TODO
-}
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
@@ -79,6 +76,13 @@ pub struct TextureDescriptor {
 pub(crate) struct Texture<B: hal::Backend> {
     pub raw: B::Image,
     pub aspects: hal::format::Aspects,
+}
+
+pub(crate) struct TextureView<B: hal::Backend> {
+    pub raw: B::ImageView,
+    pub source_id: Stored<TextureId>,
+    pub format: TextureFormat,
+    pub samples: hal::image::NumSamples,
 }
 
 #[repr(C)]

--- a/wgpu-rs/src/lib.rs
+++ b/wgpu-rs/src/lib.rs
@@ -8,7 +8,7 @@ use std::ffi::CString;
 pub use wgn::{
     AdapterDescriptor, Color, CommandBufferDescriptor, DeviceDescriptor, Extensions, Extent3d,
     Origin3d, PowerPreference, ShaderModuleDescriptor, ShaderStage,
-    BindGroupLayoutBinding, BindingType, TextureFormat,
+    BindGroupLayoutBinding, BindingType, TextureDimension, TextureDescriptor, TextureFormat, TextureUsageFlags,
     PrimitiveTopology, BlendStateDescriptor, ColorWriteFlags, DepthStencilStateDescriptor,
     RenderPassDescriptor, RenderPassColorAttachmentDescriptor, RenderPassDepthStencilAttachmentDescriptor,
     LoadOp, StoreOp,
@@ -26,6 +26,10 @@ pub struct Adapter {
 
 pub struct Device {
     id: wgn::DeviceId,
+}
+
+pub struct Texture {
+    id: wgn::TextureId,
 }
 
 pub struct TextureView {
@@ -236,6 +240,12 @@ impl Device {
                 depth_stencil_state: desc.depth_stencil_state.id,
                 attachment_state: desc.attachment_state.id,
             }),
+        }
+    }
+
+    pub fn create_texture(&self, desc: TextureDescriptor) -> Texture {
+        Texture {
+            id: wgn::wgpu_device_create_texture(self.id, &desc),
         }
     }
 }


### PR DESCRIPTION
For now, we create the render pass and the frame buffer in place. Of course, we'd need to cache it properly, but this is blocked on W3C discussions on the API side.