### PR TITLE
Retain labels for resources

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -316,6 +316,23 @@ pub struct BindGroupLayout<B: hal::Backend> {
     pub(crate) desc_counts: DescriptorCounts,
     pub(crate) dynamic_count: usize,
     pub(crate) count_validator: BindingTypeMaxCountValidator,
+    #[cfg(debug_assertions)]
+    pub(crate) label: String,
+}
+
+impl<B: hal::Backend> crate::hub::Resource for BindGroupLayout<B> {
+    const TYPE: &'static str = "BindGroupLayout";
+
+    fn life_guard(&self) -> &LifeGuard {
+        unreachable!()
+    }
+
+    fn label(&self) -> &str {
+        #[cfg(debug_assertions)]
+        return &self.label;
+        #[cfg(not(debug_assertions))]
+        return "";
+    }
 }
 
 #[derive(Clone, Debug, Error)]
@@ -488,6 +505,14 @@ impl<B: hal::Backend> PipelineLayout<B> {
     }
 }
 
+impl<B: hal::Backend> crate::hub::Resource for PipelineLayout<B> {
+    const TYPE: &'static str = "PipelineLayout";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Debug, Hash, PartialEq)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
@@ -582,6 +607,14 @@ impl<B: hal::Backend> Borrow<RefCount> for BindGroup<B> {
 impl<B: hal::Backend> Borrow<()> for BindGroup<B> {
     fn borrow(&self) -> &() {
         &DUMMY_SELECTOR
+    }
+}
+
+impl<B: hal::Backend> crate::hub::Resource for BindGroup<B> {
+    const TYPE: &'static str = "BindGroup";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
     }
 }
 

--- a/wgpu-core/src/command/allocator.rs
+++ b/wgpu-core/src/command/allocator.rs
@@ -8,6 +8,9 @@ use crate::{
     PrivateFeatures, Stored, SubmissionIndex,
 };
 
+#[cfg(debug_assertions)]
+use crate::LabelHelpers;
+
 use hal::{command::CommandBuffer as _, device::Device as _, pool::CommandPool as _};
 use parking_lot::Mutex;
 use thiserror::Error;
@@ -80,9 +83,11 @@ impl<B: GfxBackend> CommandAllocator<B> {
         device: &B::Device,
         limits: wgt::Limits,
         private_features: PrivateFeatures,
+        label: &crate::Label,
         #[cfg(feature = "trace")] enable_tracing: bool,
     ) -> Result<CommandBuffer<B>, CommandAllocatorError> {
         //debug_assert_eq!(device_id.backend(), B::VARIANT);
+        let _ = label; // silence warning on release
         let thread_id = thread::current().id();
         let mut inner = self.inner.lock();
 
@@ -126,6 +131,8 @@ impl<B: GfxBackend> CommandAllocator<B> {
             } else {
                 None
             },
+            #[cfg(debug_assertions)]
+            label: label.to_string_or_default(),
         })
     }
 }

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -52,7 +52,7 @@ use crate::{
     span,
     track::{TrackerSet, UsageConflict},
     validation::check_buffer_usage,
-    Label, LifeGuard, RefCount, Stored, MAX_BIND_GROUPS,
+    Label, LabelHelpers, LifeGuard, RefCount, Stored, MAX_BIND_GROUPS,
 };
 use arrayvec::ArrayVec;
 use std::{
@@ -351,6 +351,14 @@ impl RenderBundle {
 impl Borrow<RefCount> for RenderBundle {
     fn borrow(&self) -> &RefCount {
         self.life_guard.ref_count.as_ref().unwrap()
+    }
+}
+
+impl crate::hub::Resource for RenderBundle {
+    const TYPE: &'static str = "RenderBundle";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
     }
 }
 
@@ -1018,7 +1026,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 },
                 used: state.trackers,
                 context: bundle_encoder.context,
