### PR TITLE
hal/mtl: disable fragment r/w buffers in fragment shaders on macOS 10.11

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -582,7 +582,8 @@ impl super::PrivateCapabilities {
             } else {
                 MTLLanguageVersion::V1_0
             },
-            exposed_queues: 1,
+            // macOS 10.11 doesn't support read-write resources
+            fragment_rw_storage: !os_is_mac || Self::version_at_least(major, minor, 10, 12),
             read_write_texture_tier: if os_is_mac {
                 if Self::version_at_least(major, minor, 10, 13) {
                     device.read_write_texture_support()
@@ -903,6 +904,10 @@ impl super::PrivateCapabilities {
 
     pub fn capabilities(&self) -> crate::Capabilities {
         let mut downlevel = wgt::DownlevelCapabilities::default();
+        downlevel.flags.set(
+            wgt::DownlevelFlags::FRAGMENT_WRITABLE_STORAGE,
+            self.fragment_rw_storage,
+        );
         downlevel.flags.set(
             wgt::DownlevelFlags::CUBE_ARRAY_TEXTURES,
             self.texture_cube_array,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -141,7 +141,7 @@ impl crate::Instance<Api> for Instance {
 struct PrivateCapabilities {
     family_check: bool,
     msl_version: mtl::MTLLanguageVersion,
-    exposed_queues: usize,
+    fragment_rw_storage: bool,
     read_write_texture_tier: mtl::MTLReadWriteTextureTier,
     resource_heaps: bool,
     argument_buffers: bool,


### PR DESCRIPTION
**Connections**
Fixes #2100

**Description**
Fortunately, we have a downlevel capability for this.
So macOS 10.11 is not conformant.

**Testing**
untested
