### PR TITLE
hal/vulkan: Enable depth clip if available

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -821,6 +821,13 @@ impl super::InstanceShared {
                 let mut_ref = features.robustness2.as_mut().unwrap();
                 mut_ref.p_next = mem::replace(&mut features2.p_next, mut_ref as *mut _ as *mut _);
             }
+            if capabilities.supports_extension(vk::ExtDepthClipEnableFn::name()) {
+                features.depth_clip_enable =
+                    Some(vk::PhysicalDeviceDepthClipEnableFeaturesEXT::builder().build());
+
+                let mut_ref = features.depth_clip_enable.as_mut().unwrap();
+                mut_ref.p_next = mem::replace(&mut features2.p_next, mut_ref as *mut _ as *mut _);
+            }
 
             unsafe {
                 get_device_properties.get_physical_device_features2_khr(phd, &mut features2);
@@ -847,6 +854,7 @@ impl super::InstanceShared {
             null_p_next(&mut features.timeline_semaphore);
             null_p_next(&mut features.image_robustness);
             null_p_next(&mut features.robustness2);
+            null_p_next(&mut features.depth_clip_enable);
         }
 
         (capabilities, features)


### PR DESCRIPTION
**Connections**
None that I know of

**Description**
The `DEPTH_CLIP_CONTROL` feature was failing to be requested when using
the vulkan backend because the functionality wasn't being activated.

This wasn't being done even if the VK_EXT_depth_clip_enable was present
causing validation errors when requesting DEPTH_CLIP_CONTROL in the
device.

~~Strangely this was being done for raw calls to `wgpu_hal::Adapter::open`
because it calls `physical_device_features` and then
`from_extensions_and_requested_features`.~~

**Testing**
Modified the cube test to require this feature, without this patch it failed to start.
Furthermore I checked that my gpu really did support the extension trough `vulkaninfo`.
