### PR TITLE
Fix replaying issues with dropped texture views

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -139,6 +139,7 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
     ) {
         use wgc::device::trace::Action as A;
         log::info!("action {:?}", action);
+        //TODO: find a way to force ID perishing without excessive `maintain()` calls.
         match action {
             A::Init { .. } => panic!("Unexpected Action::Init: has to be the first action only"),
             A::CreateSwapChain { .. } | A::PresentSwapChain(_) => {
@@ -182,7 +183,7 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                 }
             }
             A::DestroyTextureView(id) => {
-                self.texture_view_drop::<B>(id).unwrap();
+                self.texture_view_drop::<B>(id, true).unwrap();
             }
             A::CreateSampler(id, desc) => {
                 self.device_maintain_ids::<B>(device).unwrap();
@@ -196,6 +197,7 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
             }
             A::GetSwapChainTexture { id, parent_id } => {
                 if let Some(id) = id {
+                    self.device_maintain_ids::<B>(device).unwrap();
                     self.swap_chain_get_current_texture_view::<B>(parent_id, id)
                         .unwrap()
                         .view_id

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -326,10 +326,9 @@ impl<B: hal::Backend> LifetimeTracker<B> {
             .iter()
             .position(|a| unsafe { !device.get_fence_status(&a.fence).unwrap_or(false) })
             .unwrap_or_else(|| self.active.len());
-        let last_done = if done_count != 0 {
-            self.active[done_count - 1].index
-        } else {
-            return Ok(0);
+        let last_done = match done_count.checked_sub(1) {
+            Some(i) => self.active[i].index,
+            None => return Ok(0),
         };
 
         for a in self.active.drain(..done_count) {


### PR DESCRIPTION
**Connections**
Fixes replaying of https://github.com/gfx-rs/wgpu/issues/1158#issuecomment-763272796

**Description**
The main fix is calling `maintain` in the player before getting the new view from the swapchain. That allows the device to properly remove the ID that is just about to be used.

**Testing**
Tested on that API trace.