### PR TITLE
First Phase of Tracing Transition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8052e2d8aabbb8d556d6abbcce2a22b9590996c5f849b9c7ce4544a2e3b984e"
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "approx"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +160,17 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "chrono"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
 
 [[package]]
 name = "cloudabi"
@@ -545,6 +565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +686,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -820,6 +855,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "void",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -1023,6 +1068,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1145,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1204,26 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1233,12 +1314,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1253,29 +1355,61 @@ dependencies = [
 [[package]]
 name = "tracing"
 version = "0.1.15"
-source = "git+https://github.com/tokio-rs/tracing?rev=845746a2a302f0dfac88ba56ea37dc1e1cb0cd85#845746a2a302f0dfac88ba56ea37dc1e1cb0cd85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
 dependencies = [
  "cfg-if",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.8"
-source = "git+https://github.com/tokio-rs/tracing?rev=845746a2a302f0dfac88ba56ea37dc1e1cb0cd85#845746a2a302f0dfac88ba56ea37dc1e1cb0cd85"
-dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn",
 ]
 
 [[package]]
 name = "tracing-core"
 version = "0.1.10"
-source = "git+https://github.com/tokio-rs/tracing?rev=845746a2a302f0dfac88ba56ea37dc1e1cb0cd85#845746a2a302f0dfac88ba56ea37dc1e1cb0cd85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a11b459109e38ff6e1b580bafef4142a11d44889f5d07424cbce2fd2a2a119"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1463,13 +1597,16 @@ dependencies = [
  "log",
  "loom",
  "naga",
+ "once_cell",
  "parking_lot",
  "raw-window-handle",
  "ron",
  "serde",
  "smallvec",
  "spirv_headers",
+ "thread-id",
  "tracing",
+ "tracing-subscriber",
  "vec_map",
  "wgpu-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,6 @@ dependencies = [
  "log",
  "loom",
  "naga",
- "once_cell",
  "parking_lot",
  "raw-window-handle",
  "ron",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,6 +1251,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.15"
+source = "git+https://github.com/tokio-rs/tracing?rev=845746a2a302f0dfac88ba56ea37dc1e1cb0cd85#845746a2a302f0dfac88ba56ea37dc1e1cb0cd85"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.8"
+source = "git+https://github.com/tokio-rs/tracing?rev=845746a2a302f0dfac88ba56ea37dc1e1cb0cd85#845746a2a302f0dfac88ba56ea37dc1e1cb0cd85"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.10"
+source = "git+https://github.com/tokio-rs/tracing?rev=845746a2a302f0dfac88ba56ea37dc1e1cb0cd85#845746a2a302f0dfac88ba56ea37dc1e1cb0cd85"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1469,7 @@ dependencies = [
  "serde",
  "smallvec",
  "spirv_headers",
+ "tracing",
  "vec_map",
  "wgpu-types",
 ]

--- a/dummy/Cargo.toml
+++ b/dummy/Cargo.toml
@@ -13,4 +13,4 @@ publish = false
 path = "../wgpu-core"
 package = "wgpu-core"
 version = "0.5"
-features = ["battery", "serial-pass", "trace"]
+features = ["battery", "serial-pass", "subscriber", "trace"]

--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -441,7 +441,8 @@ fn main() {
     env_logger::init();
 
     #[cfg(feature = "renderdoc")]
-    let mut _rd = renderdoc::RenderDoc::<renderdoc::V110>::new()
+    #[cfg_attr(feature = "winit", allow(unused))]
+    let mut rd = renderdoc::RenderDoc::<renderdoc::V110>::new()
         .expect("Failed to connect to RenderDoc: are you running without it?");
 
     //TODO: setting for the backend bits
@@ -514,14 +515,14 @@ fn main() {
     #[cfg(not(feature = "winit"))]
     {
         #[cfg(feature = "renderdoc")]
-        _rd.start_frame_capture(ptr::null(), ptr::null());
+        rd.start_frame_capture(ptr::null(), ptr::null());
 
         while let Some(action) = actions.pop() {
             gfx_select!(device => global.process(device, action, &dir, &mut command_buffer_id_manager));
         }
 
         #[cfg(feature = "renderdoc")]
-        _rd.end_frame_capture(ptr::null(), ptr::null());
+        rd.end_frame_capture(ptr::null(), ptr::null());
         gfx_select!(device => global.device_poll(device, true));
     }
     #[cfg(feature = "winit")]

--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -441,7 +441,7 @@ fn main() {
     env_logger::init();
 
     #[cfg(feature = "renderdoc")]
-    let mut rd = renderdoc::RenderDoc::<renderdoc::V110>::new()
+    let mut _rd = renderdoc::RenderDoc::<renderdoc::V110>::new()
         .expect("Failed to connect to RenderDoc: are you running without it?");
 
     //TODO: setting for the backend bits
@@ -514,14 +514,14 @@ fn main() {
     #[cfg(not(feature = "winit"))]
     {
         #[cfg(feature = "renderdoc")]
-        rd.start_frame_capture(ptr::null(), ptr::null());
+        _rd.start_frame_capture(ptr::null(), ptr::null());
 
         while let Some(action) = actions.pop() {
             gfx_select!(device => global.process(device, action, &dir, &mut command_buffer_id_manager));
         }
 
         #[cfg(feature = "renderdoc")]
-        rd.end_frame_capture(ptr::null(), ptr::null());
+        _rd.end_frame_capture(ptr::null(), ptr::null());
         gfx_select!(device => global.device_poll(device, true));
     }
     #[cfg(feature = "winit")]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -19,6 +19,8 @@ trace = ["ron", "serde", "wgt/trace"]
 replay = ["serde", "wgt/replay"]
 # Enable serializable compute/render passes, and bundle encoders.
 serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
+# Enable chrome-tracing backend and default tracing subscriber
+subscriber = ["once_cell", "thread-id", "tracing-subscriber"]
 
 [dependencies]
 arrayvec = "0.5"
@@ -28,13 +30,16 @@ fxhash = "0.2"
 log = "0.4"
 hal = { package = "gfx-hal", version = "0.5.2" }
 gfx-backend-empty = "0.5"
+once_cell = { version = "1", optional = true }
 parking_lot = "0.10"
 raw-window-handle = { version = "0.3", optional = true }
 ron = { version = "0.5", optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 smallvec = "1"
 spirv_headers = { version = "1.4.2" }
-tracing = { git = "https://github.com/tokio-rs/tracing", rev = "845746a2a302f0dfac88ba56ea37dc1e1cb0cd85" }
+thread-id = { version = "3", optional = true }
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing-subscriber =  { version = "0.2", optional = true }
 vec_map = "0.8.1"
 
 [dependencies.naga]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -20,7 +20,7 @@ replay = ["serde", "wgt/replay"]
 # Enable serializable compute/render passes, and bundle encoders.
 serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
 # Enable chrome-tracing backend and default tracing subscriber
-subscriber = ["once_cell", "thread-id", "tracing-subscriber"]
+subscriber = ["thread-id", "tracing-subscriber"]
 
 [dependencies]
 arrayvec = "0.5"
@@ -30,7 +30,6 @@ fxhash = "0.2"
 log = "0.4"
 hal = { package = "gfx-hal", version = "0.5.2" }
 gfx-backend-empty = "0.5"
-once_cell = { version = "1", optional = true }
 parking_lot = "0.10"
 raw-window-handle = { version = "0.3", optional = true }
 ron = { version = "0.5", optional = true }

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -34,6 +34,7 @@ ron = { version = "0.5", optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 smallvec = "1"
 spirv_headers = { version = "1.4.2" }
+tracing = { git = "https://github.com/tokio-rs/tracing", rev = "845746a2a302f0dfac88ba56ea37dc1e1cb0cd85" }
 vec_map = "0.8.1"
 
 [dependencies.naga]

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -63,7 +63,7 @@ impl RenderBundleEncoder {
         parent_id: id::DeviceId,
         base: Option<BasePass<RenderCommand>>,
     ) -> Self {
-        span!(_guard, ERROR, "RenderBundleEncoder::new");
+        span!(_guard, INFO, "RenderBundleEncoder::new");
         RenderBundleEncoder {
             base: base.unwrap_or_else(BasePass::new),
             parent_id,
@@ -483,7 +483,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::RenderBundleDescriptor<Label>,
         id_in: Input<G, id::RenderBundleId>,
     ) -> id::RenderBundleId {
-        span!(_guard, ERROR, "RenderBundleEncoder::finish");
+        span!(_guard, INFO, "RenderBundleEncoder::finish");
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -773,7 +773,7 @@ pub mod bundle_ffi {
         offsets: *const DynamicOffset,
         offset_length: usize,
     ) {
-        span!(_guard, ERROR, "RenderBundle::set_bind_group");
+        span!(_guard, DEBUG, "RenderBundle::set_bind_group");
         bundle.base.commands.push(RenderCommand::SetBindGroup {
             index: index.try_into().unwrap(),
             num_dynamic_offsets: offset_length.try_into().unwrap(),
@@ -790,7 +790,7 @@ pub mod bundle_ffi {
         bundle: &mut RenderBundleEncoder,
         pipeline_id: id::RenderPipelineId,
     ) {
-        span!(_guard, ERROR, "RenderBundle::set_pipeline");
+        span!(_guard, DEBUG, "RenderBundle::set_pipeline");
         bundle
             .base
             .commands
@@ -804,7 +804,7 @@ pub mod bundle_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        span!(_guard, ERROR, "RenderBundle::set_index_buffer");
+        span!(_guard, DEBUG, "RenderBundle::set_index_buffer");
         bundle.base.commands.push(RenderCommand::SetIndexBuffer {
             buffer_id,
             offset,
@@ -820,7 +820,7 @@ pub mod bundle_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        span!(_guard, ERROR, "RenderBundle::set_vertex_buffer");
+        span!(_guard, DEBUG, "RenderBundle::set_vertex_buffer");
         bundle.base.commands.push(RenderCommand::SetVertexBuffer {
             slot,
             buffer_id,
@@ -837,7 +837,7 @@ pub mod bundle_ffi {
         first_vertex: u32,
         first_instance: u32,
     ) {
-        span!(_guard, ERROR, "RenderBundle::draw");
+        span!(_guard, DEBUG, "RenderBundle::draw");
         bundle.base.commands.push(RenderCommand::Draw {
             vertex_count,
             instance_count,
@@ -855,7 +855,7 @@ pub mod bundle_ffi {
         base_vertex: i32,
         first_instance: u32,
     ) {
-        span!(_guard, ERROR, "RenderBundle::draw_indexed");
+        span!(_guard, DEBUG, "RenderBundle::draw_indexed");
         bundle.base.commands.push(RenderCommand::DrawIndexed {
             index_count,
             instance_count,
@@ -871,7 +871,7 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, ERROR, "RenderBundle::draw_indirect");
+        span!(_guard, DEBUG, "RenderBundle::draw_indirect");
         bundle
             .base
             .commands
@@ -884,7 +884,7 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, ERROR, "RenderBundle::draw_indexed_indirect");
+        span!(_guard, DEBUG, "RenderBundle::draw_indexed_indirect");
         bundle
             .base
             .commands
@@ -896,13 +896,13 @@ pub mod bundle_ffi {
         _bundle: &mut RenderBundleEncoder,
         _label: RawString,
     ) {
-        span!(_guard, ERROR, "RenderBundle::push_debug_group");
+        span!(_guard, DEBUG, "RenderBundle::push_debug_group");
         //TODO
     }
 
     #[no_mangle]
     pub unsafe extern "C" fn wgpu_render_bundle_pop_debug_group(_bundle: &mut RenderBundleEncoder) {
-        span!(_guard, ERROR, "RenderBundle::pop_debug_group");
+        span!(_guard, DEBUG, "RenderBundle::pop_debug_group");
         //TODO
     }
 
@@ -911,7 +911,7 @@ pub mod bundle_ffi {
         _bundle: &mut RenderBundleEncoder,
         _label: RawString,
     ) {
-        span!(_guard, ERROR, "RenderBundle::insert_debug_marker");
+        span!(_guard, DEBUG, "RenderBundle::insert_debug_marker");
         //TODO
     }
 }

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -43,6 +43,7 @@ use crate::{
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Input, Storage, Token},
     id,
     resource::BufferUse,
+    span,
     track::TrackerSet,
     LifeGuard, RefCount, Stored, MAX_BIND_GROUPS,
 };
@@ -62,6 +63,7 @@ impl RenderBundleEncoder {
         parent_id: id::DeviceId,
         base: Option<BasePass<RenderCommand>>,
     ) -> Self {
+        span!(_guard, TRACE, "RenderBundleEncoder::new");
         RenderBundleEncoder {
             base: base.unwrap_or_else(BasePass::new),
             parent_id,
@@ -481,6 +483,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::RenderBundleDescriptor<Label>,
         id_in: Input<G, id::RenderBundleId>,
     ) -> id::RenderBundleId {
+        span!(_guard, TRACE, "RenderBundleEncoder::finish");
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -752,7 +755,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
 pub mod bundle_ffi {
     use super::{RenderBundleEncoder, RenderCommand};
-    use crate::{id, RawString};
+    use crate::{id, RawString, span};
     use std::{convert::TryInto, slice};
     use wgt::{BufferAddress, BufferSize, DynamicOffset};
 
@@ -770,6 +773,7 @@ pub mod bundle_ffi {
         offsets: *const DynamicOffset,
         offset_length: usize,
     ) {
+        span!(_guard, TRACE, "RenderBundle::set_bind_group");
         bundle.base.commands.push(RenderCommand::SetBindGroup {
             index: index.try_into().unwrap(),
             num_dynamic_offsets: offset_length.try_into().unwrap(),
@@ -786,6 +790,7 @@ pub mod bundle_ffi {
         bundle: &mut RenderBundleEncoder,
         pipeline_id: id::RenderPipelineId,
     ) {
+        span!(_guard, TRACE, "RenderBundle::set_pipeline");
         bundle
             .base
             .commands
@@ -799,6 +804,7 @@ pub mod bundle_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
+        span!(_guard, TRACE, "RenderBundle::set_index_buffer");
         bundle.base.commands.push(RenderCommand::SetIndexBuffer {
             buffer_id,
             offset,
@@ -814,6 +820,7 @@ pub mod bundle_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
+        span!(_guard, TRACE, "RenderBundle::set_vertex_buffer");
         bundle.base.commands.push(RenderCommand::SetVertexBuffer {
             slot,
             buffer_id,
@@ -830,6 +837,7 @@ pub mod bundle_ffi {
         first_vertex: u32,
         first_instance: u32,
     ) {
+        span!(_guard, TRACE, "RenderBundle::draw");
         bundle.base.commands.push(RenderCommand::Draw {
             vertex_count,
             instance_count,
@@ -847,6 +855,7 @@ pub mod bundle_ffi {
         base_vertex: i32,
         first_instance: u32,
     ) {
+        span!(_guard, TRACE, "RenderBundle::draw_indexed");
         bundle.base.commands.push(RenderCommand::DrawIndexed {
             index_count,
             instance_count,
@@ -862,6 +871,7 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
+        span!(_guard, TRACE, "RenderBundle::draw_indirect");
         bundle
             .base
             .commands
@@ -874,6 +884,7 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
+        span!(_guard, TRACE, "RenderBundle::draw_indexed_indirect");
         bundle
             .base
             .commands
@@ -885,11 +896,13 @@ pub mod bundle_ffi {
         _bundle: &mut RenderBundleEncoder,
         _label: RawString,
     ) {
+        span!(_guard, TRACE, "RenderBundle::push_debug_group");
         //TODO
     }
 
     #[no_mangle]
     pub unsafe extern "C" fn wgpu_render_bundle_pop_debug_group(_bundle: &mut RenderBundleEncoder) {
+        span!(_guard, TRACE, "RenderBundle::pop_debug_group");
         //TODO
     }
 
@@ -898,6 +911,7 @@ pub mod bundle_ffi {
         _bundle: &mut RenderBundleEncoder,
         _label: RawString,
     ) {
+        span!(_guard, TRACE, "RenderBundle::insert_debug_marker");
         //TODO
     }
 }

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -63,7 +63,7 @@ impl RenderBundleEncoder {
         parent_id: id::DeviceId,
         base: Option<BasePass<RenderCommand>>,
     ) -> Self {
-        span!(_guard, TRACE, "RenderBundleEncoder::new");
+        span!(_guard, ERROR, "RenderBundleEncoder::new");
         RenderBundleEncoder {
             base: base.unwrap_or_else(BasePass::new),
             parent_id,
@@ -483,7 +483,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::RenderBundleDescriptor<Label>,
         id_in: Input<G, id::RenderBundleId>,
     ) -> id::RenderBundleId {
-        span!(_guard, TRACE, "RenderBundleEncoder::finish");
+        span!(_guard, ERROR, "RenderBundleEncoder::finish");
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -755,7 +755,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
 pub mod bundle_ffi {
     use super::{RenderBundleEncoder, RenderCommand};
-    use crate::{id, RawString, span};
+    use crate::{id, span, RawString};
     use std::{convert::TryInto, slice};
     use wgt::{BufferAddress, BufferSize, DynamicOffset};
 
@@ -773,7 +773,7 @@ pub mod bundle_ffi {
         offsets: *const DynamicOffset,
         offset_length: usize,
     ) {
-        span!(_guard, TRACE, "RenderBundle::set_bind_group");
+        span!(_guard, ERROR, "RenderBundle::set_bind_group");
         bundle.base.commands.push(RenderCommand::SetBindGroup {
             index: index.try_into().unwrap(),
             num_dynamic_offsets: offset_length.try_into().unwrap(),
@@ -790,7 +790,7 @@ pub mod bundle_ffi {
         bundle: &mut RenderBundleEncoder,
         pipeline_id: id::RenderPipelineId,
     ) {
-        span!(_guard, TRACE, "RenderBundle::set_pipeline");
+        span!(_guard, ERROR, "RenderBundle::set_pipeline");
         bundle
             .base
             .commands
@@ -804,7 +804,7 @@ pub mod bundle_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        span!(_guard, TRACE, "RenderBundle::set_index_buffer");
+        span!(_guard, ERROR, "RenderBundle::set_index_buffer");
         bundle.base.commands.push(RenderCommand::SetIndexBuffer {
             buffer_id,
             offset,
@@ -820,7 +820,7 @@ pub mod bundle_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        span!(_guard, TRACE, "RenderBundle::set_vertex_buffer");
+        span!(_guard, ERROR, "RenderBundle::set_vertex_buffer");
         bundle.base.commands.push(RenderCommand::SetVertexBuffer {
             slot,
             buffer_id,
@@ -837,7 +837,7 @@ pub mod bundle_ffi {
         first_vertex: u32,
         first_instance: u32,
     ) {
-        span!(_guard, TRACE, "RenderBundle::draw");
+        span!(_guard, ERROR, "RenderBundle::draw");
         bundle.base.commands.push(RenderCommand::Draw {
             vertex_count,
             instance_count,
@@ -855,7 +855,7 @@ pub mod bundle_ffi {
         base_vertex: i32,
         first_instance: u32,
     ) {
-        span!(_guard, TRACE, "RenderBundle::draw_indexed");
+        span!(_guard, ERROR, "RenderBundle::draw_indexed");
         bundle.base.commands.push(RenderCommand::DrawIndexed {
             index_count,
             instance_count,
@@ -871,7 +871,7 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, TRACE, "RenderBundle::draw_indirect");
+        span!(_guard, ERROR, "RenderBundle::draw_indirect");
         bundle
             .base
             .commands
@@ -884,7 +884,7 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, TRACE, "RenderBundle::draw_indexed_indirect");
+        span!(_guard, ERROR, "RenderBundle::draw_indexed_indirect");
         bundle
             .base
             .commands
@@ -896,13 +896,13 @@ pub mod bundle_ffi {
         _bundle: &mut RenderBundleEncoder,
         _label: RawString,
     ) {
-        span!(_guard, TRACE, "RenderBundle::push_debug_group");
+        span!(_guard, ERROR, "RenderBundle::push_debug_group");
         //TODO
     }
 
     #[no_mangle]
     pub unsafe extern "C" fn wgpu_render_bundle_pop_debug_group(_bundle: &mut RenderBundleEncoder) {
-        span!(_guard, TRACE, "RenderBundle::pop_debug_group");
+        span!(_guard, ERROR, "RenderBundle::pop_debug_group");
         //TODO
     }
 
@@ -911,7 +911,7 @@ pub mod bundle_ffi {
         _bundle: &mut RenderBundleEncoder,
         _label: RawString,
     ) {
-        span!(_guard, TRACE, "RenderBundle::insert_debug_marker");
+        span!(_guard, ERROR, "RenderBundle::insert_debug_marker");
         //TODO
     }
 }

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -107,7 +107,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         mut base: BasePassRef<ComputeCommand>,
     ) {
-        span!(_guard, TRACE, "CommandEncoder::run_compute_pass");
+        span!(_guard, ERROR, "CommandEncoder::run_compute_pass");
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -316,7 +316,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
 pub mod compute_ffi {
     use super::{ComputeCommand, ComputePass};
-    use crate::{id, RawString, span};
+    use crate::{id, span, RawString};
     use std::{convert::TryInto, ffi, slice};
     use wgt::{BufferAddress, DynamicOffset};
 
@@ -334,7 +334,7 @@ pub mod compute_ffi {
         offsets: *const DynamicOffset,
         offset_length: usize,
     ) {
-        span!(_guard, TRACE, "ComputePass::set_bind_group");
+        span!(_guard, ERROR, "ComputePass::set_bind_group");
         pass.base.commands.push(ComputeCommand::SetBindGroup {
             index: index.try_into().unwrap(),
             num_dynamic_offsets: offset_length.try_into().unwrap(),
@@ -350,7 +350,7 @@ pub mod compute_ffi {
         pass: &mut ComputePass,
         pipeline_id: id::ComputePipelineId,
     ) {
-        span!(_guard, TRACE, "ComputePass::set_pipeline");
+        span!(_guard, ERROR, "ComputePass::set_pipeline");
         pass.base
             .commands
             .push(ComputeCommand::SetPipeline(pipeline_id));
@@ -363,7 +363,7 @@ pub mod compute_ffi {
         groups_y: u32,
         groups_z: u32,
     ) {
-        span!(_guard, TRACE, "ComputePass::dispatch");
+        span!(_guard, ERROR, "ComputePass::dispatch");
         pass.base
             .commands
             .push(ComputeCommand::Dispatch([groups_x, groups_y, groups_z]));
@@ -375,7 +375,7 @@ pub mod compute_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, TRACE, "ComputePass::dispatch_indirect");
+        span!(_guard, ERROR, "ComputePass::dispatch_indirect");
         pass.base
             .commands
             .push(ComputeCommand::DispatchIndirect { buffer_id, offset });
@@ -387,7 +387,7 @@ pub mod compute_ffi {
         label: RawString,
         color: u32,
     ) {
-        span!(_guard, TRACE, "ComputePass::push_debug_group");
+        span!(_guard, ERROR, "ComputePass::push_debug_group");
         let bytes = ffi::CStr::from_ptr(label).to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 
@@ -399,7 +399,7 @@ pub mod compute_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_compute_pass_pop_debug_group(pass: &mut ComputePass) {
-        span!(_guard, TRACE, "ComputePass::pop_debug_group");
+        span!(_guard, ERROR, "ComputePass::pop_debug_group");
         pass.base.commands.push(ComputeCommand::PopDebugGroup);
     }
 
@@ -409,7 +409,7 @@ pub mod compute_ffi {
         label: RawString,
         color: u32,
     ) {
-        span!(_guard, TRACE, "ComputePass::insert_debug_marker");
+        span!(_guard, ERROR, "ComputePass::insert_debug_marker");
         let bytes = ffi::CStr::from_ptr(label).to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -11,6 +11,7 @@ use crate::{
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Token},
     id,
     resource::BufferUse,
+    span,
 };
 
 use hal::command::CommandBuffer as _;
@@ -106,6 +107,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         mut base: BasePassRef<ComputeCommand>,
     ) {
+        span!(_guard, TRACE, "CommandEncoder::run_compute_pass");
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -314,7 +316,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
 pub mod compute_ffi {
     use super::{ComputeCommand, ComputePass};
-    use crate::{id, RawString};
+    use crate::{id, RawString, span};
     use std::{convert::TryInto, ffi, slice};
     use wgt::{BufferAddress, DynamicOffset};
 
@@ -332,6 +334,7 @@ pub mod compute_ffi {
         offsets: *const DynamicOffset,
         offset_length: usize,
     ) {
+        span!(_guard, TRACE, "ComputePass::set_bind_group");
         pass.base.commands.push(ComputeCommand::SetBindGroup {
             index: index.try_into().unwrap(),
             num_dynamic_offsets: offset_length.try_into().unwrap(),
@@ -347,6 +350,7 @@ pub mod compute_ffi {
         pass: &mut ComputePass,
         pipeline_id: id::ComputePipelineId,
     ) {
+        span!(_guard, TRACE, "ComputePass::set_pipeline");
         pass.base
             .commands
             .push(ComputeCommand::SetPipeline(pipeline_id));
@@ -359,6 +363,7 @@ pub mod compute_ffi {
         groups_y: u32,
         groups_z: u32,
     ) {
+        span!(_guard, TRACE, "ComputePass::dispatch");
         pass.base
             .commands
             .push(ComputeCommand::Dispatch([groups_x, groups_y, groups_z]));
@@ -370,6 +375,7 @@ pub mod compute_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
+        span!(_guard, TRACE, "ComputePass::dispatch_indirect");
         pass.base
             .commands
             .push(ComputeCommand::DispatchIndirect { buffer_id, offset });
@@ -381,6 +387,7 @@ pub mod compute_ffi {
         label: RawString,
         color: u32,
     ) {
+        span!(_guard, TRACE, "ComputePass::push_debug_group");
         let bytes = ffi::CStr::from_ptr(label).to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 
@@ -392,6 +399,7 @@ pub mod compute_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_compute_pass_pop_debug_group(pass: &mut ComputePass) {
+        span!(_guard, TRACE, "ComputePass::pop_debug_group");
         pass.base.commands.push(ComputeCommand::PopDebugGroup);
     }
 
@@ -401,6 +409,7 @@ pub mod compute_ffi {
         label: RawString,
         color: u32,
     ) {
+        span!(_guard, TRACE, "ComputePass::insert_debug_marker");
         let bytes = ffi::CStr::from_ptr(label).to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -107,7 +107,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         mut base: BasePassRef<ComputeCommand>,
     ) {
-        span!(_guard, ERROR, "CommandEncoder::run_compute_pass");
+        span!(_guard, INFO, "CommandEncoder::run_compute_pass");
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -254,7 +254,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     assert_eq!(
                         state.pipeline,
                         PipelineState::Set,
-                        "Dispatch error: Pipeline is missing"
+                        "Dispatch DEBUG: Pipeline is missing"
                     );
                     unsafe {
                         raw.dispatch(groups);
@@ -264,7 +264,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     assert_eq!(
                         state.pipeline,
                         PipelineState::Set,
-                        "Dispatch error: Pipeline is missing"
+                        "Dispatch DEBUG: Pipeline is missing"
                     );
                     let (src_buffer, src_pending) = cmb.trackers.buffers.use_replace(
                         &*buffer_guard,
@@ -334,7 +334,7 @@ pub mod compute_ffi {
         offsets: *const DynamicOffset,
         offset_length: usize,
     ) {
-        span!(_guard, ERROR, "ComputePass::set_bind_group");
+        span!(_guard, DEBUG, "ComputePass::set_bind_group");
         pass.base.commands.push(ComputeCommand::SetBindGroup {
             index: index.try_into().unwrap(),
             num_dynamic_offsets: offset_length.try_into().unwrap(),
@@ -350,7 +350,7 @@ pub mod compute_ffi {
         pass: &mut ComputePass,
         pipeline_id: id::ComputePipelineId,
     ) {
-        span!(_guard, ERROR, "ComputePass::set_pipeline");
+        span!(_guard, DEBUG, "ComputePass::set_pipeline");
         pass.base
             .commands
             .push(ComputeCommand::SetPipeline(pipeline_id));
@@ -363,7 +363,7 @@ pub mod compute_ffi {
         groups_y: u32,
         groups_z: u32,
     ) {
-        span!(_guard, ERROR, "ComputePass::dispatch");
+        span!(_guard, DEBUG, "ComputePass::dispatch");
         pass.base
             .commands
             .push(ComputeCommand::Dispatch([groups_x, groups_y, groups_z]));
@@ -375,7 +375,7 @@ pub mod compute_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, ERROR, "ComputePass::dispatch_indirect");
+        span!(_guard, DEBUG, "ComputePass::dispatch_indirect");
         pass.base
             .commands
             .push(ComputeCommand::DispatchIndirect { buffer_id, offset });
@@ -387,7 +387,7 @@ pub mod compute_ffi {
         label: RawString,
         color: u32,
     ) {
-        span!(_guard, ERROR, "ComputePass::push_debug_group");
+        span!(_guard, DEBUG, "ComputePass::push_debug_group");
         let bytes = ffi::CStr::from_ptr(label).to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 
@@ -399,7 +399,7 @@ pub mod compute_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_compute_pass_pop_debug_group(pass: &mut ComputePass) {
-        span!(_guard, ERROR, "ComputePass::pop_debug_group");
+        span!(_guard, DEBUG, "ComputePass::pop_debug_group");
         pass.base.commands.push(ComputeCommand::PopDebugGroup);
     }
 
@@ -409,7 +409,7 @@ pub mod compute_ffi {
         label: RawString,
         color: u32,
     ) {
-        span!(_guard, ERROR, "ComputePass::insert_debug_marker");
+        span!(_guard, DEBUG, "ComputePass::insert_debug_marker");
         let bytes = ffi::CStr::from_ptr(label).to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Storage, Token},
     id,
     resource::{Buffer, Texture},
+    span,
     track::TrackerSet,
     PrivateFeatures, Stored,
 };
@@ -139,6 +140,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         _desc: &wgt::CommandBufferDescriptor,
     ) -> id::CommandBufferId {
+        span!(_guard, TRACE, "CommandEncoder::finish");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (swap_chain_guard, mut token) = hub.swap_chains.read(&mut token);
@@ -164,6 +167,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) {
+        span!(_guard, TRACE, "CommandEncoder::push_debug_group");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -181,6 +186,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) {
+        span!(_guard, TRACE, "CommandEncoder::insert_debug_marker");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -194,6 +201,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_encoder_pop_debug_group<B: GfxBackend>(&self, encoder_id: id::CommandEncoderId) {
+        span!(_guard, TRACE, "CommandEncoder::pop_debug_marker");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -140,7 +140,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         _desc: &wgt::CommandBufferDescriptor,
     ) -> id::CommandBufferId {
-        span!(_guard, ERROR, "CommandEncoder::finish");
+        span!(_guard, INFO, "CommandEncoder::finish");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -167,7 +167,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) {
-        span!(_guard, ERROR, "CommandEncoder::push_debug_group");
+        span!(_guard, DEBUG, "CommandEncoder::push_debug_group");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -186,7 +186,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) {
-        span!(_guard, ERROR, "CommandEncoder::insert_debug_marker");
+        span!(_guard, DEBUG, "CommandEncoder::insert_debug_marker");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -201,7 +201,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_encoder_pop_debug_group<B: GfxBackend>(&self, encoder_id: id::CommandEncoderId) {
-        span!(_guard, ERROR, "CommandEncoder::pop_debug_marker");
+        span!(_guard, DEBUG, "CommandEncoder::pop_debug_marker");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -140,7 +140,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         _desc: &wgt::CommandBufferDescriptor,
     ) -> id::CommandBufferId {
-        span!(_guard, TRACE, "CommandEncoder::finish");
+        span!(_guard, ERROR, "CommandEncoder::finish");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -167,7 +167,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) {
-        span!(_guard, TRACE, "CommandEncoder::push_debug_group");
+        span!(_guard, ERROR, "CommandEncoder::push_debug_group");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -186,7 +186,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) {
-        span!(_guard, TRACE, "CommandEncoder::insert_debug_marker");
+        span!(_guard, ERROR, "CommandEncoder::insert_debug_marker");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -201,7 +201,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_encoder_pop_debug_group<B: GfxBackend>(&self, encoder_id: id::CommandEncoderId) {
-        span!(_guard, TRACE, "CommandEncoder::pop_debug_marker");
+        span!(_guard, ERROR, "CommandEncoder::pop_debug_marker");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -342,7 +342,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         color_attachments: &[ColorAttachmentDescriptor],
         depth_stencil_attachment: Option<&DepthStencilAttachmentDescriptor>,
     ) {
-        span!(_guard, ERROR, "CommandEncoder::run_render_pass");
+        span!(_guard, INFO, "CommandEncoder::run_render_pass");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1317,7 +1317,7 @@ pub mod render_ffi {
         offsets: *const DynamicOffset,
         offset_length: usize,
     ) {
-        span!(_guard, ERROR, "RenderPass::set_bind_group");
+        span!(_guard, DEBUG, "RenderPass::set_bind_group");
         pass.base.commands.push(RenderCommand::SetBindGroup {
             index: index.try_into().unwrap(),
             num_dynamic_offsets: offset_length.try_into().unwrap(),
@@ -1333,7 +1333,7 @@ pub mod render_ffi {
         pass: &mut RenderPass,
         pipeline_id: id::RenderPipelineId,
     ) {
-        span!(_guard, ERROR, "RenderPass::set_pipeline");
+        span!(_guard, DEBUG, "RenderPass::set_pipeline");
         pass.base
             .commands
             .push(RenderCommand::SetPipeline(pipeline_id));
@@ -1346,7 +1346,7 @@ pub mod render_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        span!(_guard, ERROR, "RenderPass::set_index_buffer");
+        span!(_guard, DEBUG, "RenderPass::set_index_buffer");
         pass.base.commands.push(RenderCommand::SetIndexBuffer {
             buffer_id,
             offset,
@@ -1362,7 +1362,7 @@ pub mod render_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        span!(_guard, ERROR, "RenderPass::set_vertex_buffer");
+        span!(_guard, DEBUG, "RenderPass::set_vertex_buffer");
         pass.base.commands.push(RenderCommand::SetVertexBuffer {
             slot,
             buffer_id,
@@ -1373,7 +1373,7 @@ pub mod render_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_pass_set_blend_color(pass: &mut RenderPass, color: &Color) {
-        span!(_guard, ERROR, "RenderPass::set_blend_color");
+        span!(_guard, DEBUG, "RenderPass::set_blend_color");
         pass.base
             .commands
             .push(RenderCommand::SetBlendColor(*color));
@@ -1381,7 +1381,7 @@ pub mod render_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_pass_set_stencil_reference(pass: &mut RenderPass, value: u32) {
-        span!(_guard, ERROR, "RenderPass::set_stencil_buffer");
+        span!(_guard, DEBUG, "RenderPass::set_stencil_buffer");
         pass.base
             .commands
             .push(RenderCommand::SetStencilReference(value));
@@ -1397,7 +1397,7 @@ pub mod render_ffi {
         depth_min: f32,
         depth_max: f32,
     ) {
-        span!(_guard, ERROR, "RenderPass::set_viewport");
+        span!(_guard, DEBUG, "RenderPass::set_viewport");
         pass.base.commands.push(RenderCommand::SetViewport {
             rect: Rect { x, y, w, h },
             depth_min,
@@ -1413,7 +1413,7 @@ pub mod render_ffi {
         w: u32,
         h: u32,
     ) {
-        span!(_guard, ERROR, "RenderPass::set_scissor_rect");
+        span!(_guard, DEBUG, "RenderPass::set_scissor_rect");
         pass.base
             .commands
             .push(RenderCommand::SetScissor(Rect { x, y, w, h }));
@@ -1427,7 +1427,7 @@ pub mod render_ffi {
         first_vertex: u32,
         first_instance: u32,
     ) {
-        span!(_guard, ERROR, "RenderPass::draw");
+        span!(_guard, DEBUG, "RenderPass::draw");
         pass.base.commands.push(RenderCommand::Draw {
             vertex_count,
             instance_count,
@@ -1445,7 +1445,7 @@ pub mod render_ffi {
         base_vertex: i32,
         first_instance: u32,
     ) {
-        span!(_guard, ERROR, "RenderPass::draw_indexed");
+        span!(_guard, DEBUG, "RenderPass::draw_indexed");
         pass.base.commands.push(RenderCommand::DrawIndexed {
             index_count,
             instance_count,
@@ -1461,7 +1461,7 @@ pub mod render_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, ERROR, "RenderPass::draw_indirect");
+        span!(_guard, DEBUG, "RenderPass::draw_indirect");
         pass.base
             .commands
             .push(RenderCommand::DrawIndirect { buffer_id, offset });
@@ -1473,7 +1473,7 @@ pub mod render_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, ERROR, "RenderPass::draw_indexed_indirect");
+        span!(_guard, DEBUG, "RenderPass::draw_indexed_indirect");
         pass.base
             .commands
             .push(RenderCommand::DrawIndexedIndirect { buffer_id, offset });
@@ -1485,7 +1485,7 @@ pub mod render_ffi {
         label: RawString,
         color: u32,
     ) {
-        span!(_guard, ERROR, "RenderPass::push_debug_group");
+        span!(_guard, DEBUG, "RenderPass::push_debug_group");
         let bytes = ffi::CStr::from_ptr(label).to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 
@@ -1497,7 +1497,7 @@ pub mod render_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_pass_pop_debug_group(pass: &mut RenderPass) {
-        span!(_guard, ERROR, "RenderPass::pop_debug_group");
+        span!(_guard, DEBUG, "RenderPass::pop_debug_group");
         pass.base.commands.push(RenderCommand::PopDebugGroup);
     }
 
@@ -1507,7 +1507,7 @@ pub mod render_ffi {
         label: RawString,
         color: u32,
     ) {
-        span!(_guard, ERROR, "RenderPass::insert_debug_marker");
+        span!(_guard, DEBUG, "RenderPass::insert_debug_marker");
         let bytes = ffi::CStr::from_ptr(label).to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 
@@ -1523,7 +1523,7 @@ pub mod render_ffi {
         render_bundle_ids: *const id::RenderBundleId,
         render_bundle_ids_length: usize,
     ) {
-        span!(_guard, ERROR, "RenderPass::execute_bundles");
+        span!(_guard, DEBUG, "RenderPass::execute_bundles");
         for &bundle_id in slice::from_raw_parts(render_bundle_ids, render_bundle_ids_length) {
             pass.base
                 .commands

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -342,7 +342,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         color_attachments: &[ColorAttachmentDescriptor],
         depth_stencil_attachment: Option<&DepthStencilAttachmentDescriptor>,
     ) {
-        span!(_guard, TRACE, "CommandEncoder::run_render_pass");
+        span!(_guard, ERROR, "CommandEncoder::run_render_pass");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1317,7 +1317,7 @@ pub mod render_ffi {
         offsets: *const DynamicOffset,
         offset_length: usize,
     ) {
-        span!(_guard, TRACE, "RenderPass::set_bind_group");
+        span!(_guard, ERROR, "RenderPass::set_bind_group");
         pass.base.commands.push(RenderCommand::SetBindGroup {
             index: index.try_into().unwrap(),
             num_dynamic_offsets: offset_length.try_into().unwrap(),
@@ -1333,7 +1333,7 @@ pub mod render_ffi {
         pass: &mut RenderPass,
         pipeline_id: id::RenderPipelineId,
     ) {
-        span!(_guard, TRACE, "RenderPass::set_pipeline");
+        span!(_guard, ERROR, "RenderPass::set_pipeline");
         pass.base
             .commands
             .push(RenderCommand::SetPipeline(pipeline_id));
@@ -1346,7 +1346,7 @@ pub mod render_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        span!(_guard, TRACE, "RenderPass::set_index_buffer");
+        span!(_guard, ERROR, "RenderPass::set_index_buffer");
         pass.base.commands.push(RenderCommand::SetIndexBuffer {
             buffer_id,
             offset,
@@ -1362,7 +1362,7 @@ pub mod render_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        span!(_guard, TRACE, "RenderPass::set_vertex_buffer");
+        span!(_guard, ERROR, "RenderPass::set_vertex_buffer");
         pass.base.commands.push(RenderCommand::SetVertexBuffer {
             slot,
             buffer_id,
@@ -1373,7 +1373,7 @@ pub mod render_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_pass_set_blend_color(pass: &mut RenderPass, color: &Color) {
-        span!(_guard, TRACE, "RenderPass::set_blend_color");
+        span!(_guard, ERROR, "RenderPass::set_blend_color");
         pass.base
             .commands
             .push(RenderCommand::SetBlendColor(*color));
@@ -1381,7 +1381,7 @@ pub mod render_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_pass_set_stencil_reference(pass: &mut RenderPass, value: u32) {
-        span!(_guard, TRACE, "RenderPass::set_stencil_buffer");
+        span!(_guard, ERROR, "RenderPass::set_stencil_buffer");
         pass.base
             .commands
             .push(RenderCommand::SetStencilReference(value));
@@ -1397,7 +1397,7 @@ pub mod render_ffi {
         depth_min: f32,
         depth_max: f32,
     ) {
-        span!(_guard, TRACE, "RenderPass::set_viewport");
+        span!(_guard, ERROR, "RenderPass::set_viewport");
         pass.base.commands.push(RenderCommand::SetViewport {
             rect: Rect { x, y, w, h },
             depth_min,
@@ -1413,7 +1413,7 @@ pub mod render_ffi {
         w: u32,
         h: u32,
     ) {
-        span!(_guard, TRACE, "RenderPass::set_scissor_rect");
+        span!(_guard, ERROR, "RenderPass::set_scissor_rect");
         pass.base
             .commands
             .push(RenderCommand::SetScissor(Rect { x, y, w, h }));
@@ -1427,7 +1427,7 @@ pub mod render_ffi {
         first_vertex: u32,
         first_instance: u32,
     ) {
-        span!(_guard, TRACE, "RenderPass::draw");
+        span!(_guard, ERROR, "RenderPass::draw");
         pass.base.commands.push(RenderCommand::Draw {
             vertex_count,
             instance_count,
@@ -1445,7 +1445,7 @@ pub mod render_ffi {
         base_vertex: i32,
         first_instance: u32,
     ) {
-        span!(_guard, TRACE, "RenderPass::draw_indexed");
+        span!(_guard, ERROR, "RenderPass::draw_indexed");
         pass.base.commands.push(RenderCommand::DrawIndexed {
             index_count,
             instance_count,
@@ -1461,7 +1461,7 @@ pub mod render_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, TRACE, "RenderPass::draw_indirect");
+        span!(_guard, ERROR, "RenderPass::draw_indirect");
         pass.base
             .commands
             .push(RenderCommand::DrawIndirect { buffer_id, offset });
@@ -1473,7 +1473,7 @@ pub mod render_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, TRACE, "RenderPass::draw_indexed_indirect");
+        span!(_guard, ERROR, "RenderPass::draw_indexed_indirect");
         pass.base
             .commands
             .push(RenderCommand::DrawIndexedIndirect { buffer_id, offset });
@@ -1485,7 +1485,7 @@ pub mod render_ffi {
         label: RawString,
         color: u32,
     ) {
-        span!(_guard, TRACE, "RenderPass::push_debug_group");
+        span!(_guard, ERROR, "RenderPass::push_debug_group");
         let bytes = ffi::CStr::from_ptr(label).to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 
@@ -1497,7 +1497,7 @@ pub mod render_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_pass_pop_debug_group(pass: &mut RenderPass) {
-        span!(_guard, TRACE, "RenderPass::pop_debug_group");
+        span!(_guard, ERROR, "RenderPass::pop_debug_group");
         pass.base.commands.push(RenderCommand::PopDebugGroup);
     }
 
@@ -1507,7 +1507,7 @@ pub mod render_ffi {
         label: RawString,
         color: u32,
     ) {
-        span!(_guard, TRACE, "RenderPass::insert_debug_marker");
+        span!(_guard, ERROR, "RenderPass::insert_debug_marker");
         let bytes = ffi::CStr::from_ptr(label).to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 
@@ -1523,7 +1523,7 @@ pub mod render_ffi {
         render_bundle_ids: *const id::RenderBundleId,
         render_bundle_ids_length: usize,
     ) {
-        span!(_guard, TRACE, "RenderPass::execute_bundles");
+        span!(_guard, ERROR, "RenderPass::execute_bundles");
         for &bundle_id in slice::from_raw_parts(render_bundle_ids, render_bundle_ids_length) {
             pass.base
                 .commands

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -10,6 +10,7 @@ use crate::{
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Storage, Token},
     id::{BufferId, CommandEncoderId, TextureId},
     resource::{BufferUse, Texture, TextureUse},
+    span,
 };
 
 use hal::command::CommandBuffer as _;
@@ -266,6 +267,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination_offset: BufferAddress,
         size: BufferAddress,
     ) {
+        span!(_guard, TRACE, "CommandEncoder::copy_buffer_to_buffer");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -379,6 +382,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &TextureCopyView,
         copy_size: &Extent3d,
     ) {
+        span!(_guard, TRACE, "CommandEncoder::copy_buffer_to_texture");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (mut cmb_guard, mut token) = hub.command_buffers.write(&mut token);
@@ -472,6 +477,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &BufferCopyView,
         copy_size: &Extent3d,
     ) {
+        span!(_guard, TRACE, "CommandEncoder::copy_texture_to_buffer");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (mut cmb_guard, mut token) = hub.command_buffers.write(&mut token);
@@ -573,6 +580,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &TextureCopyView,
         copy_size: &Extent3d,
     ) {
+        span!(_guard, TRACE, "CommandEncoder::copy_texture_to_texture");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -267,7 +267,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination_offset: BufferAddress,
         size: BufferAddress,
     ) {
-        span!(_guard, ERROR, "CommandEncoder::copy_buffer_to_buffer");
+        span!(_guard, INFO, "CommandEncoder::copy_buffer_to_buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -382,7 +382,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &TextureCopyView,
         copy_size: &Extent3d,
     ) {
-        span!(_guard, ERROR, "CommandEncoder::copy_buffer_to_texture");
+        span!(_guard, INFO, "CommandEncoder::copy_buffer_to_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -477,7 +477,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &BufferCopyView,
         copy_size: &Extent3d,
     ) {
-        span!(_guard, ERROR, "CommandEncoder::copy_texture_to_buffer");
+        span!(_guard, INFO, "CommandEncoder::copy_texture_to_buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -580,7 +580,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &TextureCopyView,
         copy_size: &Extent3d,
     ) {
-        span!(_guard, ERROR, "CommandEncoder::copy_texture_to_texture");
+        span!(_guard, INFO, "CommandEncoder::copy_texture_to_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -267,7 +267,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination_offset: BufferAddress,
         size: BufferAddress,
     ) {
-        span!(_guard, TRACE, "CommandEncoder::copy_buffer_to_buffer");
+        span!(_guard, ERROR, "CommandEncoder::copy_buffer_to_buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -382,7 +382,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &TextureCopyView,
         copy_size: &Extent3d,
     ) {
-        span!(_guard, TRACE, "CommandEncoder::copy_buffer_to_texture");
+        span!(_guard, ERROR, "CommandEncoder::copy_buffer_to_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -477,7 +477,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &BufferCopyView,
         copy_size: &Extent3d,
     ) {
-        span!(_guard, TRACE, "CommandEncoder::copy_texture_to_buffer");
+        span!(_guard, ERROR, "CommandEncoder::copy_texture_to_buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -580,7 +580,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &TextureCopyView,
         copy_size: &Extent3d,
     ) {
-        span!(_guard, TRACE, "CommandEncoder::copy_texture_to_texture");
+        span!(_guard, ERROR, "CommandEncoder::copy_texture_to_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -635,7 +635,7 @@ impl<B: hal::Backend> Device<B> {
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn device_extensions<B: GfxBackend>(&self, device_id: id::DeviceId) -> wgt::Extensions {
-        span!(_guard, TRACE, "Device::extensions");
+        span!(_guard, ERROR, "Device::extensions");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -646,7 +646,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_limits<B: GfxBackend>(&self, device_id: id::DeviceId) -> wgt::Limits {
-        span!(_guard, TRACE, "Device::limits");
+        span!(_guard, ERROR, "Device::limits");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -657,7 +657,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_capabilities<B: GfxBackend>(&self, device_id: id::DeviceId) -> wgt::Capabilities {
-        span!(_guard, TRACE, "Device::capabilities");
+        span!(_guard, ERROR, "Device::capabilities");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -673,7 +673,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::BufferDescriptor<Label>,
         id_in: Input<G, id::BufferId>,
     ) -> id::BufferId {
-        span!(_guard, TRACE, "Device::create_buffer");
+        span!(_guard, ERROR, "Device::create_buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -793,7 +793,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         data: &[u8],
     ) {
-        span!(_guard, TRACE, "Device::set_buffer_sub_data");
+        span!(_guard, ERROR, "Device::set_buffer_sub_data");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -852,7 +852,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         data: &mut [u8],
     ) {
-        span!(_guard, TRACE, "Device::get_buffer_sub_data");
+        span!(_guard, ERROR, "Device::get_buffer_sub_data");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -890,7 +890,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn buffer_destroy<B: GfxBackend>(&self, buffer_id: id::BufferId) {
-        span!(_guard, TRACE, "Buffer::destroy");
+        span!(_guard, ERROR, "Buffer::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -916,7 +916,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::TextureDescriptor<Label>,
         id_in: Input<G, id::TextureId>,
     ) -> id::TextureId {
-        span!(_guard, TRACE, "Device::create_texture");
+        span!(_guard, ERROR, "Device::create_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -947,7 +947,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn texture_destroy<B: GfxBackend>(&self, texture_id: id::TextureId) {
-        span!(_guard, TRACE, "Texture::destroy");
+        span!(_guard, ERROR, "Texture::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -972,7 +972,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: Option<&wgt::TextureViewDescriptor<Label>>,
         id_in: Input<G, id::TextureViewId>,
     ) -> id::TextureViewId {
-        span!(_guard, TRACE, "Texture::create_view");
+        span!(_guard, ERROR, "Texture::create_view");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1064,7 +1064,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn texture_view_destroy<B: GfxBackend>(&self, texture_view_id: id::TextureViewId) {
-        span!(_guard, TRACE, "Texture::view_destroy");
+        span!(_guard, ERROR, "Texture::view_destroy");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1099,7 +1099,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::SamplerDescriptor<Label>,
         id_in: Input<G, id::SamplerId>,
     ) -> id::SamplerId {
-        span!(_guard, TRACE, "Device::create_sampler");
+        span!(_guard, ERROR, "Device::create_sampler");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1166,7 +1166,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn sampler_destroy<B: GfxBackend>(&self, sampler_id: id::SamplerId) {
-        span!(_guard, TRACE, "Sampler::destroy");
+        span!(_guard, ERROR, "Sampler::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1192,7 +1192,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::BindGroupLayoutDescriptor,
         id_in: Input<G, id::BindGroupLayoutId>,
     ) -> Result<id::BindGroupLayoutId, binding_model::BindGroupLayoutError> {
-        span!(_guard, TRACE, "Device::create_bind_group_layout");
+        span!(_guard, ERROR, "Device::create_bind_group_layout");
 
         let mut token = Token::root();
         let hub = B::hub(self);
@@ -1312,7 +1312,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         bind_group_layout_id: id::BindGroupLayoutId,
     ) {
-        span!(_guard, TRACE, "BindGroupLayout::destroy");
+        span!(_guard, ERROR, "BindGroupLayout::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1342,7 +1342,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &binding_model::PipelineLayoutDescriptor,
         id_in: Input<G, id::PipelineLayoutId>,
     ) -> Result<id::PipelineLayoutId, binding_model::PipelineLayoutError> {
-        span!(_guard, TRACE, "Device::create_pipeline_layout");
+        span!(_guard, ERROR, "Device::create_pipeline_layout");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1407,7 +1407,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn pipeline_layout_destroy<B: GfxBackend>(&self, pipeline_layout_id: id::PipelineLayoutId) {
-        span!(_guard, TRACE, "PipelineLayout::destroy");
+        span!(_guard, ERROR, "PipelineLayout::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1439,7 +1439,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     ) -> Result<id::BindGroupId, BindGroupError> {
         use crate::binding_model::BindingResource as Br;
 
-        span!(_guard, TRACE, "Device::create_bind_group");
+        span!(_guard, ERROR, "Device::create_bind_group");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1809,7 +1809,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn bind_group_destroy<B: GfxBackend>(&self, bind_group_id: id::BindGroupId) {
-        span!(_guard, TRACE, "BindGroup::destroy");
+        span!(_guard, ERROR, "BindGroup::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1835,7 +1835,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         source: pipeline::ShaderModuleSource,
         id_in: Input<G, id::ShaderModuleId>,
     ) -> id::ShaderModuleId {
-        span!(_guard, TRACE, "Device::create_shader_module");
+        span!(_guard, ERROR, "Device::create_shader_module");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1917,7 +1917,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn shader_module_destroy<B: GfxBackend>(&self, shader_module_id: id::ShaderModuleId) {
-        span!(_guard, TRACE, "ShaderModule::destroy");
+        span!(_guard, ERROR, "ShaderModule::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1943,7 +1943,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::CommandEncoderDescriptor<Label>,
         id_in: Input<G, id::CommandEncoderId>,
     ) -> id::CommandEncoderId {
-        span!(_guard, TRACE, "Device::create_command_encoder");
+        span!(_guard, ERROR, "Device::create_command_encoder");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1981,7 +1981,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_encoder_destroy<B: GfxBackend>(&self, command_encoder_id: id::CommandEncoderId) {
-        span!(_guard, TRACE, "CommandEncoder::destroy");
+        span!(_guard, ERROR, "CommandEncoder::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1998,7 +1998,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_buffer_destroy<B: GfxBackend>(&self, command_buffer_id: id::CommandBufferId) {
-        span!(_guard, TRACE, "CommandBuffer::destroy");
+        span!(_guard, ERROR, "CommandBuffer::drop");
         self.command_encoder_destroy::<B>(command_buffer_id)
     }
 
@@ -2007,13 +2007,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         device_id: id::DeviceId,
         desc: &wgt::RenderBundleEncoderDescriptor,
     ) -> id::RenderBundleEncoderId {
-        span!(_guard, TRACE, "Device::create_render_bundle_encoder");
+        span!(_guard, ERROR, "Device::create_render_bundle_encoder");
         let encoder = command::RenderBundleEncoder::new(desc, device_id, None);
         Box::into_raw(Box::new(encoder))
     }
 
     pub fn render_bundle_destroy<B: GfxBackend>(&self, render_bundle_id: id::RenderBundleId) {
-        span!(_guard, TRACE, "RenderBundle::destroy");
+        span!(_guard, ERROR, "RenderBundle::drop");
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -2038,7 +2038,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &pipeline::RenderPipelineDescriptor,
         id_in: Input<G, id::RenderPipelineId>,
     ) -> Result<id::RenderPipelineId, pipeline::RenderPipelineError> {
-        span!(_guard, TRACE, "Device::create_render_pipeline");
+        span!(_guard, ERROR, "Device::create_render_pipeline");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2414,7 +2414,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn render_pipeline_destroy<B: GfxBackend>(&self, render_pipeline_id: id::RenderPipelineId) {
-        span!(_guard, TRACE, "RenderPipeline::destroy");
+        span!(_guard, ERROR, "RenderPipeline::drop");
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -2443,7 +2443,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &pipeline::ComputePipelineDescriptor,
         id_in: Input<G, id::ComputePipelineId>,
     ) -> Result<id::ComputePipelineId, pipeline::ComputePipelineError> {
-        span!(_guard, TRACE, "Device::create_compute_pipeline");
+        span!(_guard, ERROR, "Device::create_compute_pipeline");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2543,7 +2543,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         compute_pipeline_id: id::ComputePipelineId,
     ) {
-        span!(_guard, TRACE, "ComputePipeline::destroy");
+        span!(_guard, ERROR, "ComputePipeline::drop");
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -2572,7 +2572,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         surface_id: id::SurfaceId,
         desc: &wgt::SwapChainDescriptor,
     ) -> id::SwapChainId {
-        span!(_guard, TRACE, "Device::create_swap_chain");
+        span!(_guard, ERROR, "Device::create_swap_chain");
 
         fn validate_swap_chain_descriptor(
             config: &mut hal::window::SwapchainConfig,
@@ -2701,7 +2701,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_poll<B: GfxBackend>(&self, device_id: id::DeviceId, force_wait: bool) {
-        span!(_guard, TRACE, "Device::poll");
+        span!(_guard, ERROR, "Device::poll");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2717,7 +2717,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         force_wait: bool,
         callbacks: &mut Vec<BufferMapPendingCallback>,
     ) {
-        span!(_guard, TRACE, "Device::poll_devices");
+        span!(_guard, ERROR, "Device::poll_devices");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2748,7 +2748,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_destroy<B: GfxBackend>(&self, device_id: id::DeviceId) {
-        span!(_guard, TRACE, "Device::destroy");
+        span!(_guard, ERROR, "Device::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2773,7 +2773,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         range: Range<BufferAddress>,
         op: resource::BufferMapOperation,
     ) {
-        span!(_guard, TRACE, "Device::buffer_map_async");
+        span!(_guard, ERROR, "Device::buffer_map_async");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2833,7 +2833,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         _size: Option<BufferSize>,
     ) -> *mut u8 {
-        span!(_guard, TRACE, "Device::buffer_get_mapped_range");
+        span!(_guard, ERROR, "Device::buffer_get_mapped_range");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2853,7 +2853,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn buffer_unmap<B: GfxBackend>(&self, buffer_id: id::BufferId) {
-        span!(_guard, TRACE, "Device::buffer_unmap");
+        span!(_guard, ERROR, "Device::buffer_unmap");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -635,7 +635,7 @@ impl<B: hal::Backend> Device<B> {
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn device_extensions<B: GfxBackend>(&self, device_id: id::DeviceId) -> wgt::Extensions {
-        span!(_guard, ERROR, "Device::extensions");
+        span!(_guard, INFO, "Device::extensions");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -646,7 +646,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_limits<B: GfxBackend>(&self, device_id: id::DeviceId) -> wgt::Limits {
-        span!(_guard, ERROR, "Device::limits");
+        span!(_guard, INFO, "Device::limits");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -657,7 +657,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_capabilities<B: GfxBackend>(&self, device_id: id::DeviceId) -> wgt::Capabilities {
-        span!(_guard, ERROR, "Device::capabilities");
+        span!(_guard, INFO, "Device::capabilities");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -673,7 +673,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::BufferDescriptor<Label>,
         id_in: Input<G, id::BufferId>,
     ) -> id::BufferId {
-        span!(_guard, ERROR, "Device::create_buffer");
+        span!(_guard, INFO, "Device::create_buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -793,7 +793,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         data: &[u8],
     ) {
-        span!(_guard, ERROR, "Device::set_buffer_sub_data");
+        span!(_guard, INFO, "Device::set_buffer_sub_data");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -852,7 +852,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         data: &mut [u8],
     ) {
-        span!(_guard, ERROR, "Device::get_buffer_sub_data");
+        span!(_guard, INFO, "Device::get_buffer_sub_data");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -890,7 +890,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn buffer_destroy<B: GfxBackend>(&self, buffer_id: id::BufferId) {
-        span!(_guard, ERROR, "Buffer::drop");
+        span!(_guard, INFO, "Buffer::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -916,7 +916,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::TextureDescriptor<Label>,
         id_in: Input<G, id::TextureId>,
     ) -> id::TextureId {
-        span!(_guard, ERROR, "Device::create_texture");
+        span!(_guard, INFO, "Device::create_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -947,7 +947,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn texture_destroy<B: GfxBackend>(&self, texture_id: id::TextureId) {
-        span!(_guard, ERROR, "Texture::drop");
+        span!(_guard, INFO, "Texture::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -972,7 +972,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: Option<&wgt::TextureViewDescriptor<Label>>,
         id_in: Input<G, id::TextureViewId>,
     ) -> id::TextureViewId {
-        span!(_guard, ERROR, "Texture::create_view");
+        span!(_guard, INFO, "Texture::create_view");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1064,7 +1064,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn texture_view_destroy<B: GfxBackend>(&self, texture_view_id: id::TextureViewId) {
-        span!(_guard, ERROR, "Texture::view_destroy");
+        span!(_guard, INFO, "Texture::view_destroy");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1099,7 +1099,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::SamplerDescriptor<Label>,
         id_in: Input<G, id::SamplerId>,
     ) -> id::SamplerId {
-        span!(_guard, ERROR, "Device::create_sampler");
+        span!(_guard, INFO, "Device::create_sampler");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1166,7 +1166,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn sampler_destroy<B: GfxBackend>(&self, sampler_id: id::SamplerId) {
-        span!(_guard, ERROR, "Sampler::drop");
+        span!(_guard, INFO, "Sampler::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1192,7 +1192,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::BindGroupLayoutDescriptor,
         id_in: Input<G, id::BindGroupLayoutId>,
     ) -> Result<id::BindGroupLayoutId, binding_model::BindGroupLayoutError> {
-        span!(_guard, ERROR, "Device::create_bind_group_layout");
+        span!(_guard, INFO, "Device::create_bind_group_layout");
 
         let mut token = Token::root();
         let hub = B::hub(self);
@@ -1312,7 +1312,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         bind_group_layout_id: id::BindGroupLayoutId,
     ) {
-        span!(_guard, ERROR, "BindGroupLayout::drop");
+        span!(_guard, INFO, "BindGroupLayout::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1342,7 +1342,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &binding_model::PipelineLayoutDescriptor,
         id_in: Input<G, id::PipelineLayoutId>,
     ) -> Result<id::PipelineLayoutId, binding_model::PipelineLayoutError> {
-        span!(_guard, ERROR, "Device::create_pipeline_layout");
+        span!(_guard, INFO, "Device::create_pipeline_layout");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1407,7 +1407,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn pipeline_layout_destroy<B: GfxBackend>(&self, pipeline_layout_id: id::PipelineLayoutId) {
-        span!(_guard, ERROR, "PipelineLayout::drop");
+        span!(_guard, INFO, "PipelineLayout::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1439,7 +1439,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     ) -> Result<id::BindGroupId, BindGroupError> {
         use crate::binding_model::BindingResource as Br;
 
-        span!(_guard, ERROR, "Device::create_bind_group");
+        span!(_guard, INFO, "Device::create_bind_group");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1809,7 +1809,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn bind_group_destroy<B: GfxBackend>(&self, bind_group_id: id::BindGroupId) {
-        span!(_guard, ERROR, "BindGroup::drop");
+        span!(_guard, INFO, "BindGroup::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1835,7 +1835,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         source: pipeline::ShaderModuleSource,
         id_in: Input<G, id::ShaderModuleId>,
     ) -> id::ShaderModuleId {
-        span!(_guard, ERROR, "Device::create_shader_module");
+        span!(_guard, INFO, "Device::create_shader_module");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1917,7 +1917,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn shader_module_destroy<B: GfxBackend>(&self, shader_module_id: id::ShaderModuleId) {
-        span!(_guard, ERROR, "ShaderModule::drop");
+        span!(_guard, INFO, "ShaderModule::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1943,7 +1943,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::CommandEncoderDescriptor<Label>,
         id_in: Input<G, id::CommandEncoderId>,
     ) -> id::CommandEncoderId {
-        span!(_guard, ERROR, "Device::create_command_encoder");
+        span!(_guard, INFO, "Device::create_command_encoder");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1981,7 +1981,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_encoder_destroy<B: GfxBackend>(&self, command_encoder_id: id::CommandEncoderId) {
-        span!(_guard, ERROR, "CommandEncoder::drop");
+        span!(_guard, INFO, "CommandEncoder::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1998,7 +1998,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_buffer_destroy<B: GfxBackend>(&self, command_buffer_id: id::CommandBufferId) {
-        span!(_guard, ERROR, "CommandBuffer::drop");
+        span!(_guard, INFO, "CommandBuffer::drop");
         self.command_encoder_destroy::<B>(command_buffer_id)
     }
 
@@ -2007,13 +2007,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         device_id: id::DeviceId,
         desc: &wgt::RenderBundleEncoderDescriptor,
     ) -> id::RenderBundleEncoderId {
-        span!(_guard, ERROR, "Device::create_render_bundle_encoder");
+        span!(_guard, INFO, "Device::create_render_bundle_encoder");
         let encoder = command::RenderBundleEncoder::new(desc, device_id, None);
         Box::into_raw(Box::new(encoder))
     }
 
     pub fn render_bundle_destroy<B: GfxBackend>(&self, render_bundle_id: id::RenderBundleId) {
-        span!(_guard, ERROR, "RenderBundle::drop");
+        span!(_guard, INFO, "RenderBundle::drop");
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -2038,7 +2038,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &pipeline::RenderPipelineDescriptor,
         id_in: Input<G, id::RenderPipelineId>,
     ) -> Result<id::RenderPipelineId, pipeline::RenderPipelineError> {
-        span!(_guard, ERROR, "Device::create_render_pipeline");
+        span!(_guard, INFO, "Device::create_render_pipeline");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2414,7 +2414,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn render_pipeline_destroy<B: GfxBackend>(&self, render_pipeline_id: id::RenderPipelineId) {
-        span!(_guard, ERROR, "RenderPipeline::drop");
+        span!(_guard, INFO, "RenderPipeline::drop");
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -2443,7 +2443,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &pipeline::ComputePipelineDescriptor,
         id_in: Input<G, id::ComputePipelineId>,
     ) -> Result<id::ComputePipelineId, pipeline::ComputePipelineError> {
-        span!(_guard, ERROR, "Device::create_compute_pipeline");
+        span!(_guard, INFO, "Device::create_compute_pipeline");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2543,7 +2543,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         compute_pipeline_id: id::ComputePipelineId,
     ) {
-        span!(_guard, ERROR, "ComputePipeline::drop");
+        span!(_guard, INFO, "ComputePipeline::drop");
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -2572,7 +2572,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         surface_id: id::SurfaceId,
         desc: &wgt::SwapChainDescriptor,
     ) -> id::SwapChainId {
-        span!(_guard, ERROR, "Device::create_swap_chain");
+        span!(_guard, INFO, "Device::create_swap_chain");
 
         fn validate_swap_chain_descriptor(
             config: &mut hal::window::SwapchainConfig,
@@ -2701,7 +2701,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_poll<B: GfxBackend>(&self, device_id: id::DeviceId, force_wait: bool) {
-        span!(_guard, ERROR, "Device::poll");
+        span!(_guard, INFO, "Device::poll");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2717,7 +2717,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         force_wait: bool,
         callbacks: &mut Vec<BufferMapPendingCallback>,
     ) {
-        span!(_guard, ERROR, "Device::poll_devices");
+        span!(_guard, INFO, "Device::poll_devices");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2748,7 +2748,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_destroy<B: GfxBackend>(&self, device_id: id::DeviceId) {
-        span!(_guard, ERROR, "Device::drop");
+        span!(_guard, INFO, "Device::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2773,7 +2773,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         range: Range<BufferAddress>,
         op: resource::BufferMapOperation,
     ) {
-        span!(_guard, ERROR, "Device::buffer_map_async");
+        span!(_guard, INFO, "Device::buffer_map_async");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2833,7 +2833,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         _size: Option<BufferSize>,
     ) -> *mut u8 {
-        span!(_guard, ERROR, "Device::buffer_get_mapped_range");
+        span!(_guard, INFO, "Device::buffer_get_mapped_range");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2853,7 +2853,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn buffer_unmap<B: GfxBackend>(&self, buffer_id: id::BufferId) {
-        span!(_guard, ERROR, "Device::buffer_unmap");
+        span!(_guard, INFO, "Device::buffer_unmap");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     binding_model::{self, BindGroupError},
     command, conv,
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Hub, Input, Token},
-    id, pipeline, resource, swap_chain,
+    id, pipeline, resource, span, swap_chain,
     track::{BufferState, TextureState, TrackerSet},
     validation, FastHashMap, LifeGuard, PrivateFeatures, Stored, SubmissionIndex, MAX_BIND_GROUPS,
 };
@@ -635,6 +635,8 @@ impl<B: hal::Backend> Device<B> {
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn device_extensions<B: GfxBackend>(&self, device_id: id::DeviceId) -> wgt::Extensions {
+        span!(_guard, TRACE, "Device::extensions");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, _) = hub.devices.read(&mut token);
@@ -644,6 +646,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_limits<B: GfxBackend>(&self, device_id: id::DeviceId) -> wgt::Limits {
+        span!(_guard, TRACE, "Device::limits");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, _) = hub.devices.read(&mut token);
@@ -653,6 +657,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_capabilities<B: GfxBackend>(&self, device_id: id::DeviceId) -> wgt::Capabilities {
+        span!(_guard, TRACE, "Device::capabilities");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, _) = hub.devices.read(&mut token);
@@ -667,6 +673,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::BufferDescriptor<Label>,
         id_in: Input<G, id::BufferId>,
     ) -> id::BufferId {
+        span!(_guard, TRACE, "Device::create_buffer");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -785,6 +793,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         data: &[u8],
     ) {
+        span!(_guard, TRACE, "Device::set_buffer_sub_data");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -842,6 +852,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         data: &mut [u8],
     ) {
+        span!(_guard, TRACE, "Device::get_buffer_sub_data");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -878,6 +890,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn buffer_destroy<B: GfxBackend>(&self, buffer_id: id::BufferId) {
+        span!(_guard, TRACE, "Buffer::destroy");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -902,6 +916,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::TextureDescriptor<Label>,
         id_in: Input<G, id::TextureId>,
     ) -> id::TextureId {
+        span!(_guard, TRACE, "Device::create_texture");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -931,6 +947,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn texture_destroy<B: GfxBackend>(&self, texture_id: id::TextureId) {
+        span!(_guard, TRACE, "Texture::destroy");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -954,6 +972,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: Option<&wgt::TextureViewDescriptor<Label>>,
         id_in: Input<G, id::TextureViewId>,
     ) -> id::TextureViewId {
+        span!(_guard, TRACE, "Texture::create_view");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -1044,6 +1064,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn texture_view_destroy<B: GfxBackend>(&self, texture_view_id: id::TextureViewId) {
+        span!(_guard, TRACE, "Texture::view_destroy");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -1077,6 +1099,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::SamplerDescriptor<Label>,
         id_in: Input<G, id::SamplerId>,
     ) -> id::SamplerId {
+        span!(_guard, TRACE, "Device::create_sampler");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -1142,6 +1166,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn sampler_destroy<B: GfxBackend>(&self, sampler_id: id::SamplerId) {
+        span!(_guard, TRACE, "Sampler::destroy");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -1166,6 +1192,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::BindGroupLayoutDescriptor,
         id_in: Input<G, id::BindGroupLayoutId>,
     ) -> Result<id::BindGroupLayoutId, binding_model::BindGroupLayoutError> {
+        span!(_guard, TRACE, "Device::create_bind_group_layout");
+
         let mut token = Token::root();
         let hub = B::hub(self);
         let mut entry_map = FastHashMap::default();
@@ -1284,6 +1312,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         bind_group_layout_id: id::BindGroupLayoutId,
     ) {
+        span!(_guard, TRACE, "BindGroupLayout::destroy");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_id, ref_count) = {
@@ -1312,6 +1342,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &binding_model::PipelineLayoutDescriptor,
         id_in: Input<G, id::PipelineLayoutId>,
     ) -> Result<id::PipelineLayoutId, binding_model::PipelineLayoutError> {
+        span!(_guard, TRACE, "Device::create_pipeline_layout");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -1375,6 +1407,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn pipeline_layout_destroy<B: GfxBackend>(&self, pipeline_layout_id: id::PipelineLayoutId) {
+        span!(_guard, TRACE, "PipelineLayout::destroy");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_id, ref_count) = {
@@ -1404,6 +1438,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id_in: Input<G, id::BindGroupId>,
     ) -> Result<id::BindGroupId, BindGroupError> {
         use crate::binding_model::BindingResource as Br;
+
+        span!(_guard, TRACE, "Device::create_bind_group");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1773,6 +1809,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn bind_group_destroy<B: GfxBackend>(&self, bind_group_id: id::BindGroupId) {
+        span!(_guard, TRACE, "BindGroup::destroy");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -1797,6 +1835,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         source: pipeline::ShaderModuleSource,
         id_in: Input<G, id::ShaderModuleId>,
     ) -> id::ShaderModuleId {
+        span!(_guard, TRACE, "Device::create_shader_module");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -1877,6 +1917,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn shader_module_destroy<B: GfxBackend>(&self, shader_module_id: id::ShaderModuleId) {
+        span!(_guard, TRACE, "ShaderModule::destroy");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -1901,6 +1943,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::CommandEncoderDescriptor<Label>,
         id_in: Input<G, id::CommandEncoderId>,
     ) -> id::CommandEncoderId {
+        span!(_guard, TRACE, "Device::create_command_encoder");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -1937,6 +1981,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_encoder_destroy<B: GfxBackend>(&self, command_encoder_id: id::CommandEncoderId) {
+        span!(_guard, TRACE, "CommandEncoder::destroy");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -1952,6 +1998,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_buffer_destroy<B: GfxBackend>(&self, command_buffer_id: id::CommandBufferId) {
+        span!(_guard, TRACE, "CommandBuffer::destroy");
         self.command_encoder_destroy::<B>(command_buffer_id)
     }
 
@@ -1960,11 +2007,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         device_id: id::DeviceId,
         desc: &wgt::RenderBundleEncoderDescriptor,
     ) -> id::RenderBundleEncoderId {
+        span!(_guard, TRACE, "Device::create_render_bundle_encoder");
         let encoder = command::RenderBundleEncoder::new(desc, device_id, None);
         Box::into_raw(Box::new(encoder))
     }
 
     pub fn render_bundle_destroy<B: GfxBackend>(&self, render_bundle_id: id::RenderBundleId) {
+        span!(_guard, TRACE, "RenderBundle::destroy");
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -1989,6 +2038,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &pipeline::RenderPipelineDescriptor,
         id_in: Input<G, id::RenderPipelineId>,
     ) -> Result<id::RenderPipelineId, pipeline::RenderPipelineError> {
+        span!(_guard, TRACE, "Device::create_render_pipeline");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -2363,6 +2414,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn render_pipeline_destroy<B: GfxBackend>(&self, render_pipeline_id: id::RenderPipelineId) {
+        span!(_guard, TRACE, "RenderPipeline::destroy");
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -2391,6 +2443,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &pipeline::ComputePipelineDescriptor,
         id_in: Input<G, id::ComputePipelineId>,
     ) -> Result<id::ComputePipelineId, pipeline::ComputePipelineError> {
+        span!(_guard, TRACE, "Device::create_compute_pipeline");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -2489,6 +2543,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         compute_pipeline_id: id::ComputePipelineId,
     ) {
+        span!(_guard, TRACE, "ComputePipeline::destroy");
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -2517,6 +2572,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         surface_id: id::SurfaceId,
         desc: &wgt::SwapChainDescriptor,
     ) -> id::SwapChainId {
+        span!(_guard, TRACE, "Device::create_swap_chain");
+
         fn validate_swap_chain_descriptor(
             config: &mut hal::window::SwapchainConfig,
             caps: &hal::window::SurfaceCapabilities,
@@ -2644,6 +2701,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_poll<B: GfxBackend>(&self, device_id: id::DeviceId, force_wait: bool) {
+        span!(_guard, TRACE, "Device::poll");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let callbacks = {
@@ -2658,6 +2717,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         force_wait: bool,
         callbacks: &mut Vec<BufferMapPendingCallback>,
     ) {
+        span!(_guard, TRACE, "Device::poll_devices");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -2687,6 +2748,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_destroy<B: GfxBackend>(&self, device_id: id::DeviceId) {
+        span!(_guard, TRACE, "Device::destroy");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let device = {
@@ -2710,6 +2773,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         range: Range<BufferAddress>,
         op: resource::BufferMapOperation,
     ) {
+        span!(_guard, TRACE, "Device::buffer_map_async");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -2768,6 +2833,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         _size: Option<BufferSize>,
     ) -> *mut u8 {
+        span!(_guard, TRACE, "Device::buffer_get_mapped_range");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (buffer_guard, _) = hub.buffers.read(&mut token);
@@ -2786,6 +2853,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn buffer_unmap<B: GfxBackend>(&self, buffer_id: id::BufferId) {
+        span!(_guard, TRACE, "Device::buffer_unmap");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -131,7 +131,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_offset: wgt::BufferAddress,
         data: &[u8],
     ) {
-        span!(_guard, ERROR, "Queue::write_buffer");
+        span!(_guard, INFO, "Queue::write_buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -241,7 +241,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         data_layout: &wgt::TextureDataLayout,
         size: &wgt::Extent3d,
     ) {
-        span!(_guard, ERROR, "Queue::write_texture");
+        span!(_guard, INFO, "Queue::write_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -370,7 +370,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         queue_id: id::QueueId,
         command_buffer_ids: &[id::CommandBufferId],
     ) {
-        span!(_guard, ERROR, "Queue::submit");
+        span!(_guard, INFO, "Queue::submit");
 
         let hub = B::hub(self);
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -10,6 +10,7 @@ use crate::{
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Token},
     id,
     resource::{BufferMapState, BufferUse, TextureUse},
+    span,
 };
 
 use gfx_memory::{Block, Heaps, MemoryBlock};
@@ -130,6 +131,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_offset: wgt::BufferAddress,
         data: &[u8],
     ) {
+        span!(_guard, TRACE, "Queue::write_buffer");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (mut device_guard, mut token) = hub.devices.write(&mut token);
@@ -238,6 +241,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         data_layout: &wgt::TextureDataLayout,
         size: &wgt::Extent3d,
     ) {
+        span!(_guard, TRACE, "Queue::write_texture");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (mut device_guard, mut token) = hub.devices.write(&mut token);
@@ -365,6 +370,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         queue_id: id::QueueId,
         command_buffer_ids: &[id::CommandBufferId],
     ) {
+        span!(_guard, TRACE, "Queue::submit");
+
         let hub = B::hub(self);
 
         let callbacks = {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -131,7 +131,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_offset: wgt::BufferAddress,
         data: &[u8],
     ) {
-        span!(_guard, TRACE, "Queue::write_buffer");
+        span!(_guard, ERROR, "Queue::write_buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -241,7 +241,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         data_layout: &wgt::TextureDataLayout,
         size: &wgt::Extent3d,
     ) {
-        span!(_guard, TRACE, "Queue::write_texture");
+        span!(_guard, ERROR, "Queue::write_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -370,7 +370,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         queue_id: id::QueueId,
         command_buffer_ids: &[id::CommandBufferId],
     ) {
-        span!(_guard, TRACE, "Queue::submit");
+        span!(_guard, ERROR, "Queue::submit");
 
         let hub = B::hub(self);
 

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -578,7 +578,7 @@ pub struct Global<G: GlobalIdentityHandlerFactory> {
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn new(name: &str, factory: G, backends: wgt::BackendBit) -> Self {
-        span!(_guard, TRACE, "Global::new");
+        span!(_guard, ERROR, "Global::new");
         Global {
             instance: Instance::new(name, 1, backends),
             surfaces: Registry::without_backend(&factory, "Surface"),

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -578,7 +578,7 @@ pub struct Global<G: GlobalIdentityHandlerFactory> {
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn new(name: &str, factory: G, backends: wgt::BackendBit) -> Self {
-        span!(_guard, ERROR, "Global::new");
+        span!(_guard, INFO, "Global::new");
         Global {
             instance: Instance::new(name, 1, backends),
             surfaces: Registry::without_backend(&factory, "Surface"),

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -15,6 +15,7 @@ use crate::{
     instance::{Adapter, Instance, Surface},
     pipeline::{ComputePipeline, RenderPipeline, ShaderModule},
     resource::{Buffer, Sampler, Texture, TextureView},
+    span,
     swap_chain::SwapChain,
     Epoch, Index,
 };
@@ -577,6 +578,7 @@ pub struct Global<G: GlobalIdentityHandlerFactory> {
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn new(name: &str, factory: G, backends: wgt::BackendBit) -> Self {
+        span!(_guard, TRACE, "Global::new");
         Global {
             instance: Instance::new(name, 1, backends),
             surfaces: Registry::without_backend(&factory, "Surface"),

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -147,7 +147,7 @@ pub struct Adapter<B: hal::Backend> {
 
 impl<B: hal::Backend> Adapter<B> {
     fn new(raw: hal::adapter::Adapter<B>, unsafe_extensions: wgt::UnsafeExtensions) -> Self {
-        span!(_guard, ERROR, "Adapter::new");
+        span!(_guard, INFO, "Adapter::new");
 
         let adapter_features = raw.physical_device.features();
 
@@ -297,7 +297,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         handle: &impl raw_window_handle::HasRawWindowHandle,
         id_in: Input<G, SurfaceId>,
     ) -> SurfaceId {
-        span!(_guard, ERROR, "Instance::create_surface");
+        span!(_guard, INFO, "Instance::create_surface");
 
         let surface = unsafe {
             Surface {
@@ -341,7 +341,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         unsafe_extensions: wgt::UnsafeExtensions,
         inputs: AdapterInputs<Input<G, AdapterId>>,
     ) -> Vec<AdapterId> {
-        span!(_guard, ERROR, "Instance::enumerate_adapters");
+        span!(_guard, INFO, "Instance::enumerate_adapters");
 
         let instance = &self.instance;
         let mut token = Token::root();
@@ -421,7 +421,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         unsafe_extensions: wgt::UnsafeExtensions,
         inputs: AdapterInputs<Input<G, AdapterId>>,
     ) -> Option<AdapterId> {
-        span!(_guard, ERROR, "Instance::pick_adapter");
+        span!(_guard, INFO, "Instance::pick_adapter");
 
         let instance = &self.instance;
         let mut token = Token::root();
@@ -626,7 +626,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_get_info<B: GfxBackend>(&self, adapter_id: AdapterId) -> AdapterInfo {
-        span!(_guard, ERROR, "Adapter::get_info");
+        span!(_guard, INFO, "Adapter::get_info");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -636,7 +636,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_extensions<B: GfxBackend>(&self, adapter_id: AdapterId) -> wgt::Extensions {
-        span!(_guard, ERROR, "Adapter::extensions");
+        span!(_guard, INFO, "Adapter::extensions");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -647,7 +647,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_limits<B: GfxBackend>(&self, adapter_id: AdapterId) -> wgt::Limits {
-        span!(_guard, ERROR, "Adapter::limits");
+        span!(_guard, INFO, "Adapter::limits");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -658,7 +658,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_capabilities<B: GfxBackend>(&self, adapter_id: AdapterId) -> wgt::Capabilities {
-        span!(_guard, ERROR, "Adapter::capabilities");
+        span!(_guard, INFO, "Adapter::capabilities");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -669,7 +669,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_destroy<B: GfxBackend>(&self, adapter_id: AdapterId) {
-        span!(_guard, ERROR, "Adapter::drop");
+        span!(_guard, INFO, "Adapter::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -697,7 +697,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         trace_path: Option<&std::path::Path>,
         id_in: Input<G, DeviceId>,
     ) -> DeviceId {
-        span!(_guard, ERROR, "Adapter::request_device");
+        span!(_guard, INFO, "Adapter::request_device");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -7,7 +7,7 @@ use crate::{
     device::Device,
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Input, Token},
     id::{AdapterId, DeviceId, SurfaceId},
-    power, LifeGuard, PrivateFeatures, Stored, MAX_BIND_GROUPS,
+    power, span, LifeGuard, PrivateFeatures, Stored, MAX_BIND_GROUPS,
 };
 
 use wgt::{Backend, BackendBit, DeviceDescriptor, PowerPreference, BIND_BUFFER_ALIGNMENT};
@@ -147,6 +147,8 @@ pub struct Adapter<B: hal::Backend> {
 
 impl<B: hal::Backend> Adapter<B> {
     fn new(raw: hal::adapter::Adapter<B>, unsafe_extensions: wgt::UnsafeExtensions) -> Self {
+        span!(_guard, TRACE, "Adapter::new");
+
         let adapter_features = raw.physical_device.features();
 
         let mut extensions = wgt::Extensions::default() | wgt::Extensions::MAPPABLE_PRIMARY_BUFFERS;
@@ -295,6 +297,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         handle: &impl raw_window_handle::HasRawWindowHandle,
         id_in: Input<G, SurfaceId>,
     ) -> SurfaceId {
+        span!(_guard, TRACE, "Instance::create_surface");
+
         let surface = unsafe {
             Surface {
                 #[cfg(any(
@@ -337,6 +341,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         unsafe_extensions: wgt::UnsafeExtensions,
         inputs: AdapterInputs<Input<G, AdapterId>>,
     ) -> Vec<AdapterId> {
+        span!(_guard, TRACE, "Instance::enumerate_adapters");
+
         let instance = &self.instance;
         let mut token = Token::root();
         let mut adapters = Vec::new();
@@ -415,6 +421,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         unsafe_extensions: wgt::UnsafeExtensions,
         inputs: AdapterInputs<Input<G, AdapterId>>,
     ) -> Option<AdapterId> {
+        span!(_guard, TRACE, "Instance::pick_adapter");
+
         let instance = &self.instance;
         let mut token = Token::root();
         let (surface_guard, mut token) = self.surfaces.read(&mut token);
@@ -618,6 +626,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_get_info<B: GfxBackend>(&self, adapter_id: AdapterId) -> AdapterInfo {
+        span!(_guard, TRACE, "Adapter::get_info");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (adapter_guard, _) = hub.adapters.read(&mut token);
@@ -626,6 +636,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_extensions<B: GfxBackend>(&self, adapter_id: AdapterId) -> wgt::Extensions {
+        span!(_guard, TRACE, "Adapter::extensions");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (adapter_guard, _) = hub.adapters.read(&mut token);
@@ -635,6 +647,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_limits<B: GfxBackend>(&self, adapter_id: AdapterId) -> wgt::Limits {
+        span!(_guard, TRACE, "Adapter::limits");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (adapter_guard, _) = hub.adapters.read(&mut token);
@@ -644,6 +658,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_capabilities<B: GfxBackend>(&self, adapter_id: AdapterId) -> wgt::Capabilities {
+        span!(_guard, TRACE, "Adapter::capabilities");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (adapter_guard, _) = hub.adapters.read(&mut token);
@@ -653,6 +669,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_destroy<B: GfxBackend>(&self, adapter_id: AdapterId) {
+        span!(_guard, TRACE, "Adapter::destroy");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let (mut guard, _) = hub.adapters.write(&mut token);
@@ -679,6 +697,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         trace_path: Option<&std::path::Path>,
         id_in: Input<G, DeviceId>,
     ) -> DeviceId {
+        span!(_guard, TRACE, "Adapter::request_device");
+
         let hub = B::hub(self);
         let mut token = Token::root();
         let device = {

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -147,7 +147,7 @@ pub struct Adapter<B: hal::Backend> {
 
 impl<B: hal::Backend> Adapter<B> {
     fn new(raw: hal::adapter::Adapter<B>, unsafe_extensions: wgt::UnsafeExtensions) -> Self {
-        span!(_guard, TRACE, "Adapter::new");
+        span!(_guard, ERROR, "Adapter::new");
 
         let adapter_features = raw.physical_device.features();
 
@@ -297,7 +297,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         handle: &impl raw_window_handle::HasRawWindowHandle,
         id_in: Input<G, SurfaceId>,
     ) -> SurfaceId {
-        span!(_guard, TRACE, "Instance::create_surface");
+        span!(_guard, ERROR, "Instance::create_surface");
 
         let surface = unsafe {
             Surface {
@@ -341,7 +341,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         unsafe_extensions: wgt::UnsafeExtensions,
         inputs: AdapterInputs<Input<G, AdapterId>>,
     ) -> Vec<AdapterId> {
-        span!(_guard, TRACE, "Instance::enumerate_adapters");
+        span!(_guard, ERROR, "Instance::enumerate_adapters");
 
         let instance = &self.instance;
         let mut token = Token::root();
@@ -421,7 +421,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         unsafe_extensions: wgt::UnsafeExtensions,
         inputs: AdapterInputs<Input<G, AdapterId>>,
     ) -> Option<AdapterId> {
-        span!(_guard, TRACE, "Instance::pick_adapter");
+        span!(_guard, ERROR, "Instance::pick_adapter");
 
         let instance = &self.instance;
         let mut token = Token::root();
@@ -626,7 +626,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_get_info<B: GfxBackend>(&self, adapter_id: AdapterId) -> AdapterInfo {
-        span!(_guard, TRACE, "Adapter::get_info");
+        span!(_guard, ERROR, "Adapter::get_info");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -636,7 +636,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_extensions<B: GfxBackend>(&self, adapter_id: AdapterId) -> wgt::Extensions {
-        span!(_guard, TRACE, "Adapter::extensions");
+        span!(_guard, ERROR, "Adapter::extensions");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -647,7 +647,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_limits<B: GfxBackend>(&self, adapter_id: AdapterId) -> wgt::Limits {
-        span!(_guard, TRACE, "Adapter::limits");
+        span!(_guard, ERROR, "Adapter::limits");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -658,7 +658,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_capabilities<B: GfxBackend>(&self, adapter_id: AdapterId) -> wgt::Capabilities {
-        span!(_guard, TRACE, "Adapter::capabilities");
+        span!(_guard, ERROR, "Adapter::capabilities");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -669,7 +669,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_destroy<B: GfxBackend>(&self, adapter_id: AdapterId) {
-        span!(_guard, TRACE, "Adapter::destroy");
+        span!(_guard, ERROR, "Adapter::drop");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -697,7 +697,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         trace_path: Option<&std::path::Path>,
         id_in: Input<G, DeviceId>,
     ) -> DeviceId {
-        span!(_guard, TRACE, "Adapter::request_device");
+        span!(_guard, ERROR, "Adapter::request_device");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -31,7 +31,7 @@ pub mod device;
 pub mod hub;
 pub mod id;
 pub mod instance;
-mod logging;
+pub mod logging;
 pub mod pipeline;
 pub mod power;
 pub mod resource;

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod device;
 pub mod hub;
 pub mod id;
 pub mod instance;
+mod logging;
 pub mod pipeline;
 pub mod power;
 pub mod resource;

--- a/wgpu-core/src/logging/mod.rs
+++ b/wgpu-core/src/logging/mod.rs
@@ -1,0 +1,11 @@
+#[macro_export]
+macro_rules! span {
+    ($guard_name:tt, $level:ident, $name:expr, $($fields:tt)*) => {
+        let span = tracing::span!(tracing::Level::$level, $name, $($fields)*);
+        let $guard_name = span.enter();
+    };
+    ($guard_name:tt, $level:ident, $name:expr) => {
+        let span = tracing::span!(tracing::Level::$level, $name);
+        let $guard_name = span.enter();
+    };
+}

--- a/wgpu-core/src/logging/mod.rs
+++ b/wgpu-core/src/logging/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "subscriber")]
+pub mod subscriber;
+
 #[macro_export]
 macro_rules! span {
     ($guard_name:tt, $level:ident, $name:expr, $($fields:tt)*) => {

--- a/wgpu-core/src/logging/subscriber.rs
+++ b/wgpu-core/src/logging/subscriber.rs
@@ -1,0 +1,212 @@
+use std::{
+    borrow::Cow,
+    fmt, io,
+    io::Write,
+    path::Path,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+use tracing::{
+    field::{Field, Visit},
+    span, Event, Metadata, Subscriber,
+};
+use tracing_subscriber::{
+    layer::{Context, SubscriberExt},
+    registry::LookupSpan,
+    EnvFilter, Layer,
+};
+
+/// Set up the "standard" logger.
+///
+/// This is fairly inflexible, but a good default to start with. If you need more customization,
+/// take what this function does and implement it however you need.
+///
+/// # Args
+///
+/// - `chrome_tracing_path` if set to `Some`, will create a trace compatible with chrome://tracing
+///   at that location.  
+pub fn initialize_default_subscriber(chrome_trace_path: Option<impl AsRef<Path>>) {
+    let chrome_tracing_layer_opt =
+        chrome_trace_path.map(|path| ChromeTracingLayer::with_file(path).unwrap());
+
+    // Tracing currently doesn't support type erasure with layer composition
+    if let Some(chrome_tracing_layer) = chrome_tracing_layer_opt {
+        tracing::subscriber::set_global_default(
+            tracing_subscriber::Registry::default()
+                .with(chrome_tracing_layer)
+                .with(tracing_subscriber::fmt::Layer::new())
+                .with(EnvFilter::from_default_env()),
+        )
+        .unwrap();
+    } else {
+        tracing::subscriber::set_global_default(
+            tracing_subscriber::Registry::default()
+                .with(tracing_subscriber::fmt::Layer::new())
+                .with(EnvFilter::from_default_env()),
+        )
+        .unwrap();
+    }
+}
+
+static CURRENT_PROCESS_ID: once_cell::sync::Lazy<u32> =
+    once_cell::sync::Lazy::new(|| std::process::id());
+
+thread_local! {
+    static CURRENT_THREAD_ID: usize = thread_id::get();
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum EventType {
+    Begin,
+    Event,
+    End,
+}
+
+/// A layer to add to a [`tracing_subscriber::Registry`] to output to a chrome
+/// trace.
+///
+/// If you want an easy "set and forget" method of installing this and normal
+/// tracing logging, call [`initialize_default_subscriber`].
+#[derive(Debug, Clone)]
+pub struct ChromeTracingLayer {
+    file: Arc<Mutex<std::fs::File>>,
+    start_time: Instant,
+}
+
+impl ChromeTracingLayer {
+    /// Create a trace which outputs to the given file. The file will be cleared if it exits.
+    pub fn with_file(file: impl AsRef<Path>) -> io::Result<Self> {
+        std::fs::File::create(file).map(|mut file| {
+            writeln!(file, "[").unwrap();
+            ChromeTracingLayer {
+                file: Arc::new(Mutex::new(file)),
+                start_time: Instant::now(),
+            }
+        })
+    }
+
+    fn write_event(
+        &self,
+        mut fields: Option<EventVisitor>,
+        metadata: &'static Metadata<'static>,
+        event_type: EventType,
+    ) {
+        if let Some(EventVisitor { trace: false, .. }) = fields {
+            return;
+        }
+
+        let current_time = Instant::now();
+
+        let diff = current_time - self.start_time;
+        let diff_in_us = diff.as_micros();
+
+        let event_type_str = match event_type {
+            EventType::Begin => "B",
+            EventType::Event => "i",
+            EventType::End => "E",
+        };
+
+        let instant_scope = if event_type == EventType::Event {
+            r#","s": "p""#
+        } else {
+            ""
+        };
+
+        let name = match event_type {
+            EventType::Event => fields
+                .as_mut()
+                .and_then(|fields| fields.message.take())
+                .map_or_else(
+                    || {
+                        let name = metadata.name();
+                        // The default name for events has a path in it, filter paths only on windows
+                        if cfg!(target_os = "windows") {
+                            Cow::Owned(name.replace("\\", "\\\\"))
+                        } else {
+                            Cow::Borrowed(name)
+                        }
+                    },
+                    Cow::from,
+                ),
+            EventType::Begin | EventType::End => Cow::Borrowed(metadata.name()),
+        };
+
+        let category = fields
+            .as_mut()
+            .and_then(|fields| fields.category.take())
+            .map_or_else(|| Cow::Borrowed("trace"), Cow::from);
+
+        let mut file = self.file.lock().unwrap();
+        writeln!(
+            file,
+            r#"{{ "name": "{}", "cat": "{}", "ph": "{}", "ts": {}, "pid": {}, "tid": {} {} }},"#,
+            name,
+            category,
+            event_type_str,
+            diff_in_us,
+            *CURRENT_PROCESS_ID,
+            CURRENT_THREAD_ID.with(|v| *v),
+            instant_scope,
+        )
+        .unwrap();
+    }
+}
+
+impl Drop for ChromeTracingLayer {
+    fn drop(&mut self) {
+        println!("drop");
+        let mut file = self.file.lock().unwrap();
+        writeln!(file, "]").unwrap();
+        file.flush().unwrap();
+    }
+}
+
+#[derive(Debug, Default)]
+struct EventVisitor {
+    message: Option<String>,
+    category: Option<String>,
+    trace: bool,
+}
+
+impl Visit for EventVisitor {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        match field.name() {
+            "trace" => self.trace = value,
+            _ => {}
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        match field.name() {
+            "message" => self.message = Some(format!("{:?}", value)),
+            "category" => self.category = Some(format!("{:?}", value)),
+            _ => {}
+        }
+    }
+}
+
+impl<S> Layer<S> for ChromeTracingLayer
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut event_visitor = EventVisitor::default();
+        event.record(&mut event_visitor);
+
+        self.write_event(Some(event_visitor), event.metadata(), EventType::Event);
+    }
+
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).unwrap();
+        self.write_event(None, span.metadata(), EventType::Begin);
+    }
+
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        if std::thread::panicking() {
+            return;
+        }
+
+        let span = ctx.span(id).unwrap();
+        self.write_event(None, span.metadata(), EventType::End);
+    }
+}

--- a/wgpu-core/src/logging/subscriber.rs
+++ b/wgpu-core/src/logging/subscriber.rs
@@ -48,9 +48,6 @@ pub fn initialize_default_subscriber(chrome_trace_path: Option<impl AsRef<Path>>
     }
 }
 
-static CURRENT_PROCESS_ID: once_cell::sync::Lazy<u32> =
-    once_cell::sync::Lazy::new(|| std::process::id());
-
 thread_local! {
     static CURRENT_THREAD_ID: usize = thread_id::get();
 }
@@ -71,6 +68,7 @@ enum EventType {
 pub struct ChromeTracingLayer {
     file: Arc<Mutex<std::fs::File>>,
     start_time: Instant,
+    process_id: u32,
 }
 
 impl ChromeTracingLayer {
@@ -81,6 +79,7 @@ impl ChromeTracingLayer {
             ChromeTracingLayer {
                 file: Arc::new(Mutex::new(file)),
                 start_time: Instant::now(),
+                process_id: std::process::id(),
             }
         })
     }
@@ -144,7 +143,7 @@ impl ChromeTracingLayer {
             category,
             event_type_str,
             diff_in_us,
-            *CURRENT_PROCESS_ID,
+            self.process_id,
             CURRENT_THREAD_ID.with(|v| *v),
             instant_scope,
         )

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -94,7 +94,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         swap_chain_id: SwapChainId,
         view_id_in: Input<G, TextureViewId>,
     ) -> SwapChainOutput {
-        span!(_guard, TRACE, "SwapChain::get_next_texture");
+        span!(_guard, ERROR, "SwapChain::get_next_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -179,7 +179,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn swap_chain_present<B: GfxBackend>(&self, swap_chain_id: SwapChainId) {
-        span!(_guard, TRACE, "SwapChain::present");
+        span!(_guard, ERROR, "SwapChain::present");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -219,6 +219,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         if let Err(e) = err {
             log::warn!("present failed: {:?}", e);
         }
+
+        tracing::debug!(trace = true, "Presented. End of Frame");
 
         for fbo in sc.acquired_framebuffers.drain(..) {
             unsafe {

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -38,7 +38,7 @@ use crate::{
     conv,
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Input, Token},
     id::{DeviceId, SwapChainId, TextureViewId},
-    resource, LifeGuard, PrivateFeatures, Stored, SubmissionIndex,
+    resource, span, LifeGuard, PrivateFeatures, Stored, SubmissionIndex,
 };
 
 use hal::{self, device::Device as _, queue::CommandQueue as _, window::PresentationSurface as _};
@@ -94,6 +94,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         swap_chain_id: SwapChainId,
         view_id_in: Input<G, TextureViewId>,
     ) -> SwapChainOutput {
+        span!(_guard, TRACE, "SwapChain::get_next_texture");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -177,6 +179,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn swap_chain_present<B: GfxBackend>(&self, swap_chain_id: SwapChainId) {
+        span!(_guard, TRACE, "SwapChain::present");
+
         let hub = B::hub(self);
         let mut token = Token::root();
 

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -94,7 +94,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         swap_chain_id: SwapChainId,
         view_id_in: Input<G, TextureViewId>,
     ) -> SwapChainOutput {
-        span!(_guard, ERROR, "SwapChain::get_next_texture");
+        span!(_guard, INFO, "SwapChain::get_next_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -179,7 +179,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn swap_chain_present<B: GfxBackend>(&self, swap_chain_id: SwapChainId) {
-        span!(_guard, ERROR, "SwapChain::present");
+        span!(_guard, INFO, "SwapChain::present");
 
         let hub = B::hub(self);
         let mut token = Token::root();


### PR DESCRIPTION
## Connections

First step in the implementation of #491. https://github.com/gfx-rs/wgpu-rs/pull/395

## Description

This adds the tracing crate, implements a tracing "layer" for chrome tracing, and instruments every entrypoint into wgpu.

Tracing is added as a main dependency. A feature is added called `subscriber` which guards the tracing and default logger implementation, as that adds 3 dependencies. 

The main macro is there to make creating a span a simple one line process. This macro will come in useful in the next couple stages. Use of this macro is used unqualified with it imported into scope as that style allows IntelliJ ides to actually find the macro.

I also removed a really annoying warning that was driving me crazy.

This PR does not make sure the logging output from tracing is up to snuff, that will be done when logging output and conversion is the priority.

Both commits should compile individually, so shouldn't need to be squashed.

## Testing

This PR was tested with the wgpu-rs PR on various examples, as well as my personal project.
