### PR TITLE
explicitly set Vulkan debug message types instead of !empty()

### DIFF
--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -208,7 +208,11 @@ impl super::Instance {
             let vk_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
                 .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
                 .message_severity(severity)
-                .message_type(!vk::DebugUtilsMessageTypeFlagsEXT::empty())
+                .message_type(
+                    vk::DebugUtilsMessageTypeFlagsEXT::GENERAL
+                        | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION
+                        | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE,
+                )
                 .pfn_user_callback(Some(debug_utils_messenger_callback));
             let messenger = extension
                 .create_debug_utils_messenger(&vk_info, None)


### PR DESCRIPTION
**Connections**
Did not create an issue for this to reduce overhead.

**Description**
Fixes:
* The Vulkan spec states: messageType must be a valid combination of VkDebugUtilsMessageTypeFlagBitsEXT values

Full message:
```
VUID-VkDebugUtilsMessengerCreateInfoEXT-messageType-parameter(ERROR / SPEC): msgNum: -553000032 - Validation Error: [ VUID-VkDebugUtilsMessengerCreateInfoEXT-messageType-parameter ] Object 0: VK_NULL_HANDLE, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xdf09e3a0 | vkCreateDebugUtilsMessengerEXT: value of pCreateInfo->messageType contains flag bits that are not recognized members of VkDebugUtilsMessageTypeFlagBitsEXT The Vulkan spec states: messageType must be a valid combination of VkDebugUtilsMessageTypeFlagBitsEXT values (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkDebugUtilsMessengerCreateInfoEXT-messageType-parameter)
    Objects: 1
        [0] 0, type: 3, name: NULL
```

**Testing**
Ran a few examples in debug and release mode.