### PR TITLE
Don't assume a pipeline is always bound

### DIFF
--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -182,6 +182,9 @@ impl Binder {
             if old.push_constant_ranges != new.push_constant_ranges {
                 bind_range.start = 0;
             }
+        } else {
+            // if there was no pipeline layout, reset everything
+            bind_range.start = 0;
         }
 
         (bind_range.start, &self.payloads[bind_range])

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -369,22 +369,23 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         bind_group,
                         &temp_offsets,
                     );
-                    if !entries.is_empty() {
-                        let pipeline_layout =
-                            &pipeline_layout_guard[pipeline_layout_id.unwrap()].raw;
-                        let desc_sets = entries.iter().map(|e| {
-                            bind_group_guard[e.group_id.as_ref().unwrap().value]
-                                .raw
-                                .raw()
-                        });
-                        let offsets = entries.iter().flat_map(|e| &e.dynamic_offsets).cloned();
-                        unsafe {
-                            raw.bind_compute_descriptor_sets(
-                                pipeline_layout,
-                                index as usize,
-                                desc_sets,
-                                offsets,
-                            );
+                    if let Some(pipeline_layout_id) = pipeline_layout_id {
+                        if !entries.is_empty() {
+                            let pipeline_layout = &pipeline_layout_guard[pipeline_layout_id].raw;
+                            let desc_sets = entries.iter().map(|e| {
+                                bind_group_guard[e.group_id.as_ref().unwrap().value]
+                                    .raw
+                                    .raw()
+                            });
+                            let offsets = entries.iter().flat_map(|e| &e.dynamic_offsets).cloned();
+                            unsafe {
+                                raw.bind_compute_descriptor_sets(
+                                    pipeline_layout,
+                                    index as usize,
+                                    desc_sets,
+                                    offsets,
+                                );
+                            }
                         }
                     }
                 }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1141,22 +1141,25 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             bind_group,
                             &temp_offsets,
                         );
-                        if !entries.is_empty() {
-                            let pipeline_layout =
-                                &pipeline_layout_guard[pipeline_layout_id.unwrap()].raw;
-                            let desc_sets = entries.iter().map(|e| {
-                                bind_group_guard[e.group_id.as_ref().unwrap().value]
-                                    .raw
-                                    .raw()
-                            });
-                            let offsets = entries.iter().flat_map(|e| &e.dynamic_offsets).cloned();
-                            unsafe {
-                                raw.bind_graphics_descriptor_sets(
-                                    pipeline_layout,
-                                    index as usize,
-                                    desc_sets,
-                                    offsets,
-                                );
+                        if let Some(pipeline_layout_id) = pipeline_layout_id {
+                            if !entries.is_empty() {
+                                let pipeline_layout =
+                                    &pipeline_layout_guard[pipeline_layout_id].raw;
+                                let desc_sets = entries.iter().map(|e| {
+                                    bind_group_guard[e.group_id.as_ref().unwrap().value]
+                                        .raw
+                                        .raw()
+                                });
+                                let offsets =
+                                    entries.iter().flat_map(|e| &e.dynamic_offsets).cloned();
+                                unsafe {
+                                    raw.bind_graphics_descriptor_sets(
+                                        pipeline_layout,
+                                        index as usize,
+                                        desc_sets,
+                                        offsets,
+                                    );
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
**Connections**
Was looking at https://bugzilla.mozilla.org/show_bug.cgi?id=1705043 trying to figure out what's going on there.

**Description**
This should fix a scenario where one starts with binding groups, and then binds the pipeline.

**Testing**
Tested on wgpu-rs examples