### PR TITLE
Update gfx and naga to gfx-12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
 [[package]]
 name = "gfx-auxil"
 version = "0.8.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=80655862ac4afc5efb6675eb9ac7c38e73544750#80655862ac4afc5efb6675eb9ac7c38e73544750"
+source = "git+https://github.com/gfx-rs/gfx?rev=a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce#a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx11"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=80655862ac4afc5efb6675eb9ac7c38e73544750#80655862ac4afc5efb6675eb9ac7c38e73544750"
+source = "git+https://github.com/gfx-rs/gfx?rev=a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce#a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=80655862ac4afc5efb6675eb9ac7c38e73544750#80655862ac4afc5efb6675eb9ac7c38e73544750"
+source = "git+https://github.com/gfx-rs/gfx?rev=a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce#a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-empty"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=80655862ac4afc5efb6675eb9ac7c38e73544750#80655862ac4afc5efb6675eb9ac7c38e73544750"
+source = "git+https://github.com/gfx-rs/gfx?rev=a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce#a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce"
 dependencies = [
  "gfx-hal",
  "log",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-gl"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=80655862ac4afc5efb6675eb9ac7c38e73544750#80655862ac4afc5efb6675eb9ac7c38e73544750"
+source = "git+https://github.com/gfx-rs/gfx?rev=a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce#a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-metal"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=80655862ac4afc5efb6675eb9ac7c38e73544750#80655862ac4afc5efb6675eb9ac7c38e73544750"
+source = "git+https://github.com/gfx-rs/gfx?rev=a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce#a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=80655862ac4afc5efb6675eb9ac7c38e73544750#80655862ac4afc5efb6675eb9ac7c38e73544750"
+source = "git+https://github.com/gfx-rs/gfx?rev=a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce#a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce"
 dependencies = [
  "arrayvec",
  "ash",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "gfx-hal"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=80655862ac4afc5efb6675eb9ac7c38e73544750#80655862ac4afc5efb6675eb9ac7c38e73544750"
+source = "git+https://github.com/gfx-rs/gfx?rev=a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce#a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce"
 dependencies = [
  "bitflags",
  "naga",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.3.1"
-source = "git+https://github.com/gfx-rs/naga?tag=gfx-11#539db1a317d62c8c50e21ff908cf952c731a05b6"
+source = "git+https://github.com/gfx-rs/naga?tag=gfx-12#fa7d4d8b51d4eeffe9f648d285466637f733a4a1"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -1212,7 +1212,7 @@ dependencies = [
 [[package]]
 name = "range-alloc"
 version = "0.1.2"
-source = "git+https://github.com/gfx-rs/gfx?rev=80655862ac4afc5efb6675eb9ac7c38e73544750#80655862ac4afc5efb6675eb9ac7c38e73544750"
+source = "git+https://github.com/gfx-rs/gfx?rev=a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce#a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce"
 
 [[package]]
 name = "raw-window-handle"

--- a/dummy/Cargo.toml
+++ b/dummy/Cargo.toml
@@ -12,4 +12,4 @@ publish = false
 [dependencies.wgc]
 path = "../wgpu-core"
 package = "wgpu-core"
-features = ["cross", "serial-pass", "trace"]
+features = ["serial-pass", "trace"]

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -13,6 +13,7 @@ license = "MPL-2.0"
 publish = false
 
 [features]
+cross = ["wgc/cross"]
 
 [dependencies]
 env_logger = "0.8"

--- a/player/tests/data/bind-group.ron
+++ b/player/tests/data/bind-group.ron
@@ -11,7 +11,7 @@
             id: Id(0, 1, Empty),
             desc: (
                 label: None,
-                experimental_translation: true,
+                flags: (bits: 3),
             ),
             data: "empty.wgsl",
         ),

--- a/player/tests/data/buffer-zero-init.ron
+++ b/player/tests/data/buffer-zero-init.ron
@@ -84,7 +84,7 @@
             id: Id(0, 1, Empty),
             desc: (
                 label: None,
-                experimental_translation: true,
+                flags: (bits: 3),
             ),
             data: "buffer-zero-init-for-binding.wgsl",
         ),

--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -13,7 +13,7 @@
             id: Id(0, 1, Empty),
             desc: (
                 label: None,
-                experimental_translation: true,
+                flags: (bits: 3),
             ),
             data: "quad.wgsl",
         ),

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -38,28 +38,28 @@ thiserror = "1"
 gpu-alloc = { version = "0.3", features = ["tracing"] }
 gpu-descriptor = { version = "0.1", features = ["tracing"] }
 
-hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "80655862ac4afc5efb6675eb9ac7c38e73544750" }
-gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "80655862ac4afc5efb6675eb9ac7c38e73544750" }
+hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce" }
+gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce" }
 
 [target.'cfg(all(not(target_arch = "wasm32"), all(unix, not(target_os = "ios"), not(target_os = "macos"))))'.dependencies]
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "80655862ac4afc5efb6675eb9ac7c38e73544750", features = ["naga"] }
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "80655862ac4afc5efb6675eb9ac7c38e73544750" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce", features = ["naga"] }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce" }
 
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
-gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "80655862ac4afc5efb6675eb9ac7c38e73544750" }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "80655862ac4afc5efb6675eb9ac7c38e73544750", optional = true }
+gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce", optional = true }
 
 [target.'cfg(all(not(target_arch = "wasm32"), windows))'.dependencies]
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "80655862ac4afc5efb6675eb9ac7c38e73544750" }
-gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "80655862ac4afc5efb6675eb9ac7c38e73544750" }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "80655862ac4afc5efb6675eb9ac7c38e73544750", features = ["naga"] }
+gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce" }
+gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce", features = ["naga"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "80655862ac4afc5efb6675eb9ac7c38e73544750" }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "a76e68713ff46f0e5a3d0c31516e20d18bf0a3ce" }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-11"
+tag = "gfx-12"
 features = ["spv-in", "spv-out", "wgsl-in"]
 
 [dependencies.wgt]


### PR DESCRIPTION
**Connections**
Picks up https://github.com/gfx-rs/gfx/pull/3650
Fixes #1225

**Description**
Also fixes our playtests, interestingly. One of the changes here was that now `Analysis` is needed for everything, including the SPV-out backend of Naga. And we can only get it via validating the `naga::Module`.

What we used to was: if validation isn't enabled, we'd carry the module around, and then still try to produce a SPIR-V from it, if there is no original SPIR-V. This precise thing was happening in the tests. However, we had `dummy` backend depending on the `wgpu-core/cross` feature, which means the playtests were actually built and run with spirv-cross enabled!
Another factor here is the introduction of `ShaderModule::flags` instead of a single boolean, which was done in #1093. The problem here was that the playtest RON files weren't updated accordingly, they still had `experimental_translation: true` in them, which got ignored now.
So with this combination of events, the playtests ended up generating SPIR-V from Naga modules, without validation(!), and passing the SPIR-V to gfx-rs and SPIRV-Cross... Which still worked, as we'd expect, but definitely not want here.

So this PR fixes everything. It makes it required to have the validation for a module, and we force-validate if there is no SPV source to fall back on. And it disables "cross" feature implicitly enabled in testing.

**Testing**
Tested on wgpu-rs examples.