### PR TITLE
Remove a `log::error!` debugging statement from the gles queue

### DIFF
--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -493,21 +493,7 @@ impl super::Queue {
                             glow::CompressedPixelUnpackData::Slice(src_data)
                         }
                     };
-                    log::error!(
-                        "bytes_per_row: {}, \
-                         minimum_rows_per_image: {}, \
-                         rows_per_image: {}, \
-                         bytes_per_image: {}, \
-                         minimum_bytes_per_image: {}, \
-                         bytes_in_upload: {}\
-                        ",
-                        bytes_per_row,
-                        minimum_rows_per_image,
-                        rows_per_image,
-                        bytes_per_image,
-                        minimum_bytes_per_image,
-                        bytes_in_upload
-                    );
+
                     match dst_target {
                         glow::TEXTURE_3D
                         | glow::TEXTURE_CUBE_MAP_ARRAY


### PR DESCRIPTION
@cwfitzgerald I'm guessing we can remove this now? Or optionally change to to a `log::trace!`.