### PR TITLE
feat(deno_webgpu): Implement Surface API ops

### DIFF
--- a/deno_webgpu/02_idl_types.js
+++ b/deno_webgpu/02_idl_types.js
@@ -2037,7 +2037,7 @@
     },
     {
       key: "compositingAlphaMode",
-      converter: webidl.converter["GPUCanvasCompositingAlphaMode"],
+      converter: webidl.converters["GPUCanvasCompositingAlphaMode"],
       defaultValue: "opaque",
     },
     {

--- a/deno_webgpu/02_idl_types.js
+++ b/deno_webgpu/02_idl_types.js
@@ -12,6 +12,7 @@
     GPUAdapter,
     GPUSupportedLimits,
     GPUSupportedFeatures,
+    GPUCanvasContext,
     GPUDevice,
     GPUQueue,
     GPUBuffer,
@@ -1999,4 +2000,54 @@
 
   // TYPEDEF: GPUFlagsConstant
   webidl.converters["GPUFlagsConstant"] = webidl.converters["unsigned long"];
+
+  // INTERFACE: GPUCanvasContext
+  webidl.converters["GPUCanvasContext"] = webidl.createInterfaceConverter(
+    "GPUCanvasContext",
+    GPUCanvasContext,
+  );
+
+  // ENUM: GPUCanvasCompositingAlphaMode
+  webidl.converters["GPUCanvasCompositingAlphaMode"] = webidl.createEnumConverter(
+    "GPUCanvasCompositingAlphaMode",
+    ["opaque", "premultiplied"],
+  );
+
+  // DICTIONARY: GPUCanvasConfiguration
+  const dictMembersGPUCanvasConfiguration = [
+    {
+      key: "device",
+      converter: webidl.converters["GPUDevice"],
+      required: true,
+    },
+    {
+      key: "format",
+      converter: webidl.converters["GPUTextureFormat"],
+      required: true,
+    },
+    {
+      key: "usage",
+      converter: webidl.converters["GPUTextureUsageFlags"],
+      defaultValue: 0x10, // GPUTextureUsage.RENDER_ATTACHMENT
+    },
+    {
+      key: "colorSpace",
+      converter: webidl.converters["GPUPredefinedColorSpace"],
+      defaultValue: "srgb",
+    },
+    {
+      key: "compositingAlphaMode",
+      converter: webidl.converter["GPUCanvasCompositingAlphaMode"],
+      defaultValue: "opaque",
+    },
+    {
+      key: "size",
+      converter: webidl.converters["GPUExtent3D"],
+      required: false,
+    },
+  ];
+  webidl.converters["GPUCanvasConfiguration"] = webidl.createDictionaryConverter(
+    "GPUCanvasConfiguration",
+    dictMembersGPUCanvasConfiguration,
+  );
 })(this);

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -14,5 +14,6 @@ description = "WebGPU implementation for Deno"
 deno_core = { git = "https://github.com/denoland/deno", rev = "ca75752e5a9499a0a997809f02b18c2ba1ecd58d" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.10", features = ["full"] }
-wgpu-core = { path = "../wgpu-core", features = ["trace", "replay", "serde"] }
+wgpu-core = { path = "../wgpu-core", features = ["trace", "replay", "serde", "raw-window-handle"] }
 wgpu-types = { path = "../wgpu-types", features = ["trace", "replay", "serde"] }
+raw-window-handle = "0.4"

--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -68,6 +68,8 @@ pub mod render_pass;
 pub mod sampler;
 pub mod shader;
 pub mod texture;
+pub mod surface;
+pub use surface::init_surface_ext;
 
 pub struct Unstable(pub bool);
 
@@ -82,7 +84,7 @@ fn check_unstable(state: &OpState, api_name: &str) {
     }
 }
 
