### PR TITLE
Switch pipeline flag to mutation of depth/stencil

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1083,10 +1083,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     if !context.compatible(&pipeline.pass_context) {
                         return Err(RenderCommandError::IncompatiblePipeline.into());
                     }
-                    if pipeline
-                        .flags
-                        .contains(PipelineFlags::DEPTH_STENCIL_READ_ONLY)
-                        && !is_ds_read_only
+                    if pipeline.flags.contains(PipelineFlags::WRITES_DEPTH_STENCIL)
+                        && is_ds_read_only
                     {
                         return Err(RenderCommandError::IncompatibleReadOnlyDepthStencil.into());
                     }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2396,8 +2396,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             if ds.needs_stencil_reference() {
                 flags |= pipeline::PipelineFlags::STENCIL_REFERENCE;
             }
-            if ds.is_read_only() {
-                flags |= pipeline::PipelineFlags::DEPTH_STENCIL_READ_ONLY;
+            if !ds.is_read_only() {
+                flags |= pipeline::PipelineFlags::WRITES_DEPTH_STENCIL;
             }
         }
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -74,7 +74,7 @@ bitflags::bitflags! {
     pub struct PipelineFlags: u32 {
         const BLEND_COLOR = 1;
         const STENCIL_REFERENCE = 2;
-        const DEPTH_STENCIL_READ_ONLY = 4;
+        const WRITES_DEPTH_STENCIL = 4;
     }
 }
 


### PR DESCRIPTION
**Connections**
Reported on the matrix

**Description**
If the pass mutates depth/stencil, but the pipeline doesn't, it's not a bug!

**Testing**
on it...