### PR TITLE
Error types for buffer mapping API

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -390,7 +390,8 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                     self.queue_write_buffer::<B>(device, id, range.start, &bin);
                 } else {
                     self.device_wait_for_buffer::<B>(device, id).unwrap();
-                    self.device_set_buffer_sub_data::<B>(device, id, range.start, &bin[..size]);
+                    self.device_set_buffer_sub_data::<B>(device, id, range.start, &bin[..size])
+                        .unwrap();
                 }
             }
             A::WriteTexture {

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -97,7 +97,8 @@ impl Test {
                     callback: map_callback,
                     user_data: ptr::null_mut(),
                 }
-            ));
+            ))
+            .unwrap();
         }
 
         println!("\t\t\tWaiting...");
@@ -107,7 +108,8 @@ impl Test {
             println!("\t\t\tChecking {}", expect.name);
             let buffer = wgc::id::TypedId::zip(expect.buffer.index, expect.buffer.epoch, backend);
             let ptr =
-                gfx_select!(device => global.buffer_get_mapped_range(buffer, expect.offset, None));
+                gfx_select!(device => global.buffer_get_mapped_range(buffer, expect.offset, None))
+                    .unwrap();
             let contents = unsafe { slice::from_raw_parts(ptr, expect.data.len()) };
             assert_eq!(&expect.data[..], contents);
         }


### PR DESCRIPTION
**Connections**
Part of #638 

**Description**
Adds safe error handling for buffer mapping/unmapping functions.

**Testing**
Checked with core, and ran tests with player.