### PR TITLE
Convert the existing error types to `thiserror`

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 use hal::command::CommandBuffer as _;
+use thiserror::Error;
 use wgt::{BufferAddress, BufferUsage, Extent3d, TextureDataLayout, TextureUsage};
 
 use std::iter;
@@ -27,36 +28,33 @@ pub type BufferCopyView = wgt::BufferCopyView<BufferId>;
 pub type TextureCopyView = wgt::TextureCopyView<TextureId>;
 
 /// Error encountered while attempting a data transfer.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Error, Eq, PartialEq)]
 pub enum TransferError {
-    /// The source buffer/texture is missing the `COPY_SRC` usage flag.
+    #[error("source buffer/texture is missing the `COPY_SRC` usage flag")]
     MissingCopySrcUsageFlag,
-    /// The destination buffer/texture is missing the `COPY_DST` usage flag.
+    #[error("destination buffer/texture is missing the `COPY_DST` usage flag")]
     MissingCopyDstUsageFlag,
-    /// Copy would end up overruning the bounds of the destination buffer/texture.
+    #[error("copy would end up overruning the bounds of the destination buffer/texture")]
     BufferOverrun,
-    /// Buffer offset is not aligned to block size.
+    #[error("buffer offset is not aligned to block size")]
     UnalignedBufferOffset,
-    /// Copy size is not a multiple of block size.
+    #[error("copy size is not a multiple of block size")]
     UnalignedCopySize,
-    /// Copy width is not a multiple of block size.
+    #[error("copy width is not a multiple of block size")]
     UnalignedCopyWidth,
-    /// Copy height is not a multiple of block size.
+    #[error("copy height is not a multiple of block size")]
     UnalignedCopyHeight,
-    /// Bytes per row is not a multiple of the required alignment.
+    #[error("bytes per row is not a multiple of the required alignment")]
     UnalignedBytesPerRow,
-    /// Number of rows per image is not a multiple of the required alignment.
+    #[error("number of rows per image is not a multiple of the required alignment")]
     UnalignedRowsPerImage,
-    /// Number of bytes per row is less than the number of bytes in a complete row.
+    #[error("number of bytes per row is less than the number of bytes in a complete row")]
     InvalidBytesPerRow,
-    /// Copy size is invalid.
-    ///
-    /// This can happen if the image is 1D and the copy height and depth
-    /// are not both set to 1.
+    #[error("image is 1D and the copy height and depth are not both set to 1")]
     InvalidCopySize,
-    /// Number of rows per image is invalid.
+    #[error("number of rows per image is invalid")]
     InvalidRowsPerImage,
-    /// The source and destination layers have different aspects.
+    #[error("source and destination layers have different aspects")]
     MismatchedAspects,
 }
 

--- a/wgpu-core/src/power.rs
+++ b/wgpu-core/src/power.rs
@@ -2,21 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
+    #[error("battery status is unsupported on this platform")]
     Unsupported,
+    #[error("battery status retrieval failed: {0}")]
     Error(Box<dyn std::error::Error>),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::Unsupported => write!(f, "Battery status is unsupported on this platform"),
-            Error::Error(err) => write!(f, "Battery status retrieval failed: {}", err),
-        }
-    }
 }
 
 #[cfg(all(

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -8,6 +8,46 @@ use thiserror::Error;
 use wgt::{BindGroupLayoutEntry, BindingType};
 
 #[derive(Clone, Debug, Error)]
+#[error("buffer usage is {actual:?} which does not contain required usage {expected:?}")]
+pub struct MissingBufferUsageError {
+    pub(crate) actual: wgt::BufferUsage,
+    pub(crate) expected: wgt::BufferUsage,
+}
+
+/// Checks that the given buffer usage contains the required buffer usage,
+/// returns an error otherwise.
+pub fn check_buffer_usage(
+    actual: wgt::BufferUsage,
+    expected: wgt::BufferUsage,
+) -> Result<(), MissingBufferUsageError> {
+    if !actual.contains(expected) {
+        Err(MissingBufferUsageError { actual, expected })
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Error)]
+#[error("texture usage is {actual:?} which does not contain required usage {expected:?}")]
+pub struct MissingTextureUsageError {
+    pub(crate) actual: wgt::TextureUsage,
+    pub(crate) expected: wgt::TextureUsage,
+}
+
+/// Checks that the given texture usage contains the required texture usage,
+/// returns an error otherwise.
+pub fn check_texture_usage(
+    actual: wgt::TextureUsage,
+    expected: wgt::TextureUsage,
+) -> Result<(), MissingTextureUsageError> {
+    if !actual.contains(expected) {
+        Err(MissingTextureUsageError { actual, expected })
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Error)]
 pub enum BindingError {
     #[error("binding is missing from the pipeline layout")]
     Missing,


### PR DESCRIPTION
**Connections**
Part of #638

**Description**
Converts the crate's existing error types from a manual `Display` implementation to using `thiserror`.

**Testing**
Tested with core and `wgpu-rs`.