### PR TITLE
Update rendy-memory and rendy-descriptor to 0.4 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,8 +1047,8 @@ dependencies = [
 
 [[package]]
 name = "rendy-descriptor"
-version = "0.3.0"
-source = "git+https://github.com/amethyst/rendy?rev=db6adbe7454f52ebf559a38dd88580aa3ebbcaaf#db6adbe7454f52ebf559a38dd88580aa3ebbcaaf"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1060,8 +1060,8 @@ dependencies = [
 
 [[package]]
 name = "rendy-memory"
-version = "0.3.0"
-source = "git+https://github.com/amethyst/rendy?rev=db6adbe7454f52ebf559a38dd88580aa3ebbcaaf#db6adbe7454f52ebf559a38dd88580aa3ebbcaaf"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "colorful 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1464,8 +1464,8 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rendy-descriptor 0.3.0 (git+https://github.com/amethyst/rendy?rev=db6adbe7454f52ebf559a38dd88580aa3ebbcaaf)",
- "rendy-memory 0.3.0 (git+https://github.com/amethyst/rendy?rev=db6adbe7454f52ebf559a38dd88580aa3ebbcaaf)",
+ "rendy-descriptor 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rendy-memory 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winit 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1713,8 +1713,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum relevant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bbc232e13d37f4547f5b9b42a5efc380cabe5dbc1807f8b893580640b2ab0308"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum rendy-descriptor 0.3.0 (git+https://github.com/amethyst/rendy?rev=db6adbe7454f52ebf559a38dd88580aa3ebbcaaf)" = "<none>"
-"checksum rendy-memory 0.3.0 (git+https://github.com/amethyst/rendy?rev=db6adbe7454f52ebf559a38dd88580aa3ebbcaaf)" = "<none>"
+"checksum rendy-descriptor 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "263d22222b4cfe0394df001c06ff1fab363f8cb79b6ab9d8fa2d030fdcdf68b0"
+"checksum rendy-memory 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "557ed61c95042de292b4347124e9e77ec76954618cb6eeb50cec1a98d3adf51f"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusttype 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "25951e85bb2647960969f72c559392245a5bd07446a589390bf427dda31cdc4a"

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -41,8 +41,8 @@ gfx-backend-dx11 = { version = "0.3.0", optional = true }
 gfx-backend-metal = { version = "0.3.0", optional = true }
 gfx-backend-gl = { version = "0.3.0", optional = true }
 parking_lot = { version = "0.9" }
-rendy-memory = { git = "https://github.com/amethyst/rendy", rev = "db6adbe7454f52ebf559a38dd88580aa3ebbcaaf" }
-rendy-descriptor = { git = "https://github.com/amethyst/rendy", rev = "db6adbe7454f52ebf559a38dd88580aa3ebbcaaf" }
+rendy-memory = { version = "0.4" }
+rendy-descriptor = { version = "0.4" }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 vec_map = "0.8"
 winit = { version = "0.19", optional = true }


### PR DESCRIPTION
I also locally tested for regressions in `wgpu-rs` on the metal backend (only have macOS today) and the examples seemed ok.