### PR TITLE
Fix buffer memory initialization to use the tracker consistently

### DIFF
--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1084,7 +1084,6 @@ impl crate::Context for Context {
             if let wgc::pipeline::CreateRenderPipelineError::Internal { stage, ref error } = cause {
                 log::warn!("Shader translation error for stage {:?}: {}", stage, error);
                 log::warn!("Please report it to https://github.com/gfx-rs/naga");
-                log::warn!("Try enabling `wgpu/cross` feature as a workaround.");
             }
             self.handle_error(
                 &device.error_sink,
@@ -1135,7 +1134,6 @@ impl crate::Context for Context {
                     error
                 );
                 log::warn!("Please report it to https://github.com/gfx-rs/naga");
-                log::warn!("Try enabling `wgpu/cross` feature as a workaround.");
             }
             self.handle_error(
                 &device.error_sink,


### PR DESCRIPTION
**Connections**
Depends on https://github.com/gfx-rs/naga/pull/1125

**Description**
Contains a number of dx12 fixes in addition to the buffer initialization fix.
The problem there was - we used the "pending writes" command buffer to initialize buffers, but also used the device's resource tracker and its state to figure out the transitions *after* a command buffer is merged its states.

**Testing**
Ran the examples on Vulkan.