### PR TITLE
Enable parking_lot's wasm-bindgen feature on WASM.

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -274,6 +274,8 @@ web-sys = { version = "0.3.53", features = [
 ]}
 js-sys = "0.3.50"
 wasm-bindgen-futures = "0.4.23"
+# enable parking_lot's wasm-bindgen feature so that it, in turn, enables that of crate `instant`
+parking_lot = { version = "0.11", features = ["wasm-bindgen"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1.6"


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/2025

**Description**
The `wasm-bindgen` feature of `parking_lot` should be set when targeting WASM so that `parking_lot` passes the same to the `instant` crate which requires it.

[The usage instructions for the `instant` crate](https://github.com/sebcrozet/instant/blob/master/README.md) say that its primary export, `instant::Instant` is...
> A struct emulating the behavior of **std::time::Instant** if you are targeting `wasm32-unknown-unknown` or `wasm32-unknown-asmjs` **and** you enabled either the `stdweb` or the `wasm-bindgen` feature.

*(emphasis theirs)*

The former flag (`stdweb`) is irrelevant to `wgpu` because [`wasm-bindgen` overrules it, anyway](https://github.com/sebcrozet/instant/blob/master/src/wasm.rs#L116), and, for the `wasm32` platform, `wgpu` targets `wasm-bindgen` so we may as well pass that one on.

`wgpu` does *not* directly depend on `instant` and so it would be a pity to add a direct dependency simply to work around this problem. Luckily, `parking_lot`, which is the source of the dependency on `instant`, does provide [a `wasm-bindgen` feature that passes itself on to `instant`](https://github.com/Amanieu/parking_lot/blob/master/Cargo.toml#L32).

This merge request enables `parking_lot/wasm-bindgen`

**Testing**

Test by running any of the examples in a web browser: https://github.com/gfx-rs/wgpu/wiki/Running-on-the-Web-with-WebGPU-and-WebGL
