### PR TITLE
New map_async logic

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -657,19 +657,22 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                     _ => panic!("No pending mapping."),
                 };
                 log::debug!("Buffer {:?} map state -> Active", buffer_id);
-                let host = match mapping.op {
-                    resource::BufferMapOperation::Read { .. } => super::HostMap::Read,
-                    resource::BufferMapOperation::Write { .. } => super::HostMap::Write,
+                let host = mapping.op.host;
+                let status = match super::map_buffer(raw, buffer, mapping.sub_range.clone(), host) {
+                    Ok(ptr) => {
+                        buffer.map_state = resource::BufferMapState::Active {
+                            ptr,
+                            sub_range: mapping.sub_range,
+                            host,
+                        };
+                        resource::BufferMapAsyncStatus::Success
+                    }
+                    Err(e) => {
+                        log::error!("Mapping failed {:?}", e);
+                        resource::BufferMapAsyncStatus::Error
+                    }
                 };
-                let result = super::map_buffer(raw, buffer, mapping.sub_range.clone(), host);
-                if let Ok(ptr) = result {
-                    buffer.map_state = resource::BufferMapState::Active {
-                        ptr,
-                        sub_range: mapping.sub_range,
-                        host,
-                    };
-                }
-                pending_callbacks.push((mapping.op, result));
+                pending_callbacks.push((mapping.op, status));
             }
         }
         pending_callbacks

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -239,10 +239,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .bits as u32
             / BITS_PER_BYTE;
 
-        let stage_bytes_per_row = get_lowest_common_denom(
+        let bytes_per_row_alignment = get_lowest_common_denom(
             device.hal_limits.optimal_buffer_copy_pitch_alignment as u32,
             bytes_per_texel,
         );
+        let stage_bytes_per_row = align_to(bytes_per_texel * size.width, bytes_per_row_alignment);
         let stage_size = stage_bytes_per_row as u64
             * ((size.depth - 1) * data_layout.rows_per_image + size.height) as u64;
         let mut stage = device.prepare_stage(stage_size);
@@ -529,6 +530,13 @@ fn get_greatest_common_divisor(mut a: u32, mut b: u32) -> u32 {
             a = b;
             b = c;
         }
+    }
+}
+
+fn align_to(value: u32, alignment: u32) -> u32 {
+    match value % alignment {
+        0 => value,
+        other => value - other + alignment,
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -19,7 +19,7 @@ pub const COPY_BYTES_PER_ROW_ALIGNMENT: u32 = 256;
 pub const BIND_BUFFER_ALIGNMENT: u64 = 256;
 
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "peek-poke", derive(PeekPoke))]
 #[cfg_attr(
     feature = "trace",
@@ -34,7 +34,13 @@ pub const BIND_BUFFER_ALIGNMENT: u64 = 256;
 pub struct BufferSize(pub u64);
 
 impl BufferSize {
-    pub const WHOLE: BufferSize = BufferSize(!0u64);
+    pub const WHOLE: BufferSize = BufferSize(!0);
+}
+
+impl Default for BufferSize {
+    fn default() -> Self {
+        BufferSize::WHOLE
+    }
 }
 
 #[repr(u8)]
@@ -59,6 +65,12 @@ pub enum PowerPreference {
     Default = 0,
     LowPower = 1,
     HighPerformance = 2,
+}
+
+impl Default for PowerPreference {
+    fn default() -> PowerPreference {
+        PowerPreference::Default
+    }
 }
 
 bitflags::bitflags! {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -593,6 +593,7 @@ pub struct BufferDescriptor<L> {
     pub label: L,
     pub size: BufferAddress,
     pub usage: BufferUsage,
+    pub mapped_at_creation: bool,
 }
 
 impl<L> BufferDescriptor<L> {
@@ -601,6 +602,7 @@ impl<L> BufferDescriptor<L> {
             label: fun(&self.label),
             size: self.size,
             usage: self.usage,
+            mapped_at_creation: self.mapped_at_creation,
         }
     }
 }


### PR DESCRIPTION
Matches upstream changes in https://github.com/gpuweb/gpuweb/pull/708 and https://github.com/gpuweb/gpuweb/issues/796
Notably, it also changes the behavior of the buffers that are mapped at creation (used to be `create_buffer_mapped`, now just a flag in the descriptor). They go through the same staging infrastructure now as `write_buffer` / `write_texture` (if not mappable natively).
TODO:
- wgpu-native PR
- wgpu-rs https://github.com/gfx-rs/wgpu-rs/pull/344