### PR TITLE
Move validation from `Device::create_texture_from_hal()` to `Device::create_texture()`

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3122,12 +3122,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let format_features = match device
                 .describe_format_features(adapter, desc.format)
-                .map_err(|error| resource::CreateTextureError::MissingFeatures(desc.format, error)) {
+                .map_err(|error| resource::CreateTextureError::MissingFeatures(desc.format, error))
+            {
                 Ok(features) => features,
                 Err(error) => break error,
             };
 
-            let texture = device.create_texture_from_hal(hal_texture, device_id, desc, format_features);
+            let texture =
+                device.create_texture_from_hal(hal_texture, device_id, desc, format_features);
             let num_levels = texture.full_range.levels.end;
             let num_layers = texture.full_range.layers.end;
             let ref_count = texture.life_guard.add_ref();


### PR DESCRIPTION
**Connections**
It seems the mipmap validation was originally fixed in #893, and then moved to `fn create_texture_from_hal` in #1609?

**Description**
Users encountered a segfault upon creating a texture when mip_level_count was set to 0 with (at least) Vulkan.
This is due to wgpu's validation taking place after the API's texture is created.
This change moves wgpu's validation to before the API's texture is created, introducing a friendlier error instead of a segfault.

**Testing**
I ran the cube example with mip_level_count as 1, and again on 0. 
With mip_level_count set to 0, wgpu now produces the error: 

```
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_texture
    texture descriptor mip level count (0) is invalid
    
'
```
    
----
notes: 
`format_features` is being created twice (probably not worth an api change), and validation will no longer happen in the unsafe hal code-paths.