### PR TITLE
Fix the validation of vertex buffer sizes

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1164,6 +1164,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
                     state.index.pipeline_format = pipeline.index_format;
 
+                    let vertex_strides_len = pipeline.vertex_strides.len();
+                    while state.vertex.inputs.len() < vertex_strides_len {
+                        state.vertex.inputs.push(VertexBufferState::EMPTY);
+                    }
                     // Update vertex buffer limits
                     for (vbs, &(stride, rate)) in
                         state.vertex.inputs.iter_mut().zip(&pipeline.vertex_strides)
@@ -1171,7 +1175,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         vbs.stride = stride;
                         vbs.rate = rate;
                     }
-                    let vertex_strides_len = pipeline.vertex_strides.len();
                     for vbs in state.vertex.inputs.iter_mut().skip(vertex_strides_len) {
                         vbs.stride = 0;
                         vbs.rate = InputStepMode::Vertex;


### PR DESCRIPTION
**Connections**
None that i know of

**Description**
~~The vertex buffer size (in vertices) was being divided by stride causing the limit to be lower than it was supposed to be.~~
This bug wasn't triggered earlier because if the stride was 0 it wouldn't perform any calculation and the stride was only set when a set pipeline command was received and the `VertexState` `inputs` were already created so the following commands would work:
```
SetPipeline with 1 vertex buffer
SetVertexBuffer with only 4 vertices
Draw 6 vertices
```
This would have passed validation while this wouldn't
```
SetPipeline with 1 vertex buffer of stride 8
SetVertexBuffer with 4 vertices
SetPipeline with 1 vertex buffer of stride 8
SetVertexBuffer with 4 vertices
Draw 3 vertices
```

Now all draw calls have proper vertex validation and not only after the `inputs` are populated

**Testing**
This change was tested after debugging an issue with the draw calls failing in a specific order in [veloren](https://gitlab.com/veloren/veloren/-/tree/imbris/wgpu-master-rebased)