### PR TITLE
Add multiview support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,18 +984,18 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.7.1"
-source = "git+https://github.com/gfx-rs/naga?rev=eda078d#eda078d736a906b4267e4803db6b32e3162aac30"
+source = "git+https://github.com/gfx-rs/naga?rev=29571cc#29571cc4cfbb28558948b1b31ad764f55b69f37b"
 dependencies = [
  "bit-set",
  "bitflags",
  "codespan-reporting",
- "fxhash",
  "hexf-parse",
  "indexmap",
  "log",
  "num-traits 0.2.14",
  "petgraph",
  "pp-rs",
+ "rustc-hash",
  "serde",
  "spirv",
  "thiserror",
@@ -1436,6 +1436,12 @@ dependencies = [
  "bitflags",
  "serde",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rusttype"

--- a/deno_webgpu/src/bundle.rs
+++ b/deno_webgpu/src/bundle.rs
@@ -68,6 +68,7 @@ pub fn op_webgpu_create_render_bundle_encoder(
         color_formats: Cow::from(color_formats),
         sample_count: args.sample_count,
         depth_stencil,
+        multiview: None,
     };
 
     let res = wgpu_core::command::RenderBundleEncoder::new(&descriptor, device, None);

--- a/deno_webgpu/src/pipeline.rs
+++ b/deno_webgpu/src/pipeline.rs
@@ -358,6 +358,7 @@ pub fn op_webgpu_create_render_pipeline(
         depth_stencil: args.depth_stencil.map(TryInto::try_into).transpose()?,
         multisample: args.multisample.into(),
         fragment,
+        multiview: None,
     };
 
     let implicit_pipelines = match args.layout {

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "eda078d"
+rev = "29571cc"
 #version = "0.7"
 features = ["span", "validate", "wgsl-in"]
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -54,7 +54,7 @@ use crate::{
     Label, LabelHelpers, LifeGuard, Stored,
 };
 use arrayvec::ArrayVec;
-use std::{borrow::Cow, mem, ops::Range};
+use std::{borrow::Cow, mem, num::NonZeroU32, ops::Range};
 use thiserror::Error;
 
 use hal::CommandEncoder as _;
@@ -75,6 +75,8 @@ pub struct RenderBundleEncoderDescriptor<'a> {
     /// Sample count this render bundle is capable of rendering to. This must match the pipelines and
     /// the renderpasses it is used in.
     pub sample_count: u32,
+    /// If this render bundle will rendering to multiple array layers in the attachments at the same time.
+    pub multiview: Option<NonZeroU32>,
 }
 
 #[derive(Debug)]
@@ -112,6 +114,7 @@ impl RenderBundleEncoder {
                     }
                     sc
                 },
+                multiview: desc.multiview,
             },
             is_ds_read_only: match desc.depth_stencil {
                 Some(ds) => {
@@ -135,6 +138,7 @@ impl RenderBundleEncoder {
                     depth_stencil: None,
                 },
                 sample_count: 0,
+                multiview: None,
             },
             is_ds_read_only: false,
         }

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -27,6 +27,7 @@ pub(crate) fn new_render_bundle_encoder_descriptor<'a>(
             }
         }),
         sample_count: context.sample_count,
+        multiview: context.multiview,
     }
 }
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -5,7 +5,7 @@ use crate::{
     id::{DeviceId, PipelineLayoutId, ShaderModuleId},
     validation, Label, LifeGuard, Stored,
 };
-use std::{borrow::Cow, error::Error, fmt};
+use std::{borrow::Cow, error::Error, fmt, num::NonZeroU32};
 use thiserror::Error;
 
 #[allow(clippy::large_enum_variant)]
@@ -243,6 +243,9 @@ pub struct RenderPipelineDescriptor<'a> {
     pub multisample: wgt::MultisampleState,
     /// The fragment processing state for this pipeline.
     pub fragment: Option<FragmentState<'a>>,
+    /// If the pipeline will be used with a multiview render pass, this indicates how many array
+    /// layers the attachments will have.
+    pub multiview: Option<NonZeroU32>,
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -75,12 +75,12 @@ js-sys = { version = "0.3" }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "eda078d"
+rev = "29571cc"
 #version = "0.7"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "eda078d"
+rev = "29571cc"
 #version = "0.7"
 features = ["wgsl-in"]
 

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -241,6 +241,7 @@ impl<A: hal::Api> Example<A> {
                 blend: Some(wgt::BlendState::ALPHA_BLENDING),
                 write_mask: wgt::ColorWrites::default(),
             }],
