### PR TITLE
Handle read-only storage + sampled combination

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -311,6 +311,8 @@ pub struct TextureView<B: hal::Backend> {
     pub(crate) extent: wgt::Extent3d,
     pub(crate) samples: hal::image::NumSamples,
     pub(crate) framebuffer_attachment: hal::image::FramebufferAttachment,
+    /// Internal use of this texture view when used as `BindingType::Texture`.
+    pub(crate) sampled_internal_use: TextureUse,
     pub(crate) selector: TextureSelector,
     pub(crate) life_guard: LifeGuard,
 }

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -195,6 +195,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     },
                     samples: 1,
                     framebuffer_attachment: sc.framebuffer_attachment.clone(),
+                    sampled_internal_use: resource::TextureUse::empty(),
                     selector: TextureSelector {
                         layers: 0..1,
                         levels: 0..1,


### PR DESCRIPTION
**Connections**
Fixes #724

**Description**
We now keep the internal use flags for sampled textures inside the view.

**Testing**
Untested