### PR TITLE
Adding pipeline caches for wgpu-hal (only works on Vulkan so far)

### DIFF
--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -232,7 +232,7 @@ impl<A: hal::Api> Example<A> {
                 write_mask: wgt::ColorWrites::default(),
             }],
         };
-        let pipeline = unsafe { device.create_render_pipeline(&pipeline_desc).unwrap() };
+        let pipeline = unsafe { device.create_render_pipeline(&pipeline_desc, None).unwrap() };
 
         let texture_data = vec![0xFFu8; 4];
 

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1106,6 +1106,23 @@ impl crate::Device<super::Api> for super::Device {
         // just drop
     }
 
+    unsafe fn create_empty_pipeline_cache(&self) -> super::PipelineCache {
+        log::warn!("Pipeline caches are not supported on Dx12.");
+        super::PipelineCache
+    }
+
+    unsafe fn create_pipeline_cache(
+        &self,
+        _: &[u8],
+    ) -> Result<super::PipelineCache, crate::DeviceError> {
+        log::warn!("Pipeline caches are not supported on Dx12.");
+        Ok(super::PipelineCache)
+    }
+
+    unsafe fn destroy_pipeline_cache(&self, _: super::PipelineCache) {
+        log::warn!("Pipeline caches are not supported on Dx12.");
+    }
+
     unsafe fn create_render_pipeline(
         &self,
         desc: &crate::RenderPipelineDescriptor<super::Api>,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -75,6 +75,7 @@ impl crate::Api for Api {
     type BindGroup = BindGroup;
     type PipelineLayout = PipelineLayout;
     type ShaderModule = ShaderModule;
+    type PipelineCache = PipelineCache;
     type RenderPipeline = RenderPipeline;
     type ComputePipeline = ComputePipeline;
 }
@@ -494,6 +495,8 @@ pub struct ShaderModule {
     naga: crate::NagaShader,
     raw_name: Option<ffi::CString>,
 }
+
+pub struct PipelineCache;
 
 pub struct RenderPipeline {
     raw: native::PipelineState,

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -33,6 +33,7 @@ impl crate::Api for Api {
     type BindGroup = Resource;
     type PipelineLayout = Resource;
     type ShaderModule = Resource;
+    type PipelineCache = Resource;
     type RenderPipeline = Resource;
     type ComputePipeline = Resource;
 }
@@ -179,9 +180,18 @@ impl crate::Device<Api> for Context {
         Ok(Resource)
     }
     unsafe fn destroy_shader_module(&self, module: Resource) {}
+    unsafe fn create_empty_pipeline_cache(&self) -> Resource {
+        Resource
+    }
+    unsafe fn create_pipeline_cache(&self, data: &[u8]) -> Result<Resource, crate::DeviceError> {
+        Ok(Resource)
+    }
+    unsafe fn destroy_pipeline_cache(&self, cache: Resource) {}
+
     unsafe fn create_render_pipeline(
         &self,
         desc: &crate::RenderPipelineDescriptor<Api>,
+        cache: Option<&Resource>,
     ) -> Result<Resource, crate::PipelineError> {
         Ok(Resource)
     }

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1,5 +1,6 @@
 use super::conv;
 use crate::auxil::map_naga_stage;
+use crate::DeviceError;
 use glow::HasContext;
 use std::{convert::TryInto, iter, ptr, sync::Arc};
 
@@ -855,10 +856,29 @@ impl crate::Device<super::Api> for super::Device {
     }
     unsafe fn destroy_shader_module(&self, _module: super::ShaderModule) {}
 
+    unsafe fn create_empty_pipeline_cache(&self) -> super::PipelineCache {
+        log::warn!("Pipeline caches are not supported on GLes.");
+        super::PipelineCache
+    }
+
+    unsafe fn create_pipeline_cache(&self, _: &[u8]) -> Result<super::PipelineCache, DeviceError> {
+        log::warn!("Pipeline caches are not supported on GLes.");
+        Ok(super::PipelineCache)
+    }
+
+    unsafe fn destroy_pipeline_cache(&self, _: super::PipelineCache) {
+        log::warn!("Pipeline caches are not supported on GLes.");
+    }
+
     unsafe fn create_render_pipeline(
         &self,
         desc: &crate::RenderPipelineDescriptor<super::Api>,
+        cache: Option<&super::PipelineCache>,
     ) -> Result<super::RenderPipeline, crate::PipelineError> {
+        if cache.is_some() {
+            log::warn!("Pipeline caches are not supported on GLes.")
+        }
+
         let shaders = iter::once((naga::ShaderStage::Vertex, &desc.vertex_stage)).chain(
             desc.fragment_stage
                 .as_ref()

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -104,6 +104,7 @@ impl crate::Api for Api {
     type BindGroup = BindGroup;
     type PipelineLayout = PipelineLayout;
     type ShaderModule = ShaderModule;
+    type PipelineCache = PipelineCache;
     type RenderPipeline = RenderPipeline;
     type ComputePipeline = ComputePipeline;
 }
@@ -173,6 +174,8 @@ pub struct Queue {
     zero_buffer: glow::Buffer,
     temp_query_results: Vec<u64>,
 }
+
+pub struct PipelineCache;
 
 #[derive(Debug)]
 pub struct Buffer {

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -156,6 +156,7 @@ pub trait Api: Clone + Sized {
     type BindGroup: fmt::Debug + Send + Sync;
     type PipelineLayout: Send + Sync;
     type ShaderModule: fmt::Debug + Send + Sync;
+    type PipelineCache: Send + Sync;
     type RenderPipeline: Send + Sync;
     type ComputePipeline: Send + Sync;
 }
@@ -267,9 +268,13 @@ pub trait Device<A: Api>: Send + Sync {
         shader: ShaderInput,
     ) -> Result<A::ShaderModule, ShaderError>;
     unsafe fn destroy_shader_module(&self, module: A::ShaderModule);
+    unsafe fn create_empty_pipeline_cache(&self) -> A::PipelineCache;
+    unsafe fn create_pipeline_cache(&self, data: &[u8]) -> Result<A::PipelineCache, DeviceError>;
+    unsafe fn destroy_pipeline_cache(&self, cache: A::PipelineCache);
     unsafe fn create_render_pipeline(
         &self,
         desc: &RenderPipelineDescriptor<A>,
+        cache: Option<&A::PipelineCache>,
     ) -> Result<A::RenderPipeline, PipelineError>;
     unsafe fn destroy_render_pipeline(&self, pipeline: A::RenderPipeline);
     unsafe fn create_compute_pipeline(

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -682,10 +682,31 @@ impl crate::Device<super::Api> for super::Device {
     }
     unsafe fn destroy_shader_module(&self, _module: super::ShaderModule) {}
 
+    unsafe fn create_empty_pipeline_cache(&self) -> super::PipelineCache {
+        log::warn!("Pipeline caches are not supported on Metal.");
+        super::PipelineCache
+    }
+
+    unsafe fn create_pipeline_cache(
+        &self,
+        data: &[u8],
+    ) -> Result<super::PipelineCache, crate::DeviceError> {
+        log::warn!("Pipeline caches are not supported on Metal.");
+        Ok(super::PipelineCache)
+    }
+
+    unsafe fn destroy_pipeline_cache(&self, _: super::PipelineCache) {
+        log::warn!("Pipeline caches are not supported on Metal.");
+    }
+
     unsafe fn create_render_pipeline(
         &self,
         desc: &crate::RenderPipelineDescriptor<super::Api>,
+        cache: Option<&super::PipelineCache>,
     ) -> Result<super::RenderPipeline, crate::PipelineError> {
+        if cache.is_some() {
+            log::warn!("Pipeline caches are not supported on Metal.")
+        }
         let descriptor = mtl::RenderPipelineDescriptor::new();
         let (primitive_class, raw_primitive_type) =
             conv::map_primitive_topology(desc.primitive.topology);

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -57,6 +57,7 @@ impl crate::Api for Api {
     type BindGroup = BindGroup;
     type PipelineLayout = PipelineLayout;
     type ShaderModule = ShaderModule;
+    type PipelineCache = PipelineCache;
     type RenderPipeline = RenderPipeline;
     type ComputePipeline = ComputePipeline;
 }
@@ -601,6 +602,8 @@ impl PipelineStageInfo {
         self.sized_bindings.extend_from_slice(&other.sized_bindings);
     }
 }
+
+pub struct PipelineCache;
 
 pub struct RenderPipeline {
     raw: mtl::RenderPipelineState,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -69,6 +69,7 @@ impl crate::Api for Api {
     type BindGroup = BindGroup;
     type PipelineLayout = PipelineLayout;
     type ShaderModule = ShaderModule;
+    type PipelineCache = PipelineCache;
     type RenderPipeline = RenderPipeline;
     type ComputePipeline = ComputePipeline;
 }
@@ -341,6 +342,11 @@ pub struct CommandBuffer {
 #[derive(Debug)]
 pub struct ShaderModule {
     raw: vk::ShaderModule,
+}
+
+#[derive(Debug)]
+pub struct PipelineCache {
+    raw: vk::PipelineCache,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
**Connections**
(none)

**Description**
I notice gfx-hal had support for pipeline caches, but wgpu-hal still lacks support. They're not in the webgpu spec, but I think it would at least make sense to expose them for some native backends. This pull request adds support for them in wgpu-hal, but does not yet expose this functionality to wgpu-rs. It only works on the Vulkan backend so far - the rest of them just log a warning and do nothing, though I expect it should be possible to implement it for Metal using binary archives (given that gfx-hal 0.8 did just this).

**Testing**
I have tested that wgpu-hal and wgpu-rs build on my 64-bit x86 Linux running on Vulkan/OpenGL. The wgpu-rs examples and (the slightly modified) wgpu-hal halmark run properly, though none use the pipeline caches.