### PR TITLE
Compute shader workgroup size validation

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1008,7 +1008,8 @@ impl<A: HalApi> Device<A> {
                     inner,
                 })
             })?;
-        let interface = validation::Interface::new(&module, &info, self.features);
+        let interface =
+            validation::Interface::new(&module, &info, self.features, self.limits.clone());
         let hal_shader = hal::ShaderInput::Naga(hal::NagaShader { module, info });
 
         let hal_desc = hal::ShaderModuleDescriptor {


### PR DESCRIPTION
**Connections**
#1808 

**Description**
Validate the a compute shader's current workgroup size with the device limits.


I created a different PR for the same issue because I think this validation is conceptually different to the previous PR on the issue. If you prefer everything related to it in the same PR, let me know so I can do it from now on.