### PR TITLE
[Vulkan] Initialize wgpu objects from raw handles

### DIFF
--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -44,6 +44,8 @@ use parking_lot::Mutex;
 const MILLIS_TO_NANOS: u64 = 1_000_000;
 const MAX_TOTAL_ATTACHMENTS: usize = crate::MAX_COLOR_TARGETS * 2 + 1;
 
+pub type DropGuard = Box<dyn std::any::Any + Send + Sync>;
+
 #[derive(Clone)]
 pub struct Api;
 
@@ -80,6 +82,7 @@ struct DebugUtils {
 
 struct InstanceShared {
     raw: ash::Instance,
+    _drop_guard: DropGuard,
     flags: crate::InstanceFlags,
     debug_utils: Option<DebugUtils>,
     get_physical_device_properties: Option<vk::KhrGetPhysicalDeviceProperties2Fn>,
@@ -257,6 +260,7 @@ pub struct Buffer {
 #[derive(Debug)]
 pub struct Texture {
     raw: vk::Image,
+    drop_guard: Option<DropGuard>,
     block: Option<gpu_alloc::MemoryBlock<vk::DeviceMemory>>,
     usage: crate::TextureUses,
     aspects: crate::FormatAspects,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1389,6 +1389,22 @@ impl Instance {
         }
     }
 
+    /// Create an new instance of wgpu from a wgpu-hal instance.
+    ///
+    /// # Arguments
+    ///
+    /// - `hal_instance` - wgpu-hal instance.
+    ///
+    /// # Safety
+    ///
+    /// Refer to the creation of wgpu-hal Instance for every backend.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub unsafe fn from_hal<A: wgc::hub::HalApi>(hal_instance: A::Instance) -> Self {
+        Instance {
+            context: Arc::new(C::from_hal_instance::<A>(hal_instance)),
+        }
+    }
+
     /// Retrieves all available [`Adapter`]s that match the given [`Backends`].
     ///
     /// # Arguments
@@ -1418,6 +1434,21 @@ impl Instance {
         let context = Arc::clone(&self.context);
         let adapter = self.context.instance_request_adapter(options);
         async move { adapter.await.map(|id| Adapter { context, id }) }
+    }
+
+    /// Converts a wgpu-hal `ExposedAdapter` to a wgpu [`Adapter`].
+    ///
+    /// # Safety
+    ///
+    /// `hal_adapter` must be created from this instance internal handle.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub unsafe fn create_adapter_from_hal<A: wgc::hub::HalApi>(
+        &self,
+        hal_adapter: hal::ExposedAdapter<A>,
+    ) -> Adapter {
+        let context = Arc::clone(&self.context);
+        let id = context.create_adapter_from_hal(hal_adapter);
+        Adapter { context, id }
     }
 
     /// Creates a surface from a raw window handle.
@@ -1501,6 +1532,36 @@ impl Adapter {
                 )
             })
         }
+    }
+
+    /// Create a wgpu [`Device`] and [`Queue`] from a wgpu-hal `OpenDevice`
+    ///
+    /// # Safety
+    ///
+    /// - `hal_device` must be created from this adapter internal handle.
+    /// - `desc.features` must be a subset of `hal_device` features.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub unsafe fn create_device_from_hal<A: wgc::hub::HalApi>(
+        &self,
+        hal_device: hal::OpenDevice<A>,
+        desc: &DeviceDescriptor,
+        trace_path: Option<&std::path::Path>,
+    ) -> Result<(Device, Queue), RequestDeviceError> {
+        let context = Arc::clone(&self.context);
+        self.context
+            .create_device_from_hal(&self.id, hal_device, desc, trace_path)
+            .map(|(device_id, queue_id)| {
+                (
+                    Device {
+                        context: Arc::clone(&context),
+                        id: device_id,
+                    },
+                    Queue {
+                        context,
+                        id: queue_id,
+                    },
+                )
+            })
     }
 
     /// Returns an optimal texture format to use for the [`SwapChain`] with this adapter.
@@ -1683,6 +1744,27 @@ impl Device {
         Texture {
             context: Arc::clone(&self.context),
             id: Context::device_create_texture(&*self.context, &self.id, desc),
+            owned: true,
+        }
+    }
+
+    /// Creates a [`Texture`] from a wgpu-hal Texture.
+    ///
+    /// # Safety
+    ///
+    /// - `hal_texture` must be created from this device internal handle
+    /// - `hal_texture` must be created respecting `desc`
+    #[cfg(not(target_arch = "wasm32"))]
+    pub unsafe fn create_texture_from_hal<A: wgc::hub::HalApi>(
+        &self,
+        hal_texture: A::Texture,
+        desc: &TextureDescriptor,
+    ) -> Texture {
+        Texture {
+            context: Arc::clone(&self.context),
+            id: self
+                .context
+                .create_texture_from_hal::<A>(hal_texture, &self.id, desc),
             owned: true,
         }
     }


### PR DESCRIPTION
**Connections**
This PR is a successor of https://github.com/gfx-rs/gfx/pull/3762

**Description**
The `handle_is_external` flag mechanism was not enough to ensure safety, when for example the Instance is wrapped in `Arc<>` and a library cannot keep track of all its clones. This is the case with the bevy render rewrite. The solution was to let wgpu be in charge of destroying the handles, but it also has to keep a reference to a "drop guard" which is always dropped after the handle is destroyed. For the OpenXR integration, this drop guard will be `xr::Instance`.

For now this is just a proof of concept. Only instance creation is handled, and there is even type error in `wgc::Instance::from_hal()`.

I have a few concerns:
* Is it ok to expose `hal::Instance` from the wgpu crate? Or should the user pass all the parameters so `hal::Instance` can be constructed internally? This second options is more disruptive, since the wgpu-types crate would need to import all platform-specific crates to define the structure/enum to hold the raw handles.
* Without counting the call to create the `hal::Instance`, there are 4 indirection calls to save the raw instance. Can this be optimized in any way?

Do you think it is possible to merge wgpu-hal into wgpu-core? This could help with reducing the distance from the surface level API to the platform specific APIs even more.

**Testing**
Vulkan/Android (Oculus Quest) using [this sample](https://github.com/zarik5/openxrs/blob/wgpu-test/openxr/examples/vulkan.rs).
