### PR TITLE
add necessary windows lib files for vulkan, dx12, dx11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ ffi/wgpu-remote.h:  wgpu-remote/cbindgen.toml $(wildcard wgpu-native/**/*.rs wgp
 	rustup run nightly cbindgen wgpu-remote >$(FFI_DIR)/wgpu-remote.h
 
 examples-native: lib-native $(FFI_DIR)/wgpu.h examples/hello_triangle_c/main.c
-	cd examples/hello_triangle_c && $(CREATE_BUILD_DIR) && cd build && cmake .. && make
+	cd examples/hello_triangle_c && $(CREATE_BUILD_DIR) && cd build && cmake .. -DBACKEND=$(FEATURE_RUST) && make
 
 examples-remote: lib-remote $(FFI_DIR)/wgpu-remote.h examples/hello_remote_c/main.c
 	cd examples/hello_remote_c && $(CREATE_BUILD_DIR) && cd build && cmake .. && make

--- a/examples/hello_triangle_c/CMakeLists.txt
+++ b/examples/hello_triangle_c/CMakeLists.txt
@@ -3,13 +3,20 @@ cmake_minimum_required(VERSION 3.11b)
 project(hello_triangle)
 
 set(TARGET_NAME hello_triangle)
-
+set(feature-native)
 add_executable(hello_triangle main.c)
 
 if(MSVC)
     add_definitions(-DWGPU_TARGET=WGPU_TARGET_WINDOWS)
     target_compile_options(${TARGET_NAME} PRIVATE /W4)
     set(GLFW_LIBRARY glfw3)
+
+    target_link_libraries(${TARGET_NAME} userenv ws2_32 Dwmapi)
+    
+    if ("${feature-native}" STREQUAL "dx12")
+        target_link_libraries(${TARGET_NAME} d3dcompiler D3D12 DXGI)
+    endif()
+
 elseif(APPLE)
     add_definitions(-DWGPU_TARGET=WGPU_TARGET_MACOS)
     set(OS_LIBRARIES "-framework Cocoa" "-framework CoreVideo" "-framework IOKit" "-framework QuartzCore")

--- a/examples/hello_triangle_c/CMakeLists.txt
+++ b/examples/hello_triangle_c/CMakeLists.txt
@@ -3,20 +3,27 @@ cmake_minimum_required(VERSION 3.11b)
 project(hello_triangle)
 
 set(TARGET_NAME hello_triangle)
-set(feature-native)
+
+set(BACKEND_VULKAN "vulkan")
+set(BACKEND_METAL "metal")
+set(BACKEND_DX12 "dx12")
+set(AVAILABLE_BACKENDS ${BACKEND_VULKAN} ${BACKEND_METAL} ${BACKEND_DX12})
+
+if(NOT DEFINED BACKEND)
+    message(FATAL_ERROR "Backend has not been set, please do so by using the -DBACKEND= argument. \
+    Available backends: ${AVAILABLE_BACKENDS}")
+endif()
+
 add_executable(hello_triangle main.c)
 
 if(MSVC)
     add_definitions(-DWGPU_TARGET=WGPU_TARGET_WINDOWS)
     target_compile_options(${TARGET_NAME} PRIVATE /W4)
     set(GLFW_LIBRARY glfw3)
-
-    target_link_libraries(${TARGET_NAME} userenv ws2_32 Dwmapi)
-    
-    if ("${feature-native}" STREQUAL "dx12")
-        target_link_libraries(${TARGET_NAME} d3dcompiler D3D12 DXGI)
+    set(OS_LIBRARIES "userenv" "ws2_32" "Dwmapi" "dbghelp")    
+    if("${BACKEND}" STREQUAL "${BACKEND_DX12}")
+        list(APPEND OS_LIBRARIES "d3dcompiler" "D3D12" "DXGI")
     endif()
-
 elseif(APPLE)
     add_definitions(-DWGPU_TARGET=WGPU_TARGET_MACOS)
     set(OS_LIBRARIES "-framework Cocoa" "-framework CoreVideo" "-framework IOKit" "-framework QuartzCore")

--- a/examples/hello_triangle_c/CMakeLists.txt
+++ b/examples/hello_triangle_c/CMakeLists.txt
@@ -1,18 +1,22 @@
 cmake_minimum_required(VERSION 3.11b)
 
+set(BACKEND_VULKAN "vulkan")
+set(BACKEND_METAL "metal")
+set(BACKEND_DX11 "dx11")
+set(BACKEND_DX12 "dx12")
+set(AVAILABLE_BACKENDS 
+    ${BACKEND_VULKAN}
+    ${BACKEND_METAL}
+    ${BACKEND_DX11}
+    ${BACKEND_DX12})
+
+if(NOT DEFINED BACKEND OR NOT "${BACKEND}" IN_LIST AVAILABLE_BACKENDS)
+    message(FATAL_ERROR "BACKEND invalid or undefined, available backends: ${AVAILABLE_BACKENDS}")
+endif()
+
 project(hello_triangle)
 
 set(TARGET_NAME hello_triangle)
-
-set(BACKEND_VULKAN "vulkan")
-set(BACKEND_METAL "metal")
-set(BACKEND_DX12 "dx12")
-set(AVAILABLE_BACKENDS ${BACKEND_VULKAN} ${BACKEND_METAL} ${BACKEND_DX12})
-
-if(NOT DEFINED BACKEND)
-    message(FATAL_ERROR "Backend has not been set, please do so by using the -DBACKEND= argument. \
-    Available backends: ${AVAILABLE_BACKENDS}")
-endif()
 
 add_executable(hello_triangle main.c)
 
@@ -21,7 +25,9 @@ if(MSVC)
     target_compile_options(${TARGET_NAME} PRIVATE /W4)
     set(GLFW_LIBRARY glfw3)
     set(OS_LIBRARIES "userenv" "ws2_32" "Dwmapi" "dbghelp")    
-    if("${BACKEND}" STREQUAL "${BACKEND_DX12}")
+    if("${BACKEND}" STREQUAL "${BACKEND_DX11}")
+        list(APPEND OS_LIBRARIES "d3dcompiler" "D3D11" "DXGI")
+    elseif("${BACKEND}" STREQUAL "${BACKEND_DX12}")
         list(APPEND OS_LIBRARIES "d3dcompiler" "D3D12" "DXGI")
     endif()
 elseif(APPLE)


### PR DESCRIPTION
Introduce new argument BACKEND to specify the back-end framework in the hello_triangle_c CMake script. I will update the other examples, hello_remote_c & hello_compute_c (working on this one) in a future PR.

fix #188 