### PR TITLE
Force-drop the token before calling fire_map_callbacks

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -815,6 +815,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             callbacks
         };
 
+        // the map callbacks should execute with nothing locked!
+        drop(token);
         super::fire_map_callbacks(callbacks);
 
         Ok(())


### PR DESCRIPTION
**Connections**
Related to WebGPU update in Gecko

**Description**
Since the token was alive, technically, we saw an assertion firing up about concurrent access to the token root.

**Testing**
Tested in Gecko