### PR TITLE
metal: implement get_timestamp_period

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -34,6 +34,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             },
             queue: super::Queue {
                 raw: Arc::new(Mutex::new(queue)),
+                shared: Arc::clone(&self.shared),
             },
         })
     }
@@ -733,6 +734,7 @@ impl super::PrivateCapabilities {
             } else {
                 None
             },
+            supports_timestamp_period: version.at_least((10, 15), (14, 0)),
         }
     }
 


### PR DESCRIPTION
**Description**
Implemented by referring to [Apple's Correlating CPU and GPU Timestamps](https://developer.apple.com/documentation/metal/counter_sampling/correlating_cpu_and_gpu_timestamps?language=objc)

[Metal `sampleTimestamps:gpuTimestamp:` API ](https://developer.apple.com/documentation/metal/mtldevice/3194378-sampletimestamps?language=occ)available on iOS | iPadOS 14 and macOS 10.15+, but on old A8 chip, the timestamp value obtained by this API is 0.

**Testing**
On all tested Apple silicon (A-series + M1), obtained cpu_timestamp equals to gpu_timestamp:

On iPad mini4(iPadOS 14.7.1),  `sampleTimestamps: gpuTimestamp:` alway get 0

| Set | cpu_timestamp0 | cpu_timestamp1 | gpu_timestamp0 | gpu_timestamp1 | cpu_delta / gpu_delta |
|---|---|---|---|---|---|
|0|0|0|0|0|NaN|
|1|0|0|0|0|NaN|
|2|0|0|0|0|NaN|
|3|0|0|0|0|NaN|
|4|0|0|0|0|NaN|

M1 Mac `get_timestamp_period` alway equal 1.0

| Set | cpu_timestamp0 | cpu_timestamp1 | gpu_timestamp0 | gpu_timestamp1 | cpu_delta / gpu_delta |
|---|---|---|---|---|---|
| 0 | 138194481157083 | 138194481157458 | 138194481157083 | 138194481157458 | 1.0 |
|1|138255790533166|138255790533500|138255790533166|138255790533500|1.0|
|2|138287026088250|138287026088458|138287026088250|138287026088458|1.0|
|3|138316982792458|138316982792791|138316982792458|138316982792791|1.0|
|4|138347604571125|138347604571416|138347604571125|138347604571416|1.0|

iPad Pro 2018  `get_timestamp_period` alway equal 1.0

| Set | cpu_timestamp0 | cpu_timestamp1 | gpu_timestamp0 | gpu_timestamp1 | cpu_delta / gpu_delta |
|---|---|---|---|---|---|
|0|6877203414500|6877203415209|6877203414500|6877203415209|1.0|
|1|6882077772500|6882077773167|6882077772500|6882077773167|1.0|
|2|6888188876209|6888188877000|6888188876209|6888188877000|1.0|
|3|6893635111125|6893635111834|6893635111125|6893635111834|1.0|
|4|6898661053167|6898661053834|6898661053167|6898661053834|1.0|

iPhone 12 Pro  `get_timestamp_period` alway equal 1.0

| Set | cpu_timestamp0 | cpu_timestamp1 | gpu_timestamp0 | gpu_timestamp1 | cpu_delta / gpu_delta |
|---|---|---|---|---|---|
|0|1213782040268791|1213782040269208|1213782040268791|1213782040269208|1.0|
|1|1213790290374500|1213790290374833|1213790290374500|1213790290374833|1.0|
|2|1213796168203083|1213796168203416|1213796168203083|1213796168203416|1.0|
|3|1213801947666250|1213801947666375|1213801947666250|1213801947666375|1.0|
|4|1213806890532208|1213806890532666|1213806890532208|1213806890532666|1.0|

Intel Mac with UHD Graphics 630

| Set | cpu_timestamp0 | cpu_timestamp1 | gpu_timestamp0 | gpu_timestamp1 | cpu_delta / gpu_delta |
|---|---|---|---|---|---|
|0|50261833995|50261849289|11245166466|11245166650|83.11957|
|1|58979382431|58979427613|11349777048|11349777590|83.361626|
|2|2591636211|2591650045|11497757814|11497757980|83.33735|
|3|15162110646|15162121922|11648603507|11648603642|83.525925|
|4|22118358237|22118370350|11732078478|11732078623|83.53793|

Intel Mac with AMD Radeon Pro 560X

| Set | cpu_timestamp0 | cpu_timestamp1 | gpu_timestamp0 | gpu_timestamp1 | cpu_delta / gpu_delta |
|---|---|---|---|---|---|
|0|10473725127789|10473725136200|3711367240|3711378120|0.77306986|
|1|10478761342978|10478761352292|8747626520|8747636600|0.92400795|
|2|10483287948145|10483287955984|13274270640|13274279920|0.8447198|
|3|10487793189051|10487793197035|17779550800|17779560080|0.8603448|
|4|10492665234848|10492665242760|22651638880|22651648800|0.79758066|
