### PR TITLE
Detach MultiRefCount from RefCount completely

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -303,7 +303,7 @@ pub struct PipelineLayout<B: hal::Backend> {
     pub(crate) raw: B::PipelineLayout,
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) life_guard: LifeGuard,
-    pub(crate) bind_group_layout_ids: ArrayVec<[Stored<BindGroupLayoutId>; MAX_BIND_GROUPS]>,
+    pub(crate) bind_group_layout_ids: ArrayVec<[BindGroupLayoutId; MAX_BIND_GROUPS]>,
     pub(crate) push_constant_ranges: ArrayVec<[wgt::PushConstantRange; SHADER_STAGE_COUNT]>,
 }
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -505,7 +505,7 @@ impl State {
         &mut self,
         index_format: wgt::IndexFormat,
         vertex_strides: &[(wgt::BufferAddress, wgt::InputStepMode)],
-        layout_ids: &[Stored<id::BindGroupLayoutId>],
+        layout_ids: &[id::BindGroupLayoutId],
         push_constant_layouts: &[wgt::PushConstantRange],
     ) {
         self.index.set_format(index_format);
@@ -528,8 +528,8 @@ impl State {
             self.bind
                 .iter()
                 .zip(layout_ids)
-                .position(|(bs, layout_id)| match bs.bind_group {
-                    Some((_, bgl_id)) => bgl_id != layout_id.value,
+                .position(|(bs, &layout_id)| match bs.bind_group {
+                    Some((_, bgl_id)) => bgl_id != layout_id,
                     None => false,
                 })
         };

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -257,14 +257,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .reset_expectations(pipeline_layout.bind_group_layout_ids.len());
                         let mut is_compatible = true;
 
-                        for (index, (entry, bgl_id)) in state
+                        for (index, (entry, &bgl_id)) in state
                             .binder
                             .entries
                             .iter_mut()
                             .zip(&pipeline_layout.bind_group_layout_ids)
                             .enumerate()
                         {
-                            match entry.expect_layout(bgl_id.value) {
+                            match entry.expect_layout(bgl_id) {
                                 LayoutChange::Match(bg_id, offsets) if is_compatible => {
                                     let desc_set = bind_group_guard[bg_id].raw.raw();
                                     unsafe {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1111,14 +1111,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .reset_expectations(pipeline_layout.bind_group_layout_ids.len());
                         let mut is_compatible = true;
 
-                        for (index, (entry, bgl_id)) in state
+                        for (index, (entry, &bgl_id)) in state
                             .binder
                             .entries
                             .iter_mut()
                             .zip(&pipeline_layout.bind_group_layout_ids)
                             .enumerate()
                         {
-                            match entry.expect_layout(bgl_id.value) {
+                            match entry.expect_layout(bgl_id) {
                                 LayoutChange::Match(bg_id, offsets) if is_compatible => {
                                     let desc_set = bind_group_guard[bg_id].raw.raw();
                                     unsafe {

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{Epoch, Index};
-use std::{fmt, marker::PhantomData, num::NonZeroU64};
+use std::{cmp::Ordering, fmt, marker::PhantomData, num::NonZeroU64};
 use wgt::Backend;
 
 const BACKEND_BITS: usize = 3;
@@ -97,6 +97,18 @@ impl<T> PartialEq for Id<T> {
 }
 
 impl<T> Eq for Id<T> {}
+
+impl<T> PartialOrd for Id<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl<T> Ord for Id<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
 
 pub trait TypedId {
     fn zip(index: Index, epoch: Epoch, backend: Backend) -> Self;


### PR DESCRIPTION
**Connections**
Fixes #823

**Description**
The old way of trying to mix the new `MultiRefCount` with bits of existing infra with `RefCount` was not correct at all. We'd get into a situation where the refcount was already deleted, but the object is alive, for example. This PR detaches them completely.
To clarify: it's not great at all that we have manual refcounting on BGLs. And this de-duplication crap caused much more trouble than it's worth...

**Testing**
Tested on the wonderful example provided by @tiberiusferreira