### PR TITLE
Stop using Borrow<RefCount>

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -4,10 +4,11 @@
 
 use crate::{
     device::{DeviceError, SHADER_STAGE_COUNT},
+    hub::Resource,
     id::{BindGroupLayoutId, BufferId, DeviceId, SamplerId, TextureViewId, Valid},
     track::{TrackerSet, DUMMY_SELECTOR},
     validation::{MissingBufferUsageError, MissingTextureUsageError},
-    FastHashMap, Label, LifeGuard, MultiRefCount, RefCount, Stored, MAX_BIND_GROUPS,
+    FastHashMap, Label, LifeGuard, MultiRefCount, Stored, MAX_BIND_GROUPS,
 };
 
 use arrayvec::ArrayVec;
@@ -320,7 +321,7 @@ pub struct BindGroupLayout<B: hal::Backend> {
     pub(crate) label: String,
 }
 
-impl<B: hal::Backend> crate::hub::Resource for BindGroupLayout<B> {
+impl<B: hal::Backend> Resource for BindGroupLayout<B> {
     const TYPE: &'static str = "BindGroupLayout";
 
     fn life_guard(&self) -> &LifeGuard {
@@ -505,7 +506,7 @@ impl<B: hal::Backend> PipelineLayout<B> {
     }
 }
 
-impl<B: hal::Backend> crate::hub::Resource for PipelineLayout<B> {
+impl<B: hal::Backend> Resource for PipelineLayout<B> {
     const TYPE: &'static str = "PipelineLayout";
 
     fn life_guard(&self) -> &LifeGuard {
@@ -598,19 +599,13 @@ impl<B: hal::Backend> BindGroup<B> {
     }
 }
 
-impl<B: hal::Backend> Borrow<RefCount> for BindGroup<B> {
-    fn borrow(&self) -> &RefCount {
-        self.life_guard.ref_count.as_ref().unwrap()
-    }
-}
-
 impl<B: hal::Backend> Borrow<()> for BindGroup<B> {
     fn borrow(&self) -> &() {
         &DUMMY_SELECTOR
     }
 }
 
-impl<B: hal::Backend> crate::hub::Resource for BindGroup<B> {
+impl<B: hal::Backend> Resource for BindGroup<B> {
     const TYPE: &'static str = "BindGroup";
 
     fn life_guard(&self) -> &LifeGuard {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -46,21 +46,16 @@ use crate::{
     device::{
         AttachmentData, DeviceError, RenderPassContext, MAX_VERTEX_BUFFERS, SHADER_STAGE_COUNT,
     },
-    hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Input, Storage, Token},
+    hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Input, Resource, Storage, Token},
     id,
     resource::BufferUse,
     span,
     track::{TrackerSet, UsageConflict},
     validation::check_buffer_usage,
-    Label, LabelHelpers, LifeGuard, RefCount, Stored, MAX_BIND_GROUPS,
+    Label, LabelHelpers, LifeGuard, Stored, MAX_BIND_GROUPS,
 };
 use arrayvec::ArrayVec;
-use std::{
-    borrow::{Borrow, Cow},
-    iter,
-    marker::PhantomData,
-    ops::Range,
-};
+use std::{borrow::Cow, iter, marker::PhantomData, ops::Range};
 use thiserror::Error;
 
 /// Describes a [`RenderBundleEncoder`].
@@ -348,13 +343,7 @@ impl RenderBundle {
     }
 }
 
-impl Borrow<RefCount> for RenderBundle {
-    fn borrow(&self) -> &RefCount {
-        self.life_guard.ref_count.as_ref().unwrap()
-    }
-}
-
-impl crate::hub::Resource for RenderBundle {
+impl Resource for RenderBundle {
     const TYPE: &'static str = "RenderBundle";
 
     fn life_guard(&self) -> &LifeGuard {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -5,11 +5,12 @@
 use crate::{
     binding_model::{CreateBindGroupLayoutError, CreatePipelineLayoutError},
     device::{DeviceError, RenderPassContext},
+    hub::Resource,
     id::{DeviceId, PipelineLayoutId, ShaderModuleId},
     validation::StageError,
-    Label, LifeGuard, RefCount, Stored,
+    Label, LifeGuard, Stored,
 };
-use std::borrow::{Borrow, Cow};
+use std::borrow::Cow;
 use thiserror::Error;
 use wgt::{BufferAddress, IndexFormat, InputStepMode};
 
@@ -29,7 +30,7 @@ pub struct ShaderModule<B: hal::Backend> {
     pub(crate) module: Option<naga::Module>,
 }
 
-impl<B: hal::Backend> crate::hub::Resource for ShaderModule<B> {
+impl<B: hal::Backend> Resource for ShaderModule<B> {
     const TYPE: &'static str = "ShaderModule";
 
     fn life_guard(&self) -> &LifeGuard {
@@ -108,13 +109,7 @@ pub struct ComputePipeline<B: hal::Backend> {
     pub(crate) life_guard: LifeGuard,
 }
 
-impl<B: hal::Backend> Borrow<RefCount> for ComputePipeline<B> {
-    fn borrow(&self) -> &RefCount {
-        self.life_guard.ref_count.as_ref().unwrap()
-    }
-}
-
-impl<B: hal::Backend> crate::hub::Resource for ComputePipeline<B> {
+impl<B: hal::Backend> Resource for ComputePipeline<B> {
     const TYPE: &'static str = "ComputePipeline";
 
     fn life_guard(&self) -> &LifeGuard {
@@ -233,13 +228,7 @@ pub struct RenderPipeline<B: hal::Backend> {
     pub(crate) life_guard: LifeGuard,
 }
 
-impl<B: hal::Backend> Borrow<RefCount> for RenderPipeline<B> {
-    fn borrow(&self) -> &RefCount {
-        self.life_guard.ref_count.as_ref().unwrap()
-    }
-}
-
-impl<B: hal::Backend> crate::hub::Resource for RenderPipeline<B> {
+impl<B: hal::Backend> Resource for RenderPipeline<B> {
     const TYPE: &'static str = "RenderPipeline";
 
     fn life_guard(&self) -> &LifeGuard {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    device::{alloc::MemoryBlock, DeviceError},
+    device::{alloc::MemoryBlock, DeviceError, HostMap},
+    hub::Resource,
     id::{DeviceId, SwapChainId, TextureId},
     track::{TextureSelector, DUMMY_SELECTOR},
     validation::MissingBufferUsageError,
@@ -93,7 +94,7 @@ pub(crate) enum BufferMapState<B: hal::Backend> {
     Active {
         ptr: NonNull<u8>,
         sub_range: hal::buffer::SubRange,
-        host: crate::device::HostMap,
+        host: HostMap,
     },
     /// Not mapped
     Idle,
@@ -107,7 +108,7 @@ pub type BufferMapCallback = unsafe extern "C" fn(status: BufferMapAsyncStatus, 
 #[repr(C)]
 #[derive(Debug)]
 pub struct BufferMapOperation {
-    pub host: crate::device::HostMap,
+    pub host: HostMap,
     pub callback: BufferMapCallback,
     pub user_data: *mut u8,
 }
@@ -177,13 +178,7 @@ pub enum CreateBufferError {
     UsageMismatch(wgt::BufferUsage),
 }
 
-impl<B: hal::Backend> Borrow<RefCount> for Buffer<B> {
-    fn borrow(&self) -> &RefCount {
-        self.life_guard.ref_count.as_ref().unwrap()
-    }
-}
-
-impl<B: hal::Backend> crate::hub::Resource for Buffer<B> {
+impl<B: hal::Backend> Resource for Buffer<B> {
     const TYPE: &'static str = "Buffer";
 
     fn life_guard(&self) -> &LifeGuard {
@@ -243,13 +238,7 @@ pub enum CreateTextureError {
     MissingFeature(wgt::Features, wgt::TextureFormat),
 }
 
-impl<B: hal::Backend> Borrow<RefCount> for Texture<B> {
-    fn borrow(&self) -> &RefCount {
-        self.life_guard.ref_count.as_ref().unwrap()
-    }
-}
-
-impl<B: hal::Backend> crate::hub::Resource for Texture<B> {
+impl<B: hal::Backend> Resource for Texture<B> {
     const TYPE: &'static str = "Texture";
 
     fn life_guard(&self) -> &LifeGuard {
@@ -355,13 +344,7 @@ pub enum TextureViewDestroyError {
     SwapChainImage,
 }
 
-impl<B: hal::Backend> Borrow<RefCount> for TextureView<B> {
-    fn borrow(&self) -> &RefCount {
-        self.life_guard.ref_count.as_ref().unwrap()
-    }
-}
-
-impl<B: hal::Backend> crate::hub::Resource for TextureView<B> {
+impl<B: hal::Backend> Resource for TextureView<B> {
     const TYPE: &'static str = "TextureView";
 
     fn life_guard(&self) -> &LifeGuard {
@@ -441,13 +424,7 @@ pub enum CreateSamplerError {
     MissingFeature(wgt::Features),
 }
 
-impl<B: hal::Backend> Borrow<RefCount> for Sampler<B> {
-    fn borrow(&self) -> &RefCount {
-        self.life_guard.ref_count.as_ref().unwrap()
-    }
-}
-
-impl<B: hal::Backend> crate::hub::Resource for Sampler<B> {
+impl<B: hal::Backend> Resource for Sampler<B> {
     const TYPE: &'static str = "Sampler";
 
     fn life_guard(&self) -> &LifeGuard {


### PR DESCRIPTION
**Connections**
Follow-up to #931

**Description**
Takes advantage of the new `trait Resource` in the state tracker, reducing the code.

**Testing**
Not tested outside of `cargo test`