### PR TITLE
Rewrite RenderPipelineDescriptor according to aspects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Change Log
 
+## v0.7 (TBD)
+  - Major API changes:
+    - `RenderPipelineDescriptor`
+    - `BindingType`
+  - Features:
+    - (beta) WGSL support, including the ability to bypass SPIR-V entirely
+    - (beta) implicit bind group layout support
+    - timestamp and pipeline statistics queries
+    - ETC2 and ASTC compressed textures
+    - (beta) targeting WASM with WebGL backend
+    - reduced dependencies
+    - Native-only:
+      - clamp-to-border addressing
+      - polygon fill modes
+      - query a format for extra capabilities
+      - `f64` support in shaders
+  - Validation:
+    - shader interface
+    - render pipeline descriptor
+    - vertex buffers
+
 ## v0.6 (2020-08-17)
   - Crates:
     - C API is moved to [another repository](https://github.com/gfx-rs/wgpu-native)

--- a/player/tests/data/bind-group.ron
+++ b/player/tests/data/bind-group.ron
@@ -18,7 +18,7 @@
         CreateComputePipeline(Id(0, 1, Empty), (
             label: None,
             layout: Some(Id(0, 1, Empty)),
-            compute_stage: (
+            stage: (
                 module: Id(0, 1, Empty),
                 entry_point: "main",
             ),

--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -56,42 +56,24 @@
         CreateRenderPipeline(Id(0, 1, Empty), (
             label: None,
             layout: Some(Id(0, 1, Empty)),
-            vertex_stage: (
-                module: Id(0, 1, Empty),
-                entry_point: "vs_main",
-            ),
-            fragment_stage: Some((
-                module: Id(0, 1, Empty),
-                entry_point: "fs_main",
-            )),
-            rasterization_state: None,
-            primitive_topology: TriangleList,
-            color_states: [
-                (
-                    format: Rgba8Unorm,
-                    alpha_blend: (
-                        src_factor: One,
-                        dst_factor: Zero,
-                        operation: Add,
-                    ),
-                    color_blend: (
-                        src_factor: One,
-                        dst_factor: Zero,
-                        operation: Add,
-                    ),
-                    write_mask: (
-                        bits: 15,
-                    ),
+            vertex: (
+                stage: (
+                    module: Id(0, 1, Empty),
+                    entry_point: "vs_main",
                 ),
-            ],
-            depth_stencil_state: None,
-            vertex_state: (
-                index_format: None,
-                vertex_buffers: [],
+                buffers: [],
             ),
-            sample_count: 1,
-            sample_mask: 4294967295,
-            alpha_to_coverage_enabled: false,
+            fragment: Some((
+                stage: (
+                    module: Id(0, 1, Empty),
+                    entry_point: "fs_main",
+                ),
+                targets: [
+                    (
+                        format: Rgba8Unorm,
+                    ),
+                ],
+            )),
         )),
         Submit(1, [
             RunRenderPass(

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -233,7 +233,7 @@ impl RenderBundleEncoder {
                     pipeline_layout_id = Some(pipeline.layout_id.value);
 
                     state.set_pipeline(
-                        pipeline.index_format,
+                        pipeline.strip_index_format,
                         &pipeline.vertex_strides,
                         &layout.bind_group_layout_ids,
                         &layout.push_constant_ranges,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1248,7 +1248,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             }
                         }
 
-                        state.index.pipeline_format = pipeline.index_format;
+                        state.index.pipeline_format = pipeline.strip_index_format;
 
                         let vertex_strides_len = pipeline.vertex_strides.len();
                         state.vertex.buffers_required = vertex_strides_len as u32;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2658,7 +2658,7 @@ pub enum BindingType {
 }
 
 impl BindingType {
-    /// Returns true for buffer bindings with dynamic offseting enabled.
+    /// Returns true for buffer bindings with dynamic offset enabled.
     pub fn has_dynamic_offset(&self) -> bool {
         match *self {
             Self::Buffer {


### PR DESCRIPTION
**Connections**
Fixes #1166

**Description**
Totally re-imagines the structure tree for describing the rendering pipeline, based on the aspects instead of logical steps.

**Testing**
Just local testing. I don't think there is any concern that these changes might not work, they just need the clients to adapt.