### PR TITLE
Make implicit ids actually errors to start with

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1109,7 +1109,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .trackers
                             .bind_groups
                             .use_extend(&*bind_group_guard, bind_group_id, (), ())
-                            .unwrap();
+                            .map_err(|_| RenderCommandError::InvalidBindGroup(bind_group_id))
+                            .map_pass_err(scope)?;
                         bind_group
                             .validate_dynamic_bindings(&temp_offsets)
                             .map_pass_err(scope)?;


### PR DESCRIPTION
**Connections**
Follow-up to #1341

**Description**
Turns out, leaving the indices `Vacant` is also not an option, since the `hub.rs` code considers this an internal error (unexpected), and panics.

**Testing**
Tested on Austin's examples in Gecko