### PR TITLE
Big refactor of the profiling usage

### DIFF
--- a/wgpu-core/src/command/allocator.rs
+++ b/wgpu-core/src/command/allocator.rs
@@ -243,6 +243,7 @@ impl<B: hal::Backend> CommandAllocator<B> {
     }
 
     pub fn maintain(&self, device: &B::Device, last_done_index: SubmissionIndex) {
+        profiling::scope!("maintain", "CommandAllocator");
         let mut inner = self.inner.lock();
         let mut remove_threads = Vec::new();
         for (&thread_id, pool) in inner.pools.iter_mut() {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -91,7 +91,6 @@ impl RenderBundleEncoder {
         parent_id: id::DeviceId,
         base: Option<BasePass<RenderCommand>>,
     ) -> Result<Self, CreateRenderBundleError> {
-        profiling::scope!("RenderBundleEncoder::new");
         Ok(Self {
             base: base.unwrap_or_else(|| BasePass::new(&desc.label)),
             parent_id,
@@ -511,7 +510,6 @@ impl RenderBundleEncoder {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
-        profiling::scope!("RenderBundle::set_index_buffer");
         self.base.commands.push(RenderCommand::SetIndexBuffer {
             buffer_id,
             index_format,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -257,7 +257,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         base: BasePassRef<ComputeCommand>,
     ) -> Result<(), ComputePassError> {
-        profiling::scope!("CommandEncoder::run_compute_pass");
+        profiling::scope!("run_compute_pass", "CommandEncoder");
         let scope = PassErrorScope::Pass(encoder_id);
 
         let hub = B::hub(self);

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -78,6 +78,7 @@ impl<B: GfxBackend> CommandBuffer<B> {
     ) {
         use hal::command::CommandBuffer as _;
 
+        profiling::scope!("insert_barriers");
         debug_assert_eq!(B::VARIANT, base.backend());
         debug_assert_eq!(B::VARIANT, head.backend());
 
@@ -198,7 +199,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         _desc: &wgt::CommandBufferDescriptor<Label>,
     ) -> (id::CommandBufferId, Option<CommandEncoderError>) {
-        profiling::scope!("CommandEncoder::finish");
+        profiling::scope!("finish", "CommandEncoder");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -231,7 +232,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) -> Result<(), CommandEncoderError> {
-        profiling::scope!("CommandEncoder::push_debug_group");
+        profiling::scope!("push_debug_group", "CommandEncoder");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -251,7 +252,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) -> Result<(), CommandEncoderError> {
-        profiling::scope!("CommandEncoder::insert_debug_marker");
+        profiling::scope!("insert_debug_marker", "CommandEncoder");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -270,7 +271,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         encoder_id: id::CommandEncoderId,
     ) -> Result<(), CommandEncoderError> {
-        profiling::scope!("CommandEncoder::pop_debug_marker");
+        profiling::scope!("pop_debug_marker", "CommandEncoder");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -186,7 +186,6 @@ impl RenderPass {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        profiling::scope!("RenderPass::set_index_buffer");
         self.base.commands.push(RenderCommand::SetIndexBuffer {
             buffer_id,
             index_format,
@@ -518,6 +517,7 @@ impl<'a, B: GfxBackend> RenderPassInfo<'a, B> {
         device: &Device<B>,
         view_guard: &'a Storage<TextureView<B>, id::TextureViewId>,
     ) -> Result<Self, RenderPassErrorInner> {
+        profiling::scope!("start", "RenderPassInfo");
         let sample_count_limit = device.hal_limits.framebuffer_color_sample_counts;
 
         // We default to false intentionally, even if depth-stencil isn't used at all.
@@ -959,6 +959,8 @@ impl<'a, B: GfxBackend> RenderPassInfo<'a, B> {
         mut self,
         texture_guard: &Storage<Texture<B>, id::TextureId>,
     ) -> Result<(TrackerSet, Option<Stored<id::SwapChainId>>), RenderPassErrorInner> {
+        profiling::scope!("finish", "RenderPassInfo");
+
         for ra in self.render_attachments {
             let texture = &texture_guard[ra.texture_id.value];
             check_texture_usage(texture.usage, TextureUsage::RENDER_ATTACHMENT)?;
@@ -1017,7 +1019,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         color_attachments: &[RenderPassColorAttachment],
         depth_stencil_attachment: Option<&RenderPassDepthStencilAttachment>,
     ) -> Result<(), RenderPassError> {
-        profiling::scope!("CommandEncoder::run_render_pass");
+        profiling::scope!("run_render_pass", "CommandEncoder");
         let scope = PassErrorScope::Pass(encoder_id);
 
         let hub = B::hub(self);

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -334,7 +334,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination_offset: BufferAddress,
         size: BufferAddress,
     ) -> Result<(), CopyError> {
-        profiling::scope!("CommandEncoder::copy_buffer_to_buffer");
+        profiling::scope!("copy_buffer_to_buffer", "CommandEncoder");
 
         if source == destination {
             return Err(TransferError::SameSourceDestinationBuffer.into());
@@ -472,7 +472,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &ImageCopyTexture,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
-        profiling::scope!("CommandEncoder::copy_buffer_to_texture");
+        profiling::scope!("copy_buffer_to_texture", "CommandEncoder");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -622,7 +622,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &ImageCopyBuffer,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
-        profiling::scope!("CommandEncoder::copy_texture_to_buffer");
+        profiling::scope!("copy_texture_to_buffer", "CommandEncoder");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -775,7 +775,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &ImageCopyTexture,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
-        profiling::scope!("CommandEncoder::copy_texture_to_texture");
+        profiling::scope!("copy_texture_to_texture", "CommandEncoder");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/device/alloc.rs
+++ b/wgpu-core/src/device/alloc.rs
@@ -140,6 +140,7 @@ impl<B: hal::Backend> MemoryBlock<B> {
         inner_offset: wgt::BufferAddress,
         data: &[u8],
     ) -> Result<(), DeviceError> {
+        profiling::scope!("write_bytes");
         let offset = inner_offset;
         unsafe {
             self.0
@@ -154,6 +155,7 @@ impl<B: hal::Backend> MemoryBlock<B> {
         inner_offset: wgt::BufferAddress,
         data: &mut [u8],
     ) -> Result<(), DeviceError> {
+        profiling::scope!("read_bytes");
         let offset = inner_offset;
         unsafe {
             self.0
@@ -211,7 +213,7 @@ impl<B: hal::Backend> gpu_alloc::MemoryDevice<B::Memory> for MemoryDevice<'_, B>
         memory_type: u32,
         flags: gpu_alloc::AllocationFlags,
     ) -> Result<B::Memory, gpu_alloc::OutOfMemory> {
-        profiling::scope!("Allocate Memory");
+        profiling::scope!("allocate_memory");
 
         assert!(flags.is_empty());
 
@@ -221,7 +223,7 @@ impl<B: hal::Backend> gpu_alloc::MemoryDevice<B::Memory> for MemoryDevice<'_, B>
     }
 
     unsafe fn deallocate_memory(&self, memory: B::Memory) {
-        profiling::scope!("Deallocate Memory");
+        profiling::scope!("deallocate_memory");
         self.0.free_memory(memory);
     }
 
@@ -231,7 +233,7 @@ impl<B: hal::Backend> gpu_alloc::MemoryDevice<B::Memory> for MemoryDevice<'_, B>
         offset: u64,
         size: u64,
     ) -> Result<NonNull<u8>, gpu_alloc::DeviceMapError> {
-        profiling::scope!("Map memory");
+        profiling::scope!("map_memory");
         match self.0.map_memory(
             memory,
             hal::memory::Segment {
@@ -249,7 +251,7 @@ impl<B: hal::Backend> gpu_alloc::MemoryDevice<B::Memory> for MemoryDevice<'_, B>
     }
 
     unsafe fn unmap_memory(&self, memory: &mut B::Memory) {
-        profiling::scope!("Unmap memory");
+        profiling::scope!("unmap_memory");
         self.0.unmap_memory(memory);
     }
 
@@ -257,7 +259,7 @@ impl<B: hal::Backend> gpu_alloc::MemoryDevice<B::Memory> for MemoryDevice<'_, B>
         &self,
         ranges: &[gpu_alloc::MappedMemoryRange<'_, B::Memory>],
     ) -> Result<(), gpu_alloc::OutOfMemory> {
-        profiling::scope!("Invalidate memory ranges");
+        profiling::scope!("invalidate_memory_ranges");
         self.0
             .invalidate_mapped_memory_ranges(ranges.iter().map(|r| {
                 (
@@ -275,7 +277,7 @@ impl<B: hal::Backend> gpu_alloc::MemoryDevice<B::Memory> for MemoryDevice<'_, B>
         &self,
         ranges: &[gpu_alloc::MappedMemoryRange<'_, B::Memory>],
     ) -> Result<(), gpu_alloc::OutOfMemory> {
-        profiling::scope!("Flush memory ranges");
+        profiling::scope!("flush_memory_ranges");
         self.0
             .flush_mapped_memory_ranges(ranges.iter().map(|r| {
                 (

--- a/wgpu-core/src/device/descriptor.rs
+++ b/wgpu-core/src/device/descriptor.rs
@@ -61,7 +61,9 @@ impl<B: hal::Backend>
         max_sets: u32,
         flags: gpu_descriptor::DescriptorPoolCreateFlags,
     ) -> Result<B::DescriptorPool, gpu_descriptor::CreatePoolError> {
+        profiling::scope!("create_descriptor_pool");
         let mut ranges = ArrayVec::<[_; 7]>::new();
+
         ranges.push(hal::pso::DescriptorRangeDesc {
             ty: hal::pso::DescriptorType::Sampler,
             count: descriptor_count.sampler as _,
@@ -135,6 +137,7 @@ impl<B: hal::Backend>
     }
 
     unsafe fn destroy_descriptor_pool(&self, pool: B::DescriptorPool) {
+        profiling::scope!("destroy_descriptor_pool");
         hal::device::Device::destroy_descriptor_pool(self.0, pool);
     }
 
@@ -145,6 +148,8 @@ impl<B: hal::Backend>
         sets: &mut impl Extend<B::DescriptorSet>,
     ) -> Result<(), gpu_descriptor::DeviceAllocationError> {
         use gpu_descriptor::DeviceAllocationError as Dae;
+        profiling::scope!("alloc_descriptor_sets");
+
         match hal::pso::DescriptorPool::allocate(pool, layouts, sets) {
             Ok(()) => Ok(()),
             Err(hal::pso::AllocationError::OutOfMemory(oom)) => Err(match oom {
@@ -164,6 +169,7 @@ impl<B: hal::Backend>
         pool: &mut B::DescriptorPool,
         sets: impl Iterator<Item = B::DescriptorSet>,
     ) {
+        profiling::scope!("dealloc_descriptor_sets");
         hal::pso::DescriptorPool::free(pool, sets)
     }
 }

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -316,6 +316,7 @@ impl<B: hal::Backend> LifetimeTracker<B> {
         device: &B::Device,
         force_wait: bool,
     ) -> Result<SubmissionIndex, WaitIdleError> {
+        profiling::scope!("triage_submissions");
         if force_wait {
             self.wait_idle(device)?;
         }
@@ -349,6 +350,7 @@ impl<B: hal::Backend> LifetimeTracker<B> {
         memory_allocator_mutex: &Mutex<alloc::MemoryAllocator<B>>,
         descriptor_allocator_mutex: &Mutex<DescriptorAllocator<B>>,
     ) {
+        profiling::scope!("cleanup");
         unsafe {
             self.free_resources
                 .clean(device, memory_allocator_mutex, descriptor_allocator_mutex);
@@ -382,6 +384,8 @@ impl<B: GfxBackend> LifetimeTracker<B> {
         #[cfg(feature = "trace")] trace: Option<&Mutex<trace::Trace>>,
         token: &mut Token<super::Device<B>>,
     ) {
+        profiling::scope!("triage_suspected");
+
         if !self.suspected_resources.render_bundles.is_empty() {
             let (mut guard, _) = hub.render_bundles.write(token);
             let mut trackers = trackers.lock();

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -403,6 +403,7 @@ impl<B: GfxBackend> Device<B> {
         force_wait: bool,
         token: &mut Token<'token, Self>,
     ) -> Result<Vec<BufferMapPendingCallback>, WaitIdleError> {
+        profiling::scope!("maintain", "Device");
         let mut life_tracker = self.lock_life(token);
 
         life_tracker.triage_suspected(
@@ -2713,8 +2714,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         adapter_id: id::AdapterId,
         surface_id: id::SurfaceId,
     ) -> Result<TextureFormat, instance::GetSwapChainPreferredFormatError> {
-        profiling::scope!("Adapter::get_swap_chain_preferred_format");
-
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -2734,8 +2733,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         device_id: id::DeviceId,
     ) -> Result<wgt::Features, InvalidDevice> {
-        profiling::scope!("Device::features");
-
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, _) = hub.devices.read(&mut token);
@@ -2748,8 +2745,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         device_id: id::DeviceId,
     ) -> Result<wgt::Limits, InvalidDevice> {
-        profiling::scope!("Device::limits");
-
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, _) = hub.devices.read(&mut token);
@@ -2762,8 +2757,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         device_id: id::DeviceId,
     ) -> Result<wgt::DownlevelProperties, InvalidDevice> {
-        profiling::scope!("Device::downlevel_properties");
-
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, _) = hub.devices.read(&mut token);
@@ -2778,7 +2771,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &resource::BufferDescriptor,
         id_in: Input<G, id::BufferId>,
     ) -> (id::BufferId, Option<resource::CreateBufferError>) {
-        profiling::scope!("Device::create_buffer");
+        profiling::scope!("create_buffer", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2932,7 +2925,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         data: &[u8],
     ) -> Result<(), resource::BufferAccessError> {
-        profiling::scope!("Device::set_buffer_sub_data");
+        profiling::scope!("set_buffer_sub_data", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -2977,7 +2970,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         data: &mut [u8],
     ) -> Result<(), resource::BufferAccessError> {
-        profiling::scope!("Device::get_buffer_sub_data");
+        profiling::scope!("get_buffer_sub_data", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3011,7 +3004,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         buffer_id: id::BufferId,
     ) -> Result<(), resource::DestroyError> {
-        profiling::scope!("Buffer::destroy");
+        profiling::scope!("destroy", "Buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3054,7 +3047,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn buffer_drop<B: GfxBackend>(&self, buffer_id: id::BufferId, wait: bool) {
-        profiling::scope!("Buffer::drop");
+        profiling::scope!("drop", "Buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3108,7 +3101,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &resource::TextureDescriptor,
         id_in: Input<G, id::TextureId>,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
-        profiling::scope!("Device::create_texture");
+        profiling::scope!("create_texture", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3161,7 +3154,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         texture_id: id::TextureId,
     ) -> Result<(), resource::DestroyError> {
-        profiling::scope!("Texture::destroy");
+        profiling::scope!("destroy", "Texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3204,7 +3197,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn texture_drop<B: GfxBackend>(&self, texture_id: id::TextureId, wait: bool) {
-        profiling::scope!("Texture::drop");
+        profiling::scope!("drop", "Texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3258,7 +3251,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &resource::TextureViewDescriptor,
         id_in: Input<G, id::TextureViewId>,
     ) -> (id::TextureViewId, Option<resource::CreateTextureViewError>) {
-        profiling::scope!("Texture::create_view");
+        profiling::scope!("create_view", "Texture");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3310,7 +3303,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         texture_view_id: id::TextureViewId,
         wait: bool,
     ) -> Result<(), resource::TextureViewDestroyError> {
-        profiling::scope!("TextureView::drop");
+        profiling::scope!("drop", "TextureView");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3369,7 +3362,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &resource::SamplerDescriptor,
         id_in: Input<G, id::SamplerId>,
     ) -> (id::SamplerId, Option<resource::CreateSamplerError>) {
-        profiling::scope!("Device::create_sampler");
+        profiling::scope!("create_sampler", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3413,7 +3406,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn sampler_drop<B: GfxBackend>(&self, sampler_id: id::SamplerId) {
-        profiling::scope!("Sampler::drop");
+        profiling::scope!("drop", "Sampler");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3450,7 +3443,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::BindGroupLayoutId,
         Option<binding_model::CreateBindGroupLayoutError>,
     ) {
-        profiling::scope!("Device::create_bind_group_layout");
+        profiling::scope!("create_bind_group_layout", "Device");
 
         let mut token = Token::root();
         let hub = B::hub(self);
@@ -3515,7 +3508,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         bind_group_layout_id: id::BindGroupLayoutId,
     ) {
-        profiling::scope!("BindGroupLayout::drop");
+        profiling::scope!("drop", "BindGroupLayout");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3548,7 +3541,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::PipelineLayoutId,
         Option<binding_model::CreatePipelineLayoutError>,
     ) {
-        profiling::scope!("Device::create_pipeline_layout");
+        profiling::scope!("create_pipeline_layout", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3588,7 +3581,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn pipeline_layout_drop<B: GfxBackend>(&self, pipeline_layout_id: id::PipelineLayoutId) {
-        profiling::scope!("PipelineLayout::drop");
+        profiling::scope!("drop", "PipelineLayout");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3624,7 +3617,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &binding_model::BindGroupDescriptor,
         id_in: Input<G, id::BindGroupId>,
     ) -> (id::BindGroupId, Option<binding_model::CreateBindGroupError>) {
-        profiling::scope!("Device::create_bind_group");
+        profiling::scope!("create_bind_group", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3686,7 +3679,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn bind_group_drop<B: GfxBackend>(&self, bind_group_id: id::BindGroupId) {
-        profiling::scope!("BindGroup::drop");
+        profiling::scope!("drop", "BindGroup");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3724,7 +3717,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::ShaderModuleId,
         Option<pipeline::CreateShaderModuleError>,
     ) {
-        profiling::scope!("Device::create_shader_module");
+        profiling::scope!("create_shader_module", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3777,7 +3770,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn shader_module_drop<B: GfxBackend>(&self, shader_module_id: id::ShaderModuleId) {
-        profiling::scope!("ShaderModule::drop");
+        profiling::scope!("drop", "ShaderModule");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3803,7 +3796,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::CommandEncoderDescriptor<Label>,
         id_in: Input<G, id::CommandEncoderId>,
     ) -> (id::CommandEncoderId, Option<command::CommandAllocatorError>) {
-        profiling::scope!("Device::create_command_encoder");
+        profiling::scope!("create_command_encoder", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3856,7 +3849,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_encoder_drop<B: GfxBackend>(&self, command_encoder_id: id::CommandEncoderId) {
-        profiling::scope!("CommandEncoder::drop");
+        profiling::scope!("drop", "CommandEncoder");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3873,7 +3866,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_buffer_drop<B: GfxBackend>(&self, command_buffer_id: id::CommandBufferId) {
-        profiling::scope!("CommandBuffer::drop");
+        profiling::scope!("drop", "CommandBuffer");
         self.command_encoder_drop::<B>(command_buffer_id)
     }
 
@@ -3885,7 +3878,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::RenderBundleEncoderId,
         Option<command::CreateRenderBundleError>,
     ) {
-        profiling::scope!("Device::create_render_bundle_encoder");
+        profiling::scope!("create_render_bundle_encoder", "Device");
         let (encoder, error) = match command::RenderBundleEncoder::new(desc, device_id, None) {
             Ok(encoder) => (encoder, None),
             Err(e) => (command::RenderBundleEncoder::dummy(device_id), Some(e)),
@@ -3899,7 +3892,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &command::RenderBundleDescriptor,
         id_in: Input<G, id::RenderBundleId>,
     ) -> (id::RenderBundleId, Option<command::RenderBundleError>) {
-        profiling::scope!("RenderBundleEncoder::finish");
+        profiling::scope!("finish", "RenderBundleEncoder");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -3950,7 +3943,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn render_bundle_drop<B: GfxBackend>(&self, render_bundle_id: id::RenderBundleId) {
-        profiling::scope!("RenderBundle::drop");
+        profiling::scope!("drop", "RenderBundle");
         let hub = B::hub(self);
         let mut token = Token::root();
 
@@ -3983,7 +3976,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::QuerySetDescriptor,
         id_in: Input<G, id::QuerySetId>,
     ) -> (id::QuerySetId, Option<resource::CreateQuerySetError>) {
-        profiling::scope!("Device::create_query_set");
+        profiling::scope!("create_query_set", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -4067,7 +4060,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn query_set_drop<B: GfxBackend>(&self, query_set_id: id::QuerySetId) {
-        profiling::scope!("QuerySet::drop");
+        profiling::scope!("drop", "QuerySet");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -4106,7 +4099,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::RenderPipelineId,
         Option<pipeline::CreateRenderPipelineError>,
     ) {
-        profiling::scope!("Device::create_render_pipeline");
+        profiling::scope!("create_render_pipeline", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -4196,7 +4189,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn render_pipeline_drop<B: GfxBackend>(&self, render_pipeline_id: id::RenderPipelineId) {
-        profiling::scope!("RenderPipeline::drop");
+        profiling::scope!("drop", "RenderPipeline");
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -4237,7 +4230,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::ComputePipelineId,
         Option<pipeline::CreateComputePipelineError>,
     ) {
-        profiling::scope!("Device::create_compute_pipeline");
+        profiling::scope!("create_compute_pipeline", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -4327,7 +4320,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn compute_pipeline_drop<B: GfxBackend>(&self, compute_pipeline_id: id::ComputePipelineId) {
-        profiling::scope!("ComputePipeline::drop");
+        profiling::scope!("drop", "ComputePipeline");
         let hub = B::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -4364,7 +4357,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         surface_id: id::SurfaceId,
         desc: &wgt::SwapChainDescriptor,
     ) -> (id::SwapChainId, Option<swap_chain::CreateSwapChainError>) {
-        profiling::scope!("Device::create_swap_chain");
+        profiling::scope!("create_swap_chain", "Device");
 
         fn validate_swap_chain_descriptor(
             config: &mut hal::window::SwapchainConfig,
@@ -4527,8 +4520,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         device_id: id::DeviceId,
         force_wait: bool,
     ) -> Result<(), WaitIdleError> {
-        profiling::scope!("Device::poll");
-
         let hub = B::hub(self);
         let mut token = Token::root();
         let callbacks = {
@@ -4547,7 +4538,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         force_wait: bool,
         callbacks: &mut Vec<BufferMapPendingCallback>,
     ) -> Result<(), WaitIdleError> {
-        profiling::scope!("Device::poll_devices");
+        profiling::scope!("poll_devices");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -4590,7 +4581,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_drop<B: GfxBackend>(&self, device_id: id::DeviceId) {
-        profiling::scope!("Device::drop");
+        profiling::scope!("drop", "Device");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -4616,7 +4607,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         range: Range<BufferAddress>,
         op: resource::BufferMapOperation,
     ) -> Result<(), resource::BufferAccessError> {
-        profiling::scope!("Device::buffer_map_async");
+        profiling::scope!("map_async", "Buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -4679,7 +4670,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(*mut u8, u64), resource::BufferAccessError> {
-        profiling::scope!("Device::buffer_get_mapped_range");
+        profiling::scope!("get_mapped_range", "Buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -4745,7 +4736,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         buffer_id: id::BufferId,
     ) -> Result<Option<BufferMapPendingCallback>, resource::BufferAccessError> {
-        profiling::scope!("Device::buffer_unmap");
+        profiling::scope!("unmap", "Buffer");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -765,7 +765,7 @@ pub struct Global<G: GlobalIdentityHandlerFactory> {
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn new(name: &str, factory: G, backends: wgt::BackendBit) -> Self {
-        profiling::scope!("Global::new");
+        profiling::scope!("new", "Global");
         Self {
             instance: Instance::new(name, 1, backends),
             surfaces: Registry::without_backend(&factory, "Surface"),
@@ -784,6 +784,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 impl<G: GlobalIdentityHandlerFactory> Drop for Global<G> {
     fn drop(&mut self) {
         if !thread::panicking() {
+            profiling::scope!("drop", "Global");
             log::info!("Dropping Global");
             let mut surface_guard = self.surfaces.data.write();
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -128,7 +128,7 @@ pub struct Adapter<B: hal::Backend> {
 
 impl<B: GfxBackend> Adapter<B> {
     fn new(raw: hal::adapter::Adapter<B>) -> Self {
-        profiling::scope!("Adapter::new");
+        profiling::scope!("new", "Adapter");
 
         let adapter_features = raw.physical_device.features();
         let properties = raw.physical_device.properties();
@@ -344,8 +344,6 @@ impl<B: GfxBackend> Adapter<B> {
         &self,
         surface: &mut Surface,
     ) -> Result<wgt::TextureFormat, GetSwapChainPreferredFormatError> {
-        profiling::scope!("Adapter::get_swap_chain_preferred_format");
-
         let formats = {
             let surface = B::get_surface_mut(surface);
             let queue_family = &self.raw.queue_families[0];
@@ -694,7 +692,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         handle: &impl raw_window_handle::HasRawWindowHandle,
         id_in: Input<G, SurfaceId>,
     ) -> SurfaceId {
-        profiling::scope!("Instance::create_surface");
+        profiling::scope!("create_surface", "Instance");
 
         let surface = unsafe {
             backends_map! {
@@ -732,7 +730,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         layer: *mut std::ffi::c_void,
         id_in: Input<G, SurfaceId>,
     ) -> SurfaceId {
-        profiling::scope!("Instance::instance_create_surface_metal");
+        profiling::scope!("create_surface_metal", "Instance");
 
         let surface = Surface {
             #[cfg(feature = "gfx-backend-vulkan")]
@@ -750,14 +748,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn surface_drop(&self, id: SurfaceId) {
-        profiling::scope!("Surface::drop");
+        profiling::scope!("drop", "Surface");
         let mut token = Token::root();
         let (surface, _) = self.surfaces.unregister(id, &mut token);
         self.instance.destroy_surface(surface.unwrap());
     }
 
     pub fn enumerate_adapters(&self, inputs: AdapterInputs<Input<G, AdapterId>>) -> Vec<AdapterId> {
-        profiling::scope!("Instance::enumerate_adapters");
+        profiling::scope!("enumerate_adapters", "Instance");
 
         let instance = &self.instance;
         let mut token = Token::root();
@@ -800,7 +798,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &RequestAdapterOptions,
         inputs: AdapterInputs<Input<G, AdapterId>>,
     ) -> Result<AdapterId, RequestAdapterError> {
-        profiling::scope!("Instance::pick_adapter");
+        profiling::scope!("pick_adapter", "Instance");
 
         let instance = &self.instance;
         let mut token = Token::root();
@@ -955,8 +953,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         adapter_id: AdapterId,
     ) -> Result<wgt::AdapterInfo, InvalidAdapter> {
-        profiling::scope!("Adapter::get_info");
-
         let hub = B::hub(self);
         let mut token = Token::root();
         let (adapter_guard, _) = hub.adapters.read(&mut token);
@@ -971,8 +967,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         adapter_id: AdapterId,
         format: wgt::TextureFormat,
     ) -> Result<wgt::TextureFormatFeatures, InvalidAdapter> {
-        profiling::scope!("Adapter::get_texture_format_features");
-
         let hub = B::hub(self);
         let mut token = Token::root();
         let (adapter_guard, _) = hub.adapters.read(&mut token);
@@ -986,8 +980,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         adapter_id: AdapterId,
     ) -> Result<wgt::Features, InvalidAdapter> {
-        profiling::scope!("Adapter::features");
-
         let hub = B::hub(self);
         let mut token = Token::root();
         let (adapter_guard, _) = hub.adapters.read(&mut token);
@@ -1001,8 +993,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         adapter_id: AdapterId,
     ) -> Result<wgt::Limits, InvalidAdapter> {
-        profiling::scope!("Adapter::limits");
-
         let hub = B::hub(self);
         let mut token = Token::root();
         let (adapter_guard, _) = hub.adapters.read(&mut token);
@@ -1016,8 +1006,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         adapter_id: AdapterId,
     ) -> Result<wgt::DownlevelProperties, InvalidAdapter> {
-        profiling::scope!("Adapter::downlevel_properties");
-
         let hub = B::hub(self);
         let mut token = Token::root();
         let (adapter_guard, _) = hub.adapters.read(&mut token);
@@ -1028,7 +1016,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_drop<B: GfxBackend>(&self, adapter_id: AdapterId) {
-        profiling::scope!("Adapter::drop");
+        profiling::scope!("drop", "Adapter");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -1053,7 +1041,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         trace_path: Option<&std::path::Path>,
         id_in: Input<G, DeviceId>,
     ) -> (DeviceId, Option<RequestDeviceError>) {
-        profiling::scope!("Adapter::request_device");
+        profiling::scope!("request_device", "Adapter");
 
         let hub = B::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -139,7 +139,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         swap_chain_id: SwapChainId,
         view_id_in: Input<G, TextureViewId>,
     ) -> Result<SwapChainOutput, SwapChainError> {
-        profiling::scope!("SwapChain::get_next_texture");
+        profiling::scope!("get_next_texture", "SwapChain");
 
         let hub = B::hub(self);
         let mut token = Token::root();
@@ -242,7 +242,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         swap_chain_id: SwapChainId,
     ) -> Result<SwapChainStatus, SwapChainError> {
-        profiling::scope!("SwapChain::present");
+        profiling::scope!("present", "SwapChain");
 
         let hub = B::hub(self);
         let mut token = Token::root();


### PR DESCRIPTION
**Connections**

**Description**
Improves the profiling markers in many ways:
  1. remove unnecessary leftovers from the `tracing` era, such as querying device/adapter features. These are one-time and light-weight. It's unlikely we are going to be interested in them.
  2. add markers to where it really matters, such as `maintain` pieces, `submit` phases, render pass preparation, etc.
  3. shorten the markers to be strictly the function names, passing the class name as a tag

**Testing**
Tested on vange-rs