### PR TITLE
hal: Fix copy-paste error in texture copy dimensions

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -320,7 +320,7 @@ pub(crate) fn validate_texture_copy_range(
     // the virtual size.
     let copy_extent = hal::CopyExtent {
         width: copy_size.width.min(extent_virtual.width),
-        height: copy_size.width.min(extent_virtual.height),
+        height: copy_size.height.min(extent_virtual.height),
         depth,
     };
     Ok((copy_extent, array_layer_count))


### PR DESCRIPTION
**Testing**
My textures aren't cut off past the square anymore ^^
![2021-07-14_19-57-06_grim](https://user-images.githubusercontent.com/2302947/125669952-121b4da9-6f2f-4cf9-b4c3-b2f3bf081114.png)
![2021-07-14_19-50-38_grim](https://user-images.githubusercontent.com/2302947/125670442-351ebde1-e8d3-4be0-accf-5395537fc3b8.png)
