### PR TITLE
Support for --target wasm32-unknown-emscripten

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,14 @@ jobs:
             tool: clippy
             kind: web
 
+          # Emscripten WebGL
+          - name: WebAssembly emscripten
+            os: ubuntu-20.04
+            channel: stable
+            target: wasm32-unknown-emscripten
+            tool: clippy
+            kind: webgl-em
+
     name: Check ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
@@ -163,6 +171,15 @@ jobs:
 
           # build docs
           cargo doc --target ${{ matrix.target }} -p wgpu --no-deps
+
+      - name: check web-em
+        if: matrix.kind == 'webgl-em'
+        run: |
+          # check with no features
+          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu -p wgpu-core
+
+          # build docs
+          cargo doc --target ${{ matrix.target }} -p wgpu -p wgpu-core --no-deps
 
       - name: check native
         if: matrix.kind == 'local' || matrix.kind == 'other'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,8 +601,7 @@ dependencies = [
 [[package]]
 name = "glow"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f04649123493bc2483cbef4daddb45d40bbdae5adb221a63a23efdb0cc99520"
+source = "git+https://github.com/grovesNL/glow?rev=b6eb0ba#b6eb0bafa402e23db26086b82ab2c635fa9266bd"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -743,6 +742,7 @@ checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
 dependencies = [
  "libc",
  "libloading",
+ "pkg-config",
 ]
 
 [[package]]

--- a/run-wasm-emscripten-example.sh
+++ b/run-wasm-emscripten-example.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+set -- hello-triangle
+echo "Compiling..."
+EMMAKEN_CFLAGS="-g -s ERROR_ON_UNDEFINED_SYMBOLS=0 --no-entry -s FULL_ES3=1" cargo build --example $1 --target wasm32-unknown-emscripten
+
+mkdir -p target/wasm-examples/$1/
+cp target/wasm32-unknown-emscripten/debug/examples/* target/wasm-examples/$1
+cat wasm-resources/index.em.template.html | sed "s/{{example}}/$1/g" > target/wasm-examples/$1/index.html
+
+# Find a serving tool to host the example
+SERVE_CMD=""
+SERVE_ARGS=""
+if which basic-http-server; then
+    SERVE_CMD="basic-http-server"
+    SERVE_ARGS="target/wasm-examples/$1 -a 127.0.0.1:1234"
+elif which miniserve && python3 -m http.server --help > /dev/null; then
+    SERVE_CMD="miniserve"
+    SERVE_ARGS="target/wasm-examples/$1 -p 1234 --index index.html"
+elif python3 -m http.server --help > /dev/null; then
+    SERVE_CMD="python3"
+    SERVE_ARGS="-m http.server --directory target/wasm-examples/$1 1234"
+fi
+
+# Exit if we couldn't find a tool to serve the example with
+if [ "$SERVE_CMD" = "" ]; then
+    echo "Couldn't find a utility to use to serve the example web page. You can serve the `target/wasm-examples/$1` folder yourself using any simple static http file server."
+fi
+
+echo "Serving example with $SERVE_CMD at http://localhost:1234"
+$SERVE_CMD $SERVE_ARGS

--- a/wasm-resources/index.em.template.html
+++ b/wasm-resources/index.em.template.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <canvas id="canvas" width="640" height="400"></canvas>
+    <script>
+        var Module = {
+            canvas: document.getElementById("canvas"),
+        };
+    </script>
+    <script src="{{example}}.js"></script>
+  </body>
+</html>

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -43,7 +43,7 @@ gpu-descriptor = { version = "0.2", optional = true }
 inplace_it = { version ="0.3.3", optional = true }
 
 # backend: Gles
-glow = { version = "0.11", optional = true }
+glow = { git = "https://github.com/grovesNL/glow", rev = "b6eb0ba", optional = true }
 
 # backend: Dx12
 bit-set = { version = "0.5", optional = true }
@@ -59,6 +59,10 @@ egl = { package = "khronos-egl", version = "4.1", features = ["dynamic"], option
 #Note: it's only unused on Apple platforms
 libloading = { version = "0.7", optional = true }
 
+[target.'cfg(target_os = "emscripten")'.dependencies]
+egl = { package = "khronos-egl", version = "4.1", features = ["static", "no-pkg-config"], optional = true }
+libloading = { version = "0.7", optional = true }
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }
 native = { package = "d3d12", version = "0.4.1", features = ["libloading"], optional = true }
@@ -68,7 +72,7 @@ mtl = { package = "metal", version = "0.23.1" }
 objc = "0.2.5"
 core-graphics-types = "0.1"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
 wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", features = ["Window", "HtmlCanvasElement", "WebGl2RenderingContext"] }
 js-sys = { version = "0.3" }
@@ -86,4 +90,6 @@ features = ["wgsl-in"]
 
 [dev-dependencies]
 env_logger = "0.8"
+
+[target.'cfg(not(target_os = "emscripten"))'.dev-dependencies]
 winit = "0.26"

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -56,9 +56,9 @@ To address this, we invalidate the vertex buffers based on:
 
 */
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 mod egl;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 mod web;
 
 mod adapter;
@@ -67,10 +67,10 @@ mod conv;
 mod device;
 mod queue;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 use self::egl::{AdapterContext, Instance, Surface};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 use self::web::{AdapterContext, Instance, Surface};
 
 use arrayvec::ArrayVec;

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1102,10 +1102,10 @@ impl crate::Queue<super::Api> for super::Queue {
         surface: &mut super::Surface,
         texture: super::Texture,
     ) -> Result<(), crate::SurfaceError> {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
         let gl = &self.shared.context.get_without_egl_lock();
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
         let gl = &self.shared.context.glow_context;
 
         surface.present(texture, gl)

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -84,13 +84,13 @@ replay = ["serde", "wgc/replay"]
 angle = ["wgc/angle"]
 webgl = ["wgc"]
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
+[target.'cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))'.dependencies.wgc]
 package = "wgpu-core"
 path = "../wgpu-core"
 version = "0.11"
 features = ["raw-window-handle"]
 
-[target.'cfg(target_arch = "wasm32")'.dependencies.wgc]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies.wgc]
 package = "wgpu-core"
 path = "../wgpu-core"
 version = "0.11"
@@ -102,7 +102,7 @@ package = "wgpu-types"
 path = "../wgpu-types"
 version = "0.11"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.hal]
