### PR TITLE
Force point size output on Vulkan

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "130f802"
+rev = "52d74e9"
 #version = "0.6"
 features = ["wgsl-in"]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -69,12 +69,12 @@ core-graphics-types = "0.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "130f802"
+rev = "52d74e9"
 #version = "0.6"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "130f802"
+rev = "52d74e9"
 #version = "0.6"
 features = ["wgsl-in"]
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -847,6 +847,13 @@ impl super::Adapter {
                 spv::WriterFlags::LABEL_VARYINGS,
                 self.phd_capabilities.properties.vendor_id != crate::auxil::db::qualcomm::VENDOR,
             );
+            flags.set(
+                spv::WriterFlags::FORCE_POINT_SIZE,
+                //Note: we could technically disable this when we are compiling separate entry points,
+                // and we know exactly that the primitive topology is not `PointList`.
+                // But this requires cloning the `spv::Options` struct, which has heap allocations.
+                true, // could check `super::Workarounds::SEPARATE_ENTRY_POINTS`
+            );
             spv::Options {
                 lang_version: (1, 0),
                 flags,

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -90,14 +90,14 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "130f802"
+rev = "52d74e9"
 #version = "0.6"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "130f802"
+rev = "52d74e9"
 #version = "0.6"
 features = ["wgsl-in"]
 

--- a/wgpu/examples/cube/shader.wgsl
+++ b/wgpu/examples/cube/shader.wgsl
@@ -8,7 +8,7 @@ struct Locals {
     transform: mat4x4<f32>;
 };
 [[group(0), binding(0)]]
-var r_locals: Locals;
+var<uniform> r_locals: Locals;
 
 [[stage(vertex)]]
 fn vs_main(

--- a/wgpu/examples/mipmap/draw.wgsl
+++ b/wgpu/examples/mipmap/draw.wgsl
@@ -8,7 +8,7 @@ struct Locals {
     transform: mat4x4<f32>;
 };
 [[group(0), binding(0)]]
-var r_data: Locals;
+var<uniform> r_data: Locals;
 
 [[stage(vertex)]]
 fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {

--- a/wgpu/examples/skybox/shader.wgsl
+++ b/wgpu/examples/skybox/shader.wgsl
@@ -15,7 +15,7 @@ struct Data {
     cam_pos: vec4<f32>;
 };
 [[group(0), binding(0)]]
-var r_data: Data;
+var<uniform> r_data: Data;
 
 [[stage(vertex)]]
 fn vs_sky([[builtin(vertex_index)]] vertex_index: u32) -> SkyOutput {


### PR DESCRIPTION
**Connections**
Picks up https://github.com/gfx-rs/naga/pull/1372
Fixes #1752

**Description**
This enables `PointSize` builtin output for everything. Apparently, it's ok to do this for non-point topologies. I hope drivers are optimizing it out. Otherwise, we can go one step further and disable it when we know it's not needed.

Edit: filed https://github.com/gfx-rs/naga/issues/1375 to follow-up and improve this

**Testing**
Base change in Naga was tested manually. This PR wasn't, but it should work.
