### PR TITLE
Implement write_texture

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -411,11 +411,20 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                 let bin = std::fs::read(dir.join(data)).unwrap();
                 let size = (range.end - range.start) as usize;
                 if queued {
-                    self.queue_write_buffer::<B>(device, &bin, id, range.start);
+                    self.queue_write_buffer::<B>(device, id, range.start, &bin);
                 } else {
                     self.device_wait_for_buffer::<B>(device, id);
                     self.device_set_buffer_sub_data::<B>(device, id, range.start, &bin[..size]);
                 }
+            }
+            A::WriteTexture {
+                to,
+                data,
+                layout,
+                size,
+            } => {
+                let bin = std::fs::read(dir.join(data)).unwrap();
+                self.queue_write_texture::<B>(device, &to, &bin, &layout, size);
             }
             A::Submit(_index, commands) => {
                 let encoder = self.device_create_command_encoder::<B>(

--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -130,32 +130,14 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                 } => self.command_encoder_copy_buffer_to_buffer::<B>(
                     encoder, src, src_offset, dst, dst_offset, size,
                 ),
-                trace::Command::CopyBufferToTexture {
-                    src,
-                    src_layout,
-                    dst,
-                    size,
-                } => self.command_encoder_copy_buffer_to_texture::<B>(
-                    encoder,
-                    src,
-                    &src_layout,
-                    &dst,
-                    size,
-                ),
-                trace::Command::CopyTextureToBuffer {
-                    src,
-                    dst,
-                    dst_layout,
-                    size,
-                } => self.command_encoder_copy_texture_to_buffer::<B>(
-                    encoder,
-                    &src,
-                    dst,
-                    &dst_layout,
-                    size,
-                ),
+                trace::Command::CopyBufferToTexture { src, dst, size } => {
+                    self.command_encoder_copy_buffer_to_texture::<B>(encoder, &src, &dst, &size)
+                }
+                trace::Command::CopyTextureToBuffer { src, dst, size } => {
+                    self.command_encoder_copy_texture_to_buffer::<B>(encoder, &src, &dst, &size)
+                }
                 trace::Command::CopyTextureToTexture { src, dst, size } => {
-                    self.command_encoder_copy_texture_to_texture::<B>(encoder, &src, &dst, size)
+                    self.command_encoder_copy_texture_to_texture::<B>(encoder, &src, &dst, &size)
                 }
                 trace::Command::RunComputePass {
                     commands,
@@ -442,7 +424,7 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                 size,
             } => {
                 let bin = std::fs::read(dir.join(data)).unwrap();
-                self.queue_write_texture::<B>(device, &to, &bin, &layout, size);
+                self.queue_write_texture::<B>(device, &to, &bin, &layout, &size);
             }
             A::Submit(_index, commands) => {
                 let encoder = self.device_create_command_encoder::<B>(

--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -130,12 +130,30 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                 } => self.command_encoder_copy_buffer_to_buffer::<B>(
                     encoder, src, src_offset, dst, dst_offset, size,
                 ),
-                trace::Command::CopyBufferToTexture { src, dst, size } => {
-                    self.command_encoder_copy_buffer_to_texture::<B>(encoder, &src, &dst, size)
-                }
-                trace::Command::CopyTextureToBuffer { src, dst, size } => {
-                    self.command_encoder_copy_texture_to_buffer::<B>(encoder, &src, &dst, size)
-                }
+                trace::Command::CopyBufferToTexture {
+                    src,
+                    src_layout,
+                    dst,
+                    size,
+                } => self.command_encoder_copy_buffer_to_texture::<B>(
+                    encoder,
+                    src,
+                    &src_layout,
+                    &dst,
+                    size,
+                ),
+                trace::Command::CopyTextureToBuffer {
+                    src,
+                    dst,
+                    dst_layout,
+                    size,
+                } => self.command_encoder_copy_texture_to_buffer::<B>(
+                    encoder,
+                    &src,
+                    dst,
+                    &dst_layout,
+                    size,
+                ),
                 trace::Command::CopyTextureToTexture { src, dst, size } => {
                     self.command_encoder_copy_texture_to_texture::<B>(encoder, &src, &dst, size)
                 }

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -13,21 +13,11 @@ use crate::{
 };
 
 use hal::command::CommandBuffer as _;
-use wgt::{BufferAddress, BufferUsage, Extent3d, Origin3d, TextureUsage};
+use wgt::{BufferAddress, BufferUsage, Extent3d, Origin3d, TextureDataLayout, TextureUsage};
 
 use std::iter;
 
 pub(crate) const BITS_PER_BYTE: u32 = 8;
-
-#[repr(C)]
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
-pub struct TextureDataLayout {
-    pub offset: BufferAddress,
-    pub bytes_per_row: u32,
-    pub rows_per_image: u32,
-}
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -129,19 +129,14 @@ pub fn map_shader_stage_flags(shader_stage_flags: wgt::ShaderStage) -> hal::pso:
     value
 }
 
-pub fn map_origin(origin: wgt::Origin3d) -> hal::image::Offset {
-    hal::image::Offset {
-        x: origin.x as i32,
-        y: origin.y as i32,
-        z: origin.z as i32,
-    }
-}
-
-pub fn map_extent(extent: wgt::Extent3d) -> hal::image::Extent {
+pub fn map_extent(extent: wgt::Extent3d, dim: wgt::TextureDimension) -> hal::image::Extent {
     hal::image::Extent {
         width: extent.width,
         height: extent.height,
-        depth: extent.depth,
+        depth: match dim {
+            wgt::TextureDimension::D1 | wgt::TextureDimension::D2 => 1,
+            wgt::TextureDimension::D3 => extent.depth,
+        },
     }
 }
 

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -129,7 +129,7 @@ pub fn map_shader_stage_flags(shader_stage_flags: wgt::ShaderStage) -> hal::pso:
     value
 }
 
-pub fn map_extent(extent: wgt::Extent3d, dim: wgt::TextureDimension) -> hal::image::Extent {
+pub fn map_extent(extent: &wgt::Extent3d, dim: wgt::TextureDimension) -> hal::image::Extent {
     hal::image::Extent {
         width: extent.width,
         height: extent.height,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -238,7 +238,7 @@ impl<B: GfxBackend> Device<B> {
         };
         #[cfg(not(feature = "trace"))]
         match trace_path {
-            Some(_) => log::warn!("Tracing feature is not enabled"),
+            Some(_) => log::error!("Feature 'trace' is not enabled"),
             None => (),
         }
 
@@ -265,7 +265,7 @@ impl<B: GfxBackend> Device<B> {
                     Some(Mutex::new(trace))
                 }
                 Err(e) => {
-                    log::warn!("Unable to start a trace in '{:?}': {:?}", path, e);
+                    log::error!("Unable to start a trace in '{:?}': {:?}", path, e);
                     None
                 }
             }),

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -477,6 +477,7 @@ impl<B: GfxBackend> Device<B> {
                 ref_count: self.life_guard.add_ref(),
             },
             usage: desc.usage,
+            dimension: desc.dimension,
             kind,
             format: desc.format,
             full_range: hal::image::SubresourceRange {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "trace")]
 use crate::device::trace::Action;
 use crate::{
-    command::{CommandAllocator, CommandBuffer, TextureCopyView, TextureDataLayout, BITS_PER_BYTE},
+    command::{CommandAllocator, CommandBuffer, TextureCopyView, BITS_PER_BYTE},
     conv,
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Token},
     id,
@@ -192,7 +192,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         queue_id: id::QueueId,
         destination: &TextureCopyView,
         data: &[u8],
-        data_layout: &TextureDataLayout,
+        data_layout: &wgt::TextureDataLayout,
         size: wgt::Extent3d,
     ) {
         let hub = B::hub(self);

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -193,7 +193,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &TextureCopyView,
         data: &[u8],
         data_layout: &wgt::TextureDataLayout,
-        size: wgt::Extent3d,
+        size: &wgt::Extent3d,
     ) {
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -211,7 +211,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     to: destination.clone(),
                     data: data_path,
                     layout: data_layout.clone(),
-                    size,
+                    size: *size,
                 });
             }
             None => {}

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{command::TextureCopyView, id};
+use crate::{
+    command::{BufferCopyView, TextureCopyView},
+    id,
+};
 #[cfg(feature = "trace")]
 use std::io::Write as _;
 use std::ops::Range;
