### PR TITLE
validate for strip_index_format being used with non-strip topology

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2004,6 +2004,18 @@ impl<B: GfxBackend> Device<B> {
             }
         }
 
+        if desc.primitive.strip_index_format.is_some()
+            && desc.primitive.topology != wgt::PrimitiveTopology::LineStrip
+            && desc.primitive.topology != wgt::PrimitiveTopology::TriangleStrip
+        {
+            return Err(
+                pipeline::CreateRenderPipelineError::StripIndexFormatForNonStripTopology {
+                    strip_index_format: desc.primitive.strip_index_format,
+                    topology: desc.primitive.topology,
+                },
+            );
+        }
+
         let input_assembler = conv::map_primitive_state_to_input_assembler(&desc.primitive);
 
         let blender = hal::pso::BlendDesc {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -191,7 +191,7 @@ pub struct RenderPipelineDescriptor<'a> {
 pub enum CreateRenderPipelineError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("pipelie layout is invalid")]
+    #[error("pipeline layout is invalid")]
     InvalidLayout,
     #[error("unable to derive an implicit layout")]
     Implicit(#[from] ImplicitLayoutError),
@@ -210,6 +210,11 @@ pub enum CreateRenderPipelineError {
     InvalidVertexAttributeOffset {
         location: wgt::ShaderLocation,
         offset: wgt::BufferAddress,
+    },
+    #[error("strip index format was not set to None but to {strip_index_format:?} while using the non-strip topology {topology:?}")]
+    StripIndexFormatForNonStripTopology {
+        strip_index_format: Option<wgt::IndexFormat>,
+        topology: wgt::PrimitiveTopology,
     },
     #[error("missing required device features {0:?}")]
     MissingFeature(wgt::Features),


### PR DESCRIPTION
**Description**
Hit lack of this validation when porting a project to newest wgpu-rs: Accidentally set the strip_index_format for a TriangleList pipeline which left me with a Vulkan validation error (since wgpu decides to set `restart_index` in presence of a `strip_index_format`)

```
VALIDATION [VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428 (-1077750125)] : Validation Error: [ VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428 ] Object 0: handle = 0x1ebbfa512a8, type = VK_OBJECT_TYPE_DEVICE; | MessageID 
= 0xbfc2d693 | vkCreateGraphicsPipelines() pCreateInfo[0]: topology is VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST and primitiveRestartEnable is VK_TRUE. It is invalid. The Vulkan spec states: If topology is VK_PRIMITIVE_TOPOLOGY_POINT_LIST, VK_PRIMITIVE_TOPOLOGY_LINE_LIST, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY or VK_PRIMITIVE_TOPOLOGY_PATCH_LIST, primitiveRestartEnable must be VK_FALSE (https://vulkan.lunarg.com/doc/view/1.2.141.0/windows/1.2-extensions/vkspec.html#VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428)
    object info: (type: DEVICE, hndl: 2112044208808)
```

(arguably wgpu could be more clever about this and just not set `restart_index`, but that leaves the user code in a non-sense state)

**Testing**
One-off test triggering the error through wgpu-rs.