### PR TITLE
Fix Deprecated Canvas Context Name

### DIFF
--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -949,7 +949,7 @@ impl crate::Context for Context {
             .expect("expected to find single canvas")
             .into();
         let canvas_element: web_sys::HtmlCanvasElement = canvas_node.into();
-        let context: wasm_bindgen::JsValue = match canvas_element.get_context("gpupresent") {
+        let context: wasm_bindgen::JsValue = match canvas_element.get_context("webgpu") {
             Ok(Some(ctx)) => ctx.into(),
             _ => panic!("expected to get context from canvas"),
         };


### PR DESCRIPTION

**Connections**
fixes #1916 

**Description**
"gpupresent" Canvas Context name has been deprecated in favour of "webgpu", this PR simply updates the call to canvas.getContext

**Testing**
Updated test app including this change running here https://agreeable-dune-08facd403.azurestaticapps.net/ 