### PR TITLE
Track async mapping properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,18 @@ matrix:
     - env: MACOSX_DEPLOYMENT_TARGET=10.9
       os: osx
       rust: stable
-      osx_image: xcode9
+      osx_image: xcode9.4
       compiler: clang
     #- env: MACOSX_DEPLOYMENT_TARGET=10.9
     #  os: osx
     #  rust: nightly
-    #  osx_image: xcode9
+    #  osx_image: xcode9.4
     #  compiler: clang
 
     # iPhoneOS 64bit
     #- env: TARGET=aarch64-apple-ios
     #  os: osx
-    #  osx_image: xcode9
+    #  osx_image: xcode9.4
     #  rust: nightly
 
 branches:

--- a/examples/hello_compute_rust/main.rs
+++ b/examples/hello_compute_rust/main.rs
@@ -91,13 +91,8 @@ fn main() {
     device.get_queue().submit(&[encoder.finish()]);
 
     staging_buffer.map_read_async(0, size, |result: wgpu::BufferMapAsyncResult<&[u32]>| {
-        if let wgpu::BufferMapAsyncResult::Success(data) = result {
-            println!("Times: {:?}", data);
+        if let Ok(mapping) = result {
+            println!("Times: {:?}", mapping.data);
         }
     });
-
-    let encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
-    device.get_queue().submit(&[encoder.finish()]);
-
-    staging_buffer.unmap(); // TODO: staging_buffer can't be referenced from the callback
 }

--- a/examples/hello_compute_rust/main.rs
+++ b/examples/hello_compute_rust/main.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let instance = wgpu::Instance::new();
     let adapter = instance.get_adapter(&wgpu::AdapterDescriptor {
-        power_preference: wgpu::PowerPreference::LowPower,
+        power_preference: wgpu::PowerPreference::Default,
     });
     let mut device = adapter.create_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {

--- a/wgpu-bindings/wgpu.h
+++ b/wgpu-bindings/wgpu.h
@@ -754,9 +754,11 @@ WGPUSwapChainId wgpu_device_create_swap_chain(WGPUDeviceId device_id,
 
 WGPUTextureId wgpu_device_create_texture(WGPUDeviceId device_id, const WGPUTextureDescriptor *desc);
 
-void wgpu_device_destroy(WGPUBufferId device_id);
+void wgpu_device_destroy(WGPUDeviceId device_id);
 
 WGPUQueueId wgpu_device_get_queue(WGPUDeviceId device_id);
+
+void wgpu_device_wait_idle(WGPUDeviceId device_id);
 
 WGPUSurfaceId wgpu_instance_create_surface_from_macos_layer(WGPUInstanceId instance_id,
                                                             void *layer);

--- a/wgpu-bindings/wgpu.h
+++ b/wgpu-bindings/wgpu.h
@@ -758,9 +758,7 @@ void wgpu_device_destroy(WGPUDeviceId device_id);
 
 WGPUQueueId wgpu_device_get_queue(WGPUDeviceId device_id);
 
-void wgpu_device_poll(WGPUDeviceId device_id);
-
-void wgpu_device_wait_idle(WGPUDeviceId device_id);
+void wgpu_device_poll(WGPUDeviceId device_id, bool force_wait);
 
 WGPUSurfaceId wgpu_instance_create_surface_from_macos_layer(WGPUInstanceId instance_id,
                                                             void *layer);

--- a/wgpu-bindings/wgpu.h
+++ b/wgpu-bindings/wgpu.h
@@ -758,6 +758,8 @@ void wgpu_device_destroy(WGPUDeviceId device_id);
 
 WGPUQueueId wgpu_device_get_queue(WGPUDeviceId device_id);
 
+void wgpu_device_poll(WGPUDeviceId device_id);
+
 void wgpu_device_wait_idle(WGPUDeviceId device_id);
 
 WGPUSurfaceId wgpu_instance_create_surface_from_macos_layer(WGPUInstanceId instance_id,

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -502,10 +502,20 @@ pub fn device_create_buffer(
         .unwrap()
         .into();
     // TODO: allocate with rendy
+
+    // if the memory is mapped but not coherent, round up to the atom size
+    let mut mem_size = requirements.size;
+    if memory_properties.contains(hal::memory::Properties::CPU_VISIBLE) &&
+        !memory_properties.contains(hal::memory::Properties::COHERENT)
+    {
+        let mask = device.limits.non_coherent_atom_size as u64 - 1;
+        mem_size = ((mem_size - 1 ) | mask) + 1;
+    }
+
     let memory = unsafe {
         device
             .raw
-            .allocate_memory(device_type, requirements.size)
+            .allocate_memory(device_type, mem_size)
             .unwrap()
     };
     unsafe {

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -1144,7 +1144,9 @@ pub extern "C" fn wgpu_queue_submit(
 
                 // update submission IDs
                 for id in comb.trackers.buffers.used() {
-                    buffer_guard[id]
+                    let buffer = &buffer_guard[id];
+                    assert!(buffer.pending_map_operation.is_none());
+                    buffer
                         .life_guard
                         .submission_index
                         .store(submit_index, Ordering::Release);

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -5,6 +5,8 @@ use crate::{
 #[cfg(feature = "local")]
 use crate::{DeviceId, SurfaceId};
 
+#[cfg(feature = "local")]
+use log::info;
 #[cfg(feature = "remote")]
 use serde::{Deserialize, Serialize};
 
@@ -168,6 +170,7 @@ pub extern "C" fn wgpu_instance_get_adapter(
     desc: &AdapterDescriptor,
 ) -> AdapterId {
     let adapter = instance_get_adapter(instance_id, desc);
+    info!("Adapter {:?}", adapter.info);
     HUB.adapters.register_local(adapter)
 }
 

--- a/wgpu-rs/src/lib.rs
+++ b/wgpu-rs/src/lib.rs
@@ -285,6 +285,16 @@ impl Adapter {
 }
 
 impl Device {
+    /// Check for resource cleanups and mapping callbacks.
+    pub fn poll(&self) {
+        wgn::wgpu_device_poll(self.id);
+    }
+
+    /// Wait for GPU work to finish and process all the callbacks.
+    pub fn wait_idle(&self) {
+        wgn::wgpu_device_wait_idle(self.id);
+    }
+
     pub fn create_shader_module(&self, spv: &[u8]) -> ShaderModule {
         let desc = wgn::ShaderModuleDescriptor {
             code: wgn::ByteArray {

--- a/wgpu-rs/src/lib.rs
+++ b/wgpu-rs/src/lib.rs
@@ -286,13 +286,8 @@ impl Adapter {
 
 impl Device {
     /// Check for resource cleanups and mapping callbacks.
-    pub fn poll(&self) {
-        wgn::wgpu_device_poll(self.id);
-    }
-
-    /// Wait for GPU work to finish and process all the callbacks.
-    pub fn wait_idle(&self) {
-        wgn::wgpu_device_wait_idle(self.id);
+    pub fn poll(&self, force_wait: bool) {
+        wgn::wgpu_device_poll(self.id, force_wait);
     }
 
     pub fn create_shader_module(&self, spv: &[u8]) -> ShaderModule {
@@ -503,7 +498,7 @@ impl Device {
 
 impl Drop for Device {
     fn drop(&mut self) {
-        wgn::wgpu_device_wait_idle(self.id);
+        wgn::wgpu_device_poll(self.id, true);
         //TODO: make this work in general
         #[cfg(feature = "metal-auto-capture")]
         wgn::wgpu_device_destroy(self.id);

--- a/wgpu-rs/src/lib.rs
+++ b/wgpu-rs/src/lib.rs
@@ -493,15 +493,24 @@ impl Device {
 
 impl Drop for Device {
     fn drop(&mut self) {
+        wgn::wgpu_device_wait_idle(self.id);
         //TODO: make this work in general
         #[cfg(feature = "metal-auto-capture")]
         wgn::wgpu_device_destroy(self.id);
     }
 }
 
-pub enum BufferMapAsyncResult<T> {
-    Success(T),
-    Error,
+pub struct BufferAsyncMapping<T> {
+    pub data: T,
+    buffer_id: wgn::BufferId,
+}
+//TODO: proper error type
+pub type BufferMapAsyncResult<T> = Result<BufferAsyncMapping<T>, ()>;
+
+impl<T> Drop for BufferAsyncMapping<T> {
+    fn drop(&mut self) {
+        wgn::wgpu_buffer_unmap(self.buffer_id);
+    }
 }
 
 struct BufferMapReadAsyncUserData<T, F>
@@ -510,6 +519,7 @@ where
 {
     size: u32,
     callback: F,
+    buffer_id: wgn::BufferId,
     phantom: std::marker::PhantomData<T>,
 }
 
@@ -519,6 +529,7 @@ where
 {
     size: u32,
     callback: F,
+    buffer_id: wgn::BufferId,
     phantom: std::marker::PhantomData<T>,
 }
 
@@ -539,28 +550,32 @@ impl Buffer {
         extern "C" fn buffer_map_read_callback_wrapper<T, F>(
             status: wgn::BufferMapAsyncStatus,
             data: *const u8,
-            userdata: *mut u8,
+            user_data: *mut u8,
         ) where
             F: FnOnce(BufferMapAsyncResult<&[T]>),
         {
-            let userdata =
-                unsafe { Box::from_raw(userdata as *mut BufferMapReadAsyncUserData<T, F>) };
+            let user_data =
+                unsafe { Box::from_raw(user_data as *mut BufferMapReadAsyncUserData<T, F>) };
             let data = unsafe {
                 slice::from_raw_parts(
                     data as *const T,
-                    userdata.size as usize / std::mem::size_of::<T>(),
+                    user_data.size as usize / std::mem::size_of::<T>(),
                 )
             };
             if let wgn::BufferMapAsyncStatus::Success = status {
-                (userdata.callback)(BufferMapAsyncResult::Success::<&[T]>(data));
+                (user_data.callback)(Ok(BufferAsyncMapping {
+                    data,
+                    buffer_id: user_data.buffer_id,
+                }));
             } else {
-                (userdata.callback)(BufferMapAsyncResult::Error);
+                (user_data.callback)(Err(()))
             }
         }
 
-        let userdata = Box::new(BufferMapReadAsyncUserData {
+        let user_data = Box::new(BufferMapReadAsyncUserData {
             size,
             callback,
+            buffer_id: self.id,
             phantom: std::marker::PhantomData,
         });
         wgn::wgpu_buffer_map_read_async(
@@ -568,7 +583,7 @@ impl Buffer {
             start,
             size,
             buffer_map_read_callback_wrapper::<T, F>,
-            Box::into_raw(userdata) as *mut u8,
+            Box::into_raw(user_data) as *mut u8,
         );
     }
 
@@ -584,28 +599,32 @@ impl Buffer {
         extern "C" fn buffer_map_write_callback_wrapper<T, F>(
             status: wgn::BufferMapAsyncStatus,
             data: *mut u8,
-            userdata: *mut u8,
+            user_data: *mut u8,
         ) where
             F: FnOnce(BufferMapAsyncResult<&mut [T]>),
         {
-            let userdata =
-                unsafe { Box::from_raw(userdata as *mut BufferMapWriteAsyncUserData<T, F>) };
+            let user_data =
+                unsafe { Box::from_raw(user_data as *mut BufferMapWriteAsyncUserData<T, F>) };
             let data = unsafe {
                 slice::from_raw_parts_mut(
                     data as *mut T,
-                    userdata.size as usize / std::mem::size_of::<T>(),
+                    user_data.size as usize / std::mem::size_of::<T>(),
                 )
             };
             if let wgn::BufferMapAsyncStatus::Success = status {
-                (userdata.callback)(BufferMapAsyncResult::Success::<&mut [T]>(data));
+                (user_data.callback)(Ok(BufferAsyncMapping {
+                    data,
+                    buffer_id: user_data.buffer_id,
+                }));
             } else {
-                (userdata.callback)(BufferMapAsyncResult::Error);
+                (user_data.callback)(Err(()))
             }
         }
 
-        let userdata = Box::new(BufferMapWriteAsyncUserData {
+        let user_data = Box::new(BufferMapWriteAsyncUserData {
             size,
             callback,
+            buffer_id: self.id,
             phantom: std::marker::PhantomData,
         });
         wgn::wgpu_buffer_map_write_async(
@@ -613,7 +632,7 @@ impl Buffer {
             start,
             size,
             buffer_map_write_callback_wrapper::<T, F>,
-            Box::into_raw(userdata) as *mut u8,
+            Box::into_raw(user_data) as *mut u8,
         );
     }
 


### PR DESCRIPTION
Fixes #117, fixes #95, fixes #132 

The change can be logically split into 3 parts:
  1. when `ActiveSubmission` is retired, we now move the mapped buffers into the "ready to map" vector. This was the missing bit that caused mapping to not work previously.
  2. mapping callbacks in Rust wrapper are refactored and they `unmap()` automatically now on users behalf
  3. we wait for idle before destroying the device, which allows us to process all the pending callbacks. This fix gets rid of the dummy submission our compute example used to do.