### PR TITLE
Updated `gpu-alloc` to rev 2cd1ad6

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -37,7 +37,7 @@ smallvec = "1"
 thiserror = "1"
 
 # Update to 0.4 when it will be available
-gpu-alloc = { git = "https://github.com/zakarumych/gpu-alloc.git", rev = "560ad651aa8f7aefcee8f5bcf41e67a84561bcda" }
+gpu-alloc = { git = "https://github.com/zakarumych/gpu-alloc.git", rev = "2cd1ad650cdd24d1647b6041f77ced0cbf1ff2a6" }
 gpu-descriptor = { version = "0.1" }
 
 hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "2a93d52661aafcbd6441ea83e739c8ced906cd21" }


### PR DESCRIPTION
**Connections**
Updated gpu-alloc to include the commit that fixed https://github.com/zakarumych/gpu-alloc/issues/41

**Description**
It is a simple update of a dependency.

**Testing**
I have not tested this change, I just made sure that everything was still compiling correctly.
<!--
Non-trivial functional changes would need to be tested through:
  - [wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - test the examples.
  - [wgpu-native](https://github.com/gfx-rs/wgpu-native/) - check the generated C header for sanity.

Ideally, a PR needs to link to the draft PRs in these projects with relevant modifications.
See https://github.com/gfx-rs/wgpu/pull/666 for an example.
If you can add a unit/integration test here in `wgpu`, that would be best.
-->
