### PR TITLE
Fix Example Resolution Limits

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -631,6 +631,20 @@ impl Limits {
             max_push_constant_size: 0,
         }
     }
+
+    /// Modify the current limits to use the resolution limits of the other.
+    ///
+    /// This is useful because the swapchain might need to be larger than any other image in the application.
+    ///
+    /// If your application only needs 512x512, you might be running on a 4k display and need extremely high resolution limits.
+    pub fn using_resolution(self, other: Self) -> Self {
+        Self {
+            max_texture_dimension_1d: other.max_texture_dimension_1d,
+            max_texture_dimension_2d: other.max_texture_dimension_2d,
+            max_texture_dimension_3d: other.max_texture_dimension_3d,
+            ..self
+        }
+    }
 }
 
 /// Represents the sets of additional limits on an adapter,

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -137,7 +137,8 @@ async fn setup<E: Example>(title: &str) -> Setup {
         required_features - adapter_features
     );
 
-    let needed_limits = E::required_limits();
+    // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
+    let needed_limits = E::required_limits().using_resolution(adapter.limits());
 
     let trace_dir = std::env::var("WGPU_TRACE");
     let (device, queue) = adapter
@@ -396,10 +397,7 @@ pub fn test<E: Example>(mut params: FrameworkRefTest) {
     assert_eq!(params.width % 64, 0, "width needs to be aligned 64");
 
     let features = E::required_features() | params.optional_features;
-    let mut limits = E::required_limits();
-    if limits == wgpu::Limits::default() {
-        limits = test_common::lowest_reasonable_limits();
-    }
+    let limits = E::required_limits();
 
     test_common::initialize_test(
         mem::take(&mut params.base_test_parameters)

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -24,7 +24,8 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
             &wgpu::DeviceDescriptor {
                 label: None,
                 features: wgpu::Features::empty(),
-                limits: wgpu::Limits::downlevel_defaults(),
+                // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
+                limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
             },
             None,
         )

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -91,7 +91,7 @@ impl Default for TestParameters {
     fn default() -> Self {
         Self {
             required_features: Features::empty(),
-            required_limits: lowest_reasonable_limits(),
+            required_limits: Limits::downlevel_defaults(),
             required_downlevel_properties: lowest_downlevel_properties(),
             failures: Vec::new(),
         }


### PR DESCRIPTION
**Connections**

Closes #1616.

**Description**

This change automatically expands resolution to the adapter's limits so examples always work.

**Testing**

Ran locally, but couldn't make it bigger than the screen

