### PR TITLE
Clamp surface extent to within the supported range

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4558,19 +4558,25 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             config: &mut hal::SurfaceConfiguration,
             caps: &hal::SurfaceCapabilities,
         ) -> Result<(), E> {
-            let width = config.extent.width;
-            let height = config.extent.height;
-            if width < caps.extents.start().width
-                || width > caps.extents.end().width
-                || height < caps.extents.start().height
-                || height > caps.extents.end().height
+            let config_width = config.extent.width;
+            let config_height = config.extent.height;
+            let min_width = caps.extents.start().width;
+            let max_width = caps.extents.end().width;
+            let min_height = caps.extents.start().height;
+            let max_height = caps.extents.end().height;
+            if config_width < min_width
+                || config_width > max_width
+                || config_height < min_height
+                || config_height > max_height
             {
                 log::warn!(
-                    "Requested size {}x{} is outside of the supported range: {:?}",
-                    width,
-                    height,
+                    "Requested size {}x{} is outside of the supported range: {:?}, clamping size into supported range",
+                    config_width,
+                    config_height,
                     caps.extents
                 );
+                config.extent.width = config_width.clamp(min_width, max_width);
+                config.extent.height = config_height.clamp(min_height, max_height);
             }
             if !caps.present_modes.contains(&config.present_mode) {
                 log::warn!(
@@ -4588,7 +4594,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             if !caps.usage.contains(config.usage) {
                 return Err(E::UnsupportedUsage);
             }
-            if width == 0 || height == 0 {
+            if config.extent.width == 0 || config.extent.height == 0 {
                 return Err(E::ZeroArea);
             }
             Ok(())


### PR DESCRIPTION
**Connections**
Fixes #2286

**Description**
When running any of the wgpu samples with the Vulkan backend (at least on Windows), they trip a validation error:
```
[2021-12-28T14:25:22Z ERROR wgpu_hal::vulkan::instance] VALIDATION [VUID-VkSwapchainCreateInfoKHR-imageExtent-01274 (0x7cd0911d)]
        Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageExtent-01274 ] Object 0: handle = 0x24223725ad0, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x7cd0911d | vkCreateSwapchainKHR() called with imageExtent = (2858,1494), which is outside the bounds returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR(): currentExtent = (800,600), minImageExtent = (800,600), maxImageExtent = (800,600). The Vulkan spec states: imageExtent must be between minImageExtent and maxImageExtent, inclusive, where minImageExtent and maxImageExtent are members of the VkSurfaceCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR for the surface (https://vulkan.lunarg.com/doc/view/1.2.198.1/windows/1.2-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageExtent-01274)
```

This bizarre surface size request seems to be caused by a winit bug, but wgpu should handle this gracefully without violating the Vulkan spec.

To address this, I added a fallback path in `validate_surface_configuration` so that if the requested surface extents are outside of the valid range, then they will be clamped into the valid range.

**Testing**
The examples should now appear correctly without the Vulkan validation error above.
I also ran `cargo test` to be safe, although it did not trigger any validation errors in the first place.