### PR TITLE
[0.2] Higher default descriptor pool limits, better buffer offsets for mapping and descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 
-## v0.2.2 (19-03-2019)
+## v0.2.3 (20-03-2019)
   - fixed vertex format mapping
   - fixed building with "empty" backend on Windows
+  - bumped the default descriptor pool size
+  - fixed host mapping aligments
+  - validating the uniform buffer offset
 
 ## v0.2 (06-03-2019)
   - Platforms: iOS/Metal, D3D11

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,8 +320,8 @@ name = "examples"
 version = "0.1.0"
 dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu 0.2.0",
- "wgpu-native 0.2.3",
+ "wgpu 0.2.1",
+ "wgpu-native 0.2.4",
 ]
 
 [[package]]
@@ -498,7 +498,7 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "glsl-to-spirv 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu 0.2.0",
+ "wgpu 0.2.1",
 ]
 
 [[package]]
@@ -1384,10 +1384,10 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu-native 0.2.3",
+ "wgpu-native 0.2.4",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-native"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1425,7 +1425,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu-native 0.2.3",
+ "wgpu-native 0.2.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ version = "0.1.0"
 dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "wgpu 0.2.0",
- "wgpu-native 0.2.2",
+ "wgpu-native 0.2.3",
 ]
 
 [[package]]
@@ -1387,7 +1387,7 @@ name = "wgpu"
 version = "0.2.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu-native 0.2.2",
+ "wgpu-native 0.2.3",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-native"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1425,7 +1425,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu-native 0.2.2",
+ "wgpu-native 0.2.3",
 ]
 
 [[package]]

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-native"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
 	"Dzmitry Malyshau <kvark@mozilla.com>",
 	"Joshua Groves <josh@joshgroves.com>",

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-native"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
 	"Dzmitry Malyshau <kvark@mozilla.com>",
 	"Joshua Groves <josh@joshgroves.com>",

--- a/wgpu-native/src/binding_model.rs
+++ b/wgpu-native/src/binding_model.rs
@@ -22,6 +22,7 @@ pub enum BindingType {
 }
 
 #[repr(C)]
+#[derive(Clone, Debug, Hash)]
 pub struct BindGroupLayoutBinding {
     pub binding: u32,
     pub visibility: ShaderStageFlags,
@@ -36,6 +37,7 @@ pub struct BindGroupLayoutDescriptor {
 
 pub struct BindGroupLayout<B: hal::Backend> {
     pub(crate) raw: B::DescriptorSetLayout,
+    pub(crate) bindings: Vec<BindGroupLayoutBinding>,
 }
 
 #[repr(C)]

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -398,7 +398,7 @@ impl<B: hal::Backend> Device<B> {
         let desc_pool = Mutex::new(
             unsafe {
                 raw.create_descriptor_pool(
-                    100,
+                    10000,
                     &[
                         hal::pso::DescriptorRangeDesc {
                             ty: hal::pso::DescriptorType::Sampler,
@@ -406,15 +406,15 @@ impl<B: hal::Backend> Device<B> {
                         },
                         hal::pso::DescriptorRangeDesc {
                             ty: hal::pso::DescriptorType::SampledImage,
-                            count: 100,
+                            count: 1000,
                         },
                         hal::pso::DescriptorRangeDesc {
                             ty: hal::pso::DescriptorType::UniformBuffer,
-                            count: 100,
+                            count: 10000,
                         },
                         hal::pso::DescriptorRangeDesc {
                             ty: hal::pso::DescriptorType::StorageBuffer,
-                            count: 100,
+                            count: 1000,
                         },
                     ],
                 )

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -173,7 +173,8 @@ pub fn adapter_create_device(adapter_id: AdapterId, _desc: &DeviceDescriptor) ->
     let adapter = &adapter_guard[adapter_id];
     let (raw, queue_group) = adapter.open_with::<_, hal::General>(1, |_qf| true).unwrap();
     let mem_props = adapter.physical_device.memory_properties();
-    DeviceHandle::new(raw, adapter_id, queue_group, mem_props)
+    let limits = adapter.physical_device.limits();
+    DeviceHandle::new(raw, adapter_id, queue_group, mem_props, limits)
 }
 
 #[cfg(feature = "local")]

--- a/wgpu-rs/Cargo.toml
+++ b/wgpu-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
 	"Dzmitry Malyshau <kvark@mozilla.com>",
 	"Joshua Groves <josh@joshgroves.com>",

--- a/wgpu-rs/src/lib.rs
+++ b/wgpu-rs/src/lib.rs
@@ -323,7 +323,7 @@ impl Device {
                     } => wgn::BindingResource::Buffer(wgn::BufferBinding {
                         buffer: buffer.id,
                         offset: range.start,
-                        size: range.end,
+                        size: range.end - range.start,
                     }),
                     BindingResource::Sampler(ref sampler) => {
                         wgn::BindingResource::Sampler(sampler.id)


### PR DESCRIPTION
The descriptor pool sizes are temporary until we get automatic descriptor management.
~~Based on #109~~

With this in, we are tracking all resources correctly and we only get a few Vulkan validation errors at start (related to compositing), which is a great improvement.