### PR TITLE
Replace backends! Macro with CFG Aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6da2b592f5a2e590c3d94c44313bab369f2286cfe1e4134c830bf3317814866"
+
+[[package]]
 name = "chrono"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,6 +1664,7 @@ version = "0.6.0"
 dependencies = [
  "arrayvec",
  "bitflags",
+ "cfg_aliases",
  "copyless",
  "fxhash",
  "gfx-backend-dx11",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -62,3 +62,6 @@ gfx-backend-vulkan = { version = "0.6" }
 
 [dev-dependencies]
 loom = "0.3"
+
+[build-dependencies]
+cfg_aliases = "0.1"

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    // Setup cfg aliases
+    cfg_aliases::cfg_aliases! {
+        // Vendors/systems
+        apple: { any(target_os = "ios", target_os = "macos") },
+
+        // Backends
+        vulkan: { any(windows, all(unix, not(apple)), feature = "gfx-backend-vulkan") },
+        metal: { apple },
+        dx12: { windows },
+        dx11: { windows },
+        gl: { unix },
+    }
+}

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3515,19 +3515,21 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         use crate::backend;
         let mut callbacks = Vec::new();
 
-        backends! {
-            #[vulkan] {
-                self.poll_devices::<backend::Vulkan>(force_wait, &mut callbacks)?;
-            }
-            #[metal] {
-                self.poll_devices::<backend::Metal>(force_wait, &mut callbacks)?;
-            }
-            #[dx12] {
-                self.poll_devices::<backend::Dx12>(force_wait, &mut callbacks)?;
-            }
-            #[dx11] {
-                self.poll_devices::<backend::Dx11>(force_wait, &mut callbacks)?;
-            }
+        #[cfg(vulkan)]
+        {
+            self.poll_devices::<backend::Vulkan>(force_wait, &mut callbacks)?;
+        }
+        #[cfg(metal)]
+        {
+            self.poll_devices::<backend::Metal>(force_wait, &mut callbacks)?;
+        }
+        #[cfg(dx12)]
+        {
+            self.poll_devices::<backend::Dx12>(force_wait, &mut callbacks)?;
+        }
+        #[cfg(dx11)]
+        {
+            self.poll_devices::<backend::Dx11>(force_wait, &mut callbacks)?;
         }
 
         fire_map_callbacks(callbacks);

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -30,16 +30,13 @@ pub type RequestAdapterOptions = wgt::RequestAdapterOptions<SurfaceId>;
 
 #[derive(Debug)]
 pub struct Instance {
-    #[cfg(any(
-        not(any(target_os = "ios", target_os = "macos")),
-        feature = "gfx-backend-vulkan"
-    ))]
+    #[cfg(vulkan)]
     pub vulkan: Option<gfx_backend_vulkan::Instance>,
-    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg(metal)]
     pub metal: Option<gfx_backend_metal::Instance>,
-    #[cfg(windows)]
+    #[cfg(dx12)]
     pub dx12: Option<gfx_backend_dx12::Instance>,
-    #[cfg(windows)]
+    #[cfg(dx11)]
     pub dx11: Option<gfx_backend_dx11::Instance>,
 }
 
@@ -54,13 +51,13 @@ impl Instance {
                 }
             };
             Instance {
-                #[vulkan]
+                #[cfg(vulkan)]
                 vulkan: map((Backend::Vulkan, gfx_backend_vulkan::Instance::create)),
-                #[metal]
+                #[cfg(metal)]
                 metal: map((Backend::Metal, gfx_backend_metal::Instance::create)),
-                #[dx12]
+                #[cfg(dx12)]
                 dx12: map((Backend::Dx12, gfx_backend_dx12::Instance::create)),
-                #[dx11]
+                #[cfg(dx11)]
                 dx11: map((Backend::Dx11, gfx_backend_dx11::Instance::create)),
             }
         }
@@ -76,13 +73,13 @@ impl Instance {
                 }
             };
 
-            #[vulkan]
+            #[cfg(vulkan)]
             map((surface.vulkan, &mut self.vulkan)),
-            #[metal]
+            #[cfg(metal)]
             map((surface.metal, &mut self.metal)),
-            #[dx12]
+            #[cfg(dx12)]
             map((surface.dx12, &mut self.dx12)),
-            #[dx11]
+            #[cfg(dx11)]
             map((surface.dx11, &mut self.dx11)),
         }
     }
@@ -92,16 +89,13 @@ type GfxSurface<B> = <B as hal::Backend>::Surface;
 
 #[derive(Debug)]
 pub struct Surface {
-    #[cfg(any(
-        not(any(target_os = "ios", target_os = "macos")),
-        feature = "gfx-backend-vulkan"
-    ))]
+    #[cfg(vulkan)]
     pub vulkan: Option<GfxSurface<backend::Vulkan>>,
