### PR TITLE
Convert Extensions + Capabilities into Features

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -491,7 +491,7 @@ fn main() {
                         #[cfg(not(feature = "winit"))]
                         compatible_surface: None,
                     },
-                    unsafe { wgt::UnsafeExtensions::allow() },
+                    unsafe { wgt::UnsafeFeatures::allow() },
                     wgc::instance::AdapterInputs::IdSet(
                         &[wgc::id::TypedId::zip(0, 0, backend)],
                         |id| id.backend(),

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -20,8 +20,7 @@ use std::borrow::Borrow;
 #[derive(Clone, Debug)]
 pub enum BindGroupLayoutError {
     ConflictBinding(u32),
-    MissingExtension(wgt::Extensions),
-    MissingCapability(wgt::Capabilities),
+    MissingFeature(wgt::Features),
     /// Arrays of bindings can't be 0 elements long
     ZeroCount,
     /// Arrays of bindings unsupported for this type of binding

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -171,6 +171,7 @@ struct Stored<T> {
 #[derive(Clone, Copy, Debug)]
 struct PrivateFeatures {
     shader_validation: bool,
+    anisotropic_filtering: bool,
     texture_d24_s8: bool,
 }
 


### PR DESCRIPTION
**Connections**

Based on upcoming webgpu changes.

**Description**

Does what it says on the tin. The only notable change was classifying the AnisotropicFiltering extension as a WebGPU extension (per https://github.com/gpuweb/gpuweb/issues/696, but no idea if that's the correct interpretation)

**Testing**

Will be tested by upcoming wgpu-rs PR.