### PR TITLE
added id32 feature

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -20,6 +20,7 @@ trace = ["ron", "serde", "wgt/trace", "arrayvec/serde", "naga/serialize"]
 replay = ["serde", "wgt/replay", "arrayvec/serde", "naga/deserialize"]
 # Enable serializable compute/render passes, and bundle encoders.
 serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
+id32 = []
 
 [dependencies]
 arrayvec = "0.7"


### PR DESCRIPTION
**Connections**
Related to https://github.com/gfx-rs/wgpu-native/pull/171. Added feature to enable 32 bit ids.

**Description**
If you activate --features id32bits, then wgpu will generate 32 bits ids, and so wgpu-native can be used on 32bit systems like emscripten.

**Testing**
Added unit test to check corner cases.