### PR TITLE
Enable storage read/write format feature

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -281,10 +281,9 @@ impl<B: GfxBackend> Adapter<B> {
         if texture_format_properties.contains(hal::format::ImageFeature::STORAGE_ATOMIC) {
             flags |= wgt::TextureFormatFeatureFlags::STORAGE_ATOMICS;
         }
-        // TODO: Hal update required. This in turn is blocked by https://github.com/zakarumych/gpu-alloc/issues/33
-        //if texture_format_properties.contains(hal::format::ImageFeature::STORAGE_READ_WRITE) {
-        //    flags |= wgt::TextureFormatFeatureFlags::STORAGE_READ_WRITE;
-        //}
+        if texture_format_properties.contains(hal::format::ImageFeature::STORAGE_READ_WRITE) {
+            flags |= wgt::TextureFormatFeatureFlags::STORAGE_READ_WRITE;
+        }
 
         wgt::TextureFormatFeatures {
             allowed_usages,


### PR DESCRIPTION
**Connections**
#1112

**Description**
Use `wgt::TextureFormatFeatureFlags::STORAGE_READ_WRITE` in `get_texture_format_features`.
This has been waiting for a gfx update which was enabled by @ElArtista 's workaround in #1136 \o/