### PR TITLE
Add SHADER_READ usage bit to non-readonly buffers

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -594,7 +594,7 @@ pub(crate) fn map_buffer_state(usage: resource::BufferUse) -> hal::buffer::State
         access |= A::SHADER_READ;
     }
     if usage.contains(W::STORAGE_STORE) {
-        access |= A::SHADER_WRITE;
+        access |= A::SHADER_READ | A::SHADER_WRITE;
     }
     if usage.contains(W::INDIRECT) {
         access |= A::INDIRECT_COMMAND_READ;


### PR DESCRIPTION
Change-Id: I99d189e7ef295a58c2179635f95656eb9a2f5fe6

**Connections**
Fixes #949

**Description**
 Non-readonly buffers are created with the STORAGE_WRITE usage flag, but that implies SHADER_READ too.