### PR TITLE
vulkan: correctly set INDEPENDENT_BLEND，make runable on Android 8.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,7 +1046,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.8.0"
-source = "git+https://github.com/gfx-rs/naga?rev=8e2e39e#8e2e39e4d8fa5bbb657c3b170b4f6607d703e284"
+source = "git+https://github.com/gfx-rs/naga?rev=a45b9a6#a45b9a6cc691a671aa24a32114b51c5acae02420"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "8e2e39e"
+rev = "a45b9a6"
 #version = "0.8"
 features = ["span", "validate", "wgsl-in"]
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2313,7 +2313,7 @@ impl<A: HalApi> Device<A> {
                 .any(|ct| ct.write_mask != first.write_mask || ct.blend != first.blend)
         } {
             log::info!("Color targets: {:?}", color_targets);
-            self.require_downlevel_flags(wgt::DownlevelFlags::INDEPENDENT_BLENDING)?;
+            self.require_downlevel_flags(wgt::DownlevelFlags::INDEPENDENT_BLEND)?;
         }
 
         let mut io = validation::StageIo::default();

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -88,14 +88,14 @@ js-sys = { version = "0.3" }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "8e2e39e"
+rev = "a45b9a6"
 #version = "0.8"
 
 # DEV dependencies
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "8e2e39e"
+rev = "a45b9a6"
 #version = "0.8"
 features = ["wgsl-in"]
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -275,7 +275,7 @@ impl super::Adapter {
         // as we emulate the `start_instance`. But we can't deal with negatives...
         downlevel_flags.set(wgt::DownlevelFlags::BASE_VERTEX, ver >= (3, 2));
         downlevel_flags.set(
-            wgt::DownlevelFlags::INDEPENDENT_BLENDING,
+            wgt::DownlevelFlags::INDEPENDENT_BLEND,
             ver >= (3, 2) || extensions.contains("GL_EXT_draw_buffers_indexed"),
         );
         downlevel_flags.set(

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -103,7 +103,7 @@ impl PhysicalDeviceFeatures {
             // Features is a bitfield so we need to map everything manually
             core: vk::PhysicalDeviceFeatures::builder()
                 .robust_buffer_access(private_caps.robust_buffer_access)
-                .independent_blend(true)
+                .independent_blend(downlevel_flags.contains(wgt::DownlevelFlags::INDEPENDENT_BLEND))
                 .sample_rate_shading(
                     downlevel_flags.contains(wgt::DownlevelFlags::MULTISAMPLED_SHADING),
                 )
@@ -358,6 +358,7 @@ impl PhysicalDeviceFeatures {
             self.core.fragment_stores_and_atomics != 0,
         );
         dl_flags.set(Df::MULTISAMPLED_SHADING, self.core.sample_rate_shading != 0);
+        dl_flags.set(Df::INDEPENDENT_BLEND, self.core.independent_blend != 0);
 
         features.set(
             F::INDIRECT_FIRST_INSTANCE,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -901,11 +901,10 @@ bitflags::bitflags! {
         const CUBE_ARRAY_TEXTURES = 1 << 7;
         /// Supports comparison samplers.
         const COMPARISON_SAMPLERS = 1 << 8;
-        /// Supports different blending modes per color target.
-        const INDEPENDENT_BLENDING = 1 << 9;
+        /// Supports different blend operations per color attachment.
+        const INDEPENDENT_BLEND = 1 << 9;
         /// Supports storage buffers in vertex shaders.
         const VERTEX_STORAGE = 1 << 10;
-
 
         /// Supports samplers with anisotropic filtering. Note this isn't actually required by
         /// WebGPU, the implementation is allowed to completely ignore aniso clamp. This flag is

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -138,20 +138,20 @@ env_logger = "0.9"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "8e2e39e"
+rev = "a45b9a6"
 #version = "0.8"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "8e2e39e"
+rev = "a45b9a6"
 #version = "0.8"
 features = ["wgsl-in"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "8e2e39e"
+rev = "a45b9a6"
 #version = "0.8"
 features = ["wgsl-out"]
 


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/2419

**Description**
 Andorid 8.x(Vulkan 1.0) doesn't support the `independent_blend` feature, running on these devices failed at `request_device` :
`W/wgpu_hal::vulkan: Unrecognized device error ERROR_FEATURE_NOT_PRESENT`

**Testing**
Tested on these devices:
Samsung Galaxy S7 edge (Android 8.0)
Google Nexus 5x (Android 8.1)
OPPO R15 (Android 8.1)
HuaWei MatePad 11 (Android 10)
Google Pixel 5 (Android 12) 
via [wgpu-on-app](https://github.com/jinleili/wgpu_on_app).

Pixel 5 successfully runs all examples before and after this commit.

On MatePad 11, only HDR ASTC example keeps failing because the `TEXTURE_COMPRESSION_ASTC_HDR` feature is not supported.

The boid, masa-line, and cube examples previously only runs on Pixel 5 and MatePad 11, and successfully runs on all devices now.

water and shadow examples failed on Galaxy S7 edge and  Nexus 5x that because of naga compiling shader error, also tried updating naga to latest commit and got the same result:
shadow error: 
```sh
2022-02-22 14:48:46.857 9101-9101/name.jinleili.wgpu I/naga::back::spv::writer: Skip function Some("fetch_shadow")
2022-02-22 14:48:46.864 9101-9101/name.jinleili.wgpu I/Adreno: Shader compilation failed for shaderType: 1
2022-02-22 14:48:46.864 9101-9101/name.jinleili.wgpu W/wgpu_hal::vulkan: Unrecognized device error INCOMPLETE
2022-02-22 14:48:46.864 9101-9101/name.jinleili.wgpu E/wgpu::backend::direct: Handling wgpu errors as fatal by default
```
water error:
```sh
2022-02-22 14:51:02.403 9465-9465/name.jinleili.wgpu D/naga::valid::function: var LocalVariable { name: Some("out"), ty: [7], init: None }
2022-02-22 14:51:02.514 9465-9465/name.jinleili.wgpu I/Adreno: Shader compilation failed for shaderType: 1
2022-02-22 14:51:02.514 9465-9465/name.jinleili.wgpu W/wgpu_hal::vulkan: Unrecognized device error INCOMPLETE
2022-02-22 14:51:02.514 9465-9465/name.jinleili.wgpu E/wgpu::backend::direct: Handling wgpu errors as fatal by default
```

water example running on OPPO R15  get weird render result:
<img width="520" alt="截屏2022-02-22 15 23 56" src="https://user-images.githubusercontent.com/1001342/155085579-9ef024eb-af59-4aba-a547-30400daee593.png">


