### PR TITLE
Add SampleRateShading spv capability

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1104,6 +1104,7 @@ impl super::Adapter {
                 spv::Capability::ImageQuery,
                 spv::Capability::DerivativeControl,
                 spv::Capability::SampledCubeArray,
+                spv::Capability::SampleRateShading,
                 //Note: this is requested always, no matter what the actual
                 // adapter supports. It's not the responsibility of SPV-out
                 // translation to handle the storage support for formats.


### PR DESCRIPTION
**Connections**
n/a

**Description**
Using `[[builtin(sample_index)]]` throw an error:
```
Internal error in FRAGMENT shader: using `sample_index` built-in requires at least one of the capabilities [SampleRateShading], but none are available
```
while the feature is always enabled (https://github.com/gfx-rs/wgpu/blob/master/wgpu-hal/src/vulkan/adapter.rs#L103)

**Testing**
Locally tested, everything looks fine