### PR TITLE
Debug markers: version bump to v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v0.5.6 (2020-07-09)
+  - add debug markers support
+
 ## v0.5.5 (2020-05-20)
   - fix destruction of adapters, swap chains, and bind group layouts
   - fix command pool leak with temporary threads

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-core"
-version = "0.5.5"
+version = "0.5.6"
 authors = [
 	"Dzmitry Malyshau <kvark@mozilla.com>",
 	"Joshua Groves <josh@joshgroves.com>",

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -22,6 +22,8 @@ use crate::{
     LifeGuard, PrivateFeatures, Stored,
 };
 
+use hal::command::CommandBuffer as _;
+
 use peek_poke::PeekPoke;
 
 use std::{marker::PhantomData, mem, ptr, slice, thread::ThreadId};
@@ -258,5 +260,52 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
         log::debug!("Command buffer {:?} {:#?}", encoder_id, comb.trackers);
         encoder_id
+    }
+
+    pub fn command_encoder_push_debug_group<B: GfxBackend>(
+        &self,
+        encoder_id: id::CommandEncoderId,
+        label: &str,
+    ) {
+        let hub = B::hub(self);
+        let mut token = Token::root();
+
+        let (mut cmb_guard, _) = hub.command_buffers.write(&mut token);
+        let cmb = &mut cmb_guard[encoder_id];
+        let cmb_raw = cmb.raw.last_mut().unwrap();
+
+        unsafe {
+            cmb_raw.begin_debug_marker(label, 0);
+        }
+    }
+
+    pub fn command_encoder_insert_debug_marker<B: GfxBackend>(
+        &self,
+        encoder_id: id::CommandEncoderId,
+        label: &str,
+    ) {
+        let hub = B::hub(self);
+        let mut token = Token::root();
+
+        let (mut cmb_guard, _) = hub.command_buffers.write(&mut token);
+        let cmb = &mut cmb_guard[encoder_id];
+        let cmb_raw = cmb.raw.last_mut().unwrap();
+
+        unsafe {
+            cmb_raw.insert_debug_marker(label, 0);
+        }
+    }
+
+    pub fn command_encoder_pop_debug_group<B: GfxBackend>(&self, encoder_id: id::CommandEncoderId) {
+        let hub = B::hub(self);
+        let mut token = Token::root();
+
+        let (mut cmb_guard, _) = hub.command_buffers.write(&mut token);
+        let cmb = &mut cmb_guard[encoder_id];
+        let cmb_raw = cmb.raw.last_mut().unwrap();
+
+        unsafe {
+            cmb_raw.end_debug_marker();
+        }
     }
 }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -29,7 +29,7 @@ use wgt::{
     TextureUsage, BIND_BUFFER_ALIGNMENT,
 };
 
-use std::{borrow::Borrow, collections::hash_map::Entry, fmt, iter, mem, ops::Range, slice};
+use std::{borrow::Borrow, collections::hash_map::Entry, fmt, iter, mem, ops::Range, slice, str};
 
 pub type RenderPassColorAttachmentDescriptor =
     RenderPassColorAttachmentDescriptorBase<id::TextureViewId>;
@@ -101,6 +101,19 @@ enum RenderCommand {
     DrawIndexedIndirect {
         buffer_id: id::BufferId,
         offset: BufferAddress,
+    },
+    PushDebugGroup {
+        color: u32,
+        len: usize,
+        #[cfg_attr(any(feature = "trace", feature = "replay"), serde(skip))]
+        phantom_marker: PhantomSlice<u8>,
+    },
+    PopDebugGroup,
+    InsertDebugMarker {
+        color: u32,
+        len: usize,
+        #[cfg_attr(any(feature = "trace", feature = "replay"), serde(skip))]
+        phantom_marker: PhantomSlice<u8>,
     },
     End,
 }
