### PR TITLE
Web: pass correct size argument to setIndexBuffer and setVertexBuffer

### DIFF
--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -163,16 +163,23 @@ impl crate::RenderInner<Context> for RenderPass {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
-        let mapped_size = match size {
-            Some(s) => s.get() as f64,
-            None => 0f64,
+        match size {
+            Some(s) => {
+                self.0.set_index_buffer_with_f64_and_f64(
+                    &buffer.0,
+                    map_index_format(index_format),
+                    offset as f64,
+                    s.get() as f64,
+                );
+            }
+            None => {
+                self.0.set_index_buffer_with_f64(
+                    &buffer.0,
+                    map_index_format(index_format),
+                    offset as f64,
+                );
+            }
         };
-        self.0.set_index_buffer_with_f64_and_f64(
-            &buffer.0,
-            map_index_format(index_format),
-            offset as f64,
-            mapped_size,
-        );
     }
     fn set_vertex_buffer(
         &mut self,
@@ -292,16 +299,23 @@ impl crate::RenderInner<Context> for RenderBundleEncoder {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
-        let mapped_size = match size {
-            Some(s) => s.get() as f64,
-            None => 0f64,
+        match size {
+            Some(s) => {
+                self.0.set_index_buffer_with_f64_and_f64(
+                    &buffer.0,
+                    map_index_format(index_format),
+                    offset as f64,
+                    s.get() as f64,
+                );
+            }
+            None => {
+                self.0.set_index_buffer_with_f64(
+                    &buffer.0,
+                    map_index_format(index_format),
+                    offset as f64,
+                );
+            }
         };
-        self.0.set_index_buffer_with_f64_and_f64(
-            &buffer.0,
-            map_index_format(index_format),
-            offset as f64,
-            mapped_size,
-        );
     }
     fn set_vertex_buffer(
         &mut self,

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -188,12 +188,20 @@ impl crate::RenderInner<Context> for RenderPass {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
-        let mapped_size = match size {
-            Some(s) => s.get() as f64,
-            None => 0f64,
+        match size {
+            Some(s) => {
+                self.0.set_vertex_buffer_with_f64_and_f64(
+                    slot,
+                    &buffer.0,
+                    offset as f64,
+                    s.get() as f64,
+                );
+            }
+            None => {
+                self.0
+                    .set_vertex_buffer_with_f64(slot, &buffer.0, offset as f64);
+            }
         };
-        self.0
-            .set_vertex_buffer_with_f64_and_f64(slot, &buffer.0, offset as f64, mapped_size);
     }
     fn set_push_constants(&mut self, _stages: wgt::ShaderStages, _offset: u32, _data: &[u8]) {
         panic!("PUSH_CONSTANTS feature must be enabled to call multi_draw_indexed_indirect")
@@ -324,12 +332,20 @@ impl crate::RenderInner<Context> for RenderBundleEncoder {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
-        let mapped_size = match size {
-            Some(s) => s.get() as f64,
-            None => 0f64,
+        match size {
+            Some(s) => {
+                self.0.set_vertex_buffer_with_f64_and_f64(
+                    slot,
+                    &buffer.0,
+                    offset as f64,
+                    s.get() as f64,
+                );
+            }
+            None => {
+                self.0
+                    .set_vertex_buffer_with_f64(slot, &buffer.0, offset as f64);
+            }
         };
-        self.0
-            .set_vertex_buffer_with_f64_and_f64(slot, &buffer.0, offset as f64, mapped_size);
     }
     fn set_push_constants(&mut self, _stages: wgt::ShaderStages, _offset: u32, _data: &[u8]) {
         panic!("PUSH_CONSTANTS feature must be enabled to call multi_draw_indexed_indirect")


### PR DESCRIPTION
**Connections**
* https://github.com/gfx-rs/wgpu/issues/2157

**Description**
Chrome Canary started validating the `size` argument in the methods `setIndexBuffer` and `setVertexBuffer` on [`GPURenderEncoderBase`](https://www.w3.org/TR/webgpu/#gpurenderencoderbase). This PR corrects an issue where `wgpu` was passing `size` as `0` when the BufferSlice was open-ended. In that case, `size` should be passed as `undefined`.

**Testing**
Run some of the web examples using WebGPU and Chrome Canary `98.0.4720.0` or later.
