### PR TITLE
Handle zero-sized bindings as an error

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -58,11 +58,18 @@ pub enum CreateBindGroupError {
     BindingArrayLengthMismatch { actual: usize, expected: usize },
     #[error("bound buffer range {range:?} does not fit in buffer of size {size}")]
     BindingRangeTooLarge {
+        buffer: BufferId,
         range: Range<wgt::BufferAddress>,
         size: u64,
     },
     #[error("buffer binding size {actual} is less than minimum {min}")]
-    BindingSizeTooSmall { actual: u64, min: u64 },
+    BindingSizeTooSmall {
+        buffer: BufferId,
+        actual: u64,
+        min: u64,
+    },
+    #[error("buffer binding size is zero")]
+    BindingZeroSize(BufferId),
     #[error("number of bindings in bind group descriptor ({actual}) does not match the number of bindings defined in the bind group layout ({expected})")]
     BindingsNumMismatch { actual: usize, expected: usize },
     #[error("binding {0} is used at least twice in the descriptor")]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -870,6 +870,7 @@ impl<'a, B: GfxBackend> RenderPassInfo<'a, B> {
             TextureViewInner::SwapChain { ref image, .. } => Borrow::borrow(image),
         });
 
+        //Note: the order of iteration has to match `AttachmentData::all()`
         let attachments = color_attachments
             .iter()
             .zip(&rp_key.colors)

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1296,6 +1296,7 @@ impl<B: GfxBackend> Device<B> {
                             let end = bb.offset + size.get();
                             if end > buffer.size {
                                 return Err(Error::BindingRangeTooLarge {
+                                    buffer: bb.buffer_id,
                                     range: bb.offset..end,
                                     size: buffer.size,
                                 });
@@ -1322,10 +1323,13 @@ impl<B: GfxBackend> Device<B> {
                         let min_size = non_zero.get();
                         if min_size > bind_size {
                             return Err(Error::BindingSizeTooSmall {
+                                buffer: bb.buffer_id,
                                 actual: bind_size,
                                 min: min_size,
                             });
                         }
+                    } else if bind_size == 0 {
+                        return Err(Error::BindingZeroSize(bb.buffer_id));
                     }
 
                     let sub_range = hal::buffer::SubRange {


### PR DESCRIPTION
**Connections**
Fixes #1165

**Description**
Adds buffer IDs to the binding errors, also adds a variant for zero sized bindings.

**Testing**
Tested on a hand-written example.