### PR TITLE
Unify `wgpu-core` and `wgpu-rs` types

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -228,8 +228,7 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                 self.device_create_pipeline_layout::<B>(
                     device,
                     &wgc::binding_model::PipelineLayoutDescriptor {
-                        bind_group_layouts: bind_group_layouts.as_ptr(),
-                        bind_group_layouts_length: bind_group_layouts.len(),
+                        bind_group_layouts: &bind_group_layouts,
                     },
                     id,
                 )

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -229,12 +229,7 @@ pub struct BindGroupLayout<B: hal::Backend> {
     pub(crate) count_validator: BindingTypeMaxCountValidator,
 }
 
-#[repr(C)]
-#[derive(Debug)]
-pub struct PipelineLayoutDescriptor {
-    pub bind_group_layouts: *const BindGroupLayoutId,
-    pub bind_group_layouts_length: usize,
-}
+pub type PipelineLayoutDescriptor<'a> = wgt::PipelineLayoutDescriptor<'a, BindGroupLayoutId>;
 
 #[derive(Clone, Debug)]
 pub enum PipelineLayoutError {
@@ -260,7 +255,8 @@ pub struct BufferBinding {
     pub size: Option<wgt::BufferSize>,
 }
 
-// Note: Duplicated in wgpu-rs as BindingResource
+// Note: Duplicated in `wgpu-rs` as `BindingResource`
+// They're different enough that it doesn't make sense to share a common type
 #[derive(Debug)]
 pub enum BindingResource<'a> {
     Buffer(BufferBinding),
@@ -269,20 +265,10 @@ pub enum BindingResource<'a> {
     TextureViewArray(&'a [TextureViewId]),
 }
 
-// Note: Duplicated in wgpu-rs as Binding
-#[derive(Debug)]
-pub struct BindGroupEntry<'a> {
-    pub binding: u32,
-    pub resource: BindingResource<'a>,
-}
+pub type BindGroupEntry<'a> = wgt::BindGroupEntry<BindingResource<'a>>;
 
-// Note: Duplicated in wgpu-rs as BindGroupDescriptor
-#[derive(Debug)]
-pub struct BindGroupDescriptor<'a> {
-    pub label: Option<&'a str>,
-    pub layout: BindGroupLayoutId,
-    pub entries: &'a [BindGroupEntry<'a>],
-}
+pub type BindGroupDescriptor<'a> =
+    wgt::BindGroupDescriptor<'a, BindGroupLayoutId, BindGroupEntry<'a>>;
 
 #[derive(Debug)]
 pub enum BindError {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -58,11 +58,8 @@ fn is_depth_stencil_read_only(
     true
 }
 
-#[derive(Debug)]
-pub struct RenderPassDescriptor<'a> {
-    pub color_attachments: &'a [ColorAttachmentDescriptor],
-    pub depth_stencil_attachment: Option<&'a DepthStencilAttachmentDescriptor>,
-}
+pub type RenderPassDescriptor<'a> =
+    wgt::RenderPassDescriptor<'a, ColorAttachmentDescriptor, &'a DepthStencilAttachmentDescriptor>;
 
 #[derive(Clone, Copy, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -24,8 +24,10 @@ use hal::{
 use parking_lot::{Mutex, MutexGuard};
 use wgt::{BufferAddress, BufferSize, InputStepMode, TextureDimension, TextureFormat};
 
+#[cfg(feature = "trace")]
+use std::slice;
 use std::{
-    collections::hash_map::Entry, ffi, iter, marker::PhantomData, mem, ops::Range, ptr, slice,
+    collections::hash_map::Entry, ffi, iter, marker::PhantomData, mem, ops::Range, ptr,
     sync::atomic::Ordering,
 };
 
@@ -1357,13 +1359,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let (device_guard, mut token) = hub.devices.read(&mut token);
         let device = &device_guard[device_id];
-        let bind_group_layout_ids = unsafe {
-            slice::from_raw_parts(desc.bind_group_layouts, desc.bind_group_layouts_length)
-        };
+        let bind_group_layout_ids = desc.bind_group_layouts;
 
