### PR TITLE
Don't depend on gfx-auxil

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
  "arrayvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "copyless 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-auxil 0.1.0 (git+https://github.com/gfx-rs/gfx?rev=46386475f7e823e807ec984c372ffe04dcc0a22b)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-backend-dx11 0.4.0 (git+https://github.com/gfx-rs/gfx?rev=46386475f7e823e807ec984c372ffe04dcc0a22b)",
  "gfx-backend-dx12 0.4.0 (git+https://github.com/gfx-rs/gfx?rev=46386475f7e823e807ec984c372ffe04dcc0a22b)",
  "gfx-backend-empty 0.4.0 (git+https://github.com/gfx-rs/gfx?rev=46386475f7e823e807ec984c372ffe04dcc0a22b)",

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -26,10 +26,10 @@ metal-auto-capture = ["gfx-backend-metal/auto-capture"]
 arrayvec = "0.5"
 bitflags = "1.0"
 copyless = "0.1"
+fxhash = "0.2"
 lazy_static = { version = "1.1.0", optional = true }
 log = "0.4"
 hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "46386475f7e823e807ec984c372ffe04dcc0a22b" }
-gfx-auxil = { git = "https://github.com/gfx-rs/gfx", rev = "46386475f7e823e807ec984c372ffe04dcc0a22b" }
 gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "46386475f7e823e807ec984c372ffe04dcc0a22b" }
 parking_lot = "0.9"
 raw-window-handle = { version = "0.3", optional = true }

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -25,6 +25,7 @@ use crate::{
     CommandEncoderId,
     ComputePipelineId,
     DeviceId,
+    FastHashMap,
     Features,
     LifeGuard,
     PipelineLayoutId,
@@ -48,7 +49,6 @@ use crate::{gfx_select, hub::GLOBAL};
 
 use arrayvec::ArrayVec;
 use copyless::VecHelper as _;
-use gfx_auxil::FastHashMap;
 use hal::{
     self,
     command::CommandBuffer as _,

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -229,3 +229,6 @@ pub(crate) struct Features {
     pub max_bind_groups: u32,
     pub supports_texture_d24_s8: bool,
 }
+
+/// Fast hash map used internally.
+type FastHashMap<K, V> = std::collections::HashMap<K, V, std::hash::BuildHasherDefault<fxhash::FxHasher>>;

--- a/wgpu-native/src/track/mod.rs
+++ b/wgpu-native/src/track/mod.rs
@@ -11,14 +11,13 @@ use crate::{
     Backend,
     BindGroupId,
     Epoch,
+    FastHashMap,
     Index,
     RefCount,
     SamplerId,
     TextureViewId,
     TypedId,
 };
-
-use gfx_auxil::FastHashMap;
 
 use std::{
     borrow::Borrow,


### PR DESCRIPTION
Problem with gfx-auxil is that version 0.1 drags spirv_cross dependency (not needed on Vulkan), and the published crates haven't been switched to gfx-auxil-0.2