### PR TITLE
Fix resizing behaviour of hello-triangle example

### DIFF
--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -93,6 +93,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                 config.width = size.width;
                 config.height = size.height;
                 surface.configure(&device, &config);
+                window.request_redraw();
             }
             Event::RedrawRequested(_) => {
                 let frame = surface

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -93,6 +93,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                 config.width = size.width;
                 config.height = size.height;
                 surface.configure(&device, &config);
+                // On macos the window needs to be redrawn manually after resizing
                 window.request_redraw();
             }
             Event::RedrawRequested(_) => {

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -108,6 +108,8 @@ async fn run(event_loop: EventLoop<()>, viewports: Vec<(Window, wgpu::Color)>) {
                 // Recreate the swap chain with the new size
                 if let Some(viewport) = viewports.get_mut(&window_id) {
                     viewport.resize(&device, size);
+                    // On macos the window needs to be redrawn manually after resizing
+                    viewport.desc.window.request_redraw();
                 }
             }
             Event::RedrawRequested(window_id) => {


### PR DESCRIPTION
On macos the window is not updated until requested explicitly.

**Connections**
Issue was first raised in #2144.

**Description**
The window extended and the surface was resized accordingly, but the window was never updated with the new render.

**Testing**
Tested on Intel macbook pro.
