### PR TITLE
Naga update and surface cleanup fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/naga?rev=1907a92#1907a92928933f312da10daad85bdc6de7d5f9a9"
+source = "git+https://github.com/gfx-rs/naga?rev=69b70f8#69b70f8cc3acb988fa3f34d6a615c8c02259428c"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "1907a92"
+rev = "69b70f8"
 features = ["wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -724,6 +724,14 @@ impl<A: HalApi, F: GlobalIdentityHandlerFactory> Hub<A, F> {
 
         for element in surface_guard.map.iter_mut() {
             if let Element::Occupied(ref mut surface, _epoch) = *element {
+                if surface
+                    .presentation
+                    .as_ref()
+                    .map_or(wgt::Backend::Empty, |p| p.backend())
+                    != A::VARIANT
+                {
+                    continue;
+                }
                 if let Some(present) = surface.presentation.take() {
                     let device = &devices[present.device_id.value];
                     let suf = A::get_surface_mut(surface);

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -36,6 +36,12 @@ pub(crate) struct Presentation {
     pub(crate) acquired_texture: Option<Stored<TextureId>>,
 }
 
+impl Presentation {
+    pub(crate) fn backend(&self) -> wgt::Backend {
+        crate::id::TypedId::unzip(self.device_id.value.0).2
+    }
+}
+
 #[derive(Clone, Debug, Error)]
 pub enum SurfaceError {
     #[error("surface is invalid")]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -65,11 +65,11 @@ core-graphics-types = "0.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "1907a92"
+rev = "69b70f8"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "1907a92"
+rev = "69b70f8"
 features = ["wgsl-in"]
 
 [dev-dependencies]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -75,13 +75,13 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "1907a92"
+rev = "69b70f8"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "1907a92"
+rev = "69b70f8"
 features = ["wgsl-in"]
 
 [[example]]


### PR DESCRIPTION
**Connections**
Picks up #1193

**Description**
Also fixes clearing logic so that it doesn't try to free a surface from a different backend/device.

**Testing**
Running the examples
