### PR TITLE
Wrap all validation logs with catch_unwinds

### DIFF
--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -58,7 +58,9 @@ unsafe extern "system" fn output_debug_string_handler(
         return excpt::EXCEPTION_CONTINUE_SEARCH;
     }
 
-    log::log!(level, "{}", message);
+    let _ = std::panic::catch_unwind(|| {
+        log::log!(level, "{}", message);
+    });
 
     if cfg!(debug_assertions) && level == log::Level::Error {
         // Panicking behind FFI is UB, so we just exit.

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -262,14 +262,16 @@ fn gl_debug_message_callback(source: u32, gltype: u32, id: u32, severity: u32, m
         _ => unreachable!(),
     };
 
-    log::log!(
-        log_severity,
-        "GLES: [{}/{}] ID {} : {}",
-        source_str,
-        type_str,
-        id,
-        message
-    );
+    let _ = std::panic::catch_unwind(|| {
+        log::log!(
+            log_severity,
+            "GLES: [{}/{}] ID {} : {}",
+            source_str,
+            type_str,
+            id,
+            message
+        );
+    });
 
     if cfg!(debug_assertions) && log_severity == log::Level::Error {
         std::process::exit(1);

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -44,14 +44,16 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         CStr::from_ptr(cd.p_message).to_string_lossy()
     };
 
-    log::log!(
-        level,
-        "{:?} [{} (0x{:x})]\n\t{}",
-        message_type,
-        message_id_name,
-        cd.message_id_number,
-        message,
-    );
+    let _ = std::panic::catch_unwind(|| {
+        log::log!(
+            level,
+            "{:?} [{} (0x{:x})]\n\t{}",
+            message_type,
+            message_id_name,
+            cd.message_id_number,
+            message,
+        );
+    });
 
     if cd.queue_label_count != 0 {
         let labels = slice::from_raw_parts(cd.p_queue_labels, cd.queue_label_count as usize);
@@ -64,7 +66,10 @@ unsafe extern "system" fn debug_utils_messenger_callback(
                     .map(|lbl| CStr::from_ptr(lbl).to_string_lossy())
             })
             .collect::<Vec<_>>();
-        log::log!(level, "\tqueues: {}", names.join(", "));
+
+        let _ = std::panic::catch_unwind(|| {
+            log::log!(level, "\tqueues: {}", names.join(", "));
+        });
     }
 
     if cd.cmd_buf_label_count != 0 {
@@ -78,7 +83,10 @@ unsafe extern "system" fn debug_utils_messenger_callback(
                     .map(|lbl| CStr::from_ptr(lbl).to_string_lossy())
             })
             .collect::<Vec<_>>();
-        log::log!(level, "\tcommand buffers: {}", names.join(", "));
+
+        let _ = std::panic::catch_unwind(|| {
+            log::log!(level, "\tcommand buffers: {}", names.join(", "));
+        });
     }
 
     if cd.object_count != 0 {
@@ -99,7 +107,9 @@ unsafe extern "system" fn debug_utils_messenger_callback(
                 )
             })
             .collect::<Vec<_>>();
-        log::log!(level, "\tobjects: {}", names.join(", "));
+        let _ = std::panic::catch_unwind(|| {
+            log::log!(level, "\tobjects: {}", names.join(", "));
+        });
     }
 
     // uncommenting this is useful for tests


### PR DESCRIPTION
**Connections**

Closes #2487

**Description**

Wraps all log calls with catch_unwind on VK, GL, and DX12

**Testing**
Unneeded
