### PR TITLE
Special mode for rebinding only dynamic offsets

### DIFF
--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -183,6 +183,17 @@ impl Binder {
         (bind_range.start, &self.payloads[bind_range])
     }
 
+    pub(super) fn is_group_assigned(
+        &self,
+        index: usize,
+        bind_group_id: Valid<BindGroupId>,
+    ) -> bool {
+        match self.payloads[index].group_id {
+            Some(ref stored) => stored.value == bind_group_id,
+            None => false,
+        }
+    }
+
     pub(super) fn assign_group<'a, A: HalApi>(
         &'a mut self,
         index: usize,

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -604,6 +604,7 @@ impl RenderBundle {
                         index as u32,
                         &bind_group.raw,
                         &offsets[num_dynamic_offsets as usize..],
+                        hal::BindingInvalidation::All,
                     );
                     offsets = &offsets[num_dynamic_offsets as usize..];
                 }

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -370,6 +370,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                                     index as u32 + i as u32,
                                     raw_bg,
                                     &e.dynamic_offsets,
+                                    hal::BindingInvalidation::All,
                                 );
                             }
                         }
@@ -411,6 +412,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                                         start_index as u32 + i as u32,
                                         raw_bg,
                                         &e.dynamic_offsets,
+                                        hal::BindingInvalidation::All,
                                     );
                                 }
                             }

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -644,16 +644,33 @@ impl<A: hal::Api> Example<A> {
         unsafe {
             ctx.encoder.begin_render_pass(&pass_desc);
             ctx.encoder.set_render_pipeline(&self.pipeline);
-            ctx.encoder
-                .set_bind_group(&self.pipeline_layout, 0, &self.global_group, &[]);
+            ctx.encoder.set_bind_group(
+                &self.pipeline_layout,
+                0,
+                &self.global_group,
+                &[],
+                hal::BindingInvalidation::All,
+            );
+            ctx.encoder.set_bind_group(
+                &self.pipeline_layout,
+                1,
+                &self.local_group,
+                &[0],
+                hal::BindingInvalidation::All,
+            );
         }
 
         for i in 0..self.bunnies.len() {
             let offset =
                 (i as wgt::DynamicOffset) * (wgt::BIND_BUFFER_ALIGNMENT as wgt::DynamicOffset);
             unsafe {
-                ctx.encoder
-                    .set_bind_group(&self.pipeline_layout, 1, &self.local_group, &[offset]);
+                ctx.encoder.set_bind_group(
+                    &self.pipeline_layout,
+                    1,
+                    &self.local_group,
+                    &[offset],
+                    hal::BindingInvalidation::DynamicOffsetsOnly,
+                );
                 ctx.encoder.draw(0, 4, 0, 1);
             }
         }

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -294,6 +294,7 @@ impl crate::CommandEncoder<Api> for Encoder {
         index: u32,
         group: &Resource,
         dynamic_offsets: &[wgt::DynamicOffset],
+        invalidation: crate::BindingInvalidation,
     ) {
     }
     unsafe fn set_push_constants(

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -504,6 +504,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         index: u32,
         group: &super::BindGroup,
         dynamic_offsets: &[wgt::DynamicOffset],
+        invalidation: crate::BindingInvalidation,
     ) {
         let mut do_index = 0;
         let mut dirty_textures = 0u32;
@@ -528,6 +529,9 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                             if has_dynamic_offset {
                                 offset += dynamic_offsets[do_index] as i32;
                                 do_index += 1;
+                            } else if invalidation == crate::BindingInvalidation::DynamicOffsetsOnly
+                            {
+                                continue;
                             }
                             match ty {
                                 wgt::BufferBindingType::Uniform => glow::UNIFORM_BUFFER,
@@ -546,6 +550,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                         size,
                     });
                 }