-                life_guard: LifeGuard::new(),
+                life_guard: LifeGuard::new(desc.label.borrow_or_default()),
             }
         };
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -47,6 +47,8 @@ pub struct CommandBuffer<B: hal::Backend> {
     private_features: PrivateFeatures,
     #[cfg(feature = "trace")]
     pub(crate) commands: Option<Vec<crate::device::trace::Command>>,
+    #[cfg(debug_assertions)]
+    pub(crate) label: String,
 }
 
 impl<B: GfxBackend> CommandBuffer<B> {
@@ -98,6 +100,21 @@ impl<B: GfxBackend> CommandBuffer<B> {
                 buffer_barriers.chain(texture_barriers),
             );
         }
+    }
+}
+
+impl<B: hal::Backend> crate::hub::Resource for CommandBuffer<B> {
+    const TYPE: &'static str = "CommandBuffer";
+
+    fn life_guard(&self) -> &crate::LifeGuard {
+        unreachable!()
+    }
+
+    fn label(&self) -> &str {
+        #[cfg(debug_assertions)]
+        return &self.label;
+        #[cfg(not(debug_assertions))]
+        return "";
     }
 }
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -224,7 +224,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .as_ref()
             .ok_or(TransferError::InvalidBuffer(buffer_id))?;
         if !dst.usage.contains(wgt::BufferUsage::COPY_DST) {
-            Err(TransferError::MissingCopyDstUsageFlag)?;
+            Err(TransferError::MissingCopyDstUsageFlag(
+                Some(buffer_id),
+                None,
+            ))?;
         }
         dst.life_guard.use_at(device.active_submission_index + 1);
 
@@ -357,7 +360,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
 
         if !dst.usage.contains(wgt::TextureUsage::COPY_DST) {
-            Err(TransferError::MissingCopyDstUsageFlag)?
+            Err(TransferError::MissingCopyDstUsageFlag(
+                None,
+                Some(destination.texture),
+            ))?
         }
         validate_texture_copy_range(
             destination,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -107,6 +107,18 @@ pub struct Surface {
     pub gl: Option<GfxSurface<backend::Gl>>,
 }
 
+impl crate::hub::Resource for Surface {
+    const TYPE: &'static str = "Surface";
+
+    fn life_guard(&self) -> &LifeGuard {
+        unreachable!()
+    }
+
+    fn label(&self) -> &str {
+        "<Surface>"
+    }
+}
+
 #[derive(Debug)]
 pub struct Adapter<B: hal::Backend> {
     pub(crate) raw: hal::adapter::Adapter<B>,
@@ -212,8 +224,16 @@ impl<B: hal::Backend> Adapter<B> {
             raw,
             features,
             limits,
-            life_guard: LifeGuard::new(),
+            life_guard: LifeGuard::new("<Adapter>"),
         }
+    }
+}
+
+impl<B: hal::Backend> crate::hub::Resource for Adapter<B> {
+    const TYPE: &'static str = "Adapter";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
     }
 }
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -29,6 +29,18 @@ pub struct ShaderModule<B: hal::Backend> {
     pub(crate) module: Option<naga::Module>,
 }
 
+impl<B: hal::Backend> crate::hub::Resource for ShaderModule<B> {
+    const TYPE: &'static str = "ShaderModule";
+
+    fn life_guard(&self) -> &LifeGuard {
+        unreachable!()
+    }
+
+    fn label(&self) -> &str {
+        "<ShaderModule>"
+    }
+}
+
 #[derive(Clone, Debug, Error)]
 pub enum CreateShaderModuleError {
     #[error(transparent)]
@@ -99,6 +111,14 @@ pub struct ComputePipeline<B: hal::Backend> {
 impl<B: hal::Backend> Borrow<RefCount> for ComputePipeline<B> {
     fn borrow(&self) -> &RefCount {
         self.life_guard.ref_count.as_ref().unwrap()
+    }
+}
+
+impl<B: hal::Backend> crate::hub::Resource for ComputePipeline<B> {
+    const TYPE: &'static str = "ComputePipeline";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
     }
 }
 
@@ -216,5 +236,13 @@ pub struct RenderPipeline<B: hal::Backend> {
 impl<B: hal::Backend> Borrow<RefCount> for RenderPipeline<B> {
     fn borrow(&self) -> &RefCount {
         self.life_guard.ref_count.as_ref().unwrap()
+    }
+}
+
+impl<B: hal::Backend> crate::hub::Resource for RenderPipeline<B> {
+    const TYPE: &'static str = "RenderPipeline";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
     }
 }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -183,6 +183,14 @@ impl<B: hal::Backend> Borrow<RefCount> for Buffer<B> {
     }
 }
 
