### PR TITLE
Backport Validation Error Related Problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## wgpu-hal 0.12.5 (2022-04-19)
+  - fix crashes when logging in debug message callbacks
+  - fix program termination when dx12 or gles error messages happen.
+  - implement validation canary
+  - DX12:
+    - Ignore erroneous validation error from DXGI debug layer. 
+
 ## wgpu-hal-0.12.4 (2022-01-24)
   - Metal:
     - check for MSL-2.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "arrayvec",
  "ash",

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-hal"
-version = "0.12.4"
+version = "0.12.5"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU hardware abstraction layer"

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -58,6 +58,19 @@ unsafe extern "system" fn output_debug_string_handler(
         return excpt::EXCEPTION_CONTINUE_SEARCH;
     }
 
+    let dxgi_debug_layer_bug_text1 = "ID3D12CommandQueue::Present";
+    // We currently dont cross command list types, so this text has the
+    // highest chance of being a true positive for this issue.
+    let dxgi_debug_layer_bug_text2 = "resource state on previous Command List type";
+    if level == log::Level::Error
+        && message.contains(dxgi_debug_layer_bug_text1)
+        && message.contains(dxgi_debug_layer_bug_text2)
+    {
+        // This is a bug in the DXGI and D3D12 validation layer when on windows 11.
+        // See https://stackoverflow.com/q/69805245 for more.
+        return excpt::EXCEPTION_CONTINUE_SEARCH;
+    }
+
     let _ = std::panic::catch_unwind(|| {
         log::log!(level, "{}", message);
     });

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -58,7 +58,9 @@ unsafe extern "system" fn output_debug_string_handler(
         return excpt::EXCEPTION_CONTINUE_SEARCH;
     }
 
-    log::log!(level, "{}", message);
+    let _ = std::panic::catch_unwind(|| {
+        log::log!(level, "{}", message);
+    });
 
     if cfg!(debug_assertions) && level == log::Level::Error {
         // Panicking behind FFI is UB, so we just exit.

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -63,8 +63,8 @@ unsafe extern "system" fn output_debug_string_handler(
     });
 
     if cfg!(debug_assertions) && level == log::Level::Error {
-        // Panicking behind FFI is UB, so we just exit.
-        std::process::exit(1);
+        // Set canary and continue
+        crate::VALIDATION_CANARY.set();
     }
 
     excpt::EXCEPTION_CONTINUE_EXECUTION

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -259,7 +259,8 @@ fn gl_debug_message_callback(source: u32, gltype: u32, id: u32, severity: u32, m
     });
 
     if cfg!(debug_assertions) && log_severity == log::Level::Error {
-        std::process::exit(1);
+        // Set canary and continue
+        crate::VALIDATION_CANARY.set();
     }
 }
 

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -247,14 +247,16 @@ fn gl_debug_message_callback(source: u32, gltype: u32, id: u32, severity: u32, m
         _ => unreachable!(),
     };
 
