### PR TITLE
Query support fixes

### DIFF
--- a/player/tests/data/all.ron
+++ b/player/tests/data/all.ron
@@ -5,6 +5,7 @@
 		"buffer-copy.ron",
 		"clear-buffer-image.ron",
 		"buffer-zero-init.ron",
+		"pipeline-statistics-query.ron",
 		"quad.ron",
 	],
 )

--- a/player/tests/data/pipeline-statistics-query.ron
+++ b/player/tests/data/pipeline-statistics-query.ron
@@ -1,0 +1,81 @@
+(
+    features: (bits: 0x0000_0000_0000_0008), // PIPELINE_STATISTICS_QUERY
+    expectations: [
+        (
+            name: "Queried number of compute invocations is correct",
+            buffer: (index: 0, epoch: 1),
+            offset: 0,
+            data: Raw([0x2A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+        ),
+    ],
+    actions: [
+        CreatePipelineLayout(Id(0, 1, Empty), (
+            label: Some("empty"),
+            bind_group_layouts: [],
+            push_constant_ranges: [],
+        )),
+        CreateShaderModule(
+            id: Id(0, 1, Empty),
+            desc: (
+                label: None,
+                flags: (bits: 3),
+            ),
+            data: "empty.wgsl",
+        ),
+        CreateComputePipeline(
+            id: Id(0, 1, Empty),
+            desc: (
+                label: None,
+                layout: Some(Id(0, 1, Empty)),
+                stage: (
+                    module: Id(0, 1, Empty),
+                    entry_point: "main",
+                ),
+            ),
+        ),
+        CreateQuerySet(
+            id: Id(0, 1, Empty),
+            desc: (
+                label: Some("Compute Invocation QuerySet"),
+                count: 2,
+                ty: PipelineStatistics((bits: 0x10)), // COMPUTE_SHADER_INVOCATIONS
+            ),
+        ),
+        CreateBuffer(
+            Id(0, 1, Empty),
+            (
+                label: Some("Compute Invocation Result Buffer"),
+                size: 8,
+                usage: (
+                    bits: 9, // COPY_DST | MAP_READ
+                ),
+                mapped_at_creation: false,
+            ),
+        ),
+        Submit(1, [
+            RunComputePass(
+                base: (
+                    commands: [
+                        SetPipeline(Id(0, 1, Empty)),
+                        BeginPipelineStatisticsQuery(
+                            query_set_id: Id(0, 1, Empty),
+                            query_index: 0,
+                        ),
+                        Dispatch((2, 3, 7,)),
+                        EndPipelineStatisticsQuery,
+                    ],
+                    dynamic_offsets: [],
+                    string_data: [],
+                    push_constant_data: [],
+                ),
+            ),
+            ResolveQuerySet(
+                query_set_id: Id(0, 1, Empty),
+                start_query: 0,
+                query_count: 1,
+                destination: Id(0, 1, Empty),
+                destination_offset: 0,
+            )
+        ]),
+    ],
+)

--- a/player/tests/data/pipeline-statistics-query.ron
+++ b/player/tests/data/pipeline-statistics-query.ron
@@ -5,7 +5,7 @@
             name: "Queried number of compute invocations is correct",
             buffer: (index: 0, epoch: 1),
             offset: 0,
-            data: Raw([0x2A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            data: U64([0x0, 0x2A]),
         ),
     ],
     actions: [
@@ -38,14 +38,14 @@
             desc: (
                 label: Some("Compute Invocation QuerySet"),
                 count: 2,
-                ty: PipelineStatistics((bits: 0x10)), // COMPUTE_SHADER_INVOCATIONS
+                ty: PipelineStatistics((bits: 0x18)), // FRAGMENT_SHADER_INVOCATIONS | COMPUTE_SHADER_INVOCATIONS
             ),
         ),
         CreateBuffer(
             Id(0, 1, Empty),
             (
                 label: Some("Compute Invocation Result Buffer"),
-                size: 8,
+                size: 16,
                 usage: (
                     bits: 9, // COPY_DST | MAP_READ
                 ),

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -26,6 +26,7 @@ struct RawId {
 #[derive(serde::Deserialize)]
 enum ExpectedData {
     Raw(Vec<u8>),
+    U64(Vec<u64>),
     File(String, usize),
 }
 
@@ -33,6 +34,7 @@ impl ExpectedData {
     fn len(&self) -> usize {
         match self {
             ExpectedData::Raw(vec) => vec.len(),
+            ExpectedData::U64(vec) => vec.len() * std::mem::size_of::<u64>(),
             ExpectedData::File(_, size) => *size,
         }
     }
@@ -137,6 +139,10 @@ impl Test<'_> {
 
                     bin
                 }
+                ExpectedData::U64(vec) => vec
+                    .into_iter()
+                    .flat_map(|u| u.to_ne_bytes().to_vec())
+                    .collect::<Vec<u8>>(),
             };
 
             if &expected_data[..] != contents {

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -279,6 +279,7 @@ impl crate::CommandEncoder<Api> for Encoder {
         range: Range<u32>,
         buffer: &Resource,
         offset: wgt::BufferAddress,
+        stride: wgt::BufferSize,
     ) {
     }
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -398,6 +398,7 @@ pub trait CommandEncoder<A: Api>: Send + Sync {
         range: Range<u32>,
         buffer: &A::Buffer,
         offset: wgt::BufferAddress,
+        stride: wgt::BufferSize,
     );
 
     // render passes

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -296,6 +296,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         range: Range<u32>,
         buffer: &super::Buffer,
         offset: wgt::BufferAddress,
+        _: wgt::BufferSize, // Metal doesn't support queries that are bigger than a single element are not supported
     ) {
         let encoder = self.enter_blit();
         let size = (range.end - range.start) as u64 * crate::QUERY_SIZE;

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -210,6 +210,8 @@ impl PhysicalDeviceFeatures {
             | F::SAMPLED_TEXTURE_BINDING_ARRAY
             | F::STORAGE_TEXTURE_BINDING_ARRAY
             | F::BUFFER_BINDING_ARRAY
+            | F::TIMESTAMP_QUERY
+            | F::PIPELINE_STATISTICS_QUERY
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
         let mut dl_flags = Df::all();
 

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -331,6 +331,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         range: Range<u32>,
         buffer: &super::Buffer,
         offset: wgt::BufferAddress,
+        stride: wgt::BufferSize,
     ) {
         self.device.raw.cmd_copy_query_pool_results(
             self.active,
@@ -339,7 +340,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             range.end - range.start,
             buffer.raw,
             offset,
-            0,
+            stride.get(),
             vk::QueryResultFlags::TYPE_64 | vk::QueryResultFlags::WAIT,
         );
     }


### PR DESCRIPTION
**Connections**
Fixes #1374 for master
If PR is accepted,I already have a fix for 0.9 which came out as a sideproduct: https://github.com/Wumpf/wgpu/tree/v0.9-fix-buffer-init-on-query-resolve

**Description**
Fixes:
* (affects master, v0.8, v0.9) query resolve operation not marking buffers as initialized
* (affects master) Broken query stride handling for Vulkan
* (affects master) Vulkan not advertising query support

**Testing**
* added new test
* mipmap sample
