### PR TITLE
Fix mapping of readonly flags in binding types

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -98,7 +98,7 @@ pub fn map_binding_type(binding: &binding_model::BindGroupLayoutEntry) -> hal::p
             },
         },
         Bt::ReadonlyStorageBuffer => pso::DescriptorType::Buffer {
-            ty: pso::BufferDescriptorType::Storage { read_only: false },
+            ty: pso::BufferDescriptorType::Storage { read_only: true },
             format: pso::BufferDescriptorFormat::Structured {
                 dynamic_offset: binding.has_dynamic_offset,
             },
@@ -110,10 +110,10 @@ pub fn map_binding_type(binding: &binding_model::BindGroupLayoutEntry) -> hal::p
             },
         },
         Bt::ReadonlyStorageTexture => pso::DescriptorType::Image {
-            ty: pso::ImageDescriptorType::Storage { read_only: false },
+            ty: pso::ImageDescriptorType::Storage { read_only: true },
         },
         Bt::WriteonlyStorageTexture => pso::DescriptorType::Image {
-            ty: pso::ImageDescriptorType::Storage { read_only: true },
+            ty: pso::ImageDescriptorType::Storage { read_only: false },
         },
     }
 }


### PR DESCRIPTION
When trying out the DX12 backend I encountered crashes on creation of compute pipelines (worked previously with Vulkan), complaining that not the root signature would not match with the compute shader due to unbound UAVs. After some digging I found that readonly images were mapped oddly, see proposed fix.

With this fix most of my previously failing pipelines are successfully created. However, I'm still having issues with a compute pipeline using a `readonly uimage3D` which fails to create iff I use a readonly `StorageTexture` _and actually perform a load on it_ (so might be a shader conversion issue in here as well, potentially on my glsl->spirv side). It works if I either use readonly==false on the `BindingType` or don't use the image in the shader it. Will try to come up with an isolated repro case for this.
With that bit of background, could be that the odd flags I'm fixing here were somehow intentional? :)

Related to https://github.com/gfx-rs/gfx/issues/2933 I figure.
All described usage was via wgpu-rs


_edit:_ Apologies, made a bit of a mess by rebasing to v5.0. It's master based again