### PR TITLE
Add strip_index_format to linestrip in conservative-raster example

### DIFF
--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -157,6 +157,7 @@ impl framework::Example for Example {
                     primitive: wgpu::PrimitiveState {
                         polygon_mode: wgpu::PolygonMode::Line,
                         topology: wgpu::PrimitiveTopology::LineStrip,
+                        strip_index_format: Some(wgpu::IndexFormat::Uint32),
                         ..Default::default()
                     },
                     depth_stencil: None,


### PR DESCRIPTION
**Description**
Without specifying `strip_index_format`, `create_render_pipeline` will return `NoStripIndexFormatForStripTopology` [here](../blob/2ef72b93130f84695b6f791ac2c3887501fed414/wgpu-core/src/device/mod.rs#L2228-L2234) if the GPU supports `POLYGON_MODE_LINE`.

**Testing**
With dx12 and Vulkan backends, was unable to run without strip index format set, and was able to run with it.  No tests cover this change, but ran them anyway.
