### PR TITLE
Check render bundle encoding for RODS

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -81,7 +81,7 @@ pub struct RenderBundleEncoder {
     base: BasePass<RenderCommand>,
     parent_id: id::DeviceId,
     pub(crate) context: RenderPassContext,
-    is_ds_read_only: bool,
+    pub(crate) is_ds_read_only: bool,
 }
 
 impl RenderBundleEncoder {

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -72,10 +72,10 @@ pub enum RenderCommandError {
     InvalidPipeline(id::RenderPipelineId),
     #[error("QuerySet {0:?} is invalid")]
     InvalidQuerySet(id::QuerySetId),
-    #[error("Render pipeline is incompatible with render pass")]
-    IncompatiblePipeline(#[from] crate::device::RenderPassCompatibilityError),
-    #[error("pipeline is not compatible with the depth-stencil read-only render pass")]
-    IncompatibleReadOnlyDepthStencil,
+    #[error("Render pipeline targets are incompatible with render pass")]
+    IncompatiblePipelineTargets(#[from] crate::device::RenderPassCompatibilityError),
+    #[error("pipeline writes to depth/stencil, while the pass has read-only depth/stencil")]
+    IncompatiblePipelineRods,
     #[error("buffer {0:?} is in error {1:?}")]
     Buffer(id::BufferId, BufferError),
     #[error("buffer {0:?} is destroyed")]

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1939,7 +1939,7 @@ impl<A: HalApi> Device<A> {
                 .iter()
                 .any(|ct| ct.write_mask != first.write_mask || ct.blend != first.blend)
         } {
-            log::error!("Color targets: {:?}", color_targets);
+            log::info!("Color targets: {:?}", color_targets);
             self.require_downlevel_flags(wgt::DownlevelFlags::INDEPENDENT_BLENDING)?;
         }
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3779,6 +3779,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     desc: trace::new_render_bundle_encoder_descriptor(
                         desc.label.clone(),
                         &bundle_encoder.context,
+                        bundle_encoder.is_ds_read_only,
                     ),
                     base: bundle_encoder.to_base_pass(),
                 });

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -13,11 +13,19 @@ pub const FILE_NAME: &str = "trace.ron";
 pub(crate) fn new_render_bundle_encoder_descriptor<'a>(
     label: crate::Label<'a>,
     context: &'a super::RenderPassContext,
+    is_ds_read_only: bool,
 ) -> crate::command::RenderBundleEncoderDescriptor<'a> {
     crate::command::RenderBundleEncoderDescriptor {
         label,
         color_formats: Cow::Borrowed(&context.attachments.colors),
-        depth_stencil_format: context.attachments.depth_stencil,
+        depth_stencil: context.attachments.depth_stencil.map(|format| {
+            let aspects = hal::FormatAspects::from(format);
+            wgt::RenderBundleDepthStencil {
+                format,
+                depth_read_only: is_ds_read_only && aspects.contains(hal::FormatAspects::DEPTH),
+                stencil_read_only: is_ds_read_only && aspects.contains(hal::FormatAspects::STENCIL),
+            }
+        }),
         sample_count: context.sample_count,
     }
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2746,6 +2746,20 @@ impl<L> CommandBufferDescriptor<L> {
     }
 }
 
+/// Describes the depth/stencil attachment for render bundles.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "trace", derive(serde::Serialize))]
+#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+pub struct RenderBundleDepthStencil {
+    /// Format of the attachment.
+    pub format: TextureFormat,
+    /// True if the depth aspect is used but not modified.
+    pub depth_read_only: bool,
+    /// True if the stencil aspect is used but not modified.
+    pub stencil_read_only: bool,
+}
+
 /// Describes a [`RenderBundle`].
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/wgpu/examples/msaa-line/main.rs
+++ b/wgpu/examples/msaa-line/main.rs
@@ -77,7 +77,7 @@ impl Example {
             device.create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
                 label: None,
                 color_formats: &[sc_desc.format],
-                depth_stencil_format: None,
+                depth_stencil: None,
                 sample_count,
             });
         encoder.set_pipeline(&pipeline);

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1291,7 +1291,7 @@ impl crate::Context for Context {
         let descriptor = wgc::command::RenderBundleEncoderDescriptor {
             label: desc.label.map(Borrowed),
             color_formats: Borrowed(desc.color_formats),
-            depth_stencil_format: desc.depth_stencil_format,
+            depth_stencil: desc.depth_stencil,
             sample_count: desc.sample_count,
         };
         match wgc::command::RenderBundleEncoder::new(&descriptor, device.id, None) {

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1514,8 +1514,8 @@ impl crate::Context for Context {
         if let Some(ref label) = desc.label {
             mapped_desc.label(label);
         }
-        if let Some(dsf) = desc.depth_stencil_format {
-            mapped_desc.depth_stencil_format(map_texture_format(dsf));
+        if let Some(ds) = desc.depth_stencil {
+            mapped_desc.depth_stencil_format(map_texture_format(ds.format));
         }
         mapped_desc.sample_count(desc.sample_count);
         RenderBundleEncoder(device.0.create_render_bundle_encoder(&mapped_desc))

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1324,9 +1324,9 @@ pub struct RenderBundleEncoderDescriptor<'a> {
     /// The formats of the color attachments that this render bundle is capable to rendering to. This
     /// must match the formats of the color attachments in the renderpass this render bundle is executed in.
     pub color_formats: &'a [TextureFormat],
-    /// The formats of the depth attachment that this render bundle is capable to rendering to. This
-    /// must match the formats of the depth attachments in the renderpass this render bundle is executed in.
-    pub depth_stencil_format: Option<TextureFormat>,
+    /// Information about the depth attachment that this render bundle is capable to rendering to. This
+    /// must match the format of the depth attachments in the renderpass this render bundle is executed in.
+    pub depth_stencil: Option<wgt::RenderBundleDepthStencil>,
     /// Sample count this render bundle is capable of rendering to. This must match the pipelines and
     /// the renderpasses it is used in.
     pub sample_count: u32,


### PR DESCRIPTION
**Connections**
Matches https://github.com/gpuweb/gpuweb/pull/1979

**Description**
Allows render bundles to be encoded for RODS.
In addition, validates that bundle RODS matches the pass RODS when executing. This part of the spec isn't written yet, and it's safer to be on the strict side.

**Testing**
Untested
