### PR TITLE
Respect texture view aspect on creation

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -91,6 +91,8 @@ pub enum CreateBindGroupError {
     },
     #[error("the given sampler is/is not a comparison sampler, while the layout type indicates otherwise")]
     WrongSamplerComparison,
+    #[error("bound texture views can not have both depth and stencil aspects enabled")]
+    DepthStencilAspect,
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -276,6 +276,11 @@ pub enum CreateTextureViewError {
     InvalidMipLevelCount { requested: u32, total: u8 },
     #[error("TextureView array layer count + base array layer {requested} must be <= Texture depth/array layer count {total}")]
     InvalidArrayLayerCount { requested: u32, total: u16 },
+    #[error("Aspect {requested:?} is not in the source texture ({total:?})")]
+    InvalidAspect {
+        requested: hal::format::Aspects,
+        total: hal::format::Aspects,
+    },
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1780,6 +1780,11 @@ impl<'a> TextureViewDescriptor<Option<Cow<'a, str>>> {
 }
 
 impl<L> TextureViewDescriptor<L> {
+    pub fn aspect(&mut self, aspect: TextureAspect) -> &mut Self {
+        self.aspect = aspect;
+        self
+    }
+
     pub fn base_mip_level(&mut self, base_mip_level: u32) -> &mut Self {
         self.base_mip_level = base_mip_level;
         self


### PR DESCRIPTION
**Connections**
Fixing https://github.com/gfx-rs/wgpu-rs/issues/498 (but needs wgpu-rs update then)

**Description**
We added the aspect field to texture view descriptor but didn't respect it properly.
We do that now, and also disallow Depth-Stencil sampled views

**Testing**
Used the modified water example for testing.