### PR TITLE
Implement ETC2 and ASTC textures

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -233,6 +233,13 @@ pub(crate) fn validate_texture_copy_range(
     let block_height = block_height as u32;
 
     let mut extent = texture_dimension.level_extent(texture_copy_view.mip_level as u8);
+
+    // Adjust extent for the physical size of mips
+    if texture_copy_view.mip_level != 0 {
+        extent.width = conv::align_up(extent.width, block_width);
+        extent.height = conv::align_up(extent.height, block_height);
+    }
+
     match texture_dimension {
         hal::image::Kind::D1(..) => {
             if (copy_size.height, copy_size.depth) != (1, 1) {
@@ -512,6 +519,17 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             ))?
         }
 
+        // WebGPU uses the physical size of the texture for copies whereas vulkan uses
+        // the virtual size. We have passed validation, so it's safe to use the
+        // image extent data directly. We want the provided copy size to be no larger than
+        // the virtual size.
+        let max_image_extent = dst_texture.kind.level_extent(destination.mip_level as _);
+        let image_extent = Extent3d {
+            width: copy_size.width.min(max_image_extent.width),
+            height: copy_size.height.min(max_image_extent.height),
+            depth: copy_size.depth,
+        };
+
         let buffer_width = (source.layout.bytes_per_row / bytes_per_block) * block_width as u32;
         let region = hal::command::BufferImageCopy {
             buffer_offset: source.layout.offset,
@@ -519,7 +537,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             buffer_height: source.layout.rows_per_image,
             image_layers: dst_layers,
             image_offset: dst_offset,
-            image_extent: conv::map_extent(copy_size, dst_texture.dimension),
+            image_extent: conv::map_extent(&image_extent, dst_texture.dimension),
         };
         let cmb_raw = cmd_buf.raw.last_mut().unwrap();
         unsafe {
@@ -641,6 +659,17 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             ))?
         }
 
+        // WebGPU uses the physical size of the texture for copies whereas vulkan uses
+        // the virtual size. We have passed validation, so it's safe to use the
+        // image extent data directly. We want the provided copy size to be no larger than
+        // the virtual size.
+        let max_image_extent = src_texture.kind.level_extent(source.mip_level as _);
+        let image_extent = Extent3d {
+            width: copy_size.width.min(max_image_extent.width),
+            height: copy_size.height.min(max_image_extent.height),
+            depth: copy_size.depth,
+        };
+
         let buffer_width =
             (destination.layout.bytes_per_row / bytes_per_block) * block_width as u32;
         let region = hal::command::BufferImageCopy {
@@ -649,7 +678,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             buffer_height: destination.layout.rows_per_image,
             image_layers: src_layers,
             image_offset: src_offset,
-            image_extent: conv::map_extent(copy_size, src_texture.dimension),
+            image_extent: conv::map_extent(&image_extent, src_texture.dimension),
         };
         let cmb_raw = cmd_buf.raw.last_mut().unwrap();
         unsafe {
@@ -765,12 +794,28 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             copy_size,
         )?;
 
+        // WebGPU uses the physical size of the texture for copies whereas vulkan uses
+        // the virtual size. We have passed validation, so it's safe to use the
+        // image extent data directly. We want the provided copy size to be no larger than
+        // the virtual size.
+        let max_src_image_extent = src_texture.kind.level_extent(source.mip_level as _);
+        let max_dst_image_extent = dst_texture.kind.level_extent(destination.mip_level as _);
+        let image_extent = Extent3d {
+            width: copy_size
+                .width
+                .min(max_src_image_extent.width.min(max_dst_image_extent.width)),
+            height: copy_size
+                .height
+                .min(max_src_image_extent.height.min(max_dst_image_extent.height)),
+            depth: copy_size.depth,
+        };
+
         let region = hal::command::ImageCopy {
             src_subresource: src_layers,
             src_offset,
             dst_subresource: dst_layers,
             dst_offset,
-            extent: conv::map_extent(copy_size, src_texture.dimension),
+            extent: conv::map_extent(&image_extent, src_texture.dimension),
         };
         let cmb_raw = cmd_buf.raw.last_mut().unwrap();
         unsafe {

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -396,124 +396,48 @@ pub(crate) fn map_texture_format(
         Tf::Bc6hRgbUfloat => H::Bc6hUfloat,
         Tf::Bc7RgbaUnorm => H::Bc7Unorm,
         Tf::Bc7RgbaUnormSrgb => H::Bc7Srgb,
-    }
-}
 
