### PR TITLE
Make examples work again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,9 @@ else
 	CREATE_BUILD_DIR=mkdir -p $(BUILD_DIR)
 endif
 
-.PHONY: all check test doc clear lib-native lib-remote example-compute example-triangle example-remote
+.PHONY: all check test doc clear lib-native lib-remote \
+	example-compute example-triangle example-remote \
+	run-example-compute run-example-triangle run-example-remote
 
 all: example-compute example-triangle example-remote
 
@@ -56,10 +58,19 @@ $(FFI_DIR)/wgpu-remote.h: wgpu-remote/cbindgen.toml $(WILDCARD_WGPU_NATIVE_AND_R
 	rustup run nightly cbindgen -o $(FFI_DIR)/wgpu-remote.h wgpu-remote
 
 example-compute: lib-native $(FFI_DIR)/wgpu.h examples/compute/main.c
-	cd examples/compute && $(CREATE_BUILD_DIR) && cd build && cmake .. $(GENERATOR_PLATFORM) && cmake --build .
+	cd examples/compute && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. $(GENERATOR_PLATFORM) && cmake --build .
+
+run-example-compute: example-compute
+	cd examples/compute/build && ./compute 1 2 3 4
 
 example-triangle: lib-native $(FFI_DIR)/wgpu.h examples/triangle/main.c
-	cd examples/triangle && $(CREATE_BUILD_DIR) && cd build && cmake .. $(GENERATOR_PLATFORM) && cmake --build .
+	cd examples/triangle && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. $(GENERATOR_PLATFORM) && cmake --build .
+
+run-example-triangle: example-triangle
+	cd examples/triangle/build && ./triangle
 
 example-remote: lib-remote $(FFI_DIR)/wgpu-remote.h examples/remote/main.c
-	cd examples/remote && $(CREATE_BUILD_DIR) && cd build && cmake .. && cmake --build .
+	cd examples/remote && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. $(GENERATOR_PLATFORM) && cmake --build .
+
+run-example-remote: example-remote
+	cd examples/remote/build && ./remote

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -45,6 +45,10 @@ int main() {
                 {
                     .anisotropic_filtering = false,
                 },
+            .limits =
+                {
+                    .max_bind_groups = 1,
+                },
         });
 
     WGPUShaderModuleId vertex_shader = wgpu_device_create_shader_module(device,

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -1172,8 +1172,12 @@ pub fn device_create_pipeline_layout<B: GfxBackend>(
     let mut token = Token::root();
 
     let (device_guard, mut token) = hub.devices.read(&mut token);
+    let device = &device_guard[device_id];
     let bind_group_layout_ids =
         unsafe { slice::from_raw_parts(desc.bind_group_layouts, desc.bind_group_layouts_length) };
+
+    assert!(desc.bind_group_layouts_length <= (device.features.max_bind_groups as usize),
+        "Cannot set a bind group which is beyond the `max_bind_groups` limit requested on device creation");
 
     // TODO: push constants
     let pipeline_layout = {
@@ -1182,9 +1186,7 @@ pub fn device_create_pipeline_layout<B: GfxBackend>(
             .iter()
             .map(|&id| &bind_group_layout_guard[id].raw);
         unsafe {
-            device_guard[device_id]
-                .raw
-                .create_pipeline_layout(descriptor_set_layouts, &[])
+            device.raw.create_pipeline_layout(descriptor_set_layouts, &[])
         }
         .unwrap()
     };


### PR DESCRIPTION
This PR fixes the C example code to not crash and actually run.

I've also added a few assertions to ensure a warning is emitted next time somebody forgots to increase `max_bind_groups` to something non-zero on device creation.

To help with debugging the examples, I've configured CMake to include debug info in the builds. Some new Makefile targets for the examples have been added to automate running them.