### PR TITLE
Refactor adapter stuff out from `instance`.

### DIFF
--- a/wgpu-core/src/adapter.rs
+++ b/wgpu-core/src/adapter.rs
@@ -218,11 +218,11 @@ impl<F: IdentityFilter<AdapterId>> BackendIds<F> {
             ))]
             vulkan: inputs.find(Backend::Vulkan),
             #[cfg(any(target_os = "ios", target_os = "macos"))]
-            metal: inputs.find(Backend::Vulkan),
+            metal: inputs.find(Backend::Metal),
             #[cfg(windows)]
-            dx12: inputs.find(Backend::Vulkan),
+            dx12: inputs.find(Backend::Dx12),
             #[cfg(windows)]
-            dx11: inputs.find(Backend::Vulkan),
+            dx11: inputs.find(Backend::Dx11),
         }
     }
 }
@@ -236,11 +236,11 @@ impl<F: IdentityFilter<AdapterId>> Clone for BackendIds<F> {
             ))]
             vulkan: self.vulkan.clone(),
             #[cfg(any(target_os = "ios", target_os = "macos"))]
-            metal: self.vulkan.clone(),
+            metal: self.metal.clone(),
             #[cfg(windows)]
-            dx12: self.vulkan.clone(),
+            dx12: self.dx12.clone(),
             #[cfg(windows)]
-            dx11: self.vulkan.clone(),
+            dx11: self.dx11.clone(),
         }
     }
 }

