### PR TITLE
Finish error model implementation

### DIFF
--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -161,7 +161,8 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
             A::CreateBuffer { id, desc } => {
                 let label = Label::new(&desc.label);
                 self.device_maintain_ids::<B>(device);
-                self.device_create_buffer::<B>(device, &desc.map_label(|_| label.as_ptr()), id);
+                self.device_create_buffer::<B>(device, &desc.map_label(|_| label.as_ptr()), id)
+                    .unwrap();
             }
             A::DestroyBuffer(id) => {
                 self.buffer_destroy::<B>(id);

--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -203,6 +203,7 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
             A::GetSwapChainTexture { id, parent_id } => {
                 if let Some(id) = id {
                     self.swap_chain_get_current_texture_view::<B>(parent_id, id)
+                        .unwrap()
                         .view_id
                         .unwrap();
                 }

--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -142,6 +142,7 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
             }
         }
         self.command_encoder_finish::<B>(encoder, &wgt::CommandBufferDescriptor { todo: 0 })
+            .unwrap()
     }
 
     fn process<B: wgc::hub::GfxBackend>(

--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -170,7 +170,8 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
             A::CreateTexture { id, desc } => {
                 let label = Label::new(&desc.label);
                 self.device_maintain_ids::<B>(device);
-                self.device_create_texture::<B>(device, &desc.map_label(|_| label.as_ptr()), id);
+                self.device_create_texture::<B>(device, &desc.map_label(|_| label.as_ptr()), id)
+                    .unwrap();
             }
             A::DestroyTexture(id) => {
                 self.texture_destroy::<B>(id);

--- a/player/src/main.rs
+++ b/player/src/main.rs
@@ -396,7 +396,8 @@ impl GlobalExt for wgc::hub::Global<IdentityPassThroughFactory> {
                     self.queue_write_buffer::<B>(device, id, range.start, &bin);
                 } else {
                     self.device_wait_for_buffer::<B>(device, id);
-                    self.device_set_buffer_sub_data::<B>(device, id, range.start, &bin[..size]);
+                    self.device_set_buffer_sub_data::<B>(device, id, range.start, &bin[..size])
+                        .unwrap();
                 }
             }
             A::WriteTexture {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -46,7 +46,7 @@ use crate::{
     resource::BufferUse,
     span,
     track::TrackerSet,
-    validation::{MissingBufferUsageError, MissingTextureUsageError},
+    validation::{check_buffer_usage, MissingBufferUsageError, MissingTextureUsageError},
     LifeGuard, RefCount, Stored, MAX_BIND_GROUPS,
 };
 use arrayvec::ArrayVec;
@@ -695,32 +695,6 @@ impl fmt::Display for RenderCommandError {
                 index_limit,
             ),
         }
-    }
-}
-
-/// Checks that the given buffer usage contains the required buffer usage,
-/// returns an error otherwise.
-pub fn check_buffer_usage(
-    actual: wgt::BufferUsage,
-    expected: wgt::BufferUsage,
-) -> Result<(), MissingBufferUsageError> {
-    if !actual.contains(expected) {
-        Err(MissingBufferUsageError { actual, expected })
-    } else {
-        Ok(())
-    }
-}
-
-/// Checks that the given buffer usage contains the required buffer usage,
-/// returns an error otherwise.
-pub fn check_texture_usage(
-    actual: wgt::TextureUsage,
-    expected: wgt::TextureUsage,
-) -> Result<(), MissingTextureUsageError> {
-    if !actual.contains(expected) {
-        Err(MissingTextureUsageError { actual, expected })
-    } else {
-        Ok(())
     }
 }
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -6,13 +6,15 @@ use crate::{
     binding_model::{BindError, PushConstantUploadError},
     command::{
         bind::{Binder, LayoutChange},
-        check_buffer_usage, BasePass, BasePassRef, CommandBuffer,
+        BasePass, BasePassRef, CommandBuffer,
     },
     device::all_buffer_stages,
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Token},
     id,
     resource::BufferUse,
