### PR TITLE
Limits 1D texture mips to 1

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -671,8 +671,12 @@ impl<A: HalApi> Device<A> {
         )?;
 
         let mips = desc.mip_level_count;
-        if mips == 0 || mips > hal::MAX_MIP_LEVELS || mips > desc.size.max_mips() {
-            return Err(resource::CreateTextureError::InvalidMipLevelCount(mips));
+        let max_levels_allowed = desc.size.max_mips(desc.dimension).min(hal::MAX_MIP_LEVELS);
+        if mips == 0 || mips > max_levels_allowed {
+            return Err(resource::CreateTextureError::InvalidMipLevelCount {
+                requested: mips,
+                maximum: max_levels_allowed,
+            });
         }
 
         // Enforce having COPY_DST/DEPTH_STENCIL_WRIT/COLOR_TARGET otherwise we wouldn't be able to initialize the texture.

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -301,9 +301,11 @@ pub enum CreateTextureError {
     InvalidDimension(#[from] TextureDimensionError),
     #[error("Depth texture kind {0:?} of format {0:?} can't be created")]
     InvalidDepthKind(wgt::TextureDimension, wgt::TextureFormat),
-    #[error("texture descriptor mip level count ({0}) is invalid")]
-    InvalidMipLevelCount(u32),
-    #[error("The texture usages {0:?} are not allowed on a texture of type {1:?}")]
+    #[error(
+        "Texture descriptor mip level count {requested} is invalid, maximum allowed is {maximum}"
+    )]
+    InvalidMipLevelCount { requested: u32, maximum: u32 },
+    #[error("Texture usages {0:?} are not allowed on a texture of type {1:?}")]
     InvalidUsages(wgt::TextureUsages, wgt::TextureFormat),
     #[error("Texture format {0:?} can't be used")]
     MissingFeatures(wgt::TextureFormat, #[source] MissingFeatures),

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -295,7 +295,7 @@ impl framework::Example for Skybox {
             depth_or_array_layers: 1,
             ..size
         };
-        let max_mips = layer_size.max_mips();
+        let max_mips = layer_size.max_mips(wgpu::TextureDimension::D2);
 
         log::debug!(
             "Copying {:?} skybox images of size {}, {}, 6 with {} mips to gpu",


### PR DESCRIPTION
**Connections**
Matches https://github.com/gpuweb/gpuweb/pull/2491

**Description**
Moare validation!
Also, moves the tests out of the doc tests.
They look much better when they are actual Rust code.

**Testing**
Untested
