### PR TITLE
More consistent descriptor passing

### DIFF
--- a/examples/hello_triangle_c/main.c
+++ b/examples/hello_triangle_c/main.c
@@ -234,7 +234,7 @@ int main() {
 
         WGPURenderPassId rpass =
             wgpu_command_encoder_begin_render_pass(cmd_encoder,
-                (WGPURenderPassDescriptor){
+                &(WGPURenderPassDescriptor){
                     .color_attachments = color_attachments,
                     .color_attachments_length = RENDER_PASS_ATTACHMENTS_LENGTH,
                     .depth_stencil_attachment = NULL,

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -670,7 +670,7 @@ WGPUComputePassId wgpu_command_encoder_begin_compute_pass(WGPUCommandEncoderId c
 
 #if defined(WGPU_LOCAL)
 WGPURenderPassId wgpu_command_encoder_begin_render_pass(WGPUCommandEncoderId command_encoder_id,
-                                                        WGPURenderPassDescriptor desc);
+                                                        const WGPURenderPassDescriptor *desc);
 #endif
 
 WGPUCommandBufferId wgpu_command_encoder_finish(WGPUCommandEncoderId command_encoder_id);

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -164,7 +164,7 @@ pub extern "C" fn wgpu_command_encoder_finish(
 
 pub fn command_encoder_begin_render_pass(
     command_encoder_id: CommandEncoderId,
-    desc: RenderPassDescriptor,
+    desc: &RenderPassDescriptor,
 ) -> RenderPass<Backend> {
     let device_guard = HUB.devices.read();
     let mut cmb_guard = HUB.command_buffers.write();
@@ -406,7 +406,7 @@ pub fn command_encoder_begin_render_pass(
 #[no_mangle]
 pub extern "C" fn wgpu_command_encoder_begin_render_pass(
     command_encoder_id: CommandEncoderId,
-    desc: RenderPassDescriptor,
+    desc: &RenderPassDescriptor,
 ) -> RenderPassId {
     let pass = command_encoder_begin_render_pass(command_encoder_id, desc);
     HUB.render_passes.register_local(pass)


### PR DESCRIPTION
also use pointer for descriptor in `wgpu_command_encoder_begin_render_pass` for consistency reasons