### PR TITLE
egl: Report if clamp to border is available

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -289,6 +289,10 @@ impl super::Adapter {
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | wgt::Features::CLEAR_COMMANDS;
         features.set(
+            wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER,
+            extensions.contains("GL_EXT_texture_border_clamp"),
+        );
+        features.set(
             wgt::Features::DEPTH_CLIP_CONTROL,
             extensions.contains("GL_EXT_depth_clamp"),
         );


### PR DESCRIPTION
**Connections**
None

**Description**
Reports the availability of `Features::ADDRESS_MODE_CLAMP_TO_BORDER` in the `egl` backend if the extension `GL_EXT_texture_border_clamp`, this way apps that require it can execute in the gl backend.

**Testing**
The cube exampled was patched with the following
```patch
diff --git a/wgpu/examples/cube/main.rs b/wgpu/examples/cube/main.rs
index f06c5643..e00d7889 100644
--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -111,6 +111,10 @@ impl framework::Example for Example {
         wgt::Features::POLYGON_MODE_LINE
     }
 
+    fn required_features() -> wgpu::Features {
+        wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER
+    }
+
     fn init(
         config: &wgpu::SurfaceConfiguration,
         _adapter: &wgpu::Adapter,
@@ -152,11 +156,17 @@ impl framework::Example for Example {
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Texture {
                         multisampled: false,
-                        sample_type: wgpu::TextureSampleType::Uint,
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
                         view_dimension: wgpu::TextureViewDimension::D2,
                     },
                     count: None,
                 },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
             ],
         });
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -179,7 +189,7 @@ impl framework::Example for Example {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::R8Uint,
+            format: wgpu::TextureFormat::R8Unorm,
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
         });
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
@@ -194,6 +204,18 @@ impl framework::Example for Example {
             texture_extent,
         );
 
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: None,
+            address_mode_u: wgpu::AddressMode::ClampToBorder,
+            address_mode_v: wgpu::AddressMode::ClampToBorder,
+            address_mode_w: wgpu::AddressMode::ClampToBorder,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
+            border_color: Some(wgpu::SamplerBorderColor::OpaqueWhite),
+            ..Default::default()
+        });
+
         // Create other resources
         let mx_total = Self::generate_matrix(config.width as f32 / config.height as f32);
         let mx_ref: &[f32; 16] = mx_total.as_ref();
@@ -215,6 +237,10 @@ impl framework::Example for Example {
                     binding: 1,
                     resource: wgpu::BindingResource::TextureView(&texture_view),
                 },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&sampler),
+                },
             ],
             label: None,
         });
diff --git a/wgpu/examples/cube/shader.wgsl b/wgpu/examples/cube/shader.wgsl
index 9051a6cb..2cd77520 100644
--- a/wgpu/examples/cube/shader.wgsl
+++ b/wgpu/examples/cube/shader.wgsl
@@ -22,12 +22,16 @@ fn vs_main(
 }
 
 [[group(0), binding(1)]]
-var r_color: texture_2d<u32>;
+var r_color: texture_2d<f32>;
+
+[[group(0), binding(2)]]
+var r_sampler: sampler;
+
 
 [[stage(fragment)]]
 fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
-    let tex = textureLoad(r_color, vec2<i32>(in.tex_coord * 256.0), 0);
-    let v = f32(tex.x) / 255.0;
+    let tex = textureSample(r_color, r_sampler, in.tex_coord + vec2<f32>(0.5));
+    let v = tex.x;
     return vec4<f32>(1.0 - (v * 5.0), 1.0 - (v * 15.0), 1.0 - (v * 50.0), 1.0);
 }
```
And the result has expected had 3 quarters of each face black, this might seem weird since the border is set white but the texture only has a red channel and it's value is subtracted from 1.0 so the value is essentially reversed hence white goes to black.