### PR TITLE
Disable Intel Fastclear in GL Backend

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -396,6 +396,11 @@ impl crate::Instance<super::Api> for Instance {
             None
         };
 
+        // Workaround Mesa driver bug on Intel cards by disabling fastclear:
+        // https://gitlab.freedesktop.org/mesa/mesa/-/issues/2565
+        // https://github.com/gfx-rs/wgpu/issues/1627#issuecomment-877854185
+        std::env::set_var("INTEL_DEBUG", "nofc");
+
         let display = if let (Some(library), Some(egl)) =
             (wayland_library, egl.upcast::<egl::EGL1_5>())
         {


### PR DESCRIPTION
This works around a Mesa bug on Intel cards:

- https://gitlab.freedesktop.org/mesa/mesa/-/issues/2565
- https://github.com/gfx-rs/wgpu/issues/1627#issuecomment-877854185

**Connections**
Related to pixelated edges in GL backend brought up in #1627.

**Description**
This just adds the `INTEL_DEBUG=nofc` environment variable setting when creating an `Instance` using the GL backend in `wgpu_hal`. This is just a workaround until the mesa bug is fixed.

I wanted to wait until adapters were enumerated to determine that the user wanted to use an Intel Mesa adapter, but the environment variable has to be set before the x11 display was opened so that wasn't an option.

This may not be the strategy we want to take with this one, but it seems relatively harmless. Because the environment variable prefixed with `INTEL` anyway, it might not effect devices other than the ones we want to, which would be good.

**Testing**
I tested this on Ubuntu 20.04 with Mesa Intel(R) UHD Graphics (CML GT2) on using the GL backend.
