### PR TITLE
Gecko integration bits

### DIFF
--- a/wgpu-remote/cbindgen.toml
+++ b/wgpu-remote/cbindgen.toml
@@ -1,9 +1,20 @@
-header = ""
+header = """/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */"""
+autogen_warning = """/* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
+ * To generate this file:
+ *   1. Get the latest cbindgen using `cargo install --force cbindgen`
+ *      a. Alternatively, you can clone `https://github.com/eqrion/cbindgen` and use a tagged release
+ *   2. Run `rustup run nightly cbindgen toolkit/library/rust/ --lockfile Cargo.lock --crate wgpu-remote -o dom/webgpu/ffi/wgpu_ffi_generated.h`
+ */
+
+typedef void WGPUEmpty;
+"""
 include_version = true
 braces = "SameLine"
 line_length = 100
 tab_width = 2
-language = "C"
+language = "C++"
 
 [export]
 prefix = "WGPU"
@@ -14,6 +25,10 @@ parse_deps = true
 include = ["wgpu-native"]
 
 [fn]
+prefix = "WGPU_INLINE"
+postfix = "WGPU_FUNC"
+args = "Vertical"
+rename_args = "GeckoCase"
 
 [struct]
 derive_eq = true
@@ -24,3 +39,8 @@ derive_helper_methods = true
 
 [macro_expansion]
 bitflags = true
+
+[defines]
+"target_os = windows" = "XP_WIN"
+"target_os = macos" = "XP_MACOSX"
+"target_os = android" = "ANDROID"

--- a/wgpu-remote/src/lib.rs
+++ b/wgpu-remote/src/lib.rs
@@ -9,7 +9,6 @@ use wgn::{AdapterId, Backend, DeviceId, IdentityManager, SurfaceId};
 use crate::server::Server;
 
 use ipc_channel::ipc;
-use log::error;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
@@ -124,7 +123,7 @@ pub extern "C" fn wgpu_initialize() -> Infrastructure {
             }
         }
         Err(e) => {
-            error!("WGPU initialize failed: {:?}", e);
+            log::error!("WGPU initialize failed: {:?}", e);
             Infrastructure {
                 client: ptr::null_mut(),
                 server: ptr::null_mut(),

--- a/wgpu-remote/src/server.rs
+++ b/wgpu-remote/src/server.rs
@@ -47,3 +47,20 @@ pub extern "C" fn wgpu_server_process(server: &Server) {
         }
     }
 }
+
+#[no_mangle]
+pub extern "C" fn wgpu_server_loop(server: *mut Server) {
+    assert!(!server.is_null());
+    log::info!("WGPU server loop started");
+    while let Ok(message) = unsafe { server.as_ref() }
+        .unwrap().channel.recv()
+    {
+        match process(message) {
+            ControlFlow::Continue => {}
+            ControlFlow::Terminate => break,
+        }
+    }
+    // drop the server
+    log::info!("WGPU server loop finished");
+    let _ = unsafe { Box::from_raw(server) };
+}


### PR DESCRIPTION
This PR is just for showing the current changes I have to do for Gecko. They don't particularly seem relevant to wgpu-remote as a standalone repository. In fact, I'm not sure yet if it even needs to be a standalone: we might end up with a case where wgpu-native is usable by itself, but wgpu-remote is completely within Gecko.

The biggest unresolved problem now, and possibly the last major problem, is how to organize IPC - #146.