### PR TITLE
swap_chain_present returns SwapChainStatus

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1137,7 +1137,6 @@ pub enum SwapChainStatus {
     Timeout,
     Outdated,
     Lost,
-    OutOfMemory,
 }
 
 /// Describes the attachments of a render pass.


### PR DESCRIPTION
**Connections**
Needed by https://github.com/gfx-rs/wgpu-rs/pull/452

**Description**
For `swap_chain_present` moves the PresentError cases out of the Err and into the Ok.
This means we can `.unwrap()` the result in wgpu and it will only panic on an error that the user cant handle.

**Testing**
Ran the wgpu-rs examples.
