### PR TITLE
metal: Set preserveInvariance for shader options

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -979,6 +979,11 @@ impl super::PrivateCapabilities {
             supports_depth_clip_control: device
                 .supports_feature_set(MTLFeatureSet::iOS_GPUFamily4_v1)
                 || os_is_mac,
+            supports_preserve_invariance: if os_is_mac {
+                Self::version_at_least(major, minor, 11, 0)
+            } else {
+                Self::version_at_least(major, minor, 13, 0)
+            },
         }
     }
 

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -76,6 +76,10 @@ impl super::Device {
         let options = mtl::CompileOptions::new();
         options.set_language_version(self.shared.private_caps.msl_version);
 
+        if self.shared.private_caps.supports_preserve_invariance {
+            options.set_preserve_invariance(true);
+        }
+
         let library = self
             .shared
             .device

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -229,6 +229,7 @@ struct PrivateCapabilities {
     supports_arrays_of_textures_write: bool,
     supports_mutability: bool,
     supports_depth_clip_control: bool,
+    supports_preserve_invariance: bool,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This fixes, for example, depth prepass resulting in ever so slightly
different depth values for later render passes.

**Connections**
BVE-Reborn/rend3#317

**Description**
By default, metal enables "fastMath" optimizations for shaders, which may result in ever so slightly values for, for example depth, or other values. Setting the `preserveInvariance` pessimizes this for vertex shader locations, so that depth prepasses work consistently.

**Testing**
With rend3 examples
