### PR TITLE
hal/vk: use actual view usage for imageless framebuffers

### DIFF
--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -200,8 +200,8 @@ struct RenderPassKey {
 struct FramebufferAttachment {
     /// Can be NULL if the framebuffer is image-less
     raw: vk::ImageView,
-    texture_usage: crate::TextureUses,
     raw_image_flags: vk::ImageCreateFlags,
+    view_usage: crate::TextureUses,
     view_format: wgt::TextureFormat,
 }
 


### PR DESCRIPTION
**Connections**
Fixes #1700

**Description**
Vulkan spec is confusing. See [attachment info](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFramebufferAttachmentImageInfo.html):
> usage is a bitmask of VkImageUsageFlagBits, matching the value of VkImageCreateInfo::usage used to create an image used with this framebuffer.

It doesn't talk about interaction with `ImageViewUsageCreateInfo`, which allows you to constrain the usage on a view.

**Testing**
Unable to test right now. @initial-algebra could you give it a spin?
