### PR TITLE
Enforce MSRV with a large CI refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   RUST_BACKTRACE: 1
+  RUST_VERSION: 1.53
 
 jobs:
   build:
@@ -18,7 +19,7 @@ jobs:
           # Windows
           - name: Windows x86_64
             os: windows-2019
-            channel: stable
+            channel: ${{ env.RUST_VERSION }}
             target: x86_64-pc-windows-msvc
             kind: test
             backends: dx12 # dx11
@@ -34,7 +35,7 @@ jobs:
           # Mac has no software runners, so don't run tests
           - name: MacOS x86_64
             os: macos-10.15
-            channel: stable
+            channel: ${{ env.RUST_VERSION }}
             target: x86_64-apple-darwin
             kind: compile
 
@@ -42,7 +43,7 @@ jobs:
           # IOS
           - name: IOS aarch64
             os: macos-10.15
-            channel: stable
+            channel: ${{ env.RUST_VERSION }}
             target: aarch64-apple-ios
             kind: compile
 
@@ -50,7 +51,7 @@ jobs:
           # Linux
           - name: Linux x86_64
             os: ubuntu-20.04
-            channel: stable
+            channel: ${{ env.RUST_VERSION }}
             target: x86_64-unknown-linux-gnu
             kind: test
             backends: vulkan # gl
@@ -65,7 +66,7 @@ jobs:
           # Android
           - name: Android aarch64
             os: ubuntu-20.04
-            channel: stable
+            channel: ${{ env.RUST_VERSION }}
             target: aarch64-linux-android
             kind: compile
 
@@ -73,7 +74,7 @@ jobs:
           # WebGPU/WebGL
           - name: WebAssembly
             os: ubuntu-20.04
-            channel: stable
+            channel: ${{ env.RUST_VERSION }}
             target: wasm32-unknown-unknown
             kind: webgl
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
 
           # check with all features
           # explicitly don't mention wgpu-hal so that --all-features don't apply to it
-          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu -p wgpu-core -p wgpu-info -p player --examples --tests --all-features 
+          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu -p wgpu-core -p wgpu-info -p player --examples --tests --all-features
 
           # build docs
           cargo doc --target ${{ matrix.target }} --no-deps
@@ -167,7 +167,10 @@ jobs:
         shell: bash
         run: |
           # run wgpu-info
-          cargo run --target ${{ matrix.target }} --bin wgpu-info
+          cargo run --bin wgpu-info
+          # run player tests
+          cargo test -p player
+
           for backend in ${{ matrix.backends }}; do
             echo "======= NATIVE TESTS $backend ======";
             # run player tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,15 @@ jobs:
           # Windows
           - name: Windows x86_64
             os: windows-2019
-            channel: ${{ env.RUST_VERSION }}
             target: x86_64-pc-windows-msvc
+            tool: clippy
             kind: test
             backends: dx12 # dx11
 
           - name: Windows Nightly x86_64
             os: windows-2019
-            channel: nightly
             target: x86_64-pc-windows-msvc
+            tool: check
             kind: compile
           
           # MacOS
@@ -35,48 +35,48 @@ jobs:
           # Mac has no software runners, so don't run tests
           - name: MacOS x86_64
             os: macos-10.15
-            channel: ${{ env.RUST_VERSION }}
             target: x86_64-apple-darwin
+            tool: clippy
             kind: compile
 
           
           # IOS
           - name: IOS aarch64
             os: macos-10.15
-            channel: ${{ env.RUST_VERSION }}
             target: aarch64-apple-ios
+            tool: clippy
             kind: compile
 
 
           # Linux
           - name: Linux x86_64
             os: ubuntu-20.04
-            channel: ${{ env.RUST_VERSION }}
             target: x86_64-unknown-linux-gnu
+            tool: clippy
             kind: test
             backends: vulkan # gl
 
           - name: Linux Nightly x86_64
             os: ubuntu-20.04
-            channel: nightly
             target: x86_64-unknown-linux-gnu
+            tool: check
             kind: compile
 
           
           # Android
           - name: Android aarch64
             os: ubuntu-20.04
-            channel: ${{ env.RUST_VERSION }}
             target: aarch64-linux-android
