### PR TITLE
hal/vk: Enable image robustness where available

### DIFF
--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -163,6 +163,7 @@ struct PrivateCapabilities {
     can_present: bool,
     non_coherent_map_mask: wgt::BufferAddress,
     robust_buffer_access: bool,
+    robust_image_access: bool,
 }
 
 bitflags::bitflags!(


### PR DESCRIPTION
**Connections**
Related to #1978

**Description**
We detect if image robustness is exposed, and enable it in order to save on runtime checks.

**Testing**
Untested
