### PR TITLE
hal/gles: properly check for buffer allocation

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -289,6 +289,10 @@ impl super::Adapter {
 
         let mut private_caps = super::PrivateCapabilities::empty();
         private_caps.set(
+            super::PrivateCapabilities::BUFFER_ALLOCATION,
+            extensions.contains("GL_EXT_buffer_storage"),
+        );
+        private_caps.set(
             super::PrivateCapabilities::SHADER_BINDING_LAYOUT,
             ver >= (3, 1),
         );
@@ -400,7 +404,6 @@ impl super::Adapter {
                 shared: Arc::new(super::AdapterShared {
                     context,
                     private_caps,
-                    downlevel_flags,
                     workarounds,
                     shading_language_version,
                 }),

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -328,7 +328,14 @@ impl crate::Device<super::Api> for super::Device {
         let is_coherent = desc
             .memory_flags
             .contains(crate::MemoryFlags::PREFER_COHERENT);
+
         let mut map_flags = 0;
+        if desc.usage.contains(crate::BufferUses::MAP_READ) {
+            map_flags |= glow::MAP_READ_BIT;
+        }
+        if desc.usage.contains(crate::BufferUses::MAP_WRITE) {
+            map_flags |= glow::MAP_WRITE_BIT;
+        }
 
         let raw = gl.create_buffer().unwrap();
         gl.bind_buffer(target, Some(raw));
@@ -339,8 +346,8 @@ impl crate::Device<super::Api> for super::Device {
 
         if self
             .shared
-            .downlevel_flags
-            .contains(wgt::DownlevelFlags::VERTEX_STORAGE | wgt::DownlevelFlags::FRAGMENT_STORAGE)
+            .private_caps
+            .contains(super::PrivateCapabilities::BUFFER_ALLOCATION)
         {
             if is_host_visible {
                 map_flags |= glow::MAP_PERSISTENT_BIT;
@@ -348,13 +355,6 @@ impl crate::Device<super::Api> for super::Device {
                     map_flags |= glow::MAP_COHERENT_BIT;
                 }
             }
-            if desc.usage.contains(crate::BufferUses::MAP_READ) {
-                map_flags |= glow::MAP_READ_BIT;
-            }
-            if desc.usage.contains(crate::BufferUses::MAP_WRITE) {
-                map_flags |= glow::MAP_WRITE_BIT;
-            }
-
             gl.buffer_storage(target, raw_size, None, map_flags);
         } else {
             assert!(!is_coherent);

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -119,19 +119,21 @@ bitflags::bitflags! {
     /// Flags that affect internal code paths but do not
     /// change the exposed feature set.
     struct PrivateCapabilities: u32 {
+        /// Indicates support for `glBufferStorage` allocation.
+        const BUFFER_ALLOCATION = 1 << 0;
         /// Support explicit layouts in shader.
-        const SHADER_BINDING_LAYOUT = 1 << 0;
+        const SHADER_BINDING_LAYOUT = 1 << 1;
         /// Support extended shadow sampling instructions.
-        const SHADER_TEXTURE_SHADOW_LOD = 1 << 1;
+        const SHADER_TEXTURE_SHADOW_LOD = 1 << 2;
         /// Support memory barriers.
-        const MEMORY_BARRIERS = 1 << 2;
+        const MEMORY_BARRIERS = 1 << 3;
         /// Vertex buffer layouts separate from the data.
-        const VERTEX_BUFFER_LAYOUT = 1 << 3;
-        /// Indicates that buffers used as ELEMENT_ARRAY_BUFFER may be created / initialized / used
+        const VERTEX_BUFFER_LAYOUT = 1 << 4;
+        /// Indicates that buffers used as `GL_ELEMENT_ARRAY_BUFFER` may be created / initialized / used
         /// as other targets, if not present they must not be mixed with other targets.
-        const INDEX_BUFFER_ROLE_CHANGE = 1 << 4;
+        const INDEX_BUFFER_ROLE_CHANGE = 1 << 5;
         /// Indicates that the device supports disabling draw buffers
-        const CAN_DISABLE_DRAW_BUFFER = 1 << 5;
+        const CAN_DISABLE_DRAW_BUFFER = 1 << 6;
     }
 }
 
@@ -175,7 +177,6 @@ struct TextureFormatDesc {
 struct AdapterShared {
     context: AdapterContext,
     private_caps: PrivateCapabilities,
-    downlevel_flags: wgt::DownlevelFlags,
     workarounds: Workarounds,
     shading_language_version: naga::back::glsl::Version,
 }


### PR DESCRIPTION
**Connections**
Fixes #2082

**Description**
We had 2 paths: with `glBufferStorage` and without. The former was always good, but the check for it was totally wrong (checked for SSBO instead). The latter was missing the MAP_READ/WRITE flags.

**Testing**
About to test now...
