### PR TITLE
Add a way to destroy a pass by a mutable reference

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -155,8 +155,7 @@ impl super::RawPass {
 
     pub unsafe fn finish_render(mut self) -> (Vec<u8>, id::CommandEncoderId) {
         self.finish(RenderCommand::End);
-        let (vec, parent_id) = self.into_vec();
-        (vec, parent_id)
+        self.into_vec()
     }
 }
 


### PR DESCRIPTION
This will make https://github.com/gfx-rs/wgpu-rs/issues/299 much easier.