### PR TITLE
Implement Extensions Interface

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -497,6 +497,7 @@ fn main() {
                         #[cfg(not(feature = "winit"))]
                         compatible_surface: None,
                     },
+                    unsafe { wgt::UnsafeExtensions::allow() },
                     wgc::instance::AdapterInputs::IdSet(
                         &[wgc::id::TypedId::zip(0, 0, backend)],
                         |id| id.backend(),


### PR DESCRIPTION
## Description

This is the first step of implementing #691. This implements the described changes to all the core structs and to `SamplerDescriptor`. I intend this PR to be an example of what the plan looks like. If we think this works, we can roll out the rest of the changes either in bulk or as we need them. 

The rolling out of this is also tied to the rolling out of #689. Hopefully the macro work done in https://github.com/gfx-rs/wgpu-native/pull/34 will make this easier.

## Questions

One outstanding question I had is what the default values for lod_min/max should be. As of right now I just derive default, which puts them at zero, which is probably a reasonable default, though most of the examples use -100, 100 which is normally what you use when doing mipmapping.

## TODO:

- [ ] Discuss if this meets our needs
- [x] Implement this in wgpu-rs (https://github.com/gfx-rs/wgpu-rs/pull/350)
- [ ] Implement this in wgpu-native