### PR TITLE
hal/gles: support ASTC, fix WebGL extensions for compressed formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,9 +600,8 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f04649123493bc2483cbef4daddb45d40bbdae5adb221a63a23efdb0cc99520"
+version = "0.11.1"
+source = "git+https://github.com/grovesNL/glow?rev=5851ca6#5851ca65e6b6f4f2c59683245c07de1843c85452"
 dependencies = [
  "js-sys",
  "slotmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,8 @@ default-members = ["wgpu", "wgpu-hal", "wgpu-info"]
 [patch."https://github.com/zakarumych/gpu-alloc"]
 #gpu-alloc = { path = "../gpu-alloc/gpu-alloc" }
 
-[patch."https://github.com/grovesNL/glow"]
-#glow = { path = "../glow" }
-
 [patch.crates-io]
+#glow = { path = "../glow" }
 #metal = { path = "../metal-rs" }
 #web-sys = { path = "../wasm-bindgen/crates/web-sys" }
 #js-sys = { path = "../wasm-bindgen/crates/js-sys" }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -43,7 +43,7 @@ gpu-descriptor = { version = "0.2", optional = true }
 inplace_it = { version ="0.3.3", optional = true }
 
 # backend: Gles
-glow = { version = "0.11", optional = true }
+glow = { git = "https://github.com/grovesNL/glow", rev = "5851ca6", optional = true }
 
 # backend: Dx12
 bit-set = { version = "0.5", optional = true }

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -67,13 +67,13 @@ impl super::AdapterShared {
                 glow::UNSIGNED_INT,
             ),
             Tf::Rgb9e5Ufloat => (glow::RGB9_E5, glow::RGB, glow::UNSIGNED_INT_5_9_9_9_REV),
-            Tf::Bc1RgbaUnorm
-            | Tf::Bc1RgbaUnormSrgb
-            | Tf::Bc2RgbaUnorm
-            | Tf::Bc2RgbaUnormSrgb
-            | Tf::Bc3RgbaUnorm
-            | Tf::Bc3RgbaUnormSrgb
-            | Tf::Bc4RUnorm
+            Tf::Bc1RgbaUnorm => (glow::COMPRESSED_RGBA_S3TC_DXT1_EXT, glow::RGBA, 0),
+            Tf::Bc1RgbaUnormSrgb => (glow::COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT, glow::RGBA, 0),
+            Tf::Bc2RgbaUnorm => (glow::COMPRESSED_RGBA_S3TC_DXT3_EXT, glow::RGBA, 0),
+            Tf::Bc2RgbaUnormSrgb => (glow::COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT, glow::RGBA, 0),
+            Tf::Bc3RgbaUnorm => (glow::COMPRESSED_RGBA_S3TC_DXT5_EXT, glow::RGBA, 0),
+            Tf::Bc3RgbaUnormSrgb => (glow::COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT, glow::RGBA, 0),
+            Tf::Bc4RUnorm
             | Tf::Bc4RSnorm
             | Tf::Bc5RgUnorm
             | Tf::Bc5RgSnorm
@@ -104,34 +104,46 @@ impl super::AdapterShared {
             Tf::EacR11Snorm => (glow::COMPRESSED_SIGNED_R11_EAC, glow::RED, 0),
             Tf::EacRg11Unorm => (glow::COMPRESSED_RG11_EAC, glow::RG, 0),
             Tf::EacRg11Snorm => (glow::COMPRESSED_SIGNED_RG11_EAC, glow::RG, 0),
-            Tf::Astc4x4RgbaUnorm
-            | Tf::Astc4x4RgbaUnormSrgb
-            | Tf::Astc5x4RgbaUnorm
-            | Tf::Astc5x4RgbaUnormSrgb
-            | Tf::Astc5x5RgbaUnorm
-            | Tf::Astc5x5RgbaUnormSrgb
-            | Tf::Astc6x5RgbaUnorm
-            | Tf::Astc6x5RgbaUnormSrgb
-            | Tf::Astc6x6RgbaUnorm
-            | Tf::Astc6x6RgbaUnormSrgb
-            | Tf::Astc8x5RgbaUnorm
-            | Tf::Astc8x5RgbaUnormSrgb
-            | Tf::Astc8x6RgbaUnorm
-            | Tf::Astc8x6RgbaUnormSrgb
-            | Tf::Astc10x5RgbaUnorm
-            | Tf::Astc10x5RgbaUnormSrgb
-            | Tf::Astc10x6RgbaUnorm
-            | Tf::Astc10x6RgbaUnormSrgb
-            | Tf::Astc8x8RgbaUnorm
-            | Tf::Astc8x8RgbaUnormSrgb
-            | Tf::Astc10x8RgbaUnorm
-            | Tf::Astc10x8RgbaUnormSrgb
-            | Tf::Astc10x10RgbaUnorm
-            | Tf::Astc10x10RgbaUnormSrgb
-            | Tf::Astc12x10RgbaUnorm
-            | Tf::Astc12x10RgbaUnormSrgb
-            | Tf::Astc12x12RgbaUnorm
-            | Tf::Astc12x12RgbaUnormSrgb => unimplemented!(),
+            Tf::Astc4x4RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_4x4_KHR, glow::RGBA, 0),
+            Tf::Astc4x4RgbaUnormSrgb => (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR, glow::RGBA, 0),
+            Tf::Astc5x4RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_5x4_KHR, glow::RGBA, 0),
+            Tf::Astc5x4RgbaUnormSrgb => (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR, glow::RGBA, 0),
+            Tf::Astc5x5RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_5x5_KHR, glow::RGBA, 0),
+            Tf::Astc5x5RgbaUnormSrgb => (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR, glow::RGBA, 0),
+            Tf::Astc6x5RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_6x5_KHR, glow::RGBA, 0),
+            Tf::Astc6x5RgbaUnormSrgb => (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR, glow::RGBA, 0),
+            Tf::Astc6x6RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_6x6_KHR, glow::RGBA, 0),
+            Tf::Astc6x6RgbaUnormSrgb => (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR, glow::RGBA, 0),
+            Tf::Astc8x5RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_8x5_KHR, glow::RGBA, 0),
+            Tf::Astc8x5RgbaUnormSrgb => (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR, glow::RGBA, 0),
+            Tf::Astc8x6RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_8x6_KHR, glow::RGBA, 0),
+            Tf::Astc8x6RgbaUnormSrgb => (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR, glow::RGBA, 0),
+            Tf::Astc8x8RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_8x8_KHR, glow::RGBA, 0),
+            Tf::Astc8x8RgbaUnormSrgb => (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR, glow::RGBA, 0),
+            Tf::Astc10x5RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_10x5_KHR, glow::RGBA, 0),
+            Tf::Astc10x5RgbaUnormSrgb => {
+                (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR, glow::RGBA, 0)
+            }
+            Tf::Astc10x6RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_10x6_KHR, glow::RGBA, 0),
+            Tf::Astc10x6RgbaUnormSrgb => {
+                (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR, glow::RGBA, 0)
+            }
+            Tf::Astc10x8RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_10x8_KHR, glow::RGBA, 0),
+            Tf::Astc10x8RgbaUnormSrgb => {
+                (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR, glow::RGBA, 0)
+            }
+            Tf::Astc10x10RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_10x10_KHR, glow::RGBA, 0),
+            Tf::Astc10x10RgbaUnormSrgb => {
+                (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR, glow::RGBA, 0)
+            }
+            Tf::Astc12x10RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_12x10_KHR, glow::RGBA, 0),
+            Tf::Astc12x10RgbaUnormSrgb => {
+                (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR, glow::RGBA, 0)
+            }
+            Tf::Astc12x12RgbaUnorm => (glow::COMPRESSED_RGBA_ASTC_12x12_KHR, glow::RGBA, 0),
+            Tf::Astc12x12RgbaUnormSrgb => {
+                (glow::COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR, glow::RGBA, 0)
+            }
         };
 
         super::TextureFormatDesc {


### PR DESCRIPTION
**Connections**
Blocked by https://github.com/grovesNL/glow/pull/198
Switches glow to github (! be careful when backporting to 0.11)

**Description**
Turns out, ETC2 is a part of GLES3 but not guaranteed on WebGL2.
This PR makes our backend query for proper extensions, and with it we support ASTC LDR.

**Testing**
Tested on skybox example on WebGL, which is now fixed 🎉 