-    span, MissingBufferUsageError,
+    span,
+    validation::check_buffer_usage,
+    MissingBufferUsageError,
 };
 
 use hal::command::CommandBuffer as _;

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -6,7 +6,7 @@ use crate::{
     binding_model::BindError,
     command::{
         bind::{Binder, LayoutChange},
-        check_buffer_usage, check_texture_usage, BasePass, BasePassRef, RenderCommandError,
+        BasePass, BasePassRef, RenderCommandError,
     },
     conv,
     device::{
@@ -19,6 +19,7 @@ use crate::{
     resource::{BufferUse, TextureUse, TextureViewInner},
     span,
     track::TrackerSet,
+    validation::{check_buffer_usage, check_texture_usage},
     MissingBufferUsageError, MissingTextureUsageError, Stored,
 };
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -25,7 +25,7 @@ use parking_lot::{Mutex, MutexGuard};
 use wgt::{BufferAddress, BufferSize, InputStepMode, TextureDimension, TextureFormat};
 
 use std::{
-    collections::hash_map::Entry, ffi, iter, marker::PhantomData, mem, ops::Range, ptr,
+    collections::hash_map::Entry, ffi, fmt, iter, marker::PhantomData, mem, ops::Range, ptr,
     sync::atomic::Ordering,
 };
 
@@ -383,7 +383,7 @@ impl<B: GfxBackend> Device<B> {
         self_id: id::DeviceId,
         desc: &wgt::BufferDescriptor<Label>,
         memory_kind: gfx_memory::Kind,
-    ) -> resource::Buffer<B> {
+    ) -> Result<resource::Buffer<B>, CreateBufferError> {
         debug_assert_eq!(self_id.backend(), B::VARIANT);
         let (mut usage, _memory_properties) = conv::map_buffer_usage(desc.usage);
         if desc.mapped_at_creation && !desc.usage.contains(wgt::BufferUsage::MAP_WRITE) {
@@ -406,11 +406,9 @@ impl<B: GfxBackend> Device<B> {
                 let is_native_only = self
                     .features
                     .contains(wgt::Features::MAPPABLE_PRIMARY_BUFFERS);
-                assert!(
-                    is_native_only,
-                    "MAP usage can only be combined with the opposite COPY, requested {:?}",
-                    desc.usage
-                );
+                if !is_native_only {
+                    return Err(CreateBufferError::UsageMismatch(desc.usage));
+                }
                 MemoryUsage::Dynamic {
                     sparse_updates: false,
                 }
@@ -437,7 +435,7 @@ impl<B: GfxBackend> Device<B> {
                 .unwrap()
         };
 
-        resource::Buffer {
+        Ok(resource::Buffer {
             raw: buffer,
             device_id: Stored {
                 value: self_id,
@@ -450,7 +448,7 @@ impl<B: GfxBackend> Device<B> {
             sync_mapped_writes: None,
             map_state: resource::BufferMapState::Idle,
             life_guard: LifeGuard::new(),
-        }
+        })
     }
 
     fn create_texture(
@@ -660,7 +658,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         device_id: id::DeviceId,
         desc: &wgt::BufferDescriptor<Label>,
         id_in: Input<G, id::BufferId>,
-    ) -> id::BufferId {
+    ) -> Result<id::BufferId, CreateBufferError> {
         span!(_guard, INFO, "Device::create_buffer");
 
         let hub = B::hub(self);
@@ -668,17 +666,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         log::info!("Create buffer {:?} with ID {:?}", desc, id_in);
 
-        if desc.mapped_at_creation {
-            assert_eq!(
-                desc.size % wgt::COPY_BUFFER_ALIGNMENT,
-                0,
-                "Buffers that are mapped at creation have to be aligned to COPY_BUFFER_ALIGNMENT"
-            );
+        if desc.mapped_at_creation && desc.size % wgt::COPY_BUFFER_ALIGNMENT != 0 {
+            return Err(CreateBufferError::UnalignedSize);
         }
 
         let (device_guard, mut token) = hub.devices.read(&mut token);
         let device = &device_guard[device_id];
-        let mut buffer = device.create_buffer(device_id, desc, gfx_memory::Kind::General);
+        let mut buffer = device.create_buffer(device_id, desc, gfx_memory::Kind::General)?;
         let ref_count = buffer.life_guard.add_ref();
 
         let buffer_use = if !desc.mapped_at_creation {
@@ -714,7 +708,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     mapped_at_creation: false,
                 },
                 gfx_memory::Kind::Linear,
-            );
+            )?;
             let ptr = stage
                 .memory
                 .map(&device.raw, hal::memory::Segment::ALL)
@@ -749,7 +743,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .buffers
             .init(id, ref_count, BufferState::with_usage(buffer_use))
             .unwrap();
-        id
+        Ok(id)
     }
 
     #[cfg(feature = "replay")]
@@ -3054,6 +3048,25 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 }
                 unmap_buffer(&device.raw, buffer);
             }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum CreateBufferError {
+    UsageMismatch(wgt::BufferUsage),
+    UnalignedSize,
+}
+
+impl fmt::Display for CreateBufferError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::UsageMismatch(usage) => write!(
+                f,
+                "`MAP` usage can only be combined with the opposite `COPY`, requested {:?}",
+                usage,
+            ),
+            Self::UnalignedSize => write!(f, "buffers that are mapped at creation have to be aligned to `COPY_BUFFER_ALIGNMENT`"),
         }
     }
 }

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -44,6 +44,9 @@ mod track;
 mod validation;
 
 pub use hal::pso::read_spirv;
