### PR TITLE
hal/dx12: compact register allocation, naga update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/naga?rev=bbfa9a0#bbfa9a0f9e0599fe09ad9428bf359e6dea2664c6"
+source = "git+https://github.com/gfx-rs/naga?rev=e97c8f9#e97c8f944121a58bbc908ecb64bdf97d4ada039d"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "bbfa9a0"
+rev = "e97c8f9"
 features = ["wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -65,11 +65,11 @@ core-graphics-types = "0.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "bbfa9a0"
+rev = "e97c8f9"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "bbfa9a0"
+rev = "e97c8f9"
 features = ["wgsl-in"]
 
 [dev-dependencies]

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -161,9 +161,9 @@ enum MemoryArchitecture {
 
 #[derive(Debug, Clone, Copy)]
 struct PrivateCapabilities {
+    instance_flags: crate::InstanceFlags,
     heterogeneous_resource_heaps: bool,
     memory_architecture: MemoryArchitecture,
-    shader_debug_info: bool,
     heap_create_not_zeroed: bool,
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -110,7 +110,7 @@ bitflags::bitflags! {
         /// Vulkan + Metal + DX12 + Browser WebGPU
         const PRIMARY = Self::VULKAN.bits
             | Self::METAL.bits
-            //| Self::DX12.bits // enable when Naga is polished
+            | Self::DX12.bits
             | Self::BROWSER_WEBGPU.bits;
         /// All the apis that wgpu offers second tier of support for. These may
         /// be unsupported/still experimental.

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -75,13 +75,13 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "bbfa9a0"
+rev = "e97c8f9"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "bbfa9a0"
+rev = "e97c8f9"
 features = ["wgsl-in"]
 
 [[example]]

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -800,6 +800,6 @@ fn water() {
         base_test_parameters: framework::test_common::TestParameters::default()
             .downlevel_flags(wgpu::DownlevelFlags::READ_ONLY_DEPTH_STENCIL),
         tolerance: 5,
-        max_outliers: 300, // bounded by rpi4 on vk
+        max_outliers: 460, // bounded by DX12, then rpi4 on vk
     });
 }


### PR DESCRIPTION
**Connections**
Heavily depends on https://github.com/gfx-rs/naga/pull/1136

**Description**
Makes DX12 to run all of the examples 🎉 .

**Testing**
Re-enables DX12 in `PRIMARY` set, which also enables the reference tests on it.

![wgpu-dx12-shadow](https://user-images.githubusercontent.com/107301/126940717-aefad5b2-1eba-4523-ba6a-53a5744ba313.JPG)

