### PR TITLE
lint: deno_webgpu & wgpu-core

### DIFF
--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -264,7 +264,7 @@ pub async fn op_webgpu_request_adapter(
 
     let descriptor = wgpu_core::instance::RequestAdapterOptions {
         power_preference: match args.power_preference {
-            Some(power_preference) => power_preference.into(),
+            Some(power_preference) => power_preference,
             None => PowerPreference::default(),
         },
         force_fallback_adapter: args.force_fallback_adapter,

--- a/deno_webgpu/src/pipeline.rs
+++ b/deno_webgpu/src/pipeline.rs
@@ -209,10 +209,10 @@ impl TryFrom<GpuDepthStencilState> for wgpu_types::DepthStencilState {
         Ok(wgpu_types::DepthStencilState {
             format: state.format,
             depth_write_enabled: state.depth_write_enabled,
-            depth_compare: state.depth_compare.into(),
+            depth_compare: state.depth_compare,
             stencil: wgpu_types::StencilState {
-                front: state.stencil_front.into(),
-                back: state.stencil_back.into(),
+                front: state.stencil_front,
+                back: state.stencil_back,
                 read_mask: state.stencil_read_mask,
                 write_mask: state.stencil_write_mask,
             },
@@ -322,7 +322,7 @@ pub fn op_webgpu_create_render_pipeline(
         let mut targets = Vec::with_capacity(fragment.targets.len());
 
         for target in fragment.targets {
-            targets.push(target.try_into()?);
+            targets.push(target);
         }
 
         Some(wgpu_core::pipeline::FragmentState {
@@ -356,7 +356,7 @@ pub fn op_webgpu_create_render_pipeline(
         },
         primitive: args.primitive.into(),
         depth_stencil: args.depth_stencil.map(TryInto::try_into).transpose()?,
-        multisample: args.multisample.into(),
+        multisample: args.multisample,
         fragment,
         multiview: None,
     };

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -137,7 +137,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     unsafe {
                         hal::Device::create_texture_view(
                             &device.raw,
-                            &ast.texture.borrow(),
+                            ast.texture.borrow(),
                             &clear_view_desc,
                         )
                     }


### PR DESCRIPTION
Mostly unnecessary `.into()`s