### PR TITLE
Validate Dynamic Bindings are In-Bounds

### DIFF
--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -84,7 +84,6 @@ impl BindGroupEntry {
                 ref_count: bind_group.life_guard.add_ref(),
             },
         });
-        //TODO: validate the count of dynamic offsets to match the layout
         self.dynamic_offsets.clear();
         self.dynamic_offsets.extend_from_slice(offsets);
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -546,7 +546,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .bind_groups
                             .use_extend(&*bind_group_guard, bind_group_id, (), ())
                             .unwrap();
-                        assert_eq!(bind_group.dynamic_count, offsets.len());
+                        assert_eq!(bind_group.dynamic_binding_info.len(), offsets.len());
 
                         state.set_bind_group(index, bind_group_id, bind_group.layout_id, offsets);
                         state.trackers.merge_extend(&bind_group.used);

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 use hal::command::CommandBuffer as _;
-use wgt::{BufferAddress, BufferUsage, BIND_BUFFER_ALIGNMENT};
+use wgt::{BufferAddress, BufferUsage};
 
 use std::{fmt, iter, str};
 
@@ -160,22 +160,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     let offsets = &base.dynamic_offsets[..num_dynamic_offsets as usize];
                     base.dynamic_offsets = &base.dynamic_offsets[num_dynamic_offsets as usize..];
 
-                    for off in offsets {
-                        assert_eq!(
-                            *off as BufferAddress % BIND_BUFFER_ALIGNMENT,
-                            0,
-                            "Misaligned dynamic buffer offset: {} does not align with {}",
-                            off,
-                            BIND_BUFFER_ALIGNMENT
-                        );
-                    }
-
                     let bind_group = cmb
                         .trackers
                         .bind_groups
                         .use_extend(&*bind_group_guard, bind_group_id, (), ())
                         .unwrap();
-                    assert_eq!(bind_group.dynamic_count, offsets.len());
+                    bind_group.validate_dynamic_bindings(offsets).unwrap();
 
                     log::trace!(
                         "Encoding barriers on binding of {:?} to {:?}",

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -26,7 +26,7 @@ use hal::command::CommandBuffer as _;
 use wgt::{
     BufferAddress, BufferSize, BufferUsage, Color, IndexFormat, InputStepMode, LoadOp,
     RenderPassColorAttachmentDescriptorBase, RenderPassDepthStencilAttachmentDescriptorBase,
-    StoreOp, TextureUsage, BIND_BUFFER_ALIGNMENT,
+    StoreOp, TextureUsage,
 };
 
 use std::{borrow::Borrow, collections::hash_map::Entry, fmt, iter, ops::Range, str};
@@ -877,21 +877,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 } => {
                     let offsets = &base.dynamic_offsets[..num_dynamic_offsets as usize];
                     base.dynamic_offsets = &base.dynamic_offsets[num_dynamic_offsets as usize..];
-                    for off in offsets {
-                        assert_eq!(
-                            *off as BufferAddress % BIND_BUFFER_ALIGNMENT,
-                            0,
-                            "Misaligned dynamic buffer offset: {} does not align with {}",
-                            off,
-                            BIND_BUFFER_ALIGNMENT
-                        );
-                    }
 
                     let bind_group = trackers
                         .bind_groups
                         .use_extend(&*bind_group_guard, bind_group_id, (), ())
                         .unwrap();
-                    assert_eq!(bind_group.dynamic_count, offsets.len());
+                    bind_group.validate_dynamic_bindings(offsets).unwrap();
 
                     trackers.merge_extend(&bind_group.used);
 


### PR DESCRIPTION
**Connections**

Closes #756 

**Description**

Needed to store some basic info about all dynamic bindings in the bind group.

I wasn't exactly sure where to put the validation function, so I stuck it as an inherent function on the BindGroup. Can be moved if this isn't ideal.

I also moved offset alignment validation into the validation function to help reduce duplication between render/compute.

**Testing**

None of the examples use dynamic indexing, so it's hard to test this as is.

@FlorianUekermann could you possibly test this patch with your repro case?