### PR TITLE
Implement min_{uniform,storage}_buffer_offset_alignment limits

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -93,8 +93,8 @@ pub enum CreateBindGroupError {
     MissingTextureUsage(#[from] MissingTextureUsageError),
     #[error("binding declared as a single item, but bind group is using it as an array")]
     SingleBindingExpected,
-    #[error("buffer offset {0} does not respect `BIND_BUFFER_ALIGNMENT`")]
-    UnalignedBufferOffset(wgt::BufferAddress),
+    #[error("buffer offset {0} does not respect device's requested `{1}` limit {2}")]
+    UnalignedBufferOffset(wgt::BufferAddress, &'static str, u32),
     #[error(
         "buffer binding {binding} range {given} exceeds `max_*_buffer_binding_size` limit {limit}"
     )]
@@ -655,9 +655,14 @@ pub enum BindError {
     #[error("number of dynamic offsets ({actual}) doesn't match the number of dynamic bindings in the bind group layout ({expected})")]
     MismatchedDynamicOffsetCount { actual: usize, expected: usize },
     #[error(
-        "dynamic binding at index {idx}: offset {offset} does not respect `BIND_BUFFER_ALIGNMENT`"
+        "dynamic binding at index {idx}: offset {offset} does not respect device's requested `{limit_name}` limit {alignment}"
     )]
-    UnalignedDynamicBinding { idx: usize, offset: u32 },
+    UnalignedDynamicBinding {
+        idx: usize,
+        offset: u32,
+        alignment: u32,
+        limit_name: &'static str,
+    },
     #[error("dynamic binding at index {idx} with offset {offset} would overrun the buffer (limit: {max})")]
     DynamicBindingOutOfBounds { idx: usize, offset: u32, max: u64 },
 }
