### PR TITLE
Implement Anisotropic Filtering Extension and Expose Extension Interface

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -429,7 +429,7 @@ fn checked_u32_as_u16(value: u32) -> u16 {
     value as u16
 }
 
-fn is_power_of_two(val: u32) -> bool {
+pub fn is_power_of_two(val: u32) -> bool {
     val != 0 && (val & (val - 1)) == 0
 }
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -7,7 +7,7 @@ use crate::{
     device::Device,
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Input, Token},
     id::{AdapterId, DeviceId, SurfaceId},
-    power, LifeGuard, Stored,
+    power, LifeGuard, Stored, MAX_BIND_GROUPS,
 };
 
 use wgt::{Backend, BackendBit, DeviceDescriptor, PowerPreference, BIND_BUFFER_ALIGNMENT};
@@ -527,6 +527,32 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         AdapterInfo::from_gfx(adapter.raw.info.clone(), adapter_id.backend())
     }
 
+    pub fn adapter_extensions<B: GfxBackend>(&self, adapter_id: AdapterId) -> wgt::Extensions {
+        let hub = B::hub(self);
+        let mut token = Token::root();
+        let (adapter_guard, _) = hub.adapters.read(&mut token);
+        let adapter = &adapter_guard[adapter_id];
+
+        let features = adapter.raw.physical_device.features();
+
+        wgt::Extensions {
+            anisotropic_filtering: features.contains(hal::Features::SAMPLER_ANISOTROPY),
+        }
+    }
+
+    pub fn adapter_limits<B: GfxBackend>(&self, adapter_id: AdapterId) -> wgt::Limits {
+        let hub = B::hub(self);
+        let mut token = Token::root();
+        let (adapter_guard, _) = hub.adapters.read(&mut token);
+        let adapter = &adapter_guard[adapter_id];
+
+        let limits = adapter.raw.physical_device.limits();
+
+        wgt::Limits {
+            max_bind_groups: (limits.max_bound_descriptor_sets as u32).min(MAX_BIND_GROUPS as u32),
+        }
+    }
+
     pub fn adapter_destroy<B: GfxBackend>(&self, adapter_id: AdapterId) {
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -560,15 +586,28 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let (adapter_guard, _) = hub.adapters.read(&mut token);
             let adapter = &adapter_guard[adapter_id];
             let phd = &adapter.raw.physical_device;
+
+            let available_features = adapter.raw.physical_device.features();
+
+            // Check features that are always needed
             let wishful_features = hal::Features::VERTEX_STORES_AND_ATOMICS
                 | hal::Features::FRAGMENT_STORES_AND_ATOMICS
                 | hal::Features::NDC_Y_UP;
-            let enabled_features = adapter.raw.physical_device.features() & wishful_features;
+            let mut enabled_features = available_features & wishful_features;
             if enabled_features != wishful_features {
                 log::warn!(
                     "Missing features: {:?}",
                     wishful_features - enabled_features
                 );
+            }
+
+            // Check features needed by extensions
+            if desc.extensions.anisotropic_filtering {
+                assert!(
+                    available_features.contains(hal::Features::SAMPLER_ANISOTROPY),
+                    "Missing feature SAMPLER_ANISOTROPY for anisotropic filtering extension"
+                );
+                enabled_features |= hal::Features::SAMPLER_ANISOTROPY;
             }
 
             let family = adapter

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -88,6 +88,10 @@ impl From<Backend> for BackendBit {
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct Extensions {
+    /// This is a native only extension. Support is planned to be added to webgpu,
+    /// but it is not yet implemented.
+    ///
+    /// https://github.com/gpuweb/gpuweb/issues/696
     pub anisotropic_filtering: bool,
 }
 
@@ -926,6 +930,11 @@ pub struct SamplerDescriptor<L> {
     pub lod_min_clamp: f32,
     pub lod_max_clamp: f32,
     pub compare: CompareFunction,
+    /// Anisotropic filtering extension must be enabled if this value is
+    /// anything other than 0 and 1.
+    ///
+    /// Valid values are 0, 1, 2, 4, 8, and 16.
+    pub anisotropy_clamp: u8,
 }
 
 impl<L> SamplerDescriptor<L> {
@@ -941,6 +950,7 @@ impl<L> SamplerDescriptor<L> {
             lod_min_clamp: self.lod_min_clamp,
             lod_max_clamp: self.lod_max_clamp,
             compare: self.compare,
+            anisotropy_clamp: self.anisotropy_clamp,
         }
     }
 }


### PR DESCRIPTION
**Connections**

Resolves #568.

**Description**

This PR solves two tightly related problems:
 - Adds the ability to create a sampler with anisotropic filtering
 - Adds the webgpu interface for getting the limits/extensions on adapters and devies.

**Testing**

I have tested this against my codebase which uses it. Adding an example in wgpu-rs on how to use extensions/limits would be good, especially as we have native/webgpu extensions, but can come as a future enhancement, once we feel the extension situation has stabilized a bit.

**TODO**

- [x] Allow wgpu-rs to call limit/extension interface (https://github.com/gfx-rs/wgpu-rs/pull/338)
- [ ] Determine how wgpu-native is going to adopt this functionality.
- [ ] After discussing #691, what changes need to be made. 