### PR TITLE
[0.12] Properly set msl version to 2.3 if supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+  - Metal:
+    - Check for MSL 2.3
+
 ## wgpu-hal-0.12.3, deno-webgpu-? (2022-01-20)
   - Metal:
     - preserve vertex invariance

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -574,7 +574,9 @@ impl super::PrivateCapabilities {
         Self {
             family_check,
             msl_version: if os_is_mac {
-                if Self::version_at_least(major, minor, 10, 15) {
+                if Self::version_at_least(major, minor, 11, 0) {
+                    MTLLanguageVersion::V2_3
+                } else if Self::version_at_least(major, minor, 10, 15) {
                     MTLLanguageVersion::V2_2
                 } else if Self::version_at_least(major, minor, 10, 14) {
                     MTLLanguageVersion::V2_1
@@ -587,6 +589,8 @@ impl super::PrivateCapabilities {
                 } else {
                     MTLLanguageVersion::V1_0
                 }
+            } else if Self::version_at_least(major, minor, 14, 0) {
+                MTLLanguageVersion::V2_3
             } else if Self::version_at_least(major, minor, 13, 0) {
                 MTLLanguageVersion::V2_2
             } else if Self::version_at_least(major, minor, 12, 0) {


### PR DESCRIPTION
**Connections**

Allows https://github.com/gfx-rs/naga/pull/1685 to work by checking for MSL 2.3

**Description**

We just never needed to check for anything above 2.2 before so we didn't have it.

**Testing**

Testing rend3
