### PR TITLE
hal/dx12: enable TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES

### DIFF
--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -183,6 +183,7 @@ impl super::Adapter {
             | wgt::Features::POLYGON_MODE_LINE
             | wgt::Features::POLYGON_MODE_POINT
             | wgt::Features::VERTEX_WRITABLE_STORAGE
+            | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | wgt::Features::TIMESTAMP_QUERY
             | wgt::Features::TEXTURE_COMPRESSION_BC
             | wgt::Features::CLEAR_COMMANDS


### PR DESCRIPTION
**Connections**
fix #2185 

**Description**
DX12 backend already implements texture_format_capabilities, so we can simply expose it.