### PR TITLE
vulkan: HDR ASTC formats support

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -197,6 +197,7 @@ impl Surface {
             wgt::TextureFormat::Rgba8UnormSrgb,
             wgt::TextureFormat::Bgra8Unorm,
             wgt::TextureFormat::Rgba8Unorm,
+            wgt::TextureFormat::Rgba16Float,
         ];
 
         let suf = A::get_surface(self);

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -121,7 +121,22 @@ impl super::PrivateCapabilities {
                     AstcBlock::B12x10 => F::ASTC_12X10_SRGB_BLOCK,
                     AstcBlock::B12x12 => F::ASTC_12X12_SRGB_BLOCK,
                 },
-                AstcChannel::Hdr => unimplemented!(),
+                AstcChannel::Hdr => match block {
+                    AstcBlock::B4x4 => F::ASTC_4X4_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B5x4 => F::ASTC_5X4_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B5x5 => F::ASTC_5X5_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B6x5 => F::ASTC_6X5_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B6x6 => F::ASTC_6X6_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B8x5 => F::ASTC_8X5_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B8x6 => F::ASTC_8X6_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B8x8 => F::ASTC_8X8_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B10x5 => F::ASTC_10X5_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B10x6 => F::ASTC_10X6_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B10x8 => F::ASTC_10X8_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B10x10 => F::ASTC_10X10_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B12x10 => F::ASTC_12X10_SFLOAT_BLOCK_EXT,
+                    AstcBlock::B12x12 => F::ASTC_12X12_SFLOAT_BLOCK_EXT,
+                },
             },
         }
     }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -517,12 +517,19 @@ impl super::Device {
             None => vk::SwapchainKHR::null(),
         };
 
+        let color_space = if config.format == wgt::TextureFormat::Rgba16Float {
+            // Enable wide color gamut mode
+            // Vulkan swapchain for Android only supports DISPLAY_P3_NONLINEAR_EXT and EXTENDED_SRGB_LINEAR_EXT
+            vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT
+        } else {
+            vk::ColorSpaceKHR::SRGB_NONLINEAR
+        };
         let info = vk::SwapchainCreateInfoKHR::builder()
             .flags(vk::SwapchainCreateFlagsKHR::empty())
             .surface(surface.raw)
             .min_image_count(config.swap_chain_size)
             .image_format(self.shared.private_caps.map_texture_format(config.format))
-            .image_color_space(vk::ColorSpaceKHR::SRGB_NONLINEAR)
+            .image_color_space(color_space)
             .image_extent(vk::Extent2D {
                 width: config.extent.width,
                 height: config.extent.height,

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -162,6 +162,9 @@ impl super::Instance {
 
         extensions.push(vk::KhrGetPhysicalDeviceProperties2Fn::name());
 
+        // Provid wide color gamut
+        extensions.push(vk::ExtSwapchainColorspaceFn::name());
+
         // Only keep available extensions.
         extensions.retain(|&ext| {
             if instance_extensions


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/2371

**Description**
- Add `astc_hdr` field to PhysicalDeviceFeatures to hold `PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT` when this feature is supported;
- Set TEXTURE_COMPRESSION_ASTC_HDR feature if `astc_hdr` is not none, then use this feature  to enable extension;
- Enable `ExtSwapchainColorspaceFn` during create `Instance`  to provide wide color gamut support;
- Choose `EXTENDED_SRGB_LINEAR_EXT`  color space when creating the swapchain;
	- HDR ASTC formarts need linear color space to display, and vulkan swapchain for Android only supports `DISPLAY_P3_NONLINEAR_EXT` and `EXTENDED_SRGB_LINEAR_EXT`
	- Maybe better way is using `get_physical_device_surface_formats` detect color space to choose, but need `PhysicalDevice` as a parameter that `fn create_swapchain` cannot provide, that needs to change a lot of code.



**Testing**
Running on maOS 12.2.1 (M1 Max MacBook Pro, vulkan-portability) can perfectly display HDR ASTC texture via [wgpu-on-app demo](https://github.com/jinleili/wgpu-on-app), but on Ubundu 20.04, currently vulkan driver cannot support WCG color space:
```sh
Using llvmpipe (LLVM 13.0.0, 128 bits) (Vulkan)
WARNING: lavapipe is not a conformant vulkan implementation, testing use only.
thread 'main' panicked at 'Error in Surface::configure: requested format Rgba16Float is not in list of supported formats: [Bgra8Unorm, Bgra8UnormSrgb]', /home/parallels/Downloads/forks/wgpu/wgpu/src/backend/direct.rs:231:9
```

The vk backend on Android has weak support for HDR ASTC formats,  I'm tested a lot of Android devices(real devices + cloud devices), all cannot find `VK_EXT_texture_compression_astc_hdr` extension, screenshots below are of tested cloud Android devices with GL Extensions Viewer installed to detect the vulkan extensions:
<img width="750" alt="cloud android device" src="https://user-images.githubusercontent.com/1001342/154828103-ac66d603-aa2e-491e-96b2-919ba1ce2b79.png">
|<img width="400" alt="vulkan extensions (android 9)" src="https://user-images.githubusercontent.com/1001342/154828172-aba4a0fa-3f84-4d40-bfbc-2138954b4fa3.png">| <img width="400" alt="vulkan extensions (android 10)" src="https://user-images.githubusercontent.com/1001342/154828185-ec263fa3-1737-42e0-aa65-3a8cc5f07832.png"> |
|---|---|
