### PR TITLE
Fix msaa-line example's unnecessary MSAA data store

### DIFF
--- a/wgpu/examples/msaa-line/main.rs
+++ b/wgpu/examples/msaa-line/main.rs
@@ -250,21 +250,25 @@ impl framework::Example for Example {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         {
-            let ops = wgpu::Operations {
-                load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
-                store: true,
-            };
             let rpass_color_attachment = if self.sample_count == 1 {
                 wgpu::RenderPassColorAttachment {
                     view,
                     resolve_target: None,
-                    ops,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: true,
+                    },
                 }
             } else {
                 wgpu::RenderPassColorAttachment {
                     view: &self.multisampled_framebuffer,
                     resolve_target: Some(view),
-                    ops,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        // Storing pre-resolve MSAA data is unnecessary if it isn't used later.
+                        // On tile-based GPU, avoid store can reduce your app's memory footprint.
+                        store: false,
+                    },
                 }
             };
 


### PR DESCRIPTION
**Description**
Storing pre-resolve MSAA data is unnecessary if it isn't used later. On tile-based GPU, avoid store can reduce app's memory footprint.

**Testing**
Tested on M1 macOS, Android 8.1 && 10.0 Phones(both GL and VULKAN backend), iPhone 12

**Addition info**
<details>
	<summary>Debugging msaa-line example on macOS:</summary>
	<pre><code>
warning message：Storing pre-resolve MSAA data is unnecessary if it isn't used later. 

<img width="1106" alt="macOS" src="https://user-images.githubusercontent.com/1001342/150950782-f9b764a4-c932-4729-9cfa-36da5df38357.png">
	</code></pre>
</details>

<details>
	<summary>Debugging on iPhone:</summary>
	<pre><code>
warning message：Storing pre-resolve MSAA data is unnecessary if it isn't used later. 
It increases your app's memory footprint and can be avoided by using memoryless textures.

<img width="1601" alt="iPhone" src="https://user-images.githubusercontent.com/1001342/150950927-03941d60-99a2-40b3-b16d-c943c38e187d.png">
	</code></pre>
</details>