### PR TITLE
Another big tracking refactor

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* Generated with cbindgen:0.9.1 */
+/* Generated with cbindgen:0.11.1 */
 
 /* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
  * To generate this file:

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -56,7 +56,7 @@ impl<F: IdentityFilter<ComputePassId>> Global<F> {
 
         // There are no transitions to be made: we've already been inserting barriers
         // into the parent command buffer while recording this compute pass.
-        log::debug!("Compute pass {:?} tracker: {:#?}", pass_id, pass.trackers);
+        log::debug!("Compute pass {:?} {:#?}", pass_id, pass.trackers);
         cmb.trackers = pass.trackers;
         cmb.raw.push(pass.raw);
     }

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -11,7 +11,7 @@ use crate::{
     hub::{GfxBackend, Global, IdentityFilter, Token},
     id::{BindGroupId, BufferId, CommandBufferId, ComputePassId, ComputePipelineId},
     resource::BufferUsage,
-    track::{Stitch, TrackerSet},
+    track::TrackerSet,
     BufferAddress,
     Stored,
 };
@@ -112,7 +112,6 @@ impl<F> Global<F> {
             &mut pass.raw,
             &mut pass.trackers,
             &bind_group.used,
-            Stitch::Last,
             &*buffer_guard,
             &*texture_guard,
         );

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -34,7 +34,7 @@ use crate::{
         TextureViewId,
     },
     resource::{Buffer, Texture, TextureUsage, TextureViewInner},
-    track::{Stitch, TrackerSet},
+    track::TrackerSet,
     Color,
     Features,
     LifeGuard,
@@ -118,17 +118,15 @@ impl<B: GfxBackend> CommandBuffer<B> {
         raw: &mut B::CommandBuffer,
         base: &mut TrackerSet,
         head: &TrackerSet,
-        stitch: Stitch,
         buffer_guard: &Storage<Buffer<B>, BufferId>,
         texture_guard: &Storage<Texture<B>, TextureId>,
     ) {
-        log::trace!("\tstitch {:?}", stitch);
         debug_assert_eq!(B::VARIANT, base.backend());
         debug_assert_eq!(B::VARIANT, head.backend());
 
         let buffer_barriers = base
             .buffers
-            .merge_replace(&head.buffers, stitch)
+            .merge_replace(&head.buffers)
             .map(|pending| {
                 log::trace!("\tbuffer -> {:?}", pending);
                 hal::memory::Barrier::Buffer {
@@ -140,7 +138,7 @@ impl<B: GfxBackend> CommandBuffer<B> {
             });
         let texture_barriers = base
             .textures
-            .merge_replace(&head.textures, stitch)
+            .merge_replace(&head.textures)
             .map(|pending| {
                 log::trace!("\ttexture -> {:?}", pending);
                 hal::memory::Barrier::Image {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -186,7 +186,7 @@ impl<F: IdentityFilter<RenderPassId>> Global<F> {
             pass.raw.end_render_pass();
         }
         pass.trackers.optimize();
-        log::debug!("Render pass {:?} tracker: {:#?}", pass_id, pass.trackers);
+        log::debug!("Render pass {:?} {:#?}", pass_id, pass.trackers);
 
         let cmb = &mut cmb_guard[pass.cmb_id.value];
         let (buffer_guard, mut token) = hub.buffers.read(&mut token);
@@ -207,6 +207,11 @@ impl<F: IdentityFilter<RenderPassId>> Global<F> {
             None => {
                 cmb.trackers.merge_extend(&pass.trackers);
             }
+        }
+
+        if false {
+            log::debug!("Command buffer {:?} after render pass {:#?}",
+                pass.cmb_id.value, cmb.trackers);
         }
 
         cmb.raw.push(pass.raw);

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -13,7 +13,7 @@ use crate::{
     id::{BindGroupId, BufferId, CommandBufferId, RenderPassId, RenderPipelineId},
     pipeline::{IndexFormat, InputStepMode, PipelineFlags},
     resource::BufferUsage,
-    track::{Stitch, TrackerSet},
+    track::TrackerSet,
     BufferAddress,
     Color,
     Stored,
@@ -199,7 +199,6 @@ impl<F: IdentityFilter<RenderPassId>> Global<F> {
                     last,
                     &mut cmb.trackers,
                     &pass.trackers,
-                    Stitch::Last,
                     &*buffer_guard,
                     &*texture_guard,
                 );

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -129,6 +129,7 @@ impl<B: GfxBackend> RenderPass<B> {
         raw: B::CommandBuffer,
         cmb_id: Stored<CommandBufferId>,
         context: RenderPassContext,
+        trackers: TrackerSet,
         sample_count: u8,
         max_bind_groups: u32,
     ) -> Self {
@@ -137,7 +138,7 @@ impl<B: GfxBackend> RenderPass<B> {
             cmb_id,
             context,
             binder: Binder::new(max_bind_groups),
-            trackers: TrackerSet::new(B::VARIANT),
+            trackers,
             blend_color_status: OptionalState::Unused,
             stencil_reference_status: OptionalState::Unused,
             index_state: IndexState {

--- a/wgpu-core/src/device.rs
+++ b/wgpu-core/src/device.rs
@@ -817,13 +817,12 @@ impl<F: IdentityFilter<BufferId>> Global<F> {
         let ref_count = buffer.life_guard.ref_count.clone();
 
         let id = hub.buffers.register_identity(id_in, buffer, &mut token);
-        let ok =
-            device
-                .trackers
-                .lock()
-                .buffers
-                .init(id, ref_count, (), resource::BufferUsage::empty());
-        assert!(ok);
+        device
+            .trackers
+            .lock()
+            .buffers
+            .init(id, ref_count, &())
+            .unwrap();
         id
     }
 
@@ -857,13 +856,15 @@ impl<F: IdentityFilter<BufferId>> Global<F> {
         }
 
         let id = hub.buffers.register_identity(id_in, buffer, &mut token);
-        let ok = device.trackers.lock().buffers.init(
-            id,
-            ref_count,
-            (),
-            resource::BufferUsage::MAP_WRITE,
-        );
-        assert!(ok);
+        device.trackers
+            .lock()
+            .buffers.init(
+                id,
+                ref_count,
+                &(),
+            )
+            .unwrap()
+            .set((), resource::BufferUsage::MAP_WRITE);
         id
     }
 
@@ -967,13 +968,15 @@ impl<F: IdentityFilter<TextureId>> Global<F> {
         let ref_count = texture.life_guard.ref_count.clone();
 
         let id = hub.textures.register_identity(id_in, texture, &mut token);
-        let ok = device.trackers.lock().textures.init(
-            id,
-            ref_count,
-            range,
-            resource::TextureUsage::UNINITIALIZED,
-        );
-        assert!(ok);
+        device.trackers
+            .lock()
+            .textures.init(
+                id,
+                ref_count,
+                &range,
+            )
+            .unwrap()
+            .set(range, resource::TextureUsage::UNINITIALIZED);
         id
     }
 
@@ -1079,8 +1082,10 @@ impl<F: IdentityFilter<TextureViewId>> Global<F> {
         let ref_count = view.life_guard.ref_count.clone();
 
         let id = hub.texture_views.register_identity(id_in, view, &mut token);
-        let ok = device.trackers.lock().views.init(id, ref_count, (), ());
-        assert!(ok);
+        device.trackers
+            .lock()
+            .views.init(id, ref_count, &())
+            .unwrap();
         id
     }
 
@@ -1150,8 +1155,10 @@ impl<F: IdentityFilter<SamplerId>> Global<F> {
         let ref_count = sampler.life_guard.ref_count.clone();
 
         let id = hub.samplers.register_identity(id_in, sampler, &mut token);
-        let ok = device.trackers.lock().samplers.init(id, ref_count, (), ());
-        assert!(ok);
+        device.trackers
+            .lock()
+            .samplers.init(id, ref_count, &())
+            .unwrap();
         id
     }
 
@@ -1427,15 +1434,15 @@ impl<F: IdentityFilter<BindGroupId>> Global<F> {
         let id = hub
             .bind_groups
             .register_identity(id_in, bind_group, &mut token);
-        log::debug!("Bind group {:?} tracker : {:#?}",
+        log::debug!("Bind group {:?} {:#?}",
             id, hub.bind_groups.read(&mut token).0[id].used);
 
-        let ok = device
+        device
             .trackers
             .lock()
             .bind_groups
-            .init(id, ref_count, (), ());
-        assert!(ok);
+            .init(id, ref_count, &())
+            .unwrap();
         id
     }
 
@@ -1630,7 +1637,7 @@ impl<F: AllIdentityFilter + IdentityFilter<CommandBufferId>> Global<F> {
                 }
             }
 
-            log::debug!("Device tracker after submission: {:#?}", trackers);
+            log::debug!("Device after submission {}: {:#?}", submit_index, trackers);
 
             // now prepare the GPU submission
             let fence = device.raw.create_fence(false).unwrap();

--- a/wgpu-core/src/device.rs
+++ b/wgpu-core/src/device.rs
@@ -29,7 +29,7 @@ use crate::{
     pipeline,
     resource,
     swap_chain,
-    track::{SEPARATE_DEPTH_STENCIL_STATES, Stitch, TrackerSet},
+    track::{SEPARATE_DEPTH_STENCIL_STATES, TrackerSet},
     BufferAddress,
     FastHashMap,
     Features,
@@ -1618,7 +1618,6 @@ impl<F: AllIdentityFilter + IdentityFilter<CommandBufferId>> Global<F> {
                     &mut transit,
                     &mut *trackers,
                     &comb.trackers,
-                    Stitch::Init,
                     &*buffer_guard,
                     &*texture_guard,
                 );

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -35,7 +35,7 @@ pub const SEPARATE_DEPTH_STENCIL_STATES: bool = false;
 /// usage as well as the last/current one, similar to `Range`.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Unit<U> {
-    init: U,
+    first: Option<U>,
     last: U,
 }
 
@@ -43,32 +43,15 @@ impl<U: Copy> Unit<U> {
     /// Create a new unit from a given usage.
     fn new(usage: U) -> Self {
         Unit {
-            init: usage,
+            first: None,
             last: usage,
         }
     }
 
-    /// Select one of the ends of the usage, based on the
-    /// given `Stitch`.
-    ///
-    /// In some scenarios, when merging two trackers
-    /// A and B for a resource, we want to connect A to the initial state
-    /// of B. In other scenarios, we want to reach the last state of B.
-    fn select(&self, stitch: Stitch) -> U {
-        match stitch {
-            Stitch::Init => self.init,
-            Stitch::Last => self.last,
-        }
+    /// Return a usage to link to.
+    fn port(&self) -> U {
+        self.first.unwrap_or(self.last)
     }
-}
-
-/// Mode of stitching to states together.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Stitch {
-    /// Stitch to the init state of the other resource.
-    Init,
-    /// Stitch to the last state of the other resource.
-    Last,
 }
 
 /// The main trait that abstracts away the tracking logic of
@@ -119,15 +102,10 @@ pub trait ResourceState: Clone {
     /// `PendingTransition` pushed to this vector, or extended with the
     /// other read-only usage, unless there is a usage conflict, and
     /// the error is generated (returning the conflict).
-    ///
-    /// `stitch` only defines the end points of generated transitions.
-    /// Last states of `self` are nevertheless updated to the *last* states
-    /// of `other`, if `output` is provided.
     fn merge(
         &mut self,
         id: Self::Id,
         other: &Self,
-        stitch: Stitch,
         output: Option<&mut Vec<PendingTransition<Self>>>,
     ) -> Result<(), PendingTransition<Self>>;
 
@@ -331,7 +309,7 @@ impl<S: ResourceState> ResourceTracker<S> {
                     let id = S::Id::zip(index, new.epoch, self.backend);
                     e.into_mut()
                         .state
-                        .merge(id, &new.state, Stitch::Last, None)?;
+                        .merge(id, &new.state, None)?;
                 }
             }
         }
@@ -343,7 +321,6 @@ impl<S: ResourceState> ResourceTracker<S> {
     pub fn merge_replace<'a>(
         &'a mut self,
         other: &'a Self,
-        stitch: Stitch,
     ) -> Drain<PendingTransition<S>> {
         for (&index, new) in other.map.iter() {
             match self.map.entry(index) {
@@ -355,7 +332,7 @@ impl<S: ResourceState> ResourceTracker<S> {
                     let id = S::Id::zip(index, new.epoch, self.backend);
                     e.into_mut()
                         .state
-                        .merge(id, &new.state, stitch, Some(&mut self.temp))
+                        .merge(id, &new.state, Some(&mut self.temp))
                         .ok(); //TODO: unwrap?
                 }
             }
@@ -426,7 +403,6 @@ impl<I: Copy + fmt::Debug + TypedId> ResourceState for PhantomData<I> {
         &mut self,
         _id: Self::Id,
         _other: &Self,
-        _stitch: Stitch,
         _output: Option<&mut Vec<PendingTransition<Self>>>,
     ) -> Result<(), PendingTransition<Self>> {
         Ok(())


### PR DESCRIPTION
Fixes #409
Note: there is way more code that had to be thrown out in the process of this PR than there is in the PR itself.
Also fixes [this comment](https://github.com/gfx-rs/wgpu/blob/04e17b3f4fe44d816cebeadc0e89bf588cfefe70/wgpu-core/src/track/texture.rs#L29):
> //TODO: make this less awkward!

## Logic
Instead of having a run-time per-operation control over what state is being used for stitching (with `Stitch` enum), we are now deriving this automatically on a per-subresource level. Whenever we are detecting a transition for a sub-resource, and we know there wasn't any "first" state associated with it in the current tracker, we are saving this "first" state. Unlike previous code, where it was confusing what of `Unit` fields (`init`, `last`) are valid, now `first` is `Option<>`, so we know we should be using it if it's there.

This allows us to have this hybrid tracking state of a render pass, where all resources are immutable (and their usage is extended), except for the output attachments. This, together with a whole lot of refactoring, gets us #409.

I'm actually quite happy with the tracking code now. It's finally taking shape we aren't afraid to tell others about :)

Note: this was tested on wgpu-rs examples and vange-rs.