### PR TITLE
Switch naga to latest on git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,8 +967,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70938c43114c164e8ef86e608b39e68d3e4c8bca25e105bf4a3e788042a804a"
+source = "git+https://github.com/gfx-rs/naga?rev=93db57c#93db57c12b4a5eff48bdd00c494efa5ec89567ad"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -35,9 +35,9 @@ smallvec = "1"
 thiserror = "1"
 
 [dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "4e181d6"
-version = "0.6"
+git = "https://github.com/gfx-rs/naga"
+rev = "93db57c"
+#version = "0.6"
 features = ["wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -68,14 +68,14 @@ objc = "0.2.5"
 core-graphics-types = "0.1"
 
 [dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "4e181d6"
-version = "0.6"
+git = "https://github.com/gfx-rs/naga"
+rev = "93db57c"
+#version = "0.6"
 
 [dev-dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "4e181d6"
-version = "0.6"
+git = "https://github.com/gfx-rs/naga"
+rev = "93db57c"
+#version = "0.6"
 features = ["wgsl-in"]
 
 [dev-dependencies]

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -836,7 +836,8 @@ impl super::Adapter {
                 lang_version: (1, 0),
                 flags,
                 capabilities: Some(capabilities.iter().cloned().collect()),
-                index_bounds_check_policy: naga::back::IndexBoundsCheckPolicy::Restrict,
+                index_bounds_check_policy: naga::back::BoundsCheckPolicy::Restrict,
+                image_bounds_check_policy: naga::back::BoundsCheckPolicy::Restrict,
             }
         };
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -88,16 +88,16 @@ pollster = "0.2"
 env_logger = "0.8"
 
 [dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "4e181d6"
-version = "0.6"
+git = "https://github.com/gfx-rs/naga"
+rev = "93db57c"
+#version = "0.6"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "4e181d6"
-version = "0.6"
+git = "https://github.com/gfx-rs/naga"
+rev = "93db57c"
+#version = "0.6"
 features = ["wgsl-in"]
 
 [[example]]


### PR DESCRIPTION
**Connections**
Picks up https://github.com/gfx-rs/naga/pull/1247 and a bag of other fixes.

**Description**
Switching back to git dependency now (was temporary pointing to crates during release)

**Testing**
integrated!
