### PR TITLE
fix typo regarding structure rename in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ TBD:
     - conservative rasterization (native-only)
     - buffer resource indexing (native-only)
   - API adjustments to the spec:
-    - Renamed `RenderPassDepthStencilAttachmentDescriptor` to `RenderPassDepthStencilAttachment`:
+    - Renamed `RenderPassColorAttachmentDescriptor` to `RenderPassColorAttachment`:
       - Renamed the `attachment` member to `view`
     - Renamed `RenderPassDepthStencilAttachmentDescriptor` to `RenderPassDepthStencilAttachment`:
       - Renamed the `attachment` member to `view`


### PR DESCRIPTION
**Description**
Just fixing a typo I realised was there when trying to use the changelog to fix my code, thanks for adding a list of changes to the latest changelogs!
