### PR TITLE
Support descriptor arrays which are shorter than the BGL

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -65,8 +65,16 @@ pub enum CreateBindGroupError {
     InvalidTextureView(TextureViewId),
     #[error("sampler {0:?} is invalid")]
     InvalidSampler(SamplerId),
-    #[error("binding count declared with {expected} items, but {actual} items were provided")]
+    #[error(
+        "binding count declared with at most {expected} items, but {actual} items were provided"
+    )]
+    BindingArrayPartialLengthMismatch { actual: usize, expected: usize },
+    #[error(
+        "binding count declared with exactly {expected} items, but {actual} items were provided"
+    )]
     BindingArrayLengthMismatch { actual: usize, expected: usize },
+    #[error("array binding provided zero elements")]
+    BindingArrayZeroLength,
     #[error("bound buffer range {range:?} does not fit in buffer of size {size}")]
     BindingRangeTooLarge {
         buffer: BufferId,

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -152,3 +152,12 @@ pub fn check_texture_dimension_size(
 
     Ok(())
 }
+
+pub fn bind_group_layout_flags(features: wgt::Features) -> hal::BindGroupLayoutFlags {
+    let mut flags = hal::BindGroupLayoutFlags::empty();
+    flags.set(
+        hal::BindGroupLayoutFlags::PARTIALLY_BOUND,
+        features.contains(wgt::Features::PARTIALLY_BOUND_BINDING_ARRAY),
+    );
+    flags
+}

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -19,7 +19,7 @@ use smallvec::SmallVec;
 use thiserror::Error;
 use wgt::{BufferAddress, TextureFormat, TextureViewDimension};
 
-use std::{borrow::Cow, iter, marker::PhantomData, mem, ops::Range, ptr};
+use std::{borrow::Cow, iter, marker::PhantomData, mem, num::NonZeroU32, ops::Range, ptr};
 
 mod life;
 pub mod queue;
@@ -1183,10 +1183,13 @@ impl<A: HalApi> Device<A> {
                 })?;
         }
 
