### PR TITLE
Add Device::as_hal and always assume texture from hal is initialized

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3199,13 +3199,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     ///
     /// - `hal_texture` must be created from `device_id` corresponding raw handle.
     /// - `hal_texture` must be created respecting `desc`
+    /// - `hal_texture` must be initialized
     pub unsafe fn create_texture_from_hal<A: HalApi>(
         &self,
         hal_texture: A::Texture,
         device_id: id::DeviceId,
         desc: &resource::TextureDescriptor,
         id_in: Input<G, id::TextureId>,
-        initialized: bool,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
         profiling::scope!("create_texture", "Device");
 
@@ -3245,9 +3245,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 texture.hal_usage |= hal::TextureUses::COPY_DST;
             }
 
-            if initialized {
-                texture.initialization_status = TextureInitTracker::new(desc.mip_level_count, 0);
-            }
+            texture.initialization_status = TextureInitTracker::new(desc.mip_level_count, 0);
 
             let num_levels = texture.full_range.levels.end;
             let num_layers = texture.full_range.layers.end;

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -210,6 +210,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         hal_texture_callback(hal_texture);
     }
 
+    /// # Safety
+    ///
+    /// - The raw device handle must not be manually destroyed
     pub unsafe fn device_as_hal<A: HalApi, F: FnOnce(Option<&A::Device>) -> R, R>(
         &self,
         id: DeviceId,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -209,6 +209,22 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         hal_texture_callback(hal_texture);
     }
+
+    pub unsafe fn device_as_hal<A: HalApi, F: FnOnce(Option<&A::Device>) -> R, R>(
+        &self,
+        id: DeviceId,
+        hal_device_callback: F,
+    ) -> R {
+        profiling::scope!("as_hal", "Device");
+
+        let hub = A::hub(self);
+        let mut token = Token::root();
+        let (guard, _) = hub.devices.read(&mut token);
+        let device = guard.get(id).ok();
+        let hal_device = device.map(|device| &device.raw);
+
+        hal_device_callback(hal_device)
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1,3 +1,4 @@
+use parking_lot::Mutex;
 use std::{
     ptr,
     sync::{atomic, Arc},
@@ -191,6 +192,10 @@ impl super::Device {
             mip_levels,
             copy_size,
         }
+    }
+
+    pub fn raw_device(&self) -> &Mutex<mtl::Device> {
+        &self.shared.device
     }
 }
 

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -100,6 +100,7 @@ impl Context {
         hal_texture: A::Texture,
         device: &Device,
         desc: &TextureDescriptor,
+        initialized: bool,
     ) -> Texture {
         let global = &self.0;
         let (id, error) = global.create_texture_from_hal::<A>(
@@ -107,6 +108,7 @@ impl Context {
             device.id,
             &desc.map_label(|l| l.map(Borrowed)),
             PhantomData,
+            initialized,
         );
         if let Some(cause) = error {
             self.handle_error(
@@ -121,6 +123,16 @@ impl Context {
             id,
             error_sink: Arc::clone(&device.error_sink),
         }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub unsafe fn device_as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Device>) -> R, R>(
+        &self,
+        device: &Device,
+        hal_device_callback: F,
+    ) -> R {
+        self.0
+            .device_as_hal::<A, F, R>(device.id, hal_device_callback)
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -100,7 +100,6 @@ impl Context {
         hal_texture: A::Texture,
         device: &Device,
         desc: &TextureDescriptor,
-        initialized: bool,
     ) -> Texture {
         let global = &self.0;
         let (id, error) = global.create_texture_from_hal::<A>(
@@ -108,7 +107,6 @@ impl Context {
             device.id,
             &desc.map_label(|l| l.map(Borrowed)),
             PhantomData,
-            initialized,
         );
         if let Some(cause) = error {
             self.handle_error(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1825,6 +1825,7 @@ impl Device {
     ///
     /// - `hal_texture` must be created from this device internal handle
     /// - `hal_texture` must be created respecting `desc`
+    /// - `hal_texture` must be initialized
     #[cfg(not(target_arch = "wasm32"))]
     pub unsafe fn create_texture_from_hal<A: wgc::hub::HalApi>(
         &self,
@@ -1835,29 +1836,7 @@ impl Device {
             context: Arc::clone(&self.context),
             id: self
                 .context
-                .create_texture_from_hal::<A>(hal_texture, &self.id, desc, false),
-            owned: true,
-        }
-    }
-
-    /// Creates an initialized [`Texture`] from a wgpu-hal Texture.
-    ///
-    /// # Safety
-    ///
-    /// - `hal_texture` must be created from this device internal handle
-    /// - `hal_texture` must be created respecting `desc`
-    /// - `hal_texture` must be initialized
-    #[cfg(not(target_arch = "wasm32"))]
-    pub unsafe fn create_texture_from_hal_initialized<A: wgc::hub::HalApi>(
-        &self,
-        hal_texture: A::Texture,
-        desc: &TextureDescriptor,
-    ) -> Texture {
-        Texture {
-            context: Arc::clone(&self.context),
-            id: self
-                .context
-                .create_texture_from_hal::<A>(hal_texture, &self.id, desc, true),
+                .create_texture_from_hal::<A>(hal_texture, &self.id, desc),
             owned: true,
         }
     }


### PR DESCRIPTION
**Description**

`Device::create_texture_from_hal` method will assume that the texture is not initialized and filled with 0, so I add a `Device::create_texture_from_hal_initialized` method to help users import an initialized texture from outside, which is very useful in building applications such as video players.

**Testing**
1. Get a metal texture from CoreVideo
2. Create a wgpu texture with `create_texture_from_hal_initialized` from the metal texture
3. Render the texture