### PR TITLE
Use `#[non_exhaustive]` attribute on structures

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -162,46 +162,39 @@ impl<B: hal::Backend> Adapter<B> {
 
         let adapter_limits = raw.physical_device.limits();
 
-        let default_limits = wgt::Limits::default();
+        let mut limits = wgt::Limits::default();
 
         // All these casts to u32 are safe as the underlying vulkan types are u32s.
         // If another backend provides larger limits than u32, we need to clamp them to u32::MAX.
         // TODO: fix all gfx-hal backends to produce limits we care about, and remove .max
-        let limits = wgt::Limits {
-            max_bind_groups: (adapter_limits.max_bound_descriptor_sets as u32)
-                .min(MAX_BIND_GROUPS as u32)
-                .max(default_limits.max_bind_groups),
-            max_dynamic_uniform_buffers_per_pipeline_layout: (adapter_limits
-                .max_descriptor_set_uniform_buffers_dynamic
-                as u32)
-                .max(default_limits.max_dynamic_uniform_buffers_per_pipeline_layout),
-            max_dynamic_storage_buffers_per_pipeline_layout: (adapter_limits
-                .max_descriptor_set_storage_buffers_dynamic
-                as u32)
-                .max(default_limits.max_dynamic_storage_buffers_per_pipeline_layout),
-            max_sampled_textures_per_shader_stage: (adapter_limits
-                .max_per_stage_descriptor_sampled_images
-                as u32)
-                .max(default_limits.max_sampled_textures_per_shader_stage),
-            max_samplers_per_shader_stage: (adapter_limits.max_per_stage_descriptor_samplers
-                as u32)
-                .max(default_limits.max_samplers_per_shader_stage),
-            max_storage_buffers_per_shader_stage: (adapter_limits
-                .max_per_stage_descriptor_storage_buffers
-                as u32)
-                .max(default_limits.max_storage_buffers_per_shader_stage),
-            max_storage_textures_per_shader_stage: (adapter_limits
-                .max_per_stage_descriptor_storage_images
-                as u32)
-                .max(default_limits.max_storage_textures_per_shader_stage),
-            max_uniform_buffers_per_shader_stage: (adapter_limits
-                .max_per_stage_descriptor_uniform_buffers
-                as u32)
-                .max(default_limits.max_uniform_buffers_per_shader_stage),
-            max_uniform_buffer_binding_size: (adapter_limits.max_uniform_buffer_range as u32)
-                .max(default_limits.max_uniform_buffer_binding_size),
-            _non_exhaustive: unsafe { wgt::NonExhaustive::new() },
-        };
+        limits.max_bind_groups = (adapter_limits.max_bound_descriptor_sets as u32)
+            .min(MAX_BIND_GROUPS as u32)
+            .max(limits.max_bind_groups);
+        limits.max_dynamic_uniform_buffers_per_pipeline_layout =
+            (adapter_limits.max_descriptor_set_uniform_buffers_dynamic as u32)
+                .max(limits.max_dynamic_uniform_buffers_per_pipeline_layout);
+        limits.max_dynamic_storage_buffers_per_pipeline_layout =
+            (adapter_limits.max_descriptor_set_storage_buffers_dynamic as u32)
+                .max(limits.max_dynamic_storage_buffers_per_pipeline_layout);
+        limits.max_sampled_textures_per_shader_stage =
+            (adapter_limits.max_per_stage_descriptor_sampled_images as u32)
+                .max(limits.max_sampled_textures_per_shader_stage);
+
+        limits.max_samplers_per_shader_stage = (adapter_limits.max_per_stage_descriptor_samplers
+            as u32)
+            .max(limits.max_samplers_per_shader_stage);
+        limits.max_storage_buffers_per_shader_stage =
+            (adapter_limits.max_per_stage_descriptor_storage_buffers as u32)
+                .max(limits.max_storage_buffers_per_shader_stage);
+
+        limits.max_storage_textures_per_shader_stage =
+            (adapter_limits.max_per_stage_descriptor_storage_images as u32)
+                .max(limits.max_storage_textures_per_shader_stage);
+        limits.max_uniform_buffers_per_shader_stage =
+            (adapter_limits.max_per_stage_descriptor_uniform_buffers as u32)
+                .max(limits.max_uniform_buffers_per_shader_stage);
+        limits.max_uniform_buffer_binding_size = (adapter_limits.max_uniform_buffer_range as u32)
+            .max(limits.max_uniform_buffer_binding_size);
 
         Adapter {
             raw,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -101,30 +101,6 @@ impl From<Backend> for BackendBit {
     }
 }
 
-/// This type is not to be constructed by any users of wgpu. If you construct this type, any semver
-/// guarantees made by wgpu are invalidated and a non-breaking change may break your code.
-///
-/// If you are here trying to construct it, the solution is to use partial construction with the
-/// default:
-///
-/// ```ignore
-/// let limits = Limits {
-///     max_bind_groups: 2,
-///     ..Limits::default()
-/// }
-/// ```
-#[doc(hidden)]
-#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "trace", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct NonExhaustive(());
-
-impl NonExhaustive {
-    pub unsafe fn new() -> Self {
-        Self(())
-    }
-}
-
 bitflags::bitflags! {
     /// Features that are not guaranteed to be supported.
     ///
@@ -253,6 +229,7 @@ bitflags::bitflags! {
 /// See also: https://gpuweb.github.io/gpuweb/#dictdef-gpulimits
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct Limits {
@@ -274,8 +251,6 @@ pub struct Limits {
     pub max_uniform_buffers_per_shader_stage: u32,
     /// Maximum size in bytes of a binding to a uniform buffer. Defaults to 16384. Higher is "better".
     pub max_uniform_buffer_binding_size: u32,
-    /// This struct must be partially constructed from its default.
-    pub _non_exhaustive: NonExhaustive,
 }
 
 impl Default for Limits {
@@ -290,7 +265,6 @@ impl Default for Limits {
             max_storage_textures_per_shader_stage: 4,
             max_uniform_buffers_per_shader_stage: 12,
             max_uniform_buffer_binding_size: 16384,
-            _non_exhaustive: unsafe { NonExhaustive::new() },
         }
     }
 }
@@ -1407,6 +1381,7 @@ impl Default for FilterMode {
 
 /// Describes a [`Sampler`]
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct SamplerDescriptor<L> {
@@ -1432,8 +1407,6 @@ pub struct SamplerDescriptor<L> {
     pub compare: Option<CompareFunction>,
     /// Valid values: 1, 2, 4, 8, and 16.
     pub anisotropy_clamp: Option<u8>,
-    /// This struct must be partially constructed from its default
-    pub _non_exhaustive: NonExhaustive,
 }
 
 impl<L: Default> Default for SamplerDescriptor<L> {
@@ -1450,7 +1423,6 @@ impl<L: Default> Default for SamplerDescriptor<L> {
             lod_max_clamp: std::f32::MAX,
             compare: Default::default(),
             anisotropy_clamp: Default::default(),
-            _non_exhaustive: Default::default(),
         }
     }
 }
@@ -1469,7 +1441,6 @@ impl<L> SamplerDescriptor<L> {
             lod_max_clamp: self.lod_max_clamp,
             compare: self.compare,
             anisotropy_clamp: self.anisotropy_clamp,
-            _non_exhaustive: self._non_exhaustive,
         }
     }
 }
@@ -1715,6 +1686,7 @@ pub enum BindingType {
 
 /// Describes a single binding inside a bind group.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct BindGroupLayoutEntry {
@@ -1731,9 +1703,6 @@ pub struct BindGroupLayoutEntry {
     ///
     /// If this value is Some and `ty` is any other variant, bind group creation will fail.
     pub count: Option<u32>,
-    /// This struct should be partially initalized using the default method, but binding, visibility,
-    /// and ty should be set.
-    pub _non_exhaustive: NonExhaustive,
 }
 
 impl BindGroupLayoutEntry {
@@ -1743,7 +1712,6 @@ impl BindGroupLayoutEntry {
             visibility,
             ty,
             count: None,
-            _non_exhaustive: unsafe { NonExhaustive::new() },
         }
     }
 


### PR DESCRIPTION
**Description**
The `#[non_exhaustive]` attribute [can also be applied on structures](https://doc.rust-lang.org/reference/attributes/type_system.html). This will make it impossible to explicitly initialize those structures by specifying the field values outside the `wgpu-types` crate.

**Testing**
Checked with `player` and `wgpu-rs`.