### PR TITLE
Fix Tests on DX12/GL

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -219,6 +219,12 @@ impl super::Adapter {
             vertex_shader_storage_blocks.min(fragment_shader_storage_blocks)
         };
 
+        let max_storage_textures_per_shader_stage = if vertex_shader_storage_textures == 0 {
+            fragment_shader_storage_textures
+        } else {
+            vertex_shader_storage_textures.min(fragment_shader_storage_textures)
+        };
+
         let mut features = wgt::Features::empty()
             | wgt::Features::TEXTURE_COMPRESSION_ETC2
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
@@ -228,7 +234,9 @@ impl super::Adapter {
         );
         features.set(
             wgt::Features::VERTEX_WRITABLE_STORAGE,
-            ver >= (3, 1) && !vertex_ssbo_false_zero,
+            ver >= (3, 1)
+                && (vertex_shader_storage_blocks != 0 || vertex_ssbo_false_zero)
+                && vertex_shader_storage_textures != 0,
         );
 
         let mut downlevel_flags = wgt::DownlevelFlags::empty()
@@ -275,8 +283,7 @@ impl super::Adapter {
             max_sampled_textures_per_shader_stage: super::MAX_TEXTURE_SLOTS as u32,
             max_samplers_per_shader_stage: super::MAX_SAMPLERS as u32,
             max_storage_buffers_per_shader_stage,
-            max_storage_textures_per_shader_stage: vertex_shader_storage_textures
-                .min(fragment_shader_storage_textures),
+            max_storage_textures_per_shader_stage,
             max_uniform_buffers_per_shader_stage,
             max_uniform_buffer_binding_size: gl.get_parameter_i32(glow::MAX_UNIFORM_BLOCK_SIZE)
                 as u32,

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -798,7 +798,8 @@ fn water() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
-            .downlevel_flags(wgpu::DownlevelFlags::READ_ONLY_DEPTH_STENCIL),
+            .downlevel_flags(wgpu::DownlevelFlags::READ_ONLY_DEPTH_STENCIL)
+            .specific_failure(Some(wgpu::Backends::DX12), None, Some("Basic"), false), // WARP has a bug https://github.com/gfx-rs/wgpu/issues/1730
         tolerance: 5,
         max_outliers: 460, // bounded by DX12, then rpi4 on vk
     });


### PR DESCRIPTION
**Connections**

Marks #1730 as known failure

Closes #1695

**Description**

This fixes up tests on both DX12 and GL

**Testing**

Tests
