### PR TITLE
hal/dx12: fix the binding model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/naga?rev=feee1a2#feee1a2edbcae2a9ad7d9cb39a71ae4e0a5578e9"
+source = "git+https://github.com/gfx-rs/naga?rev=7b9b56a#7b9b56a6abe153a382e611db293bdf74b391906e"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "feee1a2"
+rev = "7b9b56a"
 features = ["wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -65,11 +65,11 @@ core-graphics-types = "0.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "feee1a2"
+rev = "7b9b56a"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "feee1a2"
+rev = "7b9b56a"
 features = ["wgsl-in"]
 
 [dev-dependencies]

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1050,8 +1050,8 @@ impl crate::Device<super::Api> for super::Device {
 
         let mut bind_group_infos =
             arrayvec::ArrayVec::<super::BindGroupInfo, { crate::MAX_BIND_GROUPS }>::default();
-        for (index, bgl) in desc.bind_group_layouts.iter().rev().enumerate() {
-            let space = root_space_offset + index as u32;
+        for (index, bgl) in desc.bind_group_layouts.iter().enumerate() {
+            let space = root_space_offset + (desc.bind_group_layouts.len() - 1 - index) as u32;
             let mut info = super::BindGroupInfo {
                 tables: super::TableTypes::empty(),
                 base_root_index: parameters.len() as u32,
@@ -1192,8 +1192,6 @@ impl crate::Device<super::Api> for super::Device {
 
         // Ensure that we didn't reallocate!
         debug_assert_eq!(ranges.len(), total_non_dynamic_entries);
-        // remember that we pushed them in reverse
-        bind_group_infos.reverse();
 
         let (blob, error) = self
             .library

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -257,14 +257,6 @@ pub struct Queue {
 unsafe impl Send for Queue {}
 unsafe impl Sync for Queue {}
 
-impl Drop for Queue {
-    fn drop(&mut self) {
-        unsafe {
-            self.raw.destroy();
-        }
-    }
-}
-
 #[derive(Default)]
 struct Temp {
     marker: Vec<u16>,

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -75,13 +75,13 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "feee1a2"
+rev = "7b9b56a"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "feee1a2"
+rev = "7b9b56a"
 features = ["wgsl-in"]
 
 [[example]]


### PR DESCRIPTION
**Connections**
Depends on https://github.com/gfx-rs/naga/pull/1114
Makes the halmark + bunnymark run on DX12

**Description**
There was a mess-up in trying to use top-down layout...
Also fixes double-free on the queue in DX12.

**Testing**
Examples
