### PR TITLE
Allows for depth texture copies

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -95,6 +95,8 @@ pub enum TransferError {
     CopyFromForbiddenTextureFormat(wgt::TextureFormat),
     #[error("copying to textures with format {0:?} is forbidden")]
     CopyToForbiddenTextureFormat(wgt::TextureFormat),
+    #[error("the entire texture must be copied when copiying from depth texture")]
+    InvalidDepthTextureExtent,
 }
 
 impl PrettyError for TransferError {
@@ -294,6 +296,17 @@ pub(crate) fn validate_texture_copy_range(
     )?;
     // physical size can be larger than the virtual
     let extent = extent_virtual.physical_size(desc.format);
+
+    match desc.format {
+        wgt::TextureFormat::Depth32Float
+        | wgt::TextureFormat::Depth24Plus
+        | wgt::TextureFormat::Depth24PlusStencil8 => {
+            if *copy_size != extent {
+                return Err(TransferError::InvalidDepthTextureExtent);
+            }
+        }
+        _ => {}
+    }
 
     let x_copy_max = texture_copy_view.origin.x + copy_size.width;
     if x_copy_max > extent.width {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -653,19 +653,6 @@ impl<A: HalApi> Device<A> {
             .describe_format_features(adapter, desc.format)
             .map_err(|error| resource::CreateTextureError::MissingFeatures(desc.format, error))?;
 
-        // Ensure `D24Plus` textures cannot be copied
-        match desc.format {
-            TextureFormat::Depth24Plus | TextureFormat::Depth24PlusStencil8 => {
-                if desc
-                    .usage
-                    .intersects(wgt::TextureUsages::COPY_SRC | wgt::TextureUsages::COPY_DST)
-                {
-                    return Err(resource::CreateTextureError::CannotCopyD24Plus);
-                }
-            }
-            _ => {}
-        }
-
         if desc.usage.is_empty() {
             return Err(resource::CreateTextureError::EmptyUsage);
         }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -255,8 +255,6 @@ pub enum TextureDimensionError {
 pub enum CreateTextureError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("D24Plus textures cannot be copied")]
-    CannotCopyD24Plus,
     #[error("Textures cannot have empty usage flags")]
     EmptyUsage,
     #[error(transparent)]


### PR DESCRIPTION
**Connections**
n/a

**Description**
Currently, depth texture cannot use the COPY_SRC or COPY_DST usage flag, this is now possible. The copy checks the whole texture is copied.

**Testing**
Debian bullseye, Nvidia + VK backend