### PR TITLE
Background thread for automatic device polling

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1,5 +1,5 @@
 use crate::{
-    device::{Device, DeviceDescriptor},
+    device::{BufferMapNotifier, Device, DeviceDescriptor},
     hub::{Global, GlobalIdentityHandlerFactory, HalApi, Input, Token},
     id::{AdapterId, DeviceId, SurfaceId, Valid},
     present::Presentation,
@@ -275,6 +275,7 @@ impl<A: HalApi> Adapter<A> {
         self_id: AdapterId,
         open: hal::OpenDevice<A>,
         desc: &DeviceDescriptor,
+        buffer_map_notifier: Option<BufferMapNotifier>,
         trace_path: Option<&std::path::Path>,
     ) -> Result<Device<A>, RequestDeviceError> {
         // Verify all features were exposed by the adapter
@@ -331,6 +332,7 @@ impl<A: HalApi> Adapter<A> {
             caps.alignments.clone(),
             caps.downlevel.clone(),
             desc,
+            buffer_map_notifier,
             trace_path,
         )
         .or(Err(RequestDeviceError::OutOfMemory))
@@ -340,6 +342,7 @@ impl<A: HalApi> Adapter<A> {
         &self,
         self_id: AdapterId,
         desc: &DeviceDescriptor,
+        buffer_map_notifier: Option<BufferMapNotifier>,
         trace_path: Option<&std::path::Path>,
     ) -> Result<Device<A>, RequestDeviceError> {
         let open = unsafe { self.raw.adapter.open(desc.features) }.map_err(|err| match err {
@@ -347,7 +350,7 @@ impl<A: HalApi> Adapter<A> {
             hal::DeviceError::OutOfMemory => RequestDeviceError::OutOfMemory,
         })?;
 
-        self.create_device_from_hal(self_id, open, desc, trace_path)
+        self.create_device_from_hal(self_id, open, desc, buffer_map_notifier, trace_path)
     }
 }
 
@@ -820,6 +823,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         adapter_id: AdapterId,
         desc: &DeviceDescriptor,
+        buffer_map_notifier: Option<BufferMapNotifier>,
         trace_path: Option<&std::path::Path>,
         id_in: Input<G, DeviceId>,
     ) -> (DeviceId, Option<RequestDeviceError>) {
@@ -835,10 +839,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Ok(adapter) => adapter,
                 Err(_) => break RequestDeviceError::InvalidAdapter,
             };
-            let device = match adapter.create_device(adapter_id, desc, trace_path) {
-                Ok(device) => device,
-                Err(e) => break e,
-            };
+            let device =
+                match adapter.create_device(adapter_id, desc, buffer_map_notifier, trace_path) {
+                    Ok(device) => device,
+                    Err(e) => break e,
+                };
             let id = fid.assign(device, &mut token);
             return (id.0, None);
         };
@@ -856,6 +861,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         adapter_id: AdapterId,
         hal_device: hal::OpenDevice<A>,
         desc: &DeviceDescriptor,
+        buffer_map_notifier: Option<BufferMapNotifier>,
         trace_path: Option<&std::path::Path>,
         id_in: Input<G, DeviceId>,
     ) -> (DeviceId, Option<RequestDeviceError>) {
@@ -871,11 +877,16 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Ok(adapter) => adapter,
                 Err(_) => break RequestDeviceError::InvalidAdapter,
             };
-            let device =
-                match adapter.create_device_from_hal(adapter_id, hal_device, desc, trace_path) {
-                    Ok(device) => device,
-                    Err(e) => break e,
-                };
+            let device = match adapter.create_device_from_hal(
+                adapter_id,
+                hal_device,
+                desc,
+                buffer_map_notifier,
+                trace_path,
+            ) {
+                Ok(device) => device,
+                Err(e) => break e,
+            };
             let id = fid.assign(device, &mut token);
             return (id.0, None);
         };

--- a/wgpu/examples/capture/main.rs
+++ b/wgpu/examples/capture/main.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::mem::size_of;
-use wgpu::{Buffer, Device};
+use wgpu::Buffer;
 
 async fn run(png_output_path: &str) {
     let args: Vec<_> = env::args().collect();
@@ -20,14 +20,14 @@ async fn run(png_output_path: &str) {
             return;
         }
     };
