### PR TITLE
Update testing limits for rpi4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,6 +2010,7 @@ dependencies = [
 name = "wgpu-info"
 version = "0.9.0"
 dependencies = [
+ "env_logger",
  "wgpu",
 ]
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ wgpu features a set of unit, integration, and example based tests. All framework
 To run the test suite, run the following command:
 
 ```
-cargo run --bin wgpu-info -- cargo test
+cargo run --bin wgpu-info -- cargo test --no-fail-fast
 ```
 
 To run any individual test on a specific adapter, populate the following environment variables:
@@ -51,7 +51,7 @@ To run any individual test on a specific adapter, populate the following environ
 Then to run an example's reftests, run:
 
 ```
-cargo test --example <example-name>
+cargo test --example <example-name> --no-fail-fast
 ```
 
 Or run a part of the integration test suite:

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -265,7 +265,8 @@ impl Inner {
             egl::CONTEXT_CLIENT_VERSION,
             3, // Request GLES 3.0 or higher
         ];
-        if flags.contains(crate::InstanceFlags::DEBUG) && !cfg!(target_os = "android") {
+        // Debug requires EGL 1.5+
+        if flags.contains(crate::InstanceFlags::DEBUG) && version >= (1, 5) {
             log::info!("\tEGL context: +debug");
             //TODO: figure out why this is needed
             context_attributes.push(egl::CONTEXT_OPENGL_DEBUG);

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -10,4 +10,5 @@ keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+env_logger = "0.8"
 wgpu = { version = "0.9", path = "../wgpu" }

--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -85,6 +85,8 @@ fn print_info_from_adapter(adapter: &wgpu::Adapter, idx: usize) {
 }
 
 fn main() {
+    env_logger::init();
+
     let args: Vec<_> = std::env::args().skip(1).collect();
 
     let instance = wgpu::Instance::new(wgpu::Backends::all());

--- a/wgpu/examples/boids/main.rs
+++ b/wgpu/examples/boids/main.rs
@@ -327,7 +327,7 @@ fn boids() {
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS),
-        tollerance: 0,
+        tolerance: 0,
         max_outliers: 600, // Currently bounded by rpi4
     });
 }

--- a/wgpu/examples/boids/main.rs
+++ b/wgpu/examples/boids/main.rs
@@ -325,8 +325,9 @@ fn boids() {
         width: 1024,
         height: 768,
         optional_features: wgpu::Features::default(),
-        base_test_parameters: framework::test_common::TestParameters::default(),
+        base_test_parameters: framework::test_common::TestParameters::default()
+            .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS),
         tollerance: 0,
-        max_outliers: 50,
+        max_outliers: 600, // Currently bounded by rpi4
     });
 }

--- a/wgpu/examples/bunnymark/main.rs
+++ b/wgpu/examples/bunnymark/main.rs
@@ -358,7 +358,7 @@ fn bunnymark() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default(),
-        tollerance: 1,
+        tolerance: 1,
         max_outliers: 50,
     });
 }

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -321,7 +321,7 @@ fn conservative_raster() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default(),
-        tollerance: 0,
+        tolerance: 0,
         max_outliers: 0,
     });
 }

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -389,7 +389,7 @@ fn cube() {
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default(),
         tollerance: 1,
-        max_outliers: 3,
+        max_outliers: 500, // Bounded by rpi4
     });
 }
 
@@ -402,6 +402,6 @@ fn cube_lines() {
         optional_features: wgpu::Features::NON_FILL_POLYGON_MODE,
         base_test_parameters: framework::test_common::TestParameters::default(),
         tollerance: 2,
-        max_outliers: 400, // Line rasterization is very different between vendors
+        max_outliers: 500, // Bounded by rpi4 & intel 620 on GL
     });
 }

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -388,7 +388,7 @@ fn cube() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default(),
-        tollerance: 1,
+        tolerance: 1,
         max_outliers: 500, // Bounded by rpi4
     });
 }
