### PR TITLE
Added is_surface_supported

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2545,6 +2545,24 @@ impl<G: GlobalIdentityHandlerFactory> ImplicitPipelineIds<'_, G> {
 }
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
+    pub fn adapter_is_surface_supported<A: HalApi>(
+        &self,
+        adapter_id: id::AdapterId,
+        surface_id: id::SurfaceId,
+    ) -> Result<bool, instance::IsSurfaceSupportedError> {
+        let hub = A::hub(self);
+        let mut token = Token::root();
+
+        let (mut surface_guard, mut token) = self.surfaces.write(&mut token);
+        let (adapter_guard, mut _token) = hub.adapters.read(&mut token);
+        let adapter = adapter_guard
+            .get(adapter_id)
+            .map_err(|_| instance::IsSurfaceSupportedError::InvalidAdapter)?;
+        let surface = surface_guard
+            .get_mut(surface_id)
+            .map_err(|_| instance::IsSurfaceSupportedError::InvalidSurface)?;
+        Ok(adapter.is_surface_supported(surface))
+    }
     pub fn adapter_get_swap_chain_preferred_format<A: HalApi>(
         &self,
         adapter_id: id::AdapterId,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -181,6 +181,15 @@ impl<A: HalApi> Adapter<A> {
         }
     }
 
+    pub fn is_surface_supported(&self, surface: &mut Surface) -> bool {
+        unsafe {
+            self.raw
+                .adapter
+                .surface_capabilities(A::get_surface_mut(surface))
+        }
+        .is_some()
+    }
+
     pub fn get_swap_chain_preferred_format(
         &self,
         surface: &mut Surface,
@@ -342,6 +351,14 @@ impl<A: hal::Api> crate::hub::Resource for Adapter<A> {
     fn life_guard(&self) -> &LifeGuard {
         &self.life_guard
     }
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum IsSurfaceSupportedError {
+    #[error("invalid adapter")]
+    InvalidAdapter,
+    #[error("invalid surface")]
+    InvalidSurface,
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -795,6 +795,18 @@ impl crate::Context for Context {
         ready(Ok((device, device_id)))
     }
 
+    fn adapter_is_surface_supported(
+        &self,
+        adapter: &Self::AdapterId,
+        surface: &Self::SurfaceId,
+    ) -> bool {
+        let global = &self.0;
+        match wgc::gfx_select!(adapter => global.adapter_is_surface_supported(*adapter, *surface)) {
+            Ok(result) => result,
+            Err(err) => self.handle_error_fatal(err, "Adapter::is_surface_supported"),
+        }
+    }
+
     fn adapter_get_swap_chain_preferred_format(
         &self,
         adapter: &Self::AdapterId,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -199,6 +199,11 @@ trait Context: Debug + Send + Sized + Sync {
         trace_dir: Option<&std::path::Path>,
     ) -> Self::RequestDeviceFuture;
     fn instance_poll_all_devices(&self, force_wait: bool);
+    fn adapter_is_surface_supported(
+        &self,
+        adapter: &Self::AdapterId,
+        surface: &Self::SurfaceId,
+    ) -> bool;
     fn adapter_get_swap_chain_preferred_format(
         &self,
         adapter: &Self::AdapterId,
@@ -1562,6 +1567,11 @@ impl Adapter {
                     },
                 )
             })
+    }
+
+    /// Returns whether this adapter may present to the passed surface.
+    pub fn is_surface_supported(&self, surface: &Surface) -> bool {
+        Context::adapter_is_surface_supported(&*self.context, &self.id, &surface.id)
     }
 
     /// Returns an optimal texture format to use for the [`SwapChain`] with this adapter.


### PR DESCRIPTION
**Connections**
Implements the feature proposed in https://github.com/gfx-rs/wgpu/issues/1755.

**Description**
This pull requests adds a method on wgpu::Adapter one to query whether an adapter is supported by a surface, `is_surface_supported`.

**Testing**
I have not implemented any tests, though I have made sure it builds and the extant tests all pass on my machine (64-bit Linux, NAVI10 gpu).