### PR TITLE
Use General allocator at all times for now

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -281,12 +281,13 @@ impl<B: GfxBackend> Device<B> {
         let (kind, mem_usage) = {
             use wgt::BufferUsage as Bu;
 
+            //TODO: use linear allocation when we can ensure the freeing is linear
             if !desc.usage.intersects(Bu::MAP_READ | Bu::MAP_WRITE) {
                 (Kind::General, MemoryUsage::Private)
             } else if (Bu::MAP_WRITE | Bu::COPY_SRC).contains(desc.usage) {
-                (Kind::Linear, MemoryUsage::Staging { read_back: false })
+                (Kind::General, MemoryUsage::Staging { read_back: false })
             } else if (Bu::MAP_READ | Bu::COPY_DST).contains(desc.usage) {
-                (Kind::Linear, MemoryUsage::Staging { read_back: true })
+                (Kind::General, MemoryUsage::Staging { read_back: true })
             } else {
                 (
                     Kind::General,


### PR DESCRIPTION
In all user-managed resources, we don't have control of the lifetime. Since we don't know when it's released, we can't use any more specific allocator kind than `General`.

Previously, we assumed that buffers created for MAP_READ+COPY_SRC, for example, were one-time buffers created to copy data. However, there appear to be cases where they were used to fill data in once, and then persistently used as a copy source destination.

In the future, one WebGPU data transfer story is settled, we'll be able to use `Linear` kind again for all internally managed uploads. I.e. writeBuffer, writeTexture, and createBuffeMappedOnlyAtStart.