### PR TITLE
Match upstream API changes for IndexFormat

### DIFF
--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -86,7 +86,7 @@
             ],
             depth_stencil_state: None,
             vertex_state: (
-                index_format: Uint16,
+                index_format: None,
                 vertex_buffers: [],
             ),
             sample_count: 1,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -41,6 +41,8 @@ pub enum DrawError {
     },
     #[error("index {last_index} extends beyond limit {index_limit}")]
     IndexBeyondLimit { last_index: u32, index_limit: u32 },
+    #[error("pipeline index format and buffer index format do not match")]
+    UnmatchedIndexFormats,
 }
 
 /// Error encountered when encoding a render command.
@@ -112,6 +114,7 @@ pub enum RenderCommand {
     SetPipeline(id::RenderPipelineId),
     SetIndexBuffer {
         buffer_id: id::BufferId,
+        index_format: wgt::IndexFormat,
         offset: BufferAddress,
         size: Option<BufferSize>,
     },

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -151,7 +151,7 @@ pub struct VertexBufferDescriptor<'a> {
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub struct VertexStateDescriptor<'a> {
     /// The format of any index buffers used with this pipeline.
-    pub index_format: IndexFormat,
+    pub index_format: Option<IndexFormat>,
     /// The format of any vertex buffers used with this pipeline.
     pub vertex_buffers: Cow<'a, [VertexBufferDescriptor<'a>]>,
 }
@@ -240,7 +240,7 @@ pub struct RenderPipeline<B: hal::Backend> {
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) pass_context: RenderPassContext,
     pub(crate) flags: PipelineFlags,
-    pub(crate) index_format: IndexFormat,
+    pub(crate) index_format: Option<IndexFormat>,
     pub(crate) vertex_strides: Vec<(BufferAddress, InputStepMode)>,
     pub(crate) life_guard: LifeGuard,
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -963,8 +963,7 @@ impl DepthStencilStateDescriptor {
 /// Format of indices used with pipeline.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "trace", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum IndexFormat {
     /// Indices are 16 bit unsigned integers.
     Uint16 = 0,


### PR DESCRIPTION
**Connections**
#978 

**Description**
Match upstream API changes for IndexFormat.

- `index_format` from `VertexStateDescriptor` is now a `Option`
- `RenderCommand::SetIndexBuffer` now has a `index_format` attribute
- The index format for execution is now set when matched both `RenderCommand::SetPipeline` and `RenderCommand::SetIndexBuffer`.

**Testing**
Tested with the examples of https://github.com/kejor/wgpu-rs/commit/e5f82a21972842806774629534ab97051043489d

---

Should I implement this?https://github.com/gpuweb/gpuweb/blob/0855ad9b97d4fa6a8cb4d51740675a21044f099c/spec/index.bs#L3703