### PR TITLE
Add support for raw vulkan types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,7 @@ dependencies = [
 [[package]]
 name = "gfx-auxil"
 version = "0.9.0"
+source = "git+https://github.com/gfx-rs/gfx?rev=7a60e1c13abef5973c22f2194c539403871f1085#7a60e1c13abef5973c22f2194c539403871f1085"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -466,6 +467,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx11"
 version = "0.8.0"
+source = "git+https://github.com/gfx-rs/gfx?rev=7a60e1c13abef5973c22f2194c539403871f1085#7a60e1c13abef5973c22f2194c539403871f1085"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -487,6 +489,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.8.0"
+source = "git+https://github.com/gfx-rs/gfx?rev=7a60e1c13abef5973c22f2194c539403871f1085#7a60e1c13abef5973c22f2194c539403871f1085"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -508,6 +511,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-empty"
 version = "0.8.0"
+source = "git+https://github.com/gfx-rs/gfx?rev=7a60e1c13abef5973c22f2194c539403871f1085#7a60e1c13abef5973c22f2194c539403871f1085"
 dependencies = [
  "gfx-hal",
  "log",
@@ -517,6 +521,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-gl"
 version = "0.8.1"
+source = "git+https://github.com/gfx-rs/gfx?rev=7a60e1c13abef5973c22f2194c539403871f1085#7a60e1c13abef5973c22f2194c539403871f1085"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -539,6 +544,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-metal"
 version = "0.8.1"
+source = "git+https://github.com/gfx-rs/gfx?rev=7a60e1c13abef5973c22f2194c539403871f1085#7a60e1c13abef5973c22f2194c539403871f1085"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -564,6 +570,7 @@ dependencies = [
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.8.0"
+source = "git+https://github.com/gfx-rs/gfx?rev=7a60e1c13abef5973c22f2194c539403871f1085#7a60e1c13abef5973c22f2194c539403871f1085"
 dependencies = [
  "arrayvec",
  "ash",
@@ -584,6 +591,7 @@ dependencies = [
 [[package]]
 name = "gfx-hal"
 version = "0.8.0"
+source = "git+https://github.com/gfx-rs/gfx?rev=7a60e1c13abef5973c22f2194c539403871f1085#7a60e1c13abef5973c22f2194c539403871f1085"
 dependencies = [
  "bitflags",
  "naga",
@@ -594,6 +602,7 @@ dependencies = [
 [[package]]
 name = "gfx-renderdoc"
 version = "0.1.0"
+source = "git+https://github.com/gfx-rs/gfx?rev=7a60e1c13abef5973c22f2194c539403871f1085#7a60e1c13abef5973c22f2194c539403871f1085"
 dependencies = [
  "libloading 0.7.0",
  "log",
@@ -1171,6 +1180,7 @@ dependencies = [
 [[package]]
 name = "range-alloc"
 version = "0.1.2"
+source = "git+https://github.com/gfx-rs/gfx?rev=7a60e1c13abef5973c22f2194c539403871f1085#7a60e1c13abef5973c22f2194c539403871f1085"
 
 [[package]]
 name = "raw-window-handle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,6 @@ dependencies = [
 [[package]]
 name = "gfx-auxil"
 version = "0.9.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=27a1dae3796d33d23812f2bb8c7e3b5aea18b521#27a1dae3796d33d23812f2bb8c7e3b5aea18b521"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -467,12 +466,12 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx11"
 version = "0.8.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=27a1dae3796d33d23812f2bb8c7e3b5aea18b521#27a1dae3796d33d23812f2bb8c7e3b5aea18b521"
 dependencies = [
  "arrayvec",
  "bitflags",
  "gfx-auxil",
  "gfx-hal",
+ "gfx-renderdoc",
  "libloading 0.7.0",
  "log",
  "parking_lot",
@@ -488,7 +487,6 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.8.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=27a1dae3796d33d23812f2bb8c7e3b5aea18b521#27a1dae3796d33d23812f2bb8c7e3b5aea18b521"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -496,6 +494,7 @@ dependencies = [
  "d3d12",
  "gfx-auxil",
  "gfx-hal",
+ "gfx-renderdoc",
  "log",
  "parking_lot",
  "range-alloc",
@@ -509,7 +508,6 @@ dependencies = [
 [[package]]
 name = "gfx-backend-empty"
 version = "0.8.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=27a1dae3796d33d23812f2bb8c7e3b5aea18b521#27a1dae3796d33d23812f2bb8c7e3b5aea18b521"
 dependencies = [
  "gfx-hal",
  "log",
@@ -519,7 +517,6 @@ dependencies = [
 [[package]]
 name = "gfx-backend-gl"
 version = "0.8.1"
-source = "git+https://github.com/gfx-rs/gfx?rev=27a1dae3796d33d23812f2bb8c7e3b5aea18b521#27a1dae3796d33d23812f2bb8c7e3b5aea18b521"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -542,7 +539,6 @@ dependencies = [
 [[package]]
 name = "gfx-backend-metal"
 version = "0.8.1"
-source = "git+https://github.com/gfx-rs/gfx?rev=27a1dae3796d33d23812f2bb8c7e3b5aea18b521#27a1dae3796d33d23812f2bb8c7e3b5aea18b521"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -568,21 +564,19 @@ dependencies = [
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.8.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=27a1dae3796d33d23812f2bb8c7e3b5aea18b521#27a1dae3796d33d23812f2bb8c7e3b5aea18b521"
 dependencies = [
  "arrayvec",
  "ash",
  "byteorder",
  "core-graphics-types",
  "gfx-hal",
+ "gfx-renderdoc",
  "inplace_it",
- "libloading 0.7.0",
  "log",
  "naga",
  "objc",
  "parking_lot",
  "raw-window-handle",
- "renderdoc-sys",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -590,12 +584,20 @@ dependencies = [
 [[package]]
 name = "gfx-hal"
 version = "0.8.0"
-source = "git+https://github.com/gfx-rs/gfx?rev=27a1dae3796d33d23812f2bb8c7e3b5aea18b521#27a1dae3796d33d23812f2bb8c7e3b5aea18b521"
 dependencies = [
  "bitflags",
  "naga",
  "raw-window-handle",
  "thiserror",
+]
+
+[[package]]
+name = "gfx-renderdoc"
+version = "0.1.0"
+dependencies = [
+ "libloading 0.7.0",
+ "log",
+ "renderdoc-sys",
 ]
 
 [[package]]
@@ -1169,7 +1171,6 @@ dependencies = [
 [[package]]
 name = "range-alloc"
 version = "0.1.2"
-source = "git+https://github.com/gfx-rs/gfx?rev=27a1dae3796d33d23812f2bb8c7e3b5aea18b521#27a1dae3796d33d23812f2bb8c7e3b5aea18b521"
 
 [[package]]
 name = "raw-window-handle"
@@ -1619,6 +1620,7 @@ name = "wgpu-core"
 version = "0.8.0"
 dependencies = [
  "arrayvec",
+ "ash",
  "bitflags",
  "cfg_aliases",
  "copyless",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -39,24 +39,26 @@ thiserror = "1"
 gpu-alloc = "0.4"
 gpu-descriptor = "0.1"
 
-hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "27a1dae3796d33d23812f2bb8c7e3b5aea18b521" }
-gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "27a1dae3796d33d23812f2bb8c7e3b5aea18b521" }
+hal = { package = "gfx-hal", path = "../../gfx/src/hal" }
+gfx-backend-empty = { path = "../../gfx/src/backend/empty" }
 
 [target.'cfg(all(not(target_arch = "wasm32"), all(unix, not(target_os = "ios"), not(target_os = "macos"))))'.dependencies]
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "27a1dae3796d33d23812f2bb8c7e3b5aea18b521", features = ["naga"] }
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "27a1dae3796d33d23812f2bb8c7e3b5aea18b521" }
+gfx-backend-vulkan = { path = "../../gfx/src/backend/vulkan", features = ["naga"] }
+gfx-backend-gl = { path = "../../gfx/src/backend/gl" }
+ash = "0.32"
 
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
-gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "27a1dae3796d33d23812f2bb8c7e3b5aea18b521" }
+gfx-backend-metal = { path = "../../gfx/src/backend/metal" }
 #TODO: could also depend on gfx-backend-vulkan for Vulkan Portability
 
 [target.'cfg(all(not(target_arch = "wasm32"), windows))'.dependencies]
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "27a1dae3796d33d23812f2bb8c7e3b5aea18b521" }
-gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "27a1dae3796d33d23812f2bb8c7e3b5aea18b521" }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "27a1dae3796d33d23812f2bb8c7e3b5aea18b521", features = ["naga"] }
+gfx-backend-dx12 = { path = "../../gfx/src/backend/dx12" }
+gfx-backend-dx11 = { path = "../../gfx/src/backend/dx11" }
+gfx-backend-vulkan = { path = "../../gfx/src/backend/vulkan" }
+ash = "0.32"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "27a1dae3796d33d23812f2bb8c7e3b5aea18b521" }
+gfx-backend-gl = { path = "../../gfx/src/backend/gl" }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -39,26 +39,26 @@ thiserror = "1"
 gpu-alloc = "0.4"
 gpu-descriptor = "0.1"
 
-hal = { package = "gfx-hal", path = "../../gfx/src/hal" }
-gfx-backend-empty = { path = "../../gfx/src/backend/empty" }
+hal = { package = "gfx-hal", git = "https://github.com/gfx-rs/gfx", rev = "7a60e1c13abef5973c22f2194c539403871f1085" }
+gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "7a60e1c13abef5973c22f2194c539403871f1085" }
 
 [target.'cfg(all(not(target_arch = "wasm32"), all(unix, not(target_os = "ios"), not(target_os = "macos"))))'.dependencies]
-gfx-backend-vulkan = { path = "../../gfx/src/backend/vulkan", features = ["naga"] }
-gfx-backend-gl = { path = "../../gfx/src/backend/gl" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "7a60e1c13abef5973c22f2194c539403871f1085", features = ["naga"] }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "7a60e1c13abef5973c22f2194c539403871f1085" }
 ash = "0.32"
 
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
-gfx-backend-metal = { path = "../../gfx/src/backend/metal" }
+gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "7a60e1c13abef5973c22f2194c539403871f1085" }
 #TODO: could also depend on gfx-backend-vulkan for Vulkan Portability
 
 [target.'cfg(all(not(target_arch = "wasm32"), windows))'.dependencies]
-gfx-backend-dx12 = { path = "../../gfx/src/backend/dx12" }
-gfx-backend-dx11 = { path = "../../gfx/src/backend/dx11" }
-gfx-backend-vulkan = { path = "../../gfx/src/backend/vulkan" }
+gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "7a60e1c13abef5973c22f2194c539403871f1085" }
+gfx-backend-dx11 = { git = "https://github.com/gfx-rs/gfx", rev = "7a60e1c13abef5973c22f2194c539403871f1085" }
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "7a60e1c13abef5973c22f2194c539403871f1085", features = ["naga"] }
 ash = "0.32"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-gfx-backend-gl = { path = "../../gfx/src/backend/gl" }
+gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "7a60e1c13abef5973c22f2194c539403871f1085" }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -448,6 +448,7 @@ impl<B: GfxBackend> LifetimeTracker<B> {
                                 raw
                             }
                             resource::TextureViewInner::SwapChain { .. } => unreachable!(),
+                            resource::TextureViewInner::Raw { .. } => unreachable!(),
                         };
 
                         let submit_index = res.life_guard.submission_index.load(Ordering::Acquire);

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -615,6 +615,7 @@ impl<B: GfxBackend, F: GlobalIdentityHandlerFactory> Hub<B, F> {
                             }
                         }
                         TextureViewInner::SwapChain { .. } => {} //TODO
+                        TextureViewInner::Raw { .. } => {} //TODO
                     }
                 }
             }