+[target.'cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))'.dependencies.hal]
 package = "wgpu-hal"
 path = "../wgpu-hal"
 version = "0.11"
@@ -127,9 +127,11 @@ noise = { version = "0.7", default-features = false }
 obj = "0.10"
 png = "0.16"
 rand = "0.7.2"
+
+[target.'cfg(not(target_os = "emscripten"))'.dev-dependencies]
 winit = "0.26"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))'.dev-dependencies]
 async-executor = "1.0"
 pollster = "0.2"
 env_logger = "0.8"
@@ -153,7 +155,7 @@ rev = "c69f676"
 #version = "0.7"
 features = ["wgsl-out"]
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
 wasm-bindgen = "0.2.76" # remember to change version in wiki as well
 web-sys = { version = "0.3.53", features = [
     "Document",
@@ -284,7 +286,7 @@ wasm-bindgen-futures = "0.4.23"
 # enable parking_lot's wasm-bindgen feature so that it, in turn, enables that of crate `instant`
 parking_lot = { version = "0.11", features = ["wasm-bindgen"] }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dev-dependencies]
 console_error_panic_hook = "0.1.6"
 console_log = "0.1.2"
 # We need the Location feature in the framework examples

--- a/wgpu/src/backend/mod.rs
+++ b/wgpu/src/backend/mod.rs
@@ -1,12 +1,32 @@
-#[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
+#[cfg(all(
+    target_arch = "wasm32",
+    not(target_os = "emscripten"),
+    not(feature = "webgl")
+))]
 mod web;
-#[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
+#[cfg(all(
+    target_arch = "wasm32",
+    not(target_os = "emscripten"),
+    not(feature = "webgl")
+))]
 pub(crate) use web::{BufferMappedRange, Context};
 
-#[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    target_os = "emscripten",
+    feature = "webgl"
+))]
 mod direct;
-#[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    target_os = "emscripten",
+    feature = "webgl"
+))]
 pub(crate) use direct::{BufferMappedRange, Context};
 
-#[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    target_os = "emscripten",
+    feature = "webgl"
+))]
 mod native_gpu_future;

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1511,7 +1511,11 @@ impl Instance {
     /// # Safety
     ///
     /// - canvas must be a valid <canvas> element to create a surface upon.
-    #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        not(target_os = "emscripten"),
+        not(feature = "webgl")
+    ))]
     pub unsafe fn create_surface_from_canvas(
         &self,
         canvas: &web_sys::HtmlCanvasElement,
@@ -1527,7 +1531,11 @@ impl Instance {
     /// # Safety
     ///
     /// - canvas must be a valid OffscreenCanvas to create a surface upon.
-    #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        not(target_os = "emscripten"),
+        not(feature = "webgl")
+    ))]
     pub unsafe fn create_surface_from_offscreen_canvas(
         &self,
         canvas: &web_sys::OffscreenCanvas,


### PR DESCRIPTION
**Description**
I found that adding support for `wasm32-unknown-emscripten` is not so hard. Even more implementation is not depended on 3rd party libraries like winit or stdweb. It's because emscripten it self provides complete implementation for creating OpenGL 3.0 context. So crates like glow, khronos-egl works as is. Only visible differences between emscripten and native platform is that emscripten does not support pbuffer (which is not needed) and window will created automatically.

I think supporting `wasm32-unknown-emscripten` will be a great unique feature of wgpu.

**Testing**

You can test this changes by calling `./run-wasm-emscripten-example.sh`. However you need to install [emsdk](https://github.com/emscripten-core/emsdk) first, and `emcc` should be in your path.