+        let bgl_flags = conv::bind_group_layout_flags(self.features);
+
         let mut hal_bindings = entry_map.values().cloned().collect::<Vec<_>>();
         hal_bindings.sort_by_key(|b| b.binding);
         let hal_desc = hal::BindGroupLayoutDescriptor {
             label,
+            flags: bgl_flags,
             entries: &hal_bindings,
         };
         let raw = unsafe {
@@ -1387,7 +1390,7 @@ impl<A: HalApi> Device<A> {
                 .entries
                 .get(&binding)
                 .ok_or(Error::MissingBindingDeclaration(binding))?;
-            let res_index = match entry.resource {
+            let (res_index, count) = match entry.resource {
                 Br::Buffer(ref bb) => {
                     let bb = Self::create_buffer_binding(
                         bb,
@@ -1402,21 +1405,11 @@ impl<A: HalApi> Device<A> {
 
                     let res_index = hal_buffers.len();
                     hal_buffers.push(bb);
-                    res_index
+                    (res_index, 1)
                 }
                 Br::BufferArray(ref bindings_array) => {
-                    if let Some(count) = decl.count {
-                        let count = count.get() as usize;
-                        let num_bindings = bindings_array.len();
-                        if count != num_bindings {
-                            return Err(Error::BindingArrayLengthMismatch {
-                                actual: num_bindings,
-                                expected: count,
-                            });
-                        }
-                    } else {
-                        return Err(Error::SingleBindingExpected);
-                    }
+                    let num_bindings = bindings_array.len();
+                    Self::check_array_binding(self.features, decl.count, num_bindings)?;
 
                     let res_index = hal_buffers.len();
                     for bb in bindings_array.iter() {
@@ -1432,7 +1425,7 @@ impl<A: HalApi> Device<A> {
                         )?;
                         hal_buffers.push(bb);
                     }
-                    res_index
+                    (res_index, num_bindings)
                 }
                 Br::Sampler(id) => {
                     match decl.ty {
@@ -1464,7 +1457,7 @@ impl<A: HalApi> Device<A> {
 
                             let res_index = hal_samplers.len();
                             hal_samplers.push(&sampler.raw);
-                            res_index
+                            (res_index, 1)
                         }
                         _ => {
                             return Err(Error::WrongBindingType {
@@ -1505,21 +1498,11 @@ impl<A: HalApi> Device<A> {
                         view: &view.raw,
                         usage: internal_use,
                     });
-                    res_index
+                    (res_index, 1)
                 }
                 Br::TextureViewArray(ref bindings_array) => {
-                    if let Some(count) = decl.count {
-                        let count = count.get() as usize;
-                        let num_bindings = bindings_array.len();
-                        if count != num_bindings {
-                            return Err(Error::BindingArrayLengthMismatch {
-                                actual: num_bindings,
-                                expected: count,
-                            });
-                        }
-                    } else {
-                        return Err(Error::SingleBindingExpected);
-                    }
+                    let num_bindings = bindings_array.len();
+                    Self::check_array_binding(self.features, decl.count, num_bindings)?;
 
                     let res_index = hal_textures.len();
                     for &id in bindings_array.iter() {
@@ -1551,13 +1534,14 @@ impl<A: HalApi> Device<A> {
                         });
                     }
 
-                    res_index
+                    (res_index, num_bindings)
                 }
             };
 
             hal_entries.push(hal::BindGroupEntry {
                 binding,
                 resource_index: res_index as u32,
+                count: count as u32,
             });
         }
 
@@ -1594,6 +1578,39 @@ impl<A: HalApi> Device<A> {
             used_buffer_ranges,
             dynamic_binding_info,
         })
+    }
+
+    fn check_array_binding(
+        features: wgt::Features,
+        count: Option<NonZeroU32>,
+        num_bindings: usize,
+    ) -> Result<(), super::binding_model::CreateBindGroupError> {
+        use super::binding_model::CreateBindGroupError as Error;
+
+        if let Some(count) = count {
+            let count = count.get() as usize;
+            if count < num_bindings {
+                return Err(Error::BindingArrayPartialLengthMismatch {
+                    actual: num_bindings,
+                    expected: count,
+                });
+            }
+            if count != num_bindings
+                && !features.contains(wgt::Features::PARTIALLY_BOUND_BINDING_ARRAY)
+            {
+                return Err(Error::BindingArrayLengthMismatch {
+                    actual: num_bindings,
+                    expected: count,
+                });
+            }
+            if num_bindings == 0 {
+                return Err(Error::BindingArrayZeroLength);
+            }
+        } else {
+            return Err(Error::SingleBindingExpected);
+        };
+
+        Ok(())
     }
 
     fn texture_use_parameters(

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -334,10 +334,12 @@ impl<A: HalApi> Adapter<A> {
         desc: &DeviceDescriptor,
         trace_path: Option<&std::path::Path>,
     ) -> Result<Device<A>, RequestDeviceError> {
-        let open = unsafe { self.raw.adapter.open(desc.features) }.map_err(|err| match err {
-            hal::DeviceError::Lost => RequestDeviceError::DeviceLost,
-            hal::DeviceError::OutOfMemory => RequestDeviceError::OutOfMemory,
-        })?;
+        let open = unsafe { self.raw.adapter.open(desc.features, &desc.limits) }.map_err(
+            |err| match err {
+                hal::DeviceError::Lost => RequestDeviceError::DeviceLost,
+                hal::DeviceError::OutOfMemory => RequestDeviceError::OutOfMemory,
+            },
+        )?;
 
         self.create_device_from_hal(self_id, open, desc, trace_path)
     }

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -102,8 +102,11 @@ impl<A: hal::Api> Example<A> {
             );
             (exposed.adapter, exposed.capabilities)
         };
-        let hal::OpenDevice { device, mut queue } =
-            unsafe { adapter.open(wgt::Features::empty()).unwrap() };
+        let hal::OpenDevice { device, mut queue } = unsafe {
+            adapter
+                .open(wgt::Features::empty(), &wgt::Limits::default())
+                .unwrap()
+        };
 
         let window_size: (u32, u32) = window.inner_size().into();
         let surface_config = hal::SurfaceConfiguration {
@@ -146,6 +149,7 @@ impl<A: hal::Api> Example<A> {
 
         let global_bgl_desc = hal::BindGroupLayoutDescriptor {
             label: None,
+            flags: hal::BindGroupLayoutFlags::empty(),
             entries: &[
                 wgt::BindGroupLayoutEntry {
                     binding: 0,
@@ -183,6 +187,8 @@ impl<A: hal::Api> Example<A> {
             unsafe { device.create_bind_group_layout(&global_bgl_desc).unwrap() };
 
         let local_bgl_desc = hal::BindGroupLayoutDescriptor {
+            label: None,
+            flags: hal::BindGroupLayoutFlags::empty(),
             entries: &[wgt::BindGroupLayoutEntry {
                 binding: 0,
                 visibility: wgt::ShaderStages::VERTEX,
@@ -193,7 +199,6 @@ impl<A: hal::Api> Example<A> {
                 },
                 count: None,
             }],
-            label: None,
         };
         let local_group_layout =
             unsafe { device.create_bind_group_layout(&local_bgl_desc).unwrap() };
@@ -417,14 +422,17 @@ impl<A: hal::Api> Example<A> {
                     hal::BindGroupEntry {
                         binding: 0,
                         resource_index: 0,
+                        count: 1,
                     },
                     hal::BindGroupEntry {
                         binding: 1,
                         resource_index: 0,
+                        count: 1,
                     },
                     hal::BindGroupEntry {
                         binding: 2,
                         resource_index: 0,
+                        count: 1,
                     },
                 ],
             };
@@ -446,6 +454,7 @@ impl<A: hal::Api> Example<A> {
                 entries: &[hal::BindGroupEntry {
                     binding: 0,
                     resource_index: 0,
+                    count: 1,
                 }],
             };
             unsafe { device.create_bind_group(&local_group_desc).unwrap() }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -262,6 +262,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
     unsafe fn open(
         &self,
         features: wgt::Features,
+        _limits: &wgt::Limits,
     ) -> Result<crate::OpenDevice<super::Api>, crate::DeviceError> {
         let queue = self
             .device

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -74,7 +74,11 @@ impl crate::Surface<Api> for Context {
 }
 
 impl crate::Adapter<Api> for Context {
-    unsafe fn open(&self, features: wgt::Features) -> DeviceResult<crate::OpenDevice<Api>> {
+    unsafe fn open(
+        &self,
+        features: wgt::Features,
+        _limits: &wgt::Limits,
+    ) -> DeviceResult<crate::OpenDevice<Api>> {
         Err(crate::DeviceError::Lost)
     }
     unsafe fn texture_format_capabilities(

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -419,6 +419,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
     unsafe fn open(
         &self,
         features: wgt::Features,
+        _limits: &wgt::Limits,
     ) -> Result<crate::OpenDevice<super::Api>, crate::DeviceError> {
         let gl = &self.shared.context.lock();
         gl.pixel_store_i32(glow::UNPACK_ALIGNMENT, 1);

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -188,7 +188,11 @@ pub trait Surface<A: Api>: Send + Sync {
 }
 
 pub trait Adapter<A: Api>: Send + Sync {
-    unsafe fn open(&self, features: wgt::Features) -> Result<OpenDevice<A>, DeviceError>;
+    unsafe fn open(
+        &self,
+        features: wgt::Features,
+        limits: &wgt::Limits,
+    ) -> Result<OpenDevice<A>, DeviceError>;
 
     /// Return the set of supported capabilities for a texture format.
     unsafe fn texture_format_capabilities(
@@ -525,6 +529,14 @@ bitflags!(
 );
 
 bitflags!(
+    /// Pipeline layout creation flags.
+    pub struct BindGroupLayoutFlags: u32 {
+        /// Allows for bind group binding arrays to be shorter than the array in the BGL.
+        const PARTIALLY_BOUND = 1 << 0;
+    }
+);
+
+bitflags!(
     /// Texture format capability flags.
     pub struct TextureFormatCapabilities: u32 {
         /// Format can be sampled.
@@ -798,6 +810,7 @@ pub struct SamplerDescriptor<'a> {
 #[derive(Clone, Debug)]
 pub struct BindGroupLayoutDescriptor<'a> {
     pub label: Label<'a>,
+    pub flags: BindGroupLayoutFlags,
     pub entries: &'a [wgt::BindGroupLayoutEntry],
 }
 
@@ -847,6 +860,7 @@ impl<A: Api> Clone for TextureBinding<'_, A> {
 pub struct BindGroupEntry {
     pub binding: u32,
     pub resource_index: u32,
+    pub count: u32,
 }
 
 /// BindGroup descriptor.

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -19,6 +19,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
     unsafe fn open(
         &self,
         features: wgt::Features,
+        _limits: &wgt::Limits,
     ) -> Result<crate::OpenDevice<super::Api>, crate::DeviceError> {
         let queue = self
             .shared

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -377,7 +377,12 @@ impl
             })
             .collect::<ArrayVec<_, 8>>();
 
-        let mut vk_flags = vk::DescriptorPoolCreateFlags::empty();
+        let mut vk_flags =
+            if flags.contains(gpu_descriptor::DescriptorPoolCreateFlags::UPDATE_AFTER_BIND) {
+                vk::DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
+            } else {
+                vk::DescriptorPoolCreateFlags::empty()
+            };
         if flags.contains(gpu_descriptor::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET) {
             vk_flags |= vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET;
         }
@@ -1012,9 +1017,69 @@ impl crate::Device<super::Api> for super::Device {
             })
             .collect::<Vec<_>>();
 
-        let vk_info = vk::DescriptorSetLayoutCreateInfo::builder()
-            .flags(vk::DescriptorSetLayoutCreateFlags::empty())
-            .bindings(&vk_bindings);
+        let vk_info = vk::DescriptorSetLayoutCreateInfo::builder().bindings(&vk_bindings);
+
+        let mut binding_flag_info;
+        let binding_flag_vec;
+        let mut requires_update_after_bind = false;
+
+        let partially_bound = desc
+            .flags
+            .contains(crate::BindGroupLayoutFlags::PARTIALLY_BOUND);
+
+        let vk_info = if !self.shared.uab_types.is_empty() || partially_bound {
+            binding_flag_vec = desc
+                .entries
+                .iter()
+                .map(|entry| {
+                    let mut flags = vk::DescriptorBindingFlags::empty();
+
+                    if partially_bound && entry.count.is_some() {
+                        flags |= vk::DescriptorBindingFlags::PARTIALLY_BOUND;
+                    }
+
+                    let uab_type = match entry.ty {
+                        wgt::BindingType::Buffer {
+                            ty: wgt::BufferBindingType::Uniform,
+                            ..
+                        } => super::UpdateAfterBindTypes::UNIFORM_BUFFER,
+                        wgt::BindingType::Buffer {
+                            ty: wgt::BufferBindingType::Storage { .. },
+                            ..
+                        } => super::UpdateAfterBindTypes::STORAGE_BUFFER,
+                        wgt::BindingType::Texture { .. } => {
+                            super::UpdateAfterBindTypes::SAMPLED_TEXTURE
+                        }
+                        wgt::BindingType::StorageTexture { .. } => {
+                            super::UpdateAfterBindTypes::STORAGE_TEXTURE
+                        }
+                        _ => super::UpdateAfterBindTypes::empty(),
+                    };
+
+                    if !uab_type.is_empty() && self.shared.uab_types.contains(uab_type) {
+                        flags |= vk::DescriptorBindingFlags::UPDATE_AFTER_BIND;
+                        requires_update_after_bind = true;
+                    }
+
+                    flags
+                })
+                .collect::<Vec<_>>();
+
+            binding_flag_info = vk::DescriptorSetLayoutBindingFlagsCreateInfo::builder()
+                .binding_flags(&binding_flag_vec);
+
+            vk_info.push_next(&mut binding_flag_info)
+        } else {
+            vk_info
+        };
+
+        let dsl_create_flags = if requires_update_after_bind {
+            vk::DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND_POOL
+        } else {
+            vk::DescriptorSetLayoutCreateFlags::empty()
+        };
+
+        let vk_info = vk_info.flags(dsl_create_flags);
 
         let raw = self
             .shared
@@ -1030,6 +1095,7 @@ impl crate::Device<super::Api> for super::Device {
             raw,
             desc_count,
             types: types.into_boxed_slice(),
+            requires_update_after_bind,
         })
     }
     unsafe fn destroy_bind_group_layout(&self, bg_layout: super::BindGroupLayout) {
@@ -1085,7 +1151,11 @@ impl crate::Device<super::Api> for super::Device {
         let mut vk_sets = self.desc_allocator.lock().allocate(
             &*self.shared,
             &desc.layout.raw,
-            gpu_descriptor::DescriptorSetLayoutCreateFlags::empty(),
+            if desc.layout.requires_update_after_bind {
+                gpu_descriptor::DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND
+            } else {
+                gpu_descriptor::DescriptorSetLayoutCreateFlags::empty()
+            },
             &desc.layout.desc_count,
             1,
         )?;
@@ -1122,7 +1192,7 @@ impl crate::Device<super::Api> for super::Device {
                 vk::DescriptorType::SAMPLED_IMAGE | vk::DescriptorType::STORAGE_IMAGE => {
                     let index = image_infos.len();
                     let start = entry.resource_index;
-                    let end = start + size;
+                    let end = start + entry.count;
                     image_infos.extend(desc.textures[start as usize..end as usize].iter().map(
                         |binding| {
                             let layout =
@@ -1141,7 +1211,7 @@ impl crate::Device<super::Api> for super::Device {
                 | vk::DescriptorType::STORAGE_BUFFER_DYNAMIC => {
                     let index = buffer_infos.len();
                     let start = entry.resource_index;
-                    let end = start + size;
+                    let end = start + entry.count;
                     buffer_infos.extend(desc.buffers[start as usize..end as usize].iter().map(
                         |binding| {
                             vk::DescriptorBufferInfo::builder()

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -227,6 +227,82 @@ struct FramebufferKey {
     sample_count: u32,
 }
 
+bitflags::bitflags! {
+    pub struct UpdateAfterBindTypes: u8 {
+        const UNIFORM_BUFFER = 0x1;
+        const STORAGE_BUFFER = 0x2;
+        const SAMPLED_TEXTURE = 0x4;
+        const STORAGE_TEXTURE = 0x8;
+    }
+}
+
+impl UpdateAfterBindTypes {
+    fn from_limits(limits: &wgt::Limits, phd_limits: &vk::PhysicalDeviceLimits) -> Self {
+        let mut uab_types = UpdateAfterBindTypes::empty();
+        uab_types.set(
+            UpdateAfterBindTypes::UNIFORM_BUFFER,
+            limits.max_uniform_buffers_per_shader_stage
+                > phd_limits.max_per_stage_descriptor_uniform_buffers,
+        );
+        uab_types.set(
+            UpdateAfterBindTypes::STORAGE_BUFFER,
+            limits.max_storage_buffers_per_shader_stage
+                > phd_limits.max_per_stage_descriptor_storage_buffers,
+        );
+        uab_types.set(
+            UpdateAfterBindTypes::SAMPLED_TEXTURE,
+            limits.max_sampled_textures_per_shader_stage
+                > phd_limits.max_per_stage_descriptor_sampled_images,
+        );
+        uab_types.set(
+            UpdateAfterBindTypes::STORAGE_TEXTURE,
+            limits.max_storage_textures_per_shader_stage
+                > phd_limits.max_per_stage_descriptor_storage_images,
+        );
+        uab_types
+    }
+
+    fn from_features(features: &adapter::PhysicalDeviceFeatures) -> Self {
+        let mut uab_types = UpdateAfterBindTypes::empty();
+        if let Some(vk_12) = features.vulkan_1_2 {
+            uab_types.set(
+                UpdateAfterBindTypes::UNIFORM_BUFFER,
+                vk_12.descriptor_binding_uniform_buffer_update_after_bind != 0,
+            );
+            uab_types.set(
+                UpdateAfterBindTypes::STORAGE_BUFFER,
+                vk_12.descriptor_binding_storage_buffer_update_after_bind != 0,
+            );
+            uab_types.set(
+                UpdateAfterBindTypes::SAMPLED_TEXTURE,
+                vk_12.descriptor_binding_sampled_image_update_after_bind != 0,
+            );
+            uab_types.set(
+                UpdateAfterBindTypes::STORAGE_TEXTURE,
+                vk_12.descriptor_binding_storage_image_update_after_bind != 0,
+            );
+        } else if let Some(di) = features.descriptor_indexing {
+            uab_types.set(
+                UpdateAfterBindTypes::UNIFORM_BUFFER,
+                di.descriptor_binding_uniform_buffer_update_after_bind != 0,
+            );
+            uab_types.set(
+                UpdateAfterBindTypes::STORAGE_BUFFER,
+                di.descriptor_binding_storage_buffer_update_after_bind != 0,
+            );
+            uab_types.set(
+                UpdateAfterBindTypes::SAMPLED_TEXTURE,
+                di.descriptor_binding_sampled_image_update_after_bind != 0,
+            );
+            uab_types.set(
+                UpdateAfterBindTypes::STORAGE_TEXTURE,
+                di.descriptor_binding_storage_image_update_after_bind != 0,
+            );
+        }
+        uab_types
+    }
+}
+
 struct DeviceShared {
     raw: ash::Device,
     handle_is_owned: bool,
@@ -234,6 +310,7 @@ struct DeviceShared {
     extension_fns: DeviceExtensionFunctions,
     vendor_id: u32,
     timestamp_period: f32,
+    uab_types: UpdateAfterBindTypes,
     downlevel_flags: wgt::DownlevelFlags,
     private_caps: PrivateCapabilities,
     workarounds: Workarounds,
@@ -314,6 +391,7 @@ pub struct BindGroupLayout {
     raw: vk::DescriptorSetLayout,
     desc_count: gpu_descriptor::DescriptorTotalCount,
     types: Box<[(vk::DescriptorType, u32)]>,
+    requires_update_after_bind: bool,
 }
 
 #[derive(Debug)]

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -330,6 +330,10 @@ bitflags::bitflags! {
         ///
         /// This is a native only feature.
         const UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING = 1 << 21;
+        /// Allows the user to create bind groups continaing arrays with less bindings than the BindGroupLayout.
+        ///
+        /// This is a native only feature.
+        const PARTIALLY_BOUND_BINDING_ARRAY = 1 << 22;
         /// Allows the user to create unsized uniform arrays of bindings:
         ///
         /// eg. `uniform texture2D textures[]`.
@@ -339,7 +343,7 @@ bitflags::bitflags! {
         /// - Vulkan 1.2+ (or VK_EXT_descriptor_indexing)'s runtimeDescriptorArray feature
         ///
         /// This is a native only feature.
-        const UNSIZED_BINDING_ARRAY = 1 << 22;
+        const UNSIZED_BINDING_ARRAY = 1 << 23;
         /// Allows the user to call [`RenderPass::multi_draw_indirect`] and [`RenderPass::multi_draw_indexed_indirect`].
         ///
         /// Allows multiple indirect calls to be dispatched from a single buffer.
@@ -349,7 +353,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const MULTI_DRAW_INDIRECT = 1 << 23;
+        const MULTI_DRAW_INDIRECT = 1 << 24;
         /// Allows the user to call [`RenderPass::multi_draw_indirect_count`] and [`RenderPass::multi_draw_indexed_indirect_count`].
         ///
         /// This allows the use of a buffer containing the actual number of draw calls.
@@ -359,7 +363,7 @@ bitflags::bitflags! {
         /// - Vulkan 1.2+ (or VK_KHR_draw_indirect_count)
         ///
         /// This is a native only feature.
-        const MULTI_DRAW_INDIRECT_COUNT = 1 << 24;
+        const MULTI_DRAW_INDIRECT_COUNT = 1 << 25;
         /// Allows the use of push constants: small, fast bits of memory that can be updated
         /// inside a [`RenderPass`].
         ///
@@ -376,7 +380,7 @@ bitflags::bitflags! {
         /// - OpenGL (emulated with uniforms)
         ///
         /// This is a native only feature.
-        const PUSH_CONSTANTS = 1 << 25;
+        const PUSH_CONSTANTS = 1 << 26;
         /// Allows the use of [`AddressMode::ClampToBorder`].
         ///
         /// Supported platforms:
@@ -387,7 +391,7 @@ bitflags::bitflags! {
         /// - OpenGL
         ///
         /// This is a web and native feature.
-        const ADDRESS_MODE_CLAMP_TO_BORDER = 1 << 26;
+        const ADDRESS_MODE_CLAMP_TO_BORDER = 1 << 27;
         /// Allows the user to set [`PolygonMode::Line`] in [`PrimitiveState::polygon_mode`]
         ///
         /// This allows drawing polygons/triangles as lines (wireframe) instead of filled
@@ -398,7 +402,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const POLYGON_MODE_LINE= 1 << 27;
+        const POLYGON_MODE_LINE= 1 << 28;
         /// Allows the user to set [`PolygonMode::Point`] in [`PrimitiveState::polygon_mode`]
         ///
         /// This allows only drawing the vertices of polygons/triangles instead of filled
@@ -408,7 +412,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const POLYGON_MODE_POINT = 1 << 28;
+        const POLYGON_MODE_POINT = 1 << 29;
         /// Enables ETC family of compressed textures. All ETC textures use 4x4 pixel blocks.
         /// ETC2 RGB and RGBA1 are 8 bytes per block. RTC2 RGBA8 and EAC are 16 bytes per block.
         ///
@@ -423,7 +427,7 @@ bitflags::bitflags! {
         /// - Mobile (some)
         ///
         /// This is a native-only feature.
-        const TEXTURE_COMPRESSION_ETC2 = 1 << 29;
+        const TEXTURE_COMPRESSION_ETC2 = 1 << 30;
         /// Enables ASTC family of compressed textures. ASTC textures use pixel blocks varying from 4x4 to 12x12.
         /// Blocks are always 16 bytes.
         ///
@@ -438,7 +442,7 @@ bitflags::bitflags! {
         /// - Mobile (some)
         ///
         /// This is a native-only feature.
-        const TEXTURE_COMPRESSION_ASTC_LDR = 1 << 30;
+        const TEXTURE_COMPRESSION_ASTC_LDR = 1 << 31;
         /// Enables device specific texture format features.
         ///
         /// See `TextureFormatFeatures` for a listing of the features in question.
@@ -450,7 +454,7 @@ bitflags::bitflags! {
         /// This extension does not enable additional formats.
         ///
         /// This is a native-only feature.
-        const TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 1 << 31;
+        const TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 1 << 32;
         /// Enables 64-bit floating point types in SPIR-V shaders.
         ///
         /// Note: even when supported by GPU hardware, 64-bit floating point operations are
@@ -460,7 +464,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native-only feature.
-        const SHADER_FLOAT64 = 1 << 32;
+        const SHADER_FLOAT64 = 1 << 33;
         /// Enables using 64-bit types for vertex attributes.
         ///
         /// Requires SHADER_FLOAT64.
@@ -468,7 +472,7 @@ bitflags::bitflags! {
         /// Supported Platforms: N/A
         ///
         /// This is a native-only feature.
-        const VERTEX_ATTRIBUTE_64BIT = 1 << 33;
+        const VERTEX_ATTRIBUTE_64BIT = 1 << 34;
         /// Allows the user to set a overestimation-conservative-rasterization in [`PrimitiveState::conservative`]
         ///
         /// Processing of degenerate triangles/lines is hardware specific.
@@ -478,7 +482,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const CONSERVATIVE_RASTERIZATION = 1 << 34;
+        const CONSERVATIVE_RASTERIZATION = 1 << 35;
         /// Enables bindings of writable storage buffers and textures visible to vertex shaders.
         ///
         /// Note: some (tiled-based) platforms do not support vertex shaders with any side-effects.
@@ -487,14 +491,14 @@ bitflags::bitflags! {
         /// - All
         ///
         /// This is a native-only feature.
-        const VERTEX_WRITABLE_STORAGE = 1 << 35;
+        const VERTEX_WRITABLE_STORAGE = 1 << 36;
         /// Enables clear to zero for buffers & textures.
         ///
         /// Supported platforms:
         /// - All
         ///
         /// This is a native only feature.
-        const CLEAR_COMMANDS = 1 << 36;
+        const CLEAR_COMMANDS = 1 << 37;
         /// Enables creating shader modules from SPIR-V binary data (unsafe).
         ///
         /// SPIR-V data is not parsed or interpreted in any way; you can use
@@ -506,7 +510,7 @@ bitflags::bitflags! {
         /// Vulkan implementation.
         ///
         /// This is a native only feature.
-        const SPIRV_SHADER_PASSTHROUGH = 1 << 37;
+        const SPIRV_SHADER_PASSTHROUGH = 1 << 38;
         /// Enables `builtin(primitive_index)` in fragment shaders.
         ///
         /// Note: enables geometry processing for pipelines using the builtin.
@@ -517,7 +521,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const SHADER_PRIMITIVE_INDEX = 1 << 38;
+        const SHADER_PRIMITIVE_INDEX = 1 << 39;
     }
 }
 


### PR DESCRIPTION
**Connections**

Closes #1635
Closes #1111

**Description**

This allows BG arrays to have fewer elements than are in the BGLs. As long as that element count is non-zero.

**Testing**

Rend3
