### PR TITLE
hal/vk: relay semaphore

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2446,7 +2446,7 @@ impl<A: hal::Api> Device<A> {
         self.command_allocator.into_inner().dispose(&self.raw);
         unsafe {
             self.raw.destroy_fence(self.fence);
-            self.raw.exit();
+            self.raw.exit(self.queue);
         }
     }
 }

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -518,10 +518,9 @@ impl<A: hal::Api> Example<A> {
             self.device.destroy_pipeline_layout(self.pipeline_layout);
 
             self.surface.unconfigure(&self.device);
-            self.device.exit();
+            self.device.exit(self.queue);
             self.instance.destroy_surface(self.surface);
             drop(self.adapter);
-            drop(self.queue);
         }
     }
 

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -592,13 +592,14 @@ impl super::Device {
 }
 
 impl crate::Device<super::Api> for super::Device {
-    unsafe fn exit(self) {
+    unsafe fn exit(self, queue: super::Queue) {
         self.rtv_pool.into_inner().destroy();
         self.dsv_pool.into_inner().destroy();
         self.srv_uav_pool.into_inner().destroy();
         self.sampler_pool.into_inner().destroy();
         self.shared.destroy();
         self.idler.destroy();
+        queue.raw.destroy();
 
         // Debug tracking alive objects
         if !thread::panicking() {

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -106,7 +106,7 @@ impl crate::Queue<Api> for Context {
 }
 
 impl crate::Device<Api> for Context {
-    unsafe fn exit(self) {}
+    unsafe fn exit(self, queue: Context) {}
     unsafe fn create_buffer(&self, desc: &crate::BufferDescriptor) -> DeviceResult<Resource> {
         Ok(Resource)
     }

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -289,9 +289,12 @@ impl super::Device {
 }
 
 impl crate::Device<super::Api> for super::Device {
-    unsafe fn exit(self) {
+    unsafe fn exit(self, queue: super::Queue) {
         let gl = &self.shared.context;
         gl.delete_vertex_array(self.main_vao);
+        gl.delete_framebuffer(queue.draw_fbo);
+        gl.delete_framebuffer(queue.copy_fbo);
+        gl.delete_buffer(queue.zero_buffer);
     }
 
     unsafe fn create_buffer(

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -204,7 +204,7 @@ pub trait Adapter<A: Api>: Send + Sync {
 
 pub trait Device<A: Api>: Send + Sync {
     /// Exit connection to this logical device.
-    unsafe fn exit(self);
+    unsafe fn exit(self, queue: A::Queue);
     /// Creates a new buffer.
     ///
     /// The initial usage is `BufferUses::empty()`.

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -161,7 +161,7 @@ impl super::Device {
 }
 
 impl crate::Device<super::Api> for super::Device {
-    unsafe fn exit(self) {}
+    unsafe fn exit(self, _queue: super::Queue) {}
 
     unsafe fn create_buffer(&self, desc: &crate::BufferDescriptor) -> DeviceResult<super::Buffer> {
         let map_read = desc.usage.contains(crate::BufferUses::MAP_READ);

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -860,6 +860,10 @@ impl crate::Adapter<super::Api> for super::Adapter {
             swapchain_fn,
             device: Arc::clone(&shared),
             family_index,
+            relay_semaphore: shared
+                .raw
+                .create_semaphore(&vk::SemaphoreCreateInfo::builder(), None)?,
+            relay_active: false,
         };
 
         let mem_allocator = {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -538,9 +538,12 @@ impl super::Device {
 }
 
 impl crate::Device<super::Api> for super::Device {
-    unsafe fn exit(self) {
+    unsafe fn exit(self, queue: super::Queue) {
         self.mem_allocator.into_inner().cleanup(&*self.shared);
         self.desc_allocator.into_inner().cleanup(&*self.shared);
+        self.shared
+            .raw
+            .destroy_semaphore(queue.relay_semaphore, None);
         self.shared.free_resources();
     }
 


### PR DESCRIPTION
**Connections**
Somewhere on the Matrix, by @pythonesque

**Description**
Vulkan (somewhat confusingly) requires semaphore synchronization between `vkQueueSubmit` and `vkQueuePresent` *even if* it's done on the same queue.
This PR exercises a dumb idea of just keeping one binary semaphore as a "relay" between all queue commands, all concealed within hal/vk backend.

**Testing**
Running Halmark shows that all the things break here. I'm not seeing anything particularly wrong with the code though. My humble guess is that AMD driver (at least) isn't happy about the mix of binary and timeline semaphores used together in the same signal operation.
