### PR TITLE
Work Around Fastclear Bug for Web and Native GL

### DIFF
--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -444,10 +444,11 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 self.cmd_buffer
                     .commands
                     .push(match cat.target.view.sample_type {
-                        wgt::TextureSampleType::Float { .. } => C::ClearColorF(
-                            i as u32,
-                            [c.r as f32, c.g as f32, c.b as f32, c.a as f32],
-                        ),
+                        wgt::TextureSampleType::Float { .. } => C::ClearColorF {
+                            draw_buffer: i as u32,
+                            color: [c.r as f32, c.g as f32, c.b as f32, c.a as f32],
+                            is_srgb: cat.target.view.format.describe().srgb,
+                        },
                         wgt::TextureSampleType::Depth => unimplemented!(),
                         wgt::TextureSampleType::Uint => C::ClearColorU(
                             i as u32,

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -248,8 +248,10 @@ impl super::Device {
                         return Err(crate::DeviceError::Lost.into());
                     }
                     super::BindingRegister::Textures | super::BindingRegister::Images => {
-                        let loc = gl.get_uniform_location(program, name).unwrap();
-                        gl.uniform_1_i32(Some(&loc), slot as _);
+                        gl.uniform_1_i32(
+                            gl.get_uniform_location(program, name).as_ref(),
+                            slot as _,
+                        );
                     }
                 }
             }
@@ -589,6 +591,7 @@ impl crate::Device<super::Api> for super::Device {
                 & crate::FormatAspects::from(desc.range.aspect),
             mip_levels: desc.range.base_mip_level..end_mip_level,
             array_layers: desc.range.base_array_layer..end_array_layer,
+            format: texture.format,
         })
     }
     unsafe fn destroy_texture_view(&self, _view: super::TextureView) {}

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -422,11 +422,6 @@ impl crate::Instance<super::Api> for Instance {
             None
         };
 
-        // Workaround Mesa driver bug on Intel cards by disabling fastclear:
-        // https://gitlab.freedesktop.org/mesa/mesa/-/issues/2565
-        // https://github.com/gfx-rs/wgpu/issues/1627#issuecomment-877854185
-        std::env::set_var("INTEL_DEBUG", "nofc");
-
         let display = if let (Some(library), Some(egl)) =
             (wayland_library, egl.upcast::<egl::EGL1_5>())
         {

--- a/wgpu-hal/src/gles/shader_clear.frag
+++ b/wgpu-hal/src/gles/shader_clear.frag
@@ -1,0 +1,7 @@
+#version 300 es
+precision lowp float;
+uniform vec4 color;
+out vec4 frag;
+void main() {
+  frag = color;
+}

--- a/wgpu-hal/src/gles/shader_clear.vert
+++ b/wgpu-hal/src/gles/shader_clear.vert
@@ -1,0 +1,11 @@
+#version 300 es
+precision lowp float;
+// A triangle that fills the whole screen
+const vec2[3] TRIANGLE_POS = vec2[](
+  vec2( 0.0, -3.0),
+  vec2(-3.0,  1.0),
+  vec2( 3.0,  1.0)
+);
+void main() {
+  gl_Position = vec4(TRIANGLE_POS[gl_VertexID], 0.0, 1.0);
+}


### PR DESCRIPTION
**Connections**
Resolves #1627 

**Description**
Works around Mesa fastclear bug by doing a manual shader clear on effected platforms

**Testing**
Tested on Mesa Intel(R) UHD Graphics (CML GT2) (Gl)
