### PR TITLE
Prevent an invalid texture from being registered in device_create_texture

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1262,6 +1262,16 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let device = device_guard
             .get(device_id)
             .map_err(|_| DeviceError::Invalid)?;
+
+        let texture_features = conv::texture_features(desc.format);
+        if texture_features != wgt::Features::empty() && !device.features.contains(texture_features)
+        {
+            return Err(resource::CreateTextureError::MissingFeature(
+                texture_features,
+                desc.format,
+            ));
+        }
+
         let texture = device.create_texture(device_id, desc)?;
         let num_levels = texture.full_range.levels.end;
         let num_layers = texture.full_range.layers.end;
@@ -1275,15 +1285,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 .add(trace::Action::CreateTexture(id.0, desc.clone())),
             None => (),
         };
-
-        let texture_features = conv::texture_features(desc.format);
-        if texture_features != wgt::Features::empty() && !device.features.contains(texture_features)
-        {
-            return Err(resource::CreateTextureError::MissingFeature(
-                texture_features,
-                desc.format,
-            ));
-        }
 
         device
             .trackers


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._
Since we checked the usage of a `Feature` in `device_create_texture()` after registering the new `Id`, there could be a case where it returns an error after registering the texture as a valid one, which further panics when the client tries to register it as an `error_id`.

To solve this, the check for the usage of a `Feature` is now done before registering the new `Id`.

**Testing**
_Explain how this change is tested._
Tested with wgpu-rs examples and CTS in Servo.
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