--- a/wgpu-core/src/adapter.rs
+++ b/wgpu-core/src/adapter.rs
@@ -1,0 +1,246 @@
+use crate::{
+    backend,
+    hub::{GfxBackend, Global, IdentityFilter, Token},
+    id::AdapterId,
+    Backend,
+};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+pub use hal::adapter::AdapterInfo;
+use hal::Instance;
+
+#[derive(Debug)]
+pub struct RawAdapter<B: hal::Backend> {
+    pub(crate) raw: hal::adapter::Adapter<B>,
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub(crate) enum Adapter {
+    #[cfg(any(
+        not(any(target_os = "ios", target_os = "macos")),
+        feature = "gfx-backend-vulkan"
+    ))]
+    Vulkan(RawAdapter<gfx_backend_vulkan::Backend>),
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    Metal(RawAdapter<gfx_backend_metal::Backend>),
+    #[cfg(windows)]
+    Dx12(RawAdapter<gfx_backend_dx12::Backend>),
+    #[cfg(windows)]
+    Dx11(RawAdapter<gfx_backend_dx11::Backend>),
+}
+
+impl Adapter {
+    pub(crate) fn enumerate<F: IdentityFilter<AdapterId>>(
+        global: &Global<F>,
+        inputs: AdapterInputs<F::Input>,
+    ) -> (Vec<Adapter>, BackendIds<F>) {
+        let instance = &global.instance;
+        let backend_ids = BackendIds::<F>::new(inputs);
+        let mut adapters = Vec::new();
+
+        #[cfg(any(
+            not(any(target_os = "ios", target_os = "macos")),
+            feature = "gfx-backend-vulkan"
+        ))]
+        {
+            if let Some(ref inst) = instance.vulkan {
+                if backend_ids.vulkan.is_some() {
+                    for raw in inst.enumerate_adapters() {
+                        adapters.push(Adapter::Vulkan(RawAdapter { raw }));
+                    }
+                }
+            }
+        }
+        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        {
+            if backend_ids.metal.is_some() {
+                for raw in instance.metal.enumerate_adapters() {
+                    adapters.push(Adapter::Metal(RawAdapter { raw }));
+                }
+            }
+        }
+        #[cfg(windows)]
+        {
+            if let Some(ref inst) = instance.dx12 {
+                if backend_ids.dx12.is_some() {
+                    for raw in inst.enumerate_adapters() {
+                        adapters.push(Adapter::Dx12(RawAdapter { raw }));
+                    }
+                }
+            }
+
+            if backend_ids.dx11.is_some() {
+                for raw in instance.dx11.enumerate_adapters() {
+                    adapters.push(Adapter::Dx11(RawAdapter { raw }));
+                }
+            }
+        }
+
+        if adapters.is_empty() {
+            log::warn!("No adapters are available!");
+        }
+
+        (adapters, backend_ids)
+    }
+
+    pub(crate) fn info(&self) -> AdapterInfo {
+        match self {
+            #[cfg(any(
+                not(any(target_os = "ios", target_os = "macos")),
+                feature = "gfx-backend-vulkan"
+            ))]
+            Self::Vulkan(adapter) => adapter.raw.info.clone(),
+            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            Self::Metal(adapter) => adapter.raw.info.clone(),
+            #[cfg(windows)]
+            Self::Dx12(adapter) => adapter.raw.info.clone(),
+            #[cfg(windows)]
+            Self::Dx11(adapter) => adapter.raw.info.clone(),
+        }
+    }
+
+    pub(crate) fn register<F: IdentityFilter<AdapterId>>(
+        self,
+        global: &Global<F>,
+        backend_ids: BackendIds<F>,
+    ) -> AdapterId {
+        let mut token = Token::root();
+
+        match self {
+            #[cfg(any(
+                not(any(target_os = "ios", target_os = "macos")),
+                feature = "gfx-backend-vulkan"
+            ))]
+            Adapter::Vulkan(adapter) => {
+                log::info!("Adapter Vulkan {:?}", adapter.raw.info);
+                backend::Vulkan::hub(global).adapters.register_identity(
+                    backend_ids.vulkan.unwrap(),
+                    adapter,
+                    &mut token,
+                )
+            }
+            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            Adapter::Metal(adapter) => {
+                log::info!("Adapter Metal {:?}", adapter.raw.info);
+                backend::Metal::hub(global).adapters.register_identity(
+                    backend_ids.metal.unwrap(),
+                    adapter,
+                    &mut token,
+                )
+            }
+            #[cfg(windows)]
+            Adapter::Dx12(adapter) => {
+                log::info!("Adapter Dx12 {:?}", adapter.raw.info);
+                backend::Dx12::hub(global).adapters.register_identity(
+                    backend_ids.dx12.unwrap(),
+                    adapter,
+                    &mut token,
+                )
+            }
+            #[cfg(windows)]
+            Adapter::Dx11(adapter) => {
+                log::info!("Adapter Dx11 {:?}", adapter.raw.info);
+                backend::Dx11::hub(global).adapters.register_identity(
+                    backend_ids.dx11.unwrap(),
+                    adapter,
+                    &mut token,
+                )
+            }
+        }
+    }
+}
+
+pub enum AdapterInputs<'a, I> {
+    IdSet(&'a [I], fn(&I) -> Backend),
+    Mask(BackendBit, fn() -> I),
+}
+
+impl<I: Clone> AdapterInputs<'_, I> {
+    fn find(&self, b: Backend) -> Option<I> {
+        match *self {
+            AdapterInputs::IdSet(ids, ref fun) => ids.iter().find(|id| fun(id) == b).cloned(),
+            AdapterInputs::Mask(bits, ref fun) => {
+                if bits.contains(b.into()) {
+                    Some(fun())
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+bitflags::bitflags! {
+    #[repr(transparent)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct BackendBit: u32 {
+        const VULKAN = 1 << Backend::Vulkan as u32;
+        const GL = 1 << Backend::Gl as u32;
+        const METAL = 1 << Backend::Metal as u32;
+        const DX12 = 1 << Backend::Dx12 as u32;
+        const DX11 = 1 << Backend::Dx11 as u32;
+        /// Vulkan + METAL + DX12
+        const PRIMARY = Self::VULKAN.bits | Self::METAL.bits | Self::DX12.bits;
+        /// OpenGL + DX11
+        const SECONDARY = Self::GL.bits | Self::DX11.bits;
+    }
+}
+
+impl From<Backend> for BackendBit {
+    fn from(backend: Backend) -> Self {
+        BackendBit::from_bits(1 << backend as u32).unwrap()
+    }
+}
+
+pub(crate) struct BackendIds<F: IdentityFilter<AdapterId>> {
+    #[cfg(any(
+        not(any(target_os = "ios", target_os = "macos")),
+        feature = "gfx-backend-vulkan"
+    ))]
+    pub(crate) vulkan: Option<F::Input>,
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    pub(crate) metal: Option<F::Input>,
+    #[cfg(windows)]
+    pub(crate) dx12: Option<F::Input>,
+    #[cfg(windows)]
+    pub(crate) dx11: Option<F::Input>,
+}
+
+impl<F: IdentityFilter<AdapterId>> BackendIds<F> {
+    pub(crate) fn new(inputs: AdapterInputs<F::Input>) -> Self {
+        Self {
+            #[cfg(any(
+                not(any(target_os = "ios", target_os = "macos")),
+                feature = "gfx-backend-vulkan"
+            ))]
+            vulkan: inputs.find(Backend::Vulkan),
+            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            metal: inputs.find(Backend::Vulkan),
+            #[cfg(windows)]
+            dx12: inputs.find(Backend::Vulkan),
+            #[cfg(windows)]
+            dx11: inputs.find(Backend::Vulkan),
+        }
+    }
+}
+
+impl<F: IdentityFilter<AdapterId>> Clone for BackendIds<F> {
+    fn clone(&self) -> Self {
+        Self {
+            #[cfg(any(
+                not(any(target_os = "ios", target_os = "macos")),
+                feature = "gfx-backend-vulkan"
+            ))]
+            vulkan: self.vulkan.clone(),
+            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            metal: self.vulkan.clone(),
+            #[cfg(windows)]
+            dx12: self.vulkan.clone(),
+            #[cfg(windows)]
+            dx11: self.vulkan.clone(),
+        }
+    }
+}

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{
+    adapter::RawAdapter,
     backend,
     binding_model::{BindGroup, BindGroupLayout, PipelineLayout},
     command::CommandBuffer,
@@ -25,7 +26,7 @@ use crate::{
         TextureViewId,
         TypedId,
     },
-    instance::{Adapter, Instance, Surface},
+    instance::{Instance, Surface},
     pipeline::{ComputePipeline, RenderPipeline},
     resource::{Buffer, Sampler, Texture, TextureView},
     swap_chain::SwapChain,
@@ -160,11 +161,11 @@ pub enum Root {}
 impl Access<Instance> for Root {}
 impl Access<Surface> for Root {}
 impl Access<Surface> for Instance {}
-impl<B: hal::Backend> Access<Adapter<B>> for Root {}
-impl<B: hal::Backend> Access<Adapter<B>> for Surface {}
+impl<B: hal::Backend> Access<RawAdapter<B>> for Root {}
+impl<B: hal::Backend> Access<RawAdapter<B>> for Surface {}
 impl<B: hal::Backend> Access<Device<B>> for Root {}
 impl<B: hal::Backend> Access<Device<B>> for Surface {}
-impl<B: hal::Backend> Access<Device<B>> for Adapter<B> {}
+impl<B: hal::Backend> Access<Device<B>> for RawAdapter<B> {}
 impl<B: hal::Backend> Access<SwapChain<B>> for Root {}
 impl<B: hal::Backend> Access<SwapChain<B>> for Device<B> {}
 impl<B: hal::Backend> Access<PipelineLayout<B>> for Root {}
@@ -360,7 +361,7 @@ impl<T, I: TypedId + Copy, F: IdentityFilter<I>> Registry<T, I, F> {
 
 #[derive(Debug)]
 pub struct Hub<B: hal::Backend, F> {
-    pub adapters: Registry<Adapter<B>, AdapterId, F>,
+    pub adapters: Registry<RawAdapter<B>, AdapterId, F>,
     pub devices: Registry<Device<B>, DeviceId, F>,
     pub swap_chains: Registry<SwapChain<B>, SwapChainId, F>,
     pub pipeline_layouts: Registry<PipelineLayout<B>, PipelineLayoutId, F>,

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -94,7 +94,7 @@ impl<T> TypedId for Id<T> {
 }
 
 
-pub type AdapterId = Id<crate::instance::Adapter<Dummy>>;
+pub type AdapterId = Id<crate::adapter::RawAdapter<Dummy>>;
 pub type SurfaceId = Id<crate::instance::Surface>;
 // Device
 pub type DeviceId = Id<crate::device::Device<Dummy>>;

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -203,9 +203,12 @@ impl<F: IdentityFilter<AdapterId>> Global<F> {
             PowerPreference::HighPerformance => discrete.or(other).or(integrated).or(virt),
         };
 
-        let selected = preferred_gpu.unwrap();
-
-        Some(selected.register(self, backend_ids))
+        if let Some(selected) = preferred_gpu {
+            Some(selected.register(self, backend_ids))
+        } else {
+            log::warn!("Some adapters are present, but enumerating them failed!");
+            None
+        }
     }
 
     pub fn adapter_get_info<B: GfxBackend>(&self, adapter_id: AdapterId) -> AdapterInfo {

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod backend {
     pub use gfx_backend_vulkan::Backend as Vulkan;
 }
 
+pub mod adapter;
 pub mod binding_model;
 pub mod command;
 pub mod conv;

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -153,13 +153,13 @@ pub extern "C" fn wgpu_create_surface_from_windows_hwnd(
 #[no_mangle]
 pub unsafe extern "C" fn wgpu_request_adapter_async(
     desc: Option<&core::instance::RequestAdapterOptions>,
-    mask: core::instance::BackendBit,
+    mask: core::adapter::BackendBit,
     callback: RequestAdapterCallback,
     userdata: *mut std::ffi::c_void,
 ) {
     let id = GLOBAL.pick_adapter(
         &desc.cloned().unwrap_or_default(),
-        core::instance::AdapterInputs::Mask(mask, || PhantomData),
+        core::adapter::AdapterInputs::Mask(mask, || PhantomData),
     );
     callback(
         id.unwrap_or(id::AdapterId::ERROR),
@@ -176,7 +176,7 @@ pub extern "C" fn wgpu_adapter_request_device(
     gfx_select!(adapter_id => GLOBAL.adapter_request_device(adapter_id, desc, PhantomData))
 }
 
-pub fn wgpu_adapter_get_info(adapter_id: id::AdapterId) -> core::instance::AdapterInfo {
+pub fn wgpu_adapter_get_info(adapter_id: id::AdapterId) -> core::adapter::AdapterInfo {
     gfx_select!(adapter_id => GLOBAL.adapter_get_info(adapter_id))
 }
 

--- a/wgpu-remote/src/server.rs
+++ b/wgpu-remote/src/server.rs
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn wgpu_server_instance_request_adapter(
     let ids = slice::from_raw_parts(ids, id_length);
     match global.pick_adapter(
         desc,
-        core::instance::AdapterInputs::IdSet(ids, |i| i.backend()),
+        core::adapter::AdapterInputs::IdSet(ids, |i| i.backend()),
     ) {
         Some(id) => ids.iter().position(|&i| i == id).unwrap() as i8,
         None => -1,


### PR DESCRIPTION
In a quest to make `wgpu` able to enumerate GPUs, deliver information to the user and then being able to select a specific GPU, I ended up refactoring quite a bit.

-  `Adapter` is now named `RawAdapter`
-  new `Adapter` enum, which encapsulates backend agnostic `RawAdapter`
-  new module `adapter`, where I moved things that I thought make more sense there
-  new `enumerate_adaptors` function, which returns `Vec<AdapterId>`

Please keep in mind that I'm still very new to the project and not entirely sure what exactly I'm doing.