### PR TITLE
Feature-gate include_spirv macro

### DIFF
--- a/wgpu/src/macros.rs
+++ b/wgpu/src/macros.rs
@@ -45,6 +45,7 @@ fn test_vertex_attr_array() {
 ///
 /// It ensures the word alignment as well as the magic number.
 #[macro_export]
+#[cfg(feature = "spirv")]
 macro_rules! include_spirv {
     ($($token:tt)*) => {
         {


### PR DESCRIPTION
`wgpu::util::make_spirv` is gated behind the `spirv` feature; the `include_spirv` macro should be too.

Error before this change (with macro-backtrace on):
```
error[E0425]: cannot find function `make_spirv` in module `$crate::util`
  --> /home/dhardy/.cargo/git/checkouts/wgpu-53e70f8674b08dd4/145da6a/wgpu/src/macros.rs:54:39
   |
48 | / macro_rules! include_spirv {
49 | |     ($($token:tt)*) => {
50 | |         {
51 | |             //log::info!("including '{}'", $($token)*);
...  |
54 | |                 source: $crate::util::make_spirv(include_bytes!($($token)*)),
   | |                                       ^^^^^^^^^^ not found in `$crate::util`
...  |
57 | |     };
58 | | }
   | |_- in this expansion of `include_spirv!` (#2)
   | 
  ::: kas-wgpu/src/draw/shaders.rs:24:1
   |
24 | / macro_rules! create {
25 | |     ($device:ident, $path:expr) => {{
26 | |         $device.create_shader_module(&include_spirv!($path))
   | |                                       --------------------- in this macro invocation (#2)
27 | |     }};
28 | | }
   | |_- in this expansion of `create!` (#1)
...
42 |           let frag_glyph = create!(device, "shaders/glyph.frag.spv");
   |                            ----------------------------------------- in this macro invocation (#1)
```
