### PR TITLE
Pass [u8] instead of [u32] for push constants

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1041,12 +1041,12 @@ pub mod bundle_ffi {
     ) {
         span!(_guard, DEBUG, "RenderBundle::set_push_constants");
         assert_eq!(
-            offset & 3,
+            offset & (wgt::PUSH_CONSTANT_ALIGNMENT - 1),
             0,
             "Push constant offset must be aligned to 4 bytes."
         );
         assert_eq!(
-            size_bytes & 3,
+            size_bytes & (wgt::PUSH_CONSTANT_ALIGNMENT - 1),
             0,
             "Push constant size must be aligned to 4 bytes."
         );
@@ -1057,7 +1057,7 @@ pub mod bundle_ffi {
 
         pass.base.push_constant_data.extend(
             data_slice
-                .chunks_exact(4)
+                .chunks_exact(wgt::PUSH_CONSTANT_ALIGNMENT as usize)
                 .map(|arr| u32::from_ne_bytes([arr[0], arr[1], arr[2], arr[3]])),
         );
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -232,7 +232,8 @@ impl RenderBundle {
                     let pipeline_layout = &pipeline_layout_guard[pipeline_layout_id];
 
                     if let Some(values_offset) = values_offset {
-                        let values_end_offset = (values_offset + size_bytes / 4) as usize;
+                        let values_end_offset =
+                            (values_offset + size_bytes / wgt::PUSH_CONSTANT_ALIGNMENT) as usize;
                         let data_slice = &self.base.push_constant_data
                             [(values_offset as usize)..values_end_offset];
 
@@ -1036,14 +1037,30 @@ pub mod bundle_ffi {
         stages: wgt::ShaderStage,
         offset: u32,
         size_bytes: u32,
-        data: *const u32,
+        data: *const u8,
     ) {
         span!(_guard, DEBUG, "RenderBundle::set_push_constants");
-        let data_slice = slice::from_raw_parts(data, (size_bytes / 4) as usize);
+        assert_eq!(
+            offset & 3,
+            0,
+            "Push constant offset must be aligned to 4 bytes."
+        );
+        assert_eq!(
+            size_bytes & 3,
+            0,
+            "Push constant size must be aligned to 4 bytes."
+        );
+        let data_slice = slice::from_raw_parts(data, size_bytes as usize);
         let value_offset = pass.base.push_constant_data.len().try_into().expect(
             "Ran out of push constant space. Don't set 4gb of push constants per RenderBundle.",
         );
-        pass.base.push_constant_data.extend_from_slice(data_slice);
+
+        pass.base.push_constant_data.extend(
+            data_slice
+                .chunks_exact(4)
+                .map(|arr| u32::from_ne_bytes([arr[0], arr[1], arr[2], arr[3]])),
+        );
+
         pass.base.commands.push(RenderCommand::SetPushConstant {
             stages,
             offset,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -356,7 +356,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     values_offset,
                 } => {
                     let end_offset_bytes = offset + size_bytes;
-                    let values_end_offset = (values_offset + size_bytes / 4) as usize;
+                    let values_end_offset =
+                        (values_offset + size_bytes / wgt::PUSH_CONSTANT_ALIGNMENT) as usize;
                     let data_slice =
                         &base.push_constant_data[(values_offset as usize)..values_end_offset];
 
@@ -481,14 +482,30 @@ pub mod compute_ffi {
         pass: &mut ComputePass,
         offset: u32,
         size_bytes: u32,
-        data: *const u32,
+        data: *const u8,
     ) {
-        span!(_guard, DEBUG, "RenderPass::set_push_constant");
-        let data_slice = slice::from_raw_parts(data, (size_bytes / 4) as usize);
+        span!(_guard, DEBUG, "ComputePass::set_push_constant");
+        assert_eq!(
+            offset & 3,
+            0,
+            "Push constant offset must be aligned to 4 bytes."
+        );
+        assert_eq!(
+            size_bytes & 3,
+            0,
+            "Push constant size must be aligned to 4 bytes."
+        );
+        let data_slice = slice::from_raw_parts(data, size_bytes as usize);
         let value_offset = pass.base.push_constant_data.len().try_into().expect(
             "Ran out of push constant space. Don't set 4gb of push constants per ComputePass.",
         );
-        pass.base.push_constant_data.extend_from_slice(data_slice);
+
+        pass.base.push_constant_data.extend(
+            data_slice
+                .chunks_exact(4)
+                .map(|arr| u32::from_ne_bytes([arr[0], arr[1], arr[2], arr[3]])),
+        );
+
         pass.base.commands.push(ComputeCommand::SetPushConstant {
             offset,
             size_bytes,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -502,7 +502,7 @@ pub mod compute_ffi {
 
         pass.base.push_constant_data.extend(
             data_slice
-                .chunks_exact(wgt::PUSH_CONSTANT_ALIGNMENT)
+                .chunks_exact(wgt::PUSH_CONSTANT_ALIGNMENT as usize)
                 .map(|arr| u32::from_ne_bytes([arr[0], arr[1], arr[2], arr[3]])),
         );
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -486,12 +486,12 @@ pub mod compute_ffi {
     ) {
         span!(_guard, DEBUG, "ComputePass::set_push_constant");
         assert_eq!(
-            offset & 3,
+            offset & (wgt::PUSH_CONSTANT_ALIGNMENT - 1),
             0,
             "Push constant offset must be aligned to 4 bytes."
         );
         assert_eq!(
-            size_bytes & 3,
+            size_bytes & (wgt::PUSH_CONSTANT_ALIGNMENT - 1),
             0,
             "Push constant size must be aligned to 4 bytes."
         );
@@ -502,7 +502,7 @@ pub mod compute_ffi {
 
         pass.base.push_constant_data.extend(
             data_slice
-                .chunks_exact(4)
+                .chunks_exact(wgt::PUSH_CONSTANT_ALIGNMENT)
                 .map(|arr| u32::from_ne_bytes([arr[0], arr[1], arr[2], arr[3]])),
         );
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -264,9 +264,9 @@ where
     PushFn: FnMut(u32, &[u32]),
 {
     let mut count_words = 0_u32;
-    let size_words = size_bytes / 4;
+    let size_words = size_bytes / wgt::PUSH_CONSTANT_ALIGNMENT;
     while count_words < size_words {
-        let count_bytes = count_words * 4;
+        let count_bytes = count_words * wgt::PUSH_CONSTANT_ALIGNMENT;
         let size_to_write_words =
             (size_words - count_words).min(PUSH_CONSTANT_CLEAR_ARRAY.len() as u32);
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1737,7 +1737,7 @@ pub mod render_ffi {
 
         pass.base.push_constant_data.extend(
             data_slice
-                .chunks_exact(wgt::PUSH_CONSTANT_ALIGNMENT)
+                .chunks_exact(wgt::PUSH_CONSTANT_ALIGNMENT as usize)
                 .map(|arr| u32::from_ne_bytes([arr[0], arr[1], arr[2], arr[3]])),
         );
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1249,7 +1249,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         values_offset.ok_or(RenderPassError::InvalidValuesOffset)?;
 
                     let end_offset_bytes = offset + size_bytes;
-                    let values_end_offset = (values_offset + size_bytes / 4) as usize;
+                    let values_end_offset =
+                        (values_offset + size_bytes / wgt::PUSH_CONSTANT_ALIGNMENT) as usize;
                     let data_slice =
                         &base.push_constant_data[(values_offset as usize)..values_end_offset];
 
@@ -1716,14 +1717,30 @@ pub mod render_ffi {
         stages: wgt::ShaderStage,
         offset: u32,
         size_bytes: u32,
-        data: *const u32,
+        data: *const u8,
     ) {
         span!(_guard, DEBUG, "RenderPass::set_push_constants");
-        let data_slice = slice::from_raw_parts(data, (size_bytes / 4) as usize);
+        assert_eq!(
+            offset & 3,
+            0,
+            "Push constant offset must be aligned to 4 bytes."
+        );
+        assert_eq!(
+            size_bytes & 3,
+            0,
+            "Push constant size must be aligned to 4 bytes."
+        );
+        let data_slice = slice::from_raw_parts(data, size_bytes as usize);
         let value_offset = pass.base.push_constant_data.len().try_into().expect(
             "Ran out of push constant space. Don't set 4gb of push constants per RenderPass.",
         );
-        pass.base.push_constant_data.extend_from_slice(data_slice);
+
+        pass.base.push_constant_data.extend(
+            data_slice
+                .chunks_exact(4)
+                .map(|arr| u32::from_ne_bytes([arr[0], arr[1], arr[2], arr[3]])),
+        );
+
         pass.base.commands.push(RenderCommand::SetPushConstant {
             stages,
             offset,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1721,12 +1721,12 @@ pub mod render_ffi {
     ) {
         span!(_guard, DEBUG, "RenderPass::set_push_constants");
         assert_eq!(
-            offset & 3,
+            offset & (wgt::PUSH_CONSTANT_ALIGNMENT - 1),
             0,
             "Push constant offset must be aligned to 4 bytes."
         );
         assert_eq!(
-            size_bytes & 3,
+            size_bytes & (wgt::PUSH_CONSTANT_ALIGNMENT - 1),
             0,
             "Push constant size must be aligned to 4 bytes."
         );
@@ -1737,7 +1737,7 @@ pub mod render_ffi {
 
         pass.base.push_constant_data.extend(
             data_slice
-                .chunks_exact(4)
+                .chunks_exact(wgt::PUSH_CONSTANT_ALIGNMENT)
                 .map(|arr| u32::from_ne_bytes([arr[0], arr[1], arr[2], arr[3]])),
         );
 


### PR DESCRIPTION
**Connections**
This is a follow-up of https://github.com/gfx-rs/wgpu-rs/issues/544.

**Description**
Becuase `&[u8]` is broadly recognized as a type for buffers, it makes more sense to type push constant buffers as `&[u8]` rather than `&[u32]`. Detailed rationale can be found in [this issue](https://github.com/gfx-rs/wgpu-rs/issues/544).

**Testing**
This is trivially tested with `cargo test`.