### PR TITLE
[Backport 0.9] adapter specific render targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log
+## wgpu-core-0.9.2
+  - fix `Features::TEXTURE_SPECIFIC_FORMAT_FEATURES` not being supported for rendertargets
 
 ## wgpu-core-0.9.1 (2021-07-13)
   - fix buffer inits delayed by a frame

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arrayvec",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-core"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU core logic on gfx-hal"

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -627,8 +627,8 @@ impl<B: GfxBackend> Device<B> {
     ) -> Result<resource::Texture<B>, resource::CreateTextureError> {
         debug_assert_eq!(self_id.backend(), B::VARIANT);
 
-        let format_desc = desc.format.describe();
-        self.require_features(format_desc.required_features)
+        let format_features = self
+            .describe_format_features(adapter, desc.format)
             .map_err(|error| resource::CreateTextureError::MissingFeatures(desc.format, error))?;
 
         // Ensure `D24Plus` textures cannot be copied
@@ -647,15 +647,6 @@ impl<B: GfxBackend> Device<B> {
         if desc.usage.is_empty() {
             return Err(resource::CreateTextureError::EmptyUsage);
         }
-
-        let format_features = if self
-            .features
-            .contains(wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES)
-        {
-            adapter.get_texture_format_features(desc.format)
-        } else {
-            format_desc.guaranteed_format_features
-        };
 
         let missing_allowed_usages = desc.usage - format_features.allowed_usages;
         if !missing_allowed_usages.is_empty() {
@@ -2112,6 +2103,7 @@ impl<B: GfxBackend> Device<B> {
     fn create_render_pipeline<G: GlobalIdentityHandlerFactory>(
         &self,
         self_id: id::DeviceId,
+        adapter: &crate::instance::Adapter<B>,
         desc: &pipeline::RenderPipelineDescriptor,
         implicit_context: Option<ImplicitPipelineContext>,
         hub: &Hub<B, G>,
@@ -2262,16 +2254,14 @@ impl<B: GfxBackend> Device<B> {
         };
         for (i, cs) in color_states.iter().enumerate() {
             let error = loop {
-                let format_desc = cs.format.describe();
-                self.require_features(format_desc.required_features)?;
-                if !format_desc
-                    .guaranteed_format_features
+                let format_features = self.describe_format_features(adapter, cs.format)?;
+                if !format_features
                     .allowed_usages
                     .contains(wgt::TextureUsage::RENDER_ATTACHMENT)
                 {
                     break Some(pipeline::ColorStateError::FormatNotRenderable(cs.format));
                 }
-                if cs.blend.is_some() && !format_desc.guaranteed_format_features.filterable {
+                if cs.blend.is_some() && !format_features.filterable {
                     break Some(pipeline::ColorStateError::FormatNotBlendable(cs.format));
                 }
                 let hal_format = conv::map_texture_format(cs.format, self.private_features);
@@ -2296,10 +2286,8 @@ impl<B: GfxBackend> Device<B> {
 
         if let Some(ds) = depth_stencil_state {
             let error = loop {
-                let format_desc = ds.format.describe();
-                self.require_features(format_desc.required_features)?;
-                if !format_desc
-                    .guaranteed_format_features
+                if !self
+                    .describe_format_features(adapter, ds.format)?
                     .allowed_usages
                     .contains(wgt::TextureUsage::RENDER_ATTACHMENT)
                 {
@@ -2641,6 +2629,24 @@ impl<B: GfxBackend> Device<B> {
             life_guard: LifeGuard::new(desc.label.borrow_or_default()),
         };
         Ok(pipeline)
+    }
+
+    fn describe_format_features(
+        &self,
+        adapter: &crate::instance::Adapter<B>,
+        format: TextureFormat,
+    ) -> Result<wgt::TextureFormatFeatures, MissingFeatures> {
+        let format_desc = format.describe();
+        self.require_features(format_desc.required_features)?;
+
+        if self
+            .features
+            .contains(wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES)
+        {
+            Ok(adapter.get_texture_format_features(format))
+        } else {
+            Ok(format_desc.guaranteed_format_features)
+        }
     }
 
     fn wait_for_submit(
@@ -4194,12 +4200,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let fid = hub.render_pipelines.prepare(id_in);
         let implicit_context = implicit_pipeline_ids.map(|ipi| ipi.prepare(&hub));
 
+        let (adapter_guard, mut token) = hub.adapters.read(&mut token);
         let (device_guard, mut token) = hub.devices.read(&mut token);
         let error = loop {
             let device = match device_guard.get(device_id) {
                 Ok(device) => device,
                 Err(_) => break DeviceError::Invalid.into(),
             };
+            let adapter = &adapter_guard[device.adapter_id.value];
             #[cfg(feature = "trace")]
             if let Some(ref trace) = device.trace {
                 trace.lock().add(trace::Action::CreateRenderPipeline {
@@ -4211,6 +4219,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let pipeline = match device.create_render_pipeline(
                 device_id,
+                adapter,
                 desc,
                 implicit_context,
                 &hub,


### PR DESCRIPTION
Backport of #1528
Fixes #1682 

clean cherry-pick except for generic name adjustment