### PR TITLE
Creating buffers with size 0 actually creates them with size 1

### DIFF
--- a/wgpu-rs/src/lib.rs
+++ b/wgpu-rs/src/lib.rs
@@ -499,7 +499,7 @@ impl Device {
         assert_ne!(type_size, 0);
 
         let desc = BufferDescriptor {
-            size: type_size * count as u32,
+            size: (type_size * count as u32).max(1),
             usage,
         };
         let mut ptr: *mut u8 = std::ptr::null_mut();


### PR DESCRIPTION
closes https://github.com/gfx-rs/wgpu/issues/135

One concern I have is if the buffer is uninitialized before the call to `self.data.copy_from_slice(slice);`
If that is the case, my new `fill_from_slice` implementation will leave memory uninitialized when the user tries to create an empty buffer.