### PR TITLE
Make ShaderSource #[non_exhaustive]

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -753,6 +753,7 @@ impl Drop for ShaderModule {
 }
 
 /// Source of a shader module.
+#[non_exhaustive]
 pub enum ShaderSource<'a> {
     /// SPIR-V module represented as a slice of words.
     ///


### PR DESCRIPTION
**Connections**
N/A

**Description**
Users should not exhaustively match on `ShaderSource` due to variants that are only exposed via feature flags. This patch ensures that they don't do so accidentally.

**Testing**
None