### PR TITLE
Basic render pipeline compatibility check

### DIFF
--- a/wgpu-native/src/pipeline.rs
+++ b/wgpu-native/src/pipeline.rs
@@ -1,3 +1,4 @@
+use crate::device::RenderPassContext;
 use crate::resource;
 use crate::{
     ByteArray, PipelineLayoutId, ShaderModuleId,
@@ -280,4 +281,5 @@ pub struct RenderPipelineDescriptor {
 pub struct RenderPipeline<B: hal::Backend> {
     pub(crate) raw: B::GraphicsPipeline,
     pub(crate) layout_id: PipelineLayoutId,
+    pub(crate) pass_context: RenderPassContext,
 }


### PR DESCRIPTION
A bit of refactoring for nicer code, and now we are matching the attachment formats of pipelines bound to passes.