### PR TITLE
Finish error model refactor

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -306,11 +306,13 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                     .unwrap();
             }
             A::Submit(_index, commands) => {
-                let encoder = self.device_create_command_encoder::<B>(
-                    device,
-                    &wgt::CommandEncoderDescriptor { label: ptr::null() },
-                    comb_manager.alloc(device.backend()),
-                );
+                let encoder = self
+                    .device_create_command_encoder::<B>(
+                        device,
+                        &wgt::CommandEncoderDescriptor { label: ptr::null() },
+                        comb_manager.alloc(device.backend()),
+                    )
+                    .unwrap();
                 let cmdbuf = self.encode_commands::<B>(encoder, commands);
                 self.queue_submit::<B>(device, &[cmdbuf]).unwrap();
             }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -10,6 +10,7 @@ mod render;
 mod transfer;
 
 pub(crate) use self::allocator::CommandAllocator;
+pub use self::allocator::CommandAllocatorError;
 pub use self::bundle::*;
 pub use self::compute::*;
 pub use self::render::*;

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -304,7 +304,7 @@ impl<B: hal::Backend> LifetimeTracker<B> {
         let done_count = self
             .active
             .iter()
-            .position(|a| unsafe { !device.get_fence_status(&a.fence).unwrap() })
+            .position(|a| unsafe { !device.get_fence_status(&a.fence).unwrap_or(false) })
             .unwrap_or_else(|| self.active.len());
         let last_done = if done_count != 0 {
             self.active[done_count - 1].index

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -485,7 +485,7 @@ impl<B: GfxBackend> Device<B> {
             _ => {}
         }
 
-        let kind = conv::map_texture_dimension_size(desc.dimension, desc.size, desc.sample_count);
+        let kind = conv::map_texture_dimension_size(desc.dimension, desc.size, desc.sample_count)?;
         let format = conv::map_texture_format(desc.format, self.private_features);
         let aspects = format.surface_desc().aspects;
         let usage = conv::map_texture_usage(desc.usage, aspects);
@@ -3063,6 +3063,8 @@ pub enum CreateBufferError {
 pub enum CreateTextureError {
     #[error("D24Plus textures cannot be copied")]
     CannotCopyD24Plus,
+    #[error(transparent)]
+    InvalidDimension(#[from] conv::MapTextureDimensionSizeError),
     #[error(
         "texture descriptor mip level count ({0}) must be less than device max mip levels ({})",
         MAX_MIP_LEVELS

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -423,9 +423,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         let cmdbuf = &mut command_buffer_guard[cmb_id];
                         #[cfg(feature = "trace")]
                         match device.trace {
-                            Some(ref trace) => trace
-                                .lock()
-                                .add(Action::Submit(submit_index, cmdbuf.commands.take().unwrap())),
+                            Some(ref trace) => trace.lock().add(Action::Submit(
+                                submit_index,
+                                cmdbuf.commands.take().unwrap(),
+                            )),
                             None => (),
                         };
 


### PR DESCRIPTION
**Connections**
I think this is the last part of #638. I've reviewed all the remaining `unwrap`s and `assert`s in the code, and these should be the last ones left which ought to return errors (the remaining ones seem to uphold internal invariants).

**Description**
Implements error handling for various conditions, which are then returned to the caller. Including, but not limited to:
- running out of memory when creating a command pool
- running out of memory when creating a frame buffer for a render pass
- invalid dimensions when creating a texture

**Testing**
Tested with core and player.