### PR TITLE
Add spans to provide more information profile gaps

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -128,35 +128,65 @@ impl<A: hal::Api> NonReferencedResources<A> {
     }
 
     unsafe fn clean(&mut self, device: &A::Device) {
-        for raw in self.buffers.drain(..) {
-            device.destroy_buffer(raw);
+        if !self.buffers.is_empty() {
+            profiling::scope!("destroy_buffers");
+            for raw in self.buffers.drain(..) {
+                device.destroy_buffer(raw);
+            }
         }
-        for raw in self.textures.drain(..) {
-            device.destroy_texture(raw);
+        if !self.textures.is_empty() {
+            profiling::scope!("destroy_textures");
+            for raw in self.textures.drain(..) {
+                device.destroy_texture(raw);
+            }
         }
-        for (_, raw) in self.texture_views.drain(..) {
-            device.destroy_texture_view(raw);
+        if !self.texture_views.is_empty() {
+            profiling::scope!("destroy_texture_views");
+            for (_, raw) in self.texture_views.drain(..) {
+                device.destroy_texture_view(raw);
+            }
         }
-        for raw in self.samplers.drain(..) {
-            device.destroy_sampler(raw);
+        if !self.samplers.is_empty() {
+            profiling::scope!("destroy_samplers");
+            for raw in self.samplers.drain(..) {
+                device.destroy_sampler(raw);
+            }
         }
-        for raw in self.bind_groups.drain(..) {
-            device.destroy_bind_group(raw);
+        if !self.bind_groups.is_empty() {
+            profiling::scope!("destroy_bind_groups");
+            for raw in self.bind_groups.drain(..) {
+                device.destroy_bind_group(raw);
+            }
         }
-        for raw in self.compute_pipes.drain(..) {
-            device.destroy_compute_pipeline(raw);
+        if !self.compute_pipes.is_empty() {
+            profiling::scope!("destroy_compute_pipelines");
+            for raw in self.compute_pipes.drain(..) {
+                device.destroy_compute_pipeline(raw);
+            }
         }
-        for raw in self.render_pipes.drain(..) {
-            device.destroy_render_pipeline(raw);
+        if !self.render_pipes.is_empty() {
+            profiling::scope!("destroy_render_pipelines");
+            for raw in self.render_pipes.drain(..) {
+                device.destroy_render_pipeline(raw);
+            }
         }
-        for raw in self.bind_group_layouts.drain(..) {
-            device.destroy_bind_group_layout(raw);
+        if !self.bind_group_layouts.is_empty() {
+            profiling::scope!("destroy_bind_group_layouts");
+            for raw in self.bind_group_layouts.drain(..) {
+                device.destroy_bind_group_layout(raw);
+            }
         }
-        for raw in self.pipeline_layouts.drain(..) {
-            device.destroy_pipeline_layout(raw);
+        if !self.pipeline_layouts.is_empty() {
+            profiling::scope!("destroy_pipeline_layouts");
+            for raw in self.pipeline_layouts.drain(..) {
+                device.destroy_pipeline_layout(raw);
+            }
         }
-        for raw in self.query_sets.drain(..) {
-            device.destroy_query_set(raw);
+        if !self.query_sets.is_empty() {
+            profiling::scope!("destroy_query_sets");
+            for raw in self.query_sets.drain(..) {
+                device.destroy_query_set(raw);
+            }
         }
     }
 }
@@ -290,7 +320,7 @@ impl<A: hal::Api> LifetimeTracker<A> {
     }
 
     pub fn cleanup(&mut self, device: &A::Device) {
-        profiling::scope!("cleanup");
+        profiling::scope!("cleanup", "LifetimeTracker");
         unsafe {
             self.free_resources.clean(device);
         }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2658,6 +2658,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         surface_id: id::SurfaceId,
         adapter_id: id::AdapterId,
     ) -> Result<TextureFormat, instance::GetSurfacePreferredFormatError> {
+        profiling::scope!("surface_get_preferred_format");
         let hub = A::hub(self);
         let mut token = Token::root();
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -193,6 +193,7 @@ impl Surface {
 
         let suf = A::get_surface(self);
         let caps = unsafe {
+            profiling::scope!("surface_capabilities");
             adapter
                 .raw
                 .adapter
@@ -517,6 +518,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 if let Some(ref inst) = *instance_field {
                     let hub = HalApi::hub(self);
                     if let Some(id_backend) = inputs.find(backend) {
+                        profiling::scope!("enumerating", backend_info);
                         for raw in unsafe {inst.enumerate_adapters()} {
                             let adapter = Adapter::new(raw);
                             log::info!("Adapter {} {:?}", backend_info, adapter.raw.info);

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -22,6 +22,7 @@ renderdoc = ["libloading", "renderdoc-sys"]
 [dependencies]
 bitflags = "1.0"
 parking_lot = "0.11"
+profiling = { version = "1", default-features = false }
 raw-window-handle = "0.3"
 thiserror = "1"
 

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -767,9 +767,14 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 };
                 self.temp.barriers.push(barrier);
             }
-            list.ResourceBarrier(self.temp.barriers.len() as u32, self.temp.barriers.as_ptr());
+
+            if !self.temp.barriers.is_empty() {
+                profiling::scope!("ID3D12GraphicsCommandList::ResourceBarrier");
+                list.ResourceBarrier(self.temp.barriers.len() as u32, self.temp.barriers.as_ptr());
+            }
 
             for resolve in self.pass.resolves.iter() {
+                profiling::scope!("ID3D12GraphicsCommandList::ResolveSubresource");
                 list.ResolveSubresource(
                     resolve.dst.0.as_mut_ptr(),
                     resolve.dst.1,
@@ -784,7 +789,10 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 let transition = barrier.u.Transition_mut();
                 mem::swap(&mut transition.StateBefore, &mut transition.StateAfter);
             }
-            list.ResourceBarrier(self.temp.barriers.len() as u32, self.temp.barriers.as_ptr());
+            if !self.temp.barriers.is_empty() {
+                profiling::scope!("ID3D12GraphicsCommandList::ResourceBarrier");
+                list.ResourceBarrier(self.temp.barriers.len() as u32, self.temp.barriers.as_ptr());
+            }
         }
 
         self.end_pass();

--- a/wgpu-hal/src/dx12/descriptor.rs
+++ b/wgpu-hal/src/dx12/descriptor.rs
@@ -41,14 +41,17 @@ impl GeneralHeap {
         ty: native::DescriptorHeapType,
         total_handles: u64,
     ) -> Result<Self, crate::DeviceError> {
-        let raw = device
-            .create_descriptor_heap(
-                total_handles as u32,
-                ty,
-                native::DescriptorHeapFlags::SHADER_VISIBLE,
-                0,
-            )
-            .into_device_result("Descriptor heap creation")?;
+        let raw = {
+            profiling::scope!("ID3D12Device::CreateDescriptorHeap");
+            device
+                .create_descriptor_heap(
+                    total_handles as u32,
+                    ty,
+                    native::DescriptorHeapFlags::SHADER_VISIBLE,
+                    0,
+                )
+                .into_device_result("Descriptor heap creation")?
+        };
 
         Ok(Self {
             raw,

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -183,6 +183,7 @@ impl crate::Instance<super::Api> for super::Instance {
         for cur_index in 0.. {
             let raw = match factory6 {
                 Some(factory) => {
+                    profiling::scope!("IDXGIFactory6::EnumAdapterByGpuPreference");
                     let mut adapter2 = native::WeakPtr::<dxgi1_2::IDXGIAdapter2>::null();
                     let hr = factory.EnumAdapterByGpuPreference(
                         cur_index,
@@ -202,6 +203,7 @@ impl crate::Instance<super::Api> for super::Instance {
                     adapter2
                 }
                 None => {
+                    profiling::scope!("IDXGIFactory1::EnumAdapters1");
                     let mut adapter1 = native::WeakPtr::<dxgi::IDXGIAdapter1>::null();
                     let hr = self
                         .factory

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -615,14 +615,17 @@ impl crate::Surface<Api> for Surface {
                     SwapEffect: dxgi::DXGI_SWAP_EFFECT_FLIP_DISCARD,
                 };
 
-                let hr = self.factory.CreateSwapChainForHwnd(
-                    device.present_queue.as_mut_ptr() as *mut _,
-                    self.wnd_handle,
-                    &raw_desc,
-                    ptr::null(),
-                    ptr::null_mut(),
-                    swap_chain1.mut_void() as *mut *mut _,
-                );
+                let hr = {
+                    profiling::scope!("IDXGIFactory4::CreateSwapChainForHwnd");
+                    self.factory.CreateSwapChainForHwnd(
+                        device.present_queue.as_mut_ptr() as *mut _,
+                        self.wnd_handle,
+                        &raw_desc,
+                        ptr::null(),
+                        ptr::null_mut(),
+                        swap_chain1.mut_void() as *mut *mut _,
+                    )
+                };
 
                 if let Err(err) = hr.into_result() {
                     log::error!("SwapChain creation error: {}", err);
@@ -724,7 +727,10 @@ impl crate::Queue<Api> for Queue {
             self.temp_lists.push(cmd_buf.raw.as_list());
         }
 
-        self.raw.execute_command_lists(&self.temp_lists);
+        {
+            profiling::scope!("ID3D12CommandQueue::ExecuteCommandLists");
+            self.raw.execute_command_lists(&self.temp_lists);
+        }
 
         if let Some((fence, value)) = signal_fence {
             self.raw
@@ -746,6 +752,8 @@ impl crate::Queue<Api> for Queue {
             wgt::PresentMode::Fifo => (1, 0),
             wgt::PresentMode::Mailbox => (1, 0),
         };
+
+        profiling::scope!("IDXGISwapchain3::Present");
         sc.raw.Present(interval, flags);
 
         Ok(())

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -108,7 +108,11 @@ unsafe extern "system" fn debug_utils_messenger_callback(
 
 impl super::Swapchain {
     unsafe fn release_resources(self, device: &ash::Device) -> Self {
-        let _ = device.device_wait_idle();
+        profiling::scope!("Swapchain::release_resources");
+        {
+            profiling::scope!("vkDeviceWaitIdle");
+            let _ = device.device_wait_idle();
+        };
         device.destroy_fence(self.fence, None);
         self
     }


### PR DESCRIPTION
**Description**

Trying to fill in some information gaps in profiles.
- If there is a long running api call, mark it specifically to indicate what is the actual root performance loss.
- Add spans in places where there there was a decent amount of work happening, but there was no explanation as to why.

Did this for dx12 and vulkan as these are the platforms I have access to.

**Testing**

Inspected logs in tracy
