### PR TITLE
[0.8] Backport "Fix dynamic stencil reference for Replace ops"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## wgpu-types-0.8.1 (2021-06-08)
+  - fix dynamic stencil reference for Replace ops
+
 ## v0.8.1 (2021-05-06)
   - fix SPIR-V generation from WGSL, which was broken due to "Kernel" capability
   - validate buffer storage classes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bitflags",
  "serde",

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-types"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU types"

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1805,7 +1805,7 @@ impl StencilState {
     }
     /// Returns true if the stencil state uses the reference value for testing.
     pub fn needs_ref_value(&self) -> bool {
-        self.front.compare.needs_ref_value() || self.back.compare.needs_ref_value()
+        self.front.needs_ref_value() || self.back.needs_ref_value()
     }
 }
 
@@ -1935,6 +1935,14 @@ impl StencilFaceState {
         depth_fail_op: StencilOperation::Keep,
         pass_op: StencilOperation::Keep,
     };
+
+    /// Returns true if the face state uses the reference value for testing or operation.
+    pub fn needs_ref_value(&self) -> bool {
+        self.compare.needs_ref_value()
+            || self.fail_op == StencilOperation::Replace
+            || self.depth_fail_op == StencilOperation::Replace
+            || self.pass_op == StencilOperation::Replace
+    }
 }
 
 impl Default for StencilFaceState {


### PR DESCRIPTION
**Connections**
Backport of #1393

**Description**
Cherry picks the fix from #1393 to fix dynamic stencil reference for Replace ops.

**Testing**
Briefly tested on windows with vulkan.
