### PR TITLE
Add COPY_DST to Metal's surface usage bits

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -384,7 +384,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 height: 4096,
                 depth_or_array_layers: 1,
             },
-            usage: crate::TextureUses::COLOR_TARGET, //TODO: expose more
+            usage: crate::TextureUses::COLOR_TARGET | crate::TextureUses::COPY_DST, //TODO: expose more
         })
     }
 }


### PR DESCRIPTION
**Description**
After `cargo upgrade`-ing wgpu-core from 0.12.0 to 0.12.2, and wgpu-hal from 0.12.0 to 0.12.4, a Metal surface with usage flags `TextureUsages::RENDER_ATTACHMENT | TextureUsages::COPY_DST` could not be configured anymore (macOS 11.6.2) due to a validation mismatch. This PR adds the `COPY_DST` flag to Metal's surface capabilities so validation now passes for this particular usage flag. See "Discussion" below.

**Testing**
The simplest way to test is to add a `wgpu::TextureUsages::COPY_DST` usage flag to hello_triangle example's surface configuration. Prior to this change (and given you're on macOS), you'll get a panic `Error in Surface::configure: requested usage is not supported`. This change fixes the panic.

**Discussion**
I see there's a TODO for possibly exposing more flags, but I'm not knowledgeable enough to add them without discussing first. For example, I feel `DEPTH_STENCIL_WRITE` would also work? I'm happy to test out any additional changes and update the PR.
