### PR TITLE
[v0.9] fix buffer inits being delayed by a frame

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -601,12 +601,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let device = device_guard
                 .get_mut(queue_id)
                 .map_err(|_| DeviceError::Invalid)?;
-            let pending_write_command_buffer = device.pending_writes.finish();
             device.temp_suspected.clear();
             device.active_submission_index += 1;
             let submit_index = device.active_submission_index;
 
-            let fence = {
+            let (fence, pending_write_command_buffer) = {
                 let mut signal_swapchain_semaphores = SmallVec::<[_; 1]>::new();
                 let (mut swap_chain_guard, mut token) = hub.swap_chains.write(&mut token);
                 let (mut command_buffer_guard, mut token) = hub.command_buffers.write(&mut token);
@@ -758,6 +757,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                 }
 
+                // Finish pending writes. Don't do this earlier since buffer init may lead to additional writes (see initialize_buffer_memory).
+                let pending_write_command_buffer = device.pending_writes.finish();
+
                 // now prepare the GPU submission
                 let mut fence = device
                     .raw
@@ -786,7 +788,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         Some(&mut fence),
                     );
                 }
-                fence
+                (fence, pending_write_command_buffer)
             };
 
             if let Some(comb_raw) = pending_write_command_buffer {


### PR DESCRIPTION
**Connections**
Fixes #1555

**Description**
Fix buffer inits being inserted into the next submit call
Haven't checked how long this issue exists already, but this pretty much kills all user data that is generated by rendering/compute

**Testing**
Tested on provided repro project in ticket. Pretty bad bug so would like to see a regression test but can't come up right now with anything easier than the taking over the given example :/