### PR TITLE
const in ShaderStage that represents vertex and fragment access

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -566,6 +566,8 @@ bitflags::bitflags! {
         const VERTEX = 1;
         /// Binding is visible from the fragment shader of a render pipeline.
         const FRAGMENT = 2;
+        /// Binding is visible from the vertex and fragment shaders of a render pipeline.
+        const VERTEX_FRAGMENT = 3;
         /// Binding is visible from the compute shader of a compute pipeline.
         const COMPUTE = 4;
     }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -567,7 +567,7 @@ bitflags::bitflags! {
         /// Binding is visible from the fragment shader of a render pipeline.
         const FRAGMENT = 2;
         /// Binding is visible from the vertex and fragment shaders of a render pipeline.
-        const VERTEX_FRAGMENT = 3;
+        const VERTEX_FRAGMENT = Self::VERTEX.bits | Self::FRAGMENT.bits;
         /// Binding is visible from the compute shader of a compute pipeline.
         const COMPUTE = 4;
     }


### PR DESCRIPTION
We can store `ShaderStage`s as const values or members of const structs in all individual cases, but for example `ShaderStage::VERTEX | ShaderStage::FRAGMENT` cannot be stored in a const. 

The suggested change is to add another member of ShaderStage which provides a const-friendly way of storing `ShaderStage`s intended for both vertex and fragment shaders.

This is not very elegant, but would be convenient.
