### PR TITLE
Hard error on SPIRV parsing failure when VALIDATION is requested

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1005,10 +1005,11 @@ impl<B: GfxBackend> Device<B> {
                 let module = match parser.parse() {
                     Ok(module) => Some(module),
                     Err(err) => {
-                        // TODO: eventually, when Naga gets support for all features,
-                        // we want to convert these to a hard error,
                         log::warn!("Failed to parse shader SPIR-V code: {:?}", err);
-                        log::warn!("Shader module will not be validated or reflected");
+                        if desc.flags.contains(wgt::ShaderFlags::VALIDATION) {
+                            return Err(pipeline::CreateShaderModuleError::Parsing);
+                        }
+                        log::warn!("\tProceeding unsafely without validation");
                         None
                     }
                 };


### PR DESCRIPTION
**Connections**
Follow-up from https://github.com/gfx-rs/wgpu/issues/1350#issuecomment-825186159

**Description**
If the user provided SPIR-V, and they requested VALIDATION, and we fail to parse the file - there is no point to proceed.
VALIDATION flag should be a gaurantee of safe operation, so we can't just throw the same SPIR-V at SPIRV-Cross and pretend that it's ok.

**Testing**
Tested on noclip shaders