### PR TITLE
Ensure wait_for_fences is never called on 0 fences

### DIFF
--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -177,7 +177,7 @@ impl<B: hal::Backend> PendingResources<B> {
         heaps_mutex: &Mutex<Heaps<B>>,
         force_wait: bool,
     ) -> SubmissionIndex {
-        if force_wait {
+        if force_wait && !self.active.is_empty() {
             let status = unsafe {
                 device.wait_for_fences(
                     self.active.iter().map(|a| &a.fence),


### PR DESCRIPTION
I don't see any reason why self.active should never be empty.

This fixes the validation errors but not the slowdown of https://github.com/gfx-rs/wgpu/issues/207
I presume the slowdown was causing self.active to clear.