### PR TITLE
Add `Feature::SHADER_PRIMITIVE_INDEX` to support `builtin(primitive_index)` in fragment shaders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/naga?rev=458db0b#458db0b5228854dc417283f4b9742e03f25bc492"
+source = "git+https://github.com/gfx-rs/naga?rev=8f71a36#8f71a368eff3a18fd348ab6193cb183df0f49f95"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "458db0b"
+rev = "8f71a36"
 features = ["wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -898,6 +898,11 @@ impl<A: HalApi> Device<A> {
             Caps::FLOAT64,
             self.features.contains(wgt::Features::SHADER_FLOAT64),
         );
+        caps.set(
+            Caps::PRIMITIVE_INDEX,
+            self.features
+                .contains(wgt::Features::SHADER_PRIMITIVE_INDEX),
+        );
         let info = naga::valid::Validator::new(naga::valid::ValidationFlags::all(), caps)
             .validate(&module)?;
         let interface = validation::Interface::new(&module, &info, self.features);

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -65,11 +65,11 @@ core-graphics-types = "0.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "458db0b"
+rev = "8f71a36"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "458db0b"
+rev = "8f71a36"
 features = ["wgsl-in"]
 
 [dev-dependencies]

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -125,6 +125,7 @@ impl PhysicalDeviceFeatures {
                 //.shader_int64(requested_features.contains(wgt::Features::SHADER_INT64))
                 //.shader_int16(requested_features.contains(wgt::Features::SHADER_INT16))
                 //.shader_resource_residency(requested_features.contains(wgt::Features::SHADER_RESOURCE_RESIDENCY))
+                .geometry_shader(requested_features.contains(wgt::Features::SHADER_PRIMITIVE_INDEX))
                 .build(),
             vulkan_1_2: if api_version >= vk::API_VERSION_1_2 {
                 Some(
@@ -290,6 +291,7 @@ impl PhysicalDeviceFeatures {
             F::TEXTURE_BINDING_ARRAY,
             self.core.shader_sampled_image_array_dynamic_indexing != 0,
         );
+        features.set(F::SHADER_PRIMITIVE_INDEX, self.core.geometry_shader != 0);
         if Self::all_features_supported(
             &features,
             &[

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -479,6 +479,17 @@ bitflags::bitflags! {
         ///
         /// This is a native only feature.
         const SPIRV_SHADER_PASSTHROUGH = 0x0000_0800_0000_0000;
+        /// Enables `builtin(primitive_index)` in fragment shaders.
+        ///
+        /// Note: enables geometry processing for pipelines using the builtin.
+        /// This may come with a significant performance impact on some hardware.
+        /// Other pipelines are not affected.
+        ///
+        /// Supported platforms:
+        /// - Vulkan
+        ///
+        /// This is a native only feature.
+        const SHADER_PRIMITIVE_INDEX = 0x0000_1000_0000_0000;
     }
 }
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -73,13 +73,13 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "458db0b"
+rev = "8f71a36"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "458db0b"
+rev = "8f71a36"
 features = ["wgsl-in"]
 
 [[example]]


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/1669
https://github.com/gfx-rs/naga/pull/1097

**Description**
Allows fragment shaders to access the index of the current primitive via a new builtin variable.

**Testing**
Works on my machine.

- passes the capability to my fork of `naga` for basic validation and translation
- enables the `geometryShader` feature for Vulkan
- is refused by DX12

Needs to be implemented and tested for OpenGL, DirectX and Metal.