### PR TITLE
Allow creating a surface by passing a metal layer.

### DIFF
--- a/wgpu-rs/src/lib.rs
+++ b/wgpu-rs/src/lib.rs
@@ -242,6 +242,13 @@ impl Instance {
             id: wgn::wgpu_instance_create_surface_from_winit(self.id, window),
         }
     }
+    
+    #[cfg(feature = "metal")]
+    pub fn create_surface_with_metal_layer(&self, window: *mut std::ffi::c_void) -> Surface {
+        Surface {
+            id: wgn::wgpu_instance_create_surface_from_macos_layer(self.id, window),
+        }
+    }
 }
 
 impl Adapter {


### PR DESCRIPTION
This is useful if you're using `SDL2`
```rust
    let canvas = window.into_canvas().build().unwrap();
    let metal_layer = unsafe { sdl2::sys::SDL_RenderGetMetalLayer(canvas.raw()) }; 
    let surface = instance.create_surface_with_metal_layer(metal_layer);
```

For now, Metal only - but could be useful in the future if there was a trait or a facade to use for setting up a surface. The intention is to support other window backends without depending on them directly as a dependency. 