### PR TITLE
Detailed limits check and error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/naga?rev=68a2efd3c5db62c2c011ccbad84f58be5e539fe3#68a2efd3c5db62c2c011ccbad84f58be5e539fe3"
+source = "git+https://github.com/gfx-rs/naga?rev=0b9af95793e319817e74a30601cbcd4bad9bb3e6#0b9af95793e319817e74a30601cbcd4bad9bb3e6"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     track::{BufferState, TextureSelector, TextureState, TrackerSet, UsageConflict},
     validation::{self, check_buffer_usage, check_texture_usage},
     FastHashMap, Label, LabelHelpers as _, LifeGuard, MultiRefCount, Stored, SubmissionIndex,
-    DOWNLEVEL_ERROR_WARNING_MESSAGE,
+    DOWNLEVEL_ERROR_MESSAGE,
 };
 
 use arrayvec::ArrayVec;
@@ -2426,7 +2426,7 @@ pub struct MissingFeatures(pub wgt::Features);
 #[derive(Clone, Debug, Error)]
 #[error(
     "Downlevel flags {0:?} are required but not supported on the device.\n{}",
-    DOWNLEVEL_ERROR_WARNING_MESSAGE
+    DOWNLEVEL_ERROR_MESSAGE
 )]
 pub struct MissingDownlevelFlags(pub wgt::DownlevelFlags);
 

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -81,15 +81,6 @@ impl RefCount {
         unsafe { self.0.as_ref() }.load(Ordering::Acquire)
     }
 
-    /// This works like `std::mem::drop`, except that it returns a boolean which is true if and only
-    /// if we deallocated the underlying memory, i.e. if this was the last clone of this `RefCount`
-    /// to be dropped. This is useful for loom testing because it allows us to verify that we
-    /// deallocated the underlying memory exactly once.
-    #[cfg(test)]
-    fn rich_drop_outer(self) -> bool {
-        unsafe { std::mem::ManuallyDrop::new(self).rich_drop_inner() }
-    }
-
     /// This function exists to allow `Self::rich_drop_outer` and `Drop::drop` to share the same
     /// logic. To use this safely from outside of `Drop::drop`, the calling function must move
     /// `Self` into a `ManuallyDrop`.
@@ -191,7 +182,7 @@ support enough features to be a fully compliant implementation of WebGPU. A subs
 If you are running this program on native and not in a browser and wish to limit the features you use to the supported subset, \
 call Adapter::downlevel_properties or Device::downlevel_properties to get a listing of the features the current \
 platform supports.";
-const DOWNLEVEL_ERROR_WARNING_MESSAGE: &str = "This is not an invalid use of WebGPU: the underlying API or device does not \
+const DOWNLEVEL_ERROR_MESSAGE: &str = "This is not an invalid use of WebGPU: the underlying API or device does not \
 support enough features to be a fully compliant implementation. A subset of the features can still be used. \
 If you are running this program on native and not in a browser and wish to work around this issue, call \
 Adapter::downlevel_properties or Device::downlevel_properties to get a listing of the features the current \


### PR DESCRIPTION
**Connections**
Related to #1590

**Description**
The old comparison "A < B" was simply wrong, because it would do every field in order and could bail out mid-way without reaching for all limits.

**Testing**
Untested