-    let (device, buffer, buffer_dimensions) = create_red_image_with_dimensions(width, height).await;
-    create_png(png_output_path, device, buffer, &buffer_dimensions).await;
+    let (buffer, buffer_dimensions) = create_red_image_with_dimensions(width, height).await;
+    create_png(png_output_path, buffer, &buffer_dimensions).await;
 }
 
 async fn create_red_image_with_dimensions(
     width: usize,
     height: usize,
-) -> (Device, Buffer, BufferDimensions) {
+) -> (Buffer, BufferDimensions) {
     let adapter = wgpu::Instance::new(wgpu::Backends::PRIMARY)
         .request_adapter(&wgpu::RequestAdapterOptions::default())
         .await
@@ -41,6 +41,7 @@ async fn create_red_image_with_dimensions(
                 limits: wgpu::Limits::downlevel_defaults(),
             },
             None,
+            true,
         )
         .await
         .unwrap();
@@ -113,58 +114,52 @@ async fn create_red_image_with_dimensions(
     };
 
     queue.submit(Some(command_buffer));
-    (device, output_buffer, buffer_dimensions)
+    (output_buffer, buffer_dimensions)
 }
 
 async fn create_png(
     png_output_path: &str,
-    device: Device,
     output_buffer: Buffer,
     buffer_dimensions: &BufferDimensions,
 ) {
-    // Note that we're not calling `.await` here.
     let buffer_slice = output_buffer.slice(..);
-    let buffer_future = buffer_slice.map_async(wgpu::MapMode::Read);
+    if let Err(_) = buffer_slice.map_async(wgpu::MapMode::Read).await {
+        return;
+    }
 
-    // Poll the device in a blocking manner so that our future resolves.
-    // In an actual application, `device.poll(...)` should
-    // be called in an event loop or on another thread.
-    device.poll(wgpu::Maintain::Wait);
     // If a file system is available, write the buffer as a PNG
     let has_file_system_available = cfg!(not(target_arch = "wasm32"));
     if !has_file_system_available {
         return;
     }
 
-    if let Ok(()) = buffer_future.await {
-        let padded_buffer = buffer_slice.get_mapped_range();
+    let padded_buffer = buffer_slice.get_mapped_range();
 
-        let mut png_encoder = png::Encoder::new(
-            File::create(png_output_path).unwrap(),
-            buffer_dimensions.width as u32,
-            buffer_dimensions.height as u32,
-        );
-        png_encoder.set_depth(png::BitDepth::Eight);
-        png_encoder.set_color(png::ColorType::RGBA);
-        let mut png_writer = png_encoder
-            .write_header()
-            .unwrap()
-            .into_stream_writer_with_size(buffer_dimensions.unpadded_bytes_per_row);
+    let mut png_encoder = png::Encoder::new(
+        File::create(png_output_path).unwrap(),
+        buffer_dimensions.width as u32,
+        buffer_dimensions.height as u32,
+    );
+    png_encoder.set_depth(png::BitDepth::Eight);
+    png_encoder.set_color(png::ColorType::RGBA);
+    let mut png_writer = png_encoder
+        .write_header()
+        .unwrap()
+        .into_stream_writer_with_size(buffer_dimensions.unpadded_bytes_per_row);
 
-        // from the padded_buffer we write just the unpadded bytes into the image
-        for chunk in padded_buffer.chunks(buffer_dimensions.padded_bytes_per_row) {
-            png_writer
-                .write_all(&chunk[..buffer_dimensions.unpadded_bytes_per_row])
-                .unwrap();
-        }
-        png_writer.finish().unwrap();
-
-        // With the current interface, we have to make sure all mapped views are
-        // dropped before we unmap the buffer.
-        drop(padded_buffer);
-
-        output_buffer.unmap();
+    // from the padded_buffer we write just the unpadded bytes into the image
+    for chunk in padded_buffer.chunks(buffer_dimensions.padded_bytes_per_row) {
+        png_writer
+            .write_all(&chunk[..buffer_dimensions.unpadded_bytes_per_row])
+            .unwrap();
     }
+    png_writer.finish().unwrap();
+
+    // With the current interface, we have to make sure all mapped views are
+    // dropped before we unmap the buffer.
+    drop(padded_buffer);
+
+    output_buffer.unmap();
 }
 
 struct BufferDimensions {
@@ -218,9 +213,8 @@ mod tests {
         let (device, output_buffer, dimensions) =
             create_red_image_with_dimensions(100usize, 200usize).await;
         let buffer_slice = output_buffer.slice(..);
-        let buffer_future = buffer_slice.map_async(wgpu::MapMode::Read);
-        device.poll(wgpu::Maintain::Wait);
-        buffer_future
+        buffer_slice
+            .map_async(wgpu::MapMode::Read)
             .await
             .expect("failed to map buffer slice for capture test");
         let padded_buffer = buffer_slice.get_mapped_range();

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -149,6 +149,7 @@ async fn setup<E: Example>(title: &str) -> Setup {
                 limits: needed_limits,
             },
             trace_dir.ok().as_ref().map(std::path::Path::new),
+            true,
         )
         .await
         .expect("Unable to find a suitable GPU adapter!");

--- a/wgpu/examples/hello-compute/main.rs
+++ b/wgpu/examples/hello-compute/main.rs
@@ -50,6 +50,7 @@ async fn execute_gpu(numbers: &[u32]) -> Option<Vec<u32>> {
                 limits: wgpu::Limits::downlevel_defaults(),
             },
             None,
+            true,
         )
         .await
         .unwrap();
@@ -145,18 +146,9 @@ async fn execute_gpu_inner(
     // Submits command encoder for processing
     queue.submit(Some(encoder.finish()));
 
-    // Note that we're not calling `.await` here.
     let buffer_slice = staging_buffer.slice(..);
-    // Gets the future representing when `staging_buffer` can be read from
-    let buffer_future = buffer_slice.map_async(wgpu::MapMode::Read);
-
-    // Poll the device in a blocking manner so that our future resolves.
-    // In an actual application, `device.poll(...)` should
-    // be called in an event loop or on another thread.
-    device.poll(wgpu::Maintain::Wait);
-
-    // Awaits until `buffer_future` can be read from
-    if let Ok(()) = buffer_future.await {
+    // Awaits until `buffer_slice` can be read from
+    if let Ok(()) = buffer_slice.map_async(wgpu::MapMode::Read).await {
         // Gets contents of buffer
         let data = buffer_slice.get_mapped_range();
         // Since contents are got in bytes, this converts these bytes back to u32

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -28,6 +28,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                 limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
             },
             None,
+            true,
         )
         .await
         .expect("Failed to create device");

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -82,6 +82,7 @@ async fn run(event_loop: EventLoop<()>, viewports: Vec<(Window, wgpu::Color)>) {
                 limits: wgpu::Limits::downlevel_defaults(),
             },
             None,
+            true,
         )
         .await
         .expect("Failed to create device");

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -18,7 +18,10 @@ use std::{
     marker::PhantomData,
     ops::Range,
     slice,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    },
 };
 
 const LABEL: &str = "label";
