### PR TITLE
Rename `level_count` to `mip_level_count`

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -788,7 +788,7 @@ impl<B: GfxBackend> Device<B> {
             };
 
         let required_level_count =
-            desc.base_mip_level + desc.level_count.map_or(1, |count| count.get());
+            desc.base_mip_level + desc.mip_level_count.map_or(1, |count| count.get());
         let required_layer_count =
             desc.base_array_layer + desc.array_layer_count.map_or(1, |count| count.get());
         let level_end = texture.full_range.levels.end;
@@ -819,7 +819,7 @@ impl<B: GfxBackend> Device<B> {
         }
 
         let end_level = desc
-            .level_count
+            .mip_level_count
             .map_or(level_end, |_| required_level_count as u8);
         let end_layer = desc
             .array_layer_count
@@ -849,7 +849,7 @@ impl<B: GfxBackend> Device<B> {
         let range = hal::image::SubresourceRange {
             aspects,
             level_start: desc.base_mip_level as _,
-            level_count: desc.level_count.map(|v| v.get() as _),
+            level_count: desc.mip_level_count.map(|v| v.get() as _),
             layer_start: desc.base_array_layer as _,
             layer_count: desc.array_layer_count.map(|v| v.get() as _),
         };

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -302,7 +302,7 @@ pub struct TextureViewDescriptor<'a> {
     /// Mip level count.
     /// If `Some(count)`, `base_mip_level + count` must be less or equal to underlying texture mip count.
     /// If `None`, considered to include the rest of the mipmap levels, but at least 1 in total.
-    pub level_count: Option<NonZeroU32>,
+    pub mip_level_count: Option<NonZeroU32>,
     /// Base array layer.
     pub base_array_layer: u32,
     /// Layer count.


### PR DESCRIPTION
**Description**
This PR renames `level_count` to `mip_level_count` on `TextureViewDescriptor`. This follows the naming in the specification, located at https://gpuweb.github.io/gpuweb/#texture-view-creation

**Testing**
`cargo build` and `cargo test` only, naming changes will be made downstream in wgpu-rs too.