### PR TITLE
Use `repr(transparent)` for shader flags

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -483,6 +483,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
+    #[repr(transparent)]
     #[derive(Default)]
     #[cfg_attr(feature = "trace", derive(serde::Serialize))]
     #[cfg_attr(feature = "replay", derive(serde::Deserialize))]


### PR DESCRIPTION
**Connections**
None

**Description**
This allows cbindgen to generate bindings for shader flags in wgpu-native.

**Testing**
After `WGPUShaderFlags` is exposed in wgpu-native, bindings for `WGPUShaderFlags` will be generated in wgpu.h