### PR TITLE
Reproduce Naga's nicer error reporting for WGSL

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -31,6 +31,7 @@ use wgt::{BufferAddress, InputStepMode, TextureDimension, TextureFormat, Texture
 use std::{
     borrow::Cow,
     collections::{hash_map::Entry, BTreeMap},
+    error::Error,
     iter,
     marker::PhantomData,
     mem,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1040,12 +1040,16 @@ impl<B: GfxBackend> Device<B> {
             }
             pipeline::ShaderModuleSource::Wgsl(code) => {
                 profiling::scope!("naga::wgsl::parse_str");
-                // TODO: refactor the corresponding Naga error to be owned, and then
-                // display it instead of unwrapping
                 match naga::front::wgsl::parse_str(&code) {
                     Ok(module) => (None, Some(module)),
                     Err(err) => {
                         log::error!("Failed to parse WGSL code for {:?}: {}", desc.label, err);
+                        log::error!("{}:", err);
+                        let mut e = err.source();
+                        while let Some(source) = e {
+                            log::error!("\t{}", source);
+                            e = source.source();
+                        }
                         return Err(pipeline::CreateShaderModuleError::Parsing);
                     }
                 }


### PR DESCRIPTION
Closes https://github.com/gfx-rs/wgpu-native/issues/104

Basically, I find myself copying WGSL code to a file and running Naga from the command line on it, because that way I get prettier errors than when pushing the (faulty) WGSL via wgpu-native's  `create_shader_module`. Would be nice if the error reports were equally good.

WIP: does not seem to help yet, except duplicating part of the error message.