### PR TITLE
Add Debug Implementations to Remaining Public Types

### DIFF
--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -54,7 +54,16 @@ use rendy_memory::{Block, Heaps, MemoryBlock};
 
 #[cfg(feature = "local")]
 use std::sync::atomic::AtomicBool;
-use std::{collections::hash_map::Entry, ffi, iter, ptr, ops::Range, slice, sync::atomic::Ordering};
+use std::{
+    collections::hash_map::Entry,
+    ffi,
+    fmt,
+    iter,
+    ptr,
+    ops::Range,
+    slice,
+    sync::atomic::Ordering,
+};
 
 const CLEANUP_WAIT_MS: u64 = 5000;
 pub const MAX_COLOR_TARGETS: usize = 4;
@@ -515,6 +524,23 @@ impl Device<back::Backend> {
                 BufferMapOperation::Write(_, on_write, userdata) => on_write(status, ptr, userdata),
             }
         }
+    }
+}
+
+impl<B: hal::Backend> fmt::Debug for Device<B> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Device")
+            .field("raw", &self.raw)
+            .field("adapter_id", &self.adapter_id)
+            .field("com_allocator", &self.com_allocator)
+            .field("mem_allocator", &self.mem_allocator)
+            .field("desc_allocator", &self.desc_allocator)
+            .field("life_guard", &self.life_guard)
+            .field("trackers", &self.trackers)
+            .field("render_passes", &self.render_passes)
+            .field("framebuffers", &self.framebuffers)
+            .field("pending", &self.pending)
+            .finish()
     }
 }
 

--- a/wgpu-native/src/hub.rs
+++ b/wgpu-native/src/hub.rs
@@ -43,7 +43,7 @@ use parking_lot::Mutex;
 use parking_lot::RwLock;
 use vec_map::VecMap;
 
-use std::{ops, sync::Arc};
+use std::{fmt, ops, sync::Arc};
 
 /// A simple structure to manage identities of objects.
 #[derive(Debug)]
@@ -206,4 +206,26 @@ pub struct Hub {
 
 lazy_static! {
     pub static ref HUB: Hub = Hub::default();
+}
+
+impl fmt::Debug for Hub {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Hub")
+            .field("surfaces", &self.surfaces)
+            .field("devices", &self.devices)
+            .field("pipeline_layouts", &self.pipeline_layouts)
+            .field("bind_group_layouts", &self.bind_group_layouts)
+            .field("bind_groups", &self.bind_groups)
+            .field("shader_modules", &self.shader_modules)
+            .field("command_buffers", &self.command_buffers)
+            .field("render_pipelines", &self.render_pipelines)
+            .field("compute_pipelines", &self.compute_pipelines)
+            .field("render_passes", &self.render_passes)
+            .field("compute_passes", &self.compute_passes)
+            .field("buffers", &self.buffers)
+            .field("textures", &self.textures)
+            .field("texture_views", &self.texture_views)
+            .field("samplers", &self.samplers)
+            .finish()
+    }
 }

--- a/wgpu-native/src/swap_chain.rs
+++ b/wgpu-native/src/swap_chain.rs
@@ -18,6 +18,7 @@ use parking_lot::Mutex;
 
 use std::{
     iter,
+    fmt,
     mem,
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -41,6 +42,7 @@ impl SwapChainLink<Mutex<SwapImageEpoch>> {
     }
 }
 
+#[derive(Debug)]
 pub struct Surface<B: hal::Backend> {
     pub(crate) raw: B::Surface,
     pub(crate) swap_chain: Option<SwapChain<B>>,
@@ -76,6 +78,18 @@ pub struct SwapChain<B: hal::Backend> {
     pub(crate) sem_available: B::Semaphore,
     #[cfg_attr(not(feature = "local"), allow(dead_code))] //TODO: remove
     pub(crate) command_pool: hal::CommandPool<B, hal::General>,
+}
+
+impl<B: hal::Backend> fmt::Debug for SwapChain<B> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SwapChain")
+            .field("raw", &self.raw)
+            .field("device_id", &self.device_id)
+            .field("desc", &self.desc)
+            .field("acquired", &self.acquired)
+            .field("sem_available", &self.sem_available)
+            .finish()
+    }
 }
 
 #[repr(C)]


### PR DESCRIPTION
There were some types that could not derive `Debug` automatically in #216 because they (or types they transitively contained) contained types from external crates that do not implement `Debug`. By adding custom `Debug` impls, we can handle this case. The Debug impls given here do the same thing `#[derive(Debug)]` would do, except that they skip the fields that do not themselves implement `Debug`.

After this, all public types will implement `Debug`, as requested in #76.
Closes #76 