### PR TITLE
Implicitly add `COPY_DST` when using `create_texture_with_data`

### DIFF
--- a/wgpu/src/util/device.rs
+++ b/wgpu/src/util/device.rs
@@ -82,14 +82,10 @@ impl DeviceExt for crate::Device {
         desc: &crate::TextureDescriptor,
         data: &[u8],
     ) -> crate::Texture {
-        let texture = if desc.usage.contains(crate::TextureUsages::COPY_DST) {
-            self.create_texture(desc)
-        } else {
-            // Implicitly add the COPY_DST usage
-            let mut desc = desc.to_owned();
-            desc.usage |= crate::TextureUsages::COPY_DST;
-            self.create_texture(&desc)
-        };
+        // Implicitly add the COPY_DST usage
+        let mut desc = desc.to_owned();
+        desc.usage |= crate::TextureUsages::COPY_DST;
+        let texture = self.create_texture(&desc);
 
         let format_info = desc.format.describe();
         let layer_iterations = desc.array_layer_count();


### PR DESCRIPTION
**Connections**
Fixes: #1621

**Description**
> The documentation for device.create_texture_with_data doesn't mention that the usage must contain COPY_DST, but it also doesn't implicitly add that flag. I think it should either mention that COPY_DST is required or add it implicitly. Not sure which is the desired way to go though.

It feels kinda ugly to have to clone the descriptor. It's not a big deal performance-wise, but still.
An alternative to this would be a nicer validation error message.