### PR TITLE
Enable VK_KHR_timeline_semaphore On Vulkan < 1.2

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -437,6 +437,7 @@ impl PhysicalDeviceCapabilities {
             }
 
             extensions.push(vk::ExtSamplerFilterMinmaxFn::name());
+            extensions.push(vk::KhrTimelineSemaphoreFn::name());
 
             if requested_features.intersects(indexing_features()) {
                 extensions.push(vk::ExtDescriptorIndexingFn::name());


### PR DESCRIPTION
**Connections**
Fixes #1640 

**Description**
This is my attempt to fix #1640.

**Testing**
Test the `cube` example on:
- `Intel(R) UHD Graphics (CML GT2) (Vulkan)`
- `Using GeForce GTX 1650 (Vulkan)`
