### PR TITLE
Unpin nightly date for bindings generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ lib-rust: Cargo.lock wgpu-rs/Cargo.toml $(wildcard wgpu-rs/**/*.rs)
 	cargo build --manifest-path wgpu-rs/Cargo.toml --features $(FEATURE_RUST)
 
 wgpu-bindings/*.h: Cargo.lock wgpu-bindings/src/*.rs lib-native
-	cargo +nightly-2018-12-27 run --manifest-path wgpu-bindings/Cargo.toml
+	cargo +nightly run --manifest-path wgpu-bindings/Cargo.toml
 
 examples-native: lib-native wgpu-bindings/wgpu.h $(wildcard wgpu-native/**/*.c)
 	#$(MAKE) -C examples


### PR DESCRIPTION
rust-lang/rust#57915 allows us to run bindings generation with nightly again, so we shouldn't have to pin to an older nightly date anymore (assuming everyone has a recent nightly).