### PR TITLE
Update ash to `0.35`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.34.0+1.2.203"
+version = "0.35.0+1.2.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df"
+checksum = "5a7638ce84f8c84d6fd6faa63aa267574d345181ba591c0eeb5550d4c30cd600"
 dependencies = [
  "libloading",
 ]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -37,7 +37,7 @@ block = { version = "0.1", optional = true }
 foreign-types = { version = "0.3", optional = true }
 
 # backend: Vulkan
-ash = { version = "0.34", optional = true, default-features = false, features = ["debug", "loaded"] }
+ash = { version = "0.35", optional = true }
 gpu-alloc = { version = "0.5", optional = true }
 gpu-descriptor = { version = "0.2", optional = true }
 inplace_it = { version ="0.3.3", optional = true }


### PR DESCRIPTION
Hopefully they don't start releasing breaking versions every week.

**Testing**
Ran some examples
