### PR TITLE
Request buffer FAST_DEVICE_ACCESS only with some non MAP or COPY usage

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -448,7 +448,8 @@ impl<B: GfxBackend> Device<B> {
 
             let mut flags = Uf::empty();
             let map_flags = desc.usage & (Bu::MAP_READ | Bu::MAP_WRITE);
-            if !(desc.usage - map_flags).is_empty() {
+            let map_copy_flags = desc.usage & (Bu::MAP_READ | Bu::MAP_WRITE | Bu::COPY_SRC | Bu::COPY_DST);
+            if map_flags.is_empty() || !(desc.usage - map_copy_flags).is_empty() {
                 flags |= Uf::FAST_DEVICE_ACCESS;
             }
             if transient {


### PR DESCRIPTION
**Connections**
Fixes #1113 

**Description**
On Linux AMD (and likely elsewhere) buffers with FAST_DEVICE_ACCESS are very slow to access when mapped. This makes sure that upload/download buffers don't request it unless those buffers are leveraging MAPPABLE_PRIMARY_BUFFERS for some non-map/copy usage.

**Testing**
I reran the failing reproduction case in the linked issue.