-type Instance = wgpu_core::hub::Global<wgpu_core::hub::IdentityManagerFactory>;
+pub type Instance = wgpu_core::hub::Global<wgpu_core::hub::IdentityManagerFactory>;
 
 struct WebGpuAdapter(wgpu_core::id::AdapterId);
 impl Resource for WebGpuAdapter {

--- a/deno_webgpu/src/surface.rs
+++ b/deno_webgpu/src/surface.rs
@@ -1,0 +1,213 @@
+use deno_core::error::anyhow;
+use deno_core::error::AnyError;
+use deno_core::op_sync;
+use deno_core::Extension;
+use deno_core::OpState;
+use deno_core::Resource;
+use deno_core::ResourceId;
+use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::RawWindowHandle;
+use serde::Deserialize;
+use std::borrow::Cow;
+use wgpu_types::TextureFormat;
+
+use crate::texture::WebGpuTexture;
+use crate::Instance;
+use crate::WebGpuAdapter;
+use crate::WebGpuDevice;
+
+pub struct DynHasRawWindowHandle(Box<dyn HasRawWindowHandle>);
+
+unsafe impl HasRawWindowHandle for DynHasRawWindowHandle {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        self.0.raw_window_handle()
+    }
+}
+
+pub struct WindowResource(DynHasRawWindowHandle);
+impl Resource for WindowResource {
+    fn name(&self) -> Cow<str> {
+        "window".into()
+    }
+}
+
+pub struct WebGpuSurface(wgpu_core::id::SurfaceId);
+impl Resource for WebGpuSurface {
+    fn name(&self) -> Cow<str> {
+        "webGPUSurface".into()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSurfaceArgs {
+    window_rid: ResourceId,
+}
+
+pub fn op_webgpu_create_surface(
+    state: &mut OpState,
+    args: CreateSurfaceArgs,
+    _: (),
+) -> Result<ResourceId, AnyError> {
+    let window = state
+        .resource_table
+        .get::<WindowResource>(args.window_rid)?;
+    let instance = state.borrow::<Instance>();
+    let surface = instance.instance_create_surface(&window.0, std::marker::PhantomData);
+    Ok(state.resource_table.add(WebGpuSurface(surface)))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigureSurfaceArgs {
+    device_rid: ResourceId,
+    surface_rid: ResourceId,
+    format: TextureFormat,
+    usage: u32,
+    width: u32,
+    height: u32,
+}
+
+pub fn op_webgpu_configure_surface(
+    state: &mut OpState,
+    args: ConfigureSurfaceArgs,
+    _: (),
+) -> Result<(), AnyError> {
+    let surface = state
+        .resource_table
+        .get::<WebGpuSurface>(args.surface_rid)?;
+    let device = state.resource_table.get::<WebGpuDevice>(args.device_rid)?;
+    let instance = state.borrow::<Instance>();
+
+    let config = wgpu_types::SurfaceConfiguration {
+        usage: wgpu_types::TextureUsages::from_bits(args.usage).unwrap(),
+        format: args.format,
+        width: args.width,
+        height: args.height,
+        present_mode: wgpu_types::PresentMode::Fifo,
+    };
+
+    match gfx_select!(device.0 => instance.surface_configure(
+        surface.0,
+        device.0,
+        &config
+    )) {
+        Some(err) => Err(err.into()),
+        None => Ok(()),
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SurfacePreferredFormatArgs {
+    adapter_rid: ResourceId,
+    surface_rid: ResourceId,
+}
+
+pub fn op_webgpu_surface_get_preferred_format(
+    state: &mut OpState,
+    args: SurfacePreferredFormatArgs,
+    _: (),
+) -> Result<wgpu_types::TextureFormat, AnyError> {
+    let surface = state
+        .resource_table
+        .get::<WebGpuSurface>(args.surface_rid)?;
+    let adapter = state
+        .resource_table
+        .get::<WebGpuAdapter>(args.adapter_rid)?;
+    let instance = state.borrow::<Instance>();
+
+    match gfx_select!(adapter.0 => instance.surface_get_preferred_format(
+        surface.0,
+        adapter.0
+    )) {
+        Ok(format) => Ok(format),
+        Err(err) => Err(err.into()),
+    }
+}
+
+pub fn op_webgpu_surface_get_current_texture(
+    state: &mut OpState,
+    args: SurfacePreferredFormatArgs,
+    _: (),
+) -> Result<ResourceId, AnyError> {
+    let surface = state
+        .resource_table
+        .get::<WebGpuSurface>(args.surface_rid)?;
+    let adapter = state
+        .resource_table
+        .get::<WebGpuAdapter>(args.adapter_rid)?;
+    let instance = state.borrow::<Instance>();
+
+    let output = gfx_select!(
+        adapter.0 => instance.surface_get_current_texture(surface.0, std::marker::PhantomData)
+    )?;
+
+    if let Some(texture) = output.texture_id {
+        Ok(state.resource_table.add(WebGpuTexture(texture)))
+    } else {
+        Err(anyhow!(
+            "Failed to get current texture. Surface Status: {:?}",
+            output.status
+        ))
+    }
+}
+
+pub fn op_webgpu_surface_present(
+    state: &mut OpState,
+    args: SurfacePreferredFormatArgs,
+    _: (),
+) -> Result<String, AnyError> {
+    let surface = state
+        .resource_table
+        .get::<WebGpuSurface>(args.surface_rid)?;
+    let adapter = state
+        .resource_table
+        .get::<WebGpuAdapter>(args.adapter_rid)?;
+    let instance = state.borrow::<Instance>();
+
+    let status = gfx_select!(adapter.0 => instance.surface_present(surface.0))?;
+
+    Ok(String::from(match status {
+        wgpu_types::SurfaceStatus::Good => "good",
+        wgpu_types::SurfaceStatus::Suboptimal => "suboptimal",
+        wgpu_types::SurfaceStatus::Timeout => "timeout",
+        wgpu_types::SurfaceStatus::Outdated => "outdated",
+        wgpu_types::SurfaceStatus::Lost => "lost",
+    }))
+}
+
+pub fn op_webgpu_surface_drop(state: &mut OpState, rid: ResourceId, _: ()) -> Result<(), AnyError> {
+    let surface = state.resource_table.get::<WebGpuSurface>(rid)?;
+    let instance = state.borrow::<Instance>();
+    instance.surface_drop(surface.0);
+    Ok(())
+}
+
+pub fn init_surface_ext() -> Extension {
+    Extension::builder()
+        .ops(vec![
+            (
+                "op_webgpu_create_surface",
+                op_sync(op_webgpu_create_surface),
+            ),
+            (
+                "op_webgpu_configure_surface",
+                op_sync(op_webgpu_configure_surface),
+            ),
+            (
+                "op_webgpu_surface_get_preferred_format",
+                op_sync(op_webgpu_surface_get_preferred_format),
+            ),
+            (
+                "op_webgpu_surface_get_current_texture",
+                op_sync(op_webgpu_surface_get_current_texture),
+            ),
+            (
+                "op_webgpu_surface_present",
+                op_sync(op_webgpu_surface_present),
+            ),
+            ("op_webgpu_surface_drop", op_sync(op_webgpu_surface_drop)),
+        ])
+        .build()
+}

--- a/deno_webgpu/webgpu.idl
+++ b/deno_webgpu/webgpu.idl
@@ -1109,3 +1109,27 @@ dictionary GPUExtent3DDict {
 };
 typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 
+enum GPUCanvasCompositingAlphaMode {
+    "opaque",
+    "premultiplied",
+};
+
+dictionary GPUCanvasConfiguration {
+    required GPUDevice device;
+    required GPUTextureFormat format;
+    GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
+    GPUPredefinedColorSpace colorSpace = "srgb";
+    GPUCanvasCompositingAlphaMode compositingAlphaMode = "opaque";
+    GPUExtent3D size;
+};
+
+[Exposed=(Window, DedicatedWorker), SecureContext]
+interface GPUCanvasContext {
+    readonly attribute (HTMLCanvasElement or OffscreenCanvas) canvas;
+
+    undefined configure(GPUCanvasConfiguration configuration);
+    undefined unconfigure();
+
+    GPUTextureFormat getPreferredFormat(GPUAdapter adapter);
+    GPUTexture getCurrentTexture();
+};


### PR DESCRIPTION
**Description**
Implements only the ops (for now?) required to operate wgpu Surface API. This enables the projects which embed `deno_runtime` to add support for rendering through WebGPU on a window. Currently want to use in my [project](https://github.com/DjDeveloperr/deno_desktop), which at the moment implements these ops in there itself,
using a fork of Deno which is not fun to maintain.

These new ops are not exposed by default, instead, there is a new function exported from `deno_webgpu` called `init_surface_ext` which returns an `Extension` to register these ops.

**TODO**
- JS bindings: without JS bindings, using these ops is not possible without hacks including patching private properties of certain objects. [Look at this](https://github.com/DjDeveloperr/deno_desktop/blob/main/src/core.js). But how to expose these bindings in such a way that it is spec compliant is a challenge in itself because WebGPU API is very much tied to HTML canvas.
