### PR TITLE
Make spirv an optional feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,6 +1053,7 @@ dependencies = [
  "num-traits 0.2.14",
  "petgraph",
  "rose_tree",
+ "serde",
  "spirv_headers",
  "thiserror",
 ]

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -29,7 +29,7 @@ features = ["replay"]
 [dependencies.wgc]
 path = "../wgpu-core"
 package = "wgpu-core"
-features = ["replay", "raw-window-handle"]
+features = ["spirv", "replay", "raw-window-handle"]
 
 [dev-dependencies]
 serde = "1"

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -29,7 +29,7 @@ features = ["replay"]
 [dependencies.wgc]
 path = "../wgpu-core"
 package = "wgpu-core"
-features = ["spirv", "replay", "raw-window-handle"]
+features = ["replay", "raw-window-handle"]
 
 [dev-dependencies]
 serde = "1"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -13,11 +13,10 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
-spirv = ["naga/spv-in"]
 # Enable API tracing
-trace = ["ron", "serde", "wgt/trace", "arrayvec/serde"]
+trace = ["ron", "serde", "wgt/trace", "arrayvec/serde", "naga/serialize"]
 # Enable API replaying
-replay = ["serde", "wgt/replay", "arrayvec/serde"]
+replay = ["serde", "wgt/replay", "arrayvec/serde", "naga/deserialize"]
 # Enable serializable compute/render passes, and bundle encoders.
 serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
 

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
+spirv = ["naga/spv-in"]
 # Enable API tracing
 trace = ["ron", "serde", "wgt/trace", "arrayvec/serde"]
 # Enable API replaying
@@ -37,7 +38,7 @@ thiserror = "1"
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
 tag = "gfx-26"
