### PR TITLE
Makefile package command and travis github releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .vs
 build
 ffi/dawn*.h
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ script:
       make example-compute example-triangle VERBOSE=1;
     fi
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME != "windows" ]]; then make VERBOSE=1; fi
-  - make package
+  - if [[ $TRAVIS_RUST_VERSION == "stable" ]]; then make package; fi
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,3 +75,17 @@ script:
       make example-compute example-triangle VERBOSE=1;
     fi
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME != "windows" ]]; then make VERBOSE=1; fi
+  - make package
+
+deploy:
+  provider: releases
+  api_key:
+    secure: TODO
+  file_glob: true
+  file: dist/wgpu-*.zip
+  skip_cleanup: true
+  overwrite: true
+  on:
+    tags: true
+    condition: $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_BRANCH == $TRAVIS_TAG
+    skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ script:
 deploy:
   provider: releases
   api_key:
-    secure: TODO
+    secure: kS8vjHOnLEknb2qxf2dPxMW8S5KcpjSkSgoi23WXiX3DZ2v8DIJMxVLanJhD3mbr1oI1NGXQHrTeeA/HBEEJcOVzlQo38MgNo/Jyt1k4jLRyCEDL0LjO+M1zAQGoEDWlyyjeu+Alw3SFKqGoZeuYDZ/mxUpEapFMD++8w4IjON2fI6iNumcIMeAg3Ns6Y4wHYQPzfIQQf5svI9dh1lf7PhlFB/btONBPi6rXxU/UwCnHBoOPydl5OwjggaUAjCJSf8i/FDLWt5XpvA2UsML2AbcFNuwFhNGhf6ArwEsqgcMCGL6jACetvI/l3ZL96h5dsgzRLW0ruvnvpEm3y3aw9wCjEAcnQMZCBPlIfOpj5MH/guh526QWCVQ3rwRUJOhua9T2yvwda3ICYspyVShzlbwscA9yLwvsuO+6Hl+upuE2IPfLvS6QpnXVlIWHe/3HqOoQggDdsWvnZhhGNKASKsi9vNgTvec/1iX846/KGcV3nYeHIWFrvP0IgWtEqQrgcWj9w6X7LDdaTFmrkKwKnNn4ClLQYPnlWQS71iX0gwRhONGaSAEfFca6vwVTa8AGSQUEHphe5lT7LtAy6UhlbjZNuKvUR+pn+l0EoWlZzm+uxKMtGR+mG9h6My+GA3hCWWtX/Xc94TvuJ1cg+uRu48+rD21vv3cr2fEVDRq7pGg=
   file_glob: true
   file: dist/wgpu-*.zip
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,12 @@ endif
 	example-compute example-triangle example-remote \
 	run-example-compute run-example-triangle run-example-remote \
 	lib-native lib-native-release \
-	lib-remote lib-remote-release
+	lib-remote
 
 #TODO: example-remote
 all: example-compute example-triangle lib-remote
 
-package: lib-native lib-native-release lib-remote lib-remote-release
+package: lib-native lib-native-release
 	mkdir -p dist
 	echo "$(GIT_TAG_FULL)" > dist/commit-sha
 	for RELEASE in debug release; do \
@@ -91,9 +91,6 @@ lib-native-release: Cargo.lock wgpu-native/Cargo.toml $(WILDCARD_WGPU_NATIVE)
 
 lib-remote: Cargo.lock wgpu-remote/Cargo.toml $(WILDCARD_WGPU_REMOTE)
 	cargo build --manifest-path wgpu-remote/Cargo.toml
