### PR TITLE
Update submission indices on all stateless resources

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1720,6 +1720,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         info.trackers
                             .merge_extend(&bundle.used)
                             .map_pass_err(scope)?;
+                        // Start tracking the bind groups specifically, as they are the only
+                        // compound resources, to make it easier to update submission indices
+                        // later at submission time.
+                        cmd_buf
+                            .trackers
+                            .bind_groups
+                            .merge_extend(&bundle.used.bind_groups)
+                            .unwrap();
                         state.reset_bundle();
                     }
                 }

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -263,6 +263,7 @@ impl<A: hal::Api> Access<QuerySet<A>> for Device<A> {}
 impl<A: hal::Api> Access<QuerySet<A>> for CommandBuffer<A> {}
 impl<A: hal::Api> Access<QuerySet<A>> for RenderPipeline<A> {}
 impl<A: hal::Api> Access<QuerySet<A>> for ComputePipeline<A> {}
+impl<A: hal::Api> Access<QuerySet<A>> for Sampler<A> {}
 impl<A: hal::Api> Access<ShaderModule<A>> for Device<A> {}
 impl<A: hal::Api> Access<ShaderModule<A>> for BindGroupLayout<A> {}
 impl<A: hal::Api> Access<Buffer<A>> for Root {}

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -271,6 +271,11 @@ impl<S: ResourceState> ResourceTracker<S> {
             .map(move |(&index, resource)| Valid(S::Id::zip(index, resource.epoch, backend)))
     }
 
+    /// Return true if there is nothing here.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
     /// Clear the tracked contents.
     fn clear(&mut self) {
         self.map.clear();


### PR DESCRIPTION
**Connections**
This is partially a regression by #1547, but also fixing more things.

**Description**
We stopped tracking the stateless resources included in bind groups. But we still need to update their submission indices, so that they don't get removed too early.
The PR also does the same for render bundles, but with a twist: bind groups used in a bundle are merged early.

**Testing**
untested
