### PR TITLE
Add Naïve Debug Derives Where Possible

### DIFF
--- a/wgpu-native/src/binding_model.rs
+++ b/wgpu-native/src/binding_model.rs
@@ -45,11 +45,13 @@ pub struct BindGroupLayoutBinding {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct BindGroupLayoutDescriptor {
     pub bindings: *const BindGroupLayoutBinding,
     pub bindings_length: usize,
 }
 
+#[derive(Debug)]
 pub struct BindGroupLayout<B: hal::Backend> {
     pub(crate) raw: B::DescriptorSetLayout,
     pub(crate) bindings: Vec<BindGroupLayoutBinding>,
@@ -58,17 +60,20 @@ pub struct BindGroupLayout<B: hal::Backend> {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct PipelineLayoutDescriptor {
     pub bind_group_layouts: *const BindGroupLayoutId,
     pub bind_group_layouts_length: usize,
 }
 
+#[derive(Debug)]
 pub struct PipelineLayout<B: hal::Backend> {
     pub(crate) raw: B::PipelineLayout,
     pub(crate) bind_group_layout_ids: ArrayVec<[BindGroupLayoutId; MAX_BIND_GROUPS]>,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct BufferBinding {
     pub buffer: BufferId,
     pub offset: BufferAddress,
@@ -76,6 +81,7 @@ pub struct BufferBinding {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub enum BindingResource {
     Buffer(BufferBinding),
     Sampler(SamplerId),
@@ -83,18 +89,21 @@ pub enum BindingResource {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct BindGroupBinding {
     pub binding: u32,
     pub resource: BindingResource,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct BindGroupDescriptor {
     pub layout: BindGroupLayoutId,
     pub bindings: *const BindGroupBinding,
     pub bindings_length: usize,
 }
 
+#[derive(Debug)]
 pub struct BindGroup<B: hal::Backend> {
     pub(crate) raw: DescriptorSet<B>,
     pub(crate) layout_id: BindGroupLayoutId,

--- a/wgpu-native/src/command/allocator.rs
+++ b/wgpu-native/src/command/allocator.rs
@@ -7,6 +7,7 @@ use parking_lot::Mutex;
 
 use std::{collections::HashMap, sync::atomic::Ordering, thread};
 
+#[derive(Debug)]
 struct CommandPool<B: hal::Backend> {
     raw: B::CommandPool,
     available: Vec<B::CommandBuffer>,
@@ -23,6 +24,7 @@ impl<B: hal::Backend> CommandPool<B> {
     }
 }
 
+#[derive(Debug)]
 struct Inner<B: hal::Backend> {
     pools: HashMap<thread::ThreadId, CommandPool<B>>,
     pending: Vec<CommandBuffer<B>>,
@@ -40,6 +42,7 @@ impl<B: hal::Backend> Inner<B> {
     }
 }
 
+#[derive(Debug)]
 pub struct CommandAllocator<B: hal::Backend> {
     queue_family: hal::queue::QueueFamilyId,
     inner: Mutex<Inner<B>>,

--- a/wgpu-native/src/command/bind.rs
+++ b/wgpu-native/src/command/bind.rs
@@ -7,17 +7,20 @@ use std::convert::identity;
 pub const MAX_BIND_GROUPS: usize = 4;
 type BindGroupMask = u8;
 
+#[derive(Debug)]
 pub struct BindGroupPair {
     layout_id: BindGroupLayoutId,
     group_id: Stored<BindGroupId>,
 }
 
+#[derive(Debug)]
 pub enum LayoutChange {
     Unchanged,
     Match(BindGroupId),
     Mismatch,
 }
 
+#[derive(Debug)]
 pub enum Provision {
     Unchanged,
     Changed {
@@ -39,7 +42,7 @@ where
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct BindGroupEntry {
     expected_layout_id: Option<BindGroupLayoutId>,
     provided: Option<BindGroupPair>,
@@ -117,7 +120,7 @@ impl BindGroupEntry {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Binder {
     pub(crate) pipeline_layout_id: Option<PipelineLayoutId>, //TODO: strongly `Stored`
     pub(crate) entries: [BindGroupEntry; MAX_BIND_GROUPS],

--- a/wgpu-native/src/command/compute.rs
+++ b/wgpu-native/src/command/compute.rs
@@ -17,6 +17,7 @@ use hal::{self, command::RawCommandBuffer};
 
 use std::{iter, slice};
 
+#[derive(Debug)]
 pub struct ComputePass<B: hal::Backend> {
     raw: B::CommandBuffer,
     cmb_id: Stored<CommandBufferId>,

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -59,6 +59,7 @@ pub enum StoreOp {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct RenderPassColorAttachmentDescriptor {
     pub attachment: TextureViewId,
     pub resolve_target: *const TextureViewId,
@@ -68,6 +69,7 @@ pub struct RenderPassColorAttachmentDescriptor {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct RenderPassDepthStencilAttachmentDescriptor<T> {
     pub attachment: T,
     pub depth_load_op: LoadOp,
@@ -79,12 +81,14 @@ pub struct RenderPassDepthStencilAttachmentDescriptor<T> {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct RenderPassDescriptor {
     pub color_attachments: *const RenderPassColorAttachmentDescriptor,
     pub color_attachments_length: usize,
     pub depth_stencil_attachment: *const RenderPassDepthStencilAttachmentDescriptor<TextureViewId>,
 }
 
+#[derive(Debug)]
 pub struct CommandBuffer<B: hal::Backend> {
     pub(crate) raw: Vec<B::CommandBuffer>,
     is_recording: bool,
@@ -147,6 +151,7 @@ impl CommandBufferHandle {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct CommandEncoderDescriptor {
     // MSVC doesn't allow zero-sized structs
     // We can remove this when we actually have a field

--- a/wgpu-native/src/command/render.rs
+++ b/wgpu-native/src/command/render.rs
@@ -109,6 +109,7 @@ impl VertexState {
     }
 }
 
+#[derive(Debug)]
 pub struct RenderPass<B: hal::Backend> {
     raw: B::CommandBuffer,
     cmb_id: Stored<CommandBufferId>,

--- a/wgpu-native/src/command/transfer.rs
+++ b/wgpu-native/src/command/transfer.rs
@@ -22,6 +22,7 @@ use std::iter;
 const BITS_PER_BYTE: u32 = 8;
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct BufferCopyView {
     pub buffer: BufferId,
     pub offset: BufferAddress,
@@ -30,6 +31,7 @@ pub struct BufferCopyView {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct TextureCopyView {
     pub texture: TextureId,
     pub mip_level: u32,

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -113,6 +113,7 @@ enum ResourceId {
     TextureView(TextureViewId),
 }
 
+#[derive(Debug)]
 enum NativeResource<B: hal::Backend> {
     Buffer(B::Buffer, MemoryBlock<B>),
     Image(B::Image, MemoryBlock<B>),
@@ -120,6 +121,7 @@ enum NativeResource<B: hal::Backend> {
     Framebuffer(B::Framebuffer),
 }
 
+#[derive(Debug)]
 struct ActiveSubmission<B: hal::Backend> {
     index: SubmissionIndex,
     fence: B::Fence,
@@ -138,6 +140,7 @@ struct ActiveSubmission<B: hal::Backend> {
 ///   3. When `ActiveSubmission` is retired, the mapped buffers associated with it are moved to `ready_to_map` vector.
 ///   4. Finally, `handle_mapping` issues all the callbacks.
 
+#[derive(Debug)]
 struct PendingResources<B: hal::Backend> {
     /// Resources that the user has requested be mapped, but are still in use.
     mapped: Vec<Stored<BufferId>>,
@@ -515,6 +518,7 @@ impl Device<back::Backend> {
     }
 }
 
+#[derive(Debug)]
 pub struct ShaderModule<B: hal::Backend> {
     pub(crate) raw: B::ShaderModule,
 }

--- a/wgpu-native/src/hub.rs
+++ b/wgpu-native/src/hub.rs
@@ -46,6 +46,7 @@ use vec_map::VecMap;
 use std::{ops, sync::Arc};
 
 /// A simple structure to manage identities of objects.
+#[derive(Debug)]
 pub struct IdentityManager<I: TypedId> {
     free: Vec<Index>,
     epochs: Vec<Epoch>,
@@ -87,6 +88,7 @@ impl<I: TypedId> IdentityManager<I> {
     }
 }
 
+#[derive(Debug)]
 pub struct Storage<T, I: TypedId> {
     //TODO: consider concurrent hashmap?
     map: VecMap<(T, Epoch)>,
@@ -119,6 +121,7 @@ impl<T, I: TypedId> Storage<T, I> {
     }
 }
 
+#[derive(Debug)]
 pub struct Registry<T, I: TypedId> {
     #[cfg(feature = "local")]
     identity: Mutex<IdentityManager<I>>,

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -90,6 +90,7 @@ impl Drop for RefCount {
     }
 }
 
+#[derive(Debug)]
 struct LifeGuard {
     ref_count: RefCount,
     submission_index: AtomicUsize,
@@ -184,6 +185,7 @@ pub struct Extent3d {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct ByteArray {
     pub bytes: *const u8,
     pub length: usize,

--- a/wgpu-native/src/pipeline.rs
+++ b/wgpu-native/src/pipeline.rs
@@ -194,6 +194,7 @@ pub struct VertexAttributeDescriptor {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct VertexBufferDescriptor {
     pub stride: BufferAddress,
     pub step_mode: InputStepMode,
@@ -202,6 +203,7 @@ pub struct VertexBufferDescriptor {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct VertexInputDescriptor {
     pub index_format: IndexFormat,
     pub vertex_buffers: *const VertexBufferDescriptor,
@@ -209,22 +211,26 @@ pub struct VertexInputDescriptor {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct ShaderModuleDescriptor {
     pub code: ByteArray,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct PipelineStageDescriptor {
     pub module: ShaderModuleId,
     pub entry_point: RawString,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct ComputePipelineDescriptor {
     pub layout: PipelineLayoutId,
     pub compute_stage: PipelineStageDescriptor,
 }
 
+#[derive(Debug)]
 pub struct ComputePipeline<B: hal::Backend> {
     pub(crate) raw: B::ComputePipeline,
     pub(crate) layout_id: PipelineLayoutId,
@@ -266,6 +272,7 @@ pub struct RasterizationStateDescriptor {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct RenderPipelineDescriptor {
     pub layout: PipelineLayoutId,
     pub vertex_stage: PipelineStageDescriptor,
@@ -287,6 +294,7 @@ bitflags! {
     }
 }
 
+#[derive(Debug)]
 pub struct RenderPipeline<B: hal::Backend> {
     pub(crate) raw: B::GraphicsPipeline,
     pub(crate) layout_id: PipelineLayoutId,

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -35,13 +35,14 @@ bitflags! {
 }
 
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BufferDescriptor {
     pub size: BufferAddress,
     pub usage: BufferUsage,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub enum BufferMapAsyncStatus {
     Success,
     Error,
@@ -49,7 +50,7 @@ pub enum BufferMapAsyncStatus {
     ContextLost,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum BufferMapOperation {
     Read(std::ops::Range<u64>, BufferMapReadCallback, *mut u8),
     Write(std::ops::Range<u64>, BufferMapWriteCallback, *mut u8),
@@ -58,6 +59,7 @@ pub(crate) enum BufferMapOperation {
 unsafe impl Send for BufferMapOperation {}
 unsafe impl Sync for BufferMapOperation {}
 
+#[derive(Debug)]
 pub struct Buffer<B: hal::Backend> {
     pub(crate) raw: B::Buffer,
     pub(crate) device_id: Stored<DeviceId>,
@@ -166,6 +168,7 @@ bitflags! {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct TextureDescriptor {
     pub size: Extent3d,
     pub array_layer_count: u32,
@@ -176,6 +179,7 @@ pub struct TextureDescriptor {
     pub usage: TextureUsage,
 }
 
+#[derive(Debug)]
 pub(crate) enum TexturePlacement<B: hal::Backend> {
     #[cfg_attr(feature = "remote", allow(unused))]
     SwapChain(SwapChainLink<Mutex<SwapImageEpoch>>),
@@ -194,6 +198,7 @@ impl<B: hal::Backend> TexturePlacement<B> {
     }
 }
 
+#[derive(Debug)]
 pub struct Texture<B: hal::Backend> {
     pub(crate) raw: B::Image,
     pub(crate) device_id: Stored<DeviceId>,
@@ -231,6 +236,7 @@ pub enum TextureViewDimension {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct TextureViewDescriptor {
     pub format: TextureFormat,
     pub dimension: TextureViewDimension,
@@ -241,6 +247,7 @@ pub struct TextureViewDescriptor {
     pub array_count: u32,
 }
 
+#[derive(Debug)]
 pub struct TextureView<B: hal::Backend> {
     pub(crate) raw: B::ImageView,
     pub(crate) texture_id: Stored<TextureId>,
@@ -291,6 +298,7 @@ impl CompareFunction {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct SamplerDescriptor {
     pub address_mode_u: AddressMode,
     pub address_mode_v: AddressMode,
@@ -303,6 +311,7 @@ pub struct SamplerDescriptor {
     pub compare_function: CompareFunction,
 }
 
+#[derive(Debug)]
 pub struct Sampler<B: hal::Backend> {
     pub(crate) raw: B::Sampler,
 }

--- a/wgpu-native/src/swap_chain.rs
+++ b/wgpu-native/src/swap_chain.rs
@@ -26,6 +26,7 @@ pub type SwapImageEpoch = u64;
 
 const FRAME_TIMEOUT_MS: u64 = 1000;
 
+#[derive(Debug)]
 pub(crate) struct SwapChainLink<E> {
     pub swap_chain_id: SwapChainId, //TODO: strongly
     pub epoch: E,
@@ -105,6 +106,7 @@ impl SwapChainDescriptor {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct SwapChainOutput {
     pub texture_id: TextureId,
     pub view_id: TextureViewId,

--- a/wgpu-native/src/track.rs
+++ b/wgpu-native/src/track.rs
@@ -85,7 +85,7 @@ impl GenericUsage for DummyUsage {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Track<U> {
     ref_count: RefCount,
     init: U,
@@ -94,6 +94,7 @@ struct Track<U> {
 }
 
 //TODO: consider having `I` as an associated type of `U`?
+#[derive(Debug)]
 pub struct Tracker<I, U> {
     map: FastHashMap<Index, Track<U>>,
     _phantom: PhantomData<I>,
@@ -113,6 +114,7 @@ pub enum Stitch {
 }
 
 //TODO: consider rewriting this without any iterators that have side effects.
+#[derive(Debug)]
 pub struct ConsumeIterator<'a, I: TypedId, U: Copy + PartialEq> {
     src: Iter<'a, Index, Track<U>>,
     dst: &'a mut FastHashMap<Index, Track<U>>,
@@ -152,6 +154,7 @@ impl<'a, I: TypedId, U: Copy + PartialEq> Drop for ConsumeIterator<'a, I, U> {
     }
 }
 
+#[derive(Debug)]
 pub struct TrackerSet {
     pub buffers: BufferTracker,
     pub textures: TextureTracker,

--- a/wgpu-remote/src/lib.rs
+++ b/wgpu-remote/src/lib.rs
@@ -13,7 +13,7 @@ use std::ptr;
 
 mod server;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 enum InstanceMessage {
     Create(wgn::InstanceId),
     InstanceGetAdapter(wgn::InstanceId, wgn::AdapterDescriptor, wgn::AdapterId),
@@ -22,7 +22,7 @@ enum InstanceMessage {
 }
 
 /// A message on the timeline of devices, queues, and resources.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 enum GlobalMessage {
     Instance(InstanceMessage),
     //Device(DeviceMessage),
@@ -32,24 +32,27 @@ enum GlobalMessage {
     Terminate,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct IdentityHub {
     adapters: wgn::IdentityManager<AdapterId>,
     devices: wgn::IdentityManager<DeviceId>,
 }
 
+#[derive(Debug)]
 pub struct Client {
     channel: ipc::IpcSender<GlobalMessage>,
     instance_id: wgn::InstanceId,
     identity: Mutex<IdentityHub>,
 }
 
+#[derive(Debug)]
 pub struct ClientFactory {
     channel: ipc::IpcSender<GlobalMessage>,
     instance_identities: Mutex<wgn::IdentityManager<InstanceId>>,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct Infrastructure {
     pub factory: *mut ClientFactory,
     pub server: *mut Server,

--- a/wgpu-remote/src/server.rs
+++ b/wgpu-remote/src/server.rs
@@ -3,6 +3,7 @@ use crate::{GlobalMessage, InstanceMessage};
 use ipc_channel::ipc::IpcReceiver;
 use wgn;
 
+#[derive(Debug)]
 pub struct Server {
     channel: IpcReceiver<GlobalMessage>,
 }


### PR DESCRIPTION
This adds `#[derive(Debug)]` to all public structs and enums possible. This also required adding it to some private types that they transitively depend on. However, the following types depend on types from external crates that do not implement Debug:

* `device::Device`
* `hub::Hub`
* `swap_chain::Surface`
* `swap_chain::SwapChain`

To support these types, we would need to use either custom `Debug` impls or something like [Derivative](https://mcarton.github.io/rust-derivative/).

This helps improve the situation in #76.