### PR TITLE
Clean up render pass labels

### DIFF
--- a/wgpu-core/src/command/allocator.rs
+++ b/wgpu-core/src/command/allocator.rs
@@ -118,12 +118,14 @@ impl<B: GfxBackend> CommandAllocator<B> {
             used_swap_chain: None,
             limits,
             private_features,
+            has_labels: label.is_some(),
             #[cfg(feature = "trace")]
             commands: if enable_tracing {
                 Some(Vec::new())
             } else {
                 None
             },
+            #[cfg(debug_assertions)]
             label: label.to_string_or_default(),
         })
     }
@@ -209,7 +211,7 @@ impl<B: hal::Backend> CommandAllocator<B> {
     ) {
         // Record this command buffer as pending
         let mut inner = self.inner.lock();
-        let clear_label = !cmd_buf.label.is_empty();
+        let clear_label = cmd_buf.has_labels;
         inner
             .pools
             .get_mut(&cmd_buf.recorded_thread_id)

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -45,8 +45,10 @@ pub struct CommandBuffer<B: hal::Backend> {
     pub(crate) used_swap_chain: Option<(Stored<id::SwapChainId>, B::Framebuffer)>,
     limits: wgt::Limits,
     private_features: PrivateFeatures,
+    has_labels: bool,
     #[cfg(feature = "trace")]
     pub(crate) commands: Option<Vec<crate::device::trace::Command>>,
+    #[cfg(debug_assertions)]
     pub(crate) label: String,
 }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -499,6 +499,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         unsafe {
             if let Some(ref label) = base.label {
+                cmd_buf.has_labels = true;
                 device.raw.set_command_buffer_name(&mut raw, label);
             }
             raw.begin_primary(hal::command::CommandBufferFlags::ONE_TIME_SUBMIT);


### PR DESCRIPTION
**Connections**
Follow-up to #1088 to fix https://github.com/gfx-rs/wgpu/issues/1089#issuecomment-745596393

**Description**
Render passes are recorded into their own command buffers under the hood, and I forgot to properly reset the labels on them.

**Testing**
Untested