### PR TITLE
Fix SwapChainOutput Related Segfault

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2288,6 +2288,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let sc_id = surface_id.to_swap_chain_id(B::VARIANT);
         if let Some(sc) = swap_chain_guard.remove(sc_id) {
+            assert!(
+                sc.acquired_view_id.is_none(),
+                "SwapChainOutput must be dropped before a new SwapChain is made."
+            );
             unsafe {
                 device.raw.destroy_semaphore(sc.semaphore);
             }


### PR DESCRIPTION
If a user accidentally recreates a swapchain after grabbing a SwapChainOutput, then renders to it, this will trigger a segfault on render. This can be reproduced by replacing the get_next_frame code in any example with:

```rust
let frame = swap_chain
    .get_next_frame()
    .expect("Failed to acquire next swap chain texture")
    .output;
device.create_swap_chain(&surface, &sc_desc);
```

I have tested the examples, and they still work after this change, and it correctly detects this condition.

Oddly enough the following code does not panic, nor actually raise any errors, even with this PR.

```rust
let tmp = device.create_swap_chain(&surface, &sc_desc);
let frame = swap_chain
    .get_next_frame()
    .expect("Failed to acquire next swap chain texture")
    .output;
swap_chain = tmp;
```

I'm not entirely sure why.