### PR TITLE
Resource lifetime tracking

### DIFF
--- a/wgpu-bindings/wgpu.h
+++ b/wgpu-bindings/wgpu.h
@@ -387,3 +387,7 @@ WGPUTextureViewId wgpu_texture_create_default_texture_view(WGPUTextureId texture
 
 WGPUTextureViewId wgpu_texture_create_texture_view(WGPUTextureId texture_id,
                                                    const WGPUTextureViewDescriptor *desc);
+
+void wgpu_texture_destroy(WGPUDeviceId texture_id);
+
+void wgpu_texture_view_destroy(WGPUTextureViewId _texture_view_id);

--- a/wgpu-native/src/command/allocator.rs
+++ b/wgpu-native/src/command/allocator.rs
@@ -1,5 +1,5 @@
 use super::CommandBuffer;
-use {DeviceId, Stored};
+use {DeviceId, LifeGuard, Stored};
 use track::{Tracker};
 
 use hal::command::RawCommandBuffer;
@@ -61,8 +61,8 @@ impl<B: hal::Backend> CommandAllocator<B> {
         }
     }
 
-    pub fn allocate(
-        &self, device_id: DeviceId, device: &B::Device
+    pub(crate) fn allocate(
+        &self, device_id: Stored<DeviceId>, device: &B::Device
     ) -> CommandBuffer<B> {
         let thread_id = thread::current().id();
         let mut inner = self.inner.lock().unwrap();
@@ -90,7 +90,8 @@ impl<B: hal::Backend> CommandAllocator<B> {
             raw: vec![init],
             fence,
             recorded_thread_id: thread_id,
-            device_id: Stored(device_id),
+            device_id,
+            life_guard: LifeGuard::new(),
             buffer_tracker: Tracker::new(),
             texture_tracker: Tracker::new(),
         }

--- a/wgpu-native/src/command/compute.rs
+++ b/wgpu-native/src/command/compute.rs
@@ -16,10 +16,10 @@ pub struct ComputePass<B: hal::Backend> {
 }
 
 impl<B: hal::Backend> ComputePass<B> {
-    pub fn new(raw: B::CommandBuffer, cmb_id: CommandBufferId) -> Self {
+    pub(crate) fn new(raw: B::CommandBuffer, cmb_id: Stored<CommandBufferId>) -> Self {
         ComputePass {
             raw,
-            cmb_id: Stored(cmb_id),
+            cmb_id,
         }
     }
 }
@@ -34,10 +34,10 @@ pub extern "C" fn wgpu_compute_pass_end_pass(
 
     HUB.command_buffers
         .lock()
-        .get_mut(pass.cmb_id.0)
+        .get_mut(pass.cmb_id.value)
         .raw
         .push(pass.raw);
-    pass.cmb_id.0
+    pass.cmb_id.value
 }
 
 pub extern "C" fn wgpu_compute_pass_set_bind_group(

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -1,5 +1,5 @@
 use {
-    Extent3d, Stored,
+    Extent3d, LifeGuard, Stored,
     DeviceId, TextureId,
 };
 
@@ -32,6 +32,7 @@ pub(crate) struct Buffer<B: hal::Backend> {
     //pub raw: B::UnboundBuffer,
     pub raw: B::Buffer,
     pub memory_properties: hal::memory::Properties,
+    pub life_guard: LifeGuard,
     // TODO: mapping, unmap()
 }
 
@@ -82,6 +83,7 @@ pub(crate) struct Texture<B: hal::Backend> {
     pub kind: hal::image::Kind,
     pub format: TextureFormat,
     pub full_range: hal::image::SubresourceRange,
+    pub life_guard: LifeGuard,
 }
 
 
@@ -122,6 +124,7 @@ pub(crate) struct TextureView<B: hal::Backend> {
     pub format: TextureFormat,
     pub extent: hal::image::Extent,
     pub samples: hal::image::NumSamples,
+    pub life_guard: LifeGuard,
 }
 
 

--- a/wgpu-native/src/track.rs
+++ b/wgpu-native/src/track.rs
@@ -70,6 +70,7 @@ impl<
         }
     }
 
+    /// Get the last usage on a resource.
     pub(crate) fn query(
         &mut self, stored: &Stored<I>, default: U
     ) -> Query<U> {
@@ -94,6 +95,7 @@ impl<
         }
     }
 
+    /// Transit a specified resource into a different usage.
     pub(crate) fn transit(
         &mut self, id: I, ref_count: &RefCount, usage: U, permit: TrackPermit
     ) -> Result<Tracktion<U>, U> {
@@ -123,6 +125,7 @@ impl<
         }
     }
 
+    /// Consume another tacker, adding it's transitions to `self`.
     pub fn consume<'a>(
         &'a mut self, other: &'a Self
     ) -> impl 'a + Iterator<Item = (I, Range<U>)> {
@@ -142,5 +145,10 @@ impl<
                     }
                 }
             })
+    }
+
+    /// Return an iterator over used resources keys.
+    pub fn used<'a>(&'a self) -> impl 'a + Iterator<Item = I> {
+        self.map.keys().map(|&WeaklyStored(ref id)| id.clone())
     }
 }


### PR DESCRIPTION
Fixes #26

This change ends up being much more serious and intrusive, but hopefully manage-able. The idea is that the native layer would have explicit deletion calls exposed, but would still guarantee that resources live for as long as they are used by either CPU or GPU. The device, in order to guarantee that, keeps track of resources associated with fences and walks through them for clean up.

Maintaining the actual ref-counts per object up-to-date is one of the most challenging tasks. I choose to use the existing `Stored` structure to host it, so that we are forced to clone the refcounts, and it's difficult to screw up. I still had to provide the "old" semantics under the new name of `WeaklyStored` though, and we should be careful about it.

TODO:
  - [ ] review and test
  - [x] fix transition API once more, so that command buffers are stitched properly and resources are tracked by the device
  - [ ] update the Rust layer, using RAII
  - [ ] update the examples