### PR TITLE
Change run_forever() to poll_events()

### DIFF
--- a/examples/hello_triangle_rust/main.rs
+++ b/examples/hello_triangle_rust/main.rs
@@ -80,7 +80,7 @@ fn main() {
             height: size.height.round() as u32,
         },
     );
-let mut running = true;
+    let mut running = true;
     while running {
         events_loop.poll_events(|event| match event {
             Event::WindowEvent { event, .. } => match event {

--- a/examples/hello_triangle_rust/main.rs
+++ b/examples/hello_triangle_rust/main.rs
@@ -60,8 +60,7 @@ fn main() {
     });
 
     use wgpu::winit::{
-        ControlFlow, ElementState, Event, EventsLoop, KeyboardInput, VirtualKeyCode, Window,
-        WindowEvent,
+        ElementState, Event, EventsLoop, KeyboardInput, VirtualKeyCode, Window, WindowEvent,
     };
 
     let mut events_loop = EventsLoop::new();
@@ -81,9 +80,9 @@ fn main() {
             height: size.height.round() as u32,
         },
     );
-
-    events_loop.run_forever(|event| {
-        match event {
+    let mut running = true;
+    while running {
+        events_loop.poll_events(|event| match event {
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::KeyboardInput {
                     input:
@@ -94,14 +93,14 @@ fn main() {
                         },
                     ..
                 } => match code {
-                    VirtualKeyCode::Escape => return ControlFlow::Break,
+                    VirtualKeyCode::Escape => running = false,
                     _ => {}
                 },
-                WindowEvent::CloseRequested => return ControlFlow::Break,
+                WindowEvent::CloseRequested => running = false,
                 _ => {}
             },
             _ => {}
-        }
+        });
 
         let frame = swap_chain.get_next_texture();
         let mut encoder =
@@ -122,7 +121,5 @@ fn main() {
         }
 
         device.get_queue().submit(&[encoder.finish()]);
-
-        ControlFlow::Continue
-    });
+    }
 }

--- a/examples/hello_triangle_rust/main.rs
+++ b/examples/hello_triangle_rust/main.rs
@@ -80,7 +80,7 @@ fn main() {
             height: size.height.round() as u32,
         },
     );
-    let mut running = true;
+let mut running = true;
     while running {
         events_loop.poll_events(|event| match event {
             Event::WindowEvent { event, .. } => match event {


### PR DESCRIPTION
Due to tomaka/winit#276, `run_forever()` can slow the program.
Because the presentation mode of the swap chain is FIFO,  when `get_next_texture()` is called, it is waiting for the next refresh. If the amout of event per second is superior to the refresh rate, the whole program accumulate event, and closing the window can take a lot of time.
`poll_events()` prevents this.

See also tomaka/winit#459