### PR TITLE
Implement compressed textures in DX12

### DIFF
--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -176,7 +176,8 @@ impl super::Adapter {
             | wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER
             | wgt::Features::NON_FILL_POLYGON_MODE
             | wgt::Features::VERTEX_WRITABLE_STORAGE
-            | wgt::Features::TIMESTAMP_QUERY;
+            | wgt::Features::TIMESTAMP_QUERY
+            | wgt::Features::TEXTURE_COMPRESSION_BC;
         //TODO: in order to expose this, we need to run a compute shader
         // that extract the necessary statistics out of the D3D12 result.
         // Alternatively, we could allocate a buffer for the query set,

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -13,6 +13,18 @@ fn make_box(origin: &wgt::Origin3d, size: &crate::CopyExtent) -> d3d12::D3D12_BO
     }
 }
 
+fn upround_extent(size: crate::CopyExtent, block_size: u32) -> crate::CopyExtent {
+    debug_assert!(block_size.is_power_of_two());
+
+    let block_mask = block_size - 1;
+
+    crate::CopyExtent {
+        width: (size.width + block_mask) & !(block_mask),
+        height: (size.height + block_mask) & !(block_mask),
+        depth: size.depth,
+    }
+}
+
 impl super::Temp {
     fn prepare_marker(&mut self, marker: &str) -> (&[u16], u32) {
         self.marker.clear();
@@ -381,8 +393,11 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             u: mem::zeroed(),
         };
 
+        let block_size = src.format.describe().block_dimensions.0 as u32;
         for r in regions {
-            let src_box = make_box(&r.src_base.origin, &r.size);
+            let uprounded_size = upround_extent(r.size, block_size);
+
+            let src_box = make_box(&r.src_base.origin, &uprounded_size);
             *src_location.u.SubresourceIndex_mut() = src.calc_subresource_for_copy(&r.src_base);
             *dst_location.u.SubresourceIndex_mut() = dst.calc_subresource_for_copy(&r.dst_base);
 
@@ -418,18 +433,21 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         };
         let raw_format = conv::map_texture_format(dst.format);
 
+        let block_size = dst.format.describe().block_dimensions.0 as u32;
         for r in regions {
-            let src_box = make_box(&wgt::Origin3d::ZERO, &r.size);
+            let uprounded_size = upround_extent(r.size, block_size);
+
+            let src_box = make_box(&wgt::Origin3d::ZERO, &uprounded_size);
             *src_location.u.PlacedFootprint_mut() = d3d12::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
                 Offset: r.buffer_layout.offset,
                 Footprint: d3d12::D3D12_SUBRESOURCE_FOOTPRINT {
                     Format: raw_format,
-                    Width: r.size.width,
+                    Width: uprounded_size.width,
                     Height: r
                         .buffer_layout
                         .rows_per_image
-                        .map_or(r.size.height, |count| count.get()),
-                    Depth: r.size.depth,
+                        .map_or(uprounded_size.height, |count| count.get() * block_size),
+                    Depth: uprounded_size.depth,
                     RowPitch: r.buffer_layout.bytes_per_row.map_or(0, |count| {
                         count.get().max(d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT)
                     }),
@@ -470,19 +488,22 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         };
         let raw_format = conv::map_texture_format(src.format);
 
+        let block_size = src.format.describe().block_dimensions.0 as u32;
         for r in regions {
-            let src_box = make_box(&r.texture_base.origin, &r.size);
+            let uprounded_size = upround_extent(r.size, block_size);
+
+            let src_box = make_box(&r.texture_base.origin, &uprounded_size);
             *src_location.u.SubresourceIndex_mut() = src.calc_subresource_for_copy(&r.texture_base);
             *dst_location.u.PlacedFootprint_mut() = d3d12::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
                 Offset: r.buffer_layout.offset,
                 Footprint: d3d12::D3D12_SUBRESOURCE_FOOTPRINT {
                     Format: raw_format,
-                    Width: r.size.width,
+                    Width: uprounded_size.width,
                     Height: r
                         .buffer_layout
                         .rows_per_image
-                        .map_or(r.size.height, |count| count.get()),
-                    Depth: r.size.depth,
+                        .map_or(uprounded_size.height, |count| count.get() * block_size),
+                    Depth: uprounded_size.depth,
                     RowPitch: r.buffer_layout.bytes_per_row.map_or(0, |count| count.get()),
                 },
             };


### PR DESCRIPTION
**Connections**

This simply implements compressed textures for DX12

**Description**

Just needed to properly upround all of sizes to the block size.

**Testing**

Skybox BC1 test now passes
