### PR TITLE
Remove erroneous depth+stencil validation

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -152,8 +152,6 @@ pub enum CreateBindGroupError {
         layout_flt: bool,
         sampler_flt: bool,
     },
-    #[error("bound texture views can not have both depth and stencil aspects enabled")]
-    DepthStencilAspect,
     #[error("the adapter does not support simultaneous read + write storage texture access for the format {0:?}")]
     StorageReadWriteNotSupported(wgt::TextureFormat),
     #[error(transparent)]

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1665,12 +1665,6 @@ impl<B: GfxBackend> Device<B> {
                                 "SampledTexture, ReadonlyStorageTexture or WriteonlyStorageTexture",
                         }),
                     };
-                    if view
-                        .aspects
-                        .contains(hal::format::Aspects::DEPTH | hal::format::Aspects::STENCIL)
-                    {
-                        return Err(Error::DepthStencilAspect);
-                    }
                     match view.inner {
                         resource::TextureViewInner::Native {
                             ref raw,


### PR DESCRIPTION
**Connections**
Reported on Matrix by me.

**Description**
There was a validation check to make sure no depth+stencil textures have both a depth and stencil aspect. In reality it wasn't necessary for reasons I don't quite understand - it's gone now. 

**Testing**
Compiles. Should work. 