### PR TITLE
Fix read-write buffer barrier

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1252,7 +1252,7 @@ impl<A: HalApi> Device<A> {
                 if read_only {
                     hal::BufferUses::STORAGE_READ
                 } else {
-                    hal::BufferUses::STORAGE_WRITE
+                    hal::BufferUses::STORAGE_READ | hal::BufferUses::STORAGE_WRITE
                 },
                 limits.max_storage_buffer_binding_size,
             ),

--- a/wgpu-hal/src/dx12/conv.rs
+++ b/wgpu-hal/src/dx12/conv.rs
@@ -323,12 +323,11 @@ pub fn map_buffer_usage_to_state(usage: crate::BufferUses) -> d3d12::D3D12_RESOU
     if usage.intersects(Bu::VERTEX | Bu::UNIFORM) {
         state |= d3d12::D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
     }
-    if usage.intersects(Bu::STORAGE_READ) {
-        state |= d3d12::D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
-            | d3d12::D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-    }
     if usage.intersects(Bu::STORAGE_WRITE) {
         state |= d3d12::D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+    } else if usage.intersects(Bu::STORAGE_READ) {
+        state |= d3d12::D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
+            | d3d12::D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
     }
     if usage.intersects(Bu::INDIRECT) {
         state |= d3d12::D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -609,6 +609,7 @@ bitflags::bitflags! {
             Self::INDEX.bits | Self::VERTEX.bits | Self::UNIFORM.bits |
             Self::STORAGE_READ.bits | Self::INDIRECT.bits;
         /// The combination of exclusive usages (write-only and read-write).
+        /// These usages may still show up with others, but can't automatically be combined.
         const EXCLUSIVE = Self::MAP_WRITE.bits | Self::COPY_DST.bits | Self::STORAGE_WRITE.bits;
         /// The combination of all usages that the are guaranteed to be be ordered by the hardware.
         /// If a usage is not ordered, then even if it doesn't change between draw calls, there
@@ -631,6 +632,7 @@ bitflags::bitflags! {
         /// The combination of usages that can be used together (read-only).
         const INCLUSIVE = Self::COPY_SRC.bits | Self::RESOURCE.bits | Self::DEPTH_STENCIL_READ.bits;
         /// The combination of exclusive usages (write-only and read-write).
+        /// These usages may still show up with others, but can't automatically be combined.
         const EXCLUSIVE = Self::COPY_DST.bits | Self::COLOR_TARGET.bits | Self::DEPTH_STENCIL_WRITE.bits | Self::STORAGE_READ.bits | Self::STORAGE_WRITE.bits;
         /// The combination of all usages that the are guaranteed to be be ordered by the hardware.
         /// If a usage is not ordered, then even if it doesn't change between draw calls, there


### PR DESCRIPTION
**Connections**
Reported on Matrix by @cwfitzgerald 

**Description**
We were missing an internal usage for reading RW buffers.

**Testing**
VVL doesn't complain!
