### PR TITLE
Move BufferSize to wgpu-types

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -5,12 +5,11 @@
 use crate::{
     id::{BindGroupLayoutId, BufferId, DeviceId, SamplerId, TextureViewId},
     track::{TrackerSet, DUMMY_SELECTOR},
-    BufferSize, FastHashMap, LifeGuard, RefCount, Stored,
+    FastHashMap, LifeGuard, RefCount, Stored, MAX_BIND_GROUPS,
 };
 
 use arrayvec::ArrayVec;
 use gfx_descriptor::{DescriptorCounts, DescriptorSet};
-use wgt::{BufferAddress, TextureComponentType};
 
 #[cfg(feature = "replay")]
 use serde::Deserialize;
@@ -44,7 +43,7 @@ pub struct BindGroupLayoutEntry {
     pub multisampled: bool,
     pub has_dynamic_offset: bool,
     pub view_dimension: wgt::TextureViewDimension,
-    pub texture_component_type: TextureComponentType,
+    pub texture_component_type: wgt::TextureComponentType,
     pub storage_texture_format: wgt::TextureFormat,
 }
 
@@ -78,7 +77,7 @@ pub struct PipelineLayout<B: hal::Backend> {
     pub(crate) raw: B::PipelineLayout,
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) life_guard: LifeGuard,
-    pub(crate) bind_group_layout_ids: ArrayVec<[Stored<BindGroupLayoutId>; wgt::MAX_BIND_GROUPS]>,
+    pub(crate) bind_group_layout_ids: ArrayVec<[Stored<BindGroupLayoutId>; MAX_BIND_GROUPS]>,
 }
 
 #[repr(C)]
@@ -87,8 +86,8 @@ pub struct PipelineLayout<B: hal::Backend> {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct BufferBinding {
     pub buffer: BufferId,
-    pub offset: BufferAddress,
-    pub size: BufferSize,
+    pub offset: wgt::BufferAddress,
+    pub size: wgt::BufferSize,
 }
 
 #[repr(C)]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -17,7 +17,7 @@ use crate::{
     pipeline::PipelineFlags,
     resource::{BufferUse, TextureUse, TextureViewInner},
     track::TrackerSet,
-    BufferSize, Stored,
+    Stored,
 };
 
 use arrayvec::ArrayVec;
@@ -25,9 +25,9 @@ use hal::command::CommandBuffer as _;
 use peek_poke::{Peek, PeekPoke, Poke};
 use smallvec::SmallVec;
 use wgt::{
-    BufferAddress, BufferUsage, Color, DynamicOffset, IndexFormat, InputStepMode, LoadOp,
-    RenderPassColorAttachmentDescriptorBase, RenderPassDepthStencilAttachmentDescriptorBase,
-    TextureUsage, BIND_BUFFER_ALIGNMENT,
+    BufferAddress, BufferSize, BufferUsage, Color, DynamicOffset, IndexFormat, InputStepMode,
+    LoadOp, RenderPassColorAttachmentDescriptorBase,
+    RenderPassDepthStencilAttachmentDescriptorBase, TextureUsage, BIND_BUFFER_ALIGNMENT,
 };
 
 use std::{borrow::Borrow, collections::hash_map::Entry, fmt, iter, mem, ops::Range, slice};
@@ -1280,9 +1280,9 @@ pub mod render_ffi {
         super::{PhantomSlice, RawPass, Rect},
         RenderCommand,
     };
-    use crate::{id, BufferSize, RawString};
+    use crate::{id, RawString};
     use std::{convert::TryInto, slice};
-    use wgt::{BufferAddress, Color, DynamicOffset};
+    use wgt::{BufferAddress, BufferSize, Color, DynamicOffset};
 
     /// # Safety
     ///

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Input, Token},
     id, pipeline, resource, swap_chain,
     track::{BufferState, TextureState, TrackerSet},
-    BufferSize, FastHashMap, LifeGuard, PrivateFeatures, Stored,
+    FastHashMap, LifeGuard, PrivateFeatures, Stored,
 };
 
 use arrayvec::ArrayVec;
@@ -20,7 +20,10 @@ use hal::{
     window::{PresentationSurface as _, Surface as _},
 };
 use parking_lot::{Mutex, MutexGuard};
-use wgt::{BufferAddress, InputStepMode, TextureDimension, TextureFormat, BIND_BUFFER_ALIGNMENT};
+use wgt::{
+    BufferAddress, BufferSize, InputStepMode, TextureDimension, TextureFormat,
+    BIND_BUFFER_ALIGNMENT,
+};
 
 use std::{
     collections::hash_map::Entry, ffi, iter, marker::PhantomData, ptr, slice,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     command::{BufferCopyView, TextureCopyView},
-    id, BufferSize,
+    id,
 };
 #[cfg(feature = "trace")]
 use std::io::Write as _;
@@ -13,36 +13,6 @@ use std::ops::Range;
 //TODO: consider a readable Id that doesn't include the backend
 
 type FileName = String;
