### PR TITLE
Fix command allocator race condition with maintenance

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3606,14 +3606,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(e) => break e,
             };
 
-            let mut raw = device.cmd_allocator.extend(&command_buffer);
+            let mut raw = command_buffer.raw.first_mut().unwrap();
             unsafe {
                 if let Some(ref label) = desc.label {
                     device.raw.set_command_buffer_name(&mut raw, label);
                 }
                 raw.begin_primary(hal::command::CommandBufferFlags::ONE_TIME_SUBMIT);
             }
-            command_buffer.raw.push(raw);
 
             let id = hub
                 .command_buffers


### PR DESCRIPTION
**Connections**
Fixes #1196

**Description**
This was a recent change, where I thought it would be more pure to just prepare the pool but not create anything right away. It looked more elegant, but now we see it was flowed.

**Testing**
Not really tested the concurrent aspect of it, but it should work.
Perhaps, we can hook up Loom in the future for this task?