### PR TITLE
[WebGL] Allow creating a texture from an external `web_sys::WebGlFramebuffer` and writing to it

### DIFF
--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -427,6 +427,20 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             self.state.has_pass_label = true;
         }
 
+        let rendering_to_external_framebuffer = desc
+            .color_attachments
+            .iter()
+            .filter_map(|at| at.as_ref())
+            .any(|at| match at.target.view.inner {
+                #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+                super::TextureInner::ExternalFramebuffer { .. } => true,
+                _ => false,
+            });
+
+        if rendering_to_external_framebuffer && desc.color_attachments.len() != 1 {
+            panic!("Multiple render attachments with external framebuffers are not supported.");
+        }
+
         match desc
             .color_attachments
             .first()
@@ -489,10 +503,12 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     }
                 }
 
-                // set the draw buffers and states
-                self.cmd_buffer
-                    .commands
-                    .push(C::SetDrawColorBuffers(desc.color_attachments.len() as u8));
+                if !rendering_to_external_framebuffer {
+                    // set the draw buffers and states
+                    self.cmd_buffer
+                        .commands
+                        .push(C::SetDrawColorBuffers(desc.color_attachments.len() as u8));
+                }
             }
         }
 

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -761,6 +761,8 @@ impl crate::Device<super::Api> for super::Device {
                 super::TextureInner::Texture { raw, .. } => {
                     unsafe { gl.delete_texture(raw) };
                 }
+                #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+                super::TextureInner::ExternalFramebuffer { .. } => {}
             }
         }
 

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -184,10 +184,10 @@ impl Default for VertexAttribKind {
 }
 
 #[derive(Clone, Debug)]
