### PR TITLE
fixed lifetime inconsistency when assigning string literal as label

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1365,7 +1365,7 @@ impl<'a> BufferDescriptor<Option<Cow<'a, str>>> {
         }
     }
 
-    pub fn label(&mut self, label: impl IntoCow<'a, str>) -> &mut Self {
+    pub fn label<'b: 'a>(&mut self, label: impl IntoCow<'b, str>) -> &mut Self {
         self.label = Some(label.into_cow());
         self
     }
@@ -2022,7 +2022,7 @@ impl<'a, L, B: Clone> BindGroupDescriptor<'a, L, B> {
         }
     }
 
-    pub fn label(&mut self, label: impl IntoCow<'a, str>) -> &mut Self {
+    pub fn label<'b: 'a>(&mut self, label: impl IntoCow<'b, str>) -> &mut Self {
         self.label = Some(label.into_cow());
         self
     }
@@ -2252,7 +2252,7 @@ impl<'a> RenderBundleEncoderDescriptor<'a> {
         }
     }
 
-    pub fn label(&mut self, label: impl IntoCow<'a, str>) -> &mut Self {
+    pub fn label<'b: 'a>(&mut self, label: impl IntoCow<'b, str>) -> &mut Self {
         self.label = Some(label.into_cow());
         self
     }
@@ -2595,7 +2595,7 @@ impl<'a> BindGroupLayoutDescriptor<'a> {
         }
     }
 
-    pub fn label(&mut self, label: impl IntoCow<'a, str>) -> &mut Self {
+    pub fn label<'b: 'a>(&mut self, label: impl IntoCow<'b, str>) -> &mut Self {
         self.label = Some(label.into_cow());
         self
     }


### PR DESCRIPTION
**Connections**
It is connected to the PR #856 

**Description**
When assigning the `label` field with a string literal, the compiler would require that the lifetime `'a` is `'static`, whether we only need the string literal to outlive `'a` (which it clearly does because it's lifetime is `'static`)
**Testing**
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
