### PR TITLE
Make player automatically start/stop the capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
             channel: stable
             prepare_command: rustup default stable-msvc
             additional_core_features: trace,serial-pass
-            additional_player_features: renderdoc
+            additional_player_features:
           - name: Windows Nightly
             os: windows-2019
             channel: nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,15 +396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
-name = "float-cmp"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,7 +1126,6 @@ dependencies = [
  "env_logger",
  "log",
  "raw-window-handle",
- "renderdoc",
  "ron",
  "serde",
  "wgpu-core",
@@ -1213,21 +1203,6 @@ name = "regex-syntax"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
-
-[[package]]
-name = "renderdoc"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fd0c55a54ecce0889aaca4ee87831cfe8c83c275c439443162be1f0eab5fdc"
-dependencies = [
- "bitflags",
- "float-cmp",
- "libloading 0.6.5",
- "once_cell",
- "renderdoc-sys",
- "winapi 0.3.9",
- "wio",
-]
 
 [[package]]
 name = "renderdoc-sys"

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -19,7 +19,6 @@ cross = ["wgc/cross"]
 env_logger = "0.8"
 log = "0.4"
 raw-window-handle = "0.3"
-renderdoc = { version = "0.10", optional = true, default_features = false }
 ron = "0.6"
 winit = { version = "0.24", optional = true }
 

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -19,11 +19,6 @@ fn main() {
 
     env_logger::init();
 
-    #[cfg(feature = "renderdoc")]
-    #[cfg_attr(feature = "winit", allow(unused))]
-    let mut rd = renderdoc::RenderDoc::<renderdoc::V110>::new()
-        .expect("Failed to connect to RenderDoc: are you running without it?");
-
     //TODO: setting for the backend bits
     //TODO: setting for the target frame, or controls
 
@@ -100,15 +95,13 @@ fn main() {
     log::info!("Executing actions");
     #[cfg(not(feature = "winit"))]
     {
-        #[cfg(feature = "renderdoc")]
-        rd.start_frame_capture(std::ptr::null(), std::ptr::null());
+        gfx_select!(device => global.device_start_capture(device));
 
         while let Some(action) = actions.pop() {
             gfx_select!(device => global.process(device, action, &dir, &mut command_buffer_id_manager));
         }
 
-        #[cfg(feature = "renderdoc")]
-        rd.end_frame_capture(std::ptr::null(), std::ptr::null());
+        gfx_select!(device => global.device_stop_capture(device));
         gfx_select!(device => global.device_poll(device, true)).unwrap();
     }
     #[cfg(feature = "winit")]

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4592,6 +4592,24 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         B::hub(self).devices.label_for_resource(id)
     }
 
+    pub fn device_start_capture<B: GfxBackend>(&self, id: id::DeviceId) {
+        let hub = B::hub(self);
+        let mut token = Token::root();
+        let (device_guard, _) = hub.devices.read(&mut token);
+        if let Ok(device) = device_guard.get(id) {
+            device.raw.start_capture();
+        }
+    }
+
+    pub fn device_stop_capture<B: GfxBackend>(&self, id: id::DeviceId) {
+        let hub = B::hub(self);
+        let mut token = Token::root();
+        let (device_guard, _) = hub.devices.read(&mut token);
+        if let Ok(device) = device_guard.get(id) {
+            device.raw.stop_capture();
+        }
+    }
+
     pub fn device_drop<B: GfxBackend>(&self, device_id: id::DeviceId) {
         profiling::scope!("drop", "Device");
 
@@ -4867,29 +4885,5 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         self.buffer_unmap_inner::<B>(buffer_id)
             //Note: outside inner function so no locks are held when calling the callback
             .map(|pending_callback| fire_map_callbacks(pending_callback.into_iter()))
-    }
-
-    pub fn start_capture<B: GfxBackend>(
-        &self,
-        device_id: id::DeviceId,
-    ) -> Result<(), InvalidDevice> {
-        let hub = B::hub(self);
-        let mut token = Token::root();
-        let (device_guard, _) = hub.devices.read(&mut token);
-        let device = device_guard.get(device_id).map_err(|_| InvalidDevice)?;
-        device.raw.start_capture();
-        Ok(())
-    }
-
-    pub fn stop_capture<B: GfxBackend>(
-        &self,
-        device_id: id::DeviceId,
-    ) -> Result<(), InvalidDevice> {
-        let hub = B::hub(self);
-        let mut token = Token::root();
-        let (device_guard, _) = hub.devices.read(&mut token);
-        let device = device_guard.get(device_id).map_err(|_| InvalidDevice)?;
-        device.raw.stop_capture();
-        Ok(())
     }
 }


### PR DESCRIPTION
**Connections**
Follow-up to #1301

**Description**
Replaying compute-based workloads, or Gecko-based API traces, always wants to auto-capture everything.
This PR makes it the default.

**Testing**
Tested on a real Gecko capture :)