### PR TITLE
Add sample count to framebuffer key

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -114,12 +114,13 @@ impl<T> AttachmentData<T> {
 }
 
 pub(crate) type AttachmentDataVec<T> = ArrayVec<[T; MAX_COLOR_TARGETS + MAX_COLOR_TARGETS + 1]>;
-
 pub(crate) type RenderPassKey = AttachmentData<(hal::pass::Attachment, hal::image::Layout)>;
-pub(crate) type FramebufferKey = (
-    AttachmentData<hal::image::FramebufferAttachment>,
-    wgt::Extent3d,
-);
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub(crate) struct FramebufferKey {
+    pub(crate) attachments: AttachmentData<hal::image::FramebufferAttachment>,
+    pub(crate) extent: wgt::Extent3d,
+    pub(crate) samples: hal::image::NumSamples,
+}
 
 #[derive(Clone, Debug, Hash, PartialEq)]
 #[cfg_attr(feature = "serial-pass", derive(serde::Deserialize, serde::Serialize))]


### PR DESCRIPTION
**Connections**
Fixes #1271

**Description**
The framebuffer is created for a pass, so naturally the hashmap key for a framebuffer has to include the pass key. Otherwise, we'd be overwriting the framebuffer entry, or using a framebuffer from a different pass. The sample count was missing from our FB key.

**Testing**
Tested on a trace from #1271 that I hand-ported to latest master.