### PR TITLE
wgpu/examples/shadow: Don't run on llvmpipe.

### DIFF
--- a/wgpu/examples/shadow/main.rs
+++ b/wgpu/examples/shadow/main.rs
@@ -855,7 +855,10 @@ fn shadow() {
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
             .downlevel_flags(wgpu::DownlevelFlags::COMPARISON_SAMPLERS)
-            .specific_failure(Some(wgpu::Backends::VULKAN), None, Some("V3D"), false), // rpi4 on VK doesn't work: https://gitlab.freedesktop.org/mesa/mesa/-/issues/3916
+            // rpi4 on VK doesn't work: https://gitlab.freedesktop.org/mesa/mesa/-/issues/3916
+            .specific_failure(Some(wgpu::Backends::VULKAN), None, Some("V3D"), false)
+            // llvmpipe versions in CI are flaky: https://github.com/gfx-rs/wgpu/issues/2594
+            .specific_failure(Some(wgpu::Backends::VULKAN), None, Some("llvmpipe"), true),
         tolerance: 2,
         max_outliers: 500, // bounded by rpi4
     });


### PR DESCRIPTION
This is a workaround for #2594.