### PR TITLE
Implement TEXTURE_COMPRESSION_BC extension

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -392,6 +392,141 @@ pub(crate) fn map_texture_format(
                 H::D32SfloatS8Uint
             }
         }
+
+        // BCn compressed formats
+        Tf::Bc1RgbaUnorm => H::Bc1RgbaUnorm,
+        Tf::Bc1RgbaUnormSrgb => H::Bc1RgbaSrgb,
+        Tf::Bc2RgbaUnorm => H::Bc2Unorm,
+        Tf::Bc2RgbaUnormSrgb => H::Bc2Srgb,
+        Tf::Bc3RgbaUnorm => H::Bc3Unorm,
+        Tf::Bc3RgbaUnormSrgb => H::Bc3Srgb,
+        Tf::Bc4RUnorm => H::Bc4Unorm,
+        Tf::Bc4RSnorm => H::Bc4Snorm,
+        Tf::Bc5RgUnorm => H::Bc5Unorm,
+        Tf::Bc5RgSnorm => H::Bc5Snorm,
+        Tf::Bc6hRgbSfloat => H::Bc6hSfloat,
+        Tf::Bc6hRgbUfloat => H::Bc6hUfloat,
+        Tf::Bc7RgbaUnorm => H::Bc7Unorm,
+        Tf::Bc7RgbaUnormSrgb => H::Bc7Srgb,
+    }
+}
+
+pub fn texture_block_size(format: wgt::TextureFormat) -> (u32, u32) {
+    use wgt::TextureFormat as Tf;
+    match format {
+        Tf::R8Unorm
+        | Tf::R8Snorm
+        | Tf::R8Uint
+        | Tf::R8Sint
+        | Tf::R16Uint
+        | Tf::R16Sint
+        | Tf::R16Float
+        | Tf::Rg8Unorm
+        | Tf::Rg8Snorm
+        | Tf::Rg8Uint
+        | Tf::Rg8Sint
+        | Tf::R32Uint
+        | Tf::R32Sint
+        | Tf::R32Float
+        | Tf::Rg16Uint
+        | Tf::Rg16Sint
+        | Tf::Rg16Float
+        | Tf::Rgba8Unorm
+        | Tf::Rgba8UnormSrgb
+        | Tf::Rgba8Snorm
+        | Tf::Rgba8Uint
+        | Tf::Rgba8Sint
+        | Tf::Bgra8Unorm
+        | Tf::Bgra8UnormSrgb
+        | Tf::Rgb10a2Unorm
+        | Tf::Rg11b10Float
+        | Tf::Rg32Uint
+        | Tf::Rg32Sint
+        | Tf::Rg32Float
+        | Tf::Rgba16Uint
+        | Tf::Rgba16Sint
+        | Tf::Rgba16Float
+        | Tf::Rgba32Uint
+        | Tf::Rgba32Sint
+        | Tf::Rgba32Float => (1, 1),
+
+        Tf::Depth32Float | Tf::Depth24Plus | Tf::Depth24PlusStencil8 => {
+            unreachable!("unexpected depth format")
+        }
+
+        Tf::Bc1RgbaUnorm
+        | Tf::Bc1RgbaUnormSrgb
+        | Tf::Bc2RgbaUnorm
+        | Tf::Bc2RgbaUnormSrgb
+        | Tf::Bc3RgbaUnorm
+        | Tf::Bc3RgbaUnormSrgb
+        | Tf::Bc4RUnorm
+        | Tf::Bc4RSnorm
+        | Tf::Bc5RgUnorm
+        | Tf::Bc5RgSnorm
+        | Tf::Bc6hRgbUfloat
+        | Tf::Bc6hRgbSfloat
+        | Tf::Bc7RgbaUnorm
+        | Tf::Bc7RgbaUnormSrgb => (4, 4),
+    }
+}
+
+pub fn texture_features(format: wgt::TextureFormat) -> wgt::Features {
+    use wgt::TextureFormat as Tf;
+    match format {
+        Tf::R8Unorm
+        | Tf::R8Snorm
+        | Tf::R8Uint
+        | Tf::R8Sint
+        | Tf::R16Uint
+        | Tf::R16Sint
+        | Tf::R16Float
+        | Tf::Rg8Unorm
+        | Tf::Rg8Snorm
+        | Tf::Rg8Uint
+        | Tf::Rg8Sint
+        | Tf::R32Uint
+        | Tf::R32Sint
+        | Tf::R32Float
+        | Tf::Rg16Uint
+        | Tf::Rg16Sint
+        | Tf::Rg16Float
+        | Tf::Rgba8Unorm
+        | Tf::Rgba8UnormSrgb
+        | Tf::Rgba8Snorm
+        | Tf::Rgba8Uint
+        | Tf::Rgba8Sint
+        | Tf::Bgra8Unorm
+        | Tf::Bgra8UnormSrgb
+        | Tf::Rgb10a2Unorm
+        | Tf::Rg11b10Float
+        | Tf::Rg32Uint
+        | Tf::Rg32Sint
+        | Tf::Rg32Float
+        | Tf::Rgba16Uint
+        | Tf::Rgba16Sint
+        | Tf::Rgba16Float
+        | Tf::Rgba32Uint
+        | Tf::Rgba32Sint
+        | Tf::Rgba32Float
+        | Tf::Depth32Float
+        | Tf::Depth24Plus
+        | Tf::Depth24PlusStencil8 => wgt::Features::empty(),
+
+        Tf::Bc1RgbaUnorm
+        | Tf::Bc1RgbaUnormSrgb
+        | Tf::Bc2RgbaUnorm
+        | Tf::Bc2RgbaUnormSrgb
+        | Tf::Bc3RgbaUnorm
+        | Tf::Bc3RgbaUnormSrgb
+        | Tf::Bc4RUnorm
+        | Tf::Bc4RSnorm
+        | Tf::Bc5RgUnorm
+        | Tf::Bc5RgSnorm
+        | Tf::Bc6hRgbUfloat
+        | Tf::Bc6hRgbSfloat
+        | Tf::Bc7RgbaUnorm
+        | Tf::Bc7RgbaUnormSrgb => wgt::Features::TEXTURE_COMPRESSION_BC,
     }
 }
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -948,6 +948,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             None => (),
         };
 
