### PR TITLE
Basic windowing and presentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,8 +104,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cbindgen"
-version = "0.6.7"
-source = "git+https://github.com/grovesNL/cbindgen?branch=associated-constants#c87c6774c9f1b9540abac4fc505ed63f0e0a0798"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1061,7 +1061,7 @@ dependencies = [
 name = "wgpu-bindings"
 version = "0.1.0"
 dependencies = [
- "cbindgen 0.6.7 (git+https://github.com/grovesNL/cbindgen?branch=associated-constants)",
+ "cbindgen 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1077,6 +1077,7 @@ dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1180,7 +1181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
-"checksum cbindgen 0.6.7 (git+https://github.com/grovesNL/cbindgen?branch=associated-constants)" = "<none>"
+"checksum cbindgen 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "89ae8c2f780373f1842acb548fa53c7fd3acd6ca27d47966c69351719b239eae"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,24 @@ version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "gfx-backend-dx11"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "range-alloc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spirv_cross 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gfx-backend-dx12"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1087,7 @@ name = "wgpu-native"
 version = "0.1.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-backend-dx11 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-backend-dx12 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-backend-empty 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-backend-metal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1127,6 +1146,14 @@ dependencies = [
  "wayland-client 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wio"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1202,6 +1229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+"checksum gfx-backend-dx11 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7751e630a3472d96b1a0ce9cd6742f2e17c0f71a6e833f822b914a11f89bd7db"
 "checksum gfx-backend-dx12 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2c373f40998da0fd605a7a90ce8d775a8cbcb06558edc2ea9740df1db2077686"
 "checksum gfx-backend-empty 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6bb068297aed95a014abaa01738986c2ed5d08c5f9f152c992300c415e9b917c"
 "checksum gfx-backend-metal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "68fa011e32280f7566bddbb736734291b685c812087c99bc848d6ac7ae3e0b7f"
@@ -1294,6 +1322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c57c15bd4c0ef18dff33e263e452abe32d00e2e05771cacaa410a14cc1c0776"
+"checksum wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8a31e8a268d6941ffb7f8d7989fc93e4692bd3e75a27d400a72b4be1dadb213"
 "checksum x11 2.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39697e3123f715483d311b5826e254b6f3cfebdd83cf7ef3358f579c3d68e235"
 "checksum x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)" = "940586acb859ea05c53971ac231685799a7ec1dee66ac0bccc0e6ad96e06b4e3"
 "checksum xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 remote = ["wgpu-native/remote"]
 winit = ["wgpu/winit"]
 metal = ["wgpu-native/gfx-backend-metal"]
+dx11 = ["wgpu-native/gfx-backend-dx11"]
 dx12 = ["wgpu-native/gfx-backend-dx12"]
 vulkan = ["wgpu-native/gfx-backend-vulkan"]
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,6 +14,7 @@ path = "hello_triangle_rust/main.rs"
 [features]
 default = []
 remote = ["wgpu-native/remote"]
+winit = ["wgpu/winit"]
 metal = ["wgpu-native/gfx-backend-metal"]
 dx12 = ["wgpu-native/gfx-backend-dx12"]
 vulkan = ["wgpu-native/gfx-backend-vulkan"]

--- a/examples/hello_triangle_rust/main.rs
+++ b/examples/hello_triangle_rust/main.rs
@@ -1,4 +1,6 @@
 extern crate wgpu;
+extern crate wgpu_native;
+
 fn main() {
     let instance = wgpu::Instance::new();
     let adapter = instance.get_adapter(&wgpu::AdapterDescriptor {
@@ -9,19 +11,6 @@ fn main() {
             anisotropic_filtering: false,
         },
     });
-
-    let texture = device.create_texture(&wgpu::TextureDescriptor {
-        size: wgpu::Extent3d {
-            width: 256,
-            height: 256,
-            depth: 1,
-        },
-        array_size: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::R8g8b8a8Unorm,
-        usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
-    });
-    let color_view = texture.create_default_texture_view();
 
     let vs_bytes = include_bytes!("./../data/hello_triangle.vert.spv");
     let vs_module = device.create_shader_module(vs_bytes);
@@ -64,21 +53,89 @@ fn main() {
         depth_stencil_state: &depth_stencil_state,
     });
 
-    let mut cmd_buf = device.create_command_buffer(&wgpu::CommandBufferDescriptor {});
-
+    #[cfg(feature = "winit")]
     {
-        let rpass = cmd_buf.begin_render_pass(&wgpu::RenderPassDescriptor {
-            color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
-                attachment: &color_view,
-                load_op: wgpu::LoadOp::Clear,
-                store_op: wgpu::StoreOp::Store,
-                clear_color: wgpu::Color::GREEN,
-            }],
-            depth_stencil_attachment: None,
+        use wgpu_native::winit::{ControlFlow, Event, EventsLoop, Window, WindowEvent};
+
+        let mut events_loop = EventsLoop::new();
+        let window = Window::new(&events_loop).unwrap();
+        let size = window
+            .get_inner_size()
+            .unwrap()
+            .to_physical(window.get_hidpi_factor());
+
+        let surface = instance.create_surface(&window);
+        let swap_chain = device.create_swap_chain(&surface, &wgpu::SwapChainDescriptor {
+            usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT | wgpu::TextureUsageFlags::PRESENT,
+            format: wgpu::TextureFormat::B8g8r8a8Unorm,
+            width: size.width as u32,
+            height: size.height as u32,
         });
-        rpass.end_pass();
+
+        events_loop.run_forever(|event| {
+            match event {
+                Event::WindowEvent { event: WindowEvent::CloseRequested, .. } => {
+                    return ControlFlow::Break
+                }
+                _ => {}
+            }
+
+            let (_, view) = swap_chain.get_next_texture();
+            let mut cmd_buf = device.create_command_buffer(&wgpu::CommandBufferDescriptor {});
+            {
+                let rpass = cmd_buf.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
+                        attachment: &view,
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_color: wgpu::Color::GREEN,
+                    }],
+                    depth_stencil_attachment: None,
+                });
+                rpass.end_pass();
+            }
+
+            device
+                .get_queue()
+                .submit(&[cmd_buf]);
+
+            swap_chain.present();
+
+            ControlFlow::Continue
+        });
     }
 
