### PR TITLE
Fix destruction of resources

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -348,15 +348,14 @@ impl<A: HalApi> Device<A> {
         Self::lock_life_internal(&self.life_tracker, token)
     }
 
-    pub(crate) fn suspect_texture_view_for_destruction<'this, 'token: 'this>(
+    pub(crate) fn schedule_rogue_texture_view_for_destruction<'this, 'token: 'this>(
         &'this self,
         view_id: id::Valid<id::TextureViewId>,
+        view: resource::TextureView<A>,
         token: &mut Token<'token, Self>,
     ) {
         self.lock_life(token)
-            .suspected_resources
-            .texture_views
-            .push(view_id);
+            .schedule_texture_view_for_destruction(view_id, view);
     }
 
     fn maintain<'this, 'token: 'this, G: GlobalIdentityHandlerFactory>(

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -333,19 +333,12 @@ impl<A: HalApi> Device<A> {
         })
     }
 
-    fn lock_life_internal<'this, 'token: 'this>(
-        tracker: &'this Mutex<life::LifetimeTracker<A>>,
-        _token: &mut Token<'token, Self>,
-    ) -> MutexGuard<'this, life::LifetimeTracker<A>> {
-        tracker.lock()
-    }
-
     fn lock_life<'this, 'token: 'this>(
         &'this self,
         //TODO: fix this - the token has to be borrowed for the lock
-        token: &mut Token<'token, Self>,
+        _token: &mut Token<'token, Self>,
     ) -> MutexGuard<'this, life::LifetimeTracker<A>> {
-        Self::lock_life_internal(&self.life_tracker, token)
+        self.life_tracker.lock()
     }
 
     pub(crate) fn schedule_rogue_texture_view_for_destruction<'this, 'token: 'this>(

--- a/wgpu-core/src/swap_chain.rs
+++ b/wgpu-core/src/swap_chain.rs
@@ -267,11 +267,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 .ok_or(SwapChainError::AlreadyAcquired)?;
 
             drop(swap_chain_guard);
-            device.suspect_texture_view_for_destruction(view_id.value, &mut token);
 
-            let (mut view_guard, _) = hub.texture_views.write(&mut token);
-            let view = &mut view_guard[view_id.value];
-            let _ = view.life_guard.ref_count.take();
+            let (view, _) = hub.texture_views.unregister(view_id.value.0, &mut token);
+            if let Some(view) = view {
+                device.schedule_rogue_texture_view_for_destruction(view_id.value, view, &mut token);
+            }
 
             suf_texture
         };


### PR DESCRIPTION
**Connections**
Fixes #1552
Also fixes the VVL about swapchain frame destruction.

**Description**
Swapchain view was never registered in the device's root Hub. So the old logic of adding it to "suspected resources" didn't fire up correctly. The new logic goes straight into the submission tracker.
This path will cease to exist when either Hubs are removed, or API changes of https://github.com/webgpu-native/webgpu-headers/issues/89 are accepted.

The other resource destruction errors happened because we gathered all the resources that were abandoned by the user, and held alive only by the submitted command buffers, and we added them to the suspected list. Then we'd scan the list in `maintain`, see that they can be removed, and try to associate their destruction with one of the submissions. But the current submission was not added yet! So the logic thinks it can just remove the resources right away in this case, assuming the submission is not found because it's long gone in past.

**Testing**
Tested on our examples.
