### PR TITLE
Bump gfx to latest master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "gfx-auxil"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=59730cdeefdb00c61ba747dbcaa2087e7a5b53f6#59730cdeefdb00c61ba747dbcaa2087e7a5b53f6"
+source = "git+https://github.com/gfx-rs/gfx?rev=2d454c77ddbaae05ba222ca369c16afae0c10cd1#2d454c77ddbaae05ba222ca369c16afae0c10cd1"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -486,7 +486,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx11"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=59730cdeefdb00c61ba747dbcaa2087e7a5b53f6#59730cdeefdb00c61ba747dbcaa2087e7a5b53f6"
+source = "git+https://github.com/gfx-rs/gfx?rev=2d454c77ddbaae05ba222ca369c16afae0c10cd1#2d454c77ddbaae05ba222ca369c16afae0c10cd1"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.6.2"
-source = "git+https://github.com/gfx-rs/gfx?rev=59730cdeefdb00c61ba747dbcaa2087e7a5b53f6#59730cdeefdb00c61ba747dbcaa2087e7a5b53f6"
+source = "git+https://github.com/gfx-rs/gfx?rev=2d454c77ddbaae05ba222ca369c16afae0c10cd1#2d454c77ddbaae05ba222ca369c16afae0c10cd1"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-empty"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=59730cdeefdb00c61ba747dbcaa2087e7a5b53f6#59730cdeefdb00c61ba747dbcaa2087e7a5b53f6"
+source = "git+https://github.com/gfx-rs/gfx?rev=2d454c77ddbaae05ba222ca369c16afae0c10cd1#2d454c77ddbaae05ba222ca369c16afae0c10cd1"
 dependencies = [
  "gfx-hal",
  "log",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-gl"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=59730cdeefdb00c61ba747dbcaa2087e7a5b53f6#59730cdeefdb00c61ba747dbcaa2087e7a5b53f6"
+source = "git+https://github.com/gfx-rs/gfx?rev=2d454c77ddbaae05ba222ca369c16afae0c10cd1#2d454c77ddbaae05ba222ca369c16afae0c10cd1"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-metal"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=59730cdeefdb00c61ba747dbcaa2087e7a5b53f6#59730cdeefdb00c61ba747dbcaa2087e7a5b53f6"
+source = "git+https://github.com/gfx-rs/gfx?rev=2d454c77ddbaae05ba222ca369c16afae0c10cd1#2d454c77ddbaae05ba222ca369c16afae0c10cd1"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.6.5"
-source = "git+https://github.com/gfx-rs/gfx?rev=59730cdeefdb00c61ba747dbcaa2087e7a5b53f6#59730cdeefdb00c61ba747dbcaa2087e7a5b53f6"
+source = "git+https://github.com/gfx-rs/gfx?rev=2d454c77ddbaae05ba222ca369c16afae0c10cd1#2d454c77ddbaae05ba222ca369c16afae0c10cd1"
 dependencies = [
  "arrayvec",
  "ash",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "gfx-hal"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=59730cdeefdb00c61ba747dbcaa2087e7a5b53f6#59730cdeefdb00c61ba747dbcaa2087e7a5b53f6"
+source = "git+https://github.com/gfx-rs/gfx?rev=2d454c77ddbaae05ba222ca369c16afae0c10cd1#2d454c77ddbaae05ba222ca369c16afae0c10cd1"
 dependencies = [
  "bitflags",
  "naga",
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "range-alloc"
 version = "0.1.1"
-source = "git+https://github.com/gfx-rs/gfx?rev=59730cdeefdb00c61ba747dbcaa2087e7a5b53f6#59730cdeefdb00c61ba747dbcaa2087e7a5b53f6"
+source = "git+https://github.com/gfx-rs/gfx?rev=2d454c77ddbaae05ba222ca369c16afae0c10cd1#2d454c77ddbaae05ba222ca369c16afae0c10cd1"
 
 [[package]]
 name = "raw-window-handle"
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "spirv_cross"
-version = "0.22.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebd49af36be83ecd6290b57147e2a0e26145b832634b17146d934b197ca3713"
+checksum = "06db6bd7b6518f761593783e2896eefe55e90455efc5f44511078ce0426ed418"
 dependencies = [
  "cc",
  "js-sys",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,24 +36,24 @@ thiserror = "1"
 gpu-alloc = { git = "https://github.com/zakarumych/gpu-alloc", rev = "915d0dad0db340a4d37d5abd597b8b796e7f35f6", features = ["tracing"] }
 gpu-descriptor = { git = "https://github.com/zakarumych/gpu-descriptor", rev = "aa092613889f03f8254d6f7278d08c655324c7c7", features = ["tracing"] }
 
-hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "59730cdeefdb00c61ba747dbcaa2087e7a5b53f6" }
-gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "59730cdeefdb00c61ba747dbcaa2087e7a5b53f6" }
+hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "2d454c77ddbaae05ba222ca369c16afae0c10cd1" }
+gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "2d454c77ddbaae05ba222ca369c16afae0c10cd1" }
 
 [target.'cfg(all(not(target_arch = "wasm32"), all(unix, not(target_os = "ios"), not(target_os = "macos"))))'.dependencies]
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "59730cdeefdb00c61ba747dbcaa2087e7a5b53f6", features = ["naga"] }
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "59730cdeefdb00c61ba747dbcaa2087e7a5b53f6", features = ["naga"] }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "2d454c77ddbaae05ba222ca369c16afae0c10cd1", features = ["naga"] }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "2d454c77ddbaae05ba222ca369c16afae0c10cd1", features = ["naga"] }
 
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
-gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "59730cdeefdb00c61ba747dbcaa2087e7a5b53f6", features = ["naga"] }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "59730cdeefdb00c61ba747dbcaa2087e7a5b53f6", optional = true }
+gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "2d454c77ddbaae05ba222ca369c16afae0c10cd1", features = ["naga"] }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "2d454c77ddbaae05ba222ca369c16afae0c10cd1", optional = true }
 
 [target.'cfg(all(not(target_arch = "wasm32"), windows))'.dependencies]
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "59730cdeefdb00c61ba747dbcaa2087e7a5b53f6" }
-gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "59730cdeefdb00c61ba747dbcaa2087e7a5b53f6" }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "59730cdeefdb00c61ba747dbcaa2087e7a5b53f6", features = ["naga"] }
+gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "2d454c77ddbaae05ba222ca369c16afae0c10cd1" }
+gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "2d454c77ddbaae05ba222ca369c16afae0c10cd1" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "2d454c77ddbaae05ba222ca369c16afae0c10cd1", features = ["naga"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "59730cdeefdb00c61ba747dbcaa2087e7a5b53f6", features = ["naga"] }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "2d454c77ddbaae05ba222ca369c16afae0c10cd1", features = ["naga"] }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"


### PR DESCRIPTION
**Connections**
- This bumps `gfx` to [#3610](https://github.com/gfx-rs/gfx/pull/3610), and also includes [#3608](https://github.com/gfx-rs/gfx/pull/3608) and [#3609](https://github.com/gfx-rs/gfx/pull/3608)
- [Here](https://github.com/gfx-rs/wgpu-native/pull/66) is a draft PR to `wgpu-native`
- `wgpu-rs` requires a one-line fix to the `texture_view_drop` call (which now takes a boolean); I can PR this next.

**Description**
This fixes [pathological shader complexity in SPIRV-Cross](https://github.com/KhronosGroup/SPIRV-Cross/pull/1594), as well as a few other `gfx` PRs.

**Testing**
I updated `wgpu-native` to use this branch, then updated my [toy raytracer](https://github.com/mkeeter/rayray) to use the resulting `dylibs` and confirmed that it no longer takes forever to compile the pathological shader.

In addition, I updated `wgpu-rs` and went through the examples; nothing seems out of place.