### PR TITLE
Track GPU use of pipelines

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -142,7 +142,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                 }
                 ComputeCommand::SetPipeline(pipeline_id) => {
-                    let pipeline = &pipeline_guard[pipeline_id];
+                    let pipeline = cmb.trackers
+                        .compute_pipes
+                        .use_extend(&*pipeline_guard, pipeline_id, (), ())
+                        .unwrap();
 
                     unsafe {
                         raw.bind_compute_pipeline(&pipeline.raw);

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -183,6 +183,8 @@ impl<B: GfxBackend> CommandBuffer<B> {
         base.views.merge_extend(&head.views).unwrap();
         base.bind_groups.merge_extend(&head.bind_groups).unwrap();
         base.samplers.merge_extend(&head.samplers).unwrap();
+        base.compute_pipes.merge_extend(&head.compute_pipes).unwrap();
+        base.render_pipes.merge_extend(&head.render_pipes).unwrap();
 
         let stages = all_buffer_stages() | all_image_stages();
         unsafe {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -851,7 +851,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     };
                 }
                 RenderCommand::SetPipeline(pipeline_id) => {
-                    let pipeline = &pipeline_guard[pipeline_id];
+                    let pipeline = trackers
+                        .render_pipes
+                        .use_extend(&*pipeline_guard, pipeline_id, (), ())
+                        .unwrap();
 
                     assert!(
                         context.compatible(&pipeline.pass_context),

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -184,6 +184,7 @@ impl<B: hal::Backend> Access<ComputePipeline<B>> for Device<B> {}
 impl<B: hal::Backend> Access<ComputePipeline<B>> for BindGroup<B> {}
 impl<B: hal::Backend> Access<RenderPipeline<B>> for Device<B> {}
 impl<B: hal::Backend> Access<RenderPipeline<B>> for BindGroup<B> {}
+impl<B: hal::Backend> Access<RenderPipeline<B>> for ComputePipeline<B> {}
 impl<B: hal::Backend> Access<ShaderModule<B>> for Device<B> {}
 impl<B: hal::Backend> Access<ShaderModule<B>> for PipelineLayout<B> {}
 impl<B: hal::Backend> Access<Buffer<B>> for Root {}

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -5,11 +5,14 @@
 use crate::{
     device::RenderPassContext,
     id::{DeviceId, PipelineLayoutId, ShaderModuleId},
+    LifeGuard,
     RawString,
+    RefCount,
     Stored,
     U32Array
 };
 use wgt::{BufferAddress, ColorStateDescriptor, DepthStencilStateDescriptor, IndexFormat, InputStepMode, PrimitiveTopology, RasterizationStateDescriptor, VertexAttributeDescriptor};
+use std::borrow::Borrow;
 
 #[repr(C)]
 #[derive(Debug)]
@@ -59,6 +62,13 @@ pub struct ComputePipeline<B: hal::Backend> {
     pub(crate) raw: B::ComputePipeline,
     pub(crate) layout_id: PipelineLayoutId,
     pub(crate) device_id: Stored<DeviceId>,
+    pub(crate) life_guard: LifeGuard,
+}
+
+impl<B: hal::Backend> Borrow<RefCount> for ComputePipeline<B> {
+    fn borrow(&self) -> &RefCount {
+        self.life_guard.ref_count.as_ref().unwrap()
+    }
 }
 
 #[repr(C)]
@@ -96,4 +106,11 @@ pub struct RenderPipeline<B: hal::Backend> {
     pub(crate) index_format: IndexFormat,
     pub(crate) sample_count: u8,
     pub(crate) vertex_strides: Vec<(BufferAddress, InputStepMode)>,
+    pub(crate) life_guard: LifeGuard,
+}
+
+impl<B: hal::Backend> Borrow<RefCount> for RenderPipeline<B> {
+    fn borrow(&self) -> &RefCount {
+        self.life_guard.ref_count.as_ref().unwrap()
+    }
 }

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -9,7 +9,7 @@ mod texture;
 use crate::{
     conv,
     hub::Storage,
-    id::{BindGroupId, SamplerId, TextureViewId, TypedId},
+    id::{self, TypedId},
     resource,
     Epoch,
     FastHashMap,
@@ -464,9 +464,11 @@ pub const DUMMY_SELECTOR: () = ();
 pub struct TrackerSet {
     pub buffers: ResourceTracker<BufferState>,
     pub textures: ResourceTracker<TextureState>,
-    pub views: ResourceTracker<PhantomData<TextureViewId>>,
-    pub bind_groups: ResourceTracker<PhantomData<BindGroupId>>,
-    pub samplers: ResourceTracker<PhantomData<SamplerId>>,
+    pub views: ResourceTracker<PhantomData<id::TextureViewId>>,
+    pub bind_groups: ResourceTracker<PhantomData<id::BindGroupId>>,
+    pub samplers: ResourceTracker<PhantomData<id::SamplerId>>,
+    pub compute_pipes: ResourceTracker<PhantomData<id::ComputePipelineId>>,
+    pub render_pipes: ResourceTracker<PhantomData<id::RenderPipelineId>>,
 }
 
 impl TrackerSet {
@@ -478,6 +480,8 @@ impl TrackerSet {
             views: ResourceTracker::new(backend),
             bind_groups: ResourceTracker::new(backend),
             samplers: ResourceTracker::new(backend),
+            compute_pipes: ResourceTracker::new(backend),
+            render_pipes: ResourceTracker::new(backend),
         }
     }
 
@@ -488,6 +492,8 @@ impl TrackerSet {
         self.views.clear();
         self.bind_groups.clear();
         self.samplers.clear();
+        self.compute_pipes.clear();
+        self.render_pipes.clear();
     }
 
     /// Try to optimize the tracking representation.
@@ -497,6 +503,8 @@ impl TrackerSet {
         self.views.optimize();
         self.bind_groups.optimize();
         self.samplers.optimize();
+        self.compute_pipes.optimize();
+        self.render_pipes.optimize();
     }
 
     /// Merge all the trackers of another instance by extending
@@ -507,6 +515,8 @@ impl TrackerSet {
         self.views.merge_extend(&other.views).unwrap();
         self.bind_groups.merge_extend(&other.bind_groups).unwrap();
         self.samplers.merge_extend(&other.samplers).unwrap();
+        self.compute_pipes.merge_extend(&other.compute_pipes).unwrap();
+        self.render_pipes.merge_extend(&other.render_pipes).unwrap();
     }
 
     pub fn backend(&self) -> wgt::Backend {


### PR DESCRIPTION
Based on #533 
Fixes #529 

I think that makes us semi-complete in terms of GPU usage tracking? I was afraid that we need to track *all* the things, but now I think we don't really care to track shader modules, bind group layouts, and pipeline layouts, because these aren't GPU resources, these are just driver constructs (will need to double-check that fact).