### PR TITLE
Fix invalid mip level count check

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -515,7 +515,10 @@ impl<B: GfxBackend> Device<B> {
         let usage = conv::map_texture_usage(desc.usage, aspects);
 
         let mip_level_count = desc.mip_level_count;
-        if mip_level_count == 0 && mip_level_count > kind.compute_num_levels() as u32 {
+        if mip_level_count == 0
+            || mip_level_count > MAX_MIP_LEVELS
+            || mip_level_count > kind.compute_num_levels() as u32
+        {
             return Err(resource::CreateTextureError::InvalidMipLevelCount(
                 mip_level_count,
             ));

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -239,7 +239,7 @@ pub enum CreateTextureError {
     CannotCopyD24Plus,
     #[error(transparent)]
     InvalidDimension(#[from] TextureDimensionError),
-    #[error("texture descriptor mip level count ({0}) must be less than `MAX_MIP_LEVELS`")]
+    #[error("texture descriptor mip level count ({0}) is invalid")]
     InvalidMipLevelCount(u32),
     #[error("Feature {0:?} must be enabled to create a texture of type {1:?}")]
     MissingFeature(wgt::Features, wgt::TextureFormat),


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/894
Continues from https://github.com/gfx-rs/wgpu/pull/893

**Description**
Invalid mip level counts are allowed through `Device::create_texture`, triggering Vulkan validation errors. A fix was applied in https://github.com/gfx-rs/wgpu/pull/893, but the fix needs a minor correction to work properly.

Also added back the `MAX_MIP_LEVELS` check, because it's technically possible for `MAX_MIP_LEVELS` to be less than `kind.compute_num_levels()`, e.g. if one of the given dimensions is very big (2^16). 

Error message is updated to reflect the change in behavior: there are now three ways for a mip level count to be invalid: it's equal to zero; it's greater than `MAX_MIP_LEVELS`; or it's greater than the largest mip level count allowed for the given size.

**Testing**
Tested by manually modifying the `mipmap` example in `wgpu-rs` to pass various edge case values for `size` and `mip_level_count`.
