### PR TITLE
Fix DispatchIndirect transition for indirect buffer

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -389,7 +389,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     let (src_buffer, src_pending) = cmd_buf
                         .trackers
                         .buffers
-                        .use_replace(&*buffer_guard, buffer_id, (), BufferUse::INDIRECT)
+                        .use_extend(&*buffer_guard, buffer_id, (), BufferUse::INDIRECT)
                         .map_err(ComputePassError::InvalidIndirectBuffer)?;
                     check_buffer_usage(src_buffer.usage, BufferUsage::INDIRECT)?;
 


### PR DESCRIPTION
Previously overwrote the bufferuse, instead of extending it (as done with indirect draws already).

~Another thing I noticed is that (even after this fix) the buffer use (in vkCmdPipelineBarrier) does not set write flags if the buffer is _also_ used as write target by the shader. I don't think there any issue with having the buffer both the source for indirect draw/compute and also a write target of the shader, but I'm not 100% sure if the actual bug is not a missing validation error message - one of those things two things needs an open issue though :)~
wgpu's behavior is correct bar a missing error, at least in DX12 IndirectBuffer is a read-only state that can't be combined with write states (see https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_states). Tracked here #934