### PR TITLE
Convert `PrimitiveState::cull_mode` to `Option<Face>`

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -808,9 +808,9 @@ pub fn map_primitive_state_to_rasterizer(
             wgt::PolygonMode::Point => pso::PolygonMode::Point,
         },
         cull_face: match desc.cull_mode {
-            wgt::CullMode::None => pso::Face::empty(),
-            wgt::CullMode::Front => pso::Face::FRONT,
-            wgt::CullMode::Back => pso::Face::BACK,
+            None => pso::Face::empty(),
+            Some(wgt::Face::Front) => pso::Face::FRONT,
+            Some(wgt::Face::Back) => pso::Face::BACK,
         },
         front_face: match desc.front_face {
             wgt::FrontFace::Ccw => pso::FrontFace::CounterClockwise,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -819,24 +819,16 @@ impl Default for FrontFace {
     }
 }
 
-/// Type of faces to be culled.
+/// Face of a vertex.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
-pub enum CullMode {
-    /// No faces should be culled
-    None = 0,
-    /// Front faces should be culled
-    Front = 1,
-    /// Back faces should be culled
-    Back = 2,
-}
-
-impl Default for CullMode {
-    fn default() -> Self {
-        Self::None
-    }
+pub enum Face {
+    /// Front face
+    Front = 0,
+    /// Back face
+    Back = 1,
 }
 
 /// Type of drawing mode for polygons
@@ -876,7 +868,7 @@ pub struct PrimitiveState {
     pub front_face: FrontFace,
     /// The face culling mode.
     #[cfg_attr(any(feature = "trace", feature = "replay"), serde(default))]
-    pub cull_mode: CullMode,
+    pub cull_mode: Option<Face>,
     /// Controls the way each polygon is rasterized. Can be either `Fill` (default), `Line` or `Point`
     ///
     /// Setting this to something other than `Fill` requires `Features::NON_FILL_POLYGON_MODE` to be enabled.


### PR DESCRIPTION
**Connections**
Closes #1192 

**Description**
`wgpu::CullMode` was an enum with a `None` variant, which would be more idiomatic as an `Option` in Rust.

**Testing**
- `wgpu-rs` builds with the appropriate changes
- `wgpu-native` needs https://github.com/gfx-rs/wgpu-native/pull/71 merged before it can be updated
