### PR TITLE
Optimize submit() for no command buffers

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -294,6 +294,9 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                 self.queue_write_texture::<B>(device, &to, &bin, &layout, &size)
                     .unwrap();
             }
+            A::Submit(_index, ref commands) if commands.is_empty() => {
+                self.queue_submit::<B>(device, &[]).unwrap();
+            }
             A::Submit(_index, commands) => {
                 let (encoder, error) = self.device_create_command_encoder::<B>(
                     device,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -483,7 +483,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 let (mut swap_chain_guard, mut token) = hub.swap_chains.write(&mut token);
                 let (mut command_buffer_guard, mut token) = hub.command_buffers.write(&mut token);
 
-                {
+                if !command_buffer_ids.is_empty() {
                     let (bind_group_guard, mut token) = hub.bind_groups.read(&mut token);
                     let (compute_pipe_guard, mut token) = hub.compute_pipelines.read(&mut token);
                     let (render_pipe_guard, mut token) = hub.render_pipelines.read(&mut token);


### PR DESCRIPTION
**Connections**
Just a few bits I found when tinkering with API traces.

**Description**
No need to lock the world if there are no command buffers.

**Testing**
tested on API traces