-features = ["spv-in", "wgsl-in"]
+features = ["wgsl-in"]
 
 [dependencies.wgt]
 path = "../wgpu-types"

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -838,6 +838,7 @@ impl<A: HalApi> Device<A> {
         source: pipeline::ShaderModuleSource<'a>,
     ) -> Result<pipeline::ShaderModule<A>, pipeline::CreateShaderModuleError> {
         let module = match source {
+            #[cfg(feature = "spirv")]
             pipeline::ShaderModuleSource::SpirV(spv) => {
                 profiling::scope!("naga::spv::parse");
                 // Parse the given shader code and store its representation.
@@ -3476,6 +3477,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             if let Some(ref trace) = device.trace {
                 let mut trace = trace.lock();
                 let data = match source {
+                    #[cfg(feature = "spirv")]
                     pipeline::ShaderModuleSource::SpirV(ref spv) => {
                         trace.make_binary("spv", unsafe {
                             std::slice::from_raw_parts(spv.as_ptr() as *const u8, spv.len() * 4)

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -9,8 +9,6 @@ use std::borrow::Cow;
 use thiserror::Error;
 
 pub enum ShaderModuleSource<'a> {
-    #[cfg(feature = "spirv")]
-    SpirV(Cow<'a, [u32]>),
     Wgsl(Cow<'a, str>),
     Naga(naga::Module),
 }

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -9,6 +9,7 @@ use std::borrow::Cow;
 use thiserror::Error;
 
 pub enum ShaderModuleSource<'a> {
+    #[cfg(feature = "spirv")]
     SpirV(Cow<'a, [u32]>),
     Wgsl(Cow<'a, str>),
     Naga(naga::Module),

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 
 [features]
 default = []
-spirv = ["wgc/spirv"]
+spirv = ["naga/spv-in"]
 trace = ["serde", "wgc/trace"]
 replay = ["serde", "wgc/replay"]
 webgl = ["wgc"]
@@ -64,6 +64,11 @@ winit = { version = "0.24", features = ["web-sys"] }
 async-executor = "1.0"
 pollster = "0.2"
 env_logger = "0.8"
+
+[dependencies.naga]
+git = "https://github.com/gfx-rs/naga"
+tag = "gfx-26"
+optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 
 [features]
 default = []
+spirv = ["wgc/spirv"]
 trace = ["serde", "wgc/trace"]
 replay = ["serde", "wgc/replay"]
 webgl = ["wgc"]
@@ -78,8 +79,11 @@ features = ["wgsl-in", "spv-out"]
 
 [[example]]
 name="hello-compute"
-path="examples/hello-compute/main.rs"
 test = true
+
+[[example]]
+name="texture-arrays"
+required-features = ["spirv"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.73" # remember to change version in wiki as well

--- a/wgpu/README.md
+++ b/wgpu/README.md
@@ -43,6 +43,18 @@ The following environment variables can be used to configure how the framework e
 
 See [wiki article](https://github.com/gfx-rs/wgpu-rs/wiki/Running-on-the-Web-with-WebGPU-and-WebGL).
 
+## Shaders
+
+[WGSL](https://gpuweb.github.io/gpuweb/wgsl/) is the main shading language of WebGPU.
+
+Users can run the [naga](https://github.com/gfx-rs/naga) binary in the following way to convert their SPIR-V shaders to WGSL:
+```bash
+cargo run -- <input.spv> <output.wgsl>
+
+```
+
+In addition, SPIR-V can be used by enabling the `spirv` feature, and the cost of slightly increased build times.
+
 ## Development
 
 If you need to test local fixes to gfx or other dependencies, the simplest way is to add a Cargo patch. For example, when working on DX12 backend on Windows, you can check out the latest release branch in the [gfx-hal repository](https://github.com/gfx-rs/gfx) (e.g. currently `hal-0.8`) and add this patch to the end of `Cargo.toml`:

--- a/wgpu/README.md
+++ b/wgpu/README.md
@@ -50,7 +50,6 @@ See [wiki article](https://github.com/gfx-rs/wgpu-rs/wiki/Running-on-the-Web-wit
 Users can run the [naga](https://github.com/gfx-rs/naga) binary in the following way to convert their SPIR-V shaders to WGSL:
 ```bash
 cargo run -- <input.spv> <output.wgsl>
-
 ```
 
 In addition, SPIR-V can be used by enabling the `spirv` feature, and the cost of slightly increased build times.

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -811,7 +811,18 @@ impl crate::Context for Context {
         };
         let source = match desc.source {
             #[cfg(feature = "spirv")]
-            ShaderSource::SpirV(ref spv) => wgc::pipeline::ShaderModuleSource::SpirV(Borrowed(spv)),
+            ShaderSource::SpirV(ref spv) => {
+                profiling::scope!("naga::spv::parse");
+                // Parse the given shader code and store its representation.
+                let options = naga::front::spv::Options {
+                    adjust_coordinate_space: false, // we require NDC_Y_UP feature
+                    strict_capabilities: true,
+                    flow_graph_dump_prefix: None,
+                };
+                let parser = naga::front::spv::Parser::new(spv.iter().cloned(), &options);
+                let module = parser.parse().unwrap();
+                wgc::pipeline::ShaderModuleSource::Naga(module)
+            }
             ShaderSource::Wgsl(ref code) => wgc::pipeline::ShaderModuleSource::Wgsl(Borrowed(code)),
         };
         let (id, error) = wgc::gfx_select!(

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -810,6 +810,7 @@ impl crate::Context for Context {
             label: desc.label.map(Borrowed),
         };
         let source = match desc.source {
+            #[cfg(feature = "spirv")]
             ShaderSource::SpirV(ref spv) => wgc::pipeline::ShaderModuleSource::SpirV(Borrowed(spv)),
             ShaderSource::Wgsl(ref code) => wgc::pipeline::ShaderModuleSource::Wgsl(Borrowed(code)),
         };

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1140,6 +1140,7 @@ impl crate::Context for Context {
         desc: &crate::ShaderModuleDescriptor,
     ) -> Self::ShaderModuleId {
         let mut descriptor = match desc.source {
+            #[cfg(feature = "spirv")]
             crate::ShaderSource::SpirV(ref spv) => {
                 web_sys::GpuShaderModuleDescriptor::new(&js_sys::Uint32Array::from(&**spv))
             }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -739,6 +739,7 @@ pub enum ShaderSource<'a> {
     ///
     /// wgpu will attempt to parse and validate it, but the original binary
     /// is passed to `gfx-rs` and `spirv_cross` for translation.
+    #[cfg(feature = "spirv")]
     SpirV(Cow<'a, [u32]>),
     /// WGSL module as a string slice.
     ///

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -4,9 +4,10 @@ mod belt;
 mod device;
 mod encoder;
 
+use std::future::Future;
+#[cfg(feature = "spirv")]
 use std::{
     borrow::Cow,
-    future::Future,
     mem::{align_of, size_of},
     ptr::copy_nonoverlapping,
 };
@@ -24,15 +25,16 @@ pub use encoder::RenderEncoder;
 /// - Input length isn't multiple of 4
 /// - Input is longer than [`usize::max_value`]
 /// - SPIR-V magic number is missing from beginning of stream
+#[cfg(feature = "spirv")]
 pub fn make_spirv(data: &[u8]) -> super::ShaderSource {
     super::ShaderSource::SpirV(make_spirv_raw(data))
 }
 
 /// Version of [`make_spirv`] intended for use with [`Device::create_shader_module_spirv`].
 /// Returns raw slice instead of ShaderSource.
+#[cfg(feature = "spirv")]
 pub fn make_spirv_raw(data: &[u8]) -> Cow<[u32]> {
     const MAGIC_NUMBER: u32 = 0x0723_0203;
-
     assert_eq!(
         data.len() % size_of::<u32>(),
         0,


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/naga/issues/940 shows how much SPIR-V parsing can be a pain.

**Description**
Keep it supported natively, but put it behind a feature flag. This allows to skip compilation of parts of Naga as well as dependencies like `petgraph`.
On my machine, compiling `wgpu-core` time is reduced from 40.87s to 35.36s, which is about 13% improvement.

**Testing**
Just compiling
