### PR TITLE
Validate bind group layouts by value

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -7,6 +7,7 @@ use crate::{
     resource::TextureViewDimension,
     track::{DUMMY_SELECTOR, TrackerSet},
     BufferAddress,
+    FastHashMap,
     LifeGuard,
     RefCount,
     Stored,
@@ -41,7 +42,7 @@ pub enum BindingType {
 }
 
 #[repr(C)]
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, PartialEq)]
 pub struct BindGroupLayoutBinding {
     pub binding: u32,
     pub visibility: ShaderStage,
@@ -61,7 +62,7 @@ pub struct BindGroupLayoutDescriptor {
 #[derive(Debug)]
 pub struct BindGroupLayout<B: hal::Backend> {
     pub(crate) raw: B::DescriptorSetLayout,
-    pub(crate) bindings: Vec<BindGroupLayoutBinding>,
+    pub(crate) bindings: FastHashMap<u32, BindGroupLayoutBinding>,
     pub(crate) desc_ranges: DescriptorRanges,
     pub(crate) dynamic_count: usize,
 }

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -136,8 +136,15 @@ impl<T, I: TypedId> Storage<T, I> {
                 value
             })
     }
-}
 
+    pub fn iter(&self, backend: Backend) -> impl Iterator<Item = (I, &T)> {
+        self.map
+            .iter()
+            .map(move |(index, (value, storage_epoch))| {
+                (I::zip(index as Index, *storage_epoch, backend), value)
+            })
+    }
+}
 
 /// Type system for enforcing the lock order on shared HUB structures.
 /// If type A implements `Access<B>`, that means we are allowed to proceed


### PR DESCRIPTION
This PR widens the comparisons done between two bind group layouts to also consider them equivalent if their vectors of `BindGroupLayoutBinding`s are equal. 

Tested on various modifications of the cube example from wgpu-rs. https://gist.github.com/yanchith/56e15fe35658b14587ff9bfcbd53116f

Fixes #335 