### PR TITLE
Better compile error for not using resolver=2.

### DIFF
--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -45,8 +45,11 @@
     clippy::pattern_type_mismatch,
 )]
 
+#[cfg(all(feature = "metal", not(any(target_os = "macos", target_os = "ios"))))]
+compile_error!("Metal backend enabled on non-Apple OS. If your project is not using resolver=\"2\" in Cargo.toml, it should.");
+
 mod empty;
-#[cfg(feature = "metal")]
+#[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
 mod metal;
 #[cfg(feature = "vulkan")]
 mod vulkan;


### PR DESCRIPTION
**Connections**
Usability fix proposed in #1517 with some re-wording to make the intent clearer.

**Description**
Provide a useful compile error in case a downstream project is using old Cargo resolver, instead of the deluge of obscure errors they get r/n if not on MacOS.

**Limitations**
On MacOS, vulkan feature is totally valid, so we cannot detect resolver=1 on Mac.
