### PR TITLE
Make VertexFormat::size a const fn

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1165,7 +1165,7 @@ pub enum VertexFormat {
 }
 
 impl VertexFormat {
-    pub fn size(&self) -> u64 {
+    pub const fn size(&self) -> u64 {
         match self {
             Self::Uchar2 | Self::Char2 | Self::Uchar2Norm | Self::Char2Norm => 2,
             Self::Uchar4


### PR DESCRIPTION
**Connections**
Addresses #836 

**Description**
The `vertex_attr_array!` macro uses this function. This change enables the macro to be used in `const` contexts and for instance allows returning a `VertexBufferDescriptor` constructed in function without having the difficulties of ensuring the array from `vertex_attr_array!` lives long enough.

**Testing**
I don't believe testing is needed for this.
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