+            multiview: None,
         };
         let pipeline = unsafe { device.create_render_pipeline(&pipeline_desc).unwrap() };
 
@@ -667,6 +668,7 @@ impl<A: hal::Api> Example<A> {
                 },
             }],
             depth_stencil_attachment: None,
+            multiview: None,
         };
         unsafe {
             ctx.encoder.begin_render_pass(&pass_desc);

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -93,7 +93,7 @@ pub use vulkan::UpdateAfterBindTypes;
 use std::{
     borrow::Borrow,
     fmt,
-    num::NonZeroU8,
+    num::{NonZeroU32, NonZeroU8},
     ops::{Range, RangeInclusive},
     ptr::NonNull,
 };
@@ -991,6 +991,9 @@ pub struct RenderPipelineDescriptor<'a, A: Api> {
     pub fragment_stage: Option<ProgrammableStage<'a, A>>,
     /// The effect of draw calls on the color aspect of the output target.
     pub color_targets: &'a [wgt::ColorTargetState],
+    /// If the pipeline will be used with a multiview render pass, this indicates how many array
+    /// layers the attachments will have.
+    pub multiview: Option<NonZeroU32>,
 }
 
 /// Specifies how the alpha channel of the textures should be handled during (martin mouv i step)
@@ -1144,6 +1147,7 @@ pub struct RenderPassDescriptor<'a, A: Api> {
     pub sample_count: u32,
     pub color_attachments: &'a [ColorAttachment<'a, A>],
     pub depth_stencil_attachment: Option<DepthStencilAttachment<'a, A>>,
