### PR TITLE
Add raw_queue for d3d12 device

### DIFF
--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -290,6 +290,10 @@ impl super::Device {
         &self.raw
     }
 
+    pub fn raw_queue(&self) -> &native::CommandQueue {
+        &self.present_queue
+    }
+
     pub unsafe fn texture_from_raw(
         resource: native::Resource,
         format: wgt::TextureFormat,


### PR DESCRIPTION
**Description**

Useful for d3d11/12 interop, such as [D3D11On12](https://docs.microsoft.com/en-us/windows/win32/direct3d12/direct3d-11-on-12).