### PR TITLE
Register init-destination buffer in the pending writes

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3965,6 +3965,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 device
                     .pending_writes
                     .consume_temp(queue::TempResource::Buffer(stage_buffer), stage_memory);
+                device.pending_writes.dst_buffers.insert(buffer_id);
             }
             resource::BufferMapState::Idle => {
                 return Err(resource::BufferAccessError::NotMapped);


### PR DESCRIPTION
**Connections**
Fixes #1049

**Description**
At some recent point we introduced the map of destination buffers for copies, and I missed the case where buffers are mapped at creation.

**Testing**
Tested on the test-case in #1049