### PR TITLE
Fix command buffer and surface locking order

### DIFF
--- a/wgpu-native/src/command/compute.rs
+++ b/wgpu-native/src/command/compute.rs
@@ -35,11 +35,12 @@ impl<B: hal::Backend> ComputePass<B> {
 
 #[no_mangle]
 pub extern "C" fn wgpu_compute_pass_end_pass(pass_id: ComputePassId) -> CommandBufferId {
+    let mut command_buffer_guard = HUB.command_buffers.write();
     let pass = HUB.compute_passes.unregister(pass_id);
 
     //TODO: transitions?
 
-    HUB.command_buffers.write()[pass.cmb_id.value]
+    command_buffer_guard[pass.cmb_id.value]
         .raw
         .push(pass.raw);
     pass.cmb_id.value

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -166,9 +166,9 @@ pub fn command_encoder_begin_render_pass(
     command_encoder_id: CommandEncoderId,
     desc: RenderPassDescriptor,
 ) -> RenderPass<Backend> {
+    let device_guard = HUB.devices.read();
     let mut cmb_guard = HUB.command_buffers.write();
     let cmb = &mut cmb_guard[command_encoder_id];
-    let device_guard = HUB.devices.read();
     let device = &device_guard[cmb.device_id.value];
     let view_guard = HUB.texture_views.read();
 

--- a/wgpu-native/src/command/render.rs
+++ b/wgpu-native/src/command/render.rs
@@ -89,12 +89,11 @@ impl<B: hal::Backend> RenderPass<B> {
 
 #[no_mangle]
 pub extern "C" fn wgpu_render_pass_end_pass(pass_id: RenderPassId) -> CommandBufferId {
+    let mut cmb_guard = HUB.command_buffers.write();
     let mut pass = HUB.render_passes.unregister(pass_id);
     unsafe {
         pass.raw.end_render_pass();
     }
-
-    let mut cmb_guard = HUB.command_buffers.write();
     let cmb = &mut cmb_guard[pass.cmb_id.value];
 
     match cmb.raw.last_mut() {

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -1234,6 +1234,7 @@ pub extern "C" fn wgpu_queue_submit(
         unsafe { slice::from_raw_parts(command_buffer_ptr, command_buffer_count) };
 
     let (submit_index, fence) = {
+        let surface_guard = HUB.surfaces.read();
         let mut device_guard = HUB.devices.write();
         let device = &mut device_guard[queue_id];
         let mut trackers = device.trackers.lock();
@@ -1310,7 +1311,6 @@ pub extern "C" fn wgpu_queue_submit(
         let fence = device.raw.create_fence(false).unwrap();
         {
             let command_buffer_guard = HUB.command_buffers.read();
-            let surface_guard = HUB.surfaces.read();
 
             let wait_semaphores = swap_chain_links.into_iter().flat_map(|link| {
                 let swap_chain = surface_guard[link.swap_chain_id].swap_chain.as_ref()?;
@@ -1655,9 +1655,9 @@ pub fn device_create_swap_chain(
 ) -> Vec<resource::Texture<back::Backend>> {
     info!("creating swap chain {:?}", desc);
 
+    let mut surface_guard = HUB.surfaces.write();
     let device_guard = HUB.devices.read();
     let device = &device_guard[device_id];
-    let mut surface_guard = HUB.surfaces.write();
     let surface = &mut surface_guard[surface_id];
 
     let (caps, formats, _present_modes) = {

--- a/wgpu-native/src/hub.rs
+++ b/wgpu-native/src/hub.rs
@@ -174,6 +174,7 @@ impl<T, I: TypedId + Copy> Registry<T, I> {
 #[derive(Default)]
 pub struct Hub {
     pub instances: Arc<Registry<InstanceHandle, InstanceId>>,
+    pub surfaces: Arc<Registry<SurfaceHandle, SurfaceId>>,
     pub adapters: Arc<Registry<AdapterHandle, AdapterId>>,
     pub devices: Arc<Registry<DeviceHandle, DeviceId>>,
     pub pipeline_layouts: Arc<Registry<PipelineLayoutHandle, PipelineLayoutId>>,
@@ -189,7 +190,6 @@ pub struct Hub {
     pub textures: Arc<Registry<TextureHandle, TextureId>>,
     pub texture_views: Arc<Registry<TextureViewHandle, TextureViewId>>,
     pub samplers: Arc<Registry<SamplerHandle, SamplerId>>,
-    pub surfaces: Arc<Registry<SurfaceHandle, SurfaceId>>,
 }
 
 lazy_static! {


### PR DESCRIPTION
As with all the other locking problems, we just ensure that the locks are in the same order as the fields are in `Hub` structure. This is to be enforced at compile time with #66 
Fixes #174 