### PR TITLE
player: use the wgpu-cores's gfx-select macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "gpu-alloc"
 version = "0.2.1"
-source = "git+https://github.com/zakarumych/gpu-alloc?rev=b807b5fb41dc1a102d5ed5f8506265192c7a1c5e#b807b5fb41dc1a102d5ed5f8506265192c7a1c5e"
+source = "git+https://github.com/zakarumych/gpu-alloc?rev=d07be73f9439a37c89f5b72f2500cbf0eb4ff613#d07be73f9439a37c89f5b72f2500cbf0eb4ff613"
 dependencies = [
  "bitflags",
  "gpu-alloc-types",
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "gpu-alloc-types"
 version = "0.1.0"
-source = "git+https://github.com/zakarumych/gpu-alloc?rev=b807b5fb41dc1a102d5ed5f8506265192c7a1c5e#b807b5fb41dc1a102d5ed5f8506265192c7a1c5e"
+source = "git+https://github.com/zakarumych/gpu-alloc?rev=d07be73f9439a37c89f5b72f2500cbf0eb4ff613#d07be73f9439a37c89f5b72f2500cbf0eb4ff613"
 dependencies = [
  "bitflags",
 ]

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -5,8 +5,8 @@
 /*! This is a player for WebGPU traces.
 !*/
 
-use player::{gfx_select, GlobalPlay as _, IdentityPassThroughFactory};
-use wgc::device::trace;
+use player::{GlobalPlay as _, IdentityPassThroughFactory};
+use wgc::{device::trace, gfx_select};
 
 use std::{
     fs,
@@ -55,8 +55,11 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    let global =
-        wgc::hub::Global::new("player", IdentityPassThroughFactory, wgt::BackendBit::all());
+    let global = wgc::hub::Global::new(
+        "player",
+        IdentityPassThroughFactory,
+        wgt::BackendBit::PRIMARY,
+    );
     let mut command_buffer_id_manager = wgc::hub::IdentityManager::default();
 
     #[cfg(feature = "winit")]
@@ -84,7 +87,7 @@ fn main() {
 
             let info = gfx_select!(adapter => global.adapter_get_info(adapter)).unwrap();
             log::info!("Picked '{}'", info.name);
-            let id = wgc::id::TypedId::zip(1, 0, wgt::Backend::Empty);
+            let id = wgc::id::TypedId::zip(1, 0, backend);
             let (_, error) = gfx_select!(adapter => global.adapter_request_device(
                 adapter,
                 &desc,

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -14,23 +14,6 @@ use wgc::device::trace;
 
 use std::{borrow::Cow, fmt::Debug, fs, marker::PhantomData, path::Path};
 
-#[macro_export]
-macro_rules! gfx_select {
-    ($id:expr => $global:ident.$method:ident( $($param:expr),+ )) => {
-        match $id.backend() {
-            #[cfg(not(any(target_os = "ios", target_os = "macos")))]
-            wgt::Backend::Vulkan => $global.$method::<wgc::backend::Vulkan>( $($param),+ ),
-            #[cfg(any(target_os = "ios", target_os = "macos"))]
-            wgt::Backend::Metal => $global.$method::<wgc::backend::Metal>( $($param),+ ),
-            #[cfg(windows)]
-            wgt::Backend::Dx12 => $global.$method::<wgc::backend::Dx12>( $($param),+ ),
-            #[cfg(windows)]
-            wgt::Backend::Dx11 => $global.$method::<wgc::backend::Dx11>( $($param),+ ),
-            _ => unreachable!()
-        }
-    };
-}
-
 #[derive(Debug)]
 pub struct IdentityPassThrough<I>(PhantomData<I>);
 

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -13,7 +13,7 @@
  *    - no swapchain use
 !*/
 
-use player::{gfx_select, GlobalPlay, IdentityPassThroughFactory};
+use player::{GlobalPlay, IdentityPassThroughFactory};
 use std::{
     fs::{read_to_string, File},
     io::{Read, Seek, SeekFrom},
@@ -87,7 +87,7 @@ impl Test<'_> {
     ) {
         let backend = adapter.backend();
         let device = wgc::id::TypedId::zip(test_num, 0, backend);
-        let (_, error) = gfx_select!(adapter => global.adapter_request_device(
+        let (_, error) = wgc::gfx_select!(adapter => global.adapter_request_device(
             adapter,
             &wgt::DeviceDescriptor {
                 label: None,
@@ -105,12 +105,12 @@ impl Test<'_> {
         let mut command_buffer_id_manager = wgc::hub::IdentityManager::default();
         println!("\t\t\tRunning...");
         for action in self.actions {
-            gfx_select!(device => global.process(device, action, dir, &mut command_buffer_id_manager));
+            wgc::gfx_select!(device => global.process(device, action, dir, &mut command_buffer_id_manager));
         }
         println!("\t\t\tMapping...");
         for expect in &self.expectations {
             let buffer = wgc::id::TypedId::zip(expect.buffer.index, expect.buffer.epoch, backend);
-            gfx_select!(device => global.buffer_map_async(
+            wgc::gfx_select!(device => global.buffer_map_async(
                 buffer,
                 expect.offset .. expect.offset+expect.data.len() as wgt::BufferAddress,
                 wgc::resource::BufferMapOperation {
@@ -123,13 +123,13 @@ impl Test<'_> {
         }
 
         println!("\t\t\tWaiting...");
-        gfx_select!(device => global.device_poll(device, true)).unwrap();
+        wgc::gfx_select!(device => global.device_poll(device, true)).unwrap();
 
         for expect in self.expectations {
             println!("\t\t\tChecking {}", expect.name);
             let buffer = wgc::id::TypedId::zip(expect.buffer.index, expect.buffer.epoch, backend);
             let ptr =
-                gfx_select!(device => global.buffer_get_mapped_range(buffer, expect.offset, None))
+                wgc::gfx_select!(device => global.buffer_get_mapped_range(buffer, expect.offset, None))
                     .unwrap();
             let contents = unsafe { slice::from_raw_parts(ptr, expect.data.len()) };
             let expected_data = match expect.data {
@@ -147,7 +147,7 @@ impl Test<'_> {
             assert_eq!(&expected_data[..], contents);
         }
 
-        gfx_select!(device => global.clear_backend(()));
+        wgc::gfx_select!(device => global.clear_backend(()));
     }
 }
 
@@ -192,7 +192,7 @@ impl Corpus {
 
             println!("\tBackend {:?}", backend);
             let supported_features =
-                gfx_select!(adapter => global.adapter_features(adapter)).unwrap();
+                wgc::gfx_select!(adapter => global.adapter_features(adapter)).unwrap();
             let mut test_num = 0;
             for test_path in &corpus.tests {
                 println!("\t\tTest '{:?}'", test_path);

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -241,7 +241,7 @@ macro_rules! gfx_select {
             wgt::Backend::Dx11 => $global.$method::<$crate::backend::Dx11>( $($param),* ),
             #[cfg(all(unix, not(target_os = "ios")))]
             wgt::Backend::Gl => $global.$method::<$crate::backend::Gl>( $($param),+ ),
-            _ => unreachable!()
+            other => panic!("Unexpected backend {:?}", other),
         }
     };
 }


### PR DESCRIPTION
**Connections**
Looks like I broke the player in #1034, surprised we didn't notice, and that `cargo test` still passed. The problem was having the `Empty` backend for the device.

**Description**
Fixes the `device` backend in the player, switches the backend set to be `PRIMARY`, and re-uses the `wgc::gfx-select`.

**Testing**
Replaying a trace from #1049