### PR TITLE
Fix missing memory release

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -448,8 +448,10 @@ impl<B: hal::Backend> Device<B> {
     pub(crate) fn dispose(self) {
         self.com_allocator.destroy(&self.raw);
         let desc_alloc = self.desc_allocator.into_inner();
+        let mem_alloc = self.mem_allocator.into_inner();
         unsafe {
             desc_alloc.dispose(&self.raw);
+            mem_alloc.dispose(&self.raw);
         }
     }
 }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -445,6 +445,20 @@ impl<B: hal::Backend> Device<B> {
         }
     }
 
+    pub(crate) fn destroy_buffer(&self, buffer: resource::Buffer<B>) {
+        unsafe {
+            self.mem_allocator.lock().free(&self.raw, buffer.memory);
+            self.raw.destroy_buffer(buffer.raw);
+        }
+    }
+
+    pub(crate) fn destroy_texture(&self, texture: resource::Texture<B>) {
+        unsafe {
+            self.mem_allocator.lock().free(&self.raw, texture.memory);
+            self.raw.destroy_image(texture.raw);
+        }
+    }
+
     pub(crate) fn dispose(self) {
         self.com_allocator.destroy(&self.raw);
         let desc_alloc = self.desc_allocator.into_inner();

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -438,19 +438,11 @@ impl<B: hal::Backend, F> Drop for Hub<B, F> {
             }
         }
         for (_, (texture, _)) in self.textures.data.write().map.drain() {
-            unsafe {
-                devices[texture.device_id.value]
-                    .raw
-                    .destroy_image(texture.raw);
-            }
+            devices[texture.device_id.value].destroy_texture(texture);
         }
         for (_, (buffer, _)) in self.buffers.data.write().map.drain() {
             //TODO: unmap if needed
-            unsafe {
-                devices[buffer.device_id.value]
-                    .raw
-                    .destroy_buffer(buffer.raw);
-            }
+            devices[buffer.device_id.value].destroy_buffer(buffer);
         }
         for (_, (command_buffer, _)) in self.command_buffers.data.write().map.drain() {
             devices[command_buffer.device_id.value]


### PR DESCRIPTION
This fixes the issue where the underlying memory of buffers and textures not released when calling `Global::delete`.
cc @kvark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/wgpu/449)
<!-- Reviewable:end -->
