### PR TITLE
Fix RODS layout

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -533,11 +533,10 @@ pub(crate) fn map_texture_state(
         W::COPY_SRC => L::TransferSrcOptimal,
         W::COPY_DST => L::TransferDstOptimal,
         W::SAMPLED if is_color => L::ShaderReadOnlyOptimal,
-        W::SAMPLED => L::DepthStencilReadOnlyOptimal,
         W::ATTACHMENT_READ | W::ATTACHMENT_WRITE if is_color => L::ColorAttachmentOptimal,
-        W::ATTACHMENT_READ => L::DepthStencilReadOnlyOptimal,
+        _ if is_color => L::General,
         W::ATTACHMENT_WRITE => L::DepthStencilAttachmentOptimal,
-        _ => L::General,
+        _ => L::DepthStencilReadOnlyOptimal,
     };
 
     let mut access = A::empty();


### PR DESCRIPTION
**Connections**
Fixes a validation error on the water example:
> VALIDATION [UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout (1303270965)] : Validation Error: [ UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout ] Object 0: handle = 0x5626e376bc90, name = Main Command Encoder, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x4dae5635 | Submitted command buffer expects VkImage 0x390000000039[Depth Buffer] (subresource: aspectMask 0x2 array layer 0, mip level 0) to be in layout VK_IMAGE_LAYOUT_GENERAL--instead, current layout is VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL.
    object info: (type: COMMAND_BUFFER, hndl: 94725024955536, name: Main Command Encoder)

**Description**
The problem came from the fact that I totally refactored the part that figures out how attachments I used *after* I thought about the relevant layouts, and somehow let this bug slip in.

**Testing**
Tested on the water example.