### PR TITLE
Add TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES to supported for Vulkan and Metal.

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -843,7 +843,8 @@ impl super::PrivateCapabilities {
             | F::DEPTH_CLAMPING
             | F::TEXTURE_COMPRESSION_BC
             | F::MAPPABLE_PRIMARY_BUFFERS
-            | F::VERTEX_WRITABLE_STORAGE;
+            | F::VERTEX_WRITABLE_STORAGE
+            | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
 
         features.set(
             F::SAMPLED_TEXTURE_BINDING_ARRAY

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -803,7 +803,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             .instance
             .raw
             .get_physical_device_format_properties(self.raw, vk_format);
-        let features = properties.linear_tiling_features;
+        let features = properties.optimal_tiling_features;
 
         let mut flags = Tfc::empty();
         flags.set(

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -208,7 +208,8 @@ impl PhysicalDeviceFeatures {
             | F::ADDRESS_MODE_CLAMP_TO_BORDER
             | F::SAMPLED_TEXTURE_BINDING_ARRAY
             | F::STORAGE_TEXTURE_BINDING_ARRAY
-            | F::BUFFER_BINDING_ARRAY;
+            | F::BUFFER_BINDING_ARRAY
+            | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
         let mut dl_flags = Df::all();
 
         dl_flags.set(Df::CUBE_ARRAY_TEXTURES, self.core.image_cube_array != 0);


### PR DESCRIPTION
Adapter callbacks are already there, so this is likely an oversight.

**Description**
Adapter callbacks for texture capabilities were there, but feature flags weren't enabled, which prevented use of them.
