### PR TITLE
Documentation Pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,8 +484,7 @@ dependencies = [
 [[package]]
 name = "gfx-memory"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2eed6cda674d9cd4d92229102dbd544292124533d236904f987e9afab456137"
+source = "git+https://github.com/gfx-rs/gfx-extras?rev=438353c3f75368c12024ad2fc03cbeb15f351fd9#438353c3f75368c12024ad2fc03cbeb15f351fd9"
 dependencies = [
  "fxhash",
  "gfx-hal",

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -219,20 +219,20 @@ impl AdapterInfo {
     }
 }
 
-/// Supported physical device types
+/// Supported physical device types.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub enum DeviceType {
-    /// Other
+    /// Other.
     Other,
-    /// Integrated
+    /// Integrated GPU with shared CPU/GPU memory.
     IntegratedGpu,
-    /// Discrete
+    /// Discrete GPU with separate CPU/GPU memory.
     DiscreteGpu,
-    /// Virtual / Hosted
+    /// Virtual / Hosted.
     VirtualGpu,
-    /// Cpu / Software Rendering
+    /// Cpu / Software Rendering.
     Cpu,
 }
 


### PR DESCRIPTION
## Connections

https://github.com/gfx-rs/wgpu-rs/issues/378.

## Description

The number one thing that people want to see in wgpu is better documentation, so this is a first step towards that goal. It unifies the documentation and fills it out so most things have documentation that is at least marginally helpful.

Notable changes to existing documentation:
- Removes "a" and "the" at the beginning of short descriptions.
- Always use the phrasing `Describes a...` for descriptors that create objects directly.
- Always use a period at the end of short descriptions.

## Testing

No code was changed, but constant monitoring of cargo doc output in wgpu-rs was used to keep everything completely consistent.

## TODO

- [x] wgpu-rs PR (https://github.com/gfx-rs/wgpu-rs/pull/380)
