### PR TITLE
Validate strip_index_format

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2211,6 +2211,14 @@ impl<A: HalApi> Device<A> {
             );
         }
 
+        if desc.primitive.strip_index_format.is_none() && desc.primitive.topology.is_strip() {
+            return Err(
+                pipeline::CreateRenderPipelineError::NoStripIndexFormatForStripTopology {
+                    topology: desc.primitive.topology,
+                },
+            );
+        }
+
         if desc.primitive.unclipped_depth {
             self.require_features(wgt::Features::DEPTH_CLIP_CONTROL)?;
         }

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -309,6 +309,8 @@ pub enum CreateRenderPipelineError {
         strip_index_format: Option<wgt::IndexFormat>,
         topology: wgt::PrimitiveTopology,
     },
+    #[error("strip index format is None while using the strip topology {topology:?}")]
+    NoStripIndexFormatForStripTopology { topology: wgt::PrimitiveTopology },
     #[error("Conservative Rasterization is only supported for wgt::PolygonMode::Fill")]
     ConservativeRasterizationNonFillPolygonMode,
     #[error(transparent)]

--- a/wgpu/examples/bunnymark/main.rs
+++ b/wgpu/examples/bunnymark/main.rs
@@ -125,6 +125,7 @@ impl framework::Example for Example {
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleStrip,
+                strip_index_format: Some(wgpu::IndexFormat::Uint16),
                 ..wgpu::PrimitiveState::default()
             },
             depth_stencil: None,

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -99,6 +99,7 @@ impl Example {
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleStrip,
+                strip_index_format: Some(wgpu::IndexFormat::Uint16),
                 ..Default::default()
             },
             depth_stencil: None,
@@ -292,6 +293,7 @@ impl framework::Example for Example {
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleStrip,
+                strip_index_format: Some(wgpu::IndexFormat::Uint16),
                 front_face: wgpu::FrontFace::Ccw,
                 cull_mode: Some(wgpu::Face::Back),
                 ..Default::default()


### PR DESCRIPTION
**Description**
The spec mandates that stripIndexFormat is set even when drawIndexed is
not used. (https://www.w3.org/TR/webgpu/#primitive-state)
There is some recent discussion about this though:
https://github.com/gpuweb/gpuweb/issues/2199

Doesn't seem to matter with Firefox but Chrome complains:
```
StripIndexFormat is undefined when using a strip primitive topology (PrimitiveTopology::TriangleStrip).
 - While validating primitive state.
 - While calling [Device].CreateRenderPipeline([RenderPipelineDescriptor]).
```

**Testing**
Tested the examples natively (Vulkan; Linux; AMD). Also e.g. the mipmap example now works in Chrome.