### PR TITLE
Fix New Clippy Lints From Rust 1.54.0

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -741,7 +741,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             // This will schedule destruction of all resources that are no longer needed
             // by the user but used in the command stream, among other things.
-            let callbacks = match device.maintain(&hub, false, &mut token) {
+            let callbacks = match device.maintain(hub, false, &mut token) {
                 Ok(callbacks) => callbacks,
                 Err(WaitIdleError::Device(err)) => return Err(QueueSubmitError::Queue(err)),
                 Err(WaitIdleError::StuckGpu) => return Err(QueueSubmitError::StuckGpu),

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -677,7 +677,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         profiling::scope!("create_adapter_from_hal", "Instance");
 
         let mut token = Token::root();
-        let fid = A::hub(&self).adapters.prepare(input);
+        let fid = A::hub(self).adapters.prepare(input);
 
         match A::VARIANT {
             #[cfg(vulkan)]

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -585,28 +585,28 @@ impl super::PrivateCapabilities {
             } else {
                 mtl::MTLReadWriteTextureTier::TierNone
             },
-            resource_heaps: Self::supports_any(&device, RESOURCE_HEAP_SUPPORT),
-            argument_buffers: Self::supports_any(&device, ARGUMENT_BUFFER_SUPPORT),
+            resource_heaps: Self::supports_any(device, RESOURCE_HEAP_SUPPORT),
+            argument_buffers: Self::supports_any(device, ARGUMENT_BUFFER_SUPPORT),
             shared_textures: !os_is_mac,
             mutable_comparison_samplers: Self::supports_any(
-                &device,
+                device,
                 MUTABLE_COMPARISON_SAMPLER_SUPPORT,
             ),
-            sampler_clamp_to_border: Self::supports_any(&device, SAMPLER_CLAMP_TO_BORDER_SUPPORT),
+            sampler_clamp_to_border: Self::supports_any(device, SAMPLER_CLAMP_TO_BORDER_SUPPORT),
             sampler_lod_average: {
                 // TODO: Clarify minimum macOS version with Apple (43707452)
                 let need_version = if os_is_mac { (10, 13) } else { (9, 0) };
                 Self::version_at_least(major, minor, need_version.0, need_version.1)
             },
-            base_instance: Self::supports_any(&device, BASE_INSTANCE_SUPPORT),
-            base_vertex_instance_drawing: Self::supports_any(&device, BASE_VERTEX_INSTANCE_SUPPORT),
-            dual_source_blending: Self::supports_any(&device, DUAL_SOURCE_BLEND_SUPPORT),
+            base_instance: Self::supports_any(device, BASE_INSTANCE_SUPPORT),
+            base_vertex_instance_drawing: Self::supports_any(device, BASE_VERTEX_INSTANCE_SUPPORT),
+            dual_source_blending: Self::supports_any(device, DUAL_SOURCE_BLEND_SUPPORT),
             low_power: !os_is_mac || device.is_low_power(),
             headless: os_is_mac && device.is_headless(),
-            layered_rendering: Self::supports_any(&device, LAYERED_RENDERING_SUPPORT),
-            function_specialization: Self::supports_any(&device, FUNCTION_SPECIALIZATION_SUPPORT),
-            depth_clip_mode: Self::supports_any(&device, DEPTH_CLIP_MODE),
-            texture_cube_array: Self::supports_any(&device, TEXTURE_CUBE_ARRAY_SUPPORT),
+            layered_rendering: Self::supports_any(device, LAYERED_RENDERING_SUPPORT),
+            function_specialization: Self::supports_any(device, FUNCTION_SPECIALIZATION_SUPPORT),
+            depth_clip_mode: Self::supports_any(device, DEPTH_CLIP_MODE),
+            texture_cube_array: Self::supports_any(device, TEXTURE_CUBE_ARRAY_SUPPORT),
             format_depth24_stencil8: os_is_mac && device.d24_s8_supported(),
             format_depth32_stencil8_filter: os_is_mac,
             format_depth32_stencil8_none: !os_is_mac,
@@ -614,61 +614,61 @@ impl super::PrivateCapabilities {
             format_b5: !os_is_mac,
             format_bc: os_is_mac,
             format_eac_etc: !os_is_mac,
-            format_astc: Self::supports_any(&device, ASTC_PIXEL_FORMAT_FEATURES),
-            format_any8_unorm_srgb_all: Self::supports_any(&device, ANY8_UNORM_SRGB_ALL),
-            format_any8_unorm_srgb_no_write: !Self::supports_any(&device, ANY8_UNORM_SRGB_ALL)
+            format_astc: Self::supports_any(device, ASTC_PIXEL_FORMAT_FEATURES),
+            format_any8_unorm_srgb_all: Self::supports_any(device, ANY8_UNORM_SRGB_ALL),
+            format_any8_unorm_srgb_no_write: !Self::supports_any(device, ANY8_UNORM_SRGB_ALL)
                 && !os_is_mac,
-            format_any8_snorm_all: Self::supports_any(&device, ANY8_SNORM_RESOLVE),
+            format_any8_snorm_all: Self::supports_any(device, ANY8_SNORM_RESOLVE),
             format_r16_norm_all: os_is_mac,
             format_r32_all: !Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v1,
                     MTLFeatureSet::iOS_GPUFamily2_v1,
                 ],
             ),
             format_r32_no_write: Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v1,
                     MTLFeatureSet::iOS_GPUFamily2_v1,
                 ],
             ),
             format_r32float_no_write_no_filter: Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v1,
                     MTLFeatureSet::iOS_GPUFamily2_v1,
                 ],
             ) && !os_is_mac,
             format_r32float_no_filter: !Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v1,
                     MTLFeatureSet::iOS_GPUFamily2_v1,
                 ],
             ) && !os_is_mac,
             format_r32float_all: os_is_mac,
