### PR TITLE
Handle Multi-threaded EGL Context Access

### DIFF
--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -66,7 +66,7 @@ mod device;
 mod queue;
 
 #[cfg(not(target_arch = "wasm32"))]
-use self::egl::{Instance, Surface};
+use self::egl::{AdapterContext, Instance, Surface};
 
 use arrayvec::ArrayVec;
 
@@ -161,7 +161,7 @@ struct TextureFormatDesc {
 }
 
 struct AdapterShared {
-    context: glow::Context,
+    context: AdapterContext,
     private_caps: PrivateCapabilities,
     workarounds: Workarounds,
     shading_language_version: naga::back::glsl::Version,

--- a/wgpu/examples/hello-compute/tests.rs
+++ b/wgpu/examples/hello-compute/tests.rs
@@ -59,9 +59,7 @@ fn test_compute_overflow() {
 #[test]
 fn test_multithreaded_compute() {
     initialize_test(
-        TestParameters::default()
-            .backend_failure(wgpu::Backends::GL)
-            .specific_failure(None, None, Some("V3D"), true),
+        TestParameters::default().specific_failure(None, None, Some("V3D"), true),
         |ctx| {
             use std::{sync::mpsc, thread, time::Duration};
 


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/discussions/1630, https://github.com/bevyengine/bevy/issues/841

**Description**
Implements the synchronization necessary to use the GL backend from multiple threads. Accomplishes this by using a mutex around the GL context with extra wrapping to bind and unbind the EGL context when locking and unlocking.

**Testing**
Tested on Ubunty 20.04 with a fork of the Bevy game engine and the WGPU examples ( not that the examples test the multi-threading ).

## Remaining Issues

There is only one Bevy example I cannot get to run yet and it's the `load_gltf` example. It fails with a shader translation error:

```
Jul 26 20:36:50.949 ERROR naga::back::glsl: Conflicting samplers for _group_3_binding_10    
Jul 26 20:36:50.950  WARN wgpu::backend::direct: Shader translation error for stage FRAGMENT: A image was used with multiple samplers    
Jul 26 20:36:50.950  WARN wgpu::backend::direct: Please report it to https://github.com/gfx-rs/naga    
Jul 26 20:36:50.950 ERROR wgpu::backend::direct: wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
    Internal error in FRAGMENT shader: A image was used with multiple samplers
```

Interestingly, I think the shader in question doesn't have a `group(3), binding(10)` anywhere that I know of so I'm going to have to drill down a bit more and find out exactly which shader translation is failing more.

This could potentially be fixed in a separate PR. I think the rest of this PR is rather straight-forward and the fix for the error above is probably mostly unrelated to the primary changes made in this PR.