### PR TITLE
gfx-memory update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "gfx-descriptor"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx-extras?rev=0f7dac1b05813948fa0e5999c4fe6473f0c98f9b#0f7dac1b05813948fa0e5999c4fe6473f0c98f9b"
+source = "git+https://github.com/gfx-rs/gfx-extras?rev=6387d81773e29be2220cb15186ceb875ed88303b#6387d81773e29be2220cb15186ceb875ed88303b"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "gfx-memory"
 version = "0.1.3"
-source = "git+https://github.com/gfx-rs/gfx-extras?rev=0f7dac1b05813948fa0e5999c4fe6473f0c98f9b#0f7dac1b05813948fa0e5999c4fe6473f0c98f9b"
+source = "git+https://github.com/gfx-rs/gfx-extras?rev=6387d81773e29be2220cb15186ceb875ed88303b#6387d81773e29be2220cb15186ceb875ed88303b"
 dependencies = [
  "fxhash",
  "gfx-hal",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -47,11 +47,11 @@ rev = "a9228d2aed38c71388489a95817238ff98198fa3"
 
 [dependencies.gfx-descriptor]
 git = "https://github.com/gfx-rs/gfx-extras"
-rev = "0f7dac1b05813948fa0e5999c4fe6473f0c98f9b"
+rev = "6387d81773e29be2220cb15186ceb875ed88303b"
 
 [dependencies.gfx-memory]
 git = "https://github.com/gfx-rs/gfx-extras"
-rev = "0f7dac1b05813948fa0e5999c4fe6473f0c98f9b"
+rev = "6387d81773e29be2220cb15186ceb875ed88303b"
 
 [dependencies.wgt]
 path = "../wgpu-types"

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -232,6 +232,7 @@ impl<B: GfxBackend> Device<B> {
                 hal_limits.non_coherent_atom_size as u64,
             )
         };
+        let descriptors = unsafe { DescriptorAllocator::new() };
         #[cfg(not(feature = "trace"))]
         match trace_path {
             Some(_) => log::error!("Feature 'trace' is not enabled"),
@@ -243,7 +244,7 @@ impl<B: GfxBackend> Device<B> {
             adapter_id,
             com_allocator,
             mem_allocator: Mutex::new(heaps),
-            desc_allocator: Mutex::new(DescriptorAllocator::new()),
+            desc_allocator: Mutex::new(descriptors),
             queue_group,
             life_guard: LifeGuard::new(),
             active_submission_index: 0,
@@ -1459,7 +1460,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             return Err(BindGroupError::BindingsNumMismatch { expected, actual });
         }
 
-        let mut desc_set = unsafe {
+        let mut desc_set = {
             let mut desc_sets = ArrayVec::<[_; 1]>::new();
             device
                 .desc_allocator


### PR DESCRIPTION
**Connections**
Switches gfx-extras to https://github.com/gfx-rs/gfx-extras/pull/18
Fixes #750

**Description**
Includes important correctness fixes.

**Testing**
Tested on wgpu-rs examples on macOS.
Also, by @cwfitzgerald having the repro case of #750 