-        if desc.bind_group_layouts_length > (device.limits.max_bind_groups as usize) {
+        if bind_group_layout_ids.len() > (device.limits.max_bind_groups as usize) {
             return Err(binding_model::PipelineLayoutError::TooManyGroups(
-                desc.bind_group_layouts_length,
+                bind_group_layout_ids.len(),
             ));
         }
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -248,7 +248,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (mut device_guard, mut token) = hub.devices.write(&mut token);
         let device = &mut device_guard[queue_id];
         let (texture_guard, _) = hub.textures.read(&mut token);
-        let (image_layers, image_range, image_offset) = destination.to_hal(&*texture_guard);
+        let (image_layers, image_range, image_offset) =
+            crate::command::texture_copy_view_to_hal(destination, &*texture_guard);
 
         #[cfg(feature = "trace")]
         match device.trace {

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -25,23 +25,7 @@ use hal::{
 };
 use std::fmt::Display;
 
-#[repr(C)]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "trace", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct RequestAdapterOptions {
-    pub power_preference: PowerPreference,
-    pub compatible_surface: Option<SurfaceId>,
-}
-
-impl Default for RequestAdapterOptions {
-    fn default() -> Self {
-        RequestAdapterOptions {
-            power_preference: PowerPreference::Default,
-            compatible_surface: None,
-        }
-    }
-}
+pub type RequestAdapterOptions = wgt::RequestAdapterOptions<SurfaceId>;
 
 #[derive(Debug)]
 pub struct Instance {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -9,10 +9,7 @@ use crate::{
     LifeGuard, RefCount, Stored,
 };
 use std::borrow::Borrow;
-use wgt::{
-    BufferAddress, ColorStateDescriptor, DepthStencilStateDescriptor, IndexFormat, InputStepMode,
-    PrimitiveTopology, RasterizationStateDescriptor, VertexStateDescriptor,
-};
+use wgt::{BufferAddress, IndexFormat, InputStepMode};
 
 #[repr(C)]
 #[derive(Debug)]
@@ -29,18 +26,10 @@ pub struct ShaderModule<B: hal::Backend> {
     pub(crate) module: Option<naga::Module>,
 }
 
-#[derive(Debug)]
-pub struct ProgrammableStageDescriptor<'a> {
-    pub module: ShaderModuleId,
-    pub entry_point: &'a str,
-}
+pub type ProgrammableStageDescriptor<'a> = wgt::ProgrammableStageDescriptor<'a, ShaderModuleId>;
 
-#[repr(C)]
-#[derive(Debug)]
-pub struct ComputePipelineDescriptor<'a> {
-    pub layout: PipelineLayoutId,
-    pub compute_stage: ProgrammableStageDescriptor<'a>,
-}
+pub type ComputePipelineDescriptor<'a> =
+    wgt::ComputePipelineDescriptor<PipelineLayoutId, ProgrammableStageDescriptor<'a>>;
 
 #[derive(Clone, Debug)]
 pub enum ComputePipelineError {
@@ -61,20 +50,8 @@ impl<B: hal::Backend> Borrow<RefCount> for ComputePipeline<B> {
     }
 }
 
-#[derive(Debug)]
-pub struct RenderPipelineDescriptor<'a> {
-    pub layout: PipelineLayoutId,
-    pub vertex_stage: ProgrammableStageDescriptor<'a>,
-    pub fragment_stage: Option<ProgrammableStageDescriptor<'a>>,
-    pub primitive_topology: PrimitiveTopology,
-    pub rasterization_state: Option<RasterizationStateDescriptor>,
-    pub color_states: &'a [ColorStateDescriptor],
-    pub depth_stencil_state: Option<DepthStencilStateDescriptor>,
-    pub vertex_state: VertexStateDescriptor<'a>,
-    pub sample_count: u32,
-    pub sample_mask: u32,
-    pub alpha_to_coverage_enabled: bool,
-}
+pub type RenderPipelineDescriptor<'a> =
+    wgt::RenderPipelineDescriptor<'a, PipelineLayoutId, ProgrammableStageDescriptor<'a>>;
 
 #[derive(Clone, Debug)]
 pub enum RenderPipelineError {


### PR DESCRIPTION
**Connections**
Closes #689.

**Description**
Moves a lot of types from `wgpu-rs` which were duplicated in `wgpu-core` to `wgpu-types`.

**Testing**
Checked with core, player and `wgpu-rs`.

Corresponding `wgpu-rs` PR: https://github.com/gfx-rs/wgpu-rs/pull/437