### PR TITLE
Remove raw pointers from the render pipelines API

### DIFF
--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -40,9 +40,17 @@ impl ProgrammableStageDescriptor {
     pub fn new(desc: &crate::pipeline::ProgrammableStageDescriptor) -> Self {
         ProgrammableStageDescriptor {
             module: desc.module,
-            entry_point: unsafe { std::ffi::CStr::from_ptr(desc.entry_point) }
-                .to_string_lossy()
-                .to_string(),
+            entry_point: desc.entry_point.to_string(),
+        }
+    }
+}
+
+#[cfg(feature = "replay")]
+impl ProgrammableStageDescriptor {
+    pub fn to_core(&self) -> crate::pipeline::ProgrammableStageDescriptor {
+        crate::pipeline::ProgrammableStageDescriptor {
+            module: self.module,
+            entry_point: &self.entry_point,
         }
     }
 }
@@ -58,8 +66,8 @@ pub struct ComputePipelineDescriptor {
 #[derive(Debug)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
-pub struct VertexBufferLayoutDescriptor {
-    pub array_stride: wgt::BufferAddress,
+pub struct VertexBufferDescriptor {
+    pub stride: wgt::BufferAddress,
     pub step_mode: wgt::InputStepMode,
     pub attributes: Vec<wgt::VertexAttributeDescriptor>,
 }
@@ -69,7 +77,7 @@ pub struct VertexBufferLayoutDescriptor {
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub struct VertexStateDescriptor {
     pub index_format: wgt::IndexFormat,
-    pub vertex_buffers: Vec<VertexBufferLayoutDescriptor>,
+    pub vertex_buffers: Vec<VertexBufferDescriptor>,
 }
 
 #[derive(Debug)]

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -6,30 +6,13 @@ use crate::{
     device::RenderPassContext,
     id::{DeviceId, PipelineLayoutId, ShaderModuleId},
     validation::StageError,
-    LifeGuard, RawString, RefCount, Stored,
+    LifeGuard, RefCount, Stored,
 };
 use std::borrow::Borrow;
 use wgt::{
     BufferAddress, ColorStateDescriptor, DepthStencilStateDescriptor, IndexFormat, InputStepMode,
-    PrimitiveTopology, RasterizationStateDescriptor, VertexAttributeDescriptor,
+    PrimitiveTopology, RasterizationStateDescriptor, VertexStateDescriptor,
 };
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct VertexBufferLayoutDescriptor {
-    pub array_stride: BufferAddress,
-    pub step_mode: InputStepMode,
-    pub attributes: *const VertexAttributeDescriptor,
-    pub attributes_length: usize,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct VertexStateDescriptor {
-    pub index_format: IndexFormat,
-    pub vertex_buffers: *const VertexBufferLayoutDescriptor,
-    pub vertex_buffers_length: usize,
-}
 
 #[repr(C)]
 #[derive(Debug)]
@@ -46,18 +29,17 @@ pub struct ShaderModule<B: hal::Backend> {
     pub(crate) module: Option<naga::Module>,
 }
 
-#[repr(C)]
 #[derive(Debug)]
-pub struct ProgrammableStageDescriptor {
+pub struct ProgrammableStageDescriptor<'a> {
     pub module: ShaderModuleId,
-    pub entry_point: RawString,
+    pub entry_point: &'a str,
 }
 
 #[repr(C)]
 #[derive(Debug)]
-pub struct ComputePipelineDescriptor {
+pub struct ComputePipelineDescriptor<'a> {
     pub layout: PipelineLayoutId,
-    pub compute_stage: ProgrammableStageDescriptor,
+    pub compute_stage: ProgrammableStageDescriptor<'a>,
 }
 
 #[derive(Clone, Debug)]
@@ -79,18 +61,16 @@ impl<B: hal::Backend> Borrow<RefCount> for ComputePipeline<B> {
     }
 }
 
-#[repr(C)]
 #[derive(Debug)]
-pub struct RenderPipelineDescriptor {
+pub struct RenderPipelineDescriptor<'a> {
     pub layout: PipelineLayoutId,
-    pub vertex_stage: ProgrammableStageDescriptor,
-    pub fragment_stage: *const ProgrammableStageDescriptor,
+    pub vertex_stage: ProgrammableStageDescriptor<'a>,
+    pub fragment_stage: Option<ProgrammableStageDescriptor<'a>>,
     pub primitive_topology: PrimitiveTopology,
-    pub rasterization_state: *const RasterizationStateDescriptor,
-    pub color_states: *const ColorStateDescriptor,
-    pub color_states_length: usize,
-    pub depth_stencil_state: *const DepthStencilStateDescriptor,
-    pub vertex_state: VertexStateDescriptor,
+    pub rasterization_state: Option<RasterizationStateDescriptor>,
+    pub color_states: &'a [ColorStateDescriptor],
+    pub depth_stencil_state: Option<DepthStencilStateDescriptor>,
+    pub vertex_state: VertexStateDescriptor<'a>,
     pub sample_count: u32,
     pub sample_mask: u32,
     pub alpha_to_coverage_enabled: bool,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -848,6 +848,26 @@ pub struct VertexAttributeDescriptor {
     pub shader_location: ShaderLocation,
 }
 
+/// Describes how the vertex buffer is interpreted.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub struct VertexBufferDescriptor<'a> {
+    /// The stride, in bytes, between elements of this buffer.
+    pub stride: BufferAddress,
+    /// How often this vertex buffer is "stepped" forward.
+    pub step_mode: InputStepMode,
+    /// The list of attributes which comprise a single vertex.
+    pub attributes: &'a [VertexAttributeDescriptor],
+}
+
+/// Describes vertex input state for a render pipeline.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub struct VertexStateDescriptor<'a> {
+    /// The format of any index buffers used with this pipeline.
+    pub index_format: IndexFormat,
+    /// The format of any vertex buffers used with this pipeline.
+    pub vertex_buffers: &'a [VertexBufferDescriptor<'a>],
+}
+
 /// Vertex Format for a Vertex Attribute (input).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]


### PR DESCRIPTION
**Connections**
Rust-ification of API, as part of #689

**Description**
The objective is to get rid of raw pointers in the render pipeline descriptor and associated structures.

**Testing**
Checked with `player` and the `trace` feature, and with `wgpu-rs` with the changes in https://github.com/gfx-rs/wgpu-rs/pull/425