### PR TITLE
Implement index formats

### DIFF
--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -15,6 +15,7 @@ use crate::{
         all_buffer_stages, all_image_stages, FramebufferKey, RenderPassContext, RenderPassKey,
     },
     hub::{Storage, HUB},
+    pipeline::IndexFormat,
     resource::TexturePlacement,
     swap_chain::{SwapChainLink, SwapImageEpoch},
     track::{DummyUsage, Stitch, TrackerSet},
@@ -355,6 +356,11 @@ pub fn command_encoder_begin_render_pass(
         depth_stencil: depth_stencil_attachment.map(|at| view_guard[at.attachment].format),
     };
 
+    let index_state = IndexState {
+        bound_buffer_view: None,
+        format: IndexFormat::Uint16,
+    };
+
     RenderPass::new(
         current_comb,
         Stored {
@@ -362,6 +368,7 @@ pub fn command_encoder_begin_render_pass(
             ref_count: cmb.life_guard.ref_count.clone(),
         },
         context,
+        index_state,
     )
 }
 

--- a/wgpu-native/src/conv.rs
+++ b/wgpu-native/src/conv.rs
@@ -623,3 +623,10 @@ pub fn map_rasterization_state_descriptor(
         conservative: false,
     }
 }
+
+pub fn map_index_format(index_format: pipeline::IndexFormat) -> hal::IndexType {
+    match index_format {
+        pipeline::IndexFormat::Uint16 => hal::IndexType::U16,
+        pipeline::IndexFormat::Uint32 => hal::IndexType::U32,
+    }
+}

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -1450,6 +1450,7 @@ pub fn device_create_render_pipeline(
         layout_id: desc.layout,
         pass_context,
         flags,
+        index_format: desc.vertex_buffer_state.index_format,
     }
 }
 

--- a/wgpu-native/src/pipeline.rs
+++ b/wgpu-native/src/pipeline.rs
@@ -301,4 +301,5 @@ pub struct RenderPipeline<B: hal::Backend> {
     pub(crate) layout_id: PipelineLayoutId,
     pub(crate) pass_context: RenderPassContext,
     pub(crate) flags: PipelineFlags,
+    pub(crate) index_format: IndexFormat,
 }


### PR DESCRIPTION
I decided to implement index formats to try to catch up on some of the recent changes. The idea is to either source the index format from the last bound pipeline, or switch the index format based on a newly bound pipeline, through the following:

- During `set_index_buffer`, use the index format from the render pass, and cache the bound index buffer ID and offset
- During `set_pipeline`, check if the index format has changed from the previous pipeline, and rebind the index buffer using the new index format if necessary

Some things I wasn't sure about:

- Is the usage of `get_with_extended_usage` correct here?
- Are the caches located in the correct place (i.e. `RenderPassContext`)?