### PR TITLE
Support flipped Y on VK 1.1 devices

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -968,7 +968,7 @@ impl super::Instance {
         }
         if !phd_capabilities.supports_extension(vk::AmdNegativeViewportHeightFn::name())
             && !phd_capabilities.supports_extension(vk::KhrMaintenance1Fn::name())
-            && phd_capabilities.properties.api_version < vk::API_VERSION_1_2
+            && phd_capabilities.properties.api_version < vk::API_VERSION_1_1
         {
             log::warn!(
                 "viewport Y-flip is not supported, hiding adapter: {}",


### PR DESCRIPTION
**Connections**

Closes #2475 

**Description**

Y flip is supported by all 1.1 devices, so this check was overly conservative. 

**Testing**
Unneeded
