### PR TITLE
Populate sampling pairs for validation

### DIFF
--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -934,6 +934,11 @@ impl Interface {
                 }
             }
 
+            for key in info.sampling_set.iter() {
+                ep.sampling_pairs
+                    .insert((resource_mapping[&key.image], resource_mapping[&key.sampler]));
+            }
+
             ep.workgroup_size = entry_point.workgroup_size;
 
             entry_points.insert((entry_point.stage, entry_point.name.clone()), ep);


### PR DESCRIPTION
**Connections**
Fixes #2182

**Description**
We didn't populate the set

**Testing**
Modified the skybox example:
```
Caused by:
    In Device::create_render_pipeline
      note: label = `Sky`
    error matching FRAGMENT shader requirements against the pipeline
    unable to filter the texture (ResourceBinding { group: 0, binding: 1 }) by the sampler (ResourceBinding { group: 0, binding: 2 })
    non-filterable float texture

```
