### PR TITLE
Validate min_binding_size at draw time

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -718,6 +718,9 @@ pub struct BindGroup<A: hal::Api> {
     pub(crate) used_buffer_ranges: Vec<BufferInitTrackerAction>,
     pub(crate) used_texture_ranges: Vec<TextureInitTrackerAction>,
     pub(crate) dynamic_binding_info: Vec<BindGroupDynamicBindingData>,
+    /// Actual binding sizes for buffers that don't have `min_binding_size`
+    /// specified in BGL. Listed in the order of iteration of `BGL.entries`.
+    pub(crate) late_buffer_binding_sizes: Vec<wgt::BufferSize>,
 }
 
 impl<A: hal::Api> BindGroup<A> {
@@ -782,4 +785,13 @@ pub enum GetBindGroupLayoutError {
     InvalidPipeline,
     #[error("invalid group index {0}")]
     InvalidGroupIndex(u32),
+}
+
+#[derive(Clone, Debug, Error, PartialEq)]
+#[error("Buffer is bound with size {bound_size} where the shader expects {shader_size} in group[{group_index}] compact index {compact_index}")]
+pub struct LateMinBufferBindingSizeMismatch {
+    pub group_index: u32,
+    pub compact_index: usize,
+    pub shader_size: wgt::BufferAddress,
+    pub bound_size: wgt::BufferAddress,
 }

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -2,7 +2,7 @@
 !*/
 
 use crate::{
-    binding_model::PushConstantUploadError,
+    binding_model::{LateMinBufferBindingSizeMismatch, PushConstantUploadError},
     error::ErrorFormatter,
     id,
     track::UseExtendError,
@@ -53,6 +53,8 @@ pub enum DrawError {
         pipeline: wgt::IndexFormat,
         buffer: wgt::IndexFormat,
     },
+    #[error(transparent)]
+    BindingSizeTooSmall(#[from] LateMinBufferBindingSizeMismatch),
 }
 
 /// Error encountered when encoding a render command.

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1117,6 +1117,44 @@ impl<A: HalApi> Device<A> {
             .collect()
     }
 
+    /// Generate information about late-validated buffer bindings for pipelines.
+    //TODO: should this be combined with `get_introspection_bind_group_layouts` in some way?
+    fn make_late_sized_buffer_groups<'a>(
+        shader_binding_sizes: &FastHashMap<naga::ResourceBinding, wgt::BufferSize>,
+        layout: &binding_model::PipelineLayout<A>,
+        bgl_guard: &'a Storage<binding_model::BindGroupLayout<A>, id::BindGroupLayoutId>,
+    ) -> ArrayVec<pipeline::LateSizedBufferGroup, { hal::MAX_BIND_GROUPS }> {
+        // Given the shader-required binding sizes and the pipeline layout,
+        // return the filtered list of them in the layout order,
+        // removing those with given `min_binding_size`.
+        layout
+            .bind_group_layout_ids
+            .iter()
+            .enumerate()
+            .map(|(group_index, &bgl_id)| pipeline::LateSizedBufferGroup {
+                shader_sizes: bgl_guard[bgl_id]
+                    .entries
+                    .values()
+                    .filter_map(|entry| match entry.ty {
+                        wgt::BindingType::Buffer {
+                            min_binding_size: None,
+                            ..
+                        } => {
+                            let rb = naga::ResourceBinding {
+                                group: group_index as u32,
+                                binding: entry.binding,
+                            };
+                            let shader_size =
+                                shader_binding_sizes.get(&rb).map_or(0, |nz| nz.get());
+                            Some(shader_size)
+                        }
+                        _ => None,
+                    })
+                    .collect(),
+            })
+            .collect()
+    }
+
     fn create_bind_group_layout(
         &self,
         self_id: id::DeviceId,
@@ -1296,6 +1334,7 @@ impl<A: HalApi> Device<A> {
         decl: &wgt::BindGroupLayoutEntry,
         used_buffer_ranges: &mut Vec<BufferInitTrackerAction>,
         dynamic_binding_info: &mut Vec<binding_model::BindGroupDynamicBindingData>,
+        late_buffer_binding_sizes: &mut Vec<wgt::BufferSize>,
         used: &mut TrackerSet,
         storage: &'a Storage<resource::Buffer<A>, id::BufferId>,
         limits: &wgt::Limits,
@@ -1393,8 +1432,10 @@ impl<A: HalApi> Device<A> {
                     min: min_size,
                 });
             }
-        } else if bind_size == 0 {
-            return Err(Error::BindingZeroSize(bb.buffer_id));
+        } else {
+            let late_size =
+                wgt::BufferSize::new(bind_size).ok_or(Error::BindingZeroSize(bb.buffer_id))?;
+            late_buffer_binding_sizes.push(late_size);
         }
 
         assert_eq!(bb.offset % wgt::COPY_BUFFER_ALIGNMENT, 0);
