### PR TITLE
Implement `enumerate_adapters`.

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -263,6 +263,76 @@ impl<I: Clone> AdapterInputs<'_, I> {
 }
 
 impl<F: IdentityFilter<AdapterId>> Global<F> {
+    pub fn enumerate_adapters(&self, inputs: AdapterInputs<F::Input>) -> Vec<AdapterId> {
+        let instance = &self.instance;
+        let mut token = Token::root();
+        let mut adapters = Vec::new();
+
+        #[cfg(any(
+            not(any(target_os = "ios", target_os = "macos")),
+            feature = "gfx-backend-vulkan"
+        ))]
+        {
+            if let Some(ref inst) = instance.vulkan {
+                if let Some(id_vulkan) = inputs.find(Backend::Vulkan) {
+                    for raw in inst.enumerate_adapters() {
+                        let adapter = Adapter { raw };
+                        log::info!("Adapter Vulkan {:?}", adapter.raw.info);
+                        adapters.push(backend::Vulkan::hub(self).adapters.register_identity(
+                            id_vulkan.clone(),
+                            adapter,
+                            &mut token,
+                        ));
+                    }
+                }
+            }
+        }
+        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        {
+            if let Some(id_metal) = inputs.find(Backend::Metal) {
+                for raw in instance.metal.enumerate_adapters() {
+                    let adapter = Adapter { raw };
+                    log::info!("Adapter Metal {:?}", adapter.raw.info);
+                    adapters.push(backend::Metal::hub(self).adapters.register_identity(
+                        id_metal.clone(),
+                        adapter,
+                        &mut token,
+                    ));
+                }
+            }
+        }
+        #[cfg(windows)]
+        {
+            if let Some(ref inst) = instance.dx12 {
+                if let Some(id_dx12) = inputs.find(Backend::Dx12) {
+                    for raw in inst.enumerate_adapters() {
+                        let adapter = Adapter { raw };
+                        log::info!("Adapter Dx12 {:?}", adapter.raw.info);
+                        adapters.push(backend::Dx12::hub(self).adapters.register_identity(
+                            id_dx12.clone(),
+                            adapter,
+                            &mut token,
+                        ));
+                    }
+                }
+            }
+
+            if let Some(id_dx11) = inputs.find(Backend::Dx11) {
+                for raw in instance.dx11.enumerate_adapters() {
+                    let adapter = Adapter { raw };
+                    log::info!("Adapter Dx11 {:?}", adapter.raw.info);
+                    adapters.push(backend::Dx11::hub(self).adapters.register_identity(
+                        id_dx11.clone(),
+                        adapter,
+                        &mut token,
+                    ));
+                }
+            }
+        }
+
+        adapters
+    }
+
     pub fn pick_adapter(
         &self,
         desc: &RequestAdapterOptions,


### PR DESCRIPTION
This is take two of #478, it's a much smaller change with less abstraction.

-  implement `internal_enumerate_adapters`, which refactors `instance.{BACKEND}.enumerate_adapters()` out of `pick_adapter`
-  implement `enumerate_adapters`, which just returns a vector of all GPUs in the form of `AdapterId`