### PR TITLE
Fix VVL on halmark example

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -115,7 +115,7 @@ impl super::Adapter {
             "mali",
             "intel",
         ];
-        let strings_that_imply_cpu = ["mesa offscreen", "swiftshader", "lavapipe"];
+        let strings_that_imply_cpu = ["mesa offscreen", "swiftshader", "llvmpipe"];
 
         //TODO: handle Intel Iris XE as discreet
         let inferred_device_type = if vendor.contains("qualcomm")


### PR DESCRIPTION
**Connections**
We have a bunch of VVL related to resource destruction on the halmark example.
It also seems to leak memory quite a ton and eventually hang the system.

**Description**
This PR fixes the logic of changing the command pools in halmark, its initialization sequence, and its destruction.

**Testing**
Tested on halmark and others