-    log::log!(
-        log_severity,
-        "GLES: [{}/{}] ID {} : {}",
-        source_str,
-        type_str,
-        id,
-        message
-    );
+    let _ = std::panic::catch_unwind(|| {
+        log::log!(
+            log_severity,
+            "GLES: [{}/{}] ID {} : {}",
+            source_str,
+            type_str,
+            id,
+            message
+        );
+    });
 
     if cfg!(debug_assertions) && log_severity == log::Level::Error {
         std::process::exit(1);

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -84,6 +84,7 @@ use std::{
     num::{NonZeroU32, NonZeroU8},
     ops::{Range, RangeInclusive},
     ptr::NonNull,
+    sync::atomic::AtomicBool,
 };
 
 use bitflags::bitflags;
@@ -1141,6 +1142,39 @@ pub struct RenderPassDescriptor<'a, A: Api> {
 #[derive(Clone, Debug)]
 pub struct ComputePassDescriptor<'a> {
     pub label: Label<'a>,
+}
+
+/// Stores if any API validation error has occurred in this process
+/// since it was last reset.
+///
+/// This is used for internal wgpu testing only and _must not_ be used
+/// as a way to check for errors.
+///
+/// This works as a static because `cargo nextest` runs all of our
+/// tests in separate processes, so each test gets its own canary.
+///
+/// This prevents the issue of one validation error terminating the
+/// entire process.
+pub static VALIDATION_CANARY: ValidationCanary = ValidationCanary {
+    inner: AtomicBool::new(false),
+};
+
+/// Flag for internal testing.
+pub struct ValidationCanary {
+    inner: AtomicBool,
+}
+
+impl ValidationCanary {
+    #[allow(dead_code)] // in some configurations this function is dead
+    fn set(&self) {
+        self.inner.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Returns true if any API validation error has occurred in this process
+    /// since the last call to this function.
+    pub fn get_and_reset(&self) -> bool {
+        self.inner.swap(false, std::sync::atomic::Ordering::SeqCst)
+    }
 }
 
 #[test]

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -44,14 +44,16 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         CStr::from_ptr(cd.p_message).to_string_lossy()
     };
 
-    log::log!(
-        level,
-        "{:?} [{} (0x{:x})]\n\t{}",
-        message_type,
-        message_id_name,
-        cd.message_id_number,
-        message,
-    );
+    let _ = std::panic::catch_unwind(|| {
+        log::log!(
+            level,
+            "{:?} [{} (0x{:x})]\n\t{}",
+            message_type,
+            message_id_name,
+            cd.message_id_number,
+            message,
+        );
+    });
 
     if cd.queue_label_count != 0 {
         let labels = slice::from_raw_parts(cd.p_queue_labels, cd.queue_label_count as usize);
@@ -64,7 +66,10 @@ unsafe extern "system" fn debug_utils_messenger_callback(
                     .map(|lbl| CStr::from_ptr(lbl).to_string_lossy())
             })
             .collect::<Vec<_>>();
-        log::log!(level, "\tqueues: {}", names.join(", "));
+
+        let _ = std::panic::catch_unwind(|| {
+            log::log!(level, "\tqueues: {}", names.join(", "));
+        });
     }
 
     if cd.cmd_buf_label_count != 0 {
@@ -78,7 +83,10 @@ unsafe extern "system" fn debug_utils_messenger_callback(
                     .map(|lbl| CStr::from_ptr(lbl).to_string_lossy())
             })
             .collect::<Vec<_>>();
-        log::log!(level, "\tcommand buffers: {}", names.join(", "));
+
+        let _ = std::panic::catch_unwind(|| {
+            log::log!(level, "\tcommand buffers: {}", names.join(", "));
+        });
     }
 
     if cd.object_count != 0 {
@@ -99,7 +107,9 @@ unsafe extern "system" fn debug_utils_messenger_callback(
                 )
             })
             .collect::<Vec<_>>();
-        log::log!(level, "\tobjects: {}", names.join(", "));
+        let _ = std::panic::catch_unwind(|| {
+            log::log!(level, "\tobjects: {}", names.join(", "));
+        });
     }
 
     vk::FALSE

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -112,6 +112,11 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         });
     }
 
+    if cfg!(debug_assertions) && level == log::Level::Error {
+        // Set canary and continue
+        crate::VALIDATION_CANARY.set();
+    }
+
     vk::FALSE
 }
 


### PR DESCRIPTION
**Connections**

Closes #2592

**Description**

This has actually been hit by [many people](https://old.reddit.com/r/rust_gamedev/comments/u6npjq/how_are_you_working_around_not_being_able_to_use/), so getting this backport out quickly is important.

This backports:
- the non-test parts 4d7f6eb07afb93e16ab6a0906c66e673b84924b7 to get the validation canary and prevent termination of the process when there is a validation error
- #2511 to prevent crashes in callbacks from validation errors.

This adds:
- Explicitly ignore the offending false positive from the DXGI validation layer in the debug callback.

**Testing**

Ran our test suite.
