### PR TITLE
Check parent adaptor limits instead of physical device limits

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -666,7 +666,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 log::warn!("max_bind_groups limit is missing");
             } else {
                 assert!(
-                    u32::from(limits.max_bound_descriptor_sets) >= desc.limits.max_bind_groups,
+                    u32::from(adapter.limits.max_bind_groups) >= desc.limits.max_bind_groups,
                     "Adapter does not support the requested max_bind_groups"
                 );
             }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -666,7 +666,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 log::warn!("max_bind_groups limit is missing");
             } else {
                 assert!(
-                    u32::from(adapter.limits.max_bind_groups) >= desc.limits.max_bind_groups,
+                    desc.limits.max_bind_groups <= adapter.limits.max_bind_groups,
                     "Adapter does not support the requested max_bind_groups"
                 );
             }


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu-rs/issues/411#issuecomment-653893819

**Description**
Check the given adapter limits instead of the physical device `max_bound_descriptor_sets`

**Testing**
Tested to run with project in linked comment. 
