### PR TITLE
core: make DeviceType repr(u8)

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -273,6 +273,7 @@ impl Display for RequestDeviceError {
 }
 
 /// Supported physical device types.
+#[repr(u8)]
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]


### PR DESCRIPTION
**Connections**

This PR will make gfx-rs/wgpu-native#43 mergeable.

**Description**

`DeviceType` wasn't made to be used in FFI. The enum is now set to `#[repr(u8)]`.

**Testing**

It's not tested 💯 
