### PR TITLE
Make execute_bundles() receives IntoIterator

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2628,7 +2628,7 @@ impl<'a> RenderPass<'a> {
 
     /// Execute a [render bundle][RenderBundle], which is a set of pre-recorded commands
     /// that can be run together.
-    pub fn execute_bundles<I: Iterator<Item = &'a RenderBundle>>(&mut self, render_bundles: I) {
+    pub fn execute_bundles<I: IntoIterator<Item = &'a RenderBundle>>(&mut self, render_bundles: I) {
         self.id
             .execute_bundles(render_bundles.into_iter().map(|rb| &rb.id))
     }


### PR DESCRIPTION
**Connections**

Fix #2406

**Description**

It would be better aligned with other interfaces like `Queue::submit()`, and be more convenient like we can pass `Some(render_bundle)`.

**Testing**

Ran `cargo check`
