### PR TITLE
Refactor command buffer states to ensure proper cleanup on errors

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -287,7 +287,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         base: BasePassRef<ComputeCommand>,
     ) -> Result<(), ComputePassError> {
         profiling::scope!("run_compute_pass", "CommandEncoder");
-        let scope = PassErrorScope::Pass(encoder_id);
+        let init_scope = PassErrorScope::Pass(encoder_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -295,8 +295,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (device_guard, mut token) = hub.devices.read(&mut token);
 
         let (mut cmd_buf_guard, mut token) = hub.command_buffers.write(&mut token);
-        let cmd_buf =
-            CommandBuffer::get_encoder_mut(&mut *cmd_buf_guard, encoder_id).map_pass_err(scope)?;
+        let cmd_buf = CommandBuffer::get_encoder_mut(&mut *cmd_buf_guard, encoder_id)
+            .map_pass_err(init_scope)?;
         // will be reset to true if recording is done without errors
         cmd_buf.status = CommandEncoderStatus::Error;
         let raw = cmd_buf.encoder.open();

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -952,17 +952,17 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         depth_stencil_attachment: Option<&RenderPassDepthStencilAttachment>,
     ) -> Result<(), RenderPassError> {
         profiling::scope!("run_render_pass", "CommandEncoder");
-        let scope = PassErrorScope::Pass(encoder_id);
+        let init_scope = PassErrorScope::Pass(encoder_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
 
-        let (pass_raw, trackers, query_reset_state, pending_discard_init_fixups) = {
+        let (trackers, query_reset_state, pending_discard_init_fixups) = {
             let (mut cmb_guard, mut token) = hub.command_buffers.write(&mut token);
 
-            let cmd_buf =
-                CommandBuffer::get_encoder_mut(&mut *cmb_guard, encoder_id).map_pass_err(scope)?;
+            let cmd_buf = CommandBuffer::get_encoder_mut(&mut *cmb_guard, encoder_id)
+                .map_pass_err(init_scope)?;
             // close everything while the new command encoder is filled
             cmd_buf.encoder.close();
             // will be reset to true if recording is done without errors
@@ -978,9 +978,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             }
 
             let device = &device_guard[cmd_buf.device_id.value];
-            unsafe {
-                cmd_buf.encoder.raw.begin_encoding(base.label).unwrap() //TODO: handle this better
-            };
+            cmd_buf.encoder.open_pass(base.label);
 
             let (bundle_guard, mut token) = hub.render_bundles.read(&mut token);
             let (pipeline_layout_guard, mut token) = hub.pipeline_layouts.read(&mut token);
@@ -1004,7 +1002,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 &*view_guard,
                 &*texture_guard,
             )
-            .map_pass_err(scope)?;
+            .map_pass_err(init_scope)?;
 
             let raw = &mut cmd_buf.encoder.raw;
 
@@ -1855,20 +1853,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             log::trace!("Merging {:?} with the render pass", encoder_id);
             let (trackers, pending_discard_init_fixups) =
-                info.finish(raw, &*texture_guard).map_pass_err(scope)?;
+                info.finish(raw, &*texture_guard).map_pass_err(init_scope)?;
 
-            let raw_cmd_buf = unsafe {
-                raw.end_encoding()
-                    .map_err(|_| RenderPassErrorInner::OutOfMemory)
-                    .map_pass_err(scope)?
-            };
-            cmd_buf.status = CommandEncoderStatus::Recording;
-            (
-                raw_cmd_buf,
-                trackers,
-                query_reset_state,
-                pending_discard_init_fixups,
-            )
+            cmd_buf.encoder.close();
+            (trackers, query_reset_state, pending_discard_init_fixups)
         };
 
         let (mut cmb_guard, mut token) = hub.command_buffers.write(&mut token);
@@ -1876,8 +1864,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (buffer_guard, mut token) = hub.buffers.read(&mut token);
         let (texture_guard, _) = hub.textures.read(&mut token);
 
-        let cmd_buf =
-            CommandBuffer::get_encoder_mut(&mut *cmb_guard, encoder_id).map_pass_err(scope)?;
+        let cmd_buf = cmb_guard.get_mut(encoder_id).unwrap();
         {
             let transit = cmd_buf.encoder.open();
 
@@ -1907,8 +1894,16 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 &*texture_guard,
             );
         }
+
+        // Before we finish the auxiliary encoder, let's
+        // get our pass back and place it after.
+        //Note: we could just hold onto this raw pass while recording the
+        // auxiliary encoder, but then handling errors and cleaning up
+        // would be more complicated, so we re-use `open()`/`close()`.
+        let pass_raw = cmd_buf.encoder.list.pop().unwrap();
         cmd_buf.encoder.close();
         cmd_buf.encoder.list.push(pass_raw);
+        cmd_buf.status = CommandEncoderStatus::Recording;
 
         Ok(())
     }


### PR DESCRIPTION
**Connections**
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1729648
Follow-up to #1929

**Description**
There was a number of places where we weren't properly cleaning up on error. It's easy to clean up when everything goes good, and wgpu-rs panics on error by default, so we never saw this here. But it was very much visible in Gecko.

Problems found:
  - when producing command buffer, don't forget to close the encoder if there is an error - #1929
  - when doing so, also check for active compute/render encoders in wgpu-hal/metal, not just for blit. Normally, only blit can be open, but when error happens, we may be inside a render pass.
  - there was `scope` variable shadowing, somewhat unfortunate even if unrelated
  - render pass was manually calling `begin_encoding` on a new command buffer without changing the `is_open` flag. this meant it was impossible to know how to clean it up. Now we rely on the same `open()` interface, adjusted for the pass needs.

It's possible to refactor `run_render_pass` to have an inner function, and to initialize and cleanup around the function. This would be a much bigger change. Maybe in the future?

**Testing**
Reproduced the problem on a cube example and tested on it. The repro case is basically making the bind group invalid, which is bound in a render pass.
