### PR TITLE
hal/dx12: reset command pool

### DIFF
--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -139,6 +139,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         for cmd_buf in command_buffers {
             self.free_lists.push(cmd_buf.raw);
         }
+        self.allocator.reset();
     }
 
     unsafe fn transition_buffers<'a, T>(&mut self, barriers: T)


### PR DESCRIPTION
**Connections**

**Description**
Fixes the memory leak in bunnymark on DX12

**Testing**
example!
