### PR TITLE
hal/egl: don't assume EGL-1.5 if upcast works

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -600,7 +600,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
     ) -> Option<crate::SurfaceCapabilities> {
         if surface.presentable {
             Some(crate::SurfaceCapabilities {
-                formats: if surface.enable_srgb {
+                formats: if surface.supports_srgb() {
                     vec![
                         wgt::TextureFormat::Rgba8UnormSrgb,
                         #[cfg(not(target_arch = "wasm32"))]

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -83,7 +83,6 @@ impl crate::Instance<super::Api> for Instance {
                 swapchain: None,
                 texture: None,
                 presentable: true,
-                enable_srgb: true, // WebGL only supports sRGB
             })
         } else {
             unreachable!()
@@ -107,7 +106,6 @@ pub struct Surface {
     pub(super) swapchain: Option<Swapchain>,
     texture: Option<glow::Texture>,
     pub(super) presentable: bool,
-    pub(super) enable_srgb: bool,
     present_program: Option<glow::Program>,
 }
 
@@ -168,6 +166,10 @@ impl Surface {
         gl.bind_texture(glow::TEXTURE_2D, None);
 
         program
+    }
+
+    pub fn supports_srgb(&self) -> bool {
+        true // WebGL only supports sRGB
     }
 }
 


### PR DESCRIPTION
**Connections**
Fixes  #2101

**Description**
Sometimes `upcast` works to EGL-1.5, but the reported version is 1.4. We should be careful in this case.

**Testing**
Untested
