### PR TITLE
IdentityManager: `from_index` method is unneeded.

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -28,7 +28,7 @@ impl<I: Clone + Debug + wgc::id::TypedId> wgc::hub::IdentityHandlerFactory<I>
     for IdentityPassThroughFactory
 {
     type Filter = IdentityPassThrough<I>;
-    fn spawn(&self, _min_index: u32) -> Self::Filter {
+    fn spawn(&self) -> Self::Filter {
         IdentityPassThrough(PhantomData)
     }
 }

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -114,6 +114,11 @@ impl<T> Ord for Id<T> {
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub(crate) struct Valid<I>(pub I);
 
+/// Trait carrying methods for direct `Id` access.
+///
+/// Most `wgpu-core` clients should not use this trait. Unusual clients that
+/// need to construct `Id` values directly, or access their components, like the
+/// WGPU recording player, may use this trait to do so.
 pub trait TypedId {
     fn zip(index: Index, epoch: Epoch, backend: Backend) -> Self;
     fn unzip(self) -> (Index, Epoch, Backend);


### PR DESCRIPTION
The `min_index` parameter has no useful effect. Because the range 0..n is pushed
on the free list, index values less than `min_index` do get allocated.

Document `IdentityManager` and `TypedId`.
