### PR TITLE
Add the static lifetime bound to async buffer mapping callbacks

### DIFF
--- a/examples/hello_compute_rust/main.rs
+++ b/examples/hello_compute_rust/main.rs
@@ -94,10 +94,10 @@ fn main() {
         if let wgpu::BufferMapAsyncResult::Success(data) = result {
             println!("Times: {:?}", data);
         }
-
-        // staging_buffer.unmap(); // TODO
     });
 
     let encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
     device.get_queue().submit(&[encoder.finish()]);
+
+    staging_buffer.unmap(); // TODO: staging_buffer can't be referenced from the callback
 }

--- a/examples/hello_compute_rust/main.rs
+++ b/examples/hello_compute_rust/main.rs
@@ -88,13 +88,16 @@ fn main() {
     }
     encoder.copy_buffer_to_buffer(&storage_buffer, 0, &staging_buffer, 0, size);
 
+    device.get_queue().submit(&[encoder.finish()]);
+
     staging_buffer.map_read_async(0, size, |result: wgpu::BufferMapAsyncResult<&[u32]>| {
         if let wgpu::BufferMapAsyncResult::Success(data) = result {
             println!("Times: {:?}", data);
         }
 
-        staging_buffer.unmap();
+        // staging_buffer.unmap(); // TODO
     });
 
+    let encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
     device.get_queue().submit(&[encoder.finish()]);
 }

--- a/wgpu-rs/src/lib.rs
+++ b/wgpu-rs/src/lib.rs
@@ -530,7 +530,7 @@ impl Buffer {
     pub fn map_read_async<T, F>(&self, start: u32, size: u32, callback: F)
     where
         T: 'static + Copy,
-        F: FnOnce(BufferMapAsyncResult<&[T]>),
+        F: FnOnce(BufferMapAsyncResult<&[T]>) + 'static,
     {
         let type_size = std::mem::size_of::<T>() as u32;
         assert_ne!(type_size, 0);
@@ -575,7 +575,7 @@ impl Buffer {
     pub fn map_write_async<T, F>(&self, start: u32, size: u32, callback: F)
     where
         T: 'static + Copy,
-        F: FnOnce(BufferMapAsyncResult<&mut [T]>),
+        F: FnOnce(BufferMapAsyncResult<&mut [T]>) + 'static,
     {
         let type_size = std::mem::size_of::<T>() as u32;
         assert_ne!(type_size, 0);


### PR DESCRIPTION
These callbacks are executed outside of the mapping function and could previously reference data that had been dropped. Related #95.