### PR TITLE
Track and destroy samplers

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -899,6 +899,8 @@ void wgpu_render_pass_set_viewport(WGPURenderPassId pass_id,
 WGPUAdapterId wgpu_request_adapter(const WGPURequestAdapterOptions *desc);
 #endif
 
+void wgpu_sampler_destroy(WGPUSamplerId sampler_id);
+
 #if !defined(WGPU_REMOTE)
 WGPUSwapChainOutput wgpu_swap_chain_get_next_texture(WGPUSwapChainId swap_chain_id);
 #endif

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -160,6 +160,7 @@ impl<B: GfxBackend> CommandBuffer<B> {
             });
         base.views.merge_extend(&head.views).unwrap();
         base.bind_groups.merge_extend(&head.bind_groups).unwrap();
+        base.samplers.merge_extend(&head.samplers).unwrap();
 
         let stages = all_buffer_stages() | all_image_stages();
         unsafe {

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -135,6 +135,7 @@ enum ResourceId {
     Texture(TextureId),
     TextureView(TextureViewId),
     BindGroup(BindGroupId),
+    Sampler(SamplerId),
 }
 
 #[derive(Debug)]
@@ -144,6 +145,7 @@ enum NativeResource<B: hal::Backend> {
     ImageView(B::ImageView),
     Framebuffer(B::Framebuffer),
     DescriptorSet(DescriptorSet<B>),
+    Sampler(B::Sampler),
 }
 
 #[derive(Debug)]
@@ -257,6 +259,9 @@ impl<B: GfxBackend> PendingResources<B> {
                 NativeResource::DescriptorSet(raw) => unsafe {
                     descriptor_allocator.free(iter::once(raw));
                 },
+                NativeResource::Sampler(raw) => unsafe {
+                    device.destroy_sampler(raw);
+                },
             }
         }
 
@@ -279,7 +284,8 @@ impl<B: GfxBackend> PendingResources<B> {
         let (mut bind_group_guard, mut token) = hub.bind_groups.write(&mut token);
         let (mut buffer_guard, mut token) = hub.buffers.write(&mut token);
         let (mut texture_guard, mut token) = hub.textures.write(&mut token);
-        let (mut teview_view_guard, _) = hub.texture_views.write(&mut token);
+        let (mut teview_view_guard, mut token) = hub.texture_views.write(&mut token);
+        let (mut sampler_guard, _) = hub.samplers.write(&mut token);
 
         for i in (0 .. self.referenced.len()).rev() {
             let num_refs = self.referenced[i].1.load();
@@ -328,6 +334,13 @@ impl<B: GfxBackend> PendingResources<B> {
                             bind_group.life_guard,
                             NativeResource::DescriptorSet(bind_group.raw),
                         )
+                    }
+                    ResourceId::Sampler(id) => {
+                        trackers.samplers.remove(id);
+                        let sampler = sampler_guard.remove(id).unwrap();
+                        #[cfg(not(feature = "remote"))]
+                        hub.samplers.identity.lock().free(id);
+                        (sampler.life_guard, NativeResource::Sampler(sampler.raw))
                     }
                 };
 
@@ -1041,6 +1054,11 @@ pub fn device_create_sampler<B: GfxBackend>(
 
     let sampler = resource::Sampler {
         raw: unsafe { device.raw.create_sampler(info).unwrap() },
+        device_id: Stored {
+            value: device_id,
+            ref_count: device.life_guard.ref_count.clone(),
+        },
+        life_guard: LifeGuard::new(),
     };
     hub.samplers.register_identity(id_in, sampler, &mut token)
 }
