### PR TITLE
Re-allow vk backend on Apple platforms via `vulkan-portability` feature

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -21,6 +21,7 @@ replay = ["serde", "wgt/replay", "arrayvec/serde", "naga/deserialize"]
 # Enable serializable compute/render passes, and bundle encoders.
 serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
 id32 = []
+vulkan-portability = ["hal/vulkan"]
 
 [dependencies]
 arrayvec = "0.7"

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -7,7 +7,7 @@ fn main() {
         unix_wo_apple: {all(unix, not(apple))},
 
         // Backends
-        vulkan: { all(not(wasm), any(windows, unix_wo_apple)) },
+        vulkan: { all(not(wasm), any(windows, unix_wo_apple, feature = "vulkan-portability")) },
         metal: { all(not(wasm), apple) },
         dx12: { all(not(wasm), windows) },
         dx11: { all(false, not(wasm), windows) },

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -514,6 +514,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 },
                 //acquired_texture: None,
             }),
+            #[cfg(vulkan)]
+            vulkan: None,
             #[cfg(gl)]
             gl: None,
         };

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -202,7 +202,10 @@ macro_rules! gfx_select {
         // Note: For some reason the cfg aliases defined in build.rs don't succesfully apply in this
         // macro so we must specify their equivalents manually
         match $id.backend() {
-            #[cfg(all(not(target_arch = "wasm32"), not(target_os = "ios"), not(target_os = "macos")))]
+            #[cfg(any(
+                all(not(target_arch = "wasm32"), not(target_os = "ios"), not(target_os = "macos")),
+                feature = "vulkan-portability"
+            ))]
             wgt::Backend::Vulkan => $global.$method::<$crate::api::Vulkan>( $($param),* ),
             #[cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))]
             wgt::Backend::Metal => $global.$method::<$crate::api::Metal>( $($param),* ),

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -210,12 +210,9 @@ impl crate::Surface<super::Api> for super::Surface {
         render_layer.set_presents_with_transaction(self.present_with_transaction);
         // opt-in to Metal EDR
         // EDR potentially more power used in display and more bandwidth, memory footprint.
-        #[cfg(target_os = "macos")]
-        {
-            let wants_edr = self.raw_swapchain_format == mtl::MTLPixelFormat::RGBA16Float;
-            if wants_edr != render_layer.wants_extended_dynamic_range_content() {
-                render_layer.set_wants_extended_dynamic_range_content(wants_edr);
-            }
+        let wants_edr = self.raw_swapchain_format == mtl::MTLPixelFormat::RGBA16Float;
+        if wants_edr != render_layer.wants_extended_dynamic_range_content() {
+            render_layer.set_wants_extended_dynamic_range_content(wants_edr);
         }
 
         // this gets ignored on iOS for certain OS/device combinations (iphone5s iOS 10.3)

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -630,6 +630,9 @@ impl PhysicalDeviceCapabilities {
             extensions.push(vk::ExtDepthClipEnableFn::name());
         }
 
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        extensions.push(vk::KhrPortabilitySubsetFn::name());
+
         extensions
     }
 
@@ -1494,6 +1497,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             wgt::TextureFormat::Rgba8UnormSrgb,
             wgt::TextureFormat::Bgra8Unorm,
             wgt::TextureFormat::Bgra8UnormSrgb,
+            wgt::TextureFormat::Rgba16Float,
         ];
         let formats = supported_formats
             .iter()

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -84,6 +84,7 @@ replay = ["serde", "wgc/replay"]
 angle = ["wgc/angle"]
 webgl = ["wgc"]
 emscripten = ["webgl"]
+vulkan-portability = ["wgc/vulkan-portability"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
 package = "wgpu-core"


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/2485
https://github.com/gfx-rs/wgpu/issues/2489

**Description**
- Enabled `VK_KHR_portability_subset` extension for Apple platforms.
- Add a `vulkan-portability` feature to enable vulkan backend.

Also, fixes Metal EDR `wantsExtendedDynamicRangeContent` setting on iOS. I'm double checked，although [Apple's documentation](https://developer.apple.com/documentation/quartzcore/cametallayer/1478161-wantsextendeddynamicrangecontent) marks it only for macOS, it cannot turn on EDR without setting it on iOS.

**Testing**
Tested all examples on M1 Mac,  only boids crashed on vk backend, always cause my Mac reboot and no error throwed out.
Tested build to iOS and running, using [wgpu-on-app](https://github.com/jinleili/wgpu_on_app).

Tested all examples on Intel Mac,  also only boids crashed on vk backend, throwed these error:
```sh
Using Intel(R) UHD Graphics 630 (Vulkan)
[mvk-error] VK_ERROR_DEVICE_LOST: Command buffer 0x7febc4221040 "_Present" execution failed (code 2): Caused GPU Timeout Error (00000002:kIOAccelCommandBufferCallbackErrorTimeout)
[2022-02-17T12:52:14Z ERROR wgpu_hal::vulkan::instance] GENERAL | VALIDATION | PERFORMANCE | 1111111111111111111111111111000 [ (0x0)]
        VK_ERROR_DEVICE_LOST: Command buffer 0x7febc4221040 "_Present" execution failed (code 2): Caused GPU Timeout Error (00000002:kIOAccelCommandBufferCallbackErrorTimeout)
[2022-02-17T12:52:14Z ERROR wgpu_hal::vulkan::instance]         objects: (type: QUEUE, hndl: 0x600000a65a38, name: ?)
thread 'main' panicked at 'Error in Surface::get_current_texture_view: parent device is lost', wgpu/src/backend/direct.rs:231:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'Error in Device::drop: parent device is lost', wgpu/src/backend/direct.rs:231:9
[2022-02-17T12:52:14Z ERROR wgpu_core::device] failed to wait for the device: Lost
```
`RUST_BACKTRACE=full` locate crashed at `surface_get_current_texture`:
```sh
  14:        0x10b526d6f - core::panicking::panic_fmt::h7d73f67464d78916
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:107:14
  15:        0x10af3b26f - wgpu::backend::direct::Context::handle_error_fatal::ha1bfba91354afa64
                               at /Users/LiJinlei/Rust/forks/wgpu/wgpu/src/backend/direct.rs:231:9
  16:        0x10af49d09 - <wgpu::backend::direct::Context as wgpu::Context>::surface_get_current_texture::hc9ff54a1b7d398a9
                               at /Users/LiJinlei/Rust/forks/wgpu/wgpu/src/backend/direct.rs:970:25
  17:        0x10ae88f75 - wgpu::Surface::get_current_texture::h1b2971f40ec2a252
                               at /Users/LiJinlei/Rust/forks/wgpu/wgpu/src/lib.rs:3194:13
  18:        0x10ab6abef - boids::framework::start::{{closure}}::hfce715d591ea0581
                               at /Users/LiJinlei/Rust/forks/wgpu/wgpu/examples/boids/../framework.rs:323:35
```