### PR TITLE
Do not error on zero-sized scissor commands.

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1279,9 +1279,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                     RenderCommand::SetScissor(ref rect) => {
                         let scope = PassErrorScope::SetScissorRect;
-                        if rect.w == 0
-                            || rect.h == 0
-                            || rect.x + rect.w > info.extent.width
+                        if rect.x + rect.w > info.extent.width
                             || rect.y + rect.h > info.extent.height
                         {
                             return Err(RenderCommandError::InvalidScissorRect).map_pass_err(scope);


### PR DESCRIPTION
**Connections**
Fixes #1750.

**Description**
wgpu currently throws an error if either dimension of the scissor rectangle is zero. It seems that the WebGPU spec was the holdout that caused this requirement, but the spec has since been revised to allow for zero size scissor rectangles (https://github.com/gpuweb/gpuweb/pull/1138/files).

The spec now just says:
>    * x+width is less than or equal to this.[[attachment_size]].width.
>    * y+height is less than or equal to this.[[attachment_size]].height.



This PR removes the failure condition.

**Testing**
Tested on Ubuntu 20.04 with imgui-rs/imgui-wgpu-rs projects with the Vulkan backend and verified that crashes with zero sized scissor rectangles no longer occur.
