### PR TITLE
metal: Don't skip incomplete binding resources.

### DIFF
--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -84,7 +84,11 @@ impl super::CommandState {
                 .map(|size| size.get().min(!0u32 as u64) as u32),
         );
 
-        (!result_sizes.is_empty()).then(move || (slot as _, result_sizes.as_slice()))
+        if !result_sizes.is_empty() {
+            Some((slot as _, result_sizes))
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
The old way of generating buffer size updates would only produce updates when all bindings were used by the entry point. If one happened to be missing in only one entry point, the updates wouldn't happen.
