### PR TITLE
fix run-wasm-example.sh

### DIFF
--- a/run-wasm-example.sh
+++ b/run-wasm-example.sh
@@ -8,8 +8,7 @@ cargo build --example $1 --target wasm32-unknown-unknown --features webgl
 echo "Generating bindings..."
 mkdir -p target/wasm-examples/$1
 wasm-bindgen --target web --out-dir target/wasm-examples/$1 target/wasm32-unknown-unknown/debug/examples/$1.wasm
-cp wasm-resources/index.template.html target/wasm-examples/$1/index.html
-sed -i "" "s/{{example}}/$1/g" target/wasm-examples/$1/index.html
+cat wasm-resources/index.template.html | sed "s/{{example}}/$1/g" > target/wasm-examples/$1/index.html
 
 # Find a serving tool to host the example
 SERVE_CMD=""


### PR DESCRIPTION
**Description**
After recent fix for Mac Os X run-wasm-example.sh stopped working on linux. This little change makes it cross-platform (thanks to @scoopr)

**Testing**
Run it under MacOsX and linux