### PR TITLE
Support Limits::max_bind_groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "rendy-descriptor 0.4.0 (git+https://github.com/amethyst/rendy?rev=e8ffcabc2bc74fbb282d4f71fa55c28d0ec31c86)",
  "rendy-memory 0.4.0 (git+https://github.com/amethyst/rendy?rev=e8ffcabc2bc74fbb282d4f71fa55c28d0ec31c86)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -35,6 +35,7 @@ raw-window-handle = "0.3"
 rendy-memory = { git = "https://github.com/amethyst/rendy", rev = "e8ffcabc2bc74fbb282d4f71fa55c28d0ec31c86" }
 rendy-descriptor = { git = "https://github.com/amethyst/rendy", rev = "e8ffcabc2bc74fbb282d4f71fa55c28d0ec31c86" }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
+smallvec = "0.6"
 vec_map = "0.8"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -712,6 +712,7 @@ pub fn command_encoder_begin_render_pass<B: GfxBackend>(
             },
             context,
             sample_count,
+            cmb.features.max_bind_groups,
         )
     };
     hub.render_passes.register_identity(id_in, pass, &mut token)

--- a/wgpu-native/src/command/render.rs
+++ b/wgpu-native/src/command/render.rs
@@ -234,7 +234,6 @@ pub fn render_pass_set_bind_group<B: GfxBackend>(
     let (mut pass_guard, _) = hub.render_passes.write(&mut token);
     let pass = &mut pass_guard[pass_id];
 
-
     let bind_group = pass
         .trackers
         .bind_groups

--- a/wgpu-native/src/command/render.rs
+++ b/wgpu-native/src/command/render.rs
@@ -136,13 +136,8 @@ impl<B: GfxBackend> RenderPass<B> {
         cmb_id: Stored<CommandBufferId>,
         context: RenderPassContext,
         sample_count: u8,
+        max_bind_groups: u32,
     ) -> Self {
-        let hub = B::hub();
-        let mut token = Token::root();
-        let (cmb_guard, _) = hub.command_buffers.read(&mut token);
-        let cmb = &cmb_guard[cmb_id.value];
-        let max_bind_groups = cmb.features.max_bind_groups;
-
         RenderPass {
             raw,
             cmb_id,

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -513,6 +513,7 @@ impl<B: GfxBackend> Device<B> {
         queue_group: hal::queue::QueueGroup<B>,
         mem_props: hal::adapter::MemoryProperties,
         supports_texture_d24_s8: bool,
+        max_bind_groups: u32,
     ) -> Self {
         // don't start submission index at zero
         let life_guard = LifeGuard::new();
@@ -559,6 +560,7 @@ impl<B: GfxBackend> Device<B> {
                 ready_to_map: Vec::new(),
             }),
             features: Features {
+                max_bind_groups,
                 supports_texture_d24_s8,
             }
         }

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -429,7 +429,7 @@ pub extern "C" fn wgpu_request_adapter(desc: Option<&RequestAdapterOptions>) -> 
 
 pub fn adapter_request_device<B: GfxBackend>(
     adapter_id: AdapterId,
-    _desc: &DeviceDescriptor,
+    desc: &DeviceDescriptor,
     id_in: Input<DeviceId>,
 ) -> Output<DeviceId> {
     let hub = B::hub();
@@ -462,6 +462,10 @@ pub fn adapter_request_device<B: GfxBackend>(
             BIND_BUFFER_ALIGNMENT % limits.min_uniform_buffer_offset_alignment,
             "Adapter uniform buffer offset alignment not compatible with WGPU"
         );
+        assert!(
+            u32::from(limits.max_bound_descriptor_sets) >= desc.limits.max_bind_groups,
+            "Adapter does not support the requested max_bind_groups"
+        );
 
         let mem_props = adapter.physical_device.memory_properties();
 
@@ -477,6 +481,7 @@ pub fn adapter_request_device<B: GfxBackend>(
             gpu.queue_groups.swap_remove(0),
             mem_props,
             supports_texture_d24_s8,
+            desc.limits.max_bind_groups,
         )
     };
 

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -223,5 +223,6 @@ macro_rules! gfx_select {
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Features {
+    pub max_bind_groups: u32,
     pub supports_texture_d24_s8: bool,
 }


### PR DESCRIPTION
I'm porting a Vulkano renderer to wgpu-rs [1]. It uses 6 descriptor sets, running me out of the 4 binding groups that are currently hard-coded. The DeviceDescriptor appears to let you override that default, however, so I'm guessing that this is just not hooked up yet?

To that end, this patch hooks up Limits::max_bind_groups to the Binder::entries array, allowing my port to successfully render the bits that need the 5th and 6th binding group.

This is a big ecosystem and I'm not yet super familiar with the bigger picture; I'd be more than happy to re-work anything that isn't going in the right direction, or could just be done better. Regardless, I got _much_ further than I thought I would before hitting any issues; I'm quite impressed with how mature and useful wgpu(-rs) is already for such a new project.

1- https://github.com/terrence2/openfa