### PR TITLE
web: Restore WebGPU CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         run: cargo check --manifest-path wgpu-core/Cargo.toml --features trace --target ${{ env.TARGET }}
 
   wasm:
-    if: false  # disable until hal/Gles backend is setup
     name: Web Assembly
     runs-on: ubuntu-latest
     env:
@@ -44,9 +43,10 @@ jobs:
     - uses: actions/checkout@v2
     - run: rustup target add wasm32-unknown-unknown
     - name: Check WebGPU
-      run: cargo check --all-targets --target=wasm32-unknown-unknown
-    - name: Check WebGL
-      run: cargo check --all-targets --target=wasm32-unknown-unknown --features webgl
+      run: cargo check --package wgpu --examples --target=wasm32-unknown-unknown
+    # disable until hal/Gles backend is setup
+    # - name: Check WebGL
+    #  run: cargo check --all-targets --target=wasm32-unknown-unknown --features webgl
 
   build:
     name: ${{ matrix.name }}

--- a/bors.toml
+++ b/bors.toml
@@ -7,6 +7,6 @@ status = [
   "Ubuntu Nightly",
   "Windows Stable",
   "Windows Nightly",
-  #"Web Assembly",
+  "Web Assembly",
   #"Clippy",
 ]

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1262,6 +1262,14 @@ impl crate::Context for Context {
         Sendable(device.0.create_bind_group_layout(&mapped_desc))
     }
 
+    unsafe fn device_create_shader_module_spirv(
+        &self,
+        device: &Self::DeviceId,
+        desc: &crate::ShaderModuleDescriptorSpirV,
+    ) -> Self::ShaderModuleId {
+        unreachable!("SPIRV_SHADER_PASSTHROUGH is not enabled for this backend")
+    }
+
     fn device_create_bind_group(
         &self,
         device: &Self::DeviceId,


### PR DESCRIPTION
**Connections**
Depends on/currently includes #1533

**Description**
Even though the WebGL backend needs to be temporarily disabled, we should be able to continue checking WebGPU on wasm.

**Testing**
Manually ran the CI command `cargo check --package wgpu --examples --target=wasm32-unknown-unknown` locally which seems to catch the mistake in #1533 without building wgpu-core/wgpu-hal.