### PR TITLE
Fix UB in populating dynamic offsets

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1110,10 +1110,12 @@ pub mod bundle_ffi {
             num_dynamic_offsets: offset_length.try_into().unwrap(),
             bind_group_id,
         });
-        bundle
-            .base
-            .dynamic_offsets
-            .extend_from_slice(slice::from_raw_parts(offsets, offset_length));
+        if offset_length != 0 {
+            bundle
+                .base
+                .dynamic_offsets
+                .extend_from_slice(slice::from_raw_parts(offsets, offset_length));
+        }
     }
 
     #[no_mangle]

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -551,9 +551,11 @@ pub mod compute_ffi {
             num_dynamic_offsets: offset_length.try_into().unwrap(),
             bind_group_id,
         });
-        pass.base
-            .dynamic_offsets
-            .extend_from_slice(slice::from_raw_parts(offsets, offset_length));
+        if offset_length != 0 {
+            pass.base
+                .dynamic_offsets
+                .extend_from_slice(slice::from_raw_parts(offsets, offset_length));
+        }
     }
 
     #[no_mangle]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1882,9 +1882,11 @@ pub mod render_ffi {
             num_dynamic_offsets: offset_length.try_into().unwrap(),
             bind_group_id,
         });
-        pass.base
-            .dynamic_offsets
-            .extend_from_slice(slice::from_raw_parts(offsets, offset_length));
+        if offset_length != 0 {
+            pass.base
+                .dynamic_offsets
+                .extend_from_slice(slice::from_raw_parts(offsets, offset_length));
+        }
     }
 
     #[no_mangle]


### PR DESCRIPTION
**Connections**
Related to the traces in #1123

**Description**
The dynamic offsets arrays appear to be empty in the traces, which makes no sense. We are populating them unconditionally, and I double-checked on the `shadow` example that the traces we record contain the offsets. So my only guess is that the reported traces are taken from a release build, and our code that does `slice::from_raw_parts()` on the offsets is UB because the pointer can be garbage (if length is 0). This is what the PR fixes.

**Testing**
Untested