### PR TITLE
Streghten the multi-ref-count on BGLs

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1525,10 +1525,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let device_id = {
             let (mut bind_group_layout_guard, _) = hub.bind_group_layouts.write(&mut token);
             match bind_group_layout_guard.get_mut(bind_group_layout_id) {
-                Ok(layout) => {
-                    layout.multi_ref_count.dec();
-                    layout.device_id.value
-                }
+                Ok(layout) => layout.device_id.value,
                 Err(InvalidId) => {
                     hub.bind_group_layouts
                         .unregister_locked(bind_group_layout_id, &mut *bind_group_layout_guard);

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -152,12 +152,8 @@ impl MultiRefCount {
         unsafe { self.0.as_ref() }.fetch_add(1, Ordering::AcqRel);
     }
 
-    fn dec(&self) {
-        unsafe { self.0.as_ref() }.fetch_sub(1, Ordering::AcqRel);
-    }
-
-    fn is_empty(&self) -> bool {
-        unsafe { self.0.as_ref() }.load(Ordering::Acquire) == 0
+    fn dec_and_check_empty(&self) -> bool {
+        unsafe { self.0.as_ref() }.fetch_sub(1, Ordering::AcqRel) == 1
     }
 }
 


### PR DESCRIPTION
**Connections**
Fixes #834

**Description**
Bind group layouts (BGLs) have to be somewhat uniquely tracked, and there was a synchronization issue with their use of `MultiRefCount`. What would happen in multi-thread environment is that we'd see `bind_group_layout_drop`, which first decreases the refcount, and then adds the ID to the list of suspected resources for deletion. But between these operations, something else may have triggered the triage of suspected resources, and if BGL was already there previously, it would be removed earlier than expected.

The solution I came up with is deferring the "dec()" call until the triage itself. That guarantees no gaps, and in fact it goes in line with the other resources we are tracking. I'm fairly confident that the new method works correctly at all times.

**Testing**
Tested extensively on https://github.com/gfx-rs/wgpu/issues/834#issuecomment-669362572