### PR TITLE
Don't merge stateless trackers from bind groups

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -210,8 +210,10 @@ impl RenderBundleEncoder {
                     state.set_bind_group(index, bind_group_id, bind_group.layout_id, offsets);
                     state
                         .trackers
-                        .merge_extend_all(&bind_group.used)
+                        .merge_extend_stateful(&bind_group.used)
                         .map_pass_err(scope)?;
+                    //Note: stateless trackers are not merged: the lifetime reference
+                    // is held to the bind group itself.
                 }
                 RenderCommand::SetPipeline(pipeline_id) => {
                     let scope = PassErrorScope::SetPipelineRender(pipeline_id);

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -219,7 +219,8 @@ impl State {
     ) -> Result<(), UsageConflict> {
         for id in self.binder.list_active() {
             self.trackers.merge_extend(&bind_group_guard[id].used)?;
-            base_trackers.merge_extend_stateless(&bind_group_guard[id].used);
+            //Note: stateless trackers are not merged: the lifetime reference
+            // is held to the bind group itself.
         }
 
         log::trace!("Encoding dispatch barriers");

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -945,7 +945,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         info.trackers
                             .merge_extend(&bind_group.used)
                             .map_pass_err(scope)?;
-                        cmd_buf.trackers.merge_extend_stateless(&bind_group.used);
+                        //Note: stateless trackers are not merged: the lifetime reference
+                        // is held to the bind group itself.
 
                         cmd_buf.buffer_memory_init_actions.extend(
                             bind_group.used_buffer_ranges.iter().filter_map(|action| {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -738,7 +738,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                                 .map_err(DeviceError::from)?
                         };
                         log::trace!("Stitching command buffer {:?} before submission", cmb_id);
-                        trackers.merge_extend_stateless(&baked.trackers);
+                        //Note: stateless trackers are not merged:
+                        // device already knows these resources exist.
                         CommandBuffer::insert_barriers(
                             &mut baked.encoder,
                             &mut *trackers,

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -620,27 +620,12 @@ impl TrackerSet {
         self.query_sets.optimize();
     }
 
-    /// Merge all the trackers of another instance by extending
-    /// the usage. Panics on a stateless conflict, returns a conflict otherwise.
-    pub fn merge_extend_all(&mut self, other: &Self) -> Result<(), UsageConflict> {
+    /// Merge only the stateful trackers of another instance by extending
+    /// the usage. Returns a conflict if any.
+    pub fn merge_extend_stateful(&mut self, other: &Self) -> Result<(), UsageConflict> {
         self.buffers.merge_extend(&other.buffers)?;
         self.textures.merge_extend(&other.textures)?;
-        self.merge_extend_stateless(other);
         Ok(())
-    }
-
-    /// Merge all the stateless trackers of another instance by extending
-    /// the usage. Panics on a conflict.
-    pub fn merge_extend_stateless(&mut self, other: &Self) {
-        self.views.merge_extend(&other.views).unwrap();
-        self.bind_groups.merge_extend(&other.bind_groups).unwrap();
-        self.samplers.merge_extend(&other.samplers).unwrap();
-        self.compute_pipes
-            .merge_extend(&other.compute_pipes)
-            .unwrap();
-        self.render_pipes.merge_extend(&other.render_pipes).unwrap();
-        self.bundles.merge_extend(&other.bundles).unwrap();
-        self.query_sets.merge_extend(&other.query_sets).unwrap();
     }
 
     pub fn backend(&self) -> wgt::Backend {


### PR DESCRIPTION
**Connections**
Hinted by @pythonesque on the matrix
Follow-up to #1417

**Description**
This is an optimization only.

When a bind group is used, we need to ensure two things:
  1. stateful usages are merged in (buffers and textures)
  2. other resources are help alive by the command buffer

We used to merge all of the states into the local trackers. However, the local tracker already
keeps a strong reference to the whole bind group, so the resources in it are not going away.
Therefore, we can skip having them separately in the local trackers.

**Testing**
Untested.
