### PR TITLE
Fix tracking and improve draw call validation

### DIFF
--- a/ffi/wgpu-remote.h
+++ b/ffi/wgpu-remote.h
@@ -1,6 +1,6 @@
 
 
-/* Generated with cbindgen:0.8.7 */
+/* Generated with cbindgen:0.8.6 */
 
 #include <stdarg.h>
 #include <stdbool.h>

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1,6 +1,6 @@
 #define WGPU_LOCAL
 
-/* Generated with cbindgen:0.8.7 */
+/* Generated with cbindgen:0.8.6 */
 
 #include <stdarg.h>
 #include <stdbool.h>
@@ -10,6 +10,8 @@
 #define WGPUMAX_BIND_GROUPS 4
 
 #define WGPUMAX_COLOR_TARGETS 4
+
+#define WGPUMAX_VERTEX_BUFFERS 8
 
 typedef enum {
   WGPUAddressMode_ClampToEdge = 0,

--- a/wgpu-native/src/command/allocator.rs
+++ b/wgpu-native/src/command/allocator.rs
@@ -99,7 +99,8 @@ impl<B: hal::Backend> CommandAllocator<B> {
         pool.available.pop().unwrap()
     }
 
-    pub fn after_submit(&self, cmd_buf: CommandBuffer<B>, submit_index: SubmissionIndex) {
+    pub fn after_submit(&self, mut cmd_buf: CommandBuffer<B>, submit_index: SubmissionIndex) {
+        cmd_buf.trackers.clear();
         cmd_buf
             .life_guard
             .submission_index

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -19,7 +19,6 @@ use crate::{
         RenderPassKey,
     },
     hub::{Storage, HUB},
-    pipeline::IndexFormat,
     resource::TexturePlacement,
     swap_chain::{SwapChainLink, SwapImageEpoch},
     track::{DummyUsage, Stitch, TrackerSet},
@@ -393,11 +392,6 @@ pub fn command_encoder_begin_render_pass(
         depth_stencil: depth_stencil_attachment.map(|at| view_guard[at.attachment].format),
     };
 
-    let index_state = IndexState {
-        bound_buffer_view: None,
-        format: IndexFormat::Uint16,
-    };
-
     RenderPass::new(
         current_comb,
         Stored {
@@ -405,7 +399,6 @@ pub fn command_encoder_begin_render_pass(
             ref_count: cmb.life_guard.ref_count.clone(),
         },
         context,
-        index_state,
     )
 }
 

--- a/wgpu-native/src/command/render.rs
+++ b/wgpu-native/src/command/render.rs
@@ -396,34 +396,33 @@ pub extern "C" fn wgpu_render_pass_set_pipeline(
         pass.raw.bind_graphics_pipeline(&pipeline.raw);
     }
 
-    if pass.binder.pipeline_layout_id == Some(pipeline.layout_id.clone()) {
-        return;
-    }
+    // Rebind resource
+    if pass.binder.pipeline_layout_id != Some(pipeline.layout_id.clone()) {
+        let pipeline_layout_guard = HUB.pipeline_layouts.read();
+        let pipeline_layout = &pipeline_layout_guard[pipeline.layout_id];
+        let bind_group_guard = HUB.bind_groups.read();
 
-    let pipeline_layout_guard = HUB.pipeline_layouts.read();
-    let pipeline_layout = &pipeline_layout_guard[pipeline.layout_id];
-    let bind_group_guard = HUB.bind_groups.read();
+        pass.binder.pipeline_layout_id = Some(pipeline.layout_id.clone());
+        pass.binder
+            .reset_expectations(pipeline_layout.bind_group_layout_ids.len());
 
-    pass.binder.pipeline_layout_id = Some(pipeline.layout_id.clone());
-    pass.binder
-        .reset_expectations(pipeline_layout.bind_group_layout_ids.len());
-
-    for (index, (entry, &bgl_id)) in pass
-        .binder
-        .entries
-        .iter_mut()
-        .zip(&pipeline_layout.bind_group_layout_ids)
-        .enumerate()
-    {
-        if let LayoutChange::Match(bg_id) = entry.expect_layout(bgl_id) {
-            let desc_set = &bind_group_guard[bg_id].raw;
-            unsafe {
-                pass.raw.bind_graphics_descriptor_sets(
-                    &pipeline_layout.raw,
-                    index,
-                    iter::once(desc_set),
-                    &[],
-                );
+        for (index, (entry, &bgl_id)) in pass
+            .binder
+            .entries
+            .iter_mut()
+            .zip(&pipeline_layout.bind_group_layout_ids)
+            .enumerate()
+        {
+            if let LayoutChange::Match(bg_id) = entry.expect_layout(bgl_id) {
+                let desc_set = &bind_group_guard[bg_id].raw;
+                unsafe {
+                    pass.raw.bind_graphics_descriptor_sets(
+                        &pipeline_layout.raw,
+                        index,
+                        iter::once(desc_set),
+                        &[],
+                    );
+                }
             }
         }
     }

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -58,6 +58,7 @@ use std::{collections::hash_map::Entry, ffi, iter, ptr, slice, sync::atomic::Ord
 
 const CLEANUP_WAIT_MS: u64 = 5000;
 pub const MAX_COLOR_TARGETS: usize = 4;
+pub const MAX_VERTEX_BUFFERS: usize = 8;
 
 pub fn all_buffer_stages() -> hal::pso::PipelineStage {
     use hal::pso::PipelineStage as Ps;
@@ -602,6 +603,7 @@ pub fn device_create_buffer(
         },
         memory_properties,
         memory,
+        size: desc.size,
         mapped_write_ranges: Vec::new(),
         pending_map_operation: None,
         life_guard: LifeGuard::new(),
@@ -1445,9 +1447,11 @@ pub fn device_create_render_pipeline(
             desc.vertex_input.vertex_buffers_count,
         )
     };
+    let mut vertex_strides = Vec::with_capacity(desc_vbs.len());
     let mut vertex_buffers = Vec::with_capacity(desc_vbs.len());
     let mut attributes = Vec::new();
     for (i, vb_state) in desc_vbs.iter().enumerate() {
+        vertex_strides.alloc().init((vb_state.stride, vb_state.step_mode));
         if vb_state.attributes_count == 0 {
             continue;
         }
@@ -1558,6 +1562,7 @@ pub fn device_create_render_pipeline(
         pass_context,
         flags,
         index_format: desc.vertex_input.index_format,
+        vertex_strides,
     }
 }
 

--- a/wgpu-native/src/pipeline.rs
+++ b/wgpu-native/src/pipeline.rs
@@ -293,4 +293,5 @@ pub struct RenderPipeline<B: hal::Backend> {
     pub(crate) pass_context: RenderPassContext,
     pub(crate) flags: PipelineFlags,
     pub(crate) index_format: IndexFormat,
+    pub(crate) vertex_strides: Vec<(BufferAddress, InputStepMode)>,
 }

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -62,6 +62,7 @@ pub struct Buffer<B: hal::Backend> {
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) memory_properties: hal::memory::Properties,
     pub(crate) memory: B::Memory,
+    pub(crate) size: BufferAddress,
     pub(crate) mapped_write_ranges: Vec<std::ops::Range<u64>>,
     pub(crate) pending_map_operation: Option<BufferMapOperation>,
     pub(crate) life_guard: LifeGuard,

--- a/wgpu-native/src/track.rs
+++ b/wgpu-native/src/track.rs
@@ -128,6 +128,12 @@ impl TrackerSet {
         }
     }
 
+    pub fn clear(&mut self) {
+        self.buffers.clear();
+        self.textures.clear();
+        self.views.clear();
+    }
+
     pub fn consume_by_extend(&mut self, other: &Self) {
         self.buffers.consume_by_extend(&other.buffers).unwrap();
         self.textures.consume_by_extend(&other.textures).unwrap();
@@ -280,6 +286,10 @@ impl<I: TypedId, U: Copy + GenericUsage + BitOr<Output = U> + PartialEq> Tracker
 }
 
 impl<I: TypedId + Copy, U: Copy + GenericUsage + BitOr<Output = U> + PartialEq> Tracker<I, U> {
+    fn clear(&mut self) {
+        self.map.clear();
+    }
+
     fn _get_with_usage<'a, T: 'a + Borrow<RefCount>>(
         &mut self,
         storage: &'a Storage<T, I>,


### PR DESCRIPTION
Fixes #196 

## Validation
Note: the most difficult bit is still missing - we need to know the maximum index in an index buffer. This is not meant to be done in this PR though, the logic is good enough on its own.

## Tracking
Implements a custom iterator with Drop.
Also, reset tracking of resources when a command buffer is done.