### PR TITLE
Return errors from device functions

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -181,15 +181,17 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                     parent_id,
                     desc.map(|d| d.map_label(|_| label.as_ptr())).as_ref(),
                     id,
-                );
+                )
+                .unwrap();
             }
             A::DestroyTextureView(id) => {
-                self.texture_view_destroy::<B>(id);
+                self.texture_view_destroy::<B>(id).unwrap();
             }
             A::CreateSampler(id, desc) => {
                 let label = Label::new(&desc.label);
                 self.device_maintain_ids::<B>(device);
-                self.device_create_sampler::<B>(device, &desc.map_label(|_| label.as_ptr()), id);
+                self.device_create_sampler::<B>(device, &desc.map_label(|_| label.as_ptr()), id)
+                    .unwrap();
             }
             A::DestroySampler(id) => {
                 self.sampler_destroy::<B>(id);

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -448,7 +448,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             if !buffer.life_guard.use_at(submit_index) {
                                 if let BufferMapState::Active { .. } = buffer.map_state {
                                     log::warn!("Dropped buffer has a pending mapping.");
-                                    super::unmap_buffer(&device.raw, buffer);
+                                    super::unmap_buffer(&device.raw, buffer).unwrap();
                                 }
                                 device.temp_suspected.buffers.push(id);
                             } else {


### PR DESCRIPTION
**Connections**
Part of #638 

**Description**
Lots of changes, but they should be easily reviewable commit-by-commit.

- Error types for most of the fallible resource creation errors in `device/mod.rs`

- Removed assertions and replaced them with error types

- All of the `BufferMap`, `BufferNotMapped` etc. errors were united in a single `BufferAccessError`, since it was pretty weird to have so many overlapping error types.

- Removed all `unwrap`s of `gfx-hal` errors - they are now returned to the caller.

**Testing**
Checked with core and tested with `wgpu-rs` (see https://github.com/gfx-rs/wgpu-rs/pull/469)