### PR TITLE
Use required option for glfw3

### DIFF
--- a/examples/hello_triangle_c/CMakeLists.txt
+++ b/examples/hello_triangle_c/CMakeLists.txt
@@ -21,7 +21,7 @@ else(MSVC)
     set(GLFW_LIBRARY glfw)
 endif(MSVC)
 
-find_package(glfw3)
+find_package(glfw3 REQUIRED)
 
 find_library(WGPU_LIBRARY wgpu_native
     HINTS "${CMAKE_CURRENT_SOURCE_DIR}/../../target/debug"


### PR DESCRIPTION
This is minor, but we should force glfw3 to be required for the native hello_triangle example.