### PR TITLE
Rename buffer to encoder in wgpu_command_buffer_copy_* functions

### DIFF
--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -102,7 +102,7 @@ int main(
             .todo = 0
         });
 
-    wgpu_command_buffer_copy_buffer_to_buffer(
+    wgpu_command_encoder_copy_buffer_to_buffer(
         encoder, staging_buffer, 0, storage_buffer, 0, size);
 
     WGPUComputePassId command_pass =
@@ -113,7 +113,7 @@ int main(
     wgpu_compute_pass_dispatch(command_pass, numbers_length, 1, 1);
     wgpu_compute_pass_end_pass(command_pass);
 
-    wgpu_command_buffer_copy_buffer_to_buffer(
+    wgpu_command_encoder_copy_buffer_to_buffer(
         encoder, storage_buffer, 0, staging_buffer, 0, size);
 
     WGPUQueueId queue = wgpu_device_get_queue(device);

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -283,44 +283,13 @@ typedef void (*WGPUBufferMapReadCallback)(WGPUBufferMapAsyncStatus status, const
 
 typedef void (*WGPUBufferMapWriteCallback)(WGPUBufferMapAsyncStatus status, uint8_t *data, uint8_t *userdata);
 
-typedef WGPUId WGPUGenericId_CommandBufferHandle;
-
-typedef WGPUGenericId_CommandBufferHandle WGPUCommandBufferId;
-
-typedef struct {
-  WGPUBufferId buffer;
-  WGPUBufferAddress offset;
-  uint32_t row_pitch;
-  uint32_t image_height;
-} WGPUBufferCopyView;
-
-typedef WGPUId WGPUGenericId_TextureHandle;
-
-typedef WGPUGenericId_TextureHandle WGPUTextureId;
-
-typedef struct {
-  float x;
-  float y;
-  float z;
-} WGPUOrigin3d;
-#define WGPUOrigin3d_ZERO (WGPUOrigin3d){ .x = 0, .y = 0, .z = 0 }
-
-typedef struct {
-  WGPUTextureId texture;
-  uint32_t mip_level;
-  uint32_t array_layer;
-  WGPUOrigin3d origin;
-} WGPUTextureCopyView;
-
-typedef struct {
-  uint32_t width;
-  uint32_t height;
-  uint32_t depth;
-} WGPUExtent3d;
-
 typedef WGPUId WGPUGenericId_ComputePassHandle;
 
 typedef WGPUGenericId_ComputePassHandle WGPUComputePassId;
+
+typedef WGPUId WGPUGenericId_CommandBufferHandle;
+
+typedef WGPUGenericId_CommandBufferHandle WGPUCommandBufferId;
 
 typedef WGPUCommandBufferId WGPUCommandEncoderId;
 
@@ -368,6 +337,37 @@ typedef struct {
   uintptr_t color_attachments_length;
   const WGPURenderPassDepthStencilAttachmentDescriptor_TextureViewId *depth_stencil_attachment;
 } WGPURenderPassDescriptor;
+
+typedef struct {
+  WGPUBufferId buffer;
+  WGPUBufferAddress offset;
+  uint32_t row_pitch;
+  uint32_t image_height;
+} WGPUBufferCopyView;
+
+typedef WGPUId WGPUGenericId_TextureHandle;
+
+typedef WGPUGenericId_TextureHandle WGPUTextureId;
+
+typedef struct {
+  float x;
+  float y;
+  float z;
+} WGPUOrigin3d;
+#define WGPUOrigin3d_ZERO (WGPUOrigin3d){ .x = 0, .y = 0, .z = 0 }
+
+typedef struct {
+  WGPUTextureId texture;
+  uint32_t mip_level;
+  uint32_t array_layer;
+  WGPUOrigin3d origin;
+} WGPUTextureCopyView;
+
+typedef struct {
+  uint32_t width;
+  uint32_t height;
+  uint32_t depth;
+} WGPUExtent3d;
 
 typedef struct {
   uint32_t todo;
@@ -688,28 +688,6 @@ void wgpu_buffer_map_write_async(WGPUBufferId buffer_id,
 
 void wgpu_buffer_unmap(WGPUBufferId buffer_id);
 
-void wgpu_command_buffer_copy_buffer_to_buffer(WGPUCommandBufferId command_buffer_id,
-                                               WGPUBufferId source,
-                                               WGPUBufferAddress source_offset,
-                                               WGPUBufferId destination,
-                                               WGPUBufferAddress destination_offset,
-                                               WGPUBufferAddress size);
-
-void wgpu_command_buffer_copy_buffer_to_texture(WGPUCommandBufferId command_buffer_id,
-                                                const WGPUBufferCopyView *source,
-                                                const WGPUTextureCopyView *destination,
-                                                WGPUExtent3d copy_size);
-
-void wgpu_command_buffer_copy_texture_to_buffer(WGPUCommandBufferId command_buffer_id,
-                                                const WGPUTextureCopyView *source,
-                                                const WGPUBufferCopyView *destination,
-                                                WGPUExtent3d copy_size);
-
-void wgpu_command_buffer_copy_texture_to_texture(WGPUCommandBufferId command_buffer_id,
-                                                 const WGPUTextureCopyView *source,
-                                                 const WGPUTextureCopyView *destination,
-                                                 WGPUExtent3d copy_size);
-
 #if defined(WGPU_LOCAL)
 WGPUComputePassId wgpu_command_encoder_begin_compute_pass(WGPUCommandEncoderId command_encoder_id);
 #endif
@@ -718,6 +696,28 @@ WGPUComputePassId wgpu_command_encoder_begin_compute_pass(WGPUCommandEncoderId c
 WGPURenderPassId wgpu_command_encoder_begin_render_pass(WGPUCommandEncoderId command_encoder_id,
                                                         const WGPURenderPassDescriptor *desc);
 #endif
+
+void wgpu_command_encoder_copy_buffer_to_buffer(WGPUCommandEncoderId command_encoder_id,
+                                                WGPUBufferId source,
+                                                WGPUBufferAddress source_offset,
+                                                WGPUBufferId destination,
+                                                WGPUBufferAddress destination_offset,
+                                                WGPUBufferAddress size);
+
+void wgpu_command_encoder_copy_buffer_to_texture(WGPUCommandEncoderId command_encoder_id,
+                                                 const WGPUBufferCopyView *source,
+                                                 const WGPUTextureCopyView *destination,
+                                                 WGPUExtent3d copy_size);
+
+void wgpu_command_encoder_copy_texture_to_buffer(WGPUCommandEncoderId command_encoder_id,
+                                                 const WGPUTextureCopyView *source,
+                                                 const WGPUBufferCopyView *destination,
+                                                 WGPUExtent3d copy_size);
+
+void wgpu_command_encoder_copy_texture_to_texture(WGPUCommandEncoderId command_encoder_id,
+                                                  const WGPUTextureCopyView *source,
+                                                  const WGPUTextureCopyView *destination,
+                                                  WGPUExtent3d copy_size);
 
 WGPUCommandBufferId wgpu_command_encoder_finish(WGPUCommandEncoderId command_encoder_id,
                                                 const WGPUCommandBufferDescriptor *_desc);

--- a/wgpu-native/src/command/transfer.rs
+++ b/wgpu-native/src/command/transfer.rs
@@ -7,7 +7,7 @@ use crate::{
     BufferAddress,
     BufferId,
     BufferUsage,
-    CommandBufferId,
+    CommandEncoderId,
     Extent3d,
     Origin3d,
     TextureId,
@@ -65,8 +65,8 @@ impl TextureCopyView {
 }
 
 #[no_mangle]
-pub extern "C" fn wgpu_command_buffer_copy_buffer_to_buffer(
-    command_buffer_id: CommandBufferId,
+pub extern "C" fn wgpu_command_encoder_copy_buffer_to_buffer(
+    command_encoder_id: CommandEncoderId,
     source: BufferId,
     source_offset: BufferAddress,
     destination: BufferId,
@@ -75,7 +75,7 @@ pub extern "C" fn wgpu_command_buffer_copy_buffer_to_buffer(
 ) {
     let mut token = Token::root();
     let (mut cmb_guard, mut token) = HUB.command_buffers.write(&mut token);
-    let cmb = &mut cmb_guard[command_buffer_id];
+    let cmb = &mut cmb_guard[command_encoder_id];
     let (buffer_guard, _) = HUB.buffers.read(&mut token);
     // we can't hold both src_pending and dst_pending in scope because they
     // borrow the buffer tracker mutably...
@@ -120,15 +120,15 @@ pub extern "C" fn wgpu_command_buffer_copy_buffer_to_buffer(
 }
 
 #[no_mangle]
-pub extern "C" fn wgpu_command_buffer_copy_buffer_to_texture(
-    command_buffer_id: CommandBufferId,
+pub extern "C" fn wgpu_command_encoder_copy_buffer_to_texture(
+    command_encoder_id: CommandEncoderId,
     source: &BufferCopyView,
     destination: &TextureCopyView,
     copy_size: Extent3d,
 ) {
     let mut token = Token::root();
     let (mut cmb_guard, mut token) = HUB.command_buffers.write(&mut token);
-    let cmb = &mut cmb_guard[command_buffer_id];
+    let cmb = &mut cmb_guard[command_encoder_id];
     let (buffer_guard, mut token) = HUB.buffers.read(&mut token);
     let (texture_guard, _) = HUB.textures.read(&mut token);
     let aspects = texture_guard[destination.texture].full_range.aspects;
@@ -198,15 +198,15 @@ pub extern "C" fn wgpu_command_buffer_copy_buffer_to_texture(
 }
 
 #[no_mangle]
-pub extern "C" fn wgpu_command_buffer_copy_texture_to_buffer(
-    command_buffer_id: CommandBufferId,
+pub extern "C" fn wgpu_command_encoder_copy_texture_to_buffer(
+    command_encoder_id: CommandEncoderId,
     source: &TextureCopyView,
     destination: &BufferCopyView,
     copy_size: Extent3d,
 ) {
     let mut token = Token::root();
     let (mut cmb_guard, mut token) = HUB.command_buffers.write(&mut token);
-    let cmb = &mut cmb_guard[command_buffer_id];
+    let cmb = &mut cmb_guard[command_encoder_id];
     let (buffer_guard, mut token) = HUB.buffers.read(&mut token);
     let (texture_guard, _) = HUB.textures.read(&mut token);
     let aspects = texture_guard[source.texture].full_range.aspects;
@@ -275,15 +275,15 @@ pub extern "C" fn wgpu_command_buffer_copy_texture_to_buffer(
 }
 
 #[no_mangle]
-pub extern "C" fn wgpu_command_buffer_copy_texture_to_texture(
-    command_buffer_id: CommandBufferId,
+pub extern "C" fn wgpu_command_encoder_copy_texture_to_texture(
+    command_encoder_id: CommandEncoderId,
     source: &TextureCopyView,
     destination: &TextureCopyView,
     copy_size: Extent3d,
 ) {
     let mut token = Token::root();
     let (mut cmb_guard, mut token) = HUB.command_buffers.write(&mut token);
-    let cmb = &mut cmb_guard[command_buffer_id];
+    let cmb = &mut cmb_guard[command_encoder_id];
     let (_, mut token) = HUB.buffers.read(&mut token); // skip token
     let (texture_guard, _) = HUB.textures.read(&mut token);
     // we can't hold both src_pending and dst_pending in scope because they


### PR DESCRIPTION
This also regenerates `wgpu.h` and updates uses of `wgpu_command_buffer_copy_buffer_to_buffer` in `compute/main.c`.

EDIT: all good...
~Note that I couldn't regenerate `wgpu-remote.h` because of the following cbindgen error:~

```
ERROR: Cannot find a mangling for generic path GenericPath { path: Path { name: "Adapter" }, export_name: "Adapter", generics: [Path(GenericPath { path: Path { name: "Backend" }, export_name: "Backend", generics: [], ctype: None })], ctype: None }. This usually means that a type referenced by this generic was incompatible or not found.
```

Should we investigate before merging? Maybe I am just using an unlucky nightly?

Closes: #250 