### PR TITLE
Fix cmd buffer cleanup not always using lowest active index

### DIFF
--- a/wgpu-core/src/command/allocator.rs
+++ b/wgpu-core/src/command/allocator.rs
@@ -35,7 +35,7 @@ impl<B: hal::Backend> CommandPool<B> {
             if index < lowest_active_index {
                 let cmd_buf = self.pending.swap_remove(i);
                 log::trace!(
-                    "recycling comb submitted in {} when {} is done",
+                    "recycling comb submitted in {} when {} is lowest active",
                     index,
                     lowest_active_index,
                 );

--- a/wgpu-core/src/device.rs
+++ b/wgpu-core/src/device.rs
@@ -1546,11 +1546,12 @@ impl<F: IdentityFilter<CommandEncoderId>> Global<F> {
             ref_count: device.life_guard.ref_count.clone(),
         };
 
-        // The first entry in the active list should have the lowest index
+        // Find the pending entry with the lowest active index. If none can be found that means
+        // everything in the allocator can be cleaned up, so std::usize::MAX is correct.
         let lowest_active_index = device.pending.lock()
-            .active.get(0)
-            .map(|active| active.index)
-            .unwrap_or(0);
+            .active
+            .iter()
+            .fold(std::usize::MAX, |v, active| active.index.min(v));
 
         let mut comb = device
             .com_allocator


### PR DESCRIPTION
This fixes the index picked for cleanup not always being the lowest index.
Additionally this fixes command buffers not being cleaned up if there are no active submissions, because in that case 0 would be picked, which resulted in nothing being cleaned up. Now instead if there are no active submissions, usize MAX will be picked.

Fixes #441 