### PR TITLE
hal: limit binding sizes to i32

### DIFF
--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -15,6 +15,12 @@ pub mod db {
     }
 }
 
+/// Maximum binding size for the shaders that only support `i32` indexing.
+/// Interestingly, the index itself can't reach that high, because the minimum
+/// element size is 4 bytes, but the compiler toolchain still computes the
+/// offset at some intermediate point, internally, as i32.
+pub const MAX_I32_BINDING_SIZE: u32 = 1 << 31;
+
 pub fn map_naga_stage(stage: naga::ShaderStage) -> wgt::ShaderStages {
     match stage {
         naga::ShaderStage::Vertex => wgt::ShaderStages::VERTEX,

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -240,7 +240,7 @@ impl super::Adapter {
                     max_uniform_buffers_per_shader_stage: full_heap_count,
                     max_uniform_buffer_binding_size: d3d12::D3D12_REQ_CONSTANT_BUFFER_ELEMENT_COUNT
                         * 16,
-                    max_storage_buffer_binding_size: !0,
+                    max_storage_buffer_binding_size: crate::auxil::MAX_I32_BINDING_SIZE,
                     max_vertex_buffers: d3d12::D3D12_VS_INPUT_REGISTER_COUNT
                         .min(crate::MAX_VERTEX_BUFFERS as u32),
                     max_vertex_attributes: d3d12::D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -708,8 +708,12 @@ impl PhysicalDeviceCapabilities {
             max_storage_buffers_per_shader_stage: max_storage_buffers,
             max_storage_textures_per_shader_stage: max_storage_textures,
             max_uniform_buffers_per_shader_stage: max_uniform_buffers,
-            max_uniform_buffer_binding_size: limits.max_uniform_buffer_range,
-            max_storage_buffer_binding_size: limits.max_storage_buffer_range,
+            max_uniform_buffer_binding_size: limits
+                .max_uniform_buffer_range
+                .min(crate::auxil::MAX_I32_BINDING_SIZE),
+            max_storage_buffer_binding_size: limits
+                .max_storage_buffer_range
+                .min(crate::auxil::MAX_I32_BINDING_SIZE),
             max_vertex_buffers: limits
                 .max_vertex_input_bindings
                 .min(crate::MAX_VERTEX_BUFFERS as u32),


### PR DESCRIPTION
**Connections**
Closes #2361

**Description**
Driver compiler toolchain produce an offset as i32 internally, we can't expose bindings larger than that until we start doing 64-bit indexing.

**Testing**
Untested
