### PR TITLE
Fix recycling of command buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,6 @@ dependencies = [
  "raw-window-handle",
  "smallvec",
  "winapi 0.3.8",
- "x11",
 ]
 
 [[package]]
@@ -1508,16 +1507,6 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
-]
-
-[[package]]
-name = "x11"
-version = "2.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ecd092546cb16f25783a5451538e73afc8d32e242648d54f4ae5459ba1e773"
-dependencies = [
- "libc",
- "pkg-config",
 ]
 
 [[package]]

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -234,6 +234,7 @@ impl<B: hal::Backend> LifetimeTracker<B> {
 
     /// Find the pending entry with the lowest active index. If none can be found that means
     /// everything in the allocator can be cleaned up, so std::usize::MAX is correct.
+    #[cfg(feature = "replay")]
     pub fn lowest_active_submission(&self) -> SubmissionIndex {
         self.active
             .iter()

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -312,12 +312,11 @@ impl<B: GfxBackend> Device<B> {
         );
         life_tracker.triage_mapped(global, token);
         life_tracker.triage_framebuffers(global, &mut *self.framebuffers.lock(), token);
-        let _last_done = life_tracker.triage_submissions(&self.raw, force_wait);
+        let last_done = life_tracker.triage_submissions(&self.raw, force_wait);
         let callbacks = life_tracker.handle_mapping(global, &self.raw, &self.trackers, token);
         life_tracker.cleanup(&self.raw, &self.mem_allocator, &self.desc_allocator);
 
-        self.com_allocator
-            .maintain(&self.raw, life_tracker.lowest_active_submission());
+        self.com_allocator.maintain(&self.raw, last_done);
         callbacks
     }
 


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu-rs/issues/333

**Description**
We used `lowest_common_submission()` for figuring out when to reset command buffers, but it returns !0 when there are no active submissions. Instead, we are using the exising "last done" semantics here, which works better.

**Testing**
Tested on wgpu-rs examples.