### PR TITLE
Rename output attachment usage

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1589,7 +1589,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         for ot in output_attachments {
             let texture = &texture_guard[ot.texture_id.value];
-            check_texture_usage(texture.usage, TextureUsage::OUTPUT_ATTACHMENT)?;
+            check_texture_usage(texture.usage, TextureUsage::RENDER_ATTACHMENT)?;
 
             // the tracker set of the pass is always in "extend" mode
             trackers

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -68,7 +68,7 @@ pub fn map_texture_usage(
     if usage.contains(W::STORAGE) {
         value |= U::STORAGE;
     }
-    if usage.contains(W::OUTPUT_ATTACHMENT) {
+    if usage.contains(W::RENDER_ATTACHMENT) {
         if aspects.intersects(hal::format::Aspects::DEPTH | hal::format::Aspects::STENCIL) {
             value |= U::DEPTH_STENCIL_ATTACHMENT;
         } else {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1315,8 +1315,8 @@ bitflags::bitflags! {
         const SAMPLED = 4;
         /// Allows a texture to be a [`BindingType::StorageTexture`] in a bind group.
         const STORAGE = 8;
-        /// Allows a texture to be a output attachment of a renderpass.
-        const OUTPUT_ATTACHMENT = 16;
+        /// Allows a texture to be an output attachment of a renderpass.
+        const RENDER_ATTACHMENT = 16;
     }
 }
 
@@ -1326,7 +1326,7 @@ bitflags::bitflags! {
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct SwapChainDescriptor {
-    /// The usage of the swap chain. The only supported usage is OUTPUT_ATTACHMENT
+    /// The usage of the swap chain. The only supported usage is `RENDER_ATTACHMENT`.
     pub usage: TextureUsage,
     /// The texture format of the swap chain. The only formats that are guaranteed are
     /// `Bgra8Unorm` and `Bgra8UnormSrgb`


### PR DESCRIPTION
**Connections**
Implements #1001 

**Description**
Rename OUTPUT_ATTACHMENT texture usage to RENDER_ATTACHMENT to match the WebGPU spec

**Testing**
Ensure that `wgpu-rs` and `wgpu-native` build after the rename

**TODO**
- [ ] Update `wgpu-rs`
- [ ] Update `wgpu-native`