-    let queue = device.get_queue();
-    queue.submit(&[cmd_buf]);
+    #[cfg(not(feature = "winit"))]
+    {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            size: wgpu::Extent3d {
+                width: 256,
+                height: 256,
+                depth: 1,
+            },
+            array_size: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::R8g8b8a8Unorm,
+            usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
+        });
+        let color_view = texture.create_default_texture_view();
+
+        let mut cmd_buf = device.create_command_buffer(&wgpu::CommandBufferDescriptor {});
+        {
+            let rpass = cmd_buf.begin_render_pass(&wgpu::RenderPassDescriptor {
+                color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
+                    attachment: &color_view,
+                    load_op: wgpu::LoadOp::Clear,
+                    store_op: wgpu::StoreOp::Store,
+                    clear_color: wgpu::Color::GREEN,
+                }],
+                depth_stencil_attachment: None,
+            });
+            rpass.end_pass();
+        }
+
+        device
+            .get_queue()
+            .submit(&[cmd_buf]);
+    }
 }

--- a/examples/hello_triangle_rust/main.rs
+++ b/examples/hello_triangle_rust/main.rs
@@ -55,7 +55,7 @@ fn main() {
 
     #[cfg(feature = "winit")]
     {
-        use wgpu_native::winit::{ControlFlow, Event, EventsLoop, Window, WindowEvent};
+        use wgpu_native::winit::{ControlFlow, Event, ElementState, EventsLoop, KeyboardInput, Window, WindowEvent, VirtualKeyCode};
 
         let mut events_loop = EventsLoop::new();
         let window = Window::new(&events_loop).unwrap();
@@ -74,8 +74,20 @@ fn main() {
 
         events_loop.run_forever(|event| {
             match event {
-                Event::WindowEvent { event: WindowEvent::CloseRequested, .. } => {
-                    return ControlFlow::Break
+                Event::WindowEvent { event, .. } => match event {
+                    WindowEvent::KeyboardInput {
+                        input: KeyboardInput { virtual_keycode: Some(code), state: ElementState::Pressed, .. },
+                        ..
+                    } => match code {
+                        VirtualKeyCode::Escape => {
+                            return ControlFlow::Break
+                        }
+                        _ => {}
+                    }
+                    WindowEvent::CloseRequested => {
+                        return ControlFlow::Break
+                    }
+                    _ => {}
                 }
                 _ => {}
             }
@@ -100,7 +112,6 @@ fn main() {
                 .submit(&[cmd_buf]);
 
             swap_chain.present();
-
             ControlFlow::Continue
         });
     }

--- a/wgpu-bindings/Cargo.toml
+++ b/wgpu-bindings/Cargo.toml
@@ -11,5 +11,4 @@ edition = "2018"
 default = []
 
 [dependencies]
-#cbindgen = "0.6.7"
-cbindgen = { git = "https://github.com/grovesNL/cbindgen", branch = "associated-constants"}
+cbindgen = "0.6.8"

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -25,4 +25,4 @@ gfx-backend-vulkan = { version = "0.1.0", optional = true }
 gfx-backend-dx12 = { version = "0.1.0", optional = true }
 gfx-backend-metal = { version = "0.1.0", optional = true }
 #rendy-memory = { git = "https://github.com/rustgd/rendy", rev = "ce7dd7f", features = ["gfx-hal"] }
-winit = "0.18"
+winit = { version = "0.18", optional = true }

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -22,6 +22,7 @@ parking_lot = { version = "0.7" }
 gfx-hal = "0.1.0"
 gfx-backend-empty = "0.1.0"
 gfx-backend-vulkan = { version = "0.1.0", optional = true }
+gfx-backend-dx11 = { version = "0.1.0", optional = true }
 gfx-backend-dx12 = { version = "0.1.0", optional = true }
 gfx-backend-metal = { version = "0.1.0", optional = true }
 #rendy-memory = { git = "https://github.com/rustgd/rendy", rev = "ce7dd7f", features = ["gfx-hal"] }

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -25,3 +25,4 @@ gfx-backend-vulkan = { version = "0.1.0", optional = true }
 gfx-backend-dx12 = { version = "0.1.0", optional = true }
 gfx-backend-metal = { version = "0.1.0", optional = true }
 #rendy-memory = { git = "https://github.com/rustgd/rendy", rev = "ce7dd7f", features = ["gfx-hal"] }
+winit = "0.18"

--- a/wgpu-native/src/binding_model.rs
+++ b/wgpu-native/src/binding_model.rs
@@ -2,6 +2,7 @@ use crate::{BindGroupLayoutId, BufferId, SamplerId, TextureViewId};
 
 use bitflags::bitflags;
 
+
 bitflags! {
     #[repr(transparent)]
     pub struct ShaderStageFlags: u32 {

--- a/wgpu-native/src/command/allocator.rs
+++ b/wgpu-native/src/command/allocator.rs
@@ -99,6 +99,7 @@ impl<B: hal::Backend> CommandAllocator<B> {
             life_guard: LifeGuard::new(),
             buffer_tracker: Tracker::new(),
             texture_tracker: Tracker::new(),
+            swap_chain_links: Vec::new(),
         }
     }
 

--- a/wgpu-native/src/command/compute.rs
+++ b/wgpu-native/src/command/compute.rs
@@ -5,6 +5,7 @@ use hal::command::RawCommandBuffer;
 
 use std::iter;
 
+
 pub struct ComputePass<B: hal::Backend> {
     raw: B::CommandBuffer,
     cmb_id: Stored<CommandBufferId>,

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -88,7 +88,7 @@ pub struct CommandBuffer<B: hal::Backend> {
     life_guard: LifeGuard,
     pub(crate) buffer_tracker: BufferTracker,
     pub(crate) texture_tracker: TextureTracker,
-    swap_chain_links: Vec<SwapChainLink<SwapImageEpoch>>,
+    pub(crate) swap_chain_links: Vec<SwapChainLink<SwapImageEpoch>>,
 }
 
 impl CommandBuffer<B> {

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -12,8 +12,11 @@ use crate::swap_chain::{SwapChainLink, SwapImageEpoch};
 use crate::track::{BufferTracker, TextureTracker};
 use crate::{conv, resource};
 use crate::{
-    BufferId, BufferUsageFlags, Color, CommandBufferId, ComputePassId, DeviceId, LifeGuard,
-    Origin3d, RenderPassId, Stored, TextureId, TextureUsageFlags, TextureViewId, WeaklyStored, B,
+    BufferId, CommandBufferId, ComputePassId, DeviceId,
+    RenderPassId, TextureId, TextureViewId,
+    BufferUsageFlags, TextureUsageFlags, Color, Origin3d,
+    LifeGuard, Stored, WeaklyStored,
+    B,
 };
 
 use hal::command::RawCommandBuffer;
@@ -82,10 +85,9 @@ pub struct TextureCopyView {
 
 pub struct CommandBuffer<B: hal::Backend> {
     pub(crate) raw: Vec<B::CommandBuffer>,
-    fence: B::Fence,
     recorded_thread_id: ThreadId,
     device_id: Stored<DeviceId>,
-    life_guard: LifeGuard,
+    pub(crate) life_guard: LifeGuard,
     pub(crate) buffer_tracker: BufferTracker,
     pub(crate) texture_tracker: TextureTracker,
     pub(crate) swap_chain_links: Vec<SwapChainLink<SwapImageEpoch>>,

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -11,6 +11,7 @@ use hal::Device;
 
 use crate::device::{FramebufferKey, RenderPassKey};
 use crate::registry::{Items, HUB};
+use crate::swap_chain::SwapChainLink;
 use crate::track::{BufferTracker, TextureTracker};
 use crate::{conv, resource};
 use crate::{
@@ -87,6 +88,7 @@ pub struct CommandBuffer<B: hal::Backend> {
     life_guard: LifeGuard,
     pub(crate) buffer_tracker: BufferTracker,
     pub(crate) texture_tracker: TextureTracker,
+    swap_chain_links: Vec<SwapChainLink>,
 }
 
 impl CommandBuffer<B> {
@@ -162,6 +164,7 @@ pub extern "C" fn wgpu_command_buffer_begin_render_pass(
 
     let rp_key = {
         let tracker = &mut cmb.texture_tracker;
+        //let swap_chain_links = &mut cmb.swap_chain_links;
 
         let depth_stencil_key = match desc.depth_stencil_attachment {
             Some(ref at) => {

--- a/wgpu-native/src/command/render.rs
+++ b/wgpu-native/src/command/render.rs
@@ -4,6 +4,7 @@ use crate::{CommandBuffer, CommandBufferId, RenderPassId, Stored};
 
 use hal::command::RawCommandBuffer;
 
+
 pub struct RenderPass<B: hal::Backend> {
     raw: B::CommandBuffer,
     cmb_id: Stored<CommandBufferId>,

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -20,6 +20,7 @@ use std::{ffi, slice};
 use std::collections::hash_map::{Entry, HashMap};
 use std::sync::atomic::Ordering;
 
+
 #[derive(Hash, PartialEq)]
 pub(crate) struct RenderPassKey {
     pub attachments: Vec<hal::pass::Attachment>,
@@ -902,7 +903,6 @@ pub extern "C" fn wgpu_device_create_swap_chain(
             acquired: Vec::with_capacity(num_frames as usize),
             sem_available: device.raw.create_semaphore().unwrap(),
             command_pool,
-            epoch: 1,
         });
     let swap_chain = swap_chain_guard.get_mut(swap_chain_id);
 

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -1,7 +1,9 @@
 use crate::registry::{HUB, Items};
-use crate::{WeaklyStored, Device, Surface,
-    AdapterId, DeviceId, InstanceId, SurfaceId,
+use crate::{WeaklyStored, Device,
+    AdapterId, DeviceId, InstanceId,
 };
+#[cfg(feature = "winit")]
+use crate::{Surface, SurfaceId};
 
 use hal::{self, Instance as _Instance, PhysicalDevice as _PhysicalDevice};
 
@@ -50,14 +52,7 @@ pub extern "C" fn wgpu_create_instance() -> InstanceId {
     }
 }
 
-#[cfg(all(
-    not(feature = "remote"),
-    any(
-        feature = "gfx-backend-vulkan",
-        feature = "gfx-backend-dx12",
-        feature = "gfx-backend-metal"
-    )
-))]
+#[cfg(feature = "winit")]
 #[no_mangle]
 pub extern "C" fn wgpu_instance_create_surface_from_winit(
     instance_id: InstanceId,

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -1,7 +1,13 @@
-use hal::{Instance as _Instance, PhysicalDevice as _PhysicalDevice};
+#[cfg(not(feature = "winit"))]
+extern crate winit;
 
-use crate::registry::{Items, HUB};
-use crate::{AdapterId, Device, DeviceId, InstanceId};
+use hal::{self, Instance as _Instance, PhysicalDevice as _PhysicalDevice};
+
+use crate::registry::{HUB, Items};
+use crate::{WeaklyStored, Device, Surface,
+    AdapterId, DeviceId, InstanceId, SurfaceId,
+};
+
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
@@ -47,6 +53,25 @@ pub extern "C" fn wgpu_create_instance() -> InstanceId {
     }
 }
 
+#[cfg(not(feature = "remote"))]
+#[no_mangle]
+pub extern "C" fn wgpu_instance_create_surface_from_winit(
+    instance_id: InstanceId,
+    window: &winit::Window,
+) -> SurfaceId {
+    let raw = HUB.instances
+        .read()
+        .get(instance_id)
+        .create_surface(window);
+    let surface = Surface {
+        raw,
+    };
+
+    HUB.surfaces
+        .write()
+        .register(surface)
+}
+
 #[no_mangle]
 pub extern "C" fn wgpu_instance_get_adapter(
     instance_id: InstanceId,
@@ -77,9 +102,11 @@ pub extern "C" fn wgpu_adapter_create_device(
 ) -> DeviceId {
     let mut adapter_guard = HUB.adapters.write();
     let adapter = adapter_guard.get_mut(adapter_id);
-    let (device, queue_group) = adapter.open_with::<_, hal::General>(1, |_qf| true).unwrap();
+    let (raw, queue_group) = adapter.open_with::<_, hal::General>(1, |_qf| true).unwrap();
     let mem_props = adapter.physical_device.memory_properties();
+    let device = Device::new(raw, WeaklyStored(adapter_id), queue_group, mem_props);
+
     HUB.devices
         .write()
-        .register(Device::new(device, queue_group, mem_props))
+        .register(device)
 }

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -1,12 +1,9 @@
-#[cfg(not(feature = "winit"))]
-extern crate winit;
-
-use hal::{self, Instance as _Instance, PhysicalDevice as _PhysicalDevice};
-
 use crate::registry::{HUB, Items};
 use crate::{WeaklyStored, Device, Surface,
     AdapterId, DeviceId, InstanceId, SurfaceId,
 };
+
+use hal::{self, Instance as _Instance, PhysicalDevice as _PhysicalDevice};
 
 
 #[repr(C)]

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -50,7 +50,14 @@ pub extern "C" fn wgpu_create_instance() -> InstanceId {
     }
 }
 
-#[cfg(not(feature = "remote"))]
+#[cfg(all(
+    not(feature = "remote"),
+    any(
+        feature = "gfx-backend-vulkan",
+        feature = "gfx-backend-dx12",
+        feature = "gfx-backend-metal"
+    )
+))]
 #[no_mangle]
 pub extern "C" fn wgpu_instance_create_surface_from_winit(
     instance_id: InstanceId,

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -35,21 +35,17 @@ pub struct DeviceDescriptor {
 pub extern "C" fn wgpu_create_instance() -> InstanceId {
     #[cfg(any(
         feature = "gfx-backend-vulkan",
+        feature = "gfx-backend-dx11",
         feature = "gfx-backend-dx12",
         feature = "gfx-backend-metal"
     ))]
     {
         let inst = ::back::Instance::create("wgpu", 1);
-        HUB.instances.write().register(inst)
+        if true {
+            return HUB.instances.write().register(inst);
+        }
     }
-    #[cfg(not(any(
-        feature = "gfx-backend-vulkan",
-        feature = "gfx-backend-dx12",
-        feature = "gfx-backend-metal"
-    )))]
-    {
-        unimplemented!()
-    }
+    unimplemented!()
 }
 
 #[cfg(feature = "winit")]

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -1,12 +1,15 @@
 #[cfg(feature = "winit")]
 pub extern crate winit;
 
+#[cfg(feature = "gfx-backend-dx11")]
+extern crate gfx_backend_dx11 as back;
 #[cfg(feature = "gfx-backend-dx12")]
 extern crate gfx_backend_dx12 as back;
 #[cfg(not(any(
     feature = "gfx-backend-vulkan",
+    feature = "gfx-backend-dx11",
     feature = "gfx-backend-dx12",
-    feature = "gfx-backend-metal"
+    feature = "gfx-backend-metal",
 )))]
 extern crate gfx_backend_empty as back;
 #[cfg(feature = "gfx-backend-metal")]

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -90,7 +90,7 @@ impl LifeGuard {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct Stored<T> {
     value: T,
     ref_count: RefCount,

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "remote"))]
+#[cfg(feature = "winit")]
 pub extern crate winit;
 
 #[cfg(feature = "gfx-backend-dx12")]

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "remote"))]
-extern crate winit;
+pub extern crate winit;
 
 #[cfg(feature = "gfx-backend-dx12")]
 extern crate gfx_backend_dx12 as back;

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -99,7 +99,7 @@ struct Stored<T> {
 unsafe impl<T> Send for Stored<T> {}
 unsafe impl<T> Sync for Stored<T> {}
 
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 struct WeaklyStored<T>(T);
 
 unsafe impl<T> Send for WeaklyStored<T> {}

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "remote"))]
+extern crate winit;
+
 #[cfg(feature = "gfx-backend-dx12")]
 extern crate gfx_backend_dx12 as back;
 #[cfg(not(any(
