### PR TITLE
Read-only depth-stencil support (RODS)

### DIFF
--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -211,6 +211,7 @@ struct PassComponent<T> {
     load_op: wgt::LoadOp,
     store_op: wgt::StoreOp,
     clear_value: T,
+    read_only: bool,
 }
 
 // required for PeekPoke
@@ -220,6 +221,7 @@ impl<T: Default> Default for PassComponent<T> {
             load_op: wgt::LoadOp::Clear,
             store_op: wgt::StoreOp::Clear,
             clear_value: T::default(),
+            read_only: false,
         }
     }
 }

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -530,8 +530,9 @@ pub(crate) fn map_texture_state(
         W::COPY_SRC => L::TransferSrcOptimal,
         W::COPY_DST => L::TransferDstOptimal,
         W::SAMPLED => L::ShaderReadOnlyOptimal,
-        W::OUTPUT_ATTACHMENT if is_color => L::ColorAttachmentOptimal,
-        W::OUTPUT_ATTACHMENT => L::DepthStencilAttachmentOptimal, //TODO: read-only depth/stencil
+        W::ATTACHMENT_READ | W::ATTACHMENT_WRITE if is_color => L::ColorAttachmentOptimal,
+        W::ATTACHMENT_READ => L::DepthStencilReadOnlyOptimal,
+        W::ATTACHMENT_WRITE => L::DepthStencilAttachmentOptimal,
         _ => L::General,
     };
 
@@ -545,8 +546,14 @@ pub(crate) fn map_texture_state(
     if usage.contains(W::SAMPLED) {
         access |= A::SHADER_READ;
     }
-    if usage.contains(W::OUTPUT_ATTACHMENT) {
-        //TODO: read-only attachments
+    if usage.contains(W::ATTACHMENT_READ) {
+        access |= if is_color {
+            A::COLOR_ATTACHMENT_READ
+        } else {
+            A::DEPTH_STENCIL_ATTACHMENT_READ
+        };
+    }
+    if usage.contains(W::ATTACHMENT_WRITE) {
         access |= if is_color {
             A::COLOR_ATTACHMENT_WRITE
         } else {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -93,6 +93,7 @@ bitflags::bitflags! {
     pub struct PipelineFlags: u32 {
         const BLEND_COLOR = 1;
         const STENCIL_REFERENCE = 2;
+        const DEPTH_STENCIL_READ_ONLY = 4;
     }
 }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -47,17 +47,18 @@ bitflags::bitflags! {
         const COPY_SRC = 1;
         const COPY_DST = 2;
         const SAMPLED = 4;
-        const OUTPUT_ATTACHMENT = 8;
-        const STORAGE_LOAD = 16;
-        const STORAGE_STORE = 32;
+        const ATTACHMENT_READ = 8;
+        const ATTACHMENT_WRITE = 16;
+        const STORAGE_LOAD = 32;
+        const STORAGE_STORE = 48;
         /// The combination of all read-only usages.
-        const READ_ALL = Self::COPY_SRC.bits | Self::SAMPLED.bits | Self::STORAGE_LOAD.bits;
+        const READ_ALL = Self::COPY_SRC.bits | Self::SAMPLED.bits | Self::ATTACHMENT_READ.bits | Self::STORAGE_LOAD.bits;
         /// The combination of all write-only and read-write usages.
-        const WRITE_ALL = Self::COPY_DST.bits | Self::OUTPUT_ATTACHMENT.bits | Self::STORAGE_STORE.bits;
+        const WRITE_ALL = Self::COPY_DST.bits | Self::ATTACHMENT_WRITE.bits | Self::STORAGE_STORE.bits;
         /// The combination of all usages that the are guaranteed to be be ordered by the hardware.
         /// If a usage is not ordered, then even if it doesn't change between draw calls, there
         /// still need to be pipeline barriers inserted for synchronization.
-        const ORDERED = Self::READ_ALL.bits | Self::COPY_DST.bits | Self::OUTPUT_ATTACHMENT.bits;
+        const ORDERED = Self::READ_ALL.bits | Self::COPY_DST.bits | Self::ATTACHMENT_WRITE.bits;
         const UNINITIALIZED = 0xFFFF;
     }
 }

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -342,7 +342,7 @@ mod test {
                 2..3,
                 Unit {
                     first: Some(TextureUse::COPY_SRC),
-                    last: TextureUse::OUTPUT_ATTACHMENT,
+                    last: TextureUse::ATTACHMENT_WRITE,
                 },
             ),
         ]);
@@ -385,7 +385,7 @@ mod test {
             ts1.mips[0].query(&(2..3), |&v| v),
             Some(Ok(Unit {
                 first: Some(TextureUse::SAMPLED),
-                last: TextureUse::OUTPUT_ATTACHMENT,
+                last: TextureUse::ATTACHMENT_WRITE,
             })),
             "wrong final layer 2 state"
         );
@@ -394,7 +394,7 @@ mod test {
         ts2.mips[0] = PlaneStates::from_slice(&[(
             2..3,
             Unit {
-                first: Some(TextureUse::OUTPUT_ATTACHMENT),
+                first: Some(TextureUse::ATTACHMENT_WRITE),
                 last: TextureUse::COPY_SRC,
             },
         )]);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -424,6 +424,9 @@ impl DepthStencilStateDescriptor {
     pub fn needs_stencil_reference(&self) -> bool {
         !self.stencil_front.compare.is_trivial() || !self.stencil_back.compare.is_trivial()
     }
+    pub fn is_read_only(&self) -> bool {
+        !self.depth_write_enabled && self.stencil_write_mask == 0
+    }
 }
 
 #[repr(C)]
@@ -719,9 +722,11 @@ pub struct RenderPassDepthStencilAttachmentDescriptorBase<T> {
     pub depth_load_op: LoadOp,
     pub depth_store_op: StoreOp,
     pub clear_depth: f32,
+    pub depth_read_only: bool,
     pub stencil_load_op: LoadOp,
     pub stencil_store_op: StoreOp,
     pub clear_stencil: u32,
+    pub stencil_read_only: bool,
 }
 
 #[repr(C)]


### PR DESCRIPTION
**Connections**
Fixes #680 
- [ ] wgpu-native update
- [x] wgpu-rs update - https://github.com/gfx-rs/wgpu-rs/pull/340

**Description**
~~Interestingly, this requires us to create an extra pipeline state for RODS-compatible render pipelines (one main, and one with read-only depth-stencil). This also means we are creating another compatible render pass, internally (done once).~~

**Testing**
I don't know for sure that this works properly, but I'd be comfortable landing this at least if the existing functions aren't broken.
