### PR TITLE
gles: Fix texture description for bgra formats

### DIFF
--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -30,9 +30,9 @@ impl super::AdapterShared {
             Tf::Rg16Float => (glow::RG16F, glow::RG, glow::HALF_FLOAT),
             Tf::Rgba8Unorm => (glow::RGBA8, glow::RGBA, glow::UNSIGNED_BYTE),
             Tf::Rgba8UnormSrgb => (glow::SRGB8_ALPHA8, glow::RGBA, glow::UNSIGNED_BYTE),
-            Tf::Bgra8UnormSrgb => (glow::SRGB8_ALPHA8, glow::RGBA, glow::UNSIGNED_BYTE), //TODO?
+            Tf::Bgra8UnormSrgb => (glow::SRGB8_ALPHA8, glow::BGRA, glow::UNSIGNED_BYTE), //TODO?
             Tf::Rgba8Snorm => (glow::RGBA8_SNORM, glow::RGBA, glow::BYTE),
-            Tf::Bgra8Unorm => (glow::RGBA8, glow::RGBA, glow::UNSIGNED_BYTE), //TODO?
+            Tf::Bgra8Unorm => (glow::RGBA8, glow::BGRA, glow::UNSIGNED_BYTE), //TODO?
             Tf::Rgba8Uint => (glow::RGBA8UI, glow::RGBA_INTEGER, glow::UNSIGNED_BYTE),
             Tf::Rgba8Sint => (glow::RGBA8I, glow::RGBA_INTEGER, glow::BYTE),
             Tf::Rgb10a2Unorm => (


### PR DESCRIPTION


**Connections**
None that I'm aware

**Description**
Bgra formats were previously using `glow::RGBA` as the format which caused
texture copies to produce weird colors.

This PR changes them to `glow::BGRA`

**Testing**
This change was tested on a modified fork of [veloren](https://gitlab.com/veloren/dev/veloren/-/tree/capucho/wgpu-0.10) which when using gles was producing weird colors when doing a screenshot, applying this PR fixes it.
