### PR TITLE
Expand 0.8.0 Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
     - Updated `PrimitiveState`:
       - Added `conservative` member for enabling conservative rasterization
     - Updated copy view structs:
-      - Renamed `TextureCopyView` to `ImageCopyView`
+      - Renamed `TextureCopyView` to `ImageCopyTexture`
       - Renamed `TextureDataLayout` to `ImageDataLayout`
       - The `bytes_per_row` and `rows_per_image` members of `ImageDataLayout` are now of type `NonZeroU32` <!-- wgpu-rs only -->
     - Renamed the `depth` value of `Extent3d` to `depth_or_array_layers`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
     - Updated copy view structs:
       - Renamed `TextureCopyView` to `ImageCopyView`
       - Renamed `TextureDataLayout` to `ImageDataLayout`
-      - The `bytes_per_row` member of `ImageDataLayout` is now a `NonZeroU32` <!-- wgpu-rs only -->
+      - The `bytes_per_row` and `rows_per_image` members of `ImageDataLayout` are now of type `NonZeroU32` <!-- wgpu-rs only -->
     - Renamed the `depth` value of `Extent3d` to `depth_or_array_layers`
   - Infrastructure:
     - switch from `tracing` to `profiling`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
       - Renamed the `attachment` member to `view`
     - Renamed `VertexFormat` values
       - Examples: `Float3` -> `Float32x3`, `Ushort2` -> `Uint16x2`
+    - Renamed the `depth` value of `Extent3d` to `depth_or_array_layers`
     - Updated blending options in `ColorTargetState`:
       - Renamed `BlendState` to `BlendComponent`
       - Added `BlendState` struct to hold color and alpha blend state
@@ -24,8 +25,9 @@
     - Updated copy view structs:
       - Renamed `TextureCopyView` to `ImageCopyTexture`
       - Renamed `TextureDataLayout` to `ImageDataLayout`
-      - The `bytes_per_row` and `rows_per_image` members of `ImageDataLayout` are now of type `NonZeroU32` <!-- wgpu-rs only -->
-    - Renamed the `depth` value of `Extent3d` to `depth_or_array_layers`
+      - Changed `bytes_per_row` and `rows_per_image` members of `ImageDataLayout` from `u32` to `Option<NonZeroU32>` <!-- wgpu-rs only -->
+    - Changed `BindingResource::Binding` from containing fields directly to containing a `BufferBinding`
+    - Added `BindingResource::BufferArray`
   - Infrastructure:
     - switch from `tracing` to `profiling`
     - more concrete and detailed errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@
     - blend factors are renamed, blend color is changed to blend constant
     - depth clamping is moved to `PrimitiveState`
     - render pass attachments contain `view` members
-    - copy views are renamed
+    - Updated copy view structs:
+      - Renamed `TextureCopyView` to `ImageCopyView`
+      - Renamed `TextureDataLayout` to `ImageDataLayout`
+      - The `bytes_per_row` member of `ImageDataLayout` is now a `NonZeroU32`
+    - Renamed the `depth` value of `Extent3d` to `depth_or_array_layers`
   - Infrastructure:
     - switch from `tracing` to `profiling`
     - more concrete and detailed errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,20 @@
     - conservative rasterization (native-only)
     - buffer resource indexing (native-only)
   - API adjustments to the spec:
-    - vertex formats are renamed
-    - blend factors are renamed, blend color is changed to blend constant
-    - depth clamping is moved to `PrimitiveState`
     - render pass attachments contain `view` members
+    - Renamed `VertexFormat` values
+      - Examples: `Float3` -> `Float32x3`, `Ushort2` -> `Uint16x2`
+    - Updated blending options in `ColorTargetState`:
+      - Renamed `BlendState` to `BlendComponent`
+      - Added `BlendState` struct to hold color and alpha blend state
+      - Moved `color_blend` and `alpha_blend` members into `blend` member
+    - Moved `clamp_depth` from `RastizerState` to `PrimitiveState`
+    - Updated `PrimitiveState`:
+      - Added `conservative` member for enabling conservative rasterization
     - Updated copy view structs:
       - Renamed `TextureCopyView` to `ImageCopyView`
       - Renamed `TextureDataLayout` to `ImageDataLayout`
-      - The `bytes_per_row` member of `ImageDataLayout` is now a `NonZeroU32`
+      - The `bytes_per_row` member of `ImageDataLayout` is now a `NonZeroU32` <!-- wgpu-rs only -->
     - Renamed the `depth` value of `Extent3d` to `depth_or_array_layers`
   - Infrastructure:
     - switch from `tracing` to `profiling`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
     - conservative rasterization (native-only)
     - buffer resource indexing (native-only)
   - API adjustments to the spec:
-    - render pass attachments contain `view` members
+    - Renamed `RenderPassDepthStencilAttachmentDescriptor` to `RenderPassDepthStencilAttachment`:
+      - Renamed the `attachment` member to `view`
+    - Renamed `RenderPassDepthStencilAttachmentDescriptor` to `RenderPassDepthStencilAttachment`:
+      - Renamed the `attachment` member to `view`
     - Renamed `VertexFormat` values
       - Examples: `Float3` -> `Float32x3`, `Ushort2` -> `Uint16x2`
     - Updated blending options in `ColorTargetState`:


### PR DESCRIPTION
This PR expands on the changelog notes for wgpu 0.8.0 by including more detailed information about renames and other changes. I worked on this doc as part of upgrading a medium-sized game from wgpu 0.7. I [brought up this change on the wgpu Matrix](https://matrix.to/#/!FZyQrssSlHEZqrYcOb:matrix.org/$wJ59tSoVhofs3Gy_1i6HK-LMDe7ReOgEOoRr7Lf93Aw?via=matrix.org&via=mozilla.org&via=tchncs.de).

Some of these changes only affect wgpu-rs, not wgpu-core. I'm not sure how or whether we should demarcate these. I was also unsure how to identify these changes; I only use wgpu-rs and so my notes are aimed at users upgrading it.