### PR TITLE
Fix build for iOS

### DIFF
--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -21,7 +21,7 @@ pub fn wgpu_create_surface(raw_handle: raw_window_handle::RawWindowHandle) -> id
     let instance = &GLOBAL.instance;
     let surface = match raw_handle {
         #[cfg(target_os = "ios")]
-        Rwh::IOS(h) => Surface {
+        Rwh::IOS(h) => core::instance::Surface {
             #[cfg(feature = "vulkan-portability")]
             vulkan: None,
             metal: instance


### PR DESCRIPTION
   ``` 
Compiling wgpu-native v0.4.0 (https://github.com/gfx-rs/wgpu?rev=b51053dc2dc3bbe9b2ba050fde42eeb6405fe092#b51053dc)
error[E0422]: cannot find struct, variant or union type `Surface` in this scope
  --> /Users/LiJinlei/.cargo/git/checkouts/wgpu-53e70f8674b08dd4/b51053d/wgpu-native/src/device.rs:24:24
   |
24 |         Rwh::IOS(h) => Surface {
   |                        ^^^^^^^ not found in this scope
help: possible candidate is found in another module, you can import it into scope
   ``` 