### PR TITLE
Implement sample_count field

### DIFF
--- a/wgpu-native/src/conv.rs
+++ b/wgpu-native/src/conv.rs
@@ -414,6 +414,7 @@ pub fn map_texture_dimension_size(
         depth,
     }: Extent3d,
     array_size: u32,
+    sample_size: u32,
 ) -> hal::image::Kind {
     use crate::resource::TextureDimension::*;
     use hal::image::Kind as H;
@@ -421,14 +422,19 @@ pub fn map_texture_dimension_size(
         D1 => {
             assert_eq!(height, 1);
             assert_eq!(depth, 1);
+            assert_eq!(sample_size, 1);
             H::D1(width, checked_u32_as_u16(array_size))
         }
         D2 => {
             assert_eq!(depth, 1);
-            H::D2(width, height, checked_u32_as_u16(array_size), 1) // TODO: Samples
+            assert!(sample_size == 1 || sample_size == 2 || sample_size == 4
+                || sample_size == 8 || sample_size == 16 || sample_size == 32 || sample_size == 64,
+                "Invalid sample_count of {}", sample_size);
+            H::D2(width, height, checked_u32_as_u16(array_size), sample_size as u8)
         }
         D3 => {
             assert_eq!(array_size, 1);
+            assert_eq!(sample_size, 1);
             H::D3(width, height, depth)
         }
     }

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -680,7 +680,7 @@ pub fn device_create_texture(
     device_id: DeviceId,
     desc: &resource::TextureDescriptor,
 ) -> resource::Texture<back::Backend> {
-    let kind = conv::map_texture_dimension_size(desc.dimension, desc.size, desc.array_layer_count);
+    let kind = conv::map_texture_dimension_size(desc.dimension, desc.size, desc.array_layer_count, desc.sample_count);
     let format = conv::map_texture_format(desc.format);
     let aspects = format.surface_desc().aspects;
     let usage = conv::map_texture_usage(desc.usage, aspects);


### PR DESCRIPTION
I'm trying to get MSAA working for brawllib renderer.

This PR allows for more ways to hit validation errors.
Giving a valid but mismatching sample count results in these validation errors.
```
ERROR gfx_backend_vulkan 
VALIDATION [VUID-vkCmdCopyImageToBuffer-srcImage-00188 (0)] : vkCmdCopyImageToBuffer(): srcImage for image 0xe030 was created with a sample count of VK_SAMPLE_COUNT_4_BIT but must be VK_SAMPLE_COUNT_1_BIT. The Vulkan spec states: srcImage must have a sample count equal to VK_SAMPLE_COUNT_1_BIT (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkCmdCopyImageToBuffer-srcImage-00188)
object info: (type: IMAGE, hndl: 57392)

ERROR gfx_backend_vulkan 
VALIDATION [UNASSIGNED-CoreValidation-DrawState-NumSamplesMismatch (0)] : Num samples mismatch! At draw-time in Pipeline (0x7) with 1 samples while current RenderPass (0xe) w/ 4 samples!
object info: (type: PIPELINE, hndl: 7)

ERROR gfx_backend_vulkan 
VALIDATION [VUID-vkCmdDrawIndexed-renderPass-02684 (0)] : vkCmdDrawIndexed(): RenderPasses incompatible between active render pass w/ renderPass 0xe and pipeline state object w/ renderPass 0x6 Attachment 0 is not compatible with 0: They have different samples.. The Vulkan spec states: The current render pass must be compatible with the renderPass member of the VkGraphicsPipelineCreateInfo structure specified when creating the VkPipeline bound to VK_PIPELINE_BIND_POINT_GRAPHICS. (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkCmdDrawIndexed-renderPass-02684)
object info: (type: RENDER_PASS, hndl: 14)
```