### PR TITLE
Add image cube array feature.

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -652,7 +652,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 | hal::Features::FRAGMENT_STORES_AND_ATOMICS
                 | hal::Features::NDC_Y_UP
                 | hal::Features::INDEPENDENT_BLENDING
-                | hal::Features::SAMPLER_ANISOTROPY;
+                | hal::Features::SAMPLER_ANISOTROPY
+                | hal::Features::IMAGE_CUBE_ARRAY;
             let mut enabled_features = available_features & wishful_features;
             if enabled_features != wishful_features {
                 tracing::warn!(


### PR DESCRIPTION
**Connections**
None

**Description**
Enable `IMAGE_CUBE_ARRAY` in vulkan and dx12. Note: Currently this will cause metal to break as the `available_features` from the physical device will never include `IMAGE_CUBE_ARRAY`. Thus I'm opening this as a draft until gfx-hal metal can check and pass the feature on.

**Testing**
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
I can test this with my repo using wgpu-rs here which uses cube arrays:
https://github.com/StarArawn/harmony/
