### PR TITLE
Fixed storage buffer counting towards storage textures for binding validation

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -147,7 +147,7 @@ impl BindingTypeMaxCountValidator {
                 }
             }
             wgt::BindingType::StorageBuffer { dynamic, .. } => {
-                self.storage_textures.add(binding.visibility, count);
+                self.storage_buffers.add(binding.visibility, count);
                 if dynamic {
                     self.dynamic_storage_buffers += count;
                 }


### PR DESCRIPTION
See title.
(broke my group layout creation since my compute shaders need quite a few storage buffers _and_ storage textures bound... ;-))