### PR TITLE
Refactor tracking of device last completed submission

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -259,15 +259,6 @@ impl<B: hal::Backend> LifetimeTracker<B> {
         });
     }
 
-    /// Find the pending entry with the lowest active index. If none can be found that means
-    /// everything in the allocator can be cleaned up, so std::usize::MAX is correct.
-    #[cfg(feature = "replay")]
-    pub fn lowest_active_submission(&self) -> SubmissionIndex {
-        self.active
-            .iter()
-            .fold(std::usize::MAX, |v, active| active.index.min(v))
-    }
-
     fn wait_idle(&self, device: &B::Device) {
         if !self.active.is_empty() {
             log::debug!("Waiting for IDLE...");

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Hub, Input, Token},
     id, pipeline, resource, swap_chain,
     track::{BufferState, TextureState, TrackerSet},
-    validation, FastHashMap, LifeGuard, PrivateFeatures, Stored, MAX_BIND_GROUPS,
+    validation, FastHashMap, LifeGuard, PrivateFeatures, Stored, SubmissionIndex, MAX_BIND_GROUPS,
 };
 
 use arrayvec::ArrayVec;
@@ -26,7 +26,7 @@ use wgt::{
 };
 
 use std::{
-    collections::hash_map::Entry, ffi, iter, marker::PhantomData, mem, ptr, slice,
+    collections::hash_map::Entry, ffi, iter, marker::PhantomData, mem, ops::Range, ptr, slice,
     sync::atomic::Ordering,
 };
 
