### PR TITLE
Fix issue with limits for hello-triangle

### DIFF
--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -26,7 +26,8 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                 label: None,
                 features: wgpu::Features::empty(),
                 // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
-                limits: wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits()),
+                limits: wgpu::Limits::downlevel_webgl2_defaults()
+                    .using_resolution(adapter.limits()),
             },
             None,
         )


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/2053

**Description**
When running hello_triangle, the original code for getting the limits returned 0 for max_storage_buffer_binding_size which resulted in error:
`Error in Adapter::request_device: Limit 'max_storage_buffer_binding_size' value 134217728 is better than allowed 0`


**Testing**
By running:`source run-wasm-example.sh hello-triangle`
I was able to get the triangle shown.
<img width="1052" alt="Screen Shot 2021-10-11 at 13 23 37" src="https://user-images.githubusercontent.com/14835424/137047942-a43b6a38-f477-459a-8505-1a1ee0806f04.png">

