### PR TITLE
Flush write_texture staging memory

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -401,6 +401,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             }
         }
         stage.memory.unmap(&device.raw);
+        if !stage.memory.is_coherent() {
+            stage.memory.flush_range(&device.raw, 0, None)?;
+        }
 
         let region = hal::command::BufferImageCopy {
             buffer_offset: 0,


### PR DESCRIPTION
**Connections**
Fixes part of https://github.com/gfx-rs/wgpu-rs/issues/648

**Description**
Adds the missing flush to the staging buffer in `write_texture`

**Testing**
Untested