### PR TITLE
Separate valid internal IDs from external ones

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -67,7 +67,7 @@ fn main() {
         Some(trace::Action::Init { desc, backend }) => {
             log::info!("Initializing the device for backend: {:?}", backend);
             let adapter = global
-                .pick_adapter(
+                .request_adapter(
                     &wgc::instance::RequestAdapterOptions {
                         power_preference: wgt::PowerPreference::Default,
                         #[cfg(feature = "winit")]
@@ -82,7 +82,7 @@ fn main() {
                 )
                 .expect("Unable to find an adapter for selected backend");
 
-            let info = gfx_select!(adapter => global.adapter_get_info(adapter));
+            let info = gfx_select!(adapter => global.adapter_get_info(adapter)).unwrap();
             log::info!("Picked '{}'", info.name);
             gfx_select!(adapter => global.adapter_request_device(
                 adapter,

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -155,21 +155,21 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
             }
             A::CreateBuffer(id, desc) => {
                 let label = Label::new(&desc.label);
-                self.device_maintain_ids::<B>(device);
+                self.device_maintain_ids::<B>(device).unwrap();
                 self.device_create_buffer::<B>(device, &desc.map_label(|_| label.as_ptr()), id)
                     .unwrap();
             }
             A::DestroyBuffer(id) => {
-                self.buffer_destroy::<B>(id, true);
+                self.buffer_drop::<B>(id, true);
             }
             A::CreateTexture(id, desc) => {
                 let label = Label::new(&desc.label);
-                self.device_maintain_ids::<B>(device);
+                self.device_maintain_ids::<B>(device).unwrap();
                 self.device_create_texture::<B>(device, &desc.map_label(|_| label.as_ptr()), id)
                     .unwrap();
             }
             A::DestroyTexture(id) => {
-                self.texture_destroy::<B>(id);
+                self.texture_drop::<B>(id);
             }
             A::CreateTextureView {
                 id,
@@ -177,7 +177,7 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                 desc,
             } => {
                 let label = desc.as_ref().map_or(Label(None), |d| Label::new(&d.label));
-                self.device_maintain_ids::<B>(device);
+                self.device_maintain_ids::<B>(device).unwrap();
                 self.texture_create_view::<B>(
                     parent_id,
                     desc.map(|d| d.map_label(|_| label.as_ptr())).as_ref(),
@@ -186,16 +186,16 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                 .unwrap();
             }
             A::DestroyTextureView(id) => {
-                self.texture_view_destroy::<B>(id).unwrap();
+                self.texture_view_drop::<B>(id).unwrap();
             }
             A::CreateSampler(id, desc) => {
                 let label = Label::new(&desc.label);
-                self.device_maintain_ids::<B>(device);
+                self.device_maintain_ids::<B>(device).unwrap();
                 self.device_create_sampler::<B>(device, &desc.map_label(|_| label.as_ptr()), id)
                     .unwrap();
             }
             A::DestroySampler(id) => {
-                self.sampler_destroy::<B>(id);
+                self.sampler_drop::<B>(id);
             }
             A::GetSwapChainTexture { id, parent_id } => {
                 if let Some(id) = id {
@@ -210,23 +210,23 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                     .unwrap();
             }
             A::DestroyBindGroupLayout(id) => {
-                self.bind_group_layout_destroy::<B>(id);
+                self.bind_group_layout_drop::<B>(id);
             }
             A::CreatePipelineLayout(id, desc) => {
-                self.device_maintain_ids::<B>(device);
+                self.device_maintain_ids::<B>(device).unwrap();
                 self.device_create_pipeline_layout::<B>(device, &desc, id)
                     .unwrap();
             }
             A::DestroyPipelineLayout(id) => {
-                self.pipeline_layout_destroy::<B>(id);
+                self.pipeline_layout_drop::<B>(id);
             }
             A::CreateBindGroup(id, desc) => {
-                self.device_maintain_ids::<B>(device);
+                self.device_maintain_ids::<B>(device).unwrap();
                 self.device_create_bind_group::<B>(device, &desc, id)
                     .unwrap();
             }
             A::DestroyBindGroup(id) => {
-                self.bind_group_destroy::<B>(id);
+                self.bind_group_drop::<B>(id);
             }
             A::CreateShaderModule { id, data } => {
                 let source = if data.ends_with(".wgsl") {
@@ -244,23 +244,23 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                     .unwrap();
             }
             A::DestroyShaderModule(id) => {
-                self.shader_module_destroy::<B>(id);
+                self.shader_module_drop::<B>(id);
             }
             A::CreateComputePipeline(id, desc) => {
-                self.device_maintain_ids::<B>(device);
+                self.device_maintain_ids::<B>(device).unwrap();
                 self.device_create_compute_pipeline::<B>(device, &desc, id)
                     .unwrap();
             }
             A::DestroyComputePipeline(id) => {
-                self.compute_pipeline_destroy::<B>(id);
+                self.compute_pipeline_drop::<B>(id);
             }
             A::CreateRenderPipeline(id, desc) => {
-                self.device_maintain_ids::<B>(device);
+                self.device_maintain_ids::<B>(device).unwrap();
                 self.device_create_render_pipeline::<B>(device, &desc, id)
                     .unwrap();
             }
             A::DestroyRenderPipeline(id) => {
-                self.render_pipeline_destroy::<B>(id);
+                self.render_pipeline_drop::<B>(id);
             }
             A::CreateRenderBundle { id, desc, base } => {
                 let label = Label::new(&desc.label.as_ref().unwrap());
@@ -276,7 +276,7 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                 .unwrap();
             }
             A::DestroyRenderBundle(id) => {
-                self.render_bundle_destroy::<B>(id);
+                self.render_bundle_drop::<B>(id);
             }
             A::WriteBuffer {
                 id,

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -141,7 +141,7 @@ impl Corpus {
             if !corpus.backends.contains(backend.into()) {
                 continue;
             }
-            let adapter = match global.pick_adapter(
+            let adapter = match global.request_adapter(
                 &wgc::instance::RequestAdapterOptions {
                     power_preference: wgt::PowerPreference::Default,
                     compatible_surface: None,
@@ -151,12 +151,13 @@ impl Corpus {
                     |id| id.backend(),
                 ),
             ) {
-                Some(adapter) => adapter,
-                None => continue,
+                Ok(adapter) => adapter,
+                Err(_) => continue,
             };
 
             println!("\tBackend {:?}", backend);
-            let supported_features = gfx_select!(adapter => global.adapter_features(adapter));
+            let supported_features =
+                gfx_select!(adapter => global.adapter_features(adapter)).unwrap();
             for test_path in &corpus.tests {
                 println!("\t\tTest '{:?}'", test_path);
                 let test = Test::load(dir.join(test_path), adapter.backend());

--- a/wgpu-core/src/command/allocator.rs
+++ b/wgpu-core/src/command/allocator.rs
@@ -4,8 +4,8 @@
 
 use super::CommandBuffer;
 use crate::{
-    hub::GfxBackend, id::DeviceId, track::TrackerSet, FastHashMap, PrivateFeatures, Stored,
-    SubmissionIndex,
+    device::DeviceError, hub::GfxBackend, id::DeviceId, track::TrackerSet, FastHashMap,
+    PrivateFeatures, Stored, SubmissionIndex,
 };
 
 use hal::{command::CommandBuffer as _, device::Device as _, pool::CommandPool as _};
@@ -97,7 +97,7 @@ impl<B: GfxBackend> CommandAllocator<B> {
                             self.queue_family,
                             hal::pool::CommandPoolCreateFlags::RESET_INDIVIDUAL,
                         )
-                        .or(Err(CommandAllocatorError::OutOfMemory))?
+                        .or(Err(DeviceError::OutOfMemory))?
                 };
                 let pool = CommandPool {
                     raw,
@@ -147,7 +147,7 @@ impl<B: hal::Backend> CommandAllocator<B> {
                             queue_family,
                             hal::pool::CommandPoolCreateFlags::RESET_INDIVIDUAL,
                         )
-                        .or(Err(CommandAllocatorError::OutOfMemory))?
+                        .or(Err(DeviceError::OutOfMemory))?
                 },
                 total: 0,
                 available: Vec::new(),
@@ -256,6 +256,6 @@ impl<B: hal::Backend> CommandAllocator<B> {
 
 #[derive(Clone, Debug, Error)]
 pub enum CommandAllocatorError {
-    #[error("not enough memory left")]
-    OutOfMemory,
+    #[error(transparent)]
+    Device(#[from] DeviceError),
 }

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*! Draw structures - shared between render passes and bundles.
+!*/
+
+use crate::{
+    binding_model::PushConstantUploadError,
+    id,
+    resource::BufferUse,
+    track::UseExtendError,
+    validation::{MissingBufferUsageError, MissingTextureUsageError},
+};
+pub type BufferError = UseExtendError<BufferUse>;
+
+use thiserror::Error;
+
+/// Error validating a draw call.
+#[derive(Clone, Debug, Error, PartialEq)]
+pub enum DrawError {
+    #[error("blend color needs to be set")]
+    MissingBlendColor,
+    #[error("stencil reference needs to be set")]
+    MissingStencilReference,
+    #[error("render pipeline must be set")]
+    MissingPipeline,
+    #[error("current render pipeline has a layout which is incompatible with a currently set bind group, first differing at entry index {index}")]
+    IncompatibleBindGroup {
+        index: u32,
+        //expected: BindGroupLayoutId,
+        //provided: Option<(BindGroupLayoutId, BindGroupId)>,
+    },
+    #[error("vertex {last_vertex} extends beyond limit {vertex_limit}")]
+    VertexBeyondLimit { last_vertex: u32, vertex_limit: u32 },
+    #[error("instance {last_instance} extends beyond limit {instance_limit}")]
+    InstanceBeyondLimit {
+        last_instance: u32,
+        instance_limit: u32,
+    },
+    #[error("index {last_index} extends beyond limit {index_limit}")]
+    IndexBeyondLimit { last_index: u32, index_limit: u32 },
+}
+
+/// Error encountered when encoding a render command.
+/// This is the shared error set between render bundles and passes.
+#[derive(Clone, Debug, Error)]
+pub enum RenderCommandError {
+    #[error("bind group {0:?} is invalid")]
+    InvalidBindGroup(id::BindGroupId),
+    #[error("bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
+    BindGroupIndexOutOfRange { index: u8, max: u32 },
+    #[error("dynamic buffer offset {0} does not respect `BIND_BUFFER_ALIGNMENT`")]
+    UnalignedBufferOffset(u64),
+    #[error("number of buffer offsets ({actual}) does not match the number of dynamic bindings ({expected})")]
+    InvalidDynamicOffsetCount { actual: usize, expected: usize },
+    #[error("render pipeline {0:?} is invalid")]
+    InvalidPipeline(id::RenderPipelineId),
+    #[error("render pipeline output formats and sample counts do not match render pass attachment formats")]
+    IncompatiblePipeline,
+    #[error("pipeline is not compatible with the depth-stencil read-only render pass")]
+    IncompatibleReadOnlyDepthStencil,
+    #[error("buffer {0:?} is in error {1:?}")]
+    Buffer(id::BufferId, BufferError),
+    #[error(transparent)]
+    MissingBufferUsage(#[from] MissingBufferUsageError),
+    #[error(transparent)]
+    MissingTextureUsage(#[from] MissingTextureUsageError),
+    #[error(transparent)]
+    PushConstants(#[from] PushConstantUploadError),
+}

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -53,8 +53,8 @@ impl<T> From<SerialId> for Id<T> {
 
 impl<T> Id<T> {
     #[cfg(test)]
-    pub(crate) fn dummy() -> Self {
-        Id(NonZeroU64::new(1).unwrap(), PhantomData)
+    pub(crate) fn dummy() -> Valid<Self> {
+        Valid(Id(NonZeroU64::new(1).unwrap(), PhantomData))
     }
 
     pub fn backend(self) -> Backend {
@@ -109,6 +109,14 @@ impl<T> Ord for Id<T> {
         self.0.cmp(&other.0)
     }
 }
+
+/// An internal ID that has been checked to point to
+/// a valid object in the storages.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "trace", derive(serde::Serialize))]
+#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+pub(crate) struct Valid<I>(pub I);
 
 pub trait TypedId {
     fn zip(index: Index, epoch: Epoch, backend: Backend) -> Self;

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -43,8 +43,6 @@ pub mod swap_chain;
 mod track;
 mod validation;
 
-pub use hal::pso::read_spirv;
-
 #[cfg(test)]
 use loom::sync::atomic;
 #[cfg(not(test))]
@@ -198,7 +196,7 @@ impl LifeGuard {
 
 #[derive(Clone, Debug)]
 struct Stored<T> {
-    value: T,
+    value: id::Valid<T>,
     ref_count: RefCount,
 }
 

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -3,7 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{PendingTransition, ResourceState, Unit};
-use crate::{id::BufferId, resource::BufferUse};
+use crate::{
+    id::{BufferId, Valid},
+    resource::BufferUse,
+};
 
 //TODO: store `hal::buffer::State` here to avoid extra conversions
 pub(crate) type BufferState = Unit<BufferUse>;
@@ -47,7 +50,7 @@ impl ResourceState for BufferState {
 
     fn change(
         &mut self,
-        id: Self::Id,
+        id: Valid<Self::Id>,
         _selector: Self::Selector,
         usage: Self::Usage,
         output: Option<&mut Vec<PendingTransition<Self>>>,
@@ -81,7 +84,7 @@ impl ResourceState for BufferState {
 
     fn prepend(
         &mut self,
-        id: Self::Id,
+        id: Valid<Self::Id>,
         _selector: Self::Selector,
         usage: Self::Usage,
     ) -> Result<(), PendingTransition<Self>> {
@@ -100,7 +103,7 @@ impl ResourceState for BufferState {
 
     fn merge(
         &mut self,
-        id: Self::Id,
+        id: Valid<Self::Id>,
         other: &Self,
         output: Option<&mut Vec<PendingTransition<Self>>>,
     ) -> Result<(), PendingTransition<Self>> {

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -3,7 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{range::RangedStates, PendingTransition, ResourceState, Unit};
-use crate::{device::MAX_MIP_LEVELS, id::TextureId, resource::TextureUse};
+use crate::{
+    device::MAX_MIP_LEVELS,
+    id::{TextureId, Valid},
+    resource::TextureUse,
+};
 
 use arrayvec::ArrayVec;
 
@@ -79,7 +83,7 @@ impl ResourceState for TextureState {
 
     fn change(
         &mut self,
-        id: Self::Id,
+        id: Valid<Self::Id>,
         selector: Self::Selector,
         usage: Self::Usage,
         mut output: Option<&mut Vec<PendingTransition<Self>>>,
@@ -138,7 +142,7 @@ impl ResourceState for TextureState {
 
     fn prepend(
         &mut self,
-        id: Self::Id,
+        id: Valid<Self::Id>,
         selector: Self::Selector,
         usage: Self::Usage,
     ) -> Result<(), PendingTransition<Self>> {
@@ -173,7 +177,7 @@ impl ResourceState for TextureState {
 
     fn merge(
         &mut self,
-        id: Self::Id,
+        id: Valid<Self::Id>,
         other: &Self,
         mut output: Option<&mut Vec<PendingTransition<Self>>>,
     ) -> Result<(), PendingTransition<Self>> {

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -84,6 +84,8 @@ pub enum InputError {
 /// Errors produced when validating a programmable stage of a pipeline.
 #[derive(Clone, Debug, Error)]
 pub enum StageError {
+    #[error("shader module is invalid")]
+    InvalidModule,
     #[error("unable to find an entry point matching the {0:?} execution model")]
     MissingEntryPoint(naga::ShaderStage),
     #[error("error matching global binding at index {binding} in set {set} against the pipeline layout: {error}")]


### PR DESCRIPTION
**Connections**
Closes #638 
wgpu-rs update - https://github.com/gfx-rs/wgpu-rs/pull/494

**Description**
The core change here is to allow user-specified IDs to be in the "Error" state that was introduced in #776 .

This is done by defining an internal `Valid<I>` wrapper. Now, the hub storages can be indexed by this valid wrapper only. For regular IDs, we have to go through `storage.get(index)`, which returns a `Result`. It still panics if the ID is totally garbage though, we don't want to handle what can't be expected here.

All the other changes come mostly as a consequence of that:
  - new "Invalid*" error variants are added
  - the error types are undergone sever refactoring
  - new `command/draw.rs` module for stuff shared between render passes and bundles
  - functions to generate error IDs for all the types
  - various renames, e.g. `comb` -> `cmd_buf`

The expected use by wgpu-rs is unchanged. So far, I don't think we'd be generating Error IDs, but we can always reconsider.
For browsers though, if `device_create_xxx` failed, they would generate and error ID. It will occupy the slot up until the corresponding JS object is dropped.

**Testing**
Tested on wgpu-rs examples