+// These should be exported, since they are part of enum variants
+// which show up in the public API.
+pub use validation::{MissingBufferUsageError, MissingTextureUsageError};
 
 #[cfg(test)]
 use loom::sync::atomic;

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -42,7 +42,10 @@ use crate::{
 };
 
 use hal::{self, device::Device as _, queue::CommandQueue as _, window::PresentationSurface as _};
+use std::fmt;
 use wgt::{SwapChainDescriptor, SwapChainStatus};
+
+pub use hal::window::PresentError;
 
 const FRAME_TIMEOUT_MS: u64 = 1000;
 pub const DESIRED_NUM_FRAMES: u32 = 3;
@@ -104,7 +107,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         swap_chain_id: SwapChainId,
         view_id_in: Input<G, TextureViewId>,
-    ) -> SwapChainOutput {
+    ) -> Result<SwapChainOutput, SwapChainError> {
         span!(_guard, INFO, "SwapChain::get_next_texture");
 
         let hub = B::hub(self);
@@ -135,47 +138,48 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             ),
         };
 
-        let view_id = image.map(|image| {
-            let view = resource::TextureView {
-                inner: resource::TextureViewInner::SwapChain {
-                    image,
-                    source_id: Stored {
-                        value: swap_chain_id,
-                        ref_count: sc.life_guard.add_ref(),
+        let view_id = image
+            .map(|image| {
+                let view = resource::TextureView {
+                    inner: resource::TextureViewInner::SwapChain {
+                        image,
+                        source_id: Stored {
+                            value: swap_chain_id,
+                            ref_count: sc.life_guard.add_ref(),
+                        },
                     },
-                },
-                format: sc.desc.format,
-                extent: hal::image::Extent {
-                    width: sc.desc.width,
-                    height: sc.desc.height,
-                    depth: 1,
-                },
-                samples: 1,
-                range: hal::image::SubresourceRange {
-                    aspects: hal::format::Aspects::COLOR,
-                    layers: 0..1,
-                    levels: 0..1,
-                },
-                life_guard: LifeGuard::new(),
-            };
+                    format: sc.desc.format,
+                    extent: hal::image::Extent {
+                        width: sc.desc.width,
+                        height: sc.desc.height,
+                        depth: 1,
+                    },
+                    samples: 1,
+                    range: hal::image::SubresourceRange {
+                        aspects: hal::format::Aspects::COLOR,
+                        layers: 0..1,
+                        levels: 0..1,
+                    },
+                    life_guard: LifeGuard::new(),
+                };
 
-            let ref_count = view.life_guard.add_ref();
-            let id = hub
-                .texture_views
-                .register_identity(view_id_in, view, &mut token);
+                let ref_count = view.life_guard.add_ref();
+                let id = hub
+                    .texture_views
+                    .register_identity(view_id_in, view, &mut token);
 
-            assert!(
-                sc.acquired_view_id.is_none(),
-                "Swap chain image is already acquired"
-            );
+                if sc.acquired_view_id.is_some() {
+                    return Err(SwapChainError::AlreadyAcquired);
+                }
 
-            sc.acquired_view_id = Some(Stored {
-                value: id,
-                ref_count,
-            });
+                sc.acquired_view_id = Some(Stored {
+                    value: id,
+                    ref_count,
+                });
 
-            id
-        });
+                Ok(id)
+            })
+            .transpose()?;
 
         #[cfg(feature = "trace")]
         match device.trace {
@@ -186,10 +190,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             None => (),
         };
 
-        SwapChainOutput { status, view_id }
+        Ok(SwapChainOutput { status, view_id })
     }
 
