### PR TITLE
Move from `tracing` to `log` + `profiling`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,15 +37,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,19 +152,6 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "cloudabi"
@@ -645,7 +623,6 @@ checksum = "1e7724b9aef57ea36d70faf54e0ee6265f86e41de16bed8333efdeab5b00e16b"
 dependencies = [
  "bitflags",
  "gpu-alloc-types",
- "tracing",
 ]
 
 [[package]]
@@ -666,7 +643,6 @@ dependencies = [
  "bitflags",
  "gpu-descriptor-types",
  "hashbrown",
- "tracing",
 ]
 
 [[package]]
@@ -741,12 +717,6 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "jni-sys"
@@ -857,8 +827,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "generator",
  "scoped-tls",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -868,15 +836,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -1051,16 +1010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,12 +1117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,7 +1133,6 @@ dependencies = [
  "ron",
  "serde",
  "wgpu-core",
- "wgpu-subscriber",
  "wgpu-types",
  "winit",
 ]
@@ -1212,6 +1154,12 @@ checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "profiling"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c71198452babfbba7419e716d29853c462d59da73c41485ab7dc8b4dc0c4be"
 
 [[package]]
 name = "quote"
@@ -1252,16 +1200,6 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
-dependencies = [
- "byteorder",
- "regex-syntax",
 ]
 
 [[package]]
