### PR TITLE
chore: validate offset + size in get_mapped_range

### DIFF
--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -128,7 +128,7 @@ impl Test<'_> {
             println!("\t\t\tChecking {}", expect.name);
             let buffer = wgc::id::TypedId::zip(expect.buffer.index, expect.buffer.epoch, backend);
             let (ptr, size) =
-                wgc::gfx_select!(device => global.buffer_get_mapped_range(buffer, expect.offset, wgt::BufferSize::new(expect.data.len() as u64)))
+                wgc::gfx_select!(device => global.buffer_get_mapped_range(buffer, expect.offset, wgt::BufferSize::new(expect.data.len() as wgt::BufferAddress)))
                     .unwrap();
             let contents = unsafe { slice::from_raw_parts(ptr, size as usize) };
             let expected_data = match expect.data {

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -127,10 +127,10 @@ impl Test<'_> {
         for expect in self.expectations {
             println!("\t\t\tChecking {}", expect.name);
             let buffer = wgc::id::TypedId::zip(expect.buffer.index, expect.buffer.epoch, backend);
-            let ptr =
+            let (ptr, size) =
                 wgc::gfx_select!(device => global.buffer_get_mapped_range(buffer, expect.offset, None))
                     .unwrap();
-            let contents = unsafe { slice::from_raw_parts(ptr, expect.data.len()) };
+            let contents = unsafe { slice::from_raw_parts(ptr, size as usize) };
             let expected_data = match expect.data {
                 ExpectedData::Raw(vec) => vec,
                 ExpectedData::File(name, size) => {

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -20,6 +20,7 @@ use std::{
     path::{Path, PathBuf},
     ptr, slice,
 };
+use wgt::BufferSize;
 
 #[derive(serde::Deserialize)]
 struct RawId {
@@ -128,7 +129,7 @@ impl Test<'_> {
             println!("\t\t\tChecking {}", expect.name);
             let buffer = wgc::id::TypedId::zip(expect.buffer.index, expect.buffer.epoch, backend);
             let (ptr, size) =
-                wgc::gfx_select!(device => global.buffer_get_mapped_range(buffer, expect.offset, None))
+                wgc::gfx_select!(device => global.buffer_get_mapped_range(buffer, expect.offset, Some(BufferSize::new(expect.data.len() as u64).unwrap())))
                     .unwrap();
             let contents = unsafe { slice::from_raw_parts(ptr, size as usize) };
             let expected_data = match expect.data {

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -20,7 +20,6 @@ use std::{
     path::{Path, PathBuf},
     ptr, slice,
 };
-use wgt::BufferSize;
 
 #[derive(serde::Deserialize)]
 struct RawId {
@@ -129,7 +128,7 @@ impl Test<'_> {
             println!("\t\t\tChecking {}", expect.name);
             let buffer = wgc::id::TypedId::zip(expect.buffer.index, expect.buffer.epoch, backend);
             let (ptr, size) =
-                wgc::gfx_select!(device => global.buffer_get_mapped_range(buffer, expect.offset, Some(BufferSize::new(expect.data.len() as u64).unwrap())))
+                wgc::gfx_select!(device => global.buffer_get_mapped_range(buffer, expect.offset, wgt::BufferSize::new(expect.data.len() as u64)))
                     .unwrap();
             let contents = unsafe { slice::from_raw_parts(ptr, size as usize) };
             let expected_data = match expect.data {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4557,7 +4557,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 // offset (u64) can not be < 0, so no need to validate the lower bound
                 if offset + range_size > buffer.size {
                     return Err(resource::BufferAccessError::OutOfBoundsOverrun {
-                        index: offset + range_size,
+                        index: offset + range_size - 1,
                         max: buffer.size,
                     });
                 }
@@ -4578,7 +4578,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     .unwrap_or(buffer.size);
                 if offset + range_size > range_end_offset {
                     return Err(resource::BufferAccessError::OutOfBoundsOverrun {
-                        index: offset + range_size,
+                        index: offset + range_size - 1,
                         max: range_end_offset,
                     });
                 }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4526,7 +4526,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         buffer_id: id::BufferId,
         offset: BufferAddress,
-        _size: Option<BufferSize>,
+        size: Option<BufferSize>,
     ) -> Result<*mut u8, resource::BufferAccessError> {
         span!(_guard, INFO, "Device::buffer_get_mapped_range");
 
@@ -4537,11 +4537,49 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .get(buffer_id)
             .map_err(|_| resource::BufferAccessError::Invalid)?;
 
-        match buffer.map_state {
-            resource::BufferMapState::Init { ptr, .. }
-            | resource::BufferMapState::Active { ptr, .. } => unsafe {
-                Ok(ptr.as_ptr().offset(offset as isize))
-            },
+        let range_size = if let Some(size) = size {
+            size.into()
+        } else {
+            std::cmp::max(0, buffer.size - offset)
+        };
+
+        if offset % 8 != 0 {
+            return Err(resource::BufferAccessError::UnalignedOffset { offset });
+        }
+        if range_size % 4 != 0 {
+            return Err(resource::BufferAccessError::UnalignedRangeSize { range_size });
+        }
+
+        match &buffer.map_state {
+            resource::BufferMapState::Init { ptr, .. } => {
+                // u64 can not be < 0, so no need to validate this bound
+                if offset + range_size > buffer.size {
+                    return Err(resource::BufferAccessError::OutOfBoundsOverrun {
+                        index: offset + range_size,
+                        max: buffer.size,
+                    });
+                }
+                unsafe { Ok((*ptr).as_ptr().offset(offset as isize)) }
+            }
+            resource::BufferMapState::Active { ptr, sub_range, .. } => {
+                if offset < sub_range.offset {
+                    return Err(resource::BufferAccessError::OutOfBoundsUnderrun {
+                        index: offset,
+                        min: sub_range.offset,
+                    });
+                }
+                let range_end_offset = sub_range
+                    .size
+                    .map(|size| size + sub_range.offset)
+                    .unwrap_or(buffer.size);
+                if offset + range_size > range_end_offset {
+                    return Err(resource::BufferAccessError::OutOfBoundsOverrun {
+                        index: offset + range_size,
+                        max: range_end_offset,
+                    });
+                }
+                unsafe { Ok((*ptr).as_ptr().offset(offset as isize)) }
+            }
             resource::BufferMapState::Idle | resource::BufferMapState::Waiting(_) => {
                 Err(resource::BufferAccessError::NotMapped)
             }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4563,7 +4563,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 }
                 unsafe { Ok((ptr.as_ptr().offset(offset as isize), range_size)) }
             }
-            resource::BufferMapState::Active { ptr, ref sub_range, .. } => {
+            resource::BufferMapState::Active {
+                ptr, ref sub_range, ..
+            } => {
                 if offset < sub_range.offset {
                     return Err(resource::BufferAccessError::OutOfBoundsUnderrun {
                         index: offset,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4527,7 +4527,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_id: id::BufferId,
         offset: BufferAddress,
         size: Option<BufferSize>,
-    ) -> Result<(*mut u8, u64), resource::BufferAccessError> {
+    ) -> Result<(*mut u8, wgt::BufferAddress), resource::BufferAccessError> {
         span!(_guard, INFO, "Device::buffer_get_mapped_range");
 
         let hub = B::hub(self);

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4527,7 +4527,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_id: id::BufferId,
         offset: BufferAddress,
         size: Option<BufferSize>,
-    ) -> Result<(*mut u8, wgt::BufferAddress), resource::BufferAccessError> {
+    ) -> Result<(*mut u8, u64), resource::BufferAccessError> {
         span!(_guard, INFO, "Device::buffer_get_mapped_range");
 
         let hub = B::hub(self);

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -144,6 +144,14 @@ pub enum BufferAccessError {
     NotMapped,
     #[error("buffer map range does not respect `COPY_BUFFER_ALIGNMENT`")]
     UnalignedRange,
+    #[error("buffer access invalid: offset {offset} must be multiple of 8")]
+    UnalignedOffset { offset: u64 },
+    #[error("buffer range size invalid: range_size {range_size} must be multiple of 4")]
+    UnalignedRangeSize { range_size: u64 },
+    #[error("buffer access out of bounds: index {index} would underun the buffer (limit: {min})")]
+    OutOfBoundsUnderrun { index: u64, min: u64 },
+    #[error("buffer access out of bounds: index {index} would overrun the buffer (limit: {max})")]
+    OutOfBoundsOverrun { index: u64, max: u64 },
 }
 
 #[derive(Debug)]

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -150,7 +150,7 @@ pub enum BufferAccessError {
     UnalignedRangeSize { range_size: u64 },
     #[error("buffer access out of bounds: index {index} would underun the buffer (limit: {min})")]
     OutOfBoundsUnderrun { index: u64, min: u64 },
-    #[error("buffer access out of bounds: index {index} would overrun the buffer (limit: {max})")]
+    #[error("buffer access out of bounds: last index {index} would overrun the buffer (limit: {max})")]
     OutOfBoundsOverrun { index: u64, max: u64 },
 }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -144,7 +144,7 @@ pub enum BufferAccessError {
     NotMapped,
     #[error("buffer map range does not respect `COPY_BUFFER_ALIGNMENT`")]
     UnalignedRange,
-    #[error("buffer access invalid: offset {offset} must be multiple of 8")]
+    #[error("buffer offset invalid: offset {offset} must be multiple of 8")]
     UnalignedOffset { offset: u64 },
     #[error("buffer range size invalid: range_size {range_size} must be multiple of 4")]
     UnalignedRangeSize { range_size: u64 },

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -145,13 +145,21 @@ pub enum BufferAccessError {
     #[error("buffer map range does not respect `COPY_BUFFER_ALIGNMENT`")]
     UnalignedRange,
     #[error("buffer offset invalid: offset {offset} must be multiple of 8")]
-    UnalignedOffset { offset: u64 },
+    UnalignedOffset { offset: wgt::BufferAddress },
     #[error("buffer range size invalid: range_size {range_size} must be multiple of 4")]
-    UnalignedRangeSize { range_size: u64 },
+    UnalignedRangeSize { range_size: wgt::BufferAddress },
     #[error("buffer access out of bounds: index {index} would underun the buffer (limit: {min})")]
-    OutOfBoundsUnderrun { index: u64, min: u64 },
-    #[error("buffer access out of bounds: last index {index} would overrun the buffer (limit: {max})")]
-    OutOfBoundsOverrun { index: u64, max: u64 },
+    OutOfBoundsUnderrun {
+        index: wgt::BufferAddress,
+        min: wgt::BufferAddress,
+    },
+    #[error(
+        "buffer access out of bounds: last index {index} would overrun the buffer (limit: {max})"
+    )]
+    OutOfBoundsOverrun {
+        index: wgt::BufferAddress,
+        max: wgt::BufferAddress,
+    },
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
**Connections**

Closes #818

**Description**

This commit introduces out of bounds & offset validation for
buffer_get_mapped_range, like described in the WebGPU spec. See
https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange.

**Testing**

This change is not tested. Where would be the right place to add a test for this?
