### PR TITLE
Allow strip index format None if no indexed drawing is done

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2290,14 +2290,6 @@ impl<A: HalApi> Device<A> {
             );
         }
 
-        if desc.primitive.strip_index_format.is_none() && desc.primitive.topology.is_strip() {
-            return Err(
-                pipeline::CreateRenderPipelineError::NoStripIndexFormatForStripTopology {
-                    topology: desc.primitive.topology,
-                },
-            );
-        }
-
         if desc.primitive.unclipped_depth {
             self.require_features(wgt::Features::DEPTH_CLIP_CONTROL)?;
         }

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -324,8 +324,6 @@ pub enum CreateRenderPipelineError {
         strip_index_format: Option<wgt::IndexFormat>,
         topology: wgt::PrimitiveTopology,
     },
-    #[error("strip index format is None while using the strip topology {topology:?}")]
-    NoStripIndexFormatForStripTopology { topology: wgt::PrimitiveTopology },
     #[error("Conservative Rasterization is only supported for wgt::PolygonMode::Fill")]
     ConservativeRasterizationNonFillPolygonMode,
     #[error(transparent)]

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -157,7 +157,6 @@ impl framework::Example for Example {
                     primitive: wgpu::PrimitiveState {
                         polygon_mode: wgpu::PolygonMode::Line,
                         topology: wgpu::PrimitiveTopology::LineStrip,
-                        strip_index_format: Some(wgpu::IndexFormat::Uint32),
                         ..Default::default()
                     },
                     depth_stencil: None,

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -99,7 +99,6 @@ impl Example {
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleStrip,
-                strip_index_format: Some(wgpu::IndexFormat::Uint16),
                 ..Default::default()
             },
             depth_stencil: None,
@@ -294,7 +293,6 @@ impl framework::Example for Example {
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleStrip,
-                strip_index_format: Some(wgpu::IndexFormat::Uint16),
                 front_face: wgpu::FrontFace::Ccw,
                 cull_mode: Some(wgpu::Face::Back),
                 ..Default::default()


### PR DESCRIPTION
**Connections**
Fixes #2263

**Description**
Catches up to upstream.
Allows users to care less about strips.

**Testing**
Mipmap example.
