### PR TITLE
Tweak the logging a bit to make debug level usable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "gfx-descriptor"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx-extras?rev=438353c3f75368c12024ad2fc03cbeb15f351fd9#438353c3f75368c12024ad2fc03cbeb15f351fd9"
+source = "git+https://github.com/gfx-rs/gfx-extras?rev=0f7dac1b05813948fa0e5999c4fe6473f0c98f9b#0f7dac1b05813948fa0e5999c4fe6473f0c98f9b"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "gfx-memory"
 version = "0.1.3"
-source = "git+https://github.com/gfx-rs/gfx-extras?rev=438353c3f75368c12024ad2fc03cbeb15f351fd9#438353c3f75368c12024ad2fc03cbeb15f351fd9"
+source = "git+https://github.com/gfx-rs/gfx-extras?rev=0f7dac1b05813948fa0e5999c4fe6473f0c98f9b#0f7dac1b05813948fa0e5999c4fe6473f0c98f9b"
 dependencies = [
  "fxhash",
  "gfx-hal",

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -158,7 +158,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 .expect("Used swap chain frame has already presented");
             comb.trackers.views.remove(view_id.value);
         }
-        log::debug!("Command buffer {:?} {:#?}", encoder_id, comb.trackers);
+        log::trace!("Command buffer {:?} {:#?}", encoder_id, comb.trackers);
         encoder_id
     }
 

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -629,15 +629,17 @@ impl<B: GfxBackend> LifetimeTracker<B> {
             })
             .collect::<FastHashMap<_, _>>();
 
-        log::debug!("Free framebuffers {:?}", remove_list);
-        for (ref key, submit_index) in remove_list {
-            let framebuffer = framebuffers.remove(key).unwrap();
-            self.active
-                .iter_mut()
-                .find(|a| a.index == submit_index)
-                .map_or(&mut self.free_resources, |a| &mut a.last_resources)
-                .framebuffers
-                .push(framebuffer);
+        if !remove_list.is_empty() {
+            log::debug!("Free framebuffers {:?}", remove_list);
+            for (ref key, submit_index) in remove_list {
+                let framebuffer = framebuffers.remove(key).unwrap();
+                self.active
+                    .iter_mut()
+                    .find(|a| a.index == submit_index)
+                    .map_or(&mut self.free_resources, |a| &mut a.last_resources)
+                    .framebuffers
+                    .push(framebuffer);
+            }
         }
     }
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -504,7 +504,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         comb.raw.insert(0, transit);
                     }
 
-                    log::debug!("Device after submission {}: {:#?}", submit_index, trackers);
+                    log::trace!("Device after submission {}: {:#?}", submit_index, trackers);
                 }
 
                 // now prepare the GPU submission

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -15,17 +15,17 @@ mod macros;
 pub mod backend {
     pub use gfx_backend_empty::Backend as Empty;
 
+    #[cfg(windows)]
+    pub use gfx_backend_dx11::Backend as Dx11;
+    #[cfg(windows)]
+    pub use gfx_backend_dx12::Backend as Dx12;
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    pub use gfx_backend_metal::Backend as Metal;
     #[cfg(any(
         not(any(target_os = "ios", target_os = "macos")),
         feature = "gfx-backend-vulkan"
     ))]
     pub use gfx_backend_vulkan::Backend as Vulkan;
-    #[cfg(any(target_os = "ios", target_os = "macos"))]
-    pub use gfx_backend_metal::Backend as Metal;
-    #[cfg(windows)]
-    pub use gfx_backend_dx12::Backend as Dx12;
-    #[cfg(windows)]
-    pub use gfx_backend_dx11::Backend as Dx11;
 }
 
 pub mod binding_model;


### PR DESCRIPTION
**Connections**
Nothing

**Description**
We should have somewhat stricter guidelines on what is ok in Debug level and what not. Previously, we printed all the tracking state on each command buffer and each submit. Since these happen every frame, and the amount of stuff used by a command buffer is not really limited, this resulted in a ton of spam, hiding legitimate Debug messages.

This PR leaves the tracker state outputs for things that are one-time, such as bind groups and render bundles, but moves out the per-frame tracking to the Trace level.

**Testing**
Running wgpu-rs examples.