### PR TITLE
Fix locking of device lifetime tracker on resource drop

### DIFF
--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::id;
+use std::ops::Range;
 #[cfg(feature = "trace")]
-use std::io::Write as _;
-use std::{borrow::Cow, ops::Range};
+use std::{borrow::Cow, io::Write as _};
 
 //TODO: consider a readable Id that doesn't include the backend
 


### PR DESCRIPTION
**Connections**
Fixes the player hang in #983

**Description**
It turns out the current type-level protection from locking device's lifetime tracker is not working properly. TODO is left.

**Testing**
Tested on the trace from #983