### PR TITLE
Validate swapchain extent as non-zero

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3847,7 +3847,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         fn validate_swap_chain_descriptor(
             config: &mut hal::window::SwapchainConfig,
             caps: &hal::window::SurfaceCapabilities,
-        ) {
+        ) -> Result<(), swap_chain::CreateSwapChainError> {
             let width = config.extent.width;
             let height = config.extent.height;
             if width < caps.extents.start().width
@@ -3870,6 +3870,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 );
                 config.present_mode = hal::window::PresentMode::FIFO;
             }
+            if width == 0 || height == 0 {
+                return Err(swap_chain::CreateSwapChainError::ZeroArea);
+            }
+            Ok(())
         }
 
         tracing::info!("creating swap chain {:?}", desc);
@@ -3911,7 +3915,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 });
             }
         }
-        validate_swap_chain_descriptor(&mut config, &caps);
+        validate_swap_chain_descriptor(&mut config, &caps)?;
 
         unsafe {
             B::get_surface_mut(surface)

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -91,6 +91,8 @@ pub enum CreateSwapChainError {
     InvalidSurface,
     #[error("`SwapChainOutput` must be dropped before a new `SwapChain` is made")]
     SwapChainOutputExists,
+    #[error("Both `SwapChain` width and height must be non-zero. Wait to recreate the `SwapChain` until the window has non-zero area.")]
+    ZeroArea,
     #[error("surface does not support the adapter's queue family")]
     UnsupportedQueueFamily,
     #[error("requested format {requested:?} is not in list of supported formats: {available:?}")]


### PR DESCRIPTION
**Connections**

Fixes #1026. 

**Description**

Zero area swapchains are UB under vulkan, and should be verboten.

**Testing**

Not tested
