### PR TITLE
[0.6] Don't bind groups that aren't expected by the layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## wgpu-core-0.6.3 (2020-09-04)
+  - fix group bindings that aren't related to the current pipeline
+
 ## wgpu-core-0.6.2, wgpu-types-0.6.1 (2020-09-02)
   - fix flushing of temporary staging buffers (affects DX11 mostly)
   - fix write-only stencil states

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "arrayvec",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-core"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU core logic on gfx-hal"

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -112,11 +112,12 @@ impl BindGroupEntry {
         }
     }
 
-    fn is_valid(&self) -> bool {
+    fn is_valid(&self) -> Option<bool> {
         match (self.expected_layout_id, self.provided.as_ref()) {
-            (None, _) => true,
-            (Some(_), None) => false,
-            (Some(layout), Some(pair)) => layout == pair.layout_id,
+            (None, None) => Some(true),
+            (None, Some(_)) => None,
+            (Some(_), None) => Some(false),
+            (Some(layout), Some(pair)) => Some(layout == pair.layout_id),
         }
     }
 
@@ -220,7 +221,7 @@ impl Binder {
 
     pub(super) fn invalid_mask(&self) -> BindGroupMask {
         self.entries.iter().enumerate().fold(0, |mask, (i, entry)| {
-            if entry.is_valid() {
+            if entry.is_valid().unwrap_or(true) {
                 mask
             } else {
                 mask | 1u8 << i
@@ -231,7 +232,7 @@ impl Binder {
     fn compatible_count(&self) -> usize {
         self.entries
             .iter()
-            .position(|entry| !entry.is_valid())
+            .position(|entry| !entry.is_valid().unwrap_or(false))
             .unwrap_or_else(|| self.entries.len())
     }
 }


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu-rs/issues/550

**Description**
Our `is_valid` was used in 2 different contexts with slightly different meaning. One of the was wrong.
Now it returns an option, and each context can reinterpret it as it needs.

**Testing**
Tested on that repro case in the issue.