### PR TITLE
fix the size checks in transfer buffer to image commands

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -443,7 +443,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             });
         }
 
-        if copy_size.width == 0 || copy_size.height == 0 || copy_size.width == 0 {
+        if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth == 0 {
             tracing::trace!("Ignoring copy_buffer_to_texture of size 0");
             return Ok(());
         }
@@ -583,7 +583,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             });
         }
 
-        if copy_size.width == 0 || copy_size.height == 0 || copy_size.width == 0 {
+        if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth == 0 {
             tracing::trace!("Ignoring copy_texture_to_buffer of size 0");
             return Ok(());
         }
@@ -733,7 +733,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             });
         }
 
-        if copy_size.width == 0 || copy_size.height == 0 || copy_size.width == 0 {
+        if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth == 0 {
             tracing::trace!("Ignoring copy_texture_to_texture of size 0");
             return Ok(());
         }


### PR DESCRIPTION
**Connections**
_none_

**Description**
It's fixing a trivial bug in which Extend3d was checked against a with of 0 two times, presumably instread checking depth as well.

**Testing**
Ran the tests and ran it with bevy - still worked.

