### PR TITLE
Add license headers to all Rust sources

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -8,6 +8,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define WGPUDESIRED_NUM_FRAMES 3
+
 #define WGPUMAX_BIND_GROUPS 4
 
 #define WGPUMAX_COLOR_TARGETS 4

--- a/wgpu-native/src/binding_model.rs
+++ b/wgpu-native/src/binding_model.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::{
     resource::TextureViewDimension,
     track::TrackerSet,

--- a/wgpu-native/src/command/allocator.rs
+++ b/wgpu-native/src/command/allocator.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use super::CommandBuffer;
 use crate::{hub::GfxBackend, track::TrackerSet, DeviceId, Features, LifeGuard, Stored, SubmissionIndex};
 

--- a/wgpu-native/src/command/bind.rs
+++ b/wgpu-native/src/command/bind.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::{
     hub::GfxBackend,
     BindGroup,

--- a/wgpu-native/src/command/compute.rs
+++ b/wgpu-native/src/command/compute.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::{
     command::bind::{Binder, LayoutChange},
     device::all_buffer_stages,

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 mod allocator;
 mod bind;
 mod compute;

--- a/wgpu-native/src/command/render.rs
+++ b/wgpu-native/src/command/render.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::{
     command::bind::{Binder, LayoutChange},
     conv,

--- a/wgpu-native/src/command/transfer.rs
+++ b/wgpu-native/src/command/transfer.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::{
     conv,
     device::{all_buffer_stages, all_image_stages},

--- a/wgpu-native/src/conv.rs
+++ b/wgpu-native/src/conv.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::{binding_model, command, pipeline, resource, Color, Extent3d, Features, Origin3d};
 
 pub fn map_buffer_usage(

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 #[cfg(not(feature = "remote"))]
 use crate::{
     instance::Limits,

--- a/wgpu-native/src/hub.rs
+++ b/wgpu-native/src/hub.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::{
     backend,
     id::{Input, Output},

--- a/wgpu-native/src/id.rs
+++ b/wgpu-native/src/id.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::{Backend, Epoch, Index};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::{
     backend,
     binding_model::MAX_BIND_GROUPS,

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 pub mod backend {
     #[cfg(windows)]
     pub use gfx_backend_dx11::Backend as Dx11;

--- a/wgpu-native/src/pipeline.rs
+++ b/wgpu-native/src/pipeline.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::{
     device::RenderPassContext,
     resource,

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::{
     BufferAddress,
     BufferMapReadCallback,

--- a/wgpu-native/src/swap_chain.rs
+++ b/wgpu-native/src/swap_chain.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /*! Swap chain management.
 
     ## Lifecycle

--- a/wgpu-native/src/track/buffer.rs
+++ b/wgpu-native/src/track/buffer.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use super::{PendingTransition, ResourceState, Stitch, Unit};
 use crate::{conv, resource::BufferUsage, BufferId};
 use std::ops::Range;

--- a/wgpu-native/src/track/mod.rs
+++ b/wgpu-native/src/track/mod.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 mod buffer;
 mod range;
 mod texture;

--- a/wgpu-native/src/track/range.rs
+++ b/wgpu-native/src/track/range.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use std::{cmp::Ordering, fmt::Debug, iter::Peekable, ops::Range, slice::Iter};
 
 /// Structure that keeps track of a I -> T mapping,

--- a/wgpu-native/src/track/texture.rs
+++ b/wgpu-native/src/track/texture.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use super::{range::RangedStates, PendingTransition, ResourceState, Stitch, Unit};
 use crate::{conv, device::MAX_MIP_LEVELS, resource::TextureUsage, TextureId};
 

--- a/wgpu-remote/src/lib.rs
+++ b/wgpu-remote/src/lib.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 //TODO: remove once `cbindgen` is smart enough
 extern crate wgpu_native as wgn;
 use wgn::{AdapterId, Backend, DeviceId, IdentityManager, SurfaceId};

--- a/wgpu-remote/src/server.rs
+++ b/wgpu-remote/src/server.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use crate::GlobalMessage;
 
 use ipc_channel::ipc::IpcReceiver;


### PR DESCRIPTION
Fixes #346 
the header is fairly small, so it shouldn't be in the way of editing files