### PR TITLE
hal/dx12: fix offsets into storage buffer bindings

### DIFF
--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1071,7 +1071,7 @@ impl crate::Device<super::Api> for super::Device {
                                 u: mem::zeroed(),
                             };
                             *raw_desc.u.Buffer_mut() = d3d12::D3D12_BUFFER_SRV {
-                                FirstElement: data.offset,
+                                FirstElement: data.offset / 4,
                                 NumElements: size / 4,
                                 StructureByteStride: 0,
                                 Flags: d3d12::D3D12_BUFFER_SRV_FLAG_RAW,
@@ -1089,7 +1089,7 @@ impl crate::Device<super::Api> for super::Device {
                                 u: mem::zeroed(),
                             };
                             *raw_desc.u.Buffer_mut() = d3d12::D3D12_BUFFER_UAV {
-                                FirstElement: data.offset,
+                                FirstElement: data.offset / 4,
                                 NumElements: size / 4,
                                 StructureByteStride: 0,
                                 CounterOffsetInBytes: 0,


### PR DESCRIPTION
data.offset is in bytes, and format is in DXGI_FORMAT_R32_TYPELESS