-            format_rgba8_srgb_all: Self::supports_any(&device, RGBA8_SRGB),
-            format_rgba8_srgb_no_write: !Self::supports_any(&device, RGBA8_SRGB),
-            format_rgb10a2_unorm_all: Self::supports_any(&device, RGB10A2UNORM_ALL),
-            format_rgb10a2_unorm_no_write: !Self::supports_any(&device, RGB10A2UNORM_ALL),
-            format_rgb10a2_uint_color: !Self::supports_any(&device, RGB10A2UINT_COLOR_WRITE),
-            format_rgb10a2_uint_color_write: Self::supports_any(&device, RGB10A2UINT_COLOR_WRITE),
-            format_rg11b10_all: Self::supports_any(&device, RG11B10FLOAT_ALL),
-            format_rg11b10_no_write: !Self::supports_any(&device, RG11B10FLOAT_ALL),
-            format_rgb9e5_all: Self::supports_any(&device, RGB9E5FLOAT_ALL),
-            format_rgb9e5_no_write: !Self::supports_any(&device, RGB9E5FLOAT_ALL) && !os_is_mac,
+            format_rgba8_srgb_all: Self::supports_any(device, RGBA8_SRGB),
+            format_rgba8_srgb_no_write: !Self::supports_any(device, RGBA8_SRGB),
+            format_rgb10a2_unorm_all: Self::supports_any(device, RGB10A2UNORM_ALL),
+            format_rgb10a2_unorm_no_write: !Self::supports_any(device, RGB10A2UNORM_ALL),
+            format_rgb10a2_uint_color: !Self::supports_any(device, RGB10A2UINT_COLOR_WRITE),
+            format_rgb10a2_uint_color_write: Self::supports_any(device, RGB10A2UINT_COLOR_WRITE),
+            format_rg11b10_all: Self::supports_any(device, RG11B10FLOAT_ALL),
+            format_rg11b10_no_write: !Self::supports_any(device, RG11B10FLOAT_ALL),
+            format_rgb9e5_all: Self::supports_any(device, RGB9E5FLOAT_ALL),
+            format_rgb9e5_no_write: !Self::supports_any(device, RGB9E5FLOAT_ALL) && !os_is_mac,
             format_rgb9e5_filter_only: os_is_mac,
             format_rg32_color: Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v1,
                     MTLFeatureSet::iOS_GPUFamily2_v1,
                 ],
             ),
             format_rg32_color_write: !Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v1,
                     MTLFeatureSet::iOS_GPUFamily2_v1,
@@ -676,7 +676,7 @@ impl super::PrivateCapabilities {
             ),
             format_rg32float_all: os_is_mac,
             format_rg32float_color_blend: Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v1,
                     MTLFeatureSet::iOS_GPUFamily2_v1,
