### PR TITLE
[0.6] Backport buffer and texture overrun error messages

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -37,7 +37,7 @@ pub enum TransferError {
     MissingCopySrcUsageFlag,
     #[error("destination buffer/texture is missing the `COPY_DST` usage flag")]
     MissingCopyDstUsageFlag,
-    #[error("copy would end up overruning the bounds of the destination buffer/texture")]
+    #[error("copy would end up overruning the bounds of one of the buffers or textures")]
     BufferOverrun,
     #[error("buffer offset {0} is not aligned to block size or `COPY_BUFFER_ALIGNMENT`")]
     UnalignedBufferOffset(BufferAddress),


### PR DESCRIPTION
**Connections**

#885 but neutered to be a non-breaking change.

**Description**

The original error message talked only about the destination buffer, which is very confusing as the cause of the overrun could be the source buffer.

Not worth a release on its own, but next time there's a release, we can get this fixed.

**Testing**

Strings only.
