### PR TITLE
Always return an Id by request_adapter

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -8,6 +8,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define WGPUDEFAULT_BIND_GROUPS 4
+
 #define WGPUDESIRED_NUM_FRAMES 3
 
 #define WGPUMAX_BIND_GROUPS 4


### PR DESCRIPTION
Requesting adapters is a bit special in a sense that it's exactly the place where the backend selection happens. It accepts a list of Ids, and we need to always return one, so that the remote client knows which Id was actually used and clean up the others.