+    pub multiview: Option<NonZeroU32>,
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -16,6 +16,7 @@ fn indexing_features() -> wgt::Features {
 #[derive(Debug, Default)]
 pub struct PhysicalDeviceFeatures {
     core: vk::PhysicalDeviceFeatures,
+    vulkan_1_1: Option<vk::PhysicalDeviceVulkan11Features>,
     pub(super) vulkan_1_2: Option<vk::PhysicalDeviceVulkan12Features>,
     pub(super) descriptor_indexing: Option<vk::PhysicalDeviceDescriptorIndexingFeaturesEXT>,
     imageless_framebuffer: Option<vk::PhysicalDeviceImagelessFramebufferFeaturesKHR>,
@@ -23,6 +24,7 @@ pub struct PhysicalDeviceFeatures {
     image_robustness: Option<vk::PhysicalDeviceImageRobustnessFeaturesEXT>,
     robustness2: Option<vk::PhysicalDeviceRobustness2FeaturesEXT>,
     depth_clip_enable: Option<vk::PhysicalDeviceDepthClipEnableFeaturesEXT>,
+    multiview: Option<vk::PhysicalDeviceMultiviewFeaturesKHR>,
 }
 
 // This is safe because the structs have `p_next: *mut c_void`, which we null out/never read.
@@ -159,6 +161,15 @@ impl PhysicalDeviceFeatures {
                 //.shader_resource_residency(requested_features.contains(wgt::Features::SHADER_RESOURCE_RESIDENCY))
                 .geometry_shader(requested_features.contains(wgt::Features::SHADER_PRIMITIVE_INDEX))
                 .build(),
+            vulkan_1_1: if api_version >= vk::API_VERSION_1_1 {
+                Some(
+                    vk::PhysicalDeviceVulkan11Features::builder()
+                        .multiview(requested_features.contains(wgt::Features::MULTIVIEW))
+                        .build(),
+                )
+            } else {
+                None
+            },
             vulkan_1_2: if api_version >= vk::API_VERSION_1_2 {
                 Some(
                     vk::PhysicalDeviceVulkan12Features::builder()
@@ -295,6 +306,15 @@ impl PhysicalDeviceFeatures {
             } else {
                 None
             },
+            multiview: if enabled_extensions.contains(&vk::KhrMultiviewFn::name()) {
+                Some(
+                    vk::PhysicalDeviceMultiviewFeatures::builder()
+                        .multiview(requested_features.contains(wgt::Features::MULTIVIEW))
+                        .build(),
+                )
+            } else {
+                None
+            },
         }
     }
 
@@ -390,6 +410,10 @@ impl PhysicalDeviceFeatures {
 
         let intel_windows = caps.properties.vendor_id == db::intel::VENDOR && cfg!(windows);
 
+        if let Some(ref vulkan_1_1) = self.vulkan_1_1 {
+            features.set(F::MULTIVIEW, vulkan_1_1.multiview != 0);
+        }
+
         if let Some(ref vulkan_1_2) = self.vulkan_1_2 {
             const STORAGE: F = F::STORAGE_RESOURCE_BINDING_ARRAY;
             if Self::all_features_supported(
@@ -479,6 +503,10 @@ impl PhysicalDeviceFeatures {
             features.set(F::DEPTH_CLIP_CONTROL, feature.depth_clip_enable != 0);
         }
 
+        if let Some(ref multiview) = self.multiview {
+            features.set(F::MULTIVIEW, multiview.multiview != 0);
+        }
+
         (features, dl_flags)
     }
 
@@ -521,6 +549,11 @@ impl PhysicalDeviceCapabilities {
         if self.properties.api_version < vk::API_VERSION_1_1 {
             extensions.push(vk::KhrMaintenance1Fn::name());
             extensions.push(vk::KhrMaintenance2Fn::name());
+
+            // Below Vulkan 1.1 we can get multiview from an extension
+            if requested_features.contains(wgt::Features::MULTIVIEW) {
+                extensions.push(vk::KhrMultiviewFn::name());
+            }
 
             // `VK_AMD_negative_viewport_height` is obsoleted by `VK_KHR_maintenance1` and must not be enabled alongside `VK_KHR_maintenance1` or a 1.1+ device.
             if !self.supports_extension(vk::KhrMaintenance1Fn::name()) {
@@ -727,6 +760,13 @@ impl super::InstanceShared {
                 .features(core)
                 .build();
 
+            if capabilities.properties.api_version >= vk::API_VERSION_1_1 {
+                features.vulkan_1_1 = Some(vk::PhysicalDeviceVulkan11Features::builder().build());
+
+                let mut_ref = features.vulkan_1_1.as_mut().unwrap();
+                mut_ref.p_next = mem::replace(&mut features2.p_next, mut_ref as *mut _ as *mut _);
+            }
+
             if capabilities.properties.api_version >= vk::API_VERSION_1_2 {
                 features.vulkan_1_2 = Some(vk::PhysicalDeviceVulkan12Features::builder().build());
 
@@ -793,6 +833,7 @@ impl super::InstanceShared {
         }
 
         unsafe {
+            null_p_next(&mut features.vulkan_1_1);
             null_p_next(&mut features.vulkan_1_2);
             null_p_next(&mut features.descriptor_indexing);
             null_p_next(&mut features.imageless_framebuffer);
@@ -998,6 +1039,7 @@ impl super::Adapter {
         raw_device: ash::Device,
         handle_is_owned: bool,
         enabled_extensions: &[&'static CStr],
+        features: wgt::Features,
         uab_types: super::UpdateAfterBindTypes,
         family_index: u32,
         queue_index: u32,
@@ -1044,7 +1086,8 @@ impl super::Adapter {
 
         let naga_options = {
             use naga::back::spv;
-            let capabilities = [
+
+            let mut capabilities = vec![
                 spv::Capability::Shader,
                 spv::Capability::Matrix,
                 spv::Capability::Sampled1D,
@@ -1058,6 +1101,11 @@ impl super::Adapter {
                 spv::Capability::StorageImageExtendedFormats,
                 //TODO: fill out the rest
             ];
+
+            if features.contains(wgt::Features::MULTIVIEW) {
+                capabilities.push(spv::Capability::MultiView);
+            }
+
             let mut flags = spv::WriterFlags::empty();
             flags.set(
                 spv::WriterFlags::DEBUG,
@@ -1078,17 +1126,17 @@ impl super::Adapter {
                 lang_version: (1, 0),
                 flags,
                 capabilities: Some(capabilities.iter().cloned().collect()),
-                bounds_check_policies: naga::back::BoundsCheckPolicies {
-                    index: naga::back::BoundsCheckPolicy::Restrict,
+                bounds_check_policies: naga::proc::BoundsCheckPolicies {
+                    index: naga::proc::BoundsCheckPolicy::Restrict,
                     buffer: if self.private_caps.robust_buffer_access {
-                        naga::back::BoundsCheckPolicy::Unchecked
+                        naga::proc::BoundsCheckPolicy::Unchecked
                     } else {
-                        naga::back::BoundsCheckPolicy::Restrict
+                        naga::proc::BoundsCheckPolicy::Restrict
                     },
                     image: if self.private_caps.robust_image_access {
-                        naga::back::BoundsCheckPolicy::Unchecked
+                        naga::proc::BoundsCheckPolicy::Unchecked
                     } else {
-                        naga::back::BoundsCheckPolicy::Restrict
+                        naga::proc::BoundsCheckPolicy::Restrict
                     },
                 },
             }
@@ -1222,6 +1270,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             raw_device,
             true,
             &enabled_extensions,
+            features,
             uab_types,
             family_info.queue_family_index,
             0,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -31,7 +31,7 @@ mod conv;
 mod device;
 mod instance;
 
-use std::{borrow::Borrow, ffi::CStr, sync::Arc};
+use std::{borrow::Borrow, ffi::CStr, num::NonZeroU32, sync::Arc};
 
 use arrayvec::ArrayVec;
 use ash::{
@@ -210,6 +210,7 @@ struct RenderPassKey {
     colors: ArrayVec<ColorAttachmentKey, { crate::MAX_COLOR_TARGETS }>,
     depth_stencil: Option<DepthStencilAttachmentKey>,
     sample_count: u32,
+    multiview: Option<NonZeroU32>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -373,6 +374,7 @@ impl Texture {
 #[derive(Debug)]
 pub struct TextureView {
     raw: vk::ImageView,
+    layers: NonZeroU32,
     attachment: FramebufferAttachment,
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -526,6 +526,13 @@ bitflags::bitflags! {
         ///
         /// This is a native only feature.
         const SHADER_PRIMITIVE_INDEX = 1 << 39;
+        /// Enables multiview render passes and `builtin(view_index)` in vertex shaders.
+        ///
+        /// Supported platforms:
+        /// - Vulkan
+        ///
+        /// This is a native only feature.
+        const MULTIVIEW = 1 << 40;
     }
 }
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -135,20 +135,20 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "eda078d"
+rev = "29571cc"
 #version = "0.7"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "eda078d"
+rev = "29571cc"
 #version = "0.7"
 features = ["wgsl-in"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "eda078d"
+rev = "29571cc"
 #version = "0.7"
 features = ["wgsl-out"]
 

--- a/wgpu/examples/boids/main.rs
+++ b/wgpu/examples/boids/main.rs
@@ -159,6 +159,7 @@ impl framework::Example for Example {
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
+            multiview: None,
         });
 
         // create compute pipeline

--- a/wgpu/examples/bunnymark/main.rs
+++ b/wgpu/examples/bunnymark/main.rs
@@ -130,6 +130,7 @@ impl framework::Example for Example {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
+            multiview: None,
         });
 
         let texture = {

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -113,6 +113,7 @@ impl framework::Example for Example {
                 },
                 depth_stencil: None,
                 multisample: wgpu::MultisampleState::default(),
+                multiview: None,
             });
 
         let pipeline_triangle_regular =
@@ -132,6 +133,7 @@ impl framework::Example for Example {
                 primitive: wgpu::PrimitiveState::default(),
                 depth_stencil: None,
                 multisample: wgpu::MultisampleState::default(),
+                multiview: None,
             });
 
         let pipeline_lines = if device
@@ -159,6 +161,7 @@ impl framework::Example for Example {
                     },
                     depth_stencil: None,
                     multisample: wgpu::MultisampleState::default(),
+                    multiview: None,
                 }),
             )
         } else {
@@ -218,6 +221,7 @@ impl framework::Example for Example {
                     primitive: wgpu::PrimitiveState::default(),
                     depth_stencil: None,
                     multisample: wgpu::MultisampleState::default(),
+                    multiview: None,
                 }),
                 bind_group_layout,
             )

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -260,6 +260,7 @@ impl framework::Example for Example {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
+            multiview: None,
         });
 
         let pipeline_wire = if device.features().contains(wgt::Features::POLYGON_MODE_LINE) {
@@ -295,6 +296,7 @@ impl framework::Example for Example {
                 },
                 depth_stencil: None,
                 multisample: wgpu::MultisampleState::default(),
+                multiview: None,
             });
             Some(pipeline_wire)
         } else {

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -64,6 +64,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         primitive: wgpu::PrimitiveState::default(),
         depth_stencil: None,
         multisample: wgpu::MultisampleState::default(),
+        multiview: None,
     });
 
     let mut config = wgpu::SurfaceConfiguration {

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -104,6 +104,7 @@ impl Example {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
+            multiview: None,
         });
 
         let bind_group_layout = pipeline.get_bind_group_layout(0);
@@ -300,6 +301,7 @@ impl framework::Example for Example {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
+            multiview: None,
         });
 
         // Create bind group

--- a/wgpu/examples/msaa-line/main.rs
+++ b/wgpu/examples/msaa-line/main.rs
@@ -72,6 +72,7 @@ impl Example {
                 count: sample_count,
                 ..Default::default()
             },
+            multiview: None,
         });
         let mut encoder =
             device.create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
@@ -79,6 +80,7 @@ impl Example {
                 color_formats: &[config.format],
                 depth_stencil: None,
                 sample_count,
+                multiview: None,
             });
         encoder.set_pipeline(&pipeline);
         encoder.set_vertex_buffer(0, vertex_buffer.slice(..));

--- a/wgpu/examples/shadow/main.rs
+++ b/wgpu/examples/shadow/main.rs
@@ -527,6 +527,7 @@ impl framework::Example for Example {
                     },
                 }),
                 multisample: wgpu::MultisampleState::default(),
+                multiview: None,
             });
 
             Pass {
@@ -661,6 +662,7 @@ impl framework::Example for Example {
                     bias: wgpu::DepthBiasState::default(),
                 }),
                 multisample: wgpu::MultisampleState::default(),
+                multiview: None,
             });
 
             Pass {

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -226,6 +226,7 @@ impl framework::Example for Skybox {
                 bias: wgpu::DepthBiasState::default(),
             }),
             multisample: wgpu::MultisampleState::default(),
