### PR TITLE
Prefix every wgpu-generated label with `(wgpu)`.

### DIFF
--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -450,7 +450,7 @@ fn clear_texture_via_render_passes<A: hal::Api>(
             };
             unsafe {
                 encoder.begin_render_pass(&hal::RenderPassDescriptor {
-                    label: Some("clear_texture clear pass"),
+                    label: Some("(wgpu internal) clear_texture clear pass"),
                     extent,
                     sample_count,
                     color_attachments,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -982,7 +982,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 )
             };
             let desc = hal::RenderPassDescriptor {
-                label: Some("Zero init discarded depth/stencil aspect"),
+                label: Some("(wgpu internal) Zero init discarded depth/stencil aspect"),
                 extent: view.extent,
                 sample_count: view.samples,
                 color_attachments: &[],

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -356,7 +356,7 @@ impl<A: HalApi> Device<A> {
         let zero_buffer = unsafe {
             open.device
                 .create_buffer(&hal::BufferDescriptor {
-                    label: Some("wgpu zero init buffer"),
+                    label: Some("(wgpu internal) zero init buffer"),
                     size: ZERO_BUFFER_SIZE,
                     usage: hal::BufferUses::COPY_SRC | hal::BufferUses::COPY_DST,
                     memory_flags: hal::MemoryFlags::empty(),
@@ -784,7 +784,7 @@ impl<A: HalApi> Device<A> {
             for mip_level in 0..desc.mip_level_count {
                 for array_layer in 0..desc.size.depth_or_array_layers {
                     let desc = hal::TextureViewDescriptor {
-                        label: Some("clear texture view"),
+                        label: Some("(wgpu internal) clear texture view"),
                         format: desc.format,
                         dimension,
                         usage,
@@ -3107,7 +3107,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             } else {
                 // buffer needs staging area for initialization only
                 let stage_desc = wgt::BufferDescriptor {
-                    label: Some(Cow::Borrowed("<init_buffer>")),
+                    label: Some(Cow::Borrowed(
+                        "(wgpu internal) initializing unmappable buffer",
+                    )),
                     size: desc.size,
                     usage: wgt::BufferUsages::MAP_WRITE | wgt::BufferUsages::COPY_SRC,
                     mapped_at_creation: false,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -174,7 +174,7 @@ impl<A: hal::Api> PendingWrites<A> {
         if !self.is_active {
             unsafe {
                 self.command_encoder
-                    .begin_encoding(Some("_PendingWrites"))
+                    .begin_encoding(Some("(wgpu internal) PendingWrites"))
                     .unwrap();
             }
             self.is_active = true;
@@ -196,7 +196,7 @@ impl<A: hal::Api> super::Device<A> {
     fn prepare_stage(&mut self, size: wgt::BufferAddress) -> Result<StagingData<A>, DeviceError> {
         profiling::scope!("prepare_stage");
         let stage_desc = hal::BufferDescriptor {
-            label: Some("_Staging"),
+            label: Some("(wgpu internal) Staging"),
             size,
             usage: hal::BufferUses::MAP_WRITE | hal::BufferUses::COPY_SRC,
             memory_flags: hal::MemoryFlags::TRANSIENT,
@@ -754,7 +754,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         unsafe {
                             baked
                                 .encoder
-                                .begin_encoding(Some("_Transit"))
+                                .begin_encoding(Some("(wgpu internal) Transit"))
                                 .map_err(DeviceError::from)?
                         };
                         log::trace!("Stitching command buffer {:?} before submission", cmb_id);
@@ -785,7 +785,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             unsafe {
                                 baked
                                     .encoder
-                                    .begin_encoding(Some("_Present"))
+                                    .begin_encoding(Some("(wgpu internal) Present"))
                                     .map_err(DeviceError::from)?
                             };
                             let texture_barriers = trackers

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -126,7 +126,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (texture_id, status) = match unsafe { suf.raw.acquire_texture(FRAME_TIMEOUT_MS) } {
             Ok(Some(ast)) => {
                 let clear_view_desc = hal::TextureViewDescriptor {
-                    label: Some("clear surface texture view"),
+                    label: Some("(wgpu internal) clear surface texture view"),
                     format: config.format,
                     dimension: wgt::TextureViewDimension::D2,
                     usage: hal::TextureUses::COLOR_TARGET,

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -213,8 +213,12 @@ impl super::Device {
             };
             let shader_src = format!("#version {} es \n void main(void) {{}}", version,);
             log::info!("Only vertex shader is present. Creating an empty fragment shader",);
-            let shader =
-                Self::compile_shader(gl, &shader_src, naga::ShaderStage::Fragment, Some("_dummy"))?;
+            let shader = Self::compile_shader(
+                gl,
+                &shader_src,
+                naga::ShaderStage::Fragment,
+                Some("(wgpu internal) dummy fragment shader"),
+            )?;
             shaders_to_delete.push(shader);
         }
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -338,7 +338,7 @@ impl crate::Queue<Api> for Queue {
                                 .to_owned()
                         }
                     };
-                    raw.set_label("_Signal");
+                    raw.set_label("(wgpu internal) Signal");
                     raw.add_completed_handler(&block);
 
                     fence.maintain();
@@ -370,7 +370,7 @@ impl crate::Queue<Api> for Queue {
         let queue = &self.raw.lock();
         objc::rc::autoreleasepool(|| {
             let command_buffer = queue.new_command_buffer();
-            command_buffer.set_label("_Present");
+            command_buffer.set_label("(wgpu internal) Present");
 
             // https://developer.apple.com/documentation/quartzcore/cametallayer/1478157-presentswithtransaction?language=objc
             if !texture.present_with_transaction {

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -115,7 +115,7 @@ impl StagingBelt {
             let size = self.chunk_size.max(size.get());
             Chunk {
                 buffer: device.create_buffer(&BufferDescriptor {
-                    label: Some("staging"),
+                    label: Some("(wgpu internal) StagingBelt staging buffer"),
                     size,
                     usage: BufferUsages::MAP_WRITE | BufferUsages::COPY_SRC,
                     mapped_at_creation: true,


### PR DESCRIPTION
This is intended to help developers new to wgpu or to graphics debugging quickly recognize in a debugging tool which items are wgpu-generated, as opposed to either part of their program or part of the platform graphics system.

I also removed existing marker-like text such as leading underscores and angle brackets. I'm not sure if this was the right decision, but they seemed arbitrary.

**Testing**

* The wgpu test suite gets as far as it does on my machine without this change.
* Running with a GPU debugger (Xcode/Metal) shows the changed labels as I expect.