### PR TITLE
Properly implement timestamp periods

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -841,7 +841,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut token = Token::root();
         let (device_guard, _) = hub.devices.read(&mut token);
         match device_guard.get(queue_id) {
-            Ok(_device) => Ok(1.0), //TODO?
+            Ok(device) => Ok(unsafe { device.queue.get_timestamp_period() }),
             Err(_) => Err(InvalidQueue),
         }
     }

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -746,4 +746,10 @@ impl crate::Queue<Api> for Queue {
 
         Ok(())
     }
+
+    unsafe fn get_timestamp_period(&self) -> f32 {
+        let mut frequency = 0u64;
+        self.raw.GetTimestampFrequency(&mut frequency);
+        (1_000_000_000.0 / frequency as f64) as f32
+    }
 }

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -103,6 +103,10 @@ impl crate::Queue<Api> for Context {
     ) -> Result<(), crate::SurfaceError> {
         Ok(())
     }
+
+    unsafe fn get_timestamp_period(&self) -> f32 {
+        1.0
+    }
 }
 
 impl crate::Device<Api> for Context {

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -972,4 +972,8 @@ impl crate::Queue<super::Api> for super::Queue {
         let gl = &self.shared.context.get_without_egl_lock();
         surface.present(texture, gl)
     }
+
+    unsafe fn get_timestamp_period(&self) -> f32 {
+        1.0
+    }
 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -314,6 +314,7 @@ pub trait Queue<A: Api>: Send + Sync {
         surface: &mut A::Surface,
         texture: A::SurfaceTexture,
     ) -> Result<(), SurfaceError>;
+    unsafe fn get_timestamp_period(&self) -> f32;
 }
 
 /// Encoder for commands in command buffers.

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -378,6 +378,11 @@ impl crate::Queue<Api> for Queue {
         });
         Ok(())
     }
+
+    unsafe fn get_timestamp_period(&self) -> f32 {
+        // TODO: This is hard, see https://github.com/gpuweb/gpuweb/issues/1325
+        1.0
+    }
 }
 
 #[derive(Debug)]

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -862,7 +862,7 @@ impl super::Adapter {
             vendor_id: self.phd_capabilities.properties.vendor_id,
             downlevel_flags: self.downlevel_flags,
             private_caps: self.private_caps.clone(),
-            _timestamp_period: self.phd_capabilities.properties.limits.timestamp_period,
+            timestamp_period: self.phd_capabilities.properties.limits.timestamp_period,
             render_passes: Mutex::new(Default::default()),
             framebuffers: Mutex::new(Default::default()),
         });

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -222,7 +222,7 @@ struct DeviceShared {
     instance: Arc<InstanceShared>,
     extension_fns: DeviceExtensionFunctions,
     vendor_id: u32,
-    _timestamp_period: f32,
+    timestamp_period: f32,
     downlevel_flags: wgt::DownlevelFlags,
     private_caps: PrivateCapabilities,
     render_passes: Mutex<fxhash::FxHashMap<RenderPassKey, vk::RenderPass>>,
@@ -549,6 +549,10 @@ impl crate::Queue<Api> for Queue {
             log::warn!("Suboptimal present of frame {}", texture.index);
         }
         Ok(())
+    }
+
+    unsafe fn get_timestamp_period(&self) -> f32 {
+        self.device.timestamp_period
     }
 }
 


### PR DESCRIPTION
**Connections**

None

**Description**

We weren't bubbling this up, which caused timestamp results to be ~80 times smaller than they should be on intel.

**Testing**

Manually tested using rend3 and wgpu-profiler.


**Backporting Notes**

I would appreciate this be backported, which is possible by adding a default implementation of the get_timestamp_period method on the queue trait. This makes it backwards compatible
