### PR TITLE
Track buffers and textures in the future submissions

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -879,8 +879,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (device_guard, mut token) = hub.devices.read(&mut token);
         device_guard[device_id]
             .lock_life(&mut token)
-            .suspected_resources
-            .buffers
+            .future_suspected_buffers
             .push(buffer_id);
     }
 
@@ -932,8 +931,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (device_guard, mut token) = hub.devices.read(&mut token);
         device_guard[device_id]
             .lock_life(&mut token)
-            .suspected_resources
-            .textures
+            .future_suspected_textures
             .push(texture_id);
     }
 


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu-rs/issues/362

**Description**
When we do `write_buffer` or have it mapped on creation, we record the copy command in a "pending command buffer", which is only actually executed on the next submission. We adjust the submission index on the buffer accordingly.
If the buffer is dropped *before* the next submission, and there happens to be a `maintain()` step, there is code that checks if the buffer-associated submission is one of the currently executing ones. If it doesn't fine an active one, it considers the last-used submission to already be done with, which is precisely what is not happening here, since the submission hasn't been scheduled yet.

The solution here is to always defer suspecting buffers and textures for deletion till the next submission. The buffers and textures are the only objects that may have "future" submission index, due to `write_buffer` and `write_texture`.

**Testing**
Confirmed on Linux.