### PR TITLE
Remove erroneous extra feature check

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -677,12 +677,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     .contains(wgt::Features::SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING),
             );
             enabled_features.set(
-                hal::Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING,
-                adapter
-                    .features
-                    .contains(wgt::Features::SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING),
-            );
-            enabled_features.set(
                 hal::Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING,
                 adapter
                     .features


### PR DESCRIPTION
**Connections**

None, found during investigation of DI issue.

**Description**

This line of code just shows up twice in a row, checking the same feature and setting the same feature.

**Testing**

Untested, but shouldn't affect anything.
