### PR TITLE
Remove very slow debug assertion in hubs (#2193)

### DIFF
--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -45,10 +45,6 @@ impl IdentityManager {
 
     pub fn free<I: id::TypedId + Debug>(&mut self, id: I) {
         let (index, epoch, _backend) = id.unzip();
-        // avoid doing this check in release
-        if cfg!(debug_assertions) {
-            assert!(!self.free.contains(&index));
-        }
         let pe = &mut self.epochs[index as usize];
         assert_eq!(*pe, epoch);
         *pe += 1;


### PR DESCRIPTION
**Connections**
Fix for #2193

**Description**
Removed debug assertion as suggested by @kvark to significantly improve performance

**Testing**
Tested allocating large numbers of registry identifiers (see issue #2193 for bunnymark example)
