### PR TITLE
hal/gles: fix setting filtering on integer textures

### DIFF
--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -633,6 +633,7 @@ impl crate::Device<super::Api> for super::Device {
                 }
             }
 
+            gl.bind_texture(target, None);
             match desc.format.describe().sample_type {
                 wgt::TextureSampleType::Float { filterable: false }
                 | wgt::TextureSampleType::Uint
@@ -645,7 +646,6 @@ impl crate::Device<super::Api> for super::Device {
                 | wgt::TextureSampleType::Depth => {}
             }
 
-            gl.bind_texture(target, None);
             super::TextureInner::Texture { raw, target }
         };
 


### PR DESCRIPTION
**Connections**
[_Link to the issues addressed by this PR, or dependent PRs in other repositories_](https://github.com/kvark/vange-rs/issues/153#issuecomment-975163806)

**Description**
Silly, we bound the texture after setting the filter modes...

**Testing**
Tested on vange-rs
