### PR TITLE
Use EGL_KHR_gl_colorspace for srgb if available

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -462,10 +462,17 @@ impl crate::Adapter<super::Api> for super::Adapter {
     ) -> Option<crate::SurfaceCapabilities> {
         if surface.presentable {
             Some(crate::SurfaceCapabilities {
-                formats: vec![
-                    wgt::TextureFormat::Rgba8UnormSrgb,
-                    wgt::TextureFormat::Bgra8UnormSrgb,
-                ],
+                formats: if surface.enable_srgb {
+                    vec![
+                        wgt::TextureFormat::Rgba8UnormSrgb,
+                        wgt::TextureFormat::Bgra8UnormSrgb,
+                    ]
+                } else {
+                    vec![
+                        wgt::TextureFormat::Rgba8Unorm,
+                        wgt::TextureFormat::Bgra8Unorm,
+                    ]
+                },
                 present_modes: vec![wgt::PresentMode::Fifo], //TODO
                 composite_alpha_modes: vec![crate::CompositeAlphaMode::Opaque], //TODO
                 swap_chain_sizes: 2..=2,


### PR DESCRIPTION
**Connections**

Fixes #1667 

**Description**

Uses the extension to provide SRGB if needed relevant.

I also promoted the log message about missing robustness to a warning because it is a safety issue.

**Testing**

Tested on rpi and haswell.
