### PR TITLE
Validate resource usage flags when used

### DIFF
--- a/wgpu-native/src/command/compute.rs
+++ b/wgpu-native/src/command/compute.rs
@@ -205,6 +205,7 @@ pub fn compute_pass_dispatch_indirect<B: GfxBackend>(
         (),
         BufferUsage::INDIRECT,
     );
+    assert!(src_buffer.usage.contains(BufferUsage::INDIRECT));
 
     let barriers = src_pending.map(|pending| hal::memory::Barrier::Buffer {
         states: pending.to_states(),

--- a/wgpu-native/src/command/render.rs
+++ b/wgpu-native/src/command/render.rs
@@ -320,6 +320,7 @@ pub fn render_pass_set_index_buffer<B: GfxBackend>(
         .buffers
         .use_extend(&*buffer_guard, buffer_id, (), BufferUsage::INDEX)
         .unwrap();
+    assert!(buffer.usage.contains(BufferUsage::INDEX));
 
     let range = offset .. buffer.size;
     pass.index_state.bound_buffer_view = Some((buffer_id, range));
@@ -368,6 +369,8 @@ pub fn render_pass_set_vertex_buffers<B: GfxBackend>(
             .buffers
             .use_extend(&*buffer_guard, id, (), BufferUsage::VERTEX)
             .unwrap();
+        assert!(buffer.usage.contains(BufferUsage::VERTEX));
+
         vbs.total_size = buffer.size - offset;
     }
 
@@ -459,6 +462,7 @@ pub fn render_pass_draw_indirect<B: GfxBackend>(
             BufferUsage::INDIRECT,
         )
         .unwrap();
+    assert!(buffer.usage.contains(BufferUsage::INDIRECT));
 
     unsafe {
         pass.raw.draw_indirect(&buffer.raw, indirect_offset, 1, 0);
@@ -541,6 +545,7 @@ pub fn render_pass_draw_indexed_indirect<B: GfxBackend>(
             BufferUsage::INDIRECT,
         )
         .unwrap();
+    assert!(buffer.usage.contains(BufferUsage::INDIRECT));
 
     unsafe {
         pass.raw

--- a/wgpu-native/src/command/transfer.rs
+++ b/wgpu-native/src/command/transfer.rs
@@ -85,6 +85,8 @@ pub fn command_encoder_copy_buffer_to_buffer<B: GfxBackend>(
         cmb.trackers
             .buffers
             .use_replace(&*buffer_guard, source, (), BufferUsage::COPY_SRC);
+    assert!(src_buffer.usage.contains(BufferUsage::COPY_SRC));
+
     barriers.extend(src_pending.map(|pending| hal::memory::Barrier::Buffer {
         states: pending.to_states(),
         target: &src_buffer.raw,
@@ -96,6 +98,8 @@ pub fn command_encoder_copy_buffer_to_buffer<B: GfxBackend>(
         cmb.trackers
             .buffers
             .use_replace(&*buffer_guard, destination, (), BufferUsage::COPY_DST);
+    assert!(dst_buffer.usage.contains(BufferUsage::COPY_DST));
+
     barriers.extend(dst_pending.map(|pending| hal::memory::Barrier::Buffer {
         states: pending.to_states(),
         target: &dst_buffer.raw,
@@ -155,6 +159,8 @@ pub fn command_encoder_copy_buffer_to_texture<B: GfxBackend>(
         cmb.trackers
             .buffers
             .use_replace(&*buffer_guard, source.buffer, (), BufferUsage::COPY_SRC);
+    assert!(src_buffer.usage.contains(BufferUsage::COPY_SRC));
+
     let src_barriers = src_pending.map(|pending| hal::memory::Barrier::Buffer {
         states: pending.to_states(),
         target: &src_buffer.raw,
@@ -168,6 +174,8 @@ pub fn command_encoder_copy_buffer_to_texture<B: GfxBackend>(
         destination.to_selector(aspects),
         TextureUsage::COPY_DST,
     );
+    assert!(dst_texture.usage.contains(TextureUsage::COPY_DST));
+
     let dst_barriers = dst_pending.map(|pending| hal::memory::Barrier::Image {
         states: pending.to_states(),
         target: &dst_texture.raw,
@@ -249,6 +257,8 @@ pub fn command_encoder_copy_texture_to_buffer<B: GfxBackend>(
         source.to_selector(aspects),
         TextureUsage::COPY_SRC,
     );
+    assert!(src_texture.usage.contains(TextureUsage::COPY_SRC));
+
     let src_barriers = src_pending.map(|pending| hal::memory::Barrier::Image {
         states: pending.to_states(),
         target: &src_texture.raw,
@@ -266,6 +276,8 @@ pub fn command_encoder_copy_texture_to_buffer<B: GfxBackend>(
         (),
         BufferUsage::COPY_DST,
     );
+    assert!(dst_buffer.usage.contains(BufferUsage::COPY_DST));
+
     let dst_barrier = dst_barriers.map(|pending| hal::memory::Barrier::Buffer {
         states: pending.to_states(),
         target: &dst_buffer.raw,
@@ -344,6 +356,8 @@ pub fn command_encoder_copy_texture_to_texture<B: GfxBackend>(
         source.to_selector(aspects),
         TextureUsage::COPY_SRC,
     );
+    assert!(src_texture.usage.contains(TextureUsage::COPY_SRC));
+
     barriers.extend(src_pending.map(|pending| hal::memory::Barrier::Image {
         states: pending.to_states(),
         target: &src_texture.raw,
@@ -357,6 +371,8 @@ pub fn command_encoder_copy_texture_to_texture<B: GfxBackend>(
         destination.to_selector(aspects),
         TextureUsage::COPY_DST,
     );
+    assert!(dst_texture.usage.contains(TextureUsage::COPY_DST));
+
     barriers.extend(dst_pending.map(|pending| hal::memory::Barrier::Image {
         states: pending.to_states(),
         target: &dst_texture.raw,

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -89,6 +89,7 @@ impl BufferMapOperation {
 pub struct Buffer<B: hal::Backend> {
     pub(crate) raw: B::Buffer,
     pub(crate) device_id: Stored<DeviceId>,
+    pub(crate) usage: BufferUsage,
     pub(crate) memory: MemoryBlock<B>,
     pub(crate) size: BufferAddress,
     pub(crate) mapped_write_ranges: Vec<std::ops::Range<u64>>,
@@ -226,6 +227,7 @@ impl<B: hal::Backend> TexturePlacement<B> {
 pub struct Texture<B: hal::Backend> {
     pub(crate) raw: B::Image,
     pub(crate) device_id: Stored<DeviceId>,
+    pub(crate) usage: TextureUsage,
     pub(crate) kind: hal::image::Kind,
     pub(crate) format: TextureFormat,
     pub(crate) full_range: hal::image::SubresourceRange,


### PR DESCRIPTION
This PR adds usage flag validations to the functions discussed in https://github.com/gfx-rs/wgpu/issues/228#issuecomment-528949445 and https://github.com/gfx-rs/wgpu/issues/228#issuecomment-528953096

I added `usage` fields to `Buffer` and `Texture` for convenience.

The validations themselves are run before much else happens (seemed clearer that way). This means certain `VecMap`s and `FastHashMap`s might be queried more than necessary, though. 

I also left one TODO in, which I'd like to resolve: With what usage flags should the swapchain textures be created? Currently it initializes the texture resource trackers with `UNINITIALIZED`, so I just copied the same flag for the texture. This just happens to work (that is not trigger the validations I added), because its value, `UNINITIALIZED`, pretends to be every usage flag by having all bits set. Is that by design?

Closes #228 ~(except for `BufferUsage::INDIRECT`, for which I can create another issue)~