### PR TITLE
Skip the cube compatibility on a downlevel flag

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -681,7 +681,14 @@ impl<B: GfxBackend> Device<B> {
         let mut view_caps = hal::image::ViewCapabilities::empty();
         // 2D textures with array layer counts that are multiples of 6 could be cubemaps
         // Following gpuweb/gpuweb#68 always add the hint in that case
-        if desc.dimension == TextureDimension::D2 && desc.size.depth_or_array_layers % 6 == 0 {
+        if desc.dimension == TextureDimension::D2
+            && desc.size.depth_or_array_layers % 6 == 0
+            && (desc.size.depth_or_array_layers == 6
+                || self
+                    .downlevel
+                    .flags
+                    .contains(wgt::DownlevelFlags::CUBE_ARRAY_TEXTURES))
+        {
             view_caps |= hal::image::ViewCapabilities::KIND_CUBE;
         };
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -753,7 +753,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     log::trace!("Device after submission {}: {:#?}", submit_index, trackers);
                     drop(trackers);
                     if !required_buffer_inits.map.is_empty() {
-                        device.initialize_buffer_memory(required_buffer_inits, &mut *buffer_guard)?;
+                        device
+                            .initialize_buffer_memory(required_buffer_inits, &mut *buffer_guard)?;
                     }
                 }
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -323,6 +323,10 @@ impl<B: GfxBackend> Adapter<B> {
             properties.downlevel.non_power_of_two_mipmapped_textures,
         );
         downlevel_flags.set(
+            wgt::DownlevelFlags::CUBE_ARRAY_TEXTURES,
+            adapter_features.contains(hal::Features::IMAGE_CUBE_ARRAY),
+        );
+        downlevel_flags.set(
             wgt::DownlevelFlags::ANISOTROPIC_FILTERING,
             private_features.anisotropic_filtering,
         );

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -693,8 +693,10 @@ bitflags::bitflags! {
         const DEVICE_LOCAL_IMAGE_COPIES = 0x0000_0008;
         /// Supports textures with mipmaps which have a non power of two size.
         const NON_POWER_OF_TWO_MIPMAPPED_TEXTURES = 0x0000_0010;
+        /// Supports textures that are cube arrays.
+        const CUBE_ARRAY_TEXTURES = 0x0000_0020;
         /// Supports samplers with anisotropic filtering
-        const ANISOTROPIC_FILTERING = 0x0000_0020;
+        const ANISOTROPIC_FILTERING = 0x0001_0000;
         /// All flags are in their compliant state.
         const COMPLIANT = 0x0000_003F;
     }


### PR DESCRIPTION
**Connections**
Fixes #1418

**Description**
Adds a downlevel flag for cube arrays, checks for it.

**Testing**
Untested, but should work.