### PR TITLE
Wait for idle before destroying swapchains

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -497,11 +497,14 @@ impl<B: hal::Backend> Device<B> {
         }
     }
 
+    /// Wait for idle and remove resources that we can, before we die.
+    pub(crate) fn prepare_to_die(&mut self) {
+        let mut life_tracker = self.life_tracker.lock();
+        life_tracker.triage_submissions(&self.raw, true);
+        life_tracker.cleanup(&self.raw, &self.mem_allocator, &self.desc_allocator);
+    }
+
     pub(crate) fn dispose(self) {
-        self.life_tracker.lock().triage_submissions(&self.raw, true);
-        self.life_tracker
-            .lock()
-            .cleanup(&self.raw, &self.mem_allocator, &self.desc_allocator);
         self.com_allocator.destroy(&self.raw);
         let mut desc_alloc = self.desc_allocator.into_inner();
         let mut mem_alloc = self.mem_allocator.into_inner();
@@ -2440,8 +2443,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let hub = B::hub(self);
         let mut token = Token::root();
         let device = {
-            let (device, mut token) = hub.devices.unregister(device_id, &mut token);
-            device.maintain(self, true, &mut token);
+            let (mut device, _) = hub.devices.unregister(device_id, &mut token);
+            device.prepare_to_die();
             device
         };
 

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -422,6 +422,9 @@ impl<B: GfxBackend, F: GlobalIdentityHandlerFactory> Hub<B, F> {
         use hal::{device::Device as _, window::PresentationSurface as _};
 
         let mut devices = self.devices.data.write();
+        for (device, _) in devices.map.values_mut() {
+            device.prepare_to_die();
+        }
 
         for (_, (sampler, _)) in self.samplers.data.write().map.drain() {
             unsafe {


### PR DESCRIPTION
Follow up to #636 
I was trying to address the D3D12 error in https://github.com/gfx-rs/gfx/issues/3242
The debug messages complain about a resource being used by the queue while it's being destroyed. I thought forcing a wait there would help, but it does not. I think it's still a good change to land though.

In the meantime, I wonder if it considers the swapchain to be used because it's currently presented. Could be something else I'm missing here.