### PR TITLE
hal: switch texture copies to expect physical sizes

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -339,21 +339,12 @@ pub(crate) fn validate_texture_copy_range(
         wgt::TextureDimension::D1 | wgt::TextureDimension::D2 => {
             (1, copy_size.depth_or_array_layers)
         }
-        wgt::TextureDimension::D3 => (
-            copy_size
-                .depth_or_array_layers
-                .min(extent_virtual.depth_or_array_layers),
-            1,
-        ),
+        wgt::TextureDimension::D3 => (copy_size.depth_or_array_layers, 1),
     };
 
-    // WebGPU uses the physical size of the texture for copies whereas vulkan uses
-    // the virtual size. We have passed validation, so it's safe to use the
-    // image extent data directly. We want the provided copy size to be no larger than
-    // the virtual size.
     let copy_extent = hal::CopyExtent {
-        width: copy_size.width.min(extent_virtual.width),
-        height: copy_size.height.min(extent_virtual.height),
+        width: copy_size.width,
+        height: copy_size.height,
         depth,
     };
     Ok((copy_extent, array_layer_count))

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -19,3 +19,54 @@ pub fn map_naga_stage(stage: naga::ShaderStage) -> wgt::ShaderStages {
         naga::ShaderStage::Compute => wgt::ShaderStages::COMPUTE,
     }
 }
+
+impl crate::CopyExtent {
+    pub fn min(&self, other: &Self) -> Self {
+        Self {
+            width: self.width.min(other.width),
+            height: self.height.min(other.height),
+            depth: self.depth.min(other.depth),
+        }
+    }
+
+    // Get the copy size at a specific mipmap level. This doesn't make most sense,
+    // since the copy extents are provided *for* a mipmap level to start with.
+    // But backends use `CopyExtent` more sparingly, and this piece is shared.
+    pub fn at_mip_level(&self, level: u32) -> Self {
+        Self {
+            width: (self.width >> level).max(1),
+            height: (self.height >> level).max(1),
+            depth: (self.depth >> level).max(1),
+        }
+    }
+}
+
+impl crate::TextureCopyBase {
+    pub fn max_copy_size(&self, full_size: &crate::CopyExtent) -> crate::CopyExtent {
+        let mip = full_size.at_mip_level(self.mip_level);
+        crate::CopyExtent {
+            width: mip.width - self.origin.x,
+            height: mip.height - self.origin.y,
+            depth: mip.depth - self.origin.z,
+        }
+    }
+}
+
+impl crate::BufferTextureCopy {
+    pub fn clamp_size_to_virtual(&mut self, full_size: &crate::CopyExtent) {
+        let max_size = self.texture_base.max_copy_size(full_size);
+        self.size = self.size.min(&max_size);
+    }
+}
+
+impl crate::TextureCopy {
+    pub fn clamp_size_to_virtual(
+        &mut self,
+        full_src_size: &crate::CopyExtent,
+        full_dst_size: &crate::CopyExtent,
+    ) {
+        let max_src_size = self.src_base.max_copy_size(full_src_size);
+        let max_dst_size = self.dst_base.max_copy_size(full_dst_size);
+        self.size = self.size.min(&max_src_size).min(&max_dst_size);
+    }
+}

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -13,18 +13,6 @@ fn make_box(origin: &wgt::Origin3d, size: &crate::CopyExtent) -> d3d12::D3D12_BO
     }
 }
 
