### PR TITLE
Basic support for minBufferBindingSize

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -79,13 +79,20 @@ pub fn map_binding_type(binding: &wgt::BindGroupLayoutEntry) -> hal::pso::Descri
     use hal::pso;
     use wgt::BindingType as Bt;
     match binding.ty {
-        Bt::UniformBuffer { dynamic } => pso::DescriptorType::Buffer {
+        Bt::UniformBuffer {
+            dynamic,
+            min_binding_size: _,
+        } => pso::DescriptorType::Buffer {
             ty: pso::BufferDescriptorType::Uniform,
             format: pso::BufferDescriptorFormat::Structured {
                 dynamic_offset: dynamic,
             },
         },
-        Bt::StorageBuffer { readonly, dynamic } => pso::DescriptorType::Buffer {
+        Bt::StorageBuffer {
+            readonly,
+            dynamic,
+            min_binding_size: _,
+        } => pso::DescriptorType::Buffer {
             ty: pso::BufferDescriptorType::Storage {
                 read_only: readonly,
             },
@@ -93,7 +100,7 @@ pub fn map_binding_type(binding: &wgt::BindGroupLayoutEntry) -> hal::pso::Descri
                 dynamic_offset: dynamic,
             },
         },
-        Bt::Sampler { .. } => pso::DescriptorType::Sampler,
+        Bt::Sampler { comparison: _ } => pso::DescriptorType::Sampler,
         Bt::SampledTexture { .. } => pso::DescriptorType::Image {
             ty: pso::ImageDescriptorType::Sampled {
                 with_sampler: false,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -8,9 +8,9 @@ use peek_poke::PeekPoke;
 use serde::Deserialize;
 #[cfg(feature = "trace")]
 use serde::Serialize;
-use std::{io, slice};
 
 pub type BufferAddress = u64;
+pub type NonZeroBufferAddress = std::num::NonZeroU64;
 
 /// Buffer-Texture copies on command encoders have to have the `bytes_per_row`
 /// aligned to this number.
@@ -318,46 +318,6 @@ pub struct DeviceDescriptor {
     /// Switch shader validation on/off. This is a temporary field
     /// that will be removed once our validation logic is complete.
     pub shader_validation: bool,
-}
-
-// TODO: This is copy/pasted from gfx-hal, so we need to find a new place to put
-// this function
-pub fn read_spirv<R: io::Read + io::Seek>(mut x: R) -> io::Result<Vec<u32>> {
-    let size = x.seek(io::SeekFrom::End(0))?;
-    if size % 4 != 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "input length not divisible by 4",
-        ));
-    }
-    if size > usize::max_value() as u64 {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "input too long"));
-    }
-    let words = (size / 4) as usize;
-    let mut result = Vec::<u32>::with_capacity(words);
-    x.seek(io::SeekFrom::Start(0))?;
-    unsafe {
-        // Writing all bytes through a pointer with less strict alignment when our type has no
-        // invalid bitpatterns is safe.
-        x.read_exact(slice::from_raw_parts_mut(
-            result.as_mut_ptr() as *mut u8,
-            words * 4,
-        ))?;
-        result.set_len(words);
-    }
-    const MAGIC_NUMBER: u32 = 0x0723_0203;
-    if !result.is_empty() && result[0] == MAGIC_NUMBER.swap_bytes() {
-        for word in &mut result {
-            *word = word.swap_bytes();
-        }
-    }
-    if result.is_empty() || result[0] != MAGIC_NUMBER {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "input missing SPIR-V magic number",
-        ));
-    }
-    Ok(result)
 }
 
 bitflags::bitflags! {
@@ -1288,6 +1248,11 @@ pub enum BindingType {
         /// Indicates that the binding has a dynamic offset.
         /// One offset must be passed to [RenderPass::set_bind_group] for each dynamic binding in increasing order of binding number.
         dynamic: bool,
+        /// Minimum size of the corresponding `BufferBinding` required to match this entry.
+        /// When pipeline is created, the size has to cover at least the corresponding structure in the shader
+        /// plus one element of the unbound array, which can only be last in the structure.
+        /// If `None`, the check is performed at draw call time instead of pipeline and bind group creation.
+        min_binding_size: Option<NonZeroBufferAddress>,
     },
     /// A storage buffer.
     ///
@@ -1301,6 +1266,11 @@ pub enum BindingType {
         /// Indicates that the binding has a dynamic offset.
         /// One offset must be passed to [RenderPass::set_bind_group] for each dynamic binding in increasing order of binding number.
         dynamic: bool,
+        /// Minimum size of the corresponding `BufferBinding` required to match this entry.
+        /// When pipeline is created, the size has to cover at least the corresponding structure in the shader
+        /// plus one element of the unbound array, which can only be last in the structure.
+        /// If `None`, the check is performed at draw call time instead of pipeline and bind group creation.
+        min_binding_size: Option<NonZeroBufferAddress>,
         /// The buffer can only be read in the shader and it must be annotated with `readonly`.
         ///
         /// Example GLSL syntax:
@@ -1350,9 +1320,6 @@ pub enum BindingType {
     StorageTexture {
         /// Dimension of the texture view that is going to be sampled.
         dimension: TextureViewDimension,
-        /// Component type of the texture.
-        /// This must be compatible with the format of the texture.
-        component_type: TextureComponentType,
         /// Format of the texture.
         format: TextureFormat,
         /// The texture can only be read in the shader and it must be annotated with `readonly`.
@@ -1384,19 +1351,17 @@ pub struct BindGroupLayoutEntry {
     pub _non_exhaustive: NonExhaustive,
 }
 
-impl Default for BindGroupLayoutEntry {
-    fn default() -> Self {
+impl BindGroupLayoutEntry {
+    pub fn new(binding: u32, visibility: ShaderStage, ty: BindingType) -> Self {
         Self {
-            binding: 0,
-            visibility: ShaderStage::NONE,
-            ty: BindingType::UniformBuffer { dynamic: false },
+            binding,
+            visibility,
+            ty,
             count: None,
             _non_exhaustive: unsafe { NonExhaustive::new() },
         }
     }
-}
 
-impl BindGroupLayoutEntry {
     pub fn has_dynamic_offset(&self) -> bool {
         match self.ty {
             BindingType::UniformBuffer { dynamic, .. }


### PR DESCRIPTION
**Connections**
Has basic (partial) implementation of https://github.com/gpuweb/gpuweb/pull/678
wgpu-rs update - https://github.com/gfx-rs/wgpu-rs/pull/377

**Description**
This change allows users to optionally specify the expected minimum binding size for buffers. We are then validating this against both the pipelines and bind groups.
If it's not provided, we'll need to validate at draw time - this PR doesn't do this (focus on API changes first).
It also moves out the `read_spirv`, since wgpu-types wasn't the right home for it ever.

**Testing**
Tested on wgpu-rs examples