### PR TITLE
Handle resize in the triangle example

### DIFF
--- a/examples/hello_triangle_c/main.c
+++ b/examples/hello_triangle_c/main.c
@@ -188,15 +188,35 @@ int main() {
     #error "Unsupported WGPU_TARGET"
 #endif
 
+    int prev_width = 0;
+    int prev_height = 0;
+    glfwGetWindowSize(window, &prev_width, &prev_height);
+
     WGPUSwapChainId swap_chain = wgpu_device_create_swap_chain(device, surface,
         &(WGPUSwapChainDescriptor){
             .usage = WGPUTextureUsageFlags_OUTPUT_ATTACHMENT,
             .format = WGPUTextureFormat_Bgra8Unorm,
-            .width = 640,
-            .height = 480,
+            .width = prev_width,
+            .height = prev_height,
         });
 
     while (!glfwWindowShouldClose(window)) {
+        int width = 0;
+        int height = 0;
+        glfwGetWindowSize(window, &width, &height);
+        if (width != prev_width || height != prev_height) {
+            prev_width = width;
+            prev_height = height;
+
+            swap_chain = wgpu_device_create_swap_chain(device, surface,
+                &(WGPUSwapChainDescriptor){
+                    .usage = WGPUTextureUsageFlags_OUTPUT_ATTACHMENT,
+                    .format = WGPUTextureFormat_Bgra8Unorm,
+                    .width = width,
+                    .height = height,
+                });
+        }
+
         WGPUSwapChainOutput next_texture =
             wgpu_swap_chain_get_next_texture(swap_chain);
 


### PR DESCRIPTION
Handle window resize in the C triangle example.

This fixes https://github.com/gfx-rs/wgpu/issues/166.
The reason it was failing immediately on my machine, is because my window manager was automatically resizing the window.

If I resize the window reallly fast, I still get a few:
```
[2019-05-13T11:00:23Z ERROR gfx_backend_vulkan] [Validation]  [ VUID-VkSwapchainCreateInfoKHR-imageExtent-01274 ] Object: 0x5650f23f2510 (Type = 3) | vkCreateSwapchainKHR() called with imageExtent = (798,615), which is outside the bounds returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR(): currentExtent = (590,498), minImageExtent = (590,498), maxImageExtent = (590,498). The Vulkan spec states: imageExtent must be between minImageExtent and maxImageExtent, inclusive, where minImageExtent and maxImageExtent are members of the VkSurfaceCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR for the surface (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageExtent-01274)
```

It can be merged as is. (Its certainly an improvement)
But if you know how to fix this last validation error, i would love to add it.