### PR TITLE
More consistent naming of pointer-size-pairs

### DIFF
--- a/examples/hello_triangle_c/main.c
+++ b/examples/hello_triangle_c/main.c
@@ -138,7 +138,7 @@ int main() {
                     (WGPUVertexInputDescriptor){
                         .index_format = WGPUIndexFormat_Uint16,
                         .vertex_buffers = NULL,
-                        .vertex_buffers_count = 0,
+                        .vertex_buffers_length = 0,
                     },
                 .sample_count = 1,
             });

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -515,13 +515,13 @@ typedef struct {
   WGPUBufferAddress stride;
   WGPUInputStepMode step_mode;
   const WGPUVertexAttributeDescriptor *attributes;
-  uintptr_t attributes_count;
+  uintptr_t attributes_length;
 } WGPUVertexBufferDescriptor;
 
 typedef struct {
   WGPUIndexFormat index_format;
   const WGPUVertexBufferDescriptor *vertex_buffers;
-  uintptr_t vertex_buffers_count;
+  uintptr_t vertex_buffers_length;
 } WGPUVertexInputDescriptor;
 
 typedef struct {
@@ -688,8 +688,8 @@ void wgpu_compute_pass_push_debug_group(WGPUComputePassId _pass_id, WGPURawStrin
 void wgpu_compute_pass_set_bind_group(WGPUComputePassId pass_id,
                                       uint32_t index,
                                       WGPUBindGroupId bind_group_id,
-                                      const WGPUBufferAddress *offsets_ptr,
-                                      uintptr_t offsets_count);
+                                      const WGPUBufferAddress *offsets,
+                                      uintptr_t offsets_length);
 
 void wgpu_compute_pass_set_pipeline(WGPUComputePassId pass_id, WGPUComputePipelineId pipeline_id);
 
@@ -785,8 +785,8 @@ WGPUAdapterId wgpu_instance_get_adapter(WGPUInstanceId instance_id,
 #endif
 
 void wgpu_queue_submit(WGPUQueueId queue_id,
-                       const WGPUCommandBufferId *command_buffer_ptr,
-                       uintptr_t command_buffer_count);
+                       const WGPUCommandBufferId *command_buffers,
+                       uintptr_t command_buffers_length);
 
 void wgpu_render_pass_draw(WGPURenderPassId pass_id,
                            uint32_t vertex_count,
@@ -812,8 +812,8 @@ void wgpu_render_pass_push_debug_group(WGPURenderPassId _pass_id, WGPURawString 
 void wgpu_render_pass_set_bind_group(WGPURenderPassId pass_id,
                                      uint32_t index,
                                      WGPUBindGroupId bind_group_id,
-                                     const WGPUBufferAddress *offsets_ptr,
-                                     uintptr_t offsets_count);
+                                     const WGPUBufferAddress *offsets,
+                                     uintptr_t offsets_length);
 
 void wgpu_render_pass_set_blend_color(WGPURenderPassId pass_id, const WGPUColor *color);
 
@@ -832,9 +832,9 @@ void wgpu_render_pass_set_scissor_rect(WGPURenderPassId pass_id,
 void wgpu_render_pass_set_stencil_reference(WGPURenderPassId pass_id, uint32_t value);
 
 void wgpu_render_pass_set_vertex_buffers(WGPURenderPassId pass_id,
-                                         const WGPUBufferId *buffer_ptr,
-                                         const WGPUBufferAddress *offset_ptr,
-                                         uintptr_t count);
+                                         const WGPUBufferId *buffers,
+                                         const WGPUBufferAddress *offsets,
+                                         uintptr_t length);
 
 void wgpu_render_pass_set_viewport(WGPURenderPassId pass_id,
                                    float x,

--- a/wgpu-native/src/command/compute.rs
+++ b/wgpu-native/src/command/compute.rs
@@ -59,17 +59,17 @@ pub extern "C" fn wgpu_compute_pass_set_bind_group(
     pass_id: ComputePassId,
     index: u32,
     bind_group_id: BindGroupId,
-    offsets_ptr: *const BufferAddress,
-    offsets_count: usize,
+    offsets: *const BufferAddress,
+    offsets_length: usize,
 ) {
     let mut pass_guard = HUB.compute_passes.write();
     let pass = &mut pass_guard[pass_id];
     let bind_group_guard = HUB.bind_groups.read();
     let bind_group = &bind_group_guard[bind_group_id];
 
-    assert_eq!(bind_group.dynamic_count, offsets_count);
-    let offsets = if offsets_count != 0 {
-        unsafe { slice::from_raw_parts(offsets_ptr, offsets_count) }
+    assert_eq!(bind_group.dynamic_count, offsets_length);
+    let offsets = if offsets_length != 0 {
+        unsafe { slice::from_raw_parts(offsets, offsets_length) }
     } else {
         &[]
     };

--- a/wgpu-native/src/command/render.rs
+++ b/wgpu-native/src/command/render.rs
@@ -204,17 +204,17 @@ pub extern "C" fn wgpu_render_pass_set_bind_group(
     pass_id: RenderPassId,
     index: u32,
     bind_group_id: BindGroupId,
-    offsets_ptr: *const BufferAddress,
-    offsets_count: usize,
+    offsets: *const BufferAddress,
+    offsets_length: usize,
 ) {
     let mut pass_guard = HUB.render_passes.write();
     let pass = &mut pass_guard[pass_id];
     let bind_group_guard = HUB.bind_groups.read();
     let bind_group = &bind_group_guard[bind_group_id];
 
-    assert_eq!(bind_group.dynamic_count, offsets_count);
-    let offsets = if offsets_count != 0 {
-        unsafe { slice::from_raw_parts(offsets_ptr, offsets_count) }
+    assert_eq!(bind_group.dynamic_count, offsets_length);
+    let offsets = if offsets_length != 0 {
+        unsafe { slice::from_raw_parts(offsets, offsets_length) }
     } else {
         &[]
     };
@@ -302,14 +302,14 @@ pub extern "C" fn wgpu_render_pass_set_index_buffer(
 #[no_mangle]
 pub extern "C" fn wgpu_render_pass_set_vertex_buffers(
     pass_id: RenderPassId,
-    buffer_ptr: *const BufferId,
-    offset_ptr: *const BufferAddress,
-    count: usize,
+    buffers: *const BufferId,
+    offsets: *const BufferAddress,
+    length: usize,
 ) {
     let mut pass_guard = HUB.render_passes.write();
     let buffer_guard = HUB.buffers.read();
-    let buffers = unsafe { slice::from_raw_parts(buffer_ptr, count) };
-    let offsets = unsafe { slice::from_raw_parts(offset_ptr, count) };
+    let buffers = unsafe { slice::from_raw_parts(buffers, length) };
+    let offsets = unsafe { slice::from_raw_parts(offsets, length) };
 
     let pass = &mut pass_guard[pass_id];
     for (vbs, (&id, &offset)) in pass.vertex_state.inputs.iter_mut().zip(buffers.iter().zip(offsets)) {
@@ -319,7 +319,7 @@ pub extern "C" fn wgpu_render_pass_set_vertex_buffers(
             .unwrap();
         vbs.total_size = buffer.size - offset;
     }
-    for vbs in pass.vertex_state.inputs[count..].iter_mut() {
+    for vbs in pass.vertex_state.inputs[length..].iter_mut() {
         vbs.total_size = 0;
     }
 

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -1176,11 +1176,11 @@ pub extern "C" fn wgpu_device_get_queue(device_id: DeviceId) -> QueueId {
 #[no_mangle]
 pub extern "C" fn wgpu_queue_submit(
     queue_id: QueueId,
-    command_buffer_ptr: *const CommandBufferId,
-    command_buffer_count: usize,
+    command_buffers: *const CommandBufferId,
+    command_buffers_length: usize,
 ) {
     let command_buffer_ids =
-        unsafe { slice::from_raw_parts(command_buffer_ptr, command_buffer_count) };
+        unsafe { slice::from_raw_parts(command_buffers, command_buffers_length) };
 
     let (submit_index, fence) = {
         let surface_guard = HUB.surfaces.read();
@@ -1416,7 +1416,7 @@ pub fn device_create_render_pipeline(
     let desc_vbs = unsafe {
         slice::from_raw_parts(
             desc.vertex_input.vertex_buffers,
-            desc.vertex_input.vertex_buffers_count,
+            desc.vertex_input.vertex_buffers_length,
         )
     };
     let mut vertex_strides = Vec::with_capacity(desc_vbs.len());
@@ -1424,7 +1424,7 @@ pub fn device_create_render_pipeline(
     let mut attributes = Vec::new();
     for (i, vb_state) in desc_vbs.iter().enumerate() {
         vertex_strides.alloc().init((vb_state.stride, vb_state.step_mode));
-        if vb_state.attributes_count == 0 {
+        if vb_state.attributes_length == 0 {
             continue;
         }
         vertex_buffers.alloc().init(hal::pso::VertexBufferDesc {
@@ -1436,7 +1436,7 @@ pub fn device_create_render_pipeline(
             },
         });
         let desc_atts =
-            unsafe { slice::from_raw_parts(vb_state.attributes, vb_state.attributes_count) };
+            unsafe { slice::from_raw_parts(vb_state.attributes, vb_state.attributes_length) };
         for attribute in desc_atts {
             assert_eq!(0, attribute.offset >> 32);
             attributes.alloc().init(hal::pso::AttributeDesc {

--- a/wgpu-native/src/pipeline.rs
+++ b/wgpu-native/src/pipeline.rs
@@ -198,14 +198,14 @@ pub struct VertexBufferDescriptor {
     pub stride: BufferAddress,
     pub step_mode: InputStepMode,
     pub attributes: *const VertexAttributeDescriptor,
-    pub attributes_count: usize,
+    pub attributes_length: usize,
 }
 
 #[repr(C)]
 pub struct VertexInputDescriptor {
     pub index_format: IndexFormat,
     pub vertex_buffers: *const VertexBufferDescriptor,
-    pub vertex_buffers_count: usize,
+    pub vertex_buffers_length: usize,
 }
 
 #[repr(C)]


### PR DESCRIPTION
* always plural form without _ptr suffix for pointers
* always same name as pointer for size, but with _length suffix
* special case: single size applies to multiple pointers => only use length as name