### PR TITLE
CI playtests for Dx12, Vulkan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           - name: MacOS Nightly
             os: macos-10.15
             channel: nightly
-            build_command: cargo test
+            build_command: cargo test -- --nocapture
             additional_core_features:
             additional_player_features:
           - name: Ubuntu Stable
@@ -68,7 +68,10 @@ jobs:
           - name: Ubuntu Nightly
             os: ubuntu-18.04
             channel: nightly
-            build_command: cargo test
+            build_command: | 
+              sudo add-apt-repository ppa:oibaf/graphics-drivers;
+              sudo apt-get install mesa-vulkan-drivers;
+              cargo test -- --nocapture; 
             additional_core_features: serial-pass
             additional_player_features: winit
           - name: Windows Stable
@@ -80,7 +83,7 @@ jobs:
           - name: Windows Nightly
             os: windows-2019
             channel: nightly
-            build_command: rustup default nightly-msvc; cargo test
+            build_command: rustup default nightly-msvc; cargo test -- --nocapture
             additional_core_features:
             additional_player_features:
     steps:

--- a/player/tests/data/all.ron
+++ b/player/tests/data/all.ron
@@ -1,5 +1,5 @@
 (
-	backends: (bits: 0x7),
+	backends: (bits: 0xF),
 	tests: [
 		"buffer-copy.ron",
 		"bind-group.ron",


### PR DESCRIPTION
**Connections**
#950

**Description**
Implements CI testing for Vulkan and DX12. Also, cargo test stdout will no longer be captured so that people can verify that the playtests actually ran. 

Note: If no adapters are found, nothing will run and the tests will pass. This might become a problem if the installation no longer works and no one notices. 

**Testing**
Passed CI Tests
