### PR TITLE
Don't recycle indices that reach EOL

### DIFF
--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt, marker::PhantomData, num::NonZeroU64};
 use wgt::Backend;
 
 const BACKEND_BITS: usize = 3;
-const EPOCH_MASK: u32 = (1 << (32 - BACKEND_BITS)) - 1;
+pub const EPOCH_MASK: u32 = (1 << (32 - BACKEND_BITS)) - 1;
 type Dummy = hal::api::Empty;
 
 #[repr(transparent)]


### PR DESCRIPTION
**Connections**
Related to https://github.com/gfx-rs/wgpu-native/pull/171
But also affects 64-bit systems.

**Description**
Once the epoch reaches its max value, we should never try to recycle it.

**Testing**
small unit test inside
