### PR TITLE
Implement Mappable Primary Buffers Extension

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -324,7 +324,9 @@ impl<B: GfxBackend> Device<B> {
             } else if (Bu::MAP_READ | Bu::COPY_DST).contains(desc.usage) {
                 MemoryUsage::Staging { read_back: true }
             } else {
-                let is_native_only = false;
+                let is_native_only = self
+                    .extensions
+                    .contains(wgt::Extensions::MAPPABLE_PRIMARY_BUFFERS);
                 assert!(
                     is_native_only,
                     "MAP usage can only be combined with the opposite COPY, requested {:?}",

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -128,7 +128,7 @@ impl<B: hal::Backend> Adapter<B> {
     fn new(raw: hal::adapter::Adapter<B>, unsafe_extensions: wgt::UnsafeExtensions) -> Self {
         let adapter_features = raw.physical_device.features();
 
-        let mut extensions = wgt::Extensions::default();
+        let mut extensions = wgt::Extensions::default() | wgt::Extensions::MAPPABLE_PRIMARY_BUFFERS;
         extensions.set(
             wgt::Extensions::ANISOTROPIC_FILTERING,
             adapter_features.contains(hal::Features::SAMPLER_ANISOTROPY),
@@ -646,6 +646,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     "Missing feature SAMPLER_ANISOTROPY for anisotropic filtering extension"
                 );
                 enabled_features |= hal::Features::SAMPLER_ANISOTROPY;
+            }
+            if desc
+                .extensions
+                .contains(wgt::Extensions::MAPPABLE_PRIMARY_BUFFERS)
+                && adapter.raw.info.device_type == hal::adapter::DeviceType::DiscreteGpu
+            {
+                log::warn!("Extension MAPPABLE_PRIMARY_BUFFERS enabled on a discrete gpu. This is a massive performance footgun and likely not what you wanted");
             }
 
             let family = adapter

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -132,11 +132,22 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "trace", derive(Serialize))]
     #[cfg_attr(feature = "replay", derive(Deserialize))]
     pub struct Extensions: u64 {
+        /// Allow anisotropic filtering in samplers.
+        ///
         /// This is a native only extension. Support is planned to be added to webgpu,
         /// but it is not yet implemented.
         ///
         /// https://github.com/gpuweb/gpuweb/issues/696
         const ANISOTROPIC_FILTERING = 0x0000_0000_0001_0000;
+        /// Webgpu only allows the MAP_READ and MAP_WRITE buffer usage to be matched with
+        /// COPY_DST and COPY_SRC respectively. This removes this requirement.
+        ///
+        /// This is only beneficial on systems that share memory between CPU and GPU. If enabled
+        /// on a system that doesn't, this can severely hinder performance. Only use if you understand
+        /// the consequences.
+        ///
+        /// This is a native only extension.
+        const MAPPABLE_PRIMARY_BUFFERS = 0x0000_0000_0002_0000;
         /// Extensions which are part of the upstream webgpu standard
         const ALL_WEBGPU = 0x0000_0000_0000_FFFF;
         /// Extensions that require activating the unsafe extension flag


### PR DESCRIPTION
**Connections**

#675 made `MAP_WRITE | STORAGE` on buffers not possible. This extension re-enables it. 

**Description**

UMA systems rejoice everywhere.

**Testing**

Hopefully it didn't break since it was usable a week or so ago, so this shouldn't need testing...

**Review Notes**

The name could be changed, particularly if primary has a certain meaning wrt buffers. It just seemed a reasonable description.

Knowing my luck, I got the bitflags call wrong...