### PR TITLE
Move depth clamping to primitive state

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -809,23 +809,16 @@ pub fn map_primitive_state_to_rasterizer(
     depth_stencil: Option<&wgt::DepthStencilState>,
 ) -> hal::pso::Rasterizer {
     use hal::pso;
-    let (depth_clamping, depth_bias) = match depth_stencil {
-        Some(dsd) => {
-            let bias = if dsd.bias.is_enabled() {
-                Some(pso::State::Static(pso::DepthBias {
-                    const_factor: dsd.bias.constant as f32,
-                    slope_factor: dsd.bias.slope_scale,
-                    clamp: dsd.bias.clamp,
-                }))
-            } else {
-                None
-            };
-            (dsd.clamp_depth, bias)
-        }
-        None => (false, None),
+    let depth_bias = match depth_stencil {
+        Some(dsd) if dsd.bias.is_enabled() => Some(pso::State::Static(pso::DepthBias {
+            const_factor: dsd.bias.constant as f32,
+            slope_factor: dsd.bias.slope_scale,
+            clamp: dsd.bias.clamp,
+        })),
+        _ => None,
     };
     pso::Rasterizer {
-        depth_clamping,
+        depth_clamping: desc.clamp_depth,
         polygon_mode: match desc.polygon_mode {
             wgt::PolygonMode::Fill => pso::PolygonMode::Fill,
             wgt::PolygonMode::Line => pso::PolygonMode::Line,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1023,6 +1023,11 @@ pub struct PrimitiveState {
     /// The face culling mode.
     #[cfg_attr(any(feature = "trace", feature = "replay"), serde(default))]
     pub cull_mode: Option<Face>,
+    /// If set to true, the polygon depth is clamped to 0-1 range instead of being clipped.
+    ///
+    /// Enabling this requires `Features::DEPTH_CLAMPING` to be enabled.
+    #[cfg_attr(any(feature = "trace", feature = "replay"), serde(default))]
+    pub clamp_depth: bool,
     /// Controls the way each polygon is rasterized. Can be either `Fill` (default), `Line` or `Point`
     ///
     /// Setting this to something other than `Fill` requires `Features::NON_FILL_POLYGON_MODE` to be enabled.
@@ -1751,11 +1756,6 @@ pub struct DepthStencilState {
     /// Depth bias state.
     #[cfg_attr(any(feature = "trace", feature = "replay"), serde(default))]
     pub bias: DepthBiasState,
-    /// If enabled polygon depth is clamped to 0-1 range instead of being clipped.
-    ///
-    /// Requires `Features::DEPTH_CLAMPING` enabled.
-    #[cfg_attr(any(feature = "trace", feature = "replay"), serde(default))]
-    pub clamp_depth: bool,
 }
 
 impl DepthStencilState {


### PR DESCRIPTION
**Connections**
Matches https://github.com/gpuweb/gpuweb/pull/1583

**Description**
There are valid cases where we'd want the depth clamping happening without any depth/stencil attachment or state.

**Testing**
Untested
