### PR TITLE
Fill .ready_to_map vector when map() is called

### DIFF
--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -129,6 +129,7 @@ impl<B: hal::Backend> DestroyedResources<B> {
             value: buffer,
             ref_count,
         });
+        self.ready_to_map.push(buffer);
     }
 
     /// Returns the last submission index that is done.


### PR DESCRIPTION
This should resolve #117 and #95.
When `map_write_async()` or `map_read_async()` are called, `map()` in `DestroyedResources` is called but the `.ready_to_map` field is not filled. So when `handle_mapping()` is called after submitting a queue, nothing happens because `.ready_to_map` vec is empty.