### PR TITLE
Re-export Pod from gfx-hal

### DIFF
--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -40,6 +40,7 @@ pub use self::instance::*;
 pub use self::pipeline::*;
 pub use self::resource::*;
 pub use self::swap_chain::*;
+pub use hal::memory::Pod as Pod;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
This way, Pod can be used as a trait bound in wgpu-rs