### PR TITLE
Swapchain resize

### DIFF
--- a/gfx-examples/src/framework.rs
+++ b/gfx-examples/src/framework.rs
@@ -70,7 +70,7 @@ pub fn run<E: Example>(title: &str) {
         .to_physical(window.get_hidpi_factor());
 
     let surface = instance.create_surface(&window);
-    let sc_desc = wgpu::SwapChainDescriptor {
+    let mut sc_desc = wgpu::SwapChainDescriptor {
         usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
         format: wgpu::TextureFormat::B8g8r8a8Unorm,
         width: size.width as u32,
@@ -91,7 +91,11 @@ pub fn run<E: Example>(title: &str) {
                     ..
                 } => {
                     let physical = size.to_physical(window.get_hidpi_factor());
-                    info!("Resized to {:?}", physical);
+                    info!("Resizing to {:?}", physical);
+                    sc_desc.width = physical.width as u32;
+                    sc_desc.height = physical.height as u32;
+                    swap_chain = device.create_swap_chain(&surface, &sc_desc);
+                    example.update(WindowEvent::Resized(size));
                 }
                 Event::WindowEvent { event, .. } => match event {
                     WindowEvent::KeyboardInput {

--- a/wgpu-bindings/wgpu.h
+++ b/wgpu-bindings/wgpu.h
@@ -435,9 +435,9 @@ typedef struct {
   WGPUByteArray code;
 } WGPUShaderModuleDescriptor;
 
-typedef WGPUId WGPUSwapChainId;
-
 typedef WGPUId WGPUSurfaceId;
+
+typedef WGPUSurfaceId WGPUSwapChainId;
 
 typedef uint32_t WGPUTextureUsageFlags;
 

--- a/wgpu-native/src/hub.rs
+++ b/wgpu-native/src/hub.rs
@@ -4,7 +4,7 @@ use crate::{
     RenderPassHandle, ComputePassHandle,
     PipelineLayoutHandle, RenderPipelineHandle, ComputePipelineHandle, ShaderModuleHandle,
     BufferHandle, SamplerHandle, TextureHandle, TextureViewHandle,
-    SurfaceHandle, SwapChainHandle,
+    SurfaceHandle,
 };
 
 use hal::backend::FastHashMap;
@@ -126,7 +126,6 @@ pub struct Hub {
     pub(crate) texture_views: Arc<Registry<TextureViewHandle>>,
     pub(crate) samplers: Arc<Registry<SamplerHandle>>,
     pub(crate) surfaces: Arc<Registry<SurfaceHandle>>,
-    pub(crate) swap_chains: Arc<Registry<SwapChainHandle>>,
 }
 
 lazy_static! {

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -54,10 +54,7 @@ pub extern "C" fn wgpu_instance_create_surface_from_winit(
         .read()
         .get(instance_id)
         .create_surface(window);
-    let surface = SurfaceHandle {
-        raw,
-    };
-
+    let surface = SurfaceHandle::new(raw);
     HUB.surfaces.register(surface)
 }
 
@@ -71,12 +68,11 @@ pub fn instance_create_surface_from_xlib(
     unimplemented!();
 
     #[cfg(all(unix, feature = "gfx-backend-vulkan"))]
-    SurfaceHandle {
-        raw: HUB.instances
-            .read()
-            .get(instance_id)
-            .create_surface_from_xlib(display, window),
-    }
+    SurfaceHandle::new(HUB.instances
+        .read()
+        .get(instance_id)
+        .create_surface_from_xlib(display, window)
+    )
 }
 
 #[cfg(feature = "local")]
@@ -99,12 +95,11 @@ pub fn instance_create_surface_from_macos_layer(
     unimplemented!();
 
     #[cfg(feature = "gfx-backend-metal")]
-    SurfaceHandle {
-        raw: HUB.instances
-            .read()
-            .get(instance_id)
-            .create_surface_from_layer(layer as *mut _),
-    }
+    SurfaceHandle::new(HUB.instances
+        .read()
+        .get(instance_id)
+        .create_surface_from_layer(layer as *mut _)
+    )
 }
 
 #[cfg(feature = "local")]
@@ -139,9 +134,7 @@ pub fn instance_create_surface_from_windows_hwnd(
         .create_surface_from_hwnd(hinstance, hwnd);
 
     #[cfg_attr(not(target_os = "windows"), allow(unreachable_code))]
-    SurfaceHandle {
-        raw,
-    }
+    SurfaceHandle::new(raw)
 }
 
 #[cfg(feature = "local")]

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -219,5 +219,4 @@ type ComputePassHandle = ComputePass<back::Backend>;
 // Swap chain
 pub type SurfaceId = hub::Id;
 type SurfaceHandle = Surface<back::Backend>;
-pub type SwapChainId = hub::Id;
-type SwapChainHandle = SwapChain<back::Backend>;
+pub type SwapChainId = SurfaceId;

--- a/wgpu-native/src/track.rs
+++ b/wgpu-native/src/track.rs
@@ -87,6 +87,11 @@ impl<I: Clone + Hash + Eq, U: Copy + GenericUsage + BitOr<Output = U> + PartialE
         }
     }
 
+    /// Remove an id from the tracked map.
+    pub(crate) fn remove(&mut self, id: I) -> bool {
+        self.map.remove(&WeaklyStored(id)).is_some()
+    }
+
     /// Get the last usage on a resource.
     pub(crate) fn query(&mut self, stored: &Stored<I>, default: U) -> Query<U> {
         match self.map.entry(WeaklyStored(stored.value.clone())) {


### PR DESCRIPTION
Based on #67 

Here are the steps (as outlined on Gitter) that this PR follows:
  1. create a dummy frame in the swapchain (`SwapChain::outdated`). We return it when we aren't able to acquire a real frame. No synchronization is done atm, but shouldn't be anything critical there.
  2. handle the errors on acquire and present, use the dummy frame where needed. Presentation errors are just ignored, while acquiring errors are forcing the dummy frame. The idea is that the user would know about a swapchain resize from some kind of event loop / WSI, and thus they'd know when they should actually re-create it.
  3. associate surface with a swapchain. We merge the IDs since there can't be multiple swapchains on the same surface in the near future. Merging simplifies a lot of things in the implementation, but this is to be revised for sure once we get a better look on the browser integration.
  4. when the swapchain is re-created, consume the old one associated with a surface.
