### PR TITLE
Fixed error message for BindingTypeMaxCountError

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -107,10 +107,11 @@ pub enum BindingZone {
 }
 
 #[derive(Clone, Debug, Error)]
-#[error("too many bindings of type {kind:?} in {zone}, limit is {count}")]
+#[error("too many bindings of type {kind:?} in {zone}, limit is {limit}, count was {count}")]
 pub struct BindingTypeMaxCountError {
     pub kind: BindingTypeMaxCountErrorKind,
     pub zone: BindingZone,
+    pub limit: u32,
     pub count: u32,
 }
 
@@ -173,7 +174,12 @@ impl PerStageBindingTypeCounter {
     ) -> Result<(), BindingTypeMaxCountError> {
         let (zone, count) = self.max();
         if limit < count {
-            Err(BindingTypeMaxCountError { kind, zone, count })
+            Err(BindingTypeMaxCountError {
+                kind,
+                zone,
+                limit,
+                count,
+            })
         } else {
             Ok(())
         }
@@ -242,6 +248,7 @@ impl BindingTypeMaxCountValidator {
             return Err(BindingTypeMaxCountError {
                 kind: BindingTypeMaxCountErrorKind::DynamicUniformBuffers,
                 zone: BindingZone::Pipeline,
+                limit: limits.max_dynamic_uniform_buffers_per_pipeline_layout,
                 count: self.dynamic_uniform_buffers,
             });
         }
@@ -249,6 +256,7 @@ impl BindingTypeMaxCountValidator {
             return Err(BindingTypeMaxCountError {
                 kind: BindingTypeMaxCountErrorKind::DynamicStorageBuffers,
                 zone: BindingZone::Pipeline,
+                limit: limits.max_dynamic_storage_buffers_per_pipeline_layout,
                 count: self.dynamic_storage_buffers,
             });
         }


### PR DESCRIPTION
Previously, `BindingTypeMaxCountError` would incorrectly report the binding count as the violated limit. Now it reports both the limit and the count that violated it.

Example error message before:
```
wgpu error: Validation Error

Caused by:
    In Device::create_bind_group_layout
      note: label = `BindGroupLayout write scalar`
    too many bindings of type StorageTextures in stage COMPUTE, limit is 5
```


Example error message after:
```
wgpu error: Validation Error

Caused by:
    In Device::create_bind_group_layout
      note: label = `BindGroupLayout write scalar`
    too many bindings of type StorageTextures in stage COMPUTE, limit is 4, count was 5
```