### PR TITLE
Return appropriate error when failing to allocate drawable on metal

### DIFF
--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -271,7 +271,7 @@ impl crate::Surface<super::Api> for super::Surface {
             if let Some(drawable) = render_layer.next_drawable() {
                 Ok((drawable.to_owned(), drawable.texture().to_owned()))
             } else {
-                return Err(crate::SurfaceError::Other("failed to allocate drawable due to metal resource exhaustion"));
+                Err(crate::SurfaceError::Other("failed to allocate drawable due to metal resource exhaustion"))
             }
         })?;
 

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -271,7 +271,9 @@ impl crate::Surface<super::Api> for super::Surface {
             if let Some(drawable) = render_layer.next_drawable() {
                 Ok((drawable.to_owned(), drawable.texture().to_owned()))
             } else {
-                Err(crate::SurfaceError::Other("failed to allocate drawable due to metal resource exhaustion"))
+                Err(crate::SurfaceError::Other(
+                    "failed to allocate drawable due to metal resource exhaustion",
+                ))
             }
         })?;
 


### PR DESCRIPTION
**Connections**
Supplies an appropriate error when hitting behaviour described in #1936 

**Description**
Returns an appropriate error instead of causing an uncatchable panic and putting the library in an unusable state.
