### PR TITLE
Update dev deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "ddsfile"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f357e96445b4238418b6f4f2b5a956ac1306f89f01d68b85a2d81de3a7cab9"
+checksum = "9ac3f07973d5b85a0ad9e01fbec4a2a45fdf79ea54287ade3a47ebc8e2f82cf0"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -486,12 +492,11 @@ dependencies = [
 
 [[package]]
 name = "deflate"
-version = "0.8.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
+checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
 dependencies = [
  "adler32",
- "byteorder",
 ]
 
 [[package]]
@@ -550,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -1009,11 +1014,11 @@ checksum = "0c835948974f68e0bd58636fc6c5b1fbff7b297e3046f11b3b3c18bbac012c6d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
- "adler32",
+ "adler",
 ]
 
 [[package]]
@@ -1308,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.16.8"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
+checksum = "8e8f1882177b17c98ec33a51f5910ecbf4db92ca0def706781a1f8d0c661f393"
 dependencies = [
  "bitflags",
  "crc32fast",

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 [features]
 
 [dependencies]
-env_logger = "0.8"
+env_logger = "0.9"
 log = "0.4"
 raw-window-handle = "0.4"
 ron = "0.7"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -100,7 +100,7 @@ rev = "8e2e39e"
 features = ["wgsl-in"]
 
 [dev-dependencies]
-env_logger = "0.8"
+env_logger = "0.9"
 winit = "0.26" # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -10,5 +10,5 @@ keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-env_logger = "0.8"
+env_logger = "0.9"
 wgpu = { version = "0.12", path = "../wgpu" }

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -121,20 +121,20 @@ smallvec = "1"
 bitflags = "1"
 bytemuck = { version = "1.4", features = ["derive"] }
 cgmath = "0.18"
-ddsfile = "0.4"
+ddsfile = "0.5"
 log = "0.4"
 # Opt out of noise's "default-features" to avoid "image" feature as a dependency count optimization.
 # This will not be required in the next release since it has been removed from the default feature in https://github.com/Razaekel/noise-rs/commit/1af9e1522236b2c584fb9a02150c9c67a5e6bb04#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542
 noise = { version = "0.7", default-features = false }
 obj = "0.10"
-png = "0.16"
+png = "0.17"
 rand = "0.7.2"
 winit = "0.26"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 async-executor = "1.0"
 pollster = "0.2"
-env_logger = "0.8"
+env_logger = "0.9"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"

--- a/wgpu/examples/bunnymark/main.rs
+++ b/wgpu/examples/bunnymark/main.rs
@@ -133,9 +133,9 @@ impl framework::Example for Example {
         let texture = {
             let img_data = include_bytes!("../../../logo.png");
             let decoder = png::Decoder::new(std::io::Cursor::new(img_data));
-            let (info, mut reader) = decoder.read_info().unwrap();
-            let mut buf = vec![0; info.buffer_size()];
-            reader.next_frame(&mut buf).unwrap();
+            let mut reader = decoder.read_info().unwrap();
+            let mut buf = vec![0; reader.output_buffer_size()];
+            let info = reader.next_frame(&mut buf).unwrap();
 
             let size = wgpu::Extent3d {
                 width: info.width,

--- a/wgpu/examples/capture/main.rs
+++ b/wgpu/examples/capture/main.rs
@@ -145,11 +145,12 @@ async fn create_png(
             buffer_dimensions.height as u32,
         );
         png_encoder.set_depth(png::BitDepth::Eight);
-        png_encoder.set_color(png::ColorType::RGBA);
+        png_encoder.set_color(png::ColorType::Rgba);
         let mut png_writer = png_encoder
             .write_header()
             .unwrap()
-            .into_stream_writer_with_size(buffer_dimensions.unpadded_bytes_per_row);
+            .into_stream_writer_with_size(buffer_dimensions.unpadded_bytes_per_row)
+            .unwrap();
 
         // from the padded_buffer we write just the unpadded bytes into the image
         for chunk in padded_buffer.chunks(buffer_dimensions.padded_bytes_per_row) {

--- a/wgpu/tests/common/image.rs
+++ b/wgpu/tests/common/image.rs
@@ -19,7 +19,10 @@ fn read_png(path: impl AsRef<Path>, width: u32, height: u32) -> Option<Vec<u8>> 
         }
     };
     let decoder = png::Decoder::new(Cursor::new(data));
-    let (info, mut reader) = decoder.read_info().ok()?;
+    let mut reader = decoder.read_info().ok()?;
+
+    let mut buffer = vec![0; reader.output_buffer_size()];
+    let info = reader.next_frame(&mut buffer).ok()?;
     if info.width != width {
         log::warn!("image comparison invalid: size mismatch");
         return None;
@@ -28,7 +31,7 @@ fn read_png(path: impl AsRef<Path>, width: u32, height: u32) -> Option<Vec<u8>> 
         log::warn!("image comparison invalid: size mismatch");
         return None;
     }
-    if info.color_type != png::ColorType::RGBA {
+    if info.color_type != png::ColorType::Rgba {
         log::warn!("image comparison invalid: color type mismatch");
         return None;
     }
@@ -36,9 +39,6 @@ fn read_png(path: impl AsRef<Path>, width: u32, height: u32) -> Option<Vec<u8>> 
         log::warn!("image comparison invalid: bit depth mismatch");
         return None;
     }
-
-    let mut buffer = vec![0; info.buffer_size()];
-    reader.next_frame(&mut buffer).ok()?;
 
     Some(buffer)
 }
@@ -53,7 +53,7 @@ fn write_png(
     let file = BufWriter::new(File::create(path).unwrap());
 
     let mut encoder = png::Encoder::new(file, width, height);
-    encoder.set_color(png::ColorType::RGBA);
+    encoder.set_color(png::ColorType::Rgba);
     encoder.set_depth(png::BitDepth::Eight);
     encoder.set_compression(compression);
     let mut writer = encoder.write_header().unwrap();


### PR DESCRIPTION
**Description**
Updated deps in your examples makes it easier for users to use as a base.
Looks like some of these are also used for CI infrastructure (png)

**Testing**
I think CI should catch any issues with the png changes as that seems to be the main user of png images.
I think the bunnymark example is broken on the master branch on my machine so that didnt help with testing.