### PR TITLE
Identify Apple M1 GPU as integrated

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -118,6 +118,7 @@ impl super::Adapter {
             "mali",
             "intel",
             "v3d",
+            "apple m1",
         ];
         let strings_that_imply_cpu = ["mesa offscreen", "swiftshader", "llvmpipe"];
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -988,6 +988,21 @@ impl super::PrivateCapabilities {
             } else {
                 Self::version_at_least(major, minor, 13, 0)
             },
+            has_unified_memory: if (os_is_mac && Self::version_at_least(major, minor, 10, 15))
+                || (!os_is_mac && Self::version_at_least(major, minor, 13, 0))
+            {
+                Some(device.has_unified_memory())
+            } else {
+                None
+            },
+        }
+    }
+
+    pub fn device_type(&self) -> wgt::DeviceType {
+        if self.has_unified_memory.unwrap_or(self.low_power) {
+            wgt::DeviceType::IntegratedGpu
+        } else {
+            wgt::DeviceType::DiscreteGpu
         }
     }
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -108,18 +108,13 @@ impl crate::Instance<Api> for Instance {
             .into_iter()
             .map(|dev| {
                 let name = dev.name().into();
-                let has_unified_memory = dev.has_unified_memory();
                 let shared = AdapterShared::new(dev);
                 crate::ExposedAdapter {
                     info: wgt::AdapterInfo {
                         name,
                         vendor: 0,
                         device: 0,
-                        device_type: if has_unified_memory {
-                            wgt::DeviceType::IntegratedGpu
-                        } else {
-                            wgt::DeviceType::DiscreteGpu
-                        },
+                        device_type: shared.private_caps.device_type(),
                         backend: wgt::Backend::Metal,
                     },
                     features: shared.private_caps.features(),
@@ -231,6 +226,7 @@ struct PrivateCapabilities {
     supports_mutability: bool,
     supports_depth_clip_control: bool,
     supports_preserve_invariance: bool,
+    has_unified_memory: Option<bool>,
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -108,13 +108,14 @@ impl crate::Instance<Api> for Instance {
             .into_iter()
             .map(|dev| {
                 let name = dev.name().into();
+                let has_unified_memory = dev.has_unified_memory();
                 let shared = AdapterShared::new(dev);
                 crate::ExposedAdapter {
                     info: wgt::AdapterInfo {
                         name,
                         vendor: 0,
                         device: 0,
-                        device_type: if shared.private_caps.low_power {
+                        device_type: if has_unified_memory {
                             wgt::DeviceType::IntegratedGpu
                         } else {
                             wgt::DeviceType::DiscreteGpu


### PR DESCRIPTION
**Connections**
* Closes https://github.com/gfx-rs/wgpu/issues/2426

**Description**
The Apple M1 line of GPUs use a unified memory architecture that implies they are integrated but wgpu currently uses whether they are low power (Metal backend), or name-based heuristics (GL backend) which classify them as discrete, which seems incorrect.

**Testing**
I ran a few native examples (so only tested the Metal backend) and checked the adapter info to see that it had changed to `IntegratedGpu`.