### PR TITLE
init_tracker has now a `discard` function to get single data points back to uninitialized

### DIFF
--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -171,6 +171,7 @@ where
 
 impl InitTracker<u32> {
     // Makes a single entry uninitialized if not already uninitialized
+    #[allow(dead_code)]
     pub(crate) fn discard(&mut self, pos: u32) {
         // first range where end>=idx
         let r_idx = self.uninitialized_ranges.partition_point(|r| r.end < pos);


### PR DESCRIPTION
**Connections**
Yet another split out of the zero_init (#1688) work
This is how this is going to be used:
https://github.com/gfx-rs/wgpu/commit/cc747bc2e35b8a5c9d46aa1c3b571e7ed6160e8f#diff-1fe34f06c0c0bd67a41a9cb8aa26cae0a2a4b58028ce5e064abb6f8ad23b84cfR264

**Description**
also:
* use new standardized partition_point function instead of manual impl
* remove comment about possible DiscardMemory state, as this is going to be handled differently

**Testing**
unit testing added
