### PR TITLE
web: Return None if GPU.requestAdapter returns null

### DIFF
--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -865,8 +865,8 @@ fn map_map_mode(mode: crate::MapMode) -> u32 {
 type JsFutureResult = Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>;
 
 fn future_request_adapter(result: JsFutureResult) -> Option<Sendable<web_sys::GpuAdapter>> {
-    match result {
-        Ok(js_value) => Some(Sendable(web_sys::GpuAdapter::from(js_value))),
+    match result.and_then(wasm_bindgen::JsCast::dyn_into) {
+        Ok(adapter) => Some(Sendable(adapter)),
         Err(_) => None,
     }
 }


### PR DESCRIPTION
**Description**
The [WebGPU spec](https://www.w3.org/TR/webgpu/#dom-gpu-requestadapter) says that `GPU.requestAdapter` may return `null`. For example, this happens if hardware acceleration is disabled in Chrome.

Currently `From::from` is used to cast the `JsValue` into `web_sys::GpuAdapter`. However, this will cause an unhandled TypeError in JS if the value is `null` and the cast fails.

Instead, use `JsCast::dyn_into` to properly check the cast and return `None` if it fails. Another option is to manually check for `JsValue::NULL`, but `dyn_into` feels more robust in case of  an unexpected object type.