### PR TITLE
Add check while trying to remove uninserted Ids

### DIFF
--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -152,6 +152,9 @@ impl<T, I: TypedId> Storage<T, I> {
 
     pub fn remove(&mut self, id: I) -> Option<T> {
         let (index, epoch, _) = id.unzip();
+        if index as usize >= self.map.len() {
+            return None;
+        }
         if let Element::Occupied(value, storage_epoch) =
             std::mem::replace(&mut self.map[index as usize], Element::Vacant)
         {


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_
An attempt to fix #781 
regression from #776 

**Description**
_Describe what problem this is solving, and how it's solved._
When we used `VecMap`, it simply returned `None` for even out of bounds access to the map (We depended on it returning `None`). After #776 , we get a panic. So adding a simple index check before accessing it fixes this issue.

**Testing**
_Explain how this change is tested._
Tested on wgpu-rs examples with the changes in https://github.com/gfx-rs/wgpu-rs/pull/430. All examples run fine except the `cube` which segfaults.
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
