### PR TITLE
impl Debug for StagingBelt

### DIFF
--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -2,6 +2,7 @@ use crate::{
     Buffer, BufferAddress, BufferDescriptor, BufferSize, BufferUsages, BufferViewMut,
     CommandEncoder, Device, MapMode,
 };
+use std::fmt;
 use std::pin::Pin;
 use std::task::{self, Poll};
 use std::{future::Future, sync::mpsc};
@@ -180,5 +181,16 @@ impl StagingBelt {
             .collect::<Vec<_>>();
 
         Join { futures }
+    }
+}
+
+impl fmt::Debug for StagingBelt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StagingBelt")
+            .field("chunk_size", &self.chunk_size)
+            .field("active_chunks", &self.active_chunks.len())
+            .field("closed_chunks", &self.closed_chunks.len())
+            .field("free_chunks", &self.free_chunks.len())
+            .finish_non_exhaustive()
     }
 }


### PR DESCRIPTION
**Description**

This PR adds an explicit `impl Debug for StagingBelt`. Most `wgpu` types implement `Debug`, but `StagingBelt` doesn't, so I figured it was reasonable to add. The individual `Chunk`s are not included but their counts are.

**Testing**

I didn't see any unit tests for other `Debug` impls, so I didn't add one, but I manually tested that the output was reasonable by adding debug printing to a program using `wgpu`.