### PR TITLE
hal/vulkan: use instance version instead of the device version for capabilities/features

### DIFF
--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -83,6 +83,7 @@ struct InstanceShared {
     raw: ash::Instance,
     drop_guard: Option<DropGuard>,
     flags: crate::InstanceFlags,
+    version: u32,
     debug_utils: Option<DebugUtils>,
     get_physical_device_properties: Option<vk::KhrGetPhysicalDeviceProperties2Fn>,
     entry: ash::Entry,


### PR DESCRIPTION
**Connections**
Fixes #2215

**Description**
We aren't using a single version for all checks. Instead, we distinguish the instance version and the device version.
The instance version is used for all `vkGetPhysicalDeviceXxx` checks, which the device version is used for extension checks.
I'm not 100% sure this approach is right, would be good to have @Ralith taking a look as we discussed this originally.

**Testing**
Needs confirmation from @NiklasEi