### PR TITLE
Fix raw Vulkan API

### DIFF
--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -85,6 +85,9 @@ pub mod api {
     pub use super::vulkan::Api as Vulkan;
 }
 
+#[cfg(feature = "vulkan")]
+pub use vulkan::UpdateAfterBindTypes;
+
 use std::{
     borrow::Borrow,
     fmt,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -238,7 +238,7 @@ bitflags::bitflags! {
 }
 
 impl UpdateAfterBindTypes {
-    fn from_limits(limits: &wgt::Limits, phd_limits: &vk::PhysicalDeviceLimits) -> Self {
+    pub fn from_limits(limits: &wgt::Limits, phd_limits: &vk::PhysicalDeviceLimits) -> Self {
         let mut uab_types = UpdateAfterBindTypes::empty();
         uab_types.set(
             UpdateAfterBindTypes::UNIFORM_BUFFER,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2158,12 +2158,12 @@ impl Texture {
     ///
     /// - The raw handle obtained from the hal Texture must not be manually destroyed
     #[cfg(not(target_arch = "wasm32"))]
-    pub unsafe fn as_hal<A: wgc::hub::HalApi>(
+    pub unsafe fn as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Texture>)>(
         &self,
-        hal_texture_callback: impl FnOnce(Option<&A::Texture>),
+        hal_texture_callback: F,
     ) {
         self.context
-            .texture_as_hal::<A, _>(&self.id, hal_texture_callback)
+            .texture_as_hal::<A, F>(&self.id, hal_texture_callback)
     }
 
     /// Creates a view of this texture.


### PR DESCRIPTION
**Connections**

#1880 #1995

**Description**
This PR fixes two bugs:
* In #1880, the type of the closure cannot be determined because the `A: HalApi` parameter must be specified. The solution is to convert the impl type for the closure to explicit type parameter.
* #1995 added `UpdateAfterBindTypes` parameter to the signature of `Adapter::device_from_raw()`, which was private.

Fixes #2043
