### PR TITLE
Pipeline layout validation

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -355,7 +355,8 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                         compute_stage: cs_stage.desc,
                     },
                     id,
-                );
+                )
+                .unwrap();
             }
             A::DestroyComputePipeline(id) => {
                 self.compute_pipeline_destroy::<B>(id);

--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -263,7 +263,8 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                         entries_length: entries.len(),
                     },
                     id,
-                );
+                )
+                .unwrap();
             }
             A::DestroyBindGroupLayout(id) => {
                 self.bind_group_layout_destroy::<B>(id);

--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -281,7 +281,8 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                         bind_group_layouts_length: bind_group_layouts.len(),
                     },
                     id,
-                );
+                )
+                .unwrap();
             }
             A::DestroyPipelineLayout(id) => {
                 self.pipeline_layout_destroy::<B>(id);

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -110,6 +110,11 @@ pub struct PipelineLayoutDescriptor {
     pub bind_group_layouts_length: usize,
 }
 
+#[derive(Clone, Debug)]
+pub enum PipelineLayoutError {
+    TooManyGroups(usize),
+}
+
 #[derive(Debug)]
 pub struct PipelineLayout<B: hal::Backend> {
     pub(crate) raw: B::PipelineLayout,

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -93,12 +93,14 @@ pub enum BindGroupLayoutError {
     Entry(u32, BindGroupLayoutEntryError),
 }
 
+pub(crate) type BindEntryMap = FastHashMap<u32, BindGroupLayoutEntry>;
+
 #[derive(Debug)]
 pub struct BindGroupLayout<B: hal::Backend> {
     pub(crate) raw: B::DescriptorSetLayout,
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) life_guard: LifeGuard,
-    pub(crate) entries: FastHashMap<u32, BindGroupLayoutEntry>,
+    pub(crate) entries: BindEntryMap,
     pub(crate) desc_counts: DescriptorCounts,
     pub(crate) dynamic_count: usize,
 }

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -371,14 +371,14 @@ pub(crate) fn map_texture_format(
         // Depth and stencil formats
         Tf::Depth32Float => H::D32Sfloat,
         Tf::Depth24Plus => {
-            if private_features.supports_texture_d24_s8 {
+            if private_features.texture_d24_s8 {
                 H::D24UnormS8Uint
             } else {
                 H::D32Sfloat
             }
         }
         Tf::Depth24PlusStencil8 => {
-            if private_features.supports_texture_d24_s8 {
+            if private_features.texture_d24_s8 {
                 H::D24UnormS8Uint
             } else {
                 H::D32SfloatS8Uint

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -177,6 +177,7 @@ impl<B: hal::Backend> Access<PipelineLayout<B>> for Device<B> {}
 impl<B: hal::Backend> Access<PipelineLayout<B>> for CommandBuffer<B> {}
 impl<B: hal::Backend> Access<BindGroupLayout<B>> for Root {}
 impl<B: hal::Backend> Access<BindGroupLayout<B>> for Device<B> {}
+impl<B: hal::Backend> Access<BindGroupLayout<B>> for PipelineLayout<B> {}
 impl<B: hal::Backend> Access<BindGroup<B>> for Root {}
 impl<B: hal::Backend> Access<BindGroup<B>> for Device<B> {}
 impl<B: hal::Backend> Access<BindGroup<B>> for BindGroupLayout<B> {}
@@ -191,7 +192,7 @@ impl<B: hal::Backend> Access<RenderPipeline<B>> for Device<B> {}
 impl<B: hal::Backend> Access<RenderPipeline<B>> for BindGroup<B> {}
 impl<B: hal::Backend> Access<RenderPipeline<B>> for ComputePipeline<B> {}
 impl<B: hal::Backend> Access<ShaderModule<B>> for Device<B> {}
-impl<B: hal::Backend> Access<ShaderModule<B>> for PipelineLayout<B> {}
+impl<B: hal::Backend> Access<ShaderModule<B>> for BindGroupLayout<B> {}
 impl<B: hal::Backend> Access<Buffer<B>> for Root {}
 impl<B: hal::Backend> Access<Buffer<B>> for Device<B> {}
 impl<B: hal::Backend> Access<Buffer<B>> for BindGroupLayout<B> {}

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -171,7 +171,8 @@ pub struct U32Array {
 
 #[derive(Clone, Copy, Debug)]
 struct PrivateFeatures {
-    pub supports_texture_d24_s8: bool,
+    shader_validation: bool,
+    texture_d24_s8: bool,
 }
 
 #[macro_export]

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -3,10 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{
+    binding_model::{BindEntryMap, BindGroupLayoutEntry, BindingType},
     device::RenderPassContext,
     id::{DeviceId, PipelineLayoutId, ShaderModuleId},
     LifeGuard, RawString, RefCount, Stored, U32Array,
 };
+use spirv_headers as spirv;
 use std::borrow::Borrow;
 use wgt::{
     BufferAddress, ColorStateDescriptor, DepthStencilStateDescriptor, IndexFormat, InputStepMode,
@@ -50,11 +52,194 @@ pub struct ProgrammableStageDescriptor {
     pub entry_point: RawString,
 }
 
+#[derive(Clone, Debug)]
+pub enum BindingError {
+    /// The binding is missing from the pipeline layout.
+    Missing,
+    /// The visibility flags don't include the shader stage.
+    Invisible,
+    /// The load/store access flags don't match the shader.
+    WrongUsage(naga::GlobalUse),
+    /// The type on the shader side does not match the pipeline binding.
+    WrongType,
+    /// The view dimension doesn't match the shader.
+    WrongTextureViewDimension { dim: spirv::Dim, is_array: bool },
+    /// The component type of a sampled texture doesn't match the shader.
+    WrongTextureComponentType(Option<naga::ScalarKind>),
+    /// Texture sampling capability doesn't match with the shader.
+    WrongTextureSampled,
+    /// The multisampled flag doesn't match.
+    WrongTextureMultisampled,
+}
+
+/// Errors produced when validating a programmable stage of a pipeline.
+#[derive(Clone, Debug)]
+pub enum ProgrammableStageError {
+    /// Unable to find an entry point matching the specified execution model.
+    MissingEntryPoint(spirv::ExecutionModel),
+    /// Error matching a global binding to the pipeline layout.
+    Binding {
+        set: u32,
+        binding: u32,
+        error: BindingError,
+    },
+}
+
+fn validate_binding(
+    module: &naga::Module,
+    var: &naga::GlobalVariable,
+    entry: &BindGroupLayoutEntry,
+    usage: naga::GlobalUse,
+) -> Result<(), BindingError> {
+    let allowed_usage = match module.types[var.ty].inner {
+        naga::TypeInner::Struct { .. } => match entry.ty {
+            BindingType::UniformBuffer => naga::GlobalUse::LOAD,
+            BindingType::StorageBuffer => naga::GlobalUse::all(),
+            BindingType::ReadonlyStorageBuffer => naga::GlobalUse::LOAD,
+            _ => return Err(BindingError::WrongType),
+        },
+        naga::TypeInner::Sampler => match entry.ty {
+            BindingType::Sampler | BindingType::ComparisonSampler => naga::GlobalUse::empty(),
+            _ => return Err(BindingError::WrongType),
+        },
+        naga::TypeInner::Image { base, dim, flags } => {
+            if entry.multisampled != flags.contains(naga::ImageFlags::MULTISAMPLED) {
+                return Err(BindingError::WrongTextureMultisampled);
+            }
+            if flags.contains(naga::ImageFlags::ARRAYED) {
+                match (dim, entry.view_dimension) {
+                    (spirv::Dim::Dim2D, wgt::TextureViewDimension::D2Array) => (),
+                    (spirv::Dim::DimCube, wgt::TextureViewDimension::CubeArray) => (),
+                    _ => {
+                        return Err(BindingError::WrongTextureViewDimension {
+                            dim,
+                            is_array: true,
+                        })
+                    }
+                }
+            } else {
+                match (dim, entry.view_dimension) {
+                    (spirv::Dim::Dim1D, wgt::TextureViewDimension::D1) => (),
+                    (spirv::Dim::Dim2D, wgt::TextureViewDimension::D2) => (),
+                    (spirv::Dim::Dim3D, wgt::TextureViewDimension::D3) => (),
+                    (spirv::Dim::DimCube, wgt::TextureViewDimension::Cube) => (),
+                    _ => {
+                        return Err(BindingError::WrongTextureViewDimension {
+                            dim,
+                            is_array: false,
+                        })
+                    }
+                }
+            }
+            let (allowed_usage, is_sampled) = match entry.ty {
+                BindingType::SampledTexture => {
+                    let expected_scalar_kind = match entry.texture_component_type {
+                        wgt::TextureComponentType::Float => naga::ScalarKind::Float,
+                        wgt::TextureComponentType::Sint => naga::ScalarKind::Sint,
+                        wgt::TextureComponentType::Uint => naga::ScalarKind::Uint,
+                    };
+                    match module.types[base].inner {
+                        naga::TypeInner::Scalar { kind, .. }
+                        | naga::TypeInner::Vector { kind, .. }
+                            if kind == expected_scalar_kind =>
+                        {
+                            ()
+                        }
+                        naga::TypeInner::Scalar { kind, .. }
+                        | naga::TypeInner::Vector { kind, .. } => {
+                            return Err(BindingError::WrongTextureComponentType(Some(kind)))
+                        }
+                        _ => return Err(BindingError::WrongTextureComponentType(None)),
+                    };
+                    (naga::GlobalUse::LOAD, true)
+                }
+                BindingType::ReadonlyStorageTexture => {
+                    //TODO: check entry.storage_texture_format
+                    (naga::GlobalUse::LOAD, false)
+                }
+                BindingType::WriteonlyStorageTexture => (naga::GlobalUse::STORE, false),
+                _ => return Err(BindingError::WrongType),
+            };
+            if is_sampled != flags.contains(naga::ImageFlags::SAMPLED) {
+                return Err(BindingError::WrongTextureSampled);
+            }
+            allowed_usage
+        }
+        _ => return Err(BindingError::WrongType),
+    };
+    if allowed_usage.contains(usage) {
+        Ok(())
+    } else {
+        Err(BindingError::WrongUsage(usage))
+    }
+}
+
+pub(crate) fn validate_stage(
+    module: &naga::Module,
+    group_layouts: &[&BindEntryMap],
+    entry_point_name: &str,
+    execution_model: spirv::ExecutionModel,
+) -> Result<(), ProgrammableStageError> {
+    // Since a shader module can have multiple entry points with the same name,
+    // we need to look for one with the right execution model.
+    let entry_point = module
+        .entry_points
+        .iter()
+        .find(|entry_point| {
+            entry_point.name == entry_point_name && entry_point.exec_model == execution_model
+        })
+        .ok_or(ProgrammableStageError::MissingEntryPoint(execution_model))?;
+    let stage_bit = match execution_model {
+        spirv::ExecutionModel::Vertex => wgt::ShaderStage::VERTEX,
+        spirv::ExecutionModel::Fragment => wgt::ShaderStage::FRAGMENT,
+        spirv::ExecutionModel::GLCompute => wgt::ShaderStage::COMPUTE,
+        // the entry point wouldn't match otherwise
+        _ => unreachable!(),
+    };
+
+    let function = &module.functions[entry_point.function];
+    for ((_, var), &usage) in module.global_variables.iter().zip(&function.global_usage) {
+        if usage.is_empty() {
+            continue;
+        }
+        match var.binding {
+            Some(naga::Binding::Descriptor { set, binding }) => {
+                let result = group_layouts
+                    .get(set as usize)
+                    .and_then(|map| map.get(&binding))
+                    .ok_or(BindingError::Missing)
+                    .and_then(|entry| {
+                        if entry.visibility.contains(stage_bit) {
+                            Ok(entry)
+                        } else {
+                            Err(BindingError::Invisible)
+                        }
+                    })
+                    .and_then(|entry| validate_binding(module, var, entry, usage));
+                if let Err(error) = result {
+                    return Err(ProgrammableStageError::Binding {
+                        set,
+                        binding,
+                        error,
+                    });
+                }
+            }
+            _ => {} //TODO
+        }
+    }
+    Ok(())
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct ComputePipelineDescriptor {
     pub layout: PipelineLayoutId,
     pub compute_stage: ProgrammableStageDescriptor,
+}
+
+#[derive(Clone, Debug)]
+pub enum ComputePipelineError {
+    Stage(ProgrammableStageError),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
**Connections**
Implements a solid part of #269
Starts converting the function to return results, related to #638
cc @GabrielMajeri 

**Description**
This change matches shader bindings against the pipeline layout. It's *mostly* complete, minus some bugs and not handling the `storage_texture_format` properly.

The risk here is that Naga reflection may have bugs, or our validation may have bugs, and we don't want to break the user content while this is in flux. So the PR introduces an internal `WGPU_SHADER_VALIDATION` environment variable. Switching it to "0" skips Naga shader parsing completely and allows the users to unsafely use the API.

Another aspect of the PR is that some of the functions now return `Result`. The way I see us proceeding is that any errors that we don't expect users to handle should result in panics when `wgpu` is used natively (i.e. not from a browser). These panics would happen in the "direct" backend of wgpu-rs (as well as in wgpu-native), but the `Result` would not be exposed to wgpu-rs, so that it matches the Web behavior.

At the same time, browser implementations (Gecko and Servo) will check the result on their GPU process and implement the WebGPU error model accordingly. This means `wgpu-core` can be super Rusty and safe.

**Testing**
Running on wgpu-rs examples. Most of them fail to get parsed by Naga, but `boids` succeeds and passes validation 🎉 