### PR TITLE
Implement Capability/Extension Split

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -21,6 +21,7 @@ use std::borrow::Borrow;
 pub enum BindGroupLayoutError {
     ConflictBinding(u32),
     MissingExtension(wgt::Extensions),
+    MissingCapability(wgt::Capabilities),
     /// Arrays of bindings can't be 0 elements long
     ZeroCount,
     /// Arrays of bindings unsupported for this type of binding


### PR DESCRIPTION
## Connections

Follow up to a discussion we had on #wgpu:matrix.org. 

## Description

Splits capabilities and extensions so that extensions are things you ask for and possibly change behavior and capabilities are passively enabled when their extension (if any) are enabled.