### PR TITLE
Bump the maximum bind groups to 8

### DIFF
--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -54,7 +54,7 @@ use atomic::{AtomicUsize, Ordering};
 
 use std::{os::raw::c_char, ptr};
 
-const MAX_BIND_GROUPS: usize = 4;
+const MAX_BIND_GROUPS: usize = 8;
 
 type SubmissionIndex = usize;
 type Index = u32;


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu-rs/issues/411#issuecomment-653756154

**Description**
This is the hard upper bound. It can be 4, technically, but it would make sense to raise it to at least 8.

**Testing**
Untested, should work still.