### PR TITLE
Add pervasive Naga support to shader module loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "gfx-auxil"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=1d14789011cb892f4c1a205d3f8a87d479c2e354#1d14789011cb892f4c1a205d3f8a87d479c2e354"
+source = "git+https://github.com/gfx-rs/gfx?rev=654ad48ee39ce2a341407ae2857ddf4db639ea54#654ad48ee39ce2a341407ae2857ddf4db639ea54"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx11"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=1d14789011cb892f4c1a205d3f8a87d479c2e354#1d14789011cb892f4c1a205d3f8a87d479c2e354"
+source = "git+https://github.com/gfx-rs/gfx?rev=654ad48ee39ce2a341407ae2857ddf4db639ea54#654ad48ee39ce2a341407ae2857ddf4db639ea54"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.6.2"
-source = "git+https://github.com/gfx-rs/gfx?rev=1d14789011cb892f4c1a205d3f8a87d479c2e354#1d14789011cb892f4c1a205d3f8a87d479c2e354"
+source = "git+https://github.com/gfx-rs/gfx?rev=654ad48ee39ce2a341407ae2857ddf4db639ea54#654ad48ee39ce2a341407ae2857ddf4db639ea54"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -492,7 +492,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-empty"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=1d14789011cb892f4c1a205d3f8a87d479c2e354#1d14789011cb892f4c1a205d3f8a87d479c2e354"
+source = "git+https://github.com/gfx-rs/gfx?rev=654ad48ee39ce2a341407ae2857ddf4db639ea54#654ad48ee39ce2a341407ae2857ddf4db639ea54"
 dependencies = [
  "gfx-hal",
  "log",
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-gl"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=1d14789011cb892f4c1a205d3f8a87d479c2e354#1d14789011cb892f4c1a205d3f8a87d479c2e354"
+source = "git+https://github.com/gfx-rs/gfx?rev=654ad48ee39ce2a341407ae2857ddf4db639ea54#654ad48ee39ce2a341407ae2857ddf4db639ea54"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-metal"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=1d14789011cb892f4c1a205d3f8a87d479c2e354#1d14789011cb892f4c1a205d3f8a87d479c2e354"
+source = "git+https://github.com/gfx-rs/gfx?rev=654ad48ee39ce2a341407ae2857ddf4db639ea54#654ad48ee39ce2a341407ae2857ddf4db639ea54"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -537,6 +537,7 @@ dependencies = [
  "lazy_static",
  "log",
  "metal",
+ "naga",
  "objc",
  "parking_lot 0.11.0",
  "range-alloc",
@@ -548,7 +549,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.6.5"
-source = "git+https://github.com/gfx-rs/gfx?rev=1d14789011cb892f4c1a205d3f8a87d479c2e354#1d14789011cb892f4c1a205d3f8a87d479c2e354"
+source = "git+https://github.com/gfx-rs/gfx?rev=654ad48ee39ce2a341407ae2857ddf4db639ea54#654ad48ee39ce2a341407ae2857ddf4db639ea54"
 dependencies = [
  "arrayvec",
  "ash",
@@ -567,10 +568,12 @@ dependencies = [
 [[package]]
 name = "gfx-hal"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=1d14789011cb892f4c1a205d3f8a87d479c2e354#1d14789011cb892f4c1a205d3f8a87d479c2e354"
+source = "git+https://github.com/gfx-rs/gfx?rev=654ad48ee39ce2a341407ae2857ddf4db639ea54#654ad48ee39ce2a341407ae2857ddf4db639ea54"
 dependencies = [
  "bitflags",
+ "naga",
  "raw-window-handle",
+ "thiserror",
 ]
 
 [[package]]
@@ -605,7 +608,7 @@ dependencies = [
 [[package]]
 name = "gpu-descriptor"
 version = "0.1.0"
-source = "git+https://github.com/zakarumych/gpu-descriptor?rev=831460c4b5120d9a74744d542f39a95b9816b5ab#831460c4b5120d9a74744d542f39a95b9816b5ab"
+source = "git+https://github.com/zakarumych/gpu-descriptor?rev=df74fd8c7bea03149058a41aab0e4fe04077b266#df74fd8c7bea03149058a41aab0e4fe04077b266"
 dependencies = [
  "bitflags",
  "gpu-descriptor-types",
@@ -615,7 +618,7 @@ dependencies = [
 [[package]]
 name = "gpu-descriptor-types"
 version = "0.1.0"
-source = "git+https://github.com/zakarumych/gpu-descriptor?rev=831460c4b5120d9a74744d542f39a95b9816b5ab#831460c4b5120d9a74744d542f39a95b9816b5ab"
+source = "git+https://github.com/zakarumych/gpu-descriptor?rev=df74fd8c7bea03149058a41aab0e4fe04077b266#df74fd8c7bea03149058a41aab0e4fe04077b266"
 dependencies = [
  "bitflags",
 ]
@@ -830,7 +833,7 @@ version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
- "libc 0.2.80",
+ "libc 0.1.12",
 ]
 
 [[package]]
@@ -924,13 +927,14 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.2.0"
-source = "git+https://github.com/gfx-rs/naga?rev=96c80738650822de35f77ab6a589f309460c8f39#96c80738650822de35f77ab6a589f309460c8f39"
+source = "git+https://github.com/gfx-rs/naga?tag=gfx-2#0d81b1f78c763a2f564194ec108bcb8ead10ea2e"
 dependencies = [
  "bitflags",
  "fxhash",
  "log",
  "num-traits",
  "petgraph",
+ "serde",
  "spirv_headers",
  "thiserror",
 ]
@@ -1213,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "range-alloc"
 version = "0.1.1"
-source = "git+https://github.com/gfx-rs/gfx?rev=1d14789011cb892f4c1a205d3f8a87d479c2e354#1d14789011cb892f4c1a205d3f8a87d479c2e354"
+source = "git+https://github.com/gfx-rs/gfx?rev=654ad48ee39ce2a341407ae2857ddf4db639ea54#654ad48ee39ce2a341407ae2857ddf4db639ea54"
 
 [[package]]
 name = "raw-window-handle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,15 @@ members = [
     "wgpu-core",
     "wgpu-types",
 ]
+
+#[patch."https://github.com/gfx-rs/gfx"]
+#hal = { package = "gfx-hal", path = "../gfx/src/hal" }
+#gfx-backend-vulkan = { path = "../gfx/src/backend/vulkan" }
+#gfx-backend-metal = { path = "../gfx/src/backend/metal", features = ["naga"] }
+#gfx-backend-gl = { path = "../gfx/src/backend/gl" }
+#gfx-backend-dx12 = { path = "../gfx/src/backend/dx12" }
+#gfx-backend-dx11 = { path = "../gfx/src/backend/dx11" }
+#gfx-backend-empty = { path = "../gfx/src/backend/empty" }
+
+#[patch."https://github.com/gfx-rs/naga"]
+#naga = { path = "../naga" }

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -213,5 +213,12 @@ impl Corpus {
 
 #[test]
 fn test_api() {
+    wgpu_subscriber::initialize_default_subscriber(
+        std::env::var("WGPU_CHROME_TRACE")
+            .as_ref()
+            .map(Path::new)
+            .ok(),
+    );
+
     Corpus::run_from(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/all.ron"))
 }

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -14,9 +14,9 @@ license = "MPL-2.0"
 [features]
 default = []
 # Enable API tracing
-trace = ["ron", "serde", "wgt/trace"]
+trace = ["ron", "serde", "wgt/trace", "naga/serialize"]
 # Enable API replaying
-replay = ["serde", "wgt/replay"]
+replay = ["serde", "wgt/replay", "naga/deserialize"]
 # Enable serializable compute/render passes, and bundle encoders.
 serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
 
@@ -25,8 +25,6 @@ arrayvec = "0.5"
 bitflags = "1.0"
 copyless = "0.1"
 fxhash = "0.2"
-hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "1d14789011cb892f4c1a205d3f8a87d479c2e354" }
-gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "1d14789011cb892f4c1a205d3f8a87d479c2e354" }
 parking_lot = "0.11"
 raw-window-handle = { version = "0.3", optional = true }
 ron = { version = "0.6", optional = true }
@@ -35,31 +33,33 @@ smallvec = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 thiserror = "1"
 gpu-alloc = { git = "https://github.com/zakarumych/gpu-alloc", rev = "d07be73f9439a37c89f5b72f2500cbf0eb4ff613" }
-gpu-descriptor = { git = "https://github.com/zakarumych/gpu-descriptor", rev = "831460c4b5120d9a74744d542f39a95b9816b5ab"}
+gpu-descriptor = { git = "https://github.com/zakarumych/gpu-descriptor", rev = "df74fd8c7bea03149058a41aab0e4fe04077b266"}
+
+hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "654ad48ee39ce2a341407ae2857ddf4db639ea54" }
+gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "654ad48ee39ce2a341407ae2857ddf4db639ea54" }
+
+[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "654ad48ee39ce2a341407ae2857ddf4db639ea54" }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "654ad48ee39ce2a341407ae2857ddf4db639ea54" }
+
+[target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
+gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "654ad48ee39ce2a341407ae2857ddf4db639ea54", features = ["naga"] }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "654ad48ee39ce2a341407ae2857ddf4db639ea54", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "654ad48ee39ce2a341407ae2857ddf4db639ea54" }
+gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "654ad48ee39ce2a341407ae2857ddf4db639ea54" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "654ad48ee39ce2a341407ae2857ddf4db639ea54" }
 
 [dependencies.naga]
