### PR TITLE
Unbox unnecessarily boxed function

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -554,10 +554,10 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                 let buffer = &mut buffer_guard[buffer_id];
                 let mapping = buffer.pending_mapping.take().unwrap();
                 let result = match mapping.op {
-                    resource::BufferMapOperation::Read(..) => {
+                    resource::BufferMapOperation::Read { .. } => {
                         super::map_buffer(raw, buffer, mapping.range, super::HostMap::Read)
                     }
-                    resource::BufferMapOperation::Write(..) => {
+                    resource::BufferMapOperation::Write { .. } => {
                         super::map_buffer(raw, buffer, mapping.range, super::HostMap::Write)
                     }
                 };

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -181,11 +181,11 @@ fn fire_map_callbacks<I: IntoIterator<Item = BufferMapPendingCallback>>(callback
             }
         };
         match operation {
-            resource::BufferMapOperation::Read(on_read) => {
-                on_read(status, ptr)
+            resource::BufferMapOperation::Read { callback, userdata } => unsafe {
+                callback(status, ptr, userdata)
             }
-            resource::BufferMapOperation::Write(on_write) => {
-                on_write(status, ptr)
+            resource::BufferMapOperation::Write { callback, userdata } => unsafe {
+                callback(status, ptr, userdata)
             }
         }
     }

--- a/wgpu-native/src/device.rs
+++ b/wgpu-native/src/device.rs
@@ -380,11 +380,11 @@ pub extern "C" fn wgpu_buffer_map_read_async(
     callback: core::device::BufferMapReadCallback,
     userdata: *mut u8,
 ) {
-    let operation = core::resource::BufferMapOperation::Read(
-        Box::new(move |status, data| unsafe {
-            callback(status, data, userdata)
-        }),
-    );
+    let operation = core::resource::BufferMapOperation::Read {
+        callback,
+        userdata,
+    };
+
     gfx_select!(buffer_id => GLOBAL.buffer_map_async(buffer_id, wgt::BufferUsage::MAP_READ, start .. start + size, operation))
 }
 
@@ -396,11 +396,11 @@ pub extern "C" fn wgpu_buffer_map_write_async(
     callback: core::device::BufferMapWriteCallback,
     userdata: *mut u8,
 ) {
-    let operation = core::resource::BufferMapOperation::Write(
-        Box::new(move |status, data| unsafe {
-            callback(status, data, userdata)
-        }),
-    );
+    let operation = core::resource::BufferMapOperation::Write {
+        callback,
+        userdata,
+    };
+
     gfx_select!(buffer_id => GLOBAL.buffer_map_async(buffer_id, wgt::BufferUsage::MAP_WRITE, start .. start + size, operation))
 }
 

--- a/wgpu-remote/src/server.rs
+++ b/wgpu-remote/src/server.rs
@@ -123,11 +123,11 @@ pub extern "C" fn wgpu_server_buffer_map_read(
     callback: core::device::BufferMapReadCallback,
     userdata: *mut u8,
 ) {
-    let operation = core::resource::BufferMapOperation::Read(
-        Box::new(move |status, data| unsafe {
-            callback(status, data, userdata)
-        }),
-    );
+    let operation = core::resource::BufferMapOperation::Read {
+        callback,
+        userdata,   
+    };
+    
     gfx_select!(buffer_id => global.buffer_map_async(
         buffer_id,
         wgt::BufferUsage::MAP_READ,


### PR DESCRIPTION
Internally, the async buffer mapping callbacks were unnecessarily boxed. This was pretty easy to fix.