### PR TITLE
Allow dropping of error resources

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -354,9 +354,8 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                 if trackers.bundles.remove_abandoned(id) {
                     #[cfg(feature = "trace")]
                     trace.map(|t| t.lock().add(trace::Action::DestroyRenderBundle(id.0)));
-                    let res = hub.render_bundles.unregister_locked(id.0, &mut *guard);
 
-                    if let Some(res) = res {
+                    if let Some(res) = hub.render_bundles.unregister_locked(id.0, &mut *guard) {
                         self.suspected_resources.add_trackers(&res.used);
                     }
                 }
@@ -371,9 +370,8 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                 if trackers.bind_groups.remove_abandoned(id) {
                     #[cfg(feature = "trace")]
                     trace.map(|t| t.lock().add(trace::Action::DestroyBindGroup(id.0)));
-                    let res = hub.bind_groups.unregister_locked(id.0, &mut *guard);
 
-                    if let Some(res) = res {
+                    if let Some(res) = hub.bind_groups.unregister_locked(id.0, &mut *guard) {
                         self.suspected_resources.add_trackers(&res.used);
 
                         let submit_index = res.life_guard.submission_index.load(Ordering::Acquire);
@@ -396,9 +394,8 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                 if trackers.views.remove_abandoned(id) {
                     #[cfg(feature = "trace")]
                     trace.map(|t| t.lock().add(trace::Action::DestroyTextureView(id.0)));
-                    let res = hub.texture_views.unregister_locked(id.0, &mut *guard);
 
-                    if let Some(res) = res {
+                    if let Some(res) = hub.texture_views.unregister_locked(id.0, &mut *guard) {
                         let raw = match res.inner {
                             resource::TextureViewInner::Native { raw, source_id } => {
                                 self.suspected_resources.textures.push(source_id.value);
@@ -427,9 +424,8 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                 if trackers.textures.remove_abandoned(id) {
                     #[cfg(feature = "trace")]
                     trace.map(|t| t.lock().add(trace::Action::DestroyTexture(id.0)));
-                    let res = hub.textures.unregister_locked(id.0, &mut *guard);
 
-                    if let Some(res) = res {
+                    if let Some(res) = hub.textures.unregister_locked(id.0, &mut *guard) {
                         let submit_index = res.life_guard.submission_index.load(Ordering::Acquire);
                         self.active
                             .iter_mut()
@@ -450,9 +446,8 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                 if trackers.samplers.remove_abandoned(id) {
                     #[cfg(feature = "trace")]
                     trace.map(|t| t.lock().add(trace::Action::DestroySampler(id.0)));
-                    let res = hub.samplers.unregister_locked(id.0, &mut *guard);
 
-                    if let Some(res) = res {
+                    if let Some(res) = hub.samplers.unregister_locked(id.0, &mut *guard) {
                         let submit_index = res.life_guard.submission_index.load(Ordering::Acquire);
                         self.active
                             .iter_mut()
@@ -473,10 +468,9 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                 if trackers.buffers.remove_abandoned(id) {
                     #[cfg(feature = "trace")]
                     trace.map(|t| t.lock().add(trace::Action::DestroyBuffer(id.0)));
-                    let res = hub.buffers.unregister_locked(id.0, &mut *guard);
                     tracing::debug!("Buffer {:?} is detached", id);
 
-                    if let Some(res) = res {
+                    if let Some(res) = hub.buffers.unregister_locked(id.0, &mut *guard) {
                         let submit_index = res.life_guard.submission_index.load(Ordering::Acquire);
                         self.active
                             .iter_mut()
@@ -497,9 +491,8 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                 if trackers.compute_pipes.remove_abandoned(id) {
                     #[cfg(feature = "trace")]
                     trace.map(|t| t.lock().add(trace::Action::DestroyComputePipeline(id.0)));
-                    let res = hub.compute_pipelines.unregister_locked(id.0, &mut *guard);
 
-                    if let Some(res) = res {
+                    if let Some(res) = hub.compute_pipelines.unregister_locked(id.0, &mut *guard) {
                         let submit_index = res.life_guard.submission_index.load(Ordering::Acquire);
                         self.active
                             .iter_mut()
@@ -520,9 +513,8 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                 if trackers.render_pipes.remove_abandoned(id) {
                     #[cfg(feature = "trace")]
                     trace.map(|t| t.lock().add(trace::Action::DestroyRenderPipeline(id.0)));
-                    let res = hub.render_pipelines.unregister_locked(id.0, &mut *guard);
 
-                    if let Some(res) = res {
+                    if let Some(res) = hub.render_pipelines.unregister_locked(id.0, &mut *guard) {
                         let submit_index = res.life_guard.submission_index.load(Ordering::Acquire);
                         self.active
                             .iter_mut()
@@ -547,9 +539,8 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                 if ref_count.load() == 1 {
                     #[cfg(feature = "trace")]
                     trace.map(|t| t.lock().add(trace::Action::DestroyPipelineLayout(id.0)));
-                    let layout = hub.pipeline_layouts.unregister_locked(id.0, &mut *guard);
 
-                    if let Some(lay) = layout {
+                    if let Some(lay) = hub.pipeline_layouts.unregister_locked(id.0, &mut *guard) {
                         self.suspected_resources
                             .bind_group_layouts
                             .extend_from_slice(&lay.bind_group_layout_ids);
@@ -570,8 +561,7 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                 if guard[id].multi_ref_count.dec_and_check_empty() {
                     #[cfg(feature = "trace")]
                     trace.map(|t| t.lock().add(trace::Action::DestroyBindGroupLayout(id.0)));
-                    let layout = hub.bind_group_layouts.unregister_locked(id.0, &mut *guard);
-                    if let Some(lay) = layout {
+                    if let Some(lay) = hub.bind_group_layouts.unregister_locked(id.0, &mut *guard) {
                         self.free_resources.descriptor_set_layouts.push(lay.raw);
                     }
                 }
@@ -697,10 +687,10 @@ impl<B: GfxBackend> LifetimeTracker<B> {
             {
                 buffer.map_state = resource::BufferMapState::Idle;
                 tracing::debug!("Mapping request is dropped because the buffer is destroyed.");
-                let buffer = hub
+                if let Some(buf) = hub
                     .buffers
-                    .unregister_locked(buffer_id.0, &mut *buffer_guard);
-                if let Some(buf) = buffer {
+                    .unregister_locked(buffer_id.0, &mut *buffer_guard)
+                {
                     self.free_resources.buffers.push((buf.raw, buf.memory));
                 }
             } else {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -616,8 +616,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             // finally, return the command buffers to the allocator
             for &cmb_id in command_buffer_ids {
-                let (cmd_buf, _) = hub.command_buffers.unregister(cmb_id, &mut token);
-                device.cmd_allocator.after_submit(cmd_buf, submit_index);
+                if let (Some(cmd_buf), _) = hub.command_buffers.unregister(cmb_id, &mut token) {
+                    device.cmd_allocator.after_submit(cmd_buf, submit_index);
+                }
             }
 
             callbacks

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -451,10 +451,11 @@ impl<T, I: TypedId + Copy, F: IdentityHandlerFactory<I>> Registry<T, I, F> {
         id
     }
 
-    pub fn unregister_locked(&self, id: I, guard: &mut Storage<T, I>) -> T {
-        let value = guard.remove(id).unwrap();
+    pub fn unregister_locked(&self, id: I, guard: &mut Storage<T, I>) -> Option<T> {
+        let value = guard.remove(id);
         //Note: careful about the order here!
         self.identity.free(id);
+        //Returning None is legal if it's an error ID
         value
     }
 

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -248,40 +248,44 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .take()
             .ok_or(SwapChainError::AlreadyAcquired)?;
         let (view, _) = hub.texture_views.unregister(view_id.value.0, &mut token);
-        let image = match view.inner {
-            resource::TextureViewInner::Native { .. } => unreachable!(),
-            resource::TextureViewInner::SwapChain { image, .. } => image,
-        };
+        if let Some(view) = view {
+            let image = match view.inner {
+                resource::TextureViewInner::Native { .. } => unreachable!(),
+                resource::TextureViewInner::SwapChain { image, .. } => image,
+            };
 
-        let sem = if sc.active_submission_index > device.last_completed_submission_index() {
-            Some(&sc.semaphore)
-        } else {
-            None
-        };
-        let queue = &mut device.queue_group.queues[0];
-        let result = unsafe { queue.present(B::get_surface_mut(surface), image, sem) };
+            let sem = if sc.active_submission_index > device.last_completed_submission_index() {
+                Some(&sc.semaphore)
+            } else {
+                None
+            };
+            let queue = &mut device.queue_group.queues[0];
+            let result = unsafe { queue.present(B::get_surface_mut(surface), image, sem) };
 
-        tracing::debug!(trace = true, "Presented. End of Frame");
+            tracing::debug!(trace = true, "Presented. End of Frame");
 
-        for fbo in sc.acquired_framebuffers.drain(..) {
-            unsafe {
-                device.raw.destroy_framebuffer(fbo);
+            for fbo in sc.acquired_framebuffers.drain(..) {
+                unsafe {
+                    device.raw.destroy_framebuffer(fbo);
+                }
             }
-        }
 
-        match result {
-            Ok(None) => Ok(SwapChainStatus::Good),
-            Ok(Some(_)) => Ok(SwapChainStatus::Suboptimal),
-            Err(err) => match err {
-                hal::window::PresentError::OutOfMemory(_) => {
-                    Err(SwapChainError::Device(DeviceError::OutOfMemory))
-                }
-                hal::window::PresentError::OutOfDate => Ok(SwapChainStatus::Outdated),
-                hal::window::PresentError::SurfaceLost(_) => Ok(SwapChainStatus::Lost),
-                hal::window::PresentError::DeviceLost(_) => {
-                    Err(SwapChainError::Device(DeviceError::Lost))
-                }
-            },
+            match result {
+                Ok(None) => Ok(SwapChainStatus::Good),
+                Ok(Some(_)) => Ok(SwapChainStatus::Suboptimal),
+                Err(err) => match err {
+                    hal::window::PresentError::OutOfMemory(_) => {
+                        Err(SwapChainError::Device(DeviceError::OutOfMemory))
+                    }
+                    hal::window::PresentError::OutOfDate => Ok(SwapChainStatus::Outdated),
+                    hal::window::PresentError::SurfaceLost(_) => Ok(SwapChainStatus::Lost),
+                    hal::window::PresentError::DeviceLost(_) => {
+                        Err(SwapChainError::Device(DeviceError::Lost))
+                    }
+                },
+            }
+        } else {
+            Err(SwapChainError::Invalid)
         }
     }
 }


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._
wgpu currently panics when trying to drop an error resource. `unregister_locked()` now returns `Option<T>` to handle this.

**Testing**
_Explain how this change is tested._
Tested with wgpu-rs examples and CTS in Servo.
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
