### PR TITLE
Added independent blending to the list of required device features

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -581,6 +581,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let wishful_features = hal::Features::VERTEX_STORES_AND_ATOMICS
                 | hal::Features::FRAGMENT_STORES_AND_ATOMICS
                 | hal::Features::NDC_Y_UP
+                | hal::Features::INDEPENDENT_BLENDING
                 | hal::Features::SAMPLER_ANISOTROPY;
             let mut enabled_features = available_features & wishful_features;
             if enabled_features != wishful_features {


### PR DESCRIPTION
Currently, using different blend modes on multiple render targets on the vulkan backend results in this validation error:

```
[2020-06-27T19:51:47Z ERROR gfx_backend_vulkan] 
    VALIDATION [VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-00605 (-884533293)] : Validation Error: [ VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-00605 ] Object 0: handle = 0x2ea18313250, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xcb4717d3 | Invalid Pipeline CreateInfo: If independent blend feature not enabled, all elements of pAttachments must be identical. The Vulkan spec states: If the independent blending feature is not enabled, all elements of pAttachments must be identical (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-00605)
    object info: (type: DEVICE, hndl: 3204451480144)
```

This is caused by not requesting the independent blend feature from the device.

Given how the wgpu/webgpu API looks like (it makes it very easy to use independent blending) and that there is 100% coverage of this feature on the Vulkan [feature database](https://vulkan.gpuinfo.org/listfeatures.php), I suppose this is a bug, and here's the trivial fix for it 😃 

If this is not meant to be required I'd like to make it an optional feature.

Tested manually in my personal project via wgpu-rs, using Vulkan backend.
(on this [commit](https://github.com/Wumpf/blub/commit/69b660ac5afff188b73eb5ae7ee4b8ff4f4b5a79), uses locally changed gfx-rs/wgpu)