### PR TITLE
Refactor and optimize bind group creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.2.0"
-source = "git+https://github.com/gfx-rs/naga?rev=8323521b838cf7a7cb4163c84f0f4ff237622f9a#8323521b838cf7a7cb4163c84f0f4ff237622f9a"
+source = "git+https://github.com/gfx-rs/naga?rev=aa35110471ee7915e1f4e1de61ea41f2f32f92c4#aa35110471ee7915e1f4e1de61ea41f2f32f92c4"
 dependencies = [
  "bitflags",
  "fxhash",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -40,7 +40,7 @@ gfx-memory = "0.2"
 [dependencies.naga]
 version = "0.2"
 git = "https://github.com/gfx-rs/naga"
-rev = "8323521b838cf7a7cb4163c84f0f4ff237622f9a"
+rev = "aa35110471ee7915e1f4e1de61ea41f2f32f92c4"
 features = ["spv-in", "spv-out", "wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -62,6 +62,8 @@ pub enum CreateBindGroupError {
     BindingSizeTooSmall { actual: u64, min: u64 },
     #[error("number of bindings in bind group descriptor ({actual}) does not match the number of bindings defined in the bind group layout ({expected})")]
     BindingsNumMismatch { actual: usize, expected: usize },
+    #[error("binding {0} is used at least twice in the descriptor")]
+    DuplicateBinding(u32),
     #[error("unable to find a corresponding declaration for the given binding {0}")]
     MissingBindingDeclaration(u32),
     #[error(transparent)]

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -125,7 +125,6 @@ fn get_aligned_type_size(
         Ti::Matrix {
             rows,
             columns,
-            kind: _,
             width,
         } => {
             rows as wgt::BufferAddress * columns as wgt::BufferAddress * width as wgt::BufferAddress
@@ -410,16 +409,14 @@ fn is_sub_type(sub: &naga::TypeInner, provided: &naga::TypeInner) -> bool {
             &Ti::Matrix {
                 columns: c0,
                 rows: r0,
-                kind: k0,
                 width: w0,
             },
             &Ti::Matrix {
                 columns: c1,
                 rows: r1,
-                kind: k1,
                 width: w1,
             },
-        ) => c0 == c1 && r0 == r1 && k0 == k1 && w0 <= w1,
+        ) => c0 == c1 && r0 == r1 && w0 <= w1,
         (&Ti::Struct { members: ref m0 }, &Ti::Struct { members: ref m1 }) => m0 == m1,
         _ => false,
     }


### PR DESCRIPTION
**Connections**
Fixes #960

**Description**
There is a small bag of things all related in here:
  1. It detects duplicate bindings in the `BindGroupDescriptor`. Previously, we compared the count, and formed the write array. If the expected bindings were [0, 1], and the given bindings were [0, 0], it would pass, erroneously. Now it properly errors out.
  2. It defers the *actual* descriptor set creation to after we iterate the bindings. This means any error would not make use leak descriptors any more.
  3. Finally, we form a single descriptor set write instead of having a write per binding. This is much more friendly to gfx-hal, which does the work per write, and should optimize bind group creation a bit.

**Testing**
Tested on wgpu-rs examples - https://github.com/gfx-rs/wgpu-rs/pull/589