### PR TITLE
Track pipeline layout lifetime

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -80,6 +80,7 @@ pub struct PipelineLayoutDescriptor {
 pub struct PipelineLayout<B: hal::Backend> {
     pub(crate) raw: B::PipelineLayout,
     pub(crate) device_id: Stored<DeviceId>,
+    pub(crate) life_guard: LifeGuard,
     pub(crate) bind_group_layout_ids: ArrayVec<[BindGroupLayoutId; wgt::MAX_BIND_GROUPS]>,
 }
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -176,9 +176,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
 
                     // Rebind resources
-                    if binder.pipeline_layout_id != Some(pipeline.layout_id) {
-                        let pipeline_layout = &pipeline_layout_guard[pipeline.layout_id];
-                        binder.pipeline_layout_id = Some(pipeline.layout_id);
+                    if binder.pipeline_layout_id != Some(pipeline.layout_id.value) {
+                        let pipeline_layout = &pipeline_layout_guard[pipeline.layout_id.value];
+                        binder.pipeline_layout_id = Some(pipeline.layout_id.value);
                         binder.reset_expectations(pipeline_layout.bind_group_layout_ids.len());
                         let mut is_compatible = true;
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -896,9 +896,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
 
                     // Rebind resource
-                    if state.binder.pipeline_layout_id != Some(pipeline.layout_id) {
-                        let pipeline_layout = &pipeline_layout_guard[pipeline.layout_id];
-                        state.binder.pipeline_layout_id = Some(pipeline.layout_id);
+                    if state.binder.pipeline_layout_id != Some(pipeline.layout_id.value) {
+                        let pipeline_layout = &pipeline_layout_guard[pipeline.layout_id.value];
+                        state.binder.pipeline_layout_id = Some(pipeline.layout_id.value);
                         state
                             .binder
                             .reset_expectations(pipeline_layout.bind_group_layout_ids.len());

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1005,6 +1005,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 value: device_id,
                 ref_count: device.life_guard.add_ref(),
             },
+            life_guard: LifeGuard::new(),
             bind_group_layout_ids: bind_group_layout_ids.iter().cloned().collect(),
         };
         hub.pipeline_layouts
@@ -1014,15 +1015,24 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn pipeline_layout_destroy<B: GfxBackend>(&self, pipeline_layout_id: id::PipelineLayoutId) {
         let hub = B::hub(self);
         let mut token = Token::root();
+        let (device_id, ref_count) = {
+            let (mut pipeline_layout_guard, _) = hub.pipeline_layouts.write(&mut token);
+            let layout = &mut pipeline_layout_guard[pipeline_layout_id];
+            (
+                layout.device_id.value,
+                layout.life_guard.ref_count.take().unwrap(),
+            )
+        };
+
         let (device_guard, mut token) = hub.devices.read(&mut token);
-        let (pipeline_layout, _) = hub
+        device_guard[device_id]
+            .lock_life(&mut token)
+            .suspected_resources
             .pipeline_layouts
-            .unregister(pipeline_layout_id, &mut token);
-        unsafe {
-            device_guard[pipeline_layout.device_id.value]
-                .raw
-                .destroy_pipeline_layout(pipeline_layout.raw);
-        }
+            .push(Stored {
+                value: pipeline_layout_id,
+                ref_count,
+            });
     }
 
     pub fn device_create_bind_group<B: GfxBackend>(
@@ -1667,9 +1677,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let (device_guard, mut token) = hub.devices.read(&mut token);
         let device = &device_guard[device_id];
-        let raw_pipeline = {
+        let (raw_pipeline, layout_ref_count) = {
             let (pipeline_layout_guard, mut token) = hub.pipeline_layouts.read(&mut token);
-            let layout = &pipeline_layout_guard[desc.layout].raw;
+            let layout = &pipeline_layout_guard[desc.layout];
             let (shader_module_guard, _) = hub.shader_modules.read(&mut token);
 
             let rp_key = RenderPassKey {
@@ -1777,19 +1787,20 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 depth_stencil,
                 multisampling,
                 baked_states,
-                layout,
+                layout: &layout.raw,
                 subpass,
                 flags,
                 parent,
             };
 
             // TODO: cache
-            unsafe {
+            let pipeline = unsafe {
                 device
                     .raw
                     .create_graphics_pipeline(&pipeline_desc, None)
                     .unwrap()
-            }
+            };
+            (pipeline, layout.life_guard.add_ref())
         };
 
         let pass_context = RenderPassContext {
@@ -1812,7 +1823,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let pipeline = pipeline::RenderPipeline {
             raw: raw_pipeline,
-            layout_id: desc.layout,
+            layout_id: Stored {
+                value: desc.layout,
+                ref_count: layout_ref_count,
+            },
             device_id: Stored {
                 value: device_id,
                 ref_count: device.life_guard.add_ref(),
@@ -1834,18 +1848,22 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
 
-        let device_id = {
+        let (device_id, layout_id) = {
             let (mut pipeline_guard, _) = hub.render_pipelines.write(&mut token);
             let pipeline = &mut pipeline_guard[render_pipeline_id];
             pipeline.life_guard.ref_count.take();
-            pipeline.device_id.value
+            (pipeline.device_id.value, pipeline.layout_id.clone())
         };
 
-        device_guard[device_id]
-            .lock_life(&mut token)
+        let mut life_lock = device_guard[device_id].lock_life(&mut token);
+        life_lock
             .suspected_resources
             .render_pipelines
             .push(render_pipeline_id);
+        life_lock
+            .suspected_resources
+            .pipeline_layouts
+            .push(layout_id);
     }
 
     pub fn device_create_compute_pipeline<B: GfxBackend>(
@@ -1859,9 +1877,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let (device_guard, mut token) = hub.devices.read(&mut token);
         let device = &device_guard[device_id];
-        let raw_pipeline = {
+        let (raw_pipeline, layout_ref_count) = {
             let (pipeline_layout_guard, mut token) = hub.pipeline_layouts.read(&mut token);
-            let layout = &pipeline_layout_guard[desc.layout].raw;
+            let layout = &pipeline_layout_guard[desc.layout];
             let pipeline_stage = &desc.compute_stage;
             let (shader_module_guard, _) = hub.shader_modules.read(&mut token);
 
@@ -1881,22 +1899,26 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let pipeline_desc = hal::pso::ComputePipelineDesc {
                 shader,
-                layout,
+                layout: &layout.raw,
                 flags,
                 parent,
             };
 
-            unsafe {
+            let pipeline = unsafe {
                 device
                     .raw
                     .create_compute_pipeline(&pipeline_desc, None)
                     .unwrap()
-            }
+            };
+            (pipeline, layout.life_guard.add_ref())
         };
 
         let pipeline = pipeline::ComputePipeline {
             raw: raw_pipeline,
-            layout_id: desc.layout,
+            layout_id: Stored {
+                value: desc.layout,
+                ref_count: layout_ref_count,
+            },
             device_id: Stored {
                 value: device_id,
                 ref_count: device.life_guard.add_ref(),
@@ -1915,18 +1937,22 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
 
-        let device_id = {
+        let (device_id, layout_id) = {
             let (mut pipeline_guard, _) = hub.compute_pipelines.write(&mut token);
             let pipeline = &mut pipeline_guard[compute_pipeline_id];
             pipeline.life_guard.ref_count.take();
-            pipeline.device_id.value
+            (pipeline.device_id.value, pipeline.layout_id.clone())
         };
 
-        device_guard[device_id]
-            .lock_life(&mut token)
+        let mut life_lock = device_guard[device_id].lock_life(&mut token);
+        life_lock
             .suspected_resources
             .compute_pipelines
             .push(compute_pipeline_id);
+        life_lock
+            .suspected_resources
+            .pipeline_layouts
+            .push(layout_id);
     }
 
     pub fn device_create_swap_chain<B: GfxBackend>(

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -59,7 +59,7 @@ pub struct ComputePipelineDescriptor {
 #[derive(Debug)]
 pub struct ComputePipeline<B: hal::Backend> {
     pub(crate) raw: B::ComputePipeline,
-    pub(crate) layout_id: PipelineLayoutId,
+    pub(crate) layout_id: Stored<PipelineLayoutId>,
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) life_guard: LifeGuard,
 }
@@ -98,7 +98,7 @@ bitflags::bitflags! {
 #[derive(Debug)]
 pub struct RenderPipeline<B: hal::Backend> {
     pub(crate) raw: B::GraphicsPipeline,
-    pub(crate) layout_id: PipelineLayoutId,
+    pub(crate) layout_id: Stored<PipelineLayoutId>,
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) pass_context: RenderPassContext,
     pub(crate) flags: PipelineFlags,


### PR DESCRIPTION
Fixes #580
This one is interesting: it's not instantly destroyed when dropped, like bind group layouts. And it's not tracked for GPU usage like the resources. It's somewhat in-between. We have the following classes of tracking now:
  1. no tracking, destroyed on drop. Applies to: bind group layouts, adapters
  2. only CPU-side tracking. They go to "suspected" list on drop of self or anything that can point to them. Applies to: pipeline layouts
  3. full GPU tracking. They go to "suspected" list on drop, then get associated with active submission before destruction. Applies to: buffers, textures, views, bind groups, pipelines