-    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg(metal)]
     pub metal: Option<GfxSurface<backend::Metal>>,
-    #[cfg(windows)]
+    #[cfg(dx12)]
     pub dx12: Option<GfxSurface<backend::Dx12>>,
-    #[cfg(windows)]
+    #[cfg(dx11)]
     pub dx11: Option<GfxSurface<backend::Dx11>>,
 }
 
@@ -346,13 +340,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 };
 
                 Surface {
-                    #[vulkan]
+                    #[cfg(vulkan)]
                     vulkan: map(&self.instance.vulkan),
-                    #[metal]
+                    #[cfg(metal)]
                     metal: map(&self.instance.metal),
-                    #[dx12]
+                    #[cfg(dx12)]
                     dx12: map(&self.instance.dx12),
-                    #[dx11]
+                    #[cfg(dx11)]
                     dx11: map(&self.instance.dx11),
                 }
             }
@@ -389,13 +383,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 }
             };
 
-            #[vulkan]
+            #[cfg(vulkan)]
             map((&instance.vulkan, Backend::Vulkan, "Vulkan", backend::Vulkan::hub)),
-            #[metal]
+            #[cfg(metal)]
             map((&instance.metal, Backend::Metal, "Metal", backend::Metal::hub)),
-            #[dx12]
+            #[cfg(dx12)]
             map((&instance.dx12, Backend::Dx12, "Dx12", backend::Dx12::hub)),
-            #[dx11]
+            #[cfg(dx11)]
             map((&instance.dx11, Backend::Dx11, "Dx11", backend::Dx11::hub)),
         }
 
@@ -449,28 +443,28 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             // NB: The internal function definitions are a workaround for Rust
             // being weird with lifetimes for closure literals...
-            #[vulkan]
+            #[cfg(vulkan)]
             let adapters_vk = map((&instance.vulkan, &id_vulkan, {
                 fn surface_vulkan(surf: &Surface) -> Option<&GfxSurface<backend::Vulkan>> {
                     surf.vulkan.as_ref()
                 }
                 surface_vulkan
             }));
-            #[metal]
+            #[cfg(metal)]
             let adapters_mtl = map((&instance.metal, &id_metal, {
                 fn surface_metal(surf: &Surface) -> Option<&GfxSurface<backend::Metal>> {
                     surf.metal.as_ref()
                 }
                 surface_metal
             }));
-            #[dx12]
+            #[cfg(dx12)]
             let adapters_dx12 = map((&instance.dx12, &id_dx12, {
                 fn surface_dx12(surf: &Surface) -> Option<&GfxSurface<backend::Dx12>> {
                     surf.dx12.as_ref()
                 }
                 surface_dx12
             }));
-            #[dx11]
+            #[cfg(dx11)]
             let adapters_dx11 = map((&instance.dx11, &id_dx11, {
                 fn surface_dx11(surf: &Surface) -> Option<&GfxSurface<backend::Dx11>> {
                     surf.dx11.as_ref()
@@ -526,13 +520,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 selected -= adapters_backend.len();
             };
 
-            #[vulkan]
+            #[cfg(vulkan)]
             map(("Vulkan", &mut id_vulkan, adapters_vk, backend::Vulkan::hub)),
-            #[metal]
+            #[cfg(metal)]
             map(("Metal", &mut id_metal, adapters_mtl, backend::Metal::hub)),
-            #[dx12]
+            #[cfg(dx12)]
             map(("Dx12", &mut id_dx12, adapters_dx12, backend::Dx12::hub)),
-            #[dx11]
+            #[cfg(dx11)]
             map(("Dx11", &mut id_dx11, adapters_dx11, backend::Dx11::hub)),
         }
 

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -15,16 +15,13 @@ mod macros;
 pub mod backend {
     pub use gfx_backend_empty::Backend as Empty;
 
-    #[cfg(windows)]
+    #[cfg(dx11)]
     pub use gfx_backend_dx11::Backend as Dx11;
-    #[cfg(windows)]
+    #[cfg(dx12)]
     pub use gfx_backend_dx12::Backend as Dx12;
-    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg(metal)]
     pub use gfx_backend_metal::Backend as Metal;
-    #[cfg(any(
-        not(any(target_os = "ios", target_os = "macos")),
-        feature = "gfx-backend-vulkan"
-    ))]
+    #[cfg(vulkan)]
     pub use gfx_backend_vulkan::Backend as Vulkan;
 }
 

