### PR TITLE
Initial `tracing` crate support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1498,7 @@ dependencies = [
  "serde",
  "smallvec",
  "spirv_headers",
+ "tracing",
  "vec_map",
  "wgpu-types",
 ]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -16,10 +16,11 @@ license = "MPL-2.0"
 
 [features]
 default = []
-trace = ["ron", "serde", "wgt/trace"]
-replay = ["serde", "wgt/replay"]
 #NOTE: glutin feature is not stable, use at your own risk
 #glutin = ["gfx-backend-gl/glutin"]
+profiling = ["tracing"]
+replay = ["serde", "wgt/replay"]
+trace = ["ron", "serde", "wgt/trace"]
 
 [dependencies]
 arrayvec = "0.5"
@@ -37,6 +38,7 @@ ron = { version = "0.5", optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 smallvec = "1"
 spirv_headers = { version = "1.4.2" }
+tracing = { version = "0.1.15", optional = true }
 vec_map = "0.8.1"
 
 [dependencies.naga]

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -16,6 +16,8 @@ use gfx_memory::{Block, Heaps, MemoryBlock};
 use hal::{command::CommandBuffer as _, device::Device as _, queue::CommandQueue as _};
 use smallvec::SmallVec;
 use std::iter;
+#[cfg(feature = "tracing")]
+use tracing::{event, span, Level};
 
 struct StagingData<B: hal::Backend> {
     buffer: B::Buffer,
@@ -365,6 +367,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         queue_id: id::QueueId,
         command_buffer_ids: &[id::CommandBufferId],
     ) {
+        #[cfg(feature = "tracing")]
+        let span = span!(Level::TRACE, "queue_submit");
+        #[cfg(feature = "tracing")]
+        let _guard = span.enter();
+
+        #[cfg(feature = "tracing")]
+        event!(Level::WARN, "submitting to queue");
+
         let hub = B::hub(self);
 
         let callbacks = {
@@ -544,6 +554,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         };
 
         super::fire_map_callbacks(callbacks);
+
+        #[cfg(feature = "tracing")]
+        event!(Level::WARN, "finished submission");
     }
 }
 


### PR DESCRIPTION
**Connections**

Initial work towards #491 "CPU profiling infrastructure"

**Description**

Adds a new optional feature to `wgpu-core` called `profiling`, which pulls in the `tracing` crate as a dependency.

As a test, I've added a profiling span to the `queue_submit` function.

**Note:** I'm using the `WARN` level for the events, because otherwise all of the logging/debug messages would also appear in my terminal. I'm not sure how to filter only for `tracing` messages.

**Testing**

To test locally, I've modified the `framework.rs` file from `wgpu-rs/examples`. It now looks like:
```rust
tracing_subscriber::fmt()
   .with_env_filter("[queue_submit]=warn")
   .init();

//env_logger::init();
futures::executor::block_on(run_async::<E>(event_loop, window));
```

Running the `boids` examples gives me lines such as
```
Jun 18 17:38:59.021  WARN queue_submit: wgpu_core::device::queue: submitting to queue
Jun 18 17:38:59.022  WARN queue_submit: wgpu_core::device::queue: finished submission
```
from where I can deduce it takes 1ms to perform a queue submission.

Feedbacks and ideas are welcome!