### PR TITLE
hal/dx12: do not reverse the pipeline layout

### DIFF
--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -162,6 +162,7 @@ impl super::CommandEncoder {
     }
 
     fn reset_signature(&mut self, layout: &super::PipelineLayoutShared) {
+        log::trace!("Reset signature {:?}", layout.signature);
         if let Some(root_index) = layout.special_constants_root_index {
             self.pass.root_elements[root_index as usize] =
                 super::RootElement::SpecialConstantBuffer {
@@ -701,11 +702,13 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         group: &super::BindGroup,
         dynamic_offsets: &[wgt::DynamicOffset],
     ) {
+        log::trace!("Set group[{}]", index);
         let info = &layout.bind_group_infos[index as usize];
         let mut root_index = info.base_root_index as usize;
 
         // Bind CBV/SRC/UAV descriptor tables
         if info.tables.contains(super::TableTypes::SRV_CBV_UAV) {
+            log::trace!("\tBind element[{}] = view", root_index);
             self.pass.root_elements[root_index] =
                 super::RootElement::Table(group.handle_views.unwrap().gpu);
             root_index += 1;
@@ -713,6 +716,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 
         // Bind Sampler descriptor tables.
         if info.tables.contains(super::TableTypes::SAMPLERS) {
+            log::trace!("\tBind element[{}] = sampler", root_index);
             self.pass.root_elements[root_index] =
                 super::RootElement::Table(group.handle_samplers.unwrap().gpu);
             root_index += 1;
@@ -725,6 +729,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             .zip(group.dynamic_buffers.iter())
             .zip(dynamic_offsets)
         {
+            log::trace!("\tBind element[{}] = dynamic", root_index);
             self.pass.root_elements[root_index] = super::RootElement::DynamicOffsetBuffer {
                 kind,
                 address: gpu_base + offset as native::GpuAddress,


### PR DESCRIPTION
**Connections**
Fixes a validation error in DX12 that I found in one of the vange-rs code paths

**Description**
Since the idea of reversed layout came to the code, I fixed it twice (last time in #1744), and now it turns out there is not enough foundation for it to settle at all. Imagine the following scenario:
- BGLs: A, B, C, D
- PL[1]: A, B, C
- PL[2]: A, D

When switching from PL[1] to PL[2] wgpu-core doesn't try to re-bind `A`, since it's already bound, and it's preceeding any entries that changed. With reversed layout, however, `A` in these two pipeline layouts would occupy different slots. So it would have to be re-bound completely (as opposed to just marking the root signature elements as dirty).

So TL;DR: we can't do this right now because wgpu-core follows Vulkan pipeline compatibility rules. There is no principal reason for this: we could change the behavior based on the backend, but that's just the way it works now.

**Testing**
vange-rs
