### PR TITLE
[0.6] Allign stencil reference between state setting and pipeline creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## wgpu-core-0.6.5 (2020-10-14)
+  - fix setting the stencil reference on an incompatible pipeline
+
 ## wgpu-core-0.6.4 (2020-10-05)
   - don't request device features that aren't needed
   - fix texture depth == 0 checks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "arrayvec",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-core"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU core logic on gfx-hal"

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -269,9 +269,10 @@ impl VertexState {
 
 #[derive(Debug)]
 struct State {
+    pipeline_flags: PipelineFlags,
     binder: Binder,
     blend_color: OptionalState,
-    stencil_reference: OptionalState,
+    stencil_reference: u32,
     pipeline: OptionalState,
     index: IndexState,
     vertex: VertexState,
@@ -293,9 +294,6 @@ impl State {
         }
         if self.blend_color == OptionalState::Required {
             return Err(DrawError::MissingBlendColor);
-        }
-        if self.stencil_reference == OptionalState::Required {
-            return Err(DrawError::MissingStencilReference);
         }
         Ok(())
     }
@@ -929,9 +927,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         };
 
         let mut state = State {
+            pipeline_flags: PipelineFlags::empty(),
             binder: Binder::new(cmd_buf.limits.max_bind_groups),
             blend_color: OptionalState::Unused,
-            stencil_reference: OptionalState::Unused,
+            stencil_reference: 0,
             pipeline: OptionalState::Required,
             index: IndexState::default(),
             vertex: VertexState::default(),
@@ -995,11 +994,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     };
                 }
                 RenderCommand::SetPipeline(pipeline_id) => {
-                    state.pipeline = OptionalState::Set;
                     let pipeline = trackers
                         .render_pipes
                         .use_extend(&*pipeline_guard, pipeline_id, (), ())
                         .unwrap();
+
+                    state.pipeline = OptionalState::Set;
+                    state.pipeline_flags = pipeline.flags;
 
                     if !context.compatible(&pipeline.pass_context) {
                         return Err(RenderCommandError::IncompatiblePipeline.into());
@@ -1013,12 +1014,18 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     state
                         .blend_color
                         .require(pipeline.flags.contains(PipelineFlags::BLEND_COLOR));
-                    state
-                        .stencil_reference
-                        .require(pipeline.flags.contains(PipelineFlags::STENCIL_REFERENCE));
 
                     unsafe {
                         raw.bind_graphics_pipeline(&pipeline.raw);
+                    }
+
+                    if pipeline.flags.contains(PipelineFlags::STENCIL_REFERENCE) {
+                        unsafe {
+                            raw.set_stencil_reference(
+                                hal::pso::Face::all(),
+                                state.stencil_reference,
+                            );
+                        }
                     }
 
                     // Rebind resource
@@ -1187,9 +1194,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                 }
                 RenderCommand::SetStencilReference(value) => {
-                    state.stencil_reference = OptionalState::Set;
-                    unsafe {
-                        raw.set_stencil_reference(hal::pso::Face::all(), value);
+                    state.stencil_reference = value;
+                    if state
+                        .pipeline_flags
+                        .contains(PipelineFlags::STENCIL_REFERENCE)
+                    {
+                        unsafe {
+                            raw.set_stencil_reference(hal::pso::Face::all(), value);
+                        }
                     }
                 }
                 RenderCommand::SetViewport {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2928,7 +2928,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             }
         }
         if let Some(ds) = depth_stencil_state.as_ref() {
-            if ds.stencil.needs_ref_value() {
+            if ds.stencil.is_enabled() && ds.stencil.needs_ref_value() {
                 flags |= pipeline::PipelineFlags::STENCIL_REFERENCE;
             }
             if !ds.is_read_only() {


### PR DESCRIPTION
**Connections**
Found this when running Ruffle from #983 

**Description**
There are 2 problems:
  1. setting the stencil reference can't be valid if the pipeline doesn't expect this (d'oh)
  2. our code that created the pipeline used slightly stricter conditions than the code setting the stencil, so these diverged a tiny bit

**Testing**
Tested on Ruffle