### PR TITLE
core: Use a indexmap for bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,6 +1839,7 @@ dependencies = [
  "codespan-reporting",
  "copyless",
  "fxhash",
+ "indexmap",
  "log",
  "naga",
  "parking_lot",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -34,6 +34,7 @@ ron = { version = "0.7", optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 smallvec = "1"
 thiserror = "1"
+indexmap = "1.6" # 1.7 has MSRV 1.49
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -6,7 +6,7 @@ use crate::{
     init_tracker::{BufferInitTrackerAction, TextureInitTrackerAction},
     track::{TrackerSet, UsageConflict, DUMMY_SELECTOR},
     validation::{MissingBufferUsageError, MissingTextureUsageError},
-    FastHashMap, Label, LifeGuard, MultiRefCount, Stored,
+    Label, LifeGuard, MultiRefCount, Stored,
 };
 
 use arrayvec::ArrayVec;
@@ -419,7 +419,11 @@ pub struct BindGroupLayoutDescriptor<'a> {
     pub entries: Cow<'a, [wgt::BindGroupLayoutEntry]>,
 }
 
-pub(crate) type BindEntryMap = FastHashMap<u32, wgt::BindGroupLayoutEntry>;
+pub(crate) type BindEntryMap = indexmap::IndexMap<
+    u32,
+    wgt::BindGroupLayoutEntry,
+    std::hash::BuildHasherDefault<fxhash::FxHasher>,
+>;
 
 /// Bind group layout.
 ///

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3669,7 +3669,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     .add(trace::Action::CreateBindGroupLayout(fid.id(), desc.clone()));
             }
 
-            let mut entry_map = FastHashMap::default();
+            let mut entry_map = binding_model::BindEntryMap::default();
             for entry in desc.entries.iter() {
                 if entry_map.insert(entry.binding, *entry).is_some() {
                     break 'outer binding_model::CreateBindGroupLayoutError::ConflictBinding(

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1010,13 +1010,13 @@ impl Interface {
                     .and_then(|set| {
                         let ty = res.derive_binding_type(usage, self.features)?;
                         match set.entry(res.bind.binding) {
-                            Entry::Occupied(e) if e.get().ty != ty => {
+                            indexmap::map::Entry::Occupied(e) if e.get().ty != ty => {
                                 return Err(BindingError::InconsistentlyDerivedType)
                             }
-                            Entry::Occupied(e) => {
+                            indexmap::map::Entry::Occupied(e) => {
                                 e.into_mut().visibility |= stage_bit;
                             }
-                            Entry::Vacant(e) => {
+                            indexmap::map::Entry::Vacant(e) => {
                                 e.insert(BindGroupLayoutEntry {
                                     binding: res.bind.binding,
                                     ty,


### PR DESCRIPTION
**Connections**
None that I know of

**Description**
This was being done by a standard `HashMap` but in
`make_late_sized_buffer_groups` the values were being
iterated on and since the std hashmap doesn't guaranteed
ordering the buffer might get the wrong size making for
a very nice debugging experience.

`indexmap` is already used in naga and it seemed like the best solution
for the problem, but I'm open to better suggestions.

**Testing**
This is very hard to test, all the examples ran fine but larger projects like
[veloren](https://gitlab.com/veloren/veloren) which I was using for testing hit this.

In this specific case, the fourth and ninth bindings were coming before the third when
iterating.
