### PR TITLE
Validate texture bindings

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -100,6 +100,30 @@ pub enum CreateBindGroupError {
         // Human-readable description of expected types
         expected: &'static str,
     },
+    #[error("texture binding {binding} expects multisampled = {layout_multisampled}, but given a view with samples = {view_samples}")]
+    InvalidTextureMultisample {
+        binding: u32,
+        layout_multisampled: bool,
+        view_samples: u32,
+    },
+    #[error("texture binding {binding} expects sample type = {layout_sample_type:?}, but given a view with format = {view_format:?}")]
+    InvalidTextureSampleType {
+        binding: u32,
+        layout_sample_type: wgt::TextureSampleType,
+        view_format: wgt::TextureFormat,
+    },
+    #[error("texture binding {binding} expects dimension = {layout_dimension:?}, but given a view with dimension = {view_dimension:?}")]
+    InvalidTextureDimension {
+        binding: u32,
+        layout_dimension: wgt::TextureViewDimension,
+        view_dimension: wgt::TextureViewDimension,
+    },
+    #[error("storage texture binding {binding} expects format = {layout_format:?}, but given a view with format = {view_format:?}")]
+    InvalidStorageTextureFormat {
+        binding: u32,
+        layout_format: wgt::TextureFormat,
+        view_format: wgt::TextureFormat,
+    },
     #[error("the given sampler is/is not a comparison sampler, while the layout type indicates otherwise")]
     WrongSamplerComparison,
     #[error("bound texture views can not have both depth and stencil aspects enabled")]

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -309,6 +309,7 @@ pub struct TextureView<B: hal::Backend> {
     pub(crate) aspects: hal::format::Aspects,
     pub(crate) format: wgt::TextureFormat,
     pub(crate) format_features: wgt::TextureFormatFeatures,
+    pub(crate) dimension: wgt::TextureViewDimension,
     pub(crate) extent: wgt::Extent3d,
     pub(crate) samples: hal::image::NumSamples,
     pub(crate) framebuffer_attachment: hal::image::FramebufferAttachment,

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -188,6 +188,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         allowed_usages: wgt::TextureUsage::RENDER_ATTACHMENT,
                         flags: wgt::TextureFormatFeatureFlags::empty(),
                     },
+                    dimension: wgt::TextureViewDimension::D2,
                     extent: wgt::Extent3d {
                         width: sc.desc.width,
                         height: sc.desc.height,


### PR DESCRIPTION
**Connections**
It was mentioned/requested somewhere, but I can't find the place...

**Description**
Fairly straightforward - just check the view properties against the bind group layout.

**Testing**
Tested on wgpu-rs examples