### PR TITLE
Fix validation errors + panics on empty buffers

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2767,7 +2767,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         hal::memory::Dependencies::empty(),
                         iter::once(transition_src).chain(iter::once(transition_dst)),
                     );
-                    comb.copy_buffer(&stage_buffer, &buffer.raw, iter::once(region));
+                    if buffer.size > 0 {
+                        comb.copy_buffer(&stage_buffer, &buffer.raw, iter::once(region));
+                    }
                 }
                 device
                     .pending_writes


### PR DESCRIPTION
**Description**
My previous PR left a vulkan validation error when creating an empty buffer.
This PR fixes that and also fixes a panic preventing the compute-example from running with no elements.

**Testing**
Unit test added in wgpu-rs PR. https://github.com/gfx-rs/wgpu-rs/pull/373
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
