### PR TITLE
Fix trac(y/ing) compile issue

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -535,7 +535,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             None => return,
         };
 
-        profiling::scope!("enumerating", format!("{:?}", A::VARIANT));
+        profiling::scope!("enumerating", &*format!("{:?}", A::VARIANT));
         let hub = HalApi::hub(self);
         let mut token = Token::root();
 


### PR DESCRIPTION
**Connections**

#2332 but for master and with a CI fix

**Description**

Added a CI flag to turn on `tracing`, profiling which seems to be a bit more restrictive of actual errors we will hit.

**Testing**

rend3