### PR TITLE
wgpu-hal: Work around cbindgen bug: ignore `gles::egl` module.

### DIFF
--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -56,6 +56,7 @@ To address this, we invalidate the vertex buffers based on:
 
 */
 
+///cbindgen:ignore
 #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
 mod egl;
 #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]


### PR DESCRIPTION
The definition of `EglInstance` trips eqrion/cbindgen#286. Since the `wgpu_hal::gles::egl` module is an implementation detail anyway, it should be harmless to ask cbindgen to just ignore it.

Fixes #2575.
