### PR TITLE
hal/vk: always request StorageImageExtendedFormats in SPIR-V

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -827,6 +827,10 @@ impl super::Adapter {
                 spv::Capability::Image1D,
                 spv::Capability::ImageQuery,
                 spv::Capability::DerivativeControl,
+                //Note: this is requested always, no matter what the actual
+                // adapter supports. It's not the responsibility of SPV-out
+                // translation to handle the storage support for formats.
+                spv::Capability::StorageImageExtendedFormats,
                 //TODO: fill out the rest
             ];
             let mut flags = spv::WriterFlags::empty();


### PR DESCRIPTION
**Connections**
Compensates https://github.com/gfx-rs/naga/pull/1306
Related to https://github.com/KhronosGroup/Vulkan-Docs/issues/395

**Description**
SPIR-V requires us to enable this capability, but Vulkan device doesn't require it. So we need to at least not fail on it internally...

**Testing**
TODO
