### PR TITLE
Fix macos build

### DIFF
--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -264,7 +264,7 @@ impl super::Instance {
         };
 
         let surface = {
-            let metal_loader = ext::MetalSurface::new(&self.entry, &self.shared.raw);
+            let metal_loader = ext::MetalSurface::new(&self.shared.entry, &self.shared.raw);
             let vk_info = vk::MetalSurfaceCreateInfoEXT::builder()
                 .flags(vk::MetalSurfaceCreateFlagsEXT::empty())
                 .layer(layer as *mut _)


### PR DESCRIPTION
Building on macos failed with
```
   Compiling wgpu-hal v0.9.0 (/Users/scoopr/Code/ext/wgpu/wgpu-hal)
error[E0609]: no field `entry` on type `&vulkan::Instance`
   --> /Users/scoopr/Code/ext/wgpu/wgpu-hal/src/vulkan/instance.rs:267:61
    |
267 |             let metal_loader = ext::MetalSurface::new(&self.entry, &self.shared.raw);
    |                                                             ^^^^^ unknown field
    |
    = note: available fields are: `shared`, `extensions`

error: aborting due to previous error
```

The PR fixes the issue.