@@ -1052,6 +1070,26 @@ pub extern "C" fn wgpu_device_create_sampler(
     desc: &resource::SamplerDescriptor,
 ) -> SamplerId {
     gfx_select!(device_id => device_create_sampler(device_id, desc, PhantomData))
+}
+
+pub fn sampler_destroy<B: GfxBackend>(sampler_id: SamplerId) {
+    let hub = B::hub();
+    let mut token = Token::root();
+    let (device_guard, mut token) = hub.devices.read(&mut token);
+    let (sampler_guard, _) = hub.samplers.read(&mut token);
+    let sampler = &sampler_guard[sampler_id];
+    device_guard[sampler.device_id.value]
+        .pending
+        .lock()
+        .destroy(
+            ResourceId::Sampler(sampler_id),
+            sampler.life_guard.ref_count.clone(),
+        );
+}
+
+#[no_mangle]
+pub extern "C" fn wgpu_sampler_destroy(sampler_id: SamplerId) {
+    gfx_select!(sampler_id => sampler_destroy(sampler_id))
 }
 
 pub fn device_create_bind_group_layout<B: GfxBackend>(

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -360,4 +360,6 @@ pub struct SamplerDescriptor {
 #[derive(Debug)]
 pub struct Sampler<B: hal::Backend> {
     pub(crate) raw: B::Sampler,
+    pub(crate) device_id: Stored<DeviceId>,
+    pub(crate) life_guard: LifeGuard,
 }

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -363,3 +363,9 @@ pub struct Sampler<B: hal::Backend> {
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) life_guard: LifeGuard,
 }
+
+impl<B: hal::Backend> Borrow<RefCount> for Sampler<B> {
+    fn borrow(&self) -> &RefCount {
+        &self.life_guard.ref_count
+    }
+}

--- a/wgpu-native/src/track/mod.rs
+++ b/wgpu-native/src/track/mod.rs
@@ -441,6 +441,7 @@ impl TrackerSet {
         self.textures.clear();
         self.views.clear();
         self.bind_groups.clear();
+        self.samplers.clear();
     }
 
     /// Try to optimize the tracking representation.
@@ -449,6 +450,7 @@ impl TrackerSet {
         self.textures.optimize();
         self.views.optimize();
         self.bind_groups.optimize();
+        self.samplers.optimize();
     }
 
     /// Merge all the trackers of another instance by extending
@@ -458,6 +460,7 @@ impl TrackerSet {
         self.textures.merge_extend(&other.textures).unwrap();
         self.views.merge_extend(&other.views).unwrap();
         self.bind_groups.merge_extend(&other.bind_groups).unwrap();
+        self.samplers.merge_extend(&other.samplers).unwrap();
     }
 
     pub fn backend(&self) -> Backend {

--- a/wgpu-native/src/track/mod.rs
+++ b/wgpu-native/src/track/mod.rs
@@ -2,7 +2,17 @@ mod buffer;
 mod range;
 mod texture;
 
-use crate::{hub::Storage, Backend, BindGroupId, Epoch, Index, RefCount, TextureViewId, TypedId};
+use crate::{
+    hub::Storage,
+    Backend,
+    BindGroupId,
+    Epoch,
+    Index,
+    RefCount,
+    SamplerId,
+    TextureViewId,
+    TypedId,
+};
 
 use hal::backend::FastHashMap;
 
@@ -410,7 +420,7 @@ pub struct TrackerSet {
     pub textures: ResourceTracker<TextureState>,
     pub views: ResourceTracker<PhantomData<TextureViewId>>,
     pub bind_groups: ResourceTracker<PhantomData<BindGroupId>>,
-    //TODO: samplers
+    pub samplers: ResourceTracker<PhantomData<SamplerId>>,
 }
 
 impl TrackerSet {
@@ -421,6 +431,7 @@ impl TrackerSet {
             textures: ResourceTracker::new(backend),
             views: ResourceTracker::new(backend),
             bind_groups: ResourceTracker::new(backend),
+            samplers: ResourceTracker::new(backend),
         }
     }
 


### PR DESCRIPTION
This PR adds `ResourceId::Sampler`, `NativeResource::Sampler` and
`TrackerSet::samplers`. Samplers are (similarly to bind groups)
created with their own life guard and a device id to keep the device
ref count alive. Also added are `extern wgpu_sampler_destroy` and
`sampler_destroy`.

The rest of the implementation was guided by compiler errors, so there
is a good chance I didn't find something crucial that also needed
doing. Please check :)

I also imagine we might want to add the `Drop` impl for sampler in wgpu-rs.

Fixes: #231 