### PR TITLE
add `polygon_mode: PolyonMode` to `RasterizationStateDescriptor` to allow drawing wireframes

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -797,7 +797,11 @@ pub fn map_rasterization_state_descriptor(
     use hal::pso;
     pso::Rasterizer {
         depth_clamping: desc.clamp_depth,
-        polygon_mode: pso::PolygonMode::Fill,
+        polygon_mode: match desc.polygon_mode {
+            wgt::PolygonMode::Fill => pso::PolygonMode::Fill,
+            wgt::PolygonMode::Line => pso::PolygonMode::Line,
+            wgt::PolygonMode::Point => pso::PolygonMode::Point,
+        },
         cull_face: match desc.cull_mode {
             wgt::CullMode::None => pso::Face::empty(),
             wgt::CullMode::Front => pso::Face::FRONT,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2725,6 +2725,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             )
             .with_label(&desc.label));
         }
+        if rasterization_state.polygon_mode != wgt::PolygonMode::Fill
+            && !device.features.contains(wgt::Features::NON_FILL_POLYGON_MODE)
+        {
+            return Err(pipeline::CreateRenderPipelineError::MissingFeature(
+                wgt::Features::NON_FILL_POLYGON_MODE,
+            )
+            .with_label(&desc.label));
+        }
 
         let (raw_pipeline, layout_id, layout_ref_count, derived_bind_group_count) = {
             //TODO: only lock mutable if the layout is derived

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -148,6 +148,10 @@ impl<B: hal::Backend> Adapter<B> {
             wgt::Features::MULTI_DRAW_INDIRECT_COUNT,
             adapter_features.contains(hal::Features::DRAW_INDIRECT_COUNT),
         );
+        features.set(
+            wgt::Features::NON_FILL_POLYGON_MODE,
+            adapter_features.contains(hal::Features::NON_FILL_POLYGON_MODE),
+        );
         #[cfg(not(target_os = "ios"))]
         //TODO: https://github.com/gfx-rs/gfx/issues/3346
         features.set(wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER, true);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -298,6 +298,16 @@ bitflags::bitflags! {
         ///
         /// This is a web and native feature.
         const ADDRESS_MODE_CLAMP_TO_BORDER = 0x0000_0000_0100_0000;
+        /// Allows the user to set a non-fill polygon mode in [`RasterizationStateDescriptor::polygon_mode`]
+        ///
+        /// This allows drawing polygons/triangles as lines (wireframe) or points instead of filled
+        ///
+        /// Supported platforms:
+        /// - DX12
+        /// - Vulkan
+        ///
+        /// This is a native only feature.
+        const NON_FILL_POLYGON_MODE = 0x0000_0000_0200_0000;
         /// Features which are part of the upstream WebGPU standard.
         const ALL_WEBGPU = 0x0000_0000_0000_FFFF;
         /// Features that are only available when targeting native (not web).
@@ -603,6 +613,26 @@ impl Default for CullMode {
     }
 }
 
+/// Type of drawing mode for polygons
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "trace", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub enum PolygonMode {
+    /// Polygons are filled
+    Fill = 0,
+    /// Polygons are draw as line segments
+    Line = 1,
+    /// Polygons are draw as points
+    Point = 2,
+}
+
+impl Default for PolygonMode {
+    fn default() -> Self {
+        PolygonMode::Fill
+    }
+}
+
 /// Describes the state of the rasterizer in a render pipeline.
 #[repr(C)]
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -611,6 +641,10 @@ impl Default for CullMode {
 pub struct RasterizationStateDescriptor {
     pub front_face: FrontFace,
     pub cull_mode: CullMode,
+    /// Controls the way each polygon is rasterized. Can be either `Fill` (default), `Line` or `Point`
+    ///
+    /// Setting this to something other than `Fill` requires `Features::NON_FILL_POLYGON_MODE` to be enabled.
+    pub polygon_mode: PolygonMode,
     /// If enabled polygon depth is clamped to 0-1 range instead of being clipped.
     ///
     /// Requires `Features::DEPTH_CLAMPING` enabled.


### PR DESCRIPTION
**Description**
This adds `polygon_mode: PolyonMode` to `RasterizationStateDescriptor` to allow drawing in wireframes and point mode

I added `hal::Features::NON_FILL_POLYGON_MODE` to the `wishful_features` in `instance.rs`. I don't know what side effects this might have.

**Testing**
Tested locally on my Windows machine with Vulkan backend.