### PR TITLE
Implement render pass labels in Vulkan

### DIFF
--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -868,6 +868,7 @@ impl crate::Device<super::Api> for super::Device {
             temp: super::Temp::default(),
             free: Vec::new(),
             discarded: Vec::new(),
+            rpass_debug_marker_active: false,
         })
     }
     unsafe fn destroy_command_encoder(&self, cmd_encoder: super::CommandEncoder) {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -345,6 +345,9 @@ pub struct CommandEncoder {
     temp: Temp,
     free: Vec<vk::CommandBuffer>,
     discarded: Vec<vk::CommandBuffer>,
+    /// If this is true, the active renderpass enabled a debug span,
+    /// and needs to be disabled on renderpass close.
+    rpass_debug_marker_active: bool,
 }
 
 pub struct CommandBuffer {


### PR DESCRIPTION
**Connections**

None

**Description**

This allows renderpass labels to show up in renderdoc. Just one of those small creature comforts.

**Testing**

Renderdoc'd code.
