### PR TITLE
Handle player window resizing gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d74668a6a6f0202e29f212a6d47ef8c7e092a76f4ab267b0065b6e0d175e45c6"
+checksum = "e8a70f1e87a3840ed6a3e99e02c2b861e4dbdf26f0d07e38f42ea5aff46cfce2"
 dependencies = [
  "bitflags",
  "gpu-descriptor-types",

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -51,7 +51,7 @@ fn main() {
     #[cfg(feature = "winit")]
     let window = WindowBuilder::new()
         .with_title("wgpu player")
-        .with_resizable(false)
+        .with_resizable(true)
         .build(&event_loop)
         .unwrap();
 
@@ -123,6 +123,7 @@ fn main() {
             event_loop::ControlFlow,
         };
 
+        let mut resize_desc = None;
         let mut frame_count = 0;
         event_loop.run(move |event, _, control_flow| {
             *control_flow = ControlFlow::Poll;
@@ -130,16 +131,22 @@ fn main() {
                 Event::MainEventsCleared => {
                     window.request_redraw();
                 }
-                Event::RedrawRequested(_) => loop {
+                Event::RedrawRequested(_) if resize_desc.is_none() => loop {
                     match actions.pop() {
                         Some(trace::Action::CreateSwapChain(id, desc)) => {
                             log::info!("Initializing the swapchain");
                             assert_eq!(id.to_surface_id(), surface);
-                            window.set_inner_size(winit::dpi::PhysicalSize::new(
-                                desc.width,
-                                desc.height,
-                            ));
-                            gfx_select!(device => global.device_create_swap_chain(device, surface, &desc)).unwrap();
+                            let current_size: (u32, u32) = window.inner_size().into();
+                            let size = (desc.width, desc.height);
+                            if current_size != size {
+                                window.set_inner_size(winit::dpi::PhysicalSize::new(
+                                    desc.width,
+                                    desc.height,
+                                ));
+                                resize_desc = Some(desc);
+                            } else {
+                                gfx_select!(device => global.device_create_swap_chain(device, surface, &desc)).unwrap();
+                            }
                         }
                         Some(trace::Action::PresentSwapChain(id)) => {
                             frame_count += 1;
@@ -154,6 +161,11 @@ fn main() {
                     }
                 },
                 Event::WindowEvent { event, .. } => match event {
+                    WindowEvent::Resized(_) => {
+                        if let Some(desc) = resize_desc.take() {
+                            gfx_select!(device => global.device_create_swap_chain(device, surface, &desc)).unwrap();
+                        }
+                    }
                     WindowEvent::KeyboardInput {
                         input:
                             KeyboardInput {


### PR DESCRIPTION
**Connections**
Deprecates #794 and #793

**Description**
We were often getting this kind of errors when replaying on Linux:
>VALIDATION [VUID-VkSwapchainCreateInfoKHR-imageExtent-01274 (2094043421)] : Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageExtent-01274 ] Object 0: handle = 0x56194a357250, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x7cd0911d | vkCreateSwapchainKHR() called with imageExtent = (1980,1080), which is outside the bounds returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR(): currentExtent = (800,600), minImageExtent = (800,600), maxImageExtent = (800,600). The Vulkan spec states: imageExtent must be between minImageExtent and maxImageExtent, inclusive, where minImageExtent and maxImageExtent are members of the VkSurfaceCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR for the surface (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageExtent-01274)
object info: (type: DEVICE, hndl: 94666619187792)

It's annoying to work around!

**Testing**
Tested on replaying wgpu-rs stuff.