### PR TITLE
Add texture_from_raw method for metal/dx12 device

### DIFF
--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -280,6 +280,24 @@ impl super::Device {
         );
         result
     }
+
+    pub unsafe fn texture_from_raw(
+        resource: native::Resource,
+        format: wgt::TextureFormat,
+        dimension: wgt::TextureDimension,
+        size: wgt::Extent3d,
+        mip_level_count: u32,
+        sample_count: u32,
+    ) -> super::Texture {
+        super::Texture {
+            resource,
+            format,
+            dimension,
+            size,
+            mip_level_count,
+            sample_count,
+        }
+    }
 }
 
 impl crate::Device<super::Api> for super::Device {

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -174,6 +174,24 @@ impl super::Device {
                 .set_mutability(mtl::MTLMutability::Immutable);
         }
     }
+
+    pub unsafe fn texture_from_raw(
+        raw: mtl::Texture,
+        raw_format: mtl::MTLPixelFormat,
+        raw_type: mtl::MTLTextureType,
+        array_layers: u32,
+        mip_levels: u32,
+        copy_size: crate::CopyExtent,
+    ) -> super::Texture {
+        super::Texture {
+            raw,
+            raw_format,
+            raw_type,
+            array_layers,
+            mip_levels,
+            copy_size,
+        }
+    }
 }
 
 impl crate::Device<super::Api> for super::Device {


### PR DESCRIPTION
We have a [create_texture_from_hal](https://github.com/gfx-rs/wgpu/blob/master/wgpu/src/lib.rs#L1829) method to create texture from hal, but currently metal and dx12 hal do not expose methods to create hal texture. I found that vulkan hal already has a [Device::texture_from_raw](https://github.com/gfx-rs/wgpu/blob/master/wgpu-hal/src/vulkan/device.rs#L557) method to do this, so I also add this method to metal and dx12 hal.