### PR TITLE
streamline Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ BUILD_DIR:=build
 CLEAN_FFI_DIR:=
 CREATE_BUILD_DIR:=
 
+WILDCARD_WGPU_NATIVE:=$(wildcard wgpu-native/**/*.rs)
+WILDCARD_WGPU_NATIVE_AND_REMOTE:=$(wildcard wgpu-native/**/*.rs wgpu-remote/**/*.rs)
+
 ifeq (,$(TARGET))
 	CHECK_TARGET_FLAG=
 else
@@ -43,7 +46,6 @@ else
 	endif
 endif
 
-
 .PHONY: all check test doc clear lib-native lib-remote examples-native examples-remote
 
 all: examples-native examples-remote
@@ -61,16 +63,16 @@ clear:
 	cargo clean
 	$(CLEAN_FFI_DIR)
 
-lib-native: Cargo.lock wgpu-native/Cargo.toml $(wildcard wgpu-native/**/*.rs)
+lib-native: Cargo.lock wgpu-native/Cargo.toml $(WILDCARD_WGPU_NATIVE)
 	cargo build --manifest-path wgpu-native/Cargo.toml --features "local,$(FEATURE_NATIVE)"
 
-lib-remote: Cargo.lock wgpu-remote/Cargo.toml $(wildcard wgpu-native/**/*.rs wgpu-remote/**/*.rs)
+lib-remote: Cargo.lock wgpu-remote/Cargo.toml $(WILDCARD_WGPU_NATIVE_AND_REMOTE)
 	cargo build --manifest-path wgpu-remote/Cargo.toml --features $(FEATURE_RUST)
 
-ffi/wgpu.h: wgpu-native/cbindgen.toml $(wildcard wgpu-native/**/*.rs)
+ffi/wgpu.h: wgpu-native/cbindgen.toml $(WILDCARD_WGPU_NATIVE)
 	rustup run nightly cbindgen wgpu-native > $(FFI_DIR)/wgpu.h
 
-ffi/wgpu-remote.h: wgpu-remote/cbindgen.toml $(wildcard wgpu-native/**/*.rs wgpu-remote/**/*.rs)
+ffi/wgpu-remote.h: wgpu-remote/cbindgen.toml $(WILDCARD_WGPU_NATIVE_AND_REMOTE)
 	rustup run nightly cbindgen wgpu-remote > $(FFI_DIR)/wgpu-remote.h
 
 example-compute: lib-native $(FFI_DIR)/wgpu.h examples/compute/main.c


### PR DESCRIPTION
Changes:
- Streamlining the Make commands to make it look better
- Introduced two new variables: `WILDCARD_WGPU_NATIVE` & `WILDCARD_WGPU_NATIVE_AND_REMOTE` to reduce duplicate code. Will continue to reduce duplicate after my compute example is merged, to avoid unnecessary merge conflicts

Maybe I am not too familiar with the concept FFI, but wouldn't it be easier to understand that we just generate headers and not foreign function interfaces. Basically the same, but the latter one sounds a lot more complex. We want to reach as much as possible people, so maybe renaming this would be beneficial?

So I was thinking to have the commands: `header-wgpu` and `header-wgpu-remote`, instead of `ffi-wgpu` and `ffi-wgpu-remote`.
