### PR TITLE
Simplify features

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -5,7 +5,7 @@
 use crate::{
     device::{
         descriptor::{DescriptorSet, DescriptorTotalCount},
-        DeviceError, SHADER_STAGE_COUNT,
+        DeviceError, MissingFeatures, SHADER_STAGE_COUNT,
     },
     hub::Resource,
     id::{BindGroupLayoutId, BufferId, DeviceId, SamplerId, TextureViewId, Valid},
@@ -30,15 +30,25 @@ use std::{
 use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]
+pub enum BindGroupLayoutEntryError {
+    #[error("arrays of bindings unsupported for this type of binding")]
+    ArrayUnsupported,
+    #[error(transparent)]
+    MissingFeatures(#[from] MissingFeatures),
+}
+
+#[derive(Clone, Debug, Error)]
 pub enum CreateBindGroupLayoutError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("arrays of bindings unsupported for this type of binding")]
-    ArrayUnsupported,
     #[error("conflicting binding at index {0}")]
     ConflictBinding(u32),
-    #[error("required device feature is missing: {0:?}")]
-    MissingFeature(wgt::Features),
+    #[error("binding {binding} entry is invalid")]
+    Entry {
+        binding: u32,
+        #[source]
+        error: BindGroupLayoutEntryError,
+    },
     #[error(transparent)]
     TooManyBindings(BindingTypeMaxCountError),
 }
