### PR TITLE
use native webgl2 buffers for MAP_READ usage

### DIFF
--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -201,10 +201,9 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             if !bar.usage.start.contains(crate::BufferUses::STORAGE_WRITE) {
                 continue;
             }
-            self.cmd_buffer.commands.push(C::BufferBarrier(
-                bar.buffer.raw.unwrap(),
-                bar.usage.end,
-            ));
+            self.cmd_buffer
+                .commands
+                .push(C::BufferBarrier(bar.buffer.raw.unwrap(), bar.usage.end));
         }
     }
 

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -202,7 +202,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 continue;
             }
             self.cmd_buffer.commands.push(C::BufferBarrier(
-                bar.buffer.inner.as_native().unwrap(),
+                bar.buffer.raw.unwrap(),
                 bar.usage.end,
             ));
         }
@@ -239,7 +239,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 
     unsafe fn clear_buffer(&mut self, buffer: &super::Buffer, range: crate::MemoryRange) {
         self.cmd_buffer.commands.push(C::ClearBuffer {
-            dst: buffer.inner.clone(),
+            dst: buffer.clone(),
             dst_target: buffer.target,
             range,
         });
@@ -260,9 +260,9 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         };
         for copy in regions {
             self.cmd_buffer.commands.push(C::CopyBufferToBuffer {
-                src: src.inner.clone(),
+                src: src.clone(),
                 src_target,
-                dst: dst.inner.clone(),
+                dst: dst.clone(),
                 dst_target,
                 copy,
             })
@@ -305,7 +305,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         for mut copy in regions {
             copy.clamp_size_to_virtual(&dst.copy_size);
             self.cmd_buffer.commands.push(C::CopyBufferToTexture {
-                src: src.inner.clone(),
+                src: src.clone(),
                 src_target: src.target,
                 dst: dst_raw,
                 dst_target,
@@ -331,7 +331,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 src: src_raw,
                 src_target,
                 src_format: src.format,
-                dst: dst.inner.clone(),
+                dst: dst.clone(),
                 dst_target: dst.target,
                 copy,
             })
@@ -368,7 +368,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         let query_range = start as u32..self.cmd_buffer.queries.len() as u32;
         self.cmd_buffer.commands.push(C::CopyQueryResults {
             query_range,
-            dst: buffer.inner.clone(),
+            dst: buffer.clone(),
             dst_target: buffer.target,
             dst_offset: offset,
         });
@@ -742,7 +742,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         self.state.index_format = format;
         self.cmd_buffer
             .commands
-            .push(C::SetIndexBuffer(binding.buffer.inner.as_native().unwrap()));
+            .push(C::SetIndexBuffer(binding.buffer.raw.unwrap()));
     }
     unsafe fn set_vertex_buffer<'a>(
         &mut self,
@@ -752,7 +752,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         self.state.dirty_vbuf_mask |= 1 << index;
         let (_, ref mut vb) = self.state.vertex_buffers[index as usize];
         *vb = Some(super::BufferBinding {
-            raw: binding.buffer.inner.as_native().unwrap(),
+            raw: binding.buffer.raw.unwrap(),
             offset: binding.offset,
         });
     }
@@ -834,7 +834,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 offset + draw * mem::size_of::<wgt::DrawIndirectArgs>() as wgt::BufferAddress;
             self.cmd_buffer.commands.push(C::DrawIndirect {
                 topology: self.state.topology,
-                indirect_buf: buffer.inner.as_native().unwrap(),
+                indirect_buf: buffer.raw.unwrap(),
                 indirect_offset,
             });
         }
@@ -856,7 +856,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             self.cmd_buffer.commands.push(C::DrawIndexedIndirect {
                 topology: self.state.topology,
                 index_type,
-                indirect_buf: buffer.inner.as_native().unwrap(),
+                indirect_buf: buffer.raw.unwrap(),
                 indirect_offset,
             });
         }
@@ -907,7 +907,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     }
     unsafe fn dispatch_indirect(&mut self, buffer: &super::Buffer, offset: wgt::BufferAddress) {
         self.cmd_buffer.commands.push(C::DispatchIndirect {
-            indirect_buf: buffer.inner.as_native().unwrap(),
+            indirect_buf: buffer.raw.unwrap(),
             indirect_offset: offset,
         });
     }

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1,7 +1,11 @@
 use super::conv;
 use crate::auxil::map_naga_stage;
 use glow::HasContext;
