### PR TITLE
metal: improve `push | pop_debug_marker`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,7 +995,7 @@ dependencies = [
 [[package]]
 name = "metal"
 version = "0.23.1"
-source = "git+https://github.com/gfx-rs/metal-rs?rev=a357159#a35715916fec38bbc08a510ecf7d115edc500c72"
+source = "git+https://github.com/gfx-rs/metal-rs?rev=1aaa903#1aaa9033a22b2af7ff8cae2ed412a4733799c3d3"
 dependencies = [
  "bitflags",
  "block",

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -79,7 +79,7 @@ winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser", "dc
 native = { package = "d3d12", git = "https://github.com/gfx-rs/d3d12-rs.git", rev = "ffe5e261da0a6cb85332b82ab310abd2a7e849f6", features = ["libloading"], optional = true }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
-mtl = { package = "metal", git = "https://github.com/gfx-rs/metal-rs", rev = "a357159" }
+mtl = { package = "metal", git = "https://github.com/gfx-rs/metal-rs", rev = "1aaa903" }
 objc = "0.2.5"
 core-graphics-types = "0.1"
 


### PR DESCRIPTION
**Description**
Invoking `push | pop_debug_marker`, `entry_any` may create empty blit command encoder, which results in warnings and incorrect `debug_group` hierarchy relationships:
```sh
`Blit Encoder "Oxxxx" has no work encoded to it` (Issue) Your app created an encoder that had no work encoded to it. Creating an empty encoder causes unnecessary CPU overhead and potentiallv bandwidth usage.
```

<img width="1248" alt="boids_push_debug_marker" src="https://user-images.githubusercontent.com/1001342/158048373-a60a8024-9946-45d8-ae92-7ea2aa66d49e.png">


**Testing**
Tested boids example on macOS and iOS:
<img width="1027" alt="boids_push_debug_marker-1" src="https://user-images.githubusercontent.com/1001342/158048528-e8fd4a15-3b97-4302-adbf-a825dfc87747.png">

