### PR TITLE
update link to WebGPU wiki

### DIFF
--- a/wgpu/README.md
+++ b/wgpu/README.md
@@ -45,7 +45,7 @@ The following environment variables can be used to configure how the framework e
 
 #### Run Examples on the Web (`wasm32-unknown-unknown`)
 
-See [wiki article](https://github.com/gfx-rs/wgpu-rs/wiki/Running-on-the-Web-with-WebGPU-and-WebGL).
+See [wiki article](https://github.com/gfx-rs/wgpu/wiki/Running-on-the-Web-with-WebGPU-and-WebGL).
 
 ## Shaders
 


### PR DESCRIPTION
**Description**

The current link links to the wiki page in the archived repository, not the new one.

There is another link in this README that links to the old "Applications and Libraries" wiki page, but this repository's wiki doesn't have an equivalent, so I left it unchanged.
