### PR TITLE
More validation of the surface texture lifetime

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -411,6 +411,8 @@ pub enum RenderPassErrorInner {
     InvalidResolveSourceSampleCount,
     #[error("resolve target must have a sample count of 1")]
     InvalidResolveTargetSampleCount,
+    #[error("surface texture is dropped before the render pass is finished")]
+    SurfaceTextureDropped,
     #[error("not enough memory left")]
     OutOfMemory,
     #[error("unable to clear non-present/read-only depth")]
@@ -730,6 +732,9 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
         }
 
         for ra in self.render_attachments {
+            if !texture_guard.contains(ra.texture_id.value.0) {
+                return Err(RenderPassErrorInner::SurfaceTextureDropped);
+            }
             let texture = &texture_guard[ra.texture_id.value];
             check_texture_usage(texture.desc.usage, TextureUsages::RENDER_ATTACHMENT)?;
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -164,6 +164,7 @@ pub(crate) enum TextureInner<A: hal::Api> {
     Surface {
         raw: A::SurfaceTexture,
         parent_id: Valid<SurfaceId>,
+        has_work: bool,
     },
 }
 
@@ -172,10 +173,7 @@ impl<A: hal::Api> TextureInner<A> {
         match *self {
             Self::Native { raw: Some(ref tex) } => Some(tex),
             Self::Native { raw: None } => None,
-            Self::Surface {
-                ref raw,
-                parent_id: _,
-            } => Some(std::borrow::Borrow::borrow(raw)),
+            Self::Surface { ref raw, .. } => Some(raw.borrow()),
         }
     }
 }


### PR DESCRIPTION
**Connections**
Closes #1878

**Description**
Adds `has_work` flag to surface textures. This is temporary, until #1688 takes a better care of it. cc @Wumpf 
Adds a few error conditions in addition to the "no work done":
  - if we finished recording a pass, but the surface texture is gone
  - if we are presenting a wrong frame to a wrong surface

**Testing**
Manually tested
