### PR TITLE
Fix dynamic offset handling for render bundles

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -633,7 +633,7 @@ impl RenderBundle {
                         &pipeline_layout_guard[pipeline_layout_id.unwrap()].raw,
                         index as u32,
                         &bind_group.raw,
-                        &offsets[num_dynamic_offsets as usize..],
+                        &offsets[..num_dynamic_offsets as usize],
                     );
                     offsets = &offsets[num_dynamic_offsets as usize..];
                 }


### PR DESCRIPTION
I found this while testing a "bundlemark" version of bunnymark.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
