### PR TITLE
hal/metal: support Features::NON_FILL_POLYGON_MODE

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2096,8 +2096,12 @@ impl<A: HalApi> Device<A> {
         if desc.primitive.clamp_depth {
             self.require_features(wgt::Features::DEPTH_CLAMPING)?;
         }
-        if desc.primitive.polygon_mode != wgt::PolygonMode::Fill {
-            self.require_features(wgt::Features::NON_FILL_POLYGON_MODE)?;
+
+        if desc.primitive.polygon_mode == wgt::PolygonMode::Line {
+            self.require_features(wgt::Features::LINE_POLYGON_MODE)?;
+        }
+        if desc.primitive.polygon_mode == wgt::PolygonMode::Point {
+            self.require_features(wgt::Features::POINT_POLYGON_MODE)?;
         }
 
         if desc.primitive.conservative {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2098,10 +2098,10 @@ impl<A: HalApi> Device<A> {
         }
 
         if desc.primitive.polygon_mode == wgt::PolygonMode::Line {
-            self.require_features(wgt::Features::LINE_POLYGON_MODE)?;
+            self.require_features(wgt::Features::POLYGON_MODE_LINE)?;
         }
         if desc.primitive.polygon_mode == wgt::PolygonMode::Point {
-            self.require_features(wgt::Features::POINT_POLYGON_MODE)?;
+            self.require_features(wgt::Features::POLYGON_MODE_POINT)?;
         }
 
         if desc.primitive.conservative {

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -174,8 +174,8 @@ impl super::Adapter {
             | wgt::Features::MULTI_DRAW_INDIRECT
             | wgt::Features::MULTI_DRAW_INDIRECT_COUNT
             | wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER
-            | wgt::Features::LINE_POLYGON_MODE
-            | wgt::Features::POINT_POLYGON_MODE
+            | wgt::Features::POLYGON_MODE_LINE
+            | wgt::Features::POLYGON_MODE_POINT
             | wgt::Features::VERTEX_WRITABLE_STORAGE
             | wgt::Features::TIMESTAMP_QUERY;
         //TODO: in order to expose this, we need to run a compute shader

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -174,7 +174,8 @@ impl super::Adapter {
             | wgt::Features::MULTI_DRAW_INDIRECT
             | wgt::Features::MULTI_DRAW_INDIRECT_COUNT
             | wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER
-            | wgt::Features::NON_FILL_POLYGON_MODE
+            | wgt::Features::LINE_POLYGON_MODE
+            | wgt::Features::POINT_POLYGON_MODE
             | wgt::Features::VERTEX_WRITABLE_STORAGE
             | wgt::Features::TIMESTAMP_QUERY;
         //TODO: in order to expose this, we need to run a compute shader

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -232,8 +232,8 @@ pub fn map_primitive_topology(topology: wgt::PrimitiveTopology) -> u32 {
 }
 
 pub(super) fn map_primitive_state(state: &wgt::PrimitiveState) -> super::PrimitiveState {
-    //Note: state.polygon_mode is not supported, see `Features::LINE_POLYGON_MODE` and
-    //`Features::POINT_POLYGON_MODE`
+    //Note: state.polygon_mode is not supported, see `Features::POLYGON_MODE_LINE` and
+    //`Features::POLYGON_MODE_POINT`
     super::PrimitiveState {
         //Note: we are flipping the front face, so that
         // the Y-flip in the generated GLSL keeps the same visibility.

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -232,7 +232,8 @@ pub fn map_primitive_topology(topology: wgt::PrimitiveTopology) -> u32 {
 }
 
 pub(super) fn map_primitive_state(state: &wgt::PrimitiveState) -> super::PrimitiveState {
-    //Note: state.polygon_mode is not supported, see `Features::NON_FILL_POLYGON_MODE`
+    //Note: state.polygon_mode is not supported, see `Features::LINE_POLYGON_MODE` and
+    //`Features::POINT_POLYGON_MODE`
     super::PrimitiveState {
         //Note: we are flipping the front face, so that
         // the Y-flip in the generated GLSL keeps the same visibility.

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -862,7 +862,7 @@ impl super::PrivateCapabilities {
             | F::MAPPABLE_PRIMARY_BUFFERS
             | F::VERTEX_WRITABLE_STORAGE
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | F::NON_FILL_POLYGON_MODE;
+            | F::LINE_POLYGON_MODE;
 
         features.set(
             F::TEXTURE_BINDING_ARRAY

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -861,7 +861,8 @@ impl super::PrivateCapabilities {
             | F::TEXTURE_COMPRESSION_BC
             | F::MAPPABLE_PRIMARY_BUFFERS
             | F::VERTEX_WRITABLE_STORAGE
-            | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
+            | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
+            | F::NON_FILL_POLYGON_MODE;
 
         features.set(
             F::TEXTURE_BINDING_ARRAY

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -862,7 +862,7 @@ impl super::PrivateCapabilities {
             | F::MAPPABLE_PRIMARY_BUFFERS
             | F::VERTEX_WRITABLE_STORAGE
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | F::LINE_POLYGON_MODE;
+            | F::POLYGON_MODE_LINE;
 
         features.set(
             F::TEXTURE_BINDING_ARRAY

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -587,6 +587,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         encoder.set_render_pipeline_state(&pipeline.raw);
         encoder.set_front_facing_winding(pipeline.raw_front_winding);
         encoder.set_cull_mode(pipeline.raw_cull_mode);
+        encoder.set_triangle_fill_mode(pipeline.raw_triangle_fill_mode);
         if let Some(depth_clip) = pipeline.raw_depth_clip_mode {
             encoder.set_depth_clip_mode(depth_clip);
         }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -707,10 +707,14 @@ impl crate::Device<super::Api> for super::Device {
         let raw_triangle_fill_mode = match desc.primitive.polygon_mode {
             wgt::PolygonMode::Fill => mtl::MTLTriangleFillMode::Fill,
             wgt::PolygonMode::Line => mtl::MTLTriangleFillMode::Lines,
-            wgt::PolygonMode::Point => panic!("{:?} is not enabled for this backend", wgt::Features::POINT_POLYGON_MODE),
+            wgt::PolygonMode::Point => panic!(
+                "{:?} is not enabled for this backend",
+                wgt::Features::POINT_POLYGON_MODE
+            ),
         };
 
-        let (primitive_class, raw_primitive_type) = conv::map_primitive_topology(desc.primitive.topology);
+        let (primitive_class, raw_primitive_type) =
+            conv::map_primitive_topology(desc.primitive.topology);
 
         let vs = self.load_shader(
             &desc.vertex_stage,

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -704,19 +704,13 @@ impl crate::Device<super::Api> for super::Device {
     ) -> Result<super::RenderPipeline, crate::PipelineError> {
         let descriptor = mtl::RenderPipelineDescriptor::new();
 
-        let (topology, raw_triangle_fill_mode) = match desc.primitive.polygon_mode {
-            wgt::PolygonMode::Fill => (desc.primitive.topology, mtl::MTLTriangleFillMode::Fill),
-            wgt::PolygonMode::Line => (desc.primitive.topology, mtl::MTLTriangleFillMode::Lines),
-            // If rendering points, topology (order of indices/vertices) does not matter.
-            // Therefore, no matter what the input topology is (eg. TriangleStrip, Lines, ...) the
-            // points will be rendered correctly.
-            wgt::PolygonMode::Point => (
-                wgt::PrimitiveTopology::PointList,
-                mtl::MTLTriangleFillMode::Fill,
-            ),
+        let raw_triangle_fill_mode = match desc.primitive.polygon_mode {
+            wgt::PolygonMode::Fill => mtl::MTLTriangleFillMode::Fill,
+            wgt::PolygonMode::Line => mtl::MTLTriangleFillMode::Lines,
+            wgt::PolygonMode::Point => panic!("{:?} is not enabled for this backend", wgt::Features::POINT_POLYGON_MODE),
         };
 
-        let (primitive_class, raw_primitive_type) = conv::map_primitive_topology(topology);
+        let (primitive_class, raw_primitive_type) = conv::map_primitive_topology(desc.primitive.topology);
 
         let vs = self.load_shader(
             &desc.vertex_stage,

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -709,7 +709,7 @@ impl crate::Device<super::Api> for super::Device {
             wgt::PolygonMode::Line => mtl::MTLTriangleFillMode::Lines,
             wgt::PolygonMode::Point => panic!(
                 "{:?} is not enabled for this backend",
-                wgt::Features::POINT_POLYGON_MODE
+                wgt::Features::POLYGON_MODE_POINT
             ),
         };
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -617,6 +617,7 @@ pub struct RenderPipeline {
     vs_info: PipelineStageInfo,
     fs_info: PipelineStageInfo,
     raw_primitive_type: mtl::MTLPrimitiveType,
+    raw_triangle_fill_mode: mtl::MTLTriangleFillMode,
     raw_front_winding: mtl::MTLWinding,
     raw_cull_mode: mtl::MTLCullMode,
     raw_depth_clip_mode: Option<mtl::MTLDepthClipMode>,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -70,10 +70,9 @@ impl PhysicalDeviceFeatures {
                     requested_features.contains(wgt::Features::MULTI_DRAW_INDIRECT),
                 )
                 .depth_clamp(requested_features.contains(wgt::Features::DEPTH_CLAMPING))
-                .fill_mode_non_solid(
-                    requested_features.contains(wgt::Features::LINE_POLYGON_MODE)
-                        | requested_features.contains(wgt::Features::POINT_POLYGON_MODE),
-                )
+                .fill_mode_non_solid(requested_features.intersects(
+                    wgt::Features::POLYGON_MODE_LINE | wgt::Features::POLYGON_MODE_POINT,
+                ))
                 //.depth_bounds(requested_features.contains(wgt::Features::DEPTH_BOUNDS))
                 //.alpha_to_one(requested_features.contains(wgt::Features::ALPHA_TO_ONE))
                 //.multi_viewport(requested_features.contains(wgt::Features::MULTI_VIEWPORTS))
@@ -256,8 +255,8 @@ impl PhysicalDeviceFeatures {
         //if self.core.dual_src_blend != 0
         features.set(F::MULTI_DRAW_INDIRECT, self.core.multi_draw_indirect != 0);
         features.set(F::DEPTH_CLAMPING, self.core.depth_clamp != 0);
-        features.set(F::LINE_POLYGON_MODE, self.core.fill_mode_non_solid != 0);
-        features.set(F::POINT_POLYGON_MODE, self.core.fill_mode_non_solid != 0);
+        features.set(F::POLYGON_MODE_LINE, self.core.fill_mode_non_solid != 0);
+        features.set(F::POLYGON_MODE_POINT, self.core.fill_mode_non_solid != 0);
         //if self.core.depth_bounds != 0 {
         //if self.core.alpha_to_one != 0 {
         //if self.core.multi_viewport != 0 {

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -71,7 +71,8 @@ impl PhysicalDeviceFeatures {
                 )
                 .depth_clamp(requested_features.contains(wgt::Features::DEPTH_CLAMPING))
                 .fill_mode_non_solid(
-                    requested_features.contains(wgt::Features::NON_FILL_POLYGON_MODE),
+                    requested_features.contains(wgt::Features::LINE_POLYGON_MODE)
+                        | requested_features.contains(wgt::Features::POINT_POLYGON_MODE),
                 )
                 //.depth_bounds(requested_features.contains(wgt::Features::DEPTH_BOUNDS))
                 //.alpha_to_one(requested_features.contains(wgt::Features::ALPHA_TO_ONE))
@@ -255,7 +256,8 @@ impl PhysicalDeviceFeatures {
         //if self.core.dual_src_blend != 0
         features.set(F::MULTI_DRAW_INDIRECT, self.core.multi_draw_indirect != 0);
         features.set(F::DEPTH_CLAMPING, self.core.depth_clamp != 0);
-        features.set(F::NON_FILL_POLYGON_MODE, self.core.fill_mode_non_solid != 0);
+        features.set(F::LINE_POLYGON_MODE, self.core.fill_mode_non_solid != 0);
+        features.set(F::POINT_POLYGON_MODE, self.core.fill_mode_non_solid != 0);
         //if self.core.depth_bounds != 0 {
         //if self.core.alpha_to_one != 0 {
         //if self.core.multi_viewport != 0 {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -406,7 +406,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const LINE_POLYGON_MODE= 1 << 27;
+        const POLYGON_MODE_LINE= 1 << 27;
         /// Allows the user to set [`PolygonMode::Point`] in [`PrimitiveState::polygon_mode`]
         ///
         /// This allows only drawing the vertices of polygons/triangles instead of filled
@@ -416,7 +416,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const POINT_POLYGON_MODE = 1 << 28;
+        const POLYGON_MODE_POINT = 1 << 28;
         /// Enables ETC family of compressed textures. All ETC textures use 4x4 pixel blocks.
         /// ETC2 RGB and RGBA1 are 8 bytes per block. RTC2 RGBA8 and EAC are 16 bytes per block.
         ///
@@ -1240,9 +1240,9 @@ pub struct PrimitiveState {
     pub clamp_depth: bool,
     /// Controls the way each polygon is rasterized. Can be either `Fill` (default), `Line` or `Point`
     ///
-    /// Setting this to `Line` requires `Features::LINE_POLYGON_MODE` to be enabled.
+    /// Setting this to `Line` requires `Features::POLYGON_MODE_LINE` to be enabled.
     ///
-    /// Setting this to `Point` requires `Features::POINT_POLYGON_MODE` to be enabled.
+    /// Setting this to `Point` requires `Features::POLYGON_MODE_POINT` to be enabled.
     #[cfg_attr(feature = "serde", serde(default))]
     pub polygon_mode: PolygonMode,
     /// If set to true, the primitives are rendered with conservative overestimation. I.e. any rastered pixel touched by it is filled.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -396,9 +396,9 @@ bitflags::bitflags! {
         ///
         /// This is a web and native feature.
         const ADDRESS_MODE_CLAMP_TO_BORDER = 1 << 26;
-        /// Allows the user to set a non-fill polygon mode in [`PrimitiveState::polygon_mode`]
+        /// Allows the user to set [`PolygonMode::Line`] in [`PrimitiveState::polygon_mode`]
         ///
-        /// This allows drawing polygons/triangles as lines (wireframe) or points instead of filled
+        /// This allows drawing polygons/triangles as lines (wireframe) instead of filled
         ///
         /// Supported platforms:
         /// - DX12
@@ -406,7 +406,17 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const NON_FILL_POLYGON_MODE = 1 << 27;
+        const LINE_POLYGON_MODE= 1 << 27;
+        /// Allows the user to set [`PolygonMode::Point`] in [`PrimitiveState::polygon_mode`]
+        ///
+        /// This allows only drawing the vertices of polygons/triangles instead of filled
+        ///
+        /// Supported platforms:
+        /// - DX12
+        /// - Vulkan
+        ///
+        /// This is a native only feature.
+        const POINT_POLYGON_MODE = 1 << 28;
         /// Enables ETC family of compressed textures. All ETC textures use 4x4 pixel blocks.
         /// ETC2 RGB and RGBA1 are 8 bytes per block. RTC2 RGBA8 and EAC are 16 bytes per block.
         ///
@@ -421,7 +431,7 @@ bitflags::bitflags! {
         /// - Mobile (some)
         ///
         /// This is a native-only feature.
-        const TEXTURE_COMPRESSION_ETC2 = 1 << 28;
+        const TEXTURE_COMPRESSION_ETC2 = 1 << 29;
         /// Enables ASTC family of compressed textures. ASTC textures use pixel blocks varying from 4x4 to 12x12.
         /// Blocks are always 16 bytes.
         ///
@@ -436,7 +446,7 @@ bitflags::bitflags! {
         /// - Mobile (some)
         ///
         /// This is a native-only feature.
-        const TEXTURE_COMPRESSION_ASTC_LDR = 1 << 29;
+        const TEXTURE_COMPRESSION_ASTC_LDR = 1 << 30;
         /// Enables device specific texture format features.
         ///
         /// See `TextureFormatFeatures` for a listing of the features in question.
@@ -448,7 +458,7 @@ bitflags::bitflags! {
         /// This extension does not enable additional formats.
         ///
         /// This is a native-only feature.
-        const TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 1 << 30;
+        const TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 1 << 31;
         /// Enables 64-bit floating point types in SPIR-V shaders.
         ///
         /// Note: even when supported by GPU hardware, 64-bit floating point operations are
@@ -458,7 +468,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native-only feature.
-        const SHADER_FLOAT64 = 1 << 31;
+        const SHADER_FLOAT64 = 1 << 32;
         /// Enables using 64-bit types for vertex attributes.
         ///
         /// Requires SHADER_FLOAT64.
@@ -466,7 +476,7 @@ bitflags::bitflags! {
         /// Supported Platforms: N/A
         ///
         /// This is a native-only feature.
-        const VERTEX_ATTRIBUTE_64BIT = 1 << 32;
+        const VERTEX_ATTRIBUTE_64BIT = 1 << 33;
         /// Allows the user to set a overestimation-conservative-rasterization in [`PrimitiveState::conservative`]
         ///
         /// Processing of degenerate triangles/lines is hardware specific.
@@ -476,7 +486,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const CONSERVATIVE_RASTERIZATION = 1 << 33;
+        const CONSERVATIVE_RASTERIZATION = 1 << 34;
         /// Enables bindings of writable storage buffers and textures visible to vertex shaders.
         ///
         /// Note: some (tiled-based) platforms do not support vertex shaders with any side-effects.
@@ -485,14 +495,14 @@ bitflags::bitflags! {
         /// - All
         ///
         /// This is a native-only feature.
-        const VERTEX_WRITABLE_STORAGE = 1 << 34;
+        const VERTEX_WRITABLE_STORAGE = 1 << 35;
         /// Enables clear to zero for buffers & images.
         ///
         /// Supported platforms:
         /// - All
         ///
         /// This is a native only feature.
-        const CLEAR_COMMANDS = 1 << 35;
+        const CLEAR_COMMANDS = 1 << 36;
         /// Enables creating shader modules from SPIR-V binary data (unsafe).
         ///
         /// SPIR-V data is not parsed or interpreted in any way; you can use
@@ -504,7 +514,7 @@ bitflags::bitflags! {
         /// Vulkan implementation.
         ///
         /// This is a native only feature.
-        const SPIRV_SHADER_PASSTHROUGH = 1 << 36;
+        const SPIRV_SHADER_PASSTHROUGH = 1 << 37;
         /// Enables `builtin(primitive_index)` in fragment shaders.
         ///
         /// Note: enables geometry processing for pipelines using the builtin.
@@ -515,7 +525,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const SHADER_PRIMITIVE_INDEX = 1 << 37;
+        const SHADER_PRIMITIVE_INDEX = 1 << 38;
     }
 }
 
@@ -1230,7 +1240,9 @@ pub struct PrimitiveState {
     pub clamp_depth: bool,
     /// Controls the way each polygon is rasterized. Can be either `Fill` (default), `Line` or `Point`
     ///
-    /// Setting this to something other than `Fill` requires `Features::NON_FILL_POLYGON_MODE` to be enabled.
+    /// Setting this to `Line` requires `Features::LINE_POLYGON_MODE` to be enabled.
+    ///
+    /// Setting this to `Point` requires `Features::POINT_POLYGON_MODE` to be enabled.
     #[cfg_attr(feature = "serde", serde(default))]
     pub polygon_mode: PolygonMode,
     /// If set to true, the primitives are rendered with conservative overestimation. I.e. any rastered pixel touched by it is filled.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -403,6 +403,7 @@ bitflags::bitflags! {
         /// Supported platforms:
         /// - DX12
         /// - Vulkan
+        /// - Metal
         ///
         /// This is a native only feature.
         const NON_FILL_POLYGON_MODE = 1 << 27;

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -70,7 +70,7 @@ impl framework::Example for Example {
         wgpu::Features::CONSERVATIVE_RASTERIZATION
     }
     fn optional_features() -> wgpu::Features {
-        wgpu::Features::LINE_POLYGON_MODE
+        wgpu::Features::POLYGON_MODE_LINE
     }
     fn init(
         config: &wgpu::SurfaceConfiguration,
@@ -136,7 +136,7 @@ impl framework::Example for Example {
 
         let pipeline_lines = if device
             .features()
-            .contains(wgpu::Features::LINE_POLYGON_MODE)
+            .contains(wgpu::Features::POLYGON_MODE_LINE)
         {
             Some(
                 device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -70,7 +70,7 @@ impl framework::Example for Example {
         wgpu::Features::CONSERVATIVE_RASTERIZATION
     }
     fn optional_features() -> wgpu::Features {
-        wgpu::Features::NON_FILL_POLYGON_MODE
+        wgpu::Features::LINE_POLYGON_MODE
     }
     fn init(
         config: &wgpu::SurfaceConfiguration,
@@ -136,7 +136,7 @@ impl framework::Example for Example {
 
         let pipeline_lines = if device
             .features()
-            .contains(wgpu::Features::NON_FILL_POLYGON_MODE)
+            .contains(wgpu::Features::LINE_POLYGON_MODE)
         {
             Some(
                 device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -108,7 +108,7 @@ impl Example {
 
 impl framework::Example for Example {
     fn optional_features() -> wgt::Features {
-        wgt::Features::LINE_POLYGON_MODE
+        wgt::Features::POLYGON_MODE_LINE
     }
 
     fn init(
@@ -262,7 +262,7 @@ impl framework::Example for Example {
             multisample: wgpu::MultisampleState::default(),
         });
 
-        let pipeline_wire = if device.features().contains(wgt::Features::LINE_POLYGON_MODE) {
+        let pipeline_wire = if device.features().contains(wgt::Features::POLYGON_MODE_LINE) {
             let pipeline_wire = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: None,
                 layout: Some(&pipeline_layout),
@@ -396,7 +396,7 @@ fn cube_lines() {
         image_path: "/examples/cube/screenshot-lines.png",
         width: 1024,
         height: 768,
-        optional_features: wgpu::Features::LINE_POLYGON_MODE,
+        optional_features: wgpu::Features::POLYGON_MODE_LINE,
         base_test_parameters: framework::test_common::TestParameters::default(),
         tolerance: 2,
         max_outliers: 600, // Bounded by rpi4 on GL

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -108,7 +108,7 @@ impl Example {
 
 impl framework::Example for Example {
     fn optional_features() -> wgt::Features {
-        wgt::Features::NON_FILL_POLYGON_MODE
+        wgt::Features::LINE_POLYGON_MODE
     }
 
     fn init(
@@ -262,10 +262,7 @@ impl framework::Example for Example {
             multisample: wgpu::MultisampleState::default(),
         });
 
-        let pipeline_wire = if device
-            .features()
-            .contains(wgt::Features::NON_FILL_POLYGON_MODE)
-        {
+        let pipeline_wire = if device.features().contains(wgt::Features::LINE_POLYGON_MODE) {
             let pipeline_wire = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: None,
                 layout: Some(&pipeline_layout),
@@ -399,7 +396,7 @@ fn cube_lines() {
         image_path: "/examples/cube/screenshot-lines.png",
         width: 1024,
         height: 768,
-        optional_features: wgpu::Features::NON_FILL_POLYGON_MODE,
+        optional_features: wgpu::Features::LINE_POLYGON_MODE,
         base_test_parameters: framework::test_common::TestParameters::default(),
         tolerance: 2,
         max_outliers: 600, // Bounded by rpi4 on GL


### PR DESCRIPTION
**Connections**
None

**Description**
Allows usage of `wgpu::PolygonMode::Line` and `wgpu::PolygonMode::Point` on the Metal backend. This is done by setting `MTLTriangleFillMode` to `Lines`, in case of lines, and changing the topology to `PointList` if drawing points. I believe changing the topology should be sound (see comment in commit, though please correct me if I'm wrong).

**Testing**
Manual testing by changing `polygon_mode` in the `shadow` example.

With `wgpu::PolygonMode::Line`:
![Screenshot 2021-08-30 at 12 00 05](https://user-images.githubusercontent.com/16593746/131322563-148aa249-0b92-45d8-b7ea-540323d1bff2.png)

With `wgpu::PolygonMode::Point`:
![Screenshot 2021-08-30 at 12 01 09](https://user-images.githubusercontent.com/16593746/131322706-76a01539-3e5f-4e8d-8344-63477718fa01.png)

(okay, you can barely see them, but you get the point... :)