### PR TITLE
Error handling for data transfer API

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -108,18 +108,20 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                     dst,
                     dst_offset,
                     size,
-                } => self.command_encoder_copy_buffer_to_buffer::<B>(
-                    encoder, src, src_offset, dst, dst_offset, size,
-                ),
-                trace::Command::CopyBufferToTexture { src, dst, size } => {
-                    self.command_encoder_copy_buffer_to_texture::<B>(encoder, &src, &dst, &size)
-                }
-                trace::Command::CopyTextureToBuffer { src, dst, size } => {
-                    self.command_encoder_copy_texture_to_buffer::<B>(encoder, &src, &dst, &size)
-                }
-                trace::Command::CopyTextureToTexture { src, dst, size } => {
-                    self.command_encoder_copy_texture_to_texture::<B>(encoder, &src, &dst, &size)
-                }
+                } => self
+                    .command_encoder_copy_buffer_to_buffer::<B>(
+                        encoder, src, src_offset, dst, dst_offset, size,
+                    )
+                    .unwrap(),
+                trace::Command::CopyBufferToTexture { src, dst, size } => self
+                    .command_encoder_copy_buffer_to_texture::<B>(encoder, &src, &dst, &size)
+                    .unwrap(),
+                trace::Command::CopyTextureToBuffer { src, dst, size } => self
+                    .command_encoder_copy_texture_to_buffer::<B>(encoder, &src, &dst, &size)
+                    .unwrap(),
+                trace::Command::CopyTextureToTexture { src, dst, size } => self
+                    .command_encoder_copy_texture_to_texture::<B>(encoder, &src, &dst, &size)
+                    .unwrap(),
                 trace::Command::RunComputePass { base } => {
                     self.command_encoder_run_compute_pass_impl::<B>(encoder, base.as_ref());
                 }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -280,7 +280,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             data.len() as wgt::BufferAddress,
             bytes_per_texel as wgt::BufferAddress,
             size,
-        );
+        )
+        .unwrap();
 
         let bytes_per_row_alignment = get_lowest_common_denom(
             device.hal_limits.optimal_buffer_copy_pitch_alignment as u32,
@@ -329,7 +330,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             "Write texture usage {:?} must contain flag COPY_DST",
             dst.usage
         );
-        crate::command::validate_texture_copy_range(destination, dst.kind, size);
+        crate::command::validate_texture_copy_range(destination, dst.kind, size).unwrap();
 
         dst.life_guard.use_at(device.active_submission_index + 1);
 


### PR DESCRIPTION
**Connections**
Work on the error model described in #376 

**Description**
Removes assertions from the transfer functions, instead returning a custom error type.

**Testing**
Checked with `player` and `wgpu-rs`: https://github.com/gfx-rs/wgpu-rs/pull/430