### PR TITLE
Don't flip SPIR-V coordinate space on input

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -988,8 +988,11 @@ impl<B: GfxBackend> Device<B> {
         let (spv, module) = match source {
             pipeline::ShaderModuleSource::SpirV(spv) => {
                 // Parse the given shader code and store its representation.
-                let parser =
-                    naga::front::spv::Parser::new(spv.iter().cloned(), &Default::default());
+                let options = naga::front::spv::Options {
+                    adjust_coordinate_space: false, // we require NDC_Y_UP feature
+                    flow_graph_dump_prefix: None,
+                };
+                let parser = naga::front::spv::Parser::new(spv.iter().cloned(), &options);
                 let module = match parser.parse() {
                     Ok(module) => Some(module),
                     Err(err) => {


### PR DESCRIPTION
**Connections**
fixes https://github.com/gfx-rs/wgpu-rs/issues/842

**Description**
The SPV-in by default changes the coordinate space, but for WebGPU we don't want it.

**Testing**
Untested...