### PR TITLE
Improve detection and validation of cubemap views

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -295,12 +295,12 @@ pub enum TextureDimensionError {
 pub enum CreateTextureError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("Depth Texture format {0:?} can't be used for volume textures")]
-    CannotCreateDepthVolumeTexture(wgt::TextureFormat),
     #[error("Textures cannot have empty usage flags")]
     EmptyUsage,
     #[error(transparent)]
     InvalidDimension(#[from] TextureDimensionError),
+    #[error("Depth texture kind {0:?} of format {0:?} can't be created")]
+    InvalidDepthKind(wgt::TextureDimension, wgt::TextureFormat),
     #[error("texture descriptor mip level count ({0}) is invalid")]
     InvalidMipLevelCount(u32),
     #[error("The texture usages {0:?} are not allowed on a texture of type {1:?}")]
@@ -382,6 +382,8 @@ pub enum CreateTextureViewError {
         view: wgt::TextureViewDimension,
         texture: wgt::TextureDimension,
     },
+    #[error("Invalid texture view dimension `{0:?}` of a multisampled texture")]
+    InvalidMultisampledTextureViewDimension(wgt::TextureViewDimension),
     #[error("Invalid texture depth `{depth}` for texture view of dimension `Cubemap`. Cubemap views must use images of size 6.")]
     InvalidCubemapTextureDepth { depth: u32 },
     #[error("Invalid texture depth `{depth}` for texture view of dimension `CubemapArray`. Cubemap views must use images with sizes which are a multiple of 6.")]

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -563,6 +563,7 @@ impl crate::Device<super::Api> for super::Device {
                         //HACK: detect a cube map
                         let cube_count = if desc.size.width == desc.size.height
                             && desc.size.depth_or_array_layers % 6 == 0
+                            && desc.sample_count == 1
                         {
                             Some(desc.size.depth_or_array_layers / 6)
                         } else {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -806,7 +806,11 @@ impl crate::Device<super::Api> for super::Device {
         let copy_size = conv::map_extent_to_copy_size(&desc.size, desc.dimension);
 
         let mut raw_flags = vk::ImageCreateFlags::empty();
-        if desc.dimension == wgt::TextureDimension::D2 && desc.size.depth_or_array_layers % 6 == 0 {
+        if desc.dimension == wgt::TextureDimension::D2
+            && desc.size.depth_or_array_layers % 6 == 0
+            && desc.sample_count == 1
+            && desc.size.width == desc.size.height
+        {
             raw_flags |= vk::ImageCreateFlags::CUBE_COMPATIBLE;
         }
 


### PR DESCRIPTION
**Connections**
Loosely connected to https://github.com/gpuweb/gpuweb/pull/2463
Fixes  #2323

**Description**
Vulkan doesn't allow cubemaps to be multisampled. So here we are doing 2 things:
  1. adding relevant validation to the view creation
  2. reducing the set of cases where we tell Vulkan to support cubemaps

**Testing**
Untested
