### PR TITLE
Insert WAW barriers between copies

### DIFF
--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -649,7 +649,7 @@ bitflags::bitflags! {
         /// The combination of all usages that the are guaranteed to be be ordered by the hardware.
         /// If a usage is not ordered, then even if it doesn't change between draw calls, there
         /// still need to be pipeline barriers inserted for synchronization.
-        const ORDERED = Self::INCLUSIVE.bits | Self::MAP_WRITE.bits | Self::COPY_DST.bits;
+        const ORDERED = Self::INCLUSIVE.bits | Self::MAP_WRITE.bits;
     }
 }
 
@@ -672,7 +672,7 @@ bitflags::bitflags! {
         /// The combination of all usages that the are guaranteed to be be ordered by the hardware.
         /// If a usage is not ordered, then even if it doesn't change between draw calls, there
         /// still need to be pipeline barriers inserted for synchronization.
-        const ORDERED = Self::INCLUSIVE.bits | Self::COPY_DST.bits | Self::COLOR_TARGET.bits | Self::DEPTH_STENCIL_WRITE.bits | Self::STORAGE_READ.bits;
+        const ORDERED = Self::INCLUSIVE.bits | Self::COLOR_TARGET.bits | Self::DEPTH_STENCIL_WRITE.bits | Self::STORAGE_READ.bits;
         //TODO: remove this
         const UNINITIALIZED = 0xFFFF;
     }


### PR DESCRIPTION
**Connections**
Addresses https://github.com/gfx-rs/wgpu/issues/2243#issuecomment-984763149

**Description**
Apparently, Vulkan requires write-after-write barriers for copies. Originally, we weren't sure if that's required, given that D3D12 doesn't need that. This is as simple as excluding `COPY_DST` from the `ORDERED` set, but it also revealed a tricky issue with zero-initializing textures.
A little bonus is restricting the debug utils logging severity to what `log` is configured to.

**Testing**
Tested on the examples.
