### PR TITLE
Make RenderBundleEncoder derive Debug

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -54,6 +54,7 @@ use arrayvec::ArrayVec;
 use std::{borrow::Borrow, iter, marker::PhantomData, ops::Range};
 use thiserror::Error;
 
+#[derive(Debug)]
 #[cfg_attr(feature = "serial-pass", derive(serde::Deserialize, serde::Serialize))]
 pub struct RenderBundleEncoder {
     base: BasePass<RenderCommand>,


### PR DESCRIPTION
**Connections**
This pull request originated from https://github.com/gfx-rs/wgpu-rs/pull/466. This change is needed to make public types in `wgpu-rs` derive debug.

**Description**
Make RenderBundleEncoder derive Debug.

**Testing**
