### PR TITLE
Add raw_device method for dx12, vulkan hal

### DIFF
--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -283,6 +283,10 @@ impl super::Device {
         result
     }
 
+    pub fn raw_device(&self) -> &native::Device {
+        &self.raw
+    }
+
     pub unsafe fn texture_from_raw(
         resource: native::Resource,
         format: wgt::TextureFormat,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -677,6 +677,10 @@ impl super::Device {
             },
         })
     }
+
+    pub fn raw_device(&self) -> &ash::Device {
+        &self.shared.raw
+    }
 }
 
 impl crate::Device<super::Api> for super::Device {


### PR DESCRIPTION
**Description**

Add `raw_device` method for dx12 and vulkan hal, just like metal hal.