-version = "0.2"
 git = "https://github.com/gfx-rs/naga"
-rev = "96c80738650822de35f77ab6a589f309460c8f39"
+tag = "gfx-2"
 features = ["spv-in", "spv-out", "wgsl-in"]
 
 [dependencies.wgt]
 path = "../wgpu-types"
 package = "wgpu-types"
 version = "0.6"
-
-[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "1d14789011cb892f4c1a205d3f8a87d479c2e354" }
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "1d14789011cb892f4c1a205d3f8a87d479c2e354" }
-
-[target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
-gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "1d14789011cb892f4c1a205d3f8a87d479c2e354" }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "1d14789011cb892f4c1a205d3f8a87d479c2e354", optional = true }
-
-[target.'cfg(windows)'.dependencies]
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "1d14789011cb892f4c1a205d3f8a87d479c2e354" }
-gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "1d14789011cb892f4c1a205d3f8a87d479c2e354" }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "1d14789011cb892f4c1a205d3f8a87d479c2e354" }
 
 [dev-dependencies]
 loom = "0.3"

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -6,9 +6,7 @@ fn main() {
     // Setup cfg aliases
     cfg_aliases::cfg_aliases! {
         // Vendors/systems
-        ios: { target_os = "ios" },
-        macos: { target_os = "macos" },
-        apple: { any(ios, macos) },
+        apple: { any(target_os = "ios", target_os = "macos") },
 
         // Backends
         vulkan: { any(windows, all(unix, not(apple)), feature = "gfx-backend-vulkan") },

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -500,7 +500,6 @@ impl RenderBundle {
         use hal::command::CommandBuffer as _;
 
         let mut offsets = self.base.dynamic_offsets.as_slice();
-        let mut index_type = hal::IndexType::U16;
         let mut pipeline_layout_id = None::<id::Valid<id::PipelineLayoutId>>;
 
         for command in self.base.commands.iter() {
@@ -531,7 +530,7 @@ impl RenderBundle {
                     offset,
                     size,
                 } => {
-                    index_type = conv::map_index_format(index_format);
+                    let index_type = conv::map_index_format(index_format);
 
                     let &(ref buffer, _) = buffer_guard
                         .get(buffer_id)

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -160,9 +160,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 None,
                 match err {
                     hal::window::AcquireError::OutOfMemory(_) => Err(DeviceError::OutOfMemory)?,
-                    hal::window::AcquireError::NotReady => unreachable!(), // we always set a timeout
-                    hal::window::AcquireError::Timeout => SwapChainStatus::Timeout,
-                    hal::window::AcquireError::OutOfDate => SwapChainStatus::Outdated,
+                    hal::window::AcquireError::NotReady { .. } => SwapChainStatus::Timeout,
+                    hal::window::AcquireError::OutOfDate(_) => SwapChainStatus::Outdated,
                     hal::window::AcquireError::SurfaceLost(_) => SwapChainStatus::Lost,
                     hal::window::AcquireError::DeviceLost(_) => Err(DeviceError::Lost)?,
                 },
@@ -283,7 +282,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 hal::window::PresentError::OutOfMemory(_) => {
                     Err(SwapChainError::Device(DeviceError::OutOfMemory))
                 }
-                hal::window::PresentError::OutOfDate => Ok(SwapChainStatus::Outdated),
+                hal::window::PresentError::OutOfDate(_) => Ok(SwapChainStatus::Outdated),
                 hal::window::PresentError::SurfaceLost(_) => Ok(SwapChainStatus::Lost),
                 hal::window::PresentError::DeviceLost(_) => {
                     Err(SwapChainError::Device(DeviceError::Lost))


### PR DESCRIPTION
**Connections**
Depends on https://github.com/gfx-rs/naga/pull/299 and https://github.com/gfx-rs/gfx/pull/3503
Closes #1072

**Description**
    The purpose of the PR is to support Naga modules everywhere.
    As a requirement, it updates the gfx-rs version used.
    Most of the logic is dedicated towards building a shader interface,
    where previously we just used naga's IR. Now we have our own mini-IR.

**Testing**
Tested in https://github.com/gfx-rs/wgpu-rs/pull/663 (without the experimental feature).
Enabling the experimental feature doesn't work even on the play test that we have - https://github.com/gfx-rs/naga/issues/300