### PR TITLE
web: Fix spirv-web feature for latest naga

### DIFF
--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1191,7 +1191,7 @@ impl crate::Context for Context {
                 let options = naga::front::spv::Options {
                     adjust_coordinate_space: false,
                     strict_capabilities: true,
-                    flow_graph_dump_prefix: None,
+                    block_ctx_dump_prefix: None,
                 };
                 let spv_parser = front::spv::Parser::new(spv.iter().cloned(), &options);
                 let spv_module = spv_parser.parse().unwrap();


### PR DESCRIPTION
**Description**
#1939 broke the `spirv-web` feature. `naga::front::spv::Options::flow_graph_dump_prefix` renamed to `block_ctx_dump_prefix`.

**Testing**
Ruffle was not building with wgpu master; builds with this change. Possibly CI should be changed to build with `spirv-web` feature.
