### PR TITLE
Error scopes API

### DIFF
--- a/run-wasm-example.sh
+++ b/run-wasm-example.sh
@@ -3,7 +3,8 @@
 set -e
 
 echo "Compiling..."
-cargo build --example $1 --target wasm32-unknown-unknown --features webgl
+RUSTFLAGS=--cfg=web_sys_unstable_apis
+cargo build --example $1 --target wasm32-unknown-unknown --features "$2"
 
 echo "Generating bindings..."
 mkdir -p target/wasm-examples/$1

--- a/wgpu/examples/README.md
+++ b/wgpu/examples/README.md
@@ -34,6 +34,7 @@ All framework-based examples render to the window and are reftested against the 
 | blending                     |        | :star:    | :star: |        |           |        |        |                | :star: |                     |
 | render bundles               |        |           |        |        | :star:    |        |        |                | :star: |                     |
 | compute passes               | :star: |           |        |        |           |        |        |                |        |                     |
+| error scopes                 |        |           | :star: |        |           |        |        |                |        |                     |
 | *optional extensions*        |        |           |        |        |           |        |        | :star:         |        |                     |
 | - SPIR-V shaders             |        |           |        |        |           |        |        | :star:         |        |                     |
 | - binding indexing           |        |           |        |        |           |        |        | :star:         |        |                     |


### PR DESCRIPTION
**Connections**
Closes  #1735

**Description**
Adds an ability to capture errors asynchronously using scopes.
Honestly, I find it hard to imagine this useful...

**Testing**
Locally tested on both native and the web