--- a/wgpu-core/src/macros.rs
+++ b/wgpu-core/src/macros.rs
@@ -2,140 +2,56 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-macro_rules! backends {
-    // one let statement per backend
-    (
-        #[vulkan] let $vk_field:pat = $vk_expr:expr;
-        #[metal] let $mtl_field:pat = $mtl_expr:expr;
-        #[dx12] let $dx12_field:pat = $dx12_expr:expr;
-        #[dx11] let $dx11_field:pat = $dx11_expr:expr;
-    ) => {
-        #[cfg(any(
-            windows,
-            all(unix, not(any(target_os = "ios", target_os = "macos"))),
-            feature = "gfx-backend-vulkan",
-        ))]
-        let $vk_field = $vk_expr;
-
-        #[cfg(any(target_os = "ios", target_os = "macos"))]
-        let $mtl_field = $mtl_expr;
-
-        #[cfg(windows)]
-        let $dx12_field = $dx12_expr;
-
-        #[cfg(windows)]
-        let $dx11_field = $dx11_expr;
-    };
-
-    // one block statement per backend
-    (
-        #[vulkan] $vk_block:block
-        #[metal] $mtl_block:block
-        #[dx12] $dx12_block:block
-        #[dx11] $dx11_block:block
-    ) => {
-        #[cfg(any(
-            windows,
-            all(unix, not(any(target_os = "ios", target_os = "macos"))),
-            feature = "gfx-backend-vulkan",
-        ))]
-        $vk_block
-
-        #[cfg(any(target_os = "ios", target_os = "macos"))]
-        $mtl_block
-
-        #[cfg(windows)]
-        $dx12_block
-
-        #[cfg(windows)]
-        $dx11_block
-    };
-
-    // a struct constructor with one field per backend
-    (
-        $Struct:path {
-            #[vulkan] $vk_field:ident: $vk_expr:expr,
-            #[metal] $mtl_field:ident: $mtl_expr:expr,
-            #[dx12] $dx12_field:ident: $dx12_expr:expr,
-            #[dx11] $dx11_field:ident: $dx11_expr:expr,
-        }
-    ) => {{
-        $Struct {
-            #[cfg(any(
-                windows,
-                all(unix, not(any(target_os = "ios", target_os = "macos"))),
-                feature = "gfx-backend-vulkan",
-            ))]
-            $vk_field: $vk_expr,
-
-            #[cfg(any(target_os = "ios", target_os = "macos"))]
-            $mtl_field: $mtl_expr,
-
-            #[cfg(windows)]
-            $dx12_field: $dx12_expr,
-
-            #[cfg(windows)]
-            $dx11_field: $dx11_expr,
-        }
-    }};
-}
-
 macro_rules! backends_map {
     // one let statement per backend with mapped data
     (
         let map = |$backend:pat| $map:block;
         $(
-            #[$backend_attr:ident] let $pat:pat = map($expr:expr);
+            #[cfg($backend_cfg:meta)] let $pat:pat = map($expr:expr);
         )*
     ) => {
-        backends! {
-            $(
-                #[$backend_attr]
-                let $pat = {
-                    let $backend = $expr;
-                    $map
-                };
-            )*
-        }
+        $(
+            #[cfg($backend_cfg)]
+            let $pat = {
+                let $backend = $expr;
+                $map
+            };
+        )*
     };
 
     // one block statement per backend with mapped data
     (
         let map = |$backend:pat| $map:block;
         $(
-            #[$backend_attr:ident] map($expr:expr),
+            #[cfg($backend_cfg:meta)] map($expr:expr),
         )*
     ) => {
-        backends! {
-            $(
-                #[$backend_attr]
-                {
-                    let $backend = $expr;
-                    $map
-                }
-            )*
-        }
+        $(
+            #[cfg($backend_cfg)]
+            {
+                let $backend = $expr;
+                $map
+            }
+        )*
     };
 
     // a struct constructor with one field per backend with mapped data
     (
         let map = |$backend:pat| $map:block;
-        $Struct:path {
+        $Struct:ident {
             $(
-                #[$backend_attr:ident] $ident:ident : map($expr:expr),
+                #[cfg($backend_cfg:meta)] $ident:ident : map($expr:expr),
             )*
         }
     ) => {
-        backends! {
-            $Struct {
-                $(
-                    #[$backend_attr]
-                    $ident: {
-                        let $backend = $expr;
-                        $map
-                    },
-                )*
-            }
+        $Struct {
+            $(
+                #[cfg($backend_cfg)]
+                $ident: {
+                    let $backend = $expr;
+                    $map
+                },
+            )*
         }
     };
 }
@@ -164,10 +80,10 @@ fn test_backend_macro() {
     let test_foo: Foo = backends_map! {
         let map = |init| { init - 100 };
         Foo {
-            #[vulkan] vulkan: map(101),
-            #[metal] metal: map(102),
-            #[dx12] dx12: map(103),
-            #[dx11] dx11: map(104),
+            #[cfg(vulkan)] vulkan: map(101),
+            #[cfg(metal)] metal: map(102),
+            #[cfg(dx12)] dx12: map(103),
+            #[cfg(dx11)] dx11: map(104),
         }
     };
 
@@ -179,16 +95,16 @@ fn test_backend_macro() {
             vec.push((id, chr));
         };
 
-        #[vulkan]
+        #[cfg(vulkan)]
         map((test_foo.vulkan, 'a')),
 
-        #[metal]
+        #[cfg(metal)]
         map((test_foo.metal, 'b')),
 
-        #[dx12]
+        #[cfg(dx12)]
         map((test_foo.dx12, 'c')),
 
-        #[dx11]
+        #[cfg(dx11)]
         map((test_foo.dx11, 'd')),
     }
 
@@ -216,86 +132,80 @@ fn test_backend_macro() {
             }
         };
 
-        #[vulkan]
+        #[cfg(vulkan)]
         map((test_foo.vulkan, |v| v == 1, || println!("vulkan"))),
 
-        #[metal]
+        #[cfg(metal)]
         map((test_foo.metal, |v| v == 2, || println!("metal"))),
 
-        #[dx12]
+        #[cfg(dx12)]
         map((test_foo.dx12, |v| v == 3, || println!("dx12"))),
 
-        #[dx11]
+        #[cfg(dx11)]
         map((test_foo.dx11, |v| v == 4, || println!("dx11"))),
     }
 
     // test struct construction 2
