### PR TITLE
Do texture init via clear passes when possible

### DIFF
--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -202,8 +202,8 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     if features.contains(wgpu_types::Features::VERTEX_WRITABLE_STORAGE) {
         return_features.push("vertex-writable-storage");
     }
-    if features.contains(wgpu_types::Features::CLEAR_COMMANDS) {
-        return_features.push("clear-commands");
+    if features.contains(wgpu_types::Features::CLEAR_TEXTURE) {
+        return_features.push("clear-texture");
     }
     if features.contains(wgpu_types::Features::SPIRV_SHADER_PASSTHROUGH) {
         return_features.push("spirv-shader-passthrough");
@@ -417,7 +417,7 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
             required_features.0.contains("vertex-writable-storage"),
         );
         features.set(
-            wgpu_types::Features::CLEAR_COMMANDS,
+            wgpu_types::Features::CLEAR_TEXTURE,
             required_features.0.contains("clear-commands"),
         );
         features.set(

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -41,7 +41,7 @@ pub enum ClearError {
         end_offset: BufferAddress,
         buffer_size: BufferAddress,
     },
-    #[error("destination buffer/texture is missing the `COPY_DST` usage flag")]
+    #[error("destination buffer is missing the `COPY_DST` usage flag")]
     MissingCopyDstUsageFlag(Option<BufferId>, Option<TextureId>),
     #[error("texture lacks the aspects that were specified in the image subresource range. Texture with format {texture_format:?}, specified was {subresource_range_aspects:?}")]
     MissingTextureAspect {
@@ -246,9 +246,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .inner
             .as_raw()
             .ok_or(ClearError::InvalidTexture(dst))?;
-        if !dst_texture.desc.usage.contains(TextureUsages::COPY_DST) {
-            return Err(ClearError::MissingCopyDstUsageFlag(None, Some(dst)));
-        }
 
         // actual hal barrier & operation
         let dst_barrier = dst_pending.map(|pending| pending.into_hal(dst_texture));

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -19,8 +19,8 @@ use wgt::{BufferAddress, BufferSize, BufferUsages, ImageSubresourceRange, Textur
 /// Error encountered while attempting a clear.
 #[derive(Clone, Debug, Error)]
 pub enum ClearError {
-    #[error("to use clear_buffer/texture the CLEAR_COMMANDS feature needs to be enabled")]
-    MissingClearCommandsFeature,
+    #[error("to use clear_texture the CLEAR_TEXTURE feature needs to be enabled")]
+    MissingClearTextureFeature,
     #[error("command encoder {0:?} is invalid")]
     InvalidCommandEncoder(CommandEncoderId),
     #[error("device {0:?} is invalid")]
@@ -173,8 +173,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             });
         }
 
-        if !cmd_buf.support_clear_buffer_texture {
-            return Err(ClearError::MissingClearCommandsFeature);
+        if !cmd_buf.support_clear_texture {
+            return Err(ClearError::MissingClearTextureFeature);
         }
 
         let dst_texture = texture_guard

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -164,7 +164,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let cmd_buf = CommandBuffer::get_encoder_mut(&mut *cmd_buf_guard, command_encoder_id)
             .map_err(|_| ClearError::InvalidCommandEncoder(command_encoder_id))?;
         let (_, mut token) = hub.buffers.read(&mut token); // skip token
-        let (mut texture_guard, _) = hub.textures.write(&mut token);
+        let (texture_guard, _) = hub.textures.read(&mut token);
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf.commands {
@@ -179,7 +179,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         let dst_texture = texture_guard
-            .get_mut(dst) // todo: take only write access if needed
+            .get(dst)
             .map_err(|_| ClearError::InvalidTexture(dst))?;
 
         // Check if subresource aspects are valid.

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -334,7 +334,6 @@ fn clear_texture_via_buffer_copies<A: hal::Api>(
 ) {
     // Gather list of zero_buffer copies and issue a single command then to perform them
     let mut zero_buffer_copy_regions = Vec::new();
-    let texture_desc: &wgt::TextureDescriptor<()> = &texture_desc;
     let buffer_copy_pitch = alignments.buffer_copy_pitch.get() as u32;
     let format_desc = texture_desc.format.describe();
 

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -261,12 +261,12 @@ impl<A: hal::Api> BakedCommands<A> {
                 }
                 MemoryInitKind::NeedsInitializedMemory => {
                     for (mip_level, mip_tracker) in affected_mip_trackers {
-                        ranges.extend(mip_tracker.drain(use_range.layer_range.clone()).map(
-                            |layer_range| TextureInitRange {
+                        for layer_range in mip_tracker.drain(use_range.layer_range.clone()) {
+                            ranges.push(TextureInitRange {
                                 mip_range: (mip_level as u32)..(mip_level as u32 + 1),
                                 layer_range,
-                            },
-                        ));
+                            });
+                        }
                     }
                 }
             }

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -81,7 +81,7 @@ impl CommandBufferTextureMemoryActions {
 
                     // Mark surface as implicitly initialized (this is relevant because it might have been uninitialized prior to discarding
                     init_actions.push(TextureInitTrackerAction {
-                        id: discarded_surface.texture.clone(),
+                        id: discarded_surface.texture,
                         range: TextureInitRange {
                             mip_range: discarded_surface.mip_level
                                 ..(discarded_surface.mip_level + 1),

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -119,7 +119,7 @@ impl CommandBufferTextureMemoryActions {
     }
 }
 
-// Utility function that takes discarded surfaces from register_init_action and initializes them on the spot.
+// Utility function that takes discarded surfaces from (several calls to) register_init_action and initializes them on the spot.
 // Takes care of barriers as well!
 pub(crate) fn fixup_discarded_surfaces<
     A: hal::Api,
@@ -132,14 +132,13 @@ pub(crate) fn fixup_discarded_surfaces<
     device: &Device<A>,
 ) {
     for init in inits {
-        let mip_range = init.mip_level..(init.mip_level + 1);
-        let layer_range = init.layer..(init.layer + 1);
-
         clear_texture(
             &init.texture,
             texture_guard.get(init.texture.value.0).unwrap(),
-            mip_range,
-            layer_range,
+            TextureInitRange {
+                mip_range: init.mip_level..(init.mip_level + 1),
+                layer_range: init.layer..(init.layer + 1),
+            },
             encoder,
             texture_tracker,
             device,
@@ -278,8 +277,7 @@ impl<A: hal::Api> BakedCommands<A> {
                 clear_texture(
                     &texture_use.id,
                     &*texture,
-                    range.mip_range,
-                    range.layer_range,
+                    range,
                     &mut self.encoder,
                     &mut device_tracker.textures,
                     device,

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -8,15 +8,10 @@ mod query;
 mod render;
 mod transfer;
 
-pub use self::bundle::*;
-pub(crate) use self::clear::clear_texture_no_device;
-pub(crate) use self::clear::ClearError;
-pub use self::compute::*;
-pub use self::draw::*;
+pub(crate) use self::clear::{clear_texture_no_device, ClearError};
+pub use self::{bundle::*, compute::*, draw::*, query::*, render::*, transfer::*};
+
 use self::memory_init::CommandBufferTextureMemoryActions;
-pub use self::query::*;
-pub use self::render::*;
-pub use self::transfer::*;
 
 use crate::error::{ErrorFormatter, PrettyError};
 use crate::init_tracker::BufferInitTrackerAction;

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -8,8 +8,10 @@ mod query;
 mod render;
 mod transfer;
 
-pub(crate) use self::clear::{clear_texture_no_device, ClearError};
-pub use self::{bundle::*, compute::*, draw::*, query::*, render::*, transfer::*};
+pub(crate) use self::clear::clear_texture_no_device;
+pub use self::{
+    bundle::*, clear::ClearError, compute::*, draw::*, query::*, render::*, transfer::*,
+};
 
 use self::memory_init::CommandBufferTextureMemoryActions;
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -9,8 +9,9 @@ mod render;
 mod transfer;
 
 pub use self::bundle::*;
+pub(crate) use self::clear::clear_texture_no_device;
 pub(crate) use self::clear::collect_zero_buffer_copies_for_clear_texture;
-pub use self::clear::ClearError;
+pub(crate) use self::clear::ClearError;
 pub use self::compute::*;
 pub use self::draw::*;
 use self::memory_init::CommandBufferTextureMemoryActions;

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -10,7 +10,6 @@ mod transfer;
 
 pub use self::bundle::*;
 pub(crate) use self::clear::clear_texture_no_device;
-pub(crate) use self::clear::collect_zero_buffer_copies_for_clear_texture;
 pub(crate) use self::clear::ClearError;
 pub use self::compute::*;
 pub use self::draw::*;

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -101,7 +101,7 @@ pub struct CommandBuffer<A: hal::Api> {
     buffer_memory_init_actions: Vec<BufferInitTrackerAction>,
     texture_memory_actions: CommandBufferTextureMemoryActions,
     limits: wgt::Limits,
-    support_clear_buffer_texture: bool,
+    support_clear_texture: bool,
     #[cfg(feature = "trace")]
     pub(crate) commands: Option<Vec<TraceCommand>>,
 }
@@ -129,7 +129,7 @@ impl<A: HalApi> CommandBuffer<A> {
             buffer_memory_init_actions: Default::default(),
             texture_memory_actions: Default::default(),
             limits,
-            support_clear_buffer_texture: features.contains(wgt::Features::CLEAR_COMMANDS),
+            support_clear_texture: features.contains(wgt::Features::CLEAR_TEXTURE),
             #[cfg(feature = "trace")]
             commands: if enable_tracing {
                 Some(Vec::new())

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -568,7 +568,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
         if channel.load_op == LoadOp::Load {
             pending_discard_init_fixups.extend(texture_memory_actions.register_init_action(
                 &TextureInitTrackerAction {
-                    id: view.parent_id.clone(),
+                    id: view.parent_id.value.0,
                     range: TextureInitRange::from(view.selector.clone()),
                     // Note that this is needed even if the target is discarded,
                     kind: MemoryInitKind::NeedsInitializedMemory,
@@ -578,7 +578,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
         } else if channel.store_op == StoreOp::Store {
             // Clear + Store
             texture_memory_actions.register_implicit_init(
-                view.parent_id.clone(),
+                view.parent_id.value,
                 TextureInitRange::from(view.selector.clone()),
                 texture_guard,
             );
@@ -587,7 +587,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
             // the discard happens at the *end* of a pass
             // but recording the discard right away be alright since the texture can't be used during the pass anyways
             texture_memory_actions.discard(TextureSurfaceDiscard {
-                texture: view.parent_id.clone(),
+                texture: view.parent_id.value.0,
                 mip_level: view.selector.levels.start,
                 layer: view.selector.layers.start,
             });
@@ -729,7 +729,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                     pending_discard_init_fixups.extend(
                         cmd_buf.texture_memory_actions.register_init_action(
                             &TextureInitTrackerAction {
-                                id: view.parent_id.clone(),
+                                id: view.parent_id.value.0,
                                 range: TextureInitRange::from(view.selector.clone()),
                                 kind: MemoryInitKind::NeedsInitializedMemory,
                             },
@@ -745,7 +745,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 if at.depth.store_op != at.stencil.store_op {
                     if !need_init_beforehand {
                         cmd_buf.texture_memory_actions.register_implicit_init(
-                            view.parent_id.clone(),
+                            view.parent_id.value,
                             TextureInitRange::from(view.selector.clone()),
                             texture_guard,
                         );
@@ -761,7 +761,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 } else if at.depth.store_op == StoreOp::Discard {
                     // Both are discarded using the regular path.
                     discarded_surfaces.push(TextureSurfaceDiscard {
-                        texture: view.parent_id.clone(),
+                        texture: view.parent_id.value.0,
                         mip_level: view.selector.levels.start,
                         layer: view.selector.layers.start,
                     });
@@ -838,7 +838,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 }
 
                 cmd_buf.texture_memory_actions.register_implicit_init(
-                    resolve_view.parent_id.clone(),
+                    resolve_view.parent_id.value,
                     TextureInitRange::from(resolve_view.selector.clone()),
                     texture_guard,
                 );

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -568,7 +568,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
         if channel.load_op == LoadOp::Load {
             pending_discard_init_fixups.extend(texture_memory_actions.register_init_action(
                 &TextureInitTrackerAction {
-                    id: view.parent_id.value.0,
+                    id: view.parent_id.clone(),
                     range: TextureInitRange::from(view.selector.clone()),
                     // Note that this is needed even if the target is discarded,
                     kind: MemoryInitKind::NeedsInitializedMemory,
@@ -578,7 +578,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
         } else if channel.store_op == StoreOp::Store {
             // Clear + Store
             texture_memory_actions.register_implicit_init(
-                view.parent_id.value.0,
+                view.parent_id.clone(),
                 TextureInitRange::from(view.selector.clone()),
                 texture_guard,
             );
@@ -587,7 +587,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
             // the discard happens at the *end* of a pass
             // but recording the discard right away be alright since the texture can't be used during the pass anyways
             texture_memory_actions.discard(TextureSurfaceDiscard {
-                texture: view.parent_id.value.0,
+                texture: view.parent_id.clone(),
                 mip_level: view.selector.levels.start,
                 layer: view.selector.layers.start,
             });
@@ -729,7 +729,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                     pending_discard_init_fixups.extend(
                         cmd_buf.texture_memory_actions.register_init_action(
                             &TextureInitTrackerAction {
-                                id: view.parent_id.value.0,
+                                id: view.parent_id.clone(),
                                 range: TextureInitRange::from(view.selector.clone()),
                                 kind: MemoryInitKind::NeedsInitializedMemory,
                             },
@@ -745,7 +745,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 if at.depth.store_op != at.stencil.store_op {
                     if !need_init_beforehand {
                         cmd_buf.texture_memory_actions.register_implicit_init(
-                            view.parent_id.value.0,
+                            view.parent_id.clone(),
                             TextureInitRange::from(view.selector.clone()),
                             texture_guard,
                         );
@@ -761,7 +761,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 } else if at.depth.store_op == StoreOp::Discard {
                     // Both are discarded using the regular path.
                     discarded_surfaces.push(TextureSurfaceDiscard {
-                        texture: view.parent_id.value.0,
+                        texture: view.parent_id.clone(),
                         mip_level: view.selector.levels.start,
                         layer: view.selector.layers.start,
                     });
@@ -838,7 +838,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 }
 
                 cmd_buf.texture_memory_actions.register_implicit_init(
-                    resolve_view.parent_id.value.0,
+                    resolve_view.parent_id.clone(),
                     TextureInitRange::from(resolve_view.selector.clone()),
                     texture_guard,
                 );

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -6,7 +6,7 @@ use crate::{
     device::Device,
     error::{ErrorFormatter, PrettyError},
     hub::{Global, GlobalIdentityHandlerFactory, HalApi, Storage, Token},
-    id::{self, BufferId, CommandEncoderId, TextureId},
+    id::{BufferId, CommandEncoderId, Id, TextureId, Valid},
     init_tracker::{MemoryInitKind, TextureInitRange, TextureInitTrackerAction},
     resource::{Texture, TextureErrorDimension},
     track::TextureSelector,
@@ -382,12 +382,12 @@ fn handle_texture_init<A: hal::Api>(
     device: &Device<A>,
     copy_texture: &ImageCopyTexture,
     copy_size: &Extent3d,
-    texture_guard: &Storage<Texture<A>, id::Id<Texture<hal::api::Empty>>>,
+    texture_guard: &Storage<Texture<A>, Id<Texture<hal::api::Empty>>>,
     texture: &Texture<A>,
 ) {
     let init_action = TextureInitTrackerAction {
         id: Stored {
-            value: id::Valid(copy_texture.texture),
+            value: Valid(copy_texture.texture),
             // For copies the texture object isn't discarded yet (somebody just passed it in!), so it should be safe to access the ref_count
             ref_count: texture.life_guard.ref_count.as_ref().unwrap().clone(),
         },

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -10,7 +10,6 @@ use crate::{
     init_tracker::{MemoryInitKind, TextureInitRange, TextureInitTrackerAction},
     resource::{Texture, TextureErrorDimension},
     track::TextureSelector,
-    Stored,
 };
 
 use hal::CommandEncoder as _;
@@ -386,11 +385,7 @@ fn handle_texture_init<A: hal::Api>(
     texture: &Texture<A>,
 ) {
     let init_action = TextureInitTrackerAction {
-        id: Stored {
-            value: Valid(copy_texture.texture),
-            // For copies the texture object isn't discarded yet (somebody just passed it in!), so it should be safe to access the ref_count
-            ref_count: texture.life_guard.ref_count.as_ref().unwrap().clone(),
-        },
+        id: copy_texture.texture,
         range: TextureInitRange {
             mip_range: copy_texture.mip_level..copy_texture.mip_level + 1,
             layer_range: copy_texture.origin.z
@@ -409,7 +404,7 @@ fn handle_texture_init<A: hal::Api>(
         let cmd_buf_raw = cmd_buf.encoder.open();
         for init in immediate_inits {
             clear_texture(
-                &init.texture,
+                Valid(init.texture),
                 texture,
                 TextureInitRange {
                     mip_range: init.mip_level..(init.mip_level + 1),

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -71,6 +71,10 @@ pub fn map_texture_usage(
         usage.contains(wgt::TextureUsages::COPY_SRC),
     );
     u.set(
+        hal::TextureUses::COPY_DST,
+        usage.contains(wgt::TextureUsages::COPY_DST),
+    );
+    u.set(
         hal::TextureUses::RESOURCE,
         usage.contains(wgt::TextureUsages::TEXTURE_BINDING),
     );

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -468,11 +468,14 @@ impl<A: HalApi> LifetimeTracker<A> {
                             .map_or(&mut self.free_resources, |a| &mut a.last_resources);
 
                         non_referenced_resources.textures.push(raw);
-                        non_referenced_resources.texture_views.extend(
-                            res.clear_views
-                                .into_iter()
-                                .flat_map(|layers| layers.into_iter().filter_map(|v| v)),
-                        );
+                        match res.clear_mode {
+                            resource::TextureClearMode::RenderPass(clear_views) => {
+                                non_referenced_resources
+                                    .texture_views
+                                    .extend(clear_views.into_iter());
+                            }
+                            _ => {}
+                        }
                     }
                 }
             }

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -256,7 +256,10 @@ impl<A: hal::Api> LifetimeTracker<A> {
         for res in temp_resources {
             match res {
                 TempResource::Buffer(raw) => last_resources.buffers.push(raw),
-                TempResource::Texture(raw) => last_resources.textures.push(raw),
+                TempResource::Texture(raw, views) => {
+                    last_resources.textures.push(raw);
+                    last_resources.texture_views.extend(views);
+                }
             }
         }
 
@@ -336,7 +339,10 @@ impl<A: hal::Api> LifetimeTracker<A> {
             .map_or(&mut self.free_resources, |a| &mut a.last_resources);
         match temp_resource {
             TempResource::Buffer(raw) => resources.buffers.push(raw),
-            TempResource::Texture(raw) => resources.textures.push(raw),
+            TempResource::Texture(raw, views) => {
+                resources.texture_views.extend(views);
+                resources.textures.push(raw);
+            }
         }
     }
 
@@ -455,12 +461,18 @@ impl<A: HalApi> LifetimeTracker<A> {
                             resource::TextureInner::Native { raw: Some(raw) } => raw,
                             _ => continue,
                         };
-                        self.active
+                        let non_referenced_resources = self
+                            .active
                             .iter_mut()
                             .find(|a| a.index == submit_index)
-                            .map_or(&mut self.free_resources, |a| &mut a.last_resources)
-                            .textures
-                            .push(raw);
+                            .map_or(&mut self.free_resources, |a| &mut a.last_resources);
+
+                        non_referenced_resources.textures.push(raw);
+                        non_referenced_resources.texture_views.extend(
+                            res.clear_views
+                                .into_iter()
+                                .flat_map(|layers| layers.into_iter().filter_map(|v| v)),
+                        );
                     }
                 }
             }

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -468,7 +468,8 @@ impl<A: HalApi> LifetimeTracker<A> {
                             .map_or(&mut self.free_resources, |a| &mut a.last_resources);
 
                         non_referenced_resources.textures.push(raw);
-                        if let resource::TextureClearMode::RenderPass(clear_views) = res.clear_mode
+                        if let resource::TextureClearMode::RenderPass { clear_views, .. } =
+                            res.clear_mode
                         {
                             non_referenced_resources
                                 .texture_views

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -468,13 +468,11 @@ impl<A: HalApi> LifetimeTracker<A> {
                             .map_or(&mut self.free_resources, |a| &mut a.last_resources);
 
                         non_referenced_resources.textures.push(raw);
-                        match res.clear_mode {
-                            resource::TextureClearMode::RenderPass(clear_views) => {
-                                non_referenced_resources
-                                    .texture_views
-                                    .extend(clear_views.into_iter());
-                            }
-                            _ => {}
+                        if let resource::TextureClearMode::RenderPass(clear_views) = res.clear_mode
+                        {
+                            non_referenced_resources
+                                .texture_views
+                                .extend(clear_views.into_iter());
                         }
                     }
                 }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1535,7 +1535,7 @@ impl<A: HalApi> Device<A> {
         check_texture_usage(texture.desc.usage, pub_usage)?;
 
         used_texture_ranges.push(TextureInitTrackerAction {
-            id: view.parent_id.clone(),
+            id: view.parent_id.value.0,
             range: TextureInitRange {
                 mip_range: view.desc.range.mip_range(&texture.desc),
                 layer_range: view.desc.range.layer_range(&texture.desc),

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1519,11 +1519,10 @@ impl<A: HalApi> Device<A> {
     ) -> Result<(), binding_model::CreateBindGroupError> {
         // Careful here: the texture may no longer have its own ref count,
         // if it was deleted by the user.
-        let parent_id = view.parent_id.value;
-        let texture = &texture_guard[parent_id];
+        let texture = &texture_guard[view.parent_id.value];
         used.textures
             .change_extend(
-                parent_id,
+                view.parent_id.value,
                 &view.parent_id.ref_count,
                 view.selector.clone(),
                 internal_use,
@@ -1532,7 +1531,7 @@ impl<A: HalApi> Device<A> {
         check_texture_usage(texture.desc.usage, pub_usage)?;
 
         used_texture_ranges.push(TextureInitTrackerAction {
-            id: parent_id.0,
+            id: view.parent_id.clone(),
             range: TextureInitRange {
                 mip_range: view.desc.range.mip_range(&texture.desc),
                 layer_range: view.desc.range.layer_range(&texture.desc),

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -716,7 +716,7 @@ impl<A: HalApi> Device<A> {
             };
 
             let mut clear_views = SmallVec::new();
-            for layer in 0..desc.size.depth_or_array_layers {
+            for slice_or_layer in 0..desc.size.depth_or_array_layers {
                 for mip_level in 0..desc.mip_level_count {
                     unsafe {
                         clear_views.push(
@@ -732,7 +732,7 @@ impl<A: HalApi> Device<A> {
                                             aspect: wgt::TextureAspect::All,
                                             base_mip_level: mip_level,
                                             mip_level_count: NonZeroU32::new(1),
-                                            base_array_layer: layer,
+                                            base_array_layer: slice_or_layer,
                                             array_layer_count: NonZeroU32::new(1),
                                         },
                                     },

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -730,28 +730,23 @@ impl<A: HalApi> Device<A> {
                     desc.size.depth_or_array_layers
                 };
                 for slice_or_layer in 0..num_slices_or_layers {
-                    unsafe {
-                        clear_views.push(
-                            self.raw
-                                .create_texture_view(
-                                    &raw_texture,
-                                    &hal::TextureViewDescriptor {
-                                        label: Some("clear texture view"),
-                                        format: desc.format,
-                                        dimension,
-                                        usage,
-                                        range: wgt::ImageSubresourceRange {
-                                            aspect: wgt::TextureAspect::All,
-                                            base_mip_level: mip_level,
-                                            mip_level_count: NonZeroU32::new(1),
-                                            base_array_layer: slice_or_layer,
-                                            array_layer_count: NonZeroU32::new(1),
-                                        },
-                                    },
-                                )
-                                .map_err(DeviceError::from)?,
-                        )
-                    }
+                    let desc = hal::TextureViewDescriptor {
+                        label: Some("clear texture view"),
+                        format: desc.format,
+                        dimension,
+                        usage,
+                        range: wgt::ImageSubresourceRange {
+                            aspect: wgt::TextureAspect::All,
+                            base_mip_level: mip_level,
+                            mip_level_count: NonZeroU32::new(1),
+                            base_array_layer: slice_or_layer,
+                            array_layer_count: NonZeroU32::new(1),
+                        },
+                    };
+                    clear_views.push(
+                        unsafe { self.raw.create_texture_view(&raw_texture, &desc) }
+                            .map_err(DeviceError::from)?,
+                    );
                 }
             }
             resource::TextureClearMode::RenderPass {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -683,7 +683,8 @@ impl<A: HalApi> Device<A> {
                 if format_features
                     .allowed_usages
                     .contains(wgt::TextureUsages::RENDER_ATTACHMENT)
-                    && desc.dimension != wgt::TextureDimension::D3 // Render targets into 3D textures are not 
+                    && desc.dimension != wgt::TextureDimension::D3
+                // Render targets into 3D textures are not
                 {
                     hal::TextureUses::COLOR_TARGET
                 } else {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -712,12 +712,17 @@ impl<A: HalApi> Device<A> {
             let dimension = match desc.dimension {
                 wgt::TextureDimension::D1 => wgt::TextureViewDimension::D1,
                 wgt::TextureDimension::D2 => wgt::TextureViewDimension::D2,
-                wgt::TextureDimension::D3 => wgt::TextureViewDimension::D2, // Todo? Is this even specified?
+                wgt::TextureDimension::D3 => wgt::TextureViewDimension::D3,
             };
 
             let mut clear_views = SmallVec::new();
-            for slice_or_layer in 0..desc.size.depth_or_array_layers {
                 for mip_level in 0..desc.mip_level_count {
+                let num_slices_or_layers = if desc.dimension == wgt::TextureDimension::D3 {
+                    (desc.size.depth_or_array_layers >> mip_level).max(1)
+                } else {
+                    desc.size.depth_or_array_layers
+                };
+                for slice_or_layer in 0..num_slices_or_layers {
                     unsafe {
                         clear_views.push(
                             self.raw

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -13,7 +13,7 @@ use crate::{
     id,
     init_tracker::TextureInitRange,
     resource::{BufferAccessError, BufferMapState, TextureInner},
-    track, FastHashSet, Stored,
+    track, FastHashSet,
 };
 
 use hal::{CommandEncoder as _, Device as _, Queue as _};
@@ -450,10 +450,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     .collect::<Vec<std::ops::Range<u32>>>()
                 {
                     crate::command::clear_texture_no_device(
-                        &Stored {
-                            value: id::Valid(destination.texture),
-                            ref_count: dst.life_guard.ref_count.as_ref().unwrap().clone(),
-                        },
+                        id::Valid(destination.texture),
                         &*dst,
                         TextureInitRange {
                             mip_range: destination.mip_level..(destination.mip_level + 1),

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -11,6 +11,7 @@ use crate::{
     get_lowest_common_denom,
     hub::{Global, GlobalIdentityHandlerFactory, HalApi, Token},
     id,
+    init_tracker::TextureInitRange,
     resource::{BufferAccessError, BufferMapState, TextureInner},
     track, FastHashSet, Stored,
 };
@@ -454,8 +455,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             ref_count: dst.life_guard.ref_count.as_ref().unwrap().clone(),
                         },
                         &*dst,
-                        destination.mip_level..(destination.mip_level + 1),
-                        layer_range,
+                        TextureInitRange {
+                            mip_range: destination.mip_level..(destination.mip_level + 1),
+                            layer_range,
+                        },
                         encoder,
                         &mut trackers.textures,
                         &device.alignments,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -4,7 +4,7 @@ use crate::{
     align_to,
     command::{
         extract_texture_selector, validate_linear_texture_data, validate_texture_copy_range,
-        CommandBuffer, CopySide, ImageCopyTexture, TransferError,
+        ClearError, CommandBuffer, CopySide, ImageCopyTexture, TransferError,
     },
     conv,
     device::{DeviceError, WaitIdleError},
@@ -12,7 +12,7 @@ use crate::{
     hub::{Global, GlobalIdentityHandlerFactory, HalApi, Token},
     id,
     resource::{BufferAccessError, BufferMapState, TextureInner},
-    track, FastHashSet,
+    track, FastHashSet, Stored,
 };
 
 use hal::{CommandEncoder as _, Device as _, Queue as _};
@@ -216,6 +216,8 @@ pub enum QueueWriteError {
     Queue(#[from] DeviceError),
     #[error(transparent)]
     Transfer(#[from] TransferError),
+    #[error(transparent)]
+    Clear(#[from] ClearError),
 }
 
 #[derive(Clone, Debug, Error)]
@@ -377,7 +379,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             return Ok(());
         }
 
-        let (texture_guard, _) = hub.textures.read(&mut token);
+        let (mut texture_guard, _) = hub.textures.write(&mut token); // For clear we need write access to the texture. TODO: Can we acquire write lock later?
         let (selector, dst_base, texture_format) =
             extract_texture_selector(destination, size, &*texture_guard)?;
         let format_desc = texture_format.describe();
@@ -422,7 +424,51 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let stage_size = stage_bytes_per_row as u64 * block_rows_in_copy as u64;
         let stage = device.prepare_stage(stage_size)?;
 
+        let dst = texture_guard.get_mut(destination.texture).unwrap();
+        if !dst.desc.usage.contains(wgt::TextureUsages::COPY_DST) {
+            return Err(
+                TransferError::MissingCopyDstUsageFlag(None, Some(destination.texture)).into(),
+            );
+        }
+
         let mut trackers = device.trackers.lock();
+        let encoder = device.pending_writes.activate();
+
+        // If the copy does not fully cover the layers, we need to initialize to zero *first* as we don't keep track of partial texture layer inits.
+        // Strictly speaking we only need to clear the areas of a layer untouched, but this would get increasingly messy.
+
+        let init_layer_range =
+            destination.origin.z..destination.origin.z + size.depth_or_array_layers;
+        if dst.initialization_status.mips[destination.mip_level as usize]
+            .check(init_layer_range.clone())
+            .is_some()
+        {
+            if size.width != dst.desc.size.width || size.height != dst.desc.size.height {
+                for layer_range in dst.initialization_status.mips[destination.mip_level as usize]
+                    .drain(init_layer_range)
+                    .collect::<Vec<std::ops::Range<u32>>>()
+                {
+                    crate::command::clear_texture_no_device(
+                        &Stored {
+                            value: id::Valid(destination.texture),
+                            ref_count: dst.life_guard.ref_count.as_ref().unwrap().clone(),
+                        },
+                        &*dst,
+                        destination.mip_level..(destination.mip_level + 1),
+                        layer_range,
+                        encoder,
+                        &mut trackers.textures,
+                        &device.alignments,
+                        &device.zero_buffer,
+                    )
+                    .map_err(QueueWriteError::from)?;
+                }
+            } else {
+                dst.initialization_status.mips[destination.mip_level as usize]
+                    .drain(init_layer_range);
+            }
+        }
+
         let (dst, transition) = trackers
             .textures
             .use_replace(
@@ -433,11 +479,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             )
             .unwrap();
 
-        if !dst.desc.usage.contains(wgt::TextureUsages::COPY_DST) {
-            return Err(
-                TransferError::MissingCopyDstUsageFlag(None, Some(destination.texture)).into(),
-            );
-        }
         let (hal_copy_size, array_layer_count) =
             validate_texture_copy_range(destination, &dst.desc, CopySide::Destination, size)?;
         dst.life_guard.use_at(device.active_submission_index + 1);
@@ -512,78 +553,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             usage: hal::BufferUses::MAP_WRITE..hal::BufferUses::COPY_SRC,
         };
 
-        let encoder = device.pending_writes.activate();
+        let dst_raw = dst
+            .inner
+            .as_raw()
+            .ok_or(TransferError::InvalidTexture(destination.texture))?;
+
         unsafe {
             encoder.transition_textures(transition.map(|pending| pending.into_hal(dst)));
             encoder.transition_buffers(iter::once(barrier));
-        }
-
-        // If the copy does not fully cover the layers, we need to initialize to zero *first* as we don't keep track of partial texture layer inits.
-        // Strictly speaking we only need to clear the areas of a layer untouched, but this would get increasingly messy.
-
-        let init_layer_range =
-            destination.origin.z..destination.origin.z + size.depth_or_array_layers;
-        if dst.initialization_status.mips[destination.mip_level as usize]
-            .check(init_layer_range.clone())
-            .is_some()
-        {
-            // For clear we need write access to the texture!
-            drop(texture_guard);
-            let (mut texture_guard, _) = hub.textures.write(&mut token);
-            let dst = texture_guard.get_mut(destination.texture).unwrap();
-            let dst_raw = dst
-                .inner
-                .as_raw()
-                .ok_or(TransferError::InvalidTexture(destination.texture))?;
-
-            let layers_to_initialize = dst.initialization_status.mips
-                [destination.mip_level as usize]
-                .drain(init_layer_range);
-
-            let mut zero_buffer_copy_regions = Vec::new();
-            if size.width != dst.desc.size.width || size.height != dst.desc.size.height {
-                for layer in layers_to_initialize {
-                    crate::command::collect_zero_buffer_copies_for_clear_texture(
-                        &dst.desc,
-                        device.alignments.buffer_copy_pitch.get() as u32,
-                        destination.mip_level..(destination.mip_level + 1),
-                        layer,
-                        &mut zero_buffer_copy_regions,
-                    );
-                }
-            }
-            unsafe {
-                if !zero_buffer_copy_regions.is_empty() {
-                    encoder.copy_buffer_to_texture(
-                        &device.zero_buffer,
-                        dst_raw,
-                        zero_buffer_copy_regions.iter().cloned(),
-                    );
-                    encoder.transition_textures(zero_buffer_copy_regions.iter().map(|copy| {
-                        hal::TextureBarrier {
-                            texture: dst_raw,
-                            range: wgt::ImageSubresourceRange {
-                                aspect: wgt::TextureAspect::All,
-                                base_mip_level: copy.texture_base.mip_level,
-                                mip_level_count: NonZeroU32::new(1),
-                                base_array_layer: copy.texture_base.array_layer,
-                                array_layer_count: NonZeroU32::new(1),
-                            },
-                            usage: hal::TextureUses::COPY_DST..hal::TextureUses::COPY_DST,
-                        }
-                    }));
-                }
-                encoder.copy_buffer_to_texture(&stage.buffer, dst_raw, regions);
-            }
-        } else {
-            let dst_raw = dst
-                .inner
-                .as_raw()
-                .ok_or(TransferError::InvalidTexture(destination.texture))?;
-
-            unsafe {
-                encoder.copy_buffer_to_texture(&stage.buffer, dst_raw, regions);
-            }
+            encoder.copy_buffer_to_texture(&stage.buffer, dst_raw, regions);
         }
 
         device.pending_writes.consume(stage);

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -217,7 +217,7 @@ pub enum QueueWriteError {
     #[error(transparent)]
     Transfer(#[from] TransferError),
     #[error(transparent)]
-    Clear(#[from] ClearError),
+    MemoryInitFailure(#[from] ClearError),
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -649,15 +649,12 @@ impl<A: HalApi, F: GlobalIdentityHandlerFactory> Hub<A, F> {
                         device.raw.destroy_texture(raw);
                     }
                 }
-                match texture.clear_mode {
-                    TextureClearMode::RenderPass(clear_views) => {
-                        for view in clear_views {
-                            unsafe {
-                                device.raw.destroy_texture_view(view);
-                            }
+                if let TextureClearMode::RenderPass(clear_views) = texture.clear_mode {
+                    for view in clear_views {
+                        unsafe {
+                            device.raw.destroy_texture_view(view);
                         }
                     }
-                    _ => {}
                 }
             }
         }

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -644,6 +644,17 @@ impl<A: HalApi, F: GlobalIdentityHandlerFactory> Hub<A, F> {
         for element in self.textures.data.write().map.drain(..) {
             if let Element::Occupied(texture, _) = element {
                 let device = &devices[texture.device_id.value];
+
+                for layer_clear_views in texture.clear_views {
+                    for view in layer_clear_views {
+                        if let Some(view) = view {
+                            unsafe {
+                                device.raw.destroy_texture_view(view);
+                            }
+                        }
+                    }
+                }
+
                 if let TextureInner::Native { raw: Some(raw) } = texture.inner {
                     unsafe {
                         device.raw.destroy_texture(raw);

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -649,7 +649,7 @@ impl<A: HalApi, F: GlobalIdentityHandlerFactory> Hub<A, F> {
                         device.raw.destroy_texture(raw);
                     }
                 }
-                if let TextureClearMode::RenderPass(clear_views) = texture.clear_mode {
+                if let TextureClearMode::RenderPass { clear_views, .. } = texture.clear_mode {
                     for view in clear_views {
                         unsafe {
                             device.raw.destroy_texture_view(view);

--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -20,7 +20,7 @@ mod buffer;
 mod texture;
 
 pub(crate) use buffer::{BufferInitTracker, BufferInitTrackerAction};
-pub(crate) use texture::{TextureInitRange, TextureInitTracker, TextureInitTrackerAction};
+pub(crate) use texture::{TextureInitRange, TextureInitTracker, TextureInitTrackerAction, has_copy_partial_init_tracker_coverage};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum MemoryInitKind {

--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -20,7 +20,10 @@ mod buffer;
 mod texture;
 
 pub(crate) use buffer::{BufferInitTracker, BufferInitTrackerAction};
-pub(crate) use texture::{TextureInitRange, TextureInitTracker, TextureInitTrackerAction, has_copy_partial_init_tracker_coverage};
+pub(crate) use texture::{
+    has_copy_partial_init_tracker_coverage, TextureInitRange, TextureInitTracker,
+    TextureInitTrackerAction,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum MemoryInitKind {

--- a/wgpu-core/src/init_tracker/texture.rs
+++ b/wgpu-core/src/init_tracker/texture.rs
@@ -1,5 +1,5 @@
 use super::{InitTracker, MemoryInitKind};
-use crate::{id::TextureId, track::TextureSelector, Stored};
+use crate::{id::TextureId, track::TextureSelector};
 use arrayvec::ArrayVec;
 use std::ops::Range;
 
@@ -20,7 +20,7 @@ impl From<TextureSelector> for TextureInitRange {
 
 #[derive(Debug, Clone)]
 pub(crate) struct TextureInitTrackerAction {
-    pub(crate) id: Stored<TextureId>,
+    pub(crate) id: TextureId,
     pub(crate) range: TextureInitRange,
     pub(crate) kind: MemoryInitKind,
 }

--- a/wgpu-core/src/init_tracker/texture.rs
+++ b/wgpu-core/src/init_tracker/texture.rs
@@ -83,7 +83,7 @@ impl TextureInitTracker {
 
         if mip_range_start < mip_range_end && layer_range_start < layer_range_end {
             Some(TextureInitTrackerAction {
-                id: action.id.clone(),
+                id: action.id,
                 range: TextureInitRange {
                     mip_range: mip_range_start as u32..mip_range_end as u32,
                     layer_range: layer_range_start..layer_range_end,

--- a/wgpu-core/src/init_tracker/texture.rs
+++ b/wgpu-core/src/init_tracker/texture.rs
@@ -1,5 +1,5 @@
 use super::{InitTracker, MemoryInitKind};
-use crate::{id::TextureId, track::TextureSelector};
+use crate::{id::TextureId, track::TextureSelector, Stored};
 use arrayvec::ArrayVec;
 use std::ops::Range;
 
@@ -20,7 +20,7 @@ impl From<TextureSelector> for TextureInitRange {
 
 #[derive(Debug, Clone)]
 pub(crate) struct TextureInitTrackerAction {
-    pub(crate) id: TextureId,
+    pub(crate) id: Stored<TextureId>,
     pub(crate) range: TextureInitRange,
     pub(crate) kind: MemoryInitKind,
 }
@@ -69,7 +69,7 @@ impl TextureInitTracker {
 
         if mip_range_start < mip_range_end && layer_range_start < layer_range_end {
             Some(TextureInitTrackerAction {
-                id: action.id,
+                id: action.id.clone(),
                 range: TextureInitRange {
                     mip_range: mip_range_start as u32..mip_range_end as u32,
                     layer_range: layer_range_start..layer_range_end,

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -22,6 +22,7 @@ use crate::{
     LifeGuard, Stored,
 };
 
+use arrayvec::ArrayVec;
 use hal::{Queue as _, Surface as _};
 use thiserror::Error;
 use wgt::SurfaceStatus as Status;
@@ -158,6 +159,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         levels: 0..1,
                     },
                     life_guard: LifeGuard::new("<Surface>"),
+                    clear_views: ArrayVec::new(),
                 };
 
                 let ref_count = texture.life_guard.add_ref();

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -9,6 +9,8 @@ When this texture is presented, we remove it from the device tracker as well as
 extract it from the hub.
 !*/
 
+use std::{borrow::Borrow, num::NonZeroU32};
+
 #[cfg(feature = "trace")]
 use crate::device::trace::Action;
 use crate::{
@@ -125,6 +127,31 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let suf = A::get_surface_mut(surface);
         let (texture_id, status) = match unsafe { suf.raw.acquire_texture(FRAME_TIMEOUT_MS) } {
             Ok(Some(ast)) => {
+                let clear_view_desc = hal::TextureViewDescriptor {
+                    label: Some("clear texture view"),
+                    format: config.format,
+                    dimension: wgt::TextureViewDimension::D2,
+                    usage: hal::TextureUses::COLOR_TARGET,
+                    range: wgt::ImageSubresourceRange {
+                        aspect: wgt::TextureAspect::All,
+                        base_mip_level: 0,
+                        mip_level_count: NonZeroU32::new(1),
+                        base_array_layer: 0,
+                        array_layer_count: NonZeroU32::new(1),
+                    },
+                };
+                let mut clear_views = smallvec::SmallVec::new();
+                clear_views.push(
+                    unsafe {
+                        hal::Device::create_texture_view(
+                            &device.raw,
+                            &ast.texture.borrow(),
+                            &clear_view_desc,
+                        )
+                    }
+                    .map_err(DeviceError::from)?,
+                );
+
                 let present = surface.presentation.as_mut().unwrap();
                 let texture = resource::Texture {
                     inner: resource::TextureInner::Surface {
@@ -158,7 +185,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         levels: 0..1,
                     },
                     life_guard: LifeGuard::new("<Surface>"),
-                    clear_mode: resource::TextureClearMode::None, // TODO: Shouldn't there be a view?
+                    clear_mode: resource::TextureClearMode::RenderPass {
+                        clear_views,
+                        is_color: true,
+                    },
                 };
 
                 let ref_count = texture.life_guard.add_ref();
@@ -240,6 +270,16 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let (texture, _) = hub.textures.unregister(texture_id.value.0, &mut token);
             if let Some(texture) = texture {
+                if let resource::TextureClearMode::RenderPass { clear_views, .. } =
+                    texture.clear_mode
+                {
+                    for clear_view in clear_views {
+                        unsafe {
+                            hal::Device::destroy_texture_view(&device.raw, clear_view);
+                        }
+                    }
+                }
+
                 let suf = A::get_surface_mut(surface);
                 match texture.inner {
                     resource::TextureInner::Surface {

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -22,7 +22,6 @@ use crate::{
     LifeGuard, Stored,
 };
 
-use arrayvec::ArrayVec;
 use hal::{Queue as _, Surface as _};
 use thiserror::Error;
 use wgt::SurfaceStatus as Status;
@@ -159,7 +158,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         levels: 0..1,
                     },
                     life_guard: LifeGuard::new("<Surface>"),
-                    clear_views: ArrayVec::new(),
+                    clear_mode: resource::TextureClearMode::None, // TODO: Shouldn't there be a view?
                 };
 
                 let ref_count = texture.life_guard.add_ref();

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -238,7 +238,7 @@ impl<A: hal::Api> Texture<A> {
                         dimension: match self.desc.dimension {
                             wgt::TextureDimension::D1 => wgt::TextureViewDimension::D1,
                             wgt::TextureDimension::D2 => wgt::TextureViewDimension::D2,
-                            wgt::TextureDimension::D3 => wgt::TextureViewDimension::D3,
+                            wgt::TextureDimension::D3 => panic!("Can't create clear view for D3 textures. Use clear via copy instead."),
                         },
                         usage: if self.desc.format.describe().sample_type
                             == wgt::TextureSampleType::Depth
@@ -328,6 +328,8 @@ pub enum TextureDimensionError {
 pub enum CreateTextureError {
     #[error(transparent)]
     Device(#[from] DeviceError),
+    #[error("Depth Texture format {0:?} can't be used for volume textures")]
+    CannotCreateDepthVolumeTexture(wgt::TextureFormat),
     #[error("Textures cannot have empty usage flags")]
     EmptyUsage,
     #[error(transparent)]

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -183,7 +183,10 @@ impl<A: hal::Api> TextureInner<A> {
 pub enum TextureClearMode<A: hal::Api> {
     BufferCopy,
     // View for clear via RenderPass for every subsurface
-    RenderPass(SmallVec<[A::TextureView; 1]>),
+    RenderPass {
+        clear_views: SmallVec<[A::TextureView; 1]>,
+        is_color: bool,
+    },
     // Texture can't be cleared, attempting to do so will cause panic.
     // (either because it is impossible for the type of texture or it is being destroyed)
     None,
@@ -211,7 +214,7 @@ impl<A: hal::Api> Texture<A> {
             TextureClearMode::None => {
                 panic!("Given texture can't be cleared")
             }
-            TextureClearMode::RenderPass(ref clear_views) => {
+            TextureClearMode::RenderPass{ ref clear_views, .. } => {
                 let index = mip_level + depth_or_layer * self.desc.mip_level_count;
                 &clear_views[index as usize]
             }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -204,14 +204,14 @@ pub struct Texture<A: hal::Api> {
 
 impl<A: hal::Api> Texture<A> {
     pub(crate) fn get_clear_view(&self, mip_level: u32, depth_or_layer: u32) -> &A::TextureView {
-        match &self.clear_mode {
+        match self.clear_mode {
             TextureClearMode::BufferCopy => {
                 panic!("Given texture is cleared with buffer copies, not render passes")
             }
             TextureClearMode::None => {
                 panic!("Given texture can't be cleared")
             }
-            TextureClearMode::RenderPass(clear_views) => {
+            TextureClearMode::RenderPass(ref clear_views) => {
                 let index = mip_level + depth_or_layer * self.desc.mip_level_count;
                 &clear_views[index as usize]
             }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -186,7 +186,7 @@ impl super::Adapter {
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | wgt::Features::TIMESTAMP_QUERY
             | wgt::Features::TEXTURE_COMPRESSION_BC
-            | wgt::Features::CLEAR_COMMANDS
+            | wgt::Features::CLEAR_TEXTURE
             | wgt::Features::TEXTURE_FORMAT_16BIT_NORM;
         //TODO: in order to expose this, we need to run a compute shader
         // that extract the necessary statistics out of the D3D12 result.

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -286,7 +286,7 @@ impl super::Adapter {
 
         let mut features = wgt::Features::empty()
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | wgt::Features::CLEAR_COMMANDS;
+            | wgt::Features::CLEAR_TEXTURE;
         features.set(
             wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER,
             extensions.contains("GL_EXT_texture_border_clamp"),

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -920,7 +920,7 @@ impl super::PrivateCapabilities {
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | F::PUSH_CONSTANTS
             | F::POLYGON_MODE_LINE
-            | F::CLEAR_COMMANDS
+            | F::CLEAR_TEXTURE
             | F::TEXTURE_FORMAT_16BIT_NORM;
 
         features.set(F::DEPTH_CLIP_CONTROL, self.supports_depth_clip_control);

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -332,7 +332,7 @@ impl PhysicalDeviceFeatures {
             | F::TIMESTAMP_QUERY
             | F::PIPELINE_STATISTICS_QUERY
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | F::CLEAR_COMMANDS;
+            | F::CLEAR_TEXTURE;
         let mut dl_flags = Df::all();
 
         dl_flags.set(Df::CUBE_ARRAY_TEXTURES, self.core.image_cube_array != 0);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -505,13 +505,13 @@ bitflags::bitflags! {
         ///
         /// This is a native-only feature.
         const VERTEX_WRITABLE_STORAGE = 1 << 36;
-        /// Enables clear to zero for buffers & textures.
+        /// Enables clear to zero for textures.
         ///
         /// Supported platforms:
         /// - All
         ///
         /// This is a native only feature.
-        const CLEAR_COMMANDS = 1 << 37;
+        const CLEAR_TEXTURE = 1 << 37;
         /// Enables creating shader modules from SPIR-V binary data (unsafe).
         ///
         /// SPIR-V data is not parsed or interpreted in any way; you can use

--- a/wgpu/examples/boids/main.rs
+++ b/wgpu/examples/boids/main.rs
@@ -279,7 +279,9 @@ impl framework::Example for Example {
             view,
             resolve_target: None,
             ops: wgpu::Operations {
-                load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                // Not clearing here in order to test wgpu's zero texture initialization on a surface texture.
+                // Users should avoid loading uninitialized memory since this can cause additional overhead.
+                load: wgpu::LoadOp::Load,
                 store: true,
             },
         }];

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2383,12 +2383,16 @@ impl CommandEncoder {
 
     /// Clears texture to zero.
     ///
-    /// Where possible it may be significantly more efficient to perform clears via render passes!
+    /// Note that unlike with clear_buffer, `COPY_DST` usage is not required.
+    ///
+    /// # Implementation notes
+    ///
+    /// - implemented either via buffer copies, render/depth target clear
+    /// - behaves like texture zero init, but is performed immediately (clearing is *not* delayed via marking it as uninitialized)
     ///
     /// # Panics
     ///
     /// - `CLEAR_COMMANDS` extension not enabled
-    /// - Texture does not have `COPY_DST` usage.
     /// - Range is out of bounds
     pub fn clear_texture(&mut self, texture: &Texture, subresource_range: &ImageSubresourceRange) {
         Context::command_encoder_clear_texture(
@@ -2400,6 +2404,12 @@ impl CommandEncoder {
     }
 
     /// Clears buffer to zero.
+    ///
+    /// # Implementation notes
+    ///
+    /// - implemented via backend specific function which may be emulated with buffer copies
+    /// - behaves like delayed buffer zero init (i.e. lazy zero init for buffers that weren't mapped at creation),
+    ///   but is performed immediately (clearing is *not* delayed via marking it as uninitialized)
     ///
     /// # Panics
     ///

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2387,12 +2387,12 @@ impl CommandEncoder {
     ///
     /// # Implementation notes
     ///
-    /// - implemented either via buffer copies, render/depth target clear
+    /// - implemented either via buffer copies and render/depth target clear, path depends on texture usages
     /// - behaves like texture zero init, but is performed immediately (clearing is *not* delayed via marking it as uninitialized)
     ///
     /// # Panics
     ///
-    /// - `CLEAR_COMMANDS` extension not enabled
+    /// - `CLEAR_TEXTURE` extension not enabled
     /// - Range is out of bounds
     pub fn clear_texture(&mut self, texture: &Texture, subresource_range: &ImageSubresourceRange) {
         Context::command_encoder_clear_texture(
@@ -2404,12 +2404,6 @@ impl CommandEncoder {
     }
 
     /// Clears buffer to zero.
-    ///
-    /// # Implementation notes
-    ///
-    /// - implemented via backend specific function which may be emulated with buffer copies
-    /// - behaves like delayed buffer zero init (i.e. lazy zero init for buffers that weren't mapped at creation),
-    ///   but is performed immediately (clearing is *not* delayed via marking it as uninitialized)
     ///
     /// # Panics
     ///

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -207,7 +207,7 @@ fn clear_texture_tests(ctx: &TestingContext, formats: &[wgpu::TextureFormat], su
 #[test]
 fn clear_texture_2d_uncompressed() {
     initialize_test(
-        TestParameters::default().features(wgpu::Features::CLEAR_COMMANDS),
+        TestParameters::default().features(wgpu::Features::CLEAR_TEXTURE),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_UNCOMPRESSED, true);
         },
@@ -218,7 +218,7 @@ fn clear_texture_2d_uncompressed() {
 fn clear_texture_2d_bc() {
     initialize_test(
         TestParameters::default()
-            .features(wgpu::Features::CLEAR_COMMANDS | wgpu::Features::TEXTURE_COMPRESSION_BC),
+            .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_BC),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_BC, false);
         },
@@ -228,9 +228,8 @@ fn clear_texture_2d_bc() {
 #[test]
 fn clear_texture_2d_astc() {
     initialize_test(
-        TestParameters::default().features(
-            wgpu::Features::CLEAR_COMMANDS | wgpu::Features::TEXTURE_COMPRESSION_ASTC_LDR,
-        ),
+        TestParameters::default()
+            .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_ASTC_LDR),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_ASTC, false);
         },
@@ -241,7 +240,7 @@ fn clear_texture_2d_astc() {
 fn clear_texture_2d_etc2() {
     initialize_test(
         TestParameters::default()
-            .features(wgpu::Features::CLEAR_COMMANDS | wgpu::Features::TEXTURE_COMPRESSION_ETC2),
+            .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_ETC2),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_ETC2, false);
         },

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -131,7 +131,9 @@ fn single_texture_clear_test(
         sample_count: 1, // multisampling is not supported for clear
         dimension,
         format,
-        usage: wgpu::TextureUsages::COPY_DST,
+        // Forces internally the required usages to be able to clear it.
+        // This is not visible on the API level.
+        usage: wgpu::TextureUsages::TEXTURE_BINDING,
     });
     let mut encoder = ctx
         .device

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -112,11 +112,6 @@ fn single_texture_clear_test(
     size: wgpu::Extent3d,
     dimension: wgpu::TextureDimension,
 ) {
-    // clear_texture not supported for depth textures.
-    if format.describe().sample_type == wgpu::TextureSampleType::Depth {
-        return;
-    }
-
     println!("clearing texture with {:?}", format);
 
     let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -112,7 +112,10 @@ fn single_texture_clear_test(
     size: wgpu::Extent3d,
     dimension: wgpu::TextureDimension,
 ) {
-    println!("clearing texture with {:?}", format);
+    println!(
+        "clearing texture with {:?}, dimension {:?}, size {:?}",
+        format, dimension, size
+    );
 
     let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
         label: Some(&format!("texture {:?}", format)),
@@ -186,16 +189,18 @@ fn clear_texture_tests(ctx: &TestingContext, formats: &[wgpu::TextureFormat], su
             wgpu::TextureDimension::D2,
         );
         // volume texture
-        single_texture_clear_test(
-            ctx,
-            format,
-            wgpu::Extent3d {
-                width: 16,
-                height: 16,
-                depth_or_array_layers: 16,
-            },
-            wgpu::TextureDimension::D3,
-        );
+        if format.describe().sample_type != wgt::TextureSampleType::Depth {
+            single_texture_clear_test(
+                ctx,
+                format,
+                wgpu::Extent3d {
+                    width: 16,
+                    height: 16,
+                    depth_or_array_layers: 16,
+                },
+                wgpu::TextureDimension::D3,
+            );
+        }
     }
 }
 

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -36,10 +36,13 @@ static TEXTURE_FORMATS_UNCOMPRESSED: &[wgpu::TextureFormat] = &[
     wgpu::TextureFormat::Rgba32Uint,
     wgpu::TextureFormat::Rgba32Sint,
     wgpu::TextureFormat::Rgba32Float,
+    wgpu::TextureFormat::Rgb9e5Ufloat,
+];
+
+static TEXTURE_FORMATS_DEPTH: &[wgpu::TextureFormat] = &[
     wgpu::TextureFormat::Depth32Float,
     wgpu::TextureFormat::Depth24Plus,
     wgpu::TextureFormat::Depth24PlusStencil8,
-    wgpu::TextureFormat::Rgb9e5Ufloat,
 ];
 
 // needs TEXTURE_COMPRESSION_BC
@@ -210,6 +213,7 @@ fn clear_texture_2d_uncompressed() {
         TestParameters::default().features(wgpu::Features::CLEAR_TEXTURE),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_UNCOMPRESSED, true);
+            clear_texture_tests(&ctx, TEXTURE_FORMATS_DEPTH, false);
         },
     )
 }


### PR DESCRIPTION
**Connections**
Should fix #2149 - haven't confirmed since I don't a repro at hand.
Changes clear extension semantics a bit as discussed on #2174

**Description**
Previously, render target/depth textures couldn't be initialized at all if they not also were COPY_DST, violating the spec.
Now, we always will use render passes when possible since it's expected to be faster.

All this comes with an overhaul of the texture clearing mechanisms as we tried to optimize things based on the assumption of texture-init == copy zero_buffer:
* Textures now know their `TextureClearMode` which may bring with it pre-created render views for clearing
* I consolidated all texture clears to go through more similar code paths. In some cases this trades performance against maintainability of the code, but imho it looks like a better starting point for optimizations now

Other smaller but important things in this PR:
* Rename CLEAR_COMMANDS to CLEAR_TEXTURE and change semantics a bit (see doc changes)
* creation of 3D depth texture will cause an error now, see also https://github.com/gpuweb/gpuweb/issues/2304

**Testing**
Tests in tests/clear_texture.rs clear now depth/stencil formats as well (this was not possible previously)
Ran `cargo test` locally (win10)