### PR TITLE
Bump gfx-hal and gpu-alloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "gfx-auxil"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=0244e3401e9f127617cb8636397048584e7bfe8a#0244e3401e9f127617cb8636397048584e7bfe8a"
+source = "git+https://github.com/gfx-rs/gfx?rev=40b6220a937a4c8663ce06aa8a7219cf131e60e2#40b6220a937a4c8663ce06aa8a7219cf131e60e2"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx11"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=0244e3401e9f127617cb8636397048584e7bfe8a#0244e3401e9f127617cb8636397048584e7bfe8a"
+source = "git+https://github.com/gfx-rs/gfx?rev=40b6220a937a4c8663ce06aa8a7219cf131e60e2#40b6220a937a4c8663ce06aa8a7219cf131e60e2"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.6.2"
-source = "git+https://github.com/gfx-rs/gfx?rev=0244e3401e9f127617cb8636397048584e7bfe8a#0244e3401e9f127617cb8636397048584e7bfe8a"
+source = "git+https://github.com/gfx-rs/gfx?rev=40b6220a937a4c8663ce06aa8a7219cf131e60e2#40b6220a937a4c8663ce06aa8a7219cf131e60e2"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -492,7 +492,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-empty"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=0244e3401e9f127617cb8636397048584e7bfe8a#0244e3401e9f127617cb8636397048584e7bfe8a"
+source = "git+https://github.com/gfx-rs/gfx?rev=40b6220a937a4c8663ce06aa8a7219cf131e60e2#40b6220a937a4c8663ce06aa8a7219cf131e60e2"
 dependencies = [
  "gfx-hal",
  "log",
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-gl"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=0244e3401e9f127617cb8636397048584e7bfe8a#0244e3401e9f127617cb8636397048584e7bfe8a"
+source = "git+https://github.com/gfx-rs/gfx?rev=40b6220a937a4c8663ce06aa8a7219cf131e60e2#40b6220a937a4c8663ce06aa8a7219cf131e60e2"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-metal"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=0244e3401e9f127617cb8636397048584e7bfe8a#0244e3401e9f127617cb8636397048584e7bfe8a"
+source = "git+https://github.com/gfx-rs/gfx?rev=40b6220a937a4c8663ce06aa8a7219cf131e60e2#40b6220a937a4c8663ce06aa8a7219cf131e60e2"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.6.5"
-source = "git+https://github.com/gfx-rs/gfx?rev=0244e3401e9f127617cb8636397048584e7bfe8a#0244e3401e9f127617cb8636397048584e7bfe8a"
+source = "git+https://github.com/gfx-rs/gfx?rev=40b6220a937a4c8663ce06aa8a7219cf131e60e2#40b6220a937a4c8663ce06aa8a7219cf131e60e2"
 dependencies = [
  "arrayvec",
  "ash",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "gfx-hal"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=0244e3401e9f127617cb8636397048584e7bfe8a#0244e3401e9f127617cb8636397048584e7bfe8a"
+source = "git+https://github.com/gfx-rs/gfx?rev=40b6220a937a4c8663ce06aa8a7219cf131e60e2#40b6220a937a4c8663ce06aa8a7219cf131e60e2"
 dependencies = [
  "bitflags",
  "naga",
@@ -593,16 +593,17 @@ dependencies = [
 [[package]]
 name = "gpu-alloc"
 version = "0.2.1"
-source = "git+https://github.com/zakarumych/gpu-alloc?rev=d07be73f9439a37c89f5b72f2500cbf0eb4ff613#d07be73f9439a37c89f5b72f2500cbf0eb4ff613"
+source = "git+https://github.com/zakarumych/gpu-alloc?rev=29e761f24edc50e28d238e723503b146d55d222e#29e761f24edc50e28d238e723503b146d55d222e"
 dependencies = [
  "bitflags",
  "gpu-alloc-types",
+ "tracing",
 ]
 
 [[package]]
 name = "gpu-alloc-types"
 version = "0.1.0"
-source = "git+https://github.com/zakarumych/gpu-alloc?rev=d07be73f9439a37c89f5b72f2500cbf0eb4ff613#d07be73f9439a37c89f5b72f2500cbf0eb4ff613"
+source = "git+https://github.com/zakarumych/gpu-alloc?rev=29e761f24edc50e28d238e723503b146d55d222e#29e761f24edc50e28d238e723503b146d55d222e"
 dependencies = [
  "bitflags",
 ]
@@ -1209,7 +1210,7 @@ dependencies = [
 [[package]]
 name = "range-alloc"
 version = "0.1.1"
-source = "git+https://github.com/gfx-rs/gfx?rev=0244e3401e9f127617cb8636397048584e7bfe8a#0244e3401e9f127617cb8636397048584e7bfe8a"
+source = "git+https://github.com/gfx-rs/gfx?rev=40b6220a937a4c8663ce06aa8a7219cf131e60e2#40b6220a937a4c8663ce06aa8a7219cf131e60e2"
 
 [[package]]
 name = "raw-window-handle"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -32,28 +32,28 @@ serde = { version = "1.0", features = ["serde_derive"], optional = true }
 smallvec = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 thiserror = "1"
-#TODO: enable "tracing", blocked by https://github.com/zakarumych/gpu-alloc/issues/30
-gpu-alloc = { git = "https://github.com/zakarumych/gpu-alloc", rev = "d07be73f9439a37c89f5b72f2500cbf0eb4ff613", features = [] }
+
+gpu-alloc = { git = "https://github.com/zakarumych/gpu-alloc", rev = "29e761f24edc50e28d238e723503b146d55d222e", features = ["tracing"] }
 gpu-descriptor = { git = "https://github.com/zakarumych/gpu-descriptor", rev = "df74fd8c7bea03149058a41aab0e4fe04077b266", features = ["tracing"] }
 
-hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "0244e3401e9f127617cb8636397048584e7bfe8a" }
-gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "0244e3401e9f127617cb8636397048584e7bfe8a" }
+hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "40b6220a937a4c8663ce06aa8a7219cf131e60e2" }
+gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "40b6220a937a4c8663ce06aa8a7219cf131e60e2" }
 
 [target.'cfg(all(not(target_arch = "wasm32"), all(unix, not(target_os = "ios"), not(target_os = "macos"))))'.dependencies]
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "0244e3401e9f127617cb8636397048584e7bfe8a", features = ["naga"] }
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "0244e3401e9f127617cb8636397048584e7bfe8a", features = ["naga"] }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "40b6220a937a4c8663ce06aa8a7219cf131e60e2", features = ["naga"] }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "40b6220a937a4c8663ce06aa8a7219cf131e60e2", features = ["naga"] }
 
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
-gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "0244e3401e9f127617cb8636397048584e7bfe8a", features = ["naga"] }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "0244e3401e9f127617cb8636397048584e7bfe8a", optional = true }
+gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "40b6220a937a4c8663ce06aa8a7219cf131e60e2", features = ["naga"] }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "40b6220a937a4c8663ce06aa8a7219cf131e60e2", optional = true }
 
 [target.'cfg(all(not(target_arch = "wasm32"), windows))'.dependencies]
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "0244e3401e9f127617cb8636397048584e7bfe8a" }
-gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "0244e3401e9f127617cb8636397048584e7bfe8a" }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "0244e3401e9f127617cb8636397048584e7bfe8a", features = ["naga"] }
+gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "40b6220a937a4c8663ce06aa8a7219cf131e60e2" }
+gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "40b6220a937a4c8663ce06aa8a7219cf131e60e2" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "40b6220a937a4c8663ce06aa8a7219cf131e60e2", features = ["naga"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "0244e3401e9f127617cb8636397048584e7bfe8a", features = ["naga"] }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "40b6220a937a4c8663ce06aa8a7219cf131e60e2", features = ["naga"] }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"


### PR DESCRIPTION
**Connections**

Absorbs https://github.com/zakarumych/gpu-alloc/pull/31 and https://github.com/gfx-rs/gfx/pull/3548#issuecomment-749158016

**Description**

This fixes the last of the DX11 issues listed in #1059.

**Testing**

Various examples ran.
