### PR TITLE
Make level and layer count for texture view optional

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -998,15 +998,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (format, view_kind, range) = match desc {
             Some(desc) => {
                 let kind = conv::map_texture_view_dimension(desc.dimension);
-                let end_level = if desc.level_count == 0 {
-                    texture.full_range.levels.end
-                } else {
-                    (desc.base_mip_level + desc.level_count) as u8
+                let end_level = match desc.level_count {
+                    Some(count) => (desc.base_mip_level + count.get()) as u8,
+                    None => texture.full_range.levels.end,
                 };
-                let end_layer = if desc.array_layer_count == 0 {
-                    texture.full_range.layers.end
-                } else {
-                    (desc.base_array_layer + desc.array_layer_count) as u16
+                let end_layer = match desc.array_layer_count {
+                    Some(count) => (desc.base_array_layer + count.get()) as u16,
+                    None => texture.full_range.layers.end,
                 };
                 let range = hal::image::SubresourceRange {
                     aspects: texture.full_range.aspects,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -10,7 +10,7 @@
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, ops::Range};
+use std::{borrow::Cow, num::NonZeroU32, ops::Range};
 
 /// Integral type used for buffer offsets.
 pub type BufferAddress = u64;
@@ -1342,12 +1342,16 @@ pub struct TextureViewDescriptor<L> {
     pub aspect: TextureAspect,
     /// Base mip level.
     pub base_mip_level: u32,
-    /// Mip level count. Must be at least one. base_mip_level + level_count must be less or equal to underlying texture mip count.
-    pub level_count: u32,
+    /// Mip level count.
+    /// If `Some(count)`, `base_mip_level + count` must be less or equal to underlying texture mip count.
+    /// If `None`, considered to include the rest of the mipmap levels, but at least 1 in total.
+    pub level_count: Option<NonZeroU32>,
     /// Base array layer.
     pub base_array_layer: u32,
-    /// Layer count. Must be at least one. base_array_layer + array_layer_count must be less or equal to the underlying array count.
-    pub array_layer_count: u32,
+    /// Layer count.
+    /// If `Some(count)`, `base_array_layer + count` must be less or equal to the underlying array count.
+    /// If `None`, considered to include the rest of the array layers, but at least 1 in total.
+    pub array_layer_count: Option<NonZeroU32>,
 }
 
 impl<L> TextureViewDescriptor<L> {


### PR DESCRIPTION
**Connections**
implements https://github.com/gpuweb/gpuweb/pull/945

**Description**
`NonZeroU32` is more idiomatic here

**Testing**
untested, but should work