### PR TITLE
run-wasm-example.sh installs wasm-bindgen-cli if needed

### DIFF
--- a/run-wasm-example.sh
+++ b/run-wasm-example.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+cargo install wasm-bindgen-cli
+
 echo "Compiling..."
 cargo build --example $1 --target wasm32-unknown-unknown --features webgl
 


### PR DESCRIPTION
**Description**
Finding out how to install wasm-bindgen-cli is tricky!
The actual binary is called wasm_bindgen so you look up wasm_bindgen and end up with a library and get very confused.

**Testing**
I ran the script and it works! Both with and without wasm-bindgen already installed. If its already installed it doesnt try to reinstall it.