@@ -1470,6 +1511,7 @@ impl<A: HalApi> Device<A> {
         // TODO: arrayvec/smallvec
         // Record binding info for dynamic offset validation
         let mut dynamic_binding_info = Vec::new();
+        let mut late_buffer_binding_sizes = Vec::new();
         // fill out the descriptors
         let mut used = TrackerSet::new(A::VARIANT);
 
@@ -1499,6 +1541,7 @@ impl<A: HalApi> Device<A> {
                         decl,
                         &mut used_buffer_ranges,
                         &mut dynamic_binding_info,
+                        &mut late_buffer_binding_sizes,
                         &mut used,
                         &*buffer_guard,
                         &self.limits,
@@ -1520,6 +1563,7 @@ impl<A: HalApi> Device<A> {
                             decl,
                             &mut used_buffer_ranges,
                             &mut dynamic_binding_info,
+                            &mut late_buffer_binding_sizes,
                             &mut used,
                             &*buffer_guard,
                             &self.limits,
@@ -1674,6 +1718,7 @@ impl<A: HalApi> Device<A> {
             used_buffer_ranges,
             used_texture_ranges,
             dynamic_binding_info,
+            late_buffer_binding_sizes,
         })
     }
 
@@ -2014,6 +2059,7 @@ impl<A: HalApi> Device<A> {
 
         let mut derived_group_layouts =
             ArrayVec::<binding_model::BindEntryMap, { hal::MAX_BIND_GROUPS }>::new();
+        let mut shader_binding_sizes = FastHashMap::default();
 
         let io = validation::StageIo::default();
         let (shader_module_guard, _) = hub.shader_modules.read(&mut token);
@@ -2042,6 +2088,7 @@ impl<A: HalApi> Device<A> {
                 let _ = interface.check_stage(
                     provided_layouts.as_ref().map(|p| p.as_slice()),
                     &mut derived_group_layouts,
+                    &mut shader_binding_sizes,
                     &desc.stage.entry_point,
                     flag,
                     io,
@@ -2062,6 +2109,9 @@ impl<A: HalApi> Device<A> {
         let layout = pipeline_layout_guard
             .get(pipeline_layout_id)
             .map_err(|_| pipeline::CreateComputePipelineError::InvalidLayout)?;
+
+        let late_sized_buffer_groups =
+            Device::make_late_sized_buffer_groups(&shader_binding_sizes, layout, &*bgl_guard);
 
         let pipeline_desc = hal::ComputePipelineDescriptor {
             label: desc.label.borrow_option(),
@@ -2097,6 +2147,7 @@ impl<A: HalApi> Device<A> {
                 value: id::Valid(self_id),
                 ref_count: self.life_guard.add_ref(),
             },
+            late_sized_buffer_groups,
             life_guard: LifeGuard::new(desc.label.borrow_or_default()),
         };
         Ok(pipeline)
@@ -2126,6 +2177,7 @@ impl<A: HalApi> Device<A> {
 
         let mut derived_group_layouts =
             ArrayVec::<binding_model::BindEntryMap, { hal::MAX_BIND_GROUPS }>::new();
+        let mut shader_binding_sizes = FastHashMap::default();
 
         let color_targets = desc
             .fragment
@@ -2349,6 +2401,7 @@ impl<A: HalApi> Device<A> {
                     .check_stage(
                         provided_layouts.as_ref().map(|p| p.as_slice()),
                         &mut derived_group_layouts,
+                        &mut shader_binding_sizes,
                         &stage.entry_point,
                         flag,
                         io,
@@ -2394,6 +2447,7 @@ impl<A: HalApi> Device<A> {
                             .check_stage(
                                 provided_layouts.as_ref().map(|p| p.as_slice()),
                                 &mut derived_group_layouts,
+                                &mut shader_binding_sizes,
                                 &fragment.stage.entry_point,
                                 flag,
                                 io,
@@ -2468,6 +2522,9 @@ impl<A: HalApi> Device<A> {
             self.require_features(wgt::Features::MULTIVIEW)?;
         }
 
+        let late_sized_buffer_groups =
+            Device::make_late_sized_buffer_groups(&shader_binding_sizes, layout, &*bgl_guard);
+
         let pipeline_desc = hal::RenderPipelineDescriptor {
             label: desc.label.borrow_option(),
             layout: &layout.raw,
@@ -2539,6 +2596,7 @@ impl<A: HalApi> Device<A> {
             flags,
             strip_index_format: desc.primitive.strip_index_format,
             vertex_strides,
+            late_sized_buffer_groups,
             life_guard: LifeGuard::new(desc.label.borrow_or_default()),
         };
         Ok(pipeline)

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -5,8 +5,18 @@ use crate::{
     id::{DeviceId, PipelineLayoutId, ShaderModuleId},
     validation, Label, LifeGuard, Stored,
 };
+use arrayvec::ArrayVec;
 use std::{borrow::Cow, error::Error, fmt, num::NonZeroU32};
 use thiserror::Error;
+
+/// Information about buffer bindings, which
+/// is validated against the shader (and pipeline)
+/// at draw time as opposed to initialization time.
+#[derive(Debug)]
+pub(crate) struct LateSizedBufferGroup {
+    // The order has to match `BindGroup::late_buffer_binding_sizes`.
+    pub(crate) shader_sizes: Vec<wgt::BufferAddress>,
+}
 
 #[allow(clippy::large_enum_variant)]
 pub enum ShaderModuleSource<'a> {
@@ -175,6 +185,7 @@ pub struct ComputePipeline<A: hal::Api> {
     pub(crate) raw: A::ComputePipeline,
     pub(crate) layout_id: Stored<PipelineLayoutId>,
     pub(crate) device_id: Stored<DeviceId>,
+    pub(crate) late_sized_buffer_groups: ArrayVec<LateSizedBufferGroup, { hal::MAX_BIND_GROUPS }>,
     pub(crate) life_guard: LifeGuard,
 }
 
@@ -351,6 +362,7 @@ pub struct RenderPipeline<A: hal::Api> {
     pub(crate) flags: PipelineFlags,
     pub(crate) strip_index_format: Option<wgt::IndexFormat>,
     pub(crate) vertex_strides: Vec<(wgt::BufferAddress, wgt::VertexStepMode)>,
+    pub(crate) late_sized_buffer_groups: ArrayVec<LateSizedBufferGroup, { hal::MAX_BIND_GROUPS }>,
     pub(crate) life_guard: LifeGuard,
 }
 


### PR DESCRIPTION
**Connections**
Fixes #2194

**Description**
I think validating bindings is very important, because users can waste hours investigating driver crashes otherwise.
The main sell of `wgpu` is that they should trust us.

Implementation-wise, it's complicated because we can't just go through all the bindings at draw time - this could be too slow. So there is a compaction scheme in place.

**Testing**
Tweaking the cube example gives me:
```
Caused by:
    In a RenderPass
      note: encoder = `<CommandBuffer-(0, 1, Vulkan)>`
    In a draw command, indexed:true indirect:false
      note: render pipeline = `<RenderPipeline-(0, 1, Vulkan)>`
    Buffer is bound with size 64 where the shader expects 80 in group[0] compact index 0
```

Obviously, the error could be nicer, but I don't want to invest into that just yet.
