### PR TITLE
Update naga, use binding map in DX12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/naga?rev=8f71a36#8f71a368eff3a18fd348ab6193cb183df0f49f95"
+source = "git+https://github.com/gfx-rs/naga?rev=feee1a2#feee1a2edbcae2a9ad7d9cb39a71ae4e0a5578e9"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "8f71a36"
+rev = "feee1a2"
 features = ["wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -65,11 +65,11 @@ core-graphics-types = "0.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "8f71a36"
+rev = "feee1a2"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "8f71a36"
+rev = "feee1a2"
 features = ["wgsl-in"]
 
 [dev-dependencies]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -73,13 +73,13 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "8f71a36"
+rev = "feee1a2"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "8f71a36"
+rev = "feee1a2"
 features = ["wgsl-in"]
 
 [[example]]


### PR DESCRIPTION
**Connections**
Updates naga with https://github.com/gfx-rs/naga/pull/1105

**Description**
Establishes a binding map contract between dx12 backend and naga.

**Testing**
Gets the cube running, but there is something strange there.
