### PR TITLE
Validated render usages for 3D textures

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -306,7 +306,9 @@ pub enum CreateTextureError {
     )]
     InvalidMipLevelCount { requested: u32, maximum: u32 },
     #[error("Texture usages {0:?} are not allowed on a texture of type {1:?}")]
-    InvalidUsages(wgt::TextureUsages, wgt::TextureFormat),
+    InvalidFormatUsages(wgt::TextureUsages, wgt::TextureFormat),
+    #[error("Texture usages {0:?} are not allowed on a texture of dimensions {1:?}")]
+    InvalidDimensionUsages(wgt::TextureUsages, wgt::TextureDimension),
     #[error("Texture format {0:?} can't be used")]
     MissingFeatures(wgt::TextureFormat, #[source] MissingFeatures),
 }


### PR DESCRIPTION
**Connections**
Matches https://github.com/gpuweb/gpuweb/pull/2603
Closes #2481

**Description**
It's not portable to create 2D views of 3D textures. Therefore, it's not possible to render into them.

**Testing**
Untested
