### PR TITLE
Implement SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-dx12"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c598fb38d6f51db0219ac26d16ff8b78bc134987acd1940438a5adc46b694f"
+checksum = "6e1a979a793023717bcaa7511c8cbb449bab550c093737c98674a659a2bbaf73"
 dependencies = [
  "bitflags",
  "d3d12",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-metal"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264b73ea2d8a7cff7eec3a4d08028a96cc18ff2fdf6479fb6f7febbc97dd03f"
+checksum = "412a1e0e53e9e325a7c2e0316f1a4e8a14cbe8d8bfb5f030bc3895692f8a8254"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-vulkan"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4614727b750d62766db20d94032833f7293f9307f1b2103d5f8833889f863f"
+checksum = "04af900c2597587b35e801e9d3f91fd8078cc06067421a22caa640ad2b1bc53e"
 dependencies = [
  "arrayvec",
  "ash",
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-hal"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1036da3617426192c1e8453ed2a2b6a66cf1e8c1486a921e9a8d6625234bf53c"
+checksum = "f13e8fd6aaa8f50146b9519999432e097da43466749d8863c53409322c705339"
 dependencies = [
  "bitflags",
  "raw-window-handle",
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
 ]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -27,7 +27,7 @@ bitflags = "1.0"
 copyless = "0.1"
 fxhash = "0.2"
 log = "0.4"
-hal = { package = "gfx-hal", version = "0.5.1" }
+hal = { package = "gfx-hal", version = "0.5.2" }
 gfx-backend-empty = "0.5"
 gfx-descriptor = "0.1"
 gfx-memory = "0.1"
@@ -51,16 +51,16 @@ version = "0.5"
 features = ["peek-poke"]
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
-gfx-backend-metal = { version = "0.5.3" }
-gfx-backend-vulkan = { version = "0.5.7", optional = true }
+gfx-backend-metal = { version = "0.5.4" }
+gfx-backend-vulkan = { version = "0.5.6", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
-gfx-backend-vulkan = { version = "0.5.7" }
+gfx-backend-vulkan = { version = "0.5.6" }
 
 [target.'cfg(windows)'.dependencies]
-gfx-backend-dx12 = { version = "0.5.5" }
+gfx-backend-dx12 = { version = "0.5.6" }
 gfx-backend-dx11 = { version = "0.5" }
-gfx-backend-vulkan = { version = "0.5.7" }
+gfx-backend-vulkan = { version = "0.5.8" }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "dragonfly", target_os = "freebsd"))'.dependencies]
 battery = { version = "0.7", optional = true }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1129,10 +1129,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     wgt::BindingType::SampledTexture { .. } => {
                         if !device
                             .extensions
-                            .contains(wgt::Extensions::TEXTURE_BINDING_ARRAY)
+                            .contains(wgt::Extensions::SAMPLED_TEXTURE_BINDING_ARRAY)
                         {
                             return Err(binding_model::BindGroupLayoutError::MissingExtension(
-                                wgt::Extensions::TEXTURE_BINDING_ARRAY,
+                                wgt::Extensions::SAMPLED_TEXTURE_BINDING_ARRAY,
                             ));
                         }
                     }
@@ -1497,7 +1497,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
                     }
                     binding_model::BindingResource::TextureViewArray(ref bindings_array) => {
-                        assert!(device.extensions.contains(wgt::Extensions::TEXTURE_BINDING_ARRAY), "Extension TEXTURE_BINDING_ARRAY must be enabled to use TextureViewArrays in a bind group");
+                        assert!(device.extensions.contains(wgt::Extensions::SAMPLED_TEXTURE_BINDING_ARRAY), "Extension SAMPLED_TEXTURE_BINDING_ARRAY must be enabled to use TextureViewArrays in a bind group");
 
                         if let Some(count) = decl.count {
                             assert_eq!(

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -134,8 +134,20 @@ impl<B: hal::Backend> Adapter<B> {
             adapter_features.contains(hal::Features::SAMPLER_ANISOTROPY),
         );
         extensions.set(
-            wgt::Extensions::TEXTURE_BINDING_ARRAY,
+            wgt::Extensions::SAMPLED_TEXTURE_BINDING_ARRAY,
             adapter_features.contains(hal::Features::TEXTURE_DESCRIPTOR_ARRAY),
+        );
+        extensions.set(
+            wgt::Extensions::SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING,
+            adapter_features.contains(hal::Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING),
+        );
+        extensions.set(
+            wgt::Extensions::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
+            adapter_features.contains(hal::Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING),
+        );
+        extensions.set(
+            wgt::Extensions::UNSIZED_BINDING_ARRAY,
+            adapter_features.contains(hal::Features::UNSIZED_DESCRIPTOR_ARRAY),
         );
         if unsafe_extensions.allowed() {
             // Unsafe extensions go here
@@ -641,16 +653,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             );
 
             // Check features needed by extensions
-            if desc
-                .extensions
-                .contains(wgt::Extensions::ANISOTROPIC_FILTERING)
-            {
-                assert!(
-                    available_features.contains(hal::Features::SAMPLER_ANISOTROPY),
-                    "Missing feature SAMPLER_ANISOTROPY for anisotropic filtering extension"
-                );
-                enabled_features |= hal::Features::SAMPLER_ANISOTROPY;
-            }
+            enabled_features.set(
+                hal::Features::SAMPLER_ANISOTROPY,
+                desc.extensions
+                    .contains(wgt::Extensions::ANISOTROPIC_FILTERING),
+            );
             if desc
                 .extensions
                 .contains(wgt::Extensions::MAPPABLE_PRIMARY_BUFFERS)
@@ -658,16 +665,26 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             {
                 log::warn!("Extension MAPPABLE_PRIMARY_BUFFERS enabled on a discrete gpu. This is a massive performance footgun and likely not what you wanted");
             }
-            if desc
-                .extensions
-                .contains(wgt::Extensions::TEXTURE_BINDING_ARRAY)
-            {
-                assert!(
-                    available_features.contains(hal::Features::TEXTURE_DESCRIPTOR_ARRAY),
-                    "Missing feature TEXTURE_DESCRIPTOR_ARRAY for texture binding array extension"
-                );
-                enabled_features |= hal::Features::TEXTURE_DESCRIPTOR_ARRAY;
-            }
+            enabled_features.set(
+                hal::Features::TEXTURE_DESCRIPTOR_ARRAY,
+                desc.extensions
+                    .contains(wgt::Extensions::SAMPLED_TEXTURE_BINDING_ARRAY),
+            );
+            enabled_features.set(
+                hal::Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING,
+                desc.extensions
+                    .contains(wgt::Extensions::SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING),
+            );
+            enabled_features.set(
+                hal::Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING,
+                desc.extensions
+                    .contains(wgt::Extensions::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING),
+            );
+            enabled_features.set(
+                hal::Features::UNSIZED_DESCRIPTOR_ARRAY,
+                desc.extensions
+                    .contains(wgt::Extensions::UNSIZED_BINDING_ARRAY),
+            );
 
             let family = adapter
                 .raw

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -157,7 +157,7 @@ bitflags::bitflags! {
         ///
         /// This is a native only extension.
         const MAPPABLE_PRIMARY_BUFFERS = 0x0000_0000_0002_0000;
-        /// Allows the user to create uniform arrays of textures in shaders:
+        /// Allows the user to create uniform arrays of sampled textures in shaders:
         ///
         /// eg. `uniform texture2D textures[10]`.
         ///
@@ -170,7 +170,55 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only extension.
-        const TEXTURE_BINDING_ARRAY = 0x0000_0000_0004_0000;
+        const SAMPLED_TEXTURE_BINDING_ARRAY = 0x0000_0000_0004_0000;
+        /// Allows shaders to index sampled texture arrays with dynamically uniform values:
+        ///
+        /// eg. `texture_array[uniform_value]`
+        ///
+        /// This extension means the hardware will also support SAMPLED_TEXTURE_BINDING_ARRAY,
+        /// but it still must be requested to use it.
+        ///
+        /// Supported platforms:
+        /// - DX12
+        /// - Metal (with MSL 2.0+ on macOS 10.13+)
+        /// - Vulkan (via feature shaderSampledImageArrayDynamicIndexing)
+        ///
+        /// This is a native only extension.
+        const SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING = 0x0000_0000_0008_0000;
+        /// Allows shaders to index sampled texture arrays with dynamically non-uniform values:
+        ///
+        /// eg. `texture_array[vertex_data]`
+        ///
+        /// In order to use this extension, the corresponding GLSL extension must be enabled like so:
+        ///
+        /// `#extension GL_EXT_nonuniform_qualifier : require`
+        ///
+        /// HLSL does not need any extension.
+        ///
+        /// This extension means the hardware will also support SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING
+        /// and SAMPLED_TEXTURE_BINDING_ARRAY, but they still must be requested to use them.
+        ///
+        /// Supported platforms:
+        /// - DX12
+        /// - Metal (with MSL 2.0+ on macOS 10.13+)
+        /// - Vulkan 1.2+ (or via VK_EXT_descriptor_indexing)
+        ///
+        /// This is a native only extension.
+        const SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING = 0x0000_0000_0010_0000;
+        /// Allows the user to create unsized uniform arrays of bindings:
+        ///
+        /// eg. `uniform texture2D textures[]`.
+        ///
+        /// This extension only allows them to exist and to be indexed by compile time constant
+        /// values. However if this extension exists, SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING is
+        /// _very_ likely to exist.
+        ///
+        /// Supported platforms:
+        /// - DX12
+        /// - Vulkan 1.2+ (or via VK_EXT_descriptor_indexing)
+        ///
+        /// This is a native only extension.
+        const UNSIZED_BINDING_ARRAY = 0x0000_0000_0020_0000;
         /// Extensions which are part of the upstream webgpu standard
         const ALL_WEBGPU = 0x0000_0000_0000_FFFF;
         /// Extensions that require activating the unsafe extension flag
@@ -1258,7 +1306,7 @@ pub struct BindGroupLayoutEntry {
     pub ty: BindingType,
     /// If this value is Some, indicates this entry is an array. Array size must be 1 or greater.
     ///
-    /// If this value is Some and `ty` is `BindingType::SampledTexture`, the TEXTURE_BINDING_ARRAY extension must be enabled.
+    /// If this value is Some and `ty` is `BindingType::SampledTexture`, the SAMPLED_TEXTURE_BINDING_ARRAY extension must be enabled.
     ///
     /// If this value is Some and `ty` is any other variant, bind group creation will fail.
     pub count: Option<u32>,


### PR DESCRIPTION
## Connections

Closes #483. Extends support for #106.

## Description

This forwards the descriptor indexing features gfx-hal up to wgpu. 

Note this PR also changes the name of the `TEXTURE_BINDING_ARRAY` to `SAMPLED_TEXTURE_BINDING_ARRAY` to be more consistent with extensions.

## Testing

Texture-array example was simply extended to use descriptor indexing. This works on all platforms that the feature is supported. (thanks @stararawn)

