### PR TITLE
Add license to the memory init tracker

### DIFF
--- a/wgpu-core/src/memory_init_tracker.rs
+++ b/wgpu-core/src/memory_init_tracker.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use std::ops::Range;
 
 #[derive(Debug, Clone, Copy)]

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2216,7 +2216,7 @@ impl Extent3d {
     /// This includes padding to the block width and height of the format.
     ///
     /// This is the texture extent that you must upload at when uploading to _mipmaps_ of compressed textures.
-    ///  
+    ///
     /// ```rust
     /// # use wgpu_types as wgpu;
     /// let format = wgpu::TextureFormat::Bc1RgbaUnormSrgb; // 4x4 blocks


### PR DESCRIPTION
**Connections**
Gecko's code lints complain...

**Description**
Add a license header like all the other files

**Testing**
should work!