### PR TITLE
Enable All Backends for Trace Player

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -41,8 +41,7 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    let global =
-        wgc::hub::Global::new("player", IdentityPassThroughFactory, wgt::Backends::PRIMARY);
+    let global = wgc::hub::Global::new("player", IdentityPassThroughFactory, wgt::Backends::all());
     let mut command_buffer_id_manager = wgc::hub::IdentityManager::default();
 
     #[cfg(feature = "winit")]


### PR DESCRIPTION
**Connections**
None

**Description**
I just spent a bit of time trying to figure out how to get the trace player to play an OpenGL trace before realizing that only the primary backends were enabled at instance creation. This just enables all backends in the trace player. I believe that this should be harmless as it shouldn't change anything for traces on the primary supported backends.

**Testing**
It's not tested specifically, but it's such a minor change it shouldn't matter, I think.
