### PR TITLE
hal/dx12: fix depth formats and pipeline layout

### DIFF
--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -121,6 +121,9 @@ impl super::Adapter {
             hr == 0 && features2.DepthBoundsTestSupported != 0
         };
 
+        //Note: `D3D12_FEATURE_D3D12_OPTIONS3::CastingFullyTypedFormatSupported` can be checked
+        // to know if we can skip "typeless" formats entirely.
+
         let private_caps = super::PrivateCapabilities {
             instance_flags,
             heterogeneous_resource_heaps: options.ResourceHeapTier

--- a/wgpu-hal/src/dx12/conv.rs
+++ b/wgpu-hal/src/dx12/conv.rs
@@ -129,6 +129,16 @@ pub fn map_texture_format_nodepth(format: wgt::TextureFormat) -> dxgiformat::DXG
     }
 }
 
+pub fn map_texture_format_depth_typeless(format: wgt::TextureFormat) -> dxgiformat::DXGI_FORMAT {
+    match format {
+        wgt::TextureFormat::Depth32Float => dxgiformat::DXGI_FORMAT_R32_TYPELESS,
+        wgt::TextureFormat::Depth24Plus | wgt::TextureFormat::Depth24PlusStencil8 => {
+            dxgiformat::DXGI_FORMAT_R24G8_TYPELESS
+        }
+        _ => unreachable!(),
+    }
+}
+
 pub fn map_index_format(format: wgt::IndexFormat) -> dxgiformat::DXGI_FORMAT {
     match format {
         wgt::IndexFormat::Uint16 => dxgiformat::DXGI_FORMAT_R16_UINT,


### PR DESCRIPTION
**Connections**
Closes #1727

**Description**
There were 2 problems. One was that the reversing of the pipeline layout was done wrong (again). I don't know how it still worked on one of my machines :/
The other was that the backend relied on the depth format reinterpretation without using a typeless format. This is OK on higher-level platforms, but we should be doing it more careful. I tried to approach this maximally efficient: we only use the typeless format if all of the following are true:
  1. it's a depth/stencil format
  2. it needs to be seen as SRV/UAV

So in the case of a simple depth texture, we are still going to be using a fully-qualified format, and therefore get all of the benefit of HW compression on it.

**Testing**
Ran the examples on Intel