-
-lib-remote-release: Cargo.lock wgpu-remote/Cargo.toml $(WILDCARD_WGPU_REMOTE)
-	cargo build --manifest-path wgpu-remote/Cargo.toml --release
 
 $(FFI_DIR)/wgpu.h: wgpu-native/cbindgen.toml $(WILDCARD_WGPU_NATIVE)
 	rustup run nightly cbindgen -o $(FFI_DIR)/wgpu.h wgpu-native

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ CREATE_BUILD_DIR:=
 WILDCARD_WGPU_NATIVE:=$(wildcard wgpu-native/**/*.rs wgpu-core/**/*.rs)
 WILDCARD_WGPU_REMOTE:=$(wildcard wgpu-remote/**/*.rs wgpu-core/**/*.rs)
 
+GIT_TAG=$(shell git describe --abbrev=0 --tags)
+GIT_TAG_FULL=$(shell git describe --tags)
+OS_NAME=
+
 ifeq (,$(TARGET))
 	CHECK_TARGET_FLAG=
 else
@@ -26,12 +30,37 @@ else
 	CREATE_BUILD_DIR=mkdir -p $(BUILD_DIR)
 endif
 
-.PHONY: all check test doc clear lib-native lib-remote \
+ifeq ($(OS),Windows_NT)
+	LIB_EXTENSION=dll
+	OS_NAME=windows
+else
+	UNAME_S:=$(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		LIB_EXTENSION=so
+		OS_NAME=linux
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		LIB_EXTENSION=dylib
+		OS_NAME=macos
+	endif
+endif
+
+
+.PHONY: all check test doc clear \
 	example-compute example-triangle example-remote \
-	run-example-compute run-example-triangle run-example-remote
+	run-example-compute run-example-triangle run-example-remote \
+	lib-native lib-native-release \
+	lib-remote lib-remote-release
 
 #TODO: example-remote
 all: example-compute example-triangle lib-remote
+
+package: lib-native lib-native-release lib-remote lib-remote-release
+	mkdir -p dist
+	echo "$(GIT_TAG_FULL)" > dist/commit-sha
+	for RELEASE in debug release; do \
+		zip -j dist/wgpu-$$RELEASE-$(OS_NAME)-$(GIT_TAG).zip target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) dist/commit-sha; \
+	done
 
 check:
 	cargo check --all
@@ -49,8 +78,14 @@ clear:
 lib-native: Cargo.lock wgpu-native/Cargo.toml $(WILDCARD_WGPU_NATIVE)
 	cargo build --manifest-path wgpu-native/Cargo.toml
 
+lib-native-release: Cargo.lock wgpu-native/Cargo.toml $(WILDCARD_WGPU_NATIVE)
+	cargo build --manifest-path wgpu-native/Cargo.toml --release
+
 lib-remote: Cargo.lock wgpu-remote/Cargo.toml $(WILDCARD_WGPU_REMOTE)
 	cargo build --manifest-path wgpu-remote/Cargo.toml
+
+lib-remote-release: Cargo.lock wgpu-remote/Cargo.toml $(WILDCARD_WGPU_REMOTE)
+	cargo build --manifest-path wgpu-remote/Cargo.toml --release
 
 $(FFI_DIR)/wgpu.h: wgpu-native/cbindgen.toml $(WILDCARD_WGPU_NATIVE)
 	rustup run nightly cbindgen -o $(FFI_DIR)/wgpu.h wgpu-native

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,9 @@ package: lib-native lib-native-release
 		ARCHIVE=wgpu-$$RELEASE-$(OS_NAME)-$(GIT_TAG).zip; \
 		rm -f dist/$$ARCHIVE; \
 		if [ $(ZIP_TOOL) = zip ]; then \