@@ -684,35 +684,35 @@ impl super::PrivateCapabilities {
             ),
             format_rg32float_no_filter: !os_is_mac
                 && !Self::supports_any(
-                    &device,
+                    device,
                     &[
                         MTLFeatureSet::iOS_GPUFamily1_v1,
                         MTLFeatureSet::iOS_GPUFamily2_v1,
                     ],
                 ),
             format_rgba32int_color: Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v1,
                     MTLFeatureSet::iOS_GPUFamily2_v1,
                 ],
             ),
             format_rgba32int_color_write: !Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v1,
                     MTLFeatureSet::iOS_GPUFamily2_v1,
                 ],
             ),
             format_rgba32float_color: Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v1,
                     MTLFeatureSet::iOS_GPUFamily2_v1,
                 ],
             ),
             format_rgba32float_color_write: !Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v1,
                     MTLFeatureSet::iOS_GPUFamily2_v1,
@@ -724,7 +724,7 @@ impl super::PrivateCapabilities {
                 .supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v1),
             format_depth32float_none: !device
                 .supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v1),
-            format_bgr10a2_all: Self::supports_any(&device, BGR10A2_ALL),
+            format_bgr10a2_all: Self::supports_any(device, BGR10A2_ALL),
             format_bgr10a2_no_write: !device
                 .supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v3),
             max_buffers_per_stage: 31,
@@ -737,7 +737,7 @@ impl super::PrivateCapabilities {
                 1 << 28 // 256MB otherwise
             },
             max_texture_size: if Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily3_v1,
                     MTLFeatureSet::tvOS_GPUFamily2_v1,
@@ -746,7 +746,7 @@ impl super::PrivateCapabilities {
             ) {
                 16384
             } else if Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily1_v2,
                     MTLFeatureSet::iOS_GPUFamily2_v2,
