### PR TITLE
Expose query resolve offset and respect it in the mipmap example

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -38,7 +38,7 @@ pub use wgt::{
     TextureFormat, TextureFormatFeatureFlags, TextureFormatFeatures, TextureSampleType,
     TextureUsages, TextureViewDimension, VertexAttribute, VertexFormat, VertexStepMode,
     COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT, MAP_ALIGNMENT, PUSH_CONSTANT_ALIGNMENT,
-    QUERY_SET_MAX_QUERIES, QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
+    QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
 };
 
 use backend::{BufferMappedRange, Context as C};


### PR DESCRIPTION
**Connections**
Fixes #1959

**Description**
New limit was added, but it wasn't tested by anything because CI platforms don't have queries.

**Testing**
Manually tested
