### PR TITLE
Enable the non-fill polygon mode feature if requested

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -716,6 +716,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 desc.features
                     .contains(wgt::Features::MULTI_DRAW_INDIRECT_COUNT),
             );
+            enabled_features.set(
+                hal::Features::NON_FILL_POLYGON_MODE,
+                desc.features
+                    .contains(wgt::Features::NON_FILL_POLYGON_MODE),
+            );
 
             let family = adapter
                 .raw

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -718,8 +718,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             );
             enabled_features.set(
                 hal::Features::NON_FILL_POLYGON_MODE,
-                desc.features
-                    .contains(wgt::Features::NON_FILL_POLYGON_MODE),
+                desc.features.contains(wgt::Features::NON_FILL_POLYGON_MODE),
             );
 
             let family = adapter


### PR DESCRIPTION
**Connections**
Follow up to #921

**Description**
Seeing the validation error on the cube example:
>VALIDATION [VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01413 (-212053721)] : Validation Error: [ VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01413 ] Object 0: handle = 0x55872ea38860, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xf35c5127 | vkCreateGraphicsPipelines parameter, VkPolygonMode pCreateInfos[0]->pRasterizationState->polygonMode cannot be VK_POLYGON_MODE_POINT or VK_POLYGON_MODE_LINE if VkPhysicalDeviceFeatures->fillModeNonSolid is false. The Vulkan spec states: If the non-solid fill modes feature is not enabled, polygonMode must be VK_POLYGON_MODE_FILL (https://www.khronos.org/registry/vulkan/specs/1.2-khr-extensions/html/vkspec.html#VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01413)
o

**Testing**
Untested