-struct TextureFormatDesc {
-    internal: u32,
-    external: u32,
-    data_type: u32,
+pub struct TextureFormatDesc {
+    pub internal: u32,
+    pub external: u32,
+    pub data_type: u32,
 }
 
 struct AdapterShared {
@@ -244,7 +244,7 @@ unsafe impl Sync for Buffer {}
 unsafe impl Send for Buffer {}
 
 #[derive(Clone, Debug)]
-enum TextureInner {
+pub enum TextureInner {
     Renderbuffer {
         raw: glow::Renderbuffer,
     },
@@ -253,7 +253,17 @@ enum TextureInner {
         raw: glow::Texture,
         target: BindTarget,
     },
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+    ExternalFramebuffer {
+        inner: web_sys::WebGlFramebuffer,
+    },
 }
+
+// SAFE: WASM doesn't have threads
+#[cfg(target_arch = "wasm32")]
+unsafe impl Send for TextureInner {}
+#[cfg(target_arch = "wasm32")]
+unsafe impl Sync for TextureInner {}
 
 impl TextureInner {
     fn as_native(&self) -> (glow::Texture, BindTarget) {
@@ -262,21 +272,23 @@ impl TextureInner {
                 panic!("Unexpected renderbuffer");
             }
             Self::Texture { raw, target } => (raw, target),
+            #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+            Self::ExternalFramebuffer { .. } => panic!("Unexpected external framebuffer"),
         }
     }
 }
 
 #[derive(Debug)]
 pub struct Texture {
-    inner: TextureInner,
-    drop_guard: Option<crate::DropGuard>,
-    mip_level_count: u32,
-    array_layer_count: u32,
-    format: wgt::TextureFormat,
+    pub inner: TextureInner,
+    pub drop_guard: Option<crate::DropGuard>,
+    pub mip_level_count: u32,
+    pub array_layer_count: u32,
+    pub format: wgt::TextureFormat,
     #[allow(unused)]
-    format_desc: TextureFormatDesc,
-    copy_size: CopyExtent,
-    is_cubemap: bool,
+    pub format_desc: TextureFormatDesc,
+    pub copy_size: CopyExtent,
+    pub is_cubemap: bool,
 }
 
 impl Texture {

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -143,6 +143,10 @@ impl super::Queue {
                     };
                 }
             }
+            #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+            super::TextureInner::ExternalFramebuffer { ref inner } => {
+                gl.bind_external_framebuffer(glow::FRAMEBUFFER, inner);
+            }
         }
     }
 

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -144,11 +144,9 @@ impl super::Queue {
                 }
             }
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-            super::TextureInner::ExternalFramebuffer { ref inner } => {
-                unsafe {
-                    gl.bind_external_framebuffer(glow::FRAMEBUFFER, inner);
-                }
-            }
+            super::TextureInner::ExternalFramebuffer { ref inner } => unsafe {
+                gl.bind_external_framebuffer(glow::FRAMEBUFFER, inner);
+            },
         }
     }
 

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -145,7 +145,9 @@ impl super::Queue {
             }
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             super::TextureInner::ExternalFramebuffer { ref inner } => {
-                gl.bind_external_framebuffer(glow::FRAMEBUFFER, inner);
+                unsafe {
+                    gl.bind_external_framebuffer(glow::FRAMEBUFFER, inner);
+                }
             }
         }
     }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -63,17 +63,23 @@ compile_error!("Metal API enabled on non-Apple OS. If your project is not using 
 #[cfg(all(feature = "dx12", not(windows)))]
 compile_error!("DX12 API enabled on non-Windows OS. If your project is not using resolver=\"2\" in Cargo.toml, it should.");
 
+/// DirectX11 API internals.
 #[cfg(all(feature = "dx11", windows))]
-mod dx11;
+pub mod dx11;
+/// DirectX12 API internals.
 #[cfg(all(feature = "dx12", windows))]
-mod dx12;
-mod empty;
+pub mod dx12;
+/// A dummy API implementation.
+pub mod empty;
+/// GLES API internals.
 #[cfg(all(feature = "gles"))]
-mod gles;
+pub mod gles;
+/// Metal API internals.
 #[cfg(all(feature = "metal"))]
-mod metal;
+pub mod metal;
+/// Vulkan API internals.
 #[cfg(feature = "vulkan")]
-mod vulkan;
+pub mod vulkan;
 
 pub mod auxil;
 pub mod api {

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -128,7 +128,7 @@ impl Context {
         Ok((device, queue))
     }
 
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten", feature = "webgl"))]
     pub unsafe fn create_texture_from_hal<A: wgc::hub::HalApi>(
         &self,
         hal_texture: A::Texture,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2066,7 +2066,7 @@ impl Device {
     /// - `hal_texture` must be created from this device internal handle
     /// - `hal_texture` must be created respecting `desc`
     /// - `hal_texture` must be initialized
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten", feature = "webgl"))]
     pub unsafe fn create_texture_from_hal<A: wgc::hub::HalApi>(
         &self,
         hal_texture: A::Texture,


### PR DESCRIPTION
**Description**

The [WebXR DeviceAPI](https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API) works a little different from HTML canvases as it gives you an opaque `WebGlFramebuffer` that you are intended to bind and write to: https://developer.mozilla.org/en-US/docs/Web/API/XRWebGLLayer/framebuffer

To be able to do this in wgpu we need to:

1. Be able to construct a `wgpu::Texture` from the `WebGlFramebuffer`.
2. Bind it in a renderpass and write to it successfully.

which is what this PR does.

~~It currently depends on https://github.com/grovesNL/glow/pull/218 and should not be merged until that is.~~

**Now depends on the glow branch that wgpu is using**


~~I've got a demo up at https://expenses.github.io/wgpu-vr/ (if you don't have a VR device then you can use the google cardboard stuff in chrome on android to try it out). Source: https://github.com/expenses/kiss-engine/blob/d877a28c0bf86e3b65fb438446647e2998820be4/ludum-dare/src/main.rs~~

**Outdated**

**Things to check**

There are a couple of things in this PR that I'm unsure about.

1. Is it possible to bind WebGL drawbuffers and framebuffers at the same time, so we could (in wgpu speak) bind two or more render attachments, one being the external framebuffer and the others being internal textures?
2. Given that the [opaque framebuffer can have both a color buffer attachment and a depth buffer attachment](https://www.w3.org/TR/webxr/#opaque-framebuffer), how should we be handling these? In my code I just create a texture for both: https://github.com/expenses/kiss-engine/blob/d877a28c0bf86e3b65fb438446647e2998820be4/ludum-dare/src/main.rs#L704-L772