### PR TITLE
Change the order to suspect temporary resources earlier

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -360,6 +360,7 @@ impl<A: HalApi> Device<A> {
 
         life_tracker.triage_suspected(
             hub,
+            &self.temp_suspected,
             &self.trackers,
             #[cfg(feature = "trace")]
             self.trace.as_ref(),
@@ -4159,6 +4160,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let device = device_guard.get(device_id).map_err(|_| InvalidDevice)?;
         device.lock_life(&mut token).triage_suspected(
             &hub,
+            &device.temp_suspected,
             &device.trackers,
             #[cfg(feature = "trace")]
             None,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -805,7 +805,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             }
             super::Device::lock_life_internal(&device.life_tracker, &mut token).track_submission(
                 submit_index,
-                &device.temp_suspected,
                 device.pending_writes.temp_resources.drain(..),
                 active_executions,
             );

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -277,13 +277,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let view = &mut view_guard[view_id.value];
             let _ = view.life_guard.ref_count.take();
 
-            /*
-            let (view_maybe, _) = hub.texture_views.unregister(view_id.value.0, &mut token);
-            drop(view_id); // contains the ref count
-            let view = view_maybe.ok_or(SwapChainError::Invalid)?;
-            if view.life_guard.ref_count.unwrap().load() != 1 {
-                return Err(SwapChainError::StillReferenced);
-            }*/
             suf_texture
         };
 

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -250,7 +250,7 @@ impl<S: ResourceState> ResourceTracker<S> {
             Entry::Occupied(e) => {
                 if e.get().ref_count.load() == 1 {
                     let res = e.remove();
-                    assert_eq!(res.epoch, epoch);
+                    assert_eq!(res.epoch, epoch, "Epoch mismatch for {:?}", id);
                     true
                 } else {
                     false


### PR DESCRIPTION
**Connections**
Fixes #1504

**Description**
I don't fully understand why this works.

**Testing**
tested on the privately given case, also our examples
