### PR TITLE
GLES mapping fix

### DIFF
--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -410,6 +410,10 @@ impl crate::Device<super::Api> for super::Device {
             .shared
             .workarounds
             .contains(super::Workarounds::EMULATE_BUFFER_MAP)
+            || !self
+                .shared
+                .private_caps
+                .contains(super::PrivateCapabilities::BUFFER_ALLOCATION)
         {
             let mut buf = vec![0; buffer.size as usize];
             let ptr = buf.as_mut_ptr();

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -699,8 +699,7 @@ impl Limits {
 
     /// These default limits are guarenteed to be compatible with GLES3, and D3D11, and WebGL2
     pub fn downlevel_webgl2_defaults() -> Self {
-        #[cfg(target_arch = "wasm32")]
-        let defaults = Self {
+        Self {
             max_storage_buffers_per_shader_stage: 0,
             max_storage_textures_per_shader_stage: 0,
             max_dynamic_storage_buffers_per_pipeline_layout: 0,
@@ -709,12 +708,7 @@ impl Limits {
 
             // Most of the values should be the same as the downlevel defaults
             ..Self::downlevel_defaults()
-        };
-
-        #[cfg(not(target_arch = "wasm32"))]
-        let defaults = Self::downlevel_defaults();
-
-        defaults
+        }
     }
 
     /// Modify the current limits to use the resolution limits of the other.


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/1940

**Description**
Fix running on OpenGL ES 3.0 environment

ES 3.0 actually has glMapBufferRange, but wgpu buffer implementation requires MAP_PERSISTENT_BIT, which is 3.1 extension(https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_buffer_storage.txt), so EMULATE_BUFFER_MAP workaround is required.