### PR TITLE
hal/gles: force unbind samplers

### DIFF
--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -119,16 +119,17 @@ impl super::CommandEncoder {
 
     fn rebind_sampler_states(&mut self, dirty_textures: u32, dirty_samplers: u32) {
         for (texture_index, slot) in self.state.texture_slots.iter().enumerate() {
-            if let Some(sampler_index) = slot.sampler_index {
-                if dirty_textures & (1 << texture_index) != 0
-                    || dirty_samplers & (1 << sampler_index) != 0
-                {
-                    if let Some(sampler) = self.state.samplers[sampler_index as usize] {
-                        self.cmd_buffer
-                            .commands
-                            .push(C::BindSampler(texture_index as u32, sampler));
-                    }
-                }
+            if dirty_textures & (1 << texture_index) != 0
+                || slot
+                    .sampler_index
+                    .map_or(false, |si| dirty_samplers & (1 << si) != 0)
+            {
+                let sampler = slot
+                    .sampler_index
+                    .and_then(|si| self.state.samplers[si as usize]);
+                self.cmd_buffer
+                    .commands
+                    .push(C::BindSampler(texture_index as u32, sampler));
             }
         }
     }

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -679,7 +679,7 @@ enum Command {
         offset: i32,
         size: i32,
     },
-    BindSampler(u32, glow::Sampler),
+    BindSampler(u32, Option<glow::Sampler>),
     BindTexture {
         slot: u32,
         texture: glow::Texture,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1012,7 +1012,7 @@ impl super::Queue {
                 gl.bind_buffer_range(target, slot, Some(buffer), offset, size);
             }
             C::BindSampler(texture_index, sampler) => {
-                gl.bind_sampler(texture_index, Some(sampler));
+                gl.bind_sampler(texture_index, sampler);
             }
             C::BindTexture {
                 slot,


### PR DESCRIPTION
**Connections**
Discovered in vange-rs

**Description**
It turns out that we can't just leave the sampler object in place upon changing a texture binding. The sampler has to be compatible with the texture, or GL screams in pain, even if we don't actually sample anything.
I.e. for UINT textures, the sampler can't be linear.

**Testing**
Tested on vange-rs
