### PR TITLE
Run tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           - os: macos-10.15
             name: MacOS Nightly
             channel: nightly
-            build_command: cargo check
+            build_command: cargo test
           - os: ubuntu-18.04
             name: Ubuntu Stable
             channel: stable
@@ -42,7 +42,7 @@ jobs:
           - os: ubuntu-18.04
             name: Ubuntu Nightly
             channel: nightly
-            build_command: cargo check
+            build_command: cargo test
           - os: windows-2019
             name: Windows Stable
             channel: stable
@@ -50,7 +50,7 @@ jobs:
           - os: windows-2019
             name: Windows Nightly
             channel: nightly
-            build_command: rustup default nightly-msvc; cargo check
+            build_command: rustup default nightly-msvc; cargo test
     steps:
     - uses: actions/checkout@v2
     - if: matrix.channel == 'nightly'
@@ -61,5 +61,5 @@ jobs:
         override: true
     - if: contains(matrix.build_command, 'clippy')
       run: rustup component add clippy
-    - name: cargo check
+    - name: cargo clippy/test
       run: ${{ matrix.build_command }}


### PR DESCRIPTION
The `wgpu-core` crate has a few tests, but they aren't currently run in CI. This PR fixes that.