### PR TITLE
Fix M1 in macOS incorrectly reports supported compressed texture formats

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1014,7 +1014,6 @@ impl super::PrivateCapabilities {
         use wgt::Features as F;
 
         let mut features = F::empty()
-            | F::TEXTURE_COMPRESSION_BC
             | F::INDIRECT_FIRST_INSTANCE
             | F::MAPPABLE_PRIMARY_BUFFERS
             | F::VERTEX_WRITABLE_STORAGE
@@ -1023,6 +1022,10 @@ impl super::PrivateCapabilities {
             | F::POLYGON_MODE_LINE
             | F::CLEAR_TEXTURE
             | F::TEXTURE_FORMAT_16BIT_NORM;
+
+        features.set(F::TEXTURE_COMPRESSION_ASTC_LDR, self.format_astc);
+        features.set(F::TEXTURE_COMPRESSION_BC, self.format_bc);
+        features.set(F::TEXTURE_COMPRESSION_ETC2, self.format_eac_etc);
 
         features.set(F::DEPTH_CLIP_CONTROL, self.supports_depth_clip_control);
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -720,10 +720,10 @@ impl super::PrivateCapabilities {
             format_bc: os_is_mac,
             format_eac_etc: !os_is_mac
                 // M1 in macOS supports EAC/ETC2
-                || device.supports_family(MTLGPUFamily::Apple7),
+                || (family_check && device.supports_family(MTLGPUFamily::Apple7)),
             format_astc: Self::supports_any(device, ASTC_PIXEL_FORMAT_FEATURES)
-                // A14/M1 always support ASTC
-                || device.supports_family(MTLGPUFamily::Apple7),
+                // A13/A14/M1 and later always support ASTC
+                || (family_check && device.supports_family(MTLGPUFamily::Apple6)),
             format_any8_unorm_srgb_all: Self::supports_any(device, ANY8_UNORM_SRGB_ALL),
             format_any8_unorm_srgb_no_write: !Self::supports_any(device, ANY8_UNORM_SRGB_ALL)
                 && !os_is_mac,

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -718,8 +718,12 @@ impl super::PrivateCapabilities {
             format_min_srgb_channels: if os_is_mac { 4 } else { 1 },
             format_b5: !os_is_mac,
             format_bc: os_is_mac,
-            format_eac_etc: !os_is_mac,
-            format_astc: Self::supports_any(device, ASTC_PIXEL_FORMAT_FEATURES),
+            format_eac_etc: !os_is_mac
+                // M1 in macOS supports EAC/ETC2
+                || device.supports_family(MTLGPUFamily::Apple7),
+            format_astc: Self::supports_any(device, ASTC_PIXEL_FORMAT_FEATURES)
+                // A14/M1 always support ASTC
+                || device.supports_family(MTLGPUFamily::Apple7),
             format_any8_unorm_srgb_all: Self::supports_any(device, ANY8_UNORM_SRGB_ALL),
             format_any8_unorm_srgb_no_write: !Self::supports_any(device, ANY8_UNORM_SRGB_ALL)
                 && !os_is_mac,


### PR DESCRIPTION
**Connections**
[M1 in macOS incorrectly reports supported compressed texture formats](https://github.com/gfx-rs/wgpu/issues/2452)

**Description**
The metal backend in wgpu-hal was incorrectly detecting support for ASTC and EAC/ETC2 on macOS as the M1 line of GPUs supports these formats as well as BC. It was also misrepresenting the support in the values returned from `Adapter::features()` as always support BC and never ASTC nor ETC2.

**Testing**
On an M1 running macOS, check whether the `Adapter::features()` includes all three of `TEXTURE_COMPRESSION_ASTC`, `TEXTURE_COMPRESSION_BC`, and `TEXTURE_COMPRESSION_ETC2`. I have tested this locally on an M1 Max running macOS.