### PR TITLE
Added TextureFormatFeatures::filterable which may overwrite TextureSampleType::Float.filterable

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -329,9 +329,13 @@ impl<B: GfxBackend> Adapter<B> {
             flags |= wgt::TextureFormatFeatureFlags::STORAGE_READ_WRITE;
         }
 
+        let filterable =
+            texture_format_properties.contains(hal::format::ImageFeature::SAMPLED_LINEAR);
+
         wgt::TextureFormatFeatures {
             allowed_usages,
             flags,
+            filterable,
         }
     }
 

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -187,6 +187,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     format_features: wgt::TextureFormatFeatures {
                         allowed_usages: wgt::TextureUsage::RENDER_ATTACHMENT,
                         flags: wgt::TextureFormatFeatureFlags::empty(),
+                        filterable: false,
                     },
                     dimension: wgt::TextureViewDimension::D2,
                     extent: wgt::Extent3d {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -937,6 +937,9 @@ pub struct TextureFormatFeatures {
     pub allowed_usages: TextureUsage,
     /// Additional property flags for the format.
     pub flags: TextureFormatFeatureFlags,
+    /// If `filterable` is false, the texture can't be sampled with a filtering sampler.
+    /// This may overwrite TextureSampleType::Float.filterable
+    pub filterable: bool,
 }
 
 /// Information about a texture format.
@@ -1492,6 +1495,7 @@ impl TextureFormat {
             guaranteed_format_features: TextureFormatFeatures {
                 allowed_usages,
                 flags: TextureFormatFeatureFlags::empty(),
+                filterable: sample_type == TextureSampleType::Float { filterable: true },
             },
         }
     }


### PR DESCRIPTION
**Description**
The expectation is that with `wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES` enabled, any texture format which is sampled as float may be (linearly) filtered if so supported by the adapter, not only those that the webgpu specification denotes as filterable.

This arguably causes a bit of a mess in the way we distinguish `sample_type` and `(guaranteed_)format_features`: The float sample type (via spec) essentially integrates a feature, namely if it is filterable or not. Unlike the actual format _type_ which is just a property of the format, this property may or may not be available depending on the device.
So the type of `sample_type` stays statically defined whereas the Float.filterable property suddenly becomes overwritten by a format_feature which may or may not be present. Couldn't come up with a cleaner solution so far.

**Testing**
Tested in project (blub) depending on R32F filtering - passing now what was previously causing
```
wgpu error: Validation Error

Caused by:
    In Device::create_bind_group
      note: label = `BindGroup: Narrow Range filter 1`
    texture binding 1 expects sample type = Float { filterable: true }, but given a view with format = R32Float
```
(Blub still can't run on latest wgpu because of other reported issues)