+            tool: clippy
             kind: compile
 
           
           # WebGPU/WebGL
           - name: WebAssembly
             os: ubuntu-20.04
-            channel: ${{ env.RUST_VERSION }}
             target: wasm32-unknown-unknown
-            kind: webgl
+            tool: clippy
+            kind: wasm
 
     name: Check ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -90,14 +90,26 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v2
 
-      - name: install rust
+      # Only run clippy on MSRV
+      - name: install rust stable
+        if: matrix.tool == 'clippy'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.channel }}
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
-          override: true
           profile: minimal
+          override: true
           components: clippy
+
+      # Other builds can use nightly
+      - name: install rust nightly
+        if: matrix.tool != 'clippy'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
 
       - name: caching
         uses: Swatinem/rust-cache@v1
@@ -125,14 +137,13 @@ jobs:
           echo """[profile.dev]
           debug = 1" > .cargo/config.toml
 
-      # This is separate for now because webgl isn't hooked up so we can't compile wgpu-core for wasm
       - name: check web
-        if: matrix.kind == 'webgl'
+        if: matrix.kind == 'wasm'
         run: |
-          cargo clippy --target ${{ matrix.target }} -p wgpu
+          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu
 
           # Build for WebGL
-          cargo clippy --target ${{ matrix.target }} -p wgpu --features webgl -- -D warnings
+          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu --features webgl -- -D warnings
 
           # build docs
           cargo doc --target ${{ matrix.target }} -p wgpu --no-deps
@@ -141,11 +152,11 @@ jobs:
         if: matrix.kind == 'compile' || matrix.kind == 'test'
         run: |
           # check with no features
-          cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-core -p wgpu-info -p player
+          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu -p wgpu-core -p wgpu-info -p player
 
           # check with all features
           # explicitly don't mention wgpu-hal so that --all-features don't apply to it
-          cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-core -p wgpu-info -p player --examples --tests --all-features 
+          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu -p wgpu-core -p wgpu-info -p player --examples --tests --all-features 
 
           # build docs
           cargo doc --target ${{ matrix.target }} --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
             tool: clippy
             # Mac has no software runners, so don't run tests
             kind: other
+
+          - name: MacOS aarch64
+            os: macos-11
+            target: aarch64-apple-darwin
+            tool: check
+            # Mac has no software runners, so don't run tests
+            kind: other
           
           # IOS
           - name: IOS aarch64
@@ -58,6 +65,12 @@ jobs:
             tool: clippy
             kind: local
             backends: vulkan # gl
+
+          - name: Linux aarch64
+            os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            tool: check
+            kind: other
 
           - name: Linux Nightly x86_64
             os: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ env:
   RUST_BACKTRACE: 1
   RUST_VERSION: 1.53
 
+# We distinguish the following kinds of builds:
+# - local: build for the same target as we compile on, and do local tests
+# - other: build without testing, e.g. cross-build
+# - web: build for the Web
+
 jobs:
   build:
     strategy:
@@ -21,31 +26,29 @@ jobs:
             os: windows-2019
             target: x86_64-pc-windows-msvc
             tool: clippy
-            kind: test
+            kind: local
             backends: dx12 # dx11
 
           - name: Windows Nightly x86_64
             os: windows-2019
             target: x86_64-pc-windows-msvc
             tool: check
-            kind: compile
+            kind: other
           
           # MacOS
-
-          # Mac has no software runners, so don't run tests
           - name: MacOS x86_64
             os: macos-10.15
             target: x86_64-apple-darwin
             tool: clippy
-            kind: compile
-
+            # Mac has no software runners, so don't run tests
+            kind: other
           
           # IOS
           - name: IOS aarch64
             os: macos-10.15
             target: aarch64-apple-ios
             tool: clippy
-            kind: compile
+            kind: other
 
 
           # Linux
@@ -53,14 +56,14 @@ jobs:
             os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             tool: clippy
-            kind: test
+            kind: local
             backends: vulkan # gl
 
           - name: Linux Nightly x86_64
             os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             tool: check
-            kind: compile
+            kind: other
 
           
           # Android
@@ -68,7 +71,7 @@ jobs:
             os: ubuntu-20.04
             target: aarch64-linux-android
             tool: clippy
-            kind: compile
+            kind: other
 
           
           # WebGPU/WebGL
@@ -76,7 +79,7 @@ jobs:
             os: ubuntu-20.04
             target: wasm32-unknown-unknown
             tool: clippy
-            kind: wasm
+            kind: web
 
     name: Check ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -122,7 +125,7 @@ jobs:
           echo "$ANDROID_HOME/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
 
       - name: install llvmpipe and lavapipe
-        if: matrix.os == 'ubuntu-20.04' && matrix.target != 'aarch64-linux-android' && matrix.kind == 'test'
+        if: matrix.os == 'ubuntu-20.04' && matrix.target != 'aarch64-linux-android' && matrix.kind == 'local'
         run: |
           sudo apt-get update -y -qq
           sudo add-apt-repository ppa:oibaf/graphics-drivers -y
@@ -138,7 +141,7 @@ jobs:
           debug = 1" > .cargo/config.toml
 
       - name: check web
-        if: matrix.kind == 'wasm'
+        if: matrix.kind == 'web'
         run: |
           cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu
 
@@ -149,7 +152,7 @@ jobs:
           cargo doc --target ${{ matrix.target }} -p wgpu --no-deps
 
       - name: check native
-        if: matrix.kind == 'compile' || matrix.kind == 'test'
+        if: matrix.kind == 'local' || matrix.kind == 'other'
         run: |
           # check with no features
           cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu -p wgpu-core -p wgpu-info -p player
@@ -162,21 +165,18 @@ jobs:
           cargo doc --target ${{ matrix.target }} --no-deps
           cargo doc --target ${{ matrix.target }} -p wgpu -p wgpu-core -p wgpu-info -p player --all-features --no-deps
 
-      - name: tests
-        if: matrix.kind == 'test'
+      - name: local tests
+        if: matrix.kind == 'local'
         shell: bash
         run: |
           # run wgpu-info
           cargo run --bin wgpu-info
-          # run player tests
-          cargo test -p player
-
+          # run unit and player tests
+          cargo test -p wgpu-types -p wgpu-hal -p wgpu-core -p player --no-fail-fast
+          # run native tests
           for backend in ${{ matrix.backends }}; do
             echo "======= NATIVE TESTS $backend ======";
-            # run player tests
-            WGPU_BACKEND=$backend cargo test --target ${{ matrix.target }} -p wgpu-types -p wgpu-hal -p wgpu-core --no-fail-fast -- --nocapture --test-threads=1
-            # run coretests
-            WGPU_BACKEND=$backend cargo test --target ${{ matrix.target }} -p wgpu --no-fail-fast -- --nocapture --test-threads=1
+            WGPU_BACKEND=$backend cargo test -p wgpu --no-fail-fast -- --nocapture --test-threads=1
           done
 
   fmt:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The following binaries:
 
 For an overview of all the components in the gfx-rs ecosystem, see [the big picture](./etc/big-picture.png).
 
+### MSRV policy
+
+Minimum Supported Rust Version is **1.53**.
+It is enforced on CI (in "/.github/workflows/ci.txt") with `RUST_VERSION` variable.
+This version can only be upgraded in breaking releases.
+
 ## Getting Started
 
 ### Rust

--- a/deno_webgpu/src/command_encoder.rs
+++ b/deno_webgpu/src/command_encoder.rs
@@ -431,7 +431,7 @@ pub fn op_webgpu_command_encoder_copy_texture_to_texture(
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CommandEncoderFillBufferArgs {
+pub struct CommandEncoderClearBufferArgs {
     command_encoder_rid: u32,
     destination_rid: u32,
     destination_offset: u64,
@@ -440,7 +440,7 @@ pub struct CommandEncoderFillBufferArgs {
 
 pub fn op_webgpu_command_encoder_clear_buffer(
     state: &mut OpState,
-    args: CommandEncoderFillBufferArgs,
+    args: CommandEncoderClearBufferArgs,
     _: (),
 ) -> Result<WebGpuResult, AnyError> {
     let instance = state.borrow::<super::Instance>();

--- a/player/tests/data/all.ron
+++ b/player/tests/data/all.ron
@@ -1,5 +1,5 @@
 (
-	backends: (bits: 0xF),
+	backends: 0x3E,
 	tests: [
 		"bind-group.ron",
 		"buffer-copy.ron",

--- a/player/tests/data/bind-group.ron
+++ b/player/tests/data/bind-group.ron
@@ -1,5 +1,5 @@
 (
-    features: (bits: 0x0),
+    features: 0x0,
     expectations: [], //not crash!
     actions: [
         CreatePipelineLayout(Id(0, 1, Empty), (
@@ -29,9 +29,7 @@
         CreateBuffer(Id(0, 1, Empty), (
             label: None,
             size: 16,
-            usage: (
-                bits: 64,
-            ),
+            usage: 64,
             mapped_at_creation: false,
         )),
         CreateBindGroupLayout(Id(0, 1, Empty), (
@@ -39,7 +37,7 @@
             entries: [
                 (
                     binding: 0,
-                    visibility: (bits: 0x3),
+                    visibility: 0x3,
                     ty: Buffer(
                         ty: Uniform,
                     ),

--- a/player/tests/data/buffer-copy.ron
+++ b/player/tests/data/buffer-copy.ron
@@ -1,5 +1,5 @@
 (
-    features: (bits: 0x0),
+    features: 0x0,
     expectations: [
         (
             name: "basic",
@@ -14,9 +14,7 @@
             (
                 label: Some("dummy"),
                 size: 16,
-                usage: (
-                    bits: 41,
-                ),
+                usage: 41,
                 mapped_at_creation: false,
             ),
         ),

--- a/player/tests/data/clear-buffer-texture.ron
+++ b/player/tests/data/clear-buffer-texture.ron
@@ -1,5 +1,5 @@
 (
-    features: (bits: 0x0000_0008_0000_0000),
+    features: 0x0000_0020_0000_0000,
     expectations: [
         (
             name: "Quad",
@@ -25,15 +25,12 @@
             size: (
                 width: 64,
                 height: 64,
-                depth_or_array_layers: 1,
             ),
             mip_level_count: 1,
             sample_count: 1,
-            dimension: D2,
-            format: Rgba8Unorm,
-            usage: (
-                bits: 27,
-            ),
+            dimension: r#2d,
+            format: rgba8unorm,
+            usage: 27,
         )),
         // First fill the texture to ensure it wasn't just zero initialized or "happened" to be zero.
         WriteTexture(
@@ -51,7 +48,6 @@
             size: (
                 width: 64,
                 height: 64,
-                depth_or_array_layers: 1,
             ),
         ),
         CreateBuffer(
@@ -59,9 +55,7 @@
             (
                 label: Some("Output Buffer"),
                 size: 16384,
-                usage: (
-                    bits: 9,
-                ),
+                usage: 9,
                 mapped_at_creation: false,
             ),
         ),
@@ -71,9 +65,7 @@
             (
                 label: Some("Buffer to be cleared"),
                 size: 16,
-                usage: (
-                    bits: 41,
-                ),
+                usage: 41,
                 mapped_at_creation: false,
             ),
         ),
@@ -91,7 +83,7 @@
             ClearTexture(
                 dst: Id(0, 1, Empty),
                 subresource_range: ImageSubresourceRange(
-                    aspect: All,
+                    aspect: all,
                     base_mip_level: 0,
                     mip_level_count: None,
                     base_array_layer: 0,
@@ -115,7 +107,6 @@
                 size: (
                     width: 64,
                     height: 64,
-                    depth_or_array_layers: 1,
                 ),
             ),
             // Partial clear to prove

--- a/player/tests/data/pipeline-statistics-query.ron
+++ b/player/tests/data/pipeline-statistics-query.ron
@@ -1,5 +1,5 @@
 (
-    features: (bits: 0x0000_0000_0000_0008), // PIPELINE_STATISTICS_QUERY
+    features: 0x0000_0000_0000_0010, // PIPELINE_STATISTICS_QUERY
     expectations: [
         (
             name: "Queried number of compute invocations is correct",
@@ -38,7 +38,7 @@
             desc: (
                 label: Some("Compute Invocation QuerySet"),
                 count: 2,
-                ty: PipelineStatistics((bits: 0x18)), // FRAGMENT_SHADER_INVOCATIONS | COMPUTE_SHADER_INVOCATIONS
+                ty: PipelineStatistics(0x18), // FRAGMENT_SHADER_INVOCATIONS | COMPUTE_SHADER_INVOCATIONS
             ),
         ),
         CreateBuffer(
@@ -46,9 +46,7 @@
             (
                 label: Some("Compute Invocation Result Buffer"),
                 size: 16,
-                usage: (
-                    bits: 9, // COPY_DST | MAP_READ
-                ),
+                usage: 9, // COPY_DST | MAP_READ
                 mapped_at_creation: false,
             ),
         ),

--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -1,5 +1,5 @@
 (
-    features: (bits: 0x0),
+    features: 0x0,
     expectations: [
         (
             name: "Quad",
@@ -22,15 +22,12 @@
             size: (
                 width: 64,
                 height: 64,
-                depth_or_array_layers: 1,
             ),
             mip_level_count: 1,
             sample_count: 1,
-            dimension: D2,
-            format: Rgba8Unorm,
-            usage: (
-                bits: 27,
-            ),
+            dimension: r#2d,
+            format: rgba8unorm,
+            usage: 27,
         )),
         CreateTextureView(
             id: Id(0, 1, Empty),
@@ -42,9 +39,7 @@
             (
                 label: Some("Output Buffer"),
                 size: 16384,
-                usage: (
-                    bits: 9,
-                ),
+                usage: 9,
                 mapped_at_creation: false,
             ),
         ),
@@ -72,7 +67,7 @@
                     ),
                     targets: [
                         (
-                            format: Rgba8Unorm,
+                            format: rgba8unorm,
                         ),
                     ],
                 )),
@@ -99,8 +94,8 @@
                         view: Id(0, 1, Empty),
                         resolve_target: None,
                         channel: (
-                            load_op: Clear,
-                            store_op: Store,
+                            load_op: clear,
+                            store_op: store,
                             clear_value: (
                                 r: 0,
                                 g: 0,
@@ -130,7 +125,6 @@
                 size: (
                     width: 64,
                     height: 64,
-                    depth_or_array_layers: 1,
                 ),
             ),
         ]),

--- a/player/tests/data/zero-init-buffer.ron
+++ b/player/tests/data/zero-init-buffer.ron
@@ -1,5 +1,5 @@
 (
-    features: (bits: 0x0),
+    features: 0x0,
     expectations: [
         // Ensuring that mapping zero-inits buffers.
         (
@@ -43,9 +43,7 @@
             (
                 label: Some("mapped_at_creation: false, with MAP_WRITE"),
                 size: 16,
-                usage: (
-                    bits: 131, // STORAGE + MAP_READ + MAP_WRITE
-                ),
+                usage: 131, // STORAGE + MAP_READ + MAP_WRITE
                 mapped_at_creation: false,
             ),
         ),
@@ -54,9 +52,7 @@
             (
                 label: Some("mapped_at_creation: false, without MAP_WRITE"),
                 size: 16,
-                usage: (
-                    bits: 129, // STORAGE + MAP_READ
-                ),
+                usage: 129, // STORAGE + MAP_READ
                 mapped_at_creation: false,
             ),
         ),
@@ -65,9 +61,7 @@
             (
                 label: Some("partially written"),
                 size: 24,
-                usage: (
-                    bits: 9, // MAP_READ + COPY_DST
-                ),
+                usage: 9, // MAP_READ + COPY_DST
                 mapped_at_creation: false,
             ),
         ),
@@ -91,9 +85,7 @@
         CreateBuffer(Id(3, 1, Empty), (
             label: Some("used in binding"),
             size: 16,
-            usage: (
-                bits: 129, // STORAGE + MAP_READ
-            ),
+            usage: 129, // STORAGE + MAP_READ
             mapped_at_creation: false,
         )),
         CreateBindGroupLayout(Id(0, 1, Empty), (
@@ -101,9 +93,7 @@
             entries: [
                 (
                     binding: 0,
-                    visibility: (
-                        bits: 4,
-                    ),
+                    visibility: 4,
                     ty: Buffer(
                         ty: Storage(
                             read_only: false,

--- a/player/tests/data/zero-init-texture-binding.ron
+++ b/player/tests/data/zero-init-texture-binding.ron
@@ -1,5 +1,5 @@
 (
-    features: (bits: 0x0),
+    features: 0x0,
     expectations: [
         (
             name: "Sampled Texture",
@@ -22,15 +22,12 @@
             size: (
                 width: 64,
                 height: 64,
-                depth_or_array_layers: 1,
             ),
             mip_level_count: 1,
             sample_count: 1,
-            dimension: D2,
-            format: Rgba8Unorm,
-            usage: (
-                bits: 5, // SAMPLED + COPY_SRC
-            ),
+            dimension: r#2d,
+            format: rgba8unorm,
+            usage: 5, // SAMPLED + COPY_SRC
         )),
         CreateTextureView(
             id: Id(0, 1, Empty),
@@ -42,9 +39,7 @@
             (
                 label: Some("Sampled Texture Buffer"),
                 size: 16384,
-                usage: (
-                    bits: 9,
-                ),
+                usage: 9,
                 mapped_at_creation: false,
             ),
         ),
@@ -53,15 +48,12 @@
             size: (
                 width: 64,
                 height: 64,
-                depth_or_array_layers: 1,
             ),
             mip_level_count: 1,
             sample_count: 1,
-            dimension: D2,
-            format: Rgba8Unorm,
-            usage: (
-                bits: 9, // STORAGE + COPY_SRC
-            ),
+            dimension: r#2d,
+            format: rgba8unorm,
+            usage: 9, // STORAGE + COPY_SRC
         )),
         CreateTextureView(
             id: Id(1, 1, Empty),
@@ -73,9 +65,7 @@
             (
                 label: Some("Storage Texture Buffer"),
                 size: 16384,
-                usage: (
-                    bits: 9,
-                ),
+                usage: 9,
                 mapped_at_creation: false,
             ),
         ),
@@ -86,25 +76,21 @@
             entries: [
                 (
                     binding: 0,
-                    visibility: (
-                        bits: 4, // COMPUTE
-                    ),
+                    visibility: 4, // COMPUTE
                     ty: Texture (
                         sample_type: Float(filterable: true),
-                        view_dimension: D2,
+                        view_dimension: r#2d,
                         multisampled: false,
                     ),
                     count: None,
                 ),
                 (
                     binding: 1,
-                    visibility: (
-                        bits: 4, // COMPUTE
-                    ),
+                    visibility: 4, // COMPUTE
                     ty: StorageTexture (
-                        access: WriteOnly,
-                        format: Rgba8Unorm,
-                        view_dimension: D2,
+                        access: r#write-only,
+                        format: rgba8unorm,
+                        view_dimension: r#2d,
                     ),
                     count: None,
                 ),
@@ -185,7 +171,6 @@
                 size: (
                     width: 64,
                     height: 64,
-                    depth_or_array_layers: 1,
                 ),
             ),
             CopyTextureToBuffer(
@@ -205,7 +190,6 @@
                 size: (
                     width: 64,
                     height: 64,
-                    depth_or_array_layers: 1,
                 ),
             ),
         ]),

--- a/player/tests/data/zero-init-texture-binding.wgsl
+++ b/player/tests/data/zero-init-texture-binding.wgsl
@@ -1,5 +1,5 @@
 [[group(0), binding(0)]] var tex: texture_2d<f32>;
-[[group(0), binding(1)]] var tex_storage: texture_storage_2d<rgba8uint>;
+[[group(0), binding(1)]] var tex_storage: texture_storage_2d<rgba8uint, write>;
 
 [[stage(compute), workgroup_size(1)]]
 fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {

--- a/player/tests/data/zero-init-texture-copytobuffer.ron
+++ b/player/tests/data/zero-init-texture-copytobuffer.ron
@@ -1,5 +1,5 @@
 (
-    features: (bits: 0x0),
+    features: 0x0,
     expectations: [
         (
             name: "Copy to Buffer",
@@ -15,24 +15,19 @@
             size: (
                 width: 64,
                 height: 64,
-                depth_or_array_layers: 1,
             ),
             mip_level_count: 1,
             sample_count: 1,
-            dimension: D2,
-            format: Rgba8Unorm,
-            usage: (
-                bits: 1, // COPY_SRC
-            ),
+            dimension: r#2d,
+            format: rgba8unorm,
+            usage: 1, // COPY_SRC
         )),
         CreateBuffer(
             Id(0, 1, Empty),
             (
                 label: Some("Copy to Buffer Buffer"),
                 size: 16384,
-                usage: (
-                    bits: 9,
-                ),
+                usage: 9,
                 mapped_at_creation: false,
             ),
         ),
@@ -54,7 +49,6 @@
                 size: (
                     width: 64,
                     height: 64,
-                    depth_or_array_layers: 1,
                 ),
             ),
         ]),

--- a/player/tests/data/zero-init-texture-rendertarget.ron
+++ b/player/tests/data/zero-init-texture-rendertarget.ron
@@ -1,5 +1,5 @@
 (
-    features: (bits: 0x0),
+    features: 0x0,
     expectations: [
         (
             name: "Render Target",
@@ -15,15 +15,12 @@
             size: (
                 width: 64,
                 height: 64,
-                depth_or_array_layers: 1,
             ),
             mip_level_count: 1,
             sample_count: 1,
-            dimension: D2,
-            format: Rgba8Unorm,
-            usage: (
-                bits: 17, // RENDER_ATTACHMENT + COPY_SRC
-            ),
+            dimension: r#2d,
+            format: rgba8unorm,
+            usage: 17, // RENDER_ATTACHMENT + COPY_SRC
         )),
         CreateTextureView(
             id: Id(0, 1, Empty),
@@ -35,9 +32,7 @@
             (
                 label: Some("Render Target Buffer"),
                 size: 16384,
-                usage: (
-                    bits: 9,
-                ),
+                usage: 9,
                 mapped_at_creation: false,
             ),
         ),
@@ -55,8 +50,8 @@
                         view: Id(0, 1, Empty),
                         resolve_target: None,
                         channel: (
-                            load_op: Load,
-                            store_op: Store,
+                            load_op: load,
+                            store_op: store,
                             clear_value: (
                                 r: 1, g: 1, b: 1, a: 1,
                             ),
@@ -83,7 +78,6 @@
                 size: (
                     width: 64,
                     height: 64,
-                    depth_or_array_layers: 1,
                 ),
             ),
         ]),

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -89,7 +89,7 @@ impl Test<'_> {
             adapter,
             &wgt::DeviceDescriptor {
                 label: None,
-                features: self.features | wgt::Features::MAPPABLE_PRIMARY_BUFFERS,
+                features: self.features,
                 limits: wgt::Limits::default(),
             },
             None,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -48,6 +48,7 @@ use super::{memory_init::TextureSurfaceDiscard, CommandBufferTextureMemoryAction
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(any(feature = "serial-pass", feature = "trace"), derive(Serialize))]
 #[cfg_attr(any(feature = "serial-pass", feature = "replay"), derive(Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum LoadOp {
     /// Clear the output attachment with the clear color. Clearing is faster than loading.
     Clear = 0,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -29,6 +29,7 @@ pub enum ShaderModuleSource<'a> {
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub struct ShaderModuleDescriptor<'a> {
     pub label: Label<'a>,
+    #[cfg_attr(feature = "serde", serde(default))]
     pub shader_bound_checks: wgt::ShaderBoundChecks,
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2755,7 +2755,13 @@ pub struct Extent3d {
     ///
     pub height: u32,
     ///
+    #[cfg_attr(feature = "serde", serde(default = "default_depth"))]
     pub depth_or_array_layers: u32,
+}
+
+#[cfg(feature = "serde")]
+fn default_depth() -> u32 {
+    1
 }
 
 impl Default for Extent3d {


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/pull/2228#issuecomment-985197944

**Description**
Main assumption I'm making here - is that we shouldn't test with "stable" ever.
We either care about MSRV, which we definitely need to run CI on. Or we care about the future breaking, so we pick an arbitrary fresh nightly.
If something works on MSRV and doesn't work on latest stable - it's worrying, but it should be a problem for Rust Core developers more than us, and presumably we'll see it for a while with nightly before it goes into stable.

It also addresses the perpetual problem we had with "clippy" - that new rules are introduced that break our CI. Now clippy is only tested with Rust MSRV. So we only get the breakage when MSRV is pushed forward (in a breaking release).

Finally, looks like we weren't running the player tests for a long time! So they are all fixed and enabled.

**Testing**
CI
