### PR TITLE
Update naga to latest on git

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "e226cf3"
+rev = "130f802"
 #version = "0.6"
 features = ["wgsl-in"]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -69,12 +69,12 @@ core-graphics-types = "0.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "e226cf3"
+rev = "130f802"
 #version = "0.6"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "e226cf3"
+rev = "130f802"
 #version = "0.6"
 features = ["wgsl-in"]
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -90,14 +90,14 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "e226cf3"
+rev = "130f802"
 #version = "0.6"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "e226cf3"
+rev = "130f802"
 #version = "0.6"
 features = ["wgsl-in"]
 

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -983,7 +983,7 @@ impl crate::Context for Context {
                 let options = naga::front::spv::Options {
                     adjust_coordinate_space: false, // we require NDC_Y_UP feature
                     strict_capabilities: true,
-                    flow_graph_dump_prefix: None,
+                    block_ctx_dump_prefix: None,
                 };
                 let parser = naga::front::spv::Parser::new(spv.iter().cloned(), &options);
                 let module = parser.parse().unwrap();


### PR DESCRIPTION
**Connections**
Includes gfx-rs/naga#1294

**Description**
Many shaders passed directly as `spirv` were being rejected because of issues in the spirv frontend of naga, this has now been fixed in naga so the update fixes this.

**Testing**
The changed code only integrates the new version, all testing was made in naga