+            multiview: None,
         });
         let entity_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("Entity"),
@@ -256,6 +257,7 @@ impl framework::Example for Skybox {
                 bias: wgpu::DepthBiasState::default(),
             }),
             multisample: wgpu::MultisampleState::default(),
+            multiview: None,
         });
 
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {

--- a/wgpu/examples/texture-arrays/main.rs
+++ b/wgpu/examples/texture-arrays/main.rs
@@ -253,6 +253,7 @@ impl framework::Example for Example {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
+            multiview: None,
         });
 
         Self {

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -565,6 +565,7 @@ impl framework::Example for Example {
             }),
             // No multisampling is used.
             multisample: wgpu::MultisampleState::default(),
+            multiview: None,
         });
 
         // Same idea as the water pipeline.
@@ -598,6 +599,7 @@ impl framework::Example for Example {
                 bias: wgpu::DepthBiasState::default(),
             }),
             multisample: wgpu::MultisampleState::default(),
+            multiview: None,
         });
 
         // Done

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1275,6 +1275,7 @@ impl crate::Context for Context {
                 },
                 targets: Borrowed(frag.targets),
             }),
+            multiview: desc.multiview,
         };
 
         let global = &self.0;
@@ -1496,6 +1497,7 @@ impl crate::Context for Context {
             color_formats: Borrowed(desc.color_formats),
             depth_stencil: desc.depth_stencil,
             sample_count: desc.sample_count,
+            multiview: desc.multiview,
         };
         match wgc::command::RenderBundleEncoder::new(&descriptor, device.id, None) {
             Ok(id) => id,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1293,6 +1293,9 @@ pub struct RenderPipelineDescriptor<'a> {
     pub multisample: MultisampleState,
     /// The compiled fragment stage, its entry point, and the color targets.
     pub fragment: Option<FragmentState<'a>>,
+    /// If the pipeline will be used with a multiview render pass, this indicates how many array
+    /// layers the attachments will have.
+    pub multiview: Option<NonZeroU32>,
 }
 
 /// Describes the attachments of a compute pass.
@@ -1348,6 +1351,8 @@ pub struct RenderBundleEncoderDescriptor<'a> {
     /// Sample count this render bundle is capable of rendering to. This must match the pipelines and
     /// the renderpasses it is used in.
     pub sample_count: u32,
+    /// If this render bundle will rendering to multiple array layers in the attachments at the same time.
+    pub multiview: Option<NonZeroU32>,
 }
 
 /// Surface texture that can be rendered to.

--- a/wgpu/tests/vertex_indices/mod.rs
+++ b/wgpu/tests/vertex_indices/mod.rs
@@ -77,6 +77,7 @@ fn pulling_common(
                     write_mask: wgpu::ColorWrites::ALL,
                 }],
             }),
+            multiview: None,
         });
 
     let dummy = ctx


### PR DESCRIPTION
## Connections
Fixes: https://github.com/gfx-rs/wgpu/issues/2186

## Description
Adds basic multiview support.

## Testing
You can now create a render pass with a target view with two array layers.
