### PR TITLE
Make "Unexpected varying type" a bit less annoying

### DIFF
--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -822,7 +822,11 @@ impl Interface {
                 return;
             }
             ref other => {
-                log::error!("Unexpected varying type: {:?}", other);
+                //Note: technically this should be at least `log::error`, but
+                // the reality is - every shader coming from `glslc` outputs an array
+                // of clip distances and hits this path :(
+                // So we lower it to `log::warn` to be less annoying.
+                log::warn!("Unexpected varying type: {:?}", other);
                 return;
             }
         };


### PR DESCRIPTION
**Connections**
This has been bothering most of `wgpu` users, and it's not actionable.

**Description**
Lowering the priority: Error to Warning.

**Testing**
Shouldn't need
