### PR TITLE
Fix possible out-of-bounds when trace log level enabled

### DIFF
--- a/wgpu-core/src/command/allocator.rs
+++ b/wgpu-core/src/command/allocator.rs
@@ -27,10 +27,10 @@ impl<B: hal::Backend> CommandPool<B> {
     fn maintain(&mut self, lowest_active_index: SubmissionIndex) {
         for i in (0..self.pending.len()).rev() {
             if self.pending[i].1 < lowest_active_index {
-                let cmd_buf = self.pending.swap_remove(i).0;
+                let (cmd_buf, index) = self.pending.swap_remove(i);
                 log::trace!(
                     "recycling comb submitted in {} when {} is lowest active",
-                    self.pending[i].1,
+                    index,
                     lowest_active_index,
                 );
                 self.recycle(cmd_buf);


### PR DESCRIPTION
Also, even when there was no out-of-bounds access, the log statement talked
about an incorrect submission index.

Fixes https://github.com/gfx-rs/wgpu/issues/659