### PR TITLE
Use callback for `request_adapter`

### DIFF
--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -12,6 +12,26 @@
 #define BINDINGS_LENGTH (1)
 #define BIND_GROUP_LAYOUTS_LENGTH (1)
 
+void request_adapter_callback(WGPUAdapterId const *received, void *userdata) {
+    WGPUAdapterId *id = (WGPUAdapterId*) userdata;
+    *id = *received;
+}
+
+void read_buffer_map(
+    WGPUBufferMapAsyncStatus status,
+    const uint8_t *data,
+    uint8_t *userdata) {
+    (void)userdata;
+    if (status == WGPUBufferMapAsyncStatus_Success) {
+        uint32_t *times = (uint32_t *) data;
+        printf("Times: [%d, %d, %d, %d]\n",
+            times[0],
+            times[1],
+            times[2],
+            times[3]);
+    }
+}
+
 int main(
     int argc,
     char *argv[]) {
@@ -32,7 +52,13 @@ int main(
 
     uint32_t numbers_length = size / sizeof(uint32_t);
 
-    WGPUAdapterId adapter = wgpu_request_adapter(NULL);
+    WGPUAdapterId adapter = { 0 };
+    wgpu_request_adapter_async(
+        NULL,
+        request_adapter_callback,
+        (void *) &adapter
+    );
+
     WGPUDeviceId device = wgpu_adapter_request_device(adapter, NULL);
 
     uint8_t *staging_memory;

--- a/examples/framework.c
+++ b/examples/framework.c
@@ -23,18 +23,3 @@ WGPUU32Array read_file(const char *name) {
         .length = length / 4,
     };
 }
-
-void read_buffer_map(
-    WGPUBufferMapAsyncStatus status,
-    const uint8_t *data,
-    uint8_t *userdata) {
-    (void)userdata;
-    if (status == WGPUBufferMapAsyncStatus_Success) {
-        uint32_t *times = (uint32_t *) data;
-        printf("Times: [%d, %d, %d, %d]\n",
-            times[0],
-            times[1],
-            times[2],
-            times[3]);
-    }
-}

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -32,12 +32,21 @@
 #define RENDER_PASS_ATTACHMENTS_LENGTH (1)
 #define BIND_GROUP_LAYOUTS_LENGTH (1)
 
+void request_adapter_callback(WGPUAdapterId const *received, void *userdata) {
+    WGPUAdapterId *id = (WGPUAdapterId*) userdata;
+    *id = *received;
+}
+
 int main() {
-    WGPUAdapterId adapter = wgpu_request_adapter(
+    WGPUAdapterId adapter = { 0 };
+    wgpu_request_adapter_async(
         &(WGPURequestAdapterOptions){
             .power_preference = WGPUPowerPreference_LowPower,
             .backends = 2 | 4 | 8,
-        });
+        },
+        request_adapter_callback,
+        (void *) &adapter
+    );
 
     WGPUDeviceId device = wgpu_adapter_request_device(adapter,
         &(WGPUDeviceDescriptor){

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -651,6 +651,8 @@ typedef struct {
   WGPUBackendBit backends;
 } WGPURequestAdapterOptions;
 
+typedef void (*WGPURequestAdapterCallback)(const WGPUAdapterId *adapter, void *userdata);
+
 typedef struct {
   WGPUTextureViewId view_id;
 } WGPUSwapChainOutput;
@@ -972,7 +974,9 @@ void wgpu_render_pass_set_viewport(WGPURenderPassId pass_id,
 #endif
 
 #if defined(WGPU_LOCAL)
-WGPUAdapterId wgpu_request_adapter(const WGPURequestAdapterOptions *desc);
+void wgpu_request_adapter_async(const WGPURequestAdapterOptions *desc,
+                                WGPURequestAdapterCallback callback,
+                                void *userdata);
 #endif
 
 #if defined(WGPU_LOCAL)

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -26,6 +26,7 @@ use hal::{self, adapter::PhysicalDevice as _, queue::QueueFamily as _, Instance 
 #[cfg(feature = "local")]
 use std::marker::PhantomData;
 
+use std::ffi::c_void;
 
 #[derive(Debug)]
 pub struct Instance {
@@ -301,11 +302,16 @@ pub extern "C" fn wgpu_create_surface_from_windows_hwnd(
     ))
 }
 
-pub fn request_adapter(
+pub type RequestAdapterCallback =
+    extern "C" fn(adapter: *const AdapterId, userdata: *mut c_void);
+
+pub fn request_adapter_async(
     global: &Global,
     desc: &RequestAdapterOptions,
     input_ids: &[Input<AdapterId>],
-) -> Option<AdapterId> {
+    callback: RequestAdapterCallback,
+    userdata: *mut c_void,
+) {
     let instance = &global.instance;
     let mut device_types = Vec::new();
 
@@ -321,9 +327,15 @@ pub fn request_adapter(
         }
     };
     #[cfg(not(feature = "local"))]
-    let pick = |_output, input_maybe| input_maybe;
+    let pick = |_output, input_maybe: Option<AdapterId>| {
+        let adapter = input_maybe.as_ref();
+        callback(adapter.map_or(&AdapterId::ERROR, |x| x as *const _), userdata);
+    };
     #[cfg(feature = "local")]
-    let pick = |output, _input_maybe| Some(output);
+    let pick = |output: Option<AdapterId>, _input_maybe| {
+        let adapter = output.as_ref();
+        callback(adapter.map_or(&AdapterId::ERROR, |x| x as *const _), userdata);
+    };
 
     let id_vulkan = find_input(Backend::Vulkan);
     let id_metal = find_input(Backend::Metal);
@@ -370,7 +382,8 @@ pub fn request_adapter(
 
     if device_types.is_empty() {
         log::warn!("No adapters are available!");
-        return None;
+        pick(None, None);
+        return;
     }
 
     let (mut integrated, mut discrete, mut virt, mut other) = (None, None, None, None);
@@ -415,7 +428,8 @@ pub fn request_adapter(
                 adapter,
                 &mut token,
             );
-            return pick(id_out, id_vulkan);
+            pick(Some(id_out), id_vulkan);
+            return;
         }
         selected -= adapters_vk.len();
     }
@@ -431,7 +445,8 @@ pub fn request_adapter(
                 adapter,
                 &mut token,
             );
-            return pick(id_out, id_metal);
+            pick(Some(id_out), id_metal);
+            return;
         }
         selected -= adapters_mtl.len();
     }
@@ -447,7 +462,8 @@ pub fn request_adapter(
                 adapter,
                 &mut token,
             );
-            return pick(id_out, id_dx12);
+            pick(Some(id_out), id_dx12);
+            return;
         }
         selected -= adapters_dx12.len();
         if selected < adapters_dx11.len() {
@@ -460,7 +476,8 @@ pub fn request_adapter(
                 adapter,
                 &mut token,
             );
-            return pick(id_out, id_dx11);
+            pick(Some(id_out), id_dx11);
+            return;
         }
         selected -= adapters_dx11.len();
     }
