### PR TITLE
Cache surface formats to reduce overhead with swapchain recreation

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1859,10 +1859,28 @@ impl<F: IdentityFilter<id::SwapChainId>> Global<F> {
         let surface = &mut surface_guard[surface_id];
 
         let (caps, formats) = {
-            let suf = B::get_surface_mut(surface);
             let adapter = &adapter_guard[device.adapter_id];
+
+            // cache supported formats for significantly faster swapchain re-creation
+            let supported_formats_guard = surface.supported_formats.lock();
+            let formats = match supported_formats_guard.get(&device.adapter_id) {
+                Some(supported_formats) => {
+                    let supported_formats = supported_formats.clone();
+                    drop(supported_formats_guard);
+                    supported_formats
+                }
+                None => {
+                    drop(supported_formats_guard);
+                    let gfx_surface = B::get_surface_mut(surface);
+                    let supported_formats = gfx_surface.supported_formats(&adapter.raw.physical_device);
+                    let mut supported_formats_guard = surface.supported_formats.lock();
+                    supported_formats_guard.insert(device.adapter_id, supported_formats.clone());
+                    supported_formats
+                }
+            };
+
+            let suf = B::get_surface_mut(surface);
             assert!(suf.supports_queue_family(&adapter.raw.queue_families[0]));
-            let formats = suf.supported_formats(&adapter.raw.physical_device);
             let caps = suf.capabilities(&adapter.raw.physical_device);
             (caps, formats)
         };

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1860,25 +1860,7 @@ impl<F: IdentityFilter<id::SwapChainId>> Global<F> {
 
         let (caps, formats) = {
             let adapter = &adapter_guard[device.adapter_id];
-
-            // cache supported formats for significantly faster swapchain re-creation
-            let supported_formats_guard = surface.supported_formats.lock();
-            let formats = match supported_formats_guard.get(&device.adapter_id) {
-                Some(supported_formats) => {
-                    let supported_formats = supported_formats.clone();
-                    drop(supported_formats_guard);
-                    supported_formats
-                }
-                None => {
-                    drop(supported_formats_guard);
-                    let gfx_surface = B::get_surface_mut(surface);
-                    let supported_formats = gfx_surface.supported_formats(&adapter.raw.physical_device);
-                    let mut supported_formats_guard = surface.supported_formats.lock();
-                    supported_formats_guard.insert(device.adapter_id, supported_formats.clone());
-                    supported_formats
-                }
-            };
-
+            let formats = surface.supported_formats(device.adapter_id, &adapter);
             let suf = B::get_surface_mut(surface);
             assert!(suf.supports_queue_family(&adapter.raw.queue_families[0]));
             let caps = suf.capabilities(&adapter.raw.physical_device);

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -505,6 +505,7 @@ impl<F: Default> Global<F> {
 pub trait GfxBackend: hal::Backend {
     const VARIANT: Backend;
     fn hub<F>(global: &Global<F>) -> &Hub<Self, F>;
+    fn get_surface(surface: &Surface) -> &Self::Surface;
     fn get_surface_mut(surface: &mut Surface) -> &mut Self::Surface;
 }
 
@@ -517,6 +518,9 @@ impl GfxBackend for backend::Vulkan {
     fn hub<F>(global: &Global<F>) -> &Hub<Self, F> {
         &global.hubs.vulkan
     }
+    fn get_surface(surface: &Surface) -> &Self::Surface {
+        surface.vulkan.as_ref().unwrap()
+    }
     fn get_surface_mut(surface: &mut Surface) -> &mut Self::Surface {
         surface.vulkan.as_mut().unwrap()
     }
@@ -527,6 +531,9 @@ impl GfxBackend for backend::Metal {
     const VARIANT: Backend = Backend::Metal;
     fn hub<F>(global: &Global<F>) -> &Hub<Self, F> {
         &global.hubs.metal
+    }
+    fn get_surface(surface: &Surface) -> &Self::Surface {
+        &mut surface.metal
     }
     fn get_surface_mut(surface: &mut Surface) -> &mut Self::Surface {
         &mut surface.metal
@@ -539,6 +546,9 @@ impl GfxBackend for backend::Dx12 {
     fn hub<F>(global: &Global<F>) -> &Hub<Self, F> {
         &global.hubs.dx12
     }
+    fn get_surface(surface: &Surface) -> &Self::Surface {
+        surface.dx12.as_ref().unwrap()
+    }
     fn get_surface_mut(surface: &mut Surface) -> &mut Self::Surface {
         surface.dx12.as_mut().unwrap()
     }
@@ -549,6 +559,9 @@ impl GfxBackend for backend::Dx11 {
     const VARIANT: Backend = Backend::Dx11;
     fn hub<F>(global: &Global<F>) -> &Hub<Self, F> {
         &global.hubs.dx11
+    }
+    fn get_surface(surface: &Surface) -> &Self::Surface {
+        &surface.dx11
     }
     fn get_surface_mut(surface: &mut Surface) -> &mut Self::Surface {
         &mut surface.dx11

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -57,6 +57,8 @@ impl<T> PartialEq for Id<T> {
     }
 }
 
+impl<T> Eq for Id<T> {}
+
 unsafe impl<T> peek_poke::Poke for Id<T> {
     fn max_size() -> usize {
          mem::size_of::<u64>()

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::collections::HashMap;
+
 use crate::{
     backend,
     binding_model::MAX_BIND_GROUPS,
@@ -22,6 +24,7 @@ use hal::{
     Instance as _,
 };
 
+use parking_lot::Mutex;
 
 #[derive(Debug)]
 pub struct Instance {
@@ -94,6 +97,11 @@ pub struct Surface {
     pub dx12: Option<GfxSurface<backend::Dx12>>,
     #[cfg(windows)]
     pub dx11: GfxSurface<backend::Dx11>,
+    // Cache supported surface formats per phsyical device in order to
+    // reduce overhead while re-creating swapchains. Some device/drivers
+    // have significant overhead when querying supported formats and by
+    // speeding up swapchain creation, we can enable smooth window resizing.
+    pub supported_formats: Mutex<HashMap<AdapterId, Option<Vec<hal::format::Format>>, fxhash::FxBuildHasher>>,
 }
 
 #[derive(Debug)]

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -47,7 +47,7 @@ type Index = u32;
 type Epoch = u32;
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Backend {
     Empty = 0,

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -26,6 +26,7 @@ pub fn wgpu_create_surface(raw_handle: raw_window_handle::RawWindowHandle) -> id
             metal: instance
                 .metal
                 .create_surface_from_uiview(h.ui_view, cfg!(debug_assertions)),
+            supported_formats: Default::default(),
         },
         #[cfg(target_os = "macos")]
         Rwh::MacOS(h) => {
@@ -45,6 +46,7 @@ pub fn wgpu_create_surface(raw_handle: raw_window_handle::RawWindowHandle) -> id
                 metal: instance
                     .metal
                     .create_surface_from_nsview(ns_view, cfg!(debug_assertions)),
+                supported_formats: Default::default(),
             }
         },
         #[cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))]
@@ -53,6 +55,7 @@ pub fn wgpu_create_surface(raw_handle: raw_window_handle::RawWindowHandle) -> id
                 .vulkan
                 .as_ref()
                 .map(|inst| inst.create_surface_from_xlib(h.display as _, h.window as _)),
+            supported_formats: Default::default(),
         },
         #[cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))]
         Rwh::Wayland(h) => core::instance::Surface {
@@ -60,6 +63,7 @@ pub fn wgpu_create_surface(raw_handle: raw_window_handle::RawWindowHandle) -> id
                 .vulkan
                 .as_ref()
                 .map(|inst| inst.create_surface_from_wayland(h.display, h.surface)),
+            supported_formats: Default::default(),
         },
         #[cfg(windows)]
         Rwh::Windows(h) => core::instance::Surface {
@@ -72,6 +76,7 @@ pub fn wgpu_create_surface(raw_handle: raw_window_handle::RawWindowHandle) -> id
                 .as_ref()
                 .map(|inst| inst.create_surface_from_hwnd(h.hwnd)),
             dx11: instance.dx11.create_surface_from_hwnd(h.hwnd),
+            supported_formats: Default::default(),
         },
         _ => panic!("Unsupported window handle"),
     };
@@ -121,6 +126,7 @@ pub extern "C" fn wgpu_create_surface_from_metal_layer(
             .instance
             .metal
             .create_surface_from_layer(layer as *mut _, cfg!(debug_assertions)),
+        supported_formats: Default::default(),
     };
 
     GLOBAL


### PR DESCRIPTION
Some device/drivers have significant overhead when querying
supported surface formats. This can result in choppy window resizing
due to slow swapchain re-creation.

By caching the formats, we can achieve extremely smoothe window
resizing.

Related: https://github.com/gfx-rs/gfx/pull/3159