### PR TITLE
Removes nightly from bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,7 +3,6 @@ status = [
   "MacOS x86_64",
   "IOS aarch64",
   "Linux x86_64",
-  "Linux Nightly x86_64",
   "Android aarch64",
   "WebAssembly",
   "Format",


### PR DESCRIPTION
**Connections**

Following up on the trouble #1654 had merging. We actually shouldn't force bors to wait for nightly to work.