+                _ if invalidation == crate::BindingInvalidation::DynamicOffsetsOnly => continue,
                 super::RawBinding::Sampler(sampler) => {
                     dirty_samplers |= 1 << slot;
                     self.state.samplers[slot as usize] = Some(sampler);

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -391,6 +391,7 @@ pub trait CommandEncoder<A: Api>: Send + Sync {
         index: u32,
         group: &A::BindGroup,
         dynamic_offsets: &[wgt::DynamicOffset],
+        invalidation: BindingInvalidation,
     );
 
     unsafe fn set_push_constants(
@@ -1099,6 +1100,18 @@ pub struct RenderPassDescriptor<'a, A: Api> {
 #[derive(Clone, Debug)]
 pub struct ComputePassDescriptor<'a> {
     pub label: Label<'a>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BindingInvalidation {
+    All,
+    DynamicOffsetsOnly,
+}
+
+impl Default for BindingInvalidation {
+    fn default() -> Self {
+        Self::All
+    }
 }
 
 #[test]

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -391,6 +391,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         group_index: u32,
         group: &super::BindGroup,
         dynamic_offsets: &[wgt::DynamicOffset],
+        invalidation: crate::BindingInvalidation,
     ) {
         let bg_info = &layout.bind_group_infos[group_index as usize];
 
@@ -401,6 +402,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 let mut offset = buf.offset;
                 if let Some(dyn_index) = buf.dynamic_index {
                     offset += dynamic_offsets[dyn_index as usize] as wgt::BufferAddress;
+                } else if invalidation == crate::BindingInvalidation::DynamicOffsetsOnly {
+                    continue;
                 }
                 encoder.set_vertex_buffer(
                     (bg_info.base_resource_indices.vs.buffers + index) as u64,
@@ -435,6 +438,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 let mut offset = buf.offset;
                 if let Some(dyn_index) = buf.dynamic_index {
                     offset += dynamic_offsets[dyn_index as usize] as wgt::BufferAddress;
+                } else if invalidation == crate::BindingInvalidation::DynamicOffsetsOnly {
+                    continue;
                 }
                 encoder.set_fragment_buffer(
                     (bg_info.base_resource_indices.fs.buffers + index) as u64,
@@ -463,34 +468,36 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 }
             }
 
-            for index in 0..group.counters.vs.samplers {
-                let res = group.samplers[index as usize];
-                encoder.set_vertex_sampler_state(
-                    (bg_info.base_resource_indices.vs.samplers + index) as u64,
-                    Some(res.as_native()),
-                );
-            }
-            for index in 0..group.counters.fs.samplers {
-                let res = group.samplers[(group.counters.vs.samplers + index) as usize];
-                encoder.set_fragment_sampler_state(
-                    (bg_info.base_resource_indices.fs.samplers + index) as u64,
-                    Some(res.as_native()),
-                );
-            }
+            if invalidation == crate::BindingInvalidation::All {
+                for index in 0..group.counters.vs.samplers {
+                    let res = group.samplers[index as usize];
+                    encoder.set_vertex_sampler_state(
+                        (bg_info.base_resource_indices.vs.samplers + index) as u64,
+                        Some(res.as_native()),
+                    );
+                }
+                for index in 0..group.counters.fs.samplers {
+                    let res = group.samplers[(group.counters.vs.samplers + index) as usize];
+                    encoder.set_fragment_sampler_state(
+                        (bg_info.base_resource_indices.fs.samplers + index) as u64,
+                        Some(res.as_native()),
+                    );
+                }
 
-            for index in 0..group.counters.vs.textures {
-                let res = group.textures[index as usize];
-                encoder.set_vertex_texture(
-                    (bg_info.base_resource_indices.vs.textures + index) as u64,
-                    Some(res.as_native()),
-                );
-            }
-            for index in 0..group.counters.fs.textures {
-                let res = group.textures[(group.counters.vs.textures + index) as usize];
-                encoder.set_fragment_texture(
-                    (bg_info.base_resource_indices.fs.textures + index) as u64,
-                    Some(res.as_native()),
-                );
+                for index in 0..group.counters.vs.textures {
+                    let res = group.textures[index as usize];
+                    encoder.set_vertex_texture(
+                        (bg_info.base_resource_indices.vs.textures + index) as u64,
+                        Some(res.as_native()),
+                    );
+                }
+                for index in 0..group.counters.fs.textures {
+                    let res = group.textures[(group.counters.vs.textures + index) as usize];
+                    encoder.set_fragment_texture(
+                        (bg_info.base_resource_indices.fs.textures + index) as u64,
+                        Some(res.as_native()),
+                    );
+                }
             }
         }
 
@@ -507,6 +514,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 let mut offset = buf.offset;
                 if let Some(dyn_index) = buf.dynamic_index {
                     offset += dynamic_offsets[dyn_index as usize] as wgt::BufferAddress;
+                } else if invalidation == crate::BindingInvalidation::DynamicOffsetsOnly {
+                    continue;
                 }
                 encoder.set_buffer(
                     (bg_info.base_resource_indices.cs.buffers + index) as u64,
@@ -535,19 +544,21 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 }
             }
 
-            for index in 0..group.counters.cs.samplers {
-                let res = group.samplers[(index_base.samplers + index) as usize];
-                encoder.set_sampler_state(
-                    (bg_info.base_resource_indices.cs.samplers + index) as u64,
-                    Some(res.as_native()),
-                );
-            }
-            for index in 0..group.counters.cs.textures {
-                let res = group.textures[(index_base.textures + index) as usize];
-                encoder.set_texture(
-                    (bg_info.base_resource_indices.cs.textures + index) as u64,
-                    Some(res.as_native()),
-                );
+            if invalidation == crate::BindingInvalidation::All {
+                for index in 0..group.counters.cs.samplers {
+                    let res = group.samplers[(index_base.samplers + index) as usize];
+                    encoder.set_sampler_state(
+                        (bg_info.base_resource_indices.cs.samplers + index) as u64,
+                        Some(res.as_native()),
+                    );
+                }
+                for index in 0..group.counters.cs.textures {
+                    let res = group.textures[(index_base.textures + index) as usize];
+                    encoder.set_texture(
+                        (bg_info.base_resource_indices.cs.textures + index) as u64,
+                        Some(res.as_native()),
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
**Connections**

**Description**
I noticed that Metal backend does a lot of wasted resource rebinding on Halmark example, since the only thing that changes is the dynamic offset. So this is an attempt to handle this case more carefully across the stack.

As I was finishing this work, I realized that it's better to just ask users to only rebind stuff that truly changes. I.e. in this case the test should either assume that textures can also be different between entities, or it should move the shared textures into a lower bind group, so that the most frequent one only has our dynamic offset buffers.

**Testing**
Just the examples.
