### PR TITLE
Fix memory leak in acquiring encoders

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3618,16 +3618,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 value: id::Valid(device_id),
                 ref_count: device.life_guard.add_ref(),
             };
-
-            let hal_desc = hal::CommandEncoderDescriptor {
-                label: None,
-                queue: &device.queue,
-            };
-            let encoder = match unsafe { device.raw.create_command_encoder(&hal_desc) } {
+            let encoder = match device
+                .command_allocator
+                .lock()
+                .acquire_encoder(&device.raw, &device.queue)
+            {
                 Ok(raw) => raw,
                 Err(_) => break DeviceError::OutOfMemory,
             };
-
             let command_buffer = command::CommandBuffer::new(
                 encoder,
                 dev_stored,


### PR DESCRIPTION
**Connections**
Fixes #1501 
Fixes #1531

**Description**
It was ... interesting. We were creating new command encoders all the time, but still trying to add them to the pool to re-use later. So we were constantly allocating and never freeing them, up until the end. Therefore, program as a whole was valid and non-leaking, if analyzed after termination.

**Testing**
Observed memory manually
