### PR TITLE
Use wider type for swapchain image epoch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ before_install:
 
 script:
   - cargo test
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo +nightly install cbindgen; fi
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME == "windows" ]]; then
       wget -nc -O glfw.zip https://github.com/glfw/glfw/archive/3.3.zip &&
       7z x glfw.zip -oglfw &&
@@ -69,6 +70,6 @@ script:
       export CMAKE_PREFIX_PATH=$GLFW3_INSTALL_DIR &&
       make examples-native VERBOSE=1;
     fi
-  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME != "windows" ]]; then cargo +nightly install cbindgen && make VERBOSE=1; fi
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME != "windows" ]]; then make VERBOSE=1; fi
   # TODO: Temporarily only test building the gl backend, properly test when it is usable from C
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then cd wgpu-native && cargo build --features local,gfx-backend-gl; fi

--- a/wgpu-native/src/swap_chain.rs
+++ b/wgpu-native/src/swap_chain.rs
@@ -22,7 +22,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-pub type SwapImageEpoch = u16;
+pub type SwapImageEpoch = u64;
 
 const FRAME_TIMEOUT_MS: u64 = 1000;
 


### PR DESCRIPTION
Fixes #209

I don't think we need to do anything else here because it seems to only be used internally, so this should be a simple change.

Also ensures cbindgen is installed when targeting nightly on CI. It looks like it happened to be available on some Travis environments already so I missed this in #169