### PR TITLE
Fix and improve object labels and command markers

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -404,14 +404,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             dst: destination_offset,
             size,
         };
-        let cmb_raw = cmd_buf.raw.last_mut().unwrap();
+        let cmd_buf_raw = cmd_buf.raw.last_mut().unwrap();
         unsafe {
-            cmb_raw.pipeline_barrier(
+            cmd_buf_raw.pipeline_barrier(
                 all_buffer_stages()..hal::pso::PipelineStage::TRANSFER,
                 hal::memory::Dependencies::empty(),
                 barriers,
             );
-            cmb_raw.copy_buffer(src_raw, dst_raw, iter::once(region));
+            cmd_buf_raw.copy_buffer(src_raw, dst_raw, iter::once(region));
         }
         Ok(())
     }
@@ -539,14 +539,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             image_offset: dst_offset,
             image_extent: conv::map_extent(&image_extent, dst_texture.dimension),
         };
-        let cmb_raw = cmd_buf.raw.last_mut().unwrap();
+        let cmd_buf_raw = cmd_buf.raw.last_mut().unwrap();
         unsafe {
-            cmb_raw.pipeline_barrier(
+            cmd_buf_raw.pipeline_barrier(
                 all_buffer_stages() | all_image_stages()..hal::pso::PipelineStage::TRANSFER,
                 hal::memory::Dependencies::empty(),
                 src_barriers.chain(dst_barriers),
             );
-            cmb_raw.copy_buffer_to_image(
+            cmd_buf_raw.copy_buffer_to_image(
                 src_raw,
                 dst_raw,
                 hal::image::Layout::TransferDstOptimal,
@@ -680,14 +680,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             image_offset: src_offset,
             image_extent: conv::map_extent(&image_extent, src_texture.dimension),
         };
-        let cmb_raw = cmd_buf.raw.last_mut().unwrap();
+        let cmd_buf_raw = cmd_buf.raw.last_mut().unwrap();
         unsafe {
-            cmb_raw.pipeline_barrier(
+            cmd_buf_raw.pipeline_barrier(
                 all_buffer_stages() | all_image_stages()..hal::pso::PipelineStage::TRANSFER,
                 hal::memory::Dependencies::empty(),
                 src_barriers.chain(dst_barrier),
             );
-            cmb_raw.copy_image_to_buffer(
+            cmd_buf_raw.copy_image_to_buffer(
                 src_raw,
                 hal::image::Layout::TransferSrcOptimal,
                 dst_raw,
@@ -817,14 +817,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             dst_offset,
             extent: conv::map_extent(&image_extent, src_texture.dimension),
         };
-        let cmb_raw = cmd_buf.raw.last_mut().unwrap();
+        let cmd_buf_raw = cmd_buf.raw.last_mut().unwrap();
         unsafe {
-            cmb_raw.pipeline_barrier(
+            cmd_buf_raw.pipeline_barrier(
                 all_image_stages()..hal::pso::PipelineStage::TRANSFER,
                 hal::memory::Dependencies::empty(),
                 barriers,
             );
-            cmb_raw.copy_image(
+            cmd_buf_raw.copy_image(
                 src_raw,
                 hal::image::Layout::TransferSrcOptimal,
                 dst_raw,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -653,7 +653,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             // finally, return the command buffers to the allocator
             for &cmb_id in command_buffer_ids {
                 if let (Some(cmd_buf), _) = hub.command_buffers.unregister(cmb_id, &mut token) {
-                    device.cmd_allocator.after_submit(cmd_buf, submit_index);
+                    device
+                        .cmd_allocator
+                        .after_submit(cmd_buf, &device.raw, submit_index);
                 }
             }
 

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -626,9 +626,10 @@ impl<B: GfxBackend, F: GlobalIdentityHandlerFactory> Hub<B, F> {
         }
         for element in self.command_buffers.data.write().map.drain(..) {
             if let Element::Occupied(command_buffer, _) = element {
-                devices[command_buffer.device_id.value]
+                let device = &devices[command_buffer.device_id.value];
+                device
                     .cmd_allocator
-                    .after_submit(command_buffer, 0);
+                    .after_submit(command_buffer, &device.raw, 0);
             }
         }
         for element in self.bind_groups.data.write().map.drain(..) {


### PR DESCRIPTION
**Connections**
Fixes a part of #1089 

**Description**
PR contains a bunch of small but important things:
  - reset the command buffer label after submission
  - add labels to compute and pass descriptors
  - actually push/pop markers for the scope of render bundle, compute passes
  - set the label to render pass command buffers
  - set labels on pipelines

**Testing**
Not tested much