### PR TITLE
Rename copy views and layout to match spec

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -23,8 +23,8 @@ use std::iter;
 
 pub(crate) const BITS_PER_BYTE: u32 = 8;
 
-pub type BufferCopyView = wgt::BufferCopyView<BufferId>;
-pub type TextureCopyView = wgt::TextureCopyView<TextureId>;
+pub type ImageCopyBuffer = wgt::ImageCopyBuffer<BufferId>;
+pub type ImageCopyTexture = wgt::ImageCopyTexture<TextureId>;
 
 #[derive(Clone, Debug)]
 pub enum CopySide {
@@ -106,7 +106,7 @@ pub enum CopyError {
 //TODO: we currently access each texture twice for a transfer,
 // once only to get the aspect flags, which is unfortunate.
 pub(crate) fn texture_copy_view_to_hal<B: hal::Backend>(
-    view: &TextureCopyView,
+    view: &ImageCopyTexture,
     size: &Extent3d,
     texture_guard: &Storage<Texture<B>, TextureId>,
 ) -> Result<
@@ -155,7 +155,7 @@ pub(crate) fn texture_copy_view_to_hal<B: hal::Backend>(
 /// Function copied with some modifications from webgpu standard <https://gpuweb.github.io/gpuweb/#copy-between-buffer-texture>
 /// If successful, returns number of buffer bytes required for this copy.
 pub(crate) fn validate_linear_texture_data(
-    layout: &wgt::TextureDataLayout,
+    layout: &wgt::ImageDataLayout,
     format: wgt::TextureFormat,
     buffer_size: BufferAddress,
     buffer_side: CopySide,
@@ -248,7 +248,7 @@ pub(crate) fn validate_linear_texture_data(
 
 /// Function copied with minor modifications from webgpu standard <https://gpuweb.github.io/gpuweb/#valid-texture-copy-range>
 pub(crate) fn validate_texture_copy_range(
-    texture_copy_view: &TextureCopyView,
+    texture_copy_view: &ImageCopyTexture,
     texture_format: wgt::TextureFormat,
     texture_dimension: hal::image::Kind,
     texture_side: CopySide,
@@ -468,8 +468,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn command_encoder_copy_buffer_to_texture<B: GfxBackend>(
         &self,
         command_encoder_id: CommandEncoderId,
-        source: &BufferCopyView,
-        destination: &TextureCopyView,
+        source: &ImageCopyBuffer,
+        destination: &ImageCopyTexture,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
         profiling::scope!("CommandEncoder::copy_buffer_to_texture");
@@ -618,8 +618,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn command_encoder_copy_texture_to_buffer<B: GfxBackend>(
         &self,
         command_encoder_id: CommandEncoderId,
-        source: &TextureCopyView,
-        destination: &BufferCopyView,
+        source: &ImageCopyTexture,
+        destination: &ImageCopyBuffer,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
         profiling::scope!("CommandEncoder::copy_texture_to_buffer");
@@ -771,8 +771,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn command_encoder_copy_texture_to_texture<B: GfxBackend>(
         &self,
         command_encoder_id: CommandEncoderId,
-        source: &TextureCopyView,
-        destination: &TextureCopyView,
+        source: &ImageCopyTexture,
+        destination: &ImageCopyTexture,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
         profiling::scope!("CommandEncoder::copy_texture_to_texture");

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -7,7 +7,7 @@ use crate::device::trace::Action;
 use crate::{
     command::{
         texture_copy_view_to_hal, validate_linear_texture_data, validate_texture_copy_range,
-        CommandAllocator, CommandBuffer, CopySide, TextureCopyView, TransferError, BITS_PER_BYTE,
+        CommandAllocator, CommandBuffer, CopySide, ImageCopyTexture, TransferError, BITS_PER_BYTE,
     },
     conv,
     device::{alloc, DeviceError, WaitIdleError},
@@ -294,9 +294,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn queue_write_texture<B: GfxBackend>(
         &self,
         queue_id: id::QueueId,
-        destination: &TextureCopyView,
+        destination: &ImageCopyTexture,
         data: &[u8],
-        data_layout: &wgt::TextureDataLayout,
+        data_layout: &wgt::ImageDataLayout,
         size: &wgt::Extent3d,
     ) -> Result<(), QueueWriteError> {
         profiling::scope!("Queue::write_texture");

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -108,9 +108,9 @@ pub enum Action<'a> {
         queued: bool,
     },
     WriteTexture {
-        to: crate::command::TextureCopyView,
+        to: crate::command::ImageCopyTexture,
         data: FileName,
-        layout: wgt::TextureDataLayout,
+        layout: wgt::ImageDataLayout,
         size: wgt::Extent3d,
     },
     Submit(crate::SubmissionIndex, Vec<Command>),
@@ -128,18 +128,18 @@ pub enum Command {
         size: wgt::BufferAddress,
     },
     CopyBufferToTexture {
-        src: crate::command::BufferCopyView,
-        dst: crate::command::TextureCopyView,
+        src: crate::command::ImageCopyBuffer,
+        dst: crate::command::ImageCopyTexture,
         size: wgt::Extent3d,
     },
     CopyTextureToBuffer {
-        src: crate::command::TextureCopyView,
-        dst: crate::command::BufferCopyView,
+        src: crate::command::ImageCopyTexture,
+        dst: crate::command::ImageCopyBuffer,
         size: wgt::Extent3d,
     },
     CopyTextureToTexture {
-        src: crate::command::TextureCopyView,
-        dst: crate::command::TextureCopyView,
+        src: crate::command::ImageCopyTexture,
+        dst: crate::command::ImageCopyTexture,
         size: wgt::Extent3d,
     },
     WriteTimestamp {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -34,7 +34,7 @@ pub type DynamicOffset = u32;
 ///
 /// This doesn't apply to [`Queue::write_texture`].
 ///
-/// [`bytes_per_row`]: TextureDataLayout::bytes_per_row
+/// [`bytes_per_row`]: ImageDataLayout::bytes_per_row
 pub const COPY_BYTES_PER_ROW_ALIGNMENT: u32 = 256;
 /// Bound uniform/storage buffer offsets must be aligned to this number.
 pub const BIND_BUFFER_ALIGNMENT: BufferAddress = 256;
@@ -2502,7 +2502,7 @@ impl<T> Default for RenderBundleDescriptor<Option<T>> {
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
-pub struct TextureDataLayout {
+pub struct ImageDataLayout {
     /// Offset into the buffer that is the start of the texture. Must be a multiple of texture block size.
     /// For non-compressed textures, this is 1.
     pub offset: BufferAddress,
@@ -2765,11 +2765,11 @@ pub struct BindGroupLayoutEntry {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
-pub struct BufferCopyView<B> {
+pub struct ImageCopyBuffer<B> {
     /// The buffer to be copied to/from.
     pub buffer: B,
     /// The layout of the texture data in this buffer.
-    pub layout: TextureDataLayout,
+    pub layout: ImageDataLayout,
 }
 
 /// View of a texture which can be used to copy to/from a buffer/texture.
@@ -2777,7 +2777,7 @@ pub struct BufferCopyView<B> {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
-pub struct TextureCopyView<T> {
+pub struct ImageCopyTexture<T> {
     /// The texture to be copied to/from.
     pub texture: T,
     /// The target mip level of the texture.


### PR DESCRIPTION
**Description**
Match the specification naming changes from https://github.com/gpuweb/gpuweb/pull/1375

**Testing**
None because the changes downstream to wgpu-rs and wgpu-native should be trivial (renaming only)