### PR TITLE
Fixed typo in texture size check

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -294,7 +294,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             None => {}
         }
 
-        if size.width == 0 || size.height == 0 || size.width == 0 {
+        if size.width == 0 || size.height == 0 || size.depth == 0 {
             tracing::trace!("Ignoring write_texture of size 0");
             return Ok(());
         }


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/937

**Description**
The texture's depth was omitted in the check.

**Testing**
No tests needed.
