### PR TITLE
Add helpers to convert passes to serialized forms

### DIFF
--- a/dummy/src/lib.rs
+++ b/dummy/src/lib.rs
@@ -1,1 +1,3 @@
-
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 fn main() {
     // Setup cfg aliases
     cfg_aliases::cfg_aliases! {

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -79,6 +79,11 @@ impl ComputePass {
     pub fn parent_id(&self) -> id::CommandEncoderId {
         self.parent_id
     }
+
+    #[cfg(feature = "trace")]
+    pub fn into_command(self) -> crate::device::trace::Command {
+        crate::device::trace::Command::RunComputePass { base: self.base }
+    }
 }
 
 impl fmt::Debug for ComputePass {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -163,6 +163,15 @@ impl RenderPass {
     pub fn parent_id(&self) -> id::CommandEncoderId {
         self.parent_id
     }
+
+    #[cfg(feature = "trace")]
+    pub fn into_command(self) -> crate::device::trace::Command {
+        crate::device::trace::Command::RunRenderPass {
+            base: self.base,
+            target_colors: self.color_targets.into_iter().collect(),
+            target_depth_stencil: self.depth_stencil_target,
+        }
+    }
 }
 
 impl fmt::Debug for RenderPass {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -13,7 +13,8 @@ use std::borrow::{Borrow, Cow};
 use thiserror::Error;
 use wgt::{BufferAddress, IndexFormat, InputStepMode};
 
-#[repr(C)]
+// Unable to serialize with `naga::Module` in here:
+// requires naga serialization feature.
 #[derive(Debug)]
 pub enum ShaderModuleSource<'a> {
     SpirV(Cow<'a, [u32]>),

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -6,7 +6,7 @@
 // However when building from both the wgpu crate or this crate cargo doc will claim all the links cannot be resolved
 // despite the fact that it works fine when it needs to.
 // So we just disable those warnings.
-#![allow(intra_doc_link_resolution_failure)]
+#![allow(broken_intra_doc_links)]
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1252,6 +1252,8 @@ impl<L> BufferDescriptor<L> {
 
 /// Describes a [`CommandEncoder`].
 #[repr(C)]
+#[cfg_attr(feature = "trace", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CommandEncoderDescriptor<L> {
     /// Debug label for the command encoder. This will show up in graphics debuggers for easy identification.


### PR DESCRIPTION
**Connections**
Stuff I needed to fix in the upcoming Gecko WebGPU update.

**Description**
It allows us to use the tracing `Command` more aggressively.

**Testing**
Tested in Gecko, doesn't need testing in wgpu