### PR TITLE
Added storage texture array support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ TBD:
     - Merged wgpu-rs and wgpu back into a single repository
     - Replaced gfx-rs dependencies by the new `wgpu-hal`
 
+## Unreleased
+  - Added support for storage texture arrays for Vulkan and Metal.
+
 ## v0.8 (2021-04-29)
   - Naga is used by default to translate shaders, SPIRV-Cross is optional behind `cross` feature
   - All of the examples (except "texture-array") now use WGSL

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1527,13 +1527,11 @@ impl<A: HalApi> Device<A> {
                 };
                 Ok((wgt::TextureUsage::STORAGE, internal_use))
             }
-            _ => {
-                return Err(Error::WrongBindingType {
-                    binding,
-                    actual: decl.ty,
-                    expected,
-                })
-            }
+            _ => Err(Error::WrongBindingType {
+                binding,
+                actual: decl.ty,
+                expected,
+            }),
         }
     }
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -192,6 +192,8 @@ struct PrivateCapabilities {
     can_set_maximum_drawables_count: bool,
     can_set_display_sync: bool,
     can_set_next_drawable_timeout: bool,
+    supports_arrays_of_textures: bool,
+    supports_arrays_of_textures_write: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -138,7 +138,11 @@ impl PhysicalDeviceFeatures {
                                 wgt::Features::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
                             ),
                         )
-                        //.shader_storage_image_array_non_uniform_indexing(
+                        .shader_storage_image_array_non_uniform_indexing(
+                            requested_features.contains(
+                                wgt::Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
+                            ),
+                        )
                         //.shader_storage_buffer_array_non_uniform_indexing(
                         .shader_uniform_buffer_array_non_uniform_indexing(
                             requested_features
@@ -164,7 +168,11 @@ impl PhysicalDeviceFeatures {
                                 wgt::Features::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
                             ),
                         )
-                        //.shader_storage_image_array_non_uniform_indexing(
+                        .shader_storage_image_array_non_uniform_indexing(
+                            requested_features.contains(
+                                wgt::Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
+                            ),
+                        )
                         //.shader_storage_buffer_array_non_uniform_indexing(
                         .shader_uniform_buffer_array_non_uniform_indexing(
                             requested_features
@@ -199,6 +207,7 @@ impl PhysicalDeviceFeatures {
             | F::PUSH_CONSTANTS
             | F::ADDRESS_MODE_CLAMP_TO_BORDER
             | F::SAMPLED_TEXTURE_BINDING_ARRAY
+            | F::STORAGE_TEXTURE_BINDING_ARRAY
             | F::BUFFER_BINDING_ARRAY;
         let mut dl_flags = Df::all();
 
@@ -245,6 +254,10 @@ impl PhysicalDeviceFeatures {
             self.core.shader_sampled_image_array_dynamic_indexing != 0,
         );
         features.set(
+            F::STORAGE_TEXTURE_ARRAY_DYNAMIC_INDEXING,
+            self.core.shader_storage_image_array_dynamic_indexing != 0,
+        );
+        features.set(
             F::STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING,
             self.core.shader_storage_buffer_array_dynamic_indexing != 0,
         );
@@ -270,7 +283,9 @@ impl PhysicalDeviceFeatures {
             if vulkan_1_2.shader_sampled_image_array_non_uniform_indexing != 0 {
                 features |= F::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
             }
-            //if vulkan_1_2.shader_storage_image_array_non_uniform_indexing != 0 {
+            if vulkan_1_2.shader_storage_image_array_non_uniform_indexing != 0 {
+                features |= F::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
+            }
             //if vulkan_1_2.shader_storage_buffer_array_non_uniform_indexing != 0 {
             if vulkan_1_2.shader_uniform_buffer_array_non_uniform_indexing != 0 {
                 features |= F::UNIFORM_BUFFER_ARRAY_NON_UNIFORM_INDEXING;
@@ -289,7 +304,9 @@ impl PhysicalDeviceFeatures {
             if descriptor_indexing.shader_sampled_image_array_non_uniform_indexing != 0 {
                 features |= F::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
             }
-            //if descriptor_indexing.shader_storage_image_array_non_uniform_indexing != 0 {
+            if descriptor_indexing.shader_storage_image_array_non_uniform_indexing != 0 {
+                features |= F::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
+            }
             //if descriptor_indexing.shader_storage_buffer_array_non_uniform_indexing != 0 {
             if descriptor_indexing.shader_uniform_buffer_array_non_uniform_indexing != 0 {
                 features |= F::UNIFORM_BUFFER_ARRAY_NON_UNIFORM_INDEXING;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -537,6 +537,56 @@ bitflags::bitflags! {
         ///
         /// This is a native-only feature.
         const VERTEX_WRITABLE_STORAGE = 0x0000_0020_0000_0000;
+        /// Allows the user to create uniform arrays of storage textures in shaders:
+        ///
+        /// eg. `uniform image2D textures[10]`.
+        ///
+        /// This capability allows them to exist and to be indexed by compile time constant
+        /// values.
+        ///
+        /// Supported platforms:
+        /// - Metal (with MSL 2.2+ on macOS 10.13+)
+        /// - Vulkan
+        ///
+        /// This is a native only feature.
+        const STORAGE_TEXTURE_BINDING_ARRAY = 0x0000_0040_0000_0000;
+        /// Allows shaders to index storage texture arrays with dynamically uniform values:
+        ///
+        /// eg. `texture_array[uniform_value]`
+        ///
+        /// This capability means the hardware will also support STORAGE_TEXTURE_BINDING_ARRAY.
+        ///
+        /// Supported platforms:
+        /// - Metal (with MSL 2.2+ on macOS 10.13+)
+        /// - Vulkan's shaderSampledImageArrayDynamicIndexing feature
+        ///
+        /// This is a native only feature.
+        const STORAGE_TEXTURE_ARRAY_DYNAMIC_INDEXING = 0x0000_0080_0000_0000;
+        /// Allows shaders to index storage texture arrays with dynamically non-uniform values:
+        ///
+        /// eg. `texture_array[vertex_data]`
+        ///
+        /// In order to use this capability, the corresponding GLSL extension must be enabled like so:
+        ///
+        /// `#extension GL_EXT_nonuniform_qualifier : require`
+        ///
+        /// and then used either as `nonuniformEXT` qualifier in variable declaration:
+        ///
+        /// eg. `layout(location = 0) nonuniformEXT flat in int vertex_data;`
+        ///
+        /// or as `nonuniformEXT` constructor:
+        ///
+        /// eg. `texture_array[nonuniformEXT(vertex_data)]`
+        ///
+        /// This capability means the hardware will also support STORAGE_TEXTURE_ARRAY_DYNAMIC_INDEXING
+        /// and STORAGE_TEXTURE_BINDING_ARRAY.
+        ///
+        /// Supported platforms:
+        /// - Metal (with MSL 2.2+ on macOS 10.13+)
+        /// - Vulkan 1.2+ (or VK_EXT_descriptor_indexing)'s shaderSampledImageArrayNonUniformIndexing feature)
+        ///
+        /// This is a native only feature.
+        const STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING = 0x0000_0100_0000_0000;
         /// Enables clear to zero for buffers & images.
         ///
         /// Supported platforms:


### PR DESCRIPTION
**Description**
Arrays of storage images (*f*image*n*D in GLSL parlance) should now be supported.
I also took the liberty to refactor texture format checking a bit,
and tighten up sampled texture support detection for Metal as well.

**Testing**
Not completely sure what's the proper testing approach here, open to suggestions.