-
-/// This type allows us to make the serialized representation of a BufferSize more human-readable
-#[allow(dead_code)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
-pub enum SerBufferSize {
-    Size(u64),
-    Whole,
-}
-
-#[cfg(feature = "trace")]
-impl From<BufferSize> for SerBufferSize {
-    fn from(buffer_size: BufferSize) -> Self {
-        if buffer_size == BufferSize::WHOLE {
-            Self::Whole
-        } else {
-            Self::Size(buffer_size.0)
-        }
-    }
-}
-
-#[cfg(feature = "replay")]
-impl From<SerBufferSize> for BufferSize {
-    fn from(ser_buffer_size: SerBufferSize) -> Self {
-        match ser_buffer_size {
-            SerBufferSize::Size(size) => BufferSize(size),
-            SerBufferSize::Whole => BufferSize::WHOLE,
-        }
-    }
-}
 
 pub const FILE_NAME: &str = "trace.ron";
 
@@ -53,7 +23,7 @@ pub enum BindingResource {
     Buffer {
         id: id::BufferId,
         offset: wgt::BufferAddress,
-        size: BufferSize,
+        size: wgt::BufferSize,
     },
     Sampler(id::SamplerId),
     TextureView(id::TextureViewId),

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -46,35 +46,15 @@ use std::sync::atomic;
 
 use atomic::{AtomicUsize, Ordering};
 
-use peek_poke::PeekPoke;
-
 use std::{os::raw::c_char, ptr};
+
+const MAX_BIND_GROUPS: usize = 4;
 
 type SubmissionIndex = usize;
 type Index = u32;
 type Epoch = u32;
 
 pub type RawString = *const c_char;
-
-pub const WHOLE_SIZE: wgt::BufferAddress = !0;
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, PeekPoke)]
-#[cfg_attr(
-    feature = "trace",
-    derive(serde::Serialize),
-    serde(into = "crate::device::trace::SerBufferSize")
-)]
-#[cfg_attr(
-    feature = "replay",
-    derive(serde::Deserialize),
-    serde(from = "crate::device::trace::SerBufferSize")
-)]
-pub struct BufferSize(pub u64);
-
-impl BufferSize {
-    const WHOLE: BufferSize = BufferSize(!0u64);
-}
 
 //TODO: make it private. Currently used for swapchain creation impl.
 #[derive(Debug)]
@@ -214,3 +194,9 @@ macro_rules! gfx_select {
 /// Fast hash map used internally.
 type FastHashMap<K, V> =
     std::collections::HashMap<K, V, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
+
+#[test]
+fn test_default_limits() {
+    let limits = wgt::Limits::default();
+    assert!(limits.max_bind_groups <= MAX_BIND_GROUPS as u32);
+}

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -13,6 +13,25 @@ use std::{io, ptr, slice};
 /// Bound uniform/storage buffer offsets must be aligned to this number.
 pub const BIND_BUFFER_ALIGNMENT: u64 = 256;
 
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "peek-poke", derive(PeekPoke))]
+#[cfg_attr(
+    feature = "trace",
+    derive(serde::Serialize),
+    serde(into = "SerBufferSize")
+)]
+#[cfg_attr(
+    feature = "replay",
+    derive(serde::Deserialize),
+    serde(from = "SerBufferSize")
+)]
+pub struct BufferSize(pub u64);
+
+impl BufferSize {
+    pub const WHOLE: BufferSize = BufferSize(!0u64);
+}
+
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
@@ -80,13 +99,9 @@ pub struct Limits {
     pub max_bind_groups: u32,
 }
 
-pub const MAX_BIND_GROUPS: usize = 4;
-
 impl Default for Limits {
     fn default() -> Self {
-        Limits {
-            max_bind_groups: MAX_BIND_GROUPS as u32,
-        }
+        Limits { max_bind_groups: 4 }
     }
 }
 
@@ -1003,4 +1018,34 @@ pub struct TextureDataLayout {
     pub offset: BufferAddress,
     pub bytes_per_row: u32,
     pub rows_per_image: u32,
+}
+
+/// This type allows us to make the serialized representation of a BufferSize more human-readable
+#[allow(dead_code)]
+#[cfg_attr(feature = "trace", derive(serde::Serialize))]
+#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+enum SerBufferSize {
+    Size(u64),
+    Whole,
+}
+
+#[cfg(feature = "trace")]
+impl From<BufferSize> for SerBufferSize {
+    fn from(buffer_size: BufferSize) -> Self {
+        if buffer_size == BufferSize::WHOLE {
+            Self::Whole
+        } else {
+            Self::Size(buffer_size.0)
+        }
+    }
+}
+
+#[cfg(feature = "replay")]
+impl From<SerBufferSize> for BufferSize {
+    fn from(ser_buffer_size: SerBufferSize) -> Self {
+        match ser_buffer_size {
+            SerBufferSize::Size(size) => BufferSize(size),
+            SerBufferSize::Whole => BufferSize::WHOLE,
+        }
+    }
 }


### PR DESCRIPTION
This is required to be able to update wgpu-rs, since it uses `BufferSize` in the internal API for its backends.