### PR TITLE
Followup for #356 - fix incorrect check

### DIFF
--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -509,7 +509,7 @@ pub fn adapter_request_device<B: GfxBackend>(
             BIND_BUFFER_ALIGNMENT % limits.min_uniform_buffer_offset_alignment,
             "Adapter uniform buffer offset alignment not compatible with WGPU"
         );
-        if desc.limits.max_bind_groups == 0 {
+        if limits.max_bound_descriptor_sets == 0 {
             log::warn!("max_bind_groups limit is missing");
         } else {
             assert!(


### PR DESCRIPTION
@kvark This fixes the fix created in #356 

The original patch is checking the _requested descriptor limits_, but the backend limits are what needs to be checked for this edge case.