@@ -401,7 +401,7 @@ fn cube_lines() {
         height: 768,
         optional_features: wgpu::Features::NON_FILL_POLYGON_MODE,
         base_test_parameters: framework::test_common::TestParameters::default(),
-        tollerance: 2,
+        tolerance: 2,
         max_outliers: 500, // Bounded by rpi4 & intel 620 on GL
     });
 }

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -372,7 +372,7 @@ pub struct FrameworkRefTest {
     pub height: u32,
     pub optional_features: wgpu::Features,
     pub base_test_parameters: test_common::TestParameters,
-    pub tollerance: u8,
+    pub tolerance: u8,
     pub max_outliers: usize,
 }
 
@@ -472,7 +472,7 @@ pub fn test<E: Example>(mut params: FrameworkRefTest) {
                 params.width,
                 params.height,
                 &bytes,
-                params.tollerance,
+                params.tolerance,
                 params.max_outliers,
             );
         },

--- a/wgpu/examples/hello-compute/tests.rs
+++ b/wgpu/examples/hello-compute/tests.rs
@@ -8,7 +8,7 @@ use common::{initialize_test, TestParameters};
 
 #[test]
 fn test_compute_1() {
-    initialize_test(TestParameters::default(), |ctx| {
+    initialize_test(TestParameters::default().specific_failure(Some(wgpu::Backends::GL), None, Some("V3D"), false), |ctx| {
         let input = &[1, 2, 3, 4];
 
         pollster::block_on(assert_execute_gpu(
@@ -22,7 +22,7 @@ fn test_compute_1() {
 
 #[test]
 fn test_compute_2() {
-    initialize_test(TestParameters::default(), |ctx| {
+    initialize_test(TestParameters::default().specific_failure(Some(wgpu::Backends::GL), None, Some("V3D"), false), |ctx| {
         let input = &[5, 23, 10, 9];
 
         pollster::block_on(assert_execute_gpu(
@@ -36,7 +36,7 @@ fn test_compute_2() {
 
 #[test]
 fn test_compute_overflow() {
-    initialize_test(TestParameters::default(), |ctx| {
+    initialize_test(TestParameters::default().specific_failure(Some(wgpu::Backends::GL), None, Some("V3D"), false), |ctx| {
         let input = &[77031, 837799, 8400511, 63728127];
         pollster::block_on(assert_execute_gpu(
             &ctx.device,
@@ -49,7 +49,7 @@ fn test_compute_overflow() {
 
 #[test]
 fn test_multithreaded_compute() {
-    initialize_test(TestParameters::default(), |ctx| {
+    initialize_test(TestParameters::default().backend_failures(wgpu::Backends::GL), |ctx| {
         use std::{sync::mpsc, thread, time::Duration};
 
         let ctx = Arc::new(ctx);

--- a/wgpu/examples/hello-compute/tests.rs
+++ b/wgpu/examples/hello-compute/tests.rs
@@ -8,75 +8,102 @@ use common::{initialize_test, TestParameters};
 
 #[test]
 fn test_compute_1() {
-    initialize_test(TestParameters::default().specific_failure(Some(wgpu::Backends::GL), None, Some("V3D"), false), |ctx| {
-        let input = &[1, 2, 3, 4];
+    initialize_test(
+        TestParameters::default().specific_failure(
+            Some(wgpu::Backends::GL),
+            None,
+            Some("V3D"),
+            false,
+        ),
+        |ctx| {
+            let input = &[1, 2, 3, 4];
 
-        pollster::block_on(assert_execute_gpu(
-            &ctx.device,
-            &ctx.queue,
-            input,
-            &[0, 1, 7, 2],
-        ));
-    });
+            pollster::block_on(assert_execute_gpu(
+                &ctx.device,
+                &ctx.queue,
+                input,
+                &[0, 1, 7, 2],
+            ));
+        },
+    );
 }
 
 #[test]
 fn test_compute_2() {
-    initialize_test(TestParameters::default().specific_failure(Some(wgpu::Backends::GL), None, Some("V3D"), false), |ctx| {
-        let input = &[5, 23, 10, 9];
+    initialize_test(
+        TestParameters::default().specific_failure(
+            Some(wgpu::Backends::GL),
+            None,
+            Some("V3D"),
+            false,
+        ),
+        |ctx| {
+            let input = &[5, 23, 10, 9];
 
-        pollster::block_on(assert_execute_gpu(
-            &ctx.device,
-            &ctx.queue,
-            input,
-            &[5, 15, 6, 19],
-        ));
-    });
+            pollster::block_on(assert_execute_gpu(
+                &ctx.device,
+                &ctx.queue,
+                input,
+                &[5, 15, 6, 19],
+            ));
+        },
+    );
 }
 
 #[test]
 fn test_compute_overflow() {
-    initialize_test(TestParameters::default().specific_failure(Some(wgpu::Backends::GL), None, Some("V3D"), false), |ctx| {
-        let input = &[77031, 837799, 8400511, 63728127];
-        pollster::block_on(assert_execute_gpu(
-            &ctx.device,
-            &ctx.queue,
-            input,
-            &[350, 524, OVERFLOW, OVERFLOW],
-        ));
-    });
+    initialize_test(
+        TestParameters::default().specific_failure(
+            Some(wgpu::Backends::GL),
+            None,
+            Some("V3D"),
+            false,
+        ),
+        |ctx| {
+            let input = &[77031, 837799, 8400511, 63728127];
+            pollster::block_on(assert_execute_gpu(
+                &ctx.device,
+                &ctx.queue,
+                input,
+                &[350, 524, OVERFLOW, OVERFLOW],
+            ));
+        },
+    );
 }
 
 #[test]
 fn test_multithreaded_compute() {
-    initialize_test(TestParameters::default().backend_failures(wgpu::Backends::GL), |ctx| {
-        use std::{sync::mpsc, thread, time::Duration};
+    initialize_test(
+        TestParameters::default().backend_failures(wgpu::Backends::GL),
+        |ctx| {
+            use std::{sync::mpsc, thread, time::Duration};
 
-        let ctx = Arc::new(ctx);
+            let ctx = Arc::new(ctx);
 
-        let thread_count = 8;
+            let thread_count = 8;
 
-        let (tx, rx) = mpsc::channel();
-        for _ in 0..thread_count {
-            let tx = tx.clone();
-            let ctx = Arc::clone(&ctx);
-            thread::spawn(move || {
-                let input = &[100, 100, 100];
-                pollster::block_on(assert_execute_gpu(
-                    &ctx.device,
-                    &ctx.queue,
-                    input,
-                    &[25, 25, 25],
-                ));
-                tx.send(true).unwrap();
-            });
-        }
+            let (tx, rx) = mpsc::channel();
+            for _ in 0..thread_count {
+                let tx = tx.clone();
+                let ctx = Arc::clone(&ctx);
+                thread::spawn(move || {
+                    let input = &[100, 100, 100];
+                    pollster::block_on(assert_execute_gpu(
+                        &ctx.device,
+                        &ctx.queue,
+                        input,
+                        &[25, 25, 25],
+                    ));
+                    tx.send(true).unwrap();
+                });
+            }
 
-        for _ in 0..thread_count {
-            rx.recv_timeout(Duration::from_secs(10))
-                .expect("A thread never completed.");
-        }
-    });
+            for _ in 0..thread_count {
+                rx.recv_timeout(Duration::from_secs(10))
+                    .expect("A thread never completed.");
+            }
+        },
+    );
 }
 
 async fn assert_execute_gpu(

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -483,7 +483,7 @@ fn mipmap() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
-            .backend_failures(wgpu::Backends::VULKAN),
+            .backend_failures(wgpu::Backends::VULKAN | wgpu::Backends::GL),
         tollerance: 25,
         max_outliers: 3000, // Mipmap sampling is highly variant between impls. This is currently bounded by AMD on mac
     });

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -484,7 +484,7 @@ fn mipmap() {
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
             .backend_failures(wgpu::Backends::VULKAN | wgpu::Backends::GL),
-        tollerance: 25,
+        tolerance: 25,
         max_outliers: 3000, // Mipmap sampling is highly variant between impls. This is currently bounded by AMD on mac
     });
 }

--- a/wgpu/examples/msaa-line/main.rs
+++ b/wgpu/examples/msaa-line/main.rs
@@ -291,7 +291,7 @@ fn msaa_line() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default(),
-        tollerance: 64,
+        tolerance: 64,
         max_outliers: 1 << 16, // MSAA is comically different between vendors, 32k is a decent limit
     });
 }

--- a/wgpu/examples/shadow/main.rs
+++ b/wgpu/examples/shadow/main.rs
@@ -829,8 +829,9 @@ fn shadow() {
         width: 1024,
         height: 768,
         optional_features: wgpu::Features::default(),
-        base_test_parameters: framework::test_common::TestParameters::default().downlevel_flags(wgpu::DownlevelFlags::COMPARISON_SAMPLERS),
-        tollerance: 2,
+        base_test_parameters: framework::test_common::TestParameters::default()
+            .downlevel_flags(wgpu::DownlevelFlags::COMPARISON_SAMPLERS),
+        tolerance: 2,
         max_outliers: 500, // bounded by rpi4
     });
 }

--- a/wgpu/examples/shadow/main.rs
+++ b/wgpu/examples/shadow/main.rs
@@ -829,8 +829,8 @@ fn shadow() {
         width: 1024,
         height: 768,
         optional_features: wgpu::Features::default(),
-        base_test_parameters: framework::test_common::TestParameters::default(),
+        base_test_parameters: framework::test_common::TestParameters::default().downlevel_flags(wgpu::DownlevelFlags::COMPARISON_SAMPLERS),
         tollerance: 2,
-        max_outliers: 5,
+        max_outliers: 500, // bounded by rpi4
     });
 }

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -472,7 +472,7 @@ fn skybox() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
-            .backend_failures(wgpu::Backends::VULKAN),
+            .backend_failures(wgpu::Backends::VULKAN | wgpu::Backends::GL),
         tollerance: 2,
         max_outliers: 3,
     });
@@ -499,8 +499,8 @@ fn skybox_etc2() {
         height: 768,
         optional_features: wgpu::Features::TEXTURE_COMPRESSION_ETC2,
         base_test_parameters: framework::test_common::TestParameters::default(),
-        tollerance: 5,    // TODO
-        max_outliers: 10, // TODO
+        tollerance: 5,
+        max_outliers: 50, // Bounded by rpi4
     });
 }
 

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -472,7 +472,7 @@ fn skybox() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
-            .backend_failures(wgpu::Backends::VULKAN | wgpu::Backends::GL),
+            .backend_failure(wgpu::Backends::VULKAN | wgpu::Backends::GL),
         tollerance: 2,
         max_outliers: 3,
     });

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -512,7 +512,7 @@ fn skybox_astc() {
         height: 768,
         optional_features: wgpu::Features::TEXTURE_COMPRESSION_ASTC_LDR,
         base_test_parameters: framework::test_common::TestParameters::default(),
-        tolerance: 5,    // TODO
+        tolerance: 5,     // TODO
         max_outliers: 10, // TODO
     });
 }

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -473,7 +473,7 @@ fn skybox() {
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
             .backend_failure(wgpu::Backends::VULKAN | wgpu::Backends::GL),
-        tollerance: 2,
+        tolerance: 2,
         max_outliers: 3,
     });
 }
@@ -486,7 +486,7 @@ fn skybox_bc1() {
         height: 768,
         optional_features: wgpu::Features::TEXTURE_COMPRESSION_BC,
         base_test_parameters: framework::test_common::TestParameters::default(),
-        tollerance: 5,
+        tolerance: 5,
         max_outliers: 10,
     });
 }
@@ -499,7 +499,7 @@ fn skybox_etc2() {
         height: 768,
         optional_features: wgpu::Features::TEXTURE_COMPRESSION_ETC2,
         base_test_parameters: framework::test_common::TestParameters::default(),
-        tollerance: 5,
+        tolerance: 5,
         max_outliers: 50, // Bounded by rpi4
     });
 }
@@ -512,7 +512,7 @@ fn skybox_astc() {
         height: 768,
         optional_features: wgpu::Features::TEXTURE_COMPRESSION_ASTC_LDR,
         base_test_parameters: framework::test_common::TestParameters::default(),
-        tollerance: 5,    // TODO
+        tolerance: 5,    // TODO
         max_outliers: 10, // TODO
     });
 }

--- a/wgpu/examples/texture-arrays/main.rs
+++ b/wgpu/examples/texture-arrays/main.rs
@@ -328,7 +328,7 @@ fn texture_arrays_constant() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default().failure(),
-        tollerance: 0,
+        tolerance: 0,
         max_outliers: 0,
     });
 }
