### PR TITLE
Check swapchain frame to still be in use

### DIFF
--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -370,7 +370,12 @@ impl<S: ResourceState> ResourceTracker<S> {
                     e.insert(new.clone());
                 }
                 Entry::Occupied(e) => {
-                    assert_eq!(e.get().epoch, new.epoch);
+                    assert_eq!(
+                        e.get().epoch,
+                        new.epoch,
+                        "ID {:?} wasn't properly removed",
+                        S::Id::zip(index, e.get().epoch, self.backend)
+                    );
                     let id = Valid(S::Id::zip(index, new.epoch, self.backend));
                     e.into_mut().state.merge(id, &new.state, None)?;
                 }
@@ -388,7 +393,12 @@ impl<S: ResourceState> ResourceTracker<S> {
                     e.insert(new.clone());
                 }
                 Entry::Occupied(e) => {
-                    assert_eq!(e.get().epoch, new.epoch);
+                    assert_eq!(
+                        e.get().epoch,
+                        new.epoch,
+                        "ID {:?} wasn't properly removed",
+                        S::Id::zip(index, e.get().epoch, self.backend)
+                    );
                     let id = Valid(S::Id::zip(index, new.epoch, self.backend));
                     e.into_mut()
                         .state


### PR DESCRIPTION
**Connections**
Fixes #1123

**Description**
What happened there is - the same command buffer was used to record work into multiple swapchain frames.
The ID management of those is a bit special, so the error wasn't very descriptive, internal logic caught inconsistency.
Now there is a proper error, and the old error is better.
Note that ideally we'd want "present" to work like "destroy" on textures, but essentially the users would have to fix it anyway. It's not going to make their life easier (in fact - only harder), so we can defer this to a follow-up.

**Testing**
Tested on wgpu-rs examples as well as on Terra.