### PR TITLE
hal/vulkan: use multiple semaphores in a relay

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1172,15 +1172,19 @@ impl super::Adapter {
             render_passes: Mutex::new(Default::default()),
             framebuffers: Mutex::new(Default::default()),
         });
+        let mut relay_semaphores = [vk::Semaphore::null(); 2];
+        for sem in relay_semaphores.iter_mut() {
+            *sem = shared
+                .raw
+                .create_semaphore(&vk::SemaphoreCreateInfo::builder(), None)?;
+        }
         let queue = super::Queue {
             raw: raw_queue,
             swapchain_fn,
             device: Arc::clone(&shared),
             family_index,
-            relay_semaphore: shared
-                .raw
-                .create_semaphore(&vk::SemaphoreCreateInfo::builder(), None)?,
-            relay_active: false,
+            relay_semaphores,
+            relay_index: None,
         };
 
         let mem_allocator = {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -674,9 +674,9 @@ impl crate::Device<super::Api> for super::Device {
     unsafe fn exit(self, queue: super::Queue) {
         self.mem_allocator.into_inner().cleanup(&*self.shared);
         self.desc_allocator.into_inner().cleanup(&*self.shared);
-        self.shared
-            .raw
-            .destroy_semaphore(queue.relay_semaphore, None);
+        for &sem in queue.relay_semaphores.iter() {
+            self.shared.raw.destroy_semaphore(sem, None);
+        }
         self.shared.free_resources();
     }
 


### PR DESCRIPTION
**Connections**
Attempting to work around #1672, which is currently blocking gecko.
https://phabricator.services.mozilla.com/D132058

**Description**
Intel apparently doesn't like that the same semaphore is both waited upon and signaled.
This PR makes it 2 semaphores, which we use in ping-pong fashion.

**Testing**
On Gecko
