### PR TITLE
Enable READ access for texture storage

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -540,7 +540,7 @@ pub fn map_texture_state(
         access |= A::SHADER_READ;
     }
     if usage.contains(W::STORAGE) {
-        access |= A::SHADER_WRITE;
+        access |= A::SHADER_READ | A::SHADER_WRITE;
     }
     if usage.contains(W::OUTPUT_ATTACHMENT) {
         //TODO: read-only attachments


### PR DESCRIPTION
This is a short-term workaround until we properly implement #597 