### PR TITLE
Add Texture::as_hal()

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -859,7 +859,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         trace_path: Option<&std::path::Path>,
         id_in: Input<G, DeviceId>,
     ) -> (DeviceId, Option<RequestDeviceError>) {
-        profiling::scope!("request_device", "Adapter");
+        profiling::scope!("create_device_from_hal", "Adapter");
 
         let hub = A::hub(self);
         let mut token = Token::root();

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -268,6 +268,15 @@ pub struct Texture {
     raw_flags: vk::ImageCreateFlags,
 }
 
+impl Texture {
+    /// # Safety
+    ///
+    /// - The image handle must not be manually destroyed
+    pub unsafe fn raw_handle(&self) -> vk::Image {
+        self.raw
+    }
+}
+
 #[derive(Debug)]
 pub struct TextureView {
     raw: vk::ImageView,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -118,6 +118,15 @@ impl Context {
         }
     }
 
+    pub unsafe fn texture_as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Texture>)>(
+        &self,
+        texture: &Texture,
+        hal_texture_callback: F,
+    ) {
+        self.0
+            .texture_as_hal::<A, F>(texture.id, hal_texture_callback)
+    }
+
     pub fn generate_report(&self) -> wgc::hub::GlobalReport {
         self.0.generate_report()
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2075,6 +2075,21 @@ impl Drop for Buffer {
 }
 
 impl Texture {
+    /// Returns the inner hal Texture using a callback. The hal texture will be `None` if the
+    /// backend type argument does not match with this wgpu Texture
+    ///
+    /// # Safety
+    ///
+    /// - The raw handle obtained from the hal Texture must not be manually destroyed
+    #[cfg(not(target_arch = "wasm32"))]
+    pub unsafe fn as_hal<A: wgc::hub::HalApi>(
+        &self,
+        hal_texture_callback: impl FnOnce(Option<&A::Texture>),
+    ) {
+        self.context
+            .texture_as_hal::<A, _>(&self.id, hal_texture_callback)
+    }
+
     /// Creates a view of this texture.
     pub fn create_view(&self, desc: &TextureViewDescriptor) -> TextureView {
         TextureView {


### PR DESCRIPTION
**Connections**
#1850

**Description**
As proposed in https://github.com/gfx-rs/wgpu/pull/1850#issuecomment-903812856, in this PR I try to expose a way to access a hal Texture (and `vk::Image`) from `wgpu::Texture`. To work around lifetimes I had to use two hacks: `Registry::unsafe_read()` and `HalTextureGuard`. `HalTextureGuard` is needed to keep around a reference to a `RwLockReadGuard` while the hal texture is being read. `Registry::unsafe_read()` allows to skip the need for a `Token`. I'm not sure what invariants I'm breaking with `Registry::unsafe_read()`, but having access to the `vk::Image` would break all invariants anyway.

For `Instance` and `Device` I do not need to expose the inner hal object, as this can more easily worked around with the existing `create_*_from_hal()` methods.

This PR doesn't need to be merged just yet. I want to know if there is something that I can do better.

**Testing**
None yet, but I tested the API ergonomics [here](https://github.com/alvr-org/ALVR/blob/master/alvr/experiments/graphics_tests/src/convert.rs).
