### PR TITLE
Properly return native shader module errors to users

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -154,6 +154,25 @@ pub fn map_shader_stage_flags(shader_stage_flags: wgt::ShaderStage) -> hal::pso:
     value
 }
 
+pub fn map_hal_flags_to_shader_stage(
+    shader_stage_flags: hal::pso::ShaderStageFlags,
+) -> wgt::ShaderStage {
+    use hal::pso::ShaderStageFlags as H;
+    use wgt::ShaderStage as Ss;
+
+    let mut value = Ss::empty();
+    if shader_stage_flags.contains(H::VERTEX) {
+        value |= Ss::VERTEX;
+    }
+    if shader_stage_flags.contains(H::FRAGMENT) {
+        value |= Ss::FRAGMENT;
+    }
+    if shader_stage_flags.contains(H::COMPUTE) {
+        value |= Ss::COMPUTE;
+    }
+    value
+}
+
 pub fn map_extent(extent: &wgt::Extent3d, dim: wgt::TextureDimension) -> hal::image::Extent {
     hal::image::Extent {
         width: extent.width,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -113,6 +113,8 @@ pub enum CreateComputePipelineError {
     Implicit(#[from] ImplicitLayoutError),
     #[error(transparent)]
     Stage(validation::StageError),
+    #[error("Internal error: {0}")]
+    Internal(String),
 }
 
 #[derive(Debug)]
@@ -233,6 +235,11 @@ pub enum CreateRenderPipelineError {
         flag: wgt::ShaderStage,
         #[source]
         error: validation::StageError,
+    },
+    #[error("Internal error in stage {stage:?}: {error}")]
+    Internal {
+        stage: wgt::ShaderStage,
+        error: String,
     },
 }
 


### PR DESCRIPTION
**Testing**
Disable `cross` feature, break `naga` and see what happens 😄 

```log
wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
    Internal error in stage VERTEX: Error compiling the shader "\"Compilation failed: \\n\\nprogram_source:1:1: error: unknown type name \\\'sadgasdgasdgasdg\\\'\\nsadgasdgasdgasdg aasdgadsgb>\\n^\\nprogram_source:1:28: error: expected \\\';\\\' after top level declarator\\nsadgasdgasdgasdg aasdgadsgb>\\n   
```

