### PR TITLE
Fix wgpu downlevel check

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -720,7 +720,7 @@ impl DownlevelCapabilities {
     /// If this returns false, some parts of the API will result in validation errors where they would not normally.
     /// These parts can be determined by the values in this structure.
     pub fn is_webgpu_compliant(self) -> bool {
-        self == Self::default()
+        self.flags.contains(DownlevelFlags::COMPLIANT) && self.shader_model >= ShaderModel::Sm5
     }
 }
 


### PR DESCRIPTION
**Connections**
Fixes #1529

**Description**
The anisotropic flag is not in the compliant set, but the check was made for equality of the flags (instead of inclusion).

**Testing**
Untested
