### PR TITLE
do not query work group params on gles < 3.1

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -191,6 +191,8 @@ impl super::Adapter {
         let ver = Self::parse_version(&version).ok()?;
 
         let supports_storage = ver >= (3, 1);
+        let supports_work_group_params = ver >= (3, 1);
+
         let shading_language_version = {
             let sl_version = gl.get_parameter_string(glow::SHADING_LANGUAGE_VERSION);
             log::info!("SL version: {}", &sl_version);
@@ -328,7 +330,7 @@ impl super::Adapter {
             gl.get_parameter_i32(glow::MAX_VERTEX_UNIFORM_BLOCKS)
                 .min(gl.get_parameter_i32(glow::MAX_FRAGMENT_UNIFORM_BLOCKS)) as u32;
 
-        let max_compute_workgroups_per_dimension = if cfg!(not(target_arch = "wasm32")) {
+        let max_compute_workgroups_per_dimension = if supports_work_group_params {
             gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_COUNT, 0)
                 .min(gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_COUNT, 1))
                 .min(gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_COUNT, 2))
@@ -376,17 +378,17 @@ impl super::Adapter {
             max_push_constant_size: 0,
             min_uniform_buffer_offset_alignment,
             min_storage_buffer_offset_alignment,
-            max_compute_workgroup_size_x: if cfg!(not(target_arch = "wasm32")) {
+            max_compute_workgroup_size_x: if supports_work_group_params {
                 gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_SIZE, 0) as u32
             } else {
                 0
             },
-            max_compute_workgroup_size_y: if cfg!(not(target_arch = "wasm32")) {
+            max_compute_workgroup_size_y: if supports_work_group_params {
                 gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_SIZE, 1) as u32
             } else {
                 0
             },
-            max_compute_workgroup_size_z: if cfg!(not(target_arch = "wasm32")) {
+            max_compute_workgroup_size_z: if supports_work_group_params {
                 gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_SIZE, 2) as u32
             } else {
                 0

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -328,11 +328,14 @@ impl super::Adapter {
             gl.get_parameter_i32(glow::MAX_VERTEX_UNIFORM_BLOCKS)
                 .min(gl.get_parameter_i32(glow::MAX_FRAGMENT_UNIFORM_BLOCKS)) as u32;
 
-        let max_compute_workgroups_per_dimension = gl
-            .get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_COUNT, 0)
-            .min(gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_COUNT, 1))
-            .min(gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_COUNT, 2))
-            as u32;
+        let max_compute_workgroups_per_dimension = if cfg!(not(target_arch = "wasm32")) {
+            gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_COUNT, 0)
+                .min(gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_COUNT, 1))
+                .min(gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_COUNT, 2))
+                as u32
+        } else {
+            0
+        };
 
         let limits = wgt::Limits {
             max_texture_dimension_1d: max_texture_size,
@@ -373,15 +376,21 @@ impl super::Adapter {
             max_push_constant_size: 0,
             min_uniform_buffer_offset_alignment,
             min_storage_buffer_offset_alignment,
-            max_compute_workgroup_size_x: gl
-                .get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_SIZE, 0)
-                as u32,
-            max_compute_workgroup_size_y: gl
-                .get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_SIZE, 1)
-                as u32,
-            max_compute_workgroup_size_z: gl
-                .get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_SIZE, 2)
-                as u32,
+            max_compute_workgroup_size_x: if cfg!(not(target_arch = "wasm32")) {
+                gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_SIZE, 0) as u32
+            } else {
+                0
+            },
+            max_compute_workgroup_size_y: if cfg!(not(target_arch = "wasm32")) {
+                gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_SIZE, 1) as u32
+            } else {
+                0
+            },
+            max_compute_workgroup_size_z: if cfg!(not(target_arch = "wasm32")) {
+                gl.get_parameter_indexed_i32(glow::MAX_COMPUTE_WORK_GROUP_SIZE, 2) as u32
+            } else {
+                0
+            },
             max_compute_workgroups_per_dimension,
         };
 


### PR DESCRIPTION
**Description**

gles backend queries `MAX_COMPUTE_WORK_GROUP_COUNT` and `MAX_COMPUTE_WORK_GROUP_SIZE` parameters generating `getIndexedParameter: Bad `pname`: Invalid enum value` warnings. This PR disables these queries on wasm32 and sets `max_compute_workgroup_size_*` and `max_compute_workgroups_per_dimension` to 
0

**Testing**
It can be tested on wgpu `cube` example
