### PR TITLE
Make all textures support usage COPY_SRC and COPY_DST

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -263,7 +263,7 @@ impl<B: GfxBackend> Adapter<B> {
             )))
             .optimal_tiling;
 
-        let mut allowed_usages = wgt::TextureUsage::empty();
+        let mut allowed_usages = format.describe().guaranteed_format_features.allowed_usages;
         if texture_format_properties.contains(hal::format::ImageFeature::SAMPLED) {
             allowed_usages |= wgt::TextureUsage::SAMPLED;
         }
@@ -275,12 +275,6 @@ impl<B: GfxBackend> Adapter<B> {
         }
         if texture_format_properties.contains(hal::format::ImageFeature::DEPTH_STENCIL_ATTACHMENT) {
             allowed_usages |= wgt::TextureUsage::RENDER_ATTACHMENT;
-        }
-        if texture_format_properties.contains(hal::format::ImageFeature::BLIT_SRC) {
-            allowed_usages |= wgt::TextureUsage::COPY_SRC;
-        }
-        if texture_format_properties.contains(hal::format::ImageFeature::BLIT_DST) {
-            allowed_usages |= wgt::TextureUsage::COPY_DST;
         }
 
         let mut flags = wgt::TextureFormatFeatureFlags::empty();


### PR DESCRIPTION
**Connections**
N/A

**Description**
In WebGPU, all textures should be allowed to have usages COPY_SRC and COPY_DST. However, right now when Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES is enabled any features that the backend says can't be blitted to/from will not gain these capabilities. In particular, compressed textures may not support blitting while still allowing access via copies to/from buffers.

You can also see the defaults used when TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES is not requested:
https://github.com/gfx-rs/wgpu/blob/8c00cbcc8e8b955477f2df29b4b0a20712fdef78/wgpu-types/src/lib.rs#L1224-L1342

**Testing**
I ran a [patched version of the wgpu-rs cube example](https://github.com/fintelia/wgpu-rs/tree/cube-bc4/examples/cube).