@@ -761,7 +761,7 @@ impl super::PrivateCapabilities {
             max_texture_layers: 2048,
             max_fragment_input_components: if os_is_mac { 128 } else { 60 },
             max_color_render_targets: if Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily2_v1,
                     MTLFeatureSet::iOS_GPUFamily3_v1,
@@ -778,7 +778,7 @@ impl super::PrivateCapabilities {
                 4
             },
             max_total_threadgroup_memory: if Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily4_v2,
                     MTLFeatureSet::iOS_GPUFamily5_v1,
@@ -786,7 +786,7 @@ impl super::PrivateCapabilities {
             ) {
                 64 << 10
             } else if Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily4_v1,
                     MTLFeatureSet::macOS_GPUFamily1_v2,
@@ -799,7 +799,7 @@ impl super::PrivateCapabilities {
             },
             sample_count_mask,
             supports_debug_markers: Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::macOS_GPUFamily1_v2,
                     MTLFeatureSet::macOS_GPUFamily2_v1,
@@ -829,7 +829,7 @@ impl super::PrivateCapabilities {
                 Self::version_at_least(major, minor, 11, 0)
             },
             supports_arrays_of_textures: Self::supports_any(
-                &device,
+                device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily3_v2,
                     MTLFeatureSet::iOS_GPUFamily4_v1,

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -811,7 +811,7 @@ impl crate::Device<super::Api> for super::Device {
                     attribute_desc.set_offset(at.offset);
                 }
             }
-            descriptor.set_vertex_descriptor(Some(&vertex_descriptor));
+            descriptor.set_vertex_descriptor(Some(vertex_descriptor));
         }
 
         if desc.multisample.count != 1 {

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -48,7 +48,7 @@ impl Example {
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("upscale bind group"),
-            layout: &bind_group_layout_upscale,
+            layout: bind_group_layout_upscale,
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -371,7 +371,7 @@ impl framework::Example for Example {
 
         Self::generate_mipmaps(
             &mut init_encoder,
-            &device,
+            device,
             &texture,
             &query_sets,
             MIP_LEVEL_COUNT,

--- a/wgpu/examples/msaa-line/main.rs
+++ b/wgpu/examples/msaa-line/main.rs
@@ -47,7 +47,7 @@ impl Example {
         log::info!("sample_count: {}", sample_count);
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: None,
-            layout: Some(&pipeline_layout),
+            layout: Some(pipeline_layout),
             vertex: wgpu::VertexState {
                 module: shader,
                 entry_point: "vs_main",
@@ -163,7 +163,7 @@ impl framework::Example for Example {
 
         let bundle = Example::create_bundle(
             device,
-            &sc_desc,
+            sc_desc,
             &shader,
             &pipeline_layout,
             sample_count,
@@ -261,7 +261,7 @@ impl framework::Example for Example {
             } else {
                 wgpu::RenderPassColorAttachment {
                     view: &self.multisampled_framebuffer,
-                    resolve_target: Some(&view),
+                    resolve_target: Some(view),
                     ops,
                 }
             };

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -317,7 +317,7 @@ impl framework::Example for Skybox {
         let image = ddsfile::Dds::read(&mut std::io::Cursor::new(&bytes)).unwrap();
 
         let texture = device.create_texture_with_data(
-            &queue,
+            queue,
             &wgpu::TextureDescriptor {
                 size,
                 mip_level_count: max_mips as u32,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1075,7 +1075,7 @@ impl crate::Context for Context {
         let descriptor = wgc::binding_model::PipelineLayoutDescriptor {
             label: desc.label.map(Borrowed),
             bind_group_layouts: Borrowed(&temp_layouts),
-            push_constant_ranges: Borrowed(&desc.push_constant_ranges),
+            push_constant_ranges: Borrowed(desc.push_constant_ranges),
         };
 
         let global = &self.0;
@@ -1923,7 +1923,7 @@ impl crate::Context for Context {
 
     fn command_encoder_insert_debug_marker(&self, encoder: &Self::CommandEncoderId, label: &str) {
         let global = &self.0;
-        if let Err(cause) = wgc::gfx_select!(encoder.id => global.command_encoder_insert_debug_marker(encoder.id, &label))
+        if let Err(cause) = wgc::gfx_select!(encoder.id => global.command_encoder_insert_debug_marker(encoder.id, label))
         {
             self.handle_error_nolabel(
                 &encoder.error_sink,
@@ -1934,7 +1934,7 @@ impl crate::Context for Context {
     }
     fn command_encoder_push_debug_group(&self, encoder: &Self::CommandEncoderId, label: &str) {
         let global = &self.0;
-        if let Err(cause) = wgc::gfx_select!(encoder.id => global.command_encoder_push_debug_group(encoder.id, &label))
+        if let Err(cause) = wgc::gfx_select!(encoder.id => global.command_encoder_push_debug_group(encoder.id, label))
         {
             self.handle_error_nolabel(
                 &encoder.error_sink,

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1145,7 +1145,7 @@ impl crate::Context for Context {
                 web_sys::GpuShaderModuleDescriptor::new(&js_sys::JsString::from(&**code))
             }
         };
-        if let Some(ref label) = desc.label {
+        if let Some(label) = desc.label {
             descriptor.label(label);
         }
         Sendable(device.0.create_shader_module(&descriptor))
@@ -1240,7 +1240,7 @@ impl crate::Context for Context {
             .collect::<js_sys::Array>();
 
         let mut mapped_desc = web_sys::GpuBindGroupLayoutDescriptor::new(&mapped_bindings);
-        if let Some(ref label) = desc.label {
+        if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
         Sendable(device.0.create_bind_group_layout(&mapped_desc))
@@ -1265,7 +1265,7 @@ impl crate::Context for Context {
             .map(|binding| {
                 let mapped_resource = match binding.resource {
                     crate::BindingResource::Buffer(crate::BufferBinding {
-                        ref buffer,
+                        buffer,
                         offset,
                         size,
                     }) => {
@@ -1280,10 +1280,8 @@ impl crate::Context for Context {
                     crate::BindingResource::BufferArray(..) => {
                         panic!("Web backend does not support arrays of buffers")
                     }
-                    crate::BindingResource::Sampler(ref sampler) => {
-                        JsValue::from(sampler.id.0.clone())
-                    }
-                    crate::BindingResource::TextureView(ref texture_view) => {
+                    crate::BindingResource::Sampler(sampler) => JsValue::from(sampler.id.0.clone()),
+                    crate::BindingResource::TextureView(texture_view) => {
                         JsValue::from(texture_view.id.0.clone())
                     }
                     crate::BindingResource::TextureViewArray(..) => {
@@ -1326,7 +1324,7 @@ impl crate::Context for Context {
         desc: &crate::RenderPipelineDescriptor,
     ) -> Self::RenderPipelineId {
         let mut mapped_vertex_state =
-            web_sys::GpuVertexState::new(&desc.vertex.entry_point, &desc.vertex.module.id.0);
+            web_sys::GpuVertexState::new(desc.vertex.entry_point, &desc.vertex.module.id.0);
 
         let buffers = desc
             .vertex
@@ -1388,7 +1386,7 @@ impl crate::Context for Context {
                 })
                 .collect::<js_sys::Array>();
             let mapped_fragment_desc =
-                web_sys::GpuFragmentState::new(&frag.entry_point, &frag.module.id.0, &targets);
+                web_sys::GpuFragmentState::new(frag.entry_point, &frag.module.id.0, &targets);
             mapped_desc.fragment(&mapped_fragment_desc);
         }
 
@@ -1410,7 +1408,7 @@ impl crate::Context for Context {
         desc: &crate::ComputePipelineDescriptor,
     ) -> Self::ComputePipelineId {
         let mapped_compute_stage =
-            web_sys::GpuProgrammableStage::new(&desc.entry_point, &desc.module.id.0);
+            web_sys::GpuProgrammableStage::new(desc.entry_point, &desc.module.id.0);
         let mut mapped_desc = web_sys::GpuComputePipelineDescriptor::new(&mapped_compute_stage);
         if let Some(layout) = desc.layout {
             mapped_desc.layout(&layout.id.0);
@@ -1429,7 +1427,7 @@ impl crate::Context for Context {
         let mut mapped_desc =
             web_sys::GpuBufferDescriptor::new(desc.size as f64, desc.usage.bits());
         mapped_desc.mapped_at_creation(desc.mapped_at_creation);
-        if let Some(ref label) = desc.label {
+        if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
         Sendable(device.0.create_buffer(&mapped_desc))
@@ -1445,7 +1443,7 @@ impl crate::Context for Context {
             &map_extent_3d(desc.size),
             desc.usage.bits(),
         );
-        if let Some(ref label) = desc.label {
+        if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
         mapped_desc.dimension(map_texture_dimension(desc.dimension));
@@ -1492,7 +1490,7 @@ impl crate::Context for Context {
         desc: &crate::CommandEncoderDescriptor,
     ) -> Self::CommandEncoderId {
         let mut mapped_desc = web_sys::GpuCommandEncoderDescriptor::new();
-        if let Some(ref label) = desc.label {
+        if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
         device
@@ -1511,7 +1509,7 @@ impl crate::Context for Context {
             .map(|cf| wasm_bindgen::JsValue::from(map_texture_format(*cf)))
             .collect::<js_sys::Array>();
         let mut mapped_desc = web_sys::GpuRenderBundleEncoderDescriptor::new(&mapped_color_formats);
-        if let Some(ref label) = desc.label {
+        if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
         if let Some(ds) = desc.depth_stencil {
@@ -1782,7 +1780,7 @@ impl crate::Context for Context {
         desc: &crate::ComputePassDescriptor,
     ) -> Self::ComputePassId {
         let mut mapped_desc = web_sys::GpuComputePassDescriptor::new();
-        if let Some(ref label) = desc.label {
+        if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
         ComputePass(encoder.begin_compute_pass_with_descriptor(&mapped_desc))

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -73,7 +73,7 @@ pub async fn initialize_adapter_from_env_or_default(
     instance: &Instance,
     backend_bits: wgt::Backends,
 ) -> Option<Adapter> {
-    match initialize_adapter_from_env(&instance, backend_bits) {
+    match initialize_adapter_from_env(instance, backend_bits) {
         Some(a) => Some(a),
         None => {
             instance

--- a/wgpu/tests/common/image.rs
+++ b/wgpu/tests/common/image.rs
@@ -58,7 +58,7 @@ fn write_png(
     encoder.set_compression(compression);
     let mut writer = encoder.write_header().unwrap();
 
-    writer.write_image_data(&data).unwrap();
+    writer.write_image_data(data).unwrap();
 }
 
 fn calc_difference(lhs: u8, rhs: u8) -> u8 {
@@ -122,7 +122,7 @@ pub fn compare_image_output(
                 .unwrap(),
             );
 
-            write_png(&actual_path, width, height, &data, png::Compression::Fast);
+            write_png(actual_path, width, height, data, png::Compression::Fast);
             write_png(
                 &difference_path,
                 width,


### PR DESCRIPTION
**Connections**
None

**Description**
Fixes a number of new lints introduce in the updated clippy that CI is now using. Noticed that CI was failing because of the lints on another PR after the release of Rust 1.54.0.

**Testing**