-    pub fn swap_chain_present<B: GfxBackend>(&self, swap_chain_id: SwapChainId) {
+    pub fn swap_chain_present<B: GfxBackend>(
+        &self,
+        swap_chain_id: SwapChainId,
+    ) -> Result<(), SwapChainError> {
         span!(_guard, INFO, "SwapChain::present");
 
         let hub = B::hub(self);
@@ -211,25 +218,22 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let view_id = sc
             .acquired_view_id
             .take()
-            .expect("Swap chain image is not acquired");
+            .ok_or(SwapChainError::AlreadyAcquired)?;
         let (view, _) = hub.texture_views.unregister(view_id.value, &mut token);
         let image = match view.inner {
             resource::TextureViewInner::Native { .. } => unreachable!(),
             resource::TextureViewInner::SwapChain { image, .. } => image,
         };
 
-        let err = {
-            let sem = if sc.active_submission_index > device.last_completed_submission_index() {
-                Some(&sc.semaphore)
-            } else {
-                None
-            };
-            let queue = &mut device.queue_group.queues[0];
-            unsafe { queue.present_surface(B::get_surface_mut(surface), image, sem) }
+        let sem = if sc.active_submission_index > device.last_completed_submission_index() {
+            Some(&sc.semaphore)
+        } else {
+            None
         };
-        if let Err(e) = err {
-            log::warn!("present failed: {:?}", e);
-        }
+        let queue = &mut device.queue_group.queues[0];
+        let present_result =
+            unsafe { queue.present_surface(B::get_surface_mut(surface), image, sem) };
+        present_result.map_err(|e| SwapChainError::PresentError(e))?;
 
         tracing::debug!(trace = true, "Presented. End of Frame");
 
@@ -237,6 +241,23 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             unsafe {
                 device.raw.destroy_framebuffer(fbo);
             }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum SwapChainError {
+    AlreadyAcquired,
+    PresentError(PresentError),
+}
+
+impl fmt::Display for SwapChainError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::AlreadyAcquired => write!(f, "swap chain image is already acquired"),
+            Self::PresentError(error) => write!(f, "{}", error),
         }
     }
 }

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -90,6 +90,32 @@ pub enum StageError {
     },
 }
 
+/// Checks that the given buffer usage contains the required buffer usage,
+/// returns an error otherwise.
+pub fn check_buffer_usage(
+    actual: wgt::BufferUsage,
+    expected: wgt::BufferUsage,
+) -> Result<(), MissingBufferUsageError> {
+    if !actual.contains(expected) {
+        Err(MissingBufferUsageError { actual, expected })
+    } else {
+        Ok(())
+    }
+}
+
+/// Checks that the given buffer usage contains the required buffer usage,
+/// returns an error otherwise.
+pub fn check_texture_usage(
+    actual: wgt::TextureUsage,
+    expected: wgt::TextureUsage,
+) -> Result<(), MissingTextureUsageError> {
+    if !actual.contains(expected) {
+        Err(MissingTextureUsageError { actual, expected })
+    } else {
+        Ok(())
+    }
+}
+
 fn get_aligned_type_size(
     module: &naga::Module,
     handle: naga::Handle<naga::Type>,

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -4,6 +4,7 @@
 
 use crate::{binding_model::BindEntryMap, FastHashMap};
 use spirv_headers as spirv;
+use std::fmt;
 use wgt::{BindGroupLayoutEntry, BindingType};
 
 #[derive(Clone, Debug)]
@@ -29,6 +30,38 @@ pub enum BindingError {
     WrongTextureMultisampled,
     /// The comparison flag doesn't match the shader.
     WrongSamplerComparison,
+}
+
+#[derive(Clone, Debug)]
+pub struct MissingBufferUsageError {
+    pub(crate) actual: wgt::BufferUsage,
+    pub(crate) expected: wgt::BufferUsage,
+}
+
+impl fmt::Display for MissingBufferUsageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "buffer usage is {:?} which does not contain required usage {:?}",
+            self.actual, self.expected,
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MissingTextureUsageError {
+    pub(crate) actual: wgt::TextureUsage,
+    pub(crate) expected: wgt::TextureUsage,
+}
+
+impl fmt::Display for MissingTextureUsageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "texture usage is {:?} which does not contain required usage {:?}",
+            self.actual, self.expected,
+        )
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
**Connections**
Finishes the `wgpu-core` part of #638

**Description**
This PR aims to replace all assertions and panics in the code with safe error types.

Progress:
- [X] `command/mod.rs`
- [X] `device/life.rs`
- [ ] `device/mod.rs`
- [ ] `device/queue.rs`
- [X] `binding_model.rs`
- [ ] `conv.rs`
- [ ] `instance.rs`
- [X] `swap_chain.rs`
- [ ] `validation.rs`

**Testing**
Checked with core and player. The changes in `wgpu-rs` amount to some `unwrap`s.
