### PR TITLE
Reset the bindings on the push constant change

### DIFF
--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -179,9 +179,7 @@ impl Binder {
         if let Some(old_id) = old_id_opt {
             let old = &guard[old_id];
             // root constants are the base compatibility property
-            if old.push_constant_ranges != new.push_constant_ranges
-                && bind_range.end != bind_range.start
-            {
+            if old.push_constant_ranges != new.push_constant_ranges {
                 bind_range.start = 0;
             }
         }


### PR DESCRIPTION
**Connections**
Fixes #1207
(unconfirmed!)

**Description**
I was able to replay the trace in #1207 without validation errors, so I looked deeper into what might have gone wrong.
The code isolated in #1194 looks great. However, the calling code's handling of push constants might have changed a bit.
And I see that the trace uses push constants, so here is what happened, I think:
  - layout A was set, expecting bind group layouts X and Z
  - bind groups X and Y where bound
  - layout B was set, expecting bind group layout X and Y. We see that Y group can now be bound, so we do this. The old logic in this case wasn't considering the push constants in any way, it would only consider them if bind group layouts didn't change, erroneously.
  - layout B has different push constant ranges...

So it's a one-line fix now, which I'm hoping is correct.

**Testing**
Not tested
@Wumpf would you be able to check this?