@@ -666,6 +671,8 @@ pub enum BindError {
 pub struct BindGroupDynamicBindingData {
     /// The maximum value the dynamic offset can have before running off the end of the buffer.
     pub(crate) maximum_dynamic_offset: wgt::BufferAddress,
+    /// The binding type.
+    pub(crate) binding_type: wgt::BufferBindingType,
 }
 
 #[derive(Debug)]
@@ -683,6 +690,7 @@ impl<A: hal::Api> BindGroup<A> {
     pub(crate) fn validate_dynamic_bindings(
         &self,
         offsets: &[wgt::DynamicOffset],
+        limits: &wgt::Limits,
     ) -> Result<(), BindError> {
         if self.dynamic_binding_info.len() != offsets.len() {
             return Err(BindError::MismatchedDynamicOffsetCount {
@@ -697,8 +705,23 @@ impl<A: hal::Api> BindGroup<A> {
             .zip(offsets.iter())
             .enumerate()
         {
-            if offset as wgt::BufferAddress % wgt::BIND_BUFFER_ALIGNMENT != 0 {
-                return Err(BindError::UnalignedDynamicBinding { idx, offset });
+            let (alignment, limit_name) = match info.binding_type {
+                wgt::BufferBindingType::Uniform => (
+                    limits.min_uniform_buffer_offset_alignment,
+                    "min_uniform_buffer_offset_alignment",
+                ),
+                wgt::BufferBindingType::Storage { .. } => (
+                    limits.min_storage_buffer_offset_alignment,
+                    "min_storage_buffer_offset_alignment",
+                ),
+            };
+            if offset as wgt::BufferAddress % alignment as u64 != 0 {
+                return Err(BindError::UnalignedDynamicBinding {
+                    idx,
+                    offset,
+                    alignment,
+                    limit_name,
+                });
             }
 
             if offset as wgt::BufferAddress > info.maximum_dynamic_offset {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -34,6 +34,7 @@
 #![allow(clippy::reversed_empty_ranges)]
 
 use crate::{
+    binding_model::buffer_binding_type_alignment,
     command::{
         BasePass, DrawError, MapPassErr, PassErrorScope, RenderCommand, RenderCommandError,
         StateChange,
@@ -217,16 +218,8 @@ impl RenderBundleEncoder {
                         .map(|offset| *offset as wgt::BufferAddress)
                         .zip(bind_group.dynamic_binding_info.iter())
                     {
-                        let (alignment, limit_name) = match info.binding_type {
-                            wgt::BufferBindingType::Uniform => (
-                                device.limits.min_uniform_buffer_offset_alignment,
-                                "min_uniform_buffer_offset_alignment",
-                            ),
-                            wgt::BufferBindingType::Storage { .. } => (
-                                device.limits.min_storage_buffer_offset_alignment,
-                                "min_storage_buffer_offset_alignment",
-                            ),
-                        };
+                        let (alignment, limit_name) =
+                            buffer_binding_type_alignment(&device.limits, info.binding_type);
                         if offset % alignment as u64 != 0 {
                             return Err(RenderCommandError::UnalignedBufferOffset(
                                 offset, limit_name, alignment,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -360,7 +360,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         .map_err(|_| ComputePassErrorInner::InvalidBindGroup(bind_group_id))
                         .map_pass_err(scope)?;
                     bind_group
-                        .validate_dynamic_bindings(&temp_offsets)
+                        .validate_dynamic_bindings(&temp_offsets, &cmd_buf.limits)
                         .map_pass_err(scope)?;
 
                     cmd_buf.buffer_memory_init_actions.extend(

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -65,8 +65,8 @@ pub enum RenderCommandError {
     InvalidRenderBundle(id::RenderBundleId),
     #[error("bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
     BindGroupIndexOutOfRange { index: u8, max: u32 },
-    #[error("dynamic buffer offset {0} does not respect `BIND_BUFFER_ALIGNMENT`")]
-    UnalignedBufferOffset(u64),
+    #[error("dynamic buffer offset {0} does not respect device's requested `{1}` limit {2}")]
+    UnalignedBufferOffset(u64, &'static str, u32),
     #[error("number of buffer offsets ({actual}) does not match the number of dynamic bindings ({expected})")]
     InvalidDynamicOffsetCount { actual: usize, expected: usize },
     #[error("render pipeline {0:?} is invalid")]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -882,7 +882,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .map_err(|_| RenderCommandError::InvalidBindGroup(bind_group_id))
                             .map_pass_err(scope)?;
                         bind_group
-                            .validate_dynamic_bindings(&temp_offsets)
+                            .validate_dynamic_bindings(&temp_offsets, &cmd_buf.limits)
                             .map_pass_err(scope)?;
 
                         // merge the resource tracker in

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1241,13 +1241,11 @@ impl<A: HalApi> Device<A> {
                 })
             }
         };
-        let (pub_usage, internal_use, range_limit, align, align_limit_name) = match binding_ty {
+        let (pub_usage, internal_use, range_limit) = match binding_ty {
             wgt::BufferBindingType::Uniform => (
                 wgt::BufferUsages::UNIFORM,
                 hal::BufferUses::UNIFORM,
                 limits.max_uniform_buffer_binding_size,
-                limits.min_uniform_buffer_offset_alignment,
-                "min_uniform_buffer_offset_alignment",
             ),
             wgt::BufferBindingType::Storage { read_only } => (
                 wgt::BufferUsages::STORAGE,
@@ -1257,11 +1255,11 @@ impl<A: HalApi> Device<A> {
                     hal::BufferUses::STORAGE_READ | hal::BufferUses::STORAGE_WRITE
                 },
                 limits.max_storage_buffer_binding_size,
-                limits.min_storage_buffer_offset_alignment,
-                "min_storage_buffer_offset_alignment",
             ),
         };
 
+        let (align, align_limit_name) =
+            binding_model::buffer_binding_type_alignment(limits, binding_ty);
         if bb.offset % align as u64 != 0 {
             return Err(Error::UnalignedBufferOffset(
                 bb.offset,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -6,7 +6,7 @@ use crate::{
     LabelHelpers, LifeGuard, Stored, DOWNLEVEL_WARNING_MESSAGE,
 };
 
-use wgt::{Backend, Backends, PowerPreference, BIND_BUFFER_ALIGNMENT};
+use wgt::{Backend, Backends, PowerPreference};
 
 use hal::{Adapter as _, Instance as _};
 use thiserror::Error;
@@ -62,6 +62,8 @@ fn check_limits(requested: &wgt::Limits, allowed: &wgt::Limits) -> Vec<FailedLim
     compare!(max_vertex_attributes, Less);
     compare!(max_vertex_buffer_array_stride, Less);
     compare!(max_push_constant_size, Less);
+    compare!(min_uniform_buffer_offset_alignment, Greater);
+    compare!(min_storage_buffer_offset_alignment, Greater);
     failed
 }
 
@@ -308,16 +310,6 @@ impl<A: HalApi> Adapter<A> {
             //TODO
         }
 
-        assert_eq!(
-            0,
-            BIND_BUFFER_ALIGNMENT % caps.alignments.storage_buffer_offset,
-            "Adapter storage buffer offset alignment not compatible with WGPU"
-        );
-        assert_eq!(
-            0,
-            BIND_BUFFER_ALIGNMENT % caps.alignments.uniform_buffer_offset,
-            "Adapter uniform buffer offset alignment not compatible with WGPU"
-        );
         if let Some(failed) = check_limits(&desc.limits, &caps.limits).pop() {
             return Err(RequestDeviceError::LimitsExceeded(failed));
         }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -238,6 +238,9 @@ impl super::Adapter {
                     max_vertex_attributes: d3d12::D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT,
                     max_vertex_buffer_array_stride: d3d12::D3D12_SO_BUFFER_MAX_STRIDE_IN_BYTES,
                     max_push_constant_size: 0,
+                    min_uniform_buffer_offset_alignment:
+                        d3d12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT,
+                    min_storage_buffer_offset_alignment: 4, // TODO?
                 },
                 alignments: crate::Alignments {
                     buffer_copy_offset: wgt::BufferSize::new(
@@ -248,11 +251,6 @@ impl super::Adapter {
                         d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as u64,
                     )
                     .unwrap(),
-                    uniform_buffer_offset: wgt::BufferSize::new(
-                        d3d12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT as u64,
-                    )
-                    .unwrap(),
-                    storage_buffer_offset: wgt::BufferSize::new(4).unwrap(), //TODO?
                 },
                 downlevel: wgt::DownlevelCapabilities::default(),
             },

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -288,7 +288,7 @@ impl super::Adapter {
         let max_texture_3d_size = gl.get_parameter_i32(glow::MAX_3D_TEXTURE_SIZE) as u32;
 
         let min_uniform_buffer_offset_alignment =
-            gl.get_parameter_i32(glow::UNIFORM_BUFFER_OFFSET_ALIGNMENT);
+            gl.get_parameter_i32(glow::UNIFORM_BUFFER_OFFSET_ALIGNMENT) as u32;
         let min_storage_buffer_offset_alignment = if ver >= (3, 1) {
             gl.get_parameter_i32(glow::SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT) as u32
         } else {
@@ -335,6 +335,8 @@ impl super::Adapter {
                 !0
             },
             max_push_constant_size: 0,
+            min_uniform_buffer_offset_alignment,
+            min_storage_buffer_offset_alignment,
         };
 
         let mut workarounds = super::Workarounds::empty();
@@ -379,14 +381,6 @@ impl super::Adapter {
                 alignments: crate::Alignments {
                     buffer_copy_offset: wgt::BufferSize::new(4).unwrap(),
                     buffer_copy_pitch: wgt::BufferSize::new(4).unwrap(),
-                    uniform_buffer_offset: wgt::BufferSize::new(
-                        min_storage_buffer_offset_alignment as u64,
-                    )
-                    .unwrap(),
-                    storage_buffer_offset: wgt::BufferSize::new(
-                        min_uniform_buffer_offset_alignment as u64,
-                    )
-                    .unwrap(),
                 },
             },
         })

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -665,8 +665,6 @@ pub struct Alignments {
     /// The alignment of the row pitch of the texture data stored in a buffer that is
     /// used in a GPU copy operation.
     pub buffer_copy_pitch: wgt::BufferSize,
-    pub uniform_buffer_offset: wgt::BufferSize,
-    pub storage_buffer_offset: wgt::BufferSize,
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -889,7 +889,6 @@ impl super::PrivateCapabilities {
     }
 
     pub fn capabilities(&self) -> crate::Capabilities {
-        let buffer_alignment = wgt::BufferSize::new(self.buffer_alignment).unwrap();
         let mut downlevel = wgt::DownlevelCapabilities::default();
         downlevel.flags.set(
             wgt::DownlevelFlags::CUBE_ARRAY_TEXTURES,
@@ -927,12 +926,12 @@ impl super::PrivateCapabilities {
                 max_vertex_attributes: base.max_vertex_attributes,
                 max_vertex_buffer_array_stride: base.max_vertex_buffer_array_stride,
                 max_push_constant_size: 0x1000,
+                min_uniform_buffer_offset_alignment: self.buffer_alignment as u32,
+                min_storage_buffer_offset_alignment: self.buffer_alignment as u32,
             },
             alignments: crate::Alignments {
-                buffer_copy_offset: buffer_alignment,
+                buffer_copy_offset: wgt::BufferSize::new(self.buffer_alignment).unwrap(),
                 buffer_copy_pitch: wgt::BufferSize::new(4).unwrap(),
-                uniform_buffer_offset: buffer_alignment,
-                storage_buffer_offset: buffer_alignment,
             },
             downlevel,
         }

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -503,6 +503,8 @@ impl PhysicalDeviceCapabilities {
             max_vertex_attributes: limits.max_vertex_input_attributes,
             max_vertex_buffer_array_stride: limits.max_vertex_input_binding_stride,
             max_push_constant_size: limits.max_push_constants_size,
+            min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment as u32,
+            min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment as u32,
         }
     }
 
@@ -512,10 +514,6 @@ impl PhysicalDeviceCapabilities {
             buffer_copy_offset: wgt::BufferSize::new(limits.optimal_buffer_copy_offset_alignment)
                 .unwrap(),
             buffer_copy_pitch: wgt::BufferSize::new(limits.optimal_buffer_copy_row_pitch_alignment)
-                .unwrap(),
-            storage_buffer_offset: wgt::BufferSize::new(limits.min_storage_buffer_offset_alignment)
-                .unwrap(),
-            uniform_buffer_offset: wgt::BufferSize::new(limits.min_uniform_buffer_offset_alignment)
                 .unwrap(),
         }
     }

--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -29,25 +29,27 @@ fn print_info_from_adapter(adapter: &wgpu::Adapter, idx: usize) {
         }
     }
     println!("\tLimits:");
-    let wgpu::Limits { 
-        max_texture_dimension_1d, 
-        max_texture_dimension_2d, 
-        max_texture_dimension_3d, 
-        max_texture_array_layers, 
-        max_bind_groups, 
-        max_dynamic_uniform_buffers_per_pipeline_layout, 
-        max_dynamic_storage_buffers_per_pipeline_layout, 
-        max_sampled_textures_per_shader_stage, 
-        max_samplers_per_shader_stage, 
-        max_storage_buffers_per_shader_stage, 
-        max_storage_textures_per_shader_stage, 
-        max_uniform_buffers_per_shader_stage, 
-        max_uniform_buffer_binding_size, 
-        max_storage_buffer_binding_size, 
-        max_vertex_buffers, 
-        max_vertex_attributes, 
-        max_vertex_buffer_array_stride, 
-        max_push_constant_size, 
+    let wgpu::Limits {
+        max_texture_dimension_1d,
+        max_texture_dimension_2d,
+        max_texture_dimension_3d,
+        max_texture_array_layers,
+        max_bind_groups,
+        max_dynamic_uniform_buffers_per_pipeline_layout,
+        max_dynamic_storage_buffers_per_pipeline_layout,
+        max_sampled_textures_per_shader_stage,
+        max_samplers_per_shader_stage,
+        max_storage_buffers_per_shader_stage,
+        max_storage_textures_per_shader_stage,
+        max_uniform_buffers_per_shader_stage,
+        max_uniform_buffer_binding_size,
+        max_storage_buffer_binding_size,
+        max_vertex_buffers,
+        max_vertex_attributes,
+        max_vertex_buffer_array_stride,
+        max_push_constant_size,
+        min_uniform_buffer_offset_alignment,
+        min_storage_buffer_offset_alignment,
     } = limits;
     println!("\t\tMax Texture Dimension 1d:                        {}", max_texture_dimension_1d);
     println!("\t\tMax Texture Dimension 2d:                        {}", max_texture_dimension_2d);
@@ -67,6 +69,8 @@ fn print_info_from_adapter(adapter: &wgpu::Adapter, idx: usize) {
     println!("\t\tMax Vertex Attributes:                           {}", max_vertex_attributes);
     println!("\t\tMax Vertex Buffer Array Stride:                  {}", max_vertex_buffer_array_stride);
     println!("\t\tMax Push Constant Size:                          {}", max_push_constant_size);
+    println!("\t\tMin Uniform Buffer Offset Alignment:             {}", min_uniform_buffer_offset_alignment);
+    println!("\t\tMin Storage Buffer Offset Alignment:             {}", min_storage_buffer_offset_alignment);
     println!("\tDownlevel Properties:");
     let wgpu::DownlevelCapabilities {
         shader_model,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -32,8 +32,6 @@ pub type DynamicOffset = u32;
 ///
 /// [`bytes_per_row`]: ImageDataLayout::bytes_per_row
 pub const COPY_BYTES_PER_ROW_ALIGNMENT: u32 = 256;
-/// Bound uniform/storage buffer offsets must be aligned to this number.
-pub const BIND_BUFFER_ALIGNMENT: BufferAddress = 256;
 /// An offset into the query resolve buffer has to be aligned to this.
 pub const QUERY_RESOLVE_BUFFER_ALIGNMENT: BufferAddress = 256;
 /// Buffer to buffer copy as well as buffer clear offsets and sizes must be aligned to this number.
@@ -629,6 +627,14 @@ pub struct Limits {
     /// - DX11 & OpenGL don't natively support push constants, and are emulated with uniforms,
     ///   so this number is less useful but likely 256.
     pub max_push_constant_size: u32,
+    /// Required `BufferBindingType::Uniform` alignment for `BufferBinding::offset`
+    /// when creating a `BindGroup`, or for `set_bind_group` `dynamicOffsets`.
+    /// Defaults to 256. Lower is "better".
+    pub min_uniform_buffer_offset_alignment: u32,
+    /// Required `BufferBindingType::Storage` alignment for `BufferBinding::offset`
+    /// when creating a `BindGroup`, or for `set_bind_group` `dynamicOffsets`.
+    /// Defaults to 256. Lower is "better".
+    pub min_storage_buffer_offset_alignment: u32,
 }
 
 impl Default for Limits {
@@ -652,6 +658,8 @@ impl Default for Limits {
             max_vertex_attributes: 16,
             max_vertex_buffer_array_stride: 2048,
             max_push_constant_size: 0,
+            min_uniform_buffer_offset_alignment: 256,
+            min_storage_buffer_offset_alignment: 256,
         }
     }
 }
@@ -678,6 +686,8 @@ impl Limits {
             max_vertex_attributes: 16,
             max_vertex_buffer_array_stride: 2048,
             max_push_constant_size: 0,
+            min_uniform_buffer_offset_alignment: 256,
+            min_storage_buffer_offset_alignment: 256,
         }
     }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -704,6 +704,17 @@ impl Limits {
             ..self
         }
     }
+
+    /// Modify the current limits to use the buffer alignment limits of the adapter.
+    ///
+    /// This is useful for when you'd like to dynamically use the "best" supported buffer alignments.
+    pub fn using_alignment(self, other: Self) -> Self {
+        Self {
+            min_uniform_buffer_offset_alignment: other.min_uniform_buffer_offset_alignment,
+            min_storage_buffer_offset_alignment: other.min_storage_buffer_offset_alignment,
+            ..self
+        }
+    }
 }
 
 /// Represents the sets of additional limits on an adapter,

--- a/wgpu/examples/shadow/main.rs
+++ b/wgpu/examples/shadow/main.rs
@@ -286,11 +286,13 @@ impl framework::Example for Example {
 
         let entity_uniform_size = mem::size_of::<EntityUniforms>() as wgpu::BufferAddress;
         let num_entities = 1 + cube_descs.len() as wgpu::BufferAddress;
-        assert!(entity_uniform_size <= wgpu::BIND_BUFFER_ALIGNMENT);
-        //Note: dynamic offsets also have to be aligned to `BIND_BUFFER_ALIGNMENT`.
+        let uniform_alignment =
+            device.limits().min_uniform_buffer_offset_alignment as wgpu::BufferAddress;
+        assert!(entity_uniform_size <= uniform_alignment);
+        // Note: dynamic uniform offsets also have to be aligned to `Limits::min_uniform_buffer_offset_alignment`.
         let entity_uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
-            size: num_entities * wgpu::BIND_BUFFER_ALIGNMENT,
+            size: num_entities * uniform_alignment,
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -327,7 +329,7 @@ impl framework::Example for Example {
                 index_buf: Rc::clone(&cube_index_buf),
                 index_format,
                 index_count: cube_index_data.len(),
-                uniform_offset: ((i + 1) * wgpu::BIND_BUFFER_ALIGNMENT as usize) as _,
+                uniform_offset: ((i + 1) * uniform_alignment as usize) as _,
             });
         }
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1008,7 +1008,8 @@ pub struct BufferBinding<'a> {
     /// Base offset of the buffer. For bindings with `dynamic == true`, this offset
     /// will be added to the dynamic offset provided in [`RenderPass::set_bind_group`].
     ///
-    /// The offset has to be aligned to [`BIND_BUFFER_ALIGNMENT`].
+    /// The offset has to be aligned to [`Limits::min_uniform_buffer_offset_alignment`]
+    /// or [`Limits::min_storage_buffer_offset_alignment`] appropriately.
     pub offset: BufferAddress,
     /// Size of the binding, or `None` for using the rest of the buffer.
     pub size: Option<BufferSize>,
@@ -2365,7 +2366,8 @@ impl<'a> RenderPass<'a> {
     /// in the active pipeline when any `draw()` function is called must match the layout of this bind group.
     ///
     /// If the bind group have dynamic offsets, provide them in order of their declaration.
-    /// These offsets have to be aligned to [`BIND_BUFFER_ALIGNMENT`].
+    /// These offsets have to be aligned to [`Limits::min_uniform_buffer_offset_alignment`]
+    /// or [`Limits::min_storage_buffer_offset_alignment`] appropriately.
     pub fn set_bind_group(
         &mut self,
         index: u32,
@@ -2769,7 +2771,8 @@ impl<'a> ComputePass<'a> {
     /// in the active pipeline when the `dispatch()` function is called must match the layout of this bind group.
     ///
     /// If the bind group have dynamic offsets, provide them in order of their declaration.
-    /// These offsets have to be aligned to [`BIND_BUFFER_ALIGNMENT`].
+    /// These offsets have to be aligned to [`Limits::min_uniform_buffer_offset_alignment`]
+    /// or [`Limits::min_storage_buffer_offset_alignment`] appropriately.
     pub fn set_bind_group(
         &mut self,
         index: u32,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -37,8 +37,8 @@ pub use wgt::{
     StorageTextureAccess, SurfaceConfiguration, SurfaceStatus, TextureAspect, TextureDimension,
     TextureFormat, TextureFormatFeatureFlags, TextureFormatFeatures, TextureSampleType,
     TextureUsages, TextureViewDimension, VertexAttribute, VertexFormat, VertexStepMode,
-    BIND_BUFFER_ALIGNMENT, COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT, MAP_ALIGNMENT,
-    PUSH_CONSTANT_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
+    COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT, MAP_ALIGNMENT, PUSH_CONSTANT_ALIGNMENT,
+    QUERY_SET_MAX_QUERIES, QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
 };
 
 use backend::{BufferMappedRange, Context as C};

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -60,6 +60,8 @@ pub fn lowest_reasonable_limits() -> Limits {
         max_vertex_attributes: 4,
         max_vertex_buffer_array_stride: 32,
         max_push_constant_size: 0,
+        min_uniform_buffer_offset_alignment: 256,
+        min_storage_buffer_offset_alignment: 256,
     }
 }
 


### PR DESCRIPTION
**Description**
This implements the `minUniformBufferOffsetAlignment` and `minStorageBufferOffsetAlignment` limits from the WebGPU spec.
https://www.w3.org/TR/webgpu/#dom-supported-limits-minuniformbufferoffsetalignment

This also adds a convenience method `Limits::using_alignment`, similarly to `Limits::using_resolution`.

`wgpu::BIND_BUFFER_ALIGNMENT` was _removed_ in favor of the limits, therefore this is a breaking change.

**Testing**
Manually tested on Vulkan, other backends TBD.

(Open to any and all feedback!)