@@ -768,6 +769,24 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         profiling::scope!("new", "Global");
         Self {
             instance: Instance::new(name, 1, backends),
+            surfaces: Registry::without_backend(&factory, "Surface"),
+            hubs: Hubs::new(&factory),
+        }
+    }
+
+    pub unsafe fn required_vulkan_extensions(entry: &ash::Entry) -> Vec<&'static std::ffi::CStr> {
+        Instance::required_vulkan_extensions(entry)
+    }
+
+    pub unsafe fn new_raw_vulkan(
+        entry: ash::Entry,
+        instance: ash::Instance,
+        extensions: Vec<&'static std::ffi::CStr>,
+        factory: G,
+    ) -> Self {
+        profiling::scope!("new_raw_vulkan", "Global");
+        Self {
+            instance: Instance::new_raw_vulkan(entry, instance, extensions),
             surfaces: Registry::without_backend(&factory, "Surface"),
             hubs: Hubs::new(&factory),
         }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -323,6 +323,9 @@ pub(crate) enum TextureViewInner<B: hal::Backend> {
         image: <B::Surface as hal::window::PresentationSurface<B>>::SwapchainImage,
         source_id: Stored<SwapChainId>,
     },
+    Raw {
+        raw: B::ImageView,
+    }
 }
 
 #[derive(Debug)]

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -277,6 +277,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let image = match view.inner {
             resource::TextureViewInner::Native { .. } => unreachable!(),
             resource::TextureViewInner::SwapChain { image, .. } => image,
+            resource::TextureViewInner::Raw { .. } => unreachable!(),
         };
 
         let sem = if sc.active_submission_index > device.last_completed_submission_index() {


### PR DESCRIPTION
**Connections**
This PR depends on: https://github.com/gfx-rs/gfx/pull/3767
This PR is necessary for: https://github.com/gfx-rs/wgpu/issues/602

**Description**
This adds support for using raw Vulkan instances, devices, and images with WGPU. This allows applications to use OpenXR with WGPU.

**Testing**
Bindings and example in WGPU-RS PR: https://github.com/gfx-rs/wgpu-rs/pull/919

**To-Do**
- [ ] Review public API, is this API fine for inclusion in WGPU?
- [ ] Review the way external image views affect framebuffer attachments lifetime and texture transitions (I'm not familiar enough with this system, help needed! if you happen to know the specific rules surrounding the unsafe lifetime of image views for this too, please add that to the docs)
- [ ] Document unsafe lifetime rules for external data (instances, devices, image views)
- [ ] Improve error handling in the new functions