### PR TITLE
Include shader label in log message if shader parsing fails

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1016,7 +1016,7 @@ impl<B: GfxBackend> Device<B> {
                 let module = match parser.parse() {
                     Ok(module) => Some(module),
                     Err(err) => {
-                        log::warn!("Failed to parse shader SPIR-V code: {:?}", err);
+                        log::warn!("Failed to parse shader SPIR-V code for {:?}: {:?}", desc.label, err);
                         if desc.flags.contains(wgt::ShaderFlags::VALIDATION) {
                             return Err(pipeline::CreateShaderModuleError::Parsing);
                         }
@@ -1033,7 +1033,7 @@ impl<B: GfxBackend> Device<B> {
                 match naga::front::wgsl::parse_str(&code) {
                     Ok(module) => (None, Some(module)),
                     Err(err) => {
-                        log::error!("Failed to parse WGSL code: {}", err);
+                        log::error!("Failed to parse WGSL code for {:?}: {}", desc.label, err);
                         return Err(pipeline::CreateShaderModuleError::Parsing);
                     }
                 }


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu-rs/issues/903

**Description**
This tweaks the log messages produced when shader parsing fails to indicate which shader was responsible for the failure.

**Testing**
Tested by running terra and seeing that the diagnostics now include the labels. 
