### PR TITLE
Fix buffer unmap warning

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* Generated with cbindgen:0.14.0 */
+/* Generated with cbindgen:0.14.1 */
 
 /* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
  * To generate this file:


### PR DESCRIPTION
It's more consistent if neither map_buffer or unmap_buffer care about the status.