@@ -22,6 +25,7 @@ mod instance;
 mod pipeline;
 mod registry;
 mod resource;
+mod swap_chain;
 mod track;
 
 pub use self::binding_model::*;
@@ -30,6 +34,7 @@ pub use self::device::*;
 pub use self::instance::*;
 pub use self::pipeline::*;
 pub use self::resource::*;
+pub use self::swap_chain::*;
 
 use back::Backend as B;
 pub use crate::registry::Id;
@@ -214,3 +219,9 @@ pub type RenderPassId = Id;
 type RenderPassHandle = RenderPass<B>;
 pub type ComputePassId = Id;
 type ComputePassHandle = ComputePass<B>;
+
+
+pub type SurfaceId = Id;
+type SurfaceHandle = Surface<B>;
+pub type SwapChainId = Id;
+type SwapChainHandle = SwapChain<B>;

--- a/wgpu-native/src/pipeline.rs
+++ b/wgpu-native/src/pipeline.rs
@@ -1,8 +1,8 @@
 use crate::resource;
-
 use crate::{BlendStateId, ByteArray, DepthStencilStateId, PipelineLayoutId, ShaderModuleId};
 
 use bitflags::bitflags;
+
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]

--- a/wgpu-native/src/registry/mod.rs
+++ b/wgpu-native/src/registry/mod.rs
@@ -1,8 +1,3 @@
-use std::sync::Arc;
-
-use lazy_static::lazy_static;
-use parking_lot::RwLock;
-
 use crate::{
     AdapterHandle, BindGroupLayoutHandle, BindGroupHandle,
     BlendStateHandle, CommandBufferHandle, DepthStencilStateHandle, DeviceHandle, InstanceHandle,
@@ -11,6 +6,11 @@ use crate::{
     BufferHandle, TextureHandle, TextureViewHandle,
     SurfaceHandle, SwapChainHandle,
 };
+
+use lazy_static::lazy_static;
+use parking_lot::RwLock;
+
+use std::sync::Arc;
 
 
 #[cfg(not(feature = "remote"))]

--- a/wgpu-native/src/registry/mod.rs
+++ b/wgpu-native/src/registry/mod.rs
@@ -1,15 +1,17 @@
 use std::sync::Arc;
 
+use lazy_static::lazy_static;
 use parking_lot::RwLock;
 
-use lazy_static::lazy_static;
-
 use crate::{
-    AdapterHandle, BindGroupHandle, BindGroupLayoutHandle, BlendStateHandle, BufferHandle,
-    CommandBufferHandle, ComputePassHandle, ComputePipelineHandle, DepthStencilStateHandle,
-    DeviceHandle, InstanceHandle, PipelineLayoutHandle, RenderPassHandle, RenderPipelineHandle,
-    ShaderModuleHandle, TextureHandle, TextureViewHandle,
+    AdapterHandle, BindGroupLayoutHandle, BindGroupHandle,
+    BlendStateHandle, CommandBufferHandle, DepthStencilStateHandle, DeviceHandle, InstanceHandle,
+    RenderPassHandle, ComputePassHandle,
+    PipelineLayoutHandle, RenderPipelineHandle, ComputePipelineHandle, ShaderModuleHandle,
+    BufferHandle, TextureHandle, TextureViewHandle,
+    SurfaceHandle, SwapChainHandle,
 };
+
 
 #[cfg(not(feature = "remote"))]
 mod local;
@@ -49,6 +51,8 @@ pub struct Hub {
     pub(crate) buffers: ConcreteRegistry<BufferHandle>,
     pub(crate) textures: ConcreteRegistry<TextureHandle>,
     pub(crate) texture_views: ConcreteRegistry<TextureViewHandle>,
+    pub(crate) surfaces: ConcreteRegistry<SurfaceHandle>,
+    pub(crate) swap_chains: ConcreteRegistry<SwapChainHandle>,
 }
 
 lazy_static! {

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -1,12 +1,12 @@
-use bitflags::bitflags;
-
-use hal;
-
 use crate::{
     Extent3d, LifeGuard, Stored,
     DeviceId, TextureId,
 };
-use crate::swap_chain::SwapChainLink;
+use crate::swap_chain::{SwapChainLink, SwapImageEpoch};
+
+use bitflags::bitflags;
+use hal;
+use parking_lot::Mutex;
 
 
 bitflags! {
@@ -85,7 +85,7 @@ pub(crate) struct Texture<B: hal::Backend> {
     pub kind: hal::image::Kind,
     pub format: TextureFormat,
     pub full_range: hal::image::SubresourceRange,
-    pub swap_chain_link: Option<SwapChainLink>,
+    pub swap_chain_link: Option<SwapChainLink<Mutex<SwapImageEpoch>>>,
     pub life_guard: LifeGuard,
 }
 

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -1,6 +1,14 @@
-use crate::{DeviceId, Extent3d, LifeGuard, Stored, TextureId};
-
 use bitflags::bitflags;
+use parking_lot::RwLock;
+
+use hal;
+
+use crate::{
+    Extent3d, LifeGuard, Stored,
+    DeviceId, TextureId,
+};
+use crate::swap_chain::SwapChainLink;
+
 
 bitflags! {
     #[repr(transparent)]
@@ -78,6 +86,7 @@ pub(crate) struct Texture<B: hal::Backend> {
     pub kind: hal::image::Kind,
     pub format: TextureFormat,
     pub full_range: hal::image::SubresourceRange,
+    pub swap_chain_link: RwLock<Option<SwapChainLink>>,
     pub life_guard: LifeGuard,
 }
 

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -1,5 +1,4 @@
 use bitflags::bitflags;
-use parking_lot::RwLock;
 
 use hal;
 
@@ -86,7 +85,7 @@ pub(crate) struct Texture<B: hal::Backend> {
     pub kind: hal::image::Kind,
     pub format: TextureFormat,
     pub full_range: hal::image::SubresourceRange,
-    pub swap_chain_link: RwLock<Option<SwapChainLink>>,
+    pub swap_chain_link: Option<SwapChainLink>,
     pub life_guard: LifeGuard,
 }
 
@@ -127,6 +126,7 @@ pub(crate) struct TextureView<B: hal::Backend> {
     pub format: TextureFormat,
     pub extent: hal::image::Extent,
     pub samples: hal::image::NumSamples,
+    pub is_owned_by_swap_chain: bool,
     pub life_guard: LifeGuard,
 }
 

--- a/wgpu-native/src/swap_chain.rs
+++ b/wgpu-native/src/swap_chain.rs
@@ -52,10 +52,16 @@ pub struct SwapChainDescriptor {
     pub height: u32,
 }
 
+#[repr(C)]
+pub struct SwapChainOutput {
+    pub texture_id: TextureId,
+    pub view_id: TextureViewId,
+}
+
 #[no_mangle]
 pub extern "C" fn wgpu_swap_chain_get_next_texture(
     swap_chain_id: SwapChainId,
-) -> TextureId {
+) -> SwapChainOutput {
     let mut swap_chain_guard = HUB.swap_chains.write();
     let swap_chain = swap_chain_guard.get_mut(swap_chain_id);
     let device_guard = HUB.devices.read();
@@ -81,7 +87,10 @@ pub extern "C" fn wgpu_swap_chain_get_next_texture(
         None => unreachable!(),
     }
 
-    frame.texture_id.value
+    SwapChainOutput {
+        texture_id: frame.texture_id.value,
+        view_id: frame.view_id.value,
+    }
 }
 
 #[no_mangle]

--- a/wgpu-native/src/swap_chain.rs
+++ b/wgpu-native/src/swap_chain.rs
@@ -33,6 +33,8 @@ pub(crate) struct Frame<B: hal::Backend> {
     pub comb: hal::command::CommandBuffer<B, hal::General, hal::command::MultiShot>,
 }
 
+//TODO: does it need a ref-counted lifetime?
+
 pub(crate) struct SwapChain<B: hal::Backend> {
     pub raw: B::Swapchain,
     pub device_id: Stored<DeviceId>,

--- a/wgpu-native/src/swap_chain.rs
+++ b/wgpu-native/src/swap_chain.rs
@@ -1,21 +1,24 @@
 use crate::{Stored, WeaklyStored,
-    DeviceId, SwapChainId, TextureId,
+    DeviceId, SwapChainId, TextureId, TextureViewId,
 };
+use crate::{conv, resource};
 use crate::registry::{HUB, Items};
-use crate::resource;
+use crate::track::{Tracktion, TrackPermit};
 
 use hal;
 use hal::{Device as _Device, Swapchain as _Swapchain};
 
-use std::mem;
+use parking_lot::Mutex;
+
+use std::{iter, mem};
 
 
 pub type Epoch = u16;
 
 pub(crate) struct SwapChainLink {
-    swap_chain_id: WeaklyStored<SwapChainId>, //TODO: strongly
-    epoch: Epoch,
-    image_index: hal::SwapImageIndex,
+    pub swap_chain_id: WeaklyStored<SwapChainId>, //TODO: strongly
+    pub epoch: Mutex<Epoch>,
+    pub image_index: hal::SwapImageIndex,
 }
 
 pub(crate) struct Surface<B: hal::Backend> {
@@ -23,17 +26,21 @@ pub(crate) struct Surface<B: hal::Backend> {
 }
 
 pub(crate) struct Frame<B: hal::Backend> {
-    pub texture: Stored<TextureId>,
+    pub texture_id: Stored<TextureId>,
+    pub view_id: Stored<TextureViewId>,
     pub fence: B::Fence,
     pub sem_available: B::Semaphore,
     pub sem_present: B::Semaphore,
+    pub comb: hal::command::CommandBuffer<B, hal::General, hal::command::MultiShot>,
 }
 
 pub(crate) struct SwapChain<B: hal::Backend> {
     pub raw: B::Swapchain,
     pub device_id: Stored<DeviceId>,
     pub frames: Vec<Frame<B>>,
+    pub acquired: Vec<hal::SwapImageIndex>,
     pub sem_available: B::Semaphore,
+    pub command_pool: hal::CommandPool<B, hal::General>,
     pub epoch: Epoch,
 }
 
@@ -59,6 +66,7 @@ pub extern "C" fn wgpu_swap_chain_get_next_texture(
         swap_chain.raw.acquire_image(!0, sync).unwrap()
     };
 
+    swap_chain.acquired.push(image_index);
     let frame = &mut swap_chain.frames[image_index as usize];
     unsafe {
         device.raw.wait_for_fence(&frame.fence, !0).unwrap();
@@ -67,12 +75,70 @@ pub extern "C" fn wgpu_swap_chain_get_next_texture(
     mem::swap(&mut frame.sem_available, &mut swap_chain.sem_available);
 
     let texture_guard = HUB.textures.read();
-    let texture = texture_guard.get(frame.texture.value);
-    *texture.swap_chain_link.write() = Some(SwapChainLink {
-            swap_chain_id: WeaklyStored(swap_chain_id),
-            epoch: swap_chain.epoch,
-            image_index,
-        });
+    let texture = texture_guard.get(frame.texture_id.value);
+    match texture.swap_chain_link {
+        Some(ref link) => *link.epoch.lock() = swap_chain.epoch,
+        None => unreachable!(),
+    }
 
-    frame.texture.value
+    frame.texture_id.value
+}
+
+#[no_mangle]
+pub extern "C" fn wgpu_swap_chain_present(
+    swap_chain_id: SwapChainId,
+) {
+    let mut swap_chain_guard = HUB.swap_chains.write();
+    let swap_chain = swap_chain_guard.get_mut(swap_chain_id);
+    let mut device_guard = HUB.devices.write();
+    let device = device_guard.get_mut(swap_chain.device_id.value);
+
+    let image_index = swap_chain.acquired.remove(0);
+    let frame = &mut swap_chain.frames[image_index as usize];
+
+    let texture_guard = HUB.textures.read();
+    let texture = texture_guard.get(frame.texture_id.value);
+    match texture.swap_chain_link {
+        Some(ref link) => *link.epoch.lock() += 1,
+        None => unreachable!(),
+    }
+
+    //trace!("transit {:?} to present", frame.texture_id.value);
+    let tracktion = device.texture_tracker
+        .lock()
+        .transit(
+            frame.texture_id.value,
+            &texture.life_guard.ref_count,
+            resource::TextureUsageFlags::PRESENT,
+            TrackPermit::EXTEND,
+        )
+        .unwrap();
+
+    let barrier = match tracktion {
+        Tracktion::Keep => None,
+        Tracktion::Replace { old } => Some(hal::memory::Barrier::Image {
+            states: conv::map_texture_state(old, hal::format::Aspects::COLOR) ..
+                (hal::image::Access::empty(), hal::image::Layout::Present),
+            target: &texture.raw,
+            families: None,
+            range: texture.full_range.clone(),
+        }),
+        Tracktion::Init |
+        Tracktion::Extend {..} => unreachable!(),
+    };
+
+    unsafe {
+        frame.comb.begin(false);
+        frame.comb.pipeline_barrier(
+            hal::pso::PipelineStage::TOP_OF_PIPE .. hal::pso::PipelineStage::BOTTOM_OF_PIPE,
+            hal::memory::Dependencies::empty(),
+            barrier,
+        );
+        frame.comb.finish();
+
+        // now prepare the GPU submission
+        device.raw.reset_fence(&frame.fence);
+        device.queue_group.queues[0]
+            .submit_nosemaphores(iter::once(&frame.comb), Some(&frame.fence));
+    }
 }

--- a/wgpu-native/src/swap_chain.rs
+++ b/wgpu-native/src/swap_chain.rs
@@ -1,15 +1,24 @@
 use hal;
 
+use crate::registry::{HUB, Items};
 use crate::resource;
+use crate::{Stored,
+	SwapChainId, TextureId,
+};
 
 
 pub(crate) struct Surface<B: hal::Backend> {
 	pub raw: B::Surface,
 }
 
+pub(crate) struct Frame {
+	pub texture: Stored<TextureId>,
+}
+
 pub(crate) struct SwapChain<B: hal::Backend> {
 	pub raw: B::Swapchain,
-	pub images: Vec<B::Image>,
+	pub frames: Vec<Frame>,
+	pub next_frame_index: usize,
 }
 
 #[repr(C)]
@@ -18,4 +27,21 @@ pub struct SwapChainDescriptor {
     pub format: resource::TextureFormat,
     pub width: u32,
     pub height: u32,
+}
+
+#[no_mangle]
+pub extern "C" fn wgpu_swap_chain_get_next_texture(
+    swap_chain_id: SwapChainId,
+) -> TextureId {
+	let mut swap_chain_guard = HUB.swap_chains.write();
+	let swap_chain = swap_chain_guard.get_mut(swap_chain_id);
+
+	let frame = &swap_chain.frames[swap_chain.next_frame_index];
+	swap_chain.next_frame_index += 1;
+	if swap_chain.next_frame_index == swap_chain.frames.len() {
+		swap_chain.next_frame_index = 0;
+	}
+
+	//TODO: actual synchronization
+	frame.texture.value
 }

--- a/wgpu-native/src/swap_chain.rs
+++ b/wgpu-native/src/swap_chain.rs
@@ -1,0 +1,21 @@
+use hal;
+
+use crate::resource;
+
+
+pub(crate) struct Surface<B: hal::Backend> {
+	pub raw: B::Surface,
+}
+
+pub(crate) struct SwapChain<B: hal::Backend> {
+	pub raw: B::Swapchain,
+	pub images: Vec<B::Image>,
+}
+
+#[repr(C)]
+pub struct SwapChainDescriptor {
+    pub usage: resource::TextureUsageFlags,
+    pub format: resource::TextureFormat,
+    pub width: u32,
+    pub height: u32,
+}

--- a/wgpu-native/src/track.rs
+++ b/wgpu-native/src/track.rs
@@ -8,6 +8,7 @@ use std::ops::{BitOr, Range};
 
 use bitflags::bitflags;
 
+
 #[derive(Clone, Debug, PartialEq)]
 #[allow(unused)]
 pub enum Tracktion<T> {

--- a/wgpu-rs/Cargo.toml
+++ b/wgpu-rs/Cargo.toml
@@ -11,9 +11,10 @@ edition = "2018"
 
 [features]
 default = []
-metal = ["wgpu-native/gfx-backend-metal"]
-dx12 = ["wgpu-native/gfx-backend-dx12"]
-vulkan = ["wgpu-native/gfx-backend-vulkan"]
+backed = []
+metal = ["wgpu-native/gfx-backend-metal", "backed"]
+dx12 = ["wgpu-native/gfx-backend-dx12", "backed"]
+vulkan = ["wgpu-native/gfx-backend-vulkan", "backed"]
 
 [dependencies]
 wgpu-native = { path = "../wgpu-native" }

--- a/wgpu-rs/Cargo.toml
+++ b/wgpu-rs/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 default = []
 winit = ["wgpu-native/winit"]
 metal = ["wgpu-native/gfx-backend-metal"]
+dx11 = ["wgpu-native/gfx-backend-dx11"]
 dx12 = ["wgpu-native/gfx-backend-dx12"]
 vulkan = ["wgpu-native/gfx-backend-vulkan"]
 

--- a/wgpu-rs/Cargo.toml
+++ b/wgpu-rs/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2018"
 
 [features]
 default = []
-backed = []
-metal = ["wgpu-native/gfx-backend-metal", "backed"]
-dx12 = ["wgpu-native/gfx-backend-dx12", "backed"]
-vulkan = ["wgpu-native/gfx-backend-vulkan", "backed"]
+winit = ["wgpu-native/winit"]
+metal = ["wgpu-native/gfx-backend-metal"]
+dx12 = ["wgpu-native/gfx-backend-dx12"]
+vulkan = ["wgpu-native/gfx-backend-vulkan"]
 
 [dependencies]
 wgpu-native = { path = "../wgpu-native" }

--- a/wgpu-rs/src/lib.rs
+++ b/wgpu-rs/src/lib.rs
@@ -135,8 +135,8 @@ impl Instance {
         }
     }
 
-    #[cfg(feature = "backed")]
-    pub fn create_surface(&self, window: &::winit::Window) -> Surface {
+    #[cfg(feature = "winit")]
+    pub fn create_surface(&self, window: &wgn::winit::Window) -> Surface {
         Surface {
             id: wgn::wgpu_instance_create_surface_from_winit(self.id, window)
         }

--- a/wgpu-rs/src/lib.rs
+++ b/wgpu-rs/src/lib.rs
@@ -13,6 +13,7 @@ pub use wgn::{
     RenderPassColorAttachmentDescriptor, RenderPassDepthStencilAttachmentDescriptor,
     RenderPassDescriptor, ShaderModuleDescriptor, ShaderStage, ShaderStageFlags, StoreOp,
     TextureDescriptor, TextureDimension, TextureFormat, TextureUsageFlags, TextureViewDescriptor,
+    SwapChainDescriptor,
 };
 
 pub struct Instance {
@@ -33,6 +34,14 @@ pub struct Texture {
 
 pub struct TextureView {
     id: wgn::TextureViewId,
+}
+
+pub struct Surface {
+    id: wgn::SurfaceId,
+}
+
+pub struct SwapChain {
+    id: wgn::SwapChainId,
 }
 
 pub struct BindGroupLayout {
@@ -125,6 +134,13 @@ impl Instance {
             id: wgn::wgpu_instance_get_adapter(self.id, desc),
         }
     }
+
+    #[cfg(feature = "backed")]
+    pub fn create_surface(&self, window: &::winit::Window) -> Surface {
+        Surface {
+            id: wgn::wgpu_instance_create_surface_from_winit(self.id, window)
+        }
+    }
 }
 
 impl Adapter {
@@ -148,6 +164,7 @@ impl Device {
         }
     }
 
+    //TODO: borrow instead of new object?
     pub fn get_queue(&self) -> Queue {
         Queue {
             id: wgn::wgpu_device_get_queue(self.id),
@@ -255,6 +272,12 @@ impl Device {
             id: wgn::wgpu_device_create_texture(self.id, &desc),
         }
     }
+
+    pub fn create_swap_chain(&self, surface: &Surface, desc: &SwapChainDescriptor) -> SwapChain {
+        SwapChain {
+            id: wgn::wgpu_device_create_swap_chain(self.id, surface.id, desc),
+        }
+    }
 }
 
 impl Texture {
@@ -349,5 +372,17 @@ impl Queue {
             command_buffers.as_ptr() as *const _,
             command_buffers.len(),
         );
+    }
+}
+
+impl SwapChain {
+    //TODO: borrow instead of new object?
+    pub fn get_next_texture(&self) -> (Texture, TextureView) {
+        let output = wgn::wgpu_swap_chain_get_next_texture(self.id);
+        (Texture { id: output.texture_id} , TextureView { id: output.view_id })
+    }
+
+    pub fn present(&self) {
+        wgn::wgpu_swap_chain_present(self.id);
     }
 }


### PR DESCRIPTION
- [x] native swapchain creation
- [x] native use of frames and presentation
- [x] native semaphore waits
- [x] rust wrapping
- [x] working examples

~~I may or may not bite the bullet and update gfx-rs here. Probably not :)~~

## Architecture

There is a bit of complexity here to manage all the synchronization and lifetimes properly. Essentially, presentation is exposed in Vulkan/gfx-rs as a separate hidden queue, so we inevitably run into the territory of using semaphores for synchronization, where previously we could ignore them for workloads on a single queue.

A swapchain has a fixed (at creation) number of frames, each represented by a texture plus view pair. When `get_next_texture` is called we acquire the next image index and return this pair. We wait for the associated fence to make sure the frame is no image used. We then associate a semaphore with this index for image availability.

The texture has extra information to link back to an image of the swapchain (which is `None` for regular textures). Whenever it's used, the command buffer collects that link to be used on submission, where it's just resolved to a semaphore that we wait on actual submission.

Presenting on a swapchain creates a temporary command buffer that we only use for transiting the swapchain image into presentable state. This small submission is useful for establishing a "ready" semaphore as well as a fence (waited in `get_next_image`). The "ready" semaphore is used immediately for native `present` call.