### PR TITLE
Panic with an error by default

### DIFF
--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -2165,9 +2165,8 @@ impl fmt::Debug for ErrorSinkRaw {
 }
 
 fn default_error_handler(err: crate::Error) {
-    log::error!("wgpu error: {}\n", err);
-
-    panic!("Handling wgpu errors as fatal by default");
+    log::error!("Handling wgpu errors as fatal by default");
+    panic!("wgpu error: {}\n", err);
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
**Connections**
Too many times we see people missing the actual error message.

**Description**
Flips the error reporting. The notification of "Handling wgpu errors as fatal by default" is informative but not useful.

**Testing**
Should work!