-    let test_foo_2: Foo = backends! {
-        Foo {
-            #[vulkan]
-            vulkan: 1,
+    let test_foo_2: Foo = Foo {
+        #[cfg(vulkan)]
+        vulkan: 1,
 
-            #[metal]
-            metal: 2,
+        #[cfg(metal)]
+        metal: 2,
 
-            #[dx12]
-            dx12: 3,
+        #[cfg(dx12)]
+        dx12: 3,
 
-            #[dx11]
-            dx11: 4,
-        }
+        #[cfg(dx11)]
+        dx11: 4,
     };
 
-    backends! {
-        #[vulkan]
-        let var_vulkan = test_foo_2.vulkan;
+    #[cfg(vulkan)]
+    let var_vulkan = test_foo_2.vulkan;
 
-        #[metal]
-        let var_metal = test_foo_2.metal;
+    #[cfg(metal)]
+    let var_metal = test_foo_2.metal;
 
-        #[dx12]
-        let var_dx12 = test_foo_2.dx12;
+    #[cfg(dx12)]
+    let var_dx12 = test_foo_2.dx12;
 
-        #[dx11]
-        let var_dx11 = test_foo_2.dx11;
-    }
+    #[cfg(dx11)]
+    let var_dx11 = test_foo_2.dx11;
 
     backends_map! {
         let map = |(id, chr, var)| { (chr, id, var) };
 
-        #[vulkan]
+        #[cfg(vulkan)]
         let var_vulkan = map((test_foo_2.vulkan, 'a', var_vulkan));
 
-        #[metal]
+        #[cfg(metal)]
         let var_metal = map((test_foo_2.metal, 'b', var_metal));
 
-        #[dx12]
+        #[cfg(dx12)]
         let var_dx12 = map((test_foo_2.dx12, 'c', var_dx12));
 
-        #[dx11]
+        #[cfg(dx11)]
         let var_dx11 = map((test_foo_2.dx11, 'd', var_dx11));
     }
 
-    backends! {
-        #[vulkan]
-        {
-            println!("backend int: {:?}", var_vulkan);
-        }
+    #[cfg(vulkan)]
+    {
+        println!("backend int: {:?}", var_vulkan);
+    }
 
-        #[metal]
-        {
-            println!("backend int: {:?}", var_metal);
-        }
+    #[cfg(metal)]
+    {
+        println!("backend int: {:?}", var_metal);
+    }
 
-        #[dx12]
-        {
-            println!("backend int: {:?}", var_dx12);
-        }
+    #[cfg(dx12)]
+    {
+        println!("backend int: {:?}", var_dx12);
+    }
 
-        #[dx11]
-        {
-            println!("backend int: {:?}", var_dx11);
-        }
+    #[cfg(dx11)]
+    {
+        println!("backend int: {:?}", var_dx11);
     }
 
     #[cfg(any(


### PR DESCRIPTION
**Connections**
Needs to be merged before: https://github.com/gfx-rs/wgpu/pull/907

**Description**
This change makes it easier to conditionally compile code based on graphics backends by adding `#[cfg]` aliases for the backends such as `vulkan`, `metal`, etc. This makes the code easier to read and maintain.

**Testing**
Tested the WGPU-rs cube and boids examples and they work as normal on a Linux machine with Vulkan.