### PR TITLE
Add Map Alignment type

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -28,7 +28,7 @@ use parking_lot::{Mutex, MutexGuard};
 use thiserror::Error;
 use wgt::{
     BufferAddress, BufferSize, InputStepMode, TextureDimension,
-    TextureFormat, TextureViewDimension, MAP_ALIGNMENT, COPY_BUFFER_ALIGNMENT
+    TextureFormat, TextureViewDimension
 };
 
 use std::{
@@ -4598,10 +4598,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             buffer.size - offset
         };
 
-        if offset % MAP_ALIGNMENT != 0 {
+        if offset % wgt::MAP_ALIGNMENT != 0 {
             return Err(resource::BufferAccessError::UnalignedOffset { offset });
         }
-        if range_size % COPY_BUFFER_ALIGNMENT != 0 {
+        if range_size % wgt::COPY_BUFFER_ALIGNMENT != 0 {
             return Err(resource::BufferAccessError::UnalignedRangeSize { range_size });
         }
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -27,7 +27,8 @@ use hal::{
 use parking_lot::{Mutex, MutexGuard};
 use thiserror::Error;
 use wgt::{
-    BufferAddress, BufferSize, InputStepMode, TextureDimension, TextureFormat, TextureViewDimension,
+    BufferAddress, BufferSize, InputStepMode, TextureDimension,
+    TextureFormat, TextureViewDimension, MAP_ALIGNMENT, COPY_BUFFER_ALIGNMENT
 };
 
 use std::{
@@ -4597,10 +4598,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             buffer.size - offset
         };
 
-        if offset % 8 != 0 {
+        if offset % MAP_ALIGNMENT != 0 {
             return Err(resource::BufferAccessError::UnalignedOffset { offset });
         }
-        if range_size % 4 != 0 {
+        if range_size % COPY_BUFFER_ALIGNMENT != 0 {
             return Err(resource::BufferAccessError::UnalignedRangeSize { range_size });
         }
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4526,7 +4526,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             HostMap::Write => (wgt::BufferUsage::MAP_WRITE, resource::BufferUse::MAP_WRITE),
         };
 
-        if range.start % wgt::COPY_BUFFER_ALIGNMENT != 0
+        if range.start % wgt::MAP_ALIGNMENT != 0
             || range.end % wgt::COPY_BUFFER_ALIGNMENT != 0
         {
             return Err(resource::BufferAccessError::UnalignedRange);

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -142,7 +142,7 @@ pub enum BufferAccessError {
     MissingBufferUsage(#[from] MissingBufferUsageError),
     #[error("buffer is not mapped")]
     NotMapped,
-    #[error("buffer map range does not respect `COPY_BUFFER_ALIGNMENT`")]
+    #[error("buffer map range must start aligned to `MAP_ALIGNMENT` and end to `COPY_BUFFER_ALIGNMENT`")]
     UnalignedRange,
     #[error("buffer offset invalid: offset {offset} must be multiple of 8")]
     UnalignedOffset { offset: wgt::BufferAddress },

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -40,6 +40,8 @@ pub const COPY_BYTES_PER_ROW_ALIGNMENT: u32 = 256;
 pub const BIND_BUFFER_ALIGNMENT: BufferAddress = 256;
 /// Buffer to buffer copy offsets and sizes must be aligned to this number.
 pub const COPY_BUFFER_ALIGNMENT: BufferAddress = 4;
+/// Size to align mappings.
+pub const MAP_ALIGNMENT: BufferAddress = 8;
 /// Vertex buffer strides have to be aligned to this number.
 pub const VERTEX_STRIDE_ALIGNMENT: BufferAddress = 4;
 /// Alignment all push constants need


### PR DESCRIPTION
**Description**
 In wgpu-rs, StagingBelt is aligning to 4 bytes instead of 8, failing the new validations. Adds a new type to specify mapping alignment size

**Testing**
 No testing needed afaik, only added new.
