### PR TITLE
Make ComputeCommand public

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -23,7 +23,7 @@ use std::iter;
 
 
 #[derive(Clone, Copy, Debug, PeekCopy, Poke)]
-enum ComputeCommand {
+pub enum ComputeCommand {
     SetBindGroup {
         index: u8,
         num_dynamic_offsets: u8,

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -38,10 +38,10 @@ use std::{
 
 
 #[derive(Clone, Copy, Debug, peek_poke::PeekCopy, peek_poke::Poke)]
-struct PhantomSlice<T>(PhantomData<T>);
+pub struct PhantomSlice<T>(PhantomData<T>);
 
 impl<T> PhantomSlice<T> {
-    fn new() -> Self {
+    pub fn new() -> Self {
         PhantomSlice(PhantomData)
     }
 
@@ -120,13 +120,13 @@ impl RawPass {
     }
 
     #[inline]
-    unsafe fn encode<C: peek_poke::Poke>(&mut self, command: &C) {
+    pub unsafe fn encode<C: peek_poke::Poke>(&mut self, command: &C) {
         self.ensure_extra_size(C::max_size());
         self.data = command.poke_into(self.data);
     }
 
     #[inline]
-    unsafe fn encode_slice<T: Copy>(&mut self, data: &[T]) {
+    pub unsafe fn encode_slice<T: Copy>(&mut self, data: &[T]) {
         let align_offset = self.data.align_offset(mem::align_of::<T>());
         let extra = align_offset + mem::size_of::<T>() * data.len();
         self.ensure_extra_size(extra);


### PR DESCRIPTION
Set public the `ComputeCommand`, `PhantomSlice` and some underlying functions.