### PR TITLE
Fix typo in BufferUsage docs

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1018,7 +1018,7 @@ bitflags::bitflags! {
         /// Allow a buffer to be the source buffer for a [`CommandEncoder::copy_buffer_to_buffer`] or [`CommandEncoder::copy_buffer_to_texture`]
         /// operation.
         const COPY_SRC = 4;
-        /// Allow a buffer to be the source buffer for a [`CommandEncoder::copy_buffer_to_buffer`], [`CommandEncoder::copy_buffer_to_texture`],
+        /// Allow a buffer to be the destination buffer for a [`CommandEncoder::copy_buffer_to_buffer`], [`CommandEncoder::copy_texture_to_buffer`],
         /// or [`Queue::write_buffer`] operation.
         const COPY_DST = 8;
         /// Allow a buffer to be the index buffer in a draw operation.


### PR DESCRIPTION
**Connections**

A couple people have bugged me about this in the past.

**Description**

Docs were wrong, they are now right.

**Testing**

Read it again :)
