### PR TITLE
Add pipeline statistics and timeline queries

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -430,6 +430,9 @@ impl RenderBundleEncoder {
                 RenderCommand::PushDebugGroup { color: _, len: _ } => unimplemented!(),
                 RenderCommand::InsertDebugMarker { color: _, len: _ } => unimplemented!(),
                 RenderCommand::PopDebugGroup => unimplemented!(),
+                RenderCommand::WriteTimestamp { .. }
+                | RenderCommand::BeginPipelineStatisticsQuery { .. }
+                | RenderCommand::EndPipelineStatisticsQuery => unimplemented!(),
                 RenderCommand::ExecuteBundle(_)
                 | RenderCommand::SetBlendColor(_)
                 | RenderCommand::SetStencilReference(_)
@@ -693,6 +696,9 @@ impl RenderBundle {
                 RenderCommand::PushDebugGroup { color: _, len: _ } => unimplemented!(),
                 RenderCommand::InsertDebugMarker { color: _, len: _ } => unimplemented!(),
                 RenderCommand::PopDebugGroup => unimplemented!(),
+                RenderCommand::WriteTimestamp { .. }
+                | RenderCommand::BeginPipelineStatisticsQuery { .. }
+                | RenderCommand::EndPipelineStatisticsQuery => unimplemented!(),
                 RenderCommand::ExecuteBundle(_)
                 | RenderCommand::SetBlendColor(_)
                 | RenderCommand::SetStencilReference(_)

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -75,6 +75,8 @@ pub enum RenderCommandError {
     InvalidDynamicOffsetCount { actual: usize, expected: usize },
     #[error("render pipeline {0:?} is invalid")]
     InvalidPipeline(id::RenderPipelineId),
+    #[error("QuerySet {0:?} is invalid")]
+    InvalidQuerySet(id::QuerySetId),
     #[error("Render pipeline is incompatible with render pass")]
     IncompatiblePipeline(#[from] crate::device::RenderPassCompatibilityError),
     #[error("pipeline is not compatible with the depth-stencil read-only render pass")]
@@ -195,5 +197,14 @@ pub enum RenderCommand {
         color: u32,
         len: usize,
     },
+    WriteTimestamp {
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    },
+    BeginPipelineStatisticsQuery {
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    },
+    EndPipelineStatisticsQuery,
     ExecuteBundle(id::RenderBundleId),
 }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -7,6 +7,7 @@ mod bind;
 mod bundle;
 mod compute;
 mod draw;
+mod query;
 mod render;
 mod transfer;
 
@@ -15,6 +16,7 @@ pub use self::allocator::CommandAllocatorError;
 pub use self::bundle::*;
 pub use self::compute::*;
 pub use self::draw::*;
+pub use self::query::*;
 pub use self::render::*;
 pub use self::transfer::*;
 
@@ -367,6 +369,14 @@ pub enum PassErrorScope {
         indirect: bool,
         pipeline: Option<id::RenderPipelineId>,
     },
+    #[error("While resetting queries after the renderpass was ran")]
+    QueryReset,
+    #[error("In a write_timestamp command")]
+    WriteTimestamp,
+    #[error("In a begin_pipeline_statistics_query command")]
+    BeginPipelineStatisticsQuery,
+    #[error("In a end_pipeline_statistics_query command")]
+    EndPipelineStatisticsQuery,
     #[error("In a execute_bundle command")]
     ExecuteBundle,
     #[error("In a dispatch command, indirect:{indirect}")]

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -1,0 +1,424 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use hal::command::CommandBuffer as _;
+
+#[cfg(feature = "trace")]
+use crate::device::trace::Command as TraceCommand;
+use crate::{
+    command::{CommandBuffer, CommandEncoderError},
+    device::all_buffer_stages,
+    hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Storage, Token},
+    id::{self, Id, TypedId},
+    resource::{BufferUse, QuerySet},
+    track::UseExtendError,
+    Epoch, FastHashMap, Index,
+};
+use std::{iter, marker::PhantomData};
+use thiserror::Error;
+use wgt::BufferAddress;
+
+#[derive(Debug)]
+pub(super) struct QueryResetMap<B: hal::Backend> {
+    map: FastHashMap<Index, (Vec<bool>, Epoch)>,
+    _phantom: PhantomData<B>,
+}
+impl<B: hal::Backend> QueryResetMap<B> {
+    pub fn new() -> Self {
+        Self {
+            map: FastHashMap::default(),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn use_query_set(
+        &mut self,
+        id: id::QuerySetId,
+        query_set: &QuerySet<B>,
+        query: u32,
+    ) -> bool {
+        let (index, epoch, _) = id.unzip();
+        let (vec, _) = self
+            .map
+            .entry(index)
+            .or_insert_with(|| (vec![false; query_set.desc.count as usize], epoch));
+
+        std::mem::replace(&mut vec[query as usize], true)
+    }
+
+    pub fn reset_queries(
+        self,
+        cmd_buf_raw: &mut B::CommandBuffer,
+        query_set_storage: &Storage<QuerySet<B>, id::QuerySetId>,
+        backend: wgt::Backend,
+    ) -> Result<(), id::QuerySetId> {
+        for (query_set_id, (state, epoch)) in self.map.into_iter() {
+            let id = Id::zip(query_set_id, epoch, backend);
+            let query_set = query_set_storage.get(id).map_err(|_| id)?;
+
+            debug_assert_eq!(state.len(), query_set.desc.count as usize);
+
+            // Need to find all "runs" of values which need resets. If the state vector is:
+            // [false, true, true, false, true], we want to reset [1..3, 4..5]. This minimizes
+            // the amount of resets needed.
+            let mut state_iter = state.into_iter().chain(iter::once(false)).enumerate();
+            let mut run_start: Option<u32> = None;
+            while let Some((idx, value)) = state_iter.next() {
+                match (run_start, value) {
+                    // We're inside of a run, do nothing
+                    (Some(..), true) => {}
+                    // We've hit the end of a run, dispatch a reset
+                    (Some(start), false) => {
+                        run_start = None;
+                        unsafe { cmd_buf_raw.reset_query_pool(&query_set.raw, start..idx as u32) };
+                    }
+                    // We're starting a run
+                    (None, true) => {
+                        run_start = Some(idx as u32);
+                    }
+                    // We're in a run of falses, do nothing.
+                    (None, false) => {}
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum SimplifiedQueryType {
+    Timestamp,
+    PipelineStatistics,
+}
+impl From<wgt::QueryType> for SimplifiedQueryType {
+    fn from(q: wgt::QueryType) -> Self {
+        match q {
+            wgt::QueryType::Timestamp => SimplifiedQueryType::Timestamp,
+            wgt::QueryType::PipelineStatistics(..) => SimplifiedQueryType::PipelineStatistics,
+        }
+    }
+}
+
+/// Error encountered when dealing with queries
+#[derive(Clone, Debug, Error)]
+pub enum QueryError {
+    #[error(transparent)]
+    Encoder(#[from] CommandEncoderError),
+    #[error("Error encountered while trying to use queries")]
+    Use(#[from] QueryUseError),
+    #[error("Error encountered while trying to resolve a query")]
+    Resolve(#[from] ResolveError),
+    #[error("Buffer {0:?} is invalid or destroyed")]
+    InvalidBuffer(id::BufferId),
+    #[error("QuerySet {0:?} is invalid or destroyed")]
+    InvalidQuerySet(id::QuerySetId),
+}
+
+/// Error encountered while trying to use queries
+#[derive(Clone, Debug, Error)]
+pub enum QueryUseError {
+    #[error("Query {query_index} is out of bounds for a query set of size {query_set_size}")]
+    OutOfBounds {
+        query_index: u32,
+        query_set_size: u32,
+    },
+    #[error("Query {query_index} has already been used within the same renderpass. Queries must only be used once per renderpass")]
+    UsedTwiceInsideRenderpass { query_index: u32 },
+    #[error("Query {new_query_index} was started while query {active_query_index} was already active. No more than one statistic or occlusion query may be active at once")]
+    AlreadyStarted {
+        active_query_index: u32,
+        new_query_index: u32,
+    },
+    #[error("Query was stopped while there was no active query")]
+    AlreadyStopped,
+    #[error("A query of type {query_type:?} was started using a query set of type {set_type:?}")]
+    IncompatibleType {
+        set_type: SimplifiedQueryType,
+        query_type: SimplifiedQueryType,
+    },
+}
+
+/// Error encountered while trying to resolve a query.
+#[derive(Clone, Debug, Error)]
+pub enum ResolveError {
+    #[error("Queries can only be resolved to buffers that contain the COPY_DST usage")]
+    MissingBufferUsage,
+    #[error("Resolving queries {start_query}..{end_query} would overrun the query set of size {query_set_size}")]
+    QueryOverrun {
+        start_query: u32,
+        end_query: u32,
+        query_set_size: u32,
+    },
+    #[error("Resolving queries {start_query}..{end_query} ({stride} byte queries) will end up overruning the bounds of the destination buffer of size {buffer_size} using offsets {buffer_start_offset}..{buffer_end_offset}")]
+    BufferOverrun {
+        start_query: u32,
+        end_query: u32,
+        stride: u32,
+        buffer_size: BufferAddress,
+        buffer_start_offset: BufferAddress,
+        buffer_end_offset: BufferAddress,
+    },
+}
+
+impl<B: GfxBackend> QuerySet<B> {
+    fn validate_query(
+        &self,
+        query_set_id: id::QuerySetId,
+        query_type: SimplifiedQueryType,
+        query_index: u32,
+        reset_state: Option<&mut QueryResetMap<B>>,
+    ) -> Result<hal::query::Query<'_, B>, QueryUseError> {
+        // We need to defer our resets because we are in a renderpass, add the usage to the reset map.
+        if let Some(reset) = reset_state {
+            let used = reset.use_query_set(query_set_id, self, query_index);
+            if used {
+                return Err(QueryUseError::UsedTwiceInsideRenderpass { query_index }.into());
+            }
+        }
+
+        let simple_set_type = SimplifiedQueryType::from(self.desc.ty);
+        if simple_set_type != query_type {
+            return Err(QueryUseError::IncompatibleType {
+                query_type,
+                set_type: simple_set_type,
+            }
+            .into());
+        }
+
+        if query_index >= self.desc.count {
+            return Err(QueryUseError::OutOfBounds {
+                query_index,
+                query_set_size: self.desc.count,
+            }
+            .into());
+        }
+
+        let hal_query = hal::query::Query::<B> {
+            pool: &self.raw,
+            id: query_index,
+        };
+
+        Ok(hal_query)
+    }
+
+    pub(super) fn validate_and_write_timestamp(
+        &self,
+        cmd_buf_raw: &mut B::CommandBuffer,
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+        reset_state: Option<&mut QueryResetMap<B>>,
+    ) -> Result<(), QueryUseError> {
+        let needs_reset = reset_state.is_none();
+        let hal_query = self.validate_query(
+            query_set_id,
+            SimplifiedQueryType::Timestamp,
+            query_index,
+            reset_state,
+        )?;
+
+        unsafe {
+            // If we don't have a reset state tracker which can defer resets, we must reset now.
+            if needs_reset {
+                cmd_buf_raw.reset_query_pool(&self.raw, query_index..(query_index + 1));
+            }
+            cmd_buf_raw.write_timestamp(hal::pso::PipelineStage::BOTTOM_OF_PIPE, hal_query);
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn validate_and_begin_pipeline_statistics_query(
+        &self,
+        cmd_buf_raw: &mut B::CommandBuffer,
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+        reset_state: Option<&mut QueryResetMap<B>>,
+        active_query: &mut Option<(id::QuerySetId, u32)>,
+    ) -> Result<(), QueryUseError> {
+        let needs_reset = reset_state.is_none();
+        let hal_query = self.validate_query(
+            query_set_id,
+            SimplifiedQueryType::PipelineStatistics,
+            query_index,
+            reset_state,
+        )?;
+
+        if let Some((_old_id, old_idx)) = active_query.replace((query_set_id, query_index)) {
+            return Err(QueryUseError::AlreadyStarted {
+                active_query_index: old_idx,
+                new_query_index: query_index,
+            }
+            .into());
+        }
+
+        unsafe {
+            // If we don't have a reset state tracker which can defer resets, we must reset now.
+            if needs_reset {
+                cmd_buf_raw.reset_query_pool(&self.raw, query_index..(query_index + 1));
+            }
+            cmd_buf_raw.begin_query(hal_query, hal::query::ControlFlags::empty());
+        }
+
+        Ok(())
+    }
+}
+
+pub(super) fn end_pipeline_statistics_query<B: GfxBackend>(
+    cmd_buf_raw: &mut B::CommandBuffer,
+    storage: &Storage<QuerySet<B>, id::QuerySetId>,
+    active_query: &mut Option<(id::QuerySetId, u32)>,
+) -> Result<(), QueryUseError> {
+    if let Some((query_set_id, query_index)) = active_query.take() {
+        // We can unwrap here as the validity was validated when the active query was set
+        let query_set = storage.get(query_set_id).unwrap();
+
+        let hal_query = hal::query::Query::<B> {
+            pool: &query_set.raw,
+            id: query_index,
+        };
+
+        unsafe { cmd_buf_raw.end_query(hal_query) }
+
+        Ok(())
+    } else {
+        Err(QueryUseError::AlreadyStopped)
+    }
+}
+
+impl<G: GlobalIdentityHandlerFactory> Global<G> {
+    pub fn command_encoder_write_timestamp<B: GfxBackend>(
+        &self,
+        command_encoder_id: id::CommandEncoderId,
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    ) -> Result<(), QueryError> {
+        let hub = B::hub(self);
+        let mut token = Token::root();
+
+        let (mut cmd_buf_guard, mut token) = hub.command_buffers.write(&mut token);
+        let (query_set_guard, _) = hub.query_sets.read(&mut token);
+
+        let cmd_buf = CommandBuffer::get_encoder_mut(&mut cmd_buf_guard, command_encoder_id)?;
+        let cmd_buf_raw = cmd_buf.raw.last_mut().unwrap();
+
+        #[cfg(feature = "trace")]
+        if let Some(ref mut list) = cmd_buf.commands {
+            list.push(TraceCommand::WriteTimestamp {
+                query_set_id,
+                query_index,
+            });
+        }
+
+        let query_set = cmd_buf
+            .trackers
+            .query_sets
+            .use_extend(&*query_set_guard, query_set_id, (), ())
+            .map_err(|e| match e {
+                UseExtendError::InvalidResource => QueryError::InvalidQuerySet(query_set_id),
+                _ => unreachable!(),
+            })?;
+
+        query_set.validate_and_write_timestamp(cmd_buf_raw, query_set_id, query_index, None)?;
+
+        Ok(())
+    }
+
+    pub fn command_encoder_resolve_query_set<B: GfxBackend>(
+        &self,
+        command_encoder_id: id::CommandEncoderId,
+        query_set_id: id::QuerySetId,
+        start_query: u32,
+        query_count: u32,
+        destination: id::BufferId,
+        destination_offset: BufferAddress,
+    ) -> Result<(), QueryError> {
+        let hub = B::hub(self);
+        let mut token = Token::root();
+
+        let (mut cmd_buf_guard, mut token) = hub.command_buffers.write(&mut token);
+        let (query_set_guard, mut token) = hub.query_sets.read(&mut token);
+        let (buffer_guard, _) = hub.buffers.read(&mut token);
+
+        let cmd_buf = CommandBuffer::get_encoder_mut(&mut cmd_buf_guard, command_encoder_id)?;
+        let cmd_buf_raw = cmd_buf.raw.last_mut().unwrap();
+
+        #[cfg(feature = "trace")]
+        if let Some(ref mut list) = cmd_buf.commands {
+            list.push(TraceCommand::ResolveQuerySet {
+                query_set_id,
+                start_query,
+                query_count,
+                destination,
+                destination_offset,
+            });
+        }
+
+        let query_set = cmd_buf
+            .trackers
+            .query_sets
+            .use_extend(&*query_set_guard, query_set_id, (), ())
+            .map_err(|e| match e {
+                UseExtendError::InvalidResource => QueryError::InvalidQuerySet(query_set_id),
+                _ => unreachable!(),
+            })?;
+
+        let (dst_buffer, dst_pending) = cmd_buf
+            .trackers
+            .buffers
+            .use_replace(&*buffer_guard, destination, (), BufferUse::COPY_DST)
+            .map_err(QueryError::InvalidBuffer)?;
+        let dst_barrier = dst_pending.map(|pending| pending.into_hal(dst_buffer));
+
+        if !dst_buffer.usage.contains(wgt::BufferUsage::COPY_DST) {
+            return Err(ResolveError::MissingBufferUsage.into());
+        }
+
+        let end_query = start_query + query_count;
+        if end_query > query_set.desc.count {
+            return Err(ResolveError::QueryOverrun {
+                start_query,
+                end_query,
+                query_set_size: query_set.desc.count,
+            }
+            .into());
+        }
+
+        let stride = query_set.elements * wgt::QUERY_SIZE;
+        let bytes_used = (stride * query_count) as BufferAddress;
+
+        let buffer_start_offset = destination_offset;
+        let buffer_end_offset = buffer_start_offset + bytes_used;
+
+        if buffer_end_offset > dst_buffer.size {
+            return Err(ResolveError::BufferOverrun {
+                start_query,
+                end_query,
+                stride,
+                buffer_size: dst_buffer.size,
+                buffer_start_offset,
+                buffer_end_offset,
+            }
+            .into());
+        }
+
+        unsafe {
+            cmd_buf_raw.pipeline_barrier(
+                all_buffer_stages()..hal::pso::PipelineStage::TRANSFER,
+                hal::memory::Dependencies::empty(),
+                dst_barrier,
+            );
+            cmd_buf_raw.copy_query_pool_results(
+                &query_set.raw,
+                start_query..end_query,
+                &dst_buffer.raw.as_ref().unwrap().0,
+                destination_offset,
+                stride,
+                hal::query::ResultFlags::WAIT | hal::query::ResultFlags::BITS_64,
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -677,6 +677,43 @@ pub(crate) fn map_texture_state(
     (access, layout)
 }
 
+pub fn map_query_type(ty: &wgt::QueryType) -> (hal::query::Type, u32) {
+    match ty {
+        wgt::QueryType::PipelineStatistics(pipeline_statistics) => {
+            let mut ps = hal::query::PipelineStatistic::empty();
+            ps.set(
+                hal::query::PipelineStatistic::VERTEX_SHADER_INVOCATIONS,
+                pipeline_statistics
+                    .contains(wgt::PipelineStatisticsTypes::VERTEX_SHADER_INVOCATIONS),
+            );
+            ps.set(
+                hal::query::PipelineStatistic::CLIPPING_INVOCATIONS,
+                pipeline_statistics.contains(wgt::PipelineStatisticsTypes::CLIPPER_INVOCATIONS),
+            );
+            ps.set(
+                hal::query::PipelineStatistic::CLIPPING_PRIMITIVES,
+                pipeline_statistics.contains(wgt::PipelineStatisticsTypes::CLIPPER_PRIMITIVES_OUT),
+            );
+            ps.set(
+                hal::query::PipelineStatistic::FRAGMENT_SHADER_INVOCATIONS,
+                pipeline_statistics
+                    .contains(wgt::PipelineStatisticsTypes::FRAGMENT_SHADER_INVOCATIONS),
+            );
+            ps.set(
+                hal::query::PipelineStatistic::COMPUTE_SHADER_INVOCATIONS,
+                pipeline_statistics
+                    .contains(wgt::PipelineStatisticsTypes::COMPUTE_SHADER_INVOCATIONS),
+            );
+
+            (
+                hal::query::Type::PipelineStatistics(ps),
+                pipeline_statistics.bits().count_ones(),
+            )
+        }
+        wgt::QueryType::Timestamp => (hal::query::Type::Timestamp, 1),
+    }
+}
+
 pub fn map_load_store_ops<V>(channel: &PassChannel<V>) -> hal::pass::AttachmentOps {
     hal::pass::AttachmentOps {
         load: match channel.load_op {

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -91,6 +91,11 @@ pub enum Action<'a> {
         base: crate::command::BasePass<crate::command::RenderCommand>,
     },
     DestroyRenderBundle(id::RenderBundleId),
+    CreateQuerySet {
+        id: id::QuerySetId,
+        desc: wgt::QuerySetDescriptor,
+    },
+    DestroyQuerySet(id::QuerySetId),
     WriteBuffer {
         id: id::BufferId,
         data: FileName,
@@ -131,6 +136,17 @@ pub enum Command {
         src: crate::command::TextureCopyView,
         dst: crate::command::TextureCopyView,
         size: wgt::Extent3d,
+    },
+    WriteTimestamp {
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    },
+    ResolveQuerySet {
+        query_set_id: id::QuerySetId,
+        start_query: u32,
+        query_count: u32,
+        destination: id::BufferId,
+        destination_offset: wgt::BufferAddress,
     },
     RunComputePass {
         base: crate::command::BasePass<crate::command::ComputeCommand>,

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -164,6 +164,7 @@ pub type RenderPassEncoderId = *mut crate::command::RenderPass;
 pub type ComputePassEncoderId = *mut crate::command::ComputePass;
 pub type RenderBundleEncoderId = *mut crate::command::RenderBundleEncoder;
 pub type RenderBundleId = Id<crate::command::RenderBundle>;
+pub type QuerySetId = Id<crate::resource::QuerySet<Dummy>>;
 // Swap chain
 pub type SwapChainId = Id<crate::swap_chain::SwapChain<Dummy>>;
 

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -222,6 +222,7 @@ struct PrivateFeatures {
     anisotropic_filtering: bool,
     texture_d24: bool,
     texture_d24_s8: bool,
+    timestamp_period: f32,
 }
 
 #[macro_export]

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -447,6 +447,42 @@ impl<B: hal::Backend> Borrow<()> for Sampler<B> {
         &DUMMY_SELECTOR
     }
 }
+#[derive(Clone, Debug, Error)]
+pub enum CreateQuerySetError {
+    #[error(transparent)]
+    Device(#[from] DeviceError),
+    #[error("QuerySets cannot be made with zero queries")]
+    ZeroCount,
+    #[error("{count} is too many queries for a single QuerySet. QuerySets cannot be made more than {maximum} queries.")]
+    TooManyQueries { count: u32, maximum: u32 },
+    #[error("Feature {0:?} must be enabled")]
+    MissingFeature(wgt::Features),
+}
+
+#[derive(Debug)]
+pub struct QuerySet<B: hal::Backend> {
+    pub(crate) raw: B::QueryPool,
+    pub(crate) device_id: Stored<DeviceId>,
+    pub(crate) life_guard: LifeGuard,
+    /// Amount of queries in the query set.
+    pub(crate) desc: wgt::QuerySetDescriptor,
+    /// Amount of numbers in each query (i.e. a pipeline statistics query for two attributes will have this number be two)
+    pub(crate) elements: u32,
+}
+
+impl<B: hal::Backend> Resource for QuerySet<B> {
+    const TYPE: &'static str = "QuerySet";
+
+    fn life_guard(&self) -> &LifeGuard {
+        &self.life_guard
+    }
+}
+
+impl<B: hal::Backend> Borrow<()> for QuerySet<B> {
+    fn borrow(&self) -> &() {
+        &DUMMY_SELECTOR
+    }
+}
 
 #[derive(Clone, Debug, Error)]
 pub enum DestroyError {

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -528,6 +528,7 @@ pub(crate) struct TrackerSet {
     pub compute_pipes: ResourceTracker<PhantomData<id::ComputePipelineId>>,
     pub render_pipes: ResourceTracker<PhantomData<id::RenderPipelineId>>,
     pub bundles: ResourceTracker<PhantomData<id::RenderBundleId>>,
+    pub query_sets: ResourceTracker<PhantomData<id::QuerySetId>>,
 }
 
 impl TrackerSet {
@@ -542,6 +543,7 @@ impl TrackerSet {
             compute_pipes: ResourceTracker::new(backend),
             render_pipes: ResourceTracker::new(backend),
             bundles: ResourceTracker::new(backend),
+            query_sets: ResourceTracker::new(backend),
         }
     }
 
@@ -555,6 +557,7 @@ impl TrackerSet {
         self.compute_pipes.clear();
         self.render_pipes.clear();
         self.bundles.clear();
+        self.query_sets.clear();
     }
 
     /// Try to optimize the tracking representation.
@@ -567,6 +570,7 @@ impl TrackerSet {
         self.compute_pipes.optimize();
         self.render_pipes.optimize();
         self.bundles.optimize();
+        self.query_sets.optimize();
     }
 
     /// Merge all the trackers of another instance by extending
@@ -594,6 +598,7 @@ impl TrackerSet {
             .unwrap();
         self.render_pipes.merge_extend(&other.render_pipes).unwrap();
         self.bundles.merge_extend(&other.bundles).unwrap();
+        self.query_sets.merge_extend(&other.query_sets).unwrap();
         Ok(())
     }
 


### PR DESCRIPTION
**Connections**

Closes #721 

**Description**

This adds Pipeline Statistics queries and Timeline queries. Shoutout to @z2oh for doing a good chunk of the work to enable this feature.

Currently blocked on both https://github.com/gfx-rs/gfx/pull/3563 and rollup of gfx-hal mutability changes, but is ready to review.

**Testing**

Tested in various ways on the hello-compute and hello-triangle example, tested validation extensively. Queries will be permanently added to the mipmap example once the wgpu-rs PR is finished.