### PR TITLE
Buffer tracking and unmapping

### DIFF
--- a/examples/hello_compute_rust/main.rs
+++ b/examples/hello_compute_rust/main.rs
@@ -102,10 +102,8 @@ fn main() {
             println!("Times: {:?}", results);
         }
 
+        staging_buffer.unmap();
     });
 
     device.get_queue().submit(&[encoder.finish()]);
-
-    // TODO: why does calling unmap() inside the callback prevent the program from exiting?
-    staging_buffer.unmap();
 }

--- a/gfx-examples/src/cube.rs
+++ b/gfx-examples/src/cube.rs
@@ -127,6 +127,8 @@ impl framework::Example for Example {
             if let wgpu::BufferMapAsyncResult::Success(data) = result {
                 unsafe { std::ptr::copy_nonoverlapping(vertex_data.as_ptr() as *const u8, data.as_mut_ptr(), vertex_buffer_length) };
             }
+
+            vertex_buf.unmap();
         });
 
         let index_buf = device.create_buffer(&wgpu::BufferDescriptor {
@@ -138,6 +140,8 @@ impl framework::Example for Example {
             if let wgpu::BufferMapAsyncResult::Success(data) = result {
                 unsafe { std::ptr::copy_nonoverlapping(index_data.as_ptr() as *const u8, data.as_mut_ptr(), index_buffer_length) };
             }
+
+            index_buf.unmap();
         });
 
         // Create pipeline layout
@@ -189,6 +193,8 @@ impl framework::Example for Example {
             if let wgpu::BufferMapAsyncResult::Success(data) = result {
                 unsafe { std::ptr::copy_nonoverlapping(texels.as_ptr() as *const u8, data.as_mut_ptr(), texels.len()) };
             }
+
+            temp_buf.unmap();
         });
         init_encoder.copy_buffer_to_texture(
             wgpu::BufferCopyView {
@@ -235,6 +241,8 @@ impl framework::Example for Example {
             if let wgpu::BufferMapAsyncResult::Success(data) = result {
                 unsafe { std::ptr::copy_nonoverlapping(mx_ref.as_ptr() as *const u8, data.as_mut_ptr(), 64) };
             }
+
+            uniform_buf.unmap();
         });
 
         // Create bind group
@@ -339,6 +347,8 @@ impl framework::Example for Example {
             if let wgpu::BufferMapAsyncResult::Success(data) = result {
                 unsafe { std::ptr::copy_nonoverlapping(mx_ref.as_ptr() as *const u8, data.as_mut_ptr(), 64) };
             }
+
+            self.uniform_buf.unmap();
         });
     }
 

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -40,6 +40,7 @@ pub enum BufferMapAsyncStatus {
     ContextLost,
 }
 
+#[derive(Clone)]
 pub(crate) enum BufferMapOperation {
     Read(std::ops::Range<u64>, BufferMapReadCallback, *mut u8),
     Write(std::ops::Range<u64>, BufferMapWriteCallback, *mut u8),


### PR DESCRIPTION
Adds preliminary transitioning of buffers to mapped state.
Adds buffer unmapping to the cube sample.
Modifies wgpu_queue_submit to not hold a write lock on the device during callbacks (this could definitely be cleaner, but I'm not sure which direction to take refactoring here).