### PR TITLE
webgpu: pass wgsl directly

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -82,12 +82,6 @@ git = "https://github.com/gfx-rs/naga"
 rev = "458db0b"
 features = ["wgsl-in"]
 
-# used to generate SPIR-V for the Web target
-[target.'cfg(target_arch = "wasm32")'.dependencies.naga]
-git = "https://github.com/gfx-rs/naga"
-rev = "458db0b"
-features = ["wgsl-in", "spv-out"]
-
 [[example]]
 name="boids"
 test = true

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1142,23 +1142,7 @@ impl crate::Context for Context {
                 web_sys::GpuShaderModuleDescriptor::new(&js_sys::Uint32Array::from(&**spv))
             }
             crate::ShaderSource::Wgsl(ref code) => {
-                use naga::{back::spv, front::wgsl, valid::Validator};
-                let module = wgsl::parse_str(code).unwrap();
-                let options = spv::Options {
-                    lang_version: (1, 0),
-                    flags: spv::WriterFlags::empty(),
-                    capabilities: None,
-                    index_bounds_check_policy:
-                        naga::back::IndexBoundsCheckPolicy::UndefinedBehavior,
-                };
-                let analysis = Validator::new(
-                    naga::valid::ValidationFlags::empty(),
-                    naga::valid::Capabilities::all(),
-                )
-                .validate(&module)
-                .unwrap();
-                let words = spv::write_vec(&module, &analysis, &options).unwrap();
-                web_sys::GpuShaderModuleDescriptor::new(&js_sys::Uint32Array::from(&words[..]))
+                web_sys::GpuShaderModuleDescriptor::new(&js_sys::JsString::from(&**code))
             }
         };
         if let Some(ref label) = desc.label {


### PR DESCRIPTION
**Connections**
Matrix conversation about passing WGSL to Gecko

**Description**
Gecko accepts WGSL now, so we can pass it directly instead of going through naga.

We could also consider converting SPIR-V to WGSL soon, assuming nobody is relying on the SPIR-V path with older versions of Gecko. We could do that in a separate PR though.

**Testing**
Tried hello-compute locally, using the examples HTML file and creating wasm with something like
```
RUSTFLAGS=--cfg=web_sys_unstable_apis cargo build --release --example hello-compute --target wasm32-unknown-unknown
wasm-bindgen target/wasm32-unknown-unknown/release/examples/hello-compute.wasm --out-dir target/generated --web
```