### PR TITLE
Depenency gfx update to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-dx12"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -404,10 +404,11 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-empty"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gfx-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1275,8 +1276,8 @@ version = "0.1.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-backend-dx11 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-backend-dx12 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-backend-empty 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-backend-dx12 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-backend-empty 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-backend-metal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-backend-vulkan 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1436,8 +1437,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum gfx-backend-dx11 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7751e630a3472d96b1a0ce9cd6742f2e17c0f71a6e833f822b914a11f89bd7db"
-"checksum gfx-backend-dx12 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2c373f40998da0fd605a7a90ce8d775a8cbcb06558edc2ea9740df1db2077686"
-"checksum gfx-backend-empty 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6bb068297aed95a014abaa01738986c2ed5d08c5f9f152c992300c415e9b917c"
+"checksum gfx-backend-dx12 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "635f526eb3110f47ab64145efce8510bb042df7eba147254ecd8a5d732700c11"
+"checksum gfx-backend-empty 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "590c15369f88b88e4ea748da52b27a521a758a947b4aee995539c9f0cc1beb4c"
 "checksum gfx-backend-metal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "68fa011e32280f7566bddbb736734291b685c812087c99bc848d6ac7ae3e0b7f"
 "checksum gfx-backend-vulkan 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "982c618fd9ddeea7e68b2d872b9b6cf13024fc7d4033ba90f0e54ac0d33c798f"
 "checksum gfx-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84c470bce77fcaaea6854858682a99026ff796b880b0ca30511593a6b2bc77c0"

--- a/wgpu-bindings/wgpu.h
+++ b/wgpu-bindings/wgpu.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define WGPUBITS_PER_BYTE 8
+
 typedef enum {
   WGPUAddressMode_ClampToEdge = 0,
   WGPUAddressMode_Repeat = 1,

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.1.0"
 log = "0.4"
 parking_lot = { version = "0.7" }
 gfx-hal = "0.1.0"
-gfx-backend-empty = "0.1.0"
+gfx-backend-empty = { version = "0.1.1", features = ["winit"] }
 gfx-backend-vulkan = { version = "0.1.0", optional = true }
 gfx-backend-dx11 = { version = "0.1.0", optional = true }
 gfx-backend-dx12 = { version = "0.1.0", optional = true }

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -29,19 +29,8 @@ pub struct DeviceDescriptor {
 
 #[no_mangle]
 pub extern "C" fn wgpu_create_instance() -> InstanceId {
-    #[cfg(any(
-        feature = "gfx-backend-vulkan",
-        feature = "gfx-backend-dx11",
-        feature = "gfx-backend-dx12",
-        feature = "gfx-backend-metal"
-    ))]
-    {
-        let inst = ::back::Instance::create("wgpu", 1);
-        if true {
-            return HUB.instances.write().register(inst);
-        }
-    }
-    unimplemented!()
+    let inst = ::back::Instance::create("wgpu", 1);
+    HUB.instances.write().register(inst)
 }
 
 #[cfg(feature = "winit")]
@@ -50,33 +39,17 @@ pub extern "C" fn wgpu_instance_create_surface_from_winit(
     instance_id: InstanceId,
     window: &winit::Window,
 ) -> SurfaceId {
-    //TODO: remove these workarounds when porting on gfx-hal 0.2
-    #[cfg(any(
-        feature = "gfx-backend-vulkan",
-        feature = "gfx-backend-dx11",
-        feature = "gfx-backend-dx12",
-        feature = "gfx-backend-metal"
-    ))]
-    {
-        let raw = HUB.instances
-            .read()
-            .get(instance_id)
-            .create_surface(window);
-        let surface = Surface {
-            raw,
-        };
+    let raw = HUB.instances
+        .read()
+        .get(instance_id)
+        .create_surface(window);
+    let surface = Surface {
+        raw,
+    };
 
-        HUB.surfaces
-            .write()
-            .register(surface)
-    }
-    #[cfg(not(any(
-        feature = "gfx-backend-vulkan",
-        feature = "gfx-backend-dx11",
-        feature = "gfx-backend-dx12",
-        feature = "gfx-backend-metal"
-    )))]
-    unimplemented!()
+    HUB.surfaces
+        .write()
+        .register(surface)
 }
 
 #[allow(unused)]
@@ -86,10 +59,10 @@ pub extern "C" fn wgpu_instance_create_surface_from_xlib(
     display: *mut *const std::ffi::c_void,
     window: u64,
 ) -> SurfaceId {
-    #[cfg(not(feature = "gfx-backend-vulkan"))]
+    #[cfg(not(all(unix, feature = "gfx-backend-vulkan")))]
     unimplemented!();
 
-    #[cfg(feature = "gfx-backend-vulkan")]
+    #[cfg(all(unix, feature = "gfx-backend-vulkan"))]
     {
         let raw = HUB.instances
             .read()


### PR DESCRIPTION
It appears that we still can't run on DX12, because it has `update_buffer` as `unimplemented!`. But at least we have the benefit of the empty backend updates.