### PR TITLE
Rename texture usage names according to binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - processing SPIR-V inputs for later translation now requires `spirv` compile feature enabled
     - new `Features::SPIRV_SHADER_PASSTHROUGH` run-time feature allows providing pass-through SPIR-V (orthogonal to the compile feature)
     - several bitflag names are renamed to plural: `TextureUsage`, `BufferUsage`, `ColorWrite`.
+    - renamed `TextureUsage` bits: `SAMPLED` -> `TEXTURE_BINDING`, `STORAGE` -> `STORAGE_BINDING`.
     - renamed `InputStepMode` to `VertexStepMode`
     - Implemented `Rgb9e5Ufloat` format.
   - Fixed:

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -583,7 +583,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
 
             let usage = if at.is_read_only(ds_aspects)? {
                 is_ds_read_only = true;
-                hal::TextureUses::DEPTH_STENCIL_READ | hal::TextureUses::SAMPLED
+                hal::TextureUses::DEPTH_STENCIL_READ | hal::TextureUses::RESOURCE
             } else {
                 hal::TextureUses::DEPTH_STENCIL_WRITE
             };

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -75,12 +75,12 @@ pub fn map_texture_usage(
         usage.contains(wgt::TextureUsages::COPY_DST),
     );
     u.set(
-        hal::TextureUses::SAMPLED,
-        usage.contains(wgt::TextureUsages::SAMPLED),
+        hal::TextureUses::RESOURCE,
+        usage.contains(wgt::TextureUsages::TEXTURE_BINDING),
     );
     u.set(
         hal::TextureUses::STORAGE_READ | hal::TextureUses::STORAGE_WRITE,
-        usage.contains(wgt::TextureUsages::STORAGE),
+        usage.contains(wgt::TextureUsages::STORAGE_BINDING),
     );
     let is_color = aspect.contains(hal::FormatAspects::COLOR);
     u.set(

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -218,8 +218,14 @@ impl<A: HalApi> Adapter<A> {
         let caps = unsafe { self.raw.adapter.texture_format_capabilities(format) };
         let mut allowed_usages = format.describe().guaranteed_format_features.allowed_usages;
 
-        allowed_usages.set(wgt::TextureUsages::SAMPLED, caps.contains(Tfc::SAMPLED));
-        allowed_usages.set(wgt::TextureUsages::STORAGE, caps.contains(Tfc::STORAGE));
+        allowed_usages.set(
+            wgt::TextureUsages::TEXTURE_BINDING,
+            caps.contains(Tfc::SAMPLED),
+        );
+        allowed_usages.set(
+            wgt::TextureUsages::STORAGE_BINDING,
+            caps.contains(Tfc::STORAGE),
+        );
         allowed_usages.set(
             wgt::TextureUsages::RENDER_ATTACHMENT,
             caps.intersects(Tfc::COLOR_ATTACHMENT | Tfc::DEPTH_STENCIL_ATTACHMENT),

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -241,8 +241,8 @@ mod test {
         let mut ts = TextureState::default();
         ts.mips.push(PlaneStates::empty());
         ts.mips.push(PlaneStates::from_slice(&[
-            (1..3, Unit::new(TextureUses::SAMPLED)),
-            (3..5, Unit::new(TextureUses::SAMPLED)),
+            (1..3, Unit::new(TextureUses::RESOURCE)),
+            (3..5, Unit::new(TextureUses::RESOURCE)),
             (5..6, Unit::new(TextureUses::STORAGE_READ)),
         ]));
 
@@ -252,7 +252,7 @@ mod test {
                 layers: 2..5,
             }),
             // level 1 matches
-            Some(TextureUses::SAMPLED),
+            Some(TextureUses::RESOURCE),
         );
         assert_eq!(
             ts.query(TextureSelector {
@@ -260,7 +260,7 @@ mod test {
                 layers: 2..5,
             }),
             // level 0 is empty, level 1 matches
-            Some(TextureUses::SAMPLED),
+            Some(TextureUses::RESOURCE),
         );
         assert_eq!(
             ts.query(TextureSelector {
@@ -268,7 +268,7 @@ mod test {
                 layers: 1..5,
             }),
             // level 1 matches with gaps
-            Some(TextureUses::SAMPLED),
+            Some(TextureUses::RESOURCE),
         );
         assert_eq!(
             ts.query(TextureSelector {
@@ -286,7 +286,7 @@ mod test {
         let mut ts1 = TextureState::default();
         ts1.mips.push(PlaneStates::from_slice(&[(
             1..3,
-            Unit::new(TextureUses::SAMPLED),
+            Unit::new(TextureUses::RESOURCE),
         )]));
         let mut ts2 = TextureState::default();
         assert_eq!(
@@ -308,7 +308,7 @@ mod test {
             ts1.mips[0].query(&(1..2), |&v| v),
             Some(Ok(Unit {
                 first: None,
-                last: TextureUses::SAMPLED | TextureUses::COPY_SRC,
+                last: TextureUses::RESOURCE | TextureUses::COPY_SRC,
             })),
             "wrong extension result"
         );
@@ -322,7 +322,7 @@ mod test {
                     levels: 0..1,
                     layers: 1..2,
                 },
-                usage: TextureUses::SAMPLED | TextureUses::COPY_SRC..TextureUses::COPY_DST,
+                usage: TextureUses::RESOURCE | TextureUses::COPY_SRC..TextureUses::COPY_DST,
             }),
             "wrong error on extending with incompatible state"
         );
@@ -348,7 +348,7 @@ mod test {
                         levels: 0..1,
                         layers: 1..2,
                     },
-                    usage: TextureUses::SAMPLED | TextureUses::COPY_SRC..TextureUses::COPY_DST,
+                    usage: TextureUses::RESOURCE | TextureUses::COPY_SRC..TextureUses::COPY_DST,
                 },
                 PendingTransition {
                     id,
@@ -358,7 +358,7 @@ mod test {
                     },
                     // the transition links the end of the base rage (..SAMPLED)
                     // with the start of the next range (COPY_SRC..)
-                    usage: TextureUses::SAMPLED..TextureUses::COPY_SRC,
+                    usage: TextureUses::RESOURCE..TextureUses::COPY_SRC,
                 },
             ],
             "replacing produced wrong transitions"
@@ -366,7 +366,7 @@ mod test {
         assert_eq!(
             ts1.mips[0].query(&(1..2), |&v| v),
             Some(Ok(Unit {
-                first: Some(TextureUses::SAMPLED | TextureUses::COPY_SRC),
+                first: Some(TextureUses::RESOURCE | TextureUses::COPY_SRC),
                 last: TextureUses::COPY_DST,
             })),
             "wrong final layer 1 state"
@@ -374,7 +374,7 @@ mod test {
         assert_eq!(
             ts1.mips[0].query(&(2..3), |&v| v),
             Some(Ok(Unit {
-                first: Some(TextureUses::SAMPLED),
+                first: Some(TextureUses::RESOURCE),
                 last: TextureUses::COLOR_TARGET,
             })),
             "wrong final layer 2 state"
@@ -416,7 +416,7 @@ mod test {
             ts1.mips[0].query(&(2..3), |&v| v),
             Some(Ok(Unit {
                 // the initial state here is never expected to change
-                first: Some(TextureUses::SAMPLED),
+                first: Some(TextureUses::RESOURCE),
                 last: TextureUses::COPY_DST,
             })),
             "wrong final layer 2 state"

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -268,7 +268,7 @@ impl<A: hal::Api> Example<A> {
             sample_count: 1,
             dimension: wgt::TextureDimension::D2,
             format: wgt::TextureFormat::Rgba8UnormSrgb,
-            usage: hal::TextureUses::COPY_DST | hal::TextureUses::SAMPLED,
+            usage: hal::TextureUses::COPY_DST | hal::TextureUses::RESOURCE,
             memory_flags: hal::MemoryFlags::empty(),
         };
         let texture = unsafe { device.create_texture(&texture_desc).unwrap() };
@@ -292,7 +292,7 @@ impl<A: hal::Api> Example<A> {
             let texture_barrier2 = hal::TextureBarrier {
                 texture: &texture,
                 range: wgt::ImageSubresourceRange::default(),
-                usage: hal::TextureUses::COPY_DST..hal::TextureUses::SAMPLED,
+                usage: hal::TextureUses::COPY_DST..hal::TextureUses::RESOURCE,
             };
             let copy = hal::BufferTextureCopy {
                 buffer_layout: wgt::ImageDataLayout {
@@ -378,7 +378,7 @@ impl<A: hal::Api> Example<A> {
             label: None,
             format: texture_desc.format,
             dimension: wgt::TextureViewDimension::D2,
-            usage: hal::TextureUses::SAMPLED,
+            usage: hal::TextureUses::RESOURCE,
             range: wgt::ImageSubresourceRange::default(),
         };
         let texture_view = unsafe { device.create_texture_view(&texture, &view_desc).unwrap() };
@@ -391,7 +391,7 @@ impl<A: hal::Api> Example<A> {
             };
             let texture_binding = hal::TextureBinding {
                 view: &texture_view,
-                usage: hal::TextureUses::SAMPLED,
+                usage: hal::TextureUses::RESOURCE,
             };
             let global_group_desc = hal::BindGroupDescriptor {
                 label: Some("global"),

--- a/wgpu-hal/src/dx12/conv.rs
+++ b/wgpu-hal/src/dx12/conv.rs
@@ -212,7 +212,7 @@ pub fn map_texture_usage_to_resource_flags(
         crate::TextureUses::DEPTH_STENCIL_READ | crate::TextureUses::DEPTH_STENCIL_WRITE,
     ) {
         flags |= d3d12::D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
-        if !usage.contains(crate::TextureUses::SAMPLED) {
+        if !usage.contains(crate::TextureUses::RESOURCE) {
             flags |= d3d12::D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE;
         }
     }
@@ -341,7 +341,7 @@ pub fn map_texture_usage_to_state(usage: crate::TextureUses) -> d3d12::D3D12_RES
     if usage.intersects(Tu::COPY_DST) {
         state |= d3d12::D3D12_RESOURCE_STATE_COPY_DEST;
     }
-    if usage.intersects(Tu::SAMPLED) {
+    if usage.intersects(Tu::RESOURCE) {
         state |= d3d12::D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
             | d3d12::D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
     }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -460,7 +460,7 @@ impl crate::Device<super::Api> for super::Device {
                 texture.resource,
                 texture.calc_subresource(desc.range.base_mip_level, desc.range.base_array_layer, 0),
             ),
-            handle_srv: if desc.usage.intersects(crate::TextureUses::SAMPLED) {
+            handle_srv: if desc.usage.intersects(crate::TextureUses::RESOURCE) {
                 let raw_desc = view_desc.to_srv();
                 let handle = self.srv_uav_pool.lock().alloc_handle();
                 self.raw.CreateShaderResourceView(

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -663,7 +663,7 @@ impl super::Queue {
             }
             C::TextureBarrier(usage) => {
                 let mut flags = 0;
-                if usage.contains(crate::TextureUses::SAMPLED) {
+                if usage.contains(crate::TextureUses::RESOURCE) {
                     flags |= glow::TEXTURE_FETCH_BARRIER_BIT;
                 }
                 if usage.intersects(

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -620,14 +620,14 @@ bitflags::bitflags! {
     pub struct TextureUses: u32 {
         const COPY_SRC = 1;
         const COPY_DST = 2;
-        const SAMPLED = 4;
+        const RESOURCE = 4;
         const COLOR_TARGET = 8;
         const DEPTH_STENCIL_READ = 16;
         const DEPTH_STENCIL_WRITE = 32;
         const STORAGE_READ = 64;
         const STORAGE_WRITE = 128;
         /// The combination of usages that can be used together (read-only).
-        const INCLUSIVE = Self::COPY_SRC.bits | Self::SAMPLED.bits | Self::DEPTH_STENCIL_READ.bits;
+        const INCLUSIVE = Self::COPY_SRC.bits | Self::RESOURCE.bits | Self::DEPTH_STENCIL_READ.bits;
         /// The combination of exclusive usages (write-only and read-write).
         const EXCLUSIVE = Self::COPY_DST.bits | Self::COLOR_TARGET.bits | Self::DEPTH_STENCIL_WRITE.bits | Self::STORAGE_READ.bits | Self::STORAGE_WRITE.bits;
         /// The combination of all usages that the are guaranteed to be be ordered by the hardware.

--- a/wgpu-hal/src/metal/conv.rs
+++ b/wgpu-hal/src/metal/conv.rs
@@ -9,7 +9,7 @@ pub fn map_texture_usage(usage: crate::TextureUses) -> mtl::MTLTextureUsage {
     );
     mtl_usage.set(
         mtl::MTLTextureUsage::ShaderRead,
-        usage.intersects(Tu::SAMPLED | Tu::DEPTH_STENCIL_READ | Tu::STORAGE_READ),
+        usage.intersects(Tu::RESOURCE | Tu::DEPTH_STENCIL_READ | Tu::STORAGE_READ),
     );
     mtl_usage.set(
         mtl::MTLTextureUsage::ShaderWrite,

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -162,7 +162,7 @@ pub fn derive_image_layout(
         crate::TextureUses::UNINITIALIZED => vk::ImageLayout::UNDEFINED,
         crate::TextureUses::COPY_SRC => vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
         crate::TextureUses::COPY_DST => vk::ImageLayout::TRANSFER_DST_OPTIMAL,
-        crate::TextureUses::SAMPLED if is_color => vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+        crate::TextureUses::RESOURCE if is_color => vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
         crate::TextureUses::COLOR_TARGET => vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
         crate::TextureUses::DEPTH_STENCIL_WRITE => {
             vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
@@ -187,7 +187,7 @@ pub fn map_texture_usage(usage: crate::TextureUses) -> vk::ImageUsageFlags {
     if usage.contains(crate::TextureUses::COPY_DST) {
         flags |= vk::ImageUsageFlags::TRANSFER_DST;
     }
-    if usage.contains(crate::TextureUses::SAMPLED) {
+    if usage.contains(crate::TextureUses::RESOURCE) {
         flags |= vk::ImageUsageFlags::SAMPLED;
     }
     if usage.contains(crate::TextureUses::COLOR_TARGET) {
@@ -221,7 +221,7 @@ pub fn map_texture_usage_to_barrier(
         stages |= vk::PipelineStageFlags::TRANSFER;
         access |= vk::AccessFlags::TRANSFER_WRITE;
     }
-    if usage.contains(crate::TextureUses::SAMPLED) {
+    if usage.contains(crate::TextureUses::RESOURCE) {
         stages |= shader_stages;
         access |= vk::AccessFlags::SHADER_READ;
     }
@@ -268,7 +268,7 @@ pub fn map_vk_image_usage(usage: vk::ImageUsageFlags) -> crate::TextureUses {
         bits |= crate::TextureUses::COPY_DST;
     }
     if usage.contains(vk::ImageUsageFlags::SAMPLED) {
-        bits |= crate::TextureUses::SAMPLED;
+        bits |= crate::TextureUses::RESOURCE;
     }
     if usage.contains(vk::ImageUsageFlags::COLOR_ATTACHMENT) {
         bits |= crate::TextureUses::COLOR_TARGET;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -182,7 +182,7 @@ bitflags::bitflags! {
         /// Compressed textures sacrifice some quality in exchange for significantly reduced
         /// bandwidth usage.
         ///
-        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::SAMPLED`] for BCn formats.
+        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING`] for BCn formats.
         /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
         ///
         /// Supported Platforms:
@@ -387,7 +387,7 @@ bitflags::bitflags! {
         /// Compressed textures sacrifice some quality in exchange for significantly reduced
         /// bandwidth usage.
         ///
-        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::SAMPLED`] for ETC2 formats.
+        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING`] for ETC2 formats.
         /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
         ///
         /// Supported Platforms:
@@ -402,7 +402,7 @@ bitflags::bitflags! {
         /// Compressed textures sacrifice some quality in exchange for significantly reduced
         /// bandwidth usage.
         ///
-        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::SAMPLED`] for ASTC formats.
+        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING`] for ASTC formats.
         /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
         ///
         /// Supported Platforms:
@@ -1675,9 +1675,10 @@ impl TextureFormat {
         let srgb = true;
 
         // Flags
-        let basic = TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::SAMPLED;
+        let basic =
+            TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING;
         let attachment = basic | TextureUsages::RENDER_ATTACHMENT;
-        let storage = basic | TextureUsages::STORAGE;
+        let storage = basic | TextureUsages::STORAGE_BINDING;
         let all_flags = TextureUsages::all();
 
         // See <https://gpuweb.github.io/gpuweb/#texture-format-caps> for reference
@@ -2324,9 +2325,9 @@ bitflags::bitflags! {
         /// [`CommandEncoder::copy_texture_to_texture`], or [`Queue::write_texture`] operation.
         const COPY_DST = 2;
         /// Allows a texture to be a [`BindingType::Texture`] in a bind group.
-        const SAMPLED = 4;
+        const TEXTURE_BINDING = 4;
         /// Allows a texture to be a [`BindingType::StorageTexture`] in a bind group.
-        const STORAGE = 8;
+        const STORAGE_BINDING = 8;
         /// Allows a texture to be an output attachment of a renderpass.
         const RENDER_ATTACHMENT = 16;
     }

--- a/wgpu/examples/bunnymark/main.rs
+++ b/wgpu/examples/bunnymark/main.rs
@@ -150,7 +150,7 @@ impl framework::Example for Example {
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Rgba8UnormSrgb,
-                usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::SAMPLED,
+                usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
             });
             queue.write_texture(
                 texture.as_image_copy(),

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -34,7 +34,8 @@ impl Example {
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: RENDER_TARGET_FORMAT,
-                usage: wgpu::TextureUsages::SAMPLED | wgpu::TextureUsages::RENDER_ATTACHMENT,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::RENDER_ATTACHMENT,
             })
             .create_view(&Default::default());
 

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -180,7 +180,7 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::R8Uint,
-            usage: wgpu::TextureUsages::SAMPLED | wgpu::TextureUsages::COPY_DST,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
         });
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
         queue.write_texture(

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -225,7 +225,7 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: TEXTURE_FORMAT,
-            usage: wgpu::TextureUsages::SAMPLED
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
                 | wgpu::TextureUsages::RENDER_ATTACHMENT
                 | wgpu::TextureUsages::COPY_DST,
             label: None,

--- a/wgpu/examples/shadow/main.rs
+++ b/wgpu/examples/shadow/main.rs
@@ -377,7 +377,7 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: Self::SHADOW_FORMAT,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::SAMPLED,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
             label: None,
         });
         let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -324,7 +324,7 @@ impl framework::Example for Skybox {
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: skybox_format,
-                usage: wgpu::TextureUsages::SAMPLED | wgpu::TextureUsages::COPY_DST,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
                 label: None,
             },
             &image.data,

--- a/wgpu/examples/texture-arrays/main.rs
+++ b/wgpu/examples/texture-arrays/main.rs
@@ -131,7 +131,7 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Rgba8UnormSrgb,
-            usage: wgpu::TextureUsages::SAMPLED | wgpu::TextureUsages::COPY_DST,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
             label: None,
         };
         let red_texture = device.create_texture(&wgpu::TextureDescriptor {

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -198,7 +198,7 @@ impl Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: sc_desc.format,
-            usage: wgpu::TextureUsages::SAMPLED
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
                 | wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::RENDER_ATTACHMENT,
         });
@@ -210,7 +210,7 @@ impl Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Depth32Float,
-            usage: wgpu::TextureUsages::SAMPLED
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
                 | wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::RENDER_ATTACHMENT,
         });


### PR DESCRIPTION
**Connections**
Matches https://github.com/gpuweb/gpuweb/pull/1989

**Description**
The `SAMPLED` usage name was confusing because integer and MSAA textures can't be sampled (with a sampler), but fetching data from them is under this usage.

**Testing**
No need
