### PR TITLE
Update Naga with new storage classes API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/naga?rev=a7ac13a#a7ac13a61d63620b8a0821db9176ed467fc282f7"
+source = "git+https://github.com/gfx-rs/naga?rev=300039e#300039e24703bc823cc932985947dfda66616e1e"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/player/tests/data/buffer-zero-init-for-binding.wgsl
+++ b/player/tests/data/buffer-zero-init-for-binding.wgsl
@@ -4,7 +4,7 @@ struct InOutBuffer {
 };
 
 [[group(0), binding(0)]]
-var<storage> buffer: [[access(read_write)]] InOutBuffer;
+var<storage, read_write> buffer: InOutBuffer;
 
 [[stage(compute), workgroup_size(1)]]
 fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a7ac13a"
+rev = "300039e"
 features = ["wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -65,11 +65,11 @@ core-graphics-types = "0.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a7ac13a"
+rev = "300039e"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a7ac13a"
+rev = "300039e"
 features = ["wgsl-in"]
 
 [dev-dependencies]

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -114,10 +114,14 @@ impl super::Device {
                     Some(ref br) => br.clone(),
                     None => continue,
                 };
-                // check for an immutable buffer
-                if !ep_info[var_handle].is_empty()
-                    && !var.storage_access.contains(naga::StorageAccess::STORE)
+                let storage_access_store = if let naga::StorageClass::Storage { access } = var.class
                 {
+                    access.contains(naga::StorageAccess::STORE)
+                } else {
+                    false
+                };
+                // check for an immutable buffer
+                if !ep_info[var_handle].is_empty() && !storage_access_store {
                     let psm = &layout.naga_options.per_stage_map[naga_stage];
                     let slot = psm.resources[&br].buffer.unwrap();
                     immutable_buffer_mask |= 1 << slot;

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -75,13 +75,13 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a7ac13a"
+rev = "300039e"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a7ac13a"
+rev = "300039e"
 features = ["wgsl-in"]
 
 [[example]]

--- a/wgpu/examples/boids/compute.wgsl
+++ b/wgpu/examples/boids/compute.wgsl
@@ -20,8 +20,8 @@ struct Particles {
 };
 
 [[group(0), binding(0)]] var<uniform> params : SimParams;
-[[group(0), binding(1)]] var<storage> particlesSrc : [[access(read)]] Particles;
-[[group(0), binding(2)]] var<storage> particlesDst : [[access(read_write)]] Particles;
+[[group(0), binding(1)]] var<storage, read> particlesSrc : Particles;
+[[group(0), binding(2)]] var<storage, read_write> particlesDst : Particles;
 
 // https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
 [[stage(compute), workgroup_size(64)]]

--- a/wgpu/examples/hello-compute/shader.wgsl
+++ b/wgpu/examples/hello-compute/shader.wgsl
@@ -4,7 +4,7 @@ struct PrimeIndices {
 }; // this is used as both input and output for convenience
 
 [[group(0), binding(0)]]
-var<storage> v_indices: [[access(read_write)]] PrimeIndices;
+var<storage, read_write> v_indices: PrimeIndices;
 
 // The Collatz Conjecture states that for any integer n:
 // If n is even, n = n/2

--- a/wgpu/examples/shadow/shader.wgsl
+++ b/wgpu/examples/shadow/shader.wgsl
@@ -55,7 +55,7 @@ struct Lights {
 };
 
 [[group(0), binding(1)]]
-var<storage> s_lights: [[access(read)]] Lights;
+var<storage, read> s_lights: Lights;
 [[group(0), binding(2)]]
 var t_shadow: texture_depth_2d_array;
 [[group(0), binding(3)]]

--- a/wgpu/tests/vertex_indices/draw.vert.wgsl
+++ b/wgpu/tests/vertex_indices/draw.vert.wgsl
@@ -4,7 +4,7 @@ struct Indices {
 }; // this is used as both input and output for convenience
 
 [[group(0), binding(0)]]
-var<storage> indices: [[access(read_write)]] Indices;
+var<storage, read_write> indices: Indices;
 
 [[stage(vertex)]]
 fn vs_main([[builtin(instance_index)]] instance: u32, [[builtin(vertex_index)]] index: u32) -> [[builtin(position)]] vec4<f32> {


### PR DESCRIPTION
**Connections**
None

**Description**
Updates Naga. Needed by me specifically to get https://github.com/gfx-rs/naga/pull/1144 pulled in to fix OpenGL backend with Bevy.

I had to remove the `[[access(read)]]` the shader for the shadow example or else I would get this error:

```
Caused by:
        In Device::create_shader_module
        Failed to parse a shader
        
    Shader error:
    error: expected type attribute ('access' or 'stride') or an end of the attribute list (']]'), found 'access'
       ┌─ wgsl:58:26
       │
    58 │ var<storage> s_lights: [[access(read)]] Lights;
       │                          ^^^^^^ expected type attribute ('access' or 'stride') or an end of the attribute list (']]')
```

Is this a naga bug, maybe? Seems a little off to me.

Also, I'm not exactly sure how the new struct element in the Naga `StorageClass` enum is meant to be used so let me know if any of that is wrong!

**Testing**
Tested shadow example on linux with GL and vulkan.
