### PR TITLE
Return result instead of panicking when requesting device. 

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -507,10 +507,10 @@ fn main() {
                 None,
                 wgc::id::TypedId::zip(1, 0, wgt::Backend::Empty)
             ))
+            .expect("Failed to request device")
         }
         _ => panic!("Expected Action::Init"),
     };
-
     log::info!("Executing actions");
     #[cfg(not(feature = "winit"))]
     {

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -223,8 +223,8 @@ impl AdapterInfo {
 pub enum RequestDeviceError {
     /// Unsupported feature extension was requested
     UnsupportedFeature(wgt::Features),
-    /// Adapter doesn't support the amount of requested bind groups
-    LimitsExceeded(u32),
+    /// Requested device limits were exceeded
+    LimitsExceeded,
 }
 
 impl Display for RequestDeviceError {
@@ -235,11 +235,9 @@ impl Display for RequestDeviceError {
                 "Cannot enable features that adapter doesn't support. Unsupported extensions: {:?}",
                 features
             ),
-            RequestDeviceError::LimitsExceeded(max_supported) => write!(
-                f,
-                "Adapter does only support a maximum of {} bind_groups",
-                max_supported
-            ),
+            RequestDeviceError::LimitsExceeded => {
+                write!(f, "Adapter does not support the requested max_bind_groups",)
+            }
         }
     }
 }
@@ -693,9 +691,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 log::warn!("max_bind_groups limit is missing");
             } else {
                 if adapter.limits.max_bind_groups < desc.limits.max_bind_groups {
-                    return Err(RequestDeviceError::LimitsExceeded(
-                        adapter.limits.max_bind_groups,
-                    ));
+                    return Err(RequestDeviceError::LimitsExceeded);
                 }
             }
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -236,7 +236,7 @@ impl Display for RequestDeviceError {
                 features
             ),
             RequestDeviceError::LimitsExceeded => {
-                write!(f, "Adapter does not support the requested max_bind_groups",)
+                write!(f, "Some of the requested limits are not supported",)
             }
         }
     }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -23,6 +23,7 @@ use hal::{
     window::Surface as _,
     Instance as _,
 };
+use std::fmt::Display;
 
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -213,6 +214,32 @@ impl AdapterInfo {
             device,
             device_type: device_type.into(),
             backend,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+/// Error when requesting a device from the adaptor
+pub enum RequestDeviceError {
+    /// Unsupported feature extension was requested
+    UnsupportedFeature(wgt::Features),
+    /// Adapter doesn't support the amount of requested bind groups
+    LimitsExceeded(u32),
+}
+
+impl Display for RequestDeviceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            RequestDeviceError::UnsupportedFeature(features) => write!(
+                f,
+                "Cannot enable features that adapter doesn't support. Unsupported extensions: {:?}",
+                features
+            ),
+            RequestDeviceError::LimitsExceeded(max_supported) => write!(
+                f,
+                "Adapter does only support a maximum of {} bind_groups",
+                max_supported
+            ),
         }
     }
 }
@@ -550,7 +577,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &DeviceDescriptor,
         trace_path: Option<&std::path::Path>,
         id_in: Input<G, DeviceId>,
-    ) -> DeviceId {
+    ) -> Result<DeviceId, RequestDeviceError> {
         span!(_guard, INFO, "Adapter::request_device");
 
         let hub = B::hub(self);
@@ -568,11 +595,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     desc.features & wgt::Features::ALL_UNSAFE
                 )
             }
-            assert!(
-                adapter.features.contains(desc.features),
-                "Cannot enable features that adapter doesn't support. Unsupported extensions: {:?}",
-                desc.features - adapter.features
-            );
+            if !adapter.features.contains(desc.features) {
+                return Err(RequestDeviceError::UnsupportedFeature(
+                    desc.features - adapter.features,
+                ));
+            }
 
             // Verify feature preconditions
             if desc
@@ -665,10 +692,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             if limits.max_bound_descriptor_sets == 0 {
                 log::warn!("max_bind_groups limit is missing");
             } else {
-                assert!(
-                    desc.limits.max_bind_groups <= adapter.limits.max_bind_groups,
-                    "Adapter does not support the requested max_bind_groups"
-                );
+                if adapter.limits.max_bind_groups < desc.limits.max_bind_groups {
+                    return Err(RequestDeviceError::LimitsExceeded(
+                        adapter.limits.max_bind_groups,
+                    ));
+                }
             }
 
             let mem_props = phd.memory_properties();
@@ -699,6 +727,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             )
         };
 
-        hub.devices.register_identity(id_in, device, &mut token)
+        Ok(hub.devices.register_identity(id_in, device, &mut token))
     }
 }


### PR DESCRIPTION
**Connections**
My previous [PR](https://github.com/gfx-rs/wgpu/pull/761) only fixed the issue at hand but it was suggested that the method should instead return a `Result` instead of panicking: https://github.com/gfx-rs/wgpu-rs/issues/411#issuecomment-654015751. So I created this as well, which builds on top of my previous (currently unmerged) changes. If you have a better name than `AdapterError` I am happy to change it.

**Description**
Don't panic on recoverable errors. I tried to look for previous examples how error enums where handled. I looked at [this](https://github.com/gfx-rs/wgpu/blob/master/wgpu-core/src/power.rs#L8) for inspiration. That's why I didn't implement `std::Error` for the enum.

**Testing**
No additional tests added, type system does much of the heavy lifting.
