### PR TITLE
Bump the vertex buffer sizes by 1

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -504,6 +504,9 @@ impl<A: HalApi> Device<A> {
 
         let actual_size = if desc.size == 0 {
             wgt::COPY_BUFFER_ALIGNMENT
+        } else if desc.usage.contains(wgt::BufferUsages::VERTEX) {
+            // Bumping the size by 1 so that we can bind an empty range at the end of the buffer.
+            desc.size + 1
         } else {
             desc.size
         };


### PR DESCRIPTION
**Connections**
Matches https://github.com/gpuweb/gpuweb/issues/2044#issuecomment-904077569

**Description**
Vulkan doesn't like vertex buffers bound at the end of the range.
This change adds 1 to all vertex buffers.

Impl note: it would be better to only do this for Vulkan, but then it would have a weird interaction with buffer zeroing. Since zeroing is handled on wgpu-core side, it needs to know the actual size of the buffer. Maybe we can revisit this later?

**Testing**
Untested
