### PR TITLE
Enable support for 3D textures

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -730,7 +730,7 @@ impl<A: HalApi> Device<A> {
             let dimension = match desc.dimension {
                 wgt::TextureDimension::D1 => wgt::TextureViewDimension::D1,
                 wgt::TextureDimension::D2 => wgt::TextureViewDimension::D2,
-                wgt::TextureDimension::D3 => unreachable!(),
+                wgt::TextureDimension::D3 => wgt::TextureViewDimension::D3,
             };
 
             let mut clear_views = SmallVec::new();


### PR DESCRIPTION
Currently when attempting to create a 3D texture it panics with: `internal error: entered unreachable code`

But simply adding D3 to the `match` seems to work just fine. I've tested as far as creating a 3D texture and inspecting it using RenderDoc.

Here's an example of creating a texture that is fixed by this change:

```
device.create_texture(&wgpu::TextureDescriptor {
        label: Some("Voxel texture"),
        size: wgpu::Extent3d {
                width: 128,
                height: 128,
                depth_or_array_layers: 128,
        },
        mip_level_count: 1,
        sample_count: 1,
        dimension: wgpu::TextureDimension::D3,
        format: wgpu::TextureFormat::Rgba8UnormSrgb,
        usage: wgpu::TextureUsages::TEXTURE_BINDING
                | wgpu::TextureUsages::COPY_SRC
                | wgpu::TextureUsages::COPY_DST
                | wgpu::TextureUsages::RENDER_ATTACHMENT,
});
```

A 3D texture inside RenderDoc:
![image](https://user-images.githubusercontent.com/3372/154146893-a37c13c7-389e-43c7-a770-4a4a90a1ea79.png)

