### PR TITLE
fix(deno_webgpu): add TS type declarations

### DIFF
--- a/deno_webgpu/lib.deno_webgpu.d.ts
+++ b/deno_webgpu/lib.deno_webgpu.d.ts
@@ -1,0 +1,1132 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-explicit-any no-empty-interface
+
+/// <reference no-default-lib="true" />
+/// <reference lib="esnext" />
+
+// 8cc98b6f10b7f354473a08c3773bb1de839845b9
+
+interface GPUObjectBase {
+  label: string | null;
+}
+
+declare interface GPUObjectDescriptorBase {
+  label?: string;
+}
+
+declare class GPUSupportedLimits {
+  maxTextureDimension1D?: number;
+  maxTextureDimension2D?: number;
+  maxTextureDimension3D?: number;
+  maxTextureArrayLayers?: number;
+  maxBindGroups?: number;
+  maxDynamicUniformBuffersPerPipelineLayout?: number;
+  maxDynamicStorageBuffersPerPipelineLayout?: number;
+  maxSampledTexturesPerShaderStage?: number;
+  maxSamplersPerShaderStage?: number;
+  maxStorageBuffersPerShaderStage?: number;
+  maxStorageTexturesPerShaderStage?: number;
+  maxUniformBuffersPerShaderStage?: number;
+  maxUniformBufferBindingSize?: number;
+  maxStorageBufferBindingSize?: number;
+  minUniformBufferOffsetAlignment?: number;
+  minStorageBufferOffsetAlignment?: number;
+  maxVertexBuffers?: number;
+  maxVertexAttributes?: number;
+  maxVertexBufferArrayStride?: number;
+  maxInterStageShaderComponents?: number;
+  maxComputeWorkgroupStorageSize?: number;
+  maxComputeInvocationsPerWorkgroup?: number;
+  maxComputeWorkgroupSizeX?: number;
+  maxComputeWorkgroupSizeY?: number;
+  maxComputeWorkgroupSizeZ?: number;
+  maxComputeWorkgroupsPerDimension?: number;
+}
+
+declare class GPUSupportedFeatures {
+  forEach(
+    callbackfn: (
+      value: GPUFeatureName,
+      value2: GPUFeatureName,
+      set: Set<GPUFeatureName>,
+    ) => void,
+    thisArg?: any,
+  ): void;
+  has(value: GPUFeatureName): boolean;
+  size: number;
+  [
+    Symbol
+      .iterator
+  ](): IterableIterator<GPUFeatureName>;
+  entries(): IterableIterator<[GPUFeatureName, GPUFeatureName]>;
+  keys(): IterableIterator<GPUFeatureName>;
+  values(): IterableIterator<GPUFeatureName>;
+}
+
+declare class GPU {
+  requestAdapter(
+    options?: GPURequestAdapterOptions,
+  ): Promise<GPUAdapter | null>;
+}
+
+declare interface GPURequestAdapterOptions {
+  powerPreference?: GPUPowerPreference;
+  forceFallbackAdapter?: boolean;
+}
+
+declare type GPUPowerPreference = "low-power" | "high-performance";
+
+declare class GPUAdapter {
+  readonly name: string;
+  readonly features: GPUSupportedFeatures;
+  readonly limits: GPUSupportedLimits;
+  readonly isFallbackAdapter: boolean;
+
+  requestDevice(descriptor?: GPUDeviceDescriptor): Promise<GPUDevice>;
+}
+
+declare interface GPUDeviceDescriptor extends GPUObjectDescriptorBase {
+  requiredFeatures?: GPUFeatureName[];
+  requiredLimits?: Record<string, number>;
+}
+
+declare type GPUFeatureName =
+  | "depth-clamping"
+  | "depth24unorm-stencil8"
+  | "depth32float-stencil8"
+  | "pipeline-statistics-query"
+  | "texture-compression-bc"
+  | "timestamp-query"
+  // extended from spec
+  | "mappable-primary-buffers"
+  | "sampled-texture-binding-array"
+  | "sampled-texture-array-dynamic-indexing"
+  | "sampled-texture-array-non-uniform-indexing"
+  | "unsized-binding-array"
+  | "multi-draw-indirect"
+  | "multi-draw-indirect-count"
+  | "push-constants"
+  | "address-mode-clamp-to-border"
+  | "non-fill-polygon-mode"
+  | "texture-compression-etc2"
+  | "texture-compression-astc-ldr"
+  | "texture-adapter-specific-format-features"
+  | "shader-float64"
+  | "vertex-attribute-64bit";
+
+declare class GPUDevice extends EventTarget implements GPUObjectBase {
+  label: string | null;
+
+  readonly lost: Promise<GPUDeviceLostInfo>;
+  pushErrorScope(filter: GPUErrorFilter): undefined;
+  popErrorScope(): Promise<GPUError | null>;
+  onuncapturederror:
+    | ((this: GPUDevice, ev: GPUUncapturedErrorEvent) => any)
+    | null;
+
+  readonly features: ReadonlyArray<GPUFeatureName>;
+  readonly limits: Record<string, number>;
+  readonly queue: GPUQueue;
+
+  destroy(): undefined;
+
+  createBuffer(descriptor: GPUBufferDescriptor): GPUBuffer;
+  createTexture(descriptor: GPUTextureDescriptor): GPUTexture;
+  createSampler(descriptor?: GPUSamplerDescriptor): GPUSampler;
+
+  createBindGroupLayout(
+    descriptor: GPUBindGroupLayoutDescriptor,
+  ): GPUBindGroupLayout;
+  createPipelineLayout(
+    descriptor: GPUPipelineLayoutDescriptor,
+  ): GPUPipelineLayout;
+  createBindGroup(descriptor: GPUBindGroupDescriptor): GPUBindGroup;
+
+  createShaderModule(descriptor: GPUShaderModuleDescriptor): GPUShaderModule;
+  createComputePipeline(
+    descriptor: GPUComputePipelineDescriptor,
+  ): GPUComputePipeline;
+  createRenderPipeline(
+    descriptor: GPURenderPipelineDescriptor,
+  ): GPURenderPipeline;
+  createComputePipelineAsync(
+    descriptor: GPUComputePipelineDescriptor,
+  ): Promise<GPUComputePipeline>;
+  createRenderPipelineAsync(
+    descriptor: GPURenderPipelineDescriptor,
+  ): Promise<GPURenderPipeline>;
+
+  createCommandEncoder(
+    descriptor?: GPUCommandEncoderDescriptor,
+  ): GPUCommandEncoder;
+  createRenderBundleEncoder(
+    descriptor: GPURenderBundleEncoderDescriptor,
+  ): GPURenderBundleEncoder;
+
+  createQuerySet(descriptor: GPUQuerySetDescriptor): GPUQuerySet;
+}
+
+declare class GPUBuffer implements GPUObjectBase {
+  label: string | null;
+
+  mapAsync(
+    mode: GPUMapModeFlags,
+    offset?: number,
+    size?: number,
+  ): Promise<undefined>;
+  getMappedRange(offset?: number, size?: number): ArrayBuffer;
+  unmap(): undefined;
+
+  destroy(): undefined;
+}
+
+declare interface GPUBufferDescriptor extends GPUObjectDescriptorBase {
+  size: number;
+  usage: GPUBufferUsageFlags;
+  mappedAtCreation?: boolean;
+}
+
+declare type GPUBufferUsageFlags = number;
+declare class GPUBufferUsage {
+  static MAP_READ: 0x0001;
+  static MAP_WRITE: 0x0002;
+  static COPY_SRC: 0x0004;
+  static COPY_DST: 0x0008;
+  static INDEX: 0x0010;
+  static VERTEX: 0x0020;
+  static UNIFORM: 0x0040;
+  static STORAGE: 0x0080;
+  static INDIRECT: 0x0100;
+  static QUERY_RESOLVE: 0x0200;
+}
+
+declare type GPUMapModeFlags = number;
+declare class GPUMapMode {
+  static READ: 0x0001;
+  static WRITE: 0x0002;
+}
+
+declare class GPUTexture implements GPUObjectBase {
+  label: string | null;
+
+  createView(descriptor?: GPUTextureViewDescriptor): GPUTextureView;
+  destroy(): undefined;
+}
+
+declare interface GPUTextureDescriptor extends GPUObjectDescriptorBase {
+  size: GPUExtent3D;
+  mipLevelCount?: number;
+  sampleCount?: number;
+  dimension?: GPUTextureDimension;
+  format: GPUTextureFormat;
+  usage: GPUTextureUsageFlags;
+}
+
+declare type GPUTextureDimension = "1d" | "2d" | "3d";
+
+declare type GPUTextureUsageFlags = number;
+declare class GPUTextureUsage {
+  static COPY_SRC: 0x01;
+  static COPY_DST: 0x02;
+  static TEXTURE_BINDING: 0x04;
+  static STORAGE_BINDING: 0x08;
+  static RENDER_ATTACHMENT: 0x10;
+}
+
+declare class GPUTextureView implements GPUObjectBase {
+  label: string | null;
+}
+
+declare interface GPUTextureViewDescriptor extends GPUObjectDescriptorBase {
+  format?: GPUTextureFormat;
+  dimension?: GPUTextureViewDimension;
+  aspect?: GPUTextureAspect;
+  baseMipLevel?: number;
+  mipLevelCount?: number;
+  baseArrayLayer?: number;
+  arrayLayerCount?: number;
+}
+
+declare type GPUTextureViewDimension =
+  | "1d"
+  | "2d"
+  | "2d-array"
+  | "cube"
+  | "cube-array"
+  | "3d";
+
+declare type GPUTextureAspect = "all" | "stencil-only" | "depth-only";
+
+declare type GPUTextureFormat =
+  | "r8unorm"
+  | "r8snorm"
+  | "r8uint"
+  | "r8sint"
+  | "r16uint"
+  | "r16sint"
+  | "r16float"
+  | "rg8unorm"
+  | "rg8snorm"
+  | "rg8uint"
+  | "rg8sint"
+  | "r32uint"
+  | "r32sint"
+  | "r32float"
+  | "rg16uint"
+  | "rg16sint"
+  | "rg16float"
+  | "rgba8unorm"
+  | "rgba8unorm-srgb"
+  | "rgba8snorm"
+  | "rgba8uint"
+  | "rgba8sint"
+  | "bgra8unorm"
+  | "bgra8unorm-srgb"
+  | "rgb9e5ufloat"
+  | "rgb10a2unorm"
+  | "rg11b10ufloat"
+  | "rg32uint"
+  | "rg32sint"
+  | "rg32float"
+  | "rgba16uint"
+  | "rgba16sint"
+  | "rgba16float"
+  | "rgba32uint"
+  | "rgba32sint"
+  | "rgba32float"
+  | "stencil8"
+  | "depth16unorm"
+  | "depth24plus"
+  | "depth24plus-stencil8"
+  | "depth32float"
+  | "bc1-rgba-unorm"
+  | "bc1-rgba-unorm-srgb"
+  | "bc2-rgba-unorm"
+  | "bc2-rgba-unorm-srgb"
+  | "bc3-rgba-unorm"
+  | "bc3-rgba-unorm-srgb"
+  | "bc4-r-unorm"
+  | "bc4-r-snorm"
+  | "bc5-rg-unorm"
+  | "bc5-rg-snorm"
+  | "bc6h-rgb-ufloat"
+  | "bc6h-rgb-float"
+  | "bc7-rgba-unorm"
+  | "bc7-rgba-unorm-srgb"
+  | "depth24unorm-stencil8"
+  | "depth32float-stencil8";
+
+declare class GPUSampler implements GPUObjectBase {
+  label: string | null;
+}
+
+declare interface GPUSamplerDescriptor extends GPUObjectDescriptorBase {
+  addressModeU?: GPUAddressMode;
+  addressModeV?: GPUAddressMode;
+  addressModeW?: GPUAddressMode;
+  magFilter?: GPUFilterMode;
+  minFilter?: GPUFilterMode;
+  mipmapFilter?: GPUFilterMode;
+  lodMinClamp?: number;
+  lodMaxClamp?: number;
+  compare?: GPUCompareFunction;
+  maxAnisotropy?: number;
+}
+
+declare type GPUAddressMode = "clamp-to-edge" | "repeat" | "mirror-repeat";
+
+declare type GPUFilterMode = "nearest" | "linear";
+
+declare type GPUCompareFunction =
+  | "never"
+  | "less"
+  | "equal"
+  | "less-equal"
+  | "greater"
+  | "not-equal"
+  | "greater-equal"
+  | "always";
+
+declare class GPUBindGroupLayout implements GPUObjectBase {
+  label: string | null;
+}
+
+declare interface GPUBindGroupLayoutDescriptor extends GPUObjectDescriptorBase {
+  entries: GPUBindGroupLayoutEntry[];
+}
+
+declare interface GPUBindGroupLayoutEntry {
+  binding: number;
+  visibility: GPUShaderStageFlags;
+
+  buffer?: GPUBufferBindingLayout;
+  sampler?: GPUSamplerBindingLayout;
+  texture?: GPUTextureBindingLayout;
+  storageTexture?: GPUStorageTextureBindingLayout;
+}
+
+declare type GPUShaderStageFlags = number;
+declare class GPUShaderStage {
+  static VERTEX: 0x1;
+  static FRAGMENT: 0x2;
+  static COMPUTE: 0x4;
+}
+
+declare interface GPUBufferBindingLayout {
+  type?: GPUBufferBindingType;
+  hasDynamicOffset?: boolean;
+  minBindingSize?: number;
+}
+
+declare type GPUBufferBindingType = "uniform" | "storage" | "read-only-storage";
+
+declare interface GPUSamplerBindingLayout {
+  type?: GPUSamplerBindingType;
+}
+
+declare type GPUSamplerBindingType =
+  | "filtering"
+  | "non-filtering"
+  | "comparison";
+
+declare interface GPUTextureBindingLayout {
+  sampleType?: GPUTextureSampleType;
+  viewDimension?: GPUTextureViewDimension;
+  multisampled?: boolean;
+}
+
+declare type GPUTextureSampleType =
+  | "float"
+  | "unfilterable-float"
+  | "depth"
+  | "sint"
+  | "uint";
+
+declare type GPUStorageTextureAccess = "write-only";
+
+declare interface GPUStorageTextureBindingLayout {
+  access: GPUStorageTextureAccess;
+  format: GPUTextureFormat;
+  viewDimension?: GPUTextureViewDimension;
+}
+
+declare class GPUBindGroup implements GPUObjectBase {
+  label: string | null;
+}
+
+declare interface GPUBindGroupDescriptor extends GPUObjectDescriptorBase {
+  layout: GPUBindGroupLayout;
+  entries: GPUBindGroupEntry[];
+}
+
+declare type GPUBindingResource =
+  | GPUSampler
+  | GPUTextureView
+  | GPUBufferBinding;
+
+declare interface GPUBindGroupEntry {
+  binding: number;
+  resource: GPUBindingResource;
+}
+
+declare interface GPUBufferBinding {
+  buffer: GPUBuffer;
+  offset?: number;
+  size?: number;
+}
+
+declare class GPUPipelineLayout implements GPUObjectBase {
+  label: string | null;
+}
+
+declare interface GPUPipelineLayoutDescriptor extends GPUObjectDescriptorBase {
+  bindGroupLayouts: GPUBindGroupLayout[];
+}
+
+declare type GPUCompilationMessageType = "error" | "warning" | "info";
+
+declare interface GPUCompilationMessage {
+  readonly message: string;
+  readonly type: GPUCompilationMessageType;
+  readonly lineNum: number;
+  readonly linePos: number;
+}
+
+declare interface GPUCompilationInfo {
+  readonly messages: ReadonlyArray<GPUCompilationMessage>;
+}
+
+declare class GPUShaderModule implements GPUObjectBase {
+  label: string | null;
+
+  compilationInfo(): Promise<GPUCompilationInfo>;
+}
+
+declare interface GPUShaderModuleDescriptor extends GPUObjectDescriptorBase {
+  code: string;
+  sourceMap?: any;
+}
+
+declare interface GPUPipelineDescriptorBase extends GPUObjectDescriptorBase {
+  layout?: GPUPipelineLayout;
+}
+
+declare interface GPUPipelineBase {
+  getBindGroupLayout(index: number): GPUBindGroupLayout;
+}
+
+declare interface GPUProgrammableStage {
+  module: GPUShaderModule;
+  entryPoint: string;
+}
+
+declare class GPUComputePipeline implements GPUObjectBase, GPUPipelineBase {
+  label: string | null;
+
+  getBindGroupLayout(index: number): GPUBindGroupLayout;
+}
+
+declare interface GPUComputePipelineDescriptor
+  extends GPUPipelineDescriptorBase {
+  compute: GPUProgrammableStage;
+}
+
+declare class GPURenderPipeline implements GPUObjectBase, GPUPipelineBase {
+  label: string | null;
+
+  getBindGroupLayout(index: number): GPUBindGroupLayout;
+}
+
+declare interface GPURenderPipelineDescriptor
+  extends GPUPipelineDescriptorBase {
+  vertex: GPUVertexState;
+  primitive?: GPUPrimitiveState;
+  depthStencil?: GPUDepthStencilState;
+  multisample?: GPUMultisampleState;
+  fragment?: GPUFragmentState;
+}
+
+declare type GPUPrimitiveTopology =
+  | "point-list"
+  | "line-list"
+  | "line-strip"
+  | "triangle-list"
+  | "triangle-strip";
+
+declare interface GPUPrimitiveState {
+  topology?: GPUPrimitiveTopology;
+  stripIndexFormat?: GPUIndexFormat;
+  frontFace?: GPUFrontFace;
+  cullMode?: GPUCullMode;
+  clampDepth?: boolean;
+}
+
+declare type GPUFrontFace = "ccw" | "cw";
+
+declare type GPUCullMode = "none" | "front" | "back";
+
+declare interface GPUMultisampleState {
+  count?: number;
+  mask?: number;
+  alphaToCoverageEnabled?: boolean;
+}
+
+declare interface GPUFragmentState extends GPUProgrammableStage {
+  targets: GPUColorTargetState[];
+}
+
+declare interface GPUColorTargetState {
+  format: GPUTextureFormat;
+
+  blend?: GPUBlendState;
+  writeMask?: GPUColorWriteFlags;
+}
+
+declare interface GPUBlendState {
+  color: GPUBlendComponent;
+  alpha: GPUBlendComponent;
+}
+
+declare type GPUColorWriteFlags = number;
+declare class GPUColorWrite {
+  static RED: 0x1;
+  static GREEN: 0x2;
+  static BLUE: 0x4;
+  static ALPHA: 0x8;
+  static ALL: 0xF;
+}
+
+declare interface GPUBlendComponent {
+  srcFactor: GPUBlendFactor;
+  dstFactor: GPUBlendFactor;
+  operation: GPUBlendOperation;
+}
+
+declare type GPUBlendFactor =
+  | "zero"
+  | "one"
+  | "src"
+  | "one-minus-src"
+  | "src-alpha"
+  | "one-minus-src-alpha"
+  | "dst"
+  | "one-minus-dst"
+  | "dst-alpha"
+  | "one-minus-dst-alpha"
+  | "src-alpha-saturated"
+  | "constant"
+  | "one-minus-constant";
+
+declare type GPUBlendOperation =
+  | "add"
+  | "subtract"
+  | "reverse-subtract"
+  | "min"
+  | "max";
+
+declare interface GPUDepthStencilState {
+  format: GPUTextureFormat;
+
+  depthWriteEnabled?: boolean;
+  depthCompare?: GPUCompareFunction;
+
+  stencilFront?: GPUStencilFaceState;
+  stencilBack?: GPUStencilFaceState;
+
+  stencilReadMask?: number;
+  stencilWriteMask?: number;
+
+  depthBias?: number;
+  depthBiasSlopeScale?: number;
+  depthBiasClamp?: number;
+}
+
+declare interface GPUStencilFaceState {
+  compare?: GPUCompareFunction;
+  failOp?: GPUStencilOperation;
+  depthFailOp?: GPUStencilOperation;
+  passOp?: GPUStencilOperation;
+}
+
+declare type GPUStencilOperation =
+  | "keep"
+  | "zero"
+  | "replace"
+  | "invert"
+  | "increment-clamp"
+  | "decrement-clamp"
+  | "increment-wrap"
+  | "decrement-wrap";
+
+declare type GPUIndexFormat = "uint16" | "uint32";
+
+declare type GPUVertexFormat =
+  | "uint8x2"
+  | "uint8x4"
+  | "sint8x2"
+  | "sint8x4"
+  | "unorm8x2"
+  | "unorm8x4"
+  | "snorm8x2"
+  | "snorm8x4"
+  | "uint16x2"
+  | "uint16x4"
+  | "sint16x2"
+  | "sint16x4"
+  | "unorm16x2"
+  | "unorm16x4"
+  | "snorm16x2"
+  | "snorm16x4"
+  | "float16x2"
+  | "float16x4"
+  | "float32"
+  | "float32x2"
+  | "float32x3"
+  | "float32x4"
+  | "uint32"
+  | "uint32x2"
+  | "uint32x3"
+  | "uint32x4"
+  | "sint32"
+  | "sint32x2"
+  | "sint32x3"
+  | "sint32x4";
+declare type GPUVertexStepMode = "vertex" | "instance";
+
+declare interface GPUVertexState extends GPUProgrammableStage {
+  buffers?: (GPUVertexBufferLayout | null)[];
+}
+
+declare interface GPUVertexBufferLayout {
+  arrayStride: number;
+  stepMode?: GPUVertexStepMode;
+  attributes: GPUVertexAttribute[];
+}
+
+declare interface GPUVertexAttribute {
+  format: GPUVertexFormat;
+  offset: number;
+
+  shaderLocation: number;
+}
+
+declare class GPUCommandBuffer implements GPUObjectBase {
+  label: string | null;
+
+  readonly executionTime: Promise<number>;
+}
+
+declare interface GPUCommandBufferDescriptor extends GPUObjectDescriptorBase {}
+
+declare class GPUCommandEncoder implements GPUObjectBase {
+  label: string | null;
+
+  beginRenderPass(descriptor: GPURenderPassDescriptor): GPURenderPassEncoder;
+  beginComputePass(
+    descriptor?: GPUComputePassDescriptor,
+  ): GPUComputePassEncoder;
+
+  copyBufferToBuffer(
+    source: GPUBuffer,
+    sourceOffset: number,
+    destination: GPUBuffer,
+    destinationOffset: number,
+    size: number,
+  ): undefined;
+
+  copyBufferToTexture(
+    source: GPUImageCopyBuffer,
+    destination: GPUImageCopyTexture,
+    copySize: GPUExtent3D,
+  ): undefined;
+
+  copyTextureToBuffer(
+    source: GPUImageCopyTexture,
+    destination: GPUImageCopyBuffer,
+    copySize: GPUExtent3D,
+  ): undefined;
+
+  copyTextureToTexture(
+    source: GPUImageCopyTexture,
+    destination: GPUImageCopyTexture,
+    copySize: GPUExtent3D,
+  ): undefined;
+
+  pushDebugGroup(groupLabel: string): undefined;
+  popDebugGroup(): undefined;
+  insertDebugMarker(markerLabel: string): undefined;
+
+  writeTimestamp(querySet: GPUQuerySet, queryIndex: number): undefined;
+
+  resolveQuerySet(
+    querySet: GPUQuerySet,
+    firstQuery: number,
+    queryCount: number,
+    destination: GPUBuffer,
+    destinationOffset: number,
+  ): undefined;
+
+  finish(descriptor?: GPUCommandBufferDescriptor): GPUCommandBuffer;
+}
+
+declare interface GPUCommandEncoderDescriptor extends GPUObjectDescriptorBase {
+  measureExecutionTime?: boolean;
+}
+
+declare interface GPUImageDataLayout {
+  offset?: number;
+  bytesPerRow?: number;
+  rowsPerImage?: number;
+}
+
+declare interface GPUImageCopyBuffer extends GPUImageDataLayout {
+  buffer: GPUBuffer;
+}
+
+declare interface GPUImageCopyTexture {
+  texture: GPUTexture;
+  mipLevel?: number;
+  origin?: GPUOrigin3D;
+  aspect?: GPUTextureAspect;
+}
+
+interface GPUProgrammablePassEncoder {
+  setBindGroup(
+    index: number,
+    bindGroup: GPUBindGroup,
+    dynamicOffsets?: number[],
+  ): undefined;
+
+  setBindGroup(
+    index: number,
+    bindGroup: GPUBindGroup,
+    dynamicOffsetsData: Uint32Array,
+    dynamicOffsetsDataStart: number,
+    dynamicOffsetsDataLength: number,
+  ): undefined;
+
+  pushDebugGroup(groupLabel: string): undefined;
+  popDebugGroup(): undefined;
+  insertDebugMarker(markerLabel: string): undefined;
+}
+
+declare class GPUComputePassEncoder
+  implements GPUObjectBase, GPUProgrammablePassEncoder {
+  label: string | null;
+  setBindGroup(
+    index: number,
+    bindGroup: GPUBindGroup,
+    dynamicOffsets?: number[],
+  ): undefined;
+  setBindGroup(
+    index: number,
+    bindGroup: GPUBindGroup,
+    dynamicOffsetsData: Uint32Array,
+    dynamicOffsetsDataStart: number,
+    dynamicOffsetsDataLength: number,
+  ): undefined;
+  pushDebugGroup(groupLabel: string): undefined;
+  popDebugGroup(): undefined;
+  insertDebugMarker(markerLabel: string): undefined;
+  setPipeline(pipeline: GPUComputePipeline): undefined;
+  dispatch(x: number, y?: number, z?: number): undefined;
+  dispatchIndirect(
+    indirectBuffer: GPUBuffer,
+    indirectOffset: number,
+  ): undefined;
+
+  beginPipelineStatisticsQuery(
+    querySet: GPUQuerySet,
+    queryIndex: number,
+  ): undefined;
+  endPipelineStatisticsQuery(): undefined;
+
+  writeTimestamp(querySet: GPUQuerySet, queryIndex: number): undefined;
+
+  endPass(): undefined;
+}
+
+declare interface GPUComputePassDescriptor extends GPUObjectDescriptorBase {}
+
+interface GPURenderEncoderBase {
+  setPipeline(pipeline: GPURenderPipeline): undefined;
+
+  setIndexBuffer(
+    buffer: GPUBuffer,
+    indexFormat: GPUIndexFormat,
+    offset?: number,
+    size?: number,
+  ): undefined;
+  setVertexBuffer(
+    slot: number,
+    buffer: GPUBuffer,
+    offset?: number,
+    size?: number,
+  ): undefined;
+
+  draw(
+    vertexCount: number,
+    instanceCount?: number,
+    firstVertex?: number,
+    firstInstance?: number,
+  ): undefined;
+  drawIndexed(
+    indexCount: number,
+    instanceCount?: number,
+    firstIndex?: number,
+    baseVertex?: number,
+    firstInstance?: number,
+  ): undefined;
+
+  drawIndirect(indirectBuffer: GPUBuffer, indirectOffset: number): undefined;
+  drawIndexedIndirect(
+    indirectBuffer: GPUBuffer,
+    indirectOffset: number,
+  ): undefined;
+}
+
+declare class GPURenderPassEncoder
+  implements GPUObjectBase, GPUProgrammablePassEncoder, GPURenderEncoderBase {
+  label: string | null;
+  setBindGroup(
+    index: number,
+    bindGroup: GPUBindGroup,
+    dynamicOffsets?: number[],
+  ): undefined;
+  setBindGroup(
+    index: number,
+    bindGroup: GPUBindGroup,
+    dynamicOffsetsData: Uint32Array,
+    dynamicOffsetsDataStart: number,
+    dynamicOffsetsDataLength: number,
+  ): undefined;
+  pushDebugGroup(groupLabel: string): undefined;
+  popDebugGroup(): undefined;
+  insertDebugMarker(markerLabel: string): undefined;
+  setPipeline(pipeline: GPURenderPipeline): undefined;
+  setIndexBuffer(
+    buffer: GPUBuffer,
+    indexFormat: GPUIndexFormat,
+    offset?: number,
+    size?: number,
+  ): undefined;
+  setVertexBuffer(
+    slot: number,
+    buffer: GPUBuffer,
+    offset?: number,
+    size?: number,
+  ): undefined;
+  draw(
+    vertexCount: number,
+    instanceCount?: number,
+    firstVertex?: number,
+    firstInstance?: number,
+  ): undefined;
+  drawIndexed(
+    indexCount: number,
+    instanceCount?: number,
+    firstIndex?: number,
+    baseVertex?: number,
+    firstInstance?: number,
+  ): undefined;
+  drawIndirect(indirectBuffer: GPUBuffer, indirectOffset: number): undefined;
+  drawIndexedIndirect(
+    indirectBuffer: GPUBuffer,
+    indirectOffset: number,
+  ): undefined;
+
+  setViewport(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    minDepth: number,
+    maxDepth: number,
+  ): undefined;
+
+  setScissorRect(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  ): undefined;
+
+  setBlendConstant(color: GPUColor): undefined;
+  setStencilReference(reference: number): undefined;
+
+  beginOcclusionQuery(queryIndex: number): undefined;
+  endOcclusionQuery(): undefined;
+
+  beginPipelineStatisticsQuery(
+    querySet: GPUQuerySet,
+    queryIndex: number,
+  ): undefined;
+  endPipelineStatisticsQuery(): undefined;
+
+  writeTimestamp(querySet: GPUQuerySet, queryIndex: number): undefined;
+
+  executeBundles(bundles: GPURenderBundle[]): undefined;
+  endPass(): undefined;
+}
+
+declare interface GPURenderPassDescriptor extends GPUObjectDescriptorBase {
+  colorAttachments: GPURenderPassColorAttachment[];
+  depthStencilAttachment?: GPURenderPassDepthStencilAttachment;
+  occlusionQuerySet?: GPUQuerySet;
+}
+
+declare interface GPURenderPassColorAttachment {
+  view: GPUTextureView;
+  resolveTarget?: GPUTextureView;
+
+  loadValue: GPULoadOp | GPUColor;
+  storeOp?: GPUStoreOp;
+}
+
+declare interface GPURenderPassDepthStencilAttachment {
+  view: GPUTextureView;
+
+  depthLoadValue: GPULoadOp | number;
+  depthStoreOp: GPUStoreOp;
+  depthReadOnly?: boolean;
+
+  stencilLoadValue: GPULoadOp | number;
+  stencilStoreOp: GPUStoreOp;
+  stencilReadOnly?: boolean;
+}
+
+declare type GPULoadOp = "load";
+
+declare type GPUStoreOp = "store" | "discard";
+
+declare class GPURenderBundle implements GPUObjectBase {
+  label: string | null;
+}
+
+declare interface GPURenderBundleDescriptor extends GPUObjectDescriptorBase {}
+
+declare class GPURenderBundleEncoder
+  implements GPUObjectBase, GPUProgrammablePassEncoder, GPURenderEncoderBase {
+  label: string | null;
+  draw(
+    vertexCount: number,
+    instanceCount?: number,
+    firstVertex?: number,
+    firstInstance?: number,
+  ): undefined;
+  drawIndexed(
+    indexCount: number,
+    instanceCount?: number,
+    firstIndex?: number,
+    baseVertex?: number,
+    firstInstance?: number,
+  ): undefined;
+  drawIndexedIndirect(
+    indirectBuffer: GPUBuffer,
+    indirectOffset: number,
+  ): undefined;
+  drawIndirect(indirectBuffer: GPUBuffer, indirectOffset: number): undefined;
+  insertDebugMarker(markerLabel: string): undefined;
+  popDebugGroup(): undefined;
+  pushDebugGroup(groupLabel: string): undefined;
+  setBindGroup(
+    index: number,
+    bindGroup: GPUBindGroup,
+    dynamicOffsets?: number[],
+  ): undefined;
+  setBindGroup(
+    index: number,
+    bindGroup: GPUBindGroup,
+    dynamicOffsetsData: Uint32Array,
+    dynamicOffsetsDataStart: number,
+    dynamicOffsetsDataLength: number,
+  ): undefined;
+  setIndexBuffer(
+    buffer: GPUBuffer,
+    indexFormat: GPUIndexFormat,
+    offset?: number,
+    size?: number,
+  ): undefined;
+  setPipeline(pipeline: GPURenderPipeline): undefined;
+  setVertexBuffer(
+    slot: number,
+    buffer: GPUBuffer,
+    offset?: number,
+    size?: number,
+  ): undefined;
+
+  finish(descriptor?: GPURenderBundleDescriptor): GPURenderBundle;
+}
+
+declare interface GPURenderPassLayout extends GPUObjectDescriptorBase {
+  colorFormats: GPUTextureFormat[];
+  depthStencilFormat?: GPUTextureFormat;
+  sampleCount?: number;
+}
+
+declare interface GPURenderBundleEncoderDescriptor extends GPURenderPassLayout {
+  depthReadOnly?: boolean;
+  stencilReadOnly?: boolean;
+}
+
+declare class GPUQueue implements GPUObjectBase {
+  label: string | null;
+
+  submit(commandBuffers: GPUCommandBuffer[]): undefined;
+
+  onSubmittedWorkDone(): Promise<undefined>;
+
+  writeBuffer(
+    buffer: GPUBuffer,
+    bufferOffset: number,
+    data: BufferSource,
+    dataOffset?: number,
+    size?: number,
+  ): undefined;
+
+  writeTexture(
+    destination: GPUImageCopyTexture,
+    data: BufferSource,
+    dataLayout: GPUImageDataLayout,
+    size: GPUExtent3D,
+  ): undefined;
+}
+
+declare class GPUQuerySet implements GPUObjectBase {
+  label: string | null;
+
+  destroy(): undefined;
+}
+
+declare interface GPUQuerySetDescriptor extends GPUObjectDescriptorBase {
+  type: GPUQueryType;
+  count: number;
+  pipelineStatistics?: GPUPipelineStatisticName[];
+}
+
+declare type GPUQueryType = "occlusion" | "pipeline-statistics" | "timestamp";
+
+declare type GPUPipelineStatisticName =
+  | "vertex-shader-invocations"
+  | "clipper-invocations"
+  | "clipper-primitives-out"
+  | "fragment-shader-invocations"
+  | "compute-shader-invocations";
+
+declare type GPUDeviceLostReason = "destroyed";
+
+declare interface GPUDeviceLostInfo {
+  readonly reason: GPUDeviceLostReason | undefined;
+  readonly message: string;
+}
+
+declare type GPUErrorFilter = "out-of-memory" | "validation";
+
+declare class GPUOutOfMemoryError {
+  constructor();
+}
+
+declare class GPUValidationError {
+  constructor(message: string);
+  readonly message: string;
+}
+
+declare type GPUError = GPUOutOfMemoryError | GPUValidationError;
+
+declare class GPUUncapturedErrorEvent extends Event {
+  constructor(
+    type: string,
+    gpuUncapturedErrorEventInitDict: GPUUncapturedErrorEventInit,
+  );
+  readonly error: GPUError;
+}
+
+declare interface GPUUncapturedErrorEventInit extends EventInit {
+  error?: GPUError;
+}
+
+declare interface GPUColorDict {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+declare type GPUColor = number[] | GPUColorDict;
+
+declare interface GPUOrigin3DDict {
+  x?: number;
+  y?: number;
+  z?: number;
+}
+
+declare type GPUOrigin3D = number[] | GPUOrigin3DDict;
+
+declare interface GPUExtent3DDict {
+  width: number;
+  height?: number;
+  depthOrArrayLayers?: number;
+}
+
+declare type GPUExtent3D = number[] | GPUExtent3DDict;

--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -14,6 +14,7 @@ use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::rc::Rc;
 pub use wgpu_core;
 pub use wgpu_types;
@@ -122,6 +123,10 @@ pub fn init(unstable: bool) -> Extension {
             Ok(())
         })
         .build()
+}
+
+pub fn get_declaration() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("lib.deno_webgpu.d.ts")
 }
 
 fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {


### PR DESCRIPTION
This restores the TS types to `deno_webgpu` and the `deno_webgpu::get_declaration()` func, which are necessary for `deno_webgpu` to be consumed by deno CLI