### PR TITLE
Split the tracker into stateful/stateless to reduce the overhead

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -214,7 +214,7 @@ impl RenderBundleEncoder {
                     state.set_bind_group(index, bind_group_id, bind_group.layout_id, offsets);
                     state
                         .trackers
-                        .merge_extend(&bind_group.used)
+                        .merge_extend_all(&bind_group.used)
                         .map_pass_err(scope)?;
                 }
                 RenderCommand::SetPipeline(pipeline_id) => {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     id,
     memory_init_tracker::MemoryInitTrackerAction,
     resource::{Buffer, Texture},
-    track::TrackerSet,
+    track::{BufferState, ResourceTracker, TextureState, TrackerSet},
     Label, PrivateFeatures, Stored,
 };
 
@@ -74,7 +74,8 @@ impl<B: GfxBackend> CommandBuffer<B> {
     pub(crate) fn insert_barriers(
         raw: &mut B::CommandBuffer,
         base: &mut TrackerSet,
-        head: &TrackerSet,
+        head_buffers: &ResourceTracker<BufferState>,
+        head_textures: &ResourceTracker<TextureState>,
         buffer_guard: &Storage<Buffer<B>, id::BufferId>,
         texture_guard: &Storage<Texture<B>, id::TextureId>,
     ) {
@@ -82,25 +83,17 @@ impl<B: GfxBackend> CommandBuffer<B> {
 
         profiling::scope!("insert_barriers");
         debug_assert_eq!(B::VARIANT, base.backend());
-        debug_assert_eq!(B::VARIANT, head.backend());
 
-        let buffer_barriers = base.buffers.merge_replace(&head.buffers).map(|pending| {
+        let buffer_barriers = base.buffers.merge_replace(head_buffers).map(|pending| {
             let buf = &buffer_guard[pending.id];
             pending.into_hal(buf)
         });
-        let texture_barriers = base.textures.merge_replace(&head.textures).map(|pending| {
+        let texture_barriers = base.textures.merge_replace(head_textures).map(|pending| {
             let tex = &texture_guard[pending.id];
             pending.into_hal(tex)
         });
-        base.views.merge_extend(&head.views).unwrap();
-        base.bind_groups.merge_extend(&head.bind_groups).unwrap();
-        base.samplers.merge_extend(&head.samplers).unwrap();
-        base.compute_pipes
-            .merge_extend(&head.compute_pipes)
-            .unwrap();
-        base.render_pipes.merge_extend(&head.render_pipes).unwrap();
-        base.bundles.merge_extend(&head.bundles).unwrap();
 
+        //TODO: be more deliberate about the stages
         let stages = all_buffer_stages() | all_image_stages();
         unsafe {
             raw.pipeline_barrier(

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -760,10 +760,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                                 .begin_primary(hal::command::CommandBufferFlags::ONE_TIME_SUBMIT);
                         }
                         log::trace!("Stitching command buffer {:?} before submission", cmb_id);
+                        trackers.merge_extend_stateless(&cmdbuf.trackers);
                         CommandBuffer::insert_barriers(
                             &mut transit,
                             &mut *trackers,
-                            &cmdbuf.trackers,
+                            &cmdbuf.trackers.buffers,
+                            &cmdbuf.trackers.textures,
                             &*buffer_guard,
                             &*texture_guard,
                         );


### PR DESCRIPTION
**Connections**
Implements https://github.com/gfx-rs/wgpu/issues/1413#issuecomment-851604344
Reduces the overhead for resource tracking in the Animometer benchmark by up to 50%.

**Description**
We used to use the full tracker set on the usage scopes associated with compute/render passes. A resource tracker has 2 responsibilities: ensuring the resource is held alive, and validating and recording the state transitions. This PR exploits the fact that the latter responsibility is only applicable for buffers and textures. So doing all the lifetime tracking for a pass is a waste: we can instead just attach the lifetimes to the parent command buffer, straight.

In the Animometer benchmark, there is one large buffer, and thousands of bind groups pointing to different offsets into it. The old code would fill up the pass tracker with those bind groups, and then merge it into the command buffer tracker. The new code would just fill up the command buffer tracker instead. Since there is only one buffer, the pass tracking becomes much lighter.

**Testing**
Untested. It would be nice to have some benchmarks here, possibly after #1397 ?