### PR TITLE
Add PresentMode::Mailbox

### DIFF
--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -208,7 +208,7 @@ int main() {
             .format = WGPUTextureFormat_Bgra8Unorm,
             .width = prev_width,
             .height = prev_height,
-            .present_mode = WGPUPresentMode_Vsync,
+            .present_mode = WGPUPresentMode_Fifo,
         });
 
     while (!glfwWindowShouldClose(window)) {
@@ -225,7 +225,7 @@ int main() {
                     .format = WGPUTextureFormat_Bgra8Unorm,
                     .width = width,
                     .height = height,
-                    .present_mode = WGPUPresentMode_Vsync,
+                    .present_mode = WGPUPresentMode_Fifo,
                 });
         }
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -126,9 +126,9 @@ typedef enum {
 } WGPUPowerPreference;
 
 typedef enum {
-  WGPUPresentMode_NoVsync = 0,
-  WGPUPresentMode_Vsync = 1,
-  WGPUPresentMode_Mailbox = 2,
+  WGPUPresentMode_Immediate = 0,
+  WGPUPresentMode_Mailbox = 1,
+  WGPUPresentMode_Fifo = 2,
 } WGPUPresentMode;
 
 typedef enum {

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -128,6 +128,7 @@ typedef enum {
 typedef enum {
   WGPUPresentMode_NoVsync = 0,
   WGPUPresentMode_Vsync = 1,
+  WGPUPresentMode_Mailbox = 2,
 } WGPUPresentMode;
 
 typedef enum {

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -65,6 +65,7 @@ pub struct SwapChain<B: hal::Backend> {
 pub enum PresentMode {
     NoVsync = 0,
     Vsync = 1,
+    Mailbox = 2,
 }
 
 #[repr(C)]
@@ -95,6 +96,7 @@ impl SwapChainDescriptor {
         config.present_mode = match self.present_mode {
             PresentMode::NoVsync => hal::window::PresentMode::IMMEDIATE,
             PresentMode::Vsync => hal::window::PresentMode::FIFO,
+            PresentMode::Mailbox => hal::window::PresentMode::MAILBOX,
         };
         config
     }

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -63,9 +63,20 @@ pub struct SwapChain<B: hal::Backend> {
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub enum PresentMode {
-    NoVsync = 0,
-    Vsync = 1,
-    Mailbox = 2,
+    /// The presentation engine does **not** wait for a vertical blanking period and 
+    /// the request is presented immediately. This is a low-latency presentation mode,
+    /// but visible tearing may be observed. Will fallback to `Fifo` if unavailable on the
+    /// selected  platform and backend. Not optimal for mobile. 
+    Immediate = 0,
+    /// The presentation engine waits for the next vertical blanking period to update
+    /// the current image, but frames may be submitted without delay. This is a low-latency 
+    /// presentation mode and visible tearing will **not** be observed. Will fallback to `Fifo`
+    /// if unavailable on the selected platform and backend. Not optimal for mobile.
+    Mailbox = 1,
+    /// The presentation engine waits for the next vertical blanking period to update 
+    /// the current image. The framerate will be capped at the display refresh rate, 
+    /// corresponding to the `VSync`. Tearing cannot be observed. Optimal for mobile.
+    Fifo = 2,
 }
 
 #[repr(C)]
@@ -94,9 +105,9 @@ impl SwapChainDescriptor {
         config.image_usage = conv::map_texture_usage(self.usage, hal::format::Aspects::COLOR);
         config.composite_alpha_mode = hal::window::CompositeAlphaMode::OPAQUE;
         config.present_mode = match self.present_mode {
-            PresentMode::NoVsync => hal::window::PresentMode::IMMEDIATE,
-            PresentMode::Vsync => hal::window::PresentMode::FIFO,
+            PresentMode::Immediate => hal::window::PresentMode::IMMEDIATE,
             PresentMode::Mailbox => hal::window::PresentMode::MAILBOX,
+            PresentMode::Fifo => hal::window::PresentMode::FIFO,
         };
         config
     }


### PR DESCRIPTION
@kvark 

Would you be open to renaming the presents modes to match the vulkan/gfx-hal nomenclature? Considering these aren't part of the webgpu spec, I think it would make more sense to keep things consistent.

I can update this PR if you're good with it.

```rust
pub enum PresentMode {
    /// The presentation engine does **not** wait for a vertical blanking period and 
    /// the request is presented immediately. This is a low-latency presentation mode,
    /// but visible tearing may be observed. Will fallback to `Fifo` if unavailable on the
    /// selected  platform and backend. Not optimal for mobile. 
    Immediate = 0,
    /// The presentation engine waits for the next vertical blanking period to update
    /// the current image, but frames may be submitted without delay. This is a low-latency 
    /// presentation mode and visible tearing will **not** be observed. Will fallback to `Fifo`
    /// if unavailable on the selected platform and backend. Not optimal for mobile.
    Mailbox = 1,
    /// The presentation engine waits for the next vertical blanking period to update 
    /// the current image. The framerate will be capped at the display refresh rate, 
    /// corresponding to the `VSync`. Tearing cannot be observed. Optimal for mobile.
    Fifo = 2,
}
```