### PR TITLE
Fix memory leak on macOS

### DIFF
--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -94,9 +94,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         });
 
         if let Some(label) = label {
-            objc::rc::autoreleasepool(|| {
-                raw.set_label(label);
-            });
+            raw.set_label(label);
         }
         self.raw_cmd_buf = Some(raw);
 


### PR DESCRIPTION
**Connections**
#1783 

**Description**
If we run the water example and open the Activity Monitor, and then do nothing (especially do not move the mouse to the water window), we will observe that the memory of the water process will keep growing. If we use the AMD discrete graphics card, it will grow by several megabytes per second. Using Intel integrated graphics is several hundred kilobytes per second. If we do some operations on the water window (such as moving the mouse), the memory will be reclaimed.

<img width="1368" alt="截屏2021-10-19 下午2 20 46" src="https://user-images.githubusercontent.com/11287532/137854602-76f21839-8409-4b6f-b6c6-39f08db4092f.png">

Using Instruments to monitor the memory allocation, confirmed that RenderCommandEncoder, BlitCommandEncoder and label will not be recycled without interaction.

Wrap new_render_command_encoder,  new_blit_command_encoder and set_label into an AR pool can resolve the problem.

**Testing**
Run the water example in the same way and observe the memory changes.
