### PR TITLE
dx12: switch root parameter updates from eager to lazy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "wgpu-info",
     "wgpu-types",
 ]
-default-members = ["wgpu", "player", "wgpu-hal", "wgpu-info"]
+default-members = ["wgpu", "wgpu-hal", "wgpu-info"]
 
 [patch."https://github.com/gfx-rs/naga"]
 #naga = { path = "../naga" }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -810,15 +810,14 @@ impl crate::Device<super::Api> for super::Device {
                     wgt::BindingType::Buffer {
                         has_dynamic_offset: true,
                         ..
-                    }
-                    | wgt::BindingType::Sampler { .. } => continue,
+                    } => continue,
                     ref other => conv::map_binding_type(other),
                 };
                 let bt = match range_ty {
                     native::DescriptorRangeType::CBV => &mut bind_cbv,
                     native::DescriptorRangeType::SRV => &mut bind_srv,
                     native::DescriptorRangeType::UAV => &mut bind_uav,
-                    native::DescriptorRangeType::Sampler => unreachable!(),
+                    native::DescriptorRangeType::Sampler => continue,
                 };
 
                 binding_map.insert(

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -305,9 +305,15 @@ struct PassState {
     resolves: ArrayVec<PassResolve, { crate::MAX_COLOR_TARGETS }>,
     layout: PipelineLayoutShared,
     root_elements: [RootElement; MAX_ROOT_ELEMENTS],
+    dirty_root_elements: u64,
     vertex_buffers: [d3d12::D3D12_VERTEX_BUFFER_VIEW; crate::MAX_VERTEX_BUFFERS],
     dirty_vertex_buffers: usize,
     kind: PassKind,
+}
+
+#[test]
+fn test_dirty_mask() {
+    assert_eq!(MAX_ROOT_ELEMENTS, std::mem::size_of::<u64>() * 8);
 }
 
 impl PassState {
@@ -321,6 +327,7 @@ impl PassState {
                 special_constants_root_index: None,
             },
             root_elements: [RootElement::Empty; MAX_ROOT_ELEMENTS],
+            dirty_root_elements: 0,
             vertex_buffers: [unsafe { mem::zeroed() }; crate::MAX_VERTEX_BUFFERS],
             dirty_vertex_buffers: 0,
             kind: PassKind::Transfer,


### PR DESCRIPTION
**Connections**
Fixes #1798

**Description**
I tried very hard to make state updates to be eager, but the resistance is futile.
In this case, rebinding the root tables failed because the old tables weren't compatible with the new layout.
So this PR changes the logic to be lazy. And code-wise it looks pretty neat.

**Testing**
Original test-case in rend3
