### PR TITLE
Fix Assorted Low-Hanging Validation and Error Message Issues

### DIFF
--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -26,23 +26,32 @@ pub enum DrawError {
     MissingBlendColor,
     #[error("render pipeline must be set")]
     MissingPipeline,
+    #[error("vertex buffer {index} must be set")]
+    MissingVertexBuffer { index: u32 },
+    #[error("index buffer must be set")]
+    MissingIndexBuffer,
     #[error("current render pipeline has a layout which is incompatible with a currently set bind group, first differing at entry index {index}")]
     IncompatibleBindGroup {
         index: u32,
         //expected: BindGroupLayoutId,
         //provided: Option<(BindGroupLayoutId, BindGroupId)>,
     },
-    #[error("vertex {last_vertex} extends beyond limit {vertex_limit}")]
+    #[error("vertex {last_vertex} extends beyond limit {vertex_limit}. Did you bind the correct `Vertex` step-rate vertex buffer?")]
     VertexBeyondLimit { last_vertex: u32, vertex_limit: u32 },
-    #[error("instance {last_instance} extends beyond limit {instance_limit}")]
+    #[error("instance {last_instance} extends beyond limit {instance_limit}. Did you bind the correct `Instance` step-rate vertex buffer?")]
     InstanceBeyondLimit {
         last_instance: u32,
         instance_limit: u32,
     },
-    #[error("index {last_index} extends beyond limit {index_limit}")]
+    #[error("index {last_index} extends beyond limit {index_limit}. Did you bind the correct index buffer?")]
     IndexBeyondLimit { last_index: u32, index_limit: u32 },
-    #[error("pipeline index format and buffer index format do not match")]
-    UnmatchedIndexFormats,
+    #[error(
+        "pipeline index format ({pipeline:?}) and buffer index format ({buffer:?}) do not match"
+    )]
+    UnmatchedIndexFormats {
+        pipeline: wgt::IndexFormat,
+        buffer: wgt::IndexFormat,
+    },
 }
 
 /// Error encountered when encoding a render command.

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -36,12 +36,17 @@ pub enum DrawError {
         //expected: BindGroupLayoutId,
         //provided: Option<(BindGroupLayoutId, BindGroupId)>,
     },
-    #[error("vertex {last_vertex} extends beyond limit {vertex_limit}. Did you bind the correct `Vertex` step-rate vertex buffer?")]
-    VertexBeyondLimit { last_vertex: u32, vertex_limit: u32 },
-    #[error("instance {last_instance} extends beyond limit {instance_limit}. Did you bind the correct `Instance` step-rate vertex buffer?")]
+    #[error("vertex {last_vertex} extends beyond limit {vertex_limit} imposed by the buffer in slot {slot}. Did you bind the correct `Vertex` step-rate vertex buffer?")]
+    VertexBeyondLimit {
+        last_vertex: u32,
+        vertex_limit: u32,
+        slot: u32,
+    },
+    #[error("instance {last_instance} extends beyond limit {instance_limit} imposed by the buffer in slot {slot}. Did you bind the correct `Instance` step-rate vertex buffer?")]
     InstanceBeyondLimit {
         last_instance: u32,
         instance_limit: u32,
+        slot: u32,
     },
     #[error("index {last_index} extends beyond limit {index_limit}. Did you bind the correct index buffer?")]
     IndexBeyondLimit { last_index: u32, index_limit: u32 },

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -438,6 +438,10 @@ impl<B: GfxBackend> Device<B> {
             }
         }
 
+        if desc.usage.is_empty() {
+            return Err(resource::CreateBufferError::EmptyUsage);
+        }
+
         let mem_usage = {
             use gpu_alloc::UsageFlags as Uf;
             use wgt::BufferUsage as Bu;
@@ -535,6 +539,10 @@ impl<B: GfxBackend> Device<B> {
                 }
             }
             _ => {}
+        }
+
+        if desc.usage.is_empty() {
+            return Err(resource::CreateTextureError::EmptyUsage);
         }
 
         let kind = conv::map_texture_dimension_size(desc.dimension, desc.size, desc.sample_count)?;

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -520,7 +520,8 @@ impl<B: GfxBackend> Device<B> {
     ) -> Result<resource::Texture<B>, resource::CreateTextureError> {
         debug_assert_eq!(self_id.backend(), B::VARIANT);
 
-        let features = desc.format.describe().features;
+        let format_desc = desc.format.describe();
+        let features = format_desc.features;
         if !self.features.contains(features) {
             return Err(resource::CreateTextureError::MissingFeature(
                 features,
@@ -543,6 +544,14 @@ impl<B: GfxBackend> Device<B> {
 
         if desc.usage.is_empty() {
             return Err(resource::CreateTextureError::EmptyUsage);
+        }
+
+        let missing_features = desc.usage - format_desc.allowed_usages;
+        if !missing_features.is_empty() {
+            return Err(resource::CreateTextureError::InvalidUsages(
+                missing_features,
+                desc.format,
+            ));
         }
 
         let kind = conv::map_texture_dimension_size(desc.dimension, desc.size, desc.sample_count)?;

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -238,6 +238,8 @@ pub enum CreateTextureError {
     InvalidDimension(#[from] TextureDimensionError),
     #[error("texture descriptor mip level count ({0}) is invalid")]
     InvalidMipLevelCount(u32),
+    #[error("The texture usages {0:?} are not allowed on a texture of type {1:?}")]
+    InvalidUsages(wgt::TextureUsage, wgt::TextureFormat),
     #[error("Feature {0:?} must be enabled to create a texture of type {1:?}")]
     MissingFeature(wgt::Features, wgt::TextureFormat),
 }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -174,6 +174,8 @@ pub enum CreateBufferError {
     AccessError(#[from] BufferAccessError),
     #[error("buffers that are mapped at creation have to be aligned to `COPY_BUFFER_ALIGNMENT`")]
     UnalignedSize,
+    #[error("Buffers cannot have empty usage flags")]
+    EmptyUsage,
     #[error("`MAP` usage can only be combined with the opposite `COPY`, requested {0:?}")]
     UsageMismatch(wgt::BufferUsage),
 }
@@ -230,6 +232,8 @@ pub enum CreateTextureError {
     Device(#[from] DeviceError),
     #[error("D24Plus textures cannot be copied")]
     CannotCopyD24Plus,
+    #[error("Textures cannot have empty usage flags")]
+    EmptyUsage,
     #[error(transparent)]
     InvalidDimension(#[from] TextureDimensionError),
     #[error("texture descriptor mip level count ({0}) is invalid")]


### PR DESCRIPTION
**Connections**

Closes #1085
Closes #393
Closes #1053

**Description**

These commits are independent and should be reviewed individually. Combined into a single PR to reduce noise.

Overview of what was done:
- Add validation for empty texture and buffer usage flags. (#393)
- Add allowed texture usage flags to `format.describe()` (#1085)
  Validate new textures follow the allowed usage flags.
- Properly validates vertex and buffers are bound. (#1053)
  Improves error messages when no vertex buffer is bound. (Before it said the limit was 0, now it says something is unbound)
- Improve the vertex buffer overrun messages by keeping track of which slot has the smallest index.

**Testing**

Tested on examples by artificially creating the situation I am trying to validate, as well as running clean examples to make sure they pass validation.