### PR TITLE
Allow copying from depth textures

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -482,7 +482,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         )?;
 
         let (block_width, _) = conv::texture_block_size(dst_texture.format);
-        if dst_texture.format.is_depth_format() {
+        if dst_texture.format.is_depth() {
             Err(TransferError::CopyToForbiddenTextureFormat(
                 dst_texture.format,
             ))?

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -439,11 +439,10 @@ pub fn texture_block_size(format: wgt::TextureFormat) -> (u32, u32) {
         | Tf::Rgba16Float
         | Tf::Rgba32Uint
         | Tf::Rgba32Sint
-        | Tf::Rgba32Float => (1, 1),
-
-        Tf::Depth32Float | Tf::Depth24Plus | Tf::Depth24PlusStencil8 => {
-            unreachable!("unexpected depth format")
-        }
+        | Tf::Rgba32Float
+        | Tf::Depth32Float
+        | Tf::Depth24Plus
+        | Tf::Depth24PlusStencil8 => (1, 1),
 
         Tf::Bc1RgbaUnorm
         | Tf::Bc1RgbaUnormSrgb

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -561,6 +561,22 @@ pub fn is_power_of_two(val: u32) -> bool {
     val != 0 && (val & (val - 1)) == 0
 }
 
+pub fn is_valid_copy_src_texture_format(format: wgt::TextureFormat) -> bool {
+    use wgt::TextureFormat as Tf;
+    match format {
+        Tf::Depth24Plus | Tf::Depth24PlusStencil8 => false,
+        _ => true,
+    }
+}
+
+pub fn is_valid_copy_dst_texture_format(format: wgt::TextureFormat) -> bool {
+    use wgt::TextureFormat as Tf;
+    match format {
+        Tf::Depth32Float | Tf::Depth24Plus | Tf::Depth24PlusStencil8 => false,
+        _ => true,
+    }
+}
+
 pub fn map_texture_dimension_size(
     dimension: wgt::TextureDimension,
     wgt::Extent3d {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -313,7 +313,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             size,
         )?;
         let (block_width, block_height) = conv::texture_block_size(texture_format);
-        if texture_format.is_depth_format() {
+        if texture_format.is_depth() {
             Err(TransferError::CopyToForbiddenTextureFormat(texture_format))?
         }
         let width_blocks = size.width / block_width;

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -313,6 +313,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             size,
         )?;
         let (block_width, block_height) = conv::texture_block_size(texture_format);
+        if texture_format.is_depth_format() {
+            Err(TransferError::CopyToForbiddenTextureFormat(texture_format))?
+        }
         let width_blocks = size.width / block_width;
         let height_blocks = size.height / block_width;
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -313,7 +313,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             size,
         )?;
         let (block_width, block_height) = conv::texture_block_size(texture_format);
-        if texture_format.is_depth() {
+        if !conv::is_valid_copy_dst_texture_format(texture_format) {
             Err(TransferError::CopyToForbiddenTextureFormat(texture_format))?
         }
         let width_blocks = size.width / block_width;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -809,6 +809,17 @@ pub enum TextureFormat {
     Bc7RgbaUnormSrgb = 51,
 }
 
+impl TextureFormat {
+    pub fn is_depth_format(self) -> bool {
+        match self {
+            TextureFormat::Depth32Float
+            | TextureFormat::Depth24Plus
+            | TextureFormat::Depth24PlusStencil8 => true,
+            _ => false,
+        }
+    }
+}
+
 bitflags::bitflags! {
     /// Color write mask. Disabled color channels will not be written to.
     #[repr(transparent)]

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -809,17 +809,6 @@ pub enum TextureFormat {
     Bc7RgbaUnormSrgb = 51,
 }
 
-impl TextureFormat {
-    pub fn is_depth(self) -> bool {
-        match self {
-            TextureFormat::Depth32Float
-            | TextureFormat::Depth24Plus
-            | TextureFormat::Depth24PlusStencil8 => true,
-            _ => false,
-        }
-    }
-}
-
 bitflags::bitflags! {
     /// Color write mask. Disabled color channels will not be written to.
     #[repr(transparent)]

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -810,7 +810,7 @@ pub enum TextureFormat {
 }
 
 impl TextureFormat {
-    pub fn is_depth_format(self) -> bool {
+    pub fn is_depth(self) -> bool {
         match self {
             TextureFormat::Depth32Float
             | TextureFormat::Depth24Plus


### PR DESCRIPTION
**Connections**
Fixes #900 

**Description**
Copying from depth textures failed with `unexpected depth format` before. Fix the cause in `conv::texture_block_size`. Add checks around the place where it would have (rightfully) failed before.

Seeing as this adds another variant to `TransferError`, this is not backwards compatible. The compatible alternative would be `panic`ing (which is what currently happens via `unreachable!`).
Also, I could understand if you think `TextureFormat::is_depth_format` isn't worth it to have as public api. We could pull it into `wgpu-core` in that case. It would need a doc comment in case we want to keep it there.

Should this instead be based on master instead of v0.6? Just let me know and I can rebase.