### PR TITLE
[0.4] Fix tracking of render pass attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v0.4.2 (15-12-2019)
+  - fixed render pass transitions
+
 ## v0.4.1 (28-11-2019)
   - fixed depth/stencil transitions
   - fixed dynamic offset iteration

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-native"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
 	"Dzmitry Malyshau <kvark@mozilla.com>",
 	"Joshua Groves <josh@joshgroves.com>",

--- a/wgpu-native/src/command/compute.rs
+++ b/wgpu-native/src/command/compute.rs
@@ -63,6 +63,7 @@ pub fn compute_pass_end_pass<B: GfxBackend>(global: &Global, pass_id: ComputePas
 
     // There are no transitions to be made: we've already been inserting barriers
     // into the parent command buffer while recording this compute pass.
+    log::debug!("Compute pass {:?} tracker: {:#?}", pass_id, pass.trackers);
     cmb.trackers = pass.trackers;
     cmb.raw.push(pass.raw);
 }

--- a/wgpu-native/src/command/render.rs
+++ b/wgpu-native/src/command/render.rs
@@ -190,6 +190,8 @@ pub fn render_pass_end_pass<B: GfxBackend>(global: &Global, pass_id: RenderPassI
         pass.raw.end_render_pass();
     }
     pass.trackers.optimize();
+    log::debug!("Render pass {:?} tracker: {:#?}", pass_id, pass.trackers);
+
     let cmb = &mut cmb_guard[pass.cmb_id.value];
     let (buffer_guard, mut token) = hub.buffers.read(&mut token);
     let (texture_guard, _) = hub.textures.read(&mut token);

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -1413,6 +1413,8 @@ pub fn device_create_bind_group<B: GfxBackend>(
         dynamic_count: bind_group_layout.dynamic_count,
     };
     let (id, id_out) = hub.bind_groups.new_identity(id_in);
+
+    log::debug!("Bind group {:?} tracker: {:#?}", id, bind_group.used);
     let ok = device
         .trackers
         .lock()
@@ -1649,6 +1651,8 @@ pub fn queue_submit<B: GfxBackend>(
                 comb.raw.last_mut().unwrap().finish();
             }
         }
+
+        log::debug!("Device tracker after submission: {:#?}", trackers);
 
         // now prepare the GPU submission
         let fence = device.raw.create_fence(false).unwrap();

--- a/wgpu-native/src/track/mod.rs
+++ b/wgpu-native/src/track/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 use std::{
     borrow::Borrow,
     collections::hash_map::Entry,
-    fmt::Debug,
+    fmt,
     marker::PhantomData,
     ops::Range,
     vec::Drain,
@@ -76,11 +76,11 @@ pub enum Stitch {
 /// a particular resource type, like a buffer or a texture.
 pub trait ResourceState: Clone + Default {
     /// Corresponding `HUB` identifier.
-    type Id: Copy + Debug + TypedId;
+    type Id: Copy + fmt::Debug + TypedId;
     /// A type specifying the sub-resources.
-    type Selector: Debug;
+    type Selector: fmt::Debug;
     /// Usage type for a `Unit` of a sub-resource.
-    type Usage: Debug;
+    type Usage: fmt::Debug;
 
     /// Check if all the selected sub-resources have the same
     /// usage, and return it.
@@ -135,7 +135,7 @@ pub trait ResourceState: Clone + Default {
 
 /// Structure wrapping the abstract tracking state with the relevant resource
 /// data, such as the reference count and the epoch.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 struct Resource<S> {
     ref_count: RefCount,
     state: S,
@@ -153,7 +153,6 @@ pub struct PendingTransition<S: ResourceState> {
 }
 
 /// A tracker for all resources of a given type.
-#[derive(Debug)]
 pub struct ResourceTracker<S: ResourceState> {
     /// An association of known resource indices with their tracked states.
     map: FastHashMap<Index, Resource<S>>,
@@ -161,6 +160,18 @@ pub struct ResourceTracker<S: ResourceState> {
     temp: Vec<PendingTransition<S>>,
     /// The backend variant for all the tracked resources.
     backend: Backend,
+}
+
+impl<S: ResourceState + fmt::Debug> fmt::Debug for ResourceTracker<S> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.map
+            .iter()
+            .map(|(&index, res)| {
+                ((index, res.epoch), &res.state)
+            })
+            .collect::<FastHashMap<_, _>>()
+            .fmt(formatter)
+    }
 }
 
 impl<S: ResourceState> ResourceTracker<S> {
@@ -383,7 +394,7 @@ impl<S: ResourceState> ResourceTracker<S> {
 }
 
 
-impl<I: Copy + Debug + TypedId> ResourceState for PhantomData<I> {
+impl<I: Copy + fmt::Debug + TypedId> ResourceState for PhantomData<I> {
     type Id = I;
     type Selector = ();
     type Usage = ();


### PR DESCRIPTION
Fixes #407
Also improves the debug output of the tracker.

Filed #409 for addressing this better.