### PR TITLE
Cleanup exports

### DIFF
--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -16,9 +16,8 @@
 #define BINDINGS_LENGTH (1)
 #define BIND_GROUP_LAYOUTS_LENGTH (1)
 
-void request_adapter_callback(WGPUAdapterId const *received, void *userdata) {
-    WGPUAdapterId *id = (WGPUAdapterId*) userdata;
-    *id = *received;
+void request_adapter_callback(WGPUAdapterId received, void *userdata) {
+    *(WGPUAdapterId*)userdata = received;
 }
 
 void read_buffer_map(

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -36,9 +36,8 @@
 #define RENDER_PASS_ATTACHMENTS_LENGTH (1)
 #define BIND_GROUP_LAYOUTS_LENGTH (1)
 
-void request_adapter_callback(WGPUAdapterId const *received, void *userdata) {
-    WGPUAdapterId *id = (WGPUAdapterId*) userdata;
-    *id = *received;
+void request_adapter_callback(WGPUAdapterId received, void *userdata) {
+    *(WGPUAdapterId*)userdata = received;
 }
 
 int main() {

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -649,7 +649,7 @@ typedef struct {
 
 typedef uint32_t WGPUBackendBit;
 
-typedef void (*WGPURequestAdapterCallback)(const WGPUAdapterId *adapter, void *userdata);
+typedef void (*WGPURequestAdapterCallback)(WGPUAdapterId id, void *userdata);
 
 typedef struct {
   WGPUTextureViewId view_id;

--- a/wgpu-core/src/device.rs
+++ b/wgpu-core/src/device.rs
@@ -600,11 +600,11 @@ impl<B: GfxBackend> Device<B> {
                 }
             };
             match operation {
-                resource::BufferMapOperation::Read(_, on_read, userdata) => {
-                    on_read(status, ptr, userdata)
+                resource::BufferMapOperation::Read(_, on_read) => {
+                    on_read(status, ptr)
                 }
-                resource::BufferMapOperation::Write(_, on_write, userdata) => {
-                    on_write(status, ptr, userdata)
+                resource::BufferMapOperation::Write(_, on_write) => {
+                    on_write(status, ptr)
                 }
             }
         }
@@ -1999,11 +1999,6 @@ impl<F: AllIdentityFilter + IdentityFilter<DeviceId>> Global<F> {
         device.com_allocator.destroy(&device.raw);
     }
 }
-
-pub type BufferMapReadCallback =
-    extern "C" fn(status: resource::BufferMapAsyncStatus, data: *const u8, userdata: *mut u8);
-pub type BufferMapWriteCallback =
-    extern "C" fn(status: resource::BufferMapAsyncStatus, data: *mut u8, userdata: *mut u8);
 
 impl<F> Global<F> {
     pub fn buffer_map_async<B: GfxBackend>(

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -17,7 +17,6 @@ use serde::{Deserialize, Serialize};
 pub use hal::adapter::AdapterInfo;
 use hal::{self, adapter::PhysicalDevice as _, queue::QueueFamily as _, Instance as _};
 
-use std::ffi::c_void;
 
 #[derive(Debug)]
 pub struct Instance {
@@ -152,8 +151,6 @@ pub struct DeviceDescriptor {
     pub extensions: Extensions,
     pub limits: Limits,
 }
-
-pub type RequestAdapterCallback = extern "C" fn(adapter: *const AdapterId, userdata: *mut c_void);
 
 bitflags::bitflags! {
     #[repr(transparent)]

--- a/wgpu-native/src/lib.rs
+++ b/wgpu-native/src/lib.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
-pub mod command;
-pub mod device;
+mod command;
+mod device;
+
+pub use self::command::*;
+pub use self::device::*;
 
 type Global = core::hub::Global<parking_lot::Mutex<core::hub::IdentityManager>>;
 


### PR DESCRIPTION
This is a follow-up to #381 that cleans up the exports, such that `wgpu-core` doesn't deal with any raw C things.