### PR TITLE
Refactor usage tracking to be truly sparse

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -174,12 +174,7 @@ impl<F> Global<F> {
         );
         assert!(src_buffer.usage.contains(BufferUsage::INDIRECT));
 
-        let barriers = src_pending.map(|pending| hal::memory::Barrier::Buffer {
-            states: pending.to_states(),
-            target: &src_buffer.raw,
-            families: None,
-            range: None .. None,
-        });
+        let barriers = src_pending.map(|pending| pending.into_hal(src_buffer));
 
         unsafe {
             pass.raw.pipeline_barrier(

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -327,7 +327,7 @@ impl<F: IdentityFilter<RenderPassId>> Global<F> {
                         at.attachment,
                         view.life_guard.add_ref(),
                         PhantomData,
-                    ).is_some();
+                    ).is_ok();
 
                     let layouts = match view.inner {
                         TextureViewInner::Native { ref source_id, .. } => {
@@ -387,7 +387,7 @@ impl<F: IdentityFilter<RenderPassId>> Global<F> {
                         resolve_target,
                         view.life_guard.add_ref(),
                         PhantomData,
-                    ).is_some();
+                    ).is_ok();
 
                     let layouts = match view.inner {
                         TextureViewInner::Native { ref source_id, .. } => {

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -85,13 +85,7 @@ impl<F> Global<F> {
                 .buffers
                 .use_replace(&*buffer_guard, source, (), BufferUsage::COPY_SRC);
         assert!(src_buffer.usage.contains(BufferUsage::COPY_SRC));
-
-        barriers.extend(src_pending.map(|pending| hal::memory::Barrier::Buffer {
-            states: pending.to_states(),
-            target: &src_buffer.raw,
-            families: None,
-            range: None .. None,
-        }));
+        barriers.extend(src_pending.map(|pending| pending.into_hal(src_buffer)));
 
         let (dst_buffer, dst_pending) = cmb.trackers.buffers.use_replace(
             &*buffer_guard,
@@ -100,13 +94,7 @@ impl<F> Global<F> {
             BufferUsage::COPY_DST,
         );
         assert!(dst_buffer.usage.contains(BufferUsage::COPY_DST));
-
-        barriers.extend(dst_pending.map(|pending| hal::memory::Barrier::Buffer {
-            states: pending.to_states(),
-            target: &dst_buffer.raw,
-            families: None,
-            range: None .. None,
-        }));
+        barriers.extend(dst_pending.map(|pending| pending.into_hal(dst_buffer)));
 
         let region = hal::command::BufferCopy {
             src: source_offset,
@@ -146,13 +134,7 @@ impl<F> Global<F> {
             BufferUsage::COPY_SRC,
         );
         assert!(src_buffer.usage.contains(BufferUsage::COPY_SRC));
-
-        let src_barriers = src_pending.map(|pending| hal::memory::Barrier::Buffer {
-            states: pending.to_states(),
-            target: &src_buffer.raw,
-            families: None,
-            range: None .. None,
-        });
+        let src_barriers = src_pending.map(|pending| pending.into_hal(src_buffer));
 
         let (dst_texture, dst_pending) = cmb.trackers.textures.use_replace(
             &*texture_guard,
@@ -161,13 +143,7 @@ impl<F> Global<F> {
             TextureUsage::COPY_DST,
         );
         assert!(dst_texture.usage.contains(TextureUsage::COPY_DST));
-
-        let dst_barriers = dst_pending.map(|pending| hal::memory::Barrier::Image {
-            states: pending.to_states(),
-            target: &dst_texture.raw,
-            families: None,
-            range: pending.selector,
-        });
+        let dst_barriers = dst_pending.map(|pending| pending.into_hal(dst_texture));
 
         let bytes_per_texel = conv::map_texture_format(dst_texture.format, cmb.features)
             .surface_desc()
@@ -222,13 +198,7 @@ impl<F> Global<F> {
             TextureUsage::COPY_SRC,
         );
         assert!(src_texture.usage.contains(TextureUsage::COPY_SRC));
-
-        let src_barriers = src_pending.map(|pending| hal::memory::Barrier::Image {
-            states: pending.to_states(),
-            target: &src_texture.raw,
-            families: None,
-            range: pending.selector,
-        });
+        let src_barriers = src_pending.map(|pending| pending.into_hal(src_texture));
 
         let (dst_buffer, dst_barriers) = cmb.trackers.buffers.use_replace(
             &*buffer_guard,
@@ -237,13 +207,7 @@ impl<F> Global<F> {
             BufferUsage::COPY_DST,
         );
         assert!(dst_buffer.usage.contains(BufferUsage::COPY_DST));
-
-        let dst_barrier = dst_barriers.map(|pending| hal::memory::Barrier::Buffer {
-            states: pending.to_states(),
-            target: &dst_buffer.raw,
-            families: None,
-            range: None .. None,
-        });
+        let dst_barrier = dst_barriers.map(|pending| pending.into_hal(dst_buffer));
 
         let bytes_per_texel = conv::map_texture_format(src_texture.format, cmb.features)
             .surface_desc()
@@ -303,13 +267,7 @@ impl<F> Global<F> {
             TextureUsage::COPY_SRC,
         );
         assert!(src_texture.usage.contains(TextureUsage::COPY_SRC));
-
-        barriers.extend(src_pending.map(|pending| hal::memory::Barrier::Image {
-            states: pending.to_states(),
-            target: &src_texture.raw,
-            families: None,
-            range: pending.selector,
-        }));
+        barriers.extend(src_pending.map(|pending| pending.into_hal(src_texture)));
 
         let (dst_texture, dst_pending) = cmb.trackers.textures.use_replace(
             &*texture_guard,
@@ -318,13 +276,7 @@ impl<F> Global<F> {
             TextureUsage::COPY_DST,
         );
         assert!(dst_texture.usage.contains(TextureUsage::COPY_DST));
-
-        barriers.extend(dst_pending.map(|pending| hal::memory::Barrier::Image {
-            states: pending.to_states(),
-            target: &dst_texture.raw,
-            families: None,
-            range: pending.selector,
-        }));
+        barriers.extend(dst_pending.map(|pending| pending.into_hal(dst_texture)));
 
         let region = hal::command::ImageCopy {
             src_subresource: source.to_sub_layers(aspects),

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -474,7 +474,6 @@ impl<F: IdentityFilter<id::BufferId>> Global<F> {
         let device = &device_guard[device_id];
         let buffer = device.create_buffer(device_id, desc);
         let ref_count = buffer.life_guard.add_ref();
-        let range = buffer.full_range;
 
         let id = hub.buffers.register_identity(id_in, buffer, &mut token);
         device
@@ -484,7 +483,7 @@ impl<F: IdentityFilter<id::BufferId>> Global<F> {
             .init(
                 id,
                 ref_count,
-                BufferState::from_selector(&range),
+                BufferState::with_usage(resource::BufferUsage::empty()),
             )
             .unwrap();
         id
@@ -505,7 +504,6 @@ impl<F: IdentityFilter<id::BufferId>> Global<F> {
         let device = &device_guard[device_id];
         let mut buffer = device.create_buffer(device_id, &desc);
         let ref_count = buffer.life_guard.add_ref();
-        let range = buffer.full_range;
 
         let pointer = match map_buffer(&device.raw, &mut buffer, 0 .. desc.size, HostMap::Write) {
             Ok(ptr) => ptr,
@@ -521,10 +519,9 @@ impl<F: IdentityFilter<id::BufferId>> Global<F> {
             .buffers.init(
                 id,
                 ref_count,
-                BufferState::from_selector(&range),
+                BufferState::with_usage(resource::BufferUsage::MAP_WRITE),
             )
-            .unwrap()
-            .set((), resource::BufferUsage::MAP_WRITE);
+            .unwrap();
 
         (id, pointer)
     }
@@ -639,10 +636,9 @@ impl<F: IdentityFilter<id::TextureId>> Global<F> {
             .textures.init(
                 id,
                 ref_count,
-                TextureState::from_selector(&range),
+                TextureState::with_range(&range),
             )
-            .unwrap()
-            .set(range, resource::TextureUsage::UNINITIALIZED);
+            .unwrap();
         id
     }
 

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -31,8 +31,8 @@ impl Default for BufferState {
 }
 
 impl BufferState {
-    pub fn from_selector(_full_selector: &()) -> Self {
-        BufferState::default()
+    pub fn with_usage(usage: BufferUsage) -> Self {
+        Unit::new(usage)
     }
 }
 

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -3,18 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{PendingTransition, ResourceState, Unit};
-use crate::{conv, id::BufferId, resource::BufferUsage};
-use std::ops::Range;
+use crate::{id::BufferId, resource::BufferUsage};
 
 //TODO: store `hal::buffer::State` here to avoid extra conversions
 pub type BufferState = Unit<BufferUsage>;
 
 impl PendingTransition<BufferState> {
-    /// Produce the gfx-hal buffer states corresponding to the transition.
-    pub fn to_states(&self) -> Range<hal::buffer::State> {
-        conv::map_buffer_state(self.usage.start) .. conv::map_buffer_state(self.usage.end)
-    }
-
     fn collapse(self) -> Result<BufferUsage, Self> {
         if self.usage.start.is_empty()
             || self.usage.start == self.usage.end
@@ -27,17 +21,25 @@ impl PendingTransition<BufferState> {
     }
 }
 
-impl ResourceState for BufferState {
-    type Id = BufferId;
-    type Selector = ();
-    type Usage = BufferUsage;
-
-    fn new(_full_selector: &Self::Selector) -> Self {
+impl Default for BufferState {
+    fn default() -> Self {
         BufferState {
             first: None,
             last: BufferUsage::empty(),
         }
     }
+}
+
+impl BufferState {
+    pub fn from_selector(_full_selector: &()) -> Self {
+        BufferState::default()
+    }
+}
+
+impl ResourceState for BufferState {
+    type Id = BufferId;
+    type Selector = ();
+    type Usage = BufferUsage;
 
     fn query(&self, _selector: Self::Selector) -> Option<Self::Usage> {
         Some(self.last)

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -2,30 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use super::{SEPARATE_DEPTH_STENCIL_STATES, range::RangedStates, PendingTransition, ResourceState, Unit};
-use crate::{conv, device::MAX_MIP_LEVELS, id::TextureId, resource::TextureUsage};
+use super::{range::RangedStates, PendingTransition, ResourceState, Unit};
+use crate::{device::MAX_MIP_LEVELS, id::TextureId, resource::TextureUsage};
 
 use arrayvec::ArrayVec;
 
-use std::ops::Range;
+use std::{iter, ops::Range};
 
 
 //TODO: store `hal::image::State` here to avoid extra conversions
 type PlaneStates = RangedStates<hal::image::Layer, Unit<TextureUsage>>;
-type MipState = ArrayVec<[(hal::format::Aspects, PlaneStates); 2]>;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct TextureState {
-    mips: ArrayVec<[MipState; MAX_MIP_LEVELS]>,
+    mips: ArrayVec<[PlaneStates; MAX_MIP_LEVELS]>,
+    /// True if we have the information about all the subresources here
+    full: bool,
 }
 
 impl PendingTransition<TextureState> {
-    /// Produce the gfx-hal image states corresponding to the transition.
-    pub fn to_states(&self) -> Range<hal::image::State> {
-        conv::map_texture_state(self.usage.start, self.selector.aspects)
-            .. conv::map_texture_state(self.usage.end, self.selector.aspects)
-    }
-
     fn collapse(self) -> Result<TextureUsage, Self> {
         if self.usage.start.is_empty()
             || self.usage.start == self.usage.end
@@ -38,47 +33,49 @@ impl PendingTransition<TextureState> {
     }
 }
 
+impl TextureState {
+    pub fn from_selector(full_selector: &hal::image::SubresourceRange) -> Self {
+        debug_assert_eq!(full_selector.layers.start, 0);
+        debug_assert_eq!(full_selector.levels.start, 0);
+        TextureState {
+            mips: iter::repeat_with(|| {
+                    PlaneStates::from_range(
+                        0 .. full_selector.layers.end,
+                        Unit::new(TextureUsage::UNINITIALIZED),
+                    )
+                })
+                .take(full_selector.levels.end as usize)
+                .collect(),
+            full: true,
+        }
+    }
+}
+
 impl ResourceState for TextureState {
     type Id = TextureId;
     type Selector = hal::image::SubresourceRange;
     type Usage = TextureUsage;
 
-    fn new(full_selector: &Self::Selector) -> Self {
-        TextureState {
-            mips: (0 .. full_selector.levels.end)
-                .map(|_| {
-                    let mut slices = ArrayVec::new();
-                    let aspects_without_stencil = full_selector.aspects & !hal::format::Aspects::STENCIL;
-                    if SEPARATE_DEPTH_STENCIL_STATES && full_selector.aspects != aspects_without_stencil {
-                        slices.push((aspects_without_stencil, PlaneStates::default()));
-                        slices.push((hal::format::Aspects::STENCIL, PlaneStates::default()));
-                    } else {
-                        slices.push((full_selector.aspects, PlaneStates::default()))
-                    }
-                    slices
-                })
-                .collect()
-        }
-    }
-
     fn query(&self, selector: Self::Selector) -> Option<Self::Usage> {
         let mut result = None;
+        // Note: we only consider the subresources tracked by `self`.
+        // If some are not known to `self`, it means the can assume the
+        // initial state to whatever we need, which we can always make
+        // to be the same as the query result for the known subresources.
         let num_levels = self.mips.len();
+        if self.full {
+            assert!(num_levels >= selector.levels.end as usize);
+        }
         let mip_start = num_levels.min(selector.levels.start as usize);
         let mip_end = num_levels.min(selector.levels.end as usize);
         for mip in self.mips[mip_start .. mip_end].iter() {
-            for &(aspects, ref plane_states) in mip {
-                if !selector.aspects.intersects(aspects) {
-                    continue;
+            match mip.query(&selector.layers, |unit| unit.last) {
+                None => {}
+                Some(Ok(usage)) if result == Some(usage) => {}
+                Some(Ok(usage)) if result.is_none() => {
+                    result = Some(usage);
                 }
-                match plane_states.query(&selector.layers, |unit| unit.last) {
-                    None => {}
-                    Some(Ok(usage)) if result == Some(usage) => {}
-                    Some(Ok(usage)) if result.is_none() => {
-                        result = Some(usage);
-                    }
-                    Some(Ok(_)) | Some(Err(())) => return None,
-                }
+                Some(Ok(_)) | Some(Err(())) => return None,
             }
         }
         result
@@ -91,44 +88,44 @@ impl ResourceState for TextureState {
         usage: Self::Usage,
         mut output: Option<&mut Vec<PendingTransition<Self>>>,
     ) -> Result<(), PendingTransition<Self>> {
+        if self.full {
+            assert!(self.mips.len() >= selector.levels.end as usize);
+        } else {
+            while self.mips.len() < selector.levels.end as usize {
+                self.mips.push(PlaneStates::empty());
+            }
+        }
         for (mip_id, mip) in self.mips
             [selector.levels.start as usize .. selector.levels.end as usize]
             .iter_mut()
             .enumerate()
         {
             let level = selector.levels.start + mip_id as hal::image::Level;
-            for &mut (mip_aspects, ref mut plane_states) in mip {
-                let aspects = selector.aspects & mip_aspects;
-                if aspects.is_empty() {
+            let layers = mip.isolate(&selector.layers, Unit::new(usage));
+            for &mut (ref range, ref mut unit) in layers {
+                if unit.last == usage && TextureUsage::ORDERED.contains(usage) {
                     continue;
                 }
-                debug_assert_eq!(aspects, mip_aspects);
-                let layers = plane_states.isolate(&selector.layers, Unit::new(usage));
-                for &mut (ref range, ref mut unit) in layers {
-                    if unit.last == usage && TextureUsage::ORDERED.contains(usage) {
-                        continue;
-                    }
-                    let pending = PendingTransition {
-                        id,
-                        selector: hal::image::SubresourceRange {
-                            aspects,
-                            levels: level .. level + 1,
-                            layers: range.clone(),
-                        },
-                        usage: unit.last .. usage,
-                    };
+                let pending = PendingTransition {
+                    id,
+                    selector: hal::image::SubresourceRange {
+                        aspects: hal::format::Aspects::empty(),
+                        levels: level .. level + 1,
+                        layers: range.clone(),
+                    },
+                    usage: unit.last .. usage,
+                };
 
-                    unit.last = match output {
-                        None => pending.collapse()?,
-                        Some(ref mut out) => {
-                            out.push(pending);
-                            if unit.first.is_none() {
-                                unit.first = Some(unit.last);
-                            }
-                            usage
+                unit.last = match output {
+                    None => pending.collapse()?,
+                    Some(ref mut out) => {
+                        out.push(pending);
+                        if unit.first.is_none() {
+                            unit.first = Some(unit.last);
                         }
-                    };
-                }
+                        usage
+                    }
+                };
             }
         }
         Ok(())
@@ -141,74 +138,75 @@ impl ResourceState for TextureState {
         mut output: Option<&mut Vec<PendingTransition<Self>>>,
     ) -> Result<(), PendingTransition<Self>> {
         let mut temp = Vec::new();
-        while self.mips.len() < other.mips.len() as usize {
-            self.mips.push(MipState::default());
+        if self.full {
+            assert!(self.mips.len() >= other.mips.len());
+        } else {
+            while self.mips.len() < other.mips.len() {
+                self.mips.push(PlaneStates::empty());
+            }
         }
 
         for (mip_id, (mip_self, mip_other)) in self.mips.iter_mut().zip(&other.mips).enumerate() {
             let level = mip_id as hal::image::Level;
-            for (&mut (aspects, ref mut planes_self), &(aspects_other, ref planes_other)) in mip_self.iter_mut().zip(mip_other) {
-                debug_assert_eq!(aspects, aspects_other);
-                temp.extend(planes_self.merge(planes_other, 0));
-                planes_self.clear();
+            temp.extend(mip_self.merge(mip_other, 0));
+            mip_self.clear();
 
-                for (layers, states) in temp.drain(..) {
-                    let unit = match states {
-                        Range {
-                            start: None,
-                            end: None,
-                        } => unreachable!(),
-                        Range {
-                            start: Some(start),
-                            end: None,
-                        } => start,
-                        Range {
-                            start: None,
-                            end: Some(end),
-                        } => end,
-                        Range {
-                            start: Some(start),
-                            end: Some(end),
-                        } => {
-                            let to_usage = end.port();
-                            if start.last == to_usage
-                                && TextureUsage::ORDERED.contains(to_usage)
-                            {
-                                Unit {
-                                    first: start.first,
-                                    last: end.last,
-                                }
-                            } else {
-                                let pending = PendingTransition {
-                                    id,
-                                    selector: hal::image::SubresourceRange {
-                                        aspects,
-                                        levels: level .. level+1,
-                                        layers: layers.clone(),
-                                    },
-                                    usage: start.last .. to_usage,
-                                };
+            for (layers, states) in temp.drain(..) {
+                let unit = match states {
+                    Range {
+                        start: None,
+                        end: None,
+                    } => unreachable!(),
+                    Range {
+                        start: Some(start),
+                        end: None,
+                    } => start,
+                    Range {
+                        start: None,
+                        end: Some(end),
+                    } => end,
+                    Range {
+                        start: Some(start),
+                        end: Some(end),
+                    } => {
+                        let to_usage = end.port();
+                        if start.last == to_usage
+                            && TextureUsage::ORDERED.contains(to_usage)
+                        {
+                            Unit {
+                                first: start.first,
+                                last: end.last,
+                            }
+                        } else {
+                            let pending = PendingTransition {
+                                id,
+                                selector: hal::image::SubresourceRange {
+                                    aspects: hal::format::Aspects::empty(),
+                                    levels: level .. level+1,
+                                    layers: layers.clone(),
+                                },
+                                usage: start.last .. to_usage,
+                            };
 
-                                match output {
-                                    None => {
-                                        Unit {
-                                            first: start.first,
-                                            last: pending.collapse()?,
-                                        }
+                            match output {
+                                None => {
+                                    Unit {
+                                        first: start.first,
+                                        last: pending.collapse()?,
                                     }
-                                    Some(ref mut out) => {
-                                        out.push(pending);
-                                        Unit {
-                                            first: Some(start.last),
-                                            last: end.last,
-                                        }
+                                }
+                                Some(ref mut out) => {
+                                    out.push(pending);
+                                    Unit {
+                                        first: Some(start.last),
+                                        last: end.last,
                                     }
                                 }
                             }
                         }
-                    };
-                    planes_self.append(layers, unit);
-                }
+                    }
+                };
+                mip_self.append(layers, unit);
             }
         }
 
@@ -217,9 +215,7 @@ impl ResourceState for TextureState {
 
     fn optimize(&mut self) {
         for mip in self.mips.iter_mut() {
-            for &mut (_, ref mut planes) in mip.iter_mut() {
-                planes.coalesce();
-            }
+            mip.coalesce();
         }
     }
 }
@@ -234,16 +230,14 @@ mod test {
 
     #[test]
     fn query() {
-        let mut ts = TextureState::new(&SubresourceRange {
-            aspects: Aspects::COLOR,
-            levels: 0 .. 2,
-            layers: 0 .. 10,
-        });
-        ts.mips[1][0].1 = PlaneStates::new(&[
+        let mut ts = TextureState::default();
+        ts.mips.push(PlaneStates::empty());
+        ts.mips.push(PlaneStates::from_slice(&[
             (1 .. 3, Unit::new(TextureUsage::SAMPLED)),
             (3 .. 5, Unit::new(TextureUsage::SAMPLED)),
             (5 .. 6, Unit::new(TextureUsage::STORAGE)),
-        ]);
+        ]));
+
         assert_eq!(
             ts.query(SubresourceRange {
                 aspects: Aspects::COLOR,
@@ -252,15 +246,6 @@ mod test {
             }),
             // level 1 matches
             Some(TextureUsage::SAMPLED),
-        );
-        assert_eq!(
-            ts.query(SubresourceRange {
-                aspects: Aspects::DEPTH,
-                levels: 1 .. 2,
-                layers: 2 .. 5,
-            }),
-            // no depth found
-            None,
         );
         assert_eq!(
             ts.query(SubresourceRange {

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -34,17 +34,17 @@ impl PendingTransition<TextureState> {
 }
 
 impl TextureState {
-    pub fn from_selector(full_selector: &hal::image::SubresourceRange) -> Self {
-        debug_assert_eq!(full_selector.layers.start, 0);
-        debug_assert_eq!(full_selector.levels.start, 0);
+    pub fn with_range(range: &hal::image::SubresourceRange) -> Self {
+        debug_assert_eq!(range.layers.start, 0);
+        debug_assert_eq!(range.levels.start, 0);
         TextureState {
             mips: iter::repeat_with(|| {
                     PlaneStates::from_range(
-                        0 .. full_selector.layers.end,
+                        0 .. range.layers.end,
                         Unit::new(TextureUsage::UNINITIALIZED),
                     )
                 })
-                .take(full_selector.levels.end as usize)
+                .take(range.levels.end as usize)
                 .collect(),
             full: true,
         }

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -8,8 +8,6 @@ use core::{gfx_select, hub::Token, id};
 
 use std::{marker::PhantomData, slice};
 
-use libc::{c_ulong};
-
 pub type RequestAdapterCallback =
     unsafe extern "C" fn(id: id::AdapterId, userdata: *mut std::ffi::c_void);
 pub type BufferMapReadCallback =
@@ -80,7 +78,7 @@ pub fn wgpu_create_surface(raw_handle: raw_window_handle::RawWindowHandle) -> id
 #[no_mangle]
 pub extern "C" fn wgpu_create_surface_from_xlib(
     display: *mut *const std::ffi::c_void,
-    window: c_ulong,
+    window: libc::c_ulong,
 ) -> id::SurfaceId {
     use raw_window_handle::unix::XlibHandle;
     wgpu_create_surface(raw_window_handle::RawWindowHandle::Xlib(XlibHandle {


### PR DESCRIPTION
~~This is a required step towards #438 . We want to be tracking the usage by only having resource IDs around, not resources themselves. So we aren't going to have access to `full_selector`.~~

It's also streamlining some of the verbose parts of the internal API for usage tracking.
It also uses `SmallVec` for the texture tracker ranges, essentially making it lightweight for most cases (where the layer count is 1).

Compromises:
  - removes `SEPARATE_DEPTH_STENCIL_STATES` support. It's not in the near future to enable it anyway.