### PR TITLE
example-framework: resize surface on scale factor change

### DIFF
--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -233,7 +233,12 @@ fn start<E: Example>(
                 window.request_redraw();
             }
             event::Event::WindowEvent {
-                event: WindowEvent::Resized(size),
+                event:
+                    WindowEvent::Resized(size)
+                    | WindowEvent::ScaleFactorChanged {
+                        new_inner_size: &mut size,
+                        ..
+                    },
                 ..
             } => {
                 log::info!("Resizing to {:?}", size);


### PR DESCRIPTION
**Connections**
See discussion in #1874 

**Description**
`winit` does not send `Resized` events when the scale factor changes (such as when moving a window between monitors with different DPI). This change makes sure that the surface's size is always up-to-date.

**Testing**
Manual testing using the `cube` example.