### PR TITLE
Avoid panic when requesting to unmap a buffer that is pending mapping

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -698,6 +698,8 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                     resource::BufferMapState::Idle,
                 ) {
                     resource::BufferMapState::Waiting(pending_mapping) => pending_mapping,
+                    // Mapping cancelled
+                    resource::BufferMapState::Idle => continue,
                     _ => panic!("No pending mapping."),
                 };
                 let status = if mapping.range.start != mapping.range.end {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -76,6 +76,7 @@ bitflags::bitflags! {
 pub enum BufferMapAsyncStatus {
     Success,
     Error,
+    Aborted,
     Unknown,
     ContextLost,
 }


### PR DESCRIPTION
**Connections**
Fix for #1238 

**Description**
This might not be the cleanest fix but it is quite minimal. I'm not sure what the exact intent is with the organization of things and with the async status enum, would be happy to hear critiques.

**Testing**
Tested against example in #1238 
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
