### PR TITLE
hal/vk: Remove ash from the public interface

### DIFF
--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1,7 +1,10 @@
 use super::conv;
 
 use arrayvec::ArrayVec;
-use ash::{extensions::khr, vk};
+use ash::{
+    extensions::khr,
+    vk::{self, Handle},
+};
 use inplace_it::inplace_or_alloc_from_iter;
 use parking_lot::Mutex;
 
@@ -18,7 +21,7 @@ impl super::DeviceShared {
     pub(super) unsafe fn set_object_name(
         &self,
         object_type: vk::ObjectType,
-        object: impl vk::Handle,
+        object: impl Handle,
         name: &str,
     ) {
         use std::ffi::CStr;
@@ -598,12 +601,12 @@ impl super::Device {
     /// - If `drop_guard` is `Some`, the application must manually destroy the image handle. This
     ///   can be done inside the `Drop` impl of `drop_guard`.
     pub unsafe fn texture_from_raw(
-        vk_image: vk::Image,
+        vk_image: u64,
         desc: &crate::TextureDescriptor,
         drop_guard: Option<super::DropGuard>,
     ) -> super::Texture {
         super::Texture {
-            raw: vk_image,
+            raw: vk::Image::from_raw(vk_image),
             drop_guard,
             block: None,
             usage: desc.usage,


### PR DESCRIPTION
**Connections**
#2615

**Description**
Removes ash from wgpu-hal public interface. ash objects are replaced with raw pointers or u64 handles.

The API has become more unsafe because it requires some pointer casting and transmutation to convert ash objects to pointers (and vice versa). Some methods got duplicated (`<method>` + `<method>_inner`) for ergonomics and efficiency.

I included some changes unrelated to the visibility of the ash crate. There are two new methods for improving the usability and correctness of the API: I added a `Instance::required_layers()` and merged some code into a single `Device::required_device_capabilities()` to reduce the API surface.

The most controversial change is that now the user does not pass extensions anymore to create the Instance and Device, the extension list is calculated internally in wgpu and the user just needs to pass `InstanceFlags` or `Features` and `Limits`. The user still has to create the raw instance and device using the `required_*()` methods. This change has not much effect in terms of safety but it makes sure that invariants are held at the wgpu code level, Instance and Device created from wgpu-core or from raw pointers should look as similar as possible.

**Testing**
Ergonomics evaluation with [this code](https://github.com/zarik5/openxrs/blob/wgpu-test/openxr/examples/vulkan.rs). No runtime tests yet.
