### PR TITLE
Include naga parse error in the error chain

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -895,7 +895,12 @@ impl<A: HalApi> Device<A> {
                     Ok(module) => module,
                     Err(err) => {
                         log::error!("Failed to parse WGSL code for {:?}: {}", desc.label, err);
-                        return Err(pipeline::CreateShaderModuleError::Parsing);
+                        return Err(pipeline::CreateShaderModuleError::Parsing(
+                            pipeline::NagaParseError {
+                                shader_source: code.to_string(),
+                                error: err,
+                            },
+                        ));
                     }
                 }
             }

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -45,9 +45,24 @@ impl<A: hal::Api> Resource for ShaderModule<A> {
 }
 
 #[derive(Clone, Debug, Error)]
+pub struct NagaParseError {
+    pub shader_source: String,
+    pub error: naga::front::wgsl::ParseError,
+}
+impl std::fmt::Display for NagaParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "\nShader error:\n{}",
+            self.error.emit_to_string(&self.shader_source)
+        )
+    }
+}
+
+#[derive(Clone, Debug, Error)]
 pub enum CreateShaderModuleError {
     #[error("Failed to parse a shader")]
-    Parsing,
+    Parsing(#[from] NagaParseError),
     #[error("Failed to generate the backend-specific code")]
     Generation,
     #[error(transparent)]


### PR DESCRIPTION
**Connections**
Probably makes #1424 moot

**Description**
Wraps the Naga `ParseError` with `NagaParseError` that shows the full Naga diagnostic in its `Display impl` and adding it to the `CreateShaderModuleError::Parsing` variant, allows for the wgsl diagnostics to be visible in the displayed validation error.

**Testing**
With modifying examples
