### PR TITLE
Fix panic in GLES shader processing

### DIFF
--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -35,7 +35,10 @@ impl CompilationContext<'_> {
             let br = var.binding.as_ref().unwrap();
             let slot = self.layout.get_slot(br);
 
-            let name = reflection_info.uniforms[&handle].clone();
+            let name = match reflection_info.uniforms.get(&handle) {
+                Some(name) => name.clone(),
+                None => continue,
+            };
             log::debug!(
                 "Rebind buffer: {:?} -> {}, register={:?}, slot={}",
                 var.name.as_ref(),


### PR DESCRIPTION
**Connections**  
Resolves #1803

**Description**
The GLES backend panics while trying to process uniform global variables when the variable's name is not found in the `ReflectionInfo` emitted by naga.
This seems to only happen when the uniform variable is not used in the shader stage that is currently being processed. For example, if there is a uniform block that is used in the vertex stage but is unused in the fragment stage, then the panic occurs while processing uniforms in the fragment stage.
This patch converts the panicking line into an explicit check, and ignores the corresponding global variable if the name is not found.

**Testing**
This reproduction should no longer panic: https://github.com/agausmann/wgpu-gl-unused-uniform-repro
I've also tested this patch in the [original project](https://github.com/agausmann/global-clock) that the repro is derived from, and it now successfully executes the affected render pipelines on the GL backend.