### PR TITLE
Remove extern "C" from set_index_buffer

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -436,6 +436,22 @@ impl RenderBundleEncoder {
             life_guard: LifeGuard::new(desc.label.borrow_or_default()),
         })
     }
+
+    pub fn set_index_buffer(
+        &mut self,
+        buffer_id: id::BufferId,
+        index_format: wgt::IndexFormat,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) {
+        span!(_guard, DEBUG, "RenderBundle::set_index_buffer");
+        self.base.commands.push(RenderCommand::SetIndexBuffer {
+            buffer_id,
+            index_format,
+            offset,
+            size,
+        });
+    }
 }
 
 /// Error type returned from `RenderBundleEncoder::new` if the sample count is invalid.
@@ -1074,23 +1090,6 @@ pub mod bundle_ffi {
             .base
             .commands
             .push(RenderCommand::SetPipeline(pipeline_id));
-    }
-
-    #[no_mangle]
-    pub extern "C" fn wgpu_render_bundle_set_index_buffer(
-        bundle: &mut RenderBundleEncoder,
-        buffer_id: id::BufferId,
-        index_format: wgt::IndexFormat,
-        offset: BufferAddress,
-        size: Option<BufferSize>,
-    ) {
-        span!(_guard, DEBUG, "RenderBundle::set_index_buffer");
-        bundle.base.commands.push(RenderCommand::SetIndexBuffer {
-            buffer_id,
-            index_format,
-            offset,
-            size,
-        });
     }
 
     #[no_mangle]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -29,7 +29,9 @@ use crate::{
 use arrayvec::ArrayVec;
 use hal::command::CommandBuffer as _;
 use thiserror::Error;
-use wgt::{BufferAddress, BufferUsage, Color, IndexFormat, InputStepMode, TextureUsage};
+use wgt::{
+    BufferAddress, BufferSize, BufferUsage, Color, IndexFormat, InputStepMode, TextureUsage,
+};
 
 #[cfg(any(feature = "serial-pass", feature = "replay"))]
 use serde::Deserialize;
@@ -171,6 +173,22 @@ impl RenderPass {
             target_colors: self.color_targets.into_iter().collect(),
             target_depth_stencil: self.depth_stencil_target,
         }
+    }
+
+    pub fn set_index_buffer(
+        &mut self,
+        buffer_id: id::BufferId,
+        index_format: IndexFormat,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    ) {
+        span!(_guard, DEBUG, "RenderPass::set_index_buffer");
+        self.base.commands.push(RenderCommand::SetIndexBuffer {
+            buffer_id,
+            index_format,
+            offset,
+            size,
+        });
     }
 }
 
@@ -1751,23 +1769,6 @@ pub mod render_ffi {
         pass.base
             .commands
             .push(RenderCommand::SetPipeline(pipeline_id));
-    }
-
-    #[no_mangle]
-    pub extern "C" fn wgpu_render_pass_set_index_buffer(
-        pass: &mut RenderPass,
-        buffer_id: id::BufferId,
-        index_format: wgt::IndexFormat,
-        offset: BufferAddress,
-        size: Option<BufferSize>,
-    ) {
-        span!(_guard, DEBUG, "RenderPass::set_index_buffer");
-        pass.base.commands.push(RenderCommand::SetIndexBuffer {
-            buffer_id,
-            index_format,
-            offset,
-            size,
-        });
     }
 
     #[no_mangle]


### PR DESCRIPTION
**Connections**
Fixes an issue that is blocking gfx-rs/wgpu-native#61

**Description**
Moves the ffi definition of wgpu_render_bundle_set_index_buffer / wgpu_render_pass_set_index_buffer to wgpu-native. This is needed because wgpu-native has its own version of IndexFormat that is different than the wgpu_types version. 

**Testing**
My projects with wgpu-native work
