### PR TITLE
Rename color/depth attachments to match spec

### DIFF
--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -96,7 +96,7 @@
                 ),
                 target_colors: [
                     (
-                        attachment: Id(0, 1, Empty),
+                        view: Id(0, 1, Empty),
                         resolve_target: None,
                         channel: (
                             load_op: Clear,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -158,8 +158,8 @@ pub enum Command {
     },
     RunRenderPass {
         base: crate::command::BasePass<crate::command::RenderCommand>,
-        target_colors: Vec<crate::command::ColorAttachmentDescriptor>,
-        target_depth_stencil: Option<crate::command::DepthStencilAttachmentDescriptor>,
+        target_colors: Vec<crate::command::RenderPassColorAttachment>,
+        target_depth_stencil: Option<crate::command::RenderPassDepthStencilAttachment>,
     },
 }
 


### PR DESCRIPTION
**Description**
- Rename `ColorAttachmentDescriptor` to `RenderPassColorAttachment` (https://gpuweb.github.io/gpuweb/#color-attachments)
- Rename `DepthStencilAttachmentDescriptor` to `RenderPassDepthStencilAttachment` (https://gpuweb.github.io/gpuweb/#depth-stencil-attachments)
- Rename `attachment` fields on both attachments to `view`

**Testing**
None (just `cargo build`) because the renaming downstream should be trivial.