-use std::{convert::TryInto, iter, ptr, sync::{Arc, Mutex}};
+use std::{
+    convert::TryInto,
+    iter, ptr,
+    sync::{Arc, Mutex},
+};
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::mem;
@@ -329,11 +333,7 @@ impl crate::Device<super::Api> for super::Device {
                 .private_caps
                 .contains(super::PrivateCapabilities::BUFFER_ALLOCATION);
 
-        if emulate_map
-            && desc
-                .usage
-                .intersects(crate::BufferUses::MAP_WRITE)
-        {
+        if emulate_map && desc.usage.intersects(crate::BufferUses::MAP_WRITE) {
             return Ok(super::Buffer {
                 raw: None,
                 target,
@@ -473,7 +473,11 @@ impl crate::Device<super::Api> for super::Device {
     }
     unsafe fn unmap_buffer(&self, buffer: &super::Buffer) -> Result<(), crate::DeviceError> {
         if let Some(raw) = buffer.raw {
-            if !self.shared.workarounds.contains(super::Workarounds::EMULATE_BUFFER_MAP) {
+            if !self
+                .shared
+                .workarounds
+                .contains(super::Workarounds::EMULATE_BUFFER_MAP)
+            {
                 let gl = &self.shared.context.lock();
                 gl.bind_buffer(buffer.target, Some(raw));
                 gl.unmap_buffer(buffer.target);
@@ -1114,7 +1118,7 @@ impl crate::Device<super::Api> for super::Device {
         if fence.last_completed < wait_value {
             let gl = &self.shared.context.lock();
             let timeout_ns = if cfg!(target_arch = "wasm32") {
-                0 as u64
+                0
             } else {
                 (timeout_ms as u64 * 1_000_000).min(!0u32 as u64)
             };

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -234,6 +234,7 @@ pub struct Buffer {
     target: BindTarget,
     size: wgt::BufferAddress,
     map_flags: u32,
+    map_read_allocation: Option<std::sync::Mutex<Vec<u8>>>,
 }
 
 // Safe: WASM doesn't have threads

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -210,31 +210,14 @@ pub struct Queue {
     current_index_buffer: Option<glow::Buffer>,
 }
 
-#[derive(Debug, Clone)]
-pub enum BufferInner {
-    Buffer(glow::Buffer),
-    Data(Arc<std::sync::Mutex<Vec<u8>>>),
-}
 
-impl BufferInner {
-    pub fn data_with_capacity(size: u64) -> BufferInner {
-        BufferInner::Data(Arc::new(std::sync::Mutex::new(vec![0; size as usize])))
-    }
-    pub fn as_native(&self) -> Option<glow::Buffer> {
-        match *self {
-            BufferInner::Buffer(ref buffer) => Some(*buffer),
-            BufferInner::Data(_) => None,
-        }
-    }
-}
-
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Buffer {
-    inner: BufferInner,
+    raw: Option<glow::Buffer>,
     target: BindTarget,
     size: wgt::BufferAddress,
     map_flags: u32,
-    map_read_allocation: Option<std::sync::Mutex<Vec<u8>>>,
+    data: Option<Arc<std::sync::Mutex<Vec<u8>>>>,
 }
 
 // Safe: WASM doesn't have threads
@@ -585,14 +568,14 @@ enum Command {
         indirect_offset: wgt::BufferAddress,
     },
     ClearBuffer {
-        dst: BufferInner,
+        dst: Buffer,
         dst_target: BindTarget,
         range: crate::MemoryRange,
     },
     CopyBufferToBuffer {
-        src: BufferInner,
+        src: Buffer,
         src_target: BindTarget,
-        dst: BufferInner,
+        dst: Buffer,
         dst_target: BindTarget,
         copy: crate::BufferCopy,
     },
@@ -604,7 +587,7 @@ enum Command {
         copy: crate::TextureCopy,
     },
     CopyBufferToTexture {
-        src: BufferInner,
+        src: Buffer,
         #[allow(unused)]
         src_target: BindTarget,
         dst: glow::Texture,
@@ -616,7 +599,7 @@ enum Command {
         src: glow::Texture,
         src_target: BindTarget,
         src_format: wgt::TextureFormat,
-        dst: BufferInner,
+        dst: Buffer,
         #[allow(unused)]
         dst_target: BindTarget,
         copy: crate::BufferTextureCopy,
@@ -626,7 +609,7 @@ enum Command {
     EndQuery(BindTarget),
     CopyQueryResults {
         query_range: Range<u32>,
-        dst: BufferInner,
+        dst: Buffer,
         dst_target: BindTarget,
         dst_offset: wgt::BufferAddress,
     },

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -210,7 +210,6 @@ pub struct Queue {
     current_index_buffer: Option<glow::Buffer>,
 }
 
-
 #[derive(Clone, Debug)]
 pub struct Buffer {
     raw: Option<glow::Buffer>,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -223,7 +223,8 @@ impl super::Queue {
                     }
                 }
                 None => {
-                    dst.data.as_ref().unwrap().lock().unwrap().as_mut_slice()[range.start as usize..range.end as usize]
+                    dst.data.as_ref().unwrap().lock().unwrap().as_mut_slice()
+                        [range.start as usize..range.end as usize]
                         .fill(0);
                 }
             },
@@ -250,10 +251,7 @@ impl super::Queue {
                 };
                 let size = copy.size.get() as usize;
                 match (src.raw, dst.raw) {
-                    (
-                        Some(ref src),
-                        Some(ref dst),
-                    ) => {
+                    (Some(ref src), Some(ref dst)) => {
                         gl.bind_buffer(copy_src_target, Some(*src));
                         gl.bind_buffer(copy_dst_target, Some(*dst));
                         gl.copy_buffer_sub_data(


### PR DESCRIPTION
**Description**
While memory-only buffers work great for MAP_WRITE usage, it seems it is better to create regular webgl2 buffers for MAP_READ. They may be created with _READ usage hint - it signals intent of reading back data from buffer and allows webgl2 to prefetch data to host memory and makes non-blocking read possible (take a look on bottom note of https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3)

**Testing**
I'm testing this approach in my application reading texture data each frame (`copy_texture_to_buffer`, then reading buffer data in next frame) and it works, I was able to significantly reduce time spent on reading buffer data back (comparing to direct reading texture data)

