### PR TITLE
Don't create array layer trackers for 3D textures.

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -618,7 +618,7 @@ impl<A: HalApi> Device<A> {
             format_features,
             initialization_status: TextureInitTracker::new(
                 desc.mip_level_count,
-                desc.size.depth_or_array_layers,
+                desc.array_layer_count(),
             ),
             full_range: TextureSelector {
                 levels: 0..desc.mip_level_count,


### PR DESCRIPTION
**Connections**
Fixes #2347 

**Description**
Avoids a bunch of extra erroneous clears for array layers for 3D image.
