### PR TITLE
Support trailing render passes after the swapchain rendering

### DIFF
--- a/wgpu-core/src/command/allocator.rs
+++ b/wgpu-core/src/command/allocator.rs
@@ -115,7 +115,7 @@ impl<B: GfxBackend> CommandAllocator<B> {
             recorded_thread_id: thread_id,
             device_id,
             trackers: TrackerSet::new(B::VARIANT),
-            used_swap_chain: None,
+            used_swap_chains: Default::default(),
             limits,
             private_features,
             has_labels: label.is_some(),

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -514,7 +514,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             ));
                         }
 
-                        if let Some((sc_id, fbo)) = cmdbuf.used_swap_chain.take() {
+                        for (sc_id, fbo) in cmdbuf.used_swap_chains.drain(..) {
                             let sc = &mut swap_chain_guard[sc_id.value];
                             sc.active_submission_index = submit_index;
                             if sc.acquired_view_id.is_none() {


### PR DESCRIPTION
**Connections**
Discussed on the matrix.

**Description**
Fixes a case where we have any other render pass in a command encoder that draws to the swapchain (after the pass that draws to the swapchain).

**Testing**
Tested on a modified hello-triangle example.