### PR TITLE
Set descriptor set name when creating bind group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,8 +463,7 @@ dependencies = [
 [[package]]
 name = "gfx-descriptor"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf35f5d66d1bc56e63e68d7528441453f25992bd954b84309d23c659df2c5da"
+source = "git+https://github.com/gfx-rs/gfx-extras?rev=438353c3f75368c12024ad2fc03cbeb15f351fd9#438353c3f75368c12024ad2fc03cbeb15f351fd9"
 dependencies = [
  "fxhash",
  "gfx-hal",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -29,7 +29,6 @@ fxhash = "0.2"
 log = "0.4"
 hal = { package = "gfx-hal", version = "0.5.2" }
 gfx-backend-empty = "0.5"
-gfx-descriptor = "0.1"
 parking_lot = "0.10"
 peek-poke = "0.2"
 raw-window-handle = { version = "0.3", optional = true }
@@ -42,6 +41,10 @@ vec_map = "0.8.1"
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
 rev = "e3aea9619865b16a24164d46ab29cca36ad7daf2"
+
+[dependencies.gfx-descriptor]
+git = "https://github.com/gfx-rs/gfx-extras"
+rev = "438353c3f75368c12024ad2fc03cbeb15f351fd9"
 
 [dependencies.gfx-memory]
 git = "https://github.com/gfx-rs/gfx-extras"


### PR DESCRIPTION
**Description**
There is a [`TODO` in the code](https://github.com/gfx-rs/wgpu/blob/a02a56684114da702a64e30af49d0167e273402b/wgpu-core/src/device/mod.rs#L1428) for setting the descriptor set name when creating a bind group. It was blocked on https://github.com/gfx-rs/gfx-extras/pull/5

**Testing**
Tested with examples from `wgpu-rs`.