### PR TITLE
Warn when binding a buffer that is still mapped

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1461,6 +1461,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                     if !buffer_guard[id].life_guard.use_at(submit_index) {
                         if let resource::BufferMapState::Active = buffer_guard[id].map_state {
+                            log::warn!("Dropped buffer has a pending mapping.");
                             unmap_buffer(&device.raw, &mut buffer_guard[id]);
                         }
                         device.temp_suspected.buffers.push(id);


### PR DESCRIPTION
Fixes #510

I'd like to make more contributions wrt validation. Though I'm quite new to Rust, so let's start small :)  

From the discussion in #510 I concluded that in this case the buffer has actually been dropped, does the error message make sense like this?

Do the messages logged with `log::warn`, end up in the same logging system as the layer validation messages? So a solution to get those messages into Python (for wgpu-py) would work for both kinds of validation messages?