@@ -470,8 +487,12 @@ pub fn request_adapter(
 
 #[cfg(feature = "local")]
 #[no_mangle]
-pub extern "C" fn wgpu_request_adapter(desc: Option<&RequestAdapterOptions>) -> AdapterId {
-    request_adapter(&*GLOBAL, &desc.cloned().unwrap_or_default(), &[]).unwrap()
+pub extern "C" fn wgpu_request_adapter_async(
+    desc: Option<&RequestAdapterOptions>,
+    callback: RequestAdapterCallback,
+    userdata: *mut c_void,
+) {
+    request_adapter_async(&*GLOBAL, &desc.cloned().unwrap_or_default(), &[], callback, userdata);
 }
 
 pub fn adapter_request_device<B: GfxBackend>(


### PR DESCRIPTION
For now this is mostly a signature change which allows us to start using a callback for `request_adapter`. Once we have an event loop, the callback could be scheduled to make this asynchronous. At that point the examples and server would have to be updated, because they currently rely on the callback running immediately (inline).

The reason for this change is that `request_adapter` is supposed to return a `Promise` in JS, so we can represent it with callbacks at the C API, and `Future` in Rust (though we'll probably keep using callbacks initially).

I also changed `request_adapter` to provide an adapter with `AdapterId::ERROR` when no adapters are available, so we can add basic error handling to wgpu-rs (https://github.com/gfx-rs/wgpu-rs/issues/117).