### PR TITLE
fix: blit should only draw one triangle

### DIFF
--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -98,7 +98,7 @@ impl Example {
                 targets: &[TEXTURE_FORMAT.into()],
             }),
             primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                topology: wgpu::PrimitiveTopology::TriangleList,
                 ..Default::default()
             },
             depth_stencil: None,
@@ -174,7 +174,7 @@ impl Example {
             }
             rpass.set_pipeline(&pipeline);
             rpass.set_bind_group(0, &bind_group, &[]);
-            rpass.draw(0..4, 0..1);
+            rpass.draw(0..3, 0..1);
             if let Some(ref query_sets) = query_sets {
                 rpass.write_timestamp(&query_sets.timestamp, timestamp_query_index_base + 1);
                 rpass.end_pipeline_statistics_query();


### PR DESCRIPTION
**Description**
Original shader:
https://github.com/gfx-rs/wgpu/blob/48f8811f0f6643f112baa3a2a9e2c287017a022d/wgpu/examples/mipmap/blit.wgsl#L7-L22
`x` in [0, 1]
`y` in [0, 1]
`out.tex_coord` in [(0, 0), (2, 2)]
`out.position` in [(-1, -3), (3, 1)]
Clearly it is wrong, but it actually covers the whole render area([(-1, -1), (1, 1)]), and `tex_coord` happened to be right, so it worked.
![image](https://user-images.githubusercontent.com/21034795/153534412-16be67ed-6a84-427a-8e8d-4ba9f69bc22f.png)


**Testing**
Run the mipmap example, result is the same.
master branch:
![image](https://user-images.githubusercontent.com/21034795/153532753-e9adb31a-d648-4ba5-8101-fdc511f735b5.png)
this branch:
![image](https://user-images.githubusercontent.com/21034795/153532646-9c7d04f5-6204-4e70-ad13-65b06f85279a.png)

