### PR TITLE
Return errors on create_render_pipeline

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -403,7 +403,8 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                         alpha_to_coverage_enabled: desc.alpha_to_coverage_enabled,
                     },
                     id,
-                );
+                )
+                .unwrap();
             }
             A::DestroyRenderPipeline(id) => {
                 self.render_pipeline_destroy::<B>(id);

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -94,6 +94,22 @@ pub struct RenderPipelineDescriptor {
     pub alpha_to_coverage_enabled: bool,
 }
 
+#[derive(Clone, Debug)]
+pub enum RenderPipelineError {
+    InvalidVertexAttributeOffset {
+        location: wgt::ShaderLocation,
+        offset: BufferAddress,
+    },
+    Stage {
+        flag: wgt::ShaderStage,
+        error: StageError,
+    },
+    IncompatibleOutputFormat {
+        index: u8,
+    },
+    InvalidSampleCount(u32),
+}
+
 bitflags::bitflags! {
     #[repr(transparent)]
     pub struct PipelineFlags: u32 {


### PR DESCRIPTION
This is a follow-up to #705 that switches `create_render_pipeline` to return `Result`.