### PR TITLE
Update naga to 9d2b357

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1"
 
 [dependencies.naga]
 #git = "https://github.com/gfx-rs/naga"
-#rev = "2e7d629"
+#rev = "9d2b357"
 version = "0.7"
 features = ["validate", "wgsl-in"]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -75,12 +75,12 @@ js-sys = { version = "0.3" }
 
 [dependencies.naga]
 #git = "https://github.com/gfx-rs/naga"
-#rev = "2e7d629"
+#rev = "9d2b357"
 version = "0.7"
 
 [dev-dependencies.naga]
 #git = "https://github.com/gfx-rs/naga"
-#rev = "2e7d629"
+#rev = "9d2b357"
 version = "0.7"
 features = ["wgsl-in"]
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -135,14 +135,14 @@ env_logger = "0.8"
 
 [dependencies.naga]
 #git = "https://github.com/gfx-rs/naga"
-#rev = "2e7d629"
+#rev = "9d2b357"
 version = "0.7"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 #git = "https://github.com/gfx-rs/naga"
-#rev = "2e7d629"
+#rev = "9d2b357"
 version = "0.7"
 features = ["wgsl-in"]
 


### PR DESCRIPTION
**Connections**
Picks up https://github.com/gfx-rs/naga/pull/1470

**Description**
This is critical for development, since shader validation errors are cryptic otherwise.

**Testing**
Untested