-fn upround_extent(size: crate::CopyExtent, block_size: u32) -> crate::CopyExtent {
-    debug_assert!(block_size.is_power_of_two());
-
-    let block_mask = block_size - 1;
-
-    crate::CopyExtent {
-        width: (size.width + block_mask) & !(block_mask),
-        height: (size.height + block_mask) & !(block_mask),
-        depth: size.depth,
-    }
-}
-
 impl super::Temp {
     fn prepare_marker(&mut self, marker: &str) -> (&[u16], u32) {
         self.marker.clear();
@@ -514,11 +502,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             u: mem::zeroed(),
         };
 
-        let block_size = src.format.describe().block_dimensions.0 as u32;
         for r in regions {
-            let uprounded_size = upround_extent(r.size, block_size);
-
-            let src_box = make_box(&r.src_base.origin, &uprounded_size);
+            let src_box = make_box(&r.src_base.origin, &r.size);
             *src_location.u.SubresourceIndex_mut() = src.calc_subresource_for_copy(&r.src_base);
             *dst_location.u.SubresourceIndex_mut() = dst.calc_subresource_for_copy(&r.dst_base);
 
@@ -556,19 +541,17 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 
         let block_size = dst.format.describe().block_dimensions.0 as u32;
         for r in regions {
-            let uprounded_size = upround_extent(r.size, block_size);
-
-            let src_box = make_box(&wgt::Origin3d::ZERO, &uprounded_size);
+            let src_box = make_box(&wgt::Origin3d::ZERO, &r.size);
             *src_location.u.PlacedFootprint_mut() = d3d12::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
                 Offset: r.buffer_layout.offset,
                 Footprint: d3d12::D3D12_SUBRESOURCE_FOOTPRINT {
                     Format: raw_format,
-                    Width: uprounded_size.width,
+                    Width: r.size.width,
                     Height: r
                         .buffer_layout
                         .rows_per_image
-                        .map_or(uprounded_size.height, |count| count.get() * block_size),
-                    Depth: uprounded_size.depth,
+                        .map_or(r.size.height, |count| count.get() * block_size),
+                    Depth: r.size.depth,
                     RowPitch: r.buffer_layout.bytes_per_row.map_or(0, |count| {
                         count.get().max(d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT)
                     }),
@@ -611,20 +594,18 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 
         let block_size = src.format.describe().block_dimensions.0 as u32;
         for r in regions {
-            let uprounded_size = upround_extent(r.size, block_size);
-
-            let src_box = make_box(&r.texture_base.origin, &uprounded_size);
+            let src_box = make_box(&r.texture_base.origin, &r.size);
             *src_location.u.SubresourceIndex_mut() = src.calc_subresource_for_copy(&r.texture_base);
             *dst_location.u.PlacedFootprint_mut() = d3d12::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
                 Offset: r.buffer_layout.offset,
                 Footprint: d3d12::D3D12_SUBRESOURCE_FOOTPRINT {
                     Format: raw_format,
-                    Width: uprounded_size.width,
+                    Width: r.size.width,
                     Height: r
                         .buffer_layout
                         .rows_per_image
-                        .map_or(uprounded_size.height, |count| count.get() * block_size),
-                    Depth: uprounded_size.depth,
+                        .map_or(r.size.height, |count| count.get() * block_size),
+                    Depth: r.size.depth,
                     RowPitch: r.buffer_layout.bytes_per_row.map_or(0, |count| count.get()),
                 },
             };

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -290,7 +290,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     {
         let (src_raw, src_target) = src.inner.as_native();
         let (dst_raw, dst_target) = dst.inner.as_native();
-        for copy in regions {
+        for mut copy in regions {
+            copy.clamp_size_to_virtual(&src.copy_size, &dst.copy_size);
             self.cmd_buffer.commands.push(C::CopyTextureToTexture {
                 src: src_raw,
                 src_target,
@@ -310,7 +311,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         T: Iterator<Item = crate::BufferTextureCopy>,
     {
         let (dst_raw, dst_target) = dst.inner.as_native();
-        for copy in regions {
+        for mut copy in regions {
+            copy.clamp_size_to_virtual(&dst.copy_size);
             self.cmd_buffer.commands.push(C::CopyBufferToTexture {
                 src: src.raw,
                 src_target: src.target,
@@ -332,7 +334,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         T: Iterator<Item = crate::BufferTextureCopy>,
     {
         let (src_raw, src_target) = src.inner.as_native();
-        for copy in regions {
+        for mut copy in regions {
+            copy.clamp_size_to_virtual(&src.copy_size);
             self.cmd_buffer.commands.push(C::CopyTextureToBuffer {
                 src: src_raw,
                 src_target,

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -429,6 +429,12 @@ impl crate::Device<super::Api> for super::Device {
             | crate::TextureUses::DEPTH_STENCIL_READ;
         let format_desc = self.shared.describe_texture_format(desc.format);
 
+        let mut copy_size = crate::CopyExtent {
+            width: desc.size.width,
+            height: desc.size.height,
+            depth: 1,
+        };
+
         let inner = if render_usage.contains(desc.usage)
             && desc.dimension == wgt::TextureDimension::D2
             && desc.size.depth_or_array_layers == 1
@@ -516,6 +522,7 @@ impl crate::Device<super::Api> for super::Device {
                     }
                 }
                 wgt::TextureDimension::D3 => {
+                    copy_size.depth = desc.size.depth_or_array_layers;
                     let target = glow::TEXTURE_3D;
                     gl.bind_texture(target, Some(raw));
                     gl.tex_storage_3d(
@@ -562,6 +569,7 @@ impl crate::Device<super::Api> for super::Device {
             },
             format: desc.format,
             format_desc,
+            copy_size,
         })
     }
     unsafe fn destroy_texture(&self, texture: super::Texture) {

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -984,6 +984,11 @@ impl crate::Surface<super::Api> for Surface {
             mip_level_count: 1,
             format: sc.format,
             format_desc: sc.format_desc.clone(),
+            copy_size: crate::CopyExtent {
+                width: sc.extent.width,
+                height: sc.extent.height,
+                depth: 1,
+            },
         };
         Ok(Some(crate::AcquiredSurfaceTexture {
             texture,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -230,6 +230,7 @@ pub struct Texture {
     array_layer_count: u32,
     format: wgt::TextureFormat,
     format_desc: TextureFormatDesc,
+    copy_size: crate::CopyExtent,
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -360,6 +360,7 @@ pub trait CommandEncoder<A: Api>: Send + Sync {
     /// Copy from one texture to another.
     /// Works with a single array layer.
     /// Note: `dst` current usage has to be `TextureUses::COPY_DST`.
+    /// Note: the copy extent is in physical size (rounded to the block size)
     unsafe fn copy_texture_to_texture<T>(
         &mut self,
         src: &A::Texture,
@@ -372,12 +373,14 @@ pub trait CommandEncoder<A: Api>: Send + Sync {
     /// Copy from buffer to texture.
     /// Works with a single array layer.
     /// Note: `dst` current usage has to be `TextureUses::COPY_DST`.
+    /// Note: the copy extent is in physical size (rounded to the block size)
     unsafe fn copy_buffer_to_texture<T>(&mut self, src: &A::Buffer, dst: &A::Texture, regions: T)
     where
         T: Iterator<Item = BufferTextureCopy>;
 
     /// Copy from texture to buffer.
     /// Works with a single array layer.
+    /// Note: the copy extent is in physical size (rounded to the block size)
     unsafe fn copy_texture_to_buffer<T>(
         &mut self,
         src: &A::Texture,

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -236,6 +236,11 @@ impl crate::Device<super::Api> for super::Device {
 
         let descriptor = mtl::TextureDescriptor::new();
         let mut array_layers = desc.size.depth_or_array_layers;
+        let mut copy_size = crate::CopyExtent {
+            width: desc.size.width,
+            height: desc.size.height,
+            depth: 1,
+        };
         let mtl_type = match desc.dimension {
             wgt::TextureDimension::D1 => {
                 if desc.size.depth_or_array_layers > 1 {
@@ -259,6 +264,7 @@ impl crate::Device<super::Api> for super::Device {
             wgt::TextureDimension::D3 => {
                 descriptor.set_depth(desc.size.depth_or_array_layers as u64);
                 array_layers = 1;
+                copy_size.depth = desc.size.depth_or_array_layers;
                 mtl::MTLTextureType::D3
             }
         };
@@ -283,7 +289,7 @@ impl crate::Device<super::Api> for super::Device {
             raw_type: mtl_type,
             mip_levels: desc.mip_level_count,
             array_layers,
-            size: desc.size,
+            copy_size,
         })
     }
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -297,6 +297,7 @@ pub struct Surface {
     render_layer: Mutex<mtl::MetalLayer>,
     swapchain_format: wgt::TextureFormat,
     raw_swapchain_format: mtl::MTLPixelFormat,
+    extent: wgt::Extent3d,
     main_thread_id: thread::ThreadId,
     // Useful for UI-intensive applications that are sensitive to
     // window resizing.
@@ -425,7 +426,7 @@ pub struct Texture {
     raw_type: mtl::MTLTextureType,
     array_layers: u32,
     mip_levels: u32,
-    size: wgt::Extent3d,
+    copy_size: crate::CopyExtent,
 }
 
 unsafe impl Send for Texture {}

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -62,6 +62,7 @@ impl super::Surface {
             render_layer: Mutex::new(layer),
             swapchain_format: wgt::TextureFormat::Bgra8UnormSrgb, // no value invalid, pick something not too far-fetched
             raw_swapchain_format: mtl::MTLPixelFormat::Invalid,
+            extent: wgt::Extent3d::default(),
             main_thread_id: thread::current().id(),
             present_with_transaction: false,
         }
@@ -212,6 +213,7 @@ impl crate::Surface<super::Api> for super::Surface {
         let caps = &device.shared.private_caps;
         self.swapchain_format = config.format;
         self.raw_swapchain_format = caps.map_format(config.format);
+        self.extent = config.extent;
 
         let render_layer = self.render_layer.lock();
         let framebuffer_only = config.usage == crate::TextureUses::COLOR_TARGET;
@@ -278,7 +280,11 @@ impl crate::Surface<super::Api> for super::Surface {
                 raw_type: mtl::MTLTextureType::D2,
                 array_layers: 1,
                 mip_levels: 1,
-                size: self.dimensions(),
+                copy_size: crate::CopyExtent {
+                    width: self.extent.width,
+                    height: self.extent.height,
+                    depth: 1,
+                },
             },
             drawable,
             present_with_transaction: self.present_with_transaction,

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -512,6 +512,20 @@ pub fn map_copy_extent(extent: &crate::CopyExtent) -> vk::Extent3D {
     }
 }
 
+pub fn map_extent_to_copy_size(
+    extent: &wgt::Extent3d,
+    dim: wgt::TextureDimension,
+) -> crate::CopyExtent {
+    crate::CopyExtent {
+        width: extent.width,
+        height: extent.height,
+        depth: match dim {
+            wgt::TextureDimension::D1 | wgt::TextureDimension::D2 => 1,
+            wgt::TextureDimension::D3 => extent.depth_or_array_layers,
+        },
+    }
+}
+
 pub fn map_subresource_range(
     range: &wgt::ImageSubresourceRange,
     texture_aspect: crate::FormatAspects,

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -11,6 +11,8 @@ use ash::{
     vk,
 };
 
+use super::conv;
+
 unsafe extern "system" fn debug_utils_messenger_callback(
     message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
     message_type: vk::DebugUtilsMessageTypeFlagsEXT,
@@ -706,6 +708,10 @@ impl crate::Surface<super::Api> for super::Surface {
                 aspects: crate::FormatAspects::COLOR,
                 format_info: sc.config.format.describe(),
                 raw_flags: vk::ImageCreateFlags::empty(),
+                copy_size: conv::map_extent_to_copy_size(
+                    &sc.config.extent,
+                    wgt::TextureDimension::D2,
+                ),
             },
         };
         Ok(Some(crate::AcquiredSurfaceTexture {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -268,6 +268,7 @@ pub struct Texture {
     aspects: crate::FormatAspects,
     format_info: wgt::TextureFormatInfo,
     raw_flags: vk::ImageCreateFlags,
+    copy_size: crate::CopyExtent,
 }
 
 impl Texture {


### PR DESCRIPTION
**Connections**
Fixes #1895

**Description**
Currently, wgpu-core expects physical sizes for texture copies, but wgpu-hal expects virtual.
Moreover, Metal texture-texture copies already expect physical (but not buffer-related copies), which wasn't handled properly.

This PR fixes Metal properly and aligns wgpu-hal copy API with wgpu-core.

**Testing**
Tested the examples on metal. Can confirm the "skybox" example no longer throws a validation error on Metal, at least.
