### PR TITLE
Don't require COPY_DST on surface textures

### DIFF
--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -300,9 +300,6 @@ impl<A: hal::Api> BakedCommands<A> {
                         .as_raw()
                         .ok_or(DestroyedTextureError(texture_use.id))?;
 
-                    debug_assert!(texture.hal_usage.contains(hal::TextureUses::COPY_DST),
-                            "Every texture needs to have the COPY_DST flag. Otherwise we can't ensure initialized memory!");
-
                     let mut texture_barriers = Vec::new();
                     let mut zero_buffer_copy_regions = Vec::new();
                     for range in &ranges {
@@ -332,6 +329,8 @@ impl<A: hal::Api> BakedCommands<A> {
                     }
 
                     if !zero_buffer_copy_regions.is_empty() {
+                        debug_assert!(texture.hal_usage.contains(hal::TextureUses::COPY_DST),
+                            "Texture needs to have the COPY_DST flag. Otherwise we can't ensure initialized memory!");
                         unsafe {
                             // TODO: Could safe on transition_textures calls by bundling barriers from *all* textures.
                             // (a bbit more tricky because a naive approach would have to borrow same texture several times then)

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -65,9 +65,7 @@ pub fn map_texture_usage(
     usage: wgt::TextureUsages,
     aspect: hal::FormatAspects,
 ) -> hal::TextureUses {
-    // Enforce COPY_DST, otherwise we wouldn't be able to initialize the texture.
-    let mut u = hal::TextureUses::COPY_DST;
-
+    let mut u = hal::TextureUses::empty();
     u.set(
         hal::TextureUses::COPY_SRC,
         usage.contains(wgt::TextureUsages::COPY_SRC),


### PR DESCRIPTION
**Connections**
Fixes #2135 

**Description**
The `conv` methods shouldn't carry the logic of zero-initialization, they are lower level.
So this PR moves the responsibility of adding COPY_DST to the device.

**Testing**
Running on GLES backend.
