### PR TITLE
Reformat the alignment errors, add a stride check

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -66,10 +66,7 @@ pub enum CreateBindGroupError {
     SingleBindingExpected,
     #[error("unable to create a bind group with a swap chain image")]
     SwapChainImage,
-    #[error(
-        "buffer offset {0} must be a multiple of {}",
-        wgt::BIND_BUFFER_ALIGNMENT
-    )]
+    #[error("buffer offset {0} does not respect `BIND_BUFFER_ALIGNMENT`")]
     UnalignedBufferOffset(wgt::BufferAddress),
     #[error("uniform buffer binding range exceeds `max_uniform_buffer_binding_size` limit")]
     UniformBufferRangeTooLarge,
@@ -320,10 +317,7 @@ pub enum PushConstantUploadError {
         actual: wgt::ShaderStage,
         unmatched: wgt::ShaderStage,
     },
-    #[error(
-        "provided push constant offset {0} must be aligned to {}",
-        wgt::PUSH_CONSTANT_ALIGNMENT
-    )]
+    #[error("provided push constant offset {0} does not respect `PUSH_CONSTANT_ALIGNMENT`")]
     Unaligned(u32),
 }
 
@@ -448,8 +442,7 @@ pub enum BindError {
     #[error("number of dynamic offsets ({actual}) doesn't match the number of dynamic bindings in the bind group layout ({expected})")]
     MismatchedDynamicOffsetCount { actual: usize, expected: usize },
     #[error(
-        "dynamic binding at index {idx}: offset {offset} must be aligned to {}",
-        wgt::BIND_BUFFER_ALIGNMENT
+        "dynamic binding at index {idx}: offset {offset} does not respect `BIND_BUFFER_ALIGNMENT`"
     )]
     UnalignedDynamicBinding { idx: usize, offset: u32 },
     #[error("dynamic binding at index {idx} with offset {offset} would overrun the buffer (limit: {max})")]

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -600,10 +600,7 @@ impl State {
 pub enum RenderCommandError {
     #[error("bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
     BindGroupIndexOutOfRange { index: u8, max: u32 },
-    #[error(
-        "dynamic buffer offset {0} is not a multiple of the required buffer alignment {}",
-        wgt::BIND_BUFFER_ALIGNMENT
-    )]
+    #[error("dynamic buffer offset {0} does not respect `BIND_BUFFER_ALIGNMENT`")]
     UnalignedBufferOffset(u64),
     #[error("number of buffer offsets ({actual}) does not match the number of dynamic bindings ({expected})")]
     InvalidDynamicOffsetCount { actual: usize, expected: usize },

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -38,15 +38,15 @@ pub enum TransferError {
     BufferOverrun,
     #[error("buffer offset is not aligned to block size")]
     UnalignedBufferOffset,
-    #[error("copy size is not a multiple of block size")]
+    #[error("copy size does not respect `COPY_BUFFER_ALIGNMENT`")]
     UnalignedCopySize,
-    #[error("copy width is not a multiple of block size")]
+    #[error("copy width is not a multiple of block width")]
     UnalignedCopyWidth,
-    #[error("copy height is not a multiple of block size")]
+    #[error("copy height is not a multiple of block height")]
     UnalignedCopyHeight,
-    #[error("bytes per row is not a multiple of the required alignment")]
+    #[error("bytes per row does not respect `COPY_BYTES_PER_ROW_ALIGNMENT`")]
     UnalignedBytesPerRow,
-    #[error("number of rows per image is not a multiple of the required alignment")]
+    #[error("number of rows per image is not a multiple of block height")]
     UnalignedRowsPerImage,
     #[error("number of bytes per row is less than the number of bytes in a complete row")]
     InvalidBytesPerRow,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2166,6 +2166,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             if vb_state.attributes.is_empty() {
                 continue;
             }
+            if vb_state.stride % wgt::VERTEX_STRIDE_ALIGNMENT != 0 {
+                return Err(pipeline::RenderPipelineError::UnalignedVertexStride {
+                    index: i as u32,
+                    stride: vb_state.stride,
+                });
+            }
             vertex_buffers.alloc().init(hal::pso::VertexBufferDesc {
                 binding: i as u32,
                 stride: vb_state.stride as u32,
@@ -3070,7 +3076,7 @@ pub enum BufferAccessError {
     NotMapped,
     #[error("not enough memory left")]
     OutOfMemory,
-    #[error("buffer map range is not aligned to {}", wgt::COPY_BUFFER_ALIGNMENT)]
+    #[error("buffer map range does not respect `COPY_BUFFER_ALIGNMENT`")]
     UnalignedRange,
 }
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -579,21 +579,19 @@ pub enum PrepareStageError {
 #[derive(Clone, Debug, Error)]
 pub enum QueueWriteBufferError {
     #[error("write buffer with indices {start}..{end} would overrun buffer of size {size}")]
-    BufferOverrun { start: u64, end: u64, size: u64 },
+    BufferOverrun {
+        start: wgt::BufferAddress,
+        end: wgt::BufferAddress,
+        size: wgt::BufferAddress,
+    },
     #[error(transparent)]
     MissingBufferUsage(#[from] MissingBufferUsageError),
     #[error(transparent)]
     Stage(#[from] PrepareStageError),
-    #[error(
-        "buffer offset {0} must be a multiple of {}",
-        wgt::COPY_BUFFER_ALIGNMENT
-    )]
-    UnalignedBufferOffset(u64),
-    #[error(
-        "buffer write size {0} must be a multiple of {}",
-        wgt::COPY_BUFFER_ALIGNMENT
-    )]
-    UnalignedDataSize(u64),
+    #[error("buffer offset {0} does not respect `COPY_BUFFER_ALIGNMENT`")]
+    UnalignedBufferOffset(wgt::BufferAddress),
+    #[error("buffer write size {0} does not respect `COPY_BUFFER_ALIGNMENT`")]
+    UnalignedDataSize(wgt::BufferAddress),
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -63,6 +63,8 @@ pub enum RenderPipelineError {
     IncompatibleOutputFormat { index: u8 },
     #[error("invalid sample count {0}")]
     InvalidSampleCount(u32),
+    #[error("vertex buffer {index} stride {stride} does not respect `VERTEX_STRIDE_ALIGNMENT`")]
+    UnalignedVertexStride { index: u32, stride: BufferAddress },
     #[error("vertex attribute at location {location} has invalid offset {offset}")]
     InvalidVertexAttributeOffset {
         location: wgt::ShaderLocation,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -27,6 +27,8 @@ pub const COPY_BYTES_PER_ROW_ALIGNMENT: u32 = 256;
 pub const BIND_BUFFER_ALIGNMENT: BufferAddress = 256;
 /// Buffer to buffer copy offsets and sizes must be aligned to this number.
 pub const COPY_BUFFER_ALIGNMENT: BufferAddress = 4;
+/// Vertex buffer strides have to be aligned to this number.
+pub const VERTEX_STRIDE_ALIGNMENT: BufferAddress = 4;
 /// Alignment all push constants need
 pub const PUSH_CONSTANT_ALIGNMENT: u32 = 4;
 


### PR DESCRIPTION
**Connections**
Addresses [one of the things](https://community-tc.services.mozilla.com/tasks/JQlmdXSiSK2ufM7mX8F1Tg/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FJQlmdXSiSK2ufM7mX8F1Tg%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L1999) Servo hit on the CTS

**Description**
This change affects the unaligned* error messages: instead of printing the exact value, they now refer to the constant in the code. On one hand, this involves an extra redirection for anyone who hits this. But on the other hand, it makes them aware of the actual constants they should be respecting. I think it's better in the long term, especially if we change any of these.

**Testing**
Not tested, but should work!

r? @GabrielMajeri 