### PR TITLE
wgpu-core: Register new pipelines with device's tracker.

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4484,8 +4484,17 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Ok(pair) => pair,
                 Err(e) => break e,
             };
+            let ref_count = pipeline.life_guard.add_ref();
 
             let id = fid.assign(pipeline, &mut token);
+            log::info!("Created render pipeline {:?} with {:?}", id, desc);
+
+            device
+                .trackers
+                .lock()
+                .render_pipes
+                .init(id, ref_count, PhantomData)
+                .unwrap();
             return (id.0, None);
         };
 
@@ -4615,8 +4624,17 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Ok(pair) => pair,
                 Err(e) => break e,
             };
+            let ref_count = pipeline.life_guard.add_ref();
 
             let id = fid.assign(pipeline, &mut token);
+            log::info!("Created compute pipeline {:?} with {:?}", id, desc);
+
+            device
+                .trackers
+                .lock()
+                .compute_pipes
+                .init(id, ref_count, PhantomData)
+                .unwrap();
             return (id.0, None);
         };
 

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -233,7 +233,11 @@ platform supports.";
 ///
 /// Uses of this macro have the form:
 ///
+/// ```ignore
+///
 ///     gfx_select!(id => global.method(args...))
+///
+/// ```
 ///
 /// where `id` is some [`id::Id`] resource id, `global` is a [`hub::Global`],
 /// and `method` is any method on [`Global`] that takes a single generic


### PR DESCRIPTION
Without this change, `LifetimeTracker::triage_suspected` never notices that compute or render pipelines are free, and they stick around until the hub is destroyed.

Fixes #2564.
