### PR TITLE
Add downlevel flag for storage buffers in vertex shaders

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1039,6 +1039,7 @@ impl<A: HalApi> Device<A> {
             use wgt::BindingType as Bt;
 
             let mut required_features = wgt::Features::empty();
+            let mut required_downlevel_flags = wgt::DownlevelFlags::empty();
             let (array_feature, writable_storage) = match entry.ty {
                 Bt::Buffer {
                     ty: wgt::BufferBindingType::Uniform,
@@ -1113,27 +1114,23 @@ impl<A: HalApi> Device<A> {
                     ..
                 } = entry.ty
                 {
-                    self.require_downlevel_flags(wgt::DownlevelFlags::VERTEX_STORAGE)
-                        .map_err(binding_model::BindGroupLayoutEntryError::MissingDownlevelFlags)
-                        .map_err(|error| binding_model::CreateBindGroupLayoutError::Entry {
-                            binding: entry.binding,
-                            error,
-                        })?;
+                    required_downlevel_flags |= wgt::DownlevelFlags::VERTEX_STORAGE;
                 }
             }
             if writable_storage == WritableStorage::Yes
                 && entry.visibility.contains(wgt::ShaderStages::FRAGMENT)
             {
-                self.require_downlevel_flags(wgt::DownlevelFlags::FRAGMENT_WRITABLE_STORAGE)
-                    .map_err(binding_model::BindGroupLayoutEntryError::MissingDownlevelFlags)
-                    .map_err(|error| binding_model::CreateBindGroupLayoutError::Entry {
-                        binding: entry.binding,
-                        error,
-                    })?;
+                required_downlevel_flags |= wgt::DownlevelFlags::FRAGMENT_WRITABLE_STORAGE;
             }
 
             self.require_features(required_features)
                 .map_err(binding_model::BindGroupLayoutEntryError::MissingFeatures)
+                .map_err(|error| binding_model::CreateBindGroupLayoutError::Entry {
+                    binding: entry.binding,
+                    error,
+                })?;
+            self.require_downlevel_flags(required_downlevel_flags)
+                .map_err(binding_model::BindGroupLayoutEntryError::MissingDownlevelFlags)
                 .map_err(|error| binding_model::CreateBindGroupLayoutError::Entry {
                     binding: entry.binding,
                     error,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -736,12 +736,14 @@ bitflags::bitflags! {
         const COMPARISON_SAMPLERS = 1 << 8;
         /// Supports different blending modes per color target.
         const INDEPENDENT_BLENDING = 1 << 9;
+        /// Supports storage buffers in vertex shaders.
+        const VERTEX_STORAGE = 1 << 10;
 
 
         /// Supports samplers with anisotropic filtering. Note this isn't actually required by
         /// WebGPU, the implementation is allowed to completely ignore aniso clamp. This flag is
         /// here for native backends so they can comunicate to the user of aniso is enabled.
-        const ANISOTROPIC_FILTERING = 1 << 10;
+        const ANISOTROPIC_FILTERING = 1 << 11;
     }
 }
 


### PR DESCRIPTION
**Description**
This will enable compatibility on systems that report support for storage buffers on fragment shaders but not on  vertex shaders.
This includes all Radeon Terrascale architecture GPUs.