### PR TITLE
Optionally support XCB windows on Unix

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -461,10 +461,8 @@ fn main() {
     let mut command_buffer_id_manager = wgc::hub::IdentityManager::default();
 
     #[cfg(feature = "winit")]
-    let surface = global.instance_create_surface(
-        raw_window_handle::HasRawWindowHandle::raw_window_handle(&window),
-        wgc::id::TypedId::zip(0, 1, wgt::Backend::Empty),
-    );
+    let surface =
+        global.instance_create_surface(&window, wgc::id::TypedId::zip(0, 1, wgt::Backend::Empty));
 
     let device = match actions.pop() {
         Some(trace::Action::Init { desc, backend }) => {

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -220,97 +220,69 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     #[cfg(feature = "raw-window-handle")]
     pub fn instance_create_surface(
         &self,
-        handle: raw_window_handle::RawWindowHandle,
+        handle: &impl raw_window_handle::HasRawWindowHandle,
         id_in: Input<G, SurfaceId>,
     ) -> SurfaceId {
-        use raw_window_handle::RawWindowHandle as Rwh;
-
-        let surface = match handle {
+        unsafe {
             #[cfg(target_os = "ios")]
-            Rwh::IOS(h) => Surface {
+            let surface = Surface {
                 #[cfg(feature = "gfx-backend-vulkan")]
                 vulkan: None,
-                metal: self
-                    .instance
-                    .metal
-                    .create_surface_from_uiview(h.ui_view, cfg!(debug_assertions)),
-            },
+                metal: self.instance.metal.create_surface(handle).unwrap(),
+            };
             #[cfg(target_os = "macos")]
-            Rwh::MacOS(h) => {
-                //TODO: figure out when this is needed, and how to get that without `objc`
-                //use objc::{msg_send, runtime::Object, sel, sel_impl};
-                //let ns_view = if h.ns_view.is_null() {
-                //    let ns_window = h.ns_window as *mut Object;
-                //    unsafe { msg_send![ns_window, contentView] }
-                //} else {
-                //    h.ns_view
-                //};
-                Surface {
-                    #[cfg(feature = "gfx-backend-vulkan")]
-                    vulkan: self
-                        .instance
-                        .vulkan
-                        .as_ref()
-                        .map(|inst| inst.create_surface_from_ns_view(h.ns_view)),
-                    metal: self
-                        .instance
-                        .metal
-                        .create_surface_from_nsview(h.ns_view, cfg!(debug_assertions)),
-                }
-            }
+            let surface = Surface {
+                #[cfg(feature = "gfx-backend-vulkan")]
+                vulkan: self
+                    .instance
+                    .vulkan
+                    .as_ref()
+                    .map(|inst| inst.create_surface(handle)),
+                metal: self.instance.metal.create_surface(handle).unwrap(),
+            };
             #[cfg(all(
                 unix,
                 not(target_os = "android"),
                 not(target_os = "ios"),
                 not(target_os = "macos")
             ))]
-            Rwh::Xlib(h) => Surface {
+            let surface = Surface {
                 vulkan: self
                     .instance
                     .vulkan
                     .as_ref()
-                    .map(|inst| inst.create_surface_from_xlib(h.display as _, h.window)),
-            },
-            #[cfg(all(
-                unix,
-                not(target_os = "android"),
-                not(target_os = "ios"),
-                not(target_os = "macos")
-            ))]
-            Rwh::Wayland(h) => Surface {
-                vulkan: self
-                    .instance
-                    .vulkan
-                    .as_ref()
-                    .map(|inst| inst.create_surface_from_wayland(h.display, h.surface)),
-            },
+                    .map(|inst| inst.create_surface(handle).ok())
+                    .flatten(),
+            };
             #[cfg(target_os = "android")]
-            Rwh::Android(h) => Surface {
+            let surface = Surface {
                 vulkan: self
                     .instance
                     .vulkan
                     .as_ref()
-                    .map(|inst| inst.create_surface_android(h.a_native_window)),
-            },
+                    .map(|inst| inst.create_surface(handle).ok())
+                    .flatten(),
+            };
             #[cfg(windows)]
-            Rwh::Windows(h) => Surface {
+            let surface = Surface {
                 vulkan: self
                     .instance
                     .vulkan
                     .as_ref()
-                    .map(|inst| inst.create_surface_from_hwnd(std::ptr::null_mut(), h.hwnd)),
+                    .map(|inst| inst.create_surface(handle).ok())
+                    .flatten(),
                 dx12: self
                     .instance
                     .dx12
                     .as_ref()
-                    .map(|inst| inst.create_surface_from_hwnd(h.hwnd)),
-                dx11: self.instance.dx11.create_surface_from_hwnd(h.hwnd),
-            },
-            _ => panic!("Unsupported window handle"),
-        };
+                    .map(|inst| inst.create_surface(handle).ok())
+                    .flatten(),
+                dx11: self.instance.dx11.create_surface(handle).unwrap(),
+            };
 
-        let mut token = Token::root();
-        self.surfaces.register_identity(id_in, surface, &mut token)
+            let mut token = Token::root();
+            self.surfaces.register_identity(id_in, surface, &mut token)
+        }
     }
 
     pub fn enumerate_adapters(&self, inputs: AdapterInputs<Input<G, AdapterId>>) -> Vec<AdapterId> {


### PR DESCRIPTION
`gfx-hal` supports XCB windows on Unix platforms, but it can't be used through `wgpu`. I added a new `xcb` feature to enable that support. `x11` support is now enabled using a default feature to remain backwards compatible.