### PR TITLE
Implicit layout

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -248,7 +248,7 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
             }
             A::CreateComputePipeline(id, desc) => {
                 self.device_maintain_ids::<B>(device).unwrap();
-                self.device_create_compute_pipeline::<B>(device, &desc, id)
+                self.device_create_compute_pipeline::<B>(device, &desc, id, None)
                     .unwrap();
             }
             A::DestroyComputePipeline(id) => {

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -256,7 +256,7 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
             }
             A::CreateRenderPipeline(id, desc) => {
                 self.device_maintain_ids::<B>(device).unwrap();
-                self.device_create_render_pipeline::<B>(device, &desc, id)
+                self.device_create_render_pipeline::<B>(device, &desc, id, None)
                     .unwrap();
             }
             A::DestroyRenderPipeline(id) => {

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -523,3 +523,11 @@ impl<B: hal::Backend> Borrow<()> for BindGroup<B> {
         &DUMMY_SELECTOR
     }
 }
+
+#[derive(Clone, Debug, Error)]
+pub enum GetBindGroupLayoutError {
+    #[error("pipeline is invalid")]
+    InvalidPipeline,
+    #[error("invalid group index {0}")]
+    InvalidGroupIndex(u32),
+}

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -6,7 +6,9 @@ use crate::{
     binding_model::{self, CreateBindGroupError, CreatePipelineLayoutError},
     command, conv,
     device::life::WaitIdleError,
-    hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Hub, Input, InvalidId, Token},
+    hub::{
+        GfxBackend, Global, GlobalIdentityHandlerFactory, Hub, Input, InvalidId, Storage, Token,
+    },
     id, pipeline, resource, span, swap_chain,
     track::{BufferState, TextureState, TrackerSet},
     validation::{self, check_buffer_usage, check_texture_usage},
@@ -58,6 +60,9 @@ pub const MAX_MIP_LEVELS: u32 = 16;
 pub const MAX_VERTEX_BUFFERS: usize = 16;
 pub const MAX_ANISOTROPY: u8 = 16;
 pub const SHADER_STAGE_COUNT: usize = 3;
