### PR TITLE
hal/vulkan: Respect swapchain's minImageCount

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1063,7 +1063,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
 
         Some(crate::SurfaceCapabilities {
             formats,
-            swap_chain_sizes: 1..=max_image_count,
+            swap_chain_sizes: caps.min_image_count..=max_image_count,
             current_extent,
             extents: min_extent..=max_extent,
             usage: conv::map_vk_image_usage(caps.supported_usage_flags),


### PR DESCRIPTION
**Description**
Respect `minImageCount` from the `VkSwapchainCreateInfoKHR` struct. Previously wgpu caused Vulkan validation errors like this:
```
[2021-07-14T17:15:18Z ERROR wgpu_hal::vulkan::instance] VALIDATION [VUID-VkSwapchainCreateInfoKHR-minImageCount-01271 (0xe18476f3)]
    	Validation Error: [ VUID-VkSwapchainCreateInfoKHR-minImageCount-01271 ] Object 0: handle = 0x5595501a6190, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xe18476f3 | vkCreateSwapchainKHR() called with minImageCount = 3, which is outside the bounds returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR() (i.e. minImageCount = 4, maxImageCount = 0). The Vulkan spec states: minImageCount must be greater than or equal to the value returned in the minImageCount member of the VkSurfaceCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR for the surface (https://github.com/KhronosGroup/Vulkan-Docs/search?q=)VUID-VkSwapchainCreateInfoKHR-minImageCount-01271)
```
(Wayland with AMD RADV POLARIS10 (ACO))

**Testing**
Validation error doesn't get emitted anymore.
