### PR TITLE
(macOS/iOS) readWriteTextureSupport is support on macOS 10.13+ / iOS 11.0

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -573,7 +573,17 @@ impl super::PrivateCapabilities {
                 MTLLanguageVersion::V1_0
             },
             exposed_queues: 1,
-            read_write_texture_tier: device.read_write_texture_support(),
+            read_write_texture_tier: if os_is_mac {
+                if Self::version_at_least(major, minor, 10, 13) {
+                    device.read_write_texture_support()
+                } else {
+                    mtl::MTLReadWriteTextureTier::TierNone
+                }
+            } else if Self::version_at_least(major, minor, 11, 0) {
+                device.read_write_texture_support()
+            } else {
+                mtl::MTLReadWriteTextureTier::TierNone
+            },
             resource_heaps: Self::supports_any(&device, RESOURCE_HEAP_SUPPORT),
             argument_buffers: Self::supports_any(&device, ARGUMENT_BUFFER_SUPPORT),
             shared_textures: !os_is_mac,


### PR DESCRIPTION
```
[MTLIGAccelDevice readWriteTextureSupport]: unrecognized selector sent to instance 0x7f97d1070a00
```
https://developer.apple.com/documentation/metal/mtldevice/2887289-readwritetexturesupport?language=objc