+        let texture_features = conv::texture_features(desc.format);
+        if texture_features != wgt::Features::empty() && !device.features.contains(texture_features)
+        {
+            return Err(CreateTextureError::MissingFeature(
+                texture_features,
+                desc.format,
+            ));
+        }
+
         device
             .trackers
             .lock()
@@ -3088,6 +3097,8 @@ pub enum CreateTextureError {
         MAX_MIP_LEVELS
     )]
     InvalidMipLevelCount(u32),
+    #[error("Feature {0:?} must be enabled to create a texture of type {1:?}")]
+    MissingFeature(wgt::Features, TextureFormat),
     #[error(transparent)]
     HeapsError(#[from] gfx_memory::HeapsError),
     #[error("not enough memory left")]

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -132,6 +132,10 @@ impl<B: hal::Backend> Adapter<B> {
             adapter_features.contains(hal::Features::DEPTH_CLAMP),
         );
         features.set(
+            wgt::Features::TEXTURE_COMPRESSION_BC,
+            adapter_features.contains(hal::Features::FORMAT_BC),
+        );
+        features.set(
             wgt::Features::SAMPLED_TEXTURE_BINDING_ARRAY,
             adapter_features.contains(hal::Features::TEXTURE_DESCRIPTOR_ARRAY),
         );

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -647,6 +647,32 @@ fn map_texture_format(format: wgt::TextureFormat) -> naga::TypeInner {
         Tf::Depth32Float | Tf::Depth24Plus | Tf::Depth24PlusStencil8 => {
             panic!("Unexpected depth format")
         }
+        Tf::Bc1RgbaUnorm
+        | Tf::Bc1RgbaUnormSrgb
+        | Tf::Bc2RgbaUnorm
+        | Tf::Bc2RgbaUnormSrgb
+        | Tf::Bc3RgbaUnorm
+        | Tf::Bc3RgbaUnormSrgb
+        | Tf::Bc7RgbaUnorm
+        | Tf::Bc7RgbaUnormSrgb => Ti::Vector {
+            size: Vs::Quad,
+            kind: Sk::Float,
+            width: 8,
+        },
+        Tf::Bc4RUnorm | Tf::Bc4RSnorm => Ti::Scalar {
+            kind: Sk::Float,
+            width: 8,
+        },
+        Tf::Bc5RgUnorm | Tf::Bc5RgSnorm => Ti::Vector {
+            size: Vs::Bi,
+            kind: Sk::Float,
+            width: 8,
+        },
+        Tf::Bc6hRgbUfloat | Tf::Bc6hRgbSfloat => Ti::Vector {
+            size: Vs::Tri,
+            kind: Sk::Float,
+            width: 8,
+        },
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -148,6 +148,17 @@ bitflags::bitflags! {
         ///
         /// This is a web and native feature.
         const DEPTH_CLAMPING = 0x0000_0000_0000_0001;
+        /// Enables BCn family of compressed textures. All BCn textures use 4x4 pixel blocks
+        /// with 8 or 16 bytes per block.
+        ///
+        /// Compressed textures sacrifice some quality in exchange for signifigantly reduced
+        /// bandwidth usage.
+        ///
+        /// Supported Platforms:
+        /// - desktops
+        ///
+        /// This is a web and native feature.
+        const TEXTURE_COMPRESSION_BC = 0x0000_0000_0000_0002;
         /// Webgpu only allows the MAP_READ and MAP_WRITE buffer usage to be matched with
         /// COPY_DST and COPY_SRC respectively. This removes this requirement.
         ///
@@ -634,7 +645,7 @@ pub enum TextureFormat {
     // Packed 32 bit formats
     /// Red, green, blue, and alpha channels. 10 bit integer for RGB channels, 2 bit integer for alpha channel. [0, 1023] ([0, 3] for alpha) converted to/from float [0, 1] in shader.
     Rgb10a2Unorm = 24,
-    /// Red, green, and blue channels. 11 bit float with no sign bit for RG channels. 10 bit float with no sign bti for blue channel. Float in shader.
+    /// Red, green, and blue channels. 11 bit float with no sign bit for RG channels. 10 bit float with no sign bit for blue channel. Float in shader.
     Rg11b10Float = 25,
 
     // Normal 64 bit formats
@@ -666,6 +677,104 @@ pub enum TextureFormat {
     Depth24Plus = 36,
     /// Special depth/stencil format with at least 24 bit integer depth and 8 bits integer stencil.
     Depth24PlusStencil8 = 37,
+
+    // Compressed textures usable with `TEXTURE_COMPRESSION_BC` feature.
+    /// 4x4 block compressed texture. 8 bytes per block (4 bit/px). 4 color + alpha pallet. 5 bit R + 6 bit G + 5 bit B + 1 bit alpha.
+    /// [0, 64] ([0, 1] for alpha) converted to/from float [0, 1] in shader.
+    ///
+    /// Also known as DXT1.
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc1RgbaUnorm = 38,
+    /// 4x4 block compressed texture. 8 bytes per block (4 bit/px). 4 color + alpha pallet. 5 bit R + 6 bit G + 5 bit B + 1 bit alpha.
+    /// Srgb-color [0, 64] ([0, 16] for alpha) converted to/from linear-color float [0, 1] in shader.
+    ///
+    /// Also known as DXT1.
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc1RgbaUnormSrgb = 39,
+    /// 4x4 block compressed texture. 16 bytes per block (8 bit/px). 4 color pallet. 5 bit R + 6 bit G + 5 bit B + 4 bit alpha.
+    /// [0, 64] ([0, 16] for alpha) converted to/from float [0, 1] in shader.
+    ///
+    /// Also known as DXT3.
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc2RgbaUnorm = 40,
+    /// 4x4 block compressed texture. 16 bytes per block (8 bit/px). 4 color pallet. 5 bit R + 6 bit G + 5 bit B + 4 bit alpha.
+    /// Srgb-color [0, 64] ([0, 256] for alpha) converted to/from linear-color float [0, 1] in shader.
+    ///
+    /// Also known as DXT3.
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc2RgbaUnormSrgb = 41,
+    /// 4x4 block compressed texture. 16 bytes per block (8 bit/px). 4 color pallet + 8 alpha pallet. 5 bit R + 6 bit G + 5 bit B + 8 bit alpha.
+    /// [0, 64] ([0, 256] for alpha) converted to/from float [0, 1] in shader.
+    ///
+    /// Also known as DXT5.
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc3RgbaUnorm = 42,
+    /// 4x4 block compressed texture. 16 bytes per block (8 bit/px). 4 color pallet + 8 alpha pallet. 5 bit R + 6 bit G + 5 bit B + 8 bit alpha.
+    /// Srgb-color [0, 64] ([0, 256] for alpha) converted to/from linear-color float [0, 1] in shader.
+    ///
+    /// Also known as DXT5.
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc3RgbaUnormSrgb = 43,
+    /// 4x4 block compressed texture. 8 bytes per block (4 bit/px). 8 color pallet. 8 bit R.
+    /// [0, 256] converted to/from float [0, 1] in shader.
+    ///
+    /// Also known as RGTC1.
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc4RUnorm = 44,
+    /// 4x4 block compressed texture. 8 bytes per block (4 bit/px). 8 color pallet. 8 bit R.
+    /// [-127, 127] converted to/from float [-1, 1] in shader.
+    ///
+    /// Also known as RGTC1.
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc4RSnorm = 45,
+    /// 4x4 block compressed texture. 16 bytes per block (16 bit/px). 8 color red pallet + 8 color green pallet. 8 bit RG.
+    /// [0, 256] converted to/from float [0, 1] in shader.
+    ///
+    /// Also known as RGTC2.
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc5RgUnorm = 46,
+    /// 4x4 block compressed texture. 16 bytes per block (16 bit/px). 8 color red pallet + 8 color green pallet. 8 bit RG.
+    /// [-127, 127] converted to/from float [-1, 1] in shader.
+    ///
+    /// Also known as RGTC2.
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc5RgSnorm = 47,
+    /// 4x4 block compressed texture. 16 bytes per block (16 bit/px). Variable sized pallet. 16 bit unsigned float RGB. Float in shader.
+    ///
+    /// Also known as BPTC (float).
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc6hRgbUfloat = 48,
+    /// 4x4 block compressed texture. 16 bytes per block (16 bit/px). Variable sized pallet. 16 bit signed float RGB. Float in shader.
+    ///
+    /// Also known as BPTC (float).
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc6hRgbSfloat = 49,
+    /// 4x4 block compressed texture. 16 bytes per block (16 bit/px). Variable sized pallet. 8 bit integer RGBA.
+    /// [0, 256] converted to/from float [0, 1] in shader.
+    ///
+    /// Also known as BPTC (unorm).
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc7RgbaUnorm = 50,
+    /// 4x4 block compressed texture. 16 bytes per block (16 bit/px). Variable sized pallet. 8 bit integer RGBA.
+    /// Srgb-color [0, 255] converted to/from linear-color float [0, 1] in shader.
+    ///
+    /// Also known as BPTC (unorm).
+    ///
+    /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
+    Bc7RgbaUnormSrgb = 51,
 }
 
 bitflags::bitflags! {
@@ -1743,7 +1852,21 @@ impl From<TextureFormat> for TextureComponentType {
             | TextureFormat::Rgb10a2Unorm
             | TextureFormat::Depth32Float
             | TextureFormat::Depth24Plus
-            | TextureFormat::Depth24PlusStencil8 => Self::Float,
+            | TextureFormat::Depth24PlusStencil8
+            | TextureFormat::Bc1RgbaUnorm
+            | TextureFormat::Bc1RgbaUnormSrgb
+            | TextureFormat::Bc2RgbaUnorm
+            | TextureFormat::Bc2RgbaUnormSrgb
+            | TextureFormat::Bc3RgbaUnorm
+            | TextureFormat::Bc3RgbaUnormSrgb
+            | TextureFormat::Bc4RUnorm
+            | TextureFormat::Bc4RSnorm
+            | TextureFormat::Bc5RgUnorm
+            | TextureFormat::Bc5RgSnorm
+            | TextureFormat::Bc6hRgbSfloat
+            | TextureFormat::Bc6hRgbUfloat
+            | TextureFormat::Bc7RgbaUnorm
+            | TextureFormat::Bc7RgbaUnormSrgb => Self::Float,
         }
     }
 }


### PR DESCRIPTION
**Connections**

Closes #852.

**Description**

Adds support for BCn textures as specified in the upstream issue. This also shores up the validation and copy logic to work well with the block oriented nature of compressed textures. ETC2 and ASTC should fall out of this easily.

**Testing**

No wgpu-rs changes were needed, however I tested it with the following changes in wgpu-rs: https://github.com/cwfitzgerald/wgpu-rs/commit/96c05ef4bf34c955ec5123a3ebeee1ab98916dc6.
