### PR TITLE
Fix debug markers in render passes (#981)

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1525,6 +1525,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     unsafe {
                         raw.insert_debug_marker(label, color);
                     }
+                    base.string_data = &base.string_data[len..];
                 }
                 RenderCommand::ExecuteBundle(bundle_id) => {
                     let bundle = trackers


### PR DESCRIPTION
Hey, that was easy. Didn't change anything in the debug groups markers / command pass markers, since afaict they work correctly.

I didn't add a test here because I'm not sure how to use the `player` testing apparatus, but I figure since I'm just adding a line of code that's already there for compute passes ([here](https://github.com/gfx-rs/wgpu/blob/master/wgpu-core/src/command/compute.rs#L452)) it should be alright. Let me know if there's anything else I should add.