### PR TITLE
Add Error State to Storages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,12 +1441,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,7 +1600,6 @@ dependencies = [
  "thread-id",
  "tracing",
  "tracing-subscriber",
- "vec_map",
  "wgpu-types",
 ]
 

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -39,7 +39,6 @@ spirv_headers = { version = "1.4.2" }
 thread-id = { version = "3", optional = true }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber =  { version = "0.2", optional = true }
-vec_map = "0.8.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -140,9 +140,8 @@ impl<T, I: TypedId> Storage<T, I> {
         let (index, epoch, _) = id.unzip();
         let len = self.map.len();
         if len <= index as usize {
-            for _ in 0..index as usize - len + 1 {
-                self.map.push(Element::Vacant);
-            }
+            self.map
+                .resize_with(index as usize - len + 1, || Element::Vacant);
         }
         std::mem::replace(
             &mut self.map[index as usize],

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -21,7 +21,6 @@ use crate::{
 };
 
 use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
-use vec_map::VecMap;
 use wgt::Backend;
 
 #[cfg(debug_assertions)]
@@ -78,9 +77,16 @@ impl IdentityManager {
 }
 
 #[derive(Debug)]
+pub enum Element<T> {
+    Vacant,
+    Occupied(T, Epoch),
+    Error,
+}
+
+#[derive(Debug)]
 pub struct Storage<T, I: TypedId> {
     //TODO: consider concurrent hashmap?
-    map: VecMap<(T, Epoch)>,
+    map: Vec<Element<T>>,
     kind: &'static str,
     _phantom: PhantomData<I>,
 }
@@ -89,9 +95,10 @@ impl<T, I: TypedId> ops::Index<I> for Storage<T, I> {
     type Output = T;
     fn index(&self, id: I) -> &T {
         let (index, epoch, _) = id.unzip();
-        let (ref value, storage_epoch) = match self.map.get(index as usize) {
-            Some(v) => v,
-            None => panic!("{}[{}] does not exist", self.kind, index),
+        let (ref value, storage_epoch) = match self.map[index as usize] {
+            Element::Occupied(ref v, ref w) => (v, w),
+            Element::Vacant => panic!("{}[{}] does not exist", self.kind, index),
+            _ => unreachable!(),
         };
         assert_eq!(
             epoch, *storage_epoch,
@@ -105,9 +112,10 @@ impl<T, I: TypedId> ops::Index<I> for Storage<T, I> {
 impl<T, I: TypedId> ops::IndexMut<I> for Storage<T, I> {
     fn index_mut(&mut self, id: I) -> &mut T {
         let (index, epoch, _) = id.unzip();
-        let (ref mut value, storage_epoch) = match self.map.get_mut(index as usize) {
-            Some(v) => v,
-            None => panic!("{}[{}] does not exist", self.kind, index),
+        let (value, storage_epoch) = match self.map[index as usize] {
+            Element::Occupied(ref mut v, ref w) => (v, w),
+            Element::Vacant => panic!("{}[{}] does not exist", self.kind, index),
+            _ => unreachable!(),
         };
         assert_eq!(
             epoch, *storage_epoch,
@@ -121,32 +129,55 @@ impl<T, I: TypedId> ops::IndexMut<I> for Storage<T, I> {
 impl<T, I: TypedId> Storage<T, I> {
     pub fn contains(&self, id: I) -> bool {
         let (index, epoch, _) = id.unzip();
-        match self.map.get(index as usize) {
-            Some(&(_, storage_epoch)) => epoch == storage_epoch,
-            None => false,
+        match self.map[index as usize] {
+            Element::Occupied(_, storage_epoch) => epoch == storage_epoch,
+            Element::Vacant => false,
+            _ => unreachable!(),
         }
     }
 
-    pub fn insert(&mut self, id: I, value: T) -> Option<T> {
+    pub fn insert(&mut self, id: I, value: T) -> Element<T> {
         let (index, epoch, _) = id.unzip();
-        let old = self.map.insert(index as usize, (value, epoch));
-        old.map(|(v, _storage_epoch)| v)
+        let len = self.map.len();
+        if len <= index as usize {
+            for _ in 0..index as usize - len + 1 {
+                self.map.push(Element::Vacant);
+            }
+        }
+        std::mem::replace(
+            &mut self.map[index as usize],
+            Element::Occupied(value, epoch),
+        )
     }
 
     pub fn remove(&mut self, id: I) -> Option<T> {
         let (index, epoch, _) = id.unzip();
-        self.map
-            .remove(index as usize)
-            .map(|(value, storage_epoch)| {
-                assert_eq!(epoch, storage_epoch);
-                value
-            })
+        let element = if index as usize == self.map.len() - 1 {
+            self.map.pop().unwrap()
+        } else {
+            std::mem::replace(&mut self.map[index as usize], Element::Vacant)
+        };
+        if let Element::Occupied(value, storage_epoch) = element {
+            assert_eq!(epoch, storage_epoch);
+            Some(value)
+        } else {
+            None
+        }
     }
 
     pub fn iter(&self, backend: Backend) -> impl Iterator<Item = (I, &T)> {
-        self.map.iter().map(move |(index, (value, storage_epoch))| {
-            (I::zip(index as Index, *storage_epoch, backend), value)
-        })
+        self.map
+            .iter()
+            .enumerate()
+            .filter_map(move |(index, x)| {
+                let w = if let Element::Occupied(ref value, ref storage_epoch) = x {
+                    Some((I::zip(index as Index, *storage_epoch, backend), value))
+                } else {
+                    None
+                };
+                w
+            })
+            .into_iter()
     }
 }
 
@@ -328,7 +359,7 @@ impl<T, I: TypedId, F: IdentityHandlerFactory<I>> Registry<T, I, F> {
         Registry {
             identity: factory.spawn(0),
             data: RwLock::new(Storage {
-                map: VecMap::new(),
+                map: Vec::new(),
                 kind,
                 _phantom: PhantomData,
             }),
@@ -340,7 +371,7 @@ impl<T, I: TypedId, F: IdentityHandlerFactory<I>> Registry<T, I, F> {
         Registry {
             identity: factory.spawn(1),
             data: RwLock::new(Storage {
-                map: VecMap::new(),
+                map: Vec::new(),
                 kind,
                 _phantom: PhantomData,
             }),
@@ -353,7 +384,10 @@ impl<T, I: TypedId + Copy, F: IdentityHandlerFactory<I>> Registry<T, I, F> {
     pub fn register<A: Access<T>>(&self, id: I, value: T, _token: &mut Token<A>) {
         debug_assert_eq!(id.unzip().2, self.backend);
         let old = self.data.write().insert(id, value);
-        assert!(old.is_none());
+        match old {
+            Element::Vacant => {}
+            _ => panic!("Id slot not vacant"),
+        }
     }
 
     pub fn read<'a, A: Access<T>>(
@@ -446,93 +480,151 @@ impl<B: GfxBackend, F: GlobalIdentityHandlerFactory> Hub<B, F> {
         use hal::{device::Device as _, window::PresentationSurface as _};
 
         let mut devices = self.devices.data.write();
-        for (device, _) in devices.map.values_mut() {
-            device.prepare_to_die();
-        }
-
-        for (_, (sampler, _)) in self.samplers.data.write().map.drain() {
-            unsafe {
-                devices[sampler.device_id.value]
-                    .raw
-                    .destroy_sampler(sampler.raw);
+        for element in devices.map.iter_mut() {
+            if let Element::Occupied(device, _) = element {
+                device.prepare_to_die();
             }
         }
+
+        self.samplers.data.write().map.drain(..).for_each(|x| {
+            if let Element::Occupied(sampler, _) = x {
+                unsafe {
+                    devices[sampler.device_id.value]
+                        .raw
+                        .destroy_sampler(sampler.raw);
+                }
+            }
+        });
         {
             let textures = self.textures.data.read();
-            for (_, (texture_view, _)) in self.texture_views.data.write().map.drain() {
-                match texture_view.inner {
-                    TextureViewInner::Native { raw, source_id } => {
-                        let device = &devices[textures[source_id.value].device_id.value];
-                        unsafe {
-                            device.raw.destroy_image_view(raw);
+            for element in self.texture_views.data.write().map.drain(..) {
+                if let Element::Occupied(texture_view, _) = element {
+                    match texture_view.inner {
+                        TextureViewInner::Native { raw, source_id } => {
+                            let device = &devices[textures[source_id.value].device_id.value];
+                            unsafe {
+                                device.raw.destroy_image_view(raw);
+                            }
                         }
+                        TextureViewInner::SwapChain { .. } => {} //TODO
                     }
-                    TextureViewInner::SwapChain { .. } => {} //TODO
                 }
             }
         }
 
-        for (_, (texture, _)) in self.textures.data.write().map.drain() {
-            devices[texture.device_id.value].destroy_texture(texture);
-        }
-        for (_, (buffer, _)) in self.buffers.data.write().map.drain() {
-            //TODO: unmap if needed
-            devices[buffer.device_id.value].destroy_buffer(buffer);
-        }
-        for (_, (command_buffer, _)) in self.command_buffers.data.write().map.drain() {
-            devices[command_buffer.device_id.value]
-                .com_allocator
-                .after_submit(command_buffer, 0);
-        }
-        for (_, (bind_group, _)) in self.bind_groups.data.write().map.drain() {
-            let device = &devices[bind_group.device_id.value];
-            device.destroy_bind_group(bind_group);
+        self.textures.data.write().map.drain(..).for_each(|x| {
+            if let Element::Occupied(texture, _) = x {
+                devices[texture.device_id.value].destroy_texture(texture);
+            }
+        });
+        self.buffers.data.write().map.drain(..).for_each(|x| {
+            if let Element::Occupied(buffer, _) = x {
+                //TODO: unmap if needed
+                devices[buffer.device_id.value].destroy_buffer(buffer);
+            }
+        });
+        self.command_buffers
+            .data
+            .write()
+            .map
+            .drain(..)
+            .for_each(|x| {
+                if let Element::Occupied(command_buffer, _) = x {
+                    devices[command_buffer.device_id.value]
+                        .com_allocator
+                        .after_submit(command_buffer, 0);
+                }
+            });
+        self.bind_groups.data.write().map.drain(..).for_each(|x| {
+            if let Element::Occupied(bind_group, _) = x {
+                let device = &devices[bind_group.device_id.value];
+                device.destroy_bind_group(bind_group);
+            }
+        });
+
+        self.shader_modules
+            .data
+            .write()
+            .map
+            .drain(..)
+            .for_each(|x| {
+                if let Element::Occupied(module, _) = x {
+                    let device = &devices[module.device_id.value];
+                    unsafe {
+                        device.raw.destroy_shader_module(module.raw);
+                    }
+                }
+            });
+        self.bind_group_layouts
+            .data
+            .write()
+            .map
+            .drain(..)
+            .for_each(|x| {
+                if let Element::Occupied(bgl, _) = x {
+                    let device = &devices[bgl.device_id.value];
+                    unsafe {
+                        device.raw.destroy_descriptor_set_layout(bgl.raw);
+                    }
+                }
+            });
+        self.pipeline_layouts
+            .data
+            .write()
+            .map
+            .drain(..)
+            .for_each(|x| {
+                if let Element::Occupied(pipeline_layout, _) = x {
+                    let device = &devices[pipeline_layout.device_id.value];
+                    unsafe {
+                        device.raw.destroy_pipeline_layout(pipeline_layout.raw);
+                    }
+                }
+            });
+        self.compute_pipelines
+            .data
+            .write()
+            .map
+            .drain(..)
+            .for_each(|x| {
+                if let Element::Occupied(pipeline, _) = x {
+                    let device = &devices[pipeline.device_id.value];
+                    unsafe {
+                        device.raw.destroy_compute_pipeline(pipeline.raw);
+                    }
+                }
+            });
+        self.render_pipelines
+            .data
+            .write()
+            .map
+            .drain(..)
+            .for_each(|x| {
+                if let Element::Occupied(pipeline, _) = x {
+                    let device = &devices[pipeline.device_id.value];
+                    unsafe {
+                        device.raw.destroy_graphics_pipeline(pipeline.raw);
+                    }
+                }
+            });
+
+        for (index, element) in self.swap_chains.data.write().map.drain(..).enumerate() {
+            if let Element::Occupied(swap_chain, epoch) = element {
+                let device = &devices[swap_chain.device_id.value];
+                let surface = &mut surface_guard[TypedId::zip(index as Index, epoch, B::VARIANT)];
+                let suf = B::get_surface_mut(surface);
+                unsafe {
+                    device.raw.destroy_semaphore(swap_chain.semaphore);
+                    suf.unconfigure_swapchain(&device.raw);
+                }
+            }
         }
 
-        for (_, (module, _)) in self.shader_modules.data.write().map.drain() {
-            let device = &devices[module.device_id.value];
-            unsafe {
-                device.raw.destroy_shader_module(module.raw);
+        devices.map.drain(..).for_each(|x| {
+            if let Element::Occupied(device, _) = x {
+                device.dispose();
             }
-        }
-        for (_, (bgl, _)) in self.bind_group_layouts.data.write().map.drain() {
-            let device = &devices[bgl.device_id.value];
-            unsafe {
-                device.raw.destroy_descriptor_set_layout(bgl.raw);
-            }
-        }
-        for (_, (pipeline_layout, _)) in self.pipeline_layouts.data.write().map.drain() {
-            let device = &devices[pipeline_layout.device_id.value];
-            unsafe {
-                device.raw.destroy_pipeline_layout(pipeline_layout.raw);
-            }
-        }
-        for (_, (pipeline, _)) in self.compute_pipelines.data.write().map.drain() {
-            let device = &devices[pipeline.device_id.value];
-            unsafe {
-                device.raw.destroy_compute_pipeline(pipeline.raw);
-            }
-        }
-        for (_, (pipeline, _)) in self.render_pipelines.data.write().map.drain() {
-            let device = &devices[pipeline.device_id.value];
-            unsafe {
-                device.raw.destroy_graphics_pipeline(pipeline.raw);
-            }
-        }
-
-        for (index, (swap_chain, epoch)) in self.swap_chains.data.write().map.drain() {
-            let device = &devices[swap_chain.device_id.value];
-            let surface = &mut surface_guard[TypedId::zip(index as Index, epoch, B::VARIANT)];
-            let suf = B::get_surface_mut(surface);
-            unsafe {
-                device.raw.destroy_semaphore(swap_chain.semaphore);
-                suf.unconfigure_swapchain(&device.raw);
-            }
-        }
-
-        for (_, (device, _)) in devices.map.drain() {
-            device.dispose();
-        }
+        });
     }
 }
 
@@ -609,8 +701,10 @@ impl<G: GlobalIdentityHandlerFactory> Drop for Global<G> {
             }
 
             // destroy surfaces
-            for (_, (surface, _)) in surface_guard.map.drain() {
-                self.instance.destroy_surface(surface);
+            for element in surface_guard.map.drain(..) {
+                if let Element::Occupied(surface, _) = element {
+                    self.instance.destroy_surface(surface);
+                }
             }
         }
     }


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_
fix #772 

**Description**
_Describe what problem this is solving, and how it's solved._
This aims to replace `VecMap` with a simple `Vec<Element<T>>` to keep track of valid and error Ids in Storages. This lays the foundations for #638. A new `enum Element<T>` is introduced as described in the linked issue.
The `Error` Variant is not used anywhere at the moment.

**Testing**
_Explain how this change is tested._
A Successful build is the only check done at the moment.
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
