### PR TITLE
Move backend selection to `Instance::new()`

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -486,7 +486,8 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    let global = wgc::hub::Global::new("player", IdentityPassThroughFactory);
+    let global =
+        wgc::hub::Global::new("player", IdentityPassThroughFactory, wgt::BackendBit::all());
     let mut command_buffer_id_manager = wgc::hub::IdentityManager::default();
 
     #[cfg(feature = "winit")]

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -576,9 +576,9 @@ pub struct Global<G: GlobalIdentityHandlerFactory> {
 }
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
-    pub fn new(name: &str, factory: G) -> Self {
+    pub fn new(name: &str, factory: G, backends: wgt::BackendBit) -> Self {
         Global {
-            instance: Instance::new(name, 1),
+            instance: Instance::new(name, 1, backends),
             surfaces: Registry::without_backend(&factory, "Surface"),
             hubs: Hubs::new(&factory),
         }
@@ -637,7 +637,7 @@ impl GfxBackend for backend::Metal {
         &global.hubs.metal
     }
     fn get_surface_mut(surface: &mut Surface) -> &mut Self::Surface {
-        &mut surface.metal
+        surface.metal.as_mut().unwrap()
     }
 }
 
@@ -659,7 +659,7 @@ impl GfxBackend for backend::Dx11 {
         &global.hubs.dx11
     }
     fn get_surface_mut(surface: &mut Surface) -> &mut Self::Surface {
-        &mut surface.dx11
+        surface.dx11.as_mut().unwrap()
     }
 }
 


### PR DESCRIPTION
**Connections**
Addresses https://github.com/gfx-rs/wgpu-rs/issues/337
Corresponding wgpu-rs PR: https://github.com/gfx-rs/wgpu-rs/pull/385

**Description**
This makes early backend selection possible in `Instance::new`, by only attempting to instantiate requested backends. The actual selection in `pick_adapter()` (necessarily) remains unchanged, and can be used to further restrict the request.

**Testing**
Unsure what to do here
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
