### PR TITLE
[0.5] Debug markers for command encoders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wgpu-core"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "battery 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-native"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -687,7 +687,7 @@ dependencies = [
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu-core 0.5.5",
+ "wgpu-core 0.5.6",
  "wgpu-types 0.5.1",
 ]
 
@@ -697,7 +697,7 @@ version = "0.1.0"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu-core 0.5.5",
+ "wgpu-core 0.5.6",
  "wgpu-types 0.5.1",
 ]
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* Generated with cbindgen:0.14.1 */
+/* Generated with cbindgen:0.14.3 */
 
 /* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
  * To generate this file:
@@ -416,9 +416,9 @@ typedef struct {
   uint32_t todo;
 } WGPUCommandBufferDescriptor;
 
-typedef WGPURawPass *WGPUComputePassId;
-
 typedef const char *WGPURawString;
+
+typedef WGPURawPass *WGPUComputePassId;
 
 typedef uint32_t WGPUDynamicOffset;
 
@@ -794,6 +794,16 @@ void wgpu_command_encoder_destroy(WGPUCommandEncoderId command_encoder_id);
 WGPUCommandBufferId wgpu_command_encoder_finish(WGPUCommandEncoderId encoder_id,
                                                 const WGPUCommandBufferDescriptor *desc);
 
+void wgpu_command_encoder_insert_debug_marker(WGPUCommandEncoderId command_encoder_id,
+                                              WGPURawString label,
+                                              uint32_t _color);
+
+void wgpu_command_encoder_pop_debug_group(WGPUCommandEncoderId command_encoder_id);
+
+void wgpu_command_encoder_push_debug_group(WGPUCommandEncoderId command_encoder_id,
+                                           WGPURawString label,
+                                           uint32_t _color);
+
 void wgpu_compute_pass_destroy(WGPURawPass *pass);
 
 void wgpu_compute_pass_dispatch(WGPURawPass *pass,
@@ -809,11 +819,11 @@ void wgpu_compute_pass_end_pass(WGPUComputePassId pass_id);
 
 const uint8_t *wgpu_compute_pass_finish(WGPURawPass *pass, uintptr_t *length);
 
-void wgpu_compute_pass_insert_debug_marker(WGPURawPass *_pass, WGPURawString _label);
+void wgpu_compute_pass_insert_debug_marker(WGPURawPass *pass, WGPURawString label, uint32_t color);
 
-void wgpu_compute_pass_pop_debug_group(WGPURawPass *_pass);
+void wgpu_compute_pass_pop_debug_group(WGPURawPass *pass);
 
-void wgpu_compute_pass_push_debug_group(WGPURawPass *_pass, WGPURawString _label);
+void wgpu_compute_pass_push_debug_group(WGPURawPass *pass, WGPURawString label, uint32_t color);
 
 /**
  * # Safety
@@ -934,11 +944,11 @@ void wgpu_render_pass_execute_bundles(WGPURawPass *_pass,
 
 const uint8_t *wgpu_render_pass_finish(WGPURawPass *pass, uintptr_t *length);
 
-void wgpu_render_pass_insert_debug_marker(WGPURawPass *_pass, WGPURawString _label);
+void wgpu_render_pass_insert_debug_marker(WGPURawPass *pass, WGPURawString label, uint32_t color);
 
-void wgpu_render_pass_pop_debug_group(WGPURawPass *_pass);
+void wgpu_render_pass_pop_debug_group(WGPURawPass *pass);
 
-void wgpu_render_pass_push_debug_group(WGPURawPass *_pass, WGPURawString _label);
+void wgpu_render_pass_push_debug_group(WGPURawPass *pass, WGPURawString label, uint32_t color);
 
 /**
  * # Safety

--- a/wgpu-native/Cargo.toml
+++ b/wgpu-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-native"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
 	"Dzmitry Malyshau <kvark@mozilla.com>",
 	"Joshua Groves <josh@joshgroves.com>",

--- a/wgpu-native/src/command.rs
+++ b/wgpu-native/src/command.rs
@@ -130,3 +130,30 @@ pub unsafe extern "C" fn wgpu_compute_pass_end_pass(pass_id: id::ComputePassId) 
 pub unsafe extern "C" fn wgpu_compute_pass_destroy(pass: *mut core::command::RawPass) {
     let _ = Box::from_raw(pass).into_vec();
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpu_command_encoder_push_debug_group(
+    command_encoder_id: id::CommandEncoderId,
+    label: core::RawString,
+    _color: u32,
+) {
+    let string = std::ffi::CStr::from_ptr(label).to_string_lossy();
+    gfx_select!(command_encoder_id => GLOBAL.command_encoder_push_debug_group(command_encoder_id, &string));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpu_command_encoder_pop_debug_group(
+    command_encoder_id: id::CommandEncoderId,
+) {
+    gfx_select!(command_encoder_id => GLOBAL.command_encoder_pop_debug_group(command_encoder_id));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpu_command_encoder_insert_debug_marker(
+    command_encoder_id: id::CommandEncoderId,
+    label: core::RawString,
+    _color: u32,
+) {
+    let string = std::ffi::CStr::from_ptr(label).to_string_lossy();
+    gfx_select!(command_encoder_id => GLOBAL.command_encoder_insert_debug_marker(command_encoder_id, &string));
+}


### PR DESCRIPTION
**Connections**
Follow-up to #771 

**Description**
Adds the missing functions to wgpu-native and bumps its patch version.

**Testing**
Compiling wgpu-rs