### PR TITLE
Improve validation in B2B copies and RenderCommands

### DIFF
--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -71,6 +71,10 @@ pub enum RenderCommandError {
     MissingTextureUsage(#[from] MissingTextureUsageError),
     #[error(transparent)]
     PushConstants(#[from] PushConstantUploadError),
+    #[error("Invalid Viewport parameters")]
+    InvalidViewport,
+    #[error("Invalid ScissorRect parameters")]
+    InvalidScissorRect,
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -47,7 +47,7 @@ pub enum TransferError {
     #[error("texture {0:?} is invalid")]
     InvalidTexture(TextureId),
     #[error("Source and destination cannot be the same buffer")]
-    AttemptToCopyWithinBuffer,
+    SameSourceDestinationBuffer,
     #[error("source buffer/texture is missing the `COPY_SRC` usage flag")]
     MissingCopySrcUsageFlag,
     #[error("destination buffer/texture is missing the `COPY_DST` usage flag")]
@@ -305,7 +305,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         span!(_guard, INFO, "CommandEncoder::copy_buffer_to_buffer");
 
         if source == destination {
-            Err(TransferError::AttemptToCopyWithinBuffer)?
+            Err(TransferError::SameSourceDestinationBuffer)?
         }
         let hub = B::hub(self);
         let mut token = Token::root();


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._
Validation for the following have been added-
- Validate all parameters in B2B copy even if `copy_size == 0`.
- Check for copy operations issued within same buffer.
- `RenderPass.setViewport()`
- `RenderPass.setScissorRect()`

**Testing**
_Explain how this change is tested._
Tested with CTS in Servo. More tests pass now. Will test on wgpu-rs now.
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
