### PR TITLE
Fix swapchain preferred format

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3262,6 +3262,17 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .push(layout_id);
     }
 
+    pub fn device_get_swap_chain_preferred_format<B: GfxBackend>(
+        &self,
+        _device_id: id::DeviceId,
+    ) -> Result<TextureFormat, InvalidDevice> {
+        span!(_guard, INFO, "Device::get_swap_chain_preferred_format");
+        //TODO: we can query the formats like done in `device_create_swapchain`,
+        // but its not clear which format in the list to return.
+        // For now, return `Bgra8UnormSrgb` that we know is supported everywhere.
+        Ok(TextureFormat::Bgra8UnormSrgb)
+    }
+
     pub fn device_create_swap_chain<B: GfxBackend>(
         &self,
         device_id: id::DeviceId,

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -121,22 +121,7 @@ pub struct SwapChainOutput {
     pub view_id: Option<TextureViewId>,
 }
 
-#[error("swap chain is invalid")]
-#[derive(Clone, Debug, Error)]
-pub struct InvalidSwapChain;
-
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
-    pub fn swap_chain_get_preferred_format<B: GfxBackend>(
-        &self,
-        _swap_chain_id: SwapChainId,
-    ) -> Result<wgt::TextureFormat, InvalidSwapChain> {
-        span!(_guard, INFO, "SwapChain::get_next_texture");
-        //TODO: we can query the formats like done in `device_create_swapchain`,
-        // but its not clear which format in the list to return.
-        // For now, return `Bgra8UnormSrgb` that we know is supported everywhere.
-        Ok(wgt::TextureFormat::Bgra8UnormSrgb)
-    }
-
     pub fn swap_chain_get_current_texture_view<B: GfxBackend>(
         &self,
         swap_chain_id: SwapChainId,


### PR DESCRIPTION
**Connections**

**Description**
The old API was wrong because the idea is to query the format *before* creating a swapchain, not after it:)

**Testing**
nah, should just work