### PR TITLE
Renaming CommandEncoder::clearBuffer to CommandEncoder::fillBuffer

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -77,8 +77,8 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                 trace::Command::CopyTextureToTexture { src, dst, size } => self
                     .command_encoder_copy_texture_to_texture::<A>(encoder, &src, &dst, &size)
                     .unwrap(),
-                trace::Command::ClearBuffer { dst, offset, size } => self
-                    .command_encoder_clear_buffer::<A>(encoder, dst, offset, size)
+                trace::Command::FillBuffer { dst, offset, size } => self
+                    .command_encoder_fill_buffer::<A>(encoder, dst, offset, size)
                     .unwrap(),
                 trace::Command::ClearTexture {
                     dst,

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -87,7 +87,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf.commands {
-            list.push(TraceCommand::ClearBuffer { dst, offset, size });
+            list.push(TraceCommand::FillBuffer { dst, offset, size });
         }
 
         let (dst_buffer, dst_pending) = cmd_buf

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -69,14 +69,14 @@ whereas subesource range specified start {subresource_base_array_layer} and coun
 }
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
-    pub fn command_encoder_clear_buffer<A: HalApi>(
+    pub fn command_encoder_fill_buffer<A: HalApi>(
         &self,
         command_encoder_id: CommandEncoderId,
         dst: BufferId,
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(), ClearError> {
-        profiling::scope!("CommandEncoder::clear_buffer");
+        profiling::scope!("CommandEncoder::fill_buffer");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -88,10 +88,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf.commands {
             list.push(TraceCommand::ClearBuffer { dst, offset, size });
-        }
-
-        if !cmd_buf.support_clear_buffer_texture {
-            return Err(ClearError::MissingClearCommandsFeature);
         }
 
         let (dst_buffer, dst_pending) = cmd_buf
@@ -130,7 +126,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             None => dst_buffer.size,
         };
         if offset == end {
-            log::trace!("Ignoring clear_buffer of size 0");
+            log::trace!("Ignoring fill_buffer of size 0");
             return Ok(());
         }
 

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -147,7 +147,7 @@ pub enum Command {
         dst: crate::command::ImageCopyTexture,
         size: wgt::Extent3d,
     },
-    ClearBuffer {
+    FillBuffer {
         dst: id::BufferId,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -2008,7 +2008,7 @@ impl crate::Context for Context {
         }
     }
 
-    fn command_encoder_clear_buffer(
+    fn command_encoder_fill_buffer(
         &self,
         encoder: &Self::CommandEncoderId,
         buffer: &crate::Buffer,
@@ -2016,12 +2016,12 @@ impl crate::Context for Context {
         size: Option<wgt::BufferSize>,
     ) {
         let global = &self.0;
-        if let Err(cause) = wgc::gfx_select!(encoder.id => global.command_encoder_clear_buffer(
+        if let Err(cause) = wgc::gfx_select!(encoder.id => global.command_encoder_fill_buffer(
             encoder.id,
             buffer.id.id,
             offset, size
         )) {
-            self.handle_error_nolabel(&encoder.error_sink, cause, "CommandEncoder::clear_buffer");
+            self.handle_error_nolabel(&encoder.error_sink, cause, "CommandEncoder::fill_buffer");
         }
     }
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1990,7 +1990,7 @@ impl crate::Context for Context {
     ) {
     }
 
-    fn command_encoder_clear_buffer(
+    fn command_encoder_fill_buffer(
         &self,
         _encoder: &Self::CommandEncoderId,
         _buffer: &crate::Buffer,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -424,7 +424,7 @@ trait Context: Debug + Send + Sized + Sync {
         texture: &Texture,
         subresource_range: &ImageSubresourceRange,
     );
-    fn command_encoder_clear_buffer(
+    fn command_encoder_fill_buffer(
         &self,
         encoder: &Self::CommandEncoderId,
         buffer: &Buffer,
@@ -2357,16 +2357,15 @@ impl CommandEncoder {
     ///
     /// # Panics
     ///
-    /// - `CLEAR_COMMANDS` extension not enabled
     /// - Buffer does not have `COPY_DST` usage.
     /// - Range it out of bounds
-    pub fn clear_buffer(
+    pub fn fill_buffer(
         &mut self,
         buffer: &Buffer,
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        Context::command_encoder_clear_buffer(
+        Context::command_encoder_fill_buffer(
             &*self.context,
             self.id.as_ref().unwrap(),
             buffer,


### PR DESCRIPTION
**Connections**
#2170 

**Description**
~~This PR adds `fill_buffer` to CommandEncoder for Vulkan and D3D12. Metal and GLES yet to be done (I cannot implement them 😢).~~

~~There are probably some changes to be made, mainly in the d3d12 implementation. e.g There are no deallocations over the CPU only descriptor heap. Also, I think the changes I made for d3d12 FixedSizeHeap might be problematic on multi-threading 
scenarios.~~

EDIT: For now is just a rename to keep up with the spec.

**Testing**
I only tested this PR with a small change to the `hello-compute` example. No other testing is done :(
