### PR TITLE
Add buffer debug labels

### DIFF
--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -69,6 +69,7 @@ int main(
 
     WGPUBufferId buffer = wgpu_device_create_buffer_mapped(device,
             &(WGPUBufferDescriptor){
+                .label = "buffer",
                 .size = size,
 				.usage = WGPUBufferUsage_STORAGE | WGPUBufferUsage_MAP_READ},
             &staging_memory);
@@ -80,6 +81,7 @@ int main(
     WGPUBindGroupLayoutId bind_group_layout =
         wgpu_device_create_bind_group_layout(device,
             &(WGPUBindGroupLayoutDescriptor){
+                .label = "bind group layout",
                 .entries = &(WGPUBindGroupLayoutEntry){
 					.binding = 0,
                     .visibility = WGPUShaderStage_COMPUTE,
@@ -94,7 +96,9 @@ int main(
 			.offset = 0}}};
 
     WGPUBindGroupId bind_group = wgpu_device_create_bind_group(device,
-            &(WGPUBindGroupDescriptor){.layout = bind_group_layout,
+            &(WGPUBindGroupDescriptor){
+                .label = "bind group",
+                .layout = bind_group_layout,
                 .entries = &(WGPUBindGroupEntry){
 					.binding = 0,
 					.resource = resource},
@@ -124,7 +128,7 @@ int main(
 
     WGPUCommandEncoderId encoder = wgpu_device_create_command_encoder(
         device, &(WGPUCommandEncoderDescriptor){
-            .todo = 0
+            .label = "command encoder",
         });
 
     WGPUComputePassId command_pass =

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -79,12 +79,14 @@ int main() {
     WGPUBindGroupLayoutId bind_group_layout =
         wgpu_device_create_bind_group_layout(device,
             &(WGPUBindGroupLayoutDescriptor){
+                .label = "bind group layout",
                 .entries = NULL,
                 .entries_length = 0,
             });
     WGPUBindGroupId bind_group =
         wgpu_device_create_bind_group(device,
             &(WGPUBindGroupDescriptor){
+                .label = "bind group",
                 .layout = bind_group_layout,
                 .entries = NULL,
                 .entries_length = 0,
@@ -237,7 +239,7 @@ int main() {
         }
 
         WGPUCommandEncoderId cmd_encoder = wgpu_device_create_command_encoder(
-            device, &(WGPUCommandEncoderDescriptor){.todo = 0});
+            device, &(WGPUCommandEncoderDescriptor){.label = "command encoder"});
 
         WGPURenderPassColorAttachmentDescriptor
             color_attachments[ATTACHMENTS_LENGTH] = {

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -470,6 +470,7 @@ typedef struct {
 } WGPUBindGroupEntry;
 
 typedef struct {
+  const char *label;
   WGPUBindGroupLayoutId layout;
   const WGPUBindGroupEntry *entries;
   uintptr_t entries_length;
@@ -493,6 +494,7 @@ typedef struct {
 } WGPUBindGroupLayoutEntry;
 
 typedef struct {
+  const char *label;
   const WGPUBindGroupLayoutEntry *entries;
   uintptr_t entries_length;
 } WGPUBindGroupLayoutDescriptor;
@@ -511,12 +513,13 @@ typedef uint32_t WGPUBufferUsage;
 #define WGPUBufferUsage_NONE 0
 
 typedef struct {
+  const char *label;
   WGPUBufferAddress size;
   WGPUBufferUsage usage;
 } WGPUBufferDescriptor;
 
 typedef struct {
-  uint32_t todo;
+  const char *label;
 } WGPUCommandEncoderDescriptor;
 
 typedef uint64_t WGPUId_PipelineLayout_Dummy;
@@ -671,6 +674,7 @@ typedef struct {
 } WGPUSwapChainDescriptor;
 
 typedef struct {
+  const char *label;
   WGPUExtent3d size;
   uint32_t array_layer_count;
   uint32_t mip_level_count;

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -59,6 +59,7 @@ pub struct BindGroupLayoutEntry {
 #[repr(C)]
 #[derive(Debug)]
 pub struct BindGroupLayoutDescriptor {
+    pub label: *const std::os::raw::c_char,
     pub entries: *const BindGroupLayoutEntry,
     pub entries_length: usize,
 }
@@ -115,6 +116,7 @@ pub struct BindGroupEntry {
 #[repr(C)]
 #[derive(Debug)]
 pub struct BindGroupDescriptor {
+    pub label: *const std::os::raw::c_char,
     pub layout: BindGroupLayoutId,
     pub entries: *const BindGroupEntry,
     pub entries_length: usize,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -321,6 +321,9 @@ impl<B: GfxBackend> Device<B> {
         };
 
         let mut buffer = unsafe { self.raw.create_buffer(desc.size, usage).unwrap() };
+        if let Some(label) = desc.label {
+            unsafe { self.raw.set_buffer_name(&mut buffer, label) };
+        }
         let requirements = unsafe { self.raw.get_buffer_requirements(&buffer) };
         let memory = self
             .mem_allocator

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -538,7 +538,8 @@ bitflags::bitflags! {
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct BufferDescriptor {
+pub struct BufferDescriptor<'a> {
+    pub label: Option<&'a str>,
     pub size: BufferAddress,
     pub usage: BufferUsage,
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -536,20 +536,26 @@ bitflags::bitflags! {
 }
 
 #[repr(C)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct BufferDescriptor<'a> {
-    pub label: Option<&'a str>,
+pub struct BufferDescriptor {
+    pub label: *const std::os::raw::c_char,
     pub size: BufferAddress,
     pub usage: BufferUsage,
 }
 
 #[repr(C)]
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CommandEncoderDescriptor {
     // MSVC doesn't allow zero-sized structs
     // We can remove this when we actually have a field
-    pub todo: u32,
+    // pub todo: u32,
+    pub label: *const std::os::raw::c_char,
+}
+
+impl Default for CommandEncoderDescriptor {
+    fn default() -> CommandEncoderDescriptor {
+        unsafe { std::mem::zeroed() }
+    }
 }
 
 pub type DynamicOffset = u32;
@@ -735,6 +741,7 @@ pub struct Extent3d {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TextureDescriptor {
+    pub label: *const std::os::raw::c_char,
     pub size: Extent3d,
     pub array_layer_count: u32,
     pub mip_level_count: u32,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::{io, slice};
+use std::{io, slice, ptr};
 #[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize};
 #[cfg(feature = "peek-poke")]
@@ -554,7 +554,9 @@ pub struct CommandEncoderDescriptor {
 
 impl Default for CommandEncoderDescriptor {
     fn default() -> CommandEncoderDescriptor {
-        unsafe { std::mem::zeroed() }
+        CommandEncoderDescriptor {
+            label: ptr::null(),
+        }
     }
 }
 


### PR DESCRIPTION
Related #404 

@kvark Is this what you had in mind? The webgpu headers have labels on all the descriptor structs and I didn't see any specific functions for altering/adding labels after creation. I'll add the rest if this looks good to you. 

I also went looking for [command buffer marker support](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/chap41.html#debugging-command-buffer-markers) in [gfx-hal](https://docs.rs/gfx-hal/0.4.1/gfx_hal/command/trait.CommandBuffer.html) so that I could add [group labels and markers](https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-pushdebuggroup).  Is this functionality absent in `hal` or did I miss it?



