### PR TITLE
Immediate resource destruction and freeing

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -149,6 +149,9 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                 self.device_maintain_ids::<B>(device).unwrap();
                 self.device_create_texture::<B>(device, &desc, id).unwrap();
             }
+            A::FreeTexture(id) => {
+                self.texture_destroy::<B>(id).unwrap();
+            }
             A::DestroyTexture(id) => {
                 self.texture_drop::<B>(id, true);
             }

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -139,6 +139,9 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                 self.device_maintain_ids::<B>(device).unwrap();
                 self.device_create_buffer::<B>(device, &desc, id).unwrap();
             }
+            A::FreeBuffer(id) => {
+                self.buffer_destroy::<B>(id).unwrap();
+            }
             A::DestroyBuffer(id) => {
                 self.buffer_drop::<B>(id, true);
             }

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -150,7 +150,7 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                 self.device_create_texture::<B>(device, &desc, id).unwrap();
             }
             A::DestroyTexture(id) => {
-                self.texture_drop::<B>(id);
+                self.texture_drop::<B>(id, true);
             }
             A::CreateTextureView {
                 id,

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -45,7 +45,7 @@ pub enum CreateBindGroupError {
     Device(#[from] DeviceError),
     #[error("bind group layout is invalid")]
     InvalidLayout,
-    #[error("buffer {0:?} is invalid")]
+    #[error("buffer {0:?} is invalid or destroyed")]
     InvalidBuffer(BufferId),
     #[error("texture view {0:?} is invalid")]
     InvalidTextureView(TextureViewId),

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -125,6 +125,13 @@ pub enum CreateRenderBundleError {
     InvalidSampleCount(u32),
 }
 
+/// Error type returned from `RenderBundleEncoder::new` if the sample count is invalid.
+#[derive(Clone, Debug, Error)]
+pub enum ExecutionError {
+    #[error("buffer {0:?} is destroyed")]
+    DestroyedBuffer(id::BufferId),
+}
+
 pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
 
 //Note: here, `RenderBundle` is just wrapping a raw stream of render commands.
@@ -151,8 +158,9 @@ impl RenderBundle {
     /// However the point of this function is to be lighter, since we already had
     /// a chance to go through the commands in `render_bundle_encoder_finish`.
     ///
-    /// Note that the function isn't expected to fail.
+    /// Note that the function isn't expected to fail, generally.
     /// All the validation has already been done by this point.
+    /// The only failure condition is if some of the used buffers are destroyed.
     pub(crate) unsafe fn execute<B: GfxBackend>(
         &self,
         cmd_buf: &mut B::CommandBuffer,
@@ -163,7 +171,7 @@ impl RenderBundle {
         bind_group_guard: &Storage<crate::binding_model::BindGroup<B>, id::BindGroupId>,
         pipeline_guard: &Storage<crate::pipeline::RenderPipeline<B>, id::RenderPipelineId>,
         buffer_guard: &Storage<crate::resource::Buffer<B>, id::BufferId>,
-    ) {
+    ) -> Result<(), ExecutionError> {
         use hal::command::CommandBuffer as _;
 
         let mut offsets = self.base.dynamic_offsets.as_slice();
@@ -197,9 +205,14 @@ impl RenderBundle {
                     offset,
                     size,
                 } => {
-                    let buffer = buffer_guard.get(buffer_id).unwrap();
+                    let &(ref buffer, _) = buffer_guard
+                        .get(buffer_id)
+                        .unwrap()
+                        .raw
+                        .as_ref()
+                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?;
                     let view = hal::buffer::IndexBufferView {
-                        buffer: &buffer.raw,
+                        buffer,
                         range: hal::buffer::SubRange {
                             offset,
                             size: size.map(|s| s.get()),
@@ -215,12 +228,17 @@ impl RenderBundle {
                     offset,
                     size,
                 } => {
-                    let buffer = buffer_guard.get(buffer_id).unwrap();
+                    let &(ref buffer, _) = buffer_guard
+                        .get(buffer_id)
+                        .unwrap()
+                        .raw
+                        .as_ref()
+                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?;
                     let range = hal::buffer::SubRange {
                         offset,
                         size: size.map(|s| s.get()),
                     };
-                    cmd_buf.bind_vertex_buffers(slot, iter::once((&buffer.raw, range)));
+                    cmd_buf.bind_vertex_buffers(slot, iter::once((buffer, range)));
                 }
                 RenderCommand::SetPushConstant {
                     stages,
@@ -287,8 +305,13 @@ impl RenderBundle {
                     count: None,
                     indexed: false,
                 } => {
-                    let buffer = buffer_guard.get(buffer_id).unwrap();
-                    cmd_buf.draw_indirect(&buffer.raw, offset, 1, 0);
+                    let &(ref buffer, _) = buffer_guard
+                        .get(buffer_id)
+                        .unwrap()
+                        .raw
+                        .as_ref()
+                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?;
+                    cmd_buf.draw_indirect(buffer, offset, 1, 0);
                 }
                 RenderCommand::MultiDrawIndirect {
                     buffer_id,
@@ -296,8 +319,13 @@ impl RenderBundle {
                     count: None,
                     indexed: true,
                 } => {
-                    let buffer = buffer_guard.get(buffer_id).unwrap();
-                    cmd_buf.draw_indexed_indirect(&buffer.raw, offset, 1, 0);
+                    let &(ref buffer, _) = buffer_guard
+                        .get(buffer_id)
+                        .unwrap()
+                        .raw
+                        .as_ref()
+                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?;
+                    cmd_buf.draw_indexed_indirect(buffer, offset, 1, 0);
                 }
                 RenderCommand::MultiDrawIndirect { .. }
                 | RenderCommand::MultiDrawIndirectCount { .. } => unimplemented!(),
@@ -311,6 +339,8 @@ impl RenderBundle {
                 | RenderCommand::SetScissor(_) => unreachable!(),
             }
         }
+
+        Ok(())
     }
 }
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -121,7 +121,7 @@ pub enum ComputePassError {
     BindGroupIndexOutOfRange { index: u8, max: u32 },
     #[error("compute pipeline {0:?} is invalid")]
     InvalidPipeline(id::ComputePipelineId),
-    #[error("indirect buffer {0:?} is invalid")]
+    #[error("indirect buffer {0:?} is invalid or destroyed")]
     InvalidIndirectBuffer(id::BufferId),
     #[error(transparent)]
     ResourceUsageConflict(#[from] UsageConflict),
@@ -411,6 +411,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         .use_extend(&*buffer_guard, buffer_id, (), BufferUse::INDIRECT)
                         .map_err(|_| ComputePassError::InvalidIndirectBuffer(buffer_id))?;
                     check_buffer_usage(indirect_buffer.usage, BufferUsage::INDIRECT)?;
+                    let &(ref buf_raw, _) = indirect_buffer
+                        .raw
+                        .as_ref()
+                        .ok_or(ComputePassError::InvalidIndirectBuffer(buffer_id))?;
 
                     state.flush_states(
                         raw,
@@ -420,7 +424,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         &*texture_guard,
                     )?;
                     unsafe {
-                        raw.dispatch_indirect(&indirect_buffer.raw, offset);
+                        raw.dispatch_indirect(buf_raw, offset);
                     }
                 }
                 ComputeCommand::PushDebugGroup { color, len } => {

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -65,6 +65,8 @@ pub enum RenderCommandError {
     IncompatibleReadOnlyDepthStencil,
     #[error("buffer {0:?} is in error {1:?}")]
     Buffer(id::BufferId, BufferError),
+    #[error("buffer {0:?} is destroyed")]
+    DestroyedBuffer(id::BufferId),
     #[error(transparent)]
     MissingBufferUsage(#[from] MissingBufferUsageError),
     #[error(transparent)]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -6,8 +6,8 @@ use crate::{
     binding_model::BindError,
     command::{
         bind::{Binder, LayoutChange},
-        BasePass, BasePassRef, CommandBuffer, CommandEncoderError, DrawError, RenderCommand,
-        RenderCommandError,
+        BasePass, BasePassRef, CommandBuffer, CommandEncoderError, DrawError, ExecutionError,
+        RenderCommand, RenderCommandError,
     },
     conv,
     device::{
@@ -197,7 +197,7 @@ impl OptionalState {
 
 #[derive(Debug, Default)]
 struct IndexState {
-    bound_buffer_view: Option<(id::BufferId, Range<BufferAddress>)>,
+    bound_buffer_view: Option<(id::Valid<id::BufferId>, Range<BufferAddress>)>,
     format: IndexFormat,
     limit: u32,
 }
@@ -1013,7 +1013,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     let pipeline = trackers
                         .render_pipes
                         .use_extend(&*pipeline_guard, pipeline_id, (), ())
-                        .unwrap();
+                        .map_err(|_| RenderCommandError::InvalidPipeline(pipeline_id))?;
 
                     context
                         .check_compatible(&pipeline.pass_context)
@@ -1101,13 +1101,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         state.index.update_limit();
 
                         if let Some((buffer_id, ref range)) = state.index.bound_buffer_view {
-                            let buffer = trackers
-                                .buffers
-                                .use_extend(&*buffer_guard, buffer_id, (), BufferUse::INDEX)
-                                .unwrap();
+                            let &(ref buffer, _) = buffer_guard[buffer_id].raw.as_ref().unwrap();
 
                             let view = hal::buffer::IndexBufferView {
-                                buffer: &buffer.raw,
+                                buffer,
                                 range: hal::buffer::SubRange {
                                     offset: range.start,
                                     size: Some(range.end - range.start),
@@ -1142,18 +1139,22 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     let buffer = trackers
                         .buffers
                         .use_extend(&*buffer_guard, buffer_id, (), BufferUse::INDEX)
-                        .unwrap();
+                        .map_err(|e| RenderCommandError::Buffer(buffer_id, e))?;
                     check_buffer_usage(buffer.usage, BufferUsage::INDEX)?;
+                    let &(ref buf_raw, _) = buffer
+                        .raw
+                        .as_ref()
+                        .ok_or(RenderCommandError::DestroyedBuffer(buffer_id))?;
 
                     let end = match size {
                         Some(s) => offset + s.get(),
                         None => buffer.size,
                     };
-                    state.index.bound_buffer_view = Some((buffer_id, offset..end));
+                    state.index.bound_buffer_view = Some((id::Valid(buffer_id), offset..end));
                     state.index.update_limit();
 
                     let view = hal::buffer::IndexBufferView {
-                        buffer: &buffer.raw,
+                        buffer: buf_raw,
                         range: hal::buffer::SubRange {
                             offset,
                             size: Some(end - offset),
@@ -1174,8 +1175,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     let buffer = trackers
                         .buffers
                         .use_extend(&*buffer_guard, buffer_id, (), BufferUse::VERTEX)
-                        .unwrap();
+                        .map_err(|e| RenderCommandError::Buffer(buffer_id, e))?;
                     check_buffer_usage(buffer.usage, BufferUsage::VERTEX)?;
+                    let &(ref buf_raw, _) = buffer
+                        .raw
+                        .as_ref()
+                        .ok_or(RenderCommandError::DestroyedBuffer(buffer_id))?;
+
                     let empty_slots = (1 + slot as usize).saturating_sub(state.vertex.inputs.len());
                     state
                         .vertex
@@ -1191,7 +1197,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         size: size.map(|s| s.get()),
                     };
                     unsafe {
-                        raw.bind_vertex_buffers(slot, iter::once((&buffer.raw, range)));
+                        raw.bind_vertex_buffers(slot, iter::once((buf_raw, range)));
                     }
                     state.vertex.update_limits();
                 }
@@ -1373,33 +1379,37 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         check_device_features(device.features, wgt::Features::MULTI_DRAW_INDIRECT)?;
                     }
 
-                    let buffer = trackers
+                    let indirect_buffer = trackers
                         .buffers
                         .use_extend(&*buffer_guard, buffer_id, (), BufferUse::INDIRECT)
-                        .unwrap();
-                    check_buffer_usage(buffer.usage, BufferUsage::INDIRECT)?;
+                        .map_err(|e| RenderCommandError::Buffer(buffer_id, e))?;
+                    check_buffer_usage(indirect_buffer.usage, BufferUsage::INDIRECT)?;
+                    let &(ref indirect_raw, _) = indirect_buffer
+                        .raw
+                        .as_ref()
+                        .ok_or(RenderCommandError::DestroyedBuffer(buffer_id))?;
 
                     let actual_count = count.map_or(1, |c| c.get());
 
                     let begin_offset = offset;
                     let end_offset = offset + stride * actual_count as u64;
-                    if end_offset > buffer.size {
+                    if end_offset > indirect_buffer.size {
                         return Err(RenderPassError::IndirectBufferOverrun {
                             offset,
                             count,
                             begin_offset,
                             end_offset,
-                            buffer_size: buffer.size,
+                            buffer_size: indirect_buffer.size,
                         });
                     }
 
                     match indexed {
                         false => unsafe {
-                            raw.draw_indirect(&buffer.raw, offset, actual_count, stride as u32);
+                            raw.draw_indirect(indirect_raw, offset, actual_count, stride as u32);
                         },
                         true => unsafe {
                             raw.draw_indexed_indirect(
-                                &buffer.raw,
+                                indirect_raw,
                                 offset,
                                 actual_count,
                                 stride as u32,
@@ -1427,26 +1437,35 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         wgt::Features::MULTI_DRAW_INDIRECT_COUNT,
                     )?;
 
-                    let buffer = trackers
+                    let indirect_buffer = trackers
                         .buffers
                         .use_extend(&*buffer_guard, buffer_id, (), BufferUse::INDIRECT)
-                        .unwrap();
-                    check_buffer_usage(buffer.usage, BufferUsage::INDIRECT)?;
+                        .map_err(|e| RenderCommandError::Buffer(buffer_id, e))?;
+                    check_buffer_usage(indirect_buffer.usage, BufferUsage::INDIRECT)?;
+                    let &(ref indirect_raw, _) = indirect_buffer
+                        .raw
+                        .as_ref()
+                        .ok_or(RenderCommandError::DestroyedBuffer(buffer_id))?;
+
                     let count_buffer = trackers
                         .buffers
                         .use_extend(&*buffer_guard, count_buffer_id, (), BufferUse::INDIRECT)
-                        .unwrap();
+                        .map_err(|e| RenderCommandError::Buffer(count_buffer_id, e))?;
                     check_buffer_usage(count_buffer.usage, BufferUsage::INDIRECT)?;
+                    let &(ref count_raw, _) = count_buffer
+                        .raw
+                        .as_ref()
+                        .ok_or(RenderCommandError::DestroyedBuffer(count_buffer_id))?;
 
                     let begin_offset = offset;
                     let end_offset = offset + stride * max_count as u64;
-                    if end_offset > buffer.size {
+                    if end_offset > indirect_buffer.size {
                         return Err(RenderPassError::IndirectBufferOverrun {
                             offset,
                             count: None,
                             begin_offset,
                             end_offset,
-                            buffer_size: buffer.size,
+                            buffer_size: indirect_buffer.size,
                         });
                     }
 
@@ -1463,9 +1482,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     match indexed {
                         false => unsafe {
                             raw.draw_indirect_count(
-                                &buffer.raw,
+                                indirect_raw,
                                 offset,
-                                &count_buffer.raw,
+                                count_raw,
                                 count_buffer_offset,
                                 max_count,
                                 stride as u32,
@@ -1473,9 +1492,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         },
                         true => unsafe {
                             raw.draw_indexed_indirect_count(
-                                &buffer.raw,
+                                indirect_raw,
                                 offset,
-                                &count_buffer.raw,
+                                count_raw,
                                 count_buffer_offset,
                                 max_count,
                                 stride as u32,
@@ -1525,6 +1544,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             &*buffer_guard,
                         )
                     }
+                    .map_err(|e| match e {
+                        ExecutionError::DestroyedBuffer(id) => {
+                            RenderCommandError::DestroyedBuffer(id)
+                        }
+                    })?;
 
                     trackers.merge_extend(&bundle.used)?;
                     state.reset_bundle();

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -460,6 +460,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 TextureUse::COPY_DST,
             )
             .unwrap();
+        let &(ref dst_raw, _) = dst_texture
+            .raw
+            .as_ref()
+            .ok_or(TransferError::InvalidTexture(destination.texture))?;
         if !dst_texture.usage.contains(TextureUsage::COPY_DST) {
             Err(TransferError::MissingCopyDstUsageFlag)?
         }
@@ -518,7 +522,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             );
             cmb_raw.copy_buffer_to_image(
                 src_raw,
-                &dst_texture.raw,
+                dst_raw,
                 hal::image::Layout::TransferDstOptimal,
                 iter::once(region),
             );
@@ -568,6 +572,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 TextureUse::COPY_SRC,
             )
             .unwrap();
+        let &(ref src_raw, _) = src_texture
+            .raw
+            .as_ref()
+            .ok_or(TransferError::InvalidTexture(source.texture))?;
         if !src_texture.usage.contains(TextureUsage::COPY_SRC) {
             Err(TransferError::MissingCopySrcUsageFlag)?
         }
@@ -639,7 +647,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 src_barriers.chain(dst_barrier),
             );
             cmb_raw.copy_image_to_buffer(
-                &src_texture.raw,
+                src_raw,
                 hal::image::Layout::TransferSrcOptimal,
                 dst_raw,
                 iter::once(region),
@@ -699,6 +707,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 TextureUse::COPY_SRC,
             )
             .unwrap();
+        let &(ref src_raw, _) = src_texture
+            .raw
+            .as_ref()
+            .ok_or(TransferError::InvalidTexture(source.texture))?;
         if !src_texture.usage.contains(TextureUsage::COPY_SRC) {
             Err(TransferError::MissingCopySrcUsageFlag)?
         }
@@ -714,6 +726,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 TextureUse::COPY_DST,
             )
             .unwrap();
+        let &(ref dst_raw, _) = dst_texture
+            .raw
+            .as_ref()
+            .ok_or(TransferError::InvalidTexture(destination.texture))?;
         if !dst_texture.usage.contains(TextureUsage::COPY_DST) {
             Err(TransferError::MissingCopyDstUsageFlag)?
         }
@@ -749,9 +765,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 barriers,
             );
             cmb_raw.copy_image(
-                &src_texture.raw,
+                src_raw,
                 hal::image::Layout::TransferSrcOptimal,
-                &dst_texture.raw,
+                dst_raw,
                 hal::image::Layout::TransferDstOptimal,
                 iter::once(region),
             );

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -477,7 +477,7 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                             .find(|a| a.index == submit_index)
                             .map_or(&mut self.free_resources, |a| &mut a.last_resources)
                             .buffers
-                            .push((res.raw, res.memory));
+                            .extend(res.raw);
                     }
                 }
             }
@@ -691,7 +691,7 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                     .buffers
                     .unregister_locked(buffer_id.0, &mut *buffer_guard)
                 {
-                    self.free_resources.buffers.push((buf.raw, buf.memory));
+                    self.free_resources.buffers.extend(buf.raw);
                 }
             } else {
                 let mapping = match std::mem::replace(

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -247,7 +247,7 @@ impl<B: hal::Backend> LifetimeTracker<B> {
         for (res, memory) in temp_resources {
             match res {
                 TempResource::Buffer(raw) => last_resources.buffers.push((raw, memory)),
-                //TempResource::Image(raw) => last_resources.images.push((raw, memory)),
+                TempResource::Image(raw) => last_resources.images.push((raw, memory)),
             }
         }
 
@@ -357,7 +357,7 @@ impl<B: hal::Backend> LifetimeTracker<B> {
             .map_or(&mut self.free_resources, |a| &mut a.last_resources);
         match temp_resource {
             TempResource::Buffer(raw) => resources.buffers.push((raw, memory)),
-            //TempResource::Image(raw) => resources.images.push((raw, memory)),
+            TempResource::Image(raw) => resources.images.push((raw, memory)),
         }
     }
 }
@@ -456,7 +456,7 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                             .find(|a| a.index == submit_index)
                             .map_or(&mut self.free_resources, |a| &mut a.last_resources)
                             .images
-                            .push((res.raw, res.memory));
+                            .extend(res.raw);
                     }
                 }
             }

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -35,6 +35,7 @@ pub enum Action<'a> {
         backend: wgt::Backend,
     },
     CreateBuffer(id::BufferId, crate::resource::BufferDescriptor<'a>),
+    FreeBuffer(id::BufferId),
     DestroyBuffer(id::BufferId),
     CreateTexture(id::TextureId, crate::resource::TextureDescriptor<'a>),
     DestroyTexture(id::TextureId),

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -38,6 +38,7 @@ pub enum Action<'a> {
     FreeBuffer(id::BufferId),
     DestroyBuffer(id::BufferId),
     CreateTexture(id::TextureId, crate::resource::TextureDescriptor<'a>),
+    FreeTexture(id::TextureId),
     DestroyTexture(id::TextureId),
     CreateTextureView {
         id: id::TextureViewId,

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -232,6 +232,8 @@ macro_rules! span {
 /// Fast hash map used internally.
 type FastHashMap<K, V> =
     std::collections::HashMap<K, V, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
+/// Fast hash set used internally.
+type FastHashSet<K> = std::collections::HashSet<K, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
 
 #[test]
 fn test_default_limits() {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -204,7 +204,7 @@ pub type TextureDescriptor<'a> = wgt::TextureDescriptor<Label<'a>>;
 
 #[derive(Debug)]
 pub struct Texture<B: hal::Backend> {
-    pub(crate) raw: B::Image,
+    pub(crate) raw: Option<(B::Image, MemoryBlock<B>)>,
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) usage: wgt::TextureUsage,
     pub(crate) aspects: hal::format::Aspects,
@@ -212,7 +212,6 @@ pub struct Texture<B: hal::Backend> {
     pub(crate) kind: hal::image::Kind,
     pub(crate) format: wgt::TextureFormat,
     pub(crate) full_range: TextureSelector,
-    pub(crate) memory: MemoryBlock<B>,
     pub(crate) life_guard: LifeGuard,
 }
 
@@ -314,7 +313,7 @@ pub struct TextureView<B: hal::Backend> {
 
 #[derive(Clone, Debug, Error)]
 pub enum CreateTextureViewError {
-    #[error("parent texture is invalid")]
+    #[error("parent texture is invalid or destroyed")]
     InvalidTexture,
     #[error("not enough memory left")]
     OutOfMemory,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -130,7 +130,9 @@ pub enum BufferAccessError {
     #[error(transparent)]
     Device(#[from] DeviceError),
     #[error("buffer is invalid")]
-    InvalidBuffer,
+    Invalid,
+    #[error("buffer is destroyed")]
+    Destroyed,
     #[error("buffer is already mapped")]
     AlreadyMapped,
     #[error(transparent)]
@@ -164,10 +166,9 @@ pub type BufferDescriptor<'a> = wgt::BufferDescriptor<Label<'a>>;
 
 #[derive(Debug)]
 pub struct Buffer<B: hal::Backend> {
-    pub(crate) raw: B::Buffer,
+    pub(crate) raw: Option<(B::Buffer, MemoryBlock<B>)>,
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) usage: wgt::BufferUsage,
-    pub(crate) memory: MemoryBlock<B>,
     pub(crate) size: wgt::BufferAddress,
     pub(crate) full_range: (),
     pub(crate) sync_mapped_writes: Option<hal::memory::Segment>,
@@ -424,4 +425,12 @@ impl<B: hal::Backend> Borrow<()> for Sampler<B> {
     fn borrow(&self) -> &() {
         &DUMMY_SELECTOR
     }
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum DestroyError {
+    #[error("resource is invalid")]
+    Invalid,
+    #[error("resource is already destroyed")]
+    AlreadyDestroyed,
 }

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -134,10 +134,11 @@ impl PendingTransition<BufferState> {
         buf: &'a resource::Buffer<B>,
     ) -> hal::memory::Barrier<'a, B> {
         tracing::trace!("\tbuffer -> {:?}", self);
+        let &(ref target, _) = buf.raw.as_ref().expect("Buffer is destroyed");
         hal::memory::Barrier::Buffer {
             states: conv::map_buffer_state(self.usage.start)
                 ..conv::map_buffer_state(self.usage.end),
-            target: &buf.raw,
+            target,
             range: hal::buffer::SubRange::WHOLE,
             families: None,
         }

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -152,11 +152,12 @@ impl PendingTransition<TextureState> {
         tex: &'a resource::Texture<B>,
     ) -> hal::memory::Barrier<'a, B> {
         tracing::trace!("\ttexture -> {:?}", self);
+        let &(ref target, _) = tex.raw.as_ref().expect("Texture is destroyed");
         let aspects = tex.aspects;
         hal::memory::Barrier::Image {
             states: conv::map_texture_state(self.usage.start, aspects)
                 ..conv::map_texture_state(self.usage.end, aspects),
-            target: &tex.raw,
+            target,
             range: hal::image::SubresourceRange {
                 aspects,
                 level_start: self.selector.levels.start,


### PR DESCRIPTION
**Connections**
Fixes #964

**Description**
We are making it so a buffer or a texture can have their native resources freed while they are still referenced, so without waiting for GC.

In addition, the PR adds a few missing cases where error IDs should have been handled, like at render pass encoding.

**Testing**
Tested on wgpu-rs examples, see https://github.com/gfx-rs/wgpu-rs/pull/591