### PR TITLE
Relax and imporve vertex attribute validation

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -27,8 +27,7 @@ use hal::{
 use parking_lot::{Mutex, MutexGuard};
 use thiserror::Error;
 use wgt::{
-    BufferAddress, BufferSize, InputStepMode, TextureDimension,
-    TextureFormat, TextureViewDimension
+    BufferAddress, BufferSize, InputStepMode, TextureDimension, TextureFormat, TextureViewDimension,
 };
 
 use std::{
@@ -2081,7 +2080,7 @@ impl<B: GfxBackend> Device<B> {
                 });
                 io.insert(
                     attribute.shader_location,
-                    validation::NumericType::from_vertex_format(attribute.format),
+                    validation::InterfaceVar::vertex_attribute(attribute.format),
                 );
             }
         }
@@ -2315,7 +2314,8 @@ impl<B: GfxBackend> Device<B> {
         if validated_stages.contains(wgt::ShaderStage::FRAGMENT) {
             for (i, state) in color_states.iter().enumerate() {
                 match io.get(&(i as wgt::ShaderLocation)) {
-                    Some(output) if validation::check_texture_format(state.format, output) => {}
+                    Some(ref output)
+                        if validation::check_texture_format(state.format, &output.ty) => {}
                     Some(output) => {
                         log::warn!(
                             "Incompatible fragment output[{}] from shader: {:?}, expected {:?}",
@@ -4526,9 +4526,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             HostMap::Write => (wgt::BufferUsage::MAP_WRITE, resource::BufferUse::MAP_WRITE),
         };
 
-        if range.start % wgt::MAP_ALIGNMENT != 0
-            || range.end % wgt::COPY_BUFFER_ALIGNMENT != 0
-        {
+        if range.start % wgt::MAP_ALIGNMENT != 0 || range.end % wgt::COPY_BUFFER_ALIGNMENT != 0 {
             return Err(resource::BufferAccessError::UnalignedRange);
         }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -142,7 +142,9 @@ pub enum BufferAccessError {
     MissingBufferUsage(#[from] MissingBufferUsageError),
     #[error("buffer is not mapped")]
     NotMapped,
-    #[error("buffer map range must start aligned to `MAP_ALIGNMENT` and end to `COPY_BUFFER_ALIGNMENT`")]
+    #[error(
+        "buffer map range must start aligned to `MAP_ALIGNMENT` and end to `COPY_BUFFER_ALIGNMENT`"
+    )]
     UnalignedRange,
     #[error("buffer offset invalid: offset {offset} must be multiple of 8")]
     UnalignedOffset { offset: wgt::BufferAddress },

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -4,7 +4,7 @@
 
 use crate::{binding_model::BindEntryMap, FastHashMap};
 use naga::valid::GlobalUse;
-use std::collections::hash_map::Entry;
+use std::{collections::hash_map::Entry, fmt};
 use thiserror::Error;
 use wgt::{BindGroupLayoutEntry, BindingType};
 
@@ -38,11 +38,27 @@ enum NumericDimension {
     Matrix(naga::VectorSize, naga::VectorSize),
 }
 
+impl fmt::Display for NumericDimension {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::Scalar => write!(f, ""),
+            Self::Vector(size) => write!(f, "x{}", size as u8),
+            Self::Matrix(columns, rows) => write!(f, "x{}{}", columns as u8, rows as u8),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct NumericType {
     dim: NumericDimension,
     kind: naga::ScalarKind,
     width: naga::Bytes,
+}
+
+impl fmt::Display for NumericType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}{}{}", self.kind, self.width * 8, self.dim)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -59,6 +75,12 @@ impl InterfaceVar {
             ty: NumericType::from_vertex_format(format),
             interpolation: None,
         }
+    }
+}
+
+impl fmt::Display for InterfaceVar {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} interpolated as {:?}", self.ty, self.interpolation)
     }
 }
 
@@ -166,8 +188,10 @@ pub enum BindingError {
 pub enum InputError {
     #[error("input is not provided by the earlier stage in the pipeline")]
     Missing,
-    #[error("input type is not compatible with the provided")]
-    WrongType,
+    #[error("input type is not compatible with the provided {0}")]
+    WrongType(NumericType),
+    #[error("input interpolation doesn't match provided {0:?}")]
+    InterpolationMismatch(Option<naga::Interpolation>),
 }
 
 /// Errors produced when validating a programmable stage of a pipeline.
@@ -175,19 +199,22 @@ pub enum InputError {
 pub enum StageError {
     #[error("shader module is invalid")]
     InvalidModule,
-    #[error("unable to find an entry point at {0:?} stage")]
+    #[error("unable to find entry point '{0:?}'")]
     MissingEntryPoint(String),
-    #[error("error matching global binding at index {binding} in group {group} against the pipeline layout: {error}")]
+    #[error("error matching global binding at index {binding} in group {group} against the pipeline layout")]
     Binding {
         group: u32,
         binding: u32,
+        #[source]
         error: BindingError,
     },
     #[error(
-        "error matching the stage input at {location} against the previous stage outputs: {error}"
+        "error matching the stage input at {location} ({var}) against the previous stage outputs"
     )]
     Input {
         location: wgt::ShaderLocation,
+        var: InterfaceVar,
+        #[source]
         error: InputError,
     },
 }
@@ -881,19 +908,27 @@ impl Interface {
                                         iv.ty.is_compatible_with(&provided.ty)
                                     }
                                     naga::ShaderStage::Fragment => {
+                                        if iv.interpolation != provided.interpolation {
+                                            return Err(InputError::InterpolationMismatch(
+                                                provided.interpolation,
+                                            ));
+                                        }
                                         iv.ty.is_subtype_of(&provided.ty)
-                                            && iv.interpolation == provided.interpolation
                                     }
                                     naga::ShaderStage::Compute => false,
                                 };
                                 if compatible {
                                     Ok(())
                                 } else {
-                                    Err(InputError::WrongType)
+                                    Err(InputError::WrongType(provided.ty))
                                 }
                             });
                     if let Err(error) = result {
-                        return Err(StageError::Input { location, error });
+                        return Err(StageError::Input {
+                            location,
+                            var: iv.clone(),
+                            error,
+                        });
                     }
                 }
                 Varying::BuiltIn(_) => {}


### PR DESCRIPTION
**Connections**
None

**Description**
Improves our validation of vertex attributes in the following ways:
  1. Relaxes the size matching, so that we allow the shaders to default some of the values we don't provide
  2. Require interpolation to match
  3. Make the error messages more detailed:

>     In Device::create_render_pipeline
    error in stage VERTEX
    error matching the stage input at 1 (Uint32x2 interpolated as None) against the previous stage outputs
    input type is not compatible with the provided Float32x2

**Testing**
Tested on wgpu-rs examples.