### PR TITLE
Add depth clamping support

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -635,7 +635,7 @@ pub fn map_rasterization_state_descriptor(
 ) -> hal::pso::Rasterizer {
     use hal::pso;
     pso::Rasterizer {
-        depth_clamping: false,
+        depth_clamping: desc.clamp_depth,
         polygon_mode: pso::PolygonMode::Fill,
         cull_face: match desc.cull_mode {
             wgt::CullMode::None => pso::Face::empty(),

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -128,6 +128,10 @@ impl<B: hal::Backend> Adapter<B> {
             | wgt::Features::MAPPABLE_PRIMARY_BUFFERS
             | wgt::Features::PUSH_CONSTANTS;
         features.set(
+            wgt::Features::DEPTH_CLAMPING,
+            adapter_features.contains(hal::Features::DEPTH_CLAMP),
+        );
+        features.set(
             wgt::Features::SAMPLED_TEXTURE_BINDING_ARRAY,
             adapter_features.contains(hal::Features::TEXTURE_DESCRIPTOR_ARRAY),
         );

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -55,6 +55,7 @@ pub type RenderPipelineDescriptor<'a> =
 
 #[derive(Clone, Debug)]
 pub enum RenderPipelineError {
+    MissingFeature(wgt::Features),
     InvalidVertexAttributeOffset {
         location: wgt::ShaderLocation,
         offset: BufferAddress,

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -41,10 +41,7 @@ use crate::{
     resource, span, LifeGuard, PrivateFeatures, Stored, SubmissionIndex,
 };
 
-use hal::{
-    self, device::Device as _, queue::CommandQueue as _,
-    window::PresentationSurface as _,
-};
+use hal::{self, device::Device as _, queue::CommandQueue as _, window::PresentationSurface as _};
 use thiserror::Error;
 use wgt::{SwapChainDescriptor, SwapChainStatus};
 
@@ -129,12 +126,16 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             Err(err) => (
                 None,
                 match err {
-                    hal::window::AcquireError::OutOfMemory(_) => return Err(SwapChainError::OutOfMemory),
+                    hal::window::AcquireError::OutOfMemory(_) => {
+                        return Err(SwapChainError::OutOfMemory)
+                    }
                     hal::window::AcquireError::NotReady => unreachable!(), // we always set a timeout
                     hal::window::AcquireError::Timeout => SwapChainStatus::Timeout,
                     hal::window::AcquireError::OutOfDate => SwapChainStatus::Outdated,
                     hal::window::AcquireError::SurfaceLost(_) => SwapChainStatus::Lost,
-                    hal::window::AcquireError::DeviceLost(_) => return Err(SwapChainError::DeviceLost),
+                    hal::window::AcquireError::DeviceLost(_) => {
+                        return Err(SwapChainError::DeviceLost)
+                    }
                 },
             ),
         };

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -131,6 +131,18 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "trace", derive(Serialize))]
     #[cfg_attr(feature = "replay", derive(Deserialize))]
     pub struct Features: u64 {
+        /// By default, polygon depth is clipped to 0-1 range. Anything outside of that range
+        /// is rejected, and respective fragments are not touched.
+        ///
+        /// With this extension, we can force clamping of the polygon depth to 0-1. That allows
+        /// shadow map occluders to be rendered into a tighter depth range.
+        ///
+        /// Supported platforms:
+        /// - desktops
+        /// - some mobile chips
+        ///
+        /// This is a web and native feature.
+        const DEPTH_CLAMPING = 0x0000_0000_0000_0001;
         /// Webgpu only allows the MAP_READ and MAP_WRITE buffer usage to be matched with
         /// COPY_DST and COPY_SRC respectively. This removes this requirement.
         ///
@@ -543,6 +555,10 @@ impl Default for CullMode {
 pub struct RasterizationStateDescriptor {
     pub front_face: FrontFace,
     pub cull_mode: CullMode,
+    /// If enabled polygon depth is clamped to 0-1 range instead of being clipped.
+    ///
+    /// Requires `Features::DEPTH_CLAMPING` enabled.
+    pub clamp_depth: bool,
     pub depth_bias: i32,
     pub depth_bias_slope_scale: f32,
     pub depth_bias_clamp: f32,


### PR DESCRIPTION
**Connections**
Implements https://github.com/gpuweb/gpuweb/pull/900

**Description**
Depth clamping is useful for shadow mapping and stuff. We'd want to use it in our `shadow` example.

**Testing**
Untested, should work though :)