### PR TITLE
Update `web-sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -135,7 +135,7 @@ test = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.73" # remember to change version in wiki as well
-web-sys = { version = "=0.3.50", features = [
+web-sys = { version = "=0.3.51", features = [
     "Document",
     "Navigator",
     "Node",


### PR DESCRIPTION
`wgpu` uses unstable APIs so the version has to be pinned and manually updated.

No breaking changes happened in `0.3.51` so this update is easy.