@@ -83,8 +93,6 @@ pub enum CreateBindGroupError {
     MissingBufferUsage(#[from] MissingBufferUsageError),
     #[error(transparent)]
     MissingTextureUsage(#[from] MissingTextureUsageError),
-    #[error("required device features not enabled: {0:?}")]
-    MissingFeatures(wgt::Features),
     #[error("binding declared as a single item, but bind group is using it as an array")]
     SingleBindingExpected,
     #[error("unable to create a bind group with a swap chain image")]
@@ -419,8 +427,8 @@ pub enum CreatePipelineLayoutError {
         wgt::PUSH_CONSTANT_ALIGNMENT
     )]
     MisalignedPushConstantRange { index: usize, bound: u32 },
-    #[error("device does not have required feature: {0:?}")]
-    MissingFeature(wgt::Features),
+    #[error(transparent)]
+    MissingFeatures(#[from] MissingFeatures),
     #[error("push constant range (index {index}) provides for stage(s) {provided:?} but there exists another range that provides stage(s) {intersected:?}. Each stage may only be provided by one range")]
     MoreThanOnePushConstantRangePerStage {
         index: usize,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -342,7 +342,6 @@ impl<B: GfxBackend> Device<B> {
                         spv::Capability::Image1D,
                         spv::Capability::SampledCubeArray,
                         spv::Capability::ImageCubeArray,
-                        spv::Capability::ImageMSArray,
                         spv::Capability::StorageImageExtendedFormats,
                     ]
                     .iter()

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -116,6 +116,87 @@ impl crate::hub::Resource for Surface {
     }
 }
 
+const FEATURE_MAP: &[(wgt::Features, hal::Features)] = &[
+    (wgt::Features::DEPTH_CLAMPING, hal::Features::DEPTH_CLAMP),
+    (
+        wgt::Features::TEXTURE_COMPRESSION_BC,
+        hal::Features::FORMAT_BC,
+    ),
+    (
+        wgt::Features::TEXTURE_COMPRESSION_ETC2,
+        hal::Features::FORMAT_ETC2,
+    ),
+    (
+        wgt::Features::TEXTURE_COMPRESSION_ASTC_LDR,
+        hal::Features::FORMAT_ASTC_LDR,
+    ),
+    (
+        wgt::Features::SAMPLED_TEXTURE_BINDING_ARRAY,
+        hal::Features::TEXTURE_DESCRIPTOR_ARRAY,
+    ),
+    (
+        wgt::Features::SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING,
+        hal::Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING,
+    ),
+    (
+        wgt::Features::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
+        hal::Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING,
+    ),
+    (
+        wgt::Features::UNSIZED_BINDING_ARRAY,
+        hal::Features::UNSIZED_DESCRIPTOR_ARRAY,
+    ),
+    (
+        wgt::Features::MULTI_DRAW_INDIRECT,
+        hal::Features::MULTI_DRAW_INDIRECT,
+    ),
+    (
+        wgt::Features::MULTI_DRAW_INDIRECT_COUNT,
+        hal::Features::DRAW_INDIRECT_COUNT,
+    ),
+    (
+        wgt::Features::NON_FILL_POLYGON_MODE,
+        hal::Features::NON_FILL_POLYGON_MODE,
+    ),
+    (
+        wgt::Features::PIPELINE_STATISTICS_QUERY,
+        hal::Features::PIPELINE_STATISTICS_QUERY,
+    ),
+    (wgt::Features::SHADER_FLOAT64, hal::Features::SHADER_FLOAT64),
+    (
+        wgt::Features::CONSERVATIVE_RASTERIZATION,
+        hal::Features::CONSERVATIVE_RASTERIZATION,
+    ),
+    (
+        wgt::Features::BUFFER_BINDING_ARRAY,
+        hal::Features::BUFFER_DESCRIPTOR_ARRAY,
+    ),
+    (
+        wgt::Features::UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING,
+        hal::Features::SHADER_UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING,
+    ),
+    (
+        wgt::Features::UNIFORM_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
+        hal::Features::UNIFORM_BUFFER_DESCRIPTOR_INDEXING,
+    ),
+    (
+        wgt::Features::STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING,
+        hal::Features::SHADER_STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING,
+    ),
+    (
+        wgt::Features::STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
+        hal::Features::STORAGE_BUFFER_DESCRIPTOR_INDEXING,
+    ),
+    (
+        wgt::Features::VERTEX_WRITABLE_STORAGE,
+        hal::Features::VERTEX_STORES_AND_ATOMICS,
+    ),
+    (
+        wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER,
+        hal::Features::SAMPLER_BORDER_COLOR,
+    ),
+];
+
 #[derive(Debug)]
 pub struct Adapter<B: hal::Backend> {
     pub(crate) raw: hal::adapter::Adapter<B>,
@@ -137,93 +218,12 @@ impl<B: GfxBackend> Adapter<B> {
             | wgt::Features::MAPPABLE_PRIMARY_BUFFERS
             | wgt::Features::PUSH_CONSTANTS
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
-        features.set(
-            wgt::Features::DEPTH_CLAMPING,
-            adapter_features.contains(hal::Features::DEPTH_CLAMP),
-        );
-        features.set(
-            wgt::Features::TEXTURE_COMPRESSION_BC,
-            adapter_features.contains(hal::Features::FORMAT_BC),
-        );
-        features.set(
-            wgt::Features::TEXTURE_COMPRESSION_ETC2,
-            adapter_features.contains(hal::Features::FORMAT_ETC2),
-        );
-        features.set(
-            wgt::Features::TEXTURE_COMPRESSION_ASTC_LDR,
-            adapter_features.contains(hal::Features::FORMAT_ASTC_LDR),
-        );
-        features.set(
-            wgt::Features::SAMPLED_TEXTURE_BINDING_ARRAY,
-            adapter_features.contains(hal::Features::TEXTURE_DESCRIPTOR_ARRAY),
-        );
-        features.set(
-            wgt::Features::SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING,
-            adapter_features.contains(hal::Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING),
-        );
-        features.set(
-            wgt::Features::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
-            adapter_features.contains(hal::Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING),
-        );
-        features.set(
-            wgt::Features::UNSIZED_BINDING_ARRAY,
-            adapter_features.contains(hal::Features::UNSIZED_DESCRIPTOR_ARRAY),
-        );
-        features.set(
-            wgt::Features::MULTI_DRAW_INDIRECT,
-            adapter_features.contains(hal::Features::MULTI_DRAW_INDIRECT),
-        );
-        features.set(
-            wgt::Features::MULTI_DRAW_INDIRECT_COUNT,
-            adapter_features.contains(hal::Features::DRAW_INDIRECT_COUNT),
-        );
-        features.set(
-            wgt::Features::NON_FILL_POLYGON_MODE,
-            adapter_features.contains(hal::Features::NON_FILL_POLYGON_MODE),
-        );
+        for &(hi, lo) in FEATURE_MAP.iter() {
+            features.set(hi, adapter_features.contains(lo));
+        }
         features.set(
             wgt::Features::TIMESTAMP_QUERY,
             properties.limits.timestamp_compute_and_graphics,
-        );
-        features.set(
-            wgt::Features::PIPELINE_STATISTICS_QUERY,
-            adapter_features.contains(hal::Features::PIPELINE_STATISTICS_QUERY),
-        );
-        features.set(
-            wgt::Features::SHADER_FLOAT64,
-            adapter_features.contains(hal::Features::SHADER_FLOAT64),
-        );
-        features.set(
-            wgt::Features::CONSERVATIVE_RASTERIZATION,
-            adapter_features.contains(hal::Features::CONSERVATIVE_RASTERIZATION),
-        );
-        features.set(
-            wgt::Features::BUFFER_BINDING_ARRAY,
-            adapter_features.contains(hal::Features::BUFFER_DESCRIPTOR_ARRAY),
-        );
-        features.set(
-            wgt::Features::UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING,
-            adapter_features.contains(hal::Features::SHADER_UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING),
-        );
-        features.set(
-            wgt::Features::UNIFORM_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
-            adapter_features.contains(hal::Features::UNIFORM_BUFFER_DESCRIPTOR_INDEXING),
-        );
-        features.set(
-            wgt::Features::STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING,
-            adapter_features.contains(hal::Features::SHADER_STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING),
-        );
-        features.set(
-            wgt::Features::STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
-            adapter_features.contains(hal::Features::STORAGE_BUFFER_DESCRIPTOR_INDEXING),
-        );
-        features.set(
-            wgt::Features::VERTEX_WRITABLE_STORAGE,
-            adapter_features.contains(hal::Features::VERTEX_STORES_AND_ATOMICS),
-        );
-        features.set(
-            wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER,
-            adapter_features.contains(hal::Features::SAMPLER_BORDER_COLOR),
         );
 
         let private_features = PrivateFeatures {
@@ -471,106 +471,10 @@ impl<B: GfxBackend> Adapter<B> {
             );
         }
 
-        // Features
-        enabled_features.set(
-            hal::Features::DEPTH_CLAMP,
-            desc.features.contains(wgt::Features::DEPTH_CLAMPING),
-        );
-        enabled_features.set(
-            hal::Features::FORMAT_BC,
-            desc.features
-                .contains(wgt::Features::TEXTURE_COMPRESSION_BC),
-        );
-        enabled_features.set(
-            hal::Features::FORMAT_ETC2,
-            desc.features
-                .contains(wgt::Features::TEXTURE_COMPRESSION_ETC2),
-        );
-        enabled_features.set(
-            hal::Features::FORMAT_ASTC_LDR,
-            desc.features
-                .contains(wgt::Features::TEXTURE_COMPRESSION_ASTC_LDR),
-        );
-        enabled_features.set(
-            hal::Features::TEXTURE_DESCRIPTOR_ARRAY,
-            desc.features
-                .contains(wgt::Features::SAMPLED_TEXTURE_BINDING_ARRAY),
-        );
-        enabled_features.set(
-            hal::Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING,
-            desc.features
-                .contains(wgt::Features::SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING),
-        );
-        enabled_features.set(
-            hal::Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING,
-            desc.features
-                .contains(wgt::Features::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING),
-        );
-        enabled_features.set(
-            hal::Features::UNSIZED_DESCRIPTOR_ARRAY,
-            desc.features.contains(wgt::Features::UNSIZED_BINDING_ARRAY),
-        );
-        enabled_features.set(
-            hal::Features::MULTI_DRAW_INDIRECT,
-            desc.features.contains(wgt::Features::MULTI_DRAW_INDIRECT),
-        );
-        enabled_features.set(
-            hal::Features::DRAW_INDIRECT_COUNT,
-            desc.features
-                .contains(wgt::Features::MULTI_DRAW_INDIRECT_COUNT),
-        );
-        enabled_features.set(
-            hal::Features::NON_FILL_POLYGON_MODE,
-            desc.features.contains(wgt::Features::NON_FILL_POLYGON_MODE),
-        );
-        enabled_features.set(
-            hal::Features::PIPELINE_STATISTICS_QUERY,
-            desc.features
-                .contains(wgt::Features::PIPELINE_STATISTICS_QUERY),
-        );
-        enabled_features.set(
-            hal::Features::SHADER_FLOAT64,
-            desc.features.contains(wgt::Features::SHADER_FLOAT64),
-        );
-        enabled_features.set(
-            hal::Features::CONSERVATIVE_RASTERIZATION,
-            desc.features
-                .contains(wgt::Features::CONSERVATIVE_RASTERIZATION),
-        );
-        enabled_features.set(
-            hal::Features::BUFFER_DESCRIPTOR_ARRAY,
-            desc.features.contains(wgt::Features::BUFFER_BINDING_ARRAY),
-        );
-        enabled_features.set(
-            hal::Features::SHADER_UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING,
-            desc.features
-                .contains(wgt::Features::UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING),
-        );
-        enabled_features.set(
-            hal::Features::UNIFORM_BUFFER_DESCRIPTOR_INDEXING,
-            desc.features
-                .contains(wgt::Features::UNIFORM_BUFFER_ARRAY_NON_UNIFORM_INDEXING),
-        );
-        enabled_features.set(
-            hal::Features::SHADER_STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING,
-            desc.features
-                .contains(wgt::Features::STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING),
-        );
-        enabled_features.set(
-            hal::Features::STORAGE_BUFFER_DESCRIPTOR_INDEXING,
-            desc.features
-                .contains(wgt::Features::STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING),
-        );
-        enabled_features.set(
-            hal::Features::VERTEX_STORES_AND_ATOMICS,
-            desc.features
-                .contains(wgt::Features::VERTEX_WRITABLE_STORAGE),
-        );
-        enabled_features.set(
-            hal::Features::SAMPLER_BORDER_COLOR,
-            desc.features
-                .contains(wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER),
-        );
+        // Enable low-level features
+        for &(hi, lo) in FEATURE_MAP.iter() {
+            enabled_features.set(lo, desc.features.contains(hi));
+        }
 
         let family = self
             .raw

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     binding_model::{CreateBindGroupLayoutError, CreatePipelineLayoutError},
-    device::{DeviceError, RenderPassContext},
+    device::{DeviceError, MissingFeatures, RenderPassContext},
     hub::Resource,
     id::{DeviceId, PipelineLayoutId, ShaderModuleId},
     validation, Label, LifeGuard, Stored, DOWNLEVEL_ERROR_WARNING_MESSAGE,
@@ -62,8 +62,8 @@ pub enum CreateShaderModuleError {
     Device(#[from] DeviceError),
     #[error(transparent)]
     Validation(#[from] naga::valid::ValidationError),
-    #[error("missing required device features {0:?}")]
-    MissingFeature(wgt::Features),
+    #[error(transparent)]
+    MissingFeatures(#[from] MissingFeatures),
 }
 
 /// Describes a programmable pipeline stage.
@@ -246,8 +246,8 @@ pub enum CreateRenderPipelineError {
     },
     #[error("Conservative Rasterization is only supported for wgt::PolygonMode::Fill")]
     ConservativeRasterizationNonFillPolygonMode,
-    #[error("missing required device features {0:?}")]
-    MissingFeature(wgt::Features),
+    #[error(transparent)]
+    MissingFeatures(#[from] MissingFeatures),
     #[error("error matching {stage:?} shader requirements against the pipeline")]
     Stage {
         stage: wgt::ShaderStage,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    device::{alloc::MemoryBlock, DeviceError, HostMap},
+    device::{alloc::MemoryBlock, DeviceError, HostMap, MissingFeatures},
     hub::Resource,
     id::{DeviceId, SwapChainId, TextureId},
     memory_init_tracker::MemoryInitTracker,
@@ -266,8 +266,8 @@ pub enum CreateTextureError {
     InvalidMipLevelCount(u32),
     #[error("The texture usages {0:?} are not allowed on a texture of type {1:?}")]
     InvalidUsages(wgt::TextureUsage, wgt::TextureFormat),
-    #[error("Feature {0:?} must be enabled to create a texture of type {1:?}")]
-    MissingFeature(wgt::Features, wgt::TextureFormat),
+    #[error("Texture format {0:?} can't be used")]
+    MissingFeatures(wgt::TextureFormat, #[source] MissingFeatures),
 }
 
 impl<B: hal::Backend> Resource for Texture<B> {
@@ -458,9 +458,9 @@ pub enum CreateSamplerError {
     InvalidClamp(u8),
     #[error("cannot create any more samplers")]
     TooManyObjects,
-    /// AddressMode::ClampToBorder requires feature ADDRESS_MODE_CLAMP_TO_BORDER
-    #[error("Feature {0:?} must be enabled")]
-    MissingFeature(wgt::Features),
+    /// AddressMode::ClampToBorder requires feature ADDRESS_MODE_CLAMP_TO_BORDER.
+    #[error(transparent)]
+    MissingFeatures(#[from] MissingFeatures),
 }
 
 impl<B: hal::Backend> Resource for Sampler<B> {
@@ -484,8 +484,8 @@ pub enum CreateQuerySetError {
     ZeroCount,
     #[error("{count} is too many queries for a single QuerySet. QuerySets cannot be made more than {maximum} queries.")]
     TooManyQueries { count: u32, maximum: u32 },
-    #[error("Feature {0:?} must be enabled")]
-    MissingFeature(wgt::Features),
+    #[error(transparent)]
+    MissingFeatures(#[from] MissingFeatures),
 }
 
 #[derive(Debug)]

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -526,6 +526,15 @@ bitflags::bitflags! {
         ///
         /// This is a native only feature.
         const STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING = 0x0000_0010_0000_0000;
+        /// Enables bindings of writable storage buffers and textures visible to vertex shaders.
+        ///
+        /// Note: some (tiled-based) platforms do not support vertex shaders with any side-effects.
+        ///
+        /// Supported Platforms:
+        /// - All
+        ///
+        /// This is a native-only feature.
+        const VERTEX_WRITABLE_STORAGE = 0x0000_0020_0000_0000;
         /// Features which are part of the upstream WebGPU standard.
         const ALL_WEBGPU = 0x0000_0000_0000_FFFF;
         /// Features that are only available when targeting native (not web).


### PR DESCRIPTION
**Connections**
Fixes #1390
Makes vertex writable storage optional (native-only for now)
Fixes the follow-up to #891 

**Description**
Refactors the code so that adding new features and maintaining current ones is much easier.
Refactors the way missing features are checked and reported, DRY way.

**Testing**
Not really tested