### PR TITLE
Add missing SPIRV capability

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -828,6 +828,7 @@ impl super::Adapter {
                 spv::Capability::Image1D,
                 spv::Capability::ImageQuery,
                 spv::Capability::DerivativeControl,
+                spv::Capability::SampledCubeArray,
                 //Note: this is requested always, no matter what the actual
                 // adapter supports. It's not the responsibility of SPV-out
                 // translation to handle the storage support for formats.


### PR DESCRIPTION
**Connections**
This is associated with https://github.com/gfx-rs/naga/pull/1273/commits/1c2026b877ce8138fe4a8683056d2fd513f75234

**Description**
Due to changes in naga, running bevy's `3d_scene_pipelined` example with wgpu `HEAD` will trigger the following error:

```
Sep 05 23:39:52.543 ERROR wgpu_core::device: Shader error: using sampled cube array images requires at least one of the capabilities [SampledCubeArray], but none are available
Sep 05 23:39:52.544 ERROR wgpu::backend::direct: wgpu error: Validation Error
```

**Testing**
After adding this SPIRV feature, bevy's `3d_scene_pipelined` example works as expected.
