### PR TITLE
Elide redundant set_pipeline calls.

### DIFF
--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -270,3 +270,25 @@ where
         count_words += size_to_write_words;
     }
 }
+
+#[derive(Debug)]
+struct StateChange<T> {
+    last_state: Option<T>,
+}
+
+impl<T: Copy + PartialEq> StateChange<T> {
+    fn new() -> Self {
+        Self { last_state: None }
+    }
+    fn set_and_check_redundant(&mut self, new_state: T) -> bool {
+        let already_set = self.last_state == Some(new_state);
+        self.last_state = Some(new_state);
+        already_set
+    }
+    fn is_unset(&self) -> bool {
+        self.last_state.is_none()
+    }
+    fn reset(&mut self) {
+        self.last_state = None;
+    }
+}


### PR DESCRIPTION
**Description**
This adds an check in each `set_pipeline()` call for wether the same pipeline id has already been set previously. This should cause free performance wins for suboptimal usage of the wgpu API, while having neglible overhead otherwise.

An example scenario for where this would be useful is a game that just blindly sets all render state for each object, but has few actually different objects:

```rust
for game_obj in game_objs {
    rpass.set_pipeline(...);
    rpass.set_bind_group(...);
    rpass.set_vertex_buffer(...);
    rpass.draw(...);
}
```

**Testing**
Ideally we would have tests that check that pipeline changes have been ellided, but I'm not sure how to write them in the current codebase.

**Future work**
- We could extend this kind of redundant state change detection to most `.set_*` methods on `RenderPass`es.
- If we want to guarantee this behavior in the API, we should also document it.