### PR TITLE
Mention WGPU_ADAPTER_NAME Env Var in WGPU README

### DIFF
--- a/wgpu/README.md
+++ b/wgpu/README.md
@@ -39,6 +39,10 @@ The following environment variables can be used to configure how the framework e
 
   If unset a low power adapter is preferred.
 
+- `WGPU_ADAPTER_NAME`
+
+  Select a specific adapter by specifying a substring of the adapter name.
+
 #### Run Examples on the Web (`wasm32-unknown-unknown`)
 
 See [wiki article](https://github.com/gfx-rs/wgpu-rs/wiki/Running-on-the-Web-with-WebGPU-and-WebGL).


### PR DESCRIPTION
**Connections**
None

**Description**
Mentions the new `WGPU_ADAPTER_NAME` environment variable in the WGPU readme.

**Testing**

