### PR TITLE
fix for mixed STORAGE_STORE and STORAGE_LOAD

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2009,9 +2009,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             } => (
                                 wgt::BufferUsage::STORAGE,
                                 if readonly {
-                                    resource::BufferUse::STORAGE_STORE
-                                } else {
                                     resource::BufferUse::STORAGE_LOAD
+                                } else {
+                                    resource::BufferUse::STORAGE_STORE
                                 },
                                 min_binding_size,
                                 dynamic,


### PR DESCRIPTION
**Connections**
None

**Description**
A buffer that contains dynamic data is used for both uniforms and storage read. This was a problem for wgpu and it gave a `PendingTransition` error.

**Testing**
It's a trivial fix, but I don't know if there's an example for it in wgpu-rs that can be used for testing.

It seems that the PR "Sync changes from mozilla-central" is already solving the same issue.
