### PR TITLE
Update gfx and naga to gfx-6 tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "gfx-auxil"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=7dc99d525cc7ad04161f227993181f36c68fe86e#7dc99d525cc7ad04161f227993181f36c68fe86e"
+source = "git+https://github.com/gfx-rs/gfx?rev=696947377a0ce5ba8a15a2e06ff97ed69c04f00a#696947377a0ce5ba8a15a2e06ff97ed69c04f00a"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -486,7 +486,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx11"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=7dc99d525cc7ad04161f227993181f36c68fe86e#7dc99d525cc7ad04161f227993181f36c68fe86e"
+source = "git+https://github.com/gfx-rs/gfx?rev=696947377a0ce5ba8a15a2e06ff97ed69c04f00a#696947377a0ce5ba8a15a2e06ff97ed69c04f00a"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.6.2"
-source = "git+https://github.com/gfx-rs/gfx?rev=7dc99d525cc7ad04161f227993181f36c68fe86e#7dc99d525cc7ad04161f227993181f36c68fe86e"
+source = "git+https://github.com/gfx-rs/gfx?rev=696947377a0ce5ba8a15a2e06ff97ed69c04f00a#696947377a0ce5ba8a15a2e06ff97ed69c04f00a"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-empty"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=7dc99d525cc7ad04161f227993181f36c68fe86e#7dc99d525cc7ad04161f227993181f36c68fe86e"
+source = "git+https://github.com/gfx-rs/gfx?rev=696947377a0ce5ba8a15a2e06ff97ed69c04f00a#696947377a0ce5ba8a15a2e06ff97ed69c04f00a"
 dependencies = [
  "gfx-hal",
  "log",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-gl"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=7dc99d525cc7ad04161f227993181f36c68fe86e#7dc99d525cc7ad04161f227993181f36c68fe86e"
+source = "git+https://github.com/gfx-rs/gfx?rev=696947377a0ce5ba8a15a2e06ff97ed69c04f00a#696947377a0ce5ba8a15a2e06ff97ed69c04f00a"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-metal"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=7dc99d525cc7ad04161f227993181f36c68fe86e#7dc99d525cc7ad04161f227993181f36c68fe86e"
+source = "git+https://github.com/gfx-rs/gfx?rev=696947377a0ce5ba8a15a2e06ff97ed69c04f00a#696947377a0ce5ba8a15a2e06ff97ed69c04f00a"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.6.5"
-source = "git+https://github.com/gfx-rs/gfx?rev=7dc99d525cc7ad04161f227993181f36c68fe86e#7dc99d525cc7ad04161f227993181f36c68fe86e"
+source = "git+https://github.com/gfx-rs/gfx?rev=696947377a0ce5ba8a15a2e06ff97ed69c04f00a#696947377a0ce5ba8a15a2e06ff97ed69c04f00a"
 dependencies = [
  "arrayvec",
  "ash",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "gfx-hal"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=7dc99d525cc7ad04161f227993181f36c68fe86e#7dc99d525cc7ad04161f227993181f36c68fe86e"
+source = "git+https://github.com/gfx-rs/gfx?rev=696947377a0ce5ba8a15a2e06ff97ed69c04f00a#696947377a0ce5ba8a15a2e06ff97ed69c04f00a"
 dependencies = [
  "bitflags",
  "naga",
@@ -931,8 +931,9 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.2.0"
-source = "git+https://github.com/gfx-rs/naga?tag=gfx-5#583f218c9dbca08daa6bf3efda60e80ecada63bb"
+source = "git+https://github.com/gfx-rs/naga?tag=gfx-6#6f5ff27701112abba35fa61e429e2916a157b0a1"
 dependencies = [
+ "bit-set",
  "bitflags",
  "fxhash",
  "log",
@@ -1196,7 +1197,7 @@ dependencies = [
 [[package]]
 name = "range-alloc"
 version = "0.1.1"
-source = "git+https://github.com/gfx-rs/gfx?rev=7dc99d525cc7ad04161f227993181f36c68fe86e#7dc99d525cc7ad04161f227993181f36c68fe86e"
+source = "git+https://github.com/gfx-rs/gfx?rev=696947377a0ce5ba8a15a2e06ff97ed69c04f00a#696947377a0ce5ba8a15a2e06ff97ed69c04f00a"
 
 [[package]]
 name = "raw-window-handle"

--- a/player/tests/data/quad.wgsl
+++ b/player/tests/data/quad.wgsl
@@ -5,7 +5,7 @@ var<out> out_pos: vec4<f32>;
 
 [[stage(vertex)]]
 fn vs_main() {
-    # hacky way to draw a large triangle
+    // hacky way to draw a large triangle
     var tmp1: i32 = i32(in_vertex_index) / 2;
     var tmp2: i32 = i32(in_vertex_index) & 1;
     var pos: vec2<f32> = vec2<f32>(

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,28 +36,28 @@ thiserror = "1"
 gpu-alloc = { git = "https://github.com/zakarumych/gpu-alloc", rev = "15f4fe2cebbd0bf9ab446757a8e370e0adf4c502", features = ["tracing"] }
 gpu-descriptor = { git = "https://github.com/zakarumych/gpu-descriptor", rev = "aa092613889f03f8254d6f7278d08c655324c7c7", features = ["tracing"] }
 
-hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "7dc99d525cc7ad04161f227993181f36c68fe86e" }
-gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "7dc99d525cc7ad04161f227993181f36c68fe86e" }
+hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "696947377a0ce5ba8a15a2e06ff97ed69c04f00a" }
+gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "696947377a0ce5ba8a15a2e06ff97ed69c04f00a" }
 
 [target.'cfg(all(not(target_arch = "wasm32"), all(unix, not(target_os = "ios"), not(target_os = "macos"))))'.dependencies]
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "7dc99d525cc7ad04161f227993181f36c68fe86e", features = ["naga"] }
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "7dc99d525cc7ad04161f227993181f36c68fe86e", features = ["naga"] }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "696947377a0ce5ba8a15a2e06ff97ed69c04f00a", features = ["naga"] }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "696947377a0ce5ba8a15a2e06ff97ed69c04f00a", features = ["naga"] }
 
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
-gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "7dc99d525cc7ad04161f227993181f36c68fe86e", features = ["naga"] }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "7dc99d525cc7ad04161f227993181f36c68fe86e", optional = true }
+gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "696947377a0ce5ba8a15a2e06ff97ed69c04f00a", features = ["naga"] }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "696947377a0ce5ba8a15a2e06ff97ed69c04f00a", optional = true }
 
 [target.'cfg(all(not(target_arch = "wasm32"), windows))'.dependencies]
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "7dc99d525cc7ad04161f227993181f36c68fe86e" }
-gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "7dc99d525cc7ad04161f227993181f36c68fe86e" }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "7dc99d525cc7ad04161f227993181f36c68fe86e", features = ["naga"] }
+gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "696947377a0ce5ba8a15a2e06ff97ed69c04f00a" }
+gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "696947377a0ce5ba8a15a2e06ff97ed69c04f00a" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "696947377a0ce5ba8a15a2e06ff97ed69c04f00a", features = ["naga"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "7dc99d525cc7ad04161f227993181f36c68fe86e", features = ["naga"] }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "696947377a0ce5ba8a15a2e06ff97ed69c04f00a", features = ["naga"] }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-5"
+tag = "gfx-6"
 features = ["spv-in", "spv-out", "wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -576,7 +576,10 @@ impl<B: GfxBackend, F: GlobalIdentityHandlerFactory> Hub<B, F> {
 }
 
 impl<B: GfxBackend, F: GlobalIdentityHandlerFactory> Hub<B, F> {
-    fn clear(&self, surface_guard: &mut Storage<Surface, SurfaceId>) {
+    //TODO: instead of having a hacky `with_adapters` parameter,
+    // we should have `clear_device(device_id)` that specifically destroys
+    // everything related to a logical device.
+    fn clear(&self, surface_guard: &mut Storage<Surface, SurfaceId>, with_adapters: bool) {
         use crate::resource::TextureViewInner;
         use hal::{device::Device as _, window::PresentationSurface as _};
 
@@ -703,6 +706,9 @@ impl<B: GfxBackend, F: GlobalIdentityHandlerFactory> Hub<B, F> {
                 device.dispose();
             }
         }
+        if with_adapters {
+            self.adapters.data.write().map.clear();
+        }
     }
 }
 
