### PR TITLE
hal/linux: Work around Intel+Nvidia presentation conflict

### DIFF
--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -7,6 +7,9 @@ pub mod db {
         pub const DEVICE_KABY_LAKE_MASK: u32 = 0x5900;
         pub const DEVICE_SKY_LAKE_MASK: u32 = 0x1900;
     }
+    pub mod nvidia {
+        pub const VENDOR: u32 = 0x10DE;
+    }
 }
 
 pub fn map_naga_stage(stage: naga::ShaderStage) -> wgt::ShaderStages {

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -698,6 +698,7 @@ impl super::Instance {
                     .contains(vk::FormatFeatureFlags::DEPTH_STENCIL_ATTACHMENT)
             },
             non_coherent_map_mask: phd_capabilities.properties.limits.non_coherent_atom_size - 1,
+            can_present: true,
         };
 
         let capabilities = crate::Capabilities {
@@ -1023,6 +1024,10 @@ impl crate::Adapter<super::Api> for super::Adapter {
         &self,
         surface: &super::Surface,
     ) -> Option<crate::SurfaceCapabilities> {
+        if !self.private_caps.can_present {
+            return None;
+        }
+
         let queue_family_index = 0; //TODO
         match surface.functor.get_physical_device_surface_support(
             self.raw,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -158,6 +158,8 @@ struct PrivateCapabilities {
     timeline_semaphores: bool,
     texture_d24: bool,
     texture_d24_s8: bool,
+    /// Ability to present contents to any screen. Only needed to work around broken platform configurations.
+    can_present: bool,
     non_coherent_map_mask: wgt::BufferAddress,
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -824,6 +824,8 @@ pub enum DeviceType {
     Cpu,
 }
 
+//TODO: convert `vendor` and `device` to `u32`
+
 /// Information about an adapter.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -118,9 +118,10 @@ async fn setup<E: Example>(title: &str) -> Setup {
         let surface = instance.create_surface(&window);
         (size, surface)
     };
-    let adapter = wgpu::util::initialize_adapter_from_env_or_default(&instance, backend)
-        .await
-        .expect("No suitable GPU adapters found on the system!");
+    let adapter =
+        wgpu::util::initialize_adapter_from_env_or_default(&instance, backend, Some(&surface))
+            .await
+            .expect("No suitable GPU adapters found on the system!");
 
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -1,6 +1,6 @@
 use wgt::{Backends, PowerPreference, RequestAdapterOptions};
 
-use crate::{Adapter, Instance};
+use crate::{Adapter, Instance, Surface};
 
 /// Get a set of backend bits from the environment variable WGPU_BACKEND.
 pub fn backend_bits_from_env() -> Option<Backends> {
@@ -72,6 +72,7 @@ pub fn initialize_adapter_from_env(
 pub async fn initialize_adapter_from_env_or_default(
     instance: &Instance,
     backend_bits: wgt::Backends,
+    compatible_surface: Option<&Surface>,
 ) -> Option<Adapter> {
     match initialize_adapter_from_env(instance, backend_bits) {
         Some(a) => Some(a),
@@ -80,7 +81,7 @@ pub async fn initialize_adapter_from_env_or_default(
                 .request_adapter(&RequestAdapterOptions {
                     power_preference: power_preference_from_env()
                         .unwrap_or_else(PowerPreference::default),
-                    compatible_surface: None,
+                    compatible_surface,
                 })
                 .await
         }

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -186,6 +186,7 @@ pub fn initialize_test(parameters: TestParameters, test_function: impl FnOnce(Te
     let adapter = pollster::block_on(util::initialize_adapter_from_env_or_default(
         &instance,
         backend_bits,
+        None,
     ))
     .expect("could not find sutable adapter on the system");
 


### PR DESCRIPTION
**Connections**
This periodically shows up and is very annoying: https://github.com/gfx-rs/wgpu/issues/1877#issuecomment-911504808 and potentially https://github.com/gfx-rs/wgpu/issues/1672
Also fixed upstream around 4 month ago - https://gitlab.freedesktop.org/mesa/mesa/-/issues/4688
I think there is still value in handling that internally, at least until we can detect that the Intel driver is fixed.

**Description**
Vulkan on Linux: if we detect Intel iGPU + NVidia dGPU, we disable presentation on Intel.
The PR also fixes the `compatible_surface` argument in the util and framework.

**Testing**
Manually tested on my laptop!
