### PR TITLE
Add back non-optional flags for wasm compilation

### DIFF
--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1243,7 +1243,7 @@ impl crate::Context for Context {
                 );
                 let spv_module_info = validator.validate(&spv_module).unwrap();
 
-                let wgsl_text = back::wgsl::write_string(&spv_module, &spv_module_info).unwrap();
+                let wgsl_text = back::wgsl::write_string(&spv_module, &spv_module_info, WriterFlags::empty()).unwrap();
                 web_sys::GpuShaderModuleDescriptor::new(wgsl_text.as_str())
             }
             #[cfg(feature = "glsl")]


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

(None)

**Description**
_Describe what problem this is solving, and how it's solved._

Creating a project with wasm-pack and adding [gpgpu-rs](https://github.com/UpsettingBoy/gpgpu-rs/) as a dependency leads to a failed compilation due to a missing WriterFlags argument. 

**Testing**
_Explain how this change is tested._

It builds. I don't have much experience, so I'm not sure if it makes more sense to add a default argument or if hti sbreaks the non-wasm components, but it lets me build.
