### PR TITLE
Handle winit exception in web to avoid breaking async executor

### DIFF
--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1940,7 +1940,7 @@ impl fmt::Debug for ErrorSinkRaw {
 }
 
 fn default_error_handler(err: crate::Error) {
-    eprintln!("wgpu error: {}\n", err);
+    log::error!("wgpu error: {}\n", err);
 
     panic!("Handling wgpu errors as fatal by default");
 }


### PR DESCRIPTION
This is a continuation of https://github.com/gfx-rs/wgpu-rs/pull/923.

I'd still like to fix this on our end, even if the real underlying issue is in winit. The fix is small, and we can migrate to the proper winit solution once it exists. In the mean time, we can continue working on improving webgl support without a major blocker.