### PR TITLE
Update naga to gfx-22, add interpolation sampling validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "gfx-auxil"
 version = "0.8.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=e98889ff9a4919620de1f412d46135e180d3fa30#e98889ff9a4919620de1f412d46135e180d3fa30"
+source = "git+https://github.com/gfx-rs/gfx?rev=69991710a968e1e846148cdba425077e00b6febe#69991710a968e1e846148cdba425077e00b6febe"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -475,7 +475,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx11"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=e98889ff9a4919620de1f412d46135e180d3fa30#e98889ff9a4919620de1f412d46135e180d3fa30"
+source = "git+https://github.com/gfx-rs/gfx?rev=69991710a968e1e846148cdba425077e00b6febe#69991710a968e1e846148cdba425077e00b6febe"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=e98889ff9a4919620de1f412d46135e180d3fa30#e98889ff9a4919620de1f412d46135e180d3fa30"
+source = "git+https://github.com/gfx-rs/gfx?rev=69991710a968e1e846148cdba425077e00b6febe#69991710a968e1e846148cdba425077e00b6febe"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -517,7 +517,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-empty"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=e98889ff9a4919620de1f412d46135e180d3fa30#e98889ff9a4919620de1f412d46135e180d3fa30"
+source = "git+https://github.com/gfx-rs/gfx?rev=69991710a968e1e846148cdba425077e00b6febe#69991710a968e1e846148cdba425077e00b6febe"
 dependencies = [
  "gfx-hal",
  "log",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-gl"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=e98889ff9a4919620de1f412d46135e180d3fa30#e98889ff9a4919620de1f412d46135e180d3fa30"
+source = "git+https://github.com/gfx-rs/gfx?rev=69991710a968e1e846148cdba425077e00b6febe#69991710a968e1e846148cdba425077e00b6febe"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-metal"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=e98889ff9a4919620de1f412d46135e180d3fa30#e98889ff9a4919620de1f412d46135e180d3fa30"
+source = "git+https://github.com/gfx-rs/gfx?rev=69991710a968e1e846148cdba425077e00b6febe#69991710a968e1e846148cdba425077e00b6febe"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -566,6 +566,7 @@ dependencies = [
  "naga",
  "objc",
  "parking_lot",
+ "profiling",
  "range-alloc",
  "raw-window-handle",
  "spirv_cross",
@@ -575,7 +576,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=e98889ff9a4919620de1f412d46135e180d3fa30#e98889ff9a4919620de1f412d46135e180d3fa30"
+source = "git+https://github.com/gfx-rs/gfx?rev=69991710a968e1e846148cdba425077e00b6febe#69991710a968e1e846148cdba425077e00b6febe"
 dependencies = [
  "arrayvec",
  "ash",
@@ -595,7 +596,7 @@ dependencies = [
 [[package]]
 name = "gfx-hal"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=e98889ff9a4919620de1f412d46135e180d3fa30#e98889ff9a4919620de1f412d46135e180d3fa30"
+source = "git+https://github.com/gfx-rs/gfx?rev=69991710a968e1e846148cdba425077e00b6febe#69991710a968e1e846148cdba425077e00b6febe"
 dependencies = [
  "bitflags",
  "naga",
@@ -860,7 +861,7 @@ dependencies = [
 [[package]]
 name = "metal"
 version = "0.21.0"
-source = "git+https://github.com/gfx-rs/metal-rs?rev=439c986eb7a9b91e88b61def2daa66e4043fcbef#439c986eb7a9b91e88b61def2daa66e4043fcbef"
+source = "git+https://github.com/gfx-rs/metal-rs?rev=78f632d194c7c16d18b71d7373c4080847d110b0#78f632d194c7c16d18b71d7373c4080847d110b0"
 dependencies = [
  "bitflags",
  "block",
@@ -916,7 +917,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.3.1"
-source = "git+https://github.com/gfx-rs/naga?tag=gfx-21#98252cf5d29790f85cc4397e0cf7a5b6cfaac614"
+source = "git+https://github.com/gfx-rs/naga?tag=gfx-22#9cd6fd9c205a57824644d0baedc6c15997be1e36"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -1171,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "range-alloc"
 version = "0.1.2"
-source = "git+https://github.com/gfx-rs/gfx?rev=e98889ff9a4919620de1f412d46135e180d3fa30#e98889ff9a4919620de1f412d46135e180d3fa30"
+source = "git+https://github.com/gfx-rs/gfx?rev=69991710a968e1e846148cdba425077e00b6febe#69991710a968e1e846148cdba425077e00b6febe"
 
 [[package]]
 name = "raw-window-handle"

--- a/player/tests/data/quad.wgsl
+++ b/player/tests/data/quad.wgsl
@@ -1,9 +1,9 @@
 [[stage(vertex)]]
 fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> [[builtin(position)]] vec4<f32> {
     // hacky way to draw a large triangle
-    const tmp1 = i32(vertex_index) / 2;
-    const tmp2 = i32(vertex_index) & 1;
-    const pos = vec2<f32>(
+    let tmp1 = i32(vertex_index) / 2;
+    let tmp2 = i32(vertex_index) & 1;
+    let pos = vec2<f32>(
         f32(tmp1) * 4.0 - 1.0,
         f32(tmp2) * 4.0 - 1.0
     );

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -40,28 +40,28 @@ thiserror = "1"
 gpu-alloc = { git = "https://github.com/zakarumych/gpu-alloc.git", rev = "2cd1ad650cdd24d1647b6041f77ced0cbf1ff2a6" }
 gpu-descriptor = { version = "0.1" }
 
-hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "e98889ff9a4919620de1f412d46135e180d3fa30" }
-gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "e98889ff9a4919620de1f412d46135e180d3fa30" }
+hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "69991710a968e1e846148cdba425077e00b6febe" }
+gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "69991710a968e1e846148cdba425077e00b6febe" }
 
 [target.'cfg(all(not(target_arch = "wasm32"), all(unix, not(target_os = "ios"), not(target_os = "macos"))))'.dependencies]
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "e98889ff9a4919620de1f412d46135e180d3fa30", features = ["naga"] }
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "e98889ff9a4919620de1f412d46135e180d3fa30" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "69991710a968e1e846148cdba425077e00b6febe", features = ["naga"] }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "69991710a968e1e846148cdba425077e00b6febe" }
 
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
-gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "e98889ff9a4919620de1f412d46135e180d3fa30" }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "e98889ff9a4919620de1f412d46135e180d3fa30", optional = true }
+gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "69991710a968e1e846148cdba425077e00b6febe" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "69991710a968e1e846148cdba425077e00b6febe", optional = true }
 
 [target.'cfg(all(not(target_arch = "wasm32"), windows))'.dependencies]
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "e98889ff9a4919620de1f412d46135e180d3fa30" }
-gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "e98889ff9a4919620de1f412d46135e180d3fa30" }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "e98889ff9a4919620de1f412d46135e180d3fa30", features = ["naga"] }
+gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "69991710a968e1e846148cdba425077e00b6febe" }
+gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "69991710a968e1e846148cdba425077e00b6febe" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "69991710a968e1e846148cdba425077e00b6febe", features = ["naga"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "e98889ff9a4919620de1f412d46135e180d3fa30" }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "69991710a968e1e846148cdba425077e00b6febe" }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-21"
+tag = "gfx-22"
 features = ["spv-in", "spv-out", "wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2145,7 +2145,7 @@ impl<B: GfxBackend> Device<B> {
         let baked_states = hal::pso::BakedStates {
             viewport: None,
             scissor: None,
-            blend_color: None,
+            blend_constants: None,
             depth_bounds: None,
         };
 


### PR DESCRIPTION
**Connections**
Includes https://github.com/gfx-rs/gfx/pull/3729, https://github.com/gfx-rs/gfx/pull/3719, https://github.com/gfx-rs/naga/pull/689, https://github.com/gfx-rs/naga/pull/700, and other fixes

**Description**
Update gfx and naga to latest (gfx-22 tag).
The hope is for this to be the last tag release before 0.8

**Testing**
Tested on wgpu-rs examples