### PR TITLE
Remove pod add read_spirv

### DIFF
--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -40,7 +40,7 @@ pub use self::instance::*;
 pub use self::pipeline::*;
 pub use self::resource::*;
 pub use self::swap_chain::*;
-pub use hal::memory::Pod as Pod;
+pub use hal::pso::read_spirv;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Looks like Pod is no longer used by wgpu-rs so I removed it.
read_spirv is needed in wgpu-rs now so I added it.