### PR TITLE
Expose raw command buffer

### DIFF
--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -352,9 +352,9 @@ impl Temp {
 }
 
 pub struct CommandEncoder {
-    raw: vk::CommandPool,
+    pub raw: vk::CommandPool,
     device: Arc<DeviceShared>,
-    active: vk::CommandBuffer,
+    pub active: vk::CommandBuffer,
     bind_point: vk::PipelineBindPoint,
     temp: Temp,
     free: Vec<vk::CommandBuffer>,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1950,6 +1950,25 @@ impl crate::Context for Context {
         id
     }
 
+    unsafe fn command_encoder_run_raw_commands<A, F>(
+        &self,
+        encoder: &Self::CommandEncoderId,
+        runner: F,
+    ) where
+        A: wgc::hub::HalApi,
+        F: FnOnce(&mut <A as hal::Api>::CommandEncoder),
+    {
+        let global = &self.0;
+        match global.command_encoder_run_raw_commands::<A, F>(encoder.id, runner) {
+            Err(cause) => self.handle_error_nolabel(
+                &encoder.error_sink,
+                cause,
+                "CommandEncoder::run_raw_commands",
+            ),
+            Ok(()) => {}
+        }
+    }
+
     fn command_encoder_clear_texture(
         &self,
         encoder: &Self::CommandEncoderId,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -359,6 +359,14 @@ trait Context: Debug + Send + Sized + Sync {
         index: u32,
     ) -> Self::BindGroupLayoutId;
 
+    unsafe fn command_encoder_run_raw_commands<A, F>(
+        &self,
+        encoder: &Self::CommandEncoderId,
+        runner: F,
+    ) where
+        A: wgc::hub::HalApi,
+        F: FnOnce(&mut <A as hal::Api>::CommandEncoder);
+
     fn command_encoder_copy_buffer_to_buffer(
         &self,
         encoder: &Self::CommandEncoderId,
@@ -2348,6 +2356,16 @@ impl CommandEncoder {
     pub fn pop_debug_group(&mut self) {
         let id = self.id.as_ref().unwrap();
         Context::command_encoder_pop_debug_group(&*self.context, id);
+    }
+
+    /// Running raw commands on the underlying APIs
+    pub unsafe fn run_raw_command<A, F>(&mut self, runner: F)
+    where
+        A: wgc::hub::HalApi,
+        F: FnOnce(&mut <A as hal::Api>::CommandEncoder),
+    {
+        let id = self.id.as_ref().unwrap();
+        Context::command_encoder_run_raw_commands::<A, F>(&*self.context, id, runner);
     }
 }
 


### PR DESCRIPTION
This PR exposes the raw command buffer to the user.

Usage:

```rs
unsafe {
  command_encoder.run_raw_command::<wgpu_hal::api::Vulkan, _>(|command_buffer| {
      let command_buffer = command_buffer.active;
      assert_ne!(command_buffer, vk::CommandBuffer::null());
      device.cmd_bind_pipeline(
          command_buffer,
          vk::PipelineBindPoint::RAY_TRACING_KHR,
          ray_shaders.pipeline,
      );
      raytracing_pipeline_loader.cmd_trace_rays(
          command_buffer,
          &ray_shaders.raygen_shader_binding_tables,
          &ray_shaders.miss_shader_binding_tables,
          &ray_shaders.hit_shader_binding_tables,
          &ray_shaders.callable_shader_binding_tables,
          1920, //render_state.extent.width,
          1080, //render_state.extent.height,
          1,
      );
  });
}

```

Note that this is only tested on Vulkan for now - I would like to get some feedbacks on this before proceeding.