### PR TITLE
metal: fix some supported limits

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -665,7 +665,7 @@ impl super::PrivateCapabilities {
             max_varying_components: if device
                 .supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v1)
             {
-                128
+                124
             } else {
                 60
             },
@@ -680,11 +680,7 @@ impl super::PrivateCapabilities {
             } else {
                 512
             },
-            max_total_threadgroup_memory: if device
-                .supports_feature_set(MTLFeatureSet::iOS_GPUFamily4_v2)
-            {
-                64 << 10
-            } else if Self::supports_any(
+            max_total_threadgroup_memory: if Self::supports_any(
                 device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily4_v1,
@@ -833,13 +829,12 @@ impl super::PrivateCapabilities {
                 max_push_constant_size: 0x1000,
                 min_uniform_buffer_offset_alignment: self.buffer_alignment as u32,
                 min_storage_buffer_offset_alignment: self.buffer_alignment as u32,
-                //TODO: double-check how these match Metal feature set tables
                 max_inter_stage_shader_components: self.max_varying_components,
                 max_compute_workgroup_storage_size: self.max_total_threadgroup_memory,
                 max_compute_invocations_per_workgroup: self.max_threads_per_group,
-                max_compute_workgroup_size_x: 256,
-                max_compute_workgroup_size_y: 256,
-                max_compute_workgroup_size_z: 64,
+                max_compute_workgroup_size_x: self.max_threads_per_group,
+                max_compute_workgroup_size_y: self.max_threads_per_group,
+                max_compute_workgroup_size_z: self.max_threads_per_group,
                 max_compute_workgroups_per_dimension: 0xFFFF,
             },
             alignments: crate::Alignments {


### PR DESCRIPTION
**Description**
Fixed `max_inter_stage_shader_components` according to the Metal feature set table and the implementation of WebKit:
<img width="1029" alt="截屏2022-04-18 15 29 30" src="https://user-images.githubusercontent.com/1001342/163783772-3bb3dc12-a0f1-48f3-b56c-14bf5c811c7b.png">
https://github.com/WebKit/WebKit/blob/a438d3bb8e5cc0fa8fde2b9707fd446f0e0ed539/Source/WebGPU/WebGPU/HardwareLimits.mm#L99

Fixed `max_compute_workgroup_storage_size` : 
<img width="1054" alt="截屏2022-04-18 16 25 08" src="https://user-images.githubusercontent.com/1001342/163783911-b0f21a60-ca30-4c12-bda0-cdd317afe695.png">

https://github.com/WebKit/WebKit/blob/a438d3bb8e5cc0fa8fde2b9707fd446f0e0ed539/Source/WebGPU/WebGPU/HardwareLimits.mm#L66

Fixed `max_compute_workgroup_size_xx`

**Testing**
Tested on M1 Mac and iPhone 12, none of the wgpu samples were broken.
