### PR TITLE
Validate min/max blending factors

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     command::{LoadOp, PassChannel, StoreOp},
+    pipeline::ColorStateError,
     resource, PrivateFeatures,
 };
 
@@ -196,16 +197,24 @@ pub fn map_primitive_topology(primitive_topology: wgt::PrimitiveTopology) -> hal
     }
 }
 
-pub fn map_color_target_state(desc: &wgt::ColorTargetState) -> hal::pso::ColorBlendDesc {
+pub fn map_color_target_state(
+    desc: &wgt::ColorTargetState,
+) -> Result<hal::pso::ColorBlendDesc, ColorStateError> {
     let color_mask = desc.write_mask;
-    let blend = desc.blend.as_ref().map(|bs| hal::pso::BlendState {
-        color: map_blend_component(&bs.color),
-        alpha: map_blend_component(&bs.alpha),
-    });
-    hal::pso::ColorBlendDesc {
+    let blend = desc
+        .blend
+        .as_ref()
+        .map(|bs| {
+            Ok(hal::pso::BlendState {
+                color: map_blend_component(&bs.color)?,
+                alpha: map_blend_component(&bs.alpha)?,
+            })
+        })
+        .transpose()?;
+    Ok(hal::pso::ColorBlendDesc {
         mask: map_color_write_flags(color_mask),
         blend,
-    }
+    })
 }
 
 fn map_color_write_flags(flags: wgt::ColorWrite) -> hal::pso::ColorMask {
@@ -228,25 +237,48 @@ fn map_color_write_flags(flags: wgt::ColorWrite) -> hal::pso::ColorMask {
     value
 }
 
-fn map_blend_component(component: &wgt::BlendComponent) -> hal::pso::BlendOp {
+fn map_blend_component(
+    component: &wgt::BlendComponent,
+) -> Result<hal::pso::BlendOp, ColorStateError> {
     use hal::pso::BlendOp as H;
     use wgt::BlendOperation as Bo;
-    match component.operation {
-        Bo::Add => H::Add {
-            src: map_blend_factor(component.src_factor),
-            dst: map_blend_factor(component.dst_factor),
+    Ok(match *component {
+        wgt::BlendComponent {
+            operation: Bo::Add,
+            src_factor,
+            dst_factor,
+        } => H::Add {
+            src: map_blend_factor(src_factor),
+            dst: map_blend_factor(dst_factor),
         },
-        Bo::Subtract => H::Sub {
-            src: map_blend_factor(component.src_factor),
-            dst: map_blend_factor(component.dst_factor),
+        wgt::BlendComponent {
+            operation: Bo::Subtract,
+            src_factor,
+            dst_factor,
+        } => H::Sub {
+            src: map_blend_factor(src_factor),
+            dst: map_blend_factor(dst_factor),
         },
-        Bo::ReverseSubtract => H::RevSub {
-            src: map_blend_factor(component.src_factor),
-            dst: map_blend_factor(component.dst_factor),
+        wgt::BlendComponent {
+            operation: Bo::ReverseSubtract,
+            src_factor,
+            dst_factor,
+        } => H::RevSub {
+            src: map_blend_factor(src_factor),
+            dst: map_blend_factor(dst_factor),
         },
-        Bo::Min => H::Min,
-        Bo::Max => H::Max,
-    }
+        wgt::BlendComponent {
+            operation: Bo::Min,
+            src_factor: wgt::BlendFactor::One,
+            dst_factor: wgt::BlendFactor::One,
+        } => H::Min,
+        wgt::BlendComponent {
+            operation: Bo::Max,
+            src_factor: wgt::BlendFactor::One,
+            dst_factor: wgt::BlendFactor::One,
+        } => H::Max,
+        _ => return Err(ColorStateError::InvalidMinMaxBlendFactors(*component)),
+    })
 }
 
 fn map_blend_factor(blend_factor: wgt::BlendFactor) -> hal::pso::Factor {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -197,6 +197,19 @@ pub struct RenderPipelineDescriptor<'a> {
 }
 
 #[derive(Clone, Debug, Error)]
+pub enum ColorStateError {
+    #[error("output is missing")]
+    Missing,
+    #[error("output format {pipeline} is incompatible with the shader {shader}")]
+    IncompatibleFormat {
+        pipeline: validation::NumericType,
+        shader: validation::NumericType,
+    },
+    #[error("blend factors for {0:?} must be `One`")]
+    InvalidMinMaxBlendFactors(wgt::BlendComponent),
+}
+
+#[derive(Clone, Debug, Error)]
 pub enum CreateRenderPipelineError {
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -204,10 +217,8 @@ pub enum CreateRenderPipelineError {
     InvalidLayout,
     #[error("unable to derive an implicit layout")]
     Implicit(#[from] ImplicitLayoutError),
-    #[error("missing output at index {index}")]
-    MissingOutput { index: u8 },
-    #[error("incompatible output format at index {index}")]
-    IncompatibleOutputFormat { index: u8 },
+    #[error("color state [{0}] is invalid")]
+    ColorState(u8, #[source] ColorStateError),
     #[error("invalid sample count {0}")]
     InvalidSampleCount(u32),
     #[error("the number of vertex buffers {given} exceeds the limit {limit}")]

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -702,8 +702,16 @@ impl NumericType {
 }
 
 /// Return true if the fragment `format` is covered by the provided `output`.
-pub fn check_texture_format(format: wgt::TextureFormat, output: &NumericType) -> bool {
-    NumericType::from_texture_format(format).is_subtype_of(output)
+pub fn check_texture_format(
+    format: wgt::TextureFormat,
+    output: &NumericType,
+) -> Result<(), NumericType> {
+    let nt = NumericType::from_texture_format(format);
+    if nt.is_subtype_of(output) {
+        Ok(())
+    } else {
+        Err(nt)
+    }
 }
 
 pub type StageIo = FastHashMap<wgt::ShaderLocation, InterfaceVar>;


### PR DESCRIPTION
**Connections**
Based on #1325 
Matches https://github.com/gpuweb/gpuweb/pull/1635

**Description**
This PR refactors the color state errors, giving them more detailed context, and having a dedicated enum for them.
It also adds the check for the blend factors to be (1, 1) for the min/max operations.

**Testing**
Untested