### PR TITLE
Require mapped buffers to be aligned

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -188,7 +188,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             data_size % wgt::COPY_BUFFER_ALIGNMENT,
             0,
             "Buffer write size {} must be a multiple of {}",
-            buffer_offset,
+            data_size,
             wgt::COPY_BUFFER_ALIGNMENT,
         );
         assert_eq!(


### PR DESCRIPTION
**Connections**
Likely addresses https://github.com/gfx-rs/wgpu-rs/issues/420

**Description**
We require the size and offsets of mapping to be aligned to 4. This includes buffers mapped at creation.
It allows us to use buffer copy operations to sync the contents.

**Testing**
Not really tested
