### PR TITLE
hal/gles: fix index buffer state not being reset in reset_state

### DIFF
--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -59,7 +59,7 @@ impl super::Queue {
         }
     }
 
-    unsafe fn reset_state(&self, gl: &glow::Context) {
+    unsafe fn reset_state(&mut self, gl: &glow::Context) {
         gl.use_program(None);
         gl.bind_framebuffer(glow::FRAMEBUFFER, None);
         gl.disable(glow::DEPTH_TEST);
@@ -71,6 +71,9 @@ impl super::Queue {
         if self.features.contains(wgt::Features::DEPTH_CLIP_CONTROL) {
             gl.disable(glow::DEPTH_CLAMP);
         }
+
+        gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
+        self.current_index_buffer = None;
     }
 
     unsafe fn set_attachment(


### PR DESCRIPTION
**Connections**

Fixes #2378

**Description**

See discussion in #2378 for the full background.

This fixes a webgl2 crash that I have been experiencing. The [old gfx gl implementation](https://github.com/gfx-rs/gfx/blob/master/src/backend/gl/src/queue.rs#L222) that hal/gles is based on did the same thing and this seemingly was an unintentional omission when porting it.

**Testing**

Tested webgl examples that are expected to work

- [X] cube
- [X] hello-triangle
- [X] msaa-line
- [X] shadow
- [X] skybox
- [X] water

I observed some unpleasant flickering in cube both with and without these changes.