### PR TITLE
player: enable x11 on Unix/Vulkan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "raw-window-handle",
  "smallvec",
  "winapi 0.3.8",
+ "x11",
 ]
 
 [[package]]
@@ -898,6 +899,7 @@ name = "player"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "gfx-backend-vulkan",
  "log",
  "raw-window-handle",
  "renderdoc",
@@ -1507,6 +1509,16 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "x11"
+version = "2.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ecd092546cb16f25783a5451538e73afc8d32e242648d54f4ae5459ba1e773"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -33,3 +33,6 @@ path = "../wgpu-core"
 package = "wgpu-core"
 version = "0.5"
 features = ["replay", "raw-window-handle"]
+
+[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
+gfx-backend-vulkan = { version = "0.5", features = ["x11"] }


### PR DESCRIPTION
Needed as it's no longer default in `wgpu-core` with #678