### PR TITLE
Switch all bitflag names to plural

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -41,11 +41,8 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    let global = wgc::hub::Global::new(
-        "player",
-        IdentityPassThroughFactory,
-        wgt::BackendBit::PRIMARY,
-    );
+    let global =
+        wgc::hub::Global::new("player", IdentityPassThroughFactory, wgt::Backends::PRIMARY);
     let mut command_buffer_id_manager = wgc::hub::IdentityManager::default();
 
     #[cfg(feature = "winit")]

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -159,7 +159,7 @@ impl Test<'_> {
 
 #[derive(serde::Deserialize)]
 struct Corpus {
-    backends: wgt::BackendBit,
+    backends: wgt::Backends,
     tests: Vec<String>,
 }
 

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -218,7 +218,7 @@ impl Binder {
 }
 
 struct PushConstantChange {
-    stages: wgt::ShaderStage,
+    stages: wgt::ShaderStages,
     offset: u32,
     enable: bool,
 }
@@ -251,7 +251,7 @@ pub fn compute_nonoverlapping_ranges(
 
     let mut output_ranges = ArrayVec::new();
     let mut position = 0_u32;
-    let mut stages = wgt::ShaderStage::NONE;
+    let mut stages = wgt::ShaderStages::NONE;
 
     for bk in breaks {
         if bk.offset - position > 0 && !stages.is_empty() {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1221,7 +1221,7 @@ pub mod bundle_ffi {
     #[no_mangle]
     pub unsafe extern "C" fn wgpu_render_bundle_set_push_constants(
         pass: &mut RenderBundleEncoder,
-        stages: wgt::ShaderStage,
+        stages: wgt::ShaderStages,
         offset: u32,
         size_bytes: u32,
         data: *const u8,

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -261,9 +261,9 @@ impl RenderBundleEncoder {
                     let buffer = state
                         .trackers
                         .buffers
-                        .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUse::INDEX)
+                        .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUses::INDEX)
                         .unwrap();
-                    check_buffer_usage(buffer.usage, wgt::BufferUsage::INDEX)
+                    check_buffer_usage(buffer.usage, wgt::BufferUsages::INDEX)
                         .map_pass_err(scope)?;
 
                     let end = match size {
@@ -288,9 +288,9 @@ impl RenderBundleEncoder {
                     let buffer = state
                         .trackers
                         .buffers
-                        .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUse::VERTEX)
+                        .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUses::VERTEX)
                         .unwrap();
-                    check_buffer_usage(buffer.usage, wgt::BufferUsage::VERTEX)
+                    check_buffer_usage(buffer.usage, wgt::BufferUsages::VERTEX)
                         .map_pass_err(scope)?;
 
                     let end = match size {
@@ -413,9 +413,9 @@ impl RenderBundleEncoder {
                     let buffer = state
                         .trackers
                         .buffers
-                        .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUse::INDIRECT)
+                        .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUses::INDIRECT)
                         .unwrap();
-                    check_buffer_usage(buffer.usage, wgt::BufferUsage::INDIRECT)
+                    check_buffer_usage(buffer.usage, wgt::BufferUsages::INDIRECT)
                         .map_pass_err(scope)?;
 
                     buffer_memory_init_actions.extend(
@@ -453,10 +453,10 @@ impl RenderBundleEncoder {
                     let buffer = state
                         .trackers
                         .buffers
-                        .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUse::INDIRECT)
+                        .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUses::INDIRECT)
                         .map_err(|err| RenderCommandError::Buffer(buffer_id, err))
                         .map_pass_err(scope)?;
-                    check_buffer_usage(buffer.usage, wgt::BufferUsage::INDIRECT)
+                    check_buffer_usage(buffer.usage, wgt::BufferUsages::INDIRECT)
                         .map_pass_err(scope)?;
 
                     buffer_memory_init_actions.extend(

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -13,7 +13,7 @@ use crate::{
 use hal::CommandEncoder as _;
 use thiserror::Error;
 use wgt::{
-    BufferAddress, BufferSize, BufferUsage, ImageSubresourceRange, TextureAspect, TextureUsage,
+    BufferAddress, BufferSize, BufferUsages, ImageSubresourceRange, TextureAspect, TextureUsages,
 };
 
 /// Error encountered while attempting a clear.
@@ -89,13 +89,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (dst_buffer, dst_pending) = cmd_buf
             .trackers
             .buffers
-            .use_replace(&*buffer_guard, dst, (), hal::BufferUse::COPY_DST)
+            .use_replace(&*buffer_guard, dst, (), hal::BufferUses::COPY_DST)
             .map_err(ClearError::InvalidBuffer)?;
         let dst_raw = dst_buffer
             .raw
             .as_ref()
             .ok_or(ClearError::InvalidBuffer(dst))?;
-        if !dst_buffer.usage.contains(BufferUsage::COPY_DST) {
+        if !dst_buffer.usage.contains(BufferUsages::COPY_DST) {
             return Err(ClearError::MissingCopyDstUsageFlag(Some(dst), None));
         }
 
@@ -229,14 +229,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     levels: subresource_range.base_mip_level..subresource_level_end,
                     layers: subresource_range.base_array_layer..subresource_layer_end,
                 },
-                hal::TextureUse::COPY_DST,
+                hal::TextureUses::COPY_DST,
             )
             .map_err(ClearError::InvalidTexture)?;
         let _dst_raw = dst_texture
             .raw
             .as_ref()
             .ok_or(ClearError::InvalidTexture(dst))?;
-        if !dst_texture.desc.usage.contains(TextureUsage::COPY_DST) {
+        if !dst_texture.desc.usage.contains(TextureUsages::COPY_DST) {
             return Err(ClearError::MissingCopyDstUsageFlag(None, Some(dst)));
         }
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -181,8 +181,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .map_err(|_| ClearError::InvalidTexture(dst))?;
 
         // Check if subresource aspects are valid.
-        let requested_aspects = hal::FormatAspect::from(subresource_range.aspect);
-        let clear_aspects = hal::FormatAspect::from(dst_texture.desc.format) & requested_aspects;
+        let requested_aspects = hal::FormatAspects::from(subresource_range.aspect);
+        let clear_aspects = hal::FormatAspects::from(dst_texture.desc.format) & requested_aspects;
         if clear_aspects.is_empty() {
             return Err(ClearError::MissingTextureAspect {
                 texture_format: dst_texture.desc.format,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -17,7 +17,6 @@ use crate::{
 
 use hal::CommandEncoder as _;
 use thiserror::Error;
-use wgt::{BufferAddress, BufferUsage, ShaderStage};
 
 use std::{fmt, mem, str};
 
@@ -46,7 +45,7 @@ pub enum ComputeCommand {
     Dispatch([u32; 3]),
     DispatchIndirect {
         buffer_id: id::BufferId,
-        offset: BufferAddress,
+        offset: wgt::BufferAddress,
     },
     PushDebugGroup {
         color: u32,
@@ -430,7 +429,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                                 |clear_offset, clear_data| unsafe {
                                     raw.set_push_constants(
                                         &pipeline_layout.raw,
-                                        wgt::ShaderStage::COMPUTE,
+                                        wgt::ShaderStages::COMPUTE,
                                         clear_offset,
                                         clear_data,
                                     );
@@ -464,7 +463,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
                     pipeline_layout
                         .validate_push_constant_ranges(
-                            ShaderStage::COMPUTE,
+                            wgt::ShaderStages::COMPUTE,
                             offset,
                             end_offset_bytes,
                         )
@@ -473,7 +472,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     unsafe {
                         raw.set_push_constants(
                             &pipeline_layout.raw,
-                            wgt::ShaderStage::COMPUTE,
+                            wgt::ShaderStages::COMPUTE,
                             offset,
                             data_slice,
                         );
@@ -517,7 +516,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUse::INDIRECT)
                         .map_err(|_| ComputePassErrorInner::InvalidIndirectBuffer(buffer_id))
                         .map_pass_err(scope)?;
-                    check_buffer_usage(indirect_buffer.usage, BufferUsage::INDIRECT)
+                    check_buffer_usage(indirect_buffer.usage, wgt::BufferUsage::INDIRECT)
                         .map_pass_err(scope)?;
 
                     let end_offset = offset + mem::size_of::<wgt::DispatchIndirectArgs>() as u64;

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -513,10 +513,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     let indirect_buffer = state
                         .trackers
                         .buffers
-                        .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUse::INDIRECT)
+                        .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUses::INDIRECT)
                         .map_err(|_| ComputePassErrorInner::InvalidIndirectBuffer(buffer_id))
                         .map_pass_err(scope)?;
-                    check_buffer_usage(indirect_buffer.usage, wgt::BufferUsage::INDIRECT)
+                    check_buffer_usage(indirect_buffer.usage, wgt::BufferUsages::INDIRECT)
                         .map_pass_err(scope)?;
 
                     let end_offset = offset + mem::size_of::<wgt::DispatchIndirectArgs>() as u64;

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -149,7 +149,7 @@ pub enum RenderCommand {
     },
     SetScissor(Rect<u32>),
     SetPushConstant {
-        stages: wgt::ShaderStage,
+        stages: wgt::ShaderStages,
         offset: u32,
         size_bytes: u32,
         /// None means there is no data and the data should be an array of zeros.

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -12,7 +12,7 @@ use wgt::{BufferAddress, BufferSize, Color};
 use std::num::NonZeroU32;
 use thiserror::Error;
 
-pub type BufferError = UseExtendError<hal::BufferUse>;
+pub type BufferError = UseExtendError<hal::BufferUses>;
 
 /// Error validating a draw call.
 #[derive(Clone, Debug, Error, PartialEq)]

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -351,11 +351,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (dst_buffer, dst_pending) = cmd_buf
             .trackers
             .buffers
-            .use_replace(&*buffer_guard, destination, (), hal::BufferUse::COPY_DST)
+            .use_replace(&*buffer_guard, destination, (), hal::BufferUses::COPY_DST)
             .map_err(QueryError::InvalidBuffer)?;
         let dst_barrier = dst_pending.map(|pending| pending.into_hal(dst_buffer));
 
-        if !dst_buffer.usage.contains(wgt::BufferUsage::COPY_DST) {
+        if !dst_buffer.usage.contains(wgt::BufferUsages::COPY_DST) {
             return Err(ResolveError::MissingBufferUsage.into());
         }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -26,7 +26,7 @@ use arrayvec::ArrayVec;
 use hal::CommandEncoder as _;
 use thiserror::Error;
 use wgt::{
-    BufferAddress, BufferSize, BufferUsage, Color, IndexFormat, InputStepMode, TextureUsage,
+    BufferAddress, BufferSize, BufferUsages, Color, IndexFormat, InputStepMode, TextureUsages,
 };
 
 #[cfg(any(feature = "serial-pass", feature = "replay"))]
@@ -491,8 +491,8 @@ where
 struct RenderAttachment<'a> {
     texture_id: &'a Stored<id::TextureId>,
     selector: &'a TextureSelector,
-    previous_use: Option<hal::TextureUse>,
-    new_use: hal::TextureUse,
+    previous_use: Option<hal::TextureUses>,
+    new_use: hal::TextureUses,
 }
 
 type AttachmentDataVec<T> = ArrayVec<[T; hal::MAX_COLOR_TARGETS + hal::MAX_COLOR_TARGETS + 1]>;
@@ -584,9 +584,9 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 .query(source_id.value, view.selector.clone());
             let new_use = if at.is_read_only(ds_aspects)? {
                 is_ds_read_only = true;
-                hal::TextureUse::DEPTH_STENCIL_READ | hal::TextureUse::SAMPLED
+                hal::TextureUses::DEPTH_STENCIL_READ | hal::TextureUses::SAMPLED
             } else {
-                hal::TextureUse::DEPTH_STENCIL_WRITE
+                hal::TextureUses::DEPTH_STENCIL_WRITE
             };
             render_attachments.push(RenderAttachment {
                 texture_id: source_id,
@@ -632,7 +632,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                         .trackers
                         .textures
                         .query(source_id.value, color_view.selector.clone());
-                    let new_use = hal::TextureUse::COLOR_TARGET;
+                    let new_use = hal::TextureUses::COLOR_TARGET;
                     render_attachments.push(RenderAttachment {
                         texture_id: source_id,
                         selector: &color_view.selector,
@@ -647,9 +647,9 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                     assert!(used_swap_chain.is_none());
                     used_swap_chain = Some(source_id.clone());
 
-                    let end = hal::TextureUse::empty();
+                    let end = hal::TextureUses::empty();
                     let start = match at.channel.load_op {
-                        LoadOp::Clear => hal::TextureUse::UNINITIALIZED,
+                        LoadOp::Clear => hal::TextureUses::UNINITIALIZED,
                         LoadOp::Load => end,
                     };
                     start..end
@@ -682,7 +682,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                             .trackers
                             .textures
                             .query(source_id.value, resolve_view.selector.clone());
-                        let new_use = hal::TextureUse::COLOR_TARGET;
+                        let new_use = hal::TextureUses::COLOR_TARGET;
                         render_attachments.push(RenderAttachment {
                             texture_id: source_id,
                             selector: &resolve_view.selector,
@@ -696,13 +696,13 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                     TextureViewSource::SwapChain(ref source_id) => {
                         assert!(used_swap_chain.is_none());
                         used_swap_chain = Some(source_id.clone());
-                        hal::TextureUse::UNINITIALIZED..hal::TextureUse::empty()
+                        hal::TextureUses::UNINITIALIZED..hal::TextureUses::empty()
                     }
                 };
 
                 hal_resolve_target = Some(hal::Attachment {
                     view: &resolve_view.raw,
-                    usage: hal::TextureUse::COLOR_TARGET,
+                    usage: hal::TextureUses::COLOR_TARGET,
                     boundary_usage,
                 });
             }
@@ -710,7 +710,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
             colors.push(hal::ColorAttachment {
                 target: hal::Attachment {
                     view: &color_view.raw,
-                    usage: hal::TextureUse::COLOR_TARGET,
+                    usage: hal::TextureUses::COLOR_TARGET,
                     boundary_usage,
                 },
                 resolve_target: hal_resolve_target,
@@ -773,7 +773,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
 
         for ra in self.render_attachments {
             let texture = &texture_guard[ra.texture_id.value];
-            check_texture_usage(texture.desc.usage, TextureUsage::RENDER_ATTACHMENT)?;
+            check_texture_usage(texture.desc.usage, TextureUsages::RENDER_ATTACHMENT)?;
 
             // the tracker set of the pass is always in "extend" mode
             self.trackers
@@ -1108,10 +1108,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         let buffer = info
                             .trackers
                             .buffers
-                            .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUse::INDEX)
+                            .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUses::INDEX)
                             .map_err(|e| RenderCommandError::Buffer(buffer_id, e))
                             .map_pass_err(scope)?;
-                        check_buffer_usage(buffer.usage, BufferUsage::INDEX).map_pass_err(scope)?;
+                        check_buffer_usage(buffer.usage, BufferUsages::INDEX)
+                            .map_pass_err(scope)?;
                         let buf_raw = buffer
                             .raw
                             .as_ref()
@@ -1157,10 +1158,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         let buffer = info
                             .trackers
                             .buffers
-                            .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUse::VERTEX)
+                            .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUses::VERTEX)
                             .map_err(|e| RenderCommandError::Buffer(buffer_id, e))
                             .map_pass_err(scope)?;
-                        check_buffer_usage(buffer.usage, BufferUsage::VERTEX)
+                        check_buffer_usage(buffer.usage, BufferUsages::VERTEX)
                             .map_pass_err(scope)?;
                         let buf_raw = buffer
                             .raw
@@ -1412,10 +1413,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         let indirect_buffer = info
                             .trackers
                             .buffers
-                            .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUse::INDIRECT)
+                            .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUses::INDIRECT)
                             .map_err(|e| RenderCommandError::Buffer(buffer_id, e))
                             .map_pass_err(scope)?;
-                        check_buffer_usage(indirect_buffer.usage, BufferUsage::INDIRECT)
+                        check_buffer_usage(indirect_buffer.usage, BufferUsages::INDIRECT)
                             .map_pass_err(scope)?;
                         let indirect_raw = indirect_buffer
                             .raw
@@ -1486,10 +1487,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         let indirect_buffer = info
                             .trackers
                             .buffers
-                            .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUse::INDIRECT)
+                            .use_extend(&*buffer_guard, buffer_id, (), hal::BufferUses::INDIRECT)
                             .map_err(|e| RenderCommandError::Buffer(buffer_id, e))
                             .map_pass_err(scope)?;
-                        check_buffer_usage(indirect_buffer.usage, BufferUsage::INDIRECT)
+                        check_buffer_usage(indirect_buffer.usage, BufferUsages::INDIRECT)
                             .map_pass_err(scope)?;
                         let indirect_raw = indirect_buffer
                             .raw
@@ -1504,11 +1505,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                                 &*buffer_guard,
                                 count_buffer_id,
                                 (),
-                                hal::BufferUse::INDIRECT,
+                                hal::BufferUses::INDIRECT,
                             )
                             .map_err(|e| RenderCommandError::Buffer(count_buffer_id, e))
                             .map_pass_err(scope)?;
-                        check_buffer_usage(count_buffer.usage, BufferUsage::INDIRECT)
+                        check_buffer_usage(count_buffer.usage, BufferUsages::INDIRECT)
                             .map_pass_err(scope)?;
                         let count_raw = count_buffer
                             .raw

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use hal::CommandEncoder as _;
 use thiserror::Error;
-use wgt::{BufferAddress, BufferUsage, Extent3d, TextureUsage};
+use wgt::{BufferAddress, BufferUsages, Extent3d, TextureUsages};
 
 use std::iter;
 
@@ -334,13 +334,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (src_buffer, src_pending) = cmd_buf
             .trackers
             .buffers
-            .use_replace(&*buffer_guard, source, (), hal::BufferUse::COPY_SRC)
+            .use_replace(&*buffer_guard, source, (), hal::BufferUses::COPY_SRC)
             .map_err(TransferError::InvalidBuffer)?;
         let src_raw = src_buffer
             .raw
             .as_ref()
             .ok_or(TransferError::InvalidBuffer(source))?;
-        if !src_buffer.usage.contains(BufferUsage::COPY_SRC) {
+        if !src_buffer.usage.contains(BufferUsages::COPY_SRC) {
             return Err(TransferError::MissingCopySrcUsageFlag.into());
         }
         // expecting only a single barrier
@@ -351,13 +351,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (dst_buffer, dst_pending) = cmd_buf
             .trackers
             .buffers
-            .use_replace(&*buffer_guard, destination, (), hal::BufferUse::COPY_DST)
+            .use_replace(&*buffer_guard, destination, (), hal::BufferUses::COPY_DST)
             .map_err(TransferError::InvalidBuffer)?;
         let dst_raw = dst_buffer
             .raw
             .as_ref()
             .ok_or(TransferError::InvalidBuffer(destination))?;
-        if !dst_buffer.usage.contains(BufferUsage::COPY_DST) {
+        if !dst_buffer.usage.contains(BufferUsages::COPY_DST) {
             return Err(TransferError::MissingCopyDstUsageFlag(Some(destination), None).into());
         }
         let dst_barrier = dst_pending
@@ -472,13 +472,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (src_buffer, src_pending) = cmd_buf
             .trackers
             .buffers
-            .use_replace(&*buffer_guard, source.buffer, (), hal::BufferUse::COPY_SRC)
+            .use_replace(&*buffer_guard, source.buffer, (), hal::BufferUses::COPY_SRC)
             .map_err(TransferError::InvalidBuffer)?;
         let src_raw = src_buffer
             .raw
             .as_ref()
             .ok_or(TransferError::InvalidBuffer(source.buffer))?;
-        if !src_buffer.usage.contains(BufferUsage::COPY_SRC) {
+        if !src_buffer.usage.contains(BufferUsages::COPY_SRC) {
             return Err(TransferError::MissingCopySrcUsageFlag.into());
         }
         let src_barriers = src_pending.map(|pending| pending.into_hal(src_buffer));
@@ -490,14 +490,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 &*texture_guard,
                 destination.texture,
                 dst_range,
-                hal::TextureUse::COPY_DST,
+                hal::TextureUses::COPY_DST,
             )
             .unwrap();
         let dst_raw = dst_texture
             .raw
             .as_ref()
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
-        if !dst_texture.desc.usage.contains(TextureUsage::COPY_DST) {
+        if !dst_texture.desc.usage.contains(TextureUsages::COPY_DST) {
             return Err(
                 TransferError::MissingCopyDstUsageFlag(None, Some(destination.texture)).into(),
             );
@@ -601,14 +601,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 &*texture_guard,
                 source.texture,
                 src_range,
-                hal::TextureUse::COPY_SRC,
+                hal::TextureUses::COPY_SRC,
             )
             .unwrap();
         let src_raw = src_texture
             .raw
             .as_ref()
             .ok_or(TransferError::InvalidTexture(source.texture))?;
-        if !src_texture.desc.usage.contains(TextureUsage::COPY_SRC) {
+        if !src_texture.desc.usage.contains(TextureUsages::COPY_SRC) {
             return Err(TransferError::MissingCopySrcUsageFlag.into());
         }
         let src_barriers = src_pending.map(|pending| pending.into_hal(src_texture));
@@ -620,14 +620,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 &*buffer_guard,
                 destination.buffer,
                 (),
-                hal::BufferUse::COPY_DST,
+                hal::BufferUses::COPY_DST,
             )
             .map_err(TransferError::InvalidBuffer)?;
         let dst_raw = dst_buffer
             .raw
             .as_ref()
             .ok_or(TransferError::InvalidBuffer(destination.buffer))?;
-        if !dst_buffer.usage.contains(BufferUsage::COPY_DST) {
+        if !dst_buffer.usage.contains(BufferUsages::COPY_DST) {
             return Err(
                 TransferError::MissingCopyDstUsageFlag(Some(destination.buffer), None).into(),
             );
@@ -686,7 +686,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             cmd_buf_raw.transition_textures(src_barriers);
             cmd_buf_raw.copy_texture_to_buffer(
                 src_raw,
-                hal::TextureUse::COPY_SRC,
+                hal::TextureUses::COPY_SRC,
                 dst_raw,
                 iter::once(region),
             );
@@ -740,14 +740,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 &*texture_guard,
                 source.texture,
                 src_range,
-                hal::TextureUse::COPY_SRC,
+                hal::TextureUses::COPY_SRC,
             )
             .unwrap();
         let src_raw = src_texture
             .raw
             .as_ref()
             .ok_or(TransferError::InvalidTexture(source.texture))?;
-        if !src_texture.desc.usage.contains(TextureUsage::COPY_SRC) {
+        if !src_texture.desc.usage.contains(TextureUsages::COPY_SRC) {
             return Err(TransferError::MissingCopySrcUsageFlag.into());
         }
         //TODO: try to avoid this the collection. It's needed because both
@@ -763,14 +763,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 &*texture_guard,
                 destination.texture,
                 dst_range,
-                hal::TextureUse::COPY_DST,
+                hal::TextureUses::COPY_DST,
             )
             .unwrap();
         let dst_raw = dst_texture
             .raw
             .as_ref()
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
-        if !dst_texture.desc.usage.contains(TextureUsage::COPY_DST) {
+        if !dst_texture.desc.usage.contains(TextureUsages::COPY_DST) {
             return Err(
                 TransferError::MissingCopyDstUsageFlag(None, Some(destination.texture)).into(),
             );
@@ -808,7 +808,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             cmd_buf_raw.transition_textures(barriers.into_iter());
             cmd_buf_raw.copy_texture_to_texture(
                 src_raw,
-                hal::TextureUse::COPY_SRC,
+                hal::TextureUses::COPY_SRC,
                 dst_raw,
                 iter::once(region),
             );

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -112,7 +112,7 @@ pub(crate) fn extract_texture_selector<A: hal::Api>(
 
     let format = texture.desc.format;
     let copy_aspect =
-        hal::FormatAspect::from(format) & hal::FormatAspect::from(copy_texture.aspect);
+        hal::FormatAspects::from(format) & hal::FormatAspects::from(copy_texture.aspect);
     if copy_aspect.is_empty() {
         return Err(TransferError::InvalidTextureAspect {
             format,

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -20,73 +20,76 @@ pub fn is_valid_copy_dst_texture_format(format: wgt::TextureFormat) -> bool {
     }
 }
 
-pub fn map_buffer_usage(usage: wgt::BufferUsage) -> hal::BufferUse {
-    let mut u = hal::BufferUse::empty();
+pub fn map_buffer_usage(usage: wgt::BufferUsages) -> hal::BufferUses {
+    let mut u = hal::BufferUses::empty();
     u.set(
-        hal::BufferUse::MAP_READ,
-        usage.contains(wgt::BufferUsage::MAP_READ),
+        hal::BufferUses::MAP_READ,
+        usage.contains(wgt::BufferUsages::MAP_READ),
     );
     u.set(
-        hal::BufferUse::MAP_WRITE,
-        usage.contains(wgt::BufferUsage::MAP_WRITE),
+        hal::BufferUses::MAP_WRITE,
+        usage.contains(wgt::BufferUsages::MAP_WRITE),
     );
     u.set(
-        hal::BufferUse::COPY_SRC,
-        usage.contains(wgt::BufferUsage::COPY_SRC),
+        hal::BufferUses::COPY_SRC,
+        usage.contains(wgt::BufferUsages::COPY_SRC),
     );
     u.set(
-        hal::BufferUse::COPY_DST,
-        usage.contains(wgt::BufferUsage::COPY_DST),
+        hal::BufferUses::COPY_DST,
+        usage.contains(wgt::BufferUsages::COPY_DST),
     );
     u.set(
-        hal::BufferUse::INDEX,
-        usage.contains(wgt::BufferUsage::INDEX),
+        hal::BufferUses::INDEX,
+        usage.contains(wgt::BufferUsages::INDEX),
     );
     u.set(
-        hal::BufferUse::VERTEX,
-        usage.contains(wgt::BufferUsage::VERTEX),
+        hal::BufferUses::VERTEX,
+        usage.contains(wgt::BufferUsages::VERTEX),
     );
     u.set(
-        hal::BufferUse::UNIFORM,
-        usage.contains(wgt::BufferUsage::UNIFORM),
+        hal::BufferUses::UNIFORM,
+        usage.contains(wgt::BufferUsages::UNIFORM),
     );
     u.set(
-        hal::BufferUse::STORAGE_LOAD | hal::BufferUse::STORAGE_STORE,
-        usage.contains(wgt::BufferUsage::STORAGE),
+        hal::BufferUses::STORAGE_LOAD | hal::BufferUses::STORAGE_STORE,
+        usage.contains(wgt::BufferUsages::STORAGE),
     );
     u.set(
-        hal::BufferUse::INDIRECT,
-        usage.contains(wgt::BufferUsage::INDIRECT),
+        hal::BufferUses::INDIRECT,
+        usage.contains(wgt::BufferUsages::INDIRECT),
     );
     u
 }
 
-pub fn map_texture_usage(usage: wgt::TextureUsage, aspect: hal::FormatAspects) -> hal::TextureUse {
-    let mut u = hal::TextureUse::empty();
+pub fn map_texture_usage(
+    usage: wgt::TextureUsages,
+    aspect: hal::FormatAspects,
+) -> hal::TextureUses {
+    let mut u = hal::TextureUses::empty();
     u.set(
-        hal::TextureUse::COPY_SRC,
-        usage.contains(wgt::TextureUsage::COPY_SRC),
+        hal::TextureUses::COPY_SRC,
+        usage.contains(wgt::TextureUsages::COPY_SRC),
     );
     u.set(
-        hal::TextureUse::COPY_DST,
-        usage.contains(wgt::TextureUsage::COPY_DST),
+        hal::TextureUses::COPY_DST,
+        usage.contains(wgt::TextureUsages::COPY_DST),
     );
     u.set(
-        hal::TextureUse::SAMPLED,
-        usage.contains(wgt::TextureUsage::SAMPLED),
+        hal::TextureUses::SAMPLED,
+        usage.contains(wgt::TextureUsages::SAMPLED),
     );
     u.set(
-        hal::TextureUse::STORAGE_LOAD | hal::TextureUse::STORAGE_STORE,
-        usage.contains(wgt::TextureUsage::STORAGE),
+        hal::TextureUses::STORAGE_LOAD | hal::TextureUses::STORAGE_STORE,
+        usage.contains(wgt::TextureUsages::STORAGE),
     );
     let is_color = aspect.contains(hal::FormatAspects::COLOR);
     u.set(
-        hal::TextureUse::COLOR_TARGET,
-        usage.contains(wgt::TextureUsage::RENDER_ATTACHMENT) && is_color,
+        hal::TextureUses::COLOR_TARGET,
+        usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) && is_color,
     );
     u.set(
-        hal::TextureUse::DEPTH_STENCIL_READ | hal::TextureUse::DEPTH_STENCIL_WRITE,
-        usage.contains(wgt::TextureUsage::RENDER_ATTACHMENT) && !is_color,
+        hal::TextureUses::DEPTH_STENCIL_READ | hal::TextureUses::DEPTH_STENCIL_WRITE,
+        usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) && !is_color,
     );
     u
 }

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -61,7 +61,7 @@ pub fn map_buffer_usage(usage: wgt::BufferUsage) -> hal::BufferUse {
     u
 }
 
-pub fn map_texture_usage(usage: wgt::TextureUsage, aspect: hal::FormatAspect) -> hal::TextureUse {
+pub fn map_texture_usage(usage: wgt::TextureUsage, aspect: hal::FormatAspects) -> hal::TextureUse {
     let mut u = hal::TextureUse::empty();
     u.set(
         hal::TextureUse::COPY_SRC,
@@ -79,7 +79,7 @@ pub fn map_texture_usage(usage: wgt::TextureUsage, aspect: hal::FormatAspect) ->
         hal::TextureUse::STORAGE_LOAD | hal::TextureUse::STORAGE_STORE,
         usage.contains(wgt::TextureUsage::STORAGE),
     );
-    let is_color = aspect.contains(hal::FormatAspect::COLOR);
+    let is_color = aspect.contains(hal::FormatAspects::COLOR);
     u.set(
         hal::TextureUse::COLOR_TARGET,
         usage.contains(wgt::TextureUsage::RENDER_ATTACHMENT) && is_color,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -489,14 +489,14 @@ impl<A: HalApi> Device<A> {
             if desc.size % wgt::COPY_BUFFER_ALIGNMENT != 0 {
                 return Err(resource::CreateBufferError::UnalignedSize);
             }
-            if !desc.usage.contains(wgt::BufferUsage::MAP_WRITE) {
+            if !desc.usage.contains(wgt::BufferUsages::MAP_WRITE) {
                 // we are going to be copying into it, internally
-                usage |= hal::BufferUse::COPY_DST;
+                usage |= hal::BufferUses::COPY_DST;
             }
         } else {
             // We are required to zero out (initialize) all memory.
             // This is done on demand using fill_buffer which requires write transfer usage!
-            usage |= hal::BufferUse::COPY_DST;
+            usage |= hal::BufferUses::COPY_DST;
         }
 
         let mut memory_flags = hal::MemoryFlags::empty();
@@ -542,7 +542,7 @@ impl<A: HalApi> Device<A> {
             TextureFormat::Depth24Plus | TextureFormat::Depth24PlusStencil8 => {
                 if desc
                     .usage
-                    .intersects(wgt::TextureUsage::COPY_SRC | wgt::TextureUsage::COPY_DST)
+                    .intersects(wgt::TextureUsages::COPY_SRC | wgt::TextureUsages::COPY_DST)
                 {
                     return Err(resource::CreateTextureError::CannotCopyD24Plus);
                 }
@@ -765,10 +765,10 @@ impl<A: HalApi> Device<A> {
             extent,
             samples: texture.desc.sample_count,
             // once a storage - forever a storage
-            sampled_internal_use: if texture.desc.usage.contains(wgt::TextureUsage::STORAGE) {
-                hal::TextureUse::SAMPLED | hal::TextureUse::STORAGE_LOAD
+            sampled_internal_use: if texture.desc.usage.contains(wgt::TextureUsages::STORAGE) {
+                hal::TextureUses::SAMPLED | hal::TextureUses::STORAGE_LOAD
             } else {
-                hal::TextureUse::SAMPLED
+                hal::TextureUses::SAMPLED
             },
             selector,
             life_guard: LifeGuard::new(desc.label.borrow_or_default()),
@@ -1126,16 +1126,16 @@ impl<A: HalApi> Device<A> {
         };
         let (pub_usage, internal_use, range_limit) = match binding_ty {
             wgt::BufferBindingType::Uniform => (
-                wgt::BufferUsage::UNIFORM,
-                hal::BufferUse::UNIFORM,
+                wgt::BufferUsages::UNIFORM,
+                hal::BufferUses::UNIFORM,
                 limits.max_uniform_buffer_binding_size,
             ),
             wgt::BufferBindingType::Storage { read_only } => (
-                wgt::BufferUsage::STORAGE,
+                wgt::BufferUsages::STORAGE,
                 if read_only {
-                    hal::BufferUse::STORAGE_LOAD
+                    hal::BufferUses::STORAGE_LOAD
                 } else {
-                    hal::BufferUse::STORAGE_STORE
+                    hal::BufferUses::STORAGE_STORE
                 },
                 limits.max_storage_buffer_binding_size,
             ),
@@ -1481,7 +1481,7 @@ impl<A: HalApi> Device<A> {
         decl: &wgt::BindGroupLayoutEntry,
         view: &crate::resource::TextureView<A>,
         expected: &'static str,
-    ) -> Result<(wgt::TextureUsage, hal::TextureUse), binding_model::CreateBindGroupError> {
+    ) -> Result<(wgt::TextureUsages, hal::TextureUses), binding_model::CreateBindGroupError> {
         use crate::binding_model::CreateBindGroupError as Error;
         if hal::FormatAspects::from(view.desc.format)
             .contains(hal::FormatAspects::DEPTH | hal::FormatAspects::STENCIL)
@@ -1531,7 +1531,7 @@ impl<A: HalApi> Device<A> {
                         view_dimension: view.desc.dimension,
                     });
                 }
-                Ok((wgt::TextureUsage::SAMPLED, view.sampled_internal_use))
+                Ok((wgt::TextureUsages::SAMPLED, view.sampled_internal_use))
             }
             wgt::BindingType::StorageTexture {
                 access,
@@ -1553,8 +1553,8 @@ impl<A: HalApi> Device<A> {
                     });
                 }
                 let internal_use = match access {
-                    wgt::StorageTextureAccess::ReadOnly => hal::TextureUse::STORAGE_LOAD,
-                    wgt::StorageTextureAccess::WriteOnly => hal::TextureUse::STORAGE_STORE,
+                    wgt::StorageTextureAccess::ReadOnly => hal::TextureUses::STORAGE_LOAD,
+                    wgt::StorageTextureAccess::WriteOnly => hal::TextureUses::STORAGE_STORE,
                     wgt::StorageTextureAccess::ReadWrite => {
                         if !view
                             .format_features
@@ -1564,10 +1564,10 @@ impl<A: HalApi> Device<A> {
                             return Err(Error::StorageReadWriteNotSupported(view.desc.format));
                         }
 
-                        hal::TextureUse::STORAGE_STORE | hal::TextureUse::STORAGE_LOAD
+                        hal::TextureUses::STORAGE_STORE | hal::TextureUses::STORAGE_LOAD
                     }
                 };
-                Ok((wgt::TextureUsage::STORAGE, internal_use))
+                Ok((wgt::TextureUsages::STORAGE, internal_use))
             }
             _ => Err(Error::WrongBindingType {
                 binding,
@@ -1988,7 +1988,7 @@ impl<A: HalApi> Device<A> {
                 let format_features = self.describe_format_features(adapter, cs.format)?;
                 if !format_features
                     .allowed_usages
-                    .contains(wgt::TextureUsage::RENDER_ATTACHMENT)
+                    .contains(wgt::TextureUsages::RENDER_ATTACHMENT)
                 {
                     break Some(pipeline::ColorStateError::FormatNotRenderable(cs.format));
                 }
@@ -2011,7 +2011,7 @@ impl<A: HalApi> Device<A> {
                 if !self
                     .describe_format_features(adapter, ds.format)?
                     .allowed_usages
-                    .contains(wgt::TextureUsage::RENDER_ATTACHMENT)
+                    .contains(wgt::TextureUsages::RENDER_ATTACHMENT)
                 {
                     break Some(pipeline::DepthStencilStateError::FormatNotRenderable(
                         ds.format,
@@ -2543,8 +2543,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             if let Some(ref trace) = device.trace {
                 let mut desc = desc.clone();
                 let mapped_at_creation = mem::replace(&mut desc.mapped_at_creation, false);
-                if mapped_at_creation && !desc.usage.contains(wgt::BufferUsage::MAP_WRITE) {
-                    desc.usage |= wgt::BufferUsage::COPY_DST;
+                if mapped_at_creation && !desc.usage.contains(wgt::BufferUsages::MAP_WRITE) {
+                    desc.usage |= wgt::BufferUsages::COPY_DST;
                 }
                 trace
                     .lock()
@@ -2558,8 +2558,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let ref_count = buffer.life_guard.add_ref();
 
             let buffer_use = if !desc.mapped_at_creation {
-                hal::BufferUse::empty()
-            } else if desc.usage.contains(wgt::BufferUsage::MAP_WRITE) {
+                hal::BufferUses::empty()
+            } else if desc.usage.contains(wgt::BufferUsages::MAP_WRITE) {
                 // buffer is mappable, so we are just doing that at start
                 let map_size = buffer.size;
                 let ptr = match map_buffer(&device.raw, &mut buffer, 0, map_size, HostMap::Write) {
@@ -2577,13 +2577,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     range: 0..map_size,
                     host: HostMap::Write,
                 };
-                hal::BufferUse::MAP_WRITE
+                hal::BufferUses::MAP_WRITE
             } else {
                 // buffer needs staging area for initialization only
                 let stage_desc = wgt::BufferDescriptor {
                     label: Some(Cow::Borrowed("<init_buffer>")),
                     size: desc.size,
-                    usage: wgt::BufferUsage::MAP_WRITE | wgt::BufferUsage::COPY_SRC,
+                    usage: wgt::BufferUsages::MAP_WRITE | wgt::BufferUsages::COPY_SRC,
                     mapped_at_creation: false,
                 };
                 let mut stage = match device.create_buffer(device_id, &stage_desc, true) {
@@ -2623,7 +2623,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     needs_flush: !mapping.is_coherent,
                     stage_buffer,
                 };
-                hal::BufferUse::COPY_DST
+                hal::BufferUses::COPY_DST
             };
 
             let id = fid.assign(buffer, &mut token);
@@ -2686,7 +2686,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let buffer = buffer_guard
             .get_mut(buffer_id)
             .map_err(|_| resource::BufferAccessError::Invalid)?;
-        check_buffer_usage(buffer.usage, wgt::BufferUsage::MAP_WRITE)?;
+        check_buffer_usage(buffer.usage, wgt::BufferUsages::MAP_WRITE)?;
         //assert!(buffer isn't used by the GPU);
 
         #[cfg(feature = "trace")]
@@ -2743,7 +2743,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let buffer = buffer_guard
             .get_mut(buffer_id)
             .map_err(|_| resource::BufferAccessError::Invalid)?;
-        check_buffer_usage(buffer.usage, wgt::BufferUsage::MAP_READ)?;
+        check_buffer_usage(buffer.usage, wgt::BufferUsages::MAP_READ)?;
         //assert!(buffer isn't used by the GPU);
 
         let raw_buf = buffer.raw.as_ref().unwrap();
@@ -4409,8 +4409,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
         let (pub_usage, internal_use) = match op.host {
-            HostMap::Read => (wgt::BufferUsage::MAP_READ, hal::BufferUse::MAP_READ),
-            HostMap::Write => (wgt::BufferUsage::MAP_WRITE, hal::BufferUse::MAP_WRITE),
+            HostMap::Read => (wgt::BufferUsages::MAP_READ, hal::BufferUses::MAP_READ),
+            HostMap::Write => (wgt::BufferUsages::MAP_WRITE, hal::BufferUses::MAP_WRITE),
         };
 
         if range.start % wgt::MAP_ALIGNMENT != 0 || range.end % wgt::COPY_BUFFER_ALIGNMENT != 0 {
@@ -4580,11 +4580,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 });
                 let transition_src = hal::BufferBarrier {
                     buffer: &stage_buffer,
-                    usage: hal::BufferUse::MAP_WRITE..hal::BufferUse::COPY_SRC,
+                    usage: hal::BufferUses::MAP_WRITE..hal::BufferUses::COPY_SRC,
                 };
                 let transition_dst = hal::BufferBarrier {
                     buffer: raw_buf,
-                    usage: hal::BufferUse::empty()..hal::BufferUse::COPY_DST,
+                    usage: hal::BufferUses::empty()..hal::BufferUses::COPY_DST,
                 };
                 let encoder = device.pending_writes.activate();
                 unsafe {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -207,7 +207,7 @@ impl<A: hal::Api> super::Device<A> {
         let stage_desc = hal::BufferDescriptor {
             label: Some("_Staging"),
             size,
-            usage: hal::BufferUse::MAP_WRITE | hal::BufferUse::COPY_SRC,
+            usage: hal::BufferUses::MAP_WRITE | hal::BufferUses::COPY_SRC,
             memory_flags: hal::MemoryFlags::TRANSIENT,
         };
         let buffer = unsafe { self.raw.create_buffer(&stage_desc)? };
@@ -242,7 +242,7 @@ impl<A: hal::Api> super::Device<A> {
             let transition = trackers.buffers.change_replace_tracked(
                 id::Valid(buffer_id),
                 (),
-                hal::BufferUse::COPY_DST,
+                hal::BufferUses::COPY_DST,
             );
             let buffer = buffer_guard.get(buffer_id).unwrap();
             let raw_buf = buffer
@@ -339,13 +339,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut trackers = device.trackers.lock();
         let (dst, transition) = trackers
             .buffers
-            .use_replace(&*buffer_guard, buffer_id, (), hal::BufferUse::COPY_DST)
+            .use_replace(&*buffer_guard, buffer_id, (), hal::BufferUses::COPY_DST)
             .map_err(TransferError::InvalidBuffer)?;
         let dst_raw = dst
             .raw
             .as_ref()
             .ok_or(TransferError::InvalidBuffer(buffer_id))?;
-        if !dst.usage.contains(wgt::BufferUsage::COPY_DST) {
+        if !dst.usage.contains(wgt::BufferUsages::COPY_DST) {
             return Err(TransferError::MissingCopyDstUsageFlag(Some(buffer_id), None).into());
         }
         dst.life_guard.use_at(device.active_submission_index + 1);
@@ -373,7 +373,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         });
         let barriers = iter::once(hal::BufferBarrier {
             buffer: &stage.buffer,
-            usage: hal::BufferUse::MAP_WRITE..hal::BufferUse::COPY_SRC,
+            usage: hal::BufferUses::MAP_WRITE..hal::BufferUses::COPY_SRC,
         })
         .chain(transition.map(|pending| pending.into_hal(dst)));
         let encoder = device.pending_writes.activate();
@@ -482,7 +482,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 &*texture_guard,
                 destination.texture,
                 selector,
-                hal::TextureUse::COPY_DST,
+                hal::TextureUses::COPY_DST,
             )
             .unwrap();
         let dst_raw = dst
@@ -490,7 +490,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .as_ref()
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
 
-        if !dst.desc.usage.contains(wgt::TextureUsage::COPY_DST) {
+        if !dst.desc.usage.contains(wgt::TextureUsages::COPY_DST) {
             return Err(
                 TransferError::MissingCopyDstUsageFlag(None, Some(destination.texture)).into(),
             );
@@ -562,7 +562,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let barrier = hal::BufferBarrier {
             buffer: &stage.buffer,
-            usage: hal::BufferUse::MAP_WRITE..hal::BufferUse::COPY_SRC,
+            usage: hal::BufferUses::MAP_WRITE..hal::BufferUses::COPY_SRC,
         };
         let encoder = device.pending_writes.activate();
         unsafe {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -208,7 +208,7 @@ impl<A: hal::Api> super::Device<A> {
             label: Some("_Staging"),
             size,
             usage: hal::BufferUse::MAP_WRITE | hal::BufferUse::COPY_SRC,
-            memory_flags: hal::MemoryFlag::TRANSIENT,
+            memory_flags: hal::MemoryFlags::TRANSIENT,
         };
         let buffer = unsafe { self.raw.create_buffer(&stage_desc)? };
         Ok(StagingData { buffer })

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -750,7 +750,7 @@ pub struct Global<G: GlobalIdentityHandlerFactory> {
 }
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
-    pub fn new(name: &str, factory: G, backends: wgt::BackendBit) -> Self {
+    pub fn new(name: &str, factory: G, backends: wgt::Backends) -> Self {
         profiling::scope!("new", "Global");
         Self {
             instance: Instance::new(name, backends),

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -161,15 +161,15 @@ impl<A: HalApi> Adapter<A> {
 
         let mut allowed_usages = format.describe().guaranteed_format_features.allowed_usages;
         allowed_usages.set(
-            wgt::TextureUsage::SAMPLED,
+            wgt::TextureUsages::SAMPLED,
             caps.contains(hal::TextureFormatCapabilities::SAMPLED),
         );
         allowed_usages.set(
-            wgt::TextureUsage::STORAGE,
+            wgt::TextureUsages::STORAGE,
             caps.contains(hal::TextureFormatCapabilities::STORAGE),
         );
         allowed_usages.set(
-            wgt::TextureUsage::RENDER_ATTACHMENT,
+            wgt::TextureUsages::RENDER_ATTACHMENT,
             caps.intersects(
                 hal::TextureFormatCapabilities::COLOR_ATTACHMENT
                     | hal::TextureFormatCapabilities::DEPTH_STENCIL_ATTACHMENT,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -5,7 +5,7 @@ use crate::{
     LabelHelpers, LifeGuard, Stored, DOWNLEVEL_WARNING_MESSAGE,
 };
 
-use wgt::{Backend, BackendBit, PowerPreference, BIND_BUFFER_ALIGNMENT};
+use wgt::{Backend, Backends, PowerPreference, BIND_BUFFER_ALIGNMENT};
 
 use hal::{Adapter as _, Instance as _};
 use thiserror::Error;
@@ -30,13 +30,13 @@ pub struct Instance {
 }
 
 impl Instance {
-    pub fn new(name: &str, backends: BackendBit) -> Self {
-        fn init<A: HalApi>(mask: BackendBit) -> Option<A::Instance> {
+    pub fn new(name: &str, backends: Backends) -> Self {
+        fn init<A: HalApi>(mask: Backends) -> Option<A::Instance> {
             if mask.contains(A::VARIANT.into()) {
-                let mut flags = hal::InstanceFlag::empty();
+                let mut flags = hal::InstanceFlags::empty();
                 if cfg!(debug_assertions) {
-                    flags |= hal::InstanceFlag::VALIDATION;
-                    flags |= hal::InstanceFlag::DEBUG;
+                    flags |= hal::InstanceFlags::VALIDATION;
+                    flags |= hal::InstanceFlags::DEBUG;
                 }
                 let hal_desc = hal::InstanceDescriptor {
                     name: "wgpu",
@@ -162,31 +162,31 @@ impl<A: HalApi> Adapter<A> {
         let mut allowed_usages = format.describe().guaranteed_format_features.allowed_usages;
         allowed_usages.set(
             wgt::TextureUsage::SAMPLED,
-            caps.contains(hal::TextureFormatCapability::SAMPLED),
+            caps.contains(hal::TextureFormatCapabilities::SAMPLED),
         );
         allowed_usages.set(
             wgt::TextureUsage::STORAGE,
-            caps.contains(hal::TextureFormatCapability::STORAGE),
+            caps.contains(hal::TextureFormatCapabilities::STORAGE),
         );
         allowed_usages.set(
             wgt::TextureUsage::RENDER_ATTACHMENT,
             caps.intersects(
-                hal::TextureFormatCapability::COLOR_ATTACHMENT
-                    | hal::TextureFormatCapability::DEPTH_STENCIL_ATTACHMENT,
+                hal::TextureFormatCapabilities::COLOR_ATTACHMENT
+                    | hal::TextureFormatCapabilities::DEPTH_STENCIL_ATTACHMENT,
             ),
         );
 
         let mut flags = wgt::TextureFormatFeatureFlags::empty();
         flags.set(
             wgt::TextureFormatFeatureFlags::STORAGE_ATOMICS,
-            caps.contains(hal::TextureFormatCapability::STORAGE_ATOMIC),
+            caps.contains(hal::TextureFormatCapabilities::STORAGE_ATOMIC),
         );
         flags.set(
             wgt::TextureFormatFeatureFlags::STORAGE_READ_WRITE,
-            caps.contains(hal::TextureFormatCapability::STORAGE_READ_WRITE),
+            caps.contains(hal::TextureFormatCapabilities::STORAGE_READ_WRITE),
         );
 
-        let filterable = caps.contains(hal::TextureFormatCapability::SAMPLED_LINEAR);
+        let filterable = caps.contains(hal::TextureFormatCapabilities::SAMPLED_LINEAR);
 
         wgt::TextureFormatFeatures {
             allowed_usages,
@@ -307,7 +307,7 @@ pub enum RequestDeviceError {
 
 pub enum AdapterInputs<'a, I> {
     IdSet(&'a [I], fn(&I) -> Backend),
-    Mask(BackendBit, fn(Backend) -> I),
+    Mask(Backends, fn(Backend) -> I),
 }
 
 impl<I: Clone> AdapterInputs<'_, I> {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -78,7 +78,7 @@ pub enum ImplicitLayoutError {
     #[error("missing IDs for deriving {0} bind groups")]
     MissingIds(ImplicitBindGroupCount),
     #[error("unable to reflect the shader {0:?} interface")]
-    ReflectionError(wgt::ShaderStage),
+    ReflectionError(wgt::ShaderStages),
     #[error(transparent)]
     BindGroup(#[from] CreateBindGroupLayoutError),
     #[error(transparent)]
@@ -259,13 +259,13 @@ pub enum CreateRenderPipelineError {
     MissingDownlevelFlags(#[from] MissingDownlevelFlags),
     #[error("error matching {stage:?} shader requirements against the pipeline")]
     Stage {
-        stage: wgt::ShaderStage,
+        stage: wgt::ShaderStages,
         #[source]
         error: validation::StageError,
     },
     #[error("Internal error in {stage:?} shader: {error}")]
     Internal {
-        stage: wgt::ShaderStage,
+        stage: wgt::ShaderStages,
         error: String,
     },
 }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -251,8 +251,8 @@ pub(crate) struct HalTextureViewDescriptor {
 }
 
 impl HalTextureViewDescriptor {
-    pub fn aspects(&self) -> hal::FormatAspect {
-        hal::FormatAspect::from(self.format) & hal::FormatAspect::from(self.range.aspect)
+    pub fn aspects(&self) -> hal::FormatAspects {
+        hal::FormatAspects::from(self.format) & hal::FormatAspects::from(self.range.aspect)
     }
 }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -118,7 +118,7 @@ pub type BufferDescriptor<'a> = wgt::BufferDescriptor<Label<'a>>;
 pub struct Buffer<A: hal::Api> {
     pub(crate) raw: Option<A::Buffer>,
     pub(crate) device_id: Stored<DeviceId>,
-    pub(crate) usage: wgt::BufferUsage,
+    pub(crate) usage: wgt::BufferUsages,
     pub(crate) size: wgt::BufferAddress,
     pub(crate) initialization_status: MemoryInitTracker,
     pub(crate) sync_mapped_writes: Option<hal::MemoryRange>,
@@ -137,7 +137,7 @@ pub enum CreateBufferError {
     #[error("Buffers cannot have empty usage flags")]
     EmptyUsage,
     #[error("`MAP` usage can only be combined with the opposite `COPY`, requested {0:?}")]
-    UsageMismatch(wgt::BufferUsage),
+    UsageMismatch(wgt::BufferUsages),
 }
 
 impl<A: hal::Api> Resource for Buffer<A> {
@@ -161,7 +161,7 @@ pub struct Texture<A: hal::Api> {
     pub(crate) raw: Option<A::Texture>,
     pub(crate) device_id: Stored<DeviceId>,
     pub(crate) desc: wgt::TextureDescriptor<()>,
-    pub(crate) hal_usage: hal::TextureUse,
+    pub(crate) hal_usage: hal::TextureUses,
     pub(crate) format_features: wgt::TextureFormatFeatures,
     pub(crate) full_range: TextureSelector,
     pub(crate) life_guard: LifeGuard,
@@ -201,7 +201,7 @@ pub enum CreateTextureError {
     #[error("texture descriptor mip level count ({0}) is invalid")]
     InvalidMipLevelCount(u32),
     #[error("The texture usages {0:?} are not allowed on a texture of type {1:?}")]
-    InvalidUsages(wgt::TextureUsage, wgt::TextureFormat),
+    InvalidUsages(wgt::TextureUsages, wgt::TextureFormat),
     #[error("Texture format {0:?} can't be used")]
     MissingFeatures(wgt::TextureFormat, #[source] MissingFeatures),
 }
@@ -266,7 +266,7 @@ pub struct TextureView<A: hal::Api> {
     pub(crate) extent: wgt::Extent3d,
     pub(crate) samples: u32,
     /// Internal use of this texture view when used as `BindingType::Texture`.
-    pub(crate) sampled_internal_use: hal::TextureUse,
+    pub(crate) sampled_internal_use: hal::TextureUses,
     pub(crate) selector: TextureSelector,
     pub(crate) life_guard: LifeGuard,
 }

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -170,7 +170,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             label: Some("_Frame"),
             format: sc.desc.format,
             dimension: wgt::TextureViewDimension::D2,
-            usage: hal::TextureUse::COLOR_TARGET,
+            usage: hal::TextureUses::COLOR_TARGET,
             range: wgt::ImageSubresourceRange::default(),
         };
 
@@ -194,7 +194,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         range: wgt::ImageSubresourceRange::default(),
                     },
                     format_features: wgt::TextureFormatFeatures {
-                        allowed_usages: wgt::TextureUsage::RENDER_ATTACHMENT,
+                        allowed_usages: wgt::TextureUsages::RENDER_ATTACHMENT,
                         flags: wgt::TextureFormatFeatureFlags::empty(),
                         filterable: false,
                     },
@@ -204,7 +204,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         depth_or_array_layers: 1,
                     },
                     samples: 1,
-                    sampled_internal_use: hal::TextureUse::empty(),
+                    sampled_internal_use: hal::TextureUses::empty(),
                     selector: TextureSelector {
                         layers: 0..1,
                         levels: 0..1,

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -558,14 +558,14 @@ pub enum UsageConflict {
     )]
     Buffer {
         id: id::BufferId,
-        combined_use: hal::BufferUse,
+        combined_use: hal::BufferUses,
     },
     #[error("Attempted to use texture {id:?} mips {mip_levels:?} layers {array_layers:?} as a combination of {combined_use:?} within a usage scope.")]
     Texture {
         id: id::TextureId,
         mip_levels: ops::Range<u32>,
         array_layers: ops::Range<u32>,
-        combined_use: hal::TextureUse,
+        combined_use: hal::TextureUses,
     },
 }
 

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -11,7 +11,7 @@ type PlaneStates = RangedStates<u32, Unit<TextureUse>>;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TextureSelector {
     //TODO: rename to `mip_levels` and `array_layers` for consistency
-    //pub aspects: hal::FormatAspect,
+    //pub aspects: hal::FormatAspects,
     pub levels: Range<u32>,
     pub layers: Range<u32>,
 }

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -864,15 +864,15 @@ impl Interface {
         given_layouts: Option<&[&BindEntryMap]>,
         derived_layouts: &mut [BindEntryMap],
         entry_point_name: &str,
-        stage_bit: wgt::ShaderStage,
+        stage_bit: wgt::ShaderStages,
         inputs: StageIo,
     ) -> Result<StageIo, StageError> {
         // Since a shader module can have multiple entry points with the same name,
         // we need to look for one with the right execution model.
         let shader_stage = match stage_bit {
-            wgt::ShaderStage::VERTEX => naga::ShaderStage::Vertex,
-            wgt::ShaderStage::FRAGMENT => naga::ShaderStage::Fragment,
-            wgt::ShaderStage::COMPUTE => naga::ShaderStage::Compute,
+            wgt::ShaderStages::VERTEX => naga::ShaderStage::Vertex,
+            wgt::ShaderStages::FRAGMENT => naga::ShaderStage::Fragment,
+            wgt::ShaderStages::COMPUTE => naga::ShaderStage::Compute,
             _ => unreachable!(),
         };
         let pair = (shader_stage, entry_point_name.to_string());

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -114,15 +114,15 @@ pub struct Interface {
 #[derive(Clone, Debug, Error)]
 #[error("buffer usage is {actual:?} which does not contain required usage {expected:?}")]
 pub struct MissingBufferUsageError {
-    pub(crate) actual: wgt::BufferUsage,
-    pub(crate) expected: wgt::BufferUsage,
+    pub(crate) actual: wgt::BufferUsages,
+    pub(crate) expected: wgt::BufferUsages,
 }
 
 /// Checks that the given buffer usage contains the required buffer usage,
 /// returns an error otherwise.
 pub fn check_buffer_usage(
-    actual: wgt::BufferUsage,
-    expected: wgt::BufferUsage,
+    actual: wgt::BufferUsages,
+    expected: wgt::BufferUsages,
 ) -> Result<(), MissingBufferUsageError> {
     if !actual.contains(expected) {
         Err(MissingBufferUsageError { actual, expected })
@@ -134,15 +134,15 @@ pub fn check_buffer_usage(
 #[derive(Clone, Debug, Error)]
 #[error("texture usage is {actual:?} which does not contain required usage {expected:?}")]
 pub struct MissingTextureUsageError {
-    pub(crate) actual: wgt::TextureUsage,
-    pub(crate) expected: wgt::TextureUsage,
+    pub(crate) actual: wgt::TextureUsages,
+    pub(crate) expected: wgt::TextureUsages,
 }
 
 /// Checks that the given texture usage contains the required texture usage,
 /// returns an error otherwise.
 pub fn check_texture_usage(
-    actual: wgt::TextureUsage,
-    expected: wgt::TextureUsage,
+    actual: wgt::TextureUsages,
+    expected: wgt::TextureUsages,
 ) -> Result<(), MissingTextureUsageError> {
     if !actual.contains(expected) {
         Err(MissingTextureUsageError { actual, expected })

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -80,9 +80,9 @@ impl<A: hal::Api> Example<A> {
         let instance_desc = hal::InstanceDescriptor {
             name: "example",
             flags: if cfg!(debug_assertions) {
-                hal::InstanceFlag::all()
+                hal::InstanceFlags::all()
             } else {
-                hal::InstanceFlag::empty()
+                hal::InstanceFlags::empty()
             },
         };
         let instance = unsafe { A::Instance::init(&instance_desc)? };
@@ -147,7 +147,7 @@ impl<A: hal::Api> Example<A> {
             entries: &[
                 wgt::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgt::ShaderStage::VERTEX,
+                    visibility: wgt::ShaderStages::VERTEX,
                     ty: wgt::BindingType::Buffer {
                         ty: wgt::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
@@ -157,7 +157,7 @@ impl<A: hal::Api> Example<A> {
                 },
                 wgt::BindGroupLayoutEntry {
                     binding: 1,
-                    visibility: wgt::ShaderStage::FRAGMENT,
+                    visibility: wgt::ShaderStages::FRAGMENT,
                     ty: wgt::BindingType::Texture {
                         sample_type: wgt::TextureSampleType::Float { filterable: true },
                         view_dimension: wgt::TextureViewDimension::D2,
@@ -167,7 +167,7 @@ impl<A: hal::Api> Example<A> {
                 },
                 wgt::BindGroupLayoutEntry {
                     binding: 2,
-                    visibility: wgt::ShaderStage::FRAGMENT,
+                    visibility: wgt::ShaderStages::FRAGMENT,
                     ty: wgt::BindingType::Sampler {
                         filtering: true,
                         comparison: false,
@@ -183,7 +183,7 @@ impl<A: hal::Api> Example<A> {
         let local_bgl_desc = hal::BindGroupLayoutDescriptor {
             entries: &[wgt::BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgt::ShaderStage::VERTEX,
+                visibility: wgt::ShaderStages::VERTEX,
                 ty: wgt::BindingType::Buffer {
                     ty: wgt::BufferBindingType::Uniform,
                     has_dynamic_offset: true,
@@ -239,7 +239,7 @@ impl<A: hal::Api> Example<A> {
             label: Some("stage"),
             size: texture_data.len() as wgt::BufferAddress,
             usage: hal::BufferUse::MAP_WRITE | hal::BufferUse::COPY_SRC,
-            memory_flags: hal::MemoryFlag::TRANSIENT | hal::MemoryFlag::PREFER_COHERENT,
+            memory_flags: hal::MemoryFlags::TRANSIENT | hal::MemoryFlags::PREFER_COHERENT,
         };
         let staging_buffer = unsafe { device.create_buffer(&staging_buffer_desc).unwrap() };
         unsafe {
@@ -267,7 +267,7 @@ impl<A: hal::Api> Example<A> {
             dimension: wgt::TextureDimension::D2,
             format: wgt::TextureFormat::Rgba8UnormSrgb,
             usage: hal::TextureUse::COPY_DST | hal::TextureUse::SAMPLED,
-            memory_flags: hal::MemoryFlag::empty(),
+            memory_flags: hal::MemoryFlags::empty(),
         };
         let texture = unsafe { device.create_texture(&texture_desc).unwrap() };
 
@@ -301,7 +301,7 @@ impl<A: hal::Api> Example<A> {
                 texture_base: hal::TextureCopyBase {
                     origin: wgt::Origin3d::ZERO,
                     mip_level: 0,
-                    aspect: hal::FormatAspect::COLOR,
+                    aspect: hal::FormatAspects::COLOR,
                 },
                 size: texture_desc.size,
             };
@@ -342,7 +342,7 @@ impl<A: hal::Api> Example<A> {
             label: Some("global"),
             size: mem::size_of::<Globals>() as wgt::BufferAddress,
             usage: hal::BufferUse::MAP_WRITE | hal::BufferUse::UNIFORM,
-            memory_flags: hal::MemoryFlag::PREFER_COHERENT,
+            memory_flags: hal::MemoryFlags::PREFER_COHERENT,
         };
         let global_buffer = unsafe {
             let buffer = device.create_buffer(&global_buffer_desc).unwrap();
@@ -363,7 +363,7 @@ impl<A: hal::Api> Example<A> {
             label: Some("local"),
             size: (MAX_BUNNIES as wgt::BufferAddress) * wgt::BIND_BUFFER_ALIGNMENT,
             usage: hal::BufferUse::MAP_WRITE | hal::BufferUse::UNIFORM,
-            memory_flags: hal::MemoryFlag::PREFER_COHERENT,
+            memory_flags: hal::MemoryFlags::PREFER_COHERENT,
         };
         let local_buffer = unsafe { device.create_buffer(&local_buffer_desc).unwrap() };
 
@@ -614,7 +614,7 @@ impl<A: hal::Api> Example<A> {
                     boundary_usage: hal::TextureUse::UNINITIALIZED..hal::TextureUse::empty(),
                 },
                 resolve_target: None,
-                ops: hal::AttachmentOp::STORE,
+                ops: hal::AttachmentOps::STORE,
                 clear_value: wgt::Color {
                     r: 0.1,
                     g: 0.2,

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -114,7 +114,7 @@ impl<A: hal::Api> Example<A> {
                 height: window_size.1,
                 depth_or_array_layers: 1,
             },
-            usage: hal::TextureUse::COLOR_TARGET,
+            usage: hal::TextureUses::COLOR_TARGET,
         };
         unsafe {
             surface.configure(&device, &surface_config).unwrap();
@@ -228,7 +228,7 @@ impl<A: hal::Api> Example<A> {
             color_targets: &[wgt::ColorTargetState {
                 format: surface_config.format,
                 blend: Some(wgt::BlendState::ALPHA_BLENDING),
-                write_mask: wgt::ColorWrite::default(),
+                write_mask: wgt::ColorWrites::default(),
             }],
         };
         let pipeline = unsafe { device.create_render_pipeline(&pipeline_desc).unwrap() };
@@ -238,7 +238,7 @@ impl<A: hal::Api> Example<A> {
         let staging_buffer_desc = hal::BufferDescriptor {
             label: Some("stage"),
             size: texture_data.len() as wgt::BufferAddress,
-            usage: hal::BufferUse::MAP_WRITE | hal::BufferUse::COPY_SRC,
+            usage: hal::BufferUses::MAP_WRITE | hal::BufferUses::COPY_SRC,
             memory_flags: hal::MemoryFlags::TRANSIENT | hal::MemoryFlags::PREFER_COHERENT,
         };
         let staging_buffer = unsafe { device.create_buffer(&staging_buffer_desc).unwrap() };
@@ -266,7 +266,7 @@ impl<A: hal::Api> Example<A> {
             sample_count: 1,
             dimension: wgt::TextureDimension::D2,
             format: wgt::TextureFormat::Rgba8UnormSrgb,
-            usage: hal::TextureUse::COPY_DST | hal::TextureUse::SAMPLED,
+            usage: hal::TextureUses::COPY_DST | hal::TextureUses::SAMPLED,
             memory_flags: hal::MemoryFlags::empty(),
         };
         let texture = unsafe { device.create_texture(&texture_desc).unwrap() };
@@ -280,17 +280,17 @@ impl<A: hal::Api> Example<A> {
         {
             let buffer_barrier = hal::BufferBarrier {
                 buffer: &staging_buffer,
-                usage: hal::BufferUse::empty()..hal::BufferUse::COPY_SRC,
+                usage: hal::BufferUses::empty()..hal::BufferUses::COPY_SRC,
             };
             let texture_barrier1 = hal::TextureBarrier {
                 texture: &texture,
                 range: wgt::ImageSubresourceRange::default(),
-                usage: hal::TextureUse::UNINITIALIZED..hal::TextureUse::COPY_DST,
+                usage: hal::TextureUses::UNINITIALIZED..hal::TextureUses::COPY_DST,
             };
             let texture_barrier2 = hal::TextureBarrier {
                 texture: &texture,
                 range: wgt::ImageSubresourceRange::default(),
-                usage: hal::TextureUse::COPY_DST..hal::TextureUse::SAMPLED,
+                usage: hal::TextureUses::COPY_DST..hal::TextureUses::SAMPLED,
             };
             let copy = hal::BufferTextureCopy {
                 buffer_layout: wgt::ImageDataLayout {
@@ -341,7 +341,7 @@ impl<A: hal::Api> Example<A> {
         let global_buffer_desc = hal::BufferDescriptor {
             label: Some("global"),
             size: mem::size_of::<Globals>() as wgt::BufferAddress,
-            usage: hal::BufferUse::MAP_WRITE | hal::BufferUse::UNIFORM,
+            usage: hal::BufferUses::MAP_WRITE | hal::BufferUses::UNIFORM,
             memory_flags: hal::MemoryFlags::PREFER_COHERENT,
         };
         let global_buffer = unsafe {
@@ -362,7 +362,7 @@ impl<A: hal::Api> Example<A> {
         let local_buffer_desc = hal::BufferDescriptor {
             label: Some("local"),
             size: (MAX_BUNNIES as wgt::BufferAddress) * wgt::BIND_BUFFER_ALIGNMENT,
-            usage: hal::BufferUse::MAP_WRITE | hal::BufferUse::UNIFORM,
+            usage: hal::BufferUses::MAP_WRITE | hal::BufferUses::UNIFORM,
             memory_flags: hal::MemoryFlags::PREFER_COHERENT,
         };
         let local_buffer = unsafe { device.create_buffer(&local_buffer_desc).unwrap() };
@@ -371,7 +371,7 @@ impl<A: hal::Api> Example<A> {
             label: None,
             format: texture_desc.format,
             dimension: wgt::TextureViewDimension::D2,
-            usage: hal::TextureUse::SAMPLED,
+            usage: hal::TextureUses::SAMPLED,
             range: wgt::ImageSubresourceRange::default(),
         };
         let texture_view = unsafe { device.create_texture_view(&texture, &view_desc).unwrap() };
@@ -384,7 +384,7 @@ impl<A: hal::Api> Example<A> {
             };
             let texture_binding = hal::TextureBinding {
                 view: &texture_view,
-                usage: hal::TextureUse::SAMPLED,
+                usage: hal::TextureUses::SAMPLED,
             };
             let global_group_desc = hal::BindGroupDescriptor {
                 label: Some("global"),
@@ -591,7 +591,7 @@ impl<A: hal::Api> Example<A> {
             label: None,
             format: self.surface_format,
             dimension: wgt::TextureViewDimension::D2,
-            usage: hal::TextureUse::COLOR_TARGET,
+            usage: hal::TextureUses::COLOR_TARGET,
             range: wgt::ImageSubresourceRange::default(),
         };
         let surface_tex_view = unsafe {
@@ -610,8 +610,8 @@ impl<A: hal::Api> Example<A> {
             color_attachments: &[hal::ColorAttachment {
                 target: hal::Attachment {
                     view: &surface_tex_view,
-                    usage: hal::TextureUse::COLOR_TARGET,
-                    boundary_usage: hal::TextureUse::UNINITIALIZED..hal::TextureUse::empty(),
+                    usage: hal::TextureUses::COLOR_TARGET,
+                    boundary_usage: hal::TextureUses::UNINITIALIZED..hal::TextureUses::empty(),
                 },
                 resolve_target: None,
                 ops: hal::AttachmentOps::STORE,

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -80,8 +80,8 @@ impl crate::Adapter<Api> for Context {
     unsafe fn texture_format_capabilities(
         &self,
         format: wgt::TextureFormat,
-    ) -> crate::TextureFormatCapability {
-        crate::TextureFormatCapability::empty()
+    ) -> crate::TextureFormatCapabilities {
+        crate::TextureFormatCapabilities::empty()
     }
     unsafe fn surface_capabilities(&self, surface: &Context) -> Option<crate::SurfaceCapabilities> {
         None
@@ -299,7 +299,7 @@ impl crate::CommandEncoder<Api> for Encoder {
     unsafe fn set_push_constants(
         &mut self,
         layout: &Resource,
-        stages: wgt::ShaderStage,
+        stages: wgt::ShaderStages,
         offset: u32,
         data: &[u32],
     ) {

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -252,7 +252,7 @@ impl crate::CommandEncoder<Api> for Encoder {
     unsafe fn copy_texture_to_texture<T>(
         &mut self,
         src: &Resource,
-        src_usage: crate::TextureUse,
+        src_usage: crate::TextureUses,
         dst: &Resource,
         regions: T,
     ) {
@@ -263,7 +263,7 @@ impl crate::CommandEncoder<Api> for Encoder {
     unsafe fn copy_texture_to_buffer<T>(
         &mut self,
         src: &Resource,
-        src_usage: crate::TextureUse,
+        src_usage: crate::TextureUses,
         dst: &Resource,
         regions: T,
     ) {

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -450,7 +450,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
                     height: 4096,
                     depth_or_array_layers: 1,
                 },
-                usage: crate::TextureUse::COLOR_TARGET,
+                usage: crate::TextureUses::COLOR_TARGET,
             })
         } else {
             None

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -251,18 +251,18 @@ impl super::Adapter {
             max_push_constant_size: 0,
         };
 
-        let mut private_caps = super::PrivateCapability::empty();
+        let mut private_caps = super::PrivateCapabilities::empty();
         private_caps.set(
-            super::PrivateCapability::SHADER_BINDING_LAYOUT,
+            super::PrivateCapabilities::SHADER_BINDING_LAYOUT,
             ver >= (3, 1),
         );
         private_caps.set(
-            super::PrivateCapability::SHADER_TEXTURE_SHADOW_LOD,
+            super::PrivateCapabilities::SHADER_TEXTURE_SHADOW_LOD,
             extensions.contains("GL_EXT_texture_shadow_lod"),
         );
-        private_caps.set(super::PrivateCapability::MEMORY_BARRIERS, ver >= (3, 1));
+        private_caps.set(super::PrivateCapabilities::MEMORY_BARRIERS, ver >= (3, 1));
         private_caps.set(
-            super::PrivateCapability::VERTEX_BUFFER_LAYOUT,
+            super::PrivateCapabilities::VERTEX_BUFFER_LAYOUT,
             ver >= (3, 1),
         );
 
@@ -345,8 +345,8 @@ impl crate::Adapter<super::Api> for super::Adapter {
     unsafe fn texture_format_capabilities(
         &self,
         format: wgt::TextureFormat,
-    ) -> crate::TextureFormatCapability {
-        use crate::TextureFormatCapability as Tfc;
+    ) -> crate::TextureFormatCapabilities {
+        use crate::TextureFormatCapabilities as Tfc;
         use wgt::TextureFormat as Tf;
         // The storage types are sprinkled based on section
         // "TEXTURE IMAGE LOADS AND STORES" of GLES-3.2 spec.

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -196,7 +196,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         }
         for bar in barriers {
             // GLES only synchronizes storage -> anything explicitly
-            if !bar.usage.start.contains(crate::BufferUse::STORAGE_STORE) {
+            if !bar.usage.start.contains(crate::BufferUses::STORAGE_STORE) {
                 continue;
             }
             self.cmd_buffer
@@ -216,10 +216,10 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             return;
         }
 
-        let mut combined_usage = crate::TextureUse::empty();
+        let mut combined_usage = crate::TextureUses::empty();
         for bar in barriers {
             // GLES only synchronizes storage -> anything explicitly
-            if !bar.usage.start.contains(crate::TextureUse::STORAGE_STORE) {
+            if !bar.usage.start.contains(crate::TextureUses::STORAGE_STORE) {
                 continue;
             }
             // unlike buffers, there is no need for a concrete texture
@@ -267,7 +267,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     unsafe fn copy_texture_to_texture<T>(
         &mut self,
         src: &super::Texture,
-        _src_usage: crate::TextureUse,
+        _src_usage: crate::TextureUses,
         dst: &super::Texture,
         regions: T,
     ) where
@@ -310,7 +310,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     unsafe fn copy_texture_to_buffer<T>(
         &mut self,
         src: &super::Texture,
-        _src_usage: crate::TextureUse,
+        _src_usage: crate::TextureUses,
         dst: &super::Buffer,
         regions: T,
     ) where

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -72,7 +72,7 @@ impl super::CommandEncoder {
     fn rebind_vertex_data(&mut self, first_instance: u32) {
         if self
             .private_caps
-            .contains(super::PrivateCapability::VERTEX_BUFFER_LAYOUT)
+            .contains(super::PrivateCapabilities::VERTEX_BUFFER_LAYOUT)
         {
             for (index, &(ref vb_desc, ref vb)) in self.state.vertex_buffers.iter().enumerate() {
                 if self.state.dirty_vbuf_mask & (1 << index) == 0 {
@@ -190,7 +190,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     {
         if !self
             .private_caps
-            .contains(super::PrivateCapability::MEMORY_BARRIERS)
+            .contains(super::PrivateCapabilities::MEMORY_BARRIERS)
         {
             return;
         }
@@ -211,7 +211,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     {
         if !self
             .private_caps
-            .contains(super::PrivateCapability::MEMORY_BARRIERS)
+            .contains(super::PrivateCapabilities::MEMORY_BARRIERS)
         {
             return;
         }
@@ -390,30 +390,30 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     .resolve_attachments
                     .push((attachment, rat.view.clone()));
             }
-            if !cat.ops.contains(crate::AttachmentOp::STORE) {
+            if !cat.ops.contains(crate::AttachmentOps::STORE) {
                 self.state.invalidate_attachments.push(attachment);
             }
         }
         if let Some(ref dsat) = desc.depth_stencil_attachment {
             let aspects = dsat.target.view.aspects;
             let attachment = match aspects {
-                crate::FormatAspect::DEPTH => glow::DEPTH_ATTACHMENT,
-                crate::FormatAspect::STENCIL => glow::STENCIL_ATTACHMENT,
+                crate::FormatAspects::DEPTH => glow::DEPTH_ATTACHMENT,
+                crate::FormatAspects::STENCIL => glow::STENCIL_ATTACHMENT,
                 _ => glow::DEPTH_STENCIL_ATTACHMENT,
             };
             self.cmd_buffer.commands.push(C::BindAttachment {
                 attachment,
                 view: dsat.target.view.clone(),
             });
-            if aspects.contains(crate::FormatAspect::DEPTH)
-                && !dsat.depth_ops.contains(crate::AttachmentOp::STORE)
+            if aspects.contains(crate::FormatAspects::DEPTH)
+                && !dsat.depth_ops.contains(crate::AttachmentOps::STORE)
             {
                 self.state
                     .invalidate_attachments
                     .push(glow::DEPTH_ATTACHMENT);
             }
-            if aspects.contains(crate::FormatAspect::STENCIL)
-                && !dsat.stencil_ops.contains(crate::AttachmentOp::STORE)
+            if aspects.contains(crate::FormatAspects::STENCIL)
+                && !dsat.stencil_ops.contains(crate::AttachmentOps::STORE)
             {
                 self.state
                     .invalidate_attachments
@@ -439,7 +439,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 
         // issue the clears
         for (i, cat) in desc.color_attachments.iter().enumerate() {
-            if !cat.ops.contains(crate::AttachmentOp::LOAD) {
+            if !cat.ops.contains(crate::AttachmentOps::LOAD) {
                 let c = &cat.clear_value;
                 self.cmd_buffer
                     .commands
@@ -461,12 +461,12 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             }
         }
         if let Some(ref dsat) = desc.depth_stencil_attachment {
-            if !dsat.depth_ops.contains(crate::AttachmentOp::LOAD) {
+            if !dsat.depth_ops.contains(crate::AttachmentOps::LOAD) {
                 self.cmd_buffer
                     .commands
                     .push(C::ClearDepth(dsat.clear_value.0));
             }
-            if !dsat.stencil_ops.contains(crate::AttachmentOp::LOAD) {
+            if !dsat.stencil_ops.contains(crate::AttachmentOps::LOAD) {
                 self.cmd_buffer
                     .commands
                     .push(C::ClearStencil(dsat.clear_value.1));
@@ -574,7 +574,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     unsafe fn set_push_constants(
         &mut self,
         _layout: &super::PipelineLayout,
-        _stages: wgt::ShaderStage,
+        _stages: wgt::ShaderStages,
         _offset: u32,
         _data: &[u32],
     ) {
@@ -604,7 +604,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 
         if self
             .private_caps
-            .contains(super::PrivateCapability::VERTEX_BUFFER_LAYOUT)
+            .contains(super::PrivateCapabilities::VERTEX_BUFFER_LAYOUT)
         {
             for vat in pipeline.vertex_attributes.iter() {
                 let vb = &pipeline.vertex_buffers[vat.buffer_index as usize];
@@ -655,7 +655,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         }
 
         // set depth/stencil states
-        let mut aspects = crate::FormatAspect::empty();
+        let mut aspects = crate::FormatAspects::empty();
         if pipeline.depth_bias != self.state.depth_bias {
             self.state.depth_bias = pipeline.depth_bias;
             self.cmd_buffer
@@ -663,11 +663,11 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 .push(C::SetDepthBias(pipeline.depth_bias));
         }
         if let Some(ref depth) = pipeline.depth {
-            aspects |= crate::FormatAspect::DEPTH;
+            aspects |= crate::FormatAspects::DEPTH;
             self.cmd_buffer.commands.push(C::SetDepth(depth.clone()));
         }
         if let Some(ref stencil) = pipeline.stencil {
-            aspects |= crate::FormatAspect::STENCIL;
+            aspects |= crate::FormatAspects::STENCIL;
             self.state.stencil = stencil.clone();
             self.rebind_stencil_func();
             if stencil.front.ops == stencil.back.ops

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -300,7 +300,7 @@ impl crate::Device<super::Api> for super::Device {
     ) -> Result<super::Buffer, crate::DeviceError> {
         let gl = &self.shared.context;
 
-        let target = if desc.usage.contains(crate::BufferUse::INDEX) {
+        let target = if desc.usage.contains(crate::BufferUses::INDEX) {
             glow::ELEMENT_ARRAY_BUFFER
         } else {
             glow::ARRAY_BUFFER
@@ -308,7 +308,7 @@ impl crate::Device<super::Api> for super::Device {
 
         let is_host_visible = desc
             .usage
-            .intersects(crate::BufferUse::MAP_READ | crate::BufferUse::MAP_WRITE);
+            .intersects(crate::BufferUses::MAP_READ | crate::BufferUses::MAP_WRITE);
         let is_coherent = desc
             .memory_flags
             .contains(crate::MemoryFlags::PREFER_COHERENT);
@@ -320,10 +320,10 @@ impl crate::Device<super::Api> for super::Device {
                 map_flags |= glow::MAP_COHERENT_BIT;
             }
         }
-        if desc.usage.contains(crate::BufferUse::MAP_READ) {
+        if desc.usage.contains(crate::BufferUses::MAP_READ) {
             map_flags |= glow::MAP_READ_BIT;
         }
-        if desc.usage.contains(crate::BufferUse::MAP_WRITE) {
+        if desc.usage.contains(crate::BufferUses::MAP_WRITE) {
             map_flags |= glow::MAP_WRITE_BIT;
         }
 
@@ -336,7 +336,7 @@ impl crate::Device<super::Api> for super::Device {
         gl.buffer_storage(target, raw_size, None, map_flags);
         gl.bind_buffer(target, None);
 
-        if !is_coherent && desc.usage.contains(crate::BufferUse::MAP_WRITE) {
+        if !is_coherent && desc.usage.contains(crate::BufferUses::MAP_WRITE) {
             map_flags |= glow::MAP_FLUSH_EXPLICIT_BIT;
         }
         //TODO: do we need `glow::MAP_UNSYNCHRONIZED_BIT`?
@@ -413,9 +413,9 @@ impl crate::Device<super::Api> for super::Device {
     ) -> Result<super::Texture, crate::DeviceError> {
         let gl = &self.shared.context;
 
-        let render_usage = crate::TextureUse::COLOR_TARGET
-            | crate::TextureUse::DEPTH_STENCIL_WRITE
-            | crate::TextureUse::DEPTH_STENCIL_READ;
+        let render_usage = crate::TextureUses::COLOR_TARGET
+            | crate::TextureUses::DEPTH_STENCIL_WRITE
+            | crate::TextureUses::DEPTH_STENCIL_READ;
         let format_desc = self.shared.describe_texture_format(desc.format);
 
         let inner = if render_usage.contains(desc.usage)

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -175,7 +175,7 @@ impl super::Device {
 
         let mut name_binding_map = NameBindingMap::default();
         let mut sampler_map = [None; super::MAX_TEXTURE_SLOTS];
-        let mut has_stages = wgt::ShaderStage::empty();
+        let mut has_stages = wgt::ShaderStages::empty();
         let mut shaders_to_delete = arrayvec::ArrayVec::<[_; 3]>::new();
 
         for (naga_stage, stage) in shaders {
@@ -191,7 +191,7 @@ impl super::Device {
         }
 
         // Create empty fragment shader if only vertex shader is present
-        if has_stages == wgt::ShaderStage::VERTEX {
+        if has_stages == wgt::ShaderStages::VERTEX {
             let version = match self.shared.shading_language_version {
                 naga::back::glsl::Version::Embedded(v) => v,
                 naga::back::glsl::Version::Desktop(_) => unreachable!(),
@@ -226,7 +226,7 @@ impl super::Device {
         if !self
             .shared
             .private_caps
-            .contains(super::PrivateCapability::SHADER_BINDING_LAYOUT)
+            .contains(super::PrivateCapabilities::SHADER_BINDING_LAYOUT)
         {
             // This remapping is only needed if we aren't able to put the binding layout
             // in the shader. We can't remap storage buffers this way.
@@ -311,7 +311,7 @@ impl crate::Device<super::Api> for super::Device {
             .intersects(crate::BufferUse::MAP_READ | crate::BufferUse::MAP_WRITE);
         let is_coherent = desc
             .memory_flags
-            .contains(crate::MemoryFlag::PREFER_COHERENT);
+            .contains(crate::MemoryFlags::PREFER_COHERENT);
         let mut map_flags = 0;
 
         if is_host_visible {
@@ -582,8 +582,8 @@ impl crate::Device<super::Api> for super::Device {
             //TODO: use `conv::map_view_dimension(desc.dimension)`?
             inner: texture.inner.clone(),
             sample_type: texture.format.describe().sample_type,
-            aspects: crate::FormatAspect::from(texture.format)
-                & crate::FormatAspect::from(desc.range.aspect),
+            aspects: crate::FormatAspects::from(texture.format)
+                & crate::FormatAspects::from(desc.range.aspect),
             mip_levels: desc.range.base_mip_level..end_mip_level,
             array_layers: desc.range.base_array_layer..end_array_layer,
         })
@@ -705,7 +705,7 @@ impl crate::Device<super::Api> for super::Device {
             glsl::WriterFlags::TEXTURE_SHADOW_LOD,
             self.shared
                 .private_caps
-                .contains(super::PrivateCapability::SHADER_TEXTURE_SHADOW_LOD),
+                .contains(super::PrivateCapabilities::SHADER_TEXTURE_SHADOW_LOD),
         );
         let mut binding_map = glsl::BindingMap::default();
 

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -226,7 +226,7 @@ struct Inner {
 
 impl Inner {
     fn create(
-        flags: crate::InstanceFlag,
+        flags: crate::InstanceFlags,
         egl: Arc<egl::DynamicInstance<egl::EGL1_4>>,
         display: egl::Display,
     ) -> Result<Self, crate::InstanceError> {
@@ -265,7 +265,7 @@ impl Inner {
             egl::CONTEXT_CLIENT_VERSION,
             3, // Request GLES 3.0 or higher
         ];
-        if flags.contains(crate::InstanceFlag::DEBUG) && !cfg!(target_os = "android") {
+        if flags.contains(crate::InstanceFlags::DEBUG) && !cfg!(target_os = "android") {
             log::info!("\tEGL context: +debug");
             //TODO: figure out why this is needed
             context_attributes.push(egl::CONTEXT_OPENGL_DEBUG);
@@ -328,7 +328,7 @@ impl Drop for Inner {
 
 pub struct Instance {
     wsi_library: Option<libloading::Library>,
-    flags: crate::InstanceFlag,
+    flags: crate::InstanceFlags,
     inner: Mutex<Inner>,
 }
 
@@ -395,7 +395,7 @@ impl crate::Instance<super::Api> for Instance {
             egl.get_display(egl::DEFAULT_DISPLAY).unwrap()
         };
 
-        if desc.flags.contains(crate::InstanceFlag::VALIDATION)
+        if desc.flags.contains(crate::InstanceFlags::VALIDATION)
             && client_ext_str.contains(&"EGL_KHR_debug")
         {
             log::info!("Enabling EGL debug output");
@@ -606,14 +606,14 @@ impl crate::Instance<super::Api> for Instance {
                 .map_or(ptr::null(), |p| p as *const _)
         });
 
-        if self.flags.contains(crate::InstanceFlag::DEBUG) && gl.supports_debug() {
+        if self.flags.contains(crate::InstanceFlags::DEBUG) && gl.supports_debug() {
             log::info!(
                 "Max label length: {}",
                 gl.get_parameter_i32(glow::MAX_LABEL_LENGTH)
             );
         }
 
-        if self.flags.contains(crate::InstanceFlag::VALIDATION) && gl.supports_debug() {
+        if self.flags.contains(crate::InstanceFlags::VALIDATION) && gl.supports_debug() {
             log::info!("Enabling GLES debug output");
             gl.enable(glow::DEBUG_OUTPUT);
             gl.debug_message_callback(gl_debug_message_callback);

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -358,7 +358,7 @@ struct BlendDesc {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 struct ColorTargetDesc {
-    mask: wgt::ColorWrite,
+    mask: wgt::ColorWrites,
     blend: Option<BlendDesc>,
 }
 
@@ -565,8 +565,8 @@ enum Command {
     ClearColorI(u32, [i32; 4]),
     ClearDepth(f32),
     ClearStencil(u32),
-    BufferBarrier(glow::Buffer, crate::BufferUse),
-    TextureBarrier(crate::TextureUse),
+    BufferBarrier(glow::Buffer, crate::BufferUses),
+    TextureBarrier(crate::TextureUses),
     SetViewport {
         rect: crate::Rect<i32>,
         depth: Range<f32>,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -111,7 +111,7 @@ impl crate::Api for Api {
 bitflags::bitflags! {
     /// Flags that affect internal code paths but do not
     /// change the exposed feature set.
-    struct PrivateCapability: u32 {
+    struct PrivateCapabilities: u32 {
         /// Support explicit layouts in shader.
         const SHADER_BINDING_LAYOUT = 0x0001;
         /// Support extended shadow sampling instructions.
@@ -147,7 +147,7 @@ struct TextureFormatDesc {
 
 struct AdapterShared {
     context: glow::Context,
-    private_caps: PrivateCapability,
+    private_caps: PrivateCapabilities,
     shading_language_version: naga::back::glsl::Version,
 }
 
@@ -213,7 +213,7 @@ pub struct Texture {
 pub struct TextureView {
     inner: TextureInner,
     sample_type: wgt::TextureSampleType,
-    aspects: crate::FormatAspect,
+    aspects: crate::FormatAspects,
     mip_levels: Range<u32>,
     array_layers: Range<u32>,
 }
@@ -585,7 +585,7 @@ enum Command {
     },
     SetDepth(DepthState),
     SetDepthBias(wgt::DepthBiasState),
-    ConfigureDepthStencil(crate::FormatAspect),
+    ConfigureDepthStencil(crate::FormatAspects),
     SetVertexAttribute {
         buffer: Option<glow::Buffer>,
         buffer_desc: VertexBufferDesc,
@@ -641,5 +641,5 @@ pub struct CommandBuffer {
 pub struct CommandEncoder {
     cmd_buffer: CommandBuffer,
     state: command::State,
-    private_caps: PrivateCapability,
+    private_caps: PrivateCapabilities,
 }

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -599,35 +599,35 @@ impl super::Queue {
             }
             C::BufferBarrier(raw, usage) => {
                 let mut flags = 0;
-                if usage.contains(crate::BufferUse::VERTEX) {
+                if usage.contains(crate::BufferUses::VERTEX) {
                     flags |= glow::VERTEX_ATTRIB_ARRAY_BARRIER_BIT;
                     gl.bind_buffer(glow::ARRAY_BUFFER, Some(raw));
                     gl.vertex_attrib_pointer_f32(0, 1, glow::BYTE, true, 0, 0);
                 }
-                if usage.contains(crate::BufferUse::INDEX) {
+                if usage.contains(crate::BufferUses::INDEX) {
                     flags |= glow::ELEMENT_ARRAY_BARRIER_BIT;
                     gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(raw));
                 }
-                if usage.contains(crate::BufferUse::UNIFORM) {
+                if usage.contains(crate::BufferUses::UNIFORM) {
                     flags |= glow::UNIFORM_BARRIER_BIT;
                 }
-                if usage.contains(crate::BufferUse::INDIRECT) {
+                if usage.contains(crate::BufferUses::INDIRECT) {
                     flags |= glow::COMMAND_BARRIER_BIT;
                     gl.bind_buffer(glow::DRAW_INDIRECT_BUFFER, Some(raw));
                 }
-                if usage.contains(crate::BufferUse::COPY_SRC) {
+                if usage.contains(crate::BufferUses::COPY_SRC) {
                     flags |= glow::PIXEL_BUFFER_BARRIER_BIT;
                     gl.bind_buffer(glow::PIXEL_UNPACK_BUFFER, Some(raw));
                 }
-                if usage.contains(crate::BufferUse::COPY_DST) {
+                if usage.contains(crate::BufferUses::COPY_DST) {
                     flags |= glow::PIXEL_BUFFER_BARRIER_BIT;
                     gl.bind_buffer(glow::PIXEL_PACK_BUFFER, Some(raw));
                 }
-                if usage.intersects(crate::BufferUse::MAP_READ | crate::BufferUse::MAP_WRITE) {
+                if usage.intersects(crate::BufferUses::MAP_READ | crate::BufferUses::MAP_WRITE) {
                     flags |= glow::BUFFER_UPDATE_BARRIER_BIT;
                 }
                 if usage
-                    .intersects(crate::BufferUse::STORAGE_LOAD | crate::BufferUse::STORAGE_STORE)
+                    .intersects(crate::BufferUses::STORAGE_LOAD | crate::BufferUses::STORAGE_STORE)
                 {
                     flags |= glow::SHADER_STORAGE_BARRIER_BIT;
                 }
@@ -635,21 +635,21 @@ impl super::Queue {
             }
             C::TextureBarrier(usage) => {
                 let mut flags = 0;
-                if usage.contains(crate::TextureUse::SAMPLED) {
+                if usage.contains(crate::TextureUses::SAMPLED) {
                     flags |= glow::TEXTURE_FETCH_BARRIER_BIT;
                 }
-                if usage
-                    .intersects(crate::TextureUse::STORAGE_LOAD | crate::TextureUse::STORAGE_STORE)
-                {
+                if usage.intersects(
+                    crate::TextureUses::STORAGE_LOAD | crate::TextureUses::STORAGE_STORE,
+                ) {
                     flags |= glow::SHADER_IMAGE_ACCESS_BARRIER_BIT;
                 }
-                if usage.contains(crate::TextureUse::COPY_DST) {
+                if usage.contains(crate::TextureUses::COPY_DST) {
                     flags |= glow::TEXTURE_UPDATE_BARRIER_BIT;
                 }
                 if usage.intersects(
-                    crate::TextureUse::COLOR_TARGET
-                        | crate::TextureUse::DEPTH_STENCIL_READ
-                        | crate::TextureUse::DEPTH_STENCIL_WRITE,
+                    crate::TextureUses::COLOR_TARGET
+                        | crate::TextureUses::DEPTH_STENCIL_READ
+                        | crate::TextureUses::DEPTH_STENCIL_WRITE,
                 ) {
                     flags |= glow::FRAMEBUFFER_BARRIER_BIT;
                 }
@@ -797,7 +797,7 @@ impl super::Queue {
                 draw_buffer_index,
                 desc: super::ColorTargetDesc { mask, ref blend },
             } => {
-                use wgt::ColorWrite as Cw;
+                use wgt::ColorWrites as Cw;
                 if let Some(index) = draw_buffer_index {
                     gl.color_mask_draw_buffer(
                         index,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -760,12 +760,12 @@ impl super::Queue {
                 }
             }
             C::ConfigureDepthStencil(aspects) => {
-                if aspects.contains(crate::FormatAspect::DEPTH) {
+                if aspects.contains(crate::FormatAspects::DEPTH) {
                     gl.enable(glow::DEPTH_TEST);
                 } else {
                     gl.disable(glow::DEPTH_TEST);
                 }
-                if aspects.contains(crate::FormatAspect::STENCIL) {
+                if aspects.contains(crate::FormatAspects::STENCIL) {
                     gl.enable(glow::STENCIL_TEST);
                 } else {
                     gl.disable(glow::STENCIL_TEST);

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -201,7 +201,7 @@ pub trait Device<A: Api>: Send + Sync {
     unsafe fn exit(self);
     /// Creates a new buffer.
     ///
-    /// The initial usage is `BufferUse::empty()`.
+    /// The initial usage is `BufferUses::empty()`.
     unsafe fn create_buffer(&self, desc: &BufferDescriptor) -> Result<A::Buffer, DeviceError>;
     unsafe fn destroy_buffer(&self, buffer: A::Buffer);
     //TODO: clarify if zero-sized mapping is allowed
@@ -220,7 +220,7 @@ pub trait Device<A: Api>: Send + Sync {
 
     /// Creates a new texture.
     ///
-    /// The initial usage for all subresources is `TextureUse::UNINITIALIZED`.
+    /// The initial usage for all subresources is `TextureUses::UNINITIALIZED`.
     unsafe fn create_texture(&self, desc: &TextureDescriptor) -> Result<A::Texture, DeviceError>;
     unsafe fn destroy_texture(&self, texture: A::Texture);
     unsafe fn create_texture_view(
@@ -345,17 +345,17 @@ pub trait CommandEncoder<A: Api>: Send + Sync {
     where
         T: Iterator<Item = BufferCopy>;
 
-    /// Note: `dst` current usage has to be `TextureUse::COPY_DST`.
+    /// Note: `dst` current usage has to be `TextureUses::COPY_DST`.
     unsafe fn copy_texture_to_texture<T>(
         &mut self,
         src: &A::Texture,
-        src_usage: TextureUse,
+        src_usage: TextureUses,
         dst: &A::Texture,
         regions: T,
     ) where
         T: Iterator<Item = TextureCopy>;
 
-    /// Note: `dst` current usage has to be `TextureUse::COPY_DST`.
+    /// Note: `dst` current usage has to be `TextureUses::COPY_DST`.
     unsafe fn copy_buffer_to_texture<T>(&mut self, src: &A::Buffer, dst: &A::Texture, regions: T)
     where
         T: Iterator<Item = BufferTextureCopy>;
@@ -363,7 +363,7 @@ pub trait CommandEncoder<A: Api>: Send + Sync {
     unsafe fn copy_texture_to_buffer<T>(
         &mut self,
         src: &A::Texture,
-        src_usage: TextureUse,
+        src_usage: TextureUses,
         dst: &A::Buffer,
         regions: T,
     ) where
@@ -570,8 +570,8 @@ bitflags!(
 );
 
 bitflags::bitflags! {
-    /// Similar to `wgt::BufferUsage` but for internal use.
-    pub struct BufferUse: u32 {
+    /// Similar to `wgt::BufferUsages` but for internal use.
+    pub struct BufferUses: u32 {
         const MAP_READ = 1;
         const MAP_WRITE = 2;
         const COPY_SRC = 4;
@@ -596,8 +596,8 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
-    /// Similar to `wgt::TextureUsage` but for internal use.
-    pub struct TextureUse: u32 {
+    /// Similar to `wgt::TextureUsages` but for internal use.
+    pub struct TextureUses: u32 {
         const COPY_SRC = 1;
         const COPY_DST = 2;
         const SAMPLED = 4;
@@ -675,8 +675,8 @@ pub struct SurfaceCapabilities {
 
     /// Supported texture usage flags.
     ///
-    /// Must have at least `TextureUse::COLOR_TARGET`
-    pub usage: TextureUse,
+    /// Must have at least `TextureUses::COLOR_TARGET`
+    pub usage: TextureUses,
 
     /// List of supported V-sync modes.
     ///
@@ -714,7 +714,7 @@ pub struct BufferMapping {
 pub struct BufferDescriptor<'a> {
     pub label: Label<'a>,
     pub size: wgt::BufferAddress,
-    pub usage: BufferUse,
+    pub usage: BufferUses,
     pub memory_flags: MemoryFlags,
 }
 
@@ -726,7 +726,7 @@ pub struct TextureDescriptor<'a> {
     pub sample_count: u32,
     pub dimension: wgt::TextureDimension,
     pub format: wgt::TextureFormat,
-    pub usage: TextureUse,
+    pub usage: TextureUses,
     pub memory_flags: MemoryFlags,
 }
 
@@ -742,7 +742,7 @@ pub struct TextureViewDescriptor<'a> {
     pub label: Label<'a>,
     pub format: wgt::TextureFormat,
     pub dimension: wgt::TextureViewDimension,
-    pub usage: TextureUse,
+    pub usage: TextureUses,
     pub range: wgt::ImageSubresourceRange,
 }
 
@@ -797,7 +797,7 @@ impl<A: Api> Clone for BufferBinding<'_, A> {
 #[derive(Debug)]
 pub struct TextureBinding<'a, A: Api> {
     pub view: &'a A::TextureView,
-    pub usage: TextureUse,
+    pub usage: TextureUses,
 }
 
 // Rust gets confused about the impl requirements for `A`
@@ -966,7 +966,7 @@ pub struct SurfaceConfiguration {
     /// `SurfaceCapabilities::extents` range.
     pub extent: wgt::Extent3d,
     /// Allowed usage of surface textures,
-    pub usage: TextureUse,
+    pub usage: TextureUses,
 }
 
 #[derive(Debug, Clone)]
@@ -980,14 +980,14 @@ pub struct Rect<T> {
 #[derive(Debug, Clone)]
 pub struct BufferBarrier<'a, A: Api> {
     pub buffer: &'a A::Buffer,
-    pub usage: Range<BufferUse>,
+    pub usage: Range<BufferUses>,
 }
 
 #[derive(Debug, Clone)]
 pub struct TextureBarrier<'a, A: Api> {
     pub texture: &'a A::Texture,
     pub range: wgt::ImageSubresourceRange,
-    pub usage: Range<TextureUse>,
+    pub usage: Range<TextureUses>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1023,11 +1023,11 @@ pub struct Attachment<'a, A: Api> {
     pub view: &'a A::TextureView,
     /// Contains either a single mutating usage as a target, or a valid combination
     /// of read-only usages.
-    pub usage: TextureUse,
+    pub usage: TextureUses,
     /// Defines the boundary usages for the attachment.
     /// It is expected to begin a render pass with `boundary_usage.start` usage,
     /// and will end it with `boundary_usage.end` usage.
-    pub boundary_usage: Range<TextureUse>,
+    pub boundary_usage: Range<TextureUses>,
 }
 
 // Rust gets confused about the impl requirements for `A`

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -309,7 +309,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 height: 4096,
                 depth_or_array_layers: 1,
             },
-            usage: crate::TextureUse::COLOR_TARGET, //TODO: expose more
+            usage: crate::TextureUses::COLOR_TARGET, //TODO: expose more
         })
     }
 }

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -33,8 +33,8 @@ impl crate::Adapter<super::Api> for super::Adapter {
     unsafe fn texture_format_capabilities(
         &self,
         format: wgt::TextureFormat,
-    ) -> crate::TextureFormatCapability {
-        use crate::TextureFormatCapability as Tfc;
+    ) -> crate::TextureFormatCapabilities {
+        use crate::TextureFormatCapabilities as Tfc;
         use wgt::TextureFormat as Tf;
 
         let pc = &self.shared.private_caps;

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -323,14 +323,14 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 //Note: the selection of levels and slices is already handled by `TextureView`
                 at_descriptor.set_resolve_texture(Some(&resolve.view.raw));
             }
-            let load_action = if at.ops.contains(crate::AttachmentOp::LOAD) {
+            let load_action = if at.ops.contains(crate::AttachmentOps::LOAD) {
                 mtl::MTLLoadAction::Load
             } else {
                 at_descriptor.set_clear_color(conv::map_clear_color(&at.clear_value));
                 mtl::MTLLoadAction::Clear
             };
             let store_action = conv::map_store_action(
-                at.ops.contains(crate::AttachmentOp::STORE),
+                at.ops.contains(crate::AttachmentOps::STORE),
                 at.resolve_target.is_some(),
             );
             at_descriptor.set_load_action(load_action);
@@ -338,17 +338,17 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         }
 
         if let Some(ref at) = desc.depth_stencil_attachment {
-            if at.target.view.aspects.contains(crate::FormatAspect::DEPTH) {
+            if at.target.view.aspects.contains(crate::FormatAspects::DEPTH) {
                 let at_descriptor = descriptor.depth_attachment().unwrap();
                 at_descriptor.set_texture(Some(&at.target.view.raw));
 
-                let load_action = if at.depth_ops.contains(crate::AttachmentOp::LOAD) {
+                let load_action = if at.depth_ops.contains(crate::AttachmentOps::LOAD) {
                     mtl::MTLLoadAction::Load
                 } else {
                     at_descriptor.set_clear_depth(at.clear_value.0 as f64);
                     mtl::MTLLoadAction::Clear
                 };
-                let store_action = if at.depth_ops.contains(crate::AttachmentOp::STORE) {
+                let store_action = if at.depth_ops.contains(crate::AttachmentOps::STORE) {
                     mtl::MTLStoreAction::Store
                 } else {
                     mtl::MTLStoreAction::DontCare
@@ -360,18 +360,18 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 .target
                 .view
                 .aspects
-                .contains(crate::FormatAspect::STENCIL)
+                .contains(crate::FormatAspects::STENCIL)
             {
                 let at_descriptor = descriptor.stencil_attachment().unwrap();
                 at_descriptor.set_texture(Some(&at.target.view.raw));
 
-                let load_action = if at.depth_ops.contains(crate::AttachmentOp::LOAD) {
+                let load_action = if at.depth_ops.contains(crate::AttachmentOps::LOAD) {
                     mtl::MTLLoadAction::Load
                 } else {
                     at_descriptor.set_clear_stencil(at.clear_value.1);
                     mtl::MTLLoadAction::Clear
                 };
-                let store_action = if at.depth_ops.contains(crate::AttachmentOp::STORE) {
+                let store_action = if at.depth_ops.contains(crate::AttachmentOps::STORE) {
                     mtl::MTLStoreAction::Store
                 } else {
                     mtl::MTLStoreAction::DontCare
@@ -563,7 +563,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     unsafe fn set_push_constants(
         &mut self,
         _layout: &super::PipelineLayout,
-        _stages: wgt::ShaderStage,
+        _stages: wgt::ShaderStages,
         _offset: u32,
         _data: &[u32],
     ) {

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -148,7 +148,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     unsafe fn copy_texture_to_texture<T>(
         &mut self,
         src: &super::Texture,
-        _src_usage: crate::TextureUse,
+        _src_usage: crate::TextureUses,
         dst: &super::Texture,
         regions: T,
     ) where
@@ -216,7 +216,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     unsafe fn copy_texture_to_buffer<T>(
         &mut self,
         src: &super::Texture,
-        _src_usage: crate::TextureUse,
+        _src_usage: crate::TextureUses,
         dst: &super::Buffer,
         regions: T,
     ) where

--- a/wgpu-hal/src/metal/conv.rs
+++ b/wgpu-hal/src/metal/conv.rs
@@ -1,5 +1,5 @@
-pub fn map_texture_usage(usage: crate::TextureUse) -> mtl::MTLTextureUsage {
-    use crate::TextureUse as Tu;
+pub fn map_texture_usage(usage: crate::TextureUses) -> mtl::MTLTextureUsage {
+    use crate::TextureUses as Tu;
 
     let mut mtl_usage = mtl::MTLTextureUsage::Unknown;
 
@@ -104,19 +104,19 @@ pub fn map_primitive_topology(
     }
 }
 
-pub fn map_color_write(mask: wgt::ColorWrite) -> mtl::MTLColorWriteMask {
+pub fn map_color_write(mask: wgt::ColorWrites) -> mtl::MTLColorWriteMask {
     let mut raw_mask = mtl::MTLColorWriteMask::empty();
 
-    if mask.contains(wgt::ColorWrite::RED) {
+    if mask.contains(wgt::ColorWrites::RED) {
         raw_mask |= mtl::MTLColorWriteMask::Red;
     }
-    if mask.contains(wgt::ColorWrite::GREEN) {
+    if mask.contains(wgt::ColorWrites::GREEN) {
         raw_mask |= mtl::MTLColorWriteMask::Green;
     }
-    if mask.contains(wgt::ColorWrite::BLUE) {
+    if mask.contains(wgt::ColorWrites::BLUE) {
         raw_mask |= mtl::MTLColorWriteMask::Blue;
     }
-    if mask.contains(wgt::ColorWrite::ALPHA) {
+    if mask.contains(wgt::ColorWrites::ALPHA) {
         raw_mask |= mtl::MTLColorWriteMask::Alpha;
     }
 

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -135,8 +135,8 @@ impl crate::Device<super::Api> for super::Device {
     unsafe fn exit(self) {}
 
     unsafe fn create_buffer(&self, desc: &crate::BufferDescriptor) -> DeviceResult<super::Buffer> {
-        let map_read = desc.usage.contains(crate::BufferUse::MAP_READ);
-        let map_write = desc.usage.contains(crate::BufferUse::MAP_WRITE);
+        let map_read = desc.usage.contains(crate::BufferUses::MAP_READ);
+        let map_write = desc.usage.contains(crate::BufferUses::MAP_WRITE);
 
         let mut options = mtl::MTLResourceOptions::empty();
         options |= if map_read || map_write {

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -140,7 +140,7 @@ impl crate::Device<super::Api> for super::Device {
 
         let mut options = mtl::MTLResourceOptions::empty();
         options |= if map_read || map_write {
-            // `crate::MemoryFlag::PREFER_COHERENT` is ignored here
+            // `crate::MemoryFlags::PREFER_COHERENT` is ignored here
             mtl::MTLResourceOptions::StorageModeShared
         } else {
             mtl::MTLResourceOptions::StorageModePrivate
@@ -290,7 +290,7 @@ impl crate::Device<super::Api> for super::Device {
             raw
         };
 
-        let aspects = crate::FormatAspect::from(desc.format);
+        let aspects = crate::FormatAspects::from(desc.format);
         Ok(super::TextureView { raw, aspects })
     }
     unsafe fn destroy_texture_view(&self, _view: super::TextureView) {}
@@ -717,11 +717,11 @@ impl crate::Device<super::Api> for super::Device {
         let depth_stencil = match desc.depth_stencil {
             Some(ref ds) => {
                 let raw_format = self.shared.private_caps.map_format(ds.format);
-                let aspects = crate::FormatAspect::from(ds.format);
-                if aspects.contains(crate::FormatAspect::DEPTH) {
+                let aspects = crate::FormatAspects::from(ds.format);
+                if aspects.contains(crate::FormatAspects::DEPTH) {
                     descriptor.set_depth_attachment_pixel_format(raw_format);
                 }
-                if aspects.contains(crate::FormatAspect::STENCIL) {
+                if aspects.contains(crate::FormatAspects::STENCIL) {
                     descriptor.set_stencil_attachment_pixel_format(raw_format);
                 }
 
@@ -744,7 +744,10 @@ impl crate::Device<super::Api> for super::Device {
                 desc.vertex_buffers.len(),
                 desc.layout.total_counters.vs.buffers
             );
-            return Err(crate::PipelineError::Linkage(wgt::ShaderStage::VERTEX, msg));
+            return Err(crate::PipelineError::Linkage(
+                wgt::ShaderStages::VERTEX,
+                msg,
+            ));
         }
 
         if !desc.vertex_buffers.is_empty() {
@@ -788,7 +791,7 @@ impl crate::Device<super::Api> for super::Device {
             .new_render_pipeline_state(&descriptor)
             .map_err(|e| {
                 crate::PipelineError::Linkage(
-                    wgt::ShaderStage::VERTEX | wgt::ShaderStage::FRAGMENT,
+                    wgt::ShaderStages::VERTEX | wgt::ShaderStages::FRAGMENT,
                     format!("new_render_pipeline_state: {:?}", e),
                 )
             })?;
@@ -849,7 +852,7 @@ impl crate::Device<super::Api> for super::Device {
             .new_compute_pipeline_state(&descriptor)
             .map_err(|e| {
                 crate::PipelineError::Linkage(
-                    wgt::ShaderStage::COMPUTE,
+                    wgt::ShaderStages::COMPUTE,
                     format!("new_compute_pipeline_state: {:?}", e),
                 )
             })?;

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -398,7 +398,7 @@ unsafe impl Sync for Texture {}
 #[derive(Debug)]
 pub struct TextureView {
     raw: mtl::Texture,
-    aspects: crate::FormatAspect,
+    aspects: crate::FormatAspects,
 }
 
 unsafe impl Send for TextureView {}

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -172,7 +172,7 @@ impl crate::Surface<super::Api> for super::Surface {
         self.raw_swapchain_format = caps.map_format(config.format);
 
         let render_layer = self.render_layer.lock();
-        let framebuffer_only = config.usage == crate::TextureUse::COLOR_TARGET;
+        let framebuffer_only = config.usage == crate::TextureUses::COLOR_TARGET;
         let display_sync = config.present_mode != wgt::PresentMode::Immediate;
         let drawable_size = CGSize::new(config.extent.width as f64, config.extent.height as f64);
 

--- a/wgpu-hal/src/util.rs
+++ b/wgpu-hal/src/util.rs
@@ -6,10 +6,10 @@ pub mod db {
     }
 }
 
-pub fn map_naga_stage(stage: naga::ShaderStage) -> wgt::ShaderStage {
+pub fn map_naga_stage(stage: naga::ShaderStage) -> wgt::ShaderStages {
     match stage {
-        naga::ShaderStage::Vertex => wgt::ShaderStage::VERTEX,
-        naga::ShaderStage::Fragment => wgt::ShaderStage::FRAGMENT,
-        naga::ShaderStage::Compute => wgt::ShaderStage::COMPUTE,
+        naga::ShaderStage::Vertex => wgt::ShaderStages::VERTEX,
+        naga::ShaderStage::Fragment => wgt::ShaderStages::FRAGMENT,
+        naga::ShaderStage::Compute => wgt::ShaderStages::COMPUTE,
     }
 }

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -790,7 +790,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             let mut flags = spv::WriterFlags::empty();
             flags.set(
                 spv::WriterFlags::DEBUG,
-                self.instance.flags.contains(crate::InstanceFlag::DEBUG),
+                self.instance.flags.contains(crate::InstanceFlags::DEBUG),
             );
             spv::Options {
                 lang_version: (1, 0),
@@ -866,8 +866,8 @@ impl crate::Adapter<super::Api> for super::Adapter {
     unsafe fn texture_format_capabilities(
         &self,
         format: wgt::TextureFormat,
-    ) -> crate::TextureFormatCapability {
-        use crate::TextureFormatCapability as Tfc;
+    ) -> crate::TextureFormatCapabilities {
+        use crate::TextureFormatCapabilities as Tfc;
         let vk_format = self.private_caps.map_texture_format(format);
         let properties = self
             .instance

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -219,7 +219,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     unsafe fn copy_texture_to_texture<T>(
         &mut self,
         src: &super::Texture,
-        src_usage: crate::TextureUse,
+        src_usage: crate::TextureUses,
         dst: &super::Texture,
         regions: T,
     ) where
@@ -278,7 +278,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     unsafe fn copy_texture_to_buffer<T>(
         &mut self,
         src: &super::Texture,
-        src_usage: crate::TextureUse,
+        src_usage: crate::TextureUses,
         dst: &super::Buffer,
         regions: T,
     ) where
@@ -746,7 +746,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 #[test]
 fn check_dst_image_layout() {
     assert_eq!(
-        conv::derive_image_layout(crate::TextureUse::COPY_DST, crate::FormatAspects::empty()),
+        conv::derive_image_layout(crate::TextureUses::COPY_DST, crate::FormatAspects::empty()),
         DST_IMAGE_LAYOUT
     );
 }

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -368,7 +368,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 resolve: cat
                     .resolve_target
                     .as_ref()
-                    .map(|target| target.make_attachment_key(crate::AttachmentOp::STORE, caps)),
+                    .map(|target| target.make_attachment_key(crate::AttachmentOps::STORE, caps)),
             });
             fb_key.attachments.push(cat.target.view.attachment.clone());
             if let Some(ref at) = cat.resolve_target {
@@ -469,7 +469,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     unsafe fn set_push_constants(
         &mut self,
         layout: &super::PipelineLayout,
-        stages: wgt::ShaderStage,
+        stages: wgt::ShaderStages,
         offset: u32,
         data: &[u32],
     ) {
@@ -746,7 +746,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 #[test]
 fn check_dst_image_layout() {
     assert_eq!(
-        conv::derive_image_layout(crate::TextureUse::COPY_DST, crate::FormatAspect::empty()),
+        conv::derive_image_layout(crate::TextureUse::COPY_DST, crate::FormatAspects::empty()),
         DST_IMAGE_LAYOUT
     );
 }

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -113,7 +113,7 @@ impl super::PrivateCapabilities {
 impl crate::Attachment<'_, super::Api> {
     pub(super) fn make_attachment_key(
         &self,
-        ops: crate::AttachmentOp,
+        ops: crate::AttachmentOps,
         caps: &super::PrivateCapabilities,
     ) -> super::AttachmentKey {
         let aspects = self.view.aspects();
@@ -155,10 +155,10 @@ impl crate::ColorAttachment<'_, super::Api> {
 
 pub fn derive_image_layout(
     usage: crate::TextureUse,
-    aspects: crate::FormatAspect,
+    aspects: crate::FormatAspects,
 ) -> vk::ImageLayout {
     //Note: depth textures are always sampled with RODS layout
-    let is_color = aspects.contains(crate::FormatAspect::COLOR);
+    let is_color = aspects.contains(crate::FormatAspects::COLOR);
     match usage {
         crate::TextureUse::UNINITIALIZED => vk::ImageLayout::UNDEFINED,
         crate::TextureUse::COPY_SRC => vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
@@ -336,15 +336,15 @@ pub fn map_vertex_format(vertex_format: wgt::VertexFormat) -> vk::Format {
     }
 }
 
-pub fn map_aspects(aspects: crate::FormatAspect) -> vk::ImageAspectFlags {
+pub fn map_aspects(aspects: crate::FormatAspects) -> vk::ImageAspectFlags {
     let mut flags = vk::ImageAspectFlags::empty();
-    if aspects.contains(crate::FormatAspect::COLOR) {
+    if aspects.contains(crate::FormatAspects::COLOR) {
         flags |= vk::ImageAspectFlags::COLOR;
     }
-    if aspects.contains(crate::FormatAspect::DEPTH) {
+    if aspects.contains(crate::FormatAspects::DEPTH) {
         flags |= vk::ImageAspectFlags::DEPTH;
     }
-    if aspects.contains(crate::FormatAspect::STENCIL) {
+    if aspects.contains(crate::FormatAspects::STENCIL) {
         flags |= vk::ImageAspectFlags::STENCIL;
     }
     flags
@@ -387,14 +387,14 @@ pub fn map_extent(
 }
 
 pub fn map_attachment_ops(
-    op: crate::AttachmentOp,
+    op: crate::AttachmentOps,
 ) -> (vk::AttachmentLoadOp, vk::AttachmentStoreOp) {
-    let load_op = if op.contains(crate::AttachmentOp::LOAD) {
+    let load_op = if op.contains(crate::AttachmentOps::LOAD) {
         vk::AttachmentLoadOp::LOAD
     } else {
         vk::AttachmentLoadOp::CLEAR
     };
-    let store_op = if op.contains(crate::AttachmentOp::STORE) {
+    let store_op = if op.contains(crate::AttachmentOps::STORE) {
         vk::AttachmentStoreOp::STORE
     } else {
         vk::AttachmentStoreOp::DONT_CARE
@@ -541,10 +541,10 @@ pub fn map_view_dimension(dim: wgt::TextureViewDimension) -> vk::ImageViewType {
 
 pub fn map_subresource_range(
     range: &wgt::ImageSubresourceRange,
-    texture_aspect: crate::FormatAspect,
+    texture_aspect: crate::FormatAspects,
 ) -> vk::ImageSubresourceRange {
     vk::ImageSubresourceRange {
-        aspect_mask: map_aspects(crate::FormatAspect::from(range.aspect) & texture_aspect),
+        aspect_mask: map_aspects(crate::FormatAspects::from(range.aspect) & texture_aspect),
         base_mip_level: range.base_mip_level,
         level_count: range
             .mip_level_count
@@ -559,7 +559,7 @@ pub fn map_subresource_range(
 pub fn map_subresource_layers(
     base: &crate::TextureCopyBase,
     texture_dim: wgt::TextureDimension,
-    texture_aspect: crate::FormatAspect,
+    texture_aspect: crate::FormatAspects,
     layer_count: u32,
 ) -> (vk::ImageSubresourceLayers, vk::Offset3D) {
     let (base_array_layer, offset) = map_origin(base.origin, texture_dim);
@@ -618,15 +618,15 @@ pub fn map_comparison(fun: wgt::CompareFunction) -> vk::CompareOp {
     }
 }
 
-pub fn map_shader_stage(stage: wgt::ShaderStage) -> vk::ShaderStageFlags {
+pub fn map_shader_stage(stage: wgt::ShaderStages) -> vk::ShaderStageFlags {
     let mut flags = vk::ShaderStageFlags::empty();
-    if stage.contains(wgt::ShaderStage::VERTEX) {
+    if stage.contains(wgt::ShaderStages::VERTEX) {
         flags |= vk::ShaderStageFlags::VERTEX;
     }
-    if stage.contains(wgt::ShaderStage::FRAGMENT) {
+    if stage.contains(wgt::ShaderStages::FRAGMENT) {
         flags |= vk::ShaderStageFlags::FRAGMENT;
     }
-    if stage.contains(wgt::ShaderStage::COMPUTE) {
+    if stage.contains(wgt::ShaderStages::COMPUTE) {
         flags |= vk::ShaderStageFlags::COMPUTE;
     }
     flags

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -154,18 +154,20 @@ impl crate::ColorAttachment<'_, super::Api> {
 }
 
 pub fn derive_image_layout(
-    usage: crate::TextureUse,
+    usage: crate::TextureUses,
     aspects: crate::FormatAspects,
 ) -> vk::ImageLayout {
     //Note: depth textures are always sampled with RODS layout
     let is_color = aspects.contains(crate::FormatAspects::COLOR);
     match usage {
-        crate::TextureUse::UNINITIALIZED => vk::ImageLayout::UNDEFINED,
-        crate::TextureUse::COPY_SRC => vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
-        crate::TextureUse::COPY_DST => vk::ImageLayout::TRANSFER_DST_OPTIMAL,
-        crate::TextureUse::SAMPLED if is_color => vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
-        crate::TextureUse::COLOR_TARGET => vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
-        crate::TextureUse::DEPTH_STENCIL_WRITE => vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        crate::TextureUses::UNINITIALIZED => vk::ImageLayout::UNDEFINED,
+        crate::TextureUses::COPY_SRC => vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+        crate::TextureUses::COPY_DST => vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+        crate::TextureUses::SAMPLED if is_color => vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+        crate::TextureUses::COLOR_TARGET => vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+        crate::TextureUses::DEPTH_STENCIL_WRITE => {
+            vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+        }
         _ => {
             if usage.is_empty() {
                 vk::ImageLayout::PRESENT_SRC_KHR
@@ -178,33 +180,33 @@ pub fn derive_image_layout(
     }
 }
 
-pub fn map_texture_usage(usage: crate::TextureUse) -> vk::ImageUsageFlags {
+pub fn map_texture_usage(usage: crate::TextureUses) -> vk::ImageUsageFlags {
     let mut flags = vk::ImageUsageFlags::empty();
-    if usage.contains(crate::TextureUse::COPY_SRC) {
+    if usage.contains(crate::TextureUses::COPY_SRC) {
         flags |= vk::ImageUsageFlags::TRANSFER_SRC;
     }
-    if usage.contains(crate::TextureUse::COPY_DST) {
+    if usage.contains(crate::TextureUses::COPY_DST) {
         flags |= vk::ImageUsageFlags::TRANSFER_DST;
     }
-    if usage.contains(crate::TextureUse::SAMPLED) {
+    if usage.contains(crate::TextureUses::SAMPLED) {
         flags |= vk::ImageUsageFlags::SAMPLED;
     }
-    if usage.contains(crate::TextureUse::COLOR_TARGET) {
+    if usage.contains(crate::TextureUses::COLOR_TARGET) {
         flags |= vk::ImageUsageFlags::COLOR_ATTACHMENT;
     }
-    if usage
-        .intersects(crate::TextureUse::DEPTH_STENCIL_READ | crate::TextureUse::DEPTH_STENCIL_WRITE)
-    {
+    if usage.intersects(
+        crate::TextureUses::DEPTH_STENCIL_READ | crate::TextureUses::DEPTH_STENCIL_WRITE,
+    ) {
         flags |= vk::ImageUsageFlags::DEPTH_STENCIL_ATTACHMENT;
     }
-    if usage.intersects(crate::TextureUse::STORAGE_LOAD | crate::TextureUse::STORAGE_STORE) {
+    if usage.intersects(crate::TextureUses::STORAGE_LOAD | crate::TextureUses::STORAGE_STORE) {
         flags |= vk::ImageUsageFlags::STORAGE;
     }
     flags
 }
 
 pub fn map_texture_usage_to_barrier(
-    usage: crate::TextureUse,
+    usage: crate::TextureUses,
 ) -> (vk::PipelineStageFlags, vk::AccessFlags) {
     let mut stages = vk::PipelineStageFlags::empty();
     let mut access = vk::AccessFlags::empty();
@@ -212,43 +214,43 @@ pub fn map_texture_usage_to_barrier(
         | vk::PipelineStageFlags::FRAGMENT_SHADER
         | vk::PipelineStageFlags::COMPUTE_SHADER;
 
-    if usage.contains(crate::TextureUse::COPY_SRC) {
+    if usage.contains(crate::TextureUses::COPY_SRC) {
         stages |= vk::PipelineStageFlags::TRANSFER;
         access |= vk::AccessFlags::TRANSFER_READ;
     }
-    if usage.contains(crate::TextureUse::COPY_DST) {
+    if usage.contains(crate::TextureUses::COPY_DST) {
         stages |= vk::PipelineStageFlags::TRANSFER;
         access |= vk::AccessFlags::TRANSFER_WRITE;
     }
-    if usage.contains(crate::TextureUse::SAMPLED) {
+    if usage.contains(crate::TextureUses::SAMPLED) {
         stages |= shader_stages;
         access |= vk::AccessFlags::SHADER_READ;
     }
-    if usage.contains(crate::TextureUse::COLOR_TARGET) {
+    if usage.contains(crate::TextureUses::COLOR_TARGET) {
         stages |= vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT;
         access |= vk::AccessFlags::COLOR_ATTACHMENT_READ | vk::AccessFlags::COLOR_ATTACHMENT_WRITE;
     }
-    if usage.intersects(crate::TextureUse::DEPTH_STENCIL_READ) {
+    if usage.intersects(crate::TextureUses::DEPTH_STENCIL_READ) {
         stages |= vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
             | vk::PipelineStageFlags::LATE_FRAGMENT_TESTS;
         access |= vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ;
     }
-    if usage.intersects(crate::TextureUse::DEPTH_STENCIL_WRITE) {
+    if usage.intersects(crate::TextureUses::DEPTH_STENCIL_WRITE) {
         stages |= vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
             | vk::PipelineStageFlags::LATE_FRAGMENT_TESTS;
         access |= vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ
             | vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE;
     }
-    if usage.contains(crate::TextureUse::STORAGE_LOAD) {
+    if usage.contains(crate::TextureUses::STORAGE_LOAD) {
         stages |= shader_stages;
         access |= vk::AccessFlags::SHADER_READ;
     }
-    if usage.contains(crate::TextureUse::STORAGE_STORE) {
+    if usage.contains(crate::TextureUses::STORAGE_STORE) {
         stages |= shader_stages;
         access |= vk::AccessFlags::SHADER_WRITE;
     }
 
-    if usage == crate::TextureUse::UNINITIALIZED {
+    if usage == crate::TextureUses::UNINITIALIZED {
         (
             vk::PipelineStageFlags::TOP_OF_PIPE,
             vk::AccessFlags::empty(),
@@ -258,25 +260,25 @@ pub fn map_texture_usage_to_barrier(
     }
 }
 
-pub fn map_vk_image_usage(usage: vk::ImageUsageFlags) -> crate::TextureUse {
-    let mut bits = crate::TextureUse::empty();
+pub fn map_vk_image_usage(usage: vk::ImageUsageFlags) -> crate::TextureUses {
+    let mut bits = crate::TextureUses::empty();
     if usage.contains(vk::ImageUsageFlags::TRANSFER_SRC) {
-        bits |= crate::TextureUse::COPY_SRC;
+        bits |= crate::TextureUses::COPY_SRC;
     }
     if usage.contains(vk::ImageUsageFlags::TRANSFER_DST) {
-        bits |= crate::TextureUse::COPY_DST;
+        bits |= crate::TextureUses::COPY_DST;
     }
     if usage.contains(vk::ImageUsageFlags::SAMPLED) {
-        bits |= crate::TextureUse::SAMPLED;
+        bits |= crate::TextureUses::SAMPLED;
     }
     if usage.contains(vk::ImageUsageFlags::COLOR_ATTACHMENT) {
-        bits |= crate::TextureUse::COLOR_TARGET;
+        bits |= crate::TextureUses::COLOR_TARGET;
     }
     if usage.contains(vk::ImageUsageFlags::DEPTH_STENCIL_ATTACHMENT) {
-        bits |= crate::TextureUse::DEPTH_STENCIL_READ | crate::TextureUse::DEPTH_STENCIL_WRITE;
+        bits |= crate::TextureUses::DEPTH_STENCIL_READ | crate::TextureUses::DEPTH_STENCIL_WRITE;
     }
     if usage.contains(vk::ImageUsageFlags::STORAGE) {
-        bits |= crate::TextureUse::STORAGE_LOAD | crate::TextureUse::STORAGE_STORE;
+        bits |= crate::TextureUses::STORAGE_LOAD | crate::TextureUses::STORAGE_STORE;
     }
     bits
 }
@@ -449,34 +451,34 @@ pub fn map_vk_composite_alpha(flags: vk::CompositeAlphaFlagsKHR) -> Vec<crate::C
     modes
 }
 
-pub fn map_buffer_usage(usage: crate::BufferUse) -> vk::BufferUsageFlags {
+pub fn map_buffer_usage(usage: crate::BufferUses) -> vk::BufferUsageFlags {
     let mut flags = vk::BufferUsageFlags::empty();
-    if usage.contains(crate::BufferUse::COPY_SRC) {
+    if usage.contains(crate::BufferUses::COPY_SRC) {
         flags |= vk::BufferUsageFlags::TRANSFER_SRC;
     }
-    if usage.contains(crate::BufferUse::COPY_DST) {
+    if usage.contains(crate::BufferUses::COPY_DST) {
         flags |= vk::BufferUsageFlags::TRANSFER_DST;
     }
-    if usage.contains(crate::BufferUse::UNIFORM) {
+    if usage.contains(crate::BufferUses::UNIFORM) {
         flags |= vk::BufferUsageFlags::UNIFORM_BUFFER;
     }
-    if usage.intersects(crate::BufferUse::STORAGE_LOAD | crate::BufferUse::STORAGE_STORE) {
+    if usage.intersects(crate::BufferUses::STORAGE_LOAD | crate::BufferUses::STORAGE_STORE) {
         flags |= vk::BufferUsageFlags::STORAGE_BUFFER;
     }
-    if usage.contains(crate::BufferUse::INDEX) {
+    if usage.contains(crate::BufferUses::INDEX) {
         flags |= vk::BufferUsageFlags::INDEX_BUFFER;
     }
-    if usage.contains(crate::BufferUse::VERTEX) {
+    if usage.contains(crate::BufferUses::VERTEX) {
         flags |= vk::BufferUsageFlags::VERTEX_BUFFER;
     }
-    if usage.contains(crate::BufferUse::INDIRECT) {
+    if usage.contains(crate::BufferUses::INDIRECT) {
         flags |= vk::BufferUsageFlags::INDIRECT_BUFFER;
     }
     flags
 }
 
 pub fn map_buffer_usage_to_barrier(
-    usage: crate::BufferUse,
+    usage: crate::BufferUses,
 ) -> (vk::PipelineStageFlags, vk::AccessFlags) {
     let mut stages = vk::PipelineStageFlags::empty();
     let mut access = vk::AccessFlags::empty();
@@ -484,43 +486,43 @@ pub fn map_buffer_usage_to_barrier(
         | vk::PipelineStageFlags::FRAGMENT_SHADER
         | vk::PipelineStageFlags::COMPUTE_SHADER;
 
-    if usage.contains(crate::BufferUse::MAP_READ) {
+    if usage.contains(crate::BufferUses::MAP_READ) {
         stages |= vk::PipelineStageFlags::HOST;
         access |= vk::AccessFlags::HOST_READ;
     }
-    if usage.contains(crate::BufferUse::MAP_WRITE) {
+    if usage.contains(crate::BufferUses::MAP_WRITE) {
         stages |= vk::PipelineStageFlags::HOST;
         access |= vk::AccessFlags::HOST_WRITE;
     }
-    if usage.contains(crate::BufferUse::COPY_SRC) {
+    if usage.contains(crate::BufferUses::COPY_SRC) {
         stages |= vk::PipelineStageFlags::TRANSFER;
         access |= vk::AccessFlags::TRANSFER_READ;
     }
-    if usage.contains(crate::BufferUse::COPY_DST) {
+    if usage.contains(crate::BufferUses::COPY_DST) {
         stages |= vk::PipelineStageFlags::TRANSFER;
         access |= vk::AccessFlags::TRANSFER_WRITE;
     }
-    if usage.contains(crate::BufferUse::UNIFORM) {
+    if usage.contains(crate::BufferUses::UNIFORM) {
         stages |= shader_stages;
         access |= vk::AccessFlags::UNIFORM_READ;
     }
-    if usage.intersects(crate::BufferUse::STORAGE_LOAD) {
+    if usage.intersects(crate::BufferUses::STORAGE_LOAD) {
         stages |= shader_stages;
         access |= vk::AccessFlags::SHADER_READ;
     }
-    if usage.intersects(crate::BufferUse::STORAGE_STORE) {
+    if usage.intersects(crate::BufferUses::STORAGE_STORE) {
         stages |= shader_stages;
         access |= vk::AccessFlags::SHADER_WRITE;
     }
-    if usage.contains(crate::BufferUse::INDEX) {
+    if usage.contains(crate::BufferUses::INDEX) {
         stages |= vk::PipelineStageFlags::VERTEX_INPUT;
         access |= vk::AccessFlags::INDEX_READ;
     }
-    if usage.contains(crate::BufferUse::VERTEX) {
+    if usage.contains(crate::BufferUses::VERTEX) {
         stages |= vk::PipelineStageFlags::VERTEX_INPUT;
         access |= vk::AccessFlags::VERTEX_ATTRIBUTE_READ;
     }
-    if usage.contains(crate::BufferUse::INDIRECT) {
+    if usage.contains(crate::BufferUses::INDIRECT) {
         stages |= vk::PipelineStageFlags::VERTEX_INPUT;
         access |= vk::AccessFlags::INDIRECT_COMMAND_READ;
     }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -557,7 +557,7 @@ impl crate::Device<super::Api> for super::Device {
             .intersects(crate::BufferUse::MAP_READ | crate::BufferUse::MAP_WRITE)
         {
             let mut flags = gpu_alloc::UsageFlags::HOST_ACCESS;
-            //TODO: find a way to use `crate::MemoryFlag::PREFER_COHERENT`
+            //TODO: find a way to use `crate::MemoryFlags::PREFER_COHERENT`
             flags.set(
                 gpu_alloc::UsageFlags::DOWNLOAD,
                 desc.usage.contains(crate::BufferUse::MAP_READ),
@@ -572,7 +572,7 @@ impl crate::Device<super::Api> for super::Device {
         };
         alloc_usage.set(
             gpu_alloc::UsageFlags::TRANSIENT,
-            desc.memory_flags.contains(crate::MemoryFlag::TRANSIENT),
+            desc.memory_flags.contains(crate::MemoryFlags::TRANSIENT),
         );
 
         let block = self.mem_allocator.lock().alloc(
@@ -696,7 +696,7 @@ impl crate::Device<super::Api> for super::Device {
             block: Some(block),
             usage: desc.usage,
             dim: desc.dimension,
-            aspects: crate::FormatAspect::from(desc.format),
+            aspects: crate::FormatAspects::from(desc.format),
             format_info: desc.format.describe(),
             raw_flags,
         })
@@ -1198,7 +1198,7 @@ impl crate::Device<super::Api> for super::Device {
             };
             compatible_rp_key.depth_stencil = Some(super::DepthStencilAttachmentKey {
                 base: super::AttachmentKey::compatible(vk_format, vk_layout),
-                stencil_ops: crate::AttachmentOp::all(),
+                stencil_ops: crate::AttachmentOps::all(),
             });
 
             if ds.is_depth_enabled() {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -554,17 +554,17 @@ impl crate::Device<super::Api> for super::Device {
 
         let mut alloc_usage = if desc
             .usage
-            .intersects(crate::BufferUse::MAP_READ | crate::BufferUse::MAP_WRITE)
+            .intersects(crate::BufferUses::MAP_READ | crate::BufferUses::MAP_WRITE)
         {
             let mut flags = gpu_alloc::UsageFlags::HOST_ACCESS;
             //TODO: find a way to use `crate::MemoryFlags::PREFER_COHERENT`
             flags.set(
                 gpu_alloc::UsageFlags::DOWNLOAD,
-                desc.usage.contains(crate::BufferUse::MAP_READ),
+                desc.usage.contains(crate::BufferUses::MAP_READ),
             );
             flags.set(
                 gpu_alloc::UsageFlags::UPLOAD,
-                desc.usage.contains(crate::BufferUse::MAP_WRITE),
+                desc.usage.contains(crate::BufferUses::MAP_WRITE),
             );
             flags
         } else {

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -376,7 +376,7 @@ impl crate::Instance<super::Api> for super::Instance {
                 extensions.push(ext::MetalSurface::name());
             }
 
-            if desc.flags.contains(crate::InstanceFlag::DEBUG) {
+            if desc.flags.contains(crate::InstanceFlags::DEBUG) {
                 extensions.push(ext::DebugUtils::name());
             }
 
@@ -412,7 +412,7 @@ impl crate::Instance<super::Api> for super::Instance {
         // Check requested layers against the available layers
         let layers = {
             let mut layers: Vec<&'static CStr> = Vec::new();
-            if desc.flags.contains(crate::InstanceFlag::VALIDATION) {
+            if desc.flags.contains(crate::InstanceFlags::VALIDATION) {
                 layers.push(CStr::from_bytes_with_nul(b"VK_LAYER_KHRONOS_validation\0").unwrap());
             }
 
@@ -648,7 +648,7 @@ impl crate::Surface<super::Api> for super::Surface {
                 block: None,
                 usage: sc.config.usage,
                 dim: wgt::TextureDimension::D2,
-                aspects: crate::FormatAspect::COLOR,
+                aspects: crate::FormatAspects::COLOR,
                 format_info: sc.config.format.describe(),
                 raw_flags: vk::ImageCreateFlags::empty(),
             },

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -197,7 +197,7 @@ struct RenderPassKey {
 struct FramebufferAttachment {
     /// Can be NULL if the framebuffer is image-less
     raw: vk::ImageView,
-    texture_usage: crate::TextureUse,
+    texture_usage: crate::TextureUses,
     raw_image_flags: vk::ImageCreateFlags,
     view_format: wgt::TextureFormat,
 }
@@ -247,7 +247,7 @@ pub struct Buffer {
 pub struct Texture {
     raw: vk::Image,
     block: Option<gpu_alloc::MemoryBlock<vk::DeviceMemory>>,
-    usage: crate::TextureUse,
+    usage: crate::TextureUses,
     dim: wgt::TextureDimension,
     aspects: crate::FormatAspects,
     format_info: wgt::TextureFormatInfo,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -75,7 +75,7 @@ struct DebugUtils {
 
 struct InstanceShared {
     raw: ash::Instance,
-    flags: crate::InstanceFlag,
+    flags: crate::InstanceFlags,
     debug_utils: Option<DebugUtils>,
     get_physical_device_properties: Option<vk::KhrGetPhysicalDeviceProperties2Fn>,
 }
@@ -158,7 +158,7 @@ struct AttachmentKey {
     layout_pre: vk::ImageLayout,
     layout_in: vk::ImageLayout,
     layout_post: vk::ImageLayout,
-    ops: crate::AttachmentOp,
+    ops: crate::AttachmentOps,
 }
 
 impl AttachmentKey {
@@ -169,7 +169,7 @@ impl AttachmentKey {
             layout_pre: vk::ImageLayout::GENERAL,
             layout_in,
             layout_post: vk::ImageLayout::GENERAL,
-            ops: crate::AttachmentOp::all(),
+            ops: crate::AttachmentOps::all(),
         }
     }
 }
@@ -183,7 +183,7 @@ struct ColorAttachmentKey {
 #[derive(Clone, Eq, Hash, PartialEq)]
 struct DepthStencilAttachmentKey {
     base: AttachmentKey,
-    stencil_ops: crate::AttachmentOp,
+    stencil_ops: crate::AttachmentOps,
 }
 
 #[derive(Clone, Eq, Default, Hash, PartialEq)]
@@ -249,7 +249,7 @@ pub struct Texture {
     block: Option<gpu_alloc::MemoryBlock<vk::DeviceMemory>>,
     usage: crate::TextureUse,
     dim: wgt::TextureDimension,
-    aspects: crate::FormatAspect,
+    aspects: crate::FormatAspects,
     format_info: wgt::TextureFormatInfo,
     raw_flags: vk::ImageCreateFlags,
 }
@@ -261,7 +261,7 @@ pub struct TextureView {
 }
 
 impl TextureView {
-    fn aspects(&self) -> crate::FormatAspect {
+    fn aspects(&self) -> crate::FormatAspects {
         self.attachment.view_format.into()
     }
 }

--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -87,10 +87,8 @@ fn print_info_from_adapter(adapter: &wgpu::Adapter, idx: usize) {
 fn main() {
     let args: Vec<_> = std::env::args().skip(1).collect();
 
-    let instance = wgpu::Instance::new(wgpu::BackendBit::all());
-    let adapters: Vec<_> = instance
-        .enumerate_adapters(wgpu::BackendBit::all())
-        .collect();
+    let instance = wgpu::Instance::new(wgpu::Backends::all());
+    let adapters: Vec<_> = instance.enumerate_adapters(wgpu::Backends::all()).collect();
     let adapter_count = adapters.len();
 
     if args.is_empty() {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -182,7 +182,7 @@ bitflags::bitflags! {
         /// Compressed textures sacrifice some quality in exchange for significantly reduced
         /// bandwidth usage.
         ///
-        /// Support for this feature guarantees availability of [`TextureUsage::COPY_SRC | TextureUsage::COPY_DST | TextureUsage::SAMPLED`] for BCn formats.
+        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::SAMPLED`] for BCn formats.
         /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
         ///
         /// Supported Platforms:
@@ -388,7 +388,7 @@ bitflags::bitflags! {
         /// Compressed textures sacrifice some quality in exchange for significantly reduced
         /// bandwidth usage.
         ///
-        /// Support for this feature guarantees availability of [`TextureUsage::COPY_SRC | TextureUsage::COPY_DST | TextureUsage::SAMPLED`] for ETC2 formats.
+        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::SAMPLED`] for ETC2 formats.
         /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
         ///
         /// Supported Platforms:
@@ -403,7 +403,7 @@ bitflags::bitflags! {
         /// Compressed textures sacrifice some quality in exchange for significantly reduced
         /// bandwidth usage.
         ///
-        /// Support for this feature guarantees availability of [`TextureUsage::COPY_SRC | TextureUsage::COPY_DST | TextureUsage::SAMPLED`] for ASTC formats.
+        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::SAMPLED`] for ASTC formats.
         /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
         ///
         /// Supported Platforms:
@@ -958,7 +958,7 @@ pub struct ColorTargetState {
     pub blend: Option<BlendState>,
     /// Mask which enables/disables writes to different color/alpha channel.
     #[cfg_attr(any(feature = "trace", feature = "replay"), serde(default))]
-    pub write_mask: ColorWrite,
+    pub write_mask: ColorWrites,
 }
 
 impl From<TextureFormat> for ColorTargetState {
@@ -966,7 +966,7 @@ impl From<TextureFormat> for ColorTargetState {
         Self {
             format,
             blend: None,
-            write_mask: ColorWrite::ALL,
+            write_mask: ColorWrites::ALL,
         }
     }
 }
@@ -1152,7 +1152,7 @@ bitflags::bitflags! {
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct TextureFormatFeatures {
     /// Valid bits for `TextureDescriptor::Usage` provided for format creation.
-    pub allowed_usages: TextureUsage,
+    pub allowed_usages: TextureUsages,
     /// Additional property flags for the format.
     pub flags: TextureFormatFeatureFlags,
     /// If `filterable` is false, the texture can't be sampled with a filtering sampler.
@@ -1585,10 +1585,10 @@ impl TextureFormat {
         let srgb = true;
 
         // Flags
-        let basic = TextureUsage::COPY_SRC | TextureUsage::COPY_DST | TextureUsage::SAMPLED;
-        let attachment = basic | TextureUsage::RENDER_ATTACHMENT;
-        let storage = basic | TextureUsage::STORAGE;
-        let all_flags = TextureUsage::all();
+        let basic = TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::SAMPLED;
+        let attachment = basic | TextureUsages::RENDER_ATTACHMENT;
+        let storage = basic | TextureUsages::STORAGE;
+        let all_flags = TextureUsages::all();
 
         // See <https://gpuweb.github.io/gpuweb/#texture-format-caps> for reference
         let (required_features, sample_type, srgb, block_dimensions, block_size, allowed_usages) =
@@ -1724,7 +1724,7 @@ bitflags::bitflags! {
     #[repr(transparent)]
     #[cfg_attr(feature = "trace", derive(Serialize))]
     #[cfg_attr(feature = "replay", derive(Deserialize))]
-    pub struct ColorWrite: u32 {
+    pub struct ColorWrites: u32 {
         /// Enable red channel writes
         const RED = 1;
         /// Enable green channel writes
@@ -1740,7 +1740,7 @@ bitflags::bitflags! {
     }
 }
 
-impl Default for ColorWrite {
+impl Default for ColorWrites {
     fn default() -> Self {
         Self::ALL
     }
@@ -2106,7 +2106,7 @@ bitflags::bitflags! {
     #[repr(transparent)]
     #[cfg_attr(feature = "trace", derive(Serialize))]
     #[cfg_attr(feature = "replay", derive(Deserialize))]
-    pub struct BufferUsage: u32 {
+    pub struct BufferUsages: u32 {
         /// Allow a buffer to be mapped for reading using [`Buffer::map_async`] + [`Buffer::get_mapped_range`].
         /// This does not include creating a buffer with [`BufferDescriptor::mapped_at_creation`] set.
         ///
@@ -2150,9 +2150,9 @@ pub struct BufferDescriptor<L> {
     pub size: BufferAddress,
     /// Usages of a buffer. If the buffer is used in any way that isn't specified here, the operation
     /// will panic.
-    pub usage: BufferUsage,
-    /// Allows a buffer to be mapped immediately after they are made. It does not have to be [`BufferUsage::MAP_READ`] or
-    /// [`BufferUsage::MAP_WRITE`], all buffers are allowed to be mapped at creation.
+    pub usage: BufferUsages,
+    /// Allows a buffer to be mapped immediately after they are made. It does not have to be [`BufferUsages::MAP_READ`] or
+    /// [`BufferUsages::MAP_WRITE`], all buffers are allowed to be mapped at creation.
     pub mapped_at_creation: bool,
 }
 
@@ -2223,7 +2223,7 @@ bitflags::bitflags! {
     #[repr(transparent)]
     #[cfg_attr(feature = "trace", derive(Serialize))]
     #[cfg_attr(feature = "replay", derive(Deserialize))]
-    pub struct TextureUsage: u32 {
+    pub struct TextureUsages: u32 {
         /// Allows a texture to be the source in a [`CommandEncoder::copy_texture_to_buffer`] or
         /// [`CommandEncoder::copy_texture_to_texture`] operation.
         const COPY_SRC = 1;
@@ -2246,7 +2246,7 @@ bitflags::bitflags! {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct SwapChainDescriptor {
     /// The usage of the swap chain. The only supported usage is `RENDER_ATTACHMENT`.
-    pub usage: TextureUsage,
+    pub usage: TextureUsages,
     /// The texture format of the swap chain. The only formats that are guaranteed are
     /// `Bgra8Unorm` and `Bgra8UnormSrgb`
     pub format: TextureFormat,
@@ -2474,7 +2474,7 @@ pub struct TextureDescriptor<L> {
     /// Format of the texture.
     pub format: TextureFormat,
     /// Allowed usages of the texture. If used in other ways, the operation will panic.
-    pub usage: TextureUsage,
+    pub usage: TextureUsages,
 }
 
 impl<L> TextureDescriptor<L> {
@@ -2507,7 +2507,7 @@ impl<L> TextureDescriptor<L> {
     ///   sample_count: 1,
     ///   dimension: wgpu::TextureDimension::D3,
     ///   format: wgpu::TextureFormat::Rgba8Sint,
-    ///   usage: wgpu::TextureUsage::empty(),
+    ///   usage: wgpu::TextureUsages::empty(),
     /// };
     ///
     /// assert_eq!(desc.mip_level_size(0), Some(wgpu::Extent3d { width: 100, height: 60, depth_or_array_layers: 1 }));

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -92,7 +92,7 @@ bitflags::bitflags! {
     #[repr(transparent)]
     #[cfg_attr(feature = "trace", derive(Serialize))]
     #[cfg_attr(feature = "replay", derive(Deserialize))]
-    pub struct BackendBit: u32 {
+    pub struct Backends: u32 {
         /// Supported on Windows, Linux/Android, and macOS/iOS via Vulkan Portability (with the Vulkan feature enabled)
         const VULKAN = 1 << Backend::Vulkan as u32;
         /// Currently unsupported
@@ -120,7 +120,7 @@ bitflags::bitflags! {
     }
 }
 
-impl From<Backend> for BackendBit {
+impl From<Backend> for Backends {
     fn from(backend: Backend) -> Self {
         Self::from_bits(1 << backend as u32).unwrap()
     }
@@ -741,10 +741,10 @@ bitflags::bitflags! {
     ///
     /// These can be combined so something that is visible from both vertex and fragment shaders can be defined as:
     ///
-    /// `ShaderStage::VERTEX | ShaderStage::FRAGMENT`
+    /// `ShaderStages::VERTEX | ShaderStages::FRAGMENT`
     #[repr(transparent)]
     #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-    pub struct ShaderStage: u32 {
+    pub struct ShaderStages: u32 {
         /// Binding is not visible from any shader stage.
         const NONE = 0;
         /// Binding is visible from the vertex shader of a render pipeline.
@@ -2627,7 +2627,7 @@ impl Default for FilterMode {
 pub struct PushConstantRange {
     /// Stage push constant range is visible from. Each stage can only be served by at most one range.
     /// One range can serve multiple stages however.
-    pub stages: ShaderStage,
+    pub stages: ShaderStages,
     /// Range in push constant memory to use for the stage. Must be less than [`Limits::max_push_constant_size`].
     /// Start and end must be aligned to the 4s.
     pub range: Range<u32>,
@@ -2928,7 +2928,7 @@ pub struct BindGroupLayoutEntry {
     /// of index 1, would be described as `layout(set = 0, binding = 1) uniform` in shaders.
     pub binding: u32,
     /// Which shader stages can see this binding.
-    pub visibility: ShaderStage,
+    pub visibility: ShaderStages,
     /// The type of the binding
     pub ty: BindingType,
     /// If this value is Some, indicates this entry is an array. Array size must be 1 or greater.

--- a/wgpu/examples/boids/main.rs
+++ b/wgpu/examples/boids/main.rs
@@ -62,7 +62,7 @@ impl framework::Example for Example {
         let sim_param_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Simulation Parameter Buffer"),
             contents: bytemuck::cast_slice(&sim_param_data),
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
         // create compute bind layout group and compute pipeline layout
@@ -165,7 +165,7 @@ impl framework::Example for Example {
         let vertices_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Vertex Buffer"),
             contents: bytemuck::bytes_of(&vertex_buffer_data),
-            usage: wgpu::BufferUsage::VERTEX | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
         });
 
         // buffer for all particles data of type [(posx,posy,velx,vely),...]
@@ -190,9 +190,9 @@ impl framework::Example for Example {
                 device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                     label: Some(&format!("Particle Buffer {}", i)),
                     contents: bytemuck::cast_slice(&initial_particle_data),
-                    usage: wgpu::BufferUsage::VERTEX
-                        | wgpu::BufferUsage::STORAGE
-                        | wgpu::BufferUsage::COPY_DST,
+                    usage: wgpu::BufferUsages::VERTEX
+                        | wgpu::BufferUsages::STORAGE
+                        | wgpu::BufferUsages::COPY_DST,
                 }),
             );
         }

--- a/wgpu/examples/boids/main.rs
+++ b/wgpu/examples/boids/main.rs
@@ -72,7 +72,7 @@ impl framework::Example for Example {
                 entries: &[
                     wgpu::BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: wgpu::ShaderStage::COMPUTE,
+                        visibility: wgpu::ShaderStages::COMPUTE,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,
@@ -84,7 +84,7 @@ impl framework::Example for Example {
                     },
                     wgpu::BindGroupLayoutEntry {
                         binding: 1,
-                        visibility: wgpu::ShaderStage::COMPUTE,
+                        visibility: wgpu::ShaderStages::COMPUTE,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Storage { read_only: true },
                             has_dynamic_offset: false,
@@ -94,7 +94,7 @@ impl framework::Example for Example {
                     },
                     wgpu::BindGroupLayoutEntry {
                         binding: 2,
-                        visibility: wgpu::ShaderStage::COMPUTE,
+                        visibility: wgpu::ShaderStages::COMPUTE,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Storage { read_only: false },
                             has_dynamic_offset: false,

--- a/wgpu/examples/bunnymark/main.rs
+++ b/wgpu/examples/bunnymark/main.rs
@@ -56,7 +56,7 @@ impl framework::Example for Example {
                 entries: &[
                     wgpu::BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: wgpu::ShaderStage::VERTEX,
+                        visibility: wgpu::ShaderStages::VERTEX,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,
@@ -66,7 +66,7 @@ impl framework::Example for Example {
                     },
                     wgpu::BindGroupLayoutEntry {
                         binding: 1,
-                        visibility: wgpu::ShaderStage::FRAGMENT,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
                             sample_type: wgpu::TextureSampleType::Float { filterable: true },
                             view_dimension: wgpu::TextureViewDimension::D2,
@@ -76,7 +76,7 @@ impl framework::Example for Example {
                     },
                     wgpu::BindGroupLayoutEntry {
                         binding: 2,
-                        visibility: wgpu::ShaderStage::FRAGMENT,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Sampler {
                             filtering: true,
                             comparison: false,
@@ -90,7 +90,7 @@ impl framework::Example for Example {
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::VERTEX,
+                    visibility: wgpu::ShaderStages::VERTEX,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: true,

--- a/wgpu/examples/bunnymark/main.rs
+++ b/wgpu/examples/bunnymark/main.rs
@@ -120,7 +120,7 @@ impl framework::Example for Example {
                 targets: &[wgpu::ColorTargetState {
                     format: sc_desc.format,
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),
-                    write_mask: wgpu::ColorWrite::default(),
+                    write_mask: wgpu::ColorWrites::default(),
                 }],
             }),
             primitive: wgpu::PrimitiveState {
@@ -150,7 +150,7 @@ impl framework::Example for Example {
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Rgba8UnormSrgb,
-                usage: wgpu::TextureUsage::COPY_DST | wgpu::TextureUsage::SAMPLED,
+                usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::SAMPLED,
             });
             queue.write_texture(
                 texture.as_image_copy(),
@@ -192,12 +192,12 @@ impl framework::Example for Example {
         let global_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("global"),
             contents: bytemuck::bytes_of(&globals),
-            usage: wgpu::BufferUsage::COPY_DST | wgpu::BufferUsage::UNIFORM,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
         });
         let local_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("local"),
             size: (MAX_BUNNIES as wgpu::BufferAddress) * wgpu::BIND_BUFFER_ALIGNMENT,
-            usage: wgpu::BufferUsage::COPY_DST | wgpu::BufferUsage::UNIFORM,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
             mapped_at_creation: false,
         });
 

--- a/wgpu/examples/capture/main.rs
+++ b/wgpu/examples/capture/main.rs
@@ -28,7 +28,7 @@ async fn create_red_image_with_dimensions(
     width: usize,
     height: usize,
 ) -> (Device, Buffer, BufferDimensions) {
-    let adapter = wgpu::Instance::new(wgpu::BackendBit::PRIMARY)
+    let adapter = wgpu::Instance::new(wgpu::Backends::PRIMARY)
         .request_adapter(&wgpu::RequestAdapterOptions::default())
         .await
         .unwrap();

--- a/wgpu/examples/capture/main.rs
+++ b/wgpu/examples/capture/main.rs
@@ -54,7 +54,7 @@ async fn create_red_image_with_dimensions(
     let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
         size: (buffer_dimensions.padded_bytes_per_row * buffer_dimensions.height) as u64,
-        usage: wgpu::BufferUsage::MAP_READ | wgpu::BufferUsage::COPY_DST,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });
 
@@ -71,7 +71,7 @@ async fn create_red_image_with_dimensions(
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
         format: wgpu::TextureFormat::Rgba8UnormSrgb,
-        usage: wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::COPY_SRC,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         label: None,
     });
 

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -171,7 +171,7 @@ impl framework::Example for Example {
                     entries: &[
                         wgpu::BindGroupLayoutEntry {
                             binding: 0,
-                            visibility: wgpu::ShaderStage::FRAGMENT,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
                             ty: wgpu::BindingType::Texture {
                                 sample_type: wgpu::TextureSampleType::Float { filterable: false },
                                 view_dimension: wgpu::TextureViewDimension::D2,
@@ -181,7 +181,7 @@ impl framework::Example for Example {
                         },
                         wgpu::BindGroupLayoutEntry {
                             binding: 1,
-                            visibility: wgpu::ShaderStage::FRAGMENT,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
                             ty: wgpu::BindingType::Sampler {
                                 filtering: false,
                                 comparison: false,

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -34,7 +34,7 @@ impl Example {
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: RENDER_TARGET_FORMAT,
-                usage: wgpu::TextureUsage::SAMPLED | wgpu::TextureUsage::RENDER_ATTACHMENT,
+                usage: wgpu::TextureUsages::SAMPLED | wgpu::TextureUsages::RENDER_ATTACHMENT,
             })
             .create_view(&Default::default());
 

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -124,13 +124,13 @@ impl framework::Example for Example {
         let vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Vertex Buffer"),
             contents: bytemuck::cast_slice(&vertex_data),
-            usage: wgpu::BufferUsage::VERTEX,
+            usage: wgpu::BufferUsages::VERTEX,
         });
 
         let index_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Index Buffer"),
             contents: bytemuck::cast_slice(&index_data),
-            usage: wgpu::BufferUsage::INDEX,
+            usage: wgpu::BufferUsages::INDEX,
         });
 
         // Create pipeline layout
@@ -180,7 +180,7 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::R8Uint,
-            usage: wgpu::TextureUsage::SAMPLED | wgpu::TextureUsage::COPY_DST,
+            usage: wgpu::TextureUsages::SAMPLED | wgpu::TextureUsages::COPY_DST,
         });
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
         queue.write_texture(
@@ -200,7 +200,7 @@ impl framework::Example for Example {
         let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Uniform Buffer"),
             contents: bytemuck::cast_slice(mx_ref),
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
         // Create bind group
@@ -287,7 +287,7 @@ impl framework::Example for Example {
                             },
                             alpha: wgpu::BlendComponent::REPLACE,
                         }),
-                        write_mask: wgpu::ColorWrite::ALL,
+                        write_mask: wgpu::ColorWrites::ALL,
                     }],
                 }),
                 primitive: wgpu::PrimitiveState {

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -139,7 +139,7 @@ impl framework::Example for Example {
             entries: &[
                 wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::VERTEX,
+                    visibility: wgpu::ShaderStages::VERTEX,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
@@ -149,7 +149,7 @@ impl framework::Example for Example {
                 },
                 wgpu::BindGroupLayoutEntry {
                     binding: 1,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Texture {
                         multisampled: false,
                         sample_type: wgpu::TextureSampleType::Uint,

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -178,7 +178,7 @@ fn start<E: Example>(
 ) {
     let spawner = Spawner::new();
     let mut sc_desc = wgpu::SwapChainDescriptor {
-        usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         format: adapter.get_swap_chain_preferred_format(&surface).unwrap(),
         width: size.width,
         height: size.height,
@@ -407,7 +407,7 @@ pub fn test<E: Example>(mut params: FrameworkRefTest) {
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Rgba8UnormSrgb,
-                usage: wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::COPY_SRC,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
             });
 
             let dst_view = dst_texture.create_view(&wgpu::TextureViewDescriptor::default());
@@ -415,13 +415,13 @@ pub fn test<E: Example>(mut params: FrameworkRefTest) {
             let dst_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("image map buffer"),
                 size: params.width as u64 * params.height as u64 * 4,
-                usage: wgpu::BufferUsage::COPY_DST | wgpu::BufferUsage::MAP_READ,
+                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
                 mapped_at_creation: false,
             });
 
             let mut example = E::init(
                 &wgpu::SwapChainDescriptor {
-                    usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                     format: wgpu::TextureFormat::Rgba8UnormSrgb,
                     width: params.width,
                     height: params.height,

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -110,7 +110,7 @@ async fn setup<E: Example>(title: &str) -> Setup {
 
     log::info!("Initializing the surface...");
 
-    let backend = wgpu::util::backend_bits_from_env().unwrap_or(wgpu::BackendBit::PRIMARY);
+    let backend = wgpu::util::backend_bits_from_env().unwrap_or(wgpu::Backends::PRIMARY);
 
     let instance = wgpu::Instance::new(backend);
     let (size, surface) = unsafe {

--- a/wgpu/examples/hello-compute/main.rs
+++ b/wgpu/examples/hello-compute/main.rs
@@ -80,12 +80,12 @@ async fn execute_gpu_inner(
 
     // Instantiates buffer without data.
     // `usage` of buffer specifies how it can be used:
-    //   `BufferUsage::MAP_READ` allows it to be read (outside the shader).
-    //   `BufferUsage::COPY_DST` allows it to be the destination of the copy.
+    //   `BufferUsages::MAP_READ` allows it to be read (outside the shader).
+    //   `BufferUsages::COPY_DST` allows it to be the destination of the copy.
     let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
         size,
-        usage: wgpu::BufferUsage::MAP_READ | wgpu::BufferUsage::COPY_DST,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });
 
@@ -97,9 +97,9 @@ async fn execute_gpu_inner(
     let storage_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("Storage Buffer"),
         contents: bytemuck::cast_slice(numbers),
-        usage: wgpu::BufferUsage::STORAGE
-            | wgpu::BufferUsage::COPY_DST
-            | wgpu::BufferUsage::COPY_SRC,
+        usage: wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_DST
+            | wgpu::BufferUsages::COPY_SRC,
     });
 
     // A bind group defines how buffers are accessed by shaders.

--- a/wgpu/examples/hello-compute/main.rs
+++ b/wgpu/examples/hello-compute/main.rs
@@ -33,7 +33,7 @@ async fn run() {
 
 async fn execute_gpu(numbers: &[u32]) -> Option<Vec<u32>> {
     // Instantiates instance of WebGPU
-    let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
+    let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
 
     // `request_adapter` instantiates the general connection to the GPU
     let adapter = instance

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -64,7 +64,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
     });
 
     let mut sc_desc = wgpu::SwapChainDescriptor {
-        usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         format: swapchain_format,
         width: size.width,
         height: size.height,

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -7,7 +7,7 @@ use winit::{
 
 async fn run(event_loop: EventLoop<()>, window: Window) {
     let size = window.inner_size();
-    let instance = wgpu::Instance::new(wgpu::BackendBit::all());
+    let instance = wgpu::Instance::new(wgpu::Backends::all());
     let surface = unsafe { instance.create_surface(&window) };
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -65,7 +65,7 @@ impl Viewport {
 }
 
 async fn run(event_loop: EventLoop<()>, viewports: Vec<(Window, wgpu::Color)>) {
-    let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
+    let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
     let viewports: Vec<_> = viewports
         .into_iter()
         .map(|(window, color)| ViewportDesc::new(window, color, &instance))

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -31,7 +31,7 @@ impl ViewportDesc {
         let size = self.window.inner_size();
 
         let sc_desc = wgpu::SwapChainDescriptor {
-            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: adapter
                 .get_swap_chain_preferred_format(&self.surface)
                 .unwrap(),

--- a/wgpu/examples/hello/main.rs
+++ b/wgpu/examples/hello/main.rs
@@ -1,7 +1,7 @@
 /// This example shows how to describe the adapter in use.
 async fn run() {
     #[cfg_attr(target_arch = "wasm32", allow(unused_variables))]
-    let adapter = wgpu::Instance::new(wgpu::BackendBit::PRIMARY)
+    let adapter = wgpu::Instance::new(wgpu::Backends::PRIMARY)
         .request_adapter(&wgpu::RequestAdapterOptions::default())
         .await
         .unwrap();

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -225,9 +225,9 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: TEXTURE_FORMAT,
-            usage: wgpu::TextureUsage::SAMPLED
-                | wgpu::TextureUsage::RENDER_ATTACHMENT
-                | wgpu::TextureUsage::COPY_DST,
+            usage: wgpu::TextureUsages::SAMPLED
+                | wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::COPY_DST,
             label: None,
         });
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
@@ -236,7 +236,7 @@ impl framework::Example for Example {
         let temp_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Temporary Buffer"),
             contents: texels.as_slice(),
-            usage: wgpu::BufferUsage::COPY_SRC,
+            usage: wgpu::BufferUsages::COPY_SRC,
         });
         init_encoder.copy_buffer_to_texture(
             wgpu::ImageCopyBuffer {
@@ -267,7 +267,7 @@ impl framework::Example for Example {
         let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Uniform Buffer"),
             contents: bytemuck::cast_slice(mx_ref),
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
         // Create the render pipeline
@@ -355,7 +355,7 @@ impl framework::Example for Example {
                 size: mip_passes as wgpu::BufferAddress
                     * 3
                     * mem::size_of::<u64>() as wgpu::BufferAddress,
-                usage: wgpu::BufferUsage::COPY_DST | wgpu::BufferUsage::MAP_READ,
+                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
                 mapped_at_creation: false,
             });
 

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -483,7 +483,7 @@ fn mipmap() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
-            .backend_failures(wgpu::BackendBit::VULKAN),
+            .backend_failures(wgpu::Backends::VULKAN),
         tollerance: 25,
         max_outliers: 3000, // Mipmap sampling is highly variant between impls. This is currently bounded by AMD on mac
     });

--- a/wgpu/examples/msaa-line/main.rs
+++ b/wgpu/examples/msaa-line/main.rs
@@ -104,7 +104,7 @@ impl Example {
             sample_count,
             dimension: wgpu::TextureDimension::D2,
             format: sc_desc.format,
-            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             label: None,
         };
 
@@ -157,7 +157,7 @@ impl framework::Example for Example {
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Vertex Buffer"),
             contents: bytemuck::cast_slice(&vertex_data),
-            usage: wgpu::BufferUsage::VERTEX,
+            usage: wgpu::BufferUsages::VERTEX,
         });
         let vertex_count = vertex_data.len() as u32;
 

--- a/wgpu/examples/shadow/main.rs
+++ b/wgpu/examples/shadow/main.rs
@@ -200,7 +200,7 @@ impl Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: Self::DEPTH_FORMAT,
-            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             label: None,
         });
 
@@ -226,7 +226,7 @@ impl framework::Example for Example {
             &wgpu::util::BufferInitDescriptor {
                 label: Some("Cubes Vertex Buffer"),
                 contents: bytemuck::cast_slice(&cube_vertex_data),
-                usage: wgpu::BufferUsage::VERTEX,
+                usage: wgpu::BufferUsages::VERTEX,
             },
         ));
 
@@ -234,7 +234,7 @@ impl framework::Example for Example {
             &wgpu::util::BufferInitDescriptor {
                 label: Some("Cubes Index Buffer"),
                 contents: bytemuck::cast_slice(&cube_index_data),
-                usage: wgpu::BufferUsage::INDEX,
+                usage: wgpu::BufferUsages::INDEX,
             },
         ));
 
@@ -242,13 +242,13 @@ impl framework::Example for Example {
         let plane_vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Plane Vertex Buffer"),
             contents: bytemuck::cast_slice(&plane_vertex_data),
-            usage: wgpu::BufferUsage::VERTEX,
+            usage: wgpu::BufferUsages::VERTEX,
         });
 
         let plane_index_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Plane Index Buffer"),
             contents: bytemuck::cast_slice(&plane_index_data),
-            usage: wgpu::BufferUsage::INDEX,
+            usage: wgpu::BufferUsages::INDEX,
         });
 
         struct CubeDesc {
@@ -291,7 +291,7 @@ impl framework::Example for Example {
         let entity_uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
             size: num_entities * wgpu::BIND_BUFFER_ALIGNMENT,
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
@@ -377,7 +377,7 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: Self::SHADOW_FORMAT,
-            usage: wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::SAMPLED,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::SAMPLED,
             label: None,
         });
         let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
@@ -427,9 +427,9 @@ impl framework::Example for Example {
         let light_storage_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
             size: light_uniform_size,
-            usage: wgpu::BufferUsage::STORAGE
-                | wgpu::BufferUsage::COPY_SRC
-                | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
@@ -471,7 +471,7 @@ impl framework::Example for Example {
             let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
                 label: None,
                 size: uniform_size,
-                usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
                 mapped_at_creation: false,
             });
 
@@ -586,7 +586,7 @@ impl framework::Example for Example {
             let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some("Uniform Buffer"),
                 contents: bytemuck::bytes_of(&forward_uniforms),
-                usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             });
 
             // Create bind group

--- a/wgpu/examples/shadow/main.rs
+++ b/wgpu/examples/shadow/main.rs
@@ -335,7 +335,7 @@ impl framework::Example for Example {
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: true,
@@ -453,7 +453,7 @@ impl framework::Example for Example {
                     label: None,
                     entries: &[wgpu::BindGroupLayoutEntry {
                         binding: 0, // global
-                        visibility: wgpu::ShaderStage::VERTEX,
+                        visibility: wgpu::ShaderStages::VERTEX,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,
@@ -530,7 +530,7 @@ impl framework::Example for Example {
                     entries: &[
                         wgpu::BindGroupLayoutEntry {
                             binding: 0, // global
-                            visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+                            visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                             ty: wgpu::BindingType::Buffer {
                                 ty: wgpu::BufferBindingType::Uniform,
                                 has_dynamic_offset: false,
@@ -542,7 +542,7 @@ impl framework::Example for Example {
                         },
                         wgpu::BindGroupLayoutEntry {
                             binding: 1, // lights
-                            visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+                            visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                             ty: wgpu::BindingType::Buffer {
                                 ty: wgpu::BufferBindingType::Storage { read_only: true },
                                 has_dynamic_offset: false,
@@ -552,7 +552,7 @@ impl framework::Example for Example {
                         },
                         wgpu::BindGroupLayoutEntry {
                             binding: 2,
-                            visibility: wgpu::ShaderStage::FRAGMENT,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
                             ty: wgpu::BindingType::Texture {
                                 multisampled: false,
                                 sample_type: wgpu::TextureSampleType::Depth,
@@ -562,7 +562,7 @@ impl framework::Example for Example {
                         },
                         wgpu::BindGroupLayoutEntry {
                             binding: 3,
-                            visibility: wgpu::ShaderStage::FRAGMENT,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
                             ty: wgpu::BindingType::Sampler {
                                 comparison: true,
                                 filtering: true,

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -86,7 +86,7 @@ impl Skybox {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: Self::DEPTH_FORMAT,
-            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             label: None,
         });
 
@@ -130,7 +130,7 @@ impl framework::Example for Skybox {
                     let vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                         label: Some("Vertex"),
                         contents: bytemuck::cast_slice(&vertices),
-                        usage: wgpu::BufferUsage::VERTEX,
+                        usage: wgpu::BufferUsages::VERTEX,
                     });
                     entities.push(Entity {
                         vertex_count: vertices.len() as u32,
@@ -191,7 +191,7 @@ impl framework::Example for Skybox {
         let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Buffer"),
             contents: bytemuck::cast_slice(&raw_uniforms),
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -324,7 +324,7 @@ impl framework::Example for Skybox {
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: skybox_format,
-                usage: wgpu::TextureUsage::SAMPLED | wgpu::TextureUsage::COPY_DST,
+                usage: wgpu::TextureUsages::SAMPLED | wgpu::TextureUsages::COPY_DST,
                 label: None,
             },
             &image.data,

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -145,7 +145,7 @@ impl framework::Example for Skybox {
             entries: &[
                 wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
@@ -155,7 +155,7 @@ impl framework::Example for Skybox {
                 },
                 wgpu::BindGroupLayoutEntry {
                     binding: 1,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Texture {
                         sample_type: wgpu::TextureSampleType::Float { filterable: true },
                         multisampled: false,
@@ -165,7 +165,7 @@ impl framework::Example for Skybox {
                 },
                 wgpu::BindGroupLayoutEntry {
                     binding: 2,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Sampler {
                         comparison: false,
                         filtering: true,
@@ -472,7 +472,7 @@ fn skybox() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
-            .backend_failures(wgpu::BackendBit::VULKAN),
+            .backend_failures(wgpu::Backends::VULKAN),
         tollerance: 2,
         max_outliers: 3,
     });

--- a/wgpu/examples/texture-arrays/main.rs
+++ b/wgpu/examples/texture-arrays/main.rs
@@ -174,7 +174,7 @@ impl framework::Example for Example {
             entries: &[
                 wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Texture {
                         sample_type: wgpu::TextureSampleType::Float { filterable: true },
                         view_dimension: wgpu::TextureViewDimension::D2,
@@ -184,7 +184,7 @@ impl framework::Example for Example {
                 },
                 wgpu::BindGroupLayoutEntry {
                     binding: 1,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Sampler {
                         comparison: false,
                         filtering: true,
@@ -217,7 +217,7 @@ impl framework::Example for Example {
             bind_group_layouts: &[&bind_group_layout],
             push_constant_ranges: if uniform_workaround {
                 &[wgpu::PushConstantRange {
-                    stages: wgpu::ShaderStage::FRAGMENT,
+                    stages: wgpu::ShaderStages::FRAGMENT,
                     range: 0..4,
                 }]
             } else {
@@ -301,9 +301,9 @@ impl framework::Example for Example {
         rpass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
         rpass.set_index_buffer(self.index_buffer.slice(..), self.index_format);
         if self.uniform_workaround {
-            rpass.set_push_constants(wgpu::ShaderStage::FRAGMENT, 0, bytemuck::cast_slice(&[0]));
+            rpass.set_push_constants(wgpu::ShaderStages::FRAGMENT, 0, bytemuck::cast_slice(&[0]));
             rpass.draw_indexed(0..6, 0, 0..1);
-            rpass.set_push_constants(wgpu::ShaderStage::FRAGMENT, 0, bytemuck::cast_slice(&[1]));
+            rpass.set_push_constants(wgpu::ShaderStages::FRAGMENT, 0, bytemuck::cast_slice(&[1]));
             rpass.draw_indexed(6..12, 0, 0..1);
         } else {
             rpass.draw_indexed(0..12, 0, 0..1);

--- a/wgpu/examples/texture-arrays/main.rs
+++ b/wgpu/examples/texture-arrays/main.rs
@@ -112,14 +112,14 @@ impl framework::Example for Example {
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Vertex Buffer"),
             contents: bytemuck::cast_slice(&vertex_data),
-            usage: wgpu::BufferUsage::VERTEX,
+            usage: wgpu::BufferUsages::VERTEX,
         });
 
         let index_data = create_indices();
         let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Index Buffer"),
             contents: bytemuck::cast_slice(&index_data),
-            usage: wgpu::BufferUsage::INDEX,
+            usage: wgpu::BufferUsages::INDEX,
         });
 
         let red_texture_data = create_texture_data(Color::RED);
@@ -131,7 +131,7 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Rgba8UnormSrgb,
-            usage: wgpu::TextureUsage::SAMPLED | wgpu::TextureUsage::COPY_DST,
+            usage: wgpu::TextureUsages::SAMPLED | wgpu::TextureUsages::COPY_DST,
             label: None,
         };
         let red_texture = device.create_texture(&wgpu::TextureDescriptor {

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -355,7 +355,7 @@ impl framework::Example for Example {
                     // Uniform variables such as projection/view.
                     wgpu::BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+                        visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,
@@ -368,7 +368,7 @@ impl framework::Example for Example {
                     // Reflection texture.
                     wgpu::BindGroupLayoutEntry {
                         binding: 1,
-                        visibility: wgpu::ShaderStage::FRAGMENT,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
                             multisampled: false,
                             sample_type: wgpu::TextureSampleType::Float { filterable: true },
@@ -379,7 +379,7 @@ impl framework::Example for Example {
                     // Depth texture for terrain.
                     wgpu::BindGroupLayoutEntry {
                         binding: 2,
-                        visibility: wgpu::ShaderStage::FRAGMENT,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
                             multisampled: false,
                             sample_type: wgpu::TextureSampleType::Float { filterable: true },
@@ -390,7 +390,7 @@ impl framework::Example for Example {
                     // Sampler to be able to sample the textures.
                     wgpu::BindGroupLayoutEntry {
                         binding: 3,
-                        visibility: wgpu::ShaderStage::FRAGMENT,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Sampler {
                             comparison: false,
                             filtering: true,
@@ -407,7 +407,7 @@ impl framework::Example for Example {
                     // Regular uniform variables like view/projection.
                     wgpu::BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: wgpu::ShaderStage::VERTEX,
+                        visibility: wgpu::ShaderStages::VERTEX,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -198,9 +198,9 @@ impl Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: sc_desc.format,
-            usage: wgpu::TextureUsage::SAMPLED
-                | wgpu::TextureUsage::COPY_DST
-                | wgpu::TextureUsage::RENDER_ATTACHMENT,
+            usage: wgpu::TextureUsages::SAMPLED
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::RENDER_ATTACHMENT,
         });
 
         let draw_depth_buffer = device.create_texture(&wgpu::TextureDescriptor {
@@ -210,9 +210,9 @@ impl Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Depth32Float,
-            usage: wgpu::TextureUsage::SAMPLED
-                | wgpu::TextureUsage::COPY_DST
-                | wgpu::TextureUsage::RENDER_ATTACHMENT,
+            usage: wgpu::TextureUsages::SAMPLED
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::RENDER_ATTACHMENT,
         });
 
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
@@ -338,13 +338,13 @@ impl framework::Example for Example {
         let water_vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Water vertices"),
             contents: bytemuck::cast_slice(&water_vertices),
-            usage: wgpu::BufferUsage::VERTEX,
+            usage: wgpu::BufferUsages::VERTEX,
         });
 
         let terrain_vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Terrain vertices"),
             contents: bytemuck::cast_slice(&terrain_vertices),
-            usage: wgpu::BufferUsage::VERTEX,
+            usage: wgpu::BufferUsages::VERTEX,
         });
 
         // Create the bind group layout. This is what our uniforms will look like.
@@ -438,21 +438,21 @@ impl framework::Example for Example {
         let water_uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Water Uniforms"),
             size: mem::size_of::<WaterUniforms>() as _,
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
         let terrain_normal_uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Normal Terrain Uniforms"),
             size: mem::size_of::<TerrainUniforms>() as _,
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
         let terrain_flipped_uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Flipped Terrain Uniforms"),
             size: mem::size_of::<TerrainUniforms>() as _,
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
@@ -537,7 +537,7 @@ impl framework::Example for Example {
                             operation: wgpu::BlendOperation::Max,
                         },
                     }),
-                    write_mask: wgpu::ColorWrite::ALL,
+                    write_mask: wgpu::ColorWrites::ALL,
                 }],
             }),
             // How the triangles will be rasterized. This is more important

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -43,7 +43,7 @@ impl Context {
         &self.0
     }
 
-    pub fn enumerate_adapters(&self, backends: wgt::BackendBit) -> Vec<wgc::id::AdapterId> {
+    pub fn enumerate_adapters(&self, backends: wgt::Backends) -> Vec<wgc::id::AdapterId> {
         self.0
             .enumerate_adapters(wgc::instance::AdapterInputs::Mask(backends, |_| {
                 PhantomData
@@ -235,7 +235,7 @@ mod pass_impl {
         ) {
             wgpu_render_pass_set_vertex_buffer(self, slot, buffer.id, offset, size)
         }
-        fn set_push_constants(&mut self, stages: wgt::ShaderStage, offset: u32, data: &[u8]) {
+        fn set_push_constants(&mut self, stages: wgt::ShaderStages, offset: u32, data: &[u8]) {
             unsafe {
                 wgpu_render_pass_set_push_constants(
                     self,
@@ -446,7 +446,7 @@ mod pass_impl {
             wgpu_render_bundle_set_vertex_buffer(self, slot, buffer.id, offset, size)
         }
 
-        fn set_push_constants(&mut self, stages: wgt::ShaderStage, offset: u32, data: &[u8]) {
+        fn set_push_constants(&mut self, stages: wgt::ShaderStages, offset: u32, data: &[u8]) {
             unsafe {
                 wgpu_render_bundle_set_push_constants(
                     self,
@@ -642,7 +642,7 @@ impl crate::Context for Context {
         Ready<Result<(Self::DeviceId, Self::QueueId), crate::RequestDeviceError>>;
     type MapAsyncFuture = native_gpu_future::GpuFuture<Result<(), crate::BufferAsyncError>>;
 
-    fn init(backends: wgt::BackendBit) -> Self {
+    fn init(backends: wgt::Backends) -> Self {
         Self(wgc::hub::Global::new(
             "wgpu",
             wgc::hub::IdentityManagerFactory,
@@ -666,7 +666,7 @@ impl crate::Context for Context {
                 power_preference: options.power_preference,
                 compatible_surface: options.compatible_surface.map(|surface| surface.id),
             },
-            wgc::instance::AdapterInputs::Mask(wgt::BackendBit::all(), |_| PhantomData),
+            wgc::instance::AdapterInputs::Mask(wgt::Backends::all(), |_| PhantomData),
         );
         ready(id.ok())
     }
@@ -1127,7 +1127,7 @@ impl crate::Context for Context {
             if let wgc::pipeline::CreateComputePipelineError::Internal(ref error) = cause {
                 log::warn!(
                     "Shader translation error for stage {:?}: {}",
-                    wgt::ShaderStage::COMPUTE,
+                    wgt::ShaderStages::COMPUTE,
                     error
                 );
                 log::warn!("Please report it to https://github.com/gfx-rs/naga");

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -186,7 +186,7 @@ impl crate::RenderInner<Context> for RenderPass {
         self.0
             .set_vertex_buffer_with_f64_and_f64(slot, &buffer.0, offset as f64, mapped_size);
     }
-    fn set_push_constants(&mut self, _stages: wgt::ShaderStage, _offset: u32, _data: &[u8]) {
+    fn set_push_constants(&mut self, _stages: wgt::ShaderStages, _offset: u32, _data: &[u8]) {
         panic!("PUSH_CONSTANTS feature must be enabled to call multi_draw_indexed_indirect")
     }
     fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
@@ -315,7 +315,7 @@ impl crate::RenderInner<Context> for RenderBundleEncoder {
         self.0
             .set_vertex_buffer_with_f64_and_f64(slot, &buffer.0, offset as f64, mapped_size);
     }
-    fn set_push_constants(&mut self, _stages: wgt::ShaderStage, _offset: u32, _data: &[u8]) {
+    fn set_push_constants(&mut self, _stages: wgt::ShaderStages, _offset: u32, _data: &[u8]) {
         panic!("PUSH_CONSTANTS feature must be enabled to call multi_draw_indexed_indirect")
     }
     fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
@@ -924,7 +924,7 @@ impl crate::Context for Context {
         fn(JsFutureResult) -> Result<(), crate::BufferAsyncError>,
     >;
 
-    fn init(_backends: wgt::BackendBit) -> Self {
+    fn init(_backends: wgt::Backends) -> Self {
         Context(web_sys::window().unwrap().navigator().gpu())
     }
 
@@ -960,7 +960,7 @@ impl crate::Context for Context {
         //TODO: support this check, return `None` if the flag is not set.
         // It's not trivial, since we need the Future logic to have this check,
         // and currently the Future here has no room for extra parameter `backends`.
-        //assert!(backends.contains(wgt::BackendBit::BROWSER_WEBGPU));
+        //assert!(backends.contains(wgt::Backends::BROWSER_WEBGPU));
         let mut mapped_options = web_sys::GpuRequestAdapterOptions::new();
         let mapped_power_preference = match options.power_preference {
             wgt::PowerPreference::LowPower => web_sys::GpuPowerPreference::LowPower,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -27,7 +27,7 @@ use parking_lot::Mutex;
 pub use wgt::{
     AdapterInfo, AddressMode, Backend, Backends, BindGroupLayoutEntry, BindingType, BlendComponent,
     BlendFactor, BlendOperation, BlendState, BufferAddress, BufferBindingType, BufferSize,
-    BufferUsage, Color, ColorTargetState, ColorWrite, CommandBufferDescriptor, CompareFunction,
+    BufferUsages, Color, ColorTargetState, ColorWrites, CommandBufferDescriptor, CompareFunction,
     DepthBiasState, DepthStencilState, DeviceType, DownlevelCapabilities, DownlevelFlags,
     DynamicOffset, Extent3d, Face, Features, FilterMode, FrontFace, ImageDataLayout, IndexFormat,
     InputStepMode, Limits, MultisampleState, Origin3d, PipelineStatisticsTypes, PolygonMode,
@@ -35,7 +35,7 @@ pub use wgt::{
     SamplerBorderColor, ShaderLocation, ShaderModel, ShaderStages, StencilFaceState,
     StencilOperation, StencilState, StorageTextureAccess, SwapChainDescriptor, SwapChainStatus,
     TextureAspect, TextureDimension, TextureFormat, TextureFormatFeatureFlags,
-    TextureFormatFeatures, TextureSampleType, TextureUsage, TextureViewDimension, VertexAttribute,
+    TextureFormatFeatures, TextureSampleType, TextureUsages, TextureViewDimension, VertexAttribute,
     VertexFormat, BIND_BUFFER_ALIGNMENT, COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT,
     MAP_ALIGNMENT, PUSH_CONSTANT_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE,
     VERTEX_STRIDE_ALIGNMENT,
@@ -591,7 +591,7 @@ pub struct Buffer {
     context: Arc<C>,
     id: <C as Context>::BufferId,
     map_context: Mutex<MapContext>,
-    usage: BufferUsage,
+    usage: BufferUsages,
 }
 
 /// Slice into a [`Buffer`].
@@ -1990,7 +1990,7 @@ impl<'a> BufferSlice<'a> {
         BufferViewMut {
             slice: *self,
             data,
-            readable: self.buffer.usage.contains(BufferUsage::MAP_READ),
+            readable: self.buffer.usage.contains(BufferUsages::MAP_READ),
         }
     }
 }

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Buffer, BufferAddress, BufferDescriptor, BufferSize, BufferUsage, BufferViewMut,
+    Buffer, BufferAddress, BufferDescriptor, BufferSize, BufferUsages, BufferViewMut,
     CommandEncoder, Device, MapMode,
 };
 use std::pin::Pin;
@@ -116,7 +116,7 @@ impl StagingBelt {
                 buffer: device.create_buffer(&BufferDescriptor {
                     label: Some("staging"),
                     size,
-                    usage: BufferUsage::MAP_WRITE | BufferUsage::COPY_SRC,
+                    usage: BufferUsages::MAP_WRITE | BufferUsages::COPY_SRC,
                     mapped_at_creation: true,
                 }),
                 size,

--- a/wgpu/src/util/device.rs
+++ b/wgpu/src/util/device.rs
@@ -9,7 +9,7 @@ pub struct BufferInitDescriptor<'a> {
     pub contents: &'a [u8],
     /// Usages of a buffer. If the buffer is used in any way that isn't specified here, the operation
     /// will panic.
-    pub usage: crate::BufferUsage,
+    pub usage: crate::BufferUsages,
 }
 
 /// Utility methods not meant to be in the main API.

--- a/wgpu/src/util/encoder.rs
+++ b/wgpu/src/util/encoder.rs
@@ -117,7 +117,7 @@ pub trait RenderEncoder<'a> {
     ///
     /// You would need to upload this in three set_push_constants calls. First for the `Vertex` only range 0..4, second
     /// for the `Vertex | Fragment` range 4..8, third for the `Fragment` range 8..12.
-    fn set_push_constants(&mut self, stages: wgt::ShaderStage, offset: u32, data: &[u8]);
+    fn set_push_constants(&mut self, stages: wgt::ShaderStages, offset: u32, data: &[u8]);
 }
 
 impl<'a> RenderEncoder<'a> for RenderPass<'a> {
@@ -166,7 +166,7 @@ impl<'a> RenderEncoder<'a> for RenderPass<'a> {
     }
 
     #[inline(always)]
-    fn set_push_constants(&mut self, stages: wgt::ShaderStage, offset: u32, data: &[u8]) {
+    fn set_push_constants(&mut self, stages: wgt::ShaderStages, offset: u32, data: &[u8]) {
         Self::set_push_constants(self, stages, offset, data);
     }
 }
@@ -217,7 +217,7 @@ impl<'a> RenderEncoder<'a> for RenderBundleEncoder<'a> {
     }
 
     #[inline(always)]
-    fn set_push_constants(&mut self, stages: wgt::ShaderStage, offset: u32, data: &[u8]) {
+    fn set_push_constants(&mut self, stages: wgt::ShaderStages, offset: u32, data: &[u8]) {
         Self::set_push_constants(self, stages, offset, data);
     }
 }

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -1,21 +1,21 @@
-use wgt::{BackendBit, PowerPreference, RequestAdapterOptions};
+use wgt::{Backends, PowerPreference, RequestAdapterOptions};
 
 use crate::{Adapter, Instance};
 
 /// Get a set of backend bits from the environment variable WGPU_BACKEND.
-pub fn backend_bits_from_env() -> Option<BackendBit> {
+pub fn backend_bits_from_env() -> Option<Backends> {
     Some(
         match std::env::var("WGPU_BACKEND")
             .as_deref()
             .map(str::to_lowercase)
             .as_deref()
         {
-            Ok("vulkan") => BackendBit::VULKAN,
-            Ok("dx12") => BackendBit::DX12,
-            Ok("dx11") => BackendBit::DX11,
-            Ok("metal") => BackendBit::METAL,
-            Ok("gl") => BackendBit::GL,
-            Ok("webgpu") => BackendBit::BROWSER_WEBGPU,
+            Ok("vulkan") => Backends::VULKAN,
+            Ok("dx12") => Backends::DX12,
+            Ok("dx11") => Backends::DX11,
+            Ok("metal") => Backends::METAL,
+            Ok("gl") => Backends::GL,
+            Ok("webgpu") => Backends::BROWSER_WEBGPU,
             _ => return None,
         },
     )
@@ -38,10 +38,7 @@ pub fn power_preference_from_env() -> Option<PowerPreference> {
 
 /// Initialize the adapter obeying the WGPU_ADAPTER_NAME environment variable.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn initialize_adapter_from_env(
-    instance: &Instance,
-    backend_bits: BackendBit,
-) -> Option<Adapter> {
+pub fn initialize_adapter_from_env(instance: &Instance, backend_bits: Backends) -> Option<Adapter> {
     let desired_adapter_name = std::env::var("WGPU_ADAPTER_NAME")
         .as_deref()
         .map(str::to_lowercase)
@@ -66,7 +63,7 @@ pub fn initialize_adapter_from_env(
 #[cfg(target_arch = "wasm32")]
 pub fn initialize_adapter_from_env(
     _instance: &Instance,
-    _backend_bits: BackendBit,
+    _backend_bits: Backends,
 ) -> Option<Adapter> {
     None
 }
@@ -74,7 +71,7 @@ pub fn initialize_adapter_from_env(
 /// Initialize the adapter obeying the WGPU_ADAPTER_NAME environment variable and if it doesn't exist fall back on a default adapter.
 pub async fn initialize_adapter_from_env_or_default(
     instance: &Instance,
-    backend_bits: wgt::BackendBit,
+    backend_bits: wgt::Backends,
 ) -> Option<Adapter> {
     match initialize_adapter_from_env(&instance, backend_bits) {
         Some(a) => Some(a),

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -85,7 +85,7 @@ impl DownloadBuffer {
 
         let download = device.create_buffer(&super::BufferDescriptor {
             size,
-            usage: super::BufferUsage::COPY_DST | super::BufferUsage::MAP_READ,
+            usage: super::BufferUsages::COPY_DST | super::BufferUsages::MAP_READ,
             mapped_at_creation: false,
             label: None,
         });

--- a/wgpu/tests/instance.rs
+++ b/wgpu/tests/instance.rs
@@ -1,13 +1,13 @@
 #[test]
 fn initialize() {
     let _ = wgpu::Instance::new(
-        wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::BackendBit::all),
+        wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all),
     );
 }
 
 fn request_adapter_inner(power: wgt::PowerPreference) {
     let instance = wgpu::Instance::new(
-        wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::BackendBit::all),
+        wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all),
     );
 
     let _adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {

--- a/wgpu/tests/vertex_indices/mod.rs
+++ b/wgpu/tests/vertex_indices/mod.rs
@@ -32,9 +32,9 @@ fn pulling_common(
     let buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
         size: 4 * expected.len() as u64,
-        usage: wgpu::BufferUsage::COPY_SRC
-            | wgpu::BufferUsage::STORAGE
-            | wgpu::BufferUsage::MAP_READ,
+        usage: wgpu::BufferUsages::COPY_SRC
+            | wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::MAP_READ,
         mapped_at_creation: false,
     });
 
@@ -74,7 +74,7 @@ fn pulling_common(
                 targets: &[wgpu::ColorTargetState {
                     format: wgpu::TextureFormat::Rgba8Unorm,
                     blend: None,
-                    write_mask: wgpu::ColorWrite::ALL,
+                    write_mask: wgpu::ColorWrites::ALL,
                 }],
             }),
         });
@@ -94,7 +94,7 @@ fn pulling_common(
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Rgba8Unorm,
-                usage: wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::COPY_DST,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_DST,
             },
             &[0, 0, 0, 1],
         )

--- a/wgpu/tests/vertex_indices/mod.rs
+++ b/wgpu/tests/vertex_indices/mod.rs
@@ -24,7 +24,7 @@ fn pulling_common(
                     has_dynamic_offset: false,
                     min_binding_size: NonZeroU64::new(4),
                 },
-                visibility: wgpu::ShaderStage::VERTEX,
+                visibility: wgpu::ShaderStages::VERTEX,
                 count: None,
             }],
         });
@@ -143,7 +143,7 @@ fn draw_vertex_offset() {
     initialize_test(
         TestParameters::default()
             .test_features()
-            .backend_failures(wgpu::BackendBit::DX12 | wgpu::BackendBit::DX11),
+            .backend_failures(wgpu::Backends::DX12 | wgpu::Backends::DX11),
         |ctx| {
             pulling_common(ctx, &[0, 1, 2, 3, 4, 5], |cmb| {
                 cmb.draw(0..3, 0..1);
@@ -167,7 +167,7 @@ fn draw_instanced_offset() {
     initialize_test(
         TestParameters::default()
             .test_features()
-            .backend_failures(wgpu::BackendBit::DX12 | wgpu::BackendBit::DX11),
+            .backend_failures(wgpu::Backends::DX12 | wgpu::Backends::DX11),
         |ctx| {
             pulling_common(ctx, &[0, 1, 2, 3, 4, 5], |cmb| {
                 cmb.draw(0..3, 0..1);


### PR DESCRIPTION
**Connections**
#1471 added a lot of singular bitflag names. Previously, we weren't really consistent.

**Description**
This PR changes all of the names to be plural, except for a few that don't imply singularity, and are matching WebGPU upstream. Maybe we need to convert them too?

**Testing**
self-tested
