### PR TITLE
Extended Queue::write_* docs to reflect overrun error

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3157,6 +3157,8 @@ impl Queue {
     /// This method is intended to have low performance costs.
     /// As such, the write is not immediately submitted, and instead enqueued
     /// internally to happen at the start of the next `submit()` call.
+    ///
+    /// This fails if `data` overruns the size of `buffer` starting at `offset`.
     pub fn write_buffer(&self, buffer: &Buffer, offset: BufferAddress, data: &[u8]) {
         Context::queue_write_buffer(&*self.context, &self.id, &buffer.id, offset, data)
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3158,7 +3158,7 @@ impl Queue {
     /// As such, the write is not immediately submitted, and instead enqueued
     /// internally to happen at the start of the next `submit()` call.
     ///
-    /// This fails if `data` overruns the size of `buffer` starting at `offset`.
+    /// This method fails if `data` overruns the size of `buffer` starting at `offset`.
     pub fn write_buffer(&self, buffer: &Buffer, offset: BufferAddress, data: &[u8]) {
         Context::queue_write_buffer(&*self.context, &self.id, &buffer.id, offset, data)
     }
@@ -3168,6 +3168,8 @@ impl Queue {
     /// This method is intended to have low performance costs.
     /// As such, the write is not immediately submitted, and instead enqueued
     /// internally to happen at the start of the next `submit()` call.
+    ///
+    /// This method fails if `data` overruns the size of fragment of `texture` specified with `size`.
     pub fn write_texture(
         &self,
         texture: ImageCopyTexture,


### PR DESCRIPTION
**Connections**
#2216 

**Description**
Extended documentatio with a bit about the failability of `Queue::write_buffer`.

Should I add something similar to `Queue::write_texture`?
