### PR TITLE
Properly implement compute pass usage scopes

### DIFF
--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -219,6 +219,13 @@ impl Binder {
         }
     }
 
+    pub(super) fn list_active(&self) -> impl Iterator<Item = Valid<BindGroupId>> + '_ {
+        self.entries.iter().filter_map(|e| match e.provided {
+            Some(ref pair) if e.expected_layout_id.is_some() => Some(pair.group_id.value),
+            _ => None,
+        })
+    }
+
     pub(super) fn invalid_mask(&self) -> BindGroupMask {
         self.entries.iter().enumerate().fold(0, |mask, (i, entry)| {
             if entry.is_valid().unwrap_or(true) {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -47,7 +47,7 @@ use crate::{
     id,
     resource::BufferUse,
     span,
-    track::TrackerSet,
+    track::{TrackerSet, UsageConflict},
     validation::check_buffer_usage,
     Label, LifeGuard, RefCount, Stored, MAX_BIND_GROUPS,
 };
@@ -630,6 +630,8 @@ pub enum RenderBundleError {
     #[error(transparent)]
     RenderCommand(#[from] RenderCommandError),
     #[error(transparent)]
+    ResourceUsageConflict(#[from] UsageConflict),
+    #[error(transparent)]
     Draw(#[from] DrawError),
 }
 
@@ -710,7 +712,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
 
                         state.set_bind_group(index, bind_group_id, bind_group.layout_id, offsets);
-                        state.trackers.merge_extend(&bind_group.used);
+                        state.trackers.merge_extend(&bind_group.used)?;
                     }
                     RenderCommand::SetPipeline(pipeline_id) => {
                         let pipeline = state

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -251,14 +251,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 }
 
-#[derive(Clone, Debug, Error)]
-pub enum UsageConflict {
-    #[error("buffer {0:?} combined usage is {1:?}")]
-    Buffer(id::BufferId, wgt::BufferUsage),
-    #[error("texture {0:?} combined usage is {1:?}")]
-    Texture(id::TextureId, wgt::TextureUsage),
-}
-
 fn push_constant_clear<PushFn>(offset: u32, size_bytes: u32, mut push_fn: PushFn)
 where
     PushFn: FnMut(u32, &[u32]),


### PR DESCRIPTION
**Connections**
Fixes #934 
Closes #933

**Description**
The old barriers in a compute pass were totally wrong. They didn't combine usages across the bind groups, or with indirect buffer.
This change implements the *actual* semantics as seen by the spec. At dispatch time we gather the usages across bind groups needed by the active pipeline, possibly add the indirect buffer into the mix, and that combined used is what we transition into.

I think we can find a few interesting ideas on how to make this faster. In particular - how to avoid a separate `TrackerSet` per pass. But for now correctness is more important.

**Testing**
Tested on wgpu-rs examples