### PR TITLE
Fixes vulkan-portability feature panicking on MacOS

### DIFF
--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -254,7 +254,7 @@ macro_rules! gfx_select {
         // Note: For some reason the cfg aliases defined in build.rs don't succesfully apply in this
         // macro so we must specify their equivalents manually
         match $id.backend() {
-            #[cfg(all(not(target_arch = "wasm32"), any(not(any(target_os = "ios", target_os = "macos")), feature = "gfx-backend-vulkan")))]
+            #[cfg(all(not(target_arch = "wasm32"), any(not(any(target_os = "ios", target_os = "macos")), feature = "vulkan-portability")))]
             wgt::Backend::Vulkan => $global.$method::<$crate::backend::Vulkan>( $($param),* ),
             #[cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))]
             wgt::Backend::Metal => $global.$method::<$crate::backend::Metal>( $($param),* ),


### PR DESCRIPTION
**Connections**
Fixes [#840 (wgpu-rs)](https://github.com/gfx-rs/wgpu-rs/issues/840)

**Description**
`vulkan-portability` feature panics on MacOS since it doesn't have the `gfx-backend-vulkan` feature needed by wgpu-core to enable the Vulkan backend.
This PR simply checks for the `vulkan-portability` feature instead, as suggested in the issue linked above.

**Testing**
Not really tested since `wgpu` won't build locally, but it is just a straight forward replacement of a feature check.
