### PR TITLE
Skip buffer zero initialization for Metal backend

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -758,9 +758,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                                 .map_err(DeviceError::from)?
                         };
                         log::trace!("Stitching command buffer {:?} before submission", cmb_id);
-                        baked
-                            .initialize_buffer_memory(&mut *trackers, &mut *buffer_guard)
-                            .map_err(|err| QueueSubmitError::DestroyedBuffer(err.0))?;
+                        if !device
+                            .features
+                            .contains(wgt::Features::ALLOCATED_BUFFER_ALREADY_ZERO_FILLED)
+                        {
+                            baked
+                                .initialize_buffer_memory(&mut *trackers, &mut *buffer_guard)
+                                .map_err(|err| QueueSubmitError::DestroyedBuffer(err.0))?;
+                        }
                         baked
                             .initialize_texture_memory(&mut *trackers, &mut *texture_guard, device)
                             .map_err(|err| QueueSubmitError::DestroyedTexture(err.0))?;

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -755,7 +755,8 @@ impl super::PrivateCapabilities {
             | F::PUSH_CONSTANTS
             | F::POLYGON_MODE_LINE
             | F::CLEAR_TEXTURE
-            | F::TEXTURE_FORMAT_16BIT_NORM;
+            | F::TEXTURE_FORMAT_16BIT_NORM
+            | F::ALLOCATED_BUFFER_ALREADY_ZERO_FILLED;
 
         features.set(F::TEXTURE_COMPRESSION_ASTC_LDR, self.format_astc);
         features.set(F::TEXTURE_COMPRESSION_ASTC_HDR, self.format_astc_hdr);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -569,6 +569,12 @@ bitflags::bitflags! {
         ///
         /// This is a native-only feature.
         const TEXTURE_COMPRESSION_ASTC_HDR = 1 << 43;
+        /// Skip buffer zero initialization
+        /// Supported Platforms:
+        /// - Metal
+        ///
+        /// This is a native-only feature.
+        const ALLOCATED_BUFFER_ALREADY_ZERO_FILLED = 1 << 44;
     }
 }
 


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/1904

**Testing**
Tested wgpu examples on M1 Mac, Intel Mac and iPhone 12.