+
+/// Number of implicit bind groups derived at pipeline creation.
+pub type DerivedBindGroupCount = u8;
 
 pub fn all_buffer_stages() -> hal::pso::PipelineStage {
     use hal::pso::PipelineStage as Ps;
@@ -601,6 +606,203 @@ impl<B: GfxBackend> Device<B> {
         unsafe { self.raw.create_render_pass(all, iter::once(subpass), &[]) }
     }
 
+    fn deduplicate_bind_group_layout(
+        self_id: id::DeviceId,
+        entry_map: &binding_model::BindEntryMap,
+        guard: &Storage<binding_model::BindGroupLayout<B>, id::BindGroupLayoutId>,
+    ) -> Option<id::BindGroupLayoutId> {
+        guard
+            .iter(self_id.backend())
+            .find(|(_, bgl)| bgl.device_id.value.0 == self_id && bgl.entries == *entry_map)
+            .map(|(id, value)| {
+                value.multi_ref_count.inc();
+                id
+            })
+    }
+
+    fn create_bind_group_layout(
+        &self,
+        self_id: id::DeviceId,
+        label: Option<&str>,
+        entry_map: binding_model::BindEntryMap,
+    ) -> Result<binding_model::BindGroupLayout<B>, binding_model::CreateBindGroupLayoutError> {
+        // Validate the count parameter
+        for binding in entry_map.values() {
+            if let Some(count) = binding.count {
+                if count == 0 {
+                    return Err(binding_model::CreateBindGroupLayoutError::ZeroCount);
+                }
+                match binding.ty {
+                    wgt::BindingType::SampledTexture { .. } => {
+                        if !self
+                            .features
+                            .contains(wgt::Features::SAMPLED_TEXTURE_BINDING_ARRAY)
+                        {
+                            return Err(binding_model::CreateBindGroupLayoutError::MissingFeature(
+                                wgt::Features::SAMPLED_TEXTURE_BINDING_ARRAY,
+                            ));
+                        }
+                    }
+                    _ => return Err(binding_model::CreateBindGroupLayoutError::ArrayUnsupported),
+                }
+            }
+        }
+
+        let raw_bindings = entry_map
+            .values()
+            .map(|entry| hal::pso::DescriptorSetLayoutBinding {
+                binding: entry.binding,
+                ty: conv::map_binding_type(entry),
+                count: entry
+                    .count
+                    .map_or(1, |v| v as hal::pso::DescriptorArrayIndex), //TODO: consolidate
+                stage_flags: conv::map_shader_stage_flags(entry.visibility),
+                immutable_samplers: false, // TODO
+            })
+            .collect::<Vec<_>>(); //TODO: avoid heap allocation
+
+        let raw = unsafe {
+            let mut raw_layout = self
+                .raw
+                .create_descriptor_set_layout(&raw_bindings, &[])
+                .or(Err(DeviceError::OutOfMemory))?;
+            if let Some(label) = label {
+                self.raw
+                    .set_descriptor_set_layout_name(&mut raw_layout, label);
+            }
+            raw_layout
+        };
+
+        let mut count_validator = binding_model::BindingTypeMaxCountValidator::default();
+        for entry in entry_map.values() {
+            count_validator.add_binding(entry);
+        }
+        // If a single bind group layout violates limits, the pipeline layout is definitely
+        // going to violate limits too, lets catch it now.
+        count_validator
+            .validate(&self.limits)
+            .map_err(binding_model::CreateBindGroupLayoutError::TooManyBindings)?;
+
+        Ok(binding_model::BindGroupLayout {
+            raw,
+            device_id: Stored {
+                value: id::Valid(self_id),
+                ref_count: self.life_guard.add_ref(),
+            },
+            multi_ref_count: MultiRefCount::new(),
+            desc_counts: raw_bindings.iter().cloned().collect(),
+            dynamic_count: entry_map
+                .values()
+                .filter(|b| b.has_dynamic_offset())
+                .count(),
+            count_validator,
+            entries: entry_map,
+        })
+    }
+
+    fn create_pipeline_layout(
+        &self,
+        self_id: id::DeviceId,
+        desc: &wgt::PipelineLayoutDescriptor<id::BindGroupLayoutId>,
+        bgl_guard: &Storage<binding_model::BindGroupLayout<B>, id::BindGroupLayoutId>,
+    ) -> Result<binding_model::PipelineLayout<B>, CreatePipelineLayoutError> {
+        let bind_group_layouts_count = desc.bind_group_layouts.len();
+        let device_max_bind_groups = self.limits.max_bind_groups as usize;
+        if bind_group_layouts_count > device_max_bind_groups {
+            return Err(CreatePipelineLayoutError::TooManyGroups {
+                actual: bind_group_layouts_count,
+                max: device_max_bind_groups,
+            });
+        }
+
+        if !desc.push_constant_ranges.is_empty()
+            && !self.features.contains(wgt::Features::PUSH_CONSTANTS)
+        {
+            return Err(CreatePipelineLayoutError::MissingFeature(
+                wgt::Features::PUSH_CONSTANTS,
+            ));
+        }
+        let mut used_stages = wgt::ShaderStage::empty();
+        for (index, pc) in desc.push_constant_ranges.iter().enumerate() {
+            if pc.stages.intersects(used_stages) {
+                return Err(
+                    CreatePipelineLayoutError::MoreThanOnePushConstantRangePerStage {
+                        index,
+                        provided: pc.stages,
+                        intersected: pc.stages & used_stages,
+                    },
+                );
+            }
+            used_stages |= pc.stages;
+
+            let device_max_pc_size = self.limits.max_push_constant_size;
+            if device_max_pc_size < pc.range.end {
+                return Err(CreatePipelineLayoutError::PushConstantRangeTooLarge {
+                    index,
+                    range: pc.range.clone(),
+                    max: device_max_pc_size,
+                });
+            }
+
+            if pc.range.start % wgt::PUSH_CONSTANT_ALIGNMENT != 0 {
+                return Err(CreatePipelineLayoutError::MisalignedPushConstantRange {
+                    index,
+                    bound: pc.range.start,
+                });
+            }
+            if pc.range.end % wgt::PUSH_CONSTANT_ALIGNMENT != 0 {
+                return Err(CreatePipelineLayoutError::MisalignedPushConstantRange {
+                    index,
+                    bound: pc.range.end,
+                });
+            }
+        }
+
+        let mut count_validator = binding_model::BindingTypeMaxCountValidator::default();
+
+        // validate total resource counts
+        for &id in desc.bind_group_layouts.iter() {
+            let bind_group_layout = bgl_guard
+                .get(id)
+                .map_err(|_| CreatePipelineLayoutError::InvalidBindGroupLayout(id))?;
+            count_validator.merge(&bind_group_layout.count_validator);
+        }
+        count_validator
+            .validate(&self.limits)
+            .map_err(CreatePipelineLayoutError::TooManyBindings)?;
+
+        let descriptor_set_layouts = desc
+            .bind_group_layouts
+            .iter()
+            .map(|&id| &bgl_guard.get(id).unwrap().raw);
+        let push_constants = desc
+            .push_constant_ranges
+            .iter()
+            .map(|pc| (conv::map_shader_stage_flags(pc.stages), pc.range.clone()));
+
+        Ok(binding_model::PipelineLayout {
+            raw: unsafe {
+                self.raw
+                    .create_pipeline_layout(descriptor_set_layouts, push_constants)
+                    .or(Err(DeviceError::OutOfMemory))?
+            },
+            device_id: Stored {
+                value: id::Valid(self_id),
+                ref_count: self.life_guard.add_ref(),
+            },
+            life_guard: LifeGuard::new(),
+            bind_group_layout_ids: desc
+                .bind_group_layouts
+                .iter()
+                .map(|&id| {
+                    bgl_guard.get(id).unwrap().multi_ref_count.inc();
+                    id::Valid(id)
+                })
+                .collect(),
+            push_constant_ranges: desc.push_constant_ranges.iter().cloned().collect(),
+        })
+    }
+
     fn wait_for_submit(
         &self,
         submission_index: SubmissionIndex,
@@ -705,6 +907,11 @@ impl DeviceError {
             _ => panic!("failed to bind memory: {}", err),
         }
     }
+}
+
+pub struct ImplicitPipelineIds<'a, G: GlobalIdentityHandlerFactory> {
+    pub root_id: Input<G, id::PipelineLayoutId>,
+    pub group_ids: &'a [Input<G, id::BindGroupLayoutId>],
 }
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
@@ -1400,97 +1607,18 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         // so their inputs are `PhantomData` of size 0.
         if mem::size_of::<Input<G, id::BindGroupLayoutId>>() == 0 {
             let (bgl_guard, _) = hub.bind_group_layouts.read(&mut token);
-            let bind_group_layout_id = bgl_guard
-                .iter(device_id.backend())
-                .find(|(_, bgl)| bgl.device_id.value.0 == device_id && bgl.entries == entry_map);
-
-            if let Some((id, value)) = bind_group_layout_id {
-                value.multi_ref_count.inc();
+            if let Some(id) =
+                Device::deduplicate_bind_group_layout(device_id, &entry_map, &*bgl_guard)
+            {
                 return Ok(id);
             }
         }
 
-        // Validate the count parameter
-        for binding in desc
-            .entries
-            .iter()
-            .filter(|binding| binding.count.is_some())
-        {
-            if let Some(count) = binding.count {
-                if count == 0 {
-                    return Err(binding_model::CreateBindGroupLayoutError::ZeroCount);
-                }
-                match binding.ty {
-                    wgt::BindingType::SampledTexture { .. } => {
-                        if !device
-                            .features
-                            .contains(wgt::Features::SAMPLED_TEXTURE_BINDING_ARRAY)
-                        {
-                            return Err(binding_model::CreateBindGroupLayoutError::MissingFeature(
-                                wgt::Features::SAMPLED_TEXTURE_BINDING_ARRAY,
-                            ));
-                        }
-                    }
-                    _ => return Err(binding_model::CreateBindGroupLayoutError::ArrayUnsupported),
-                }
-            } else {
-                unreachable!() // programming bug
-            }
-        }
-
-        let raw_bindings = desc
-            .entries
-            .iter()
-            .map(|binding| hal::pso::DescriptorSetLayoutBinding {
-                binding: binding.binding,
-                ty: conv::map_binding_type(binding),
-                count: binding
-                    .count
-                    .map_or(1, |v| v as hal::pso::DescriptorArrayIndex), //TODO: consolidate
-                stage_flags: conv::map_shader_stage_flags(binding.visibility),
-                immutable_samplers: false, // TODO
-            })
-            .collect::<Vec<_>>(); //TODO: avoid heap allocation
-
-        let raw = unsafe {
-            let mut raw_layout = device
-                .raw
-                .create_descriptor_set_layout(&raw_bindings, &[])
-                .or(Err(DeviceError::OutOfMemory))?;
-            if let Some(label) = desc.label.as_ref() {
-                device
-                    .raw
-                    .set_descriptor_set_layout_name(&mut raw_layout, label);
-            }
-            raw_layout
-        };
-
-        let mut count_validator = binding_model::BindingTypeMaxCountValidator::default();
-        desc.entries
-            .iter()
-            .for_each(|b| count_validator.add_binding(b));
-        // If a single bind group layout violates limits, the pipeline layout is definitely
-        // going to violate limits too, lets catch it now.
-        count_validator
-            .validate(&device.limits)
-            .map_err(binding_model::CreateBindGroupLayoutError::TooManyBindings)?;
-
-        let layout = binding_model::BindGroupLayout {
-            raw,
-            device_id: Stored {
-                value: id::Valid(device_id),
-                ref_count: device.life_guard.add_ref(),
-            },
-            multi_ref_count: MultiRefCount::new(),
-            entries: entry_map,
-            desc_counts: raw_bindings.iter().cloned().collect(),
-            dynamic_count: desc
-                .entries
-                .iter()
-                .filter(|b| b.has_dynamic_offset())
-                .count(),
-            count_validator,
-        };
+        let layout = device.create_bind_group_layout(
+            device_id,
+            desc.label.as_ref().map(|cow| cow.as_ref()),
+            entry_map,
+        )?;
 
         let id = hub
             .bind_group_layouts
@@ -1557,108 +1685,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let device = device_guard
             .get(device_id)
             .map_err(|_| DeviceError::Invalid)?;
-        let bind_group_layouts_count = desc.bind_group_layouts.len();
-        let device_max_bind_groups = device.limits.max_bind_groups as usize;
-        if bind_group_layouts_count > device_max_bind_groups {
-            return Err(CreatePipelineLayoutError::TooManyGroups {
-                actual: bind_group_layouts_count,
-                max: device_max_bind_groups,
-            });
-        }
-
-        if !desc.push_constant_ranges.is_empty()
-            && !device.features.contains(wgt::Features::PUSH_CONSTANTS)
-        {
-            return Err(CreatePipelineLayoutError::MissingFeature(
-                wgt::Features::PUSH_CONSTANTS,
-            ));
-        }
-        let mut used_stages = wgt::ShaderStage::empty();
-        for (index, pc) in desc.push_constant_ranges.iter().enumerate() {
-            if pc.stages.intersects(used_stages) {
-                return Err(
-                    CreatePipelineLayoutError::MoreThanOnePushConstantRangePerStage {
-                        index,
-                        provided: pc.stages,
-                        intersected: pc.stages & used_stages,
-                    },
-                );
-            }
-            used_stages |= pc.stages;
-
-            let device_max_pc_size = device.limits.max_push_constant_size;
-            if device_max_pc_size < pc.range.end {
-                return Err(CreatePipelineLayoutError::PushConstantRangeTooLarge {
-                    index,
-                    range: pc.range.clone(),
-                    max: device_max_pc_size,
-                });
-            }
-
-            if pc.range.start % wgt::PUSH_CONSTANT_ALIGNMENT != 0 {
-                return Err(CreatePipelineLayoutError::MisalignedPushConstantRange {
-                    index,
-                    bound: pc.range.start,
-                });
-            }
-            if pc.range.end % wgt::PUSH_CONSTANT_ALIGNMENT != 0 {
-                return Err(CreatePipelineLayoutError::MisalignedPushConstantRange {
-                    index,
-                    bound: pc.range.end,
-                });
-            }
-        }
 
         let layout = {
-            let mut count_validator = binding_model::BindingTypeMaxCountValidator::default();
-            let (bind_group_layout_guard, _) = hub.bind_group_layouts.read(&mut token);
-
-            // validate total resource counts
-            for &id in desc.bind_group_layouts.iter() {
-                let bind_group_layout = bind_group_layout_guard
-                    .get(id)
-                    .map_err(|_| CreatePipelineLayoutError::InvalidBindGroupLayout(id))?;
-                count_validator.merge(&bind_group_layout.count_validator);
-            }
-            count_validator
-                .validate(&device.limits)
-                .map_err(CreatePipelineLayoutError::TooManyBindings)?;
-
-            let descriptor_set_layouts = desc
-                .bind_group_layouts
-                .iter()
-                .map(|&id| &bind_group_layout_guard.get(id).unwrap().raw);
-            let push_constants = desc
-                .push_constant_ranges
-                .iter()
-                .map(|pc| (conv::map_shader_stage_flags(pc.stages), pc.range.clone()));
-
-            binding_model::PipelineLayout {
-                raw: unsafe {
-                    device
-                        .raw
-                        .create_pipeline_layout(descriptor_set_layouts, push_constants)
-                        .or(Err(DeviceError::OutOfMemory))?
-                },
-                device_id: Stored {
-                    value: id::Valid(device_id),
-                    ref_count: device.life_guard.add_ref(),
-                },
-                life_guard: LifeGuard::new(),
-                bind_group_layout_ids: desc
-                    .bind_group_layouts
-                    .iter()
-                    .map(|&id| {
-                        bind_group_layout_guard
-                            .get(id)
-                            .unwrap()
-                            .multi_ref_count
-                            .inc();
-                        id::Valid(id)
-                    })
-                    .collect(),
-                push_constant_ranges: desc.push_constant_ranges.iter().cloned().collect(),
-            }
+            let (bgl_guard, _) = hub.bind_group_layouts.read(&mut token);
+            device.create_pipeline_layout(device_id, desc, &*bgl_guard)?
         };
 
         let id = hub
@@ -2810,7 +2840,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         device_id: id::DeviceId,
         desc: &pipeline::ComputePipelineDescriptor,
         id_in: Input<G, id::ComputePipelineId>,
-    ) -> Result<id::ComputePipelineId, pipeline::CreateComputePipelineError> {
+        implicit_pipeline_ids: Option<ImplicitPipelineIds<G>>,
+    ) -> Result<(id::ComputePipelineId, DerivedBindGroupCount), pipeline::CreateComputePipelineError>
+    {
         span!(_guard, INFO, "Device::create_compute_pipeline");
 
         let hub = B::hub(self);
@@ -2820,39 +2852,19 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let device = device_guard
             .get(device_id)
             .map_err(|_| DeviceError::Invalid)?;
-        let (raw_pipeline, layout_id, layout_ref_count) = {
-            let (pipeline_layout_guard, mut token) = hub.pipeline_layouts.read(&mut token);
-            let (bgl_guard, mut token) = hub.bind_group_layouts.read(&mut token);
+        let (raw_pipeline, layout_id, layout_ref_count, derived_bind_group_count) = {
+            //TODO: only lock mutable if the layout is derived
+            let (mut pipeline_layout_guard, mut token) = hub.pipeline_layouts.write(&mut token);
+            let (mut bgl_guard, mut token) = hub.bind_group_layouts.write(&mut token);
 
             let mut derived_group_layouts =
                 ArrayVec::<[binding_model::BindEntryMap; MAX_BIND_GROUPS]>::new();
-            let given_group_layouts: ArrayVec<[&binding_model::BindEntryMap; MAX_BIND_GROUPS]>;
-            let group_layouts = match desc.layout {
-                Some(pipeline_layout_id) => {
-                    let layout = pipeline_layout_guard
-                        .get(pipeline_layout_id)
-                        .map_err(|_| pipeline::CreateComputePipelineError::InvalidLayout)?;
-                    given_group_layouts = layout
-                        .bind_group_layout_ids
-                        .iter()
-                        .map(|&id| &bgl_guard[id].entries)
-                        .collect();
-                    validation::IntrospectionBindGroupLayouts::Given(&given_group_layouts)
-                }
-                None => {
-                    for _ in 0..device.limits.max_bind_groups {
-                        derived_group_layouts.push(binding_model::BindEntryMap::default());
-                    }
-                    validation::IntrospectionBindGroupLayouts::Derived(&mut derived_group_layouts)
-                }
-            };
 
             let interface = validation::StageInterface::default();
             let pipeline_stage = &desc.compute_stage;
             let (shader_module_guard, _) = hub.shader_modules.read(&mut token);
 
             let entry_point_name = &pipeline_stage.entry_point;
-
             let shader_module = shader_module_guard
                 .get(pipeline_stage.module)
                 .map_err(|_| {
@@ -2862,6 +2874,28 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 })?;
 
             if let Some(ref module) = shader_module.module {
+                let given_group_layouts: ArrayVec<[&binding_model::BindEntryMap; MAX_BIND_GROUPS]>;
+                let group_layouts = match desc.layout {
+                    Some(pipeline_layout_id) => {
+                        let layout = pipeline_layout_guard
+                            .get(pipeline_layout_id)
+                            .map_err(|_| pipeline::CreateComputePipelineError::InvalidLayout)?;
+                        given_group_layouts = layout
+                            .bind_group_layout_ids
+                            .iter()
+                            .map(|&id| &bgl_guard[id].entries)
+                            .collect();
+                        validation::IntrospectionBindGroupLayouts::Given(&given_group_layouts)
+                    }
+                    None => {
+                        for _ in 0..device.limits.max_bind_groups {
+                            derived_group_layouts.push(binding_model::BindEntryMap::default());
+                        }
+                        validation::IntrospectionBindGroupLayouts::Derived(
+                            &mut derived_group_layouts,
+                        )
+                    }
+                };
                 let _ = validation::check_stage(
                     module,
                     group_layouts,
@@ -2883,11 +2917,87 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             // TODO
             let parent = hal::pso::BasePipeline::None;
 
+            let derived_bind_group_count = derived_group_layouts.len() as DerivedBindGroupCount;
+
             let pipeline_layout_id = match desc.layout {
                 Some(id) => id,
                 None => {
-                    //TODO: create a new pipeline layout
-                    unimplemented!()
+                    while derived_group_layouts
+                        .last()
+                        .map_or(false, |map| map.is_empty())
+                    {
+                        derived_group_layouts.pop();
+                    }
+                    let ids = implicit_pipeline_ids
+                        .as_ref()
+                        .ok_or(pipeline::CreateComputePipelineError::InvalidLayout)?;
+                    if ids.group_ids.len() < derived_group_layouts.len() {
+                        tracing::error!(
+                            "Not enough bind group IDs ({}) specified for the implicit layout ({})",
+                            ids.group_ids.len(),
+                            derived_group_layouts.len()
+                        );
+                        return Err(pipeline::CreateComputePipelineError::InvalidLayout);
+                    }
+
+                    let mut derived_group_layout_ids =
+                        ArrayVec::<[id::BindGroupLayoutId; MAX_BIND_GROUPS]>::new();
+                    for (bgl_id, map) in ids.group_ids.iter().zip(derived_group_layouts) {
+                        let processed_id = match Device::deduplicate_bind_group_layout(
+                            device_id,
+                            &map,
+                            &*bgl_guard,
+                        ) {
+                            Some(dedup_id) => dedup_id,
+                            None => {
+                                #[cfg(feature = "trace")]
+                                let bgl_desc = wgt::BindGroupLayoutDescriptor {
+                                    label: None,
+                                    entries: if device.trace.is_some() {
+                                        Cow::Owned(map.values().cloned().collect())
+                                    } else {
+                                        Cow::Borrowed(&[])
+                                    },
+                                };
+                                let bgl = device.create_bind_group_layout(device_id, None, map)?;
+                                let out_id = hub.bind_group_layouts.register_identity_locked(
+                                    bgl_id.clone(),
+                                    bgl,
+                                    &mut *bgl_guard,
+                                );
+                                #[cfg(feature = "trace")]
+                                match device.trace {
+                                    Some(ref trace) => trace.lock().add(
+                                        trace::Action::CreateBindGroupLayout(out_id.0, bgl_desc),
+                                    ),
+                                    None => (),
+                                };
+                                out_id.0
+                            }
+                        };
+                        derived_group_layout_ids.push(processed_id);
+                    }
+
+                    let layout_desc = wgt::PipelineLayoutDescriptor {
+                        bind_group_layouts: Cow::Borrowed(&derived_group_layout_ids),
+                        push_constant_ranges: Cow::Borrowed(&[]), //TODO?
+                    };
+                    let layout =
+                        device.create_pipeline_layout(device_id, &layout_desc, &*bgl_guard)?;
+                    let layout_id = hub.pipeline_layouts.register_identity_locked(
+                        ids.root_id.clone(),
+                        layout,
+                        &mut *pipeline_layout_guard,
+                    );
+                    #[cfg(feature = "trace")]
+                    match device.trace {
+                        Some(ref trace) => trace.lock().add(trace::Action::CreatePipelineLayout(
+                            layout_id.0,
+                            layout_desc,
+                        )),
+                        None => (),
+                    };
+                    layout_id.0
                 }
             };
             let layout = pipeline_layout_guard
@@ -2902,7 +3012,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             match unsafe { device.raw.create_compute_pipeline(&pipeline_desc, None) } {
-                Ok(pipeline) => (pipeline, pipeline_layout_id, layout.life_guard.add_ref()),
+                Ok(pipeline) => (
+                    pipeline,
+                    pipeline_layout_id,
+                    layout.life_guard.add_ref(),
+                    derived_bind_group_count,
+                ),
                 Err(hal::pso::CreationError::OutOfMemory(_)) => {
                     return Err(pipeline::CreateComputePipelineError::Device(
                         DeviceError::OutOfMemory,
@@ -2930,12 +3045,16 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         #[cfg(feature = "trace")]
         match device.trace {
-            Some(ref trace) => trace
-                .lock()
-                .add(trace::Action::CreateComputePipeline(id.0, desc.clone())),
+            Some(ref trace) => trace.lock().add(trace::Action::CreateComputePipeline(
+                id.0,
+                wgt::ComputePipelineDescriptor {
+                    layout: Some(layout_id),
+                    ..desc.clone()
+                },
+            )),
             None => (),
         };
-        Ok(id.0)
+        Ok((id.0, derived_bind_group_count))
     }
 
     pub fn compute_pipeline_error<B: GfxBackend>(

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2957,6 +2957,28 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         Ok((id.0, derived_bind_group_count))
     }
 
+    pub fn render_pipeline_get_bind_group_layout<B: GfxBackend>(
+        &self,
+        pipeline_id: id::RenderPipelineId,
+        index: u32,
+    ) -> Result<id::BindGroupLayoutId, binding_model::GetBindGroupLayoutError> {
+        let hub = B::hub(self);
+        let mut token = Token::root();
+        let (pipeline_layout_guard, mut token) = hub.pipeline_layouts.read(&mut token);
+        let (pipeline_guard, _) = hub.render_pipelines.read(&mut token);
+
+        let pipeline = pipeline_guard
+            .get(pipeline_id)
+            .map_err(|_| binding_model::GetBindGroupLayoutError::InvalidPipeline)?;
+        pipeline_layout_guard[pipeline.layout_id.value]
+            .bind_group_layout_ids
+            .get(index as usize)
+            .map(|valid| valid.0)
+            .ok_or(binding_model::GetBindGroupLayoutError::InvalidGroupIndex(
+                index,
+            ))
+    }
+
     pub fn render_pipeline_error<B: GfxBackend>(
         &self,
         id_in: Input<G, id::RenderPipelineId>,
@@ -3147,6 +3169,28 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             None => (),
         };
         Ok((id.0, derived_bind_group_count))
+    }
+
+    pub fn compute_pipeline_get_bind_group_layout<B: GfxBackend>(
+        &self,
+        pipeline_id: id::ComputePipelineId,
+        index: u32,
+    ) -> Result<id::BindGroupLayoutId, binding_model::GetBindGroupLayoutError> {
+        let hub = B::hub(self);
+        let mut token = Token::root();
+        let (pipeline_layout_guard, mut token) = hub.pipeline_layouts.read(&mut token);
+        let (pipeline_guard, _) = hub.compute_pipelines.read(&mut token);
+
+        let pipeline = pipeline_guard
+            .get(pipeline_id)
+            .map_err(|_| binding_model::GetBindGroupLayoutError::InvalidPipeline)?;
+        pipeline_layout_guard[pipeline.layout_id.value]
+            .bind_group_layout_ids
+            .get(index as usize)
+            .map(|valid| valid.0)
+            .ok_or(binding_model::GetBindGroupLayoutError::InvalidGroupIndex(
+                index,
+            ))
     }
 
     pub fn compute_pipeline_error<B: GfxBackend>(

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -239,8 +239,10 @@ impl<B: hal::Backend> Access<CommandBuffer<B>> for SwapChain<B> {}
 impl<B: hal::Backend> Access<RenderBundle> for Device<B> {}
 impl<B: hal::Backend> Access<RenderBundle> for CommandBuffer<B> {}
 impl<B: hal::Backend> Access<ComputePipeline<B>> for Device<B> {}
+impl<B: hal::Backend> Access<ComputePipeline<B>> for PipelineLayout<B> {}
 impl<B: hal::Backend> Access<ComputePipeline<B>> for BindGroup<B> {}
 impl<B: hal::Backend> Access<RenderPipeline<B>> for Device<B> {}
+impl<B: hal::Backend> Access<RenderPipeline<B>> for PipelineLayout<B> {}
 impl<B: hal::Backend> Access<RenderPipeline<B>> for BindGroup<B> {}
 impl<B: hal::Backend> Access<RenderPipeline<B>> for ComputePipeline<B> {}
 impl<B: hal::Backend> Access<ShaderModule<B>> for Device<B> {}

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -239,10 +239,8 @@ impl<B: hal::Backend> Access<CommandBuffer<B>> for SwapChain<B> {}
 impl<B: hal::Backend> Access<RenderBundle> for Device<B> {}
 impl<B: hal::Backend> Access<RenderBundle> for CommandBuffer<B> {}
 impl<B: hal::Backend> Access<ComputePipeline<B>> for Device<B> {}
-impl<B: hal::Backend> Access<ComputePipeline<B>> for PipelineLayout<B> {}
 impl<B: hal::Backend> Access<ComputePipeline<B>> for BindGroup<B> {}
 impl<B: hal::Backend> Access<RenderPipeline<B>> for Device<B> {}
-impl<B: hal::Backend> Access<RenderPipeline<B>> for PipelineLayout<B> {}
 impl<B: hal::Backend> Access<RenderPipeline<B>> for BindGroup<B> {}
 impl<B: hal::Backend> Access<RenderPipeline<B>> for ComputePipeline<B> {}
 impl<B: hal::Backend> Access<ShaderModule<B>> for Device<B> {}

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -429,6 +429,17 @@ impl<T, I: TypedId + Copy, F: IdentityHandlerFactory<I>> Registry<T, I, F> {
         Valid(id)
     }
 
+    pub(crate) fn register_identity_locked(
+        &self,
+        id_in: <F::Filter as IdentityHandler<I>>::Input,
+        value: T,
+        guard: &mut Storage<T, I>,
+    ) -> Valid<I> {
+        let id = self.identity.process(id_in, self.backend);
+        guard.insert(id, value);
+        Valid(id)
+    }
+
     pub fn register_error<A: Access<T>>(
         &self,
         id_in: <F::Filter as IdentityHandler<I>>::Input,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -38,6 +38,21 @@ pub enum CreateShaderModuleError {
 
 pub type ProgrammableStageDescriptor<'a> = wgt::ProgrammableStageDescriptor<'a, ShaderModuleId>;
 
+/// Number of implicit bind groups derived at pipeline creation.
+pub type ImplicitBindGroupCount = u8;
+
+#[derive(Clone, Debug, Error)]
+pub enum ImplicitLayoutError {
+    #[error("missing IDs for deriving {0} bind groups")]
+    MissingIds(ImplicitBindGroupCount),
+    #[error("unable to reflect the shader {0:?} interface")]
+    ReflectionError(wgt::ShaderStage),
+    #[error(transparent)]
+    BindGroup(#[from] CreateBindGroupLayoutError),
+    #[error(transparent)]
+    Pipeline(#[from] CreatePipelineLayoutError),
+}
+
 pub type ComputePipelineDescriptor<'a> =
     wgt::ComputePipelineDescriptor<PipelineLayoutId, ProgrammableStageDescriptor<'a>>;
 
@@ -47,10 +62,8 @@ pub enum CreateComputePipelineError {
     Device(#[from] DeviceError),
     #[error("pipeline layout is invalid")]
     InvalidLayout,
-    #[error("implicit bind group layout failed to validate")]
-    ImplicitBindGroupLayout(#[from] CreateBindGroupLayoutError),
-    #[error("implicit pipeline layout failed to validate")]
-    ImplicitPipelineLayout(#[from] CreatePipelineLayoutError),
+    #[error("unable to derive an implicit layout")]
+    Implicit(#[from] ImplicitLayoutError),
     #[error(transparent)]
     Stage(StageError),
 }
@@ -78,10 +91,8 @@ pub enum CreateRenderPipelineError {
     Device(#[from] DeviceError),
     #[error("pipelie layout is invalid")]
     InvalidLayout,
-    #[error("implicit bind group layout failed to validate")]
-    ImplicitBindGroupLayout(#[from] CreateBindGroupLayoutError),
-    #[error("implicit pipeline layout failed to validate")]
-    ImplicitPipelineLayout(#[from] CreatePipelineLayoutError),
+    #[error("unable to derive an implicit layout")]
+    Implicit(#[from] ImplicitLayoutError),
     #[error("incompatible output format at index {index}")]
     IncompatibleOutputFormat { index: u8 },
     #[error("invalid sample count {0}")]

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{
+    binding_model::{CreateBindGroupLayoutError, CreatePipelineLayoutError},
     device::{DeviceError, RenderPassContext},
     id::{DeviceId, PipelineLayoutId, ShaderModuleId},
     validation::StageError,
@@ -44,8 +45,12 @@ pub type ComputePipelineDescriptor<'a> =
 pub enum CreateComputePipelineError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("pipelie layout is invalid")]
+    #[error("pipeline layout is invalid")]
     InvalidLayout,
+    #[error("implicit bind group layout failed to validate")]
+    ImplicitBindGroupLayout(#[from] CreateBindGroupLayoutError),
+    #[error("implicit pipeline layout failed to validate")]
+    ImplicitPipelineLayout(#[from] CreatePipelineLayoutError),
     #[error(transparent)]
     Stage(StageError),
 }

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -78,6 +78,10 @@ pub enum CreateRenderPipelineError {
     Device(#[from] DeviceError),
     #[error("pipelie layout is invalid")]
     InvalidLayout,
+    #[error("implicit bind group layout failed to validate")]
+    ImplicitBindGroupLayout(#[from] CreateBindGroupLayoutError),
+    #[error("implicit pipeline layout failed to validate")]
+    ImplicitPipelineLayout(#[from] CreatePipelineLayoutError),
     #[error("incompatible output format at index {index}")]
     IncompatibleOutputFormat { index: u8 },
     #[error("invalid sample count {0}")]

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{binding_model::BindEntryMap, FastHashMap};
+use crate::{binding_model::BindEntryMap, FastHashMap, MAX_BIND_GROUPS};
+use arrayvec::ArrayVec;
 use std::collections::hash_map::Entry;
 use thiserror::Error;
 use wgt::{BindGroupLayoutEntry, BindingType};
@@ -683,7 +684,7 @@ pub fn check_texture_format(format: wgt::TextureFormat, output: &naga::TypeInner
 pub type StageInterface<'a> = FastHashMap<wgt::ShaderLocation, MaybeOwned<'a, naga::TypeInner>>;
 
 pub enum IntrospectionBindGroupLayouts<'a> {
-    Given(&'a [&'a BindEntryMap]),
+    Given(ArrayVec<[&'a BindEntryMap; MAX_BIND_GROUPS]>),
     Derived(&'a mut [BindEntryMap]),
 }
 
@@ -782,7 +783,7 @@ pub fn check_stage<'a>(
         match var.binding {
             Some(naga::Binding::Descriptor { set, binding }) => {
                 let result = match group_layouts {
-                    IntrospectionBindGroupLayouts::Given(layouts) => layouts
+                    IntrospectionBindGroupLayouts::Given(ref layouts) => layouts
                         .get(set as usize)
                         .and_then(|map| map.get(&binding))
                         .ok_or(BindingError::Missing)

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -755,7 +755,7 @@ fn derive_binding_type(
 
 pub fn check_stage<'a>(
     module: &'a naga::Module,
-    mut group_layouts: IntrospectionBindGroupLayouts<'a>,
+    mut group_layouts: IntrospectionBindGroupLayouts,
     entry_point_name: &str,
     stage: naga::ShaderStage,
     inputs: StageInterface<'a>,

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{binding_model::BindEntryMap, FastHashMap};
+use std::collections::hash_map::Entry;
 use thiserror::Error;
 use wgt::{BindGroupLayoutEntry, BindingType};
 
@@ -71,6 +72,8 @@ pub enum BindingError {
     WrongTextureMultisampled,
     #[error("comparison flag doesn't match the shader")]
     WrongSamplerComparison,
+    #[error("derived bind group layout type is not consistent between stages")]
+    InconsistentlyDerivedType,
 }
 
 #[derive(Clone, Debug, Error)]
@@ -159,13 +162,12 @@ fn get_aligned_type_size(
     }
 }
 
-fn check_binding(
+fn check_binding_use(
     module: &naga::Module,
     var: &naga::GlobalVariable,
     entry: &BindGroupLayoutEntry,
-    usage: naga::GlobalUse,
-) -> Result<(), BindingError> {
-    let allowed_usage = match module.types[var.ty].inner {
+) -> Result<naga::GlobalUse, BindingError> {
+    match module.types[var.ty].inner {
         naga::TypeInner::Struct { ref members } => {
             let (allowed_usage, min_size) = match entry.ty {
                 BindingType::UniformBuffer {
@@ -196,17 +198,17 @@ fn check_binding(
                 }
                 _ => (),
             }
-            allowed_usage
+            Ok(allowed_usage)
         }
         naga::TypeInner::Sampler { comparison } => match entry.ty {
             BindingType::Sampler { comparison: cmp } => {
                 if cmp == comparison {
-                    naga::GlobalUse::empty()
+                    Ok(naga::GlobalUse::empty())
                 } else {
-                    return Err(BindingError::WrongSamplerComparison);
+                    Err(BindingError::WrongSamplerComparison)
                 }
             }
-            _ => return Err(BindingError::WrongType),
+            _ => Err(BindingError::WrongType),
         },
         naga::TypeInner::Image { base, dim, flags } => {
             if flags.contains(naga::ImageFlags::MULTISAMPLED) {
@@ -284,14 +286,9 @@ fn check_binding(
             if is_sampled != flags.contains(naga::ImageFlags::SAMPLED) {
                 return Err(BindingError::WrongTextureSampled);
             }
-            allowed_usage
+            Ok(allowed_usage)
         }
-        _ => return Err(BindingError::WrongType),
-    };
-    if allowed_usage.contains(usage) {
-        Ok(())
-    } else {
-        Err(BindingError::WrongUsage(usage))
+        _ => Err(BindingError::WrongType),
     }
 }
 
@@ -685,9 +682,80 @@ pub fn check_texture_format(format: wgt::TextureFormat, output: &naga::TypeInner
 
 pub type StageInterface<'a> = FastHashMap<wgt::ShaderLocation, MaybeOwned<'a, naga::TypeInner>>;
 
+pub enum IntrospectionBindGroupLayouts<'a> {
+    Given(&'a [&'a BindEntryMap]),
+    Derived(&'a mut [BindEntryMap]),
+}
+
+fn derive_binding_type(
+    module: &naga::Module,
+    var: &naga::GlobalVariable,
+    usage: naga::GlobalUse,
+) -> Result<BindingType, BindingError> {
+    let ty = &module.types[var.ty];
+    Ok(match ty.inner {
+        naga::TypeInner::Struct { ref members } => {
+            let dynamic = false;
+            let mut actual_size = 0;
+            for (i, member) in members.iter().enumerate() {
+                actual_size += get_aligned_type_size(module, member.ty, i + 1 == members.len());
+            }
+            match var.class {
+                naga::StorageClass::Uniform => BindingType::UniformBuffer {
+                    dynamic,
+                    min_binding_size: wgt::BufferSize::new(actual_size),
+                },
+                naga::StorageClass::StorageBuffer => BindingType::StorageBuffer {
+                    dynamic,
+                    min_binding_size: wgt::BufferSize::new(actual_size),
+                    readonly: !usage.contains(naga::GlobalUse::STORE), //TODO: clarify
+                },
+                _ => return Err(BindingError::WrongType),
+            }
+        }
+        naga::TypeInner::Sampler { comparison } => BindingType::Sampler { comparison },
+        naga::TypeInner::Image { base, dim, flags } => {
+            let array = flags.contains(naga::ImageFlags::ARRAYED);
+            let dimension = match dim {
+                naga::ImageDimension::D1 => wgt::TextureViewDimension::D1,
+                naga::ImageDimension::D2 if array => wgt::TextureViewDimension::D2Array,
+                naga::ImageDimension::D2 => wgt::TextureViewDimension::D2,
+                naga::ImageDimension::D3 => wgt::TextureViewDimension::D3,
+                naga::ImageDimension::Cube if array => wgt::TextureViewDimension::CubeArray,
+                naga::ImageDimension::Cube => wgt::TextureViewDimension::Cube,
+            };
+            if flags.contains(naga::ImageFlags::SAMPLED) {
+                BindingType::SampledTexture {
+                    dimension,
+                    component_type: match module.types[base].inner {
+                        naga::TypeInner::Scalar { kind, .. }
+                        | naga::TypeInner::Vector { kind, .. } => match kind {
+                            naga::ScalarKind::Float => wgt::TextureComponentType::Float,
+                            naga::ScalarKind::Sint => wgt::TextureComponentType::Sint,
+                            naga::ScalarKind::Uint => wgt::TextureComponentType::Uint,
+                            other => {
+                                return Err(BindingError::WrongTextureComponentType(Some(other)))
+                            }
+                        },
+                        _ => return Err(BindingError::WrongTextureComponentType(None)),
+                    },
+                    multisampled: flags.contains(naga::ImageFlags::MULTISAMPLED),
+                }
+            } else {
+                BindingType::StorageTexture {
+                    dimension,
+                    format: wgt::TextureFormat::Rgba8Unorm, //TODO
+                    readonly: !flags.contains(naga::ImageFlags::CAN_STORE),
+                }
+            }
+        }
+        _ => return Err(BindingError::WrongType),
+    })
+}
+
 pub fn check_stage<'a>(
     module: &'a naga::Module,
-    group_layouts: &[&BindEntryMap],
+    mut group_layouts: IntrospectionBindGroupLayouts<'a>,
     entry_point_name: &str,
     stage: naga::ShaderStage,
     inputs: StageInterface<'a>,
@@ -713,18 +781,49 @@ pub fn check_stage<'a>(
         }
         match var.binding {
             Some(naga::Binding::Descriptor { set, binding }) => {
-                let result = group_layouts
-                    .get(set as usize)
-                    .and_then(|map| map.get(&binding))
-                    .ok_or(BindingError::Missing)
-                    .and_then(|entry| {
-                        if entry.visibility.contains(stage_bit) {
-                            Ok(entry)
-                        } else {
-                            Err(BindingError::Invisible)
-                        }
-                    })
-                    .and_then(|entry| check_binding(module, var, entry, usage));
+                let result = match group_layouts {
+                    IntrospectionBindGroupLayouts::Given(layouts) => layouts
+                        .get(set as usize)
+                        .and_then(|map| map.get(&binding))
+                        .ok_or(BindingError::Missing)
+                        .and_then(|entry| {
+                            if entry.visibility.contains(stage_bit) {
+                                Ok(entry)
+                            } else {
+                                Err(BindingError::Invisible)
+                            }
+                        })
+                        .and_then(|entry| check_binding_use(module, var, entry))
+                        .and_then(|allowed_usage| {
+                            if allowed_usage.contains(usage) {
+                                Ok(())
+                            } else {
+                                Err(BindingError::WrongUsage(usage))
+                            }
+                        }),
+                    IntrospectionBindGroupLayouts::Derived(ref mut layouts) => layouts
+                        .get_mut(set as usize)
+                        .ok_or(BindingError::Missing)
+                        .and_then(|set| {
+                            let ty = derive_binding_type(module, var, usage)?;
+                            Ok(match set.entry(binding) {
+                                Entry::Occupied(e) if e.get().ty != ty => {
+                                    return Err(BindingError::InconsistentlyDerivedType)
+                                }
+                                Entry::Occupied(e) => {
+                                    e.into_mut().visibility |= stage_bit;
+                                }
+                                Entry::Vacant(e) => {
+                                    e.insert(BindGroupLayoutEntry {
+                                        binding,
+                                        ty,
+                                        visibility: stage_bit,
+                                        count: None,
+                                    });
+                                }
+                            })
+                        }),
+                };
                 if let Err(error) = result {
                     return Err(StageError::Binding {
                         set,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2104,7 +2104,7 @@ impl<'a, M> ProgrammableStageDescriptor<'a, M> {
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub struct RenderPipelineDescriptor<'a, L, D> {
     /// The layout of bind groups for this pipeline.
-    pub layout: L,
+    pub layout: Option<L>,
     /// The compiled vertex stage and its entry point.
     pub vertex_stage: D,
     /// The compiled fragment stage and its entry point, if any.
@@ -2136,14 +2136,13 @@ pub struct RenderPipelineDescriptor<'a, L, D> {
 
 impl<'a, L, D> RenderPipelineDescriptor<'a, L, D> {
     pub fn new(
-        layout: L,
         vertex_stage: D,
         primitive_topology: PrimitiveTopology,
         color_states: impl IntoCow<'a, [ColorStateDescriptor]>,
         vertex_state: VertexStateDescriptor<'a>,
     ) -> Self {
         Self {
-            layout,
+            layout: None,
             vertex_stage,
             fragment_stage: None,
             rasterization_state: None,
@@ -2155,6 +2154,11 @@ impl<'a, L, D> RenderPipelineDescriptor<'a, L, D> {
             sample_mask: !0,
             alpha_to_coverage_enabled: false,
         }
+    }
+
+    pub fn layout(&mut self, layout: L) -> &mut Self {
+        self.layout = Some(layout);
+        self
     }
 
     pub fn fragment_stage(&mut self, stage: D) -> &mut Self {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2194,17 +2194,22 @@ impl<'a, L, D> RenderPipelineDescriptor<'a, L, D> {
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub struct ComputePipelineDescriptor<L, D> {
     /// The layout of bind groups for this pipeline.
-    pub layout: L,
+    pub layout: Option<L>,
     /// The compiled compute stage and its entry point.
     pub compute_stage: D,
 }
 
 impl<L, D> ComputePipelineDescriptor<L, D> {
-    pub fn new(layout: L, compute_stage: D) -> Self {
+    pub fn new(compute_stage: D) -> Self {
         Self {
-            layout,
+            layout: None,
             compute_stage,
         }
+    }
+
+    pub fn layout(&mut self, layout: L) -> &mut Self {
+        self.layout = Some(layout);
+        self
     }
 }
 


### PR DESCRIPTION
**Connections**
Closes #868

**Description**
The implementation can be split into 3 parts:
  1. reflecting the shader for binding expectations, and building a bind entry map from it, merging them between stages. This is only done for shaders that can be reflected, and we error on the rest, for now.
  2. based on this info, create new bind group layouts and pipeline layouts. The tricky part here is that we can't generate the ID out of thin air, so we have to pass them into the `create_xx_pipeline` function, which now also returns the number of IDs it consumed, allowing the client to free the rest.
  3. API changes in the descriptors, new methods to obtain the bind group layouts from a pipeline

**Testing**
This isn't tested, but I think it's fine: it doesn't affect the old path, and we'll be testing the new path while improving Naga and our reflection anyway.