### PR TITLE
Add LabeledContextError

### DIFF
--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -238,3 +238,11 @@ fn test_default_limits() {
     let limits = wgt::Limits::default();
     assert!(limits.max_bind_groups <= MAX_BIND_GROUPS as u32);
 }
+
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("{description} (label: {label:?})")]
+pub struct LabeledContextError<E: std::error::Error + 'static> {
+    source: E,
+    description: &'static str,
+    label: Option<String>,
+}

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -183,11 +183,25 @@ pub enum CreateRenderPipelineError {
     },
     #[error("missing required device features {0:?}")]
     MissingFeature(wgt::Features),
-    #[error("error in stage {flag:?}: {error}")]
+    #[error("error in stage {flag:?}")]
     Stage {
         flag: wgt::ShaderStage,
+        #[source]
         error: StageError,
     },
+}
+
+impl CreateRenderPipelineError {
+    pub(crate) fn with_label<'a>(
+        self,
+        label: &Option<Cow<'a, str>>,
+    ) -> crate::LabeledContextError<CreateRenderPipelineError> {
+        crate::LabeledContextError {
+            source: self,
+            description: "Creating render pipeline",
+            label: label.as_ref().map(|inner| inner.to_string()),
+        }
+    }
 }
 
 bitflags::bitflags! {


### PR DESCRIPTION
Purpose for this is to add more context to an error.
create_render_pipeline error is improved, by showing the action
(creating render pipeline) and the user provided label, to aid with
the investigation.

Example error
before:
```
wgpu error: Validation error

Caused by:
    error in stage VERTEX: unable to find an entry point matching the Vertex execution model

thread 'main' panicked at 'Handling wgpu errors as fatal by default', src/backend/direct.rs:1457:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

after:
```
wgpu error: Validation error

Caused by:
    Creating render pipeline (label: Some("hello-triangle pipeline"))
    error in stage VERTEX
    unable to find an entry point matching the Vertex execution model

thread 'main' panicked at 'Handling wgpu errors as fatal by default', src/backend/direct.rs:1457:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```