@@ -179,7 +179,9 @@ pub struct Device<B: hal::Backend> {
     pub(crate) com_allocator: command::CommandAllocator<B>,
     mem_allocator: Mutex<Heaps<B>>,
     desc_allocator: Mutex<DescriptorAllocator<B>>,
+    //Note: The submission index here corresponds to the last submission that is done.
     pub(crate) life_guard: LifeGuard,
+    pub(crate) active_submission_index: SubmissionIndex,
     pub(crate) trackers: Mutex<TrackerSet>,
     pub(crate) render_passes: Mutex<FastHashMap<RenderPassKey, B::RenderPass>>,
     pub(crate) framebuffers: Mutex<FastHashMap<FramebufferKey, B::Framebuffer>>,
@@ -208,10 +210,6 @@ impl<B: GfxBackend> Device<B> {
         desc: &wgt::DeviceDescriptor,
         trace_path: Option<&std::path::Path>,
     ) -> Self {
-        // don't start submission index at zero
-        let life_guard = LifeGuard::new();
-        life_guard.submission_index.fetch_add(1, Ordering::Relaxed);
-
         let com_allocator = command::CommandAllocator::new(queue_group.family, &raw);
         let heaps = unsafe {
             Heaps::new(
@@ -240,7 +238,8 @@ impl<B: GfxBackend> Device<B> {
             mem_allocator: Mutex::new(heaps),
             desc_allocator: Mutex::new(DescriptorAllocator::new()),
             queue_group,
-            life_guard,
+            life_guard: LifeGuard::new(),
+            active_submission_index: 0,
             trackers: Mutex::new(TrackerSet::new(B::VARIANT)),
             render_passes: Mutex::new(FastHashMap::default()),
             framebuffers: Mutex::new(FastHashMap::default()),
@@ -268,6 +267,10 @@ impl<B: GfxBackend> Device<B> {
         }
     }
 
+    pub(crate) fn last_completed_submission_index(&self) -> SubmissionIndex {
+        self.life_guard.submission_index.load(Ordering::Acquire)
+    }
+
     fn lock_life_internal<'this, 'token: 'this>(
         tracker: &'this Mutex<life::LifetimeTracker<B>>,
         _token: &mut Token<'token, Self>,
@@ -275,7 +278,7 @@ impl<B: GfxBackend> Device<B> {
         tracker.lock()
     }
 
-    fn lock_life<'this, 'token: 'this>(
+    pub(crate) fn lock_life<'this, 'token: 'this>(
         &'this self,
         token: &mut Token<'token, Self>,
     ) -> MutexGuard<'this, life::LifetimeTracker<B>> {
@@ -303,6 +306,9 @@ impl<B: GfxBackend> Device<B> {
         let callbacks = life_tracker.handle_mapping(hub, &self.raw, &self.trackers, token);
         life_tracker.cleanup(&self.raw, &self.mem_allocator, &self.desc_allocator);
 
+        self.life_guard
+            .submission_index
+            .store(last_done, Ordering::Release);
         self.com_allocator.maintain(&self.raw, last_done);
         callbacks
     }
@@ -754,14 +760,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         };
 
         let device = &device_guard[device_id];
-        let mut life_lock = device.lock_life(&mut token);
-        if life_lock.lowest_active_submission() <= last_submission {
+        if device.last_completed_submission_index() <= last_submission {
             log::info!(
                 "Waiting for submission {:?} before accessing buffer {:?}",
                 last_submission,
                 buffer_id
             );
-            life_lock.triage_submissions(&device.raw, true);
+            device
+                .lock_life(&mut token)
+                .triage_submissions(&device.raw, true);
         }
     }
 
@@ -2543,6 +2550,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             semaphore: device.raw.create_semaphore().unwrap(),
             acquired_view_id: None,
             acquired_framebuffers: Vec::new(),
+            active_submission_index: 0,
         };
         swap_chain_guard.insert(sc_id, swap_chain);
         sc_id
@@ -2629,7 +2637,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn buffer_map_async<B: GfxBackend>(
         &self,
         buffer_id: id::BufferId,
-        range: std::ops::Range<BufferAddress>,
+        range: Range<BufferAddress>,
         op: resource::BufferMapOperation,
     ) {
         let hub = B::hub(self);
@@ -2741,8 +2749,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 };
                 let _ = ptr;
 
-                let last_submit_index = device.life_guard.submission_index.load(Ordering::Relaxed);
-                buffer.life_guard.use_at(last_submit_index + 1);
+                buffer.life_guard.use_at(device.active_submission_index + 1);
                 let region = hal::command::BufferCopy {
                     src: 0,
                     dst: 0,

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -38,7 +38,7 @@ use crate::{
     conv,
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Input, Token},
     id::{DeviceId, SwapChainId, TextureViewId},
-    resource, LifeGuard, PrivateFeatures, Stored,
+    resource, LifeGuard, PrivateFeatures, Stored, SubmissionIndex,
 };
 
 use hal::{self, device::Device as _, queue::CommandQueue as _, window::PresentationSurface as _};
@@ -56,6 +56,7 @@ pub struct SwapChain<B: hal::Backend> {
     pub(crate) semaphore: B::Semaphore,
     pub(crate) acquired_view_id: Option<Stored<TextureViewId>>,
     pub(crate) acquired_framebuffers: Vec<B::Framebuffer>,
+    pub(crate) active_submission_index: SubmissionIndex,
 }
 
 pub(crate) fn swap_chain_descriptor_to_hal(
@@ -202,9 +203,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             resource::TextureViewInner::SwapChain { image, .. } => image,
         };
 
-        let err = unsafe {
+        let err = {
+            let sem = if sc.active_submission_index > device.last_completed_submission_index() {
+                Some(&sc.semaphore)
+            } else {
+                None
+            };
             let queue = &mut device.queue_group.queues[0];
-            queue.present_surface(B::get_surface_mut(surface), image, Some(&sc.semaphore))
+            unsafe { queue.present_surface(B::get_surface_mut(surface), image, sem) }
         };
         if let Err(e) = err {
             log::warn!("present failed: {:?}", e);


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu-rs/issues/358

**Description**
We used to track the next submission index in `device.life_guard.submission_index` atomic. This PR changes that to point to the last *done* submission, and also introduces a non-atomic field to keep track of the current/next submission.
This allows us to avoid waiting on the frame semaphore on presentation if the relevant submission is done by then.

**Testing**
Not tested!