### PR TITLE
hal/dx12: expose WARP as a fallback adapter

### DIFF
--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -97,7 +97,7 @@ impl super::Adapter {
             device: desc.DeviceId as usize,
             device_type: if (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0 {
                 workarounds.avoid_cpu_descriptor_overwrites = true;
-                wgt::DeviceType::VirtualGpu
+                wgt::DeviceType::Cpu
             } else if features_architecture.CacheCoherentUMA != 0 {
                 wgt::DeviceType::IntegratedGpu
             } else {


### PR DESCRIPTION
**Connections**
Noticed when investigating #2285, which only happens on WARP
#2011

**Description**
We used to expose WARP as a VirtualGPU, which means it wasn't picked up by `force_fallback_adapter` setting.

**Testing**
Trivial
