### PR TITLE
hal/vk: add physical device features for extensions

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -44,6 +44,15 @@ impl PhysicalDeviceFeatures {
         if let Some(ref mut feature) = self.imageless_framebuffer {
             info = info.push_next(feature);
         }
+        if let Some(ref mut feature) = self.timeline_semaphore {
+            info = info.push_next(feature);
+        }
+        if let Some(ref mut feature) = self.image_robustness {
+            info = info.push_next(feature);
+        }
+        if let Some(ref mut feature) = self.robustness2 {
+            info = info.push_next(feature);
+        }
         info
     }
 


### PR DESCRIPTION
**Description**
For some extensions the corresponding physical device features haven't been added in the feature chain.
Vulkan Validation Error on Android:
```
11-08 17:40:16.747 20431 20479 I RustStdoutStderr: VUID-VkSemaphoreTypeCreateInfo-timelineSemaphore-03252(ERROR / SPEC): msgNum: 963335225 - Validation Error: [ VUID-VkSemaphoreTypeCreateInfo-timelineSemaphore-03252 ] Object 0: handle = 0x7b05719180, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x396b5439 | VkCreateSemaphore: timelineSemaphore feature is not enabled, can not create timeline semaphores The Vulkan spec states: If the timelineSemaphore feature is not enabled, semaphoreType must not equal VK_SEMAPHORE_TYPE_TIMELINE (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkSemaphoreTypeCreateInfo-timelineSemaphore-03252)
```

**Testing**
Tested on Android and Windows using Vulkan backend.
