### PR TITLE
Mark unused implicit BGL ids as vacant

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -265,7 +265,7 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                             root_id: ic.root_id,
                             group_ids: &ic.group_ids,
                         });
-                let (_, _, error) =
+                let (_, error) =
                     self.device_create_compute_pipeline::<B>(device, &desc, id, implicit_ids);
                 if let Some(e) = error {
                     panic!("{:?}", e);
@@ -287,7 +287,7 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                             root_id: ic.root_id,
                             group_ids: &ic.group_ids,
                         });
-                let (_, _, error) =
+                let (_, error) =
                     self.device_create_render_pipeline::<B>(device, &desc, id, implicit_ids);
                 if let Some(e) = error {
                     panic!("{:?}", e);

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -160,10 +160,19 @@ impl<T, I: TypedId> Storage<T, I> {
         }
     }
 
-    fn insert_impl(&mut self, index: usize, element: Element<T>) {
+    fn make_room_impl(&mut self, index: usize) {
         if index >= self.map.len() {
             self.map.resize_with(index + 1, || Element::Vacant);
         }
+    }
+
+    pub(crate) fn make_room(&mut self, id: I) {
+        let (index, _, _) = id.unzip();
+        self.make_room_impl(index as usize)
+    }
+
+    fn insert_impl(&mut self, index: usize, element: Element<T>) {
+        self.make_room_impl(index);
         match std::mem::replace(&mut self.map[index], element) {
             Element::Vacant => {}
             _ => panic!("Index {:?} is already occupied", index),


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/1340

**Description**
This is not an ideal solution. We aren't marking the IDs as errors. But it's an improvement, and it resolves the crash in FF, supposedly.

**Testing**
Tested on wgpu-rs examples with implicit layouts