### PR TITLE
Custom implement Debug for RenderCommand and ComputeCommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "gfx-descriptor"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx-extras?rev=438353c3f75368c12024ad2fc03cbeb15f351fd9#438353c3f75368c12024ad2fc03cbeb15f351fd9"
+source = "git+https://github.com/gfx-rs/gfx-extras?rev=0f7dac1b05813948fa0e5999c4fe6473f0c98f9b#0f7dac1b05813948fa0e5999c4fe6473f0c98f9b"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "gfx-memory"
 version = "0.1.3"
-source = "git+https://github.com/gfx-rs/gfx-extras?rev=438353c3f75368c12024ad2fc03cbeb15f351fd9#438353c3f75368c12024ad2fc03cbeb15f351fd9"
+source = "git+https://github.com/gfx-rs/gfx-extras?rev=0f7dac1b05813948fa0e5999c4fe6473f0c98f9b#0f7dac1b05813948fa0e5999c4fe6473f0c98f9b"
 dependencies = [
  "fxhash",
  "gfx-hal",

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -17,7 +17,7 @@ use crate::{
 use hal::command::CommandBuffer as _;
 use wgt::{BufferAddress, BufferUsage, BIND_BUFFER_ALIGNMENT};
 
-use std::{iter, str};
+use std::{fmt, iter, str};
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
@@ -68,6 +68,18 @@ impl ComputePass {
 
     pub fn parent_id(&self) -> id::CommandEncoderId {
         self.parent_id
+    }
+}
+
+impl fmt::Debug for ComputePass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ComputePass {{ encoder_id: {:?}, data: {:?} commands and {:?} dynamic offsets }}",
+            self.parent_id,
+            self.base.commands.len(),
+            self.base.dynamic_offsets.len()
+        )
     }
 }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -166,6 +166,20 @@ impl RenderPass {
     }
 }
 
+impl fmt::Debug for RenderPass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RenderPass {{ encoder_id: {:?}, color_targets: {:?}, depth_stencil_target: {:?}, data: {:?} commands and {:?} dynamic offsets }}",
+            self.parent_id,
+            self.color_targets,
+            self.depth_stencil_target,
+            self.base.commands.len(),
+            self.base.dynamic_offsets.len()
+        )
+    }
+}
+
 #[derive(Debug, PartialEq)]
 enum OptionalState {
     Unused,


### PR DESCRIPTION
This would avoid unnecessarily long debug logs for Render and Compute passes to some extent. I am not sure if it would be helpful to print `dynamic_offsets` and `string_data` under `BasePass` without the content of related `Compute/Render Command`.
<!--**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._
This would avoid 
**Testing**
_Explain how this change is tested._

Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
