### PR TITLE
Remove all the IPC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
 script:
   - cargo test
   # TODO: enable GL backend
-  - (cd wgpu-native && cargo check --features local)
+  - (cd wgpu-native && cargo check --all-features)
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then (cd wgpu-native && cargo check --features gfx-backend-vulkan); fi
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then cargo check --release; fi
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo +nightly install cbindgen; fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,16 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,24 +140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "d3d12"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,11 +179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,25 +189,6 @@ dependencies = [
 [[package]]
 name = "foreign-types-shared"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -354,46 +302,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ipc-channel"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -442,44 +355,6 @@ dependencies = [
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "mio"
-version = "0.6.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -550,102 +425,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "range-alloc"
 version = "0.1.0"
 source = "git+https://github.com/gfx-rs/gfx?rev=3d5db15661127c8cad8d85522a68ec36c82f6e69#3d5db15661127c8cad8d85522a68ec36c82f6e69"
@@ -656,14 +435,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -679,14 +450,6 @@ dependencies = [
  "backtrace 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -826,30 +589,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "uuid"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "vec_map"
@@ -932,17 +674,10 @@ dependencies = [
 name = "wgpu-remote"
 version = "0.1.0"
 dependencies = [
- "ipc-channel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "wgpu-native 0.3.3",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
@@ -952,11 +687,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -977,15 +707,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "x11"
 version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,7 +723,6 @@ dependencies = [
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "f92d5d536fa03dc3d93711d97bac1fae2eb59aba467ca4c6600c0119da614f51"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
-"checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cd43d82f27d68911e6ee11ee791fb248f138f5d69424dc02e098d4f152b0b05"
@@ -1016,18 +736,12 @@ dependencies = [
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
-"checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
-"checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum d3d12 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4fda5547c55c93b070d59108464bbfd7d9da9563b2ce78fceefc6430e972a420"
 "checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
-"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum gfx-backend-dx11 0.3.0 (git+https://github.com/gfx-rs/gfx?rev=3d5db15661127c8cad8d85522a68ec36c82f6e69)" = "<none>"
@@ -1037,19 +751,13 @@ dependencies = [
 "checksum gfx-backend-vulkan 0.3.0 (git+https://github.com/gfx-rs/gfx?rev=3d5db15661127c8cad8d85522a68ec36c82f6e69)" = "<none>"
 "checksum gfx-hal 0.3.0 (git+https://github.com/gfx-rs/gfx?rev=3d5db15661127c8cad8d85522a68ec36c82f6e69)" = "<none>"
 "checksum hibitset 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "47e7292fd9f7fe89fa35c98048f2d0a69b79ed243604234d18f6f8a1aa6f408d"
-"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum ipc-channel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79d98ee7dd1d2e796d254807fd86ea7189d07571aeaa74007603e29a79d15217"
 "checksum js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "da3ea71161651a4cd97d999b2da139109c537b15ab33abc8ae4ead38deac8a03"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "42914d39aad277d9e176efbdad68acb1d5443ab65afe0e0e4f0d49352a950880"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 "checksum metal 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2832bd32c9068fb916aea0086f7422b8c31fd604d83b4393062974f862480a8f"
-"checksum mio 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "049ba5ca2b63e837adeee724aa9e36b408ed593529dcc802aa96ca14bd329bdf"
-"checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "31d20fd2b37e07cf5125be68357b588672e8cefe9a96f8c17a9d46053b3e590d"
 "checksum objc_exception 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "098cd29a2fa3c230d3463ae069cecccc3fdfd64c0d2496ab5b96f82dab6a00dc"
@@ -1058,22 +766,10 @@ dependencies = [
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
-"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
-"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-"checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum range-alloc 0.1.0 (git+https://github.com/gfx-rs/gfx?rev=3d5db15661127c8cad8d85522a68ec36c82f6e69)" = "<none>"
 "checksum raw-window-handle 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e815b85b31e4d397ca9dd8eb1d692e9cb458b9f6ae8ac2232c995dca8236f87"
-"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum relevant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bbc232e13d37f4547f5b9b42a5efc380cabe5dbc1807f8b893580640b2ab0308"
-"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rendy-descriptor 0.4.0 (git+https://github.com/amethyst/rendy?rev=e8ffcabc2bc74fbb282d4f71fa55c28d0ec31c86)" = "<none>"
 "checksum rendy-memory 0.4.0 (git+https://github.com/amethyst/rendy?rev=e8ffcabc2bc74fbb282d4f71fa55c28d0ec31c86)" = "<none>"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
@@ -1090,20 +786,15 @@ dependencies = [
 "checksum storage-map 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0a4829a5c591dc24a944a736d6b1e4053e51339a79fd5d4702c4c999a9c45e"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
-"checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "4de97fa1806bb1a99904216f6ac5e0c050dc4f8c676dc98775047c38e5c01b55"
 "checksum wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "5d82c170ef9f5b2c63ad4460dfcee93f3ec04a9a36a4cc20bc973c39e59ab8e3"
 "checksum wasm-bindgen-macro 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f07d50f74bf7a738304f6b8157f4a581e1512cd9e9cdb5baad8c31bbe8ffd81d"
 "checksum wasm-bindgen-macro-support 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "95cf8fe77e45ba5f91bc8f3da0c3aa5d464b3d8ed85d84f4d4c7cc106436b1d7"
 "checksum wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c2d4d4756b2e46d3a5422e06277d02e4d3e1d62d138b76a4c681e925743623"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
-"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x11 2.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39697e3123f715483d311b5826e254b6f3cfebdd83cf7ef3358f579c3d68e235"

--- a/examples/remote/main.c
+++ b/examples/remote/main.c
@@ -1,17 +1,28 @@
+#define WGPU_INLINE
+#define WGPU_FUNC
+
 #include "./../../ffi/wgpu-remote.h"
 #include <stdio.h>
 
 int main() {
-    WGPUInfrastructure infra = wgpu_initialize();
+    WGPUInfrastructure infra = wgpu_client_new();
 
-    if (!infra.client || !infra.server || infra.error) {
-        printf("Cannot initialize WGPU: %s", infra.error);
+    if (!infra.client || infra.error) {
+        printf("Cannot initialize WGPU client: %s", infra.error);
+        return 1;
+    }
+
+    WGPUGlobal* server = wgpu_server_new();
+
+    if (!server) {
+        printf("Cannot initialize WGPU client: %s", server);
         return 1;
     }
 
     //TODO: do something meaningful
 
-    wgpu_terminate(infra.client);
+    wgpu_server_delete(server);
+    wgpu_client_delete(infra.client);
 
     return 0;
 }

--- a/ffi/wgpu-remote.h
+++ b/ffi/wgpu-remote.h
@@ -14,62 +14,67 @@
 typedef void WGPUEmpty;
 
 
-#include <cstdarg>
-#include <cstdint>
-#include <cstdlib>
-#include <new>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
 
-enum class WGPUPowerPreference {
+typedef enum {
   WGPUPowerPreference_Default = 0,
   WGPUPowerPreference_LowPower = 1,
   WGPUPowerPreference_HighPerformance = 2,
-};
+} WGPUPowerPreference;
 
-template<typename B>
-struct WGPUAdapter;
+typedef struct WGPUClient WGPUClient;
 
-struct WGPUClient;
+typedef struct WGPUGlobal WGPUGlobal;
 
-template<typename B>
-struct WGPUDevice;
+typedef uint64_t WGPUId_Adapter_Dummy;
 
-struct WGPUGlobal;
+typedef WGPUId_Adapter_Dummy WGPUAdapterId;
 
-using WGPUDummy = WGPUEmpty;
+typedef uint64_t WGPUId_Device_Dummy;
 
-template<typename T>
-using WGPUId = uint64_t;
+typedef WGPUId_Device_Dummy WGPUDeviceId;
 
-using WGPUAdapterId = WGPUId<WGPUAdapter<WGPUDummy>>;
-
-using WGPUDeviceId = WGPUId<WGPUDevice<WGPUDummy>>;
-
-struct WGPUInfrastructure {
+typedef struct {
   WGPUClient *client;
   const uint8_t *error;
+} WGPUInfrastructure;
 
-  bool operator==(const WGPUInfrastructure& aOther) const {
-    return client == aOther.client &&
-           error == aOther.error;
-  }
-};
+typedef struct {
+  bool anisotropic_filtering;
+} WGPUExtensions;
 
-using WGPUBackendBit = uint32_t;
+typedef struct {
+  uint32_t max_bind_groups;
+} WGPULimits;
 
-struct WGPURequestAdapterOptions {
+typedef struct {
+  WGPUExtensions extensions;
+  WGPULimits limits;
+} WGPUDeviceDescriptor;
+
+typedef uint32_t WGPUBackendBit;
+
+typedef struct {
   WGPUPowerPreference power_preference;
   WGPUBackendBit backends;
-
-  bool operator==(const WGPURequestAdapterOptions& aOther) const {
-    return power_preference == aOther.power_preference &&
-           backends == aOther.backends;
-  }
-};
-
-extern "C" {
+} WGPURequestAdapterOptions;
 
 WGPU_INLINE
 void wgpu_client_delete(WGPUClient *aClient)
+WGPU_FUNC;
+
+WGPU_INLINE
+void wgpu_client_kill_adapter_ids(const WGPUClient *aClient,
+                                  const WGPUAdapterId *aIds,
+                                  uintptr_t aIdLength)
+WGPU_FUNC;
+
+WGPU_INLINE
+void wgpu_client_kill_device_id(const WGPUClient *aClient,
+                                WGPUDeviceId aId)
 WGPU_FUNC;
 
 WGPU_INLINE
@@ -84,7 +89,14 @@ WGPUDeviceId wgpu_client_make_device_id(const WGPUClient *aClient,
 WGPU_FUNC;
 
 WGPU_INLINE
-WGPUInfrastructure wgpu_client_new()
+WGPUInfrastructure wgpu_client_new(void)
+WGPU_FUNC;
+
+WGPU_INLINE
+void wgpu_server_adapter_request_device(const WGPUGlobal *aGlobal,
+                                        WGPUAdapterId aSelfId,
+                                        const WGPUDeviceDescriptor *aDesc,
+                                        WGPUDeviceId aNewId)
 WGPU_FUNC;
 
 WGPU_INLINE
@@ -92,14 +104,17 @@ void wgpu_server_delete(WGPUGlobal *aGlobal)
 WGPU_FUNC;
 
 WGPU_INLINE
-WGPUGlobal *wgpu_server_new()
+void wgpu_server_device_destroy(const WGPUGlobal *aGlobal,
+                                WGPUDeviceId aSelfId)
 WGPU_FUNC;
 
 WGPU_INLINE
-WGPUAdapterId wgpu_server_request_adapter(const WGPUGlobal *aGlobal,
-                                          const WGPURequestAdapterOptions *aDesc,
-                                          const WGPUAdapterId *aIds,
-                                          uintptr_t aIdLength)
+WGPUAdapterId wgpu_server_instance_request_adapter(const WGPUGlobal *aGlobal,
+                                                   const WGPURequestAdapterOptions *aDesc,
+                                                   const WGPUAdapterId *aIds,
+                                                   uintptr_t aIdLength)
 WGPU_FUNC;
 
-} // extern "C"
+WGPU_INLINE
+WGPUGlobal *wgpu_server_new(void)
+WGPU_FUNC;

--- a/ffi/wgpu-remote.h
+++ b/ffi/wgpu-remote.h
@@ -1,65 +1,105 @@
-
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /* Generated with cbindgen:0.9.1 */
 
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdlib.h>
+/* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
+ * To generate this file:
+ *   1. Get the latest cbindgen using `cargo install --force cbindgen`
+ *      a. Alternatively, you can clone `https://github.com/eqrion/cbindgen` and use a tagged release
+ *   2. Run `rustup run nightly cbindgen toolkit/library/rust/ --lockfile Cargo.lock --crate wgpu-remote -o dom/webgpu/ffi/wgpu_ffi_generated.h`
+ */
 
-typedef enum {
+typedef void WGPUEmpty;
+
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+
+enum class WGPUPowerPreference {
   WGPUPowerPreference_Default = 0,
   WGPUPowerPreference_LowPower = 1,
   WGPUPowerPreference_HighPerformance = 2,
-} WGPUPowerPreference;
+};
 
-typedef struct WGPUClient WGPUClient;
+template<typename B>
+struct WGPUAdapter;
 
-typedef struct WGPUServer WGPUServer;
+struct WGPUClient;
 
-typedef uint64_t WGPUId_Device_Dummy;
+template<typename B>
+struct WGPUDevice;
 
-typedef WGPUId_Device_Dummy WGPUDeviceId;
+struct WGPUGlobal;
 
-typedef uint64_t WGPUId_Adapter_Dummy;
+using WGPUDummy = WGPUEmpty;
 
-typedef WGPUId_Adapter_Dummy WGPUAdapterId;
+template<typename T>
+using WGPUId = uint64_t;
 
-typedef struct {
-  bool anisotropic_filtering;
-} WGPUExtensions;
+using WGPUAdapterId = WGPUId<WGPUAdapter<WGPUDummy>>;
 
-typedef struct {
-  uint32_t max_bind_groups;
-} WGPULimits;
+using WGPUDeviceId = WGPUId<WGPUDevice<WGPUDummy>>;
 
-typedef struct {
-  WGPUExtensions extensions;
-  WGPULimits limits;
-} WGPUDeviceDescriptor;
+struct WGPUInfrastructure {
+  WGPUClient *client;
+  const uint8_t *error;
 
-typedef uint32_t WGPUBackendBit;
+  bool operator==(const WGPUInfrastructure& aOther) const {
+    return client == aOther.client &&
+           error == aOther.error;
+  }
+};
 
-typedef struct {
+using WGPUBackendBit = uint32_t;
+
+struct WGPURequestAdapterOptions {
   WGPUPowerPreference power_preference;
   WGPUBackendBit backends;
-} WGPURequestAdapterOptions;
 
-typedef struct {
-  WGPUClient *client;
-  WGPUServer *server;
-  const uint8_t *error;
-} WGPUInfrastructure;
+  bool operator==(const WGPURequestAdapterOptions& aOther) const {
+    return power_preference == aOther.power_preference &&
+           backends == aOther.backends;
+  }
+};
 
-WGPUDeviceId wgpu_client_adapter_create_device(const WGPUClient *client,
-                                               WGPUAdapterId adapter_id,
-                                               const WGPUDeviceDescriptor *desc);
+extern "C" {
 
-WGPUAdapterId wgpu_client_request_adapter(const WGPUClient *client,
-                                          const WGPURequestAdapterOptions *desc);
+WGPU_INLINE
+void wgpu_client_delete(WGPUClient *aClient)
+WGPU_FUNC;
 
-WGPUInfrastructure wgpu_initialize(void);
+WGPU_INLINE
+uintptr_t wgpu_client_make_adapter_ids(const WGPUClient *aClient,
+                                       WGPUAdapterId *aIds,
+                                       uintptr_t aIdLength)
+WGPU_FUNC;
 
-void wgpu_server_process(const WGPUServer *server);
+WGPU_INLINE
+WGPUDeviceId wgpu_client_make_device_id(const WGPUClient *aClient,
+                                        WGPUAdapterId aAdapterId)
+WGPU_FUNC;
 
-void wgpu_terminate(WGPUClient *client);
+WGPU_INLINE
+WGPUInfrastructure wgpu_client_new()
+WGPU_FUNC;
+
+WGPU_INLINE
+void wgpu_server_delete(WGPUGlobal *aGlobal)
+WGPU_FUNC;
+
+WGPU_INLINE
+WGPUGlobal *wgpu_server_new()
+WGPU_FUNC;
+
+WGPU_INLINE
+WGPUAdapterId wgpu_server_request_adapter(const WGPUGlobal *aGlobal,
+                                          const WGPURequestAdapterOptions *aDesc,
+                                          const WGPUAdapterId *aIds,
+                                          uintptr_t aIdLength)
+WGPU_FUNC;
+
+} // extern "C"

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
 default = []
-local = ["lazy_static"]
+local = ["lazy_static", "raw-window-handle"]
 metal-auto-capture = ["gfx-backend-metal/auto-capture"]
 #NOTE: glutin feature is not stable, use at your own risk
 #glutin = ["gfx-backend-gl/glutin"]
@@ -31,7 +31,7 @@ log = "0.4"
 hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 parking_lot = "0.9"
-raw-window-handle = "0.3"
+raw-window-handle = { version = "0.3", optional = true }
 rendy-memory = { git = "https://github.com/amethyst/rendy", rev = "e8ffcabc2bc74fbb282d4f71fa55c28d0ec31c86" }
 rendy-descriptor = { git = "https://github.com/amethyst/rendy", rev = "e8ffcabc2bc74fbb282d4f71fa55c28d0ec31c86" }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }

--- a/wgpu-native/cbindgen.toml
+++ b/wgpu-native/cbindgen.toml
@@ -32,7 +32,6 @@ bitflags = true
 
 [defines]
 "feature = local" = "WGPU_LOCAL"
-"feature = remote" = "WGPU_REMOTE"
 "feature = gfx-backend-gl" = "WGPU_BACKEND_GL"
 "feature = winit" = "WGPU_WINIT"
 "feature = glutin" = "WGPU_GLUTIN"

--- a/wgpu-native/src/command/allocator.rs
+++ b/wgpu-native/src/command/allocator.rs
@@ -60,16 +60,6 @@ pub struct CommandAllocator<B: hal::Backend> {
 }
 
 impl<B: GfxBackend> CommandAllocator<B> {
-    pub fn new(queue_family: hal::queue::QueueFamilyId) -> Self {
-        CommandAllocator {
-            queue_family,
-            inner: Mutex::new(Inner {
-                pools: HashMap::new(),
-                pending: Vec::new(),
-            }),
-        }
-    }
-
     pub(crate) fn allocate(
         &self,
         device_id: Stored<DeviceId>,
@@ -101,6 +91,18 @@ impl<B: GfxBackend> CommandAllocator<B> {
             trackers: TrackerSet::new(B::VARIANT),
             used_swap_chain: None,
             features,
+        }
+    }
+}
+
+impl<B: hal::Backend> CommandAllocator<B> {
+    pub fn new(queue_family: hal::queue::QueueFamilyId) -> Self {
+        CommandAllocator {
+            queue_family,
+            inner: Mutex::new(Inner {
+                pools: HashMap::new(),
+                pending: Vec::new(),
+            }),
         }
     }
 

--- a/wgpu-native/src/command/mod.rs
+++ b/wgpu-native/src/command/mod.rs
@@ -112,7 +112,7 @@ pub struct CommandBuffer<B: hal::Backend> {
     pub(crate) raw: Vec<B::CommandBuffer>,
     is_recording: bool,
     recorded_thread_id: ThreadId,
-    device_id: Stored<DeviceId>,
+    pub(crate) device_id: Stored<DeviceId>,
     pub(crate) life_guard: LifeGuard,
     pub(crate) trackers: TrackerSet,
     pub(crate) used_swap_chain: Option<(Stored<TextureViewId>, B::Framebuffer)>,

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -768,6 +768,21 @@ impl<B: GfxBackend> Device<B> {
     }
 }
 
+impl<B: hal::Backend> Device<B> {
+    pub(crate) fn destroy_bind_group(&self, bind_group: binding_model::BindGroup<B>) {
+        unsafe {
+            self.desc_allocator.lock().free(iter::once(bind_group.raw));
+        }
+    }
+
+    pub(crate) fn destroy_self(self) {
+        self.com_allocator.destroy(&self.raw);
+        unsafe {
+            self.desc_allocator.lock().cleanup(&self.raw);
+        }
+    }
+}
+
 #[cfg(feature = "local")]
 #[no_mangle]
 pub extern "C" fn wgpu_device_get_limits(_device_id: DeviceId, limits: &mut Limits) {

--- a/wgpu-native/src/hub.rs
+++ b/wgpu-native/src/hub.rs
@@ -411,13 +411,24 @@ pub struct Global {
     hubs: Hubs,
 }
 
+impl Global {
+    fn new_impl(name: &str) -> Self {
+        Global {
+            instance: Instance::new(name, 1),
+            surfaces: Registry::new(Backend::Empty),
+            hubs: Hubs::default(),
+        }
+    }
+
+    #[cfg(not(feature = "local"))]
+    pub fn new(name: &str) -> Self {
+        Self::new_impl(name)
+    }
+}
+
 #[cfg(feature = "local")]
 lazy_static::lazy_static! {
-    pub static ref GLOBAL: Arc<Global> = Arc::new(Global {
-        instance: Instance::new("wgpu", 1),
-        surfaces: Registry::new(Backend::Empty),
-        hubs: Hubs::default(),
-    });
+    pub static ref GLOBAL: Arc<Global> = Arc::new(Global::new_impl("wgpu"));
 }
 
 pub trait GfxBackend: hal::Backend {

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -94,6 +94,7 @@ pub enum PowerPreference {
 #[cfg(feature = "local")]
 bitflags! {
     #[repr(transparent)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct BackendBit: u32 {
         const VULKAN = 1 << Backend::Vulkan as u32;
         const GL = 1 << Backend::Gl as u32;

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -58,6 +58,31 @@ impl Instance {
             dx11: gfx_backend_dx11::Instance::create(name, version).unwrap(),
         }
     }
+
+    #[cfg(not(feature = "local"))]
+    pub(crate) fn destroy_surface(&mut self, surface: Surface) {
+        //TODO: fill out the proper destruction once we are on gfx-0.4
+        #[cfg(any(
+            not(any(target_os = "ios", target_os = "macos")),
+            feature = "gfx-backend-vulkan"
+        ))]
+        {
+            if let Some(_suf) = surface.vulkan {
+                //self.vulkan.as_mut().unwrap().destroy_surface(suf);
+            }
+        }
+        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        {
+            //self.metal.destroy_surface(surface.metal);
+        }
+        #[cfg(windows)]
+        {
+            if let Some(_suf) = surface.dx12 {
+                //self.dx12.as_mut().unwrap().destroy_surface(suf);
+            }
+            //self.dx11.destroy_surface(surface.dx11);
+        }
+    }
 }
 
 type GfxSurface<B> = <B as hal::Backend>::Surface;

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::binding_model::*;
 pub use self::command::*;
 pub use self::device::*;
 #[cfg(not(feature = "local"))]
-pub use self::hub::{Access, IdentityManager, Registry, Token};
+pub use self::hub::{Access, Global, IdentityManager, Registry, Token};
 pub use self::id::*;
 pub use self::instance::*;
 pub use self::pipeline::*;

--- a/wgpu-remote/Cargo.toml
+++ b/wgpu-remote/Cargo.toml
@@ -14,8 +14,6 @@ crate-type = ["lib", "cdylib", "staticlib"]
 default = []
 
 [dependencies]
-wgpu-native = { path = "../wgpu-native", version = "0.3", features = ["serde"] }
-ipc-channel = "0.12"
+wgn = { path = "../wgpu-native", package = "wgpu-native", version = "0.3" }
 log = "0.4"
 parking_lot = { version = "0.9" }
-serde = { version = "1.0", features = ["serde_derive"] }

--- a/wgpu-remote/cbindgen.toml
+++ b/wgpu-remote/cbindgen.toml
@@ -1,9 +1,20 @@
-header = ""
+header = """/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */"""
+autogen_warning = """/* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
+ * To generate this file:
+ *   1. Get the latest cbindgen using `cargo install --force cbindgen`
+ *      a. Alternatively, you can clone `https://github.com/eqrion/cbindgen` and use a tagged release
+ *   2. Run `rustup run nightly cbindgen toolkit/library/rust/ --lockfile Cargo.lock --crate wgpu-remote -o dom/webgpu/ffi/wgpu_ffi_generated.h`
+ */
+
+typedef void WGPUEmpty;
+"""
 include_version = true
 braces = "SameLine"
 line_length = 100
 tab_width = 2
-language = "C"
+language = "C++"
 
 [export]
 prefix = "WGPU"
@@ -14,6 +25,10 @@ parse_deps = true
 include = ["wgpu-native"]
 
 [fn]
+prefix = "WGPU_INLINE"
+postfix = "WGPU_FUNC"
+args = "Vertical"
+rename_args = "GeckoCase"
 
 [struct]
 derive_eq = true
@@ -24,3 +39,8 @@ derive_helper_methods = true
 
 [macro_expansion]
 bitflags = true
+
+[defines]
+"target_os = windows" = "XP_WIN"
+"target_os = macos" = "XP_MACOSX"
+"target_os = android" = "ANDROID"

--- a/wgpu-remote/cbindgen.toml
+++ b/wgpu-remote/cbindgen.toml
@@ -14,7 +14,7 @@ include_version = true
 braces = "SameLine"
 line_length = 100
 tab_width = 2
-language = "C++"
+language = "C"
 
 [export]
 prefix = "WGPU"

--- a/wgpu-remote/src/server.rs
+++ b/wgpu-remote/src/server.rs
@@ -13,8 +13,8 @@ pub extern "C" fn wgpu_server_new() -> *mut wgn::Global {
 #[no_mangle]
 pub extern "C" fn wgpu_server_delete(global: *mut wgn::Global) {
     log::info!("Terminating WGPU server");
-    //TODO: proper cleanup
-    let _ = unsafe { Box::from_raw(global) };
+    unsafe { Box::from_raw(global) }.delete();
+    log::info!("\t...done");
 }
 
 #[no_mangle]
@@ -37,4 +37,10 @@ pub extern "C" fn wgpu_server_adapter_request_device(
 ) {
     use wgn::adapter_request_device as func;
     wgn::gfx_select!(self_id => func(global, self_id, desc, new_id));
+}
+
+#[no_mangle]
+pub extern "C" fn wgpu_server_device_destroy(global: &wgn::Global, self_id: wgn::DeviceId) {
+    use wgn::device_destroy as func;
+    wgn::gfx_select!(self_id => func(global, self_id))
 }


### PR DESCRIPTION
Closes #146 
Closes #22

We have decided to use Gecko IPC for Firefox. `wgpu-remote` will therefore provide all the Rust glue that Gecko needs for client and server:
  - initialization/termination of client/server
  - ID management for the client
  - pass encoding blobs

In Servo, we'd need to enable `serde` feature of `wgpu-native` and potentially roll out a different remoting crate that would establish a protocol based on `ipc-channel`, as we wanted originally.