### PR TITLE
Extended remote example

### DIFF
--- a/ffi/wgpu-remote.h
+++ b/ffi/wgpu-remote.h
@@ -108,11 +108,17 @@ void wgpu_server_device_destroy(const WGPUGlobal *aGlobal,
                                 WGPUDeviceId aSelfId)
 WGPU_FUNC;
 
+/**
+ * Request an adapter according to the specified options.
+ * Provide the list of IDs to pick from.
+ *
+ * Returns the index in this list, or -1 if unable to pick.
+ */
 WGPU_INLINE
-WGPUAdapterId wgpu_server_instance_request_adapter(const WGPUGlobal *aGlobal,
-                                                   const WGPURequestAdapterOptions *aDesc,
-                                                   const WGPUAdapterId *aIds,
-                                                   uintptr_t aIdLength)
+int8_t wgpu_server_instance_request_adapter(const WGPUGlobal *aGlobal,
+                                            const WGPURequestAdapterOptions *aDesc,
+                                            const WGPUAdapterId *aIds,
+                                            uintptr_t aIdLength)
 WGPU_FUNC;
 
 WGPU_INLINE

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -775,10 +775,11 @@ impl<B: hal::Backend> Device<B> {
         }
     }
 
-    pub(crate) fn destroy_self(self) {
+    pub(crate) fn dispose(self) {
         self.com_allocator.destroy(&self.raw);
+        let desc_alloc = self.desc_allocator.into_inner();
         unsafe {
-            self.desc_allocator.lock().cleanup(&self.raw);
+            desc_alloc.dispose(&self.raw);
         }
     }
 }

--- a/wgpu-native/src/hub.rs
+++ b/wgpu-native/src/hub.rs
@@ -445,7 +445,7 @@ impl<B: hal::Backend> Drop for Hub<B> {
         // self.adapters
 
         for (_, (device, _)) in devices.map.drain() {
-            device.destroy_self();
+            device.dispose();
         }
     }
 }

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -73,6 +73,7 @@ impl Instance {
         }
         #[cfg(any(target_os = "ios", target_os = "macos"))]
         {
+            let _ = surface;
             //self.metal.destroy_surface(surface.metal);
         }
         #[cfg(windows)]

--- a/wgpu-remote/src/server.rs
+++ b/wgpu-remote/src/server.rs
@@ -17,15 +17,22 @@ pub extern "C" fn wgpu_server_delete(global: *mut wgn::Global) {
     log::info!("\t...done");
 }
 
+/// Request an adapter according to the specified options.
+/// Provide the list of IDs to pick from.
+///
+/// Returns the index in this list, or -1 if unable to pick.
 #[no_mangle]
 pub extern "C" fn wgpu_server_instance_request_adapter(
     global: &wgn::Global,
     desc: &wgn::RequestAdapterOptions,
     ids: *const wgn::AdapterId,
     id_length: usize,
-) -> wgn::AdapterId {
+) -> i8 {
     let ids = unsafe { slice::from_raw_parts(ids, id_length) };
-    wgn::request_adapter(global, desc, ids).unwrap()
+    match wgn::request_adapter(global, desc, ids) {
+        Some(id) => ids.iter().position(|&i| i == id).unwrap() as i8,
+        None => -1,
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
The remote example is now successfully able to request an adapter and to clean up the IDs.
In the near future, we need to change the example so that the server is run on a different thread...