### PR TITLE
hal/gl: Allow push constants trough emulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.8.0"
-source = "git+https://github.com/JCapucho/naga?branch=glsl-out-push-constants-v2#c60d70eddf99d5858747d0a7823ab79c8cd0d019"
+source = "git+https://github.com/gfx-rs/naga?rev=81dc674#81dc67402a743b4dc6b2d24c0d306cd18799238b"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.8.0"
-source = "git+https://github.com/gfx-rs/naga?rev=a1840be#a1840beb1a96c9a49980fe3efa8e2f3dcd88abe6"
+source = "git+https://github.com/JCapucho/naga?branch=glsl-out-push-constants-v2#c60d70eddf99d5858747d0a7823ab79c8cd0d019"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ default-members = ["wgpu", "wgpu-hal", "wgpu-info"]
 
 [patch."https://github.com/gfx-rs/naga"]
 #naga = { path = "../naga" }
-naga = { git = "https://github.com/JCapucho/naga", branch = "glsl-out-push-constants-v2" }
 
 [patch."https://github.com/zakarumych/gpu-descriptor"]
 #gpu-descriptor = { path = "../gpu-descriptor/gpu-descriptor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default-members = ["wgpu", "wgpu-hal", "wgpu-info"]
 
 [patch."https://github.com/gfx-rs/naga"]
 #naga = { path = "../naga" }
+naga = { git = "https://github.com/JCapucho/naga", branch = "glsl-out-push-constants-v2" }
 
 [patch."https://github.com/zakarumych/gpu-descriptor"]
 #gpu-descriptor = { path = "../gpu-descriptor/gpu-descriptor" }

--- a/cts_runner/examples/hello-compute.js
+++ b/cts_runner/examples/hello-compute.js
@@ -4,11 +4,12 @@ const numbers = [1, 4, 3, 295];
 
 const device = await adapter.requestDevice();
 
-const shaderCode = `[[block]]
+const shaderCode = `@block
 struct PrimeIndices {
-    data: [[stride(4)]] array<u32>;
+    data: @stride(4) array<u32>;
 }; // this is used as both input and output for convenience
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var<storage, read_write> v_indices: PrimeIndices;
 // The Collatz Conjecture states that for any integer n:
 // If n is even, n = n/2
