### PR TITLE
Empty buffers are created internally with a size of 1

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -338,7 +338,7 @@ impl<B: GfxBackend> Device<B> {
             }
         };
 
-        let mut buffer = unsafe { self.raw.create_buffer(desc.size, usage).unwrap() };
+        let mut buffer = unsafe { self.raw.create_buffer(desc.size.max(1), usage).unwrap() };
         if !desc.label.is_null() {
             unsafe {
                 let label = ffi::CStr::from_ptr(desc.label).to_string_lossy();


### PR DESCRIPTION
**Connections**
closes https://github.com/gfx-rs/wgpu/issues/709

**Description**
Empty buffers can be succesfully created.

**Testing**
Tested on my project and it resolves the above issue.
