### PR TITLE
[0.4] Refactor the swap chain frame tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ branches:
 
 before_install:
 - if [[ $TRAVIS_OS_NAME == "windows" ]]; then choco install make; fi
+- if [[ $TRAVIS_RUST_VERSION != "nightly" ]] && [[ $TRAVIS_OS_NAME == "windows" ]]; then rustup default stable-msvc; fi
+- if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME == "windows" ]]; then rustup default nightly-msvc; fi
 
 script:
   - cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v0.4.3 (20-01-2020)
+  - improved swap chain error handling
+
 ## v0.4.2 (15-12-2019)
   - fixed render pass transitions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wgpu-native"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "arrayvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -649,7 +649,7 @@ version = "0.1.0"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu-native 0.4.1",
+ "wgpu-native 0.4.3",
 ]
 
 [[package]]

--- a/ffi/wgpu-remote.h
+++ b/ffi/wgpu-remote.h
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* Generated with cbindgen:0.9.1 */
+/* Generated with cbindgen:0.12.2 */
 
 /* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
  * To generate this file:

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1,7 +1,7 @@
 #define WGPU_LOCAL
 
 
-/* Generated with cbindgen:0.9.1 */
+/* Generated with cbindgen:0.12.2 */
 
 #include <stdarg.h>
 #include <stdbool.h>

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-native"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
 	"Dzmitry Malyshau <kvark@mozilla.com>",
 	"Joshua Groves <josh@joshgroves.com>",

--- a/wgpu-native/src/conv.rs
+++ b/wgpu-native/src/conv.rs
@@ -35,7 +35,7 @@ pub fn map_buffer_usage(
     if usage.contains(W::UNIFORM) {
         hal_usage |= U::UNIFORM;
     }
-    if usage.contains(W::STORAGE) {
+    if usage.intersects(W::STORAGE | W::STORAGE_READ) {
         hal_usage |= U::STORAGE;
     }
     if usage.contains(W::INDIRECT) {
@@ -514,6 +514,9 @@ pub fn map_buffer_state(usage: resource::BufferUsage) -> hal::buffer::State {
     if usage.contains(W::UNIFORM) {
         access |= A::UNIFORM_READ | A::SHADER_READ;
     }
+    if usage.contains(W::STORAGE_READ) {
+        access |= A::SHADER_READ;
+    }
     if usage.contains(W::STORAGE) {
         access |= A::SHADER_WRITE;
     }
@@ -550,7 +553,7 @@ pub fn map_texture_state(
         access |= A::SHADER_READ;
     }
     if usage.contains(W::STORAGE) {
-        access |= A::SHADER_WRITE;
+        access |= A::SHADER_READ | A::SHADER_WRITE;
     }
     if usage.contains(W::OUTPUT_ATTACHMENT) {
         //TODO: read-only attachments

--- a/wgpu-native/src/hub.rs
+++ b/wgpu-native/src/hub.rs
@@ -179,6 +179,7 @@ impl<B: hal::Backend> Access<Adapter<B>> for Surface {}
 impl<B: hal::Backend> Access<Device<B>> for Root {}
 impl<B: hal::Backend> Access<Device<B>> for Surface {}
 impl<B: hal::Backend> Access<Device<B>> for Adapter<B> {}
+impl<B: hal::Backend> Access<SwapChain<B>> for Root {}
 impl<B: hal::Backend> Access<SwapChain<B>> for Device<B> {}
 impl<B: hal::Backend> Access<PipelineLayout<B>> for Root {}
 impl<B: hal::Backend> Access<PipelineLayout<B>> for Device<B> {}

--- a/wgpu-native/src/instance.rs
+++ b/wgpu-native/src/instance.rs
@@ -22,7 +22,7 @@ use bitflags::bitflags;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use hal::{self, adapter::PhysicalDevice as _, queue::QueueFamily as _, Instance as _};
+use hal::{adapter::PhysicalDevice as _, queue::QueueFamily as _, Instance as _};
 #[cfg(feature = "local")]
 use std::marker::PhantomData;
 
@@ -485,6 +485,9 @@ pub fn adapter_request_device<B: GfxBackend>(
     let device = {
         let (adapter_guard, _) = hub.adapters.read(&mut token);
         let adapter = &adapter_guard[adapter_id].raw;
+        let wishful_features =
+            hal::Features::VERTEX_STORES_AND_ATOMICS |
+            hal::Features::FRAGMENT_STORES_AND_ATOMICS;
 
         let family = adapter
             .queue_families
@@ -494,7 +497,10 @@ pub fn adapter_request_device<B: GfxBackend>(
         let mut gpu = unsafe {
             adapter
                 .physical_device
-                .open(&[(family, &[1.0])], hal::Features::empty())
+                .open(
+                    &[(family, &[1.0])],
+                    adapter.physical_device.features() & wishful_features,
+                )
                 .unwrap()
         };
 

--- a/wgpu-native/src/resource.rs
+++ b/wgpu-native/src/resource.rs
@@ -18,7 +18,6 @@ use crate::{
 use bitflags::bitflags;
 use hal;
 use rendy_memory::MemoryBlock;
-use smallvec::SmallVec;
 
 use std::borrow::Borrow;
 
@@ -275,7 +274,6 @@ pub(crate) enum TextureViewInner<B: hal::Backend> {
     SwapChain {
         image: <B::Surface as hal::window::PresentationSurface<B>>::SwapchainImage,
         source_id: Stored<SwapChainId>,
-        framebuffers: SmallVec<[B::Framebuffer; 1]>,
     },
 }
 


### PR DESCRIPTION
On the surface, it gets us from "key not present" to "Used swap chain frame has already presented" in the case of an application presenting before submitting a command buffer. But the worst thing is that we used to lock up the driver on that presentation, so now the problem is much less mysterious.
cc @snuk182 

Fixes #458
Works around #227 