### PR TITLE
fixed mip level count check for storage textures

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -136,6 +136,8 @@ pub enum CreateBindGroupError {
         layout_format: wgt::TextureFormat,
         view_format: wgt::TextureFormat,
     },
+    #[error("storage texture bindings must have a single mip level, but given a view with mip_level_count = {mip_level_count:?} at binding {binding}")]
+    InvalidStorageTextureMipLevelCount { binding: u32, mip_level_count: u32 },
     #[error("sampler binding {binding} expects comparison = {layout_cmp}, but given a sampler with comparison = {sampler_cmp}")]
     WrongSamplerComparison {
         binding: u32,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -773,7 +773,7 @@ impl<A: HalApi> Device<A> {
                 }
                 _ => hal::TextureUses::all(),
             };
-            let mask_mip_level = if end_layer != desc.range.base_array_layer + 1 {
+            let mask_mip_level = if selector.levels.end - selector.levels.start != 1 {
                 hal::TextureUses::RESOURCE
             } else {
                 hal::TextureUses::all()
@@ -1657,6 +1657,15 @@ impl<A: HalApi> Device<A> {
                         view_dimension: view.desc.dimension,
                     });
                 }
+
+                let mip_level_count = view.selector.levels.end - view.selector.levels.start;
+                if mip_level_count != 1 {
+                    return Err(Error::InvalidStorageTextureMipLevelCount {
+                        binding,
+                        mip_level_count,
+                    });
+                }
+
                 let internal_use = match access {
                     wgt::StorageTextureAccess::WriteOnly => hal::TextureUses::STORAGE_WRITE,
                     wgt::StorageTextureAccess::ReadOnly => {


### PR DESCRIPTION
**Connections**
matrix chat

**Description**
The texture view usage was missing the storage flag, because of the wrong mip level count check. This caused a device lost error.

**Testing**
Writing a cubemap as a storage texture with a 2d array texture view now works.
