### PR TITLE
Fix Display for pass errors

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -500,7 +500,6 @@ impl RenderBundle {
         use hal::command::CommandBuffer as _;
 
         let mut offsets = self.base.dynamic_offsets.as_slice();
-        let mut index_type = hal::IndexType::U16;
         let mut pipeline_layout_id = None::<id::Valid<id::PipelineLayoutId>>;
 
         for command in self.base.commands.iter() {
@@ -531,7 +530,7 @@ impl RenderBundle {
                     offset,
                     size,
                 } => {
-                    index_type = conv::map_index_format(index_format);
+                    let index_type = conv::map_index_format(index_format);
 
                     let &(ref buffer, _) = buffer_guard
                         .get(buffer_id)

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1007,7 +1007,7 @@ where
 
 /// Error encountered when finishing recording a render bundle.
 #[derive(Clone, Debug, Error)]
-#[error("{scope}")]
+#[error("Render bundle error {scope}: {inner}")]
 pub struct RenderBundleError {
     pub scope: PassErrorScope,
     #[source]

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -146,7 +146,7 @@ pub enum ComputePassErrorInner {
 
 /// Error encountered when performing a compute pass.
 #[derive(Clone, Debug, Error)]
-#[error("{scope}")]
+#[error("Compute pass error {scope}: {inner}")]
 pub struct ComputePassError {
     pub scope: PassErrorScope,
     #[source]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -400,7 +400,7 @@ impl From<MissingTextureUsageError> for RenderPassErrorInner {
 
 /// Error encountered when performing a render pass.
 #[derive(Clone, Debug, Error)]
-#[error("{scope}")]
+#[error("Render pass error {scope}: {inner}")]
 pub struct RenderPassError {
     pub scope: PassErrorScope,
     #[source]


### PR DESCRIPTION
**Connections**
Currently printing an error only outputs the scope.

**Description**
This PR makes it print the whole error.

**Testing**
Untested