### PR TITLE
Trace push/pop debug group on command encoder

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -108,6 +108,15 @@ impl GlobalPlay for wgc::hub::Global<IdentityPassThroughFactory> {
                         destination_offset,
                     )
                     .unwrap(),
+                trace::Command::PushDebugGroup(marker) => self
+                    .command_encoder_push_debug_group::<A>(encoder, &marker)
+                    .unwrap(),
+                trace::Command::PopDebugGroup => {
+                    self.command_encoder_pop_debug_group::<A>(encoder).unwrap()
+                }
+                trace::Command::InsertDebugMarker(marker) => self
+                    .command_encoder_insert_debug_marker::<A>(encoder, &marker)
+                    .unwrap(),
                 trace::Command::RunComputePass { base } => {
                     self.command_encoder_run_compute_pass_impl::<A>(encoder, base.as_ref())
                         .unwrap();

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -168,6 +168,9 @@ pub enum Command {
         destination: id::BufferId,
         destination_offset: wgt::BufferAddress,
     },
+    PushDebugGroup(String),
+    PopDebugGroup,
+    InsertDebugMarker(String),
     RunComputePass {
         base: crate::command::BasePass<crate::command::ComputeCommand>,
     },


### PR DESCRIPTION
**Connections**
https://bugzilla.mozilla.org/show_bug.cgi?id=1743668

**Description**
Gecko uses our tracing types/infra for IPC, so having debug groups there is required.

**Testing**
Untested
