### PR TITLE
Move `#[error]` attributes after the corresponding `#[derive]`

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2507,8 +2507,8 @@ impl<B: hal::Backend> crate::hub::Resource for Device<B> {
     }
 }
 
-#[error("device is invalid")]
 #[derive(Clone, Debug, Error)]
+#[error("device is invalid")]
 pub struct InvalidDevice;
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -148,8 +148,8 @@ impl<B: hal::Backend> super::Device<B> {
     }
 }
 
-#[error("queue is invalid")]
 #[derive(Clone, Debug, Error)]
+#[error("queue is invalid")]
 pub struct InvalidQueue;
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -557,8 +557,8 @@ impl<I: Clone> AdapterInputs<'_, I> {
     }
 }
 
-#[error("adapter is invalid")]
 #[derive(Clone, Debug, Error)]
+#[error("adapter is invalid")]
 pub struct InvalidAdapter;
 
 #[derive(Clone, Debug, Error)]


### PR DESCRIPTION
**Connections**
See https://github.com/rust-lang/rust/issues/79202

**Description**
Fixes Nightly future-incompat warnings

**Testing**
There are no behavior changes intended.