### PR TITLE
Add STORAGE_LOAD usage to non-readonly buffers

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1167,7 +1167,7 @@ impl<B: GfxBackend> Device<B> {
                             if read_only {
                                 resource::BufferUse::STORAGE_LOAD
                             } else {
-                                resource::BufferUse::STORAGE_STORE
+                                resource::BufferUse::STORAGE_LOAD | resource::BufferUse::STORAGE_STORE
                             },
                         ),
                     };


### PR DESCRIPTION
Change-Id: I72261913780b5f1540f88f8eb527efd47b0872fa

**Connections**
https://github.com/gfx-rs/wgpu/issues/949

**Description**
Non-readonly buffers are created only with the STORAGE_WRITE usage flag. Add STORAGE_LOAD usage flag.