### PR TITLE
Remove Peek-Poke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,13 +76,13 @@ jobs:
             name: Ubuntu Nightly
             channel: nightly
             build_command: cargo test
-            additional_core_features:
+            additional_core_features: serial-pass
             additional_player_features: winit
           - os: windows-2019
             name: Windows Stable
             channel: stable
             build_command: rustup default stable-msvc; cargo clippy
-            additional_core_features: trace
+            additional_core_features: trace,serial-pass
             additional_player_features: renderdoc
           - os: windows-2019
             name: Windows Nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,9 @@ name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ash"
@@ -909,28 +912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peek-poke"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93fd6a575ebf1ac2668d08443c97a22872cfb463fd8b7ddd141e9f6be59af2f"
-dependencies = [
- "peek-poke-derive",
-]
-
-[[package]]
-name = "peek-poke-derive"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb44a25c5bba983be0fc8592dfaf3e6d0935ce8be0c6b15b2a39507af34a926"
-dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn",
- "synstructure",
- "unicode-xid 0.2.0",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,18 +1224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn",
- "unicode-xid 0.2.0",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,7 +1436,6 @@ dependencies = [
  "loom",
  "naga",
  "parking_lot",
- "peek-poke",
  "raw-window-handle",
  "ron",
  "serde",
@@ -1482,7 +1450,6 @@ name = "wgpu-types"
 version = "0.5.0"
 dependencies = [
  "bitflags",
- "peek-poke",
  "serde",
 ]
 

--- a/dummy/Cargo.toml
+++ b/dummy/Cargo.toml
@@ -13,4 +13,4 @@ publish = false
 path = "../wgpu-core"
 package = "wgpu-core"
 version = "0.5"
-features = ["battery", "trace"]
+features = ["battery", "serial-pass", "trace"]

--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -139,33 +139,21 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                 trace::Command::CopyTextureToTexture { src, dst, size } => {
                     self.command_encoder_copy_texture_to_texture::<B>(encoder, &src, &dst, &size)
                 }
-                trace::Command::RunComputePass {
-                    commands,
-                    dynamic_offsets,
-                } => unsafe {
-                    let mut pass = wgc::command::RawPass::new_compute(encoder);
-                    pass.fill_compute_commands(&commands, &dynamic_offsets);
-                    let (data, _) = pass.finish_compute();
-                    self.command_encoder_run_compute_pass::<B>(encoder, &data);
-                },
+                trace::Command::RunComputePass { base } => {
+                    self.command_encoder_run_compute_pass_impl::<B>(encoder, base.as_ref());
+                }
                 trace::Command::RunRenderPass {
+                    base,
                     target_colors,
                     target_depth_stencil,
-                    commands,
-                    dynamic_offsets,
-                } => unsafe {
-                    let mut pass = wgc::command::RawPass::new_render(
+                } => {
+                    self.command_encoder_run_render_pass_impl::<B>(
                         encoder,
-                        &wgc::command::RenderPassDescriptor {
-                            color_attachments: target_colors.as_ptr(),
-                            color_attachments_length: target_colors.len(),
-                            depth_stencil_attachment: target_depth_stencil.as_ref(),
-                        },
+                        base.as_ref(),
+                        &target_colors,
+                        target_depth_stencil.as_ref(),
                     );
-                    pass.fill_render_commands(&commands, &dynamic_offsets);
-                    let (data, _) = pass.finish_render();
-                    self.command_encoder_run_render_pass::<B>(encoder, &data);
-                },
+                }
             }
         }
         self.command_encoder_finish::<B>(encoder, &wgt::CommandBufferDescriptor { todo: 0 })
@@ -385,14 +373,9 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
             A::DestroyRenderPipeline(id) => {
                 self.render_pipeline_destroy::<B>(id);
             }