@@ -65,22 +68,35 @@ impl Context {
     }
 
     pub unsafe fn create_device_from_hal<A: wgc::hub::HalApi>(
-        &self,
+        self: &Arc<Context>,
         adapter: &wgc::id::AdapterId,
         hal_device: hal::OpenDevice<A>,
         desc: &crate::DeviceDescriptor,
+        auto_poll: bool,
         trace_dir: Option<&std::path::Path>,
     ) -> Result<(Device, wgc::id::QueueId), crate::RequestDeviceError> {
         let global = &self.0;
+        // First, launch the background thread and store a handle in the Device struct.
+        // Once the device ID is known, send it to the background thread.
+        let (buffer_map_notifier, id_sender) = if auto_poll {
+            let (notifier, sender) = spawn_poll_thread(Arc::clone(self));
+            (Some(notifier), Some(sender))
+        } else {
+            (None, None)
+        };
         let (device_id, error) = global.create_device_from_hal(
             *adapter,
             hal_device,
             &desc.map_label(|l| l.map(Borrowed)),
+            buffer_map_notifier,
             trace_dir,
             PhantomData,
         );
         if let Some(err) = error {
             self.handle_error_fatal(err, "Adapter::create_device_from_hal");
+        }
+        if let Some(s) = id_sender {
+            let _ = s.send(device_id);
         }
         let device = Device {
             id: device_id,
@@ -791,21 +807,34 @@ impl crate::Context for Context {
     }
 
     fn adapter_request_device(
-        &self,
+        self: &Arc<Self>,
         adapter: &Self::AdapterId,
         desc: &crate::DeviceDescriptor,
+        auto_poll: bool,
         trace_dir: Option<&std::path::Path>,
     ) -> Self::RequestDeviceFuture {
         let global = &self.0;
+        // First, launch the background thread and store a handle in the Device struct.
+        // Once the device ID is known, send it to the background thread.
+        let (buffer_map_notifier, id_sender) = if auto_poll {
+            let (notifier, sender) = spawn_poll_thread(Arc::clone(self));
+            (Some(notifier), Some(sender))
+        } else {
+            (None, None)
+        };
         let (device_id, error) = wgc::gfx_select!(*adapter => global.adapter_request_device(
             *adapter,
             &desc.map_label(|l| l.map(Borrowed)),
+            buffer_map_notifier,
             trace_dir,
             PhantomData
         ));
         if let Some(err) = error {
             log::error!("Error in Adapter::request_device: {}", err);
             return ready(Err(crate::RequestDeviceError));
+        }
+        if let Some(s) = id_sender {
+            let _ = s.send(device_id);
         }
         let device = Device {
             id: device_id,
@@ -2191,5 +2220,62 @@ impl Drop for BufferMappedRange {
     fn drop(&mut self) {
         // Intentionally left blank so that `BufferMappedRange` still
         // implements `Drop`, to match the web backend
+    }
+}
+
+/// Spawns a background thread which polls the device on request.
+///
+/// Returns
+/// - a closure which, when called, triggers a device poll,
+/// - and a `SyncSender` which is used to pass the device ID to the background thread.
+fn spawn_poll_thread(
+    context: Arc<Context>,
+) -> (
+    wgc::device::BufferMapNotifier,
+    mpsc::SyncSender<wgc::id::DeviceId>,
+) {
+    let exit_flag = Arc::new(AtomicBool::new(false));
+    let exit_flag_read = exit_flag.clone();
+    let (sender, receiver) = mpsc::sync_channel::<wgc::id::DeviceId>(1);
+    let thread = std::thread::spawn(move || {
+        let device_id = if let Ok(id) = receiver.recv() {
+            drop(receiver);
+            id
+        } else {
+            return;
+        };
+
+        while !exit_flag_read.load(Ordering::Acquire) {
+            let global = &context.0;
+            if let Err(_) = wgc::gfx_select!(device_id => global.device_poll(device_id, true)) {
+                break;
+            }
+            // If unpark() was called while we were in device_poll(), park() will return
+            // immediately; see the std::thread::park() docs for details.
+            std::thread::park();
+        }
+    });
+    let handle = PollThreadHandle { thread, exit_flag };
+    // This closure captures the PollThreadHandle, so that when the closure is dropped,
+    // the background thread is told to shut down.
+    let notifier = Arc::new(move || {
+        // Wake up background thread. If the thread isn't parked right now, this is
+        // basically a no-op, so redundant calls of the closure don't incur unnecessary
+        // overhead.
+        handle.thread.thread().unpark();
+    });
+    (notifier, sender)
+}
+
+struct PollThreadHandle {
+    thread: std::thread::JoinHandle<()>,
+    exit_flag: Arc<AtomicBool>,
+}
+
+impl Drop for PollThreadHandle {
+    fn drop(&mut self) {
+        // Shut down background thread
+        self.exit_flag.store(true, Ordering::Release);
+        self.thread.thread().unpark();
     }
 }

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -5,6 +5,7 @@ use std::{
     future::Future,
     ops::Range,
     pin::Pin,
+    sync::Arc,
     task::{self, Poll},
 };
 use wasm_bindgen::prelude::*;
@@ -991,9 +992,10 @@ impl crate::Context for Context {
     }
 
     fn adapter_request_device(
-        &self,
+        self: &Arc<Self>,
         adapter: &Self::AdapterId,
         desc: &crate::DeviceDescriptor,
+        _auto_poll: bool,
         trace_dir: Option<&std::path::Path>,
     ) -> Self::RequestDeviceFuture {
         use web_sys::GpuFeatureName as Gfn;

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -193,9 +193,10 @@ trait Context: Debug + Send + Sized + Sync {
         options: &RequestAdapterOptions<'_>,
     ) -> Self::RequestAdapterFuture;
     fn adapter_request_device(
-        &self,
+        self: &Arc<Self>,
         adapter: &Self::AdapterId,
         desc: &DeviceDescriptor,
+        auto_poll: bool,
         trace_dir: Option<&std::path::Path>,
     ) -> Self::RequestDeviceFuture;
     fn instance_poll_all_devices(&self, force_wait: bool);
@@ -1504,6 +1505,8 @@ impl Adapter {
     /// - `desc` - Description of the features and limits requested from the given device.
     /// - `trace_path` - Can be used for API call tracing, if that feature is
     ///   enabled in `wgpu-core`.
+    /// - `auto_poll` - Set to `true` to automatically resolve [`BufferSlice::map_async`]
+    ///   futures in a background thread. Ignored on the web backend.
     ///
     /// # Panics
     ///
@@ -1515,9 +1518,11 @@ impl Adapter {
         &self,
         desc: &DeviceDescriptor,
         trace_path: Option<&std::path::Path>,
+        auto_poll: bool,
     ) -> impl Future<Output = Result<(Device, Queue), RequestDeviceError>> + Send {
         let context = Arc::clone(&self.context);
-        let device = Context::adapter_request_device(&*self.context, &self.id, desc, trace_path);
+        let device =
+            Context::adapter_request_device(&self.context, &self.id, desc, auto_poll, trace_path);
         async move {
             device.await.map(|(device_id, queue_id)| {
                 (
@@ -1545,11 +1550,12 @@ impl Adapter {
         &self,
         hal_device: hal::OpenDevice<A>,
         desc: &DeviceDescriptor,
+        auto_poll: bool,
         trace_path: Option<&std::path::Path>,
     ) -> Result<(Device, Queue), RequestDeviceError> {
         let context = Arc::clone(&self.context);
         self.context
-            .create_device_from_hal(&self.id, hal_device, desc, trace_path)
+            .create_device_from_hal(&self.id, hal_device, desc, auto_poll, trace_path)
             .map(|(device_id, queue_id)| {
                 (
                     Device {
@@ -2004,14 +2010,18 @@ impl Buffer {
 impl<'a> BufferSlice<'a> {
     //TODO: fn slice(&self) -> Self
 
-    /// Map the buffer. Buffer is ready to map once the future is resolved.
+    /// Maps this slice of a buffer into memory. The buffer slice is ready to be read or written
+    /// once the future has been resolved.
     ///
-    /// For the future to complete, `device.poll(...)` must be called elsewhere in the runtime, possibly integrated
-    /// into an event loop, run on a separate thread, or continually polled in the same task runtime that this
-    /// future will be run on.
+    /// For the future to complete, the device has to be polled. This is done automatically
+    /// in a background thread if
     ///
-    /// It's expected that wgpu will eventually supply its own event loop infrastructure that will be easy to integrate
-    /// into other event loops, like winit's.
+    /// - the `auto_poll` parameter on [`Adapter::request_device`] or
+    ///    [`Adapter::create_device_from_hal`] was set to `true`, or
+    /// - the web backend of wgpu is used.
+    ///
+    /// Otherwise, [`Device::poll`] must be called manually, for example in an event loop,
+    /// on a separate thread, or in a blocking manner on the same thread.
     pub fn map_async(
         &self,
         mode: MapMode,

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -22,6 +22,7 @@ async fn initialize_device(
                 limits,
             },
             None,
+            true,
         )
         .await;
 


### PR DESCRIPTION
**Connections**
See #1871 which discusses the general problem and solution.

**Description**
The PR spawns an optional background thread which polls the device when a buffer is mapped. This enables more idiomatic code:
```rust
let buffer_slice = buffer.slice(..);
if let Ok(()) = buffer_slice.map_async(...).await {
   // ...
```
instead of
```rust
let buffer_slice = buffer.slice(..);
let fut = buffer_slice.map_async(...);
device.poll();
if let Ok(()) = fut.await {
   // ...
```
The solution adds a closure to `wgpu_core::device::Device`, which is called when a buffer mapping is set up. When a `wgpu::Device` is created, this closure is optionally set to a function which triggers a device poll on a background thread.