@@ -186,15 +189,13 @@ pub enum Command {
         size: wgt::BufferAddress,
     },
     CopyBufferToTexture {
-        src: id::BufferId,
-        src_layout: wgt::TextureDataLayout,
+        src: BufferCopyView,
         dst: TextureCopyView,
         size: wgt::Extent3d,
     },
     CopyTextureToBuffer {
         src: TextureCopyView,
-        dst: id::BufferId,
-        dst_layout: wgt::TextureDataLayout,
+        dst: BufferCopyView,
         size: wgt::Extent3d,
     },
     CopyTextureToTexture {

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    command::{BufferCopyView, TextureCopyView, TextureDataLayout},
+    command::{TextureCopyView, TextureDataLayout},
     id,
 };
 #[cfg(feature = "trace")]
@@ -189,13 +189,15 @@ pub enum Command {
         size: wgt::BufferAddress,
     },
     CopyBufferToTexture {
-        src: BufferCopyView,
+        src: id::BufferId,
+        src_layout: TextureDataLayout,
         dst: TextureCopyView,
         size: wgt::Extent3d,
     },
     CopyTextureToBuffer {
         src: TextureCopyView,
-        dst: BufferCopyView,
+        dst: id::BufferId,
+        dst_layout: TextureDataLayout,
         size: wgt::Extent3d,
     },
     CopyTextureToTexture {

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{
-    command::{TextureCopyView, TextureDataLayout},
-    id,
-};
+use crate::{command::TextureCopyView, id};
 #[cfg(feature = "trace")]
 use std::io::Write as _;
 use std::ops::Range;
@@ -171,7 +168,7 @@ pub enum Action {
     WriteTexture {
         to: TextureCopyView,
         data: FileName,
-        layout: TextureDataLayout,
+        layout: wgt::TextureDataLayout,
         size: wgt::Extent3d,
     },
     Submit(crate::SubmissionIndex, Vec<Command>),
@@ -190,14 +187,14 @@ pub enum Command {
     },
     CopyBufferToTexture {
         src: id::BufferId,
-        src_layout: TextureDataLayout,
+        src_layout: wgt::TextureDataLayout,
         dst: TextureCopyView,
         size: wgt::Extent3d,
     },
     CopyTextureToBuffer {
         src: TextureCopyView,
         dst: id::BufferId,
-        dst_layout: TextureDataLayout,
+        dst_layout: wgt::TextureDataLayout,
         size: wgt::Extent3d,
     },
     CopyTextureToTexture {

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    command::{BufferCopyView, TextureCopyView},
+    command::{BufferCopyView, TextureCopyView, TextureDataLayout},
     id,
 };
 #[cfg(feature = "trace")]
@@ -167,6 +167,12 @@ pub enum Action {
         data: FileName,
         range: Range<wgt::BufferAddress>,
         queued: bool,
+    },
+    WriteTexture {
+        to: TextureCopyView,
+        data: FileName,
+        layout: TextureDataLayout,
+        size: wgt::Extent3d,
     },
     Submit(crate::SubmissionIndex, Vec<Command>),
 }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -170,6 +170,7 @@ pub struct Texture<B: hal::Backend> {
     pub(crate) raw: B::Image,
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) usage: TextureUsage,
+    pub(crate) dimension: wgt::TextureDimension,
     pub(crate) kind: hal::image::Kind,
     pub(crate) format: TextureFormat,
     pub(crate) full_range: hal::image::SubresourceRange,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -10,6 +10,9 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::{io, ptr, slice};
 
+/// Bound uniform/storage buffer offsets must be aligned to this number.
+pub const BIND_BUFFER_ALIGNMENT: u64 = 256;
+
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
@@ -981,5 +984,12 @@ impl From<TextureFormat> for TextureComponentType {
     }
 }
 
-/// Bound uniform/storage buffer offsets must be aligned to this number.
-pub const BIND_BUFFER_ALIGNMENT: u64 = 256;
+#[repr(C)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "trace", derive(serde::Serialize))]
+#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+pub struct TextureDataLayout {
+    pub offset: BufferAddress,
+    pub bytes_per_row: u32,
+    pub rows_per_image: u32,
+}


### PR DESCRIPTION
TODO:
- [x] basic implementation
- [x] use `TextureDataLayout` in copies
- [x] share common bits of `write_buffer` and `write_texture`
- [x] use `write_texture` in wgpu-rs examples - https://github.com/gfx-rs/wgpu-rs/pull/321
- [x] update wgpu-native - https://github.com/gfx-rs/wgpu-native/pull/31
- [x] test API tracing
- [x] bring back `BufferCopyView`