### PR TITLE
Fix player warnings

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -139,12 +139,12 @@ fn main() {
                                 desc.width,
                                 desc.height,
                             ));
-                            gfx_select!(device => global.device_create_swap_chain(device, surface, &desc));
+                            gfx_select!(device => global.device_create_swap_chain(device, surface, &desc)).unwrap();
                         }
                         Some(trace::Action::PresentSwapChain(id)) => {
                             frame_count += 1;
                             log::debug!("Presenting frame {}", frame_count);
-                            gfx_select!(device => global.swap_chain_present(id));
+                            gfx_select!(device => global.swap_chain_present(id)).unwrap();
                             break;
                         }
                         Some(action) => {
@@ -170,7 +170,7 @@ fn main() {
                 },
                 Event::LoopDestroyed => {
                     log::info!("Closing");
-                    gfx_select!(device => global.device_poll(device, true));
+                    gfx_select!(device => global.device_poll(device, true)).unwrap();
                 }
                 _ => {}
             }


### PR DESCRIPTION
```
warning: unused `std::result::Result` that must be used
   --> player/src/bin/play.rs:142:29
    |
142 | ...                   gfx_select!(device => global.device_create_swap_chain(device, surface, &desc));
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_must_use)]` on by default
    = note: this `Result` may be an `Err` variant, which should be handled
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unused `std::result::Result` that must be used
   --> player/src/bin/play.rs:147:29
    |
147 | ...                   gfx_select!(device => global.swap_chain_present(id));
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unused `std::result::Result` that must be used
   --> player/src/bin/play.rs:173:21
    |
173 |                     gfx_select!(device => global.device_poll(device, true));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: 3 warnings emitted
```