-pub fn texture_block_size(format: wgt::TextureFormat) -> (u32, u32) {
-    use wgt::TextureFormat as Tf;
-    match format {
-        Tf::R8Unorm
-        | Tf::R8Snorm
-        | Tf::R8Uint
-        | Tf::R8Sint
-        | Tf::R16Uint
-        | Tf::R16Sint
-        | Tf::R16Float
-        | Tf::Rg8Unorm
-        | Tf::Rg8Snorm
-        | Tf::Rg8Uint
-        | Tf::Rg8Sint
-        | Tf::R32Uint
-        | Tf::R32Sint
-        | Tf::R32Float
-        | Tf::Rg16Uint
-        | Tf::Rg16Sint
-        | Tf::Rg16Float
-        | Tf::Rgba8Unorm
-        | Tf::Rgba8UnormSrgb
-        | Tf::Rgba8Snorm
-        | Tf::Rgba8Uint
-        | Tf::Rgba8Sint
-        | Tf::Bgra8Unorm
-        | Tf::Bgra8UnormSrgb
-        | Tf::Rgb10a2Unorm
-        | Tf::Rg11b10Float
-        | Tf::Rg32Uint
-        | Tf::Rg32Sint
-        | Tf::Rg32Float
-        | Tf::Rgba16Uint
-        | Tf::Rgba16Sint
-        | Tf::Rgba16Float
-        | Tf::Rgba32Uint
-        | Tf::Rgba32Sint
-        | Tf::Rgba32Float
-        | Tf::Depth32Float
-        | Tf::Depth24Plus
-        | Tf::Depth24PlusStencil8 => (1, 1),
+        // ETC compressed formats
+        Tf::Etc2RgbUnorm => H::Etc2R8g8b8Unorm,
+        Tf::Etc2RgbUnormSrgb => H::Etc2R8g8b8Srgb,
+        Tf::Etc2RgbA1Unorm => H::Etc2R8g8b8a1Unorm,
+        Tf::Etc2RgbA1UnormSrgb => H::Etc2R8g8b8a1Srgb,
+        Tf::Etc2RgbA8Unorm => H::Etc2R8g8b8a8Unorm,
+        Tf::Etc2RgbA8UnormSrgb => H::Etc2R8g8b8a8Unorm,
+        Tf::EacRUnorm => H::EacR11Unorm,
+        Tf::EacRSnorm => H::EacR11Snorm,
+        Tf::EtcRgUnorm => H::EacR11g11Unorm,
+        Tf::EtcRgSnorm => H::EacR11g11Snorm,
 
-        Tf::Bc1RgbaUnorm
-        | Tf::Bc1RgbaUnormSrgb
-        | Tf::Bc2RgbaUnorm
-        | Tf::Bc2RgbaUnormSrgb
-        | Tf::Bc3RgbaUnorm
-        | Tf::Bc3RgbaUnormSrgb
-        | Tf::Bc4RUnorm
-        | Tf::Bc4RSnorm
-        | Tf::Bc5RgUnorm
-        | Tf::Bc5RgSnorm
-        | Tf::Bc6hRgbUfloat
-        | Tf::Bc6hRgbSfloat
-        | Tf::Bc7RgbaUnorm
-        | Tf::Bc7RgbaUnormSrgb => (4, 4),
-    }
-}
-
-pub fn texture_features(format: wgt::TextureFormat) -> wgt::Features {
-    use wgt::TextureFormat as Tf;
-    match format {
-        Tf::R8Unorm
-        | Tf::R8Snorm
-        | Tf::R8Uint
-        | Tf::R8Sint
-        | Tf::R16Uint
-        | Tf::R16Sint
-        | Tf::R16Float
-        | Tf::Rg8Unorm
-        | Tf::Rg8Snorm
-        | Tf::Rg8Uint
-        | Tf::Rg8Sint
-        | Tf::R32Uint
-        | Tf::R32Sint
-        | Tf::R32Float
-        | Tf::Rg16Uint
-        | Tf::Rg16Sint
-        | Tf::Rg16Float
-        | Tf::Rgba8Unorm
-        | Tf::Rgba8UnormSrgb
-        | Tf::Rgba8Snorm
-        | Tf::Rgba8Uint
-        | Tf::Rgba8Sint
-        | Tf::Bgra8Unorm
-        | Tf::Bgra8UnormSrgb
-        | Tf::Rgb10a2Unorm
-        | Tf::Rg11b10Float
-        | Tf::Rg32Uint
-        | Tf::Rg32Sint
-        | Tf::Rg32Float
-        | Tf::Rgba16Uint
-        | Tf::Rgba16Sint
-        | Tf::Rgba16Float
-        | Tf::Rgba32Uint
-        | Tf::Rgba32Sint
-        | Tf::Rgba32Float
-        | Tf::Depth32Float
-        | Tf::Depth24Plus
-        | Tf::Depth24PlusStencil8 => wgt::Features::empty(),
-
-        Tf::Bc1RgbaUnorm
-        | Tf::Bc1RgbaUnormSrgb
-        | Tf::Bc2RgbaUnorm
-        | Tf::Bc2RgbaUnormSrgb
-        | Tf::Bc3RgbaUnorm
-        | Tf::Bc3RgbaUnormSrgb
-        | Tf::Bc4RUnorm
-        | Tf::Bc4RSnorm
-        | Tf::Bc5RgUnorm
-        | Tf::Bc5RgSnorm
-        | Tf::Bc6hRgbUfloat
-        | Tf::Bc6hRgbSfloat
-        | Tf::Bc7RgbaUnorm
-        | Tf::Bc7RgbaUnormSrgb => wgt::Features::TEXTURE_COMPRESSION_BC,
+        // ASTC compressed formats
+        Tf::Astc4x4RgbaUnorm => H::Astc4x4Srgb,
+        Tf::Astc4x4RgbaUnormSrgb => H::Astc4x4Srgb,
+        Tf::Astc5x4RgbaUnorm => H::Astc5x4Unorm,
+        Tf::Astc5x4RgbaUnormSrgb => H::Astc5x4Srgb,
+        Tf::Astc5x5RgbaUnorm => H::Astc5x5Unorm,
+        Tf::Astc5x5RgbaUnormSrgb => H::Astc5x5Srgb,
+        Tf::Astc6x5RgbaUnorm => H::Astc6x5Unorm,
+        Tf::Astc6x5RgbaUnormSrgb => H::Astc6x5Srgb,
+        Tf::Astc6x6RgbaUnorm => H::Astc6x6Unorm,
+        Tf::Astc6x6RgbaUnormSrgb => H::Astc6x6Srgb,
+        Tf::Astc8x5RgbaUnorm => H::Astc8x5Unorm,
+        Tf::Astc8x5RgbaUnormSrgb => H::Astc8x5Srgb,
+        Tf::Astc8x6RgbaUnorm => H::Astc8x6Unorm,
+        Tf::Astc8x6RgbaUnormSrgb => H::Astc8x6Srgb,
+        Tf::Astc10x5RgbaUnorm => H::Astc10x5Unorm,
+        Tf::Astc10x5RgbaUnormSrgb => H::Astc10x5Srgb,
+        Tf::Astc10x6RgbaUnorm => H::Astc10x6Unorm,
+        Tf::Astc10x6RgbaUnormSrgb => H::Astc10x6Srgb,
+        Tf::Astc8x8RgbaUnorm => H::Astc8x8Unorm,
+        Tf::Astc8x8RgbaUnormSrgb => H::Astc8x8Srgb,
+        Tf::Astc10x8RgbaUnorm => H::Astc10x8Unorm,
+        Tf::Astc10x8RgbaUnormSrgb => H::Astc10x8Srgb,
+        Tf::Astc10x10RgbaUnorm => H::Astc10x10Unorm,
+        Tf::Astc10x10RgbaUnormSrgb => H::Astc10x10Srgb,
+        Tf::Astc12x10RgbaUnorm => H::Astc12x10Unorm,
+        Tf::Astc12x10RgbaUnormSrgb => H::Astc12x10Srgb,
+        Tf::Astc12x12RgbaUnorm => H::Astc12x12Unorm,
+        Tf::Astc12x12RgbaUnormSrgb => H::Astc12x12Srgb,
     }
 }
 

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -755,3 +755,16 @@ pub fn map_index_format(index_format: wgt::IndexFormat) -> hal::IndexType {
         wgt::IndexFormat::Uint32 => hal::IndexType::U32,
     }
 }