@@ -343,7 +343,7 @@ fn texture_arrays_uniform() {
         optional_features: wgpu::Features::SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING
             | wgpu::Features::PUSH_CONSTANTS,
         base_test_parameters: framework::test_common::TestParameters::default().failure(),
-        tollerance: 0,
+        tolerance: 0,
         max_outliers: 0,
     });
 }
@@ -357,7 +357,7 @@ fn texture_arrays_non_uniform() {
         height: 768,
         optional_features: wgpu::Features::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
         base_test_parameters: framework::test_common::TestParameters::default().failure(),
-        tollerance: 0,
+        tolerance: 0,
         max_outliers: 0,
     });
 }
@@ -372,7 +372,7 @@ fn texture_arrays_unsized_non_uniform() {
         optional_features: wgpu::Features::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING
             | wgpu::Features::UNSIZED_BINDING_ARRAY,
         base_test_parameters: framework::test_common::TestParameters::default().failure(),
-        tollerance: 0,
+        tolerance: 0,
         max_outliers: 0,
     });
 }

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -797,8 +797,9 @@ fn water() {
         width: 1024,
         height: 768,
         optional_features: wgpu::Features::default(),
-        base_test_parameters: framework::test_common::TestParameters::default().downlevel_flags(wgpu::DownlevelFlags::READ_ONLY_DEPTH_STENCIL),
-        tollerance: 5,
+        base_test_parameters: framework::test_common::TestParameters::default()
+            .downlevel_flags(wgpu::DownlevelFlags::READ_ONLY_DEPTH_STENCIL),
+        tolerance: 5,
         max_outliers: 10,
     });
 }

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -791,13 +791,13 @@ fn main() {
 }
 
 #[test]
