### PR TITLE
[0.6] Allow copying from Depth32Float formatted textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v0.6.1 (tbd)
+  - allow copying from Depth32Float textures
+
 ## v0.6 (2020-08-17)
   - Crates:
     - C API is moved to [another repository](https://github.com/gfx-rs/wgpu-native)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrayvec",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-core"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU core logic on gfx-hal"

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -414,6 +414,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         )?;
 
         let (block_width, _) = conv::texture_block_size(dst_texture.format);
+        if !conv::is_valid_copy_dst_texture_format(dst_texture.format) {
+            panic!(
+                "copying to textures with format {:?} is forbidden",
+                dst_texture.format
+            );
+        }
 
         let buffer_width = (source.layout.bytes_per_row / bytes_per_block) * block_width;
         let region = hal::command::BufferImageCopy {
@@ -521,6 +527,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         )?;
 
         let (block_width, _) = conv::texture_block_size(src_texture.format);
+        if !conv::is_valid_copy_src_texture_format(src_texture.format) {
+            panic!(
+                "copying from textures with format {:?} is forbidden",
+                src_texture.format
+            );
+        }
 
         let buffer_width = (destination.layout.bytes_per_row / bytes_per_block) * block_width;
         let region = hal::command::BufferImageCopy {

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -439,11 +439,10 @@ pub fn texture_block_size(format: wgt::TextureFormat) -> (u32, u32) {
         | Tf::Rgba16Float
         | Tf::Rgba32Uint
         | Tf::Rgba32Sint
-        | Tf::Rgba32Float => (1, 1),
-
-        Tf::Depth32Float | Tf::Depth24Plus | Tf::Depth24PlusStencil8 => {
-            unreachable!("unexpected depth format")
-        }
+        | Tf::Rgba32Float
+        | Tf::Depth32Float
+        | Tf::Depth24Plus
+        | Tf::Depth24PlusStencil8 => (1, 1),
 
         Tf::Bc1RgbaUnorm
         | Tf::Bc1RgbaUnormSrgb
@@ -560,6 +559,22 @@ pub fn map_vertex_format(vertex_format: wgt::VertexFormat) -> hal::format::Forma
 
 pub fn is_power_of_two(val: u32) -> bool {
     val != 0 && (val & (val - 1)) == 0
+}
+
+pub fn is_valid_copy_src_texture_format(format: wgt::TextureFormat) -> bool {
+    use wgt::TextureFormat as Tf;
+    match format {
+        Tf::Depth24Plus | Tf::Depth24PlusStencil8 => false,
+        _ => true,
+    }
+}
+
+pub fn is_valid_copy_dst_texture_format(format: wgt::TextureFormat) -> bool {
+    use wgt::TextureFormat as Tf;
+    match format {
+        Tf::Depth32Float | Tf::Depth24Plus | Tf::Depth24PlusStencil8 => false,
+        _ => true,
+    }
 }
 
 pub fn map_texture_dimension_size(

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -307,6 +307,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             size,
         )?;
         let (block_width, block_height) = conv::texture_block_size(texture_format);
+        if !conv::is_valid_copy_dst_texture_format(texture_format) {
+            panic!(
+                "copying to textures with format {:?} is forbidden",
+                texture_format
+            );
+        }
         let width_blocks = size.width / block_width;
         let height_blocks = size.height / block_width;
 


### PR DESCRIPTION
**Connections**
Backport of #901 

**Description**
Copying from textures with format `Depth32Float` was reaching an `unreachable` and hence was impossible while copying from such textures should be well-defined and safe.