### PR TITLE
Add component count data to TextureFormat::describe

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1360,6 +1360,8 @@ pub struct TextureFormatInfo {
     pub block_dimensions: (u8, u8),
     /// Size in bytes of a "block" of texels. This is the size per pixel on uncompressed textures.
     pub block_size: u8,
+    /// Count of components in the texture. This determines which components there will be actual data in the shader for.
+    pub components: u8,
     /// Format will have colors be converted from srgb to linear on read and from linear to srgb on write.
     pub srgb: bool,
     /// Format features guaranteed by the WebGPU spec. Additional features are available if `Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES` is enabled.
@@ -1838,127 +1840,135 @@ impl TextureFormat {
         let all_flags = TextureUsages::all();
 
         // See <https://gpuweb.github.io/gpuweb/#texture-format-caps> for reference
-        let (required_features, sample_type, srgb, block_dimensions, block_size, allowed_usages) =
-            match self {
-                // Normal 8 bit textures
-                Self::R8Unorm => (native, float, linear, (1, 1), 1, attachment),
-                Self::R8Snorm => (native, float, linear, (1, 1), 1, basic),
-                Self::R8Uint => (native, uint, linear, (1, 1), 1, attachment),
-                Self::R8Sint => (native, sint, linear, (1, 1), 1, attachment),
+        let (
+            required_features,
+            sample_type,
+            srgb,
+            block_dimensions,
+            block_size,
+            allowed_usages,
+            components,
+        ) = match self {
+            // Normal 8 bit textures
+            Self::R8Unorm => (native, float, linear, (1, 1), 1, attachment, 1),
+            Self::R8Snorm => (native, float, linear, (1, 1), 1, basic, 1),
+            Self::R8Uint => (native, uint, linear, (1, 1), 1, attachment, 1),
+            Self::R8Sint => (native, sint, linear, (1, 1), 1, attachment, 1),
 
-                // Normal 16 bit textures
-                Self::R16Uint => (native, uint, linear, (1, 1), 2, attachment),
-                Self::R16Sint => (native, sint, linear, (1, 1), 2, attachment),
-                Self::R16Float => (native, float, linear, (1, 1), 2, attachment),
-                Self::Rg8Unorm => (native, float, linear, (1, 1), 2, attachment),
-                Self::Rg8Snorm => (native, float, linear, (1, 1), 2, attachment),
-                Self::Rg8Uint => (native, uint, linear, (1, 1), 2, attachment),
-                Self::Rg8Sint => (native, sint, linear, (1, 1), 2, basic),
+            // Normal 16 bit textures
+            Self::R16Uint => (native, uint, linear, (1, 1), 2, attachment, 1),
+            Self::R16Sint => (native, sint, linear, (1, 1), 2, attachment, 1),
+            Self::R16Float => (native, float, linear, (1, 1), 2, attachment, 1),
+            Self::Rg8Unorm => (native, float, linear, (1, 1), 2, attachment, 2),
+            Self::Rg8Snorm => (native, float, linear, (1, 1), 2, attachment, 2),
+            Self::Rg8Uint => (native, uint, linear, (1, 1), 2, attachment, 2),
+            Self::Rg8Sint => (native, sint, linear, (1, 1), 2, basic, 2),
 
-                // Normal 32 bit textures
-                Self::R32Uint => (native, uint, linear, (1, 1), 4, all_flags),
-                Self::R32Sint => (native, sint, linear, (1, 1), 4, all_flags),
-                Self::R32Float => (native, nearest, linear, (1, 1), 4, all_flags),
-                Self::Rg16Uint => (native, uint, linear, (1, 1), 4, attachment),
-                Self::Rg16Sint => (native, sint, linear, (1, 1), 4, attachment),
-                Self::Rg16Float => (native, float, linear, (1, 1), 4, attachment),
-                Self::Rgba8Unorm => (native, float, linear, (1, 1), 4, all_flags),
-                Self::Rgba8UnormSrgb => (native, float, srgb, (1, 1), 4, attachment),
-                Self::Rgba8Snorm => (native, float, linear, (1, 1), 4, storage),
-                Self::Rgba8Uint => (native, uint, linear, (1, 1), 4, all_flags),
-                Self::Rgba8Sint => (native, sint, linear, (1, 1), 4, all_flags),
-                Self::Bgra8Unorm => (native, float, linear, (1, 1), 4, attachment),
-                Self::Bgra8UnormSrgb => (native, float, srgb, (1, 1), 4, attachment),
+            // Normal 32 bit textures
+            Self::R32Uint => (native, uint, linear, (1, 1), 4, all_flags, 1),
+            Self::R32Sint => (native, sint, linear, (1, 1), 4, all_flags, 1),
+            Self::R32Float => (native, nearest, linear, (1, 1), 4, all_flags, 1),
+            Self::Rg16Uint => (native, uint, linear, (1, 1), 4, attachment, 2),
+            Self::Rg16Sint => (native, sint, linear, (1, 1), 4, attachment, 2),
+            Self::Rg16Float => (native, float, linear, (1, 1), 4, attachment, 2),
+            Self::Rgba8Unorm => (native, float, linear, (1, 1), 4, all_flags, 4),
+            Self::Rgba8UnormSrgb => (native, float, srgb, (1, 1), 4, attachment, 4),
+            Self::Rgba8Snorm => (native, float, linear, (1, 1), 4, storage, 4),
+            Self::Rgba8Uint => (native, uint, linear, (1, 1), 4, all_flags, 4),
+            Self::Rgba8Sint => (native, sint, linear, (1, 1), 4, all_flags, 4),
+            Self::Bgra8Unorm => (native, float, linear, (1, 1), 4, attachment, 4),
+            Self::Bgra8UnormSrgb => (native, float, srgb, (1, 1), 4, attachment, 4),
 
-                // Packed 32 bit textures
-                Self::Rgb10a2Unorm => (native, float, linear, (1, 1), 4, attachment),
-                Self::Rg11b10Float => (native, float, linear, (1, 1), 4, basic),
+            // Packed 32 bit textures
+            Self::Rgb10a2Unorm => (native, float, linear, (1, 1), 4, attachment, 4),
+            Self::Rg11b10Float => (native, float, linear, (1, 1), 4, basic, 3),
 
-                // Packed 32 bit textures
-                Self::Rg32Uint => (native, uint, linear, (1, 1), 8, all_flags),
-                Self::Rg32Sint => (native, sint, linear, (1, 1), 8, all_flags),
-                Self::Rg32Float => (native, nearest, linear, (1, 1), 8, all_flags),
-                Self::Rgba16Uint => (native, uint, linear, (1, 1), 8, all_flags),
-                Self::Rgba16Sint => (native, sint, linear, (1, 1), 8, all_flags),
-                Self::Rgba16Float => (native, float, linear, (1, 1), 8, all_flags),
+            // Packed 32 bit textures
+            Self::Rg32Uint => (native, uint, linear, (1, 1), 8, all_flags, 2),
+            Self::Rg32Sint => (native, sint, linear, (1, 1), 8, all_flags, 2),
+            Self::Rg32Float => (native, nearest, linear, (1, 1), 8, all_flags, 2),
+            Self::Rgba16Uint => (native, uint, linear, (1, 1), 8, all_flags, 4),
+            Self::Rgba16Sint => (native, sint, linear, (1, 1), 8, all_flags, 4),
+            Self::Rgba16Float => (native, float, linear, (1, 1), 8, all_flags, 4),
 
-                // Packed 32 bit textures
-                Self::Rgba32Uint => (native, uint, linear, (1, 1), 16, all_flags),
-                Self::Rgba32Sint => (native, sint, linear, (1, 1), 16, all_flags),
-                Self::Rgba32Float => (native, nearest, linear, (1, 1), 16, all_flags),
+            // Packed 32 bit textures
+            Self::Rgba32Uint => (native, uint, linear, (1, 1), 16, all_flags, 4),
+            Self::Rgba32Sint => (native, sint, linear, (1, 1), 16, all_flags, 4),
+            Self::Rgba32Float => (native, nearest, linear, (1, 1), 16, all_flags, 4),
 
-                // Depth-stencil textures
-                Self::Depth32Float => (native, depth, linear, (1, 1), 4, attachment),
-                Self::Depth24Plus => (native, depth, linear, (1, 1), 4, attachment),
-                Self::Depth24PlusStencil8 => (native, depth, linear, (1, 1), 4, attachment),
+            // Depth-stencil textures
+            Self::Depth32Float => (native, depth, linear, (1, 1), 4, attachment, 1),
+            Self::Depth24Plus => (native, depth, linear, (1, 1), 4, attachment, 1),
+            Self::Depth24PlusStencil8 => (native, depth, linear, (1, 1), 4, attachment, 2),
 
-                // Packed uncompressed
-                Self::Rgb9e5Ufloat => (native, float, linear, (1, 1), 4, basic),
+            // Packed uncompressed
+            Self::Rgb9e5Ufloat => (native, float, linear, (1, 1), 4, basic, 3),
 
-                // BCn compressed textures
-                Self::Bc1RgbaUnorm => (bc, float, linear, (4, 4), 8, basic),
-                Self::Bc1RgbaUnormSrgb => (bc, float, srgb, (4, 4), 8, basic),
-                Self::Bc2RgbaUnorm => (bc, float, linear, (4, 4), 16, basic),
-                Self::Bc2RgbaUnormSrgb => (bc, float, srgb, (4, 4), 16, basic),
-                Self::Bc3RgbaUnorm => (bc, float, linear, (4, 4), 16, basic),
-                Self::Bc3RgbaUnormSrgb => (bc, float, srgb, (4, 4), 16, basic),
-                Self::Bc4RUnorm => (bc, float, linear, (4, 4), 8, basic),
-                Self::Bc4RSnorm => (bc, float, linear, (4, 4), 8, basic),
-                Self::Bc5RgUnorm => (bc, float, linear, (4, 4), 16, basic),
-                Self::Bc5RgSnorm => (bc, float, linear, (4, 4), 16, basic),
-                Self::Bc6hRgbUfloat => (bc, float, linear, (4, 4), 16, basic),
-                Self::Bc6hRgbSfloat => (bc, float, linear, (4, 4), 16, basic),
-                Self::Bc7RgbaUnorm => (bc, float, linear, (4, 4), 16, basic),
-                Self::Bc7RgbaUnormSrgb => (bc, float, srgb, (4, 4), 16, basic),
+            // BCn compressed textures
+            Self::Bc1RgbaUnorm => (bc, float, linear, (4, 4), 8, basic, 4),
+            Self::Bc1RgbaUnormSrgb => (bc, float, srgb, (4, 4), 8, basic, 4),
+            Self::Bc2RgbaUnorm => (bc, float, linear, (4, 4), 16, basic, 4),
+            Self::Bc2RgbaUnormSrgb => (bc, float, srgb, (4, 4), 16, basic, 4),
+            Self::Bc3RgbaUnorm => (bc, float, linear, (4, 4), 16, basic, 4),
+            Self::Bc3RgbaUnormSrgb => (bc, float, srgb, (4, 4), 16, basic, 4),
+            Self::Bc4RUnorm => (bc, float, linear, (4, 4), 8, basic, 1),
+            Self::Bc4RSnorm => (bc, float, linear, (4, 4), 8, basic, 1),
+            Self::Bc5RgUnorm => (bc, float, linear, (4, 4), 16, basic, 2),
+            Self::Bc5RgSnorm => (bc, float, linear, (4, 4), 16, basic, 2),
+            Self::Bc6hRgbUfloat => (bc, float, linear, (4, 4), 16, basic, 3),
+            Self::Bc6hRgbSfloat => (bc, float, linear, (4, 4), 16, basic, 3),
+            Self::Bc7RgbaUnorm => (bc, float, linear, (4, 4), 16, basic, 4),
+            Self::Bc7RgbaUnormSrgb => (bc, float, srgb, (4, 4), 16, basic, 4),
 
-                // ETC compressed textures
-                Self::Etc2RgbUnorm => (etc2, float, linear, (4, 4), 8, basic),
-                Self::Etc2RgbUnormSrgb => (etc2, float, srgb, (4, 4), 8, basic),
-                Self::Etc2RgbA1Unorm => (etc2, float, linear, (4, 4), 8, basic),
-                Self::Etc2RgbA1UnormSrgb => (etc2, float, srgb, (4, 4), 8, basic),
-                //Self::Etc2RgbA8Unorm => (etc2, float, linear, (4, 4), 16, basic),
-                //Self::Etc2RgbA8UnormSrgb => (etc2, float, srgb, (4, 4), 16, basic),
-                Self::EacRUnorm => (etc2, float, linear, (4, 4), 8, basic),
-                Self::EacRSnorm => (etc2, float, linear, (4, 4), 8, basic),
-                Self::EacRgUnorm => (etc2, float, linear, (4, 4), 16, basic),
-                Self::EacRgSnorm => (etc2, float, linear, (4, 4), 16, basic),
+            // ETC compressed textures
+            Self::Etc2RgbUnorm => (etc2, float, linear, (4, 4), 8, basic, 3),
+            Self::Etc2RgbUnormSrgb => (etc2, float, srgb, (4, 4), 8, basic, 3),
+            Self::Etc2RgbA1Unorm => (etc2, float, linear, (4, 4), 8, basic, 4),
+            Self::Etc2RgbA1UnormSrgb => (etc2, float, srgb, (4, 4), 8, basic, 4),
+            //Self::Etc2RgbA8Unorm => (etc2, float, linear, (4, 4), 16, basic),
+            //Self::Etc2RgbA8UnormSrgb => (etc2, float, srgb, (4, 4), 16, basic),
+            Self::EacRUnorm => (etc2, float, linear, (4, 4), 8, basic, 1),
+            Self::EacRSnorm => (etc2, float, linear, (4, 4), 8, basic, 1),
+            Self::EacRgUnorm => (etc2, float, linear, (4, 4), 16, basic, 2),
+            Self::EacRgSnorm => (etc2, float, linear, (4, 4), 16, basic, 2),
 
-                // ASTC compressed textures
-                Self::Astc4x4RgbaUnorm => (astc_ldr, float, linear, (4, 4), 16, basic),
-                Self::Astc4x4RgbaUnormSrgb => (astc_ldr, float, srgb, (4, 4), 16, basic),
-                Self::Astc5x4RgbaUnorm => (astc_ldr, float, linear, (5, 4), 16, basic),
-                Self::Astc5x4RgbaUnormSrgb => (astc_ldr, float, srgb, (5, 4), 16, basic),
-                Self::Astc5x5RgbaUnorm => (astc_ldr, float, linear, (5, 5), 16, basic),
-                Self::Astc5x5RgbaUnormSrgb => (astc_ldr, float, srgb, (5, 5), 16, basic),
-                Self::Astc6x5RgbaUnorm => (astc_ldr, float, linear, (6, 5), 16, basic),
-                Self::Astc6x5RgbaUnormSrgb => (astc_ldr, float, srgb, (6, 5), 16, basic),
-                Self::Astc6x6RgbaUnorm => (astc_ldr, float, linear, (6, 6), 16, basic),
-                Self::Astc6x6RgbaUnormSrgb => (astc_ldr, float, srgb, (6, 6), 16, basic),
-                Self::Astc8x5RgbaUnorm => (astc_ldr, float, linear, (8, 5), 16, basic),
-                Self::Astc8x5RgbaUnormSrgb => (astc_ldr, float, srgb, (8, 5), 16, basic),
-                Self::Astc8x6RgbaUnorm => (astc_ldr, float, linear, (8, 6), 16, basic),
-                Self::Astc8x6RgbaUnormSrgb => (astc_ldr, float, srgb, (8, 6), 16, basic),
-                Self::Astc10x5RgbaUnorm => (astc_ldr, float, linear, (10, 5), 16, basic),
-                Self::Astc10x5RgbaUnormSrgb => (astc_ldr, float, srgb, (10, 5), 16, basic),
-                Self::Astc10x6RgbaUnorm => (astc_ldr, float, linear, (10, 6), 16, basic),
-                Self::Astc10x6RgbaUnormSrgb => (astc_ldr, float, srgb, (10, 6), 16, basic),
-                Self::Astc8x8RgbaUnorm => (astc_ldr, float, linear, (8, 8), 16, basic),
-                Self::Astc8x8RgbaUnormSrgb => (astc_ldr, float, srgb, (8, 8), 16, basic),
-                Self::Astc10x8RgbaUnorm => (astc_ldr, float, linear, (10, 8), 16, basic),
-                Self::Astc10x8RgbaUnormSrgb => (astc_ldr, float, srgb, (10, 8), 16, basic),
-                Self::Astc10x10RgbaUnorm => (astc_ldr, float, linear, (10, 10), 16, basic),
-                Self::Astc10x10RgbaUnormSrgb => (astc_ldr, float, srgb, (10, 10), 16, basic),
-                Self::Astc12x10RgbaUnorm => (astc_ldr, float, linear, (12, 10), 16, basic),
-                Self::Astc12x10RgbaUnormSrgb => (astc_ldr, float, srgb, (12, 10), 16, basic),
-                Self::Astc12x12RgbaUnorm => (astc_ldr, float, linear, (12, 12), 16, basic),
-                Self::Astc12x12RgbaUnormSrgb => (astc_ldr, float, srgb, (12, 12), 16, basic),
-            };
+            // ASTC compressed textures
+            Self::Astc4x4RgbaUnorm => (astc_ldr, float, linear, (4, 4), 16, basic, 4),
+            Self::Astc4x4RgbaUnormSrgb => (astc_ldr, float, srgb, (4, 4), 16, basic, 4),
+            Self::Astc5x4RgbaUnorm => (astc_ldr, float, linear, (5, 4), 16, basic, 4),
+            Self::Astc5x4RgbaUnormSrgb => (astc_ldr, float, srgb, (5, 4), 16, basic, 4),
+            Self::Astc5x5RgbaUnorm => (astc_ldr, float, linear, (5, 5), 16, basic, 4),
+            Self::Astc5x5RgbaUnormSrgb => (astc_ldr, float, srgb, (5, 5), 16, basic, 4),
+            Self::Astc6x5RgbaUnorm => (astc_ldr, float, linear, (6, 5), 16, basic, 4),
+            Self::Astc6x5RgbaUnormSrgb => (astc_ldr, float, srgb, (6, 5), 16, basic, 4),
+            Self::Astc6x6RgbaUnorm => (astc_ldr, float, linear, (6, 6), 16, basic, 4),
+            Self::Astc6x6RgbaUnormSrgb => (astc_ldr, float, srgb, (6, 6), 16, basic, 4),
+            Self::Astc8x5RgbaUnorm => (astc_ldr, float, linear, (8, 5), 16, basic, 4),
+            Self::Astc8x5RgbaUnormSrgb => (astc_ldr, float, srgb, (8, 5), 16, basic, 4),
+            Self::Astc8x6RgbaUnorm => (astc_ldr, float, linear, (8, 6), 16, basic, 4),
+            Self::Astc8x6RgbaUnormSrgb => (astc_ldr, float, srgb, (8, 6), 16, basic, 4),
+            Self::Astc10x5RgbaUnorm => (astc_ldr, float, linear, (10, 5), 16, basic, 4),
+            Self::Astc10x5RgbaUnormSrgb => (astc_ldr, float, srgb, (10, 5), 16, basic, 4),
+            Self::Astc10x6RgbaUnorm => (astc_ldr, float, linear, (10, 6), 16, basic, 4),
+            Self::Astc10x6RgbaUnormSrgb => (astc_ldr, float, srgb, (10, 6), 16, basic, 4),
+            Self::Astc8x8RgbaUnorm => (astc_ldr, float, linear, (8, 8), 16, basic, 4),
+            Self::Astc8x8RgbaUnormSrgb => (astc_ldr, float, srgb, (8, 8), 16, basic, 4),
+            Self::Astc10x8RgbaUnorm => (astc_ldr, float, linear, (10, 8), 16, basic, 4),
+            Self::Astc10x8RgbaUnormSrgb => (astc_ldr, float, srgb, (10, 8), 16, basic, 4),
+            Self::Astc10x10RgbaUnorm => (astc_ldr, float, linear, (10, 10), 16, basic, 4),
+            Self::Astc10x10RgbaUnormSrgb => (astc_ldr, float, srgb, (10, 10), 16, basic, 4),
+            Self::Astc12x10RgbaUnorm => (astc_ldr, float, linear, (12, 10), 16, basic, 4),
+            Self::Astc12x10RgbaUnormSrgb => (astc_ldr, float, srgb, (12, 10), 16, basic, 4),
+            Self::Astc12x12RgbaUnorm => (astc_ldr, float, linear, (12, 12), 16, basic, 4),
+            Self::Astc12x12RgbaUnormSrgb => (astc_ldr, float, srgb, (12, 12), 16, basic, 4),
+        };
 
         TextureFormatInfo {
             required_features,
             sample_type,
             block_dimensions,
             block_size,
+            components,
             srgb,
             guaranteed_format_features: TextureFormatFeatures {
                 allowed_usages,


### PR DESCRIPTION
**Connections**

None

**Description**

This is a useful bit of information to know about a texture format. In order to make decisions about what channels are valid, we need to know the component count, but we don't actually care about the format.

**Testing**

👀 