-fn shadow() {
+fn water() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/water/screenshot.png",
         width: 1024,
         height: 768,
         optional_features: wgpu::Features::default(),
-        base_test_parameters: framework::test_common::TestParameters::default(),
+        base_test_parameters: framework::test_common::TestParameters::default().downlevel_flags(wgpu::DownlevelFlags::READ_ONLY_DEPTH_STENCIL),
         tollerance: 5,
         max_outliers: 10,
     });

--- a/wgpu/tests/common/image.rs
+++ b/wgpu/tests/common/image.rs
@@ -70,7 +70,7 @@ pub fn compare_image_output(
     width: u32,
     height: u32,
     data: &[u8],
-    tollerance: u8,
+    tolerance: u8,
     max_outliers: usize,
 ) {
     let comparison_data = read_png(&path, width, height);
@@ -94,9 +94,9 @@ pub fn compare_image_output(
         let outliers: usize = difference_data
             .chunks_exact(4)
             .map(|colors| {
-                (colors[0] > tollerance) as usize
-                    + (colors[1] > tollerance) as usize
-                    + (colors[2] > tollerance) as usize
+                (colors[0] > tolerance) as usize
+                    + (colors[1] > tolerance) as usize
+                    + (colors[2] > tolerance) as usize
             })
             .sum();
 

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -5,7 +5,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use wgt::{Backends, DeviceDescriptor, DownlevelCapabilities, Features, Limits};
 
-use wgpu::{util, Adapter, Device, Instance, Queue};
+use wgpu::{util, Adapter, Device, DownlevelFlags, Instance, Queue};
 
 pub mod image;
 
@@ -116,6 +116,11 @@ impl TestParameters {
     /// Set the list
     pub fn limits(mut self, limits: Limits) -> Self {
         self.required_limits = limits;
+        self
+    }
+
+    pub fn downlevel_flags(mut self, downlevel_flags: DownlevelFlags) -> Self {
+        self.required_downlevel_properties.flags |= downlevel_flags;
         self
     }
 

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -131,7 +131,7 @@ impl TestParameters {
     }
 
     /// Mark the test as always failing on a specific backend, equivilant to specific_failure(backend, None, None)
-    pub fn backend_failures(mut self, backends: wgpu::Backends) -> Self {
+    pub fn backend_failure(mut self, backends: wgpu::Backends) -> Self {
         self.failures.push((Some(backends), None, None, false));
         self
     }


### PR DESCRIPTION
**Connections**

Related to #1574. Exposed #1583.

**Description**

Changes the reftesting limits to be tolerant of how the RPI4 renders. Fixes the debug half of #1577. 

Fixes some naming issues as well.

**Testing**

It is
