### PR TITLE
Release wgpu-core-0.10.3 and wgpu-hal-0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## wgpu-core-0.10.3, wgpu-hal-0.10.4 (2021-09-08)
+  - Vulkan:
+    - fix read access barriers for writable storage buffers
+    - fix shaders using cube array textures
+    - work around Linux Intel+Nvidia driver conflicts
+    - work around Adreno bug with `OpName`
+  - DX12:
+    - fix storage binding offsets
+  - Metal:
+    - fix compressed texture copies
+
 ## wgpu-core-0.10.2, wgpu-hal-0.10.3 (2021-09-01)
   - All:
     - fix querying the size of storage textures

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "arrayvec",
  "ash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b136bf483e309f330c74880370fa6f0553d9249399ac1dfa8e92c96a1612add"
+checksum = "8c5859e55c51da10b98e7a73068e0a0c5da7bbcae4fc38f86043d0c6d1b917cf"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-core"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU core logic on gfx-hal"
@@ -48,7 +48,7 @@ version = "0.10"
 [dependencies.hal]
 path = "../wgpu-hal"
 package = "wgpu-hal"
-version = "0.10.1"
+version = "0.10.4"
 
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
 hal = { path = "../wgpu-hal", package = "wgpu-hal", version = "0.10", features = ["metal"] }

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -339,21 +339,12 @@ pub(crate) fn validate_texture_copy_range(
         wgt::TextureDimension::D1 | wgt::TextureDimension::D2 => {
             (1, copy_size.depth_or_array_layers)
         }
-        wgt::TextureDimension::D3 => (
-            copy_size
-                .depth_or_array_layers
-                .min(extent_virtual.depth_or_array_layers),
-            1,
-        ),
+        wgt::TextureDimension::D3 => (copy_size.depth_or_array_layers, 1),
     };
 
-    // WebGPU uses the physical size of the texture for copies whereas vulkan uses
-    // the virtual size. We have passed validation, so it's safe to use the
-    // image extent data directly. We want the provided copy size to be no larger than
-    // the virtual size.
     let copy_extent = hal::CopyExtent {
-        width: copy_size.width.min(extent_virtual.width),
-        height: copy_size.height.min(extent_virtual.height),
+        width: copy_size.width,
+        height: copy_size.height,
         depth,
     };
     Ok((copy_extent, array_layer_count))

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1249,7 +1249,7 @@ impl<A: HalApi> Device<A> {
                 if read_only {
                     hal::BufferUses::STORAGE_READ
                 } else {
-                    hal::BufferUses::STORAGE_WRITE
+                    hal::BufferUses::STORAGE_READ | hal::BufferUses::STORAGE_WRITE
                 },
                 limits.max_storage_buffer_binding_size,
             ),

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -836,7 +836,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut token = Token::root();
         let (device_guard, _) = hub.devices.read(&mut token);
         match device_guard.get(queue_id) {
-            Ok(_device) => Ok(1.0), //TODO?
+            Ok(device) => Ok(unsafe { device.queue.get_timestamp_period() }),
             Err(_) => Err(InvalidQueue),
         }
     }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -70,7 +70,7 @@ core-graphics-types = "0.1"
 [dependencies.naga]
 #git = "https://github.com/gfx-rs/naga"
 #rev = "4e181d6"
-version = "0.6"
+version = "0.6.3"
 
 [dev-dependencies.naga]
 #git = "https://github.com/gfx-rs/naga"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-hal"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU hardware abstraction layer"

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -7,6 +7,9 @@ pub mod db {
         pub const DEVICE_KABY_LAKE_MASK: u32 = 0x5900;
         pub const DEVICE_SKY_LAKE_MASK: u32 = 0x1900;
     }
+    pub mod nvidia {
+        pub const VENDOR: u32 = 0x10DE;
+    }
 }
 
 pub fn map_naga_stage(stage: naga::ShaderStage) -> wgt::ShaderStages {

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -19,3 +19,54 @@ pub fn map_naga_stage(stage: naga::ShaderStage) -> wgt::ShaderStages {
         naga::ShaderStage::Compute => wgt::ShaderStages::COMPUTE,
     }
 }
