### PR TITLE
Fix failure mode of adapter_request_device (direct backend)

### DIFF
--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -697,7 +697,8 @@ impl crate::Context for Context {
             PhantomData
         ));
         if let Some(err) = error {
-            self.handle_error_fatal(err, "Adapter::request_device");
+            log::error!("Error in Adapter::request_device: {}", err);
+            return ready(Err(crate::RequestDeviceError));
         }
         let device = Device {
             id: device_id,


### PR DESCRIPTION
This function has a method for reporting errors, so it shouldn't panic IMO.

Possibly though we should adapt the `RequestDeviceError` type to have a `cause: Box<dyn Error>` payload? The `log::error` line is just because we have no other way of reporting this value.

I tried to test this, but...

- on v0.9 I couldn't make the request fail, even with requesting absurd limits like 1e9 something
- on master the adapter request succeeds, then the shader creation fails with `UnsupportedCapability(Float64)` (even though the request contains `wgpu::Features::SHADER_FLOAT64` and does not fail)

So the `direct` or Vulkan backend does not check features properly?