### PR TITLE
Fix support for d24unorm format

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -370,8 +370,8 @@ pub(crate) fn map_texture_format(
         // Depth and stencil formats
         Tf::Depth32Float => H::D32Sfloat,
         Tf::Depth24Plus => {
-            if private_features.texture_d24_s8 {
-                H::D24UnormS8Uint
+            if private_features.texture_d24 {
+                H::X8D24Unorm
             } else {
                 H::D32Sfloat
             }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -744,6 +744,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let private_features = PrivateFeatures {
                 shader_validation: desc.shader_validation,
                 anisotropic_filtering: enabled_features.contains(hal::Features::SAMPLER_ANISOTROPY),
+                texture_d24: phd
+                    .format_properties(Some(hal::format::Format::X8D24Unorm))
+                    .optimal_tiling
+                    .contains(hal::format::ImageFeature::DEPTH_STENCIL_ATTACHMENT),
                 texture_d24_s8: phd
                     .format_properties(Some(hal::format::Format::D24UnormS8Uint))
                     .optimal_tiling

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -199,6 +199,7 @@ struct Stored<T> {
 struct PrivateFeatures {
     shader_validation: bool,
     anisotropic_filtering: bool,
+    texture_d24: bool,
     texture_d24_s8: bool,
 }
 


### PR DESCRIPTION
**Connections**
fixes https://github.com/kvark/vange-rs/pull/121 on some platforms

**Description**
We used to associate `D24Plus` with internal `D24S8`. This results in assuming that it has both DEPTH + STENCIL. Creating a binding from it then fails with the `All` aspect, since you can't view both. This is unexpected, since the user creates `D24Plus` with just a single aspect.

**Testing**
None needed