+
+/// Take `value` and round it up to the nearest alignment `alignment`.
+///
+/// ```text
+/// (0, 3) -> 0
+/// (1, 3) -> 3
+/// (2, 3) -> 3
+/// (3, 3) -> 3
+/// (4, 3) -> 6
+/// ...
+pub fn align_up(value: u32, alignment: u32) -> u32 {
+    ((value + alignment - 1) / alignment) * alignment
+}

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -506,7 +506,7 @@ impl<B: GfxBackend> Device<B> {
     ) -> Result<resource::Texture<B>, resource::CreateTextureError> {
         debug_assert_eq!(self_id.backend(), B::VARIANT);
 
-        let features = conv::texture_features(desc.format);
+        let features = desc.format.describe().features;
         if !self.features.contains(features) {
             return Err(resource::CreateTextureError::MissingFeature(
                 features,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -324,7 +324,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             bytes_per_block as wgt::BufferAddress,
             size,
         )?;
-        let (block_width, block_height) = conv::texture_block_size(texture_format);
+
+        let (block_width, block_height) = texture_format.describe().block_dimensions;
+        let block_width = block_width as u32;
+        let block_height = block_height as u32;
+
         if !conv::is_valid_copy_dst_texture_format(texture_format) {
             Err(TransferError::CopyToForbiddenTextureFormat(texture_format))?
         }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -145,6 +145,14 @@ impl<B: GfxBackend> Adapter<B> {
             adapter_features.contains(hal::Features::FORMAT_BC),
         );
         features.set(
+            wgt::Features::TEXTURE_COMPRESSION_ETC2,
+            adapter_features.contains(hal::Features::FORMAT_ETC2),
+        );
+        features.set(
+            wgt::Features::TEXTURE_COMPRESSION_ASTC_LDR,
+            adapter_features.contains(hal::Features::FORMAT_ASTC_LDR),
+        );
+        features.set(
             wgt::Features::SAMPLED_TEXTURE_BINDING_ARRAY,
             adapter_features.contains(hal::Features::TEXTURE_DESCRIPTOR_ARRAY),
         );
@@ -270,6 +278,21 @@ impl<B: GfxBackend> Adapter<B> {
         }
 
         // Features
+        enabled_features.set(
+            hal::Features::FORMAT_BC,
+            desc.features
+                .contains(wgt::Features::TEXTURE_COMPRESSION_BC),
+        );
+        enabled_features.set(
+            hal::Features::FORMAT_ETC2,
+            desc.features
+                .contains(wgt::Features::TEXTURE_COMPRESSION_ETC2),
+        );
+        enabled_features.set(
+            hal::Features::FORMAT_ASTC_LDR,
+            desc.features
+                .contains(wgt::Features::TEXTURE_COMPRESSION_ASTC_LDR),
+        );
         enabled_features.set(
             hal::Features::TEXTURE_DESCRIPTOR_ARRAY,
             desc.features

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -592,10 +592,48 @@ impl NumericType {
             | Tf::Bc3RgbaUnorm
             | Tf::Bc3RgbaUnormSrgb
             | Tf::Bc7RgbaUnorm
-            | Tf::Bc7RgbaUnormSrgb => (NumericDimension::Vector(Vs::Quad), Sk::Float),
-            Tf::Bc4RUnorm | Tf::Bc4RSnorm => (NumericDimension::Scalar, Sk::Float),
-            Tf::Bc5RgUnorm | Tf::Bc5RgSnorm => (NumericDimension::Vector(Vs::Bi), Sk::Float),
-            Tf::Bc6hRgbUfloat | Tf::Bc6hRgbSfloat => (NumericDimension::Vector(Vs::Tri), Sk::Float),
+            | Tf::Bc7RgbaUnormSrgb
+            | Tf::Etc2RgbA1Unorm
+            | Tf::Etc2RgbA1UnormSrgb
+            | Tf::Etc2RgbA8Unorm
+            | Tf::Etc2RgbA8UnormSrgb
+            | Tf::Astc4x4RgbaUnorm
+            | Tf::Astc4x4RgbaUnormSrgb
+            | Tf::Astc5x4RgbaUnorm
+            | Tf::Astc5x4RgbaUnormSrgb
+            | Tf::Astc5x5RgbaUnorm
+            | Tf::Astc5x5RgbaUnormSrgb
+            | Tf::Astc6x5RgbaUnorm
+            | Tf::Astc6x5RgbaUnormSrgb
+            | Tf::Astc6x6RgbaUnorm
+            | Tf::Astc6x6RgbaUnormSrgb
+            | Tf::Astc8x5RgbaUnorm
+            | Tf::Astc8x5RgbaUnormSrgb
+            | Tf::Astc8x6RgbaUnorm
+            | Tf::Astc8x6RgbaUnormSrgb
+            | Tf::Astc10x5RgbaUnorm
+            | Tf::Astc10x5RgbaUnormSrgb
+            | Tf::Astc10x6RgbaUnorm
+            | Tf::Astc10x6RgbaUnormSrgb
+            | Tf::Astc8x8RgbaUnorm
+            | Tf::Astc8x8RgbaUnormSrgb
+            | Tf::Astc10x8RgbaUnorm
+            | Tf::Astc10x8RgbaUnormSrgb
+            | Tf::Astc10x10RgbaUnorm
+            | Tf::Astc10x10RgbaUnormSrgb
+            | Tf::Astc12x10RgbaUnorm
+            | Tf::Astc12x10RgbaUnormSrgb
+            | Tf::Astc12x12RgbaUnorm
+            | Tf::Astc12x12RgbaUnormSrgb => (NumericDimension::Vector(Vs::Quad), Sk::Float),
+            Tf::Bc4RUnorm | Tf::Bc4RSnorm | Tf::EacRUnorm | Tf::EacRSnorm => {
+                (NumericDimension::Scalar, Sk::Float)
+            }
+            Tf::Bc5RgUnorm | Tf::Bc5RgSnorm | Tf::EtcRgUnorm | Tf::EtcRgSnorm => {
+                (NumericDimension::Vector(Vs::Bi), Sk::Float)
+            }
+            Tf::Bc6hRgbUfloat | Tf::Bc6hRgbSfloat | Tf::Etc2RgbUnorm | Tf::Etc2RgbUnormSrgb => {
+                (NumericDimension::Vector(Vs::Tri), Sk::Float)
+            }
         };
 
         NumericType {


### PR DESCRIPTION
**Connections**

Closes #1070. Makes progress towards #1069.

**Description**

This PR has multiple functions:
 - Adds ETC and ASTC compressed textures behind features.
 - Adds three helper functions on `Extent3d` that help in calculating mip sizes: `at_mip_level`, `max_mips`, and `physical_size`.
 - Refactors various conversions into a public `TextureFormat::describe` function. I have used a decl macro to ease in the declaration and modifcation of an otherwise horribly verbose function.

I have tried to use clever multi-select based data copying to reduce the possibility for errors, but there's a _lot_ of data moving around here.

**Testing**

Upcoming wgpu-rs pr adding wider compressed texture support to the skybox example. Helper functions were tested with doctests.

Marked as draft until I can get the wgpu-rs pr done and prove it works, it is, however, ready for review.
