### PR TITLE
Add a :star: to the feature matrix of examples README

### DIFF
--- a/wgpu/examples/README.md
+++ b/wgpu/examples/README.md
@@ -45,7 +45,7 @@ All framework-based examples render to the window and are reftested against the 
 | - queries                    |        |           |        | :star: |           |        |        |                |        |                     |
 | - conservative rasterization |        |           |        |        |           |        |        |                |        | :star:              |
 | *integrations*               |        |           |        |        |           |        |        |                |        |                     |
-| - staging belt               |        |           |        |        |           |        |        |                |        |                     |
+| - staging belt               |        |           |        |        |           |        | :star: |                |        |                     |
 | - typed arena                |        |           |        |        |           |        |        |                |        |                     |
 | - obj loading                |        |           |        |        |           |        | :star: |                |        |                     |
 


### PR DESCRIPTION
On searching for the example of `StagingBelt`, I found the skybox example uses it while the README doesn't say so. I think we can add a ⭐ here.