### PR TITLE
web: Add Instance::create_surface_from_canvas (fix #1837)

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -269,6 +269,7 @@ web-sys = { version = "0.3.53", features = [
     "GpuVertexState",
     "GpuVertexStepMode",
     "HtmlCanvasElement",
+    "OffscreenCanvas",
     "Window",
 ]}
 js-sys = "0.3.50"

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -887,6 +887,30 @@ fn future_map_async(result: JsFutureResult) -> Result<(), crate::BufferAsyncErro
     result.map(|_| ()).map_err(|_| crate::BufferAsyncError)
 }
 
+impl Context {
+    pub fn instance_create_surface_from_canvas(
+        &self,
+        canvas: &web_sys::HtmlCanvasElement,
+    ) -> <Self as crate::Context>::SurfaceId {
+        let context: wasm_bindgen::JsValue = match canvas.get_context("webgpu") {
+            Ok(Some(ctx)) => ctx.into(),
+            _ => panic!("expected to get context from canvas"),
+        };
+        Sendable(context.into())
+    }
+
+    pub fn instance_create_surface_from_offscreen_canvas(
+        &self,
+        canvas: &web_sys::OffscreenCanvas,
+    ) -> <Self as crate::Context>::SurfaceId {
+        let context: wasm_bindgen::JsValue = match canvas.get_context("webgpu") {
+            Ok(Some(ctx)) => ctx.into(),
+            _ => panic!("expected to get context from canvas"),
+        };
+        Sendable(context.into())
+    }
+}
+
 impl crate::Context for Context {
     type AdapterId = Sendable<web_sys::GpuAdapter>;
     type DeviceId = Sendable<web_sys::GpuDevice>;
@@ -949,11 +973,7 @@ impl crate::Context for Context {
             .expect("expected to find single canvas")
             .into();
         let canvas_element: web_sys::HtmlCanvasElement = canvas_node.into();
-        let context: wasm_bindgen::JsValue = match canvas_element.get_context("webgpu") {
-            Ok(Some(ctx)) => ctx.into(),
-            _ => panic!("expected to get context from canvas"),
-        };
-        Sendable(context.into())
+        self.instance_create_surface_from_canvas(&canvas_element)
     }
 
     fn adapter_is_surface_supported(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1480,6 +1480,40 @@ impl Instance {
         self.context.create_surface_from_core_animation_layer(layer)
     }
 
+    /// Creates a surface from a `web_sys::HtmlCanvasElement`.
+    ///
+    /// # Safety
+    ///
+    /// - canvas must be a valid <canvas> element to create a surface upon.
+    #[cfg(target_arch = "wasm32")]
+    pub unsafe fn create_surface_from_canvas(
+        &self,
+        canvas: &web_sys::HtmlCanvasElement,
+    ) -> Surface {
+        Surface {
+            context: Arc::clone(&self.context),
+            id: self.context.instance_create_surface_from_canvas(canvas),
+        }
+    }
+
+    /// Creates a surface from a `web_sys::OffscreenCanvas`.
+    ///
+    /// # Safety
+    ///
+    /// - canvas must be a valid OffscreenCanvas to create a surface upon.
+    #[cfg(target_arch = "wasm32")]
+    pub unsafe fn create_surface_from_offscreen_canvas(
+        &self,
+        canvas: &web_sys::OffscreenCanvas,
+    ) -> Surface {
+        Surface {
+            context: Arc::clone(&self.context),
+            id: self
+                .context
+                .instance_create_surface_from_offscreen_canvas(canvas),
+        }
+    }
+
     /// Polls all devices.
     /// If `force_wait` is true and this is not running on the web,
     /// then this function will block until all in-flight buffers have been mapped.


### PR DESCRIPTION
Add specialized methods on web for creating a wgpu Surface directly
from a `web_sys::HTMLCanvasElement` and `web_sys::OffscreenCanvas`.

 * `Instance::create_surface_from_canvas`
 * `Instance::create_surface_from_offscreen_canvas`

**Connections**
Fixes #1837.

**Description**
Currently [`Instance::create_surface`](https://github.com/gfx-rs/wgpu/blob/ca6fd97c6250c084962a8b8ab153d2f6975d8277/wgpu/src/lib.rs#L1460) requires a `HasRawWindowHandle`. The web backend uses this handle to search for a canvas with a [`data-raw-handle` attribute](https://github.com/gfx-rs/wgpu/blob/master/wgpu/src/backend/web.rs#L945). 

This is handy for full-screen demos or games, or quickly compiling winit apps to both desktop and web. However, this isn't ideal for apps that are part of a larger site, or usable as a JS library. For example, the user may want to instantiate wgpu without attaching the canvas to the DOM, or the canvas may be buried inside a shadow DOM. Additionally, it'd be nice to use `OffscreenCanvas`. See #1837 for more info.

This adds web-specific `Instance::create_surface_from_canvas` and `Instance::create_surface_from_offscreen_canvas` methods that directly accept `web_sys::HtmlCanvasElement` and `web_sys::OffscreenCanvas`. These methods are only compiled for the `wasm32` architecture. This was modeled after the `Instance::create_surface_from_core_animation_layer` method for macOS.

This does add `web_sys` types to the externally visible API. However, `web_sys` is already a dependency of the project, and as WebGPU is a web-based API, wgpu should work directly with standard web types.
