### PR TITLE
support push constants on metal

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -876,6 +876,7 @@ impl super::PrivateCapabilities {
             | F::MAPPABLE_PRIMARY_BUFFERS
             | F::VERTEX_WRITABLE_STORAGE
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
+            | F::PUSH_CONSTANTS
             | F::POLYGON_MODE_LINE
             | F::CLEAR_COMMANDS;
 

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -592,7 +592,27 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         _offset: u32,
         _data: &[u32],
     ) {
-        //TODO
+        if _stages.contains(wgt::ShaderStages::COMPUTE) {
+            self.state.compute.as_ref().unwrap().set_bytes(
+                _offset as _,
+                (_data.len() * WORD_SIZE) as u64,
+                _data.as_ptr() as _,
+            )
+        }
+        if _stages.contains(wgt::ShaderStages::VERTEX) {
+            self.state.render.as_ref().unwrap().set_vertex_bytes(
+                _offset as _,
+                (_data.len() * WORD_SIZE) as u64,
+                _data.as_ptr() as _,
+            )
+        }
+        if _stages.contains(wgt::ShaderStages::FRAGMENT) {
+            self.state.render.as_ref().unwrap().set_fragment_bytes(
+                _offset as _,
+                (_data.len() * WORD_SIZE) as u64,
+                _data.as_ptr() as _,
+            )
+        }
     }
 
     unsafe fn insert_debug_marker(&mut self, label: &str) {


### PR DESCRIPTION
**Connections**

fix #1825
**Description**

support push constants on metal. needed to run https://github.com/googlefonts/compute-shader-101/tree/main/rust-gpu-toy on macOS

I have no experience working with graphics API, so I don't know if the code in the PR is actually correct :-(

**Testing**

That repo above seems to run correctly.