### PR TITLE
Replace u32 with NonZeroU32 in TextureView

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1107,22 +1107,19 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (format, view_kind, range) = match desc {
             Some(desc) => {
                 let kind = conv::map_texture_view_dimension(desc.dimension);
-                let required_level_count = desc.base_mip_level + desc.level_count.unwrap_or(1);
+                let required_level_count =
+                    desc.base_mip_level + desc.level_count.map_or(1, |count| count.get());
                 let required_layer_count =
-                    desc.base_array_layer + desc.array_layer_count.unwrap_or(1);
+                    desc.base_array_layer + desc.array_layer_count.map_or(1, |count| count.get());
                 let level_end = texture.full_range.levels.end;
                 let layer_end = texture.full_range.layers.end;
-                if required_level_count > level_end as u32
-                    || required_level_count == desc.base_mip_level
-                {
+                if required_level_count > level_end as u32 {
                     return Err(resource::CreateTextureViewError::InvalidMipLevelCount {
                         requested: required_level_count,
                         total: level_end,
                     });
                 }
-                if required_layer_count > layer_end as u32
-                    || required_layer_count == desc.base_array_layer
-                {
+                if required_layer_count > layer_end as u32 {
                     return Err(resource::CreateTextureViewError::InvalidArrayLayerCount {
                         requested: required_layer_count,
                         total: layer_end,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -10,7 +10,7 @@
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, ops::Range};
+use std::{borrow::Cow, num::NonZeroU32, ops::Range};
 
 pub use into_cow::IntoCow;
 mod into_cow;
@@ -1750,13 +1750,13 @@ pub struct TextureViewDescriptor<L> {
     /// Mip level count.
     /// If `Some(count)`, `base_mip_level + count` must be less or equal to underlying texture mip count.
     /// If `None`, considered to include the rest of the mipmap levels, but at least 1 in total.
-    pub level_count: Option<u32>,
+    pub level_count: Option<NonZeroU32>,
     /// Base array layer.
     pub base_array_layer: u32,
     /// Layer count.
     /// If `Some(count)`, `base_array_layer + count` must be less or equal to the underlying array count.
     /// If `None`, considered to include the rest of the array layers, but at least 1 in total.
-    pub array_layer_count: Option<u32>,
+    pub array_layer_count: Option<NonZeroU32>,
 }
 
 impl<'a> TextureViewDescriptor<Option<Cow<'a, str>>> {
@@ -1786,7 +1786,7 @@ impl<L> TextureViewDescriptor<L> {
     }
 
     pub fn level_count(&mut self, level_count: u32) -> &mut Self {
-        self.level_count = Some(level_count);
+        self.level_count = Some(NonZeroU32::new(level_count).unwrap());
         self
     }
 
@@ -1796,7 +1796,7 @@ impl<L> TextureViewDescriptor<L> {
     }
 
     pub fn array_layer_count(&mut self, array_layer_count: u32) -> &mut Self {
-        self.array_layer_count = Some(array_layer_count);
+        self.array_layer_count = Some(NonZeroU32::new(array_layer_count).unwrap());
         self
     }
 


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._
We now expose separate methods under `Global` to register error/invalid resources. So the check for `mip_level_count = 0` and `array_layer_count = 0` can be made on the client-side in Servo, and directly register an error resource instead of trying to create a real one.

**Testing**
_Explain how this change is tested._
Not yet tested. Will be done wgpu-rs examples.
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
