### PR TITLE
Update naga to 0e3fbc8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
+ "serde",
 ]
 
 [[package]]
@@ -983,13 +984,14 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.6.0"
-source = "git+https://github.com/gfx-rs/naga?rev=52d74e9#52d74e91a4b062d317304250b5461890913d3bb8"
+source = "git+https://github.com/gfx-rs/naga?rev=0e3fbc8#0e3fbc81664a263e8be278d11a6083b227a5b1a2"
 dependencies = [
  "bit-set",
  "bitflags",
  "codespan-reporting",
  "fxhash",
  "hexf-parse",
+ "indexmap",
  "log",
  "num-traits 0.2.14",
  "petgraph",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,9 +36,9 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "52d74e9"
+rev = "0e3fbc8"
 #version = "0.6"
-features = ["wgsl-in"]
+features = ["validate", "wgsl-in"]
 
 [dependencies.wgt]
 path = "../wgpu-types"

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -793,7 +793,7 @@ impl Interface {
         list: &mut Vec<Varying>,
         binding: Option<&naga::Binding>,
         ty: naga::Handle<naga::Type>,
-        arena: &naga::Arena<naga::Type>,
+        arena: &naga::UniqueArena<naga::Type>,
     ) {
         let numeric_ty = match arena[ty].inner {
             naga::TypeInner::Scalar { kind, width } => NumericType {

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -70,12 +70,12 @@ core-graphics-types = "0.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "52d74e9"
+rev = "0e3fbc8"
 #version = "0.6"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "52d74e9"
+rev = "0e3fbc8"
 #version = "0.6"
 features = ["wgsl-in"]
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -448,6 +448,7 @@ pub struct CommandBuffer {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum ShaderModule {
     Raw(vk::ShaderModule),
     Intermediate {

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -90,14 +90,14 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "52d74e9"
+rev = "0e3fbc8"
 #version = "0.6"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "52d74e9"
+rev = "0e3fbc8"
 #version = "0.6"
 features = ["wgsl-in"]
 


### PR DESCRIPTION
**Connections**
Picks up https://github.com/gfx-rs/naga/pull/1449, https://github.com/gfx-rs/naga/pull/1437, and a thousand other things

**Description**
preparing for the release

**Testing**
examples
