### PR TITLE
Fix write-only stencil state descriptors from not working - fixes #911

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -855,7 +855,7 @@ impl StencilStateDescriptor {
     pub fn is_enabled(&self) -> bool {
         (self.front != StencilStateFaceDescriptor::IGNORE
             || self.back != StencilStateFaceDescriptor::IGNORE)
-            && self.read_mask != 0
+            && (self.read_mask != 0 || self.write_mask != 0)
     }
     pub fn is_read_only(&self) -> bool {
         self.write_mask == 0


### PR DESCRIPTION
**Connections**
This fixes [#911 - Stencil testing broken between v0.5 and v0.6](https://github.com/gfx-rs/wgpu/issues/911).

**Description**
Write-only stencil states (read 0, write >0) are being treated as if they are disabled, which causes pipelines to act as though they don't have any stencil state set at all. This worked prior to commit 2473c259718e8b8803b86d4480e5f0f54d4048e4 (introduced in PR #873). As far as I can tell, this works fine in Vulkan, Metal, DX12 and DX11 as we've been using this approach over at Ruffle for a while now.

**Testing**
You can view the reproduction case in #911 for manual testing. I have confirmed that this fix makes that case work as expected.

I couldn't find any automated tests for wgpu-types to copy and add for this case. If that's wanted then please let me know what the best approach is.