### PR TITLE
Remove non-exhaustive markers

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -160,7 +160,6 @@ impl BindingTypeMaxCountValidator {
             wgt::BindingType::StorageTexture { .. } => {
                 self.storage_textures.add(binding.visibility, count);
             }
-            _ => unreachable!(),
         }
     }
 

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -111,7 +111,6 @@ pub fn map_binding_type(binding: &wgt::BindGroupLayoutEntry) -> hal::pso::Descri
                 read_only: readonly,
             },
         },
-        _ => unreachable!(),
     }
 }
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -200,7 +200,6 @@ impl<B: hal::Backend> Adapter<B> {
                 .max(default_limits.max_uniform_buffers_per_shader_stage),
             max_uniform_buffer_binding_size: (adapter_limits.max_uniform_buffer_range as u32)
                 .max(default_limits.max_uniform_buffer_binding_size),
-            _non_exhaustive: unsafe { wgt::NonExhaustive::new() },
         };
 
         Adapter {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -101,30 +101,6 @@ impl From<Backend> for BackendBit {
     }
 }
 
-/// This type is not to be constructed by any users of wgpu. If you construct this type, any semver
-/// guarantees made by wgpu are invalidated and a non-breaking change may break your code.
-///
-/// If you are here trying to construct it, the solution is to use partial construction with the
-/// default:
-///
-/// ```ignore
-/// let limits = Limits {
-///     max_bind_groups: 2,
-///     ..Limits::default()
-/// }
-/// ```
-#[doc(hidden)]
-#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "trace", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct NonExhaustive(());
-
-impl NonExhaustive {
-    pub unsafe fn new() -> Self {
-        Self(())
-    }
-}
-
 bitflags::bitflags! {
     /// Features that are not guaranteed to be supported.
     ///
@@ -274,8 +250,6 @@ pub struct Limits {
     pub max_uniform_buffers_per_shader_stage: u32,
     /// Maximum size in bytes of a binding to a uniform buffer. Defaults to 16384. Higher is "better".
     pub max_uniform_buffer_binding_size: u32,
-    /// This struct must be partially constructed from its default.
-    pub _non_exhaustive: NonExhaustive,
 }
 
 impl Default for Limits {
@@ -290,7 +264,6 @@ impl Default for Limits {
             max_storage_textures_per_shader_stage: 4,
             max_uniform_buffers_per_shader_stage: 12,
             max_uniform_buffer_binding_size: 16384,
-            _non_exhaustive: unsafe { NonExhaustive::new() },
         }
     }
 }
@@ -1432,8 +1405,6 @@ pub struct SamplerDescriptor<L> {
     pub compare: Option<CompareFunction>,
     /// Valid values: 1, 2, 4, 8, and 16.
     pub anisotropy_clamp: Option<u8>,
-    /// This struct must be partially constructed from its default
-    pub _non_exhaustive: NonExhaustive,
 }
 
 impl<L: Default> Default for SamplerDescriptor<L> {
@@ -1450,7 +1421,6 @@ impl<L: Default> Default for SamplerDescriptor<L> {
             lod_max_clamp: std::f32::MAX,
             compare: Default::default(),
             anisotropy_clamp: Default::default(),
-            _non_exhaustive: Default::default(),
         }
     }
 }
@@ -1469,7 +1439,6 @@ impl<L> SamplerDescriptor<L> {
             lod_max_clamp: self.lod_max_clamp,
             compare: self.compare,
             anisotropy_clamp: self.anisotropy_clamp,
-            _non_exhaustive: self._non_exhaustive,
         }
     }
 }
@@ -1608,7 +1577,6 @@ pub struct TextureDataLayout {
 /// Specific type of a binding.
 ///
 /// WebGPU spec: https://gpuweb.github.io/gpuweb/#dictdef-gpubindgrouplayoutentry
-#[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
@@ -1731,9 +1699,6 @@ pub struct BindGroupLayoutEntry {
     ///
     /// If this value is Some and `ty` is any other variant, bind group creation will fail.
     pub count: Option<u32>,
-    /// This struct should be partially initalized using the default method, but binding, visibility,
-    /// and ty should be set.
-    pub _non_exhaustive: NonExhaustive,
 }
 
 impl BindGroupLayoutEntry {
@@ -1743,7 +1708,6 @@ impl BindGroupLayoutEntry {
             visibility,
             ty,
             count: None,
-            _non_exhaustive: unsafe { NonExhaustive::new() },
         }
     }
 


### PR DESCRIPTION
Based on the previous [discussion](https://github.com/gfx-rs/wgpu/pull/774#issuecomment-657171354), this PR removes the `NonExhaustive` structure and any `#[non_exhaustive]` attribute since it's too early to decide how to ensure forward compatibility.

**Testing**
Checked the `core`, `types` and `player` crates.