### PR TITLE
Align create_swap_chain function signature

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -141,7 +141,10 @@ fn main() {
                                 resize_desc = Some(desc);
                                 break;
                             } else {
-                                gfx_select!(device => global.device_create_swap_chain(device, surface, &desc)).unwrap();
+                                let (_, error) = gfx_select!(device => global.device_create_swap_chain(device, surface, &desc));
+                                if let Some(e) = error {
+                                    panic!("{:?}", e);
+                                }
                             }
                         }
                         Some(trace::Action::PresentSwapChain(id)) => {
@@ -159,7 +162,10 @@ fn main() {
                 Event::WindowEvent { event, .. } => match event {
                     WindowEvent::Resized(_) => {
                         if let Some(desc) = resize_desc.take() {
-                            gfx_select!(device => global.device_create_swap_chain(device, surface, &desc)).unwrap();
+                            let (_, error) = gfx_select!(device => global.device_create_swap_chain(device, surface, &desc));
+                            if let Some(e) = error {
+                                panic!("{:?}", e);
+                            }
                         }
                     }
                     WindowEvent::KeyboardInput {


### PR DESCRIPTION
**Connections**
Follow-up to #1034

**Description**
Swapchains are a bit special. Browsers don't use wgpu-core's swapchains, so we never bothered to convert them into the error model. But we still need this for Deno and webgpu-headers.

**Testing**
Untested, but also harmless