@@ -266,6 +279,7 @@ struct State {
     pipeline: OptionalState,
     index: IndexState,
     vertex: VertexState,
+    debug_scope_depth: u32,
 }
 
 impl State {
@@ -832,6 +846,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 vertex_limit: 0,
                 instance_limit: 0,
             },
+            debug_scope_depth: 0,
         };
 
         let mut command = RenderCommand::Draw {
@@ -1197,6 +1212,39 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         raw.draw_indexed_indirect(&buffer.raw, offset, 1, 0);
                     }
                 }
+                RenderCommand::PushDebugGroup {
+                    color,
+                    len,
+                    phantom_marker,
+                } => unsafe {
+                    state.debug_scope_depth += 1;
+
+                    let (new_peeker, label) =
+                        { phantom_marker.decode_unaligned(peeker, len, raw_data_end) };
+                    peeker = new_peeker;
+
+                    raw.begin_debug_marker(str::from_utf8(label).unwrap(), color)
+                },
+                RenderCommand::PopDebugGroup => unsafe {
+                    assert_ne!(
+                        state.debug_scope_depth, 0,
+                        "Can't pop debug group, because number of pushed debug groups is zero!"
+                    );
+                    state.debug_scope_depth -= 1;
+
+                    raw.end_debug_marker()
+                },
+                RenderCommand::InsertDebugMarker {
+                    color,
+                    len,
+                    phantom_marker,
+                } => unsafe {
+                    let (new_peeker, label) =
+                        { phantom_marker.decode_unaligned(peeker, len, raw_data_end) };
+                    peeker = new_peeker;
+
+                    raw.insert_debug_marker(str::from_utf8(label).unwrap(), color)
+                },
                 RenderCommand::End => break,
             }
         }
@@ -1225,7 +1273,7 @@ pub mod render_ffi {
         RenderCommand,
     };
     use crate::{id, RawString};
-    use std::{convert::TryInto, slice};
+    use std::{convert::TryInto, ffi, slice};
     use wgt::{BufferAddress, Color, DynamicOffset};
 
     /// # Safety
@@ -1392,18 +1440,40 @@ pub mod render_ffi {
     }
 
     #[no_mangle]
-    pub extern "C" fn wgpu_render_pass_push_debug_group(_pass: &mut RawPass, _label: RawString) {
-        //TODO
+    pub unsafe extern "C" fn wgpu_render_pass_push_debug_group(
+        pass: &mut RawPass,
+        label: RawString,
+        color: u32,
+    ) {
+        let bytes = ffi::CStr::from_ptr(label).to_bytes();
+
+        pass.encode(&RenderCommand::PushDebugGroup {
+            color,
+            len: bytes.len(),
+            phantom_marker: PhantomSlice::default(),
+        });
+        pass.encode_slice(bytes);
     }
 
     #[no_mangle]
-    pub extern "C" fn wgpu_render_pass_pop_debug_group(_pass: &mut RawPass) {
-        //TODO
+    pub unsafe extern "C" fn wgpu_render_pass_pop_debug_group(pass: &mut RawPass) {
+        pass.encode(&RenderCommand::PopDebugGroup);
     }
 
     #[no_mangle]
-    pub extern "C" fn wgpu_render_pass_insert_debug_marker(_pass: &mut RawPass, _label: RawString) {
-        //TODO
+    pub unsafe extern "C" fn wgpu_render_pass_insert_debug_marker(
+        pass: &mut RawPass,
+        label: RawString,
+        color: u32,
+    ) {
+        let bytes = ffi::CStr::from_ptr(label).to_bytes();
+
+        pass.encode(&RenderCommand::InsertDebugMarker {
+            color,
+            len: bytes.len(),
+            phantom_marker: PhantomSlice::default(),
+        });
+        pass.encode_slice(bytes);
     }
 
     #[no_mangle]


### PR DESCRIPTION
**Connections**
In continue of https://github.com/gfx-rs/wgpu/pull/719

**Description**
Adding debug markers support to the stable version

**Testing**
Tested via cargo test to make sure it build
