### PR TITLE
Flush staging init buffers

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -85,6 +85,7 @@ pub(crate) enum BufferMapState<B: hal::Backend> {
         ptr: NonNull<u8>,
         stage_buffer: B::Buffer,
         stage_memory: MemoryBlock<B>,
+        needs_flush: bool,
     },
     /// Waiting for GPU to be done before mapping
     Waiting(BufferPendingMapping),


### PR DESCRIPTION
**Connections**
Related to https://github.com/gfx-rs/gfx/pull/3362
With the new use of `write_buffer`/`write_texture`, the results on D3D11 regressed.

**Description**
It just happened to be the case that all the backends returned coherent staging buffers, used internally for `write_*` and `mapped_at_creation == true`. However, D3D11 backend currently doesn't have the coherent memory at all, and it helped me to see that we were missing a flush() on the staging buffer.

**Testing**
Untested, but should work (tm).