### PR TITLE
hal/metal: configure Surface::render_layer contentSize

### DIFF
--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -233,7 +233,12 @@ fn start<E: Example>(
                 window.request_redraw();
             }
             event::Event::WindowEvent {
-                event: WindowEvent::Resized(size),
+                event:
+                    WindowEvent::Resized(size)
+                    | WindowEvent::ScaleFactorChanged {
+                        new_inner_size: &mut size,
+                        ..
+                    },
                 ..
             } => {
                 log::info!("Resizing to {:?}", size);


### PR DESCRIPTION
**Connections**
Fixes #1872 

**Description**
Makes sure that a surface has the correct content scaling for the window's current monitor after a `Surface::configure`.

**Testing**
See the repro steps in the linked issue.