### PR TITLE
remove PowerPreference::Default

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -69,7 +69,7 @@ fn main() {
             let adapter = global
                 .request_adapter(
                     &wgc::instance::RequestAdapterOptions {
-                        power_preference: wgt::PowerPreference::Default,
+                        power_preference: wgt::PowerPreference::LowPower,
                         #[cfg(feature = "winit")]
                         compatible_surface: Some(surface),
                         #[cfg(not(feature = "winit"))]

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -174,7 +174,7 @@ impl Corpus {
             }
             let adapter = match global.request_adapter(
                 &wgc::instance::RequestAdapterOptions {
-                    power_preference: wgt::PowerPreference::Default,
+                    power_preference: wgt::PowerPreference::LowPower,
                     compatible_surface: None,
                 },
                 wgc::instance::AdapterInputs::IdSet(

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -501,9 +501,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         let preferred_gpu = match desc.power_preference {
-            PowerPreference::Default | PowerPreference::LowPower => {
-                integrated.or(other).or(discrete).or(virt)
-            }
+            PowerPreference::LowPower => integrated.or(other).or(discrete).or(virt),
             PowerPreference::HighPerformance => discrete.or(other).or(integrated).or(virt),
         };
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -57,17 +57,15 @@ pub enum Backend {
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub enum PowerPreference {
-    /// Prefer low power when on battery, high performance when on mains.
-    Default = 0,
     /// Adapter that uses the least possible power. This is often an integerated GPU.
-    LowPower = 1,
+    LowPower = 0,
     /// Adapter that has the highest performance. This is often a discrete GPU.
-    HighPerformance = 2,
+    HighPerformance = 1,
 }
 
 impl Default for PowerPreference {
     fn default() -> Self {
-        Self::Default
+        Self::LowPower
     }
 }
 


### PR DESCRIPTION

**Connections**
Issue: #971 

**Description**
remove `PowerPreference::Default` and change related value to use `PowerPreference::LowPower` .
`PowerPreference::default()` is remain.

**Testing**
`cargo test` and `cargo build` passed
