### PR TITLE
configure rust msvc toolchain on windows on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ branches:
 
 before_install:
 - if [[ $TRAVIS_OS_NAME == "windows" ]]; then choco install make; fi
+- if [[ $TRAVIS_RUST_VERSION != "nightly" ]] && [[ $TRAVIS_OS_NAME == "windows" ]]; then rustup default stable-msvc; fi
+- if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME == "windows" ]]; then rustup default nightly-msvc; fi
 
 script:
   - cargo test


### PR DESCRIPTION
Closes #425 

@LaylConway's [proposal](https://github.com/gfx-rs/wgpu/issues/425#issuecomment-569737145) was right.

Apparently Travis configures the non-standard GNU toolchain on Windows by default; it's unclear why and kind of defeats the point of Windows CI for this project, so we reconfigure it to use the MSVC toolchain manually in the `before_install` stage.

/cc @kvark