### PR TITLE
Pass DEPTH_CLAMPING feature request to gfx-hal

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -276,6 +276,10 @@ impl<B: GfxBackend> Adapter<B> {
 
         // Features
         enabled_features.set(
+            hal::Features::DEPTH_CLAMP,
+            desc.features.contains(wgt::Features::DEPTH_CLAMPING),
+        );
+        enabled_features.set(
             hal::Features::FORMAT_BC,
             desc.features
                 .contains(wgt::Features::TEXTURE_COMPRESSION_BC),


### PR DESCRIPTION
**Connections**
Fixes #1087 

**Description**
The request for the depth clamping feature was not being passed down to `gfx-hal`. This led to a warning from the vulkan backend when attempting to use this feature.

**Testing**
ran `wgpu-rs` shadow example and the warning no longer appears
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
