### PR TITLE
Make Origin3d::{x,y,z} all have type u32

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -349,11 +349,11 @@ typedef uint64_t WGPUId_Texture_Dummy;
 typedef WGPUId_Texture_Dummy WGPUTextureId;
 
 typedef struct {
-  float x;
-  float y;
-  float z;
+  uint32_t x;
+  uint32_t y;
+  uint32_t z;
 } WGPUOrigin3d;
-#define WGPUOrigin3d_ZERO (WGPUOrigin3d){ .x = 0.0, .y = 0.0, .z = 0.0 }
+#define WGPUOrigin3d_ZERO (WGPUOrigin3d){ .x = 0, .y = 0, .z = 0 }
 
 typedef struct {
   WGPUTextureId texture;

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -159,16 +159,16 @@ impl Color {
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct Origin3d {
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
 }
 
 impl Origin3d {
     pub const ZERO: Self = Origin3d {
-        x: 0.0,
-        y: 0.0,
-        z: 0.0,
+        x: 0,
+        y: 0,
+        z: 0,
     };
 }
 


### PR DESCRIPTION
Fixes #419 