@@ -757,7 +763,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn clear_backend<B: GfxBackend>(&self, _dummy: ()) {
         let mut surface_guard = self.surfaces.data.write();
         let hub = B::hub(self);
-        hub.clear(&mut *surface_guard);
+        // this is used for tests, which keep the adapter
+        hub.clear(&mut *surface_guard, false);
     }
 }
 
@@ -770,23 +777,23 @@ impl<G: GlobalIdentityHandlerFactory> Drop for Global<G> {
             // destroy hubs
             #[cfg(vulkan)]
             {
-                self.hubs.vulkan.clear(&mut *surface_guard);
+                self.hubs.vulkan.clear(&mut *surface_guard, true);
             }
             #[cfg(metal)]
             {
-                self.hubs.metal.clear(&mut *surface_guard);
+                self.hubs.metal.clear(&mut *surface_guard, true);
             }
             #[cfg(dx12)]
             {
-                self.hubs.dx12.clear(&mut *surface_guard);
+                self.hubs.dx12.clear(&mut *surface_guard, true);
             }
             #[cfg(dx11)]
             {
-                self.hubs.dx11.clear(&mut *surface_guard);
+                self.hubs.dx11.clear(&mut *surface_guard, true);
             }
             #[cfg(gl)]
             {
-                self.hubs.gl.clear(&mut *surface_guard);
+                self.hubs.gl.clear(&mut *surface_guard, true);
             }
 
             // destroy surfaces


### PR DESCRIPTION
**Connections**
Fixes #1149 
Regression from https://github.com/gfx-rs/gfx/pull/3573

**Description**
The physical devices held references to `RawInstance` in Vulkan backend, and we weren't cleaning them up.
Note: an alternative fix could be in `gfx-backend-vulkan` - to move the `Entry` into `RawInstance`, thus delaying the shutdown. I didn't go this way because that would be less explicit.

**Testing**
Tested on wgpu-rs examples