### PR TITLE
hal/metal: fix storage binding size units

### DIFF
--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1,6 +1,7 @@
 use super::{conv, AsNative};
 use std::{mem, ops::Range};
 
+// has to match `Temp::binding_sizes`
 const WORD_SIZE: usize = 4;
 
 impl Default for super::CommandState {
@@ -63,15 +64,15 @@ impl super::CommandState {
     fn make_sizes_buffer_update<'a>(
         &self,
         stage: naga::ShaderStage,
-        result_sizes: &'a mut Vec<wgt::BufferSize>,
-    ) -> Option<(u32, &'a [wgt::BufferSize])> {
+        result_sizes: &'a mut Vec<u32>,
+    ) -> Option<(u32, &'a [u32])> {
         let stage_info = &self.stage_infos[stage];
         let slot = stage_info.sizes_slot?;
         result_sizes.clear();
         for br in stage_info.sized_bindings.iter() {
             // If it's None, this isn't the right time to update the sizes
             let size = self.storage_buffer_length_map.get(br)?;
-            result_sizes.push(*size);
+            result_sizes.push(size.get().min(!0u32 as u64) as u32);
         }
         Some((slot as _, result_sizes))
     }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -710,7 +710,7 @@ struct IndexState {
 
 #[derive(Default)]
 struct Temp {
-    binding_sizes: Vec<wgt::BufferSize>,
+    binding_sizes: Vec<u32>,
 }
 
 struct CommandState {


### PR DESCRIPTION
**Connections**
Fixes #1830

**Description**
There was a messup between units. wgpu-hal passed u64 buffer sizes where MTL sources expected u32.
So the second size always got 0, and the third was wrong, etc.

**Testing**
Manually tested
