### PR TITLE
Run-time lock protection against double root

### DIFF
--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -2000,8 +2000,10 @@ pub extern "C" fn wgpu_device_create_swap_chain(
 
 #[no_mangle]
 pub extern "C" fn wgpu_device_poll(device_id: DeviceId, force_wait: bool) {
-    let (device_guard, mut token) = HUB.devices.read(&mut Token::root());
-    let callbacks = device_guard[device_id].maintain(force_wait, &mut token);
+    let callbacks = {
+        let (device_guard, mut token) = HUB.devices.read(&mut Token::root());
+        device_guard[device_id].maintain(force_wait, &mut token)
+    };
     Device::fire_map_callbacks(callbacks);
 }
 


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/wgpu-rs/issues/42
cc @paulkernfeld 

We didn't handle a case where the root locking token would get dropped (while some children are borrowed), and a new one is created. This was the case in `wgpu_device_poll`, which ended up trying to unmap the buffers.

This PR brings a relatively simple run-time check for this. It could *probably* be done at the type level, but I'm going to leave it for any follow ups (help is welcome!), because:
  1. we'll still have a run-time check for the simple case where 2 or more root tokens are created
  2. I spent 20 minutes trying and wasn't able to get this going