### PR TITLE
Validate sampler type in `create_bind_group`

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -301,7 +301,8 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                         bindings: &entry_vec,
                     },
                     id,
-                );
+                )
+                .unwrap();
             }
             A::DestroyBindGroup(id) => {
                 self.bind_group_destroy::<B>(id);

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -28,6 +28,27 @@ pub enum BindGroupLayoutError {
     ArrayUnsupported,
 }
 
+#[derive(Clone, Debug)]
+pub enum BindGroupError {
+    /// Number of bindings in bind group descriptor does not match
+    /// the number of bindings defined in the bind group layout.
+    BindingsNumMismatch { actual: usize, expected: usize },
+    /// Unable to find a corresponding declaration for the given binding,
+    MissingBindingDeclaration(u32),
+    /// The given binding has a different type than the one in the layout.
+    WrongBindingType {
+        // Index of the binding
+        binding: u32,
+        // The type given to the function
+        actual: wgt::BindingType,
+        // Human-readable description of expected types
+        expected: &'static str,
+    },
+    /// The given sampler is/is not a comparison sampler,
+    /// while the layout type indicates otherwise.
+    WrongSamplerComparison,
+}
+
 pub(crate) type BindEntryMap = FastHashMap<u32, wgt::BindGroupLayoutEntry>;
 
 #[derive(Debug)]

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -215,6 +215,8 @@ pub struct Sampler<B: hal::Backend> {
     pub(crate) raw: B::Sampler,
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) life_guard: LifeGuard,
+    /// `true` if this is a comparison sampler
+    pub(crate) comparison: bool,
 }
 
 impl<B: hal::Backend> Borrow<RefCount> for Sampler<B> {


### PR DESCRIPTION
**Connections**
Fixes #588 

**Description**
* Makes `create_bind_group` return a `Result`, and adds a new `binding_model::BindGroupError` enum.
* Converts _some_ assertions from `create_bind_group` into `Err`s
* Validates that the type of sampler declared in the bind group layout (comparison or not) is the same as the one of the actual sampler.

**Testing**
Tested locally on the `shadow` example in `wgpu-rs`. ~Will follow up with a PR in that repo with the updated API.~ https://github.com/gfx-rs/wgpu-rs/pull/398