### PR TITLE
Free associated staging buffers

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -499,6 +499,16 @@ impl<B: GfxBackend> LifetimeTracker<B> {
 
                     if let Some(res) = hub.buffers.unregister_locked(id.0, &mut *guard) {
                         let submit_index = res.life_guard.submission_index.load(Ordering::Acquire);
+                        if let resource::BufferMapState::Init {
+                            stage_buffer,
+                            stage_memory,
+                            ..
+                        } = res.map_state
+                        {
+                            self.free_resources
+                                .buffers
+                                .push((stage_buffer, stage_memory));
+                        }
                         self.active
                             .iter_mut()
                             .find(|a| a.index == submit_index)


### PR DESCRIPTION
**Connections**
Reported on the Matrix. Having a loop that creates mapped buffers and drops them results in OOM.

**Description**
We are now checking for the map state when destroying buffers.

**Testing**
Ran through an ad-hoc example.