### PR TITLE
Fix stray header in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,6 @@
 ## v0.8.1 (2021-05-06)
   - fix SPIR-V generation from WGSL, which was broken due to "Kernel" capability
   - validate buffer storage classes
-
-## Unreleased
   - Added support for storage texture arrays for Vulkan and Metal.
 
 ## v0.8 (2021-04-29)


### PR DESCRIPTION
It's definitely released by now. I'm guessing it was part of 0.8.1.