-			zip -j dist/$$ARCHIVE target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) dist/commit-sha; \
+			zip -j dist/$$ARCHIVE target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) ffi/*.h dist/commit-sha; \
 		else \
-			7z a -tzip dist/$$ARCHIVE ./target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) ./dist/commit-sha; \
+			7z a -tzip dist/$$ARCHIVE ./target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) ./ffi/*.h ./dist/commit-sha; \
 		fi; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,9 @@ package: lib-native lib-native-release lib-remote lib-remote-release
 	mkdir -p dist
 	echo "$(GIT_TAG_FULL)" > dist/commit-sha
 	for RELEASE in debug release; do \
-		zip -j dist/wgpu-$$RELEASE-$(OS_NAME)-$(GIT_TAG).zip target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) dist/commit-sha; \
+		ARCHIVE=wgpu-$$RELEASE-$(OS_NAME)-$(GIT_TAG).zip; \
+		rm -f dist/$$ARCHIVE; \
+		zip -j dist/$$ARCHIVE target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) dist/commit-sha; \
 	done
 
 check:

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ package: lib-native lib-native-release lib-remote lib-remote-release
 		if [ $(ZIP_TOOL) = zip ]; then \
 			zip -j dist/$$ARCHIVE target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) dist/commit-sha; \
 		else \
-			7z a dist/$$ARCHIVE ./target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) ./dist/commit-sha; \
+			7z a -tzip dist/$$ARCHIVE ./target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) ./dist/commit-sha; \
 		fi; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ package: lib-native lib-native-release
 		if [ $(ZIP_TOOL) = zip ]; then \
 			zip -j dist/$$ARCHIVE target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) ffi/*.h dist/commit-sha; \
 		else \
-			7z a -tzip dist/$$ARCHIVE ./target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) ./ffi/*.h ./dist/commit-sha; \
+			7z a -tzip dist/$$ARCHIVE ./target/$$RELEASE/wgpu_*.$(LIB_EXTENSION) ./ffi/*.h ./dist/commit-sha; \
 		fi; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,10 @@ endif
 ifeq ($(OS),Windows_NT)
 	LIB_EXTENSION=dll
 	OS_NAME=windows
+	ZIP_TOOL=7z
 else
 	UNAME_S:=$(shell uname -s)
+	ZIP_TOOL=zip
 	ifeq ($(UNAME_S),Linux)
 		LIB_EXTENSION=so
 		OS_NAME=linux
@@ -61,7 +63,11 @@ package: lib-native lib-native-release lib-remote lib-remote-release
 	for RELEASE in debug release; do \
 		ARCHIVE=wgpu-$$RELEASE-$(OS_NAME)-$(GIT_TAG).zip; \
 		rm -f dist/$$ARCHIVE; \
-		zip -j dist/$$ARCHIVE target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) dist/commit-sha; \
+		if [ $(ZIP_TOOL) = zip ]; then \
+			zip -j dist/$$ARCHIVE target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) dist/commit-sha; \
+		else \
+			7z a dist/$$ARCHIVE ./target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) ./dist/commit-sha; \
+		fi; \
 	done
 
 check:


### PR DESCRIPTION
Closes #414

Approach mostly mimicked from [gfx-portability](https://github.com/gfx-rs/portability) as recommended to me by @kvark. I needed a number of commits to iron out some kinks for the Windows builds, so I would recommend using squash merge when accepting this PR.

Note that the Windows rust=nightly build fails, but it's also broken on master, so it's unrelated to the changes in this PR.

/cc @almarklein

# Questions

- [x] Would it make sense to also regenerate the `ffi/wgpu.h` and `wgpu-remote.h` header files and include them in the zip archive?

# Todo for maintainers

- [x] Configure encrypted `api_key`
As in [gfx-portability](https://github.com/gfx-rs/portability/blob/master/.travis.yml#L61) you will need to create an API key and commit it to the `.travis.yml` file. I've checked "allow edits from maintainers" so you should be able to commit to this branch directly. You may want to reference the [Travis instructions](https://docs.travis-ci.com/user/deployment/releases/#authenticating-with-an-oauth-token) as well.

- [ ] Tag revisions
Previous versions (`v0.1` - `v0.4`) have not been tagged on the master branch, you will want to do so retroactively. Also, when releasing in the future, make sure to tag the commit before pushing. Alternatively, you can schedule a travis build manually after applying the tag retroactively.