+
+impl crate::CopyExtent {
+    pub fn min(&self, other: &Self) -> Self {
+        Self {
+            width: self.width.min(other.width),
+            height: self.height.min(other.height),
+            depth: self.depth.min(other.depth),
+        }
+    }
+
+    // Get the copy size at a specific mipmap level. This doesn't make most sense,
+    // since the copy extents are provided *for* a mipmap level to start with.
+    // But backends use `CopyExtent` more sparingly, and this piece is shared.
+    pub fn at_mip_level(&self, level: u32) -> Self {
+        Self {
+            width: (self.width >> level).max(1),
+            height: (self.height >> level).max(1),
+            depth: (self.depth >> level).max(1),
+        }
+    }
+}
+
+impl crate::TextureCopyBase {
+    pub fn max_copy_size(&self, full_size: &crate::CopyExtent) -> crate::CopyExtent {
+        let mip = full_size.at_mip_level(self.mip_level);
+        crate::CopyExtent {
+            width: mip.width - self.origin.x,
+            height: mip.height - self.origin.y,
+            depth: mip.depth - self.origin.z,
+        }
+    }
+}
+
+impl crate::BufferTextureCopy {
+    pub fn clamp_size_to_virtual(&mut self, full_size: &crate::CopyExtent) {
+        let max_size = self.texture_base.max_copy_size(full_size);
+        self.size = self.size.min(&max_size);
+    }
+}
+
+impl crate::TextureCopy {
+    pub fn clamp_size_to_virtual(
+        &mut self,
+        full_src_size: &crate::CopyExtent,
+        full_dst_size: &crate::CopyExtent,
+    ) {
+        let max_src_size = self.src_base.max_copy_size(full_src_size);
+        let max_dst_size = self.dst_base.max_copy_size(full_dst_size);
+        self.size = self.size.min(&max_src_size).min(&max_dst_size);
+    }
+}

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -10,6 +10,9 @@ pub mod db {
     pub mod nvidia {
         pub const VENDOR: u32 = 0x10DE;
     }
+    pub mod qualcomm {
+        pub const VENDOR: u32 = 0x5143;
+    }
 }
 
 pub fn map_naga_stage(stage: naga::ShaderStage) -> wgt::ShaderStages {

--- a/wgpu-hal/src/dx12/conv.rs
+++ b/wgpu-hal/src/dx12/conv.rs
@@ -323,12 +323,11 @@ pub fn map_buffer_usage_to_state(usage: crate::BufferUses) -> d3d12::D3D12_RESOU
     if usage.intersects(Bu::VERTEX | Bu::UNIFORM) {
         state |= d3d12::D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
     }
-    if usage.intersects(Bu::STORAGE_READ) {
-        state |= d3d12::D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
-            | d3d12::D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-    }
     if usage.intersects(Bu::STORAGE_WRITE) {
         state |= d3d12::D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+    } else if usage.intersects(Bu::STORAGE_READ) {
+        state |= d3d12::D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
+            | d3d12::D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
     }
     if usage.intersects(Bu::INDIRECT) {
         state |= d3d12::D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1071,7 +1071,7 @@ impl crate::Device<super::Api> for super::Device {
                                 u: mem::zeroed(),
                             };
                             *raw_desc.u.Buffer_mut() = d3d12::D3D12_BUFFER_SRV {
-                                FirstElement: data.offset,
+                                FirstElement: data.offset / 4,
                                 NumElements: size / 4,
                                 StructureByteStride: 0,
                                 Flags: d3d12::D3D12_BUFFER_SRV_FLAG_RAW,
@@ -1089,7 +1089,7 @@ impl crate::Device<super::Api> for super::Device {
                                 u: mem::zeroed(),
                             };
                             *raw_desc.u.Buffer_mut() = d3d12::D3D12_BUFFER_UAV {
-                                FirstElement: data.offset,
+                                FirstElement: data.offset / 4,
                                 NumElements: size / 4,
                                 StructureByteStride: 0,
                                 CounterOffsetInBytes: 0,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -746,4 +746,10 @@ impl crate::Queue<Api> for Queue {
 
         Ok(())
     }
+
+    unsafe fn get_timestamp_period(&self) -> f32 {
+        let mut frequency = 0u64;
+        self.raw.GetTimestampFrequency(&mut frequency);
+        (1_000_000_000.0 / frequency as f64) as f32
+    }
 }

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -103,6 +103,10 @@ impl crate::Queue<Api> for Context {
     ) -> Result<(), crate::SurfaceError> {
         Ok(())
     }
+
+    unsafe fn get_timestamp_period(&self) -> f32 {
+        1.0
+    }
 }
 
 impl crate::Device<Api> for Context {

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -278,7 +278,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     {
         let (src_raw, src_target) = src.inner.as_native();
         let (dst_raw, dst_target) = dst.inner.as_native();
-        for copy in regions {
+        for mut copy in regions {
+            copy.clamp_size_to_virtual(&src.copy_size, &dst.copy_size);
             self.cmd_buffer.commands.push(C::CopyTextureToTexture {
                 src: src_raw,
                 src_target,
@@ -298,7 +299,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         T: Iterator<Item = crate::BufferTextureCopy>,
     {
         let (dst_raw, dst_target) = dst.inner.as_native();
-        for copy in regions {
+        for mut copy in regions {
+            copy.clamp_size_to_virtual(&dst.copy_size);
             self.cmd_buffer.commands.push(C::CopyBufferToTexture {
                 src: src.raw,
                 src_target: src.target,
@@ -320,7 +322,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         T: Iterator<Item = crate::BufferTextureCopy>,
     {
         let (src_raw, src_target) = src.inner.as_native();
-        for copy in regions {
+        for mut copy in regions {
+            copy.clamp_size_to_virtual(&src.copy_size);
             self.cmd_buffer.commands.push(C::CopyTextureToBuffer {
                 src: src_raw,
                 src_target,

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -429,6 +429,12 @@ impl crate::Device<super::Api> for super::Device {
             | crate::TextureUses::DEPTH_STENCIL_READ;
         let format_desc = self.shared.describe_texture_format(desc.format);
 
+        let mut copy_size = crate::CopyExtent {
+            width: desc.size.width,
+            height: desc.size.height,
+            depth: 1,
+        };
+
         let inner = if render_usage.contains(desc.usage)
             && desc.dimension == wgt::TextureDimension::D2
             && desc.size.depth_or_array_layers == 1
@@ -516,6 +522,7 @@ impl crate::Device<super::Api> for super::Device {
                     }
                 }
                 wgt::TextureDimension::D3 => {
+                    copy_size.depth = desc.size.depth_or_array_layers;
                     let target = glow::TEXTURE_3D;
                     gl.bind_texture(target, Some(raw));
                     gl.tex_storage_3d(
@@ -562,6 +569,7 @@ impl crate::Device<super::Api> for super::Device {
             },
             format: desc.format,
             format_desc,
+            copy_size,
         })
     }
     unsafe fn destroy_texture(&self, texture: super::Texture) {

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -984,6 +984,11 @@ impl crate::Surface<super::Api> for Surface {
             mip_level_count: 1,
             format: sc.format,
             format_desc: sc.format_desc.clone(),
+            copy_size: crate::CopyExtent {
+                width: sc.extent.width,
+                height: sc.extent.height,
+                depth: 1,
+            },
         };
         Ok(Some(crate::AcquiredSurfaceTexture {
             texture,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -230,6 +230,7 @@ pub struct Texture {
     array_layer_count: u32,
     format: wgt::TextureFormat,
     format_desc: TextureFormatDesc,
+    copy_size: crate::CopyExtent,
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -972,4 +972,8 @@ impl crate::Queue<super::Api> for super::Queue {
         let gl = &self.shared.context.get_without_egl_lock();
         surface.present(texture, gl)
     }
+
+    unsafe fn get_timestamp_period(&self) -> f32 {
+        1.0
+    }
 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -314,6 +314,7 @@ pub trait Queue<A: Api>: Send + Sync {
         surface: &mut A::Surface,
         texture: A::SurfaceTexture,
     ) -> Result<(), SurfaceError>;
+    unsafe fn get_timestamp_period(&self) -> f32;
 }
 
 /// Encoder for commands in command buffers.

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -355,6 +355,7 @@ pub trait CommandEncoder<A: Api>: Send + Sync {
     /// Copy from one texture to another.
     /// Works with a single array layer.
     /// Note: `dst` current usage has to be `TextureUses::COPY_DST`.
+    /// Note: the copy extent is in physical size (rounded to the block size)
     unsafe fn copy_texture_to_texture<T>(
         &mut self,
         src: &A::Texture,
@@ -367,12 +368,14 @@ pub trait CommandEncoder<A: Api>: Send + Sync {
     /// Copy from buffer to texture.
     /// Works with a single array layer.
     /// Note: `dst` current usage has to be `TextureUses::COPY_DST`.
+    /// Note: the copy extent is in physical size (rounded to the block size)
     unsafe fn copy_buffer_to_texture<T>(&mut self, src: &A::Buffer, dst: &A::Texture, regions: T)
     where
         T: Iterator<Item = BufferTextureCopy>;
 
     /// Copy from texture to buffer.
     /// Works with a single array layer.
+    /// Note: the copy extent is in physical size (rounded to the block size)
     unsafe fn copy_texture_to_buffer<T>(
         &mut self,
         src: &A::Texture,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -609,6 +609,7 @@ bitflags::bitflags! {
             Self::INDEX.bits | Self::VERTEX.bits | Self::UNIFORM.bits |
             Self::STORAGE_READ.bits | Self::INDIRECT.bits;
         /// The combination of exclusive usages (write-only and read-write).
+        /// These usages may still show up with others, but can't automatically be combined.
         const EXCLUSIVE = Self::MAP_WRITE.bits | Self::COPY_DST.bits | Self::STORAGE_WRITE.bits;
         /// The combination of all usages that the are guaranteed to be be ordered by the hardware.
         /// If a usage is not ordered, then even if it doesn't change between draw calls, there
@@ -631,6 +632,7 @@ bitflags::bitflags! {
         /// The combination of usages that can be used together (read-only).
         const INCLUSIVE = Self::COPY_SRC.bits | Self::RESOURCE.bits | Self::DEPTH_STENCIL_READ.bits;
         /// The combination of exclusive usages (write-only and read-write).
+        /// These usages may still show up with others, but can't automatically be combined.
         const EXCLUSIVE = Self::COPY_DST.bits | Self::COLOR_TARGET.bits | Self::DEPTH_STENCIL_WRITE.bits | Self::STORAGE_READ.bits | Self::STORAGE_WRITE.bits;
         /// The combination of all usages that the are guaranteed to be be ordered by the hardware.
         /// If a usage is not ordered, then even if it doesn't change between draw calls, there

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -236,6 +236,11 @@ impl crate::Device<super::Api> for super::Device {
 
         let descriptor = mtl::TextureDescriptor::new();
         let mut array_layers = desc.size.depth_or_array_layers;
+        let mut copy_size = crate::CopyExtent {
+            width: desc.size.width,
+            height: desc.size.height,
+            depth: 1,
+        };
         let mtl_type = match desc.dimension {
             wgt::TextureDimension::D1 => {
                 if desc.size.depth_or_array_layers > 1 {
@@ -259,6 +264,7 @@ impl crate::Device<super::Api> for super::Device {
             wgt::TextureDimension::D3 => {
                 descriptor.set_depth(desc.size.depth_or_array_layers as u64);
                 array_layers = 1;
+                copy_size.depth = desc.size.depth_or_array_layers;
                 mtl::MTLTextureType::D3
             }
         };
@@ -282,6 +288,7 @@ impl crate::Device<super::Api> for super::Device {
             raw_type: mtl_type,
             mip_levels: desc.mip_level_count,
             array_layers,
+            copy_size,
         })
     }
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -378,6 +378,11 @@ impl crate::Queue<Api> for Queue {
         });
         Ok(())
     }
+
+    unsafe fn get_timestamp_period(&self) -> f32 {
+        // TODO: This is hard, see https://github.com/gpuweb/gpuweb/issues/1325
+        1.0
+    }
 }
 
 #[derive(Debug)]

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -281,6 +281,7 @@ pub struct Surface {
     view: Option<NonNull<objc::runtime::Object>>,
     render_layer: Mutex<mtl::MetalLayer>,
     raw_swapchain_format: mtl::MTLPixelFormat,
+    extent: wgt::Extent3d,
     main_thread_id: thread::ThreadId,
     // Useful for UI-intensive applications that are sensitive to
     // window resizing.
@@ -408,6 +409,7 @@ pub struct Texture {
     raw_type: mtl::MTLTextureType,
     array_layers: u32,
     mip_levels: u32,
+    copy_size: crate::CopyExtent,
 }
 
 unsafe impl Send for Texture {}

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -61,6 +61,7 @@ impl super::Surface {
             view,
             render_layer: Mutex::new(layer),
             raw_swapchain_format: mtl::MTLPixelFormat::Invalid,
+            extent: wgt::Extent3d::default(),
             main_thread_id: thread::current().id(),
             present_with_transaction: false,
         }
@@ -210,6 +211,7 @@ impl crate::Surface<super::Api> for super::Surface {
 
         let caps = &device.shared.private_caps;
         self.raw_swapchain_format = caps.map_format(config.format);
+        self.extent = config.extent;
 
         let render_layer = self.render_layer.lock();
         let framebuffer_only = config.usage == crate::TextureUses::COLOR_TARGET;
@@ -275,6 +277,11 @@ impl crate::Surface<super::Api> for super::Surface {
                 raw_type: mtl::MTLTextureType::D2,
                 array_layers: 1,
                 mip_levels: 1,
+                copy_size: crate::CopyExtent {
+                    width: self.extent.width,
+                    height: self.extent.height,
+                    depth: 1,
+                },
             },
             drawable,
             present_with_transaction: self.present_with_transaction,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -838,6 +838,10 @@ impl super::Adapter {
                 spv::WriterFlags::DEBUG,
                 self.instance.flags.contains(crate::InstanceFlags::DEBUG),
             );
+            flags.set(
+                spv::WriterFlags::LABEL_VARYINGS,
+                self.phd_capabilities.properties.vendor_id != crate::auxil::db::qualcomm::VENDOR,
+            );
             spv::Options {
                 lang_version: (1, 0),
                 flags,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -697,6 +697,7 @@ impl super::Instance {
                     .contains(vk::FormatFeatureFlags::DEPTH_STENCIL_ATTACHMENT)
             },
             non_coherent_map_mask: phd_capabilities.properties.limits.non_coherent_atom_size - 1,
+            can_present: true,
         };
 
         let capabilities = crate::Capabilities {
@@ -1018,6 +1019,10 @@ impl crate::Adapter<super::Api> for super::Adapter {
         &self,
         surface: &super::Surface,
     ) -> Option<crate::SurfaceCapabilities> {
+        if !self.private_caps.can_present {
+            return None;
+        }
+
         let queue_family_index = 0; //TODO
         match surface.functor.get_physical_device_surface_support(
             self.raw,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -826,6 +826,7 @@ impl super::Adapter {
                 spv::Capability::Image1D,
                 spv::Capability::ImageQuery,
                 spv::Capability::DerivativeControl,
+                spv::Capability::SampledCubeArray,
                 //Note: this is requested always, no matter what the actual
                 // adapter supports. It's not the responsibility of SPV-out
                 // translation to handle the storage support for formats.

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -858,7 +858,7 @@ impl super::Adapter {
             vendor_id: self.phd_capabilities.properties.vendor_id,
             downlevel_flags: self.downlevel_flags,
             private_caps: self.private_caps.clone(),
-            _timestamp_period: self.phd_capabilities.properties.limits.timestamp_period,
+            timestamp_period: self.phd_capabilities.properties.limits.timestamp_period,
             render_passes: Mutex::new(Default::default()),
             framebuffers: Mutex::new(Default::default()),
         });

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -16,7 +16,9 @@ impl super::Texture {
     {
         let aspects = self.aspects;
         let fi = self.format_info;
+        let copy_size = self.copy_size;
         regions.map(move |r| {
+            let extent = r.texture_base.max_copy_size(&copy_size).min(&r.size);
             let (image_subresource, image_offset) =
                 conv::map_subresource_layers(&r.texture_base, aspects);
             vk::BufferImageCopy {
@@ -30,7 +32,7 @@ impl super::Texture {
                     .map_or(0, |rpi| rpi.get() * fi.block_dimensions.1 as u32),
                 image_subresource,
                 image_offset,
-                image_extent: conv::map_copy_extent(&r.size),
+                image_extent: conv::map_copy_extent(&extent),
             }
         })
     }
@@ -229,12 +231,16 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 conv::map_subresource_layers(&r.src_base, src.aspects);
             let (dst_subresource, dst_offset) =
                 conv::map_subresource_layers(&r.dst_base, dst.aspects);
+            let extent = r
+                .size
+                .min(&r.src_base.max_copy_size(&src.copy_size))
+                .min(&r.dst_base.max_copy_size(&dst.copy_size));
             vk::ImageCopy {
                 src_subresource,
                 src_offset,
                 dst_subresource,
                 dst_offset,
-                extent: conv::map_copy_extent(&r.size),
+                extent: conv::map_copy_extent(&extent),
             }
         });
 

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -512,6 +512,20 @@ pub fn map_copy_extent(extent: &crate::CopyExtent) -> vk::Extent3D {
     }
 }
 
+pub fn map_extent_to_copy_size(
+    extent: &wgt::Extent3d,
+    dim: wgt::TextureDimension,
+) -> crate::CopyExtent {
+    crate::CopyExtent {
+        width: extent.width,
+        height: extent.height,
+        depth: match dim {
+            wgt::TextureDimension::D1 | wgt::TextureDimension::D2 => 1,
+            wgt::TextureDimension::D3 => extent.depth_or_array_layers,
+        },
+    }
+}
+
 pub fn map_subresource_range(
     range: &wgt::ImageSubresourceRange,
     texture_aspect: crate::FormatAspects,

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -11,6 +11,8 @@ use ash::{
     vk,
 };
 
+use super::conv;
+
 unsafe extern "system" fn debug_utils_messenger_callback(
     message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
     message_type: vk::DebugUtilsMessageTypeFlagsEXT,
@@ -704,6 +706,10 @@ impl crate::Surface<super::Api> for super::Surface {
                 aspects: crate::FormatAspects::COLOR,
                 format_info: sc.config.format.describe(),
                 raw_flags: vk::ImageCreateFlags::empty(),
+                copy_size: conv::map_extent_to_copy_size(
+                    &sc.config.extent,
+                    wgt::TextureDimension::D2,
+                ),
             },
         };
         Ok(Some(crate::AcquiredSurfaceTexture {

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -598,10 +598,33 @@ impl crate::Instance<super::Api> for super::Instance {
             }
         };
 
-        raw_devices
+        let mut exposed_adapters = raw_devices
             .into_iter()
             .flat_map(|device| self.expose_adapter(device))
-            .collect()
+            .collect::<Vec<_>>();
+
+        // detect if it's an Intel + NVidia configuration
+        if cfg!(target_os = "linux") {
+            use crate::auxil::db;
+            let has_nvidia_dgpu = exposed_adapters.iter().any(|exposed| {
+                exposed.info.device_type == wgt::DeviceType::DiscreteGpu
+                    && exposed.info.vendor == db::nvidia::VENDOR as usize
+            });
+            if has_nvidia_dgpu {
+                for exposed in exposed_adapters.iter_mut() {
+                    if exposed.info.device_type == wgt::DeviceType::IntegratedGpu
+                        && exposed.info.vendor == db::intel::VENDOR as usize
+                    {
+                        // See https://gitlab.freedesktop.org/mesa/mesa/-/issues/4688
+                        log::warn!("Disabling presentation on '{}' (id {:?}) because of an Nvidia dGPU (on Linux)",
+                            exposed.info.name, exposed.adapter.raw);
+                        exposed.adapter.private_caps.can_present = false;
+                    }
+                }
+            }
+        }
+
+        exposed_adapters
     }
 }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -267,6 +267,7 @@ pub struct Texture {
     aspects: crate::FormatAspects,
     format_info: wgt::TextureFormatInfo,
     raw_flags: vk::ImageCreateFlags,
+    copy_size: crate::CopyExtent,
 }
 
 #[derive(Debug)]

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -158,6 +158,8 @@ struct PrivateCapabilities {
     timeline_semaphores: bool,
     texture_d24: bool,
     texture_d24_s8: bool,
+    /// Ability to present contents to any screen. Only needed to work around broken platform configurations.
+    can_present: bool,
     non_coherent_map_mask: wgt::BufferAddress,
 }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -221,7 +221,7 @@ struct DeviceShared {
     instance: Arc<InstanceShared>,
     extension_fns: DeviceExtensionFunctions,
     vendor_id: u32,
-    _timestamp_period: f32,
+    timestamp_period: f32,
     downlevel_flags: wgt::DownlevelFlags,
     private_caps: PrivateCapabilities,
     render_passes: Mutex<fxhash::FxHashMap<RenderPassKey, vk::RenderPass>>,
@@ -539,6 +539,10 @@ impl crate::Queue<Api> for Queue {
             log::warn!("Suboptimal present of frame {}", texture.index);
         }
         Ok(())
+    }
+
+    unsafe fn get_timestamp_period(&self) -> f32 {
+        self.device.timestamp_period
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -809,6 +809,8 @@ pub enum DeviceType {
     Cpu,
 }
 
+//TODO: convert `vendor` and `device` to `u32`
+
 /// Information about an adapter.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]


### PR DESCRIPTION
**Connections**
Includes #1898 (minus `wgpu` parts), #1899, #1907, #1908, #1911, #1921, #1926

**Description**
Another week, another patch release!

**Testing**
Manually tested
