### PR TITLE
More wrapping with LabelContextError

### DIFF
--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -87,6 +87,19 @@ pub enum CreateComputePipelineError {
     Stage(StageError),
 }
 
+impl CreateComputePipelineError {
+    pub(crate) fn with_label<'a>(
+        self,
+        label: &Option<Cow<'a, str>>,
+    ) -> crate::LabeledContextError<Self> {
+        crate::LabeledContextError {
+            source: self,
+            description: "Creating render pipeline",
+            label: label.as_ref().map(|inner| inner.to_string()),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ComputePipeline<B: hal::Backend> {
     pub(crate) raw: B::ComputePipeline,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -259,6 +259,19 @@ pub enum CreateTextureError {
     MissingFeature(wgt::Features, wgt::TextureFormat),
 }
 
+impl CreateTextureError {
+    pub(crate) fn with_label<'a>(
+        self,
+        label: &Option<Cow<'a, str>>,
+    ) -> crate::LabeledContextError<Self> {
+        crate::LabeledContextError {
+            source: self,
+            description: "Creating texture",
+            label: label.as_ref().map(|inner| inner.to_string()),
+        }
+    }
+}
+
 impl<B: hal::Backend> Borrow<RefCount> for Texture<B> {
     fn borrow(&self) -> &RefCount {
         self.life_guard.ref_count.as_ref().unwrap()

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 
 use std::{
     borrow::Borrow,
+    borrow::Cow,
     num::{NonZeroU32, NonZeroU8},
     ptr::NonNull,
 };
@@ -184,6 +185,19 @@ pub enum CreateBufferError {
     UnalignedSize,
     #[error("`MAP` usage can only be combined with the opposite `COPY`, requested {0:?}")]
     UsageMismatch(wgt::BufferUsage),
+}
+
+impl CreateBufferError {
+    pub(crate) fn with_label<'a>(
+        self,
+        label: &Option<Cow<'a, str>>,
+    ) -> crate::LabeledContextError<Self> {
+        crate::LabeledContextError {
+            source: self,
+            description: "Creating buffer",
+            label: label.as_ref().map(|inner| inner.to_string()),
+        }
+    }
 }
 
 impl<B: hal::Backend> Borrow<RefCount> for Buffer<B> {


### PR DESCRIPTION
Continuing on wrapping more context to some error messages, these wrap the creation error for Buffer, Texture and ComputePipeline.

I'm not entirely happy that I had to undo some try-operator `From` short-circuiting with more explicit error construction (the more verbose `map_err` stuff).

Otherwise this is fairly straightforward