@@ -37,8 +38,9 @@ fn collatz_iterations(n_base: u32) -> u32{
     }
     return i;
 }
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute)
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     v_indices.data[global_id.x] = collatz_iterations(v_indices.data[global_id.x]);
 }`;
 

--- a/player/tests/data/empty.wgsl
+++ b/player/tests/data/empty.wgsl
@@ -1,3 +1,4 @@
-[[stage(compute), workgroup_size(1)]]
+@stage(compute)
+@workgroup_size(1)
 fn main() {
 }

--- a/player/tests/data/quad.wgsl
+++ b/player/tests/data/quad.wgsl
@@ -1,5 +1,5 @@
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> [[builtin(position)]] vec4<f32> {
+@stage(vertex)
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
     // hacky way to draw a large triangle
     let tmp1 = i32(vertex_index) / 2;
     let tmp2 = i32(vertex_index) & 1;
@@ -10,7 +10,7 @@ fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> [[builtin(position)]]
     return vec4<f32>(pos, 0.0, 1.0);
 }
 
-[[stage(fragment)]]
-fn fs_main() -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main() -> @location(0) vec4<f32> {
     return vec4<f32>(1.0, 1.0, 1.0, 1.0);
 }

--- a/player/tests/data/zero-init-buffer-for-binding.wgsl
+++ b/player/tests/data/zero-init-buffer-for-binding.wgsl
@@ -1,11 +1,13 @@
 struct InOutBuffer {
-    data: [[stride(4)]] array<u32>;
+    data: @stride(4) array<u32>;
 };
 
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var<storage, read_write> buffer: InOutBuffer;
 
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute)
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     buffer.data[global_id.x] = buffer.data[global_id.x] + global_id.x;
 }

--- a/player/tests/data/zero-init-texture-binding.wgsl
+++ b/player/tests/data/zero-init-texture-binding.wgsl
@@ -1,6 +1,7 @@
-[[group(0), binding(0)]] var tex: texture_2d<f32>;
-[[group(0), binding(1)]] var tex_storage: texture_storage_2d<rgba8uint, write>;
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@group(0) @binding(1) var tex_storage: texture_storage_2d<rgba8uint, write>;
 
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute)
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 }

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -38,7 +38,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a1840be"
+rev = "81dc674"
 #version = "0.8"
 features = ["span", "validate", "wgsl-in"]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -82,14 +82,14 @@ js-sys = { version = "0.3" }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a1840be"
+rev = "81dc674"
 #version = "0.8"
 
 # DEV dependencies
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a1840be"
+rev = "81dc674"
 #version = "0.8"
 features = ["wgsl-in"]
 

--- a/wgpu-hal/examples/halmark/shader.wgsl
+++ b/wgpu-hal/examples/halmark/shader.wgsl
@@ -9,20 +9,22 @@ struct Locals {
     color: u32;
 };
 
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var<uniform> globals: Globals;
 
-[[group(1), binding(0)]]
+@group(1)
+@binding(0)
 var<uniform> locals: Locals;
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] tex_coords: vec2<f32>;
-    [[location(1)]] color: vec4<f32>;
+    @builtin(position) position: vec4<f32>;
+    @location(0) tex_coords: vec2<f32>;
+    @location(1) color: vec4<f32>;
 };
 
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] vi: u32) -> VertexOutput {
+@stage(vertex)
+fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
     let tc = vec2<f32>(f32(vi & 1u), 0.5 * f32(vi & 2u));
     let offset = vec2<f32>(tc.x * globals.size.x, tc.y * globals.size.y);
     let pos = globals.mvp * vec4<f32>(locals.position + offset, 0.0, 1.0);
@@ -30,12 +32,14 @@ fn vs_main([[builtin(vertex_index)]] vi: u32) -> VertexOutput {
     return VertexOutput(pos, tc, color);
 }
 
-[[group(0), binding(1)]]
+@group(0)
+@binding(1)
 var texture: texture_2d<f32>;
-[[group(0), binding(2)]]
+@group(0)
+@binding(2)
 var sam: sampler;
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return in.color * textureSampleLevel(texture, sam, in.tex_coords, 0.0);
 }

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -286,7 +286,8 @@ impl super::Adapter {
 
         let mut features = wgt::Features::empty()
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | wgt::Features::CLEAR_TEXTURE;
+            | wgt::Features::CLEAR_TEXTURE
+            | wgt::Features::PUSH_CONSTANTS;
         features.set(
             wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER | wgt::Features::ADDRESS_MODE_CLAMP_TO_ZERO,
             extensions.contains("GL_EXT_texture_border_clamp"),
@@ -399,7 +400,7 @@ impl super::Adapter {
             } else {
                 !0
             },
-            max_push_constant_size: 0,
+            max_push_constant_size: super::MAX_PUSH_CONSTANTS as u32 * 4,
             min_uniform_buffer_offset_alignment,
             min_storage_buffer_offset_alignment,
             max_inter_stage_shader_components: gl.get_parameter_i32(glow::MAX_VARYING_COMPONENTS)

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -375,3 +375,59 @@ pub(super) fn map_storage_access(access: wgt::StorageTextureAccess) -> u32 {
         wgt::StorageTextureAccess::ReadWrite => glow::READ_WRITE,
     }
 }
+
+pub(super) fn is_sampler(glsl_uniform_type: u32) -> bool {
+    match glsl_uniform_type {
+        glow::INT_SAMPLER_1D
+        | glow::INT_SAMPLER_1D_ARRAY
+        | glow::INT_SAMPLER_2D
+        | glow::INT_SAMPLER_2D_ARRAY
+        | glow::INT_SAMPLER_2D_MULTISAMPLE
+        | glow::INT_SAMPLER_2D_MULTISAMPLE_ARRAY
+        | glow::INT_SAMPLER_2D_RECT
+        | glow::INT_SAMPLER_3D
+        | glow::INT_SAMPLER_CUBE
+        | glow::INT_SAMPLER_CUBE_MAP_ARRAY
+        | glow::UNSIGNED_INT_SAMPLER_1D
+        | glow::UNSIGNED_INT_SAMPLER_1D_ARRAY
+        | glow::UNSIGNED_INT_SAMPLER_2D
+        | glow::UNSIGNED_INT_SAMPLER_2D_ARRAY
+        | glow::UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE
+        | glow::UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE_ARRAY
+        | glow::UNSIGNED_INT_SAMPLER_2D_RECT
+        | glow::UNSIGNED_INT_SAMPLER_3D
+        | glow::UNSIGNED_INT_SAMPLER_CUBE
+        | glow::UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY
+        | glow::SAMPLER_1D
+        | glow::SAMPLER_1D_SHADOW
+        | glow::SAMPLER_1D_ARRAY
+        | glow::SAMPLER_1D_ARRAY_SHADOW
+        | glow::SAMPLER_2D
+        | glow::SAMPLER_2D_SHADOW
+        | glow::SAMPLER_2D_ARRAY
+        | glow::SAMPLER_2D_ARRAY_SHADOW
+        | glow::SAMPLER_2D_MULTISAMPLE
+        | glow::SAMPLER_2D_MULTISAMPLE_ARRAY
+        | glow::SAMPLER_2D_RECT
+        | glow::SAMPLER_2D_RECT_SHADOW
+        | glow::SAMPLER_3D
+        | glow::SAMPLER_CUBE
+        | glow::SAMPLER_CUBE_MAP_ARRAY
+        | glow::SAMPLER_CUBE_MAP_ARRAY_SHADOW
+        | glow::SAMPLER_CUBE_SHADOW => true,
+        _ => false,
+    }
+}
+
+pub(super) fn uniform_byte_size(glsl_uniform_type: u32) -> u32 {
+    match glsl_uniform_type {
+        glow::FLOAT | glow::INT => 4,
+        glow::FLOAT_VEC2 | glow::INT_VEC2 => 8,
+        glow::FLOAT_VEC3 | glow::INT_VEC3 => 12,
+        glow::FLOAT_VEC4 | glow::INT_VEC4 => 16,
+        glow::FLOAT_MAT2 => 16,
+        glow::FLOAT_MAT3 => 36,
+        glow::FLOAT_MAT4 => 64,
+        _ => panic!("Unsupported uniform datatype!"),
+    }
+}

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1067,6 +1067,70 @@ impl super::Queue {
                 #[cfg(not(target_arch = "wasm32"))]
                 gl.pop_debug_group();
             }
+            C::SetPushConstants {
+                ref uniform,
+                offset,
+            } => {
+                fn get_data<T>(data: &[u8], offset: u32) -> &[T] {
+                    let raw = &data[(offset as usize)..];
+                    unsafe {
+                        slice::from_raw_parts(
+                            raw.as_ptr() as *const _,
+                            raw.len() / mem::size_of::<T>(),
+                        )
+                    }
+                }
+
+                let location = uniform.location.as_ref();
+
+                match uniform.utype {
+                    glow::FLOAT => {
+                        let data = get_data::<f32>(data_bytes, offset)[0];
+                        gl.uniform_1_f32(location, data);
+                    }
+                    glow::FLOAT_VEC2 => {
+                        let data = get_data::<[f32; 2]>(data_bytes, offset)[0];
+                        gl.uniform_2_f32_slice(location, &data);
+                    }
+                    glow::FLOAT_VEC3 => {
+                        let data = get_data::<[f32; 3]>(data_bytes, offset)[0];
+                        gl.uniform_3_f32_slice(location, &data);
+                    }
+                    glow::FLOAT_VEC4 => {
+                        let data = get_data::<[f32; 4]>(data_bytes, offset)[0];
+                        gl.uniform_4_f32_slice(location, &data);
+                    }
+                    glow::INT => {
+                        let data = get_data::<i32>(data_bytes, offset)[0];
+                        gl.uniform_1_i32(location, data);
+                    }
+                    glow::INT_VEC2 => {
+                        let data = get_data::<[i32; 2]>(data_bytes, offset)[0];
+                        gl.uniform_2_i32_slice(location, &data);
+                    }
+                    glow::INT_VEC3 => {
+                        let data = get_data::<[i32; 3]>(data_bytes, offset)[0];
+                        gl.uniform_3_i32_slice(location, &data);
+                    }
+                    glow::INT_VEC4 => {
+                        let data = get_data::<[i32; 4]>(data_bytes, offset)[0];
+                        gl.uniform_4_i32_slice(location, &data);
+                    }
+                    glow::FLOAT_MAT2 => {
+                        let data = get_data::<[f32; 4]>(data_bytes, offset)[0];
+                        gl.uniform_matrix_2_f32_slice(location, false, &data);
+                    }
+                    glow::FLOAT_MAT3 => {
+                        let data = get_data::<[f32; 9]>(data_bytes, offset)[0];
+                        gl.uniform_matrix_3_f32_slice(location, false, &data);
+                    }
+                    glow::FLOAT_MAT4 => {
+                        let data = get_data::<[f32; 16]>(data_bytes, offset)[0];
+                        gl.uniform_matrix_4_f32_slice(location, false, &data);
+                    }
+                    _ => panic!("Unsupported uniform datatype!"),
+                }
+            }
         }
     }
 }

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -136,20 +136,20 @@ env_logger = "0.8"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a1840be"
+rev = "81dc674"
 #version = "0.8"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a1840be"
+rev = "81dc674"
 #version = "0.8"
 features = ["wgsl-in"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a1840be"
+rev = "81dc674"
 #version = "0.8"
 features = ["wgsl-out"]
 

--- a/wgpu/examples/boids/compute.wgsl
+++ b/wgpu/examples/boids/compute.wgsl
@@ -14,16 +14,17 @@ struct SimParams {
 };
 
 struct Particles {
-  particles : [[stride(16)]] array<Particle>;
+  particles : @stride(16) array<Particle>;
 };
 
-[[group(0), binding(0)]] var<uniform> params : SimParams;
-[[group(0), binding(1)]] var<storage, read> particlesSrc : Particles;
-[[group(0), binding(2)]] var<storage, read_write> particlesDst : Particles;
+@group(0) @binding(0) var<uniform> params : SimParams;
+@group(0) @binding(1) var<storage, read> particlesSrc : Particles;
+@group(0) @binding(2) var<storage, read_write> particlesDst : Particles;
 
 // https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
-[[stage(compute), workgroup_size(64)]]
-fn main([[builtin(global_invocation_id)]] global_invocation_id: vec3<u32>) {
+@stage(compute)
+@workgroup_size(64)
+fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
   let total = arrayLength(&particlesSrc.particles);
   let index = global_invocation_id.x;
   if (index >= total) {

--- a/wgpu/examples/boids/draw.wgsl
+++ b/wgpu/examples/boids/draw.wgsl
@@ -1,9 +1,9 @@
-[[stage(vertex)]]
+@stage(vertex)
 fn main_vs(
-    [[location(0)]] particle_pos: vec2<f32>,
-    [[location(1)]] particle_vel: vec2<f32>,
-    [[location(2)]] position: vec2<f32>,
-) -> [[builtin(position)]] vec4<f32> {
+    @location(0) particle_pos: vec2<f32>,
+    @location(1) particle_vel: vec2<f32>,
+    @location(2) position: vec2<f32>,
+) -> @builtin(position) vec4<f32> {
     let angle = -atan2(particle_vel.x, particle_vel.y);
     let pos = vec2<f32>(
         position.x * cos(angle) - position.y * sin(angle),
@@ -12,7 +12,7 @@ fn main_vs(
     return vec4<f32>(pos + particle_pos, 0.0, 1.0);
 }
 
-[[stage(fragment)]]
-fn main_fs() -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn main_fs() -> @location(0) vec4<f32> {
     return vec4<f32>(1.0, 1.0, 1.0, 1.0);
 }

--- a/wgpu/examples/conservative-raster/triangle_and_lines.wgsl
+++ b/wgpu/examples/conservative-raster/triangle_and_lines.wgsl
@@ -1,22 +1,22 @@
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> [[builtin(position)]] vec4<f32> {
+@stage(vertex)
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
     let i: i32 = i32(vertex_index % 3u);
     let x: f32 = f32(i - 1) * 0.75;
     let y: f32 = f32((i & 1) * 2 - 1) * 0.75 + x * 0.2 + 0.1;
     return vec4<f32>(x, y, 0.0, 1.0);
 }
 
-[[stage(fragment)]]
-fn fs_main_red() -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main_red() -> @location(0) vec4<f32> {
     return vec4<f32>(1.0, 0.0, 0.0, 1.0);
 }
 
-[[stage(fragment)]]
-fn fs_main_blue() -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main_blue() -> @location(0) vec4<f32> {
     return vec4<f32>(0.13, 0.31, 0.85, 1.0); // cornflower blue in linear space
 }
 
-[[stage(fragment)]]
-fn fs_main_white() -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main_white() -> @location(0) vec4<f32> {
     return vec4<f32>(1.0, 1.0, 1.0, 1.0);
 }

--- a/wgpu/examples/conservative-raster/upscale.wgsl
+++ b/wgpu/examples/conservative-raster/upscale.wgsl
@@ -1,10 +1,10 @@
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] tex_coords: vec2<f32>;
+    @builtin(position) position: vec4<f32>;
+    @location(0) tex_coords: vec2<f32>;
 };
 
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
+@stage(vertex)
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     let x: f32 = f32(i32(vertex_index & 1u) << 2u) - 1.0;
     let y: f32 = f32(i32(vertex_index & 2u) << 1u) - 1.0;
     var output: VertexOutput;
@@ -13,12 +13,14 @@ fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
     return output;
 }
 
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var r_color: texture_2d<f32>;
-[[group(0), binding(1)]]
+@group(0)
+@binding(1)
 var r_sampler: sampler;
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return textureSample(r_color, r_sampler, in.tex_coords);
 }

--- a/wgpu/examples/cube/shader.wgsl
+++ b/wgpu/examples/cube/shader.wgsl
@@ -1,18 +1,19 @@
 struct VertexOutput {
-    [[location(0)]] tex_coord: vec2<f32>;
-    [[builtin(position)]] position: vec4<f32>;
+    @location(0) tex_coord: vec2<f32>;
+    @builtin(position) position: vec4<f32>;
 };
 
 struct Locals {
     transform: mat4x4<f32>;
 };
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var<uniform> r_locals: Locals;
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_main(
-    [[location(0)]] position: vec4<f32>,
-    [[location(1)]] tex_coord: vec2<f32>,
+    @location(0) position: vec4<f32>,
+    @location(1) tex_coord: vec2<f32>,
 ) -> VertexOutput {
     var out: VertexOutput;
     out.tex_coord = tex_coord;
@@ -20,17 +21,18 @@ fn vs_main(
     return out;
 }
 
-[[group(0), binding(1)]]
+@group(0)
+@binding(1)
 var r_color: texture_2d<u32>;
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let tex = textureLoad(r_color, vec2<i32>(in.tex_coord * 256.0), 0);
     let v = f32(tex.x) / 255.0;
     return vec4<f32>(1.0 - (v * 5.0), 1.0 - (v * 15.0), 1.0 - (v * 50.0), 1.0);
 }
 
-[[stage(fragment)]]
-fn fs_wire() -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_wire() -> @location(0) vec4<f32> {
     return vec4<f32>(0.0, 0.5, 0.0, 0.5);
 }

--- a/wgpu/examples/hello-compute/shader.wgsl
+++ b/wgpu/examples/hello-compute/shader.wgsl
@@ -1,8 +1,9 @@
 struct PrimeIndices {
-    data: [[stride(4)]] array<u32>;
+    data: @stride(4) array<u32>;
 }; // this is used as both input and output for convenience
 
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var<storage, read_write> v_indices: PrimeIndices;
 
 // The Collatz Conjecture states that for any integer n:
@@ -34,7 +35,8 @@ fn collatz_iterations(n_base: u32) -> u32{
     return i;
 }
 
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute)
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     v_indices.data[global_id.x] = collatz_iterations(v_indices.data[global_id.x]);
 }

--- a/wgpu/examples/hello-triangle/shader.wgsl
+++ b/wgpu/examples/hello-triangle/shader.wgsl
@@ -1,11 +1,11 @@
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] in_vertex_index: u32) -> [[builtin(position)]] vec4<f32> {
+@stage(vertex)
+fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> @builtin(position) vec4<f32> {
     let x = f32(i32(in_vertex_index) - 1);
     let y = f32(i32(in_vertex_index & 1u) * 2 - 1);
     return vec4<f32>(x, y, 0.0, 1.0);
 }
 
-[[stage(fragment)]]
-fn fs_main() -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main() -> @location(0) vec4<f32> {
     return vec4<f32>(1.0, 0.0, 0.0, 1.0);
 }

--- a/wgpu/examples/mipmap/blit.wgsl
+++ b/wgpu/examples/mipmap/blit.wgsl
@@ -1,10 +1,10 @@
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] tex_coords: vec2<f32>;
+    @builtin(position) position: vec4<f32>;
+    @location(0) tex_coords: vec2<f32>;
 };
 
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
+@stage(vertex)
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     var out: VertexOutput;
     let x = i32(vertex_index) / 2;
     let y = i32(vertex_index) & 1;
@@ -21,12 +21,14 @@ fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
     return out;
 }
 
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var r_color: texture_2d<f32>;
-[[group(0), binding(1)]]
+@group(0)
+@binding(1)
 var r_sampler: sampler;
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return textureSample(r_color, r_sampler, in.tex_coords);
 }

--- a/wgpu/examples/mipmap/draw.wgsl
+++ b/wgpu/examples/mipmap/draw.wgsl
@@ -1,16 +1,17 @@
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] tex_coords: vec2<f32>;
+    @builtin(position) position: vec4<f32>;
+    @location(0) tex_coords: vec2<f32>;
 };
 
 struct Locals {
     transform: mat4x4<f32>;
 };
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var<uniform> r_data: Locals;
 
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
+@stage(vertex)
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     let pos = vec2<f32>(
         100.0 * (1.0 - f32(vertex_index & 2u)),
         1000.0 * f32(vertex_index & 1u)
@@ -21,12 +22,14 @@ fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
     return out;
 }
 
-[[group(0), binding(1)]]
+@group(0)
+@binding(1)
 var r_color: texture_2d<f32>;
-[[group(0), binding(2)]]
+@group(0)
+@binding(2)
 var r_sampler: sampler;
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return textureSample(r_color, r_sampler, in.tex_coords);
 }

--- a/wgpu/examples/msaa-line/shader.wgsl
+++ b/wgpu/examples/msaa-line/shader.wgsl
@@ -1,12 +1,12 @@
 struct VertexOutput {
-    [[location(0)]] color: vec4<f32>;
-    [[builtin(position)]] position: vec4<f32>;
+    @location(0) color: vec4<f32>;
+    @builtin(position) position: vec4<f32>;
 };
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_main(
-    [[location(0)]] position: vec2<f32>,
-    [[location(1)]] color: vec4<f32>,
+    @location(0) position: vec2<f32>,
+    @location(1) color: vec4<f32>,
 ) -> VertexOutput {
     var out: VertexOutput;
     out.position = vec4<f32>(position, 0.0, 1.0);
@@ -14,7 +14,7 @@ fn vs_main(
     return out;
 }
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return in.color;
 }

--- a/wgpu/examples/shadow/shader.wgsl
+++ b/wgpu/examples/shadow/shader.wgsl
@@ -3,7 +3,8 @@ struct Globals {
     num_lights: vec4<u32>;
 };
 
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var<uniform> u_globals: Globals;
 
 struct Entity {
@@ -11,24 +12,25 @@ struct Entity {
     color: vec4<f32>;
 };
 
-[[group(1), binding(0)]]
+@group(1)
+@binding(0)
 var<uniform> u_entity: Entity;
 
-[[stage(vertex)]]
-fn vs_bake([[location(0)]] position: vec4<i32>) -> [[builtin(position)]] vec4<f32> {
+@stage(vertex)
+fn vs_bake(@location(0) position: vec4<i32>) -> @builtin(position) vec4<f32> {
     return u_globals.view_proj * u_entity.world * vec4<f32>(position);
 }
 
 struct VertexOutput {
-    [[builtin(position)]] proj_position: vec4<f32>;
-    [[location(0)]] world_normal: vec3<f32>;
-    [[location(1)]] world_position: vec4<f32>;
+    @builtin(position) proj_position: vec4<f32>;
+    @location(0) world_normal: vec3<f32>;
+    @location(1) world_position: vec4<f32>;
 };
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_main(
-    [[location(0)]] position: vec4<i32>,
-    [[location(1)]] normal: vec4<i32>,
+    @location(0) position: vec4<i32>,
+    @location(1) normal: vec4<i32>,
 ) -> VertexOutput {
     let w = u_entity.world;
     let world_pos = u_entity.world * vec4<f32>(position);
@@ -48,7 +50,7 @@ struct Light {
 };
 
 struct Lights {
-    data: [[stride(96)]] array<Light>;
+    data: @stride(96) array<Light>;
 };
 
 // Used when storage types are not supported
@@ -56,13 +58,17 @@ struct LightsWithoutStorage {
     data: array<Light, 10>;
 };
 
-[[group(0), binding(1)]]
+@group(0)
+@binding(1)
 var<storage, read> s_lights: Lights;
-[[group(0), binding(1)]]
+@group(0)
+@binding(1)
 var<uniform> u_lights: LightsWithoutStorage;
-[[group(0), binding(2)]]
+@group(0)
+@binding(2)
 var t_shadow: texture_depth_2d_array;
-[[group(0), binding(3)]]
+@group(0)
+@binding(3)
 var sampler_shadow: sampler_comparison;
 
 fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
@@ -81,8 +87,8 @@ fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
 let c_ambient: vec3<f32> = vec3<f32>(0.05, 0.05, 0.05);
 let c_max_lights: u32 = 10u;
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let normal = normalize(in.world_normal);
     // accumulate color
     var color: vec3<f32> = c_ambient;
@@ -101,8 +107,8 @@ fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
 }
 
 // The fragment entrypoint used when storage buffers are not available for the lights
-[[stage(fragment)]]
-fn fs_main_without_storage(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main_without_storage(in: VertexOutput) -> @location(0) vec4<f32> {
     let normal = normalize(in.world_normal);
     var color: vec3<f32> = c_ambient;
     for(var i = 0u; i < min(u_globals.num_lights.x, c_max_lights); i += 1u) {

--- a/wgpu/examples/skybox/shader.wgsl
+++ b/wgpu/examples/skybox/shader.wgsl
@@ -1,6 +1,6 @@
 struct SkyOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] uv: vec3<f32>;
+    @builtin(position) position: vec4<f32>;
+    @location(0) uv: vec3<f32>;
 };
 
 struct Data {
@@ -13,11 +13,12 @@ struct Data {
     // camera position
     cam_pos: vec4<f32>;
 };
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var<uniform> r_data: Data;
 
-[[stage(vertex)]]
-fn vs_sky([[builtin(vertex_index)]] vertex_index: u32) -> SkyOutput {
+@stage(vertex)
+fn vs_sky(@builtin(vertex_index) vertex_index: u32) -> SkyOutput {
     // hacky way to draw a large triangle
     let tmp1 = i32(vertex_index) / 2;
     let tmp2 = i32(vertex_index) & 1;
@@ -39,15 +40,15 @@ fn vs_sky([[builtin(vertex_index)]] vertex_index: u32) -> SkyOutput {
 }
 
 struct EntityOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(1)]] normal: vec3<f32>;
-    [[location(3)]] view: vec3<f32>;
+    @builtin(position) position: vec4<f32>;
+    @location(1) normal: vec3<f32>;
+    @location(3) view: vec3<f32>;
 };
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_entity(
-    [[location(0)]] pos: vec3<f32>,
-    [[location(1)]] normal: vec3<f32>,
+    @location(0) pos: vec3<f32>,
+    @location(1) normal: vec3<f32>,
 ) -> EntityOutput {
     var out: EntityOutput;
     out.normal = normal;
@@ -56,18 +57,20 @@ fn vs_entity(
     return out;
 }
 
-[[group(0), binding(1)]]
+@group(0)
+@binding(1)
 var r_texture: texture_cube<f32>;
-[[group(0), binding(2)]]
+@group(0)
+@binding(2)
 var r_sampler: sampler;
 
-[[stage(fragment)]]
-fn fs_sky(in: SkyOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_sky(in: SkyOutput) -> @location(0) vec4<f32> {
     return textureSample(r_texture, r_sampler, in.uv);
 }
 
-[[stage(fragment)]]
-fn fs_entity(in: EntityOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_entity(in: EntityOutput) -> @location(0) vec4<f32> {
     let incident = normalize(in.view);
     let normal = normalize(in.normal);
     let reflected = incident - 2.0 * dot(normal, incident) * normal;

--- a/wgpu/examples/water/terrain.wgsl
+++ b/wgpu/examples/water/terrain.wgsl
@@ -3,7 +3,8 @@ struct Uniforms {
     clipping_plane: vec4<f32>;
 };
 
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var<uniform> uniforms: Uniforms;
 
 let light = vec3<f32>(150.0, 70.0, 0.0);
@@ -11,17 +12,17 @@ let light_colour = vec3<f32>(1.0, 0.98, 0.82);
 let ambient = 0.2;
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] colour: vec4<f32>;
+    @builtin(position) position: vec4<f32>;
+    @location(0) colour: vec4<f32>;
     // Comment this out if using user-clipping planes:
-    [[location(1)]] clip_dist: f32;
+    @location(1) clip_dist: f32;
 };
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_main(
-    [[location(0)]] position: vec3<f32>,
-    [[location(1)]] normal: vec3<f32>,
-    [[location(2)]] colour: vec4<f32>,
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+    @location(2) colour: vec4<f32>,
 ) -> VertexOutput {
     var out: VertexOutput;
     out.position = uniforms.projection_view * vec4<f32>(position, 1.0);
@@ -35,10 +36,11 @@ fn vs_main(
     return out;
 }
 
-[[stage(fragment), early_depth_test]]
+@stage(fragment)
+@early_depth_test
 fn fs_main(
     in: VertexOutput,
-) -> [[location(0)]] vec4<f32> {
+) -> @location(0) vec4<f32> {
     // Comment this out if using user-clipping planes:
     if(in.clip_dist < 0.0) {
         discard;

--- a/wgpu/examples/water/water.wgsl
+++ b/wgpu/examples/water/water.wgsl
@@ -4,7 +4,7 @@ struct Uniforms {
     time_size_width: vec4<f32>;
     viewport_height: f32;
 };
-[[group(0), binding(0)]] var<uniform> uniforms: Uniforms;
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
 
 let light_point = vec3<f32>(150.0, 70.0, 0.0);
 let light_colour = vec3<f32>(1.0, 0.98, 0.82);
@@ -181,16 +181,16 @@ fn calc_specular(eye: vec3<f32>, normal: vec3<f32>, light: vec3<f32>) -> f32 {
 }
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] f_WaterScreenPos: vec2<f32>;
-    [[location(1)]] f_Fresnel: f32;
-    [[location(2)]] f_Light: vec3<f32>;
+    @builtin(position) position: vec4<f32>;
+    @location(0) f_WaterScreenPos: vec2<f32>;
+    @location(1) f_Fresnel: f32;
+    @location(2) f_Light: vec3<f32>;
 };
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_main(
-    [[location(0)]] position: vec2<i32>,
-    [[location(1)]] offsets: vec4<i32>,
+    @location(0) position: vec2<i32>,
+    @location(1) offsets: vec4<i32>,
 ) -> VertexOutput {
     let p_pos = vec2<f32>(position);
     let b_pos = make_position(p_pos + vec2<f32>(offsets.xy));
@@ -222,9 +222,9 @@ let water_colour = vec3<f32>(0.0, 0.46, 0.95);
 let zNear = 10.0;
 let zFar = 400.0;
 
-[[group(0), binding(1)]] var reflection: texture_2d<f32>;
-[[group(0), binding(2)]] var terrain_depth_tex: texture_2d<f32>;
-[[group(0), binding(3)]] var colour_sampler: sampler;
+@group(0) @binding(1) var reflection: texture_2d<f32>;
+@group(0) @binding(2) var terrain_depth_tex: texture_2d<f32>;
+@group(0) @binding(3) var colour_sampler: sampler;
 
 fn to_linear_depth(depth: f32) -> f32 {
     let z_n = 2.0 * depth - 1.0;
@@ -232,8 +232,8 @@ fn to_linear_depth(depth: f32) -> f32 {
     return z_e;
 }
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let reflection_colour = textureSample(reflection, colour_sampler, in.f_WaterScreenPos.xy).xyz;
 
     let pixel_depth = to_linear_depth(in.position.z);

--- a/wgpu/tests/vertex_indices/draw.vert.wgsl
+++ b/wgpu/tests/vertex_indices/draw.vert.wgsl
@@ -2,17 +2,17 @@ struct Indices {
     arr: array<u32>;
 }; // this is used as both input and output for convenience
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read_write> indices: Indices;
 
-[[stage(vertex)]]
-fn vs_main([[builtin(instance_index)]] instance: u32, [[builtin(vertex_index)]] index: u32) -> [[builtin(position)]] vec4<f32> {
+@stage(vertex)
+fn vs_main(@builtin(instance_index) instance: u32, @builtin(vertex_index) index: u32) -> @builtin(position) vec4<f32> {
     let idx = instance * 3u + index;
     indices.arr[idx] = idx;
     return vec4<f32>(0.0, 0.0, 0.0, 1.0);
 }
 
-[[stage(fragment)]]
-fn fs_main() -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main() -> @location(0) vec4<f32> {
     return vec4<f32>(0.0);
 }


### PR DESCRIPTION
**Connections**
Depends on https://github.com/gfx-rs/naga/pull/1672 so bumps `naga` revision to pick it up

**Description**
Push constants are a great way to pass small amounts of data to the gpu between draw calls.

But maintaining two code paths for backends that support push constants and those who don't can be prohibitive to picking them.

So a good middle ground is to emulate push constants in the secondary backends, this is done by using a uniform buffer for push constants.

*Implementation notes*:

The buffer is always kept mapped and when a `set_push_constants` call is issued the mapping is written to.

Push constants stages are ignored.

The uniform buffer uses the binding 0 in the shader.

**TODOS**:

- [ ] The code currently uses the pointer returned from `glMapBufferRange` as a `*mut u32` for the slice, but according to https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBufferRange.xhtml alignment is not guaranteed so it might need to be changed to a `*mut u8` and `set_push_constants` will need to convert the slice from `u32` to `u8`
- [ ] Another problem is synchronization, `glMapBufferRange` doesn't give much information but has an `GL_MAP_UNSYNCHRONIZED_BIT` so it leads me to believe that synchronization is implicit, but if someone who knows opengl better could confirm it would be helpful

**Testing**
I tested on a modified cube example
```patch
diff --git a/wgpu/examples/cube/main.rs b/wgpu/examples/cube/main.rs
index 60a49542..556ec979 100644
--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -124,10 +124,21 @@ impl Example {
 }
 
 impl framework::Example for Example {
+    fn required_features() -> wgt::Features {
+        wgt::Features::PUSH_CONSTANTS
+    }
+
     fn optional_features() -> wgt::Features {
         wgt::Features::POLYGON_MODE_LINE
     }
 
+    fn required_limits() -> wgpu::Limits {
+        wgpu::Limits {
+            max_push_constant_size: 64,
+            ..wgpu::Limits::downlevel_webgl2_defaults()
+        }
+    }
+
     fn init(
         config: &wgpu::SurfaceConfiguration,
         _adapter: &wgpu::Adapter,
@@ -179,7 +190,10 @@ impl framework::Example for Example {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
             bind_group_layouts: &[&bind_group_layout],
-            push_constant_ranges: &[],
+            push_constant_ranges: &[wgpu::PushConstantRange {
+                stages: wgpu::ShaderStages::VERTEX,
+                range: 0..4,
+            }],
         });
 
         // Create the texture
@@ -380,6 +394,7 @@ impl framework::Example for Example {
             rpass.set_bind_group(0, &self.bind_group, &[]);
             rpass.set_index_buffer(self.index_buf.slice(..), wgpu::IndexFormat::Uint16);
             rpass.set_vertex_buffer(0, self.vertex_buf.slice(..));
+            rpass.set_push_constants(wgpu::ShaderStages::VERTEX, 0, &(0.2_f32).to_ne_bytes());
             rpass.pop_debug_group();
             rpass.insert_debug_marker("Draw!");
             rpass.draw_indexed(0..self.index_count as u32, 0, 0..1);
diff --git a/wgpu/examples/cube/shader.wgsl b/wgpu/examples/cube/shader.wgsl
index 4bd4305a..ba8423b4 100644
--- a/wgpu/examples/cube/shader.wgsl
+++ b/wgpu/examples/cube/shader.wgsl
@@ -23,11 +23,16 @@ fn vs_main(
 [[group(0), binding(1)]]
 var r_color: texture_2d<u32>;
 
+struct PushConstants {
+    mul: f32;
+};
+var<push_constant> pc: PushConstants;
+
 [[stage(fragment)]]
 fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let tex = textureLoad(r_color, vec2<i32>(in.tex_coord * 256.0), 0);
     let v = f32(tex.x) / 255.0;
-    return vec4<f32>(1.0 - (v * 5.0), 1.0 - (v * 15.0), 1.0 - (v * 50.0), 1.0);
+    return pc.mul * vec4<f32>(1.0 - (v * 5.0), 1.0 - (v * 15.0), 1.0 - (v * 50.0), 1.0);
 }
 
 [[stage(fragment)]]
```

As well as a modified branch of https://gitlab.com/veloren/veloren

**Note**: I don't have much experience with openGL so the code might not be the best.
