### PR TITLE
Safe error handling for queue module

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -287,7 +287,8 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                 let bin = std::fs::read(dir.join(data)).unwrap();
                 let size = (range.end - range.start) as usize;
                 if queued {
-                    self.queue_write_buffer::<B>(device, id, range.start, &bin);
+                    self.queue_write_buffer::<B>(device, id, range.start, &bin)
+                        .unwrap();
                 } else {
                     self.device_wait_for_buffer::<B>(device, id).unwrap();
                     self.device_set_buffer_sub_data::<B>(device, id, range.start, &bin[..size])
@@ -301,7 +302,8 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                 size,
             } => {
                 let bin = std::fs::read(dir.join(data)).unwrap();
-                self.queue_write_texture::<B>(device, &to, &bin, &layout, &size);
+                self.queue_write_texture::<B>(device, &to, &bin, &layout, &size)
+                    .unwrap();
             }
             A::Submit(_index, commands) => {
                 let encoder = self.device_create_command_encoder::<B>(


### PR DESCRIPTION
**Connections**
Part of #638 

**Description**
Adds error types for the `queue.rs` module. The out-of-memory conditions are reported upwards, other internal `gfx-hal` errors are unwrapped.

**Testing**
Tested with core and player.