-            A::CreateRenderBundle {
-                id,
-                desc,
-                commands,
-                dynamic_offsets,
-            } => {
+            A::CreateRenderBundle { id, desc, base } => {
                 let label = Label::new(&desc.label);
-                let mut bundle_encoder = wgc::command::RenderBundleEncoder::new(
+                let bundle = wgc::command::RenderBundleEncoder::new(
                     &wgt::RenderBundleEncoderDescriptor {
                         label: None,
                         color_formats: &desc.color_formats,
@@ -400,10 +383,10 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                         sample_count: desc.sample_count,
                     },
                     device,
+                    Some(base),
                 );
-                bundle_encoder.fill_commands(&commands, &dynamic_offsets);
                 self.render_bundle_encoder_finish::<B>(
-                    bundle_encoder,
+                    bundle,
                     &wgt::RenderBundleDescriptor {
                         label: label.as_ptr(),
                     },

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -13,8 +13,12 @@ license = "MPL-2.0"
 
 [features]
 default = []
+# Enable API tracing
 trace = ["ron", "serde", "wgt/trace"]
+# Enable API replaying
 replay = ["serde", "wgt/replay"]
+# Enable serializable compute/render passes, and bundle encoders.
+serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
 
 [dependencies]
 arrayvec = "0.5"
@@ -25,7 +29,6 @@ log = "0.4"
 hal = { package = "gfx-hal", version = "0.5.2" }
 gfx-backend-empty = "0.5"
 parking_lot = "0.10"
-peek-poke = "0.2"
 raw-window-handle = { version = "0.3", optional = true }
 ron = { version = "0.5", optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
@@ -49,7 +52,6 @@ rev = "438353c3f75368c12024ad2fc03cbeb15f351fd9"
 path = "../wgpu-types"
 package = "wgpu-types"
 version = "0.5"
-features = ["peek-poke"]
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 gfx-backend-metal = { version = "0.5.4" }

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -67,7 +67,7 @@ pub struct PipelineLayout<B: hal::Backend> {
 pub struct BufferBinding {
     pub buffer_id: BufferId,
     pub offset: wgt::BufferAddress,
-    pub size: wgt::BufferSize,
+    pub size: Option<wgt::BufferSize>,
 }
 
 // Note: Duplicated in wgpu-rs as BindingResource

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -574,13 +574,13 @@ pub(crate) fn map_texture_state(
     (access, layout)
 }
 
-pub fn map_load_store_ops(load: wgt::LoadOp, store: wgt::StoreOp) -> hal::pass::AttachmentOps {
+pub fn map_load_store_ops<V>(channel: &wgt::PassChannel<V>) -> hal::pass::AttachmentOps {
     hal::pass::AttachmentOps {
-        load: match load {
+        load: match channel.load_op {
             wgt::LoadOp::Clear => hal::pass::AttachmentLoadOp::Clear,
             wgt::LoadOp::Load => hal::pass::AttachmentLoadOp::Load,
         },
-        store: match store {
+        store: match channel.store_op {
             wgt::StoreOp::Clear => hal::pass::AttachmentStoreOp::DontCare, //TODO!
             wgt::StoreOp::Store => hal::pass::AttachmentStoreOp::Store,
         },

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -20,7 +20,7 @@ pub enum BindingResource {
     Buffer {
         id: id::BufferId,
         offset: wgt::BufferAddress,
-        size: wgt::BufferSize,
+        size: Option<wgt::BufferSize>,
     },
     Sampler(id::SamplerId),
     TextureView(id::TextureViewId),
@@ -185,8 +185,7 @@ pub enum Action {
     CreateRenderBundle {
         id: id::RenderBundleId,
         desc: RenderBundleDescriptor,
-        commands: Vec<crate::command::RenderCommand>,
-        dynamic_offsets: Vec<wgt::DynamicOffset>,
+        base: crate::command::BasePass<crate::command::RenderCommand>,
     },
     DestroyRenderBundle(id::RenderBundleId),
     WriteBuffer {
@@ -231,14 +230,12 @@ pub enum Command {
         size: wgt::Extent3d,
     },
     RunComputePass {
-        commands: Vec<crate::command::ComputeCommand>,
-        dynamic_offsets: Vec<wgt::DynamicOffset>,
+        base: crate::command::BasePass<crate::command::ComputeCommand>,
     },
     RunRenderPass {
-        target_colors: Vec<crate::command::RenderPassColorAttachmentDescriptor>,
-        target_depth_stencil: Option<crate::command::RenderPassDepthStencilAttachmentDescriptor>,
-        commands: Vec<crate::command::RenderCommand>,
-        dynamic_offsets: Vec<wgt::DynamicOffset>,
+        base: crate::command::BasePass<crate::command::RenderCommand>,
+        target_colors: Vec<crate::command::ColorAttachmentDescriptor>,
+        target_depth_stencil: Option<crate::command::DepthStencilAttachmentDescriptor>,
     },
 }
 

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{Epoch, Index};
-use std::{fmt, marker::PhantomData, mem, num::NonZeroU64};
+use std::{fmt, marker::PhantomData, num::NonZeroU64};
 use wgt::Backend;
 
 const BACKEND_BITS: usize = 3;
@@ -16,6 +16,14 @@ type Dummy = crate::backend::Empty;
     feature = "replay",
     derive(serde::Deserialize),
     serde(from = "SerialId")
+)]
+#[cfg_attr(
+    all(feature = "serde", not(feature = "trace")),
+    derive(serde::Serialize)
+)]
+#[cfg_attr(
+    all(feature = "serde", not(feature = "replay")),
+    derive(serde::Deserialize)
 )]
 pub struct Id<T>(NonZeroU64, PhantomData<T>);
 
@@ -43,20 +51,12 @@ impl<T> From<SerialId> for Id<T> {
     }
 }
 
-// required for PeekPoke
-impl<T> Default for Id<T> {
-    fn default() -> Self {
-        Id(
-            // Create an ID that doesn't make sense:
-            // the high `BACKEND_BITS` are to be set to 0, which matches `Backend::Empty`,
-            // the other bits are all 1s
-            unsafe { NonZeroU64::new_unchecked(!0 >> BACKEND_BITS) },
-            PhantomData,
-        )
-    }
-}
-
 impl<T> Id<T> {
+    #[cfg(test)]
+    pub(crate) fn dummy() -> Self {
+        Id(NonZeroU64::new(1).unwrap(), PhantomData)
+    }
+
     pub fn backend(self) -> Backend {
         match self.0.get() >> (64 - BACKEND_BITS) as u8 {
             0 => Backend::Empty,
@@ -67,14 +67,6 @@ impl<T> Id<T> {
             5 => Backend::Gl,
             _ => unreachable!(),
         }
-    }
-
-    pub(crate) fn into_raw(self) -> u64 {
-        self.0.get()
-    }
-
-    pub(crate) fn from_raw(value: u64) -> Option<Self> {
-        NonZeroU64::new(value).map(|nz| Id(nz, PhantomData))
     }
 }
 
@@ -105,24 +97,6 @@ impl<T> PartialEq for Id<T> {
 }
 
 impl<T> Eq for Id<T> {}
-
-unsafe impl<T> peek_poke::Poke for Id<T> {
-    fn max_size() -> usize {
-        mem::size_of::<u64>()
-    }
-    unsafe fn poke_into(&self, data: *mut u8) -> *mut u8 {
-        self.0.get().poke_into(data)
-    }
-}
-
-impl<T> peek_poke::Peek for Id<T> {
-    unsafe fn peek_from(mut data: *const u8, this: *mut Self) -> *const u8 {
-        let mut v = 0u64;
-        data = u64::peek_from(data, &mut v);
-        (*this).0 = NonZeroU64::new(v).unwrap();
-        data
-    }
-}
 
 pub trait TypedId {
     fn zip(index: Index, epoch: Epoch, backend: Backend) -> Self;
@@ -166,8 +140,8 @@ pub type ComputePipelineId = Id<crate::pipeline::ComputePipeline<Dummy>>;
 // Command
 pub type CommandEncoderId = CommandBufferId;
 pub type CommandBufferId = Id<crate::command::CommandBuffer<Dummy>>;
-pub type RenderPassId = *mut crate::command::RawPass<CommandEncoderId>;
-pub type ComputePassId = *mut crate::command::RawPass<CommandEncoderId>;
+pub type RenderPassEncoderId = *mut crate::command::RenderPass;
+pub type ComputePassEncoderId = *mut crate::command::ComputePass;
 pub type RenderBundleEncoderId = *mut crate::command::RenderBundleEncoder;
 pub type RenderBundleId = Id<crate::command::RenderBundle>;
 // Swap chain

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -150,7 +150,7 @@ mod test {
             first: None,
             last: BufferUse::INDEX,
         };
-        let id = Id::default();
+        let id = Id::dummy();
         assert_eq!(
             bs.change(id, (), BufferUse::STORAGE_STORE, None),
             Err(PendingTransition {
@@ -170,7 +170,7 @@ mod test {
             first: None,
             last: BufferUse::STORAGE_STORE,
         };
-        let id = Id::default();
+        let id = Id::dummy();
         let mut list = Vec::new();
         bs.change(id, (), BufferUse::VERTEX, Some(&mut list))
             .unwrap();
@@ -216,7 +216,7 @@ mod test {
             first: None,
             last: BufferUse::VERTEX,
         };
-        let id = Id::default();
+        let id = Id::dummy();
         bs.prepend(id, (), BufferUse::INDEX).unwrap();
         bs.prepend(id, (), BufferUse::INDEX).unwrap();
         assert_eq!(

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -324,7 +324,7 @@ mod test {
 
     #[test]
     fn merge() {
-        let id = Id::default();
+        let id = Id::dummy();
         let mut ts1 = TextureState::default();
         ts1.mips.push(PlaneStates::from_slice(&[(
             1..3,
@@ -342,7 +342,7 @@ mod test {
             Unit::new(TextureUse::COPY_SRC),
         )]));
         assert_eq!(
-            ts1.merge(Id::default(), &ts2, None),
+            ts1.merge(Id::dummy(), &ts2, None),
             Ok(()),
             "failed to extend a compatible state"
         );
@@ -357,7 +357,7 @@ mod test {
 
         ts2.mips[0] = PlaneStates::from_slice(&[(1..2, Unit::new(TextureUse::COPY_DST))]);
         assert_eq!(
-            ts1.clone().merge(Id::default(), &ts2, None),
+            ts1.clone().merge(Id::dummy(), &ts2, None),
             Err(PendingTransition {
                 id,
                 selector: SubresourceRange {
@@ -381,7 +381,7 @@ mod test {
                 },
             ),
         ]);
-        ts1.merge(Id::default(), &ts2, Some(&mut list)).unwrap();
+        ts1.merge(Id::dummy(), &ts2, Some(&mut list)).unwrap();
         assert_eq!(
             &list,
             &[
@@ -433,7 +433,7 @@ mod test {
                 last: TextureUse::COPY_SRC,
             },
         )]);
-        ts1.merge(Id::default(), &ts2, Some(&mut list)).unwrap();
+        ts1.merge(Id::dummy(), &ts2, Some(&mut list)).unwrap();
         assert_eq!(&list, &[], "unexpected replacing transition");
 
         list.clear();
@@ -444,7 +444,7 @@ mod test {
                 last: TextureUse::COPY_DST,
             },
         )]);
-        ts1.merge(Id::default(), &ts2, Some(&mut list)).unwrap();
+        ts1.merge(Id::dummy(), &ts2, Some(&mut list)).unwrap();
         assert_eq!(
             &list,
             &[PendingTransition {

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -18,4 +18,3 @@ replay = ["serde"]
 [dependencies]
 bitflags = "1.0"
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
-peek-poke = { version = "0.2", optional = true }


### PR DESCRIPTION
**Connections**
Related to https://github.com/gfx-rs/wgpu/issues/738
Related to https://github.com/djg/peek-poke/issues/10

**Description**
As of #726 , the buffers have a minimum binding size that has to include the shader struct size. It, therefore, can't be zero.
We can remove the hacks we had previously and switch fully to the idiomatic `Option<NonZeroU64>`.

Peek-poke doesn't `NonZeroU64` and friends, so this made me reconsider the user of it entirely. Today, render bundles as well as the Player already represent command streams using a much rustier method. I tried to move everything to this method now, and I think this is going to work much better, and safer.

**Testing**
wgpu-rs works - https://github.com/gfx-rs/wgpu-rs/pull/396