### PR TITLE
Fix Color and Clear Problems on OpenGL Backend

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -541,11 +541,14 @@ impl crate::Instance<super::Api> for Instance {
                 egl::SINGLE_BUFFER as usize
             },
         ];
-        if inner.version >= (1, 5) {
-            // Always enable sRGB in EGL 1.5
-            attributes.push(egl::GL_COLORSPACE as usize);
-            attributes.push(egl::GL_COLORSPACE_SRGB as usize);
-        }
+        // sRGB caused color problems, making the render lighter colored than the vulkan version
+        // so we comment this out for now.
+        //
+        // if inner.version >= (1, 5) {
+        //     // Always enable sRGB in EGL 1.5
+        //     attributes.push(egl::GL_COLORSPACE as usize);
+        //     attributes.push(egl::GL_COLORSPACE_SRGB as usize);
+        // }
         attributes.push(egl::ATTRIB_NONE);
 
         let raw = if let Some(egl) = inner.egl.upcast::<egl::EGL1_5>() {

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -533,7 +533,7 @@ impl super::Queue {
                         0,
                     );
                 }
-                gl.color_mask(true, true, true, true);
+                gl.color_mask(true, true, true, false);
                 gl.depth_mask(true);
                 gl.stencil_mask(!0);
                 gl.disable(glow::DEPTH_TEST);


### PR DESCRIPTION
- Disabled writing to the alpha channel of the draw framebuffer. This
   fixes pixelated edges around the borders of the clear color.
- Disable sRGB mode when creating the EGL surface. This was causing the
  color of the OpenGL backend to appear "washed-out" compared to the
  other backends.

**Connections**
Fixes #1627

**Description**
Fixes some rendering differences between OpenGL and Vulkan backends on Linux:

**Before:**

![image](https://user-images.githubusercontent.com/25393315/125174324-3c663600-e18a-11eb-829d-3af5f0c01546.png)

**After:**

![](https://user-images.githubusercontent.com/25393315/125173960-c660cf80-e187-11eb-8c9c-11db725976df.png)


**Testing**
Tested on my Linux Pop!_OS ( Ubuntu ) 20.04 laptop using my "Mesa Intel(R) UHD Graphics (CML GT2)" adapter.

---

**Extra info:**

- I'm not 100% sure it's the right move to disable the alpha write to the draw framebuffer. It might disable the ability to use the GL backend for transparent windows, but I don't really know anything about transparent windows or if there are other problems/setup needed to make that work.
- I'm not sure _why_ disabling sRGB fixed the color issue, or whether or not there needs to be more work done to make that actually do what it's intented to do.