### PR TITLE
fix rustdoc warnings

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -441,7 +441,7 @@ pub struct PipelineLayoutDescriptor<'a> {
     /// must define the range in push constant memory that corresponds to its single `layout(push_constant)`
     /// uniform block.
     ///
-    /// If this array is non-empty, the [`Features::PUSH_CONSTANTS`] must be enabled.
+    /// If this array is non-empty, the [`Features::PUSH_CONSTANTS`](wgt::Features::PUSH_CONSTANTS) must be enabled.
     pub push_constant_ranges: Cow<'a, [wgt::PushConstantRange]>,
 }
 

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -222,7 +222,7 @@ pub(crate) fn validate_linear_texture_data(
     Ok(required_bytes_in_copy)
 }
 
-/// Function copied with minor modifications from webgpu standard https://gpuweb.github.io/gpuweb/#valid-texture-copy-range
+/// Function copied with minor modifications from webgpu standard <https://gpuweb.github.io/gpuweb/#valid-texture-copy-range>
 pub(crate) fn validate_texture_copy_range(
     texture_copy_view: &TextureCopyView,
     texture_format: wgt::TextureFormat,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -274,7 +274,7 @@ pub struct TextureViewDescriptor<'a> {
     /// The dimension of the texture view. For 1D textures, this must be `1D`. For 2D textures it must be one of
     /// `D2`, `D2Array`, `Cube`, and `CubeArray`. For 3D textures it must be `3D`
     pub dimension: Option<wgt::TextureViewDimension>,
-    /// Aspect of the texture. Color textures must be [`TextureAspect::All`].
+    /// Aspect of the texture. Color textures must be [`TextureAspect::All`](wgt::TextureAspect::All).
     pub aspect: wgt::TextureAspect,
     /// Base mip level.
     pub base_mip_level: u32,
@@ -394,7 +394,7 @@ pub struct SamplerDescriptor<'a> {
     pub compare: Option<wgt::CompareFunction>,
     /// Valid values: 1, 2, 4, 8, and 16.
     pub anisotropy_clamp: Option<NonZeroU8>,
-    /// Border color to use when address_mode is [`AddressMode::ClampToBorder`]
+    /// Border color to use when address_mode is [`AddressMode::ClampToBorder`](wgt::AddressMode::ClampToBorder)
     pub border_color: Option<wgt::SamplerBorderColor>,
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -436,7 +436,7 @@ bitflags::bitflags! {
 /// implementation needs to support more than is needed. You should ideally only request exactly what
 /// you need.
 ///
-/// See also: https://gpuweb.github.io/gpuweb/#dictdef-gpulimits
+/// See also: <https://gpuweb.github.io/gpuweb/#dictdef-gpulimits>
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
@@ -1361,7 +1361,7 @@ impl TextureFormat {
         let storage = basic | TextureUsage::STORAGE;
         let all_flags = TextureUsage::all();
 
-        // See https://gpuweb.github.io/gpuweb/#texture-format-caps for reference
+        // See <https://gpuweb.github.io/gpuweb/#texture-format-caps> for reference
         let (required_features, sample_type, srgb, block_dimensions, block_size, allowed_usages) =
             match self {
                 // Normal 8 bit textures
@@ -2455,7 +2455,7 @@ pub struct TextureDataLayout {
 
 /// Specific type of a buffer binding.
 ///
-/// WebGPU spec: https://gpuweb.github.io/gpuweb/#enumdef-gpubufferbindingtype
+/// WebGPU spec: <https://gpuweb.github.io/gpuweb/#enumdef-gpubufferbindingtype>
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
@@ -2501,7 +2501,7 @@ impl Default for BufferBindingType {
 
 /// Specific type of a sample in a texture binding.
 ///
-/// WebGPU spec: https://gpuweb.github.io/gpuweb/#enumdef-gputexturesampletype
+/// WebGPU spec: <https://gpuweb.github.io/gpuweb/#enumdef-gputexturesampletype>
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
@@ -2552,7 +2552,7 @@ impl Default for TextureSampleType {
 
 /// Specific type of a sample in a texture binding.
 ///
-/// WebGPU spec: https://gpuweb.github.io/gpuweb/#enumdef-gpustoragetextureaccess
+/// WebGPU spec: <https://gpuweb.github.io/gpuweb/#enumdef-gpustoragetextureaccess>
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
@@ -2572,7 +2572,7 @@ pub enum StorageTextureAccess {
     /// ```
     WriteOnly,
     /// The texture can be both read and written in the shader.
-    /// [`Features::STORAGE_TEXTURE_ACCESS_READ_WRITE`] must be enabled to use this access mode.
+    /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] must be enabled to use this access mode.
     ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
@@ -2584,10 +2584,10 @@ pub enum StorageTextureAccess {
 /// Specific type of a binding.
 ///
 /// WebGPU spec: the enum of
-/// - https://gpuweb.github.io/gpuweb/#dictdef-gpubufferbindinglayout
-/// - https://gpuweb.github.io/gpuweb/#dictdef-gpusamplerbindinglayout
-/// - https://gpuweb.github.io/gpuweb/#dictdef-gputexturebindinglayout
-/// - https://gpuweb.github.io/gpuweb/#dictdef-gpustoragetexturebindinglayout
+/// - <https://gpuweb.github.io/gpuweb/#dictdef-gpubufferbindinglayout>
+/// - <https://gpuweb.github.io/gpuweb/#dictdef-gpusamplerbindinglayout>
+/// - <https://gpuweb.github.io/gpuweb/#dictdef-gputexturebindinglayout>
+/// - <https://gpuweb.github.io/gpuweb/#dictdef-gpustoragetexturebindinglayout>
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
@@ -2621,7 +2621,7 @@ pub enum BindingType {
         /// A filtering sampler can only be used with a filterable texture.
         filtering: bool,
         /// Use as a comparison sampler instead of a normal sampler.
-        /// For more info take a look at the analogous functionality in OpenGL: https://www.khronos.org/opengl/wiki/Sampler_Object#Comparison_mode.
+        /// For more info take a look at the analogous functionality in OpenGL: <https://www.khronos.org/opengl/wiki/Sampler_Object#Comparison_mode>.
         comparison: bool,
     },
     /// A texture binding.
@@ -2648,7 +2648,7 @@ pub enum BindingType {
     /// layout(set=0, binding=0, r32f) uniform image2D myStorageImage;
     /// ```
     /// Note that the texture format must be specified in the shader as well.
-    /// A list of valid formats can be found in the specification here: https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.60.html#layout-qualifiers
+    /// A list of valid formats can be found in the specification here: <https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.60.html#layout-qualifiers>
     StorageTexture {
         /// Allowed access to this texture.
         access: StorageTextureAccess,


### PR DESCRIPTION
**Connections**
fixes #1213 

**Description**
Fixes rustdoc warnings (broken links, `<autourls>`)

**Testing**
`cargo doc` does not complain anymore.