### PR TITLE
Add `Clone` and `PartialEq` implementations for `SamplerDescriptor`

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -796,7 +796,7 @@ impl Default for FilterMode {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SamplerDescriptor<'a> {
     pub address_mode_u: AddressMode,
     pub address_mode_v: AddressMode,


### PR DESCRIPTION
Helps when attempting to support multiple samplers in an immediate mode
context (e.g. easily compare sampler descriptors and check if I need to
add a command to switch bind groups).