+impl<B: hal::Backend> crate::hub::Resource for Buffer<B> {
+    const TYPE: &'static str = "Buffer";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
+    }
+}
+
 impl<B: hal::Backend> Borrow<()> for Buffer<B> {
     fn borrow(&self) -> &() {
         &DUMMY_SELECTOR
@@ -238,6 +246,14 @@ pub enum CreateTextureError {
 impl<B: hal::Backend> Borrow<RefCount> for Texture<B> {
     fn borrow(&self) -> &RefCount {
         self.life_guard.ref_count.as_ref().unwrap()
+    }
+}
+
+impl<B: hal::Backend> crate::hub::Resource for Texture<B> {
+    const TYPE: &'static str = "Texture";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
     }
 }
 
@@ -345,6 +361,14 @@ impl<B: hal::Backend> Borrow<RefCount> for TextureView<B> {
     }
 }
 
+impl<B: hal::Backend> crate::hub::Resource for TextureView<B> {
+    const TYPE: &'static str = "TextureView";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
+    }
+}
+
 impl<B: hal::Backend> Borrow<()> for TextureView<B> {
     fn borrow(&self) -> &() {
         &DUMMY_SELECTOR
@@ -420,6 +444,14 @@ pub enum CreateSamplerError {
 impl<B: hal::Backend> Borrow<RefCount> for Sampler<B> {
     fn borrow(&self) -> &RefCount {
         self.life_guard.ref_count.as_ref().unwrap()
+    }
+}
+
+impl<B: hal::Backend> crate::hub::Resource for Sampler<B> {
+    const TYPE: &'static str = "Sampler";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
     }
 }
 

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -63,6 +63,14 @@ pub struct SwapChain<B: hal::Backend> {
     pub(crate) active_submission_index: SubmissionIndex,
 }
 
+impl<B: hal::Backend> crate::hub::Resource for SwapChain<B> {
+    const TYPE: &'static str = "SwapChain";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
+    }
+}
+
 #[derive(Clone, Debug, Error)]
 pub enum SwapChainError {
     #[error("swap chain is invalid")]
@@ -183,7 +191,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         layers: 0..1,
                         levels: 0..1,
                     },
-                    life_guard: LifeGuard::new(),
+                    life_guard: LifeGuard::new("<SwapChain View>"),
                 };
 
                 let ref_count = view.life_guard.add_ref();


### PR DESCRIPTION
This is wip, mostly a conversation starter.

I've attempted to have some labels show up in the errors, outside of only creation errors.
Steps to do that include,
1. Retain the label in the underlying struct (here, `Buffer`). It is guarded by `debug_assertions`
2. Add the label option to the error variant, and show it
3. Add label option to the `Element::Error` variant, so that invalid ids retain the label also. Didn't guard it with `debug_assertions` yet, but probably should. `buffer_error` now takes the label option.
4. Added a query for invalid id labels
5. Add `Global::buffer_label` for returning the label from the struct, or the invalid id.
6. Change the error variants to query the `buffer_label` when creating the error

with that (and little bit of fudging to get in to the error state), I can get
```
wgpu error: Validation error

Caused by:
    In CommandEncoder::copy_buffer_to_buffer
    buffer (0, 1, Metal) (label: Some("Staging buffer")) is invalid
```
instead of 
```
wgpu error: Validation error

Caused by:
    In CommandEncoder::copy_buffer_to_buffer
    buffer (0, 1, Metal) is invalid
```

Some of the hub handling etc. is a bit iffy for me, I really have no idea what I'm doing.

The point would be to massage this to the point that there would be a simple steps to follow on how to decorate all the errors with labels to whatever they refer to.

Other ideas I had, included trying to have `impl Debug for Id<BufferId>` to print out the label (from the struct, wouldn't work for invalid ids), but in that context I don't think I have access to the Global, so I'm not sure how resolve the id to anything useful. I suppose there could a whole separate singleton storage for id to label maps which could be easier to access in any context. Then the errors could just store the Id, and not have a separate label field.


