### PR TITLE
Store a reference to the device in texture views

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -809,6 +809,7 @@ impl<A: HalApi> Device<A> {
                 value: id::Valid(texture_id),
                 ref_count: texture.life_guard.add_ref(),
             },
+            device_id: texture.device_id.clone(),
             desc: resource::HalTextureViewDescriptor {
                 format: hal_desc.format,
                 dimension: hal_desc.dimension,
@@ -3294,15 +3295,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut token = Token::root();
 
         let (last_submit_index, device_id) = {
-            let (texture_guard, mut token) = hub.textures.read(&mut token);
             let (mut texture_view_guard, _) = hub.texture_views.write(&mut token);
 
             match texture_view_guard.get_mut(texture_view_id) {
                 Ok(view) => {
                     let _ref_count = view.life_guard.ref_count.take();
                     let last_submit_index = view.life_guard.life_count();
-                    let device_id = texture_guard[view.parent_id.value].device_id.value;
-                    (last_submit_index, device_id)
+                    (last_submit_index, view.device_id.value)
                 }
                 Err(InvalidId) => {
                     hub.texture_views

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -644,19 +644,12 @@ impl<A: HalApi, F: GlobalIdentityHandlerFactory> Hub<A, F> {
                 }
             }
         }
-        {
-            let textures = self.textures.data.read();
-            for element in self.texture_views.data.write().map.drain(..) {
-                if let Element::Occupied(texture_view, _) = element {
-                    // the texture should generally be present, unless it's a surface
-                    // texture, and we are in emergency shutdown.
-                    if textures.contains(texture_view.parent_id.value.0) {
-                        let texture = &textures[texture_view.parent_id.value];
-                        let device = &devices[texture.device_id.value];
-                        unsafe {
-                            device.raw.destroy_texture_view(texture_view.raw);
-                        }
-                    }
+
+        for element in self.texture_views.data.write().map.drain(..) {
+            if let Element::Occupied(texture_view, _) = element {
+                let device = &devices[texture_view.device_id.value];
+                unsafe {
+                    device.raw.destroy_texture_view(texture_view.raw);
                 }
             }
         }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -296,7 +296,10 @@ impl HalTextureViewDescriptor {
 #[derive(Debug)]
 pub struct TextureView<A: hal::Api> {
     pub(crate) raw: A::TextureView,
+    // The parent's refcount is held alive, but the parent may still be deleted
+    // if it's a surface texture. TODO: make this cleaner.
     pub(crate) parent_id: Stored<TextureId>,
+    pub(crate) device_id: Stored<DeviceId>,
     //TODO: store device_id for quick access?
     pub(crate) desc: HalTextureViewDescriptor,
     pub(crate) format_features: wgt::TextureFormatFeatures,


### PR DESCRIPTION
**Connections**

**Description**
If you hold onto a texture view from a surface texture for longer than the texture exists, dropping it results in this:
```
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `2`: Texture[6] is no longer alive', wgpu-core/src/hub.rs:132:9
```
It's annoying and counter-intuitive.

And technically, it shouldn't be required. It's only there because the texture views don't know their device, they have to ask their parent first.

**Testing**
Manually tested
