### PR TITLE
Disable gfx-backend-gl on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
+checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -48,7 +48,7 @@ path = "../wgpu-types"
 package = "wgpu-types"
 version = "0.6"
 
-[target.'cfg(all(unix, not(target_os = "ios")))'.dependencies]
+[target.'cfg(all(unix, not(any(target_os = "ios", target_os = "macos"))))'.dependencies]
 gfx-backend-gl = { version = "0.6" }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -15,6 +15,6 @@ fn main() {
         metal: { apple },
         dx12: { windows },
         dx11: { windows },
-        gl: { all(unix, not(ios)) },
+        gl: { all(unix, not(apple)) },
     }
 }

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -239,7 +239,7 @@ macro_rules! gfx_select {
             wgt::Backend::Dx12 => $global.$method::<$crate::backend::Dx12>( $($param),* ),
             #[cfg(windows)]
             wgt::Backend::Dx11 => $global.$method::<$crate::backend::Dx11>( $($param),* ),
-            #[cfg(all(unix, not(target_os = "ios")))]
+            #[cfg(all(unix, not(any(target_os = "ios", target_os = "macos"))))]
             wgt::Backend::Gl => $global.$method::<$crate::backend::Gl>( $($param),+ ),
             other => panic!("Unexpected backend {:?}", other),
         }


### PR DESCRIPTION
Resolve the wgpu side of https://github.com/gfx-rs/wgpu-rs/issues/646
wgpu-rs will need two changes:
https://github.com/gfx-rs/wgpu-rs/blob/e59ea495a66ce9606c3a2bbfc2efe8c0c05d413c/Cargo.toml#L53
https://github.com/gfx-rs/wgpu-rs/blob/e59ea495a66ce9606c3a2bbfc2efe8c0c05d413c/src/backend/direct.rs#L69