### PR TITLE
Fix link to the "debugging tips" page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-<!-- Thank you for filing this! Please read the [debugging tips](https://github.com/gfx-rs/wgpu/wiki/Debbugging-wgpu-Applications).
+<!-- Thank you for filing this! Please read the [debugging tips](https://github.com/gfx-rs/wgpu/wiki/Debugging-wgpu-Applications).
 That may let you investigate on your own, or provide additional information that helps us to assist.-->
 
 **Description**


### PR DESCRIPTION
**Description**
The link was broken.

**Testing**
I used the link :P
