### PR TITLE
Fix swapchain resize in the player

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -144,6 +144,7 @@ fn main() {
                                     desc.height,
                                 ));
                                 resize_desc = Some(desc);
+                                break;
                             } else {
                                 gfx_select!(device => global.device_create_swap_chain(device, surface, &desc)).unwrap();
                             }


### PR DESCRIPTION
**Connections**
Fixes #1253

**Description**
I was fixing this recently in #1209, and I'm not sure how it worked, because there is a big inner `loop` that I didn't notice before 😅 .
So now we exit the inner loop upon resize.

**Testing**
Tested on the supplied API trace