### PR TITLE
Correct program output ("Steps", not "Times")

### DIFF
--- a/wgpu/examples/hello-compute/README.md
+++ b/wgpu/examples/hello-compute/README.md
@@ -18,5 +18,5 @@ RUST_LOG=hello_compute cargo run --example hello-compute 1 4 3 295
 ## Example Output
 
 ```
-[2020-04-25T11:15:33Z INFO  hello_compute] Times: [0, 2, 7, 55]
+[2020-04-25T11:15:33Z INFO  hello_compute] Steps: [0, 2, 7, 55]
 ```


### PR DESCRIPTION
Since 985c1feb4 , hello-compute has output "Steps: ...", not "Times: ..."

**Description**
The README doesn't match the current example code's behavior.

**Testing**
I ran the command from the README
```
RUST_LOG=hello_compute cargo run --example hello-compute 1 4 3 295
```
and console output was
```
Steps: [0, 2, 7, 55]
```
I didn't see timestamp and INFO prepended to the output, that looks like Rust is logging to the journal or is configured differently.

I don't know if it's worth mentioning
> When [run in a browser](https://wgpu.rs/examples-gpu/?example=hello-compute), you have to enable Firefox's Web Developer Tools and enable "Logs" level output in its Console tab to see the output.