### PR TITLE
Introduce SamplerBindingType enum and fix bug in validation

### DIFF
--- a/deno_webgpu/src/binding.rs
+++ b/deno_webgpu/src/binding.rs
@@ -56,34 +56,7 @@ impl From<GpuBufferBindingType> for wgpu_types::BufferBindingType {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct GpuSamplerBindingLayout {
-    r#type: GpuSamplerBindingType,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
-enum GpuSamplerBindingType {
-    Filtering,
-    NonFiltering,
-    Comparison,
-}
-
-impl From<GpuSamplerBindingType> for wgpu_types::BindingType {
-    fn from(binding_type: GpuSamplerBindingType) -> Self {
-        match binding_type {
-            GpuSamplerBindingType::Filtering => wgpu_types::BindingType::Sampler {
-                filtering: true,
-                comparison: false,
-            },
-            GpuSamplerBindingType::NonFiltering => wgpu_types::BindingType::Sampler {
-                filtering: false,
-                comparison: false,
-            },
-            GpuSamplerBindingType::Comparison => wgpu_types::BindingType::Sampler {
-                filtering: true,
-                comparison: true,
-            },
-        }
-    }
+    r#type: wgpu_types::SamplerBindingType,
 }
 
 #[derive(Deserialize)]
@@ -170,7 +143,7 @@ impl TryFrom<GpuBindingType> for wgpu_types::BindingType {
                 has_dynamic_offset: buffer.has_dynamic_offset,
                 min_binding_size: std::num::NonZeroU64::new(buffer.min_binding_size),
             },
-            GpuBindingType::Sampler(sampler) => sampler.r#type.into(),
+            GpuBindingType::Sampler(sampler) => wgpu_types::BindingType::Sampler(sampler.r#type),
             GpuBindingType::Texture(texture) => wgpu_types::BindingType::Texture {
                 sample_type: texture.sample_type.into(),
                 view_dimension: texture.view_dimension,

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -177,10 +177,7 @@ impl<A: hal::Api> Example<A> {
                 wgt::BindGroupLayoutEntry {
                     binding: 2,
                     visibility: wgt::ShaderStages::FRAGMENT,
-                    ty: wgt::BindingType::Sampler {
-                        filtering: true,
-                        comparison: false,
-                    },
+                    ty: wgt::BindingType::Sampler(wgt::SamplerBindingType::Filtering),
                     count: None,
                 },
             ],

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3194,6 +3194,25 @@ pub enum StorageTextureAccess {
     ReadWrite,
 }
 
+/// Specific type of a sampler binding.
+///
+/// WebGPU spec: <https://gpuweb.github.io/gpuweb/#enumdef-gpusamplerbindingtype>
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "trace", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+pub enum SamplerBindingType {
+    /// The sampling result is produced based on more than a single color sample from a texture,
+    /// e.g. when bilinear interpolation is enabled.
+    Filtering,
+    /// The sampling result is produced based on a single color sample from a texture.
+    NonFiltering,
+    /// Use as a comparison sampler instead of a normal sampler.
+    /// For more info take a look at the analogous functionality in OpenGL: <https://www.khronos.org/opengl/wiki/Sampler_Object#Comparison_mode>.
+    Comparison,
+}
+
 /// Specific type of a binding.
 ///
 /// WebGPU spec: the enum of
@@ -3227,16 +3246,7 @@ pub enum BindingType {
     /// layout(binding = 0)
     /// uniform sampler s;
     /// ```
-    Sampler {
-        /// The sampling result is produced based on more than a single color sample from a texture,
-        /// e.g. when bilinear interpolation is enabled.
-        ///
-        /// A filtering sampler can only be used with a filterable texture.
-        filtering: bool,
-        /// Use as a comparison sampler instead of a normal sampler.
-        /// For more info take a look at the analogous functionality in OpenGL: <https://www.khronos.org/opengl/wiki/Sampler_Object#Comparison_mode>.
-        comparison: bool,
-    },
+    Sampler(SamplerBindingType),
     /// A texture binding.
     ///
     /// Example GLSL syntax:

--- a/wgpu/examples/bunnymark/main.rs
+++ b/wgpu/examples/bunnymark/main.rs
@@ -77,10 +77,7 @@ impl framework::Example for Example {
                     wgpu::BindGroupLayoutEntry {
                         binding: 2,
                         visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler {
-                            filtering: true,
-                            comparison: false,
-                        },
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                         count: None,
                     },
                 ],

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -183,10 +183,7 @@ impl framework::Example for Example {
                         wgpu::BindGroupLayoutEntry {
                             binding: 1,
                             visibility: wgpu::ShaderStages::FRAGMENT,
-                            ty: wgpu::BindingType::Sampler {
-                                filtering: false,
-                                comparison: false,
-                            },
+                            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
                             count: None,
                         },
                     ],

--- a/wgpu/examples/shadow/main.rs
+++ b/wgpu/examples/shadow/main.rs
@@ -580,10 +580,7 @@ impl framework::Example for Example {
                         wgpu::BindGroupLayoutEntry {
                             binding: 3,
                             visibility: wgpu::ShaderStages::FRAGMENT,
-                            ty: wgpu::BindingType::Sampler {
-                                comparison: true,
-                                filtering: true,
-                            },
+                            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Comparison),
                             count: None,
                         },
                     ],

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -166,10 +166,7 @@ impl framework::Example for Skybox {
                 wgpu::BindGroupLayoutEntry {
                     binding: 2,
                     visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler {
-                        comparison: false,
-                        filtering: true,
-                    },
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
             ],

--- a/wgpu/examples/texture-arrays/main.rs
+++ b/wgpu/examples/texture-arrays/main.rs
@@ -188,10 +188,7 @@ impl framework::Example for Example {
                 wgpu::BindGroupLayoutEntry {
                     binding: 1,
                     visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler {
-                        comparison: false,
-                        filtering: true,
-                    },
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
             ],

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -391,10 +391,7 @@ impl framework::Example for Example {
                     wgpu::BindGroupLayoutEntry {
                         binding: 3,
                         visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler {
-                            comparison: false,
-                            filtering: true,
-                        },
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                         count: None,
                     },
                 ],

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1283,15 +1283,18 @@ impl crate::Context for Context {
                         });
                         mapped_entry.buffer(&buffer);
                     }
-                    wgt::BindingType::Sampler {
-                        comparison,
-                        filtering,
-                    } => {
+                    wgt::BindingType::Sampler(ty) => {
                         let mut sampler = web_sys::GpuSamplerBindingLayout::new();
-                        sampler.type_(match (comparison, filtering) {
-                            (false, false) => web_sys::GpuSamplerBindingType::NonFiltering,
-                            (false, true) => web_sys::GpuSamplerBindingType::Filtering,
-                            (true, _) => web_sys::GpuSamplerBindingType::Comparison,
+                        sampler.type_(match ty {
+                            wgt::SamplerBindingType::NonFiltering => {
+                                web_sys::GpuSamplerBindingType::NonFiltering
+                            }
+                            wgt::SamplerBindingType::Filtering => {
+                                web_sys::GpuSamplerBindingType::Filtering
+                            }
+                            wgt::SamplerBindingType::Comparison => {
+                                web_sys::GpuSamplerBindingType::Comparison
+                            }
                         });
                         mapped_entry.sampler(&sampler);
                     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -32,13 +32,14 @@ pub use wgt::{
     DynamicOffset, Extent3d, Face, Features, FilterMode, FrontFace, ImageDataLayout,
     ImageSubresourceRange, IndexFormat, Limits, MultisampleState, Origin3d,
     PipelineStatisticsTypes, PolygonMode, PowerPreference, PresentMode, PrimitiveState,
-    PrimitiveTopology, PushConstantRange, QueryType, RenderBundleDepthStencil, SamplerBorderColor,
-    ShaderLocation, ShaderModel, ShaderStages, StencilFaceState, StencilOperation, StencilState,
-    StorageTextureAccess, SurfaceConfiguration, SurfaceStatus, TextureAspect, TextureDimension,
-    TextureFormat, TextureFormatFeatureFlags, TextureFormatFeatures, TextureSampleType,
-    TextureUsages, TextureViewDimension, VertexAttribute, VertexFormat, VertexStepMode,
-    COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT, MAP_ALIGNMENT, PUSH_CONSTANT_ALIGNMENT,
-    QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
+    PrimitiveTopology, PushConstantRange, QueryType, RenderBundleDepthStencil, SamplerBindingType,
+    SamplerBorderColor, ShaderLocation, ShaderModel, ShaderStages, StencilFaceState,
+    StencilOperation, StencilState, StorageTextureAccess, SurfaceConfiguration, SurfaceStatus,
+    TextureAspect, TextureDimension, TextureFormat, TextureFormatFeatureFlags,
+    TextureFormatFeatures, TextureSampleType, TextureUsages, TextureViewDimension, VertexAttribute,
+    VertexFormat, VertexStepMode, COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT,
+    MAP_ALIGNMENT, PUSH_CONSTANT_ALIGNMENT, QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES,
+    QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
 };
 
 use backend::{BufferMappedRange, Context as C};


### PR DESCRIPTION
**Description**
Was investigating why the [shadow](https://wgpu.rs/examples/?example=shadow) example didn't work in Firefox Nightly and dug around until finding the validation bug described in the first commit. Thought it made more sense to switch to an enum so there's no mapping necessary between the `(bool, bool)` tuple (filtering  & comparison) and the `SamplerBindingType` from the spec. Though it's possible that there was a good reason to use the previous representation in which case I can submit a simpler patch which just fixes the validation.

**Testing**
Tested the examples natively (Vulkan; Linux; AMD). Also tested a custom build of firefox with an updated wgpu and [this patch](https://github.com/gfx-rs/wgpu/files/7541248/patch.txt) to confirm that the shadow example now works properly.
