### PR TITLE
Add links to docs in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This is an active GitHub mirror of the WebGPU implementation in Rust, which now 
 [![Matrix](https://img.shields.io/badge/Matrix-%23wgpu%3Amatrix.org-blueviolet.svg)](https://matrix.to/#/#wgpu:matrix.org)
 [![Build Status](https://travis-ci.org/gfx-rs/wgpu.svg?branch=master)](https://travis-ci.org/gfx-rs/wgpu)
 [![Crates.io](https://img.shields.io/crates/v/wgpu-core.svg?label=wgpu-core)](https://crates.io/crates/wgpu-core)
+[![docs.rs](https://docs.rs/wgpu-core/badge.svg)](https://docs.rs/wgpu-core/)
 [![Crates.io](https://img.shields.io/crates/v/wgpu-native.svg?label=wgpu-native)](https://crates.io/crates/wgpu-native)
+[![docs.rs](https://docs.rs/wgpu-types/badge.svg)](https://docs.rs/wgpu-types/)
 
 This is the core logic of an experimental [WebGPU](https://www.w3.org/community/gpu/) implementation. It's written in Rust and is based on [gfx-hal](https://github.com/gfx-rs/gfx) with help of [gfx-extras](https://github.com/gfx-rs/gfx-extras). See the upstream [WebGPU specification](https://gpuweb.github.io/gpuweb/) (work in progress).
 
@@ -29,5 +31,5 @@ If you are looking for the native implementation or bindings to the API in other
   Vulkan | :heavy_check_mark: | :heavy_check_mark: |                    |
   Metal  |                    |                    | :heavy_check_mark: |
   OpenGL | :construction:     | :construction:     | :construction:     |
-  
+
 :heavy_check_mark: = Primary support — :white_check_mark: = Secondary support — :construction: = Unsupported, but support in progress


### PR DESCRIPTION
This PR adds badges with links to the `docs.rs` pages for the crates.