### PR TITLE
Relax depth texture views creation

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -822,11 +822,15 @@ impl<A: HalApi> Device<A> {
             extent.depth_or_array_layers = view_layer_count;
         }
         let format = desc.format.unwrap_or(texture.desc.format);
-        if format != texture.desc.format {
-            return Err(resource::CreateTextureViewError::FormatReinterpretation {
-                texture: texture.desc.format,
-                view: format,
-            });
+        match (texture.desc.format, format) {
+            (a, b) if a == b => {}
+            (wgt::TextureFormat::Depth24PlusStencil8, wgt::TextureFormat::Depth24Plus) => {}
+            _ => {
+                return Err(resource::CreateTextureViewError::FormatReinterpretation {
+                    texture: texture.desc.format,
+                    view: format,
+                });
+            }
         }
 
         // filter the usages based on the other criteria


### PR DESCRIPTION
**Connections**
n/a

**Description**
Currently impossible to sample a Depth24PlusStencil texture, this solves the problem by allowing to create a Depth24Plus view on a Depth24PlusStencil texture.

**Testing**
Tested on Debian Bullseye, Nvidia + VK backend