### PR TITLE
Assorted Fixes of Testing-Infra

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -210,7 +210,7 @@ impl<A: HalApi> Adapter<A> {
 
         let caps = &self.raw.capabilities;
         if !caps.downlevel.is_webgpu_compliant() {
-            let missing_flags = wgt::DownlevelFlags::COMPLIANT - caps.downlevel.flags;
+            let missing_flags = wgt::DownlevelFlags::compliant() - caps.downlevel.flags;
             log::warn!(
                 "Missing downlevel flags: {:?}\n{}",
                 missing_flags,

--- a/wgpu/examples/hello-compute/tests.rs
+++ b/wgpu/examples/hello-compute/tests.rs
@@ -74,7 +74,7 @@ fn test_compute_overflow() {
 #[test]
 fn test_multithreaded_compute() {
     initialize_test(
-        TestParameters::default().backend_failures(wgpu::Backends::GL),
+        TestParameters::default().backend_failure(wgpu::Backends::GL),
         |ctx| {
             use std::{sync::mpsc, thread, time::Duration};
 

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -483,7 +483,7 @@ fn mipmap() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
-            .backend_failures(wgpu::Backends::VULKAN | wgpu::Backends::GL),
+            .backend_failure(wgpu::Backends::GL),
         tolerance: 25,
         max_outliers: 3000, // Mipmap sampling is highly variant between impls. This is currently bounded by AMD on mac
     });

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -227,25 +227,33 @@ pub fn initialize_test(parameters: TestParameters, test_function: impl FnOnce(Te
             let always =
                 backend_failure.is_none() && vendor_failure.is_none() && adapter_failure.is_none();
 
-            let expect_failure_backend = backend_failure
-                .map(|f| f.contains(wgpu::Backends::from(adapter_info.backend)))
-                .unwrap_or(true);
-            let expect_failure_vendor = vendor_failure
-                .map(|v| v == adapter_info.vendor)
-                .unwrap_or(true);
+            let expect_failure_backend =
+                backend_failure.map(|f| f.contains(wgpu::Backends::from(adapter_info.backend)));
+            let expect_failure_vendor = vendor_failure.map(|v| v == adapter_info.vendor);
             let expect_failure_adapter = adapter_failure
                 .as_deref()
-                .map(|f| adapter_lowercase_name.contains(f))
-                .unwrap_or(true);
+                .map(|f| adapter_lowercase_name.contains(f));
 
-            if expect_failure_backend && expect_failure_vendor && expect_failure_adapter {
+            if expect_failure_backend.unwrap_or(true)
+                && expect_failure_vendor.unwrap_or(true)
+                && expect_failure_adapter.unwrap_or(true)
+            {
                 if always {
                     Some((FailureReasons::ALWAYS, *segfault))
                 } else {
                     let mut reason = FailureReasons::empty();
-                    reason.set(FailureReasons::BACKEND, expect_failure_backend);
-                    reason.set(FailureReasons::VENDOR, expect_failure_vendor);
-                    reason.set(FailureReasons::ADAPTER, expect_failure_adapter);
+                    reason.set(
+                        FailureReasons::BACKEND,
+                        expect_failure_backend.unwrap_or(false),
+                    );
+                    reason.set(
+                        FailureReasons::VENDOR,
+                        expect_failure_vendor.unwrap_or(false),
+                    );
+                    reason.set(
+                        FailureReasons::ADAPTER,
+                        expect_failure_adapter.unwrap_or(false),
+                    );
                     Some((reason, *segfault))
                 }
             } else {

--- a/wgpu/tests/vertex_indices/mod.rs
+++ b/wgpu/tests/vertex_indices/mod.rs
@@ -143,7 +143,7 @@ fn draw_vertex_offset() {
     initialize_test(
         TestParameters::default()
             .test_features()
-            .backend_failures(wgpu::Backends::DX12 | wgpu::Backends::DX11),
+            .backend_failure(wgpu::Backends::DX12 | wgpu::Backends::DX11),
         |ctx| {
             pulling_common(ctx, &[0, 1, 2, 3, 4, 5], |cmb| {
                 cmb.draw(0..3, 0..1);
@@ -167,7 +167,7 @@ fn draw_instanced_offset() {
     initialize_test(
         TestParameters::default()
             .test_features()
-            .backend_failures(wgpu::Backends::DX12 | wgpu::Backends::DX11),
+            .backend_failure(wgpu::Backends::DX12 | wgpu::Backends::DX11),
         |ctx| {
             pulling_common(ctx, &[0, 1, 2, 3, 4, 5], |cmb| {
                 cmb.draw(0..3, 0..1);


### PR DESCRIPTION
**Connections**

Couple of low hanging fruit issues solved here. The biggest thing done is moving the masks to associated functions instead of being members of the bitflags, this is done so `all()` only includes the actual members.

Follows up on 579de425e5b2aa861531db8b7f3d12e4fc3fb2ba to mark vk/mipmap as passing
