### PR TITLE
Check Deno build on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,3 +179,20 @@ jobs:
       - name: run rustfmt
         run: |
           cargo fmt -- --check
+
+  deno:
+    name: Deno
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+
+      - name: install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: build Deno
+        run: |
+          cargo check --manifest-path cts_runner/Cargo.toml

--- a/deno_webgpu/src/shader.rs
+++ b/deno_webgpu/src/shader.rs
@@ -39,6 +39,7 @@ pub fn op_webgpu_create_shader_module(
 
     let descriptor = wgpu_core::pipeline::ShaderModuleDescriptor {
         label: args.label.map(Cow::from),
+        shader_bound_checks: wgpu_types::ShaderBoundChecks::default(),
     };
 
     gfx_put!(device => instance.device_create_shader_module(


### PR DESCRIPTION
**Connections**
#1978 broke `deno_webgpu` without us noticing.

**Description**
We may not want to run everything on each change, but we can at least make sure Deno still builds.

**Testing**
Self-tested
