### PR TITLE
Update naga to 57b325602015ce6445749a4d8ee5d491edc818d7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,8 +1018,8 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.4.0"
-source = "git+https://github.com/gfx-rs/naga?tag=gfx-26#e3827f8e0899377c0177faa1f106ec2f3f8a9e3e"
+version = "0.5.0"
+source = "git+https://github.com/gfx-rs/naga?rev=57b325602015ce6445749a4d8ee5d491edc818d7#57b325602015ce6445749a4d8ee5d491edc818d7"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-26"
+rev = "57b325602015ce6445749a4d8ee5d491edc818d7"
 features = ["wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -48,11 +48,11 @@ core-graphics-types = "0.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-26"
+rev = "57b325602015ce6445749a4d8ee5d491edc818d7"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-26"
+rev = "57b325602015ce6445749a4d8ee5d491edc818d7"
 features = ["wgsl-in"]
 
 [dev-dependencies]

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -64,9 +64,7 @@ impl super::CommandState {
         result_sizes.clear();
         for br in stage_info.sized_bindings.iter() {
             // If it's None, this isn't the right time to update the sizes
-            let size = self
-                .storage_buffer_length_map
-                .get(&(br.group, br.binding))?;
+            let size = self.storage_buffer_length_map.get(br)?;
             result_sizes.push(*size);
         }
         Some((slot as _, result_sizes))
@@ -417,9 +415,11 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     offset,
                 );
                 if let Some(size) = buf.binding_size {
-                    self.state
-                        .storage_buffer_length_map
-                        .insert((group_index, buf.binding_location), size);
+                    let br = naga::ResourceBinding {
+                        group: group_index,
+                        binding: buf.binding_location,
+                    };
+                    self.state.storage_buffer_length_map.insert(br, size);
                     changes_sizes_buffer = true;
                 }
             }
@@ -449,9 +449,11 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     offset,
                 );
                 if let Some(size) = buf.binding_size {
-                    self.state
-                        .storage_buffer_length_map
-                        .insert((group_index, buf.binding_location), size);
+                    let br = naga::ResourceBinding {
+                        group: group_index,
+                        binding: buf.binding_location,
+                    };
+                    self.state.storage_buffer_length_map.insert(br, size);
                     changes_sizes_buffer = true;
                 }
             }
@@ -519,9 +521,11 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     offset,
                 );
                 if let Some(size) = buf.binding_size {
-                    self.state
-                        .storage_buffer_length_map
-                        .insert((group_index, buf.binding_location), size);
+                    let br = naga::ResourceBinding {
+                        group: group_index,
+                        binding: buf.binding_location,
+                    };
+                    self.state.storage_buffer_length_map.insert(br, size);
                     changes_sizes_buffer = true;
                 }
             }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -666,8 +666,7 @@ struct CommandState {
     index: Option<IndexState>,
     raw_wg_size: mtl::MTLSize,
     stage_infos: MultiStageData<PipelineStageInfo>,
-    //TODO: use `naga::ResourceBinding` for keys
-    storage_buffer_length_map: fxhash::FxHashMap<(u32, u32), wgt::BufferSize>,
+    storage_buffer_length_map: fxhash::FxHashMap<naga::ResourceBinding, wgt::BufferSize>,
 }
 
 pub struct CommandEncoder {

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -728,6 +728,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 lang_version: (1, 0),
                 flags,
                 capabilities: Some(capabilities.iter().cloned().collect()),
+                index_bounds_check_policy: naga::back::IndexBoundsCheckPolicy::Restrict,
             }
         };
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -73,19 +73,19 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-26"
+rev = "57b325602015ce6445749a4d8ee5d491edc818d7"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-26"
+rev = "57b325602015ce6445749a4d8ee5d491edc818d7"
 features = ["wgsl-in"]
 
 # used to generate SPIR-V for the Web target
 [target.'cfg(target_arch = "wasm32")'.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-26"
+rev = "57b325602015ce6445749a4d8ee5d491edc818d7"
 features = ["wgsl-in", "spv-out"]
 
 [[example]]

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1146,6 +1146,8 @@ impl crate::Context for Context {
                     lang_version: (1, 0),
                     flags: spv::WriterFlags::empty(),
                     capabilities: None,
+                    index_bounds_check_policy:
+                        naga::back::IndexBoundsCheckPolicy::UndefinedBehavior,
                 };
                 let analysis = Validator::new(
                     naga::valid::ValidationFlags::empty(),


### PR DESCRIPTION
**Connections**
Needed for #1510
Picks up https://github.com/gfx-rs/naga/pull/1039 and https://github.com/gfx-rs/naga/pull/916

**Description**
Updates Naga to latest on Git. Refactors the use of `ResourceBinding` and Metal's binding map.
Also enables safe bound check handling on Vulkan (`Restrict` policy, cc @jimblandy).

**Testing**
Examples.
