### PR TITLE
Intersect over TextureUses flags instead of contains

### DIFF
--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -491,7 +491,7 @@ impl crate::Device<super::Api> for super::Device {
             depth: 1,
         };
 
-        let inner = if render_usage.contains(desc.usage)
+        let inner = if render_usage.intersects(desc.usage)
             && desc.dimension == wgt::TextureDimension::D2
             && desc.size.depth_or_array_layers == 1
         {


### PR DESCRIPTION
**Description**
With the WebGL2 backend, when allocating a depth buffer the changed branch fails since it doesn't have the `TextureUses::COLOR_TARGET` flag. However I believe that this behavior is wrong. My current fix is to change the branch from checking that all the `render_usage` flags are set to checking if any of the flags are set.

This change fixes my problem, of the code taking the wrong branch when I allocate my depth buffer, however I am not convinced that it is the correct fix in all cases, simply because I haven't got enough insight in the totality of the logic yet.

**Testing**
I haven't made any small standalone tests yet, but I'm willing to do it if requested
