### PR TITLE
Document additional safety requirements of `Instance::create_surface`

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1454,7 +1454,8 @@ impl Instance {
     ///
     /// # Safety
     ///
-    /// - Raw Window Handle must be a valid object to create a surface upon.
+    /// - Raw Window Handle must be a valid object to create a surface upon and
+    ///   must remain valid for the lifetime of the returned surface.
     pub unsafe fn create_surface<W: raw_window_handle::HasRawWindowHandle>(
         &self,
         window: &W,


### PR DESCRIPTION
**Connections**
* Closes #1439: My issue was a misunderstanding of the safety requirements.
* Refs #1463: Provides information on the safety requirements as well as a proposed solution.

**Description**
This updates the documentation for `Instance::create_surface` to include the safety requirement that the underlying window must remain valid for the lifetime of the surface.

**Testing**
I ran `cargo doc` and I re-read the sentence a few times :)

In all seriousness, I spent way too much time trying to phrase this change. If anyone has a suggestion for better wording, I'm more than happy to update.