### PR TITLE
Don't use duplicate function name in boids shader

### DIFF
--- a/wgpu/examples/boids/draw.wgsl
+++ b/wgpu/examples/boids/draw.wgsl
@@ -1,5 +1,5 @@
 [[stage(vertex)]]
-fn main(
+fn main_vs(
     [[location(0)]] particle_pos: vec2<f32>,
     [[location(1)]] particle_vel: vec2<f32>,
     [[location(2)]] position: vec2<f32>,
@@ -13,6 +13,6 @@ fn main(
 }
 
 [[stage(fragment)]]
-fn main() -> [[location(0)]] vec4<f32> {
+fn main_fs() -> [[location(0)]] vec4<f32> {
     return vec4<f32>(1.0, 1.0, 1.0, 1.0);
 }

--- a/wgpu/examples/boids/main.rs
+++ b/wgpu/examples/boids/main.rs
@@ -137,7 +137,7 @@ impl framework::Example for Example {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &draw_shader,
-                entry_point: "main",
+                entry_point: "main_vs",
                 buffers: &[
                     wgpu::VertexBufferLayout {
                         array_stride: 4 * 4,
@@ -153,7 +153,7 @@ impl framework::Example for Example {
             },
             fragment: Some(wgpu::FragmentState {
                 module: &draw_shader,
-                entry_point: "main",
+                entry_point: "main_fs",
                 targets: &[config.format.into()],
             }),
             primitive: wgpu::PrimitiveState::default(),


### PR DESCRIPTION
**Description**
From the spec: "A declaration must not introduce a name when that
identifier is already in scope with the same end scope as another
instance of that name."

naga doesn't yet check this (gfx-rs/naga#1480) but Chrome/Tint rightly complains with:
error: redefinition of 'main'

**Testing**
Tested the boids example natively and in both Firefox Nightly and Chrome Canary.
