### PR TITLE
Fix the check for depth+stencil aspect of views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TBD
   - All:
     - expose more formats via adapter-specific feature
+    - fix creation of depth+stencil views
   - Metal:
     - fix usage of work group memory
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1568,7 +1568,9 @@ impl<A: HalApi> Device<A> {
         expected: &'static str,
     ) -> Result<(wgt::TextureUsages, hal::TextureUses), binding_model::CreateBindGroupError> {
         use crate::binding_model::CreateBindGroupError as Error;
-        if hal::FormatAspects::from(view.desc.format)
+        if view
+            .desc
+            .aspects()
             .contains(hal::FormatAspects::DEPTH | hal::FormatAspects::STENCIL)
         {
             return Err(Error::DepthStencilAspect);


### PR DESCRIPTION
**Connections**
Fixes #1835

**Description**
The check didn't take into account `wgt::TextureAspect` enum of the view.

**Testing**
Tested on the modified water example.
