### PR TITLE
Make libx11 optional

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -19,6 +19,7 @@ default = []
 trace = ["ron", "serde", "wgt/trace"]
 replay = ["serde", "wgt/replay"]
 metal-auto-capture = ["gfx-backend-metal/auto-capture"]
+x11 = ["gfx-backend-vulkan/x11"]
 #NOTE: glutin feature is not stable, use at your own risk
 #glutin = ["gfx-backend-gl/glutin"]
 
@@ -56,7 +57,7 @@ gfx-backend-metal = { version = "0.5" }
 gfx-backend-vulkan = { version = "0.5", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
-gfx-backend-vulkan = { version = "0.5", features = ["x11"] }
+gfx-backend-vulkan = { version = "0.5" }
 
 [target.'cfg(windows)'.dependencies]
 gfx-backend-dx12 = { version = "0.5" }

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -18,8 +18,6 @@ license = "MPL-2.0"
 default = []
 trace = ["ron", "serde", "wgt/trace"]
 replay = ["serde", "wgt/replay"]
-metal-auto-capture = ["gfx-backend-metal/auto-capture"]
-x11 = ["gfx-backend-vulkan/x11"]
 #NOTE: glutin feature is not stable, use at your own risk
 #glutin = ["gfx-backend-gl/glutin"]
 


### PR DESCRIPTION
**Connections**

Fixes #676 

**Description**

Make `libx11` optional with a new non-default feature. Default features need to go "to the edge". In its current state, a crate depending on `wgpu` cannot disable the `x11` feature on `gfx-backend-vulkan`.

- `wgpu` will be updated with a similar new feature, but will enable the `wgc/x11` feature by default. This should hopefully be backward compatible for any downstream user of `wgpu`.
- `wgpu-native` will also be given the same treatment.

**Testing**

This was tested with repro steps included in the linked ticket.
