### PR TITLE
Update naga to c69f676

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.7.1"
-source = "git+https://github.com/gfx-rs/naga?rev=29571cc#29571cc4cfbb28558948b1b31ad764f55b69f37b"
+source = "git+https://github.com/gfx-rs/naga?rev=c69f676#c69f67660973a3bffa3b27c295f698dc4aa01524"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "29571cc"
+rev = "c69f676"
 #version = "0.7"
 features = ["span", "validate", "wgsl-in"]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -75,12 +75,12 @@ js-sys = { version = "0.3" }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "29571cc"
+rev = "c69f676"
 #version = "0.7"
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "29571cc"
+rev = "c69f676"
 #version = "0.7"
 features = ["wgsl-in"]
 

--- a/wgpu-hal/examples/halmark/shader.wgsl
+++ b/wgpu-hal/examples/halmark/shader.wgsl
@@ -35,9 +35,9 @@ fn vs_main([[builtin(vertex_index)]] vi: u32) -> VertexOutput {
 [[group(0), binding(1)]]
 var texture: texture_2d<f32>;
 [[group(0), binding(2)]]
-var sampler: sampler;
+var sam: sampler;
 
 [[stage(fragment)]]
 fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
-    return in.color * textureSampleLevel(texture, sampler, in.tex_coords, 0.0);
+    return in.color * textureSampleLevel(texture, sam, in.tex_coords, 0.0);
 }

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -135,20 +135,20 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "29571cc"
+rev = "c69f676"
 #version = "0.7"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "29571cc"
+rev = "c69f676"
 #version = "0.7"
 features = ["wgsl-in"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "29571cc"
+rev = "c69f676"
 #version = "0.7"
 features = ["wgsl-out"]
 


### PR DESCRIPTION
**Connections**
Picks up https://github.com/gfx-rs/naga/pull/1571 and other things

**Description**
Improves our GLES-3.0 support.

**Testing**
On vange-rs
