### PR TITLE
web: add empty `device_create_shader_module_spirv`

### DIFF
--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1262,6 +1262,14 @@ impl crate::Context for Context {
         Sendable(device.0.create_bind_group_layout(&mapped_desc))
     }
 
+    unsafe fn device_create_shader_module_spirv(
+        &self,
+        device: &Self::DeviceId,
+        desc: &crate::ShaderModuleDescriptorSpirV,
+    ) -> Self::ShaderModuleId {
+        unreachable!("SPIRV_SHADER_PASSTHROUGH is not enabled for this backend")
+    }
+
     fn device_create_bind_group(
         &self,
         device: &Self::DeviceId,


### PR DESCRIPTION
**Description**
We added a SPIR-V passthrough function to the `Context` trait shared between web/native backends, but the web backend also needs an implementation of this function to fully implement the trait.

**Testing**
Compiling the web backend for WebGPU.