### PR TITLE
Improve error messages when passing buffers with the wrong usage flags

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -979,7 +979,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         .buffers
                         .use_extend(&*buffer_guard, buffer_id, (), BufferUsage::INDEX)
                         .unwrap();
-                    assert!(buffer.usage.contains(BufferUsage::INDEX));
+                    assert!(buffer.usage.contains(BufferUsage::INDEX), "An invalid setIndexBuffer call has been made. The buffer usage is {:?} which does not contain required usage INDEX", buffer.usage);
 
                     let end = if size != 0 {
                         offset + size
@@ -1012,7 +1012,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         .buffers
                         .use_extend(&*buffer_guard, buffer_id, (), BufferUsage::VERTEX)
                         .unwrap();
-                    assert!(buffer.usage.contains(BufferUsage::VERTEX));
+                    assert!(buffer.usage.contains(BufferUsage::VERTEX), "An invalid setVertexBuffer call has been made. The buffer usage is {:?} which does not contain required usage VERTEX", buffer.usage);
                     let empty_slots = (1 + slot as usize).saturating_sub(state.vertex.inputs.len());
                     state
                         .vertex
@@ -1136,7 +1136,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         .buffers
                         .use_extend(&*buffer_guard, buffer_id, (), BufferUsage::INDIRECT)
                         .unwrap();
-                    assert!(buffer.usage.contains(BufferUsage::INDIRECT));
+                    assert!(buffer.usage.contains(BufferUsage::INDIRECT), "An invalid drawIndirect call has been made. The buffer usage is {:?} which does not contain required usage INDIRECT", buffer.usage);
 
                     unsafe {
                         raw.draw_indirect(&buffer.raw, offset, 1, 0);
@@ -1149,7 +1149,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         .buffers
                         .use_extend(&*buffer_guard, buffer_id, (), BufferUsage::INDIRECT)
                         .unwrap();
-                    assert!(buffer.usage.contains(BufferUsage::INDIRECT));
+                    assert!(buffer.usage.contains(BufferUsage::INDIRECT), "An invalid drawIndexedIndirect call has been made. The buffer usage is {:?} which does not contain required usage INDIRECT", buffer.usage);
 
                     unsafe {
                         raw.draw_indexed_indirect(&buffer.raw, offset, 1, 0);


### PR DESCRIPTION
e.g.

```
thread 'main' panicked at 'An invalid setIndexBuffer call has been made. The buffer usage is COPY_DST | VERTEX which does not contain required usage INDEX
```