### PR TITLE
Fix compute pass barriers

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -686,7 +686,7 @@ void wgpu_compute_pass_push_debug_group(WGPUComputePassId _pass_id, WGPURawStrin
 void wgpu_compute_pass_set_bind_group(WGPUComputePassId pass_id,
                                       uint32_t index,
                                       WGPUBindGroupId bind_group_id,
-                                      const uint32_t *offsets_ptr,
+                                      const WGPUBufferAddress *offsets_ptr,
                                       uintptr_t offsets_count);
 
 void wgpu_compute_pass_set_pipeline(WGPUComputePassId pass_id, WGPUComputePipelineId pipeline_id);
@@ -810,7 +810,7 @@ void wgpu_render_pass_push_debug_group(WGPURenderPassId _pass_id, WGPURawString 
 void wgpu_render_pass_set_bind_group(WGPURenderPassId pass_id,
                                      uint32_t index,
                                      WGPUBindGroupId bind_group_id,
-                                     const uint32_t *offsets_ptr,
+                                     const WGPUBufferAddress *offsets_ptr,
                                      uintptr_t offsets_count);
 
 void wgpu_render_pass_set_blend_color(WGPURenderPassId pass_id, const WGPUColor *color);
@@ -831,7 +831,7 @@ void wgpu_render_pass_set_stencil_reference(WGPURenderPassId pass_id, uint32_t v
 
 void wgpu_render_pass_set_vertex_buffers(WGPURenderPassId pass_id,
                                          const WGPUBufferId *buffer_ptr,
-                                         const uint32_t *offset_ptr,
+                                         const WGPUBufferAddress *offset_ptr,
                                          uintptr_t count);
 
 void wgpu_render_pass_set_viewport(WGPURenderPassId pass_id,

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -44,7 +44,7 @@ use back::Backend;
 use hal::{command::RawCommandBuffer, Device as _};
 use log::trace;
 
-use std::{collections::hash_map::Entry, iter, slice, thread::ThreadId};
+use std::{collections::hash_map::Entry, iter, mem, slice, thread::ThreadId};
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
@@ -426,12 +426,13 @@ pub fn command_encoder_begin_compute_pass(
     let cmb = &mut cmb_guard[command_encoder_id];
 
     let raw = cmb.raw.pop().unwrap();
+    let trackers = mem::replace(&mut cmb.trackers, TrackerSet::new());
     let stored = Stored {
         value: command_encoder_id,
         ref_count: cmb.life_guard.ref_count.clone(),
     };
 
-    ComputePass::new(raw, stored)
+    ComputePass::new(raw, stored, trackers)
 }
 
 #[cfg(feature = "local")]


### PR DESCRIPTION
Fixes #193 (supposedly)
@m4b would you be able to confirm?

Basic idea is that we treat commands inside a compute pass to follow the same rule as transfer commands. We could even go as far as alias `type ComputePassEncoderId = CommandEncoderId`, but I thought maybe we can still take advantage of a separate type. Currently it gets both the backend command buffer and the tracker from the primary encoder, only to return them back in place when the pass is done.