@@ -1322,12 +1260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,27 +1313,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
-dependencies = [
- "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -1518,17 +1429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
-dependencies = [
- "libc",
- "redox_syscall",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,98 +1444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7572415bd688d401c52f6e36f4c8e805b9ae1622619303b9fa835d531db0acae"
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
-dependencies = [
- "cfg-if 0.1.10",
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -1672,12 +1486,6 @@ dependencies = [
  "winapi 0.3.9",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1834,28 +1642,17 @@ dependencies = [
  "gfx-hal",
  "gpu-alloc",
  "gpu-descriptor",
+ "log",
  "loom",
  "naga",
  "parking_lot",
+ "profiling",
  "raw-window-handle",
  "ron",
  "serde",
  "smallvec",
  "thiserror",
- "tracing",
  "wgpu-types",
-]
-
-[[package]]
-name = "wgpu-subscriber"
-version = "0.1.0"
-source = "git+https://github.com/gfx-rs/subscriber.git?rev=cdc9feb53f152f9c41905ed9efeff2c1ed214361#cdc9feb53f152f9c41905ed9efeff2c1ed214361"
-dependencies = [
- "parking_lot",
- "thread-id",
- "tracing",
- "tracing-log",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -38,10 +38,5 @@ features = ["replay", "raw-window-handle"]
 #rev = "" # insert revision here
 #features = ["auto-capture"]
 
-[dependencies.wgpu-subscriber]
-git = "https://github.com/gfx-rs/subscriber.git"
-rev = "cdc9feb53f152f9c41905ed9efeff2c1ed214361"
-version = "0.1"
-
 [dev-dependencies]
 serde = "1"

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -17,12 +17,7 @@ fn main() {
     #[cfg(feature = "winit")]
     use winit::{event_loop::EventLoop, window::WindowBuilder};
 
-    wgpu_subscriber::initialize_default_subscriber(
-        std::env::var("WGPU_CHROME_TRACE")
-            .as_ref()
-            .map(Path::new)
-            .ok(),
-    );
+    env_logger::init();
 
     #[cfg(feature = "renderdoc")]
     #[cfg_attr(feature = "winit", allow(unused))]

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -217,12 +217,7 @@ impl Corpus {
 
 #[test]
 fn test_api() {
-    wgpu_subscriber::initialize_default_subscriber(
-        std::env::var("WGPU_CHROME_TRACE")
-            .as_ref()
-            .map(Path::new)
-            .ok(),
-    );
+    env_logger::init();
 
     Corpus::run_from(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/all.ron"))
 }

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -27,16 +27,17 @@ arrayvec = "0.5"
 bitflags = "1.0"
 copyless = "0.1"
 fxhash = "0.2"
+log = "0.4"
 parking_lot = "0.11"
+profiling = { version = "0.1.10", default-features = false } # Need 0.1.10+ to prevent compile errors with proc macros disabled
 raw-window-handle = { version = "0.3", optional = true }
 ron = { version = "0.6", optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 smallvec = "1"
-tracing = { version = "0.1", default-features = false, features = ["std"] }
 thiserror = "1"
 
-gpu-alloc = { version = "0.3", features = ["tracing"] }
-gpu-descriptor = { version = "0.1", features = ["tracing"] }
+gpu-alloc = { version = "0.3" }
+gpu-descriptor = { version = "0.1" }
 
 hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "2125c1d96b09f97faaa0d7a8a0d1c5315acc8c45" }
 gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "2125c1d96b09f97faaa0d7a8a0d1c5315acc8c45" }

--- a/wgpu-core/src/command/allocator.rs
+++ b/wgpu-core/src/command/allocator.rs
@@ -32,7 +32,7 @@ impl<B: hal::Backend> CommandPool<B> {
         for i in (0..self.pending.len()).rev() {
             if self.pending[i].1 <= last_done_index {
                 let (cmd_buf, index) = self.pending.swap_remove(i);
-                tracing::trace!(
+                log::trace!(
                     "recycling cmdbuf submitted in {} when {} is last done",
                     index,
                     last_done_index,
@@ -100,7 +100,7 @@ impl<B: GfxBackend> CommandAllocator<B> {
         use std::collections::hash_map::Entry;
         let pool = match inner.pools.entry(thread_id) {
             Entry::Vacant(e) => {
-                tracing::info!("Starting on thread {:?}", thread_id);
+                log::info!("Starting on thread {:?}", thread_id);
                 let raw = unsafe {
                     device
                         .create_command_pool(
@@ -151,7 +151,7 @@ impl<B: hal::Backend> CommandAllocator<B> {
         device: &B::Device,
     ) -> Result<Self, CommandAllocatorError> {
         let internal_thread_id = thread::current().id();
-        tracing::info!("Starting on (internal) thread {:?}", internal_thread_id);
+        log::info!("Starting on (internal) thread {:?}", internal_thread_id);
         let mut pools = FastHashMap::default();
         pools.insert(
             internal_thread_id,
@@ -250,7 +250,7 @@ impl<B: hal::Backend> CommandAllocator<B> {
             }
         }
         for thread_id in remove_threads {
-            tracing::info!("Removing from thread {:?}", thread_id);
+            log::info!("Removing from thread {:?}", thread_id);
             let pool = inner.pools.remove(&thread_id).unwrap();
             pool.destroy(device);
         }
@@ -263,7 +263,7 @@ impl<B: hal::Backend> CommandAllocator<B> {
                 pool.recycle(raw);
             }
             if pool.total != pool.available.len() {
-                tracing::error!(
+                log::error!(
                     "Some command buffers are still recorded, only tracking {} / {}",
                     pool.available.len(),
                     pool.total

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -194,7 +194,7 @@ impl Binder {
         bind_group: &BindGroup<B>,
         offsets: &[wgt::DynamicOffset],
     ) -> &'a [EntryPayload] {
-        tracing::trace!("\tBinding [{}] = group {:?}", index, bind_group_id);
+        log::trace!("\tBinding [{}] = group {:?}", index, bind_group_id);
         debug_assert_eq!(B::VARIANT, bind_group_id.0.backend());
 
         let payload = &mut self.payloads[index];

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -51,7 +51,6 @@ use crate::{
     id,
     memory_init_tracker::{MemoryInitKind, MemoryInitTrackerAction},
     resource::BufferUse,
-    span,
     track::{TrackerSet, UsageConflict},
     validation::check_buffer_usage,
     Label, LabelHelpers, LifeGuard, Stored, MAX_BIND_GROUPS,
@@ -92,7 +91,7 @@ impl RenderBundleEncoder {
         parent_id: id::DeviceId,
         base: Option<BasePass<RenderCommand>>,
     ) -> Result<Self, CreateRenderBundleError> {
-        span!(_guard, INFO, "RenderBundleEncoder::new");
+        profiling::scope!("RenderBundleEncoder::new");
         Ok(Self {
             base: base.unwrap_or_else(|| BasePass::new(&desc.label)),
             parent_id,
@@ -512,7 +511,7 @@ impl RenderBundleEncoder {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
-        span!(_guard, DEBUG, "RenderBundle::set_index_buffer");
+        profiling::scope!("RenderBundle::set_index_buffer");
         self.base.commands.push(RenderCommand::SetIndexBuffer {
             buffer_id,
             index_format,
@@ -1150,7 +1149,7 @@ where
 
 pub mod bundle_ffi {
     use super::{RenderBundleEncoder, RenderCommand};
-    use crate::{id, span, RawString};
+    use crate::{id, RawString};
     use std::{convert::TryInto, slice};
     use wgt::{BufferAddress, BufferSize, DynamicOffset};
 
@@ -1166,7 +1165,6 @@ pub mod bundle_ffi {
         offsets: *const DynamicOffset,
         offset_length: usize,
     ) {
-        span!(_guard, DEBUG, "RenderBundle::set_bind_group");
         bundle.base.commands.push(RenderCommand::SetBindGroup {
             index: index.try_into().unwrap(),
             num_dynamic_offsets: offset_length.try_into().unwrap(),
@@ -1185,7 +1183,6 @@ pub mod bundle_ffi {
         bundle: &mut RenderBundleEncoder,
         pipeline_id: id::RenderPipelineId,
     ) {
-        span!(_guard, DEBUG, "RenderBundle::set_pipeline");
         bundle
             .base
             .commands
@@ -1200,7 +1197,6 @@ pub mod bundle_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        span!(_guard, DEBUG, "RenderBundle::set_vertex_buffer");
         bundle.base.commands.push(RenderCommand::SetVertexBuffer {
             slot,
             buffer_id,
@@ -1221,7 +1217,6 @@ pub mod bundle_ffi {
         size_bytes: u32,
         data: *const u8,
     ) {
-        span!(_guard, DEBUG, "RenderBundle::set_push_constants");
         assert_eq!(
             offset & (wgt::PUSH_CONSTANT_ALIGNMENT - 1),
             0,
@@ -1259,7 +1254,6 @@ pub mod bundle_ffi {
         first_vertex: u32,
         first_instance: u32,
     ) {
-        span!(_guard, DEBUG, "RenderBundle::draw");
         bundle.base.commands.push(RenderCommand::Draw {
             vertex_count,
             instance_count,
@@ -1277,7 +1271,6 @@ pub mod bundle_ffi {
         base_vertex: i32,
         first_instance: u32,
     ) {
-        span!(_guard, DEBUG, "RenderBundle::draw_indexed");
         bundle.base.commands.push(RenderCommand::DrawIndexed {
             index_count,
             instance_count,
@@ -1293,7 +1286,6 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, DEBUG, "RenderBundle::draw_indirect");
         bundle.base.commands.push(RenderCommand::MultiDrawIndirect {
             buffer_id,
             offset,
@@ -1308,7 +1300,6 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        span!(_guard, DEBUG, "RenderBundle::draw_indexed_indirect");
         bundle.base.commands.push(RenderCommand::MultiDrawIndirect {
             buffer_id,
             offset,
@@ -1326,13 +1317,11 @@ pub mod bundle_ffi {
         _bundle: &mut RenderBundleEncoder,
         _label: RawString,
     ) {
-        span!(_guard, DEBUG, "RenderBundle::push_debug_group");
         //TODO
     }
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_bundle_pop_debug_group(_bundle: &mut RenderBundleEncoder) {
-        span!(_guard, DEBUG, "RenderBundle::pop_debug_group");
         //TODO
     }
 
@@ -1345,7 +1334,6 @@ pub mod bundle_ffi {
         _bundle: &mut RenderBundleEncoder,
         _label: RawString,
     ) {
-        span!(_guard, DEBUG, "RenderBundle::insert_debug_marker");
         //TODO
     }
 }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -26,7 +26,6 @@ use crate::{
     id,
     memory_init_tracker::MemoryInitTrackerAction,
     resource::{Buffer, Texture},
-    span,
     track::TrackerSet,
     Label, PrivateFeatures, Stored,
 };
@@ -198,7 +197,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         _desc: &wgt::CommandBufferDescriptor<Label>,
     ) -> (id::CommandBufferId, Option<CommandEncoderError>) {
-        span!(_guard, INFO, "CommandEncoder::finish");
+        profiling::scope!("CommandEncoder::finish");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -217,7 +216,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         .expect("Used swap chain frame has already presented");
                     cmd_buf.trackers.views.remove(view_id.value);
                 }
-                tracing::trace!("Command buffer {:?} {:#?}", encoder_id, cmd_buf.trackers);
+                log::trace!("Command buffer {:?} {:#?}", encoder_id, cmd_buf.trackers);
                 None
             }
             Err(e) => Some(e),
@@ -231,7 +230,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) -> Result<(), CommandEncoderError> {
-        span!(_guard, DEBUG, "CommandEncoder::push_debug_group");
+        profiling::scope!("CommandEncoder::push_debug_group");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -251,7 +250,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) -> Result<(), CommandEncoderError> {
-        span!(_guard, DEBUG, "CommandEncoder::insert_debug_marker");
+        profiling::scope!("CommandEncoder::insert_debug_marker");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -270,7 +269,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         encoder_id: id::CommandEncoderId,
     ) -> Result<(), CommandEncoderError> {
-        span!(_guard, DEBUG, "CommandEncoder::pop_debug_marker");
+        profiling::scope!("CommandEncoder::pop_debug_marker");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -12,7 +12,6 @@ use crate::{
     id::{BufferId, CommandEncoderId, TextureId},
     memory_init_tracker::{MemoryInitKind, MemoryInitTrackerAction},
     resource::{BufferUse, Texture, TextureErrorDimension, TextureUse},
-    span,
     track::TextureSelector,
 };
 
@@ -310,7 +309,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination_offset: BufferAddress,
         size: BufferAddress,
     ) -> Result<(), CopyError> {
-        span!(_guard, INFO, "CommandEncoder::copy_buffer_to_buffer");
+        profiling::scope!("CommandEncoder::copy_buffer_to_buffer");
 
         if source == destination {
             return Err(TransferError::SameSourceDestinationBuffer.into());
@@ -398,7 +397,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         if size == 0 {
-            tracing::trace!("Ignoring copy_buffer_to_buffer of size 0");
+            log::trace!("Ignoring copy_buffer_to_buffer of size 0");
             return Ok(());
         }
 
@@ -448,7 +447,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &TextureCopyView,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
-        span!(_guard, INFO, "CommandEncoder::copy_buffer_to_texture");
+        profiling::scope!("CommandEncoder::copy_buffer_to_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -469,7 +468,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
-            tracing::trace!("Ignoring copy_buffer_to_texture of size 0");
+            log::trace!("Ignoring copy_buffer_to_texture of size 0");
             return Ok(());
         }
 
@@ -596,7 +595,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &BufferCopyView,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
-        span!(_guard, INFO, "CommandEncoder::copy_texture_to_buffer");
+        profiling::scope!("CommandEncoder::copy_texture_to_buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -617,7 +616,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
-            tracing::trace!("Ignoring copy_texture_to_buffer of size 0");
+            log::trace!("Ignoring copy_texture_to_buffer of size 0");
             return Ok(());
         }
 
@@ -748,7 +747,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &TextureCopyView,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
-        span!(_guard, INFO, "CommandEncoder::copy_texture_to_texture");
+        profiling::scope!("CommandEncoder::copy_texture_to_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -775,7 +774,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
-            tracing::trace!("Ignoring copy_texture_to_texture of size 0");
+            log::trace!("Ignoring copy_texture_to_texture of size 0");
             return Ok(());
         }
 

--- a/wgpu-core/src/device/alloc.rs
+++ b/wgpu-core/src/device/alloc.rs
@@ -43,7 +43,7 @@ impl<B: hal::Backend> MemoryAllocator<B> {
                     .collect::<Vec<_>>(),
             ),
             max_memory_allocation_count: if limits.max_memory_allocation_count == 0 {
-                tracing::warn!("max_memory_allocation_count is not set by gfx-rs backend");
+                log::warn!("max_memory_allocation_count is not set by gfx-rs backend");
                 !0
             } else {
                 limits.max_memory_allocation_count.min(!0u32 as usize) as u32
@@ -205,13 +205,14 @@ impl<B: hal::Backend> MemoryBlock<B> {
 }
 
 impl<B: hal::Backend> gpu_alloc::MemoryDevice<B::Memory> for MemoryDevice<'_, B> {
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     unsafe fn allocate_memory(
         &self,
         size: u64,
         memory_type: u32,
         flags: gpu_alloc::AllocationFlags,
     ) -> Result<B::Memory, gpu_alloc::OutOfMemory> {
+        profiling::scope!("Allocate Memory");
+
         assert!(flags.is_empty());
 
         self.0
@@ -219,18 +220,18 @@ impl<B: hal::Backend> gpu_alloc::MemoryDevice<B::Memory> for MemoryDevice<'_, B>
             .map_err(|_| gpu_alloc::OutOfMemory::OutOfDeviceMemory)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     unsafe fn deallocate_memory(&self, memory: B::Memory) {
+        profiling::scope!("Deallocate Memory");
         self.0.free_memory(memory);
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     unsafe fn map_memory(
         &self,
         memory: &mut B::Memory,
         offset: u64,
         size: u64,
     ) -> Result<NonNull<u8>, gpu_alloc::DeviceMapError> {
+        profiling::scope!("Map memory");
         match self.0.map_memory(
             memory,
             hal::memory::Segment {
@@ -247,16 +248,16 @@ impl<B: hal::Backend> gpu_alloc::MemoryDevice<B::Memory> for MemoryDevice<'_, B>
         }
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     unsafe fn unmap_memory(&self, memory: &mut B::Memory) {
+        profiling::scope!("Unmap memory");
         self.0.unmap_memory(memory);
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     unsafe fn invalidate_memory_ranges(
         &self,
         ranges: &[gpu_alloc::MappedMemoryRange<'_, B::Memory>],
     ) -> Result<(), gpu_alloc::OutOfMemory> {
+        profiling::scope!("Invalidate memory ranges");
         self.0
             .invalidate_mapped_memory_ranges(ranges.iter().map(|r| {
                 (
@@ -270,11 +271,11 @@ impl<B: hal::Backend> gpu_alloc::MemoryDevice<B::Memory> for MemoryDevice<'_, B>
             .map_err(|_| gpu_alloc::OutOfMemory::OutOfHostMemory)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     unsafe fn flush_memory_ranges(
         &self,
         ranges: &[gpu_alloc::MappedMemoryRange<'_, B::Memory>],
     ) -> Result<(), gpu_alloc::OutOfMemory> {
+        profiling::scope!("Flush memory ranges");
         self.0
             .flush_mapped_memory_ranges(ranges.iter().map(|r| {
                 (

--- a/wgpu-core/src/device/descriptor.rs
+++ b/wgpu-core/src/device/descriptor.rs
@@ -37,7 +37,7 @@ impl<B: hal::Backend> DescriptorAllocator<B> {
             )
         }
         .map_err(|err| {
-            tracing::warn!("Descriptor set allocation failed: {}", err);
+            log::warn!("Descriptor set allocation failed: {}", err);
             DeviceError::OutOfMemory
         })
     }

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -175,7 +175,7 @@ pub struct Trace {
 #[cfg(feature = "trace")]
 impl Trace {
     pub fn new(path: &std::path::Path) -> Result<Self, std::io::Error> {
-        tracing::info!("Tracing into '{:?}'", path);
+        log::info!("Tracing into '{:?}'", path);
         let mut file = std::fs::File::create(path.join(FILE_NAME))?;
         file.write_all(b"[\n")?;
         Ok(Self {
@@ -199,7 +199,7 @@ impl Trace {
                 let _ = writeln!(self.file, "{},", string);
             }
             Err(e) => {
-                tracing::warn!("RON serialization failure: {:?}", e);
+                log::warn!("RON serialization failure: {:?}", e);
             }
         }
     }

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -15,7 +15,6 @@ use crate::{
     instance::{Adapter, Instance, Surface},
     pipeline::{ComputePipeline, RenderPipeline, ShaderModule},
     resource::{Buffer, Sampler, Texture, TextureView},
-    span,
     swap_chain::SwapChain,
     Epoch, Index,
 };
@@ -761,7 +760,7 @@ pub struct Global<G: GlobalIdentityHandlerFactory> {
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn new(name: &str, factory: G, backends: wgt::BackendBit) -> Self {
-        span!(_guard, INFO, "Global::new");
+        profiling::scope!("Global::new");
         Self {
             instance: Instance::new(name, 1, backends),
             surfaces: Registry::without_backend(&factory, "Surface"),
@@ -780,7 +779,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 impl<G: GlobalIdentityHandlerFactory> Drop for Global<G> {
     fn drop(&mut self) {
         if !thread::panicking() {
-            tracing::info!("Dropping Global");
+            log::info!("Dropping Global");
             let mut surface_guard = self.surfaces.data.write();
 
             // destroy hubs

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -258,18 +258,6 @@ macro_rules! gfx_select {
     };
 }
 
-#[macro_export]
-macro_rules! span {
-    ($guard_name:tt, $level:ident, $name:expr, $($fields:tt)*) => {
-        let span = tracing::span!(tracing::Level::$level, $name, $($fields)*);
-        let $guard_name = span.enter();
-    };
-    ($guard_name:tt, $level:ident, $name:expr) => {
-        let span = tracing::span!(tracing::Level::$level, $name);
-        let $guard_name = span.enter();
-    };
-}
-
 /// Fast hash map used internally.
 type FastHashMap<K, V> =
     std::collections::HashMap<K, V, std::hash::BuildHasherDefault<fxhash::FxHasher>>;

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -121,7 +121,7 @@ unsafe impl Sync for BufferMapOperation {}
 
 impl BufferMapOperation {
     pub(crate) fn call_error(self) {
-        tracing::error!("wgpu_buffer_map_async failed: buffer mapping is pending");
+        log::error!("wgpu_buffer_map_async failed: buffer mapping is pending");
         unsafe {
             (self.callback)(BufferMapAsyncStatus::Error, self.user_data);
         }

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -39,7 +39,7 @@ use crate::{
     device::DeviceError,
     hub::{GfxBackend, Global, GlobalIdentityHandlerFactory, Input, Token},
     id::{DeviceId, SwapChainId, TextureViewId, Valid},
-    resource, span,
+    resource,
     track::TextureSelector,
     LifeGuard, PrivateFeatures, Stored, SubmissionIndex,
 };
@@ -139,7 +139,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         swap_chain_id: SwapChainId,
         view_id_in: Input<G, TextureViewId>,
     ) -> Result<SwapChainOutput, SwapChainError> {
-        span!(_guard, INFO, "SwapChain::get_next_texture");
+        profiling::scope!("SwapChain::get_next_texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -242,7 +242,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         swap_chain_id: SwapChainId,
     ) -> Result<SwapChainStatus, SwapChainError> {
-        span!(_guard, INFO, "SwapChain::present");
+        profiling::scope!("SwapChain::present");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -287,7 +287,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let queue = &mut device.queue_group.queues[0];
         let result = unsafe { queue.present(B::get_surface_mut(surface), image, sem) };
 
-        tracing::debug!(trace = true, "Presented. End of Frame");
+        log::debug!("Presented. End of Frame");
 
         match result {
             Ok(None) => Ok(SwapChainStatus::Good),

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -130,7 +130,7 @@ impl PendingTransition<BufferState> {
         self,
         buf: &'a resource::Buffer<B>,
     ) -> hal::memory::Barrier<'a, B> {
-        tracing::trace!("\tbuffer -> {:?}", self);
+        log::trace!("\tbuffer -> {:?}", self);
         let &(ref target, _) = buf.raw.as_ref().expect("Buffer is destroyed");
         hal::memory::Barrier::Buffer {
             states: conv::map_buffer_state(self.usage.start)
@@ -148,7 +148,7 @@ impl PendingTransition<TextureState> {
         self,
         tex: &'a resource::Texture<B>,
     ) -> hal::memory::Barrier<'a, B> {
-        tracing::trace!("\ttexture -> {:?}", self);
+        log::trace!("\ttexture -> {:?}", self);
         let &(ref target, _) = tex.raw.as_ref().expect("Texture is destroyed");
         let aspects = tex.aspects;
         hal::memory::Barrier::Image {

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -661,7 +661,7 @@ impl Interface {
                 return;
             }
             ref other => {
-                tracing::error!("Unexpected varying type: {:?}", other);
+                log::error!("Unexpected varying type: {:?}", other);
                 return;
             }
         };
@@ -673,7 +673,7 @@ impl Interface {
             },
             Some(&naga::Binding::BuiltIn(built_in)) => Varying::BuiltIn(built_in),
             None => {
-                tracing::error!("Missing binding for a varying");
+                log::error!("Missing binding for a varying");
                 return;
             }
         };
@@ -711,7 +711,7 @@ impl Interface {
                 },
                 naga::TypeInner::Sampler { comparison } => ResourceType::Sampler { comparison },
                 ref other => {
-                    tracing::error!("Unexpected resource type: {:?}", other);
+                    log::error!("Unexpected resource type: {:?}", other);
                     continue;
                 }
             };


### PR DESCRIPTION
**Connections**

Fixes #1211. Fixes #1189.

**Description**

Moves from `tracing` to `log` + `profiling`. I also removed some of the offending spans that were only for pushing commands onto a vector of commands.

**Testing**

Tested on wgpu-rs