### PR TITLE
[Vulkan] Initialize wgpu objects from raw handles, part 2

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -774,6 +774,7 @@ impl super::Adapter {
     pub unsafe fn device_from_raw(
         &self,
         raw_device: ash::Device,
+        handle_is_owned: bool,
         enabled_extensions: &[&'static CStr],
         family_index: u32,
         queue_index: u32,
@@ -845,6 +846,7 @@ impl super::Adapter {
 
         let shared = Arc::new(super::DeviceShared {
             raw: raw_device,
+            handle_is_owned,
             instance: Arc::clone(&self.instance),
             extension_fns: super::DeviceExtensionFunctions {
                 draw_indirect_count: indirect_count_fn,
@@ -944,6 +946,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
 
         self.device_from_raw(
             raw_device,
+            true,
             &enabled_extensions,
             family_info.queue_family_index,
             0,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -81,7 +81,7 @@ struct DebugUtils {
 
 struct InstanceShared {
     raw: ash::Instance,
-    _drop_guard: DropGuard,
+    drop_guard: Option<DropGuard>,
     flags: crate::InstanceFlags,
     debug_utils: Option<DebugUtils>,
     get_physical_device_properties: Option<vk::KhrGetPhysicalDeviceProperties2Fn>,
@@ -216,6 +216,7 @@ struct FramebufferKey {
 
 struct DeviceShared {
     raw: ash::Device,
+    handle_is_owned: bool,
     instance: Arc<InstanceShared>,
     extension_fns: DeviceExtensionFunctions,
     vendor_id: u32,


### PR DESCRIPTION
**Connections**

#1609

**Description**

While #1609 was needed to support OpenXR applications, this PR aims to support OpenXR runtime/SteamVR drivers implementations. `Instance::from_raw()`, `Adapter::device_from_raw()` and `Device::texture_from_raw()` are made more flexible to accomodate both use-cases.

Recap:

(With ownership I mean the responsibility of destroying the object)  
In a OpenXR game, the instance and device are created by the runtime and owned by the application. The session is created by the runtime using the instance and device and owned by the application. The swapchain textures are created by the runtime and owned by the runtime. Wgpu textures used to access the swapchain are created by the application and the handles are owned by the runtime.  
The wgpu textures must go out of scope before destroying the swapchain and session, which must be destroyed before destroying the device and instance. Drop guards are used as barriers to prevent the drop of objects on which `Instance` and `Texture` depends on, by keeping a reference to it. The presence or absence of drop guards is used also as flag for deciding if to destroy the underlying Vulkan object (`drop_guard == Some` for `Instance::from_raw()`, `drop_guard == None` for `Device::texture_from_raw()`).

This table summarizes the argument values that should be used for each call:

|                Call                 |    OpenXR application     |       OpenXR runtime       |
| :---------------------------------: | :-----------------------: | :------------------------: |
|       `Instance::from_raw()`        |   `drop_guard == Some`    |    `drop_guard == None`    |
|    `Adapter::device_from_raw()`     | `handle_is_owned == true` | `handle_is_owned == false` |
| `Device::texture_from_raw()` |   `drop_guard == Some`    |    `drop_guard == None`    |

The OpenXR runtime does not need drop guards since it's the client application that is resposible for managing the lifetime and drop order of the objects. The device does not use the `drop_guard` because not needed to enforce drop safety in the context of OpenXR.

**Testing**
None for now. I need https://github.com/MaikKlein/ash/pull/457 to be merged (and then wgpu to be updated with the new ash verison), which is orthogonal to this PR.
