### PR TITLE
Implement Bounds Checking on Buffers to Buffer and Texture Copies

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -153,7 +153,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             None => {}
         }
 
-        let mut stage = device.prepare_stage(data.len() as wgt::BufferAddress);
+        let data_size = data.len() as wgt::BufferAddress;
+        if data_size == 0 {
+            log::trace!("Ignoring write_buffer of size 0");
+            return;
+        }
+
+        let mut stage = device.prepare_stage(data_size);
         {
             let mut mapped = stage
                 .memory
@@ -177,6 +183,30 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         );
         let last_submit_index = device.life_guard.submission_index.load(Ordering::Relaxed);
         dst.life_guard.use_at(last_submit_index + 1);
+
+        assert_eq!(
+            data_size % wgt::COPY_BUFFER_ALIGNMENT,
+            0,
+            "Buffer write size {} must be a multiple of {}",
+            buffer_offset,
+            wgt::COPY_BUFFER_ALIGNMENT,
+        );
+        assert_eq!(
+            buffer_offset % wgt::COPY_BUFFER_ALIGNMENT,
+            0,
+            "Buffer offset {} must be a multiple of {}",
+            buffer_offset,
+            wgt::COPY_BUFFER_ALIGNMENT,
+        );
+        let destination_start_offset = buffer_offset;
+        let destination_end_offset = buffer_offset + data_size;
+        assert!(
+            destination_end_offset <= dst.size,
+            "Write buffer with indices {}..{} overruns destination buffer of size {}",
+            destination_start_offset,
+            destination_end_offset,
+            dst.size
+        );
 
         let region = hal::command::BufferCopy {
             src: 0,
@@ -233,11 +263,22 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             None => {}
         }
 
+        if size.width == 0 || size.height == 0 || size.width == 0 {
+            log::trace!("Ignoring write_texture of size 0");
+            return;
+        }
+
         let texture_format = texture_guard[destination.texture].format;
         let bytes_per_texel = conv::map_texture_format(texture_format, device.private_features)
             .surface_desc()
             .bits as u32
             / BITS_PER_BYTE;
+        crate::command::validate_linear_texture_data(
+            data_layout,
+            data.len() as wgt::BufferAddress,
+            bytes_per_texel as wgt::BufferAddress,
+            size,
+        );
 
         let bytes_per_row_alignment = get_lowest_common_denom(
             device.hal_limits.optimal_buffer_copy_pitch_alignment as u32,
@@ -286,6 +327,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             "Write texture usage {:?} must contain flag COPY_DST",
             dst.usage
         );
+        crate::command::validate_texture_copy_range(destination, dst.kind, size);
 
         let last_submit_index = device.life_guard.submission_index.load(Ordering::Relaxed);
         dst.life_guard.use_at(last_submit_index + 1);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -17,6 +17,8 @@ use std::{io, ptr, slice};
 pub const COPY_BYTES_PER_ROW_ALIGNMENT: u32 = 256;
 /// Bound uniform/storage buffer offsets must be aligned to this number.
 pub const BIND_BUFFER_ALIGNMENT: u64 = 256;
+/// Buffer to buffer copy offsets and sizes must be aligned to this number
+pub const COPY_BUFFER_ALIGNMENT: u64 = 4;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
**Connections**
Closes #362, closes #554
This addresses issues found by @gretchenfrage when accidentally writing off the end of a texture causing a DEVICE_LOST error.

**Description**

Adds bounds checks to write_texture and write_buffer, and copy_texture_to_texture and friends. The bounds checking functions themselves follow guidance from the webgpu standard. 

This doesn't make wgpu 100% to all the checks required by the standard, but takes care of the ones related to bounds and buffer overruns.

**Testing**

I tested this against all the examples, including intentionally making mistakes in texture copies, with this successfully catching those errors.

**Review Notes**

This code should be picked through fairly closely, as it's very likely there's some typos due to the close-but-not-quite repetition that these tests require. There's a bunch of LOC, but they are fairly boring and should be easy to understand.

I have tried to give assert messages that are as descriptive as possible, but if there is a message that could be changed to be more clear, let me know.

One thing that could change is the location of the functions. I left them where I originally wrote them, before I realized that the functions on queue also needed bounds checking, but they could have a better home elsewhere, maybe even their own file.