### PR TITLE
dx12/hal: invalidate root elements on signature change

### DIFF
--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1198,6 +1198,7 @@ impl crate::Device<super::Api> for super::Device {
         Ok(super::PipelineLayout {
             raw,
             bind_group_infos,
+            total_root_elements: total_parameters as super::RootIndex,
             naga_options: naga::back::hlsl::Options {
                 shader_model: naga::back::hlsl::ShaderModel::V5_1,
             },
@@ -1545,6 +1546,7 @@ impl crate::Device<super::Api> for super::Device {
         Ok(super::RenderPipeline {
             raw,
             signature: desc.layout.raw,
+            total_root_elements: desc.layout.total_root_elements,
             topology,
             vertex_strides,
         })
@@ -1581,6 +1583,7 @@ impl crate::Device<super::Api> for super::Device {
         Ok(super::ComputePipeline {
             raw,
             signature: desc.layout.raw,
+            total_root_elements: desc.layout.total_root_elements,
         })
     }
     unsafe fn destroy_compute_pipeline(&self, pipeline: super::ComputePipeline) {


### PR DESCRIPTION
**Connections**
A follow-up to #1602, which I hesitated to implement, but now it doesn't sound like there is any choice we have.

**Description**
D3D12's root signature is internally mapped to device's physical descriptors. But this mapping isn't guaranteed to have any properties. That is, any changes to the root signature mean that all of the bound resources need to be invalidated...

It's a bit unfortunate. gfx-backend-dx12 did a lazy flushing approach at draw call. In wgpu-hal I tried to be more aggressive, and we are rebinding everything as it goes. We can choose to go lazy if we want - this PR introduces the necessary logic and infrastructure to do so.

**Testing**
Untested.
