### PR TITLE
Do MTL feature check for Depth Clamping

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -852,7 +852,7 @@ impl super::PrivateCapabilities {
             },
             //Depth clipping is supported on all macOS GPU families and iOS family 4 and later
             supports_depth_clamping: device.supports_feature_set(MTLFeatureSet::iOS_GPUFamily4_v1)
-            || device.supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v1)
+                        || os_is_mac
         }
     }
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -852,7 +852,7 @@ impl super::PrivateCapabilities {
             },
             //Depth clipping is supported on all macOS GPU families and iOS family 4 and later
             supports_depth_clamping: device.supports_feature_set(MTLFeatureSet::iOS_GPUFamily4_v1)
-                        || os_is_mac
+                || os_is_mac,
         }
     }
 
@@ -866,7 +866,7 @@ impl super::PrivateCapabilities {
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | F::POLYGON_MODE_LINE
             | F::CLEAR_COMMANDS;
-        
+
         features.set(F::DEPTH_CLAMPING, self.supports_depth_clamping);
 
         features.set(

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -853,17 +853,22 @@ impl super::PrivateCapabilities {
         }
     }
 
-    pub fn features(&self) -> wgt::Features {
+    pub fn features(&self, device: &mtl::Device) -> wgt::Features {
         use wgt::Features as F;
 
         let mut features = F::empty()
-            | F::DEPTH_CLAMPING
             | F::TEXTURE_COMPRESSION_BC
             | F::MAPPABLE_PRIMARY_BUFFERS
             | F::VERTEX_WRITABLE_STORAGE
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | F::POLYGON_MODE_LINE
             | F::CLEAR_COMMANDS;
+         
+        //Depth clipping is supported on all macOS GPU families and iOS family 4 and later
+        if device.supports_feature_set(MTLFeatureSet::iOS_GPUFamily4_v1)
+            || device.supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v1) {
+            features |= F::DEPTH_CLAMPING;
+        }
 
         features.set(
             F::TEXTURE_BINDING_ARRAY

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -867,9 +867,7 @@ impl super::PrivateCapabilities {
             | F::POLYGON_MODE_LINE
             | F::CLEAR_COMMANDS;
         
-        if self.supports_depth_clamping {
-            features |= F::DEPTH_CLAMPING;
-        }
+        features.set(F::DEPTH_CLAMPING, self.supports_depth_clamping);
 
         features.set(
             F::TEXTURE_BINDING_ARRAY

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -850,10 +850,13 @@ impl super::PrivateCapabilities {
             } else {
                 Self::version_at_least(major, minor, 11, 0)
             },
+            //Depth clipping is supported on all macOS GPU families and iOS family 4 and later
+            supports_depth_clamping: device.supports_feature_set(MTLFeatureSet::iOS_GPUFamily4_v1)
+            || device.supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v1)
         }
     }
 
-    pub fn features(&self, device: &mtl::Device) -> wgt::Features {
+    pub fn features(&self) -> wgt::Features {
         use wgt::Features as F;
 
         let mut features = F::empty()
@@ -863,10 +866,8 @@ impl super::PrivateCapabilities {
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | F::POLYGON_MODE_LINE
             | F::CLEAR_COMMANDS;
-         
-        //Depth clipping is supported on all macOS GPU families and iOS family 4 and later
-        if device.supports_feature_set(MTLFeatureSet::iOS_GPUFamily4_v1)
-            || device.supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v1) {
+        
+        if self.supports_depth_clamping {
             features |= F::DEPTH_CLAMPING;
         }
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -109,6 +109,7 @@ impl crate::Instance<Api> for Instance {
             .map(|dev| {
                 let name = dev.name().into();
                 let shared = AdapterShared::new(dev);
+                let features = shared.private_caps.features(&shared.device.lock());
                 crate::ExposedAdapter {
                     info: wgt::AdapterInfo {
                         name,
@@ -121,7 +122,7 @@ impl crate::Instance<Api> for Instance {
                         },
                         backend: wgt::Backend::Metal,
                     },
-                    features: shared.private_caps.features(),
+                    features,
                     capabilities: shared.private_caps.capabilities(),
                     adapter: Adapter::new(Arc::new(shared)),
                 }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -109,7 +109,6 @@ impl crate::Instance<Api> for Instance {
             .map(|dev| {
                 let name = dev.name().into();
                 let shared = AdapterShared::new(dev);
-                let features = shared.private_caps.features(&shared.device.lock());
                 crate::ExposedAdapter {
                     info: wgt::AdapterInfo {
                         name,
@@ -122,7 +121,7 @@ impl crate::Instance<Api> for Instance {
                         },
                         backend: wgt::Backend::Metal,
                     },
-                    features,
+                    features: shared.private_caps.features(),
                     capabilities: shared.private_caps.capabilities(),
                     adapter: Adapter::new(Arc::new(shared)),
                 }
@@ -223,6 +222,7 @@ struct PrivateCapabilities {
     supports_arrays_of_textures: bool,
     supports_arrays_of_textures_write: bool,
     supports_mutability: bool,
+    supports_depth_clamping: bool,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
**Connections**
New discovered issue

**Description**
the DEPTH_CLAMPING feature was being enabled for all metal devices, while on iOS GPUFamily4 or newer is needed.
This caused the iOS simulator to assert on calls to to set_depth_clip_mode while Metal API validation is enabled.

**Testing**
Build internal application for both iOS simulator and iOS physical device.
On physical device (iPad Pro 2020 12.9") depth clamping feature is correctly enabled. On iOS simulator for the same device, the feature is correctly not enabled.
