### PR TITLE
Update gfx-memory to the latest commit

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -30,7 +30,6 @@ log = "0.4"
 hal = { package = "gfx-hal", version = "0.5.2" }
 gfx-backend-empty = "0.5"
 gfx-descriptor = "0.1"
-gfx-memory = "0.1"
 parking_lot = "0.10"
 peek-poke = "0.2"
 raw-window-handle = { version = "0.3", optional = true }
@@ -43,6 +42,10 @@ vec_map = "0.8.1"
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
 rev = "bce6358eb1026c13d2f1c6d365af37afe8869a86"
+
+[dependencies.gfx-memory]
+git = "https://github.com/gfx-rs/gfx-extras"
+rev = "438353c3f75368c12024ad2fc03cbeb15f351fd9"
 
 [dependencies.wgt]
 path = "../wgpu-types"

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -426,14 +426,7 @@ impl<B: GfxBackend> Device<B> {
         let memory = self
             .mem_allocator
             .lock()
-            .allocate(
-                &self.raw,
-                requirements.type_mask as u32,
-                mem_usage,
-                memory_kind,
-                requirements.size,
-                requirements.alignment,
-            )
+            .allocate(&self.raw, &requirements, mem_usage, memory_kind)
             .unwrap();
 
         unsafe {
@@ -524,11 +517,9 @@ impl<B: GfxBackend> Device<B> {
             .lock()
             .allocate(
                 &self.raw,
-                requirements.type_mask as u32,
+                &requirements,
                 gfx_memory::MemoryUsage::Private,
                 gfx_memory::Kind::General,
-                requirements.size,
-                requirements.alignment,
             )
             .unwrap();
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -90,11 +90,9 @@ impl<B: hal::Backend> super::Device<B> {
             .lock()
             .allocate(
                 &self.raw,
-                requirements.type_mask as u32,
+                &requirements,
                 gfx_memory::MemoryUsage::Staging { read_back: false },
                 gfx_memory::Kind::Linear,
-                requirements.size,
-                requirements.alignment,
             )
             .unwrap();
         unsafe {


### PR DESCRIPTION
**Description**
In order to test potential fixes for https://github.com/gfx-rs/wgpu-rs/issues/363 we need wgpu master to be able to easily test changes to gfx-memory.

Assuming we dont have any large regressions I think it could be nice to release wgpu 0.6 before merging this. I dont mind either way though.

**Testing**
I ran some wgpu-rs examples.
