### PR TITLE
Improve cubemap validation

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -317,6 +317,15 @@ pub enum CreateTextureViewError {
     InvalidTexture,
     #[error("not enough memory left")]
     OutOfMemory,
+    #[error("Invalid texture view dimension `{view:?}` with texture of dimension `{image:?}`")]
+    InvalidTextureViewDimension {
+        view: wgt::TextureViewDimension,
+        image: wgt::TextureDimension,
+    },
+    #[error("Invalid texture depth `{depth}` for texture view of dimension `Cubemap`. Cubemap views must use images of size 6.")]
+    InvalidCubemapTextureDepth { depth: u16 },
+    #[error("Invalid texture depth `{depth}` for texture view of dimension `CubemapArray`. Cubemap views must use images with sizes which are a multiple of 6.")]
+    InvalidCubemapArrayTextureDepth { depth: u16 },
     #[error(
         "TextureView mip level count + base mip level {requested} must be <= Texture mip level count {total}"
     )]

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -434,6 +434,17 @@ pub enum TextureViewDimension {
     D3,
 }
 
+impl TextureViewDimension {
+    /// Get the texture dimension required fo this texture view dimension.
+    pub fn compatible_texture_dimension(self) -> TextureDimension {
+        match self {
+            Self::D1 => TextureDimension::D1,
+            Self::D2 | Self::D2Array | Self::Cube | Self::CubeArray => TextureDimension::D2,
+            Self::D3 => TextureDimension::D3,
+        }
+    }
+}
+
 /// Alpha blend factor.
 ///
 /// Alpha blending is very complicated: see the OpenGL or Vulkan spec for more information.


### PR DESCRIPTION
**Connections**

Closes #952.

**Description**

We were missing depth-size and texture dimension validation when creating Cubemap and CubemapArray views.

I split the depth-size errors so I can give a more helpful error message in both cases.

**Testing**

Tested on the skybox example when made intensionally incorrect.