### PR TITLE
Assert on swapchain output usage before presenting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ before_install:
 
 script:
   - cargo test
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then (brew update && brew upgrade cmake && brew install glfw3 && make ffi-examples); fi
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then (brew update && brew upgrade cmake && brew install glfw3 && cargo install cbindgen && make ffi-examples); fi

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -155,6 +155,7 @@ pub struct CommandEncoderDescriptor {
 pub extern "C" fn wgpu_command_encoder_finish(
     command_encoder_id: CommandEncoderId,
 ) -> CommandBufferId {
+    //TODO: actually close the last recorded command buffer
     HUB.command_buffers.write()[command_encoder_id].is_recording = false; //TODO: check for the old value
     command_encoder_id
 }


### PR DESCRIPTION
Fixes #148 

There is no "fix" for the case on our side. The PR brings stronger requirements on the swapchain outputs: they have to be used and submitted before dropped.