### PR TITLE
Switch value of BufferUsage's INDIRECT and STORAGE_READ fields

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -502,8 +502,8 @@ typedef uint32_t WGPUBufferUsage;
 #define WGPUBufferUsage_VERTEX 32
 #define WGPUBufferUsage_UNIFORM 64
 #define WGPUBufferUsage_STORAGE 128
-#define WGPUBufferUsage_STORAGE_READ 256
-#define WGPUBufferUsage_INDIRECT 512
+#define WGPUBufferUsage_INDIRECT 256
+#define WGPUBufferUsage_STORAGE_READ 512
 #define WGPUBufferUsage_NONE 0
 
 typedef struct {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -31,8 +31,8 @@ bitflags::bitflags! {
         const VERTEX = 32;
         const UNIFORM = 64;
         const STORAGE = 128;
-        const STORAGE_READ = 256;
-        const INDIRECT = 512;
+        const INDIRECT = 256;
+        const STORAGE_READ = 512;
         const NONE = 0;
         /// The combination of all read-only usages.
         const READ_ALL = Self::MAP_READ.bits | Self::COPY_SRC.bits |


### PR DESCRIPTION
Closes #467. This makes the value of `INDIRECT` equal to it's value in the IDL spec. (`STORAGE_READ` is not present in the IDL spec.)

I changed the value in `resource.rs` and then ran `make ffi/wgpu.h`.
