### PR TITLE
hal/dx12: rewrite view creation, use arrays more aggressively

### DIFF
--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -149,8 +149,12 @@ impl super::Adapter {
             | wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER
             | wgt::Features::NON_FILL_POLYGON_MODE
             | wgt::Features::VERTEX_WRITABLE_STORAGE
-            | wgt::Features::TIMESTAMP_QUERY
-            | wgt::Features::PIPELINE_STATISTICS_QUERY;
+            | wgt::Features::TIMESTAMP_QUERY;
+        //TODO: in order to expose this, we need to run a compute shader
+        // that extract the necessary statistics out of the D3D12 result.
+        // Alternatively, we could allocate a buffer for the query set,
+        // write the results there, and issue a bunch of copy commands.
+        //| wgt::Features::PIPELINE_STATISTICS_QUERY
 
         features.set(
             wgt::Features::CONSERVATIVE_RASTERIZATION,

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -148,7 +148,14 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     {
         self.temp.barriers.clear();
 
+        log::trace!("List {:p} buffer transitions", self.list.unwrap().as_ptr());
         for barrier in barriers {
+            log::trace!(
+                "\t{:p}: usage {:?}..{:?}",
+                barrier.buffer.resource.as_ptr(),
+                barrier.usage.start,
+                barrier.usage.end
+            );
             let s0 = conv::map_buffer_usage_to_state(barrier.usage.start);
             let s1 = conv::map_buffer_usage_to_state(barrier.usage.end);
             if s0 != s1 {
@@ -190,7 +197,15 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     {
         self.temp.barriers.clear();
 
+        log::trace!("List {:p} texture transitions", self.list.unwrap().as_ptr());
         for barrier in barriers {
+            log::trace!(
+                "\t{:p}: usage {:?}..{:?}, range {:?}",
+                barrier.texture.resource.as_ptr(),
+                barrier.usage.start,
+                barrier.usage.end,
+                barrier.range
+            );
             let s0 = conv::map_texture_usage_to_state(barrier.usage.start);
             let s1 = conv::map_texture_usage_to_state(barrier.usage.end);
             if s0 != s1 {
@@ -216,10 +231,10 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 };
 
                 if barrier.range.aspect == wgt::TextureAspect::All
-                    && barrier.range.base_mip_level + mip_level_count
-                        == barrier.texture.mip_level_count
-                    && barrier.range.base_array_layer + array_layer_count
-                        == barrier.texture.array_layer_count()
+                    && barrier.range.base_mip_level == 0
+                    && mip_level_count == barrier.texture.mip_level_count
+                    && barrier.range.base_array_layer == 0
+                    && array_layer_count == barrier.texture.array_layer_count()
                 {
                     // Only one barrier if it affects the whole image.
                     self.temp.barriers.push(raw);

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -39,10 +39,11 @@ mod conv;
 mod descriptor;
 mod device;
 mod instance;
+mod view;
 
 use arrayvec::ArrayVec;
 use parking_lot::Mutex;
-use std::{borrow::Cow, mem, num::NonZeroU32, ptr, sync::Arc};
+use std::{borrow::Cow, ffi, mem, num::NonZeroU32, ptr, sync::Arc};
 use winapi::{
     shared::{dxgi, dxgi1_2, dxgi1_4, dxgitype, windef, winerror},
     um::{d3d12, synchapi, winbase, winnt},
@@ -491,6 +492,7 @@ unsafe impl Sync for PipelineLayout {}
 #[derive(Debug)]
 pub struct ShaderModule {
     naga: crate::NagaShader,
+    raw_name: Option<ffi::CString>,
 }
 
 pub struct RenderPipeline {

--- a/wgpu-hal/src/dx12/view.rs
+++ b/wgpu-hal/src/dx12/view.rs
@@ -1,0 +1,333 @@
+use super::conv;
+use std::mem;
+use winapi::um::d3d12;
+
+pub(crate) const D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING: u32 = 0x1688;
+
+pub(super) struct ViewDescriptor {
+    dimension: wgt::TextureViewDimension,
+    pub format: native::Format,
+    format_nodepth: native::Format,
+    multisampled: bool,
+    array_layer_base: u32,
+    array_layer_count: u32,
+    mip_level_base: u32,
+    mip_level_count: u32,
+}
+
+impl crate::TextureViewDescriptor<'_> {
+    pub(super) fn to_internal(&self, texture: &super::Texture) -> ViewDescriptor {
+        ViewDescriptor {
+            dimension: self.dimension,
+            format: conv::map_texture_format(self.format),
+            format_nodepth: conv::map_texture_format_nodepth(self.format),
+            multisampled: texture.sample_count > 1,
+            mip_level_base: self.range.base_mip_level,
+            mip_level_count: match self.range.mip_level_count {
+                Some(count) => count.get(),
+                None => !0,
+            },
+            array_layer_base: self.range.base_array_layer,
+            array_layer_count: match self.range.array_layer_count {
+                Some(count) => count.get(),
+                None => !0,
+            },
+        }
+    }
+}
+
+impl ViewDescriptor {
+    pub(crate) unsafe fn to_srv(&self) -> d3d12::D3D12_SHADER_RESOURCE_VIEW_DESC {
+        let mut desc = d3d12::D3D12_SHADER_RESOURCE_VIEW_DESC {
+            Format: self.format_nodepth,
+            ViewDimension: 0,
+            Shader4ComponentMapping: D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
+            u: mem::zeroed(),
+        };
+
+        match self.dimension {
+            wgt::TextureViewDimension::D1 => {
+                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE1D;
+                *desc.u.Texture1D_mut() = d3d12::D3D12_TEX1D_SRV {
+                    MostDetailedMip: self.mip_level_base,
+                    MipLevels: self.mip_level_count,
+                    ResourceMinLODClamp: 0.0,
+                }
+            }
+            /*
+            wgt::TextureViewDimension::D1Array => {
+                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE1DARRAY;
+                *desc.u.Texture1DArray_mut() = d3d12::D3D12_TEX1D_ARRAY_SRV {
+                    MostDetailedMip: self.mip_level_base,
+                    MipLevels: self.mip_level_count,
+                    FirstArraySlice: self.array_layer_base,
+                    ArraySize: self.array_layer_count,
+                    ResourceMinLODClamp: 0.0,
+                }
+            }*/
+            wgt::TextureViewDimension::D2 if self.multisampled && self.array_layer_base == 0 => {
+                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE2DMS;
+                *desc.u.Texture2DMS_mut() = d3d12::D3D12_TEX2DMS_SRV {
+                    UnusedField_NothingToDefine: 0,
+                }
+            }
+            wgt::TextureViewDimension::D2 if self.array_layer_base == 0 => {
+                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE2D;
+                *desc.u.Texture2D_mut() = d3d12::D3D12_TEX2D_SRV {
+                    MostDetailedMip: self.mip_level_base,
+                    MipLevels: self.mip_level_count,
+                    PlaneSlice: 0,
+                    ResourceMinLODClamp: 0.0,
+                }
+            }
+            wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array
+                if self.multisampled =>
+            {
+                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY;
+                *desc.u.Texture2DMSArray_mut() = d3d12::D3D12_TEX2DMS_ARRAY_SRV {
+                    FirstArraySlice: self.array_layer_base,
+                    ArraySize: self.array_layer_count,
+                }
+            }
+            wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array => {
+                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
+                *desc.u.Texture2DArray_mut() = d3d12::D3D12_TEX2D_ARRAY_SRV {
+                    MostDetailedMip: self.mip_level_base,
+                    MipLevels: self.mip_level_count,
+                    FirstArraySlice: self.array_layer_base,
+                    ArraySize: self.array_layer_count,
+                    PlaneSlice: 0,
+                    ResourceMinLODClamp: 0.0,
+                }
+            }
+            wgt::TextureViewDimension::D3 => {
+                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE3D;
+                *desc.u.Texture3D_mut() = d3d12::D3D12_TEX3D_SRV {
+                    MostDetailedMip: self.mip_level_base,
+                    MipLevels: self.mip_level_count,
+                    ResourceMinLODClamp: 0.0,
+                }
+            }
+            wgt::TextureViewDimension::Cube if self.array_layer_base == 0 => {
+                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURECUBE;
+                *desc.u.TextureCube_mut() = d3d12::D3D12_TEXCUBE_SRV {
+                    MostDetailedMip: self.mip_level_base,
+                    MipLevels: self.mip_level_count,
+                    ResourceMinLODClamp: 0.0,
+                }
+            }
+            wgt::TextureViewDimension::Cube | wgt::TextureViewDimension::CubeArray => {
+                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURECUBEARRAY;
+                *desc.u.TextureCubeArray_mut() = d3d12::D3D12_TEXCUBE_ARRAY_SRV {
+                    MostDetailedMip: self.mip_level_base,
+                    MipLevels: self.mip_level_count,
+                    First2DArrayFace: self.array_layer_base,
+                    NumCubes: self.array_layer_count / 6,
+                    ResourceMinLODClamp: 0.0,
+                }
+            }
+        }
+
+        desc
+    }
+
+    pub(crate) unsafe fn to_uav(&self) -> d3d12::D3D12_UNORDERED_ACCESS_VIEW_DESC {
+        let mut desc = d3d12::D3D12_UNORDERED_ACCESS_VIEW_DESC {
+            Format: self.format_nodepth,
+            ViewDimension: 0,
+            u: mem::zeroed(),
+        };
+
+        match self.dimension {
+            wgt::TextureViewDimension::D1 => {
+                desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE1D;
+                *desc.u.Texture1D_mut() = d3d12::D3D12_TEX1D_UAV {
+                    MipSlice: self.mip_level_base,
+                }
+            }
+            /*
+            wgt::TextureViewDimension::D1Array => {
+                desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE1DARRAY;
+                *desc.u.Texture1DArray_mut() = d3d12::D3D12_TEX1D_ARRAY_UAV {
+                    MipSlice: self.mip_level_base,
+                    FirstArraySlice: self.array_layer_base,
+                    ArraySize,
+                }
+            }*/
+            wgt::TextureViewDimension::D2 if self.array_layer_base == 0 => {
+                desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE2D;
+                *desc.u.Texture2D_mut() = d3d12::D3D12_TEX2D_UAV {
+                    MipSlice: self.mip_level_base,
+                    PlaneSlice: 0,
+                }
+            }
+            wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array => {
+                desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
+                *desc.u.Texture2DArray_mut() = d3d12::D3D12_TEX2D_ARRAY_UAV {
+                    MipSlice: self.mip_level_base,
+                    FirstArraySlice: self.array_layer_base,
+                    ArraySize: self.array_layer_count,
+                    PlaneSlice: 0,
+                }
+            }
+            wgt::TextureViewDimension::D3 => {
+                desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE3D;
+                *desc.u.Texture3D_mut() = d3d12::D3D12_TEX3D_UAV {
+                    MipSlice: self.mip_level_base,
+                    FirstWSlice: self.array_layer_base,
+                    WSize: self.array_layer_count,
+                }
+            }
+            wgt::TextureViewDimension::Cube | wgt::TextureViewDimension::CubeArray => {
+                panic!("Unable to view texture as cube UAV")
+            }
+        }
+
+        desc
+    }
+
+    pub(crate) unsafe fn to_rtv(&self) -> d3d12::D3D12_RENDER_TARGET_VIEW_DESC {
+        let mut desc = d3d12::D3D12_RENDER_TARGET_VIEW_DESC {
+            Format: self.format,
+            ViewDimension: 0,
+            u: mem::zeroed(),
+        };
+
+        match self.dimension {
+            wgt::TextureViewDimension::D1 => {
+                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE1D;
+                *desc.u.Texture1D_mut() = d3d12::D3D12_TEX1D_RTV {
+                    MipSlice: self.mip_level_base,
+                }
+            }
+            /*
+            wgt::TextureViewDimension::D1Array => {
+                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE1DARRAY;
+                *desc.u.Texture1DArray_mut() = d3d12::D3D12_TEX1D_ARRAY_RTV {
+                    MipSlice: self.mip_level_base,
+                    FirstArraySlice: self.array_layer_base,
+                    ArraySize,
+                }
+            }*/
+            wgt::TextureViewDimension::D2 if self.multisampled && self.array_layer_base == 0 => {
+                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE2DMS;
+                *desc.u.Texture2DMS_mut() = d3d12::D3D12_TEX2DMS_RTV {
+                    UnusedField_NothingToDefine: 0,
+                }
+            }
+            wgt::TextureViewDimension::D2 if self.array_layer_base == 0 => {
+                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE2D;
+                *desc.u.Texture2D_mut() = d3d12::D3D12_TEX2D_RTV {
+                    MipSlice: self.mip_level_base,
+                    PlaneSlice: 0,
+                }
+            }
+            wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array
+                if self.multisampled =>
+            {
+                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY;
+                *desc.u.Texture2DMSArray_mut() = d3d12::D3D12_TEX2DMS_ARRAY_RTV {
+                    FirstArraySlice: self.array_layer_base,
+                    ArraySize: self.array_layer_count,
+                }
+            }
+            wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array => {
+                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
+                *desc.u.Texture2DArray_mut() = d3d12::D3D12_TEX2D_ARRAY_RTV {
+                    MipSlice: self.mip_level_base,
+                    FirstArraySlice: self.array_layer_base,
+                    ArraySize: self.array_layer_count,
+                    PlaneSlice: 0,
+                }
+            }
+            wgt::TextureViewDimension::D3 => {
+                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE3D;
+                *desc.u.Texture3D_mut() = d3d12::D3D12_TEX3D_RTV {
+                    MipSlice: self.mip_level_base,
+                    FirstWSlice: self.array_layer_base,
+                    WSize: self.array_layer_count,
+                }
+            }
+            wgt::TextureViewDimension::Cube | wgt::TextureViewDimension::CubeArray => {
+                panic!("Unable to view texture as cube RTV")
+            }
+        }
+
+        desc
+    }
+
+    pub(crate) unsafe fn to_dsv(
+        &self,
+        ro_aspects: crate::FormatAspects,
+    ) -> d3d12::D3D12_DEPTH_STENCIL_VIEW_DESC {
+        let mut desc = d3d12::D3D12_DEPTH_STENCIL_VIEW_DESC {
+            Format: self.format,
+            ViewDimension: 0,
+            Flags: {
+                let mut flags = d3d12::D3D12_DSV_FLAG_NONE;
+                if ro_aspects.contains(crate::FormatAspects::DEPTH) {
+                    flags |= d3d12::D3D12_DSV_FLAG_READ_ONLY_DEPTH;
+                }
+                if ro_aspects.contains(crate::FormatAspects::STENCIL) {
+                    flags |= d3d12::D3D12_DSV_FLAG_READ_ONLY_STENCIL;
+                }
+                flags
+            },
+            u: mem::zeroed(),
+        };
+
+        match self.dimension {
+            wgt::TextureViewDimension::D1 => {
+                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE1D;
+                *desc.u.Texture1D_mut() = d3d12::D3D12_TEX1D_DSV {
+                    MipSlice: self.mip_level_base,
+                }
+            }
+            /*
+            wgt::TextureViewDimension::D1Array => {
+                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE1DARRAY;
+                *desc.u.Texture1DArray_mut() = d3d12::D3D12_TEX1D_ARRAY_DSV {
+                    MipSlice: self.mip_level_base,
+                    FirstArraySlice: self.array_layer_base,
+                    ArraySize,
+                }
+            }*/
+            wgt::TextureViewDimension::D2 if self.multisampled && self.array_layer_base == 0 => {
+                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE2DMS;
+                *desc.u.Texture2DMS_mut() = d3d12::D3D12_TEX2DMS_DSV {
+                    UnusedField_NothingToDefine: 0,
+                }
+            }
+            wgt::TextureViewDimension::D2 if self.array_layer_base == 0 => {
+                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE2D;
+                *desc.u.Texture2D_mut() = d3d12::D3D12_TEX2D_DSV {
+                    MipSlice: self.mip_level_base,
+                }
+            }
+            wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array
+                if self.multisampled =>
+            {
+                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE2DMSARRAY;
+                *desc.u.Texture2DMSArray_mut() = d3d12::D3D12_TEX2DMS_ARRAY_DSV {
+                    FirstArraySlice: self.array_layer_base,
+                    ArraySize: self.array_layer_count,
+                }
+            }
+            wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array => {
+                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
+                *desc.u.Texture2DArray_mut() = d3d12::D3D12_TEX2D_ARRAY_DSV {
+                    MipSlice: self.mip_level_base,
+                    FirstArraySlice: self.array_layer_base,
+                    ArraySize: self.array_layer_count,
+                }
+            }
+            wgt::TextureViewDimension::D3
+            | wgt::TextureViewDimension::Cube
+            | wgt::TextureViewDimension::CubeArray => {
+                panic!("Unable to view texture as cube or 3D RTV")
+            }
+        }
+
+        desc
+    }
+}


### PR DESCRIPTION
**Connections**

**Description**
D3D12 has this thing where you can't create a 2D view with non-zero base array index.
So we have special logic now to fall back to 2D array views in these cases.

**Testing**
Tested on the Shadow example.
