### PR TITLE
GLES Wayland: properly resize on configure (#2094)

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -934,15 +934,6 @@ impl crate::Surface<super::Api> for Surface {
                             library.get(b"wl_egl_window_create").unwrap();
                         let window = wl_egl_window_create(handle.surface, 640, 480) as *mut _
                             as *mut std::ffi::c_void;
-                        let wl_egl_window_resize: libloading::Symbol<WlEglWindowResizeFun> =
-                            library.get(b"wl_egl_window_resize").unwrap();
-                        wl_egl_window_resize(
-                            window,
-                            config.extent.width as i32,
-                            config.extent.height as i32,
-                            0,
-                            0,
-                        );
                         wl_window = Some(window);
                         window
                     }
@@ -1016,6 +1007,19 @@ impl crate::Surface<super::Api> for Surface {
                 }
             }
         };
+
+        if let Some(window) = wl_window {
+            let library = self.wsi.library.as_ref().unwrap();
+            let wl_egl_window_resize: libloading::Symbol<WlEglWindowResizeFun> =
+                library.get(b"wl_egl_window_resize").unwrap();
+            wl_egl_window_resize(
+                window,
+                config.extent.width as i32,
+                config.extent.height as i32,
+                0,
+                0,
+            );
+        }
 
         let format_desc = device.shared.describe_texture_format(config.format);
         let gl = &device.shared.context.lock();


### PR DESCRIPTION
**Connections**
Fixes #2094 

**Description**
Resizes Wayland window every configure() instead of only when creating the window.

**Testing**
Tested all examples on Arch Linux with swaywm on `AdapterInfo
{ name: "Mesa Intel(R) UHD Graphics (TGL GT2)", vendor: 32902, device: 0, device_type: IntegratedGpu, backend: Gl }`
Results: hello-triangle, cube, shadow, water examples are fixed. No new errors in the examples.

Ran 'cargo test', which had similar errors both before and after, like:
`[2021-12-12T16:13:23Z ERROR wgpu_hal::gles::egl] EGL 'eglMakeCurrent' code 0x3006: eglMakeCurrent`
`[2021-12-12T16:13:23Z ERROR wgpu_hal::gles::egl] EGL 'eglDestroyContext' code 0x3006: eglDestroyContext`