### PR TITLE
Fix mispelling in doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Change Log
 
-## wgpu-0.12.1
+## wgpu-core-0.12.1, wgpu-hal-0.12.1 (2021-12-29)
   - zero initialization uses now render target clears when possible (faster and doesn't enforce COPY_DST internally if not necessary)
     - fix use of MSAA targets in WebGL
     - fix not providing `COPY_DST` flag for textures causing assertions in some cases
     - fix surface textures not getting zero initialized
     - clear_texture supports now depth/stencil targets
   - error message on creating depth/stencil volume texture
+  - Vulkan:
+    - fix validation error on debug message types
+  - DX12:
+    - fix check for integrated GPUs
+    - fix stencil subresource transitions
+  - Metal:
+    - implement push constants
 
 ## wgpu-0.12 (2021-12-18)
   - API:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## wgpu-hal 0.12.5 (2022-04-19)
+  - fix crashes when logging in debug message callbacks
+  - fix program termination when dx12 or gles error messages happen.
+  - implement validation canary
+  - DX12:
+    - Ignore erroneous validation error from DXGI debug layer. 
+
 ## wgpu-hal-0.12.4 (2022-01-24)
   - Metal:
     - check for MSL-2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## wgpu-hal-0.12.3, deno-webgpu-? (2022-01-20)
+  - Metal:
+    - preserve vertex invariance
+  - Vulkan
+    - fix stencil read/write masks
+  - Gles:
+    - reset index binding properly
+  - DX12:
+    - fix copies into 1D textures
+
 ## wgpu-core-0.12.2, wgpu-hal-0.12.2 (2022-01-10)
   - fix tracy compile error
   - fix buffer binding limits beyond 2Gb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Change Log
 
-## Unreleased
-  - Fix tracy compile error
+## wgpu-core-0.12.2, wgpu-hal-0.12.2 (2022-01-10)
+  - fix tracy compile error
+  - fix buffer binding limits beyond 2Gb
+  - fix zero initialization of 3D textures
+  - Metal:
+    - fix surface texture views
+  - Gles:
+    - extend `libwayland` search paths
 
 ## wgpu-core-0.12.1, wgpu-hal-0.12.1 (2021-12-29)
   - zero initialization uses now render target clears when possible (faster and doesn't enforce COPY_DST internally if not necessary)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Unreleased
+  - Fix tracy compile error
+
 ## wgpu-core-0.12.1, wgpu-hal-0.12.1 (2021-12-29)
   - zero initialization uses now render target clears when possible (faster and doesn't enforce COPY_DST internally if not necessary)
     - fix use of MSAA targets in WebGL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## wgpu-hal-0.12.4 (2022-01-24)
+  - Metal:
+    - check for MSL-2.3
+
 ## wgpu-hal-0.12.3, deno-webgpu-? (2022-01-20)
   - Metal:
     - preserve vertex invariance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## wgpu-0.12.1
+  - zero initialization uses now render target clears when possible (faster and doesn't enforce COPY_DST internally if not necessary)
+    - fix use of MSAA targets in WebGL
+    - fix not providing `COPY_DST` flag for textures causing assertions in some cases
+    - fix surface textures not getting zero initialized
+    - clear_texture supports now depth/stencil targets
+  - error message on creating depth/stencil volume texture
+
 ## wgpu-0.12 (2021-12-18)
   - API:
     - `MULTIVIEW` feature
@@ -191,7 +199,7 @@
     - naga to `v0.5`.
   - Added:
     - `Features::VERTEX_WRITABLE_STORAGE`.
-    - `Features::CLEAR_COMMANDS` which allows you to use `cmd_buf.clear_texture` and `cmd_buf.clear_buffer`.
+    - `Features::CLEAR_COMMANDS` which allows you to use `cmd_buf.CLEAR_COMMANDS` and `cmd_buf.clear_buffer`.
   - Changed:
     - Updated default storage buffer/image limit to `8` from `4`.
   - Fixed:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "arrayvec",
  "ash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "arrayvec",
  "ash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "arrayvec",
  "ash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "arrayvec",
  "ash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.33.3+1.2.191"
+version = "0.34.0+1.2.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4f1d82f164f838ae413296d1131aa6fa79b917d25bebaa7033d25620c09219"
+checksum = "b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "arrayvec",
  "ash",

--- a/cts_runner/Cargo.toml
+++ b/cts_runner/Cargo.toml
@@ -11,12 +11,12 @@ publish = false
 resolver = "2"
 
 [dependencies]
-deno_console = { git = "https://github.com/denoland/deno", rev = "ca75752e5a9499a0a997809f02b18c2ba1ecd58d" }
-deno_core = { git = "https://github.com/denoland/deno", rev = "ca75752e5a9499a0a997809f02b18c2ba1ecd58d" }
-deno_timers = { git = "https://github.com/denoland/deno", rev = "ca75752e5a9499a0a997809f02b18c2ba1ecd58d" }
-deno_url = { git = "https://github.com/denoland/deno", rev = "ca75752e5a9499a0a997809f02b18c2ba1ecd58d" }
-deno_web = { git = "https://github.com/denoland/deno", rev = "ca75752e5a9499a0a997809f02b18c2ba1ecd58d" }
-deno_webidl = { git = "https://github.com/denoland/deno", rev = "ca75752e5a9499a0a997809f02b18c2ba1ecd58d" }
+deno_console = "0.32.0"
+deno_core = "0.114.0"
+deno_timers = "0.30.0"
+deno_url = "0.32.0"
+deno_web = "0.63.0"
+deno_webidl = "0.32.0"
 deno_webgpu = { path = "../deno_webgpu" }
-tokio = { version = "1.10.0", features = ["full"] }
+tokio = { version = "1.15.0", features = ["full"] }
 termcolor = "1.1.2"

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/gfx-rs/wgpu"
 description = "WebGPU implementation for Deno"
 
 [dependencies]
-deno_core = { git = "https://github.com/denoland/deno", rev = "ca75752e5a9499a0a997809f02b18c2ba1ecd58d" }
+deno_core = "0.114.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.10", features = ["full"] }
 wgpu-core = { path = "../wgpu-core", features = ["trace", "replay", "serde"] }

--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -202,8 +202,8 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     if features.contains(wgpu_types::Features::VERTEX_WRITABLE_STORAGE) {
         return_features.push("vertex-writable-storage");
     }
-    if features.contains(wgpu_types::Features::CLEAR_COMMANDS) {
-        return_features.push("clear-commands");
+    if features.contains(wgpu_types::Features::CLEAR_TEXTURE) {
+        return_features.push("clear-texture");
     }
     if features.contains(wgpu_types::Features::SPIRV_SHADER_PASSTHROUGH) {
         return_features.push("spirv-shader-passthrough");
@@ -417,7 +417,7 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
             required_features.0.contains("vertex-writable-storage"),
         );
         features.set(
-            wgpu_types::Features::CLEAR_COMMANDS,
+            wgpu_types::Features::CLEAR_TEXTURE,
             required_features.0.contains("clear-commands"),
         );
         features.set(

--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -264,7 +264,7 @@ pub async fn op_webgpu_request_adapter(
 
     let descriptor = wgpu_core::instance::RequestAdapterOptions {
         power_preference: match args.power_preference {
-            Some(power_preference) => power_preference.into(),
+            Some(power_preference) => power_preference,
             None => PowerPreference::default(),
         },
         force_fallback_adapter: args.force_fallback_adapter,

--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -202,7 +202,7 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     if features.contains(wgpu_types::Features::VERTEX_WRITABLE_STORAGE) {
         return_features.push("vertex-writable-storage");
     }
-    if features.contains(wgpu_types::Features::CLEAR_TEXTURE) {
+    if features.contains(wgpu_types::Features::CLEAR_COMMANDS) {
         return_features.push("clear-texture");
     }
     if features.contains(wgpu_types::Features::SPIRV_SHADER_PASSTHROUGH) {
@@ -417,7 +417,7 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
             required_features.0.contains("vertex-writable-storage"),
         );
         features.set(
-            wgpu_types::Features::CLEAR_TEXTURE,
+            wgpu_types::Features::CLEAR_COMMANDS,
             required_features.0.contains("clear-commands"),
         );
         features.set(

--- a/deno_webgpu/src/pipeline.rs
+++ b/deno_webgpu/src/pipeline.rs
@@ -209,10 +209,10 @@ impl TryFrom<GpuDepthStencilState> for wgpu_types::DepthStencilState {
         Ok(wgpu_types::DepthStencilState {
             format: state.format,
             depth_write_enabled: state.depth_write_enabled,
-            depth_compare: state.depth_compare.into(),
+            depth_compare: state.depth_compare,
             stencil: wgpu_types::StencilState {
-                front: state.stencil_front.into(),
-                back: state.stencil_back.into(),
+                front: state.stencil_front,
+                back: state.stencil_back,
                 read_mask: state.stencil_read_mask,
                 write_mask: state.stencil_write_mask,
             },
@@ -322,7 +322,7 @@ pub fn op_webgpu_create_render_pipeline(
         let mut targets = Vec::with_capacity(fragment.targets.len());
 
         for target in fragment.targets {
-            targets.push(target.try_into()?);
+            targets.push(target);
         }
 
         Some(wgpu_core::pipeline::FragmentState {
@@ -356,7 +356,7 @@ pub fn op_webgpu_create_render_pipeline(
         },
         primitive: args.primitive.into(),
         depth_stencil: args.depth_stencil.map(TryInto::try_into).transpose()?,
-        multisample: args.multisample.into(),
+        multisample: args.multisample,
         fragment,
         multiview: None,
     };

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-core"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU core logic on wgpu-hal"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-core"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU core logic on wgpu-hal"

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -3,7 +3,6 @@ use std::{num::NonZeroU32, ops::Range};
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;
 use crate::{
-    align_to,
     command::CommandBuffer,
     device::Device,
     get_lowest_common_denom,
@@ -14,7 +13,7 @@ use crate::{
     track::{ResourceTracker, TextureSelector, TextureState},
 };
 
-use hal::CommandEncoder as _;
+use hal::{auxil::align_to, CommandEncoder as _};
 use thiserror::Error;
 use wgt::{BufferAddress, BufferSize, BufferUsages, ImageSubresourceRange, TextureAspect};
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -21,8 +21,8 @@ use wgt::{BufferAddress, BufferSize, BufferUsages, ImageSubresourceRange, Textur
 /// Error encountered while attempting a clear.
 #[derive(Clone, Debug, Error)]
 pub enum ClearError {
-    #[error("to use clear_texture the CLEAR_TEXTURE feature needs to be enabled")]
-    MissingClearTextureFeature,
+    #[error("to use clear_buffer/texture the CLEAR_COMMANDS feature needs to be enabled")]
+    MissingClearCommandsFeature,
     #[error("command encoder {0:?} is invalid")]
     InvalidCommandEncoder(CommandEncoderId),
     #[error("device {0:?} is invalid")]
@@ -171,8 +171,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             });
         }
 
-        if !cmd_buf.support_clear_texture {
-            return Err(ClearError::MissingClearTextureFeature);
+        if !cmd_buf.support_clear_commands {
+            return Err(ClearError::MissingClearCommandsFeature);
         }
 
         let dst_texture = texture_guard
@@ -451,7 +451,7 @@ fn clear_texture_via_render_passes<A: hal::Api>(
             };
             unsafe {
                 encoder.begin_render_pass(&hal::RenderPassDescriptor {
-                    label: Some("clear_texture clear pass"),
+                    label: Some("CLEAR_COMMANDS clear pass"),
                     extent,
                     sample_count,
                     color_attachments,

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -8,15 +8,12 @@ mod query;
 mod render;
 mod transfer;
 
-pub use self::bundle::*;
-pub(crate) use self::clear::collect_zero_buffer_copies_for_clear_texture;
-pub use self::clear::ClearError;
-pub use self::compute::*;
-pub use self::draw::*;
+pub(crate) use self::clear::clear_texture_no_device;
+pub use self::{
+    bundle::*, clear::ClearError, compute::*, draw::*, query::*, render::*, transfer::*,
+};
+
 use self::memory_init::CommandBufferTextureMemoryActions;
-pub use self::query::*;
-pub use self::render::*;
-pub use self::transfer::*;
 
 use crate::error::{ErrorFormatter, PrettyError};
 use crate::init_tracker::BufferInitTrackerAction;
@@ -101,7 +98,7 @@ pub struct CommandBuffer<A: hal::Api> {
     buffer_memory_init_actions: Vec<BufferInitTrackerAction>,
     texture_memory_actions: CommandBufferTextureMemoryActions,
     limits: wgt::Limits,
-    support_clear_buffer_texture: bool,
+    support_clear_texture: bool,
     #[cfg(feature = "trace")]
     pub(crate) commands: Option<Vec<TraceCommand>>,
 }
@@ -129,7 +126,7 @@ impl<A: HalApi> CommandBuffer<A> {
             buffer_memory_init_actions: Default::default(),
             texture_memory_actions: Default::default(),
             limits,
-            support_clear_buffer_texture: features.contains(wgt::Features::CLEAR_COMMANDS),
+            support_clear_texture: features.contains(wgt::Features::CLEAR_TEXTURE),
             #[cfg(feature = "trace")]
             commands: if enable_tracing {
                 Some(Vec::new())

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -98,7 +98,7 @@ pub struct CommandBuffer<A: hal::Api> {
     buffer_memory_init_actions: Vec<BufferInitTrackerAction>,
     texture_memory_actions: CommandBufferTextureMemoryActions,
     limits: wgt::Limits,
-    support_clear_texture: bool,
+    support_clear_commands: bool,
     #[cfg(feature = "trace")]
     pub(crate) commands: Option<Vec<TraceCommand>>,
 }
@@ -126,7 +126,7 @@ impl<A: HalApi> CommandBuffer<A> {
             buffer_memory_init_actions: Default::default(),
             texture_memory_actions: Default::default(),
             limits,
-            support_clear_texture: features.contains(wgt::Features::CLEAR_TEXTURE),
+            support_clear_commands: features.contains(wgt::Features::CLEAR_COMMANDS),
             #[cfg(feature = "trace")]
             commands: if enable_tracing {
                 Some(Vec::new())

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -578,7 +578,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
         } else if channel.store_op == StoreOp::Store {
             // Clear + Store
             texture_memory_actions.register_implicit_init(
-                view.parent_id.value.0,
+                view.parent_id.value,
                 TextureInitRange::from(view.selector.clone()),
                 texture_guard,
             );
@@ -745,7 +745,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 if at.depth.store_op != at.stencil.store_op {
                     if !need_init_beforehand {
                         cmd_buf.texture_memory_actions.register_implicit_init(
-                            view.parent_id.value.0,
+                            view.parent_id.value,
                             TextureInitRange::from(view.selector.clone()),
                             texture_guard,
                         );
@@ -838,7 +838,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 }
 
                 cmd_buf.texture_memory_actions.register_implicit_init(
-                    resolve_view.parent_id.value.0,
+                    resolve_view.parent_id.value,
                     TextureInitRange::from(resolve_view.selector.clone()),
                     texture_guard,
                 );

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -1,16 +1,16 @@
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;
 use crate::{
-    command::{
-        collect_zero_buffer_copies_for_clear_texture, memory_init::fixup_discarded_surfaces,
-        CommandBuffer, CommandEncoderError,
-    },
+    command::{CommandBuffer, CommandEncoderError},
     conv,
     device::Device,
     error::{ErrorFormatter, PrettyError},
     hub::{Global, GlobalIdentityHandlerFactory, HalApi, Storage, Token},
-    id::{BufferId, CommandEncoderId, TextureId},
-    init_tracker::{MemoryInitKind, TextureInitRange, TextureInitTrackerAction},
+    id::{BufferId, CommandEncoderId, Id, TextureId, Valid},
+    init_tracker::{
+        has_copy_partial_init_tracker_coverage, MemoryInitKind, TextureInitRange,
+        TextureInitTrackerAction,
+    },
     resource::{Texture, TextureErrorDimension},
     track::TextureSelector,
 };
@@ -20,6 +20,8 @@ use thiserror::Error;
 use wgt::{BufferAddress, BufferUsages, Extent3d, TextureUsages};
 
 use std::iter;
+
+use super::clear::clear_texture;
 
 pub type ImageCopyBuffer = wgt::ImageCopyBuffer<BufferId>;
 pub type ImageCopyTexture = wgt::ImageCopyTexture<TextureId>;
@@ -104,6 +106,8 @@ pub enum TransferError {
         src_format: wgt::TextureFormat,
         dst_format: wgt::TextureFormat,
     },
+    #[error(transparent)]
+    MemoryInitFailure(#[from] super::ClearError),
 }
 
 impl PrettyError for TransferError {
@@ -374,60 +378,108 @@ pub(crate) fn validate_texture_copy_range(
     Ok((copy_extent, array_layer_count))
 }
 
-fn get_copy_dst_texture_init_requirement<A: HalApi>(
-    texture: &Texture<A>,
-    copy_texture: &wgt::ImageCopyTexture<TextureId>,
+fn handle_texture_init<A: hal::Api>(
+    init_kind: MemoryInitKind,
+    cmd_buf: &mut CommandBuffer<A>,
+    device: &Device<A>,
+    copy_texture: &ImageCopyTexture,
     copy_size: &Extent3d,
-) -> TextureInitTrackerAction {
-    // Attention: If we don't write full texture subresources, we need to a full clear first since we don't track subrects.
-    let dst_init_kind = if copy_size.width == texture.desc.size.width
-        && copy_size.height == texture.desc.size.height
-    {
-        MemoryInitKind::ImplicitlyInitialized
-    } else {
-        MemoryInitKind::NeedsInitializedMemory
-    };
-    TextureInitTrackerAction {
+    texture_guard: &Storage<Texture<A>, Id<Texture<hal::api::Empty>>>,
+    texture: &Texture<A>,
+) {
+    let init_action = TextureInitTrackerAction {
         id: copy_texture.texture,
         range: TextureInitRange {
             mip_range: copy_texture.mip_level..copy_texture.mip_level + 1,
             layer_range: copy_texture.origin.z
                 ..(copy_texture.origin.z + copy_size.depth_or_array_layers),
         },
-        kind: dst_init_kind,
+        kind: init_kind,
+    };
+
+    // Register the init action.
+    let immediate_inits = cmd_buf
+        .texture_memory_actions
+        .register_init_action(&{ init_action }, texture_guard);
+
+    // In rare cases we may need to insert an init operation immediately onto the command buffer.
+    if !immediate_inits.is_empty() {
+        let cmd_buf_raw = cmd_buf.encoder.open();
+        for init in immediate_inits {
+            clear_texture(
+                Valid(init.texture),
+                texture,
+                TextureInitRange {
+                    mip_range: init.mip_level..(init.mip_level + 1),
+                    layer_range: init.layer..(init.layer + 1),
+                },
+                cmd_buf_raw,
+                &mut cmd_buf.trackers.textures,
+                device,
+            )
+            .unwrap();
+        }
     }
 }
 
+// Ensures the source texture of a transfer is in the right initialization state and records the state for after the transfer operation.
 fn handle_src_texture_init<A: hal::Api>(
     cmd_buf: &mut CommandBuffer<A>,
     device: &Device<A>,
     source: &ImageCopyTexture,
-    src_base: &hal::TextureCopyBase,
     copy_size: &Extent3d,
     texture_guard: &Storage<Texture<A>, TextureId>,
-) {
-    let immediate_src_init = cmd_buf.texture_memory_actions.register_init_action(
-        &TextureInitTrackerAction {
-            id: source.texture,
-            range: TextureInitRange {
-                mip_range: src_base.mip_level..src_base.mip_level + 1,
-                layer_range: src_base.origin.z
-                    ..(src_base.origin.z + copy_size.depth_or_array_layers),
-            },
-            kind: MemoryInitKind::NeedsInitializedMemory,
-        },
+) -> Result<(), TransferError> {
+    let texture = texture_guard
+        .get(source.texture)
+        .map_err(|_| TransferError::InvalidTexture(source.texture))?;
+
+    handle_texture_init(
+        MemoryInitKind::NeedsInitializedMemory,
+        cmd_buf,
+        device,
+        source,
+        copy_size,
         texture_guard,
+        texture,
     );
-    if !immediate_src_init.is_empty() {
-        let cmd_buf_raw = cmd_buf.encoder.open();
-        fixup_discarded_surfaces(
-            immediate_src_init.into_iter(),
-            cmd_buf_raw,
-            texture_guard,
-            &mut cmd_buf.trackers.textures,
-            device,
-        );
-    }
+    Ok(())
+}
+
+// Ensures the destination texture of a transfer is in the right initialization state and records the state for after the transfer operation.
+fn handle_dst_texture_init<A: hal::Api>(
+    cmd_buf: &mut CommandBuffer<A>,
+    device: &Device<A>,
+    destination: &ImageCopyTexture,
+    copy_size: &Extent3d,
+    texture_guard: &Storage<Texture<A>, TextureId>,
+) -> Result<(), TransferError> {
+    let texture = texture_guard
+        .get(destination.texture)
+        .map_err(|_| TransferError::InvalidTexture(destination.texture))?;
+
+    // Attention: If we don't write full texture subresources, we need to a full clear first since we don't track subrects.
+    // This means that in rare cases even a *destination* texture of a transfer may need an immediate texture init.
+    let dst_init_kind = if has_copy_partial_init_tracker_coverage(
+        copy_size,
+        destination.mip_level,
+        &texture.desc,
+    ) {
+        MemoryInitKind::NeedsInitializedMemory
+    } else {
+        MemoryInitKind::ImplicitlyInitialized
+    };
+
+    handle_texture_init(
+        dst_init_kind,
+        cmd_buf,
+        device,
+        destination,
+        copy_size,
+        texture_guard,
+        texture,
+    );
+    Ok(())
 }
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
@@ -598,6 +650,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (dst_range, dst_base, _) =
             extract_texture_selector(destination, copy_size, &*texture_guard)?;
 
+        // Handle texture init *before* dealing with barrier transitions so we have an easier time inserting "immediate-inits" that may be required by prior discards in rare cases.
+        handle_dst_texture_init(cmd_buf, device, destination, copy_size, &texture_guard)?;
+
         let (src_buffer, src_pending) = cmd_buf
             .trackers
             .buffers
@@ -663,19 +718,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 source.layout.offset..(source.layout.offset + required_buffer_bytes_in_copy),
                 MemoryInitKind::NeedsInitializedMemory,
             ));
-        let mut dst_zero_buffer_copy_regions = Vec::new();
-        for immediate_init in cmd_buf.texture_memory_actions.register_init_action(
-            &get_copy_dst_texture_init_requirement(dst_texture, destination, copy_size),
-            &texture_guard,
-        ) {
-            collect_zero_buffer_copies_for_clear_texture(
-                &dst_texture.desc,
-                device.alignments.buffer_copy_pitch.get() as u32,
-                immediate_init.mip_level..(immediate_init.mip_level + 1),
-                immediate_init.layer..(immediate_init.layer + 1),
-                &mut dst_zero_buffer_copy_regions,
-            );
-        }
 
         let regions = (0..array_layer_count).map(|rel_array_layer| {
             let mut texture_base = dst_base.clone();
@@ -688,17 +730,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 size: hal_copy_size,
             }
         });
+
         let cmd_buf_raw = cmd_buf.encoder.open();
         unsafe {
             cmd_buf_raw.transition_textures(dst_barriers);
-            // potential dst buffer init (for previously discarded dst_texture + partial copy)
-            if !dst_zero_buffer_copy_regions.is_empty() {
-                cmd_buf_raw.copy_buffer_to_texture(
-                    &device.zero_buffer,
-                    dst_raw,
-                    dst_zero_buffer_copy_regions.into_iter(),
-                );
-            }
             cmd_buf_raw.transition_buffers(src_barriers);
             cmd_buf_raw.copy_buffer_to_texture(src_raw, dst_raw, regions);
         }
@@ -742,15 +777,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (src_range, src_base, _) =
             extract_texture_selector(source, copy_size, &*texture_guard)?;
 
-        // Handle src texture init *before* dealing with barrier transitions so we have an easier time inserting "immediate-inits" that may be required by prior discards in rare cases.
-        handle_src_texture_init(
-            cmd_buf,
-            device,
-            source,
-            &src_base,
-            copy_size,
-            &texture_guard,
-        );
+        // Handle texture init *before* dealing with barrier transitions so we have an easier time inserting "immediate-inits" that may be required by prior discards in rare cases.
+        handle_src_texture_init(cmd_buf, device, source, copy_size, &texture_guard)?;
 
         let (src_texture, src_pending) = cmd_buf
             .trackers
@@ -887,15 +915,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             return Err(TransferError::MismatchedAspects.into());
         }
 
-        // Handle src texture init *before* dealing with barrier transitions so we have an easier time inserting "immediate-inits" that may be required by prior discards in rare cases.
-        handle_src_texture_init(
-            cmd_buf,
-            device,
-            source,
-            &src_tex_base,
-            copy_size,
-            &texture_guard,
-        );
+        // Handle texture init *before* dealing with barrier transitions so we have an easier time inserting "immediate-inits" that may be required by prior discards in rare cases.
+        handle_src_texture_init(cmd_buf, device, source, copy_size, &texture_guard)?;
+        handle_dst_texture_init(cmd_buf, device, destination, copy_size, &texture_guard)?;
 
         let (src_texture, src_pending) = cmd_buf
             .trackers
@@ -964,20 +986,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             copy_size,
         )?;
 
-        let mut dst_zero_buffer_copy_regions = Vec::new();
-        for immediate_init in cmd_buf.texture_memory_actions.register_init_action(
-            &get_copy_dst_texture_init_requirement(dst_texture, destination, copy_size),
-            &texture_guard,
-        ) {
-            collect_zero_buffer_copies_for_clear_texture(
-                &dst_texture.desc,
-                device.alignments.buffer_copy_pitch.get() as u32,
-                immediate_init.mip_level..(immediate_init.mip_level + 1),
-                immediate_init.layer..(immediate_init.layer + 1),
-                &mut dst_zero_buffer_copy_regions,
-            );
-        }
-
         let hal_copy_size = hal::CopyExtent {
             width: src_copy_size.width.min(dst_copy_size.width),
             height: src_copy_size.height.min(dst_copy_size.height),
@@ -997,16 +1005,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let cmd_buf_raw = cmd_buf.encoder.open();
         unsafe {
             cmd_buf_raw.transition_textures(barriers.into_iter());
-
-            // potential dst buffer init (for previously discarded dst_texture + partial copy)
-            if !dst_zero_buffer_copy_regions.is_empty() {
-                cmd_buf_raw.copy_buffer_to_texture(
-                    &device.zero_buffer,
-                    dst_raw,
-                    dst_zero_buffer_copy_regions.into_iter(),
-                );
-            }
-
             cmd_buf_raw.copy_texture_to_texture(
                 src_raw,
                 hal::TextureUses::COPY_SRC,

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -71,6 +71,10 @@ pub fn map_texture_usage(
         usage.contains(wgt::TextureUsages::COPY_SRC),
     );
     u.set(
+        hal::TextureUses::COPY_DST,
+        usage.contains(wgt::TextureUsages::COPY_DST),
+    );
+    u.set(
         hal::TextureUses::RESOURCE,
         usage.contains(wgt::TextureUsages::TEXTURE_BINDING),
     );

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -618,7 +618,7 @@ impl<A: HalApi> Device<A> {
             format_features,
             initialization_status: TextureInitTracker::new(
                 desc.mip_level_count,
-                desc.size.depth_or_array_layers,
+                desc.array_layer_count(),
             ),
             full_range: TextureSelector {
                 levels: 0..desc.mip_level_count,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "trace")]
 use crate::device::trace::Action;
 use crate::{
-    align_to,
     command::{
         extract_texture_selector, validate_linear_texture_data, validate_texture_copy_range,
         ClearError, CommandBuffer, CopySide, ImageCopyTexture, TransferError,
@@ -415,7 +414,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             device.alignments.buffer_copy_pitch.get() as u32,
             format_desc.block_size as u32,
         );
-        let stage_bytes_per_row = align_to(
+        let stage_bytes_per_row = hal::auxil::align_to(
             format_desc.block_size as u32 * width_blocks,
             bytes_per_row_alignment,
         );

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -5,7 +5,7 @@ use crate::{
     id,
     instance::{Adapter, HalSurface, Instance, Surface},
     pipeline::{ComputePipeline, RenderPipeline, ShaderModule},
-    resource::{Buffer, QuerySet, Sampler, Texture, TextureView},
+    resource::{Buffer, QuerySet, Sampler, Texture, TextureClearMode, TextureView},
     Epoch, Index,
 };
 
@@ -647,6 +647,13 @@ impl<A: HalApi, F: GlobalIdentityHandlerFactory> Hub<A, F> {
                 if let TextureInner::Native { raw: Some(raw) } = texture.inner {
                     unsafe {
                         device.raw.destroy_texture(raw);
+                    }
+                }
+                if let TextureClearMode::RenderPass { clear_views, .. } = texture.clear_mode {
+                    for view in clear_views {
+                        unsafe {
+                            device.raw.destroy_texture_view(view);
+                        }
                     }
                 }
             }

--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -20,7 +20,10 @@ mod buffer;
 mod texture;
 
 pub(crate) use buffer::{BufferInitTracker, BufferInitTrackerAction};
-pub(crate) use texture::{TextureInitRange, TextureInitTracker, TextureInitTrackerAction};
+pub(crate) use texture::{
+    has_copy_partial_init_tracker_coverage, TextureInitRange, TextureInitTracker,
+    TextureInitTrackerAction,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum MemoryInitKind {

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -535,7 +535,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             None => return,
         };
 
-        profiling::scope!("enumerating", format!("{:?}", A::VARIANT));
+        profiling::scope!("enumerating", &*format!("{:?}", A::VARIANT));
         let hub = HalApi::hub(self);
         let mut token = Token::root();
 

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -252,14 +252,6 @@ pub(crate) fn get_greatest_common_divisor(mut a: u32, mut b: u32) -> u32 {
     }
 }
 
-#[inline]
-pub(crate) fn align_to(value: u32, alignment: u32) -> u32 {
-    match value % alignment {
-        0 => value,
-        other => value - other + alignment,
-    }
-}
-
 #[test]
 fn test_lcd() {
     assert_eq!(get_lowest_common_denom(2, 2), 2);

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -145,7 +145,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     unsafe {
                         hal::Device::create_texture_view(
                             &device.raw,
-                            &ast.texture.borrow(),
+                            ast.texture.borrow(),
                             &clear_view_desc,
                         )
                     }

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -9,7 +9,7 @@ When this texture is presented, we remove it from the device tracker as well as
 extract it from the hub.
 !*/
 
-use std::{borrow::Borrow, num::NonZeroU32};
+use std::borrow::Borrow;
 
 #[cfg(feature = "trace")]
 use crate::device::trace::Action;
@@ -128,17 +128,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (texture_id, status) = match unsafe { suf.raw.acquire_texture(FRAME_TIMEOUT_MS) } {
             Ok(Some(ast)) => {
                 let clear_view_desc = hal::TextureViewDescriptor {
-                    label: Some("clear texture view"),
+                    label: Some("clear surface texture view"),
                     format: config.format,
                     dimension: wgt::TextureViewDimension::D2,
                     usage: hal::TextureUses::COLOR_TARGET,
-                    range: wgt::ImageSubresourceRange {
-                        aspect: wgt::TextureAspect::All,
-                        base_mip_level: 0,
-                        mip_level_count: NonZeroU32::new(1),
-                        base_array_layer: 0,
-                        array_layer_count: NonZeroU32::new(1),
-                    },
+                    range: wgt::ImageSubresourceRange::default(),
                 };
                 let mut clear_views = smallvec::SmallVec::new();
                 clear_views.push(

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -37,7 +37,7 @@ block = { version = "0.1", optional = true }
 foreign-types = { version = "0.3", optional = true }
 
 # backend: Vulkan
-ash = { version = "0.33", optional = true }
+ash = { version = "0.34", optional = true, default-features = false, features = ["debug", "loaded"] }
 gpu-alloc = { version = "0.5", optional = true }
 gpu-descriptor = { version = "0.2", optional = true }
 inplace_it = { version ="0.3.3", optional = true }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-hal"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU hardware abstraction layer"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-hal"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU hardware abstraction layer"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-hal"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU hardware abstraction layer"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-hal"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU hardware abstraction layer"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-hal"
-version = "0.12.4"
+version = "0.12.5"
 authors = ["wgpu developers"]
 edition = "2018"
 description = "WebGPU hardware abstraction layer"

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -67,7 +67,7 @@ struct Example<A: hal::Api> {
     pipeline: A::RenderPipeline,
     bunnies: Vec<Locals>,
     local_buffer: A::Buffer,
-    local_alignment: wgt::BufferAddress,
+    local_alignment: u32,
     global_buffer: A::Buffer,
     sampler: A::Sampler,
     texture: A::Texture,
@@ -376,22 +376,13 @@ impl<A: hal::Api> Example<A> {
             buffer
         };
 
-        fn align_to(
-            value: wgt::BufferAddress,
-            alignment: wgt::BufferAddress,
-        ) -> wgt::BufferAddress {
-            match value % alignment {
-                0 => value,
-                other => value - other + alignment,
-            }
-        }
-        let local_alignment = align_to(
-            mem::size_of::<Locals>() as _,
-            capabilities.limits.min_uniform_buffer_offset_alignment as _,
+        let local_alignment = hal::auxil::align_to(
+            mem::size_of::<Locals>() as u32,
+            capabilities.limits.min_uniform_buffer_offset_alignment,
         );
         let local_buffer_desc = hal::BufferDescriptor {
             label: Some("local"),
-            size: (MAX_BUNNIES as wgt::BufferAddress) * local_alignment,
+            size: (MAX_BUNNIES as wgt::BufferAddress) * (local_alignment as wgt::BufferAddress),
             usage: hal::BufferUses::MAP_WRITE | hal::BufferUses::UNIFORM,
             memory_flags: hal::MemoryFlags::PREFER_COHERENT,
         };

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -15,6 +15,12 @@ pub mod db {
     }
 }
 
+/// Maximum binding size for the shaders that only support `i32` indexing.
+/// Interestingly, the index itself can't reach that high, because the minimum
+/// element size is 4 bytes, but the compiler toolchain still computes the
+/// offset at some intermediate point, internally, as i32.
+pub const MAX_I32_BINDING_SIZE: u32 = 1 << 31;
+
 pub fn map_naga_stage(stage: naga::ShaderStage) -> wgt::ShaderStages {
     match stage {
         naga::ShaderStage::Vertex => wgt::ShaderStages::VERTEX,

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -29,6 +29,17 @@ pub fn map_naga_stage(stage: naga::ShaderStage) -> wgt::ShaderStages {
     }
 }
 
+pub fn align_to(value: u32, alignment: u32) -> u32 {
+    if alignment.is_power_of_two() {
+        (value + alignment - 1) & !(alignment - 1)
+    } else {
+        match value % alignment {
+            0 => value,
+            other => value - other + alignment,
+        }
+    }
+}
+
 impl crate::CopyExtent {
     pub fn min(&self, other: &Self) -> Self {
         Self {

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -240,7 +240,7 @@ impl super::Adapter {
                     max_uniform_buffers_per_shader_stage: full_heap_count,
                     max_uniform_buffer_binding_size: d3d12::D3D12_REQ_CONSTANT_BUFFER_ELEMENT_COUNT
                         * 16,
-                    max_storage_buffer_binding_size: !0,
+                    max_storage_buffer_binding_size: crate::auxil::MAX_I32_BINDING_SIZE,
                     max_vertex_buffers: d3d12::D3D12_VS_INPUT_REGISTER_COUNT
                         .min(crate::MAX_VERTEX_BUFFERS as u32),
                     max_vertex_attributes: d3d12::D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT,

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -98,7 +98,7 @@ impl super::Adapter {
             device_type: if (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0 {
                 workarounds.avoid_cpu_descriptor_overwrites = true;
                 wgt::DeviceType::Cpu
-            } else if features_architecture.CacheCoherentUMA != 0 {
+            } else if features_architecture.UMA != 0 {
                 wgt::DeviceType::IntegratedGpu
             } else {
                 wgt::DeviceType::DiscreteGpu

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -186,7 +186,7 @@ impl super::Adapter {
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | wgt::Features::TIMESTAMP_QUERY
             | wgt::Features::TEXTURE_COMPRESSION_BC
-            | wgt::Features::CLEAR_COMMANDS
+            | wgt::Features::CLEAR_TEXTURE
             | wgt::Features::TEXTURE_FORMAT_16BIT_NORM;
         //TODO: in order to expose this, we need to run a compute shader
         // that extract the necessary statistics out of the D3D12 result.

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -186,7 +186,7 @@ impl super::Adapter {
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | wgt::Features::TIMESTAMP_QUERY
             | wgt::Features::TEXTURE_COMPRESSION_BC
-            | wgt::Features::CLEAR_TEXTURE
+            | wgt::Features::CLEAR_COMMANDS
             | wgt::Features::TEXTURE_FORMAT_16BIT_NORM;
         //TODO: in order to expose this, we need to run a compute shader
         // that extract the necessary statistics out of the D3D12 result.

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1,3 +1,5 @@
+use crate::FormatAspects;
+
 use super::{conv, descriptor, view, HResult as _};
 use parking_lot::Mutex;
 use std::{ffi, mem, num::NonZeroU32, ptr, slice, sync::Arc};
@@ -495,6 +497,7 @@ impl crate::Device<super::Api> for super::Device {
 
         Ok(super::TextureView {
             raw_format: view_desc.format,
+            format_aspects: FormatAspects::from(desc.format),
             target_base: (
                 texture.resource,
                 texture.calc_subresource(desc.range.base_mip_level, desc.range.base_array_layer, 0),
@@ -558,7 +561,7 @@ impl crate::Device<super::Api> for super::Device {
                 .usage
                 .intersects(crate::TextureUses::DEPTH_STENCIL_WRITE)
             {
-                let raw_desc = view_desc.to_dsv(crate::FormatAspects::empty());
+                let raw_desc = view_desc.to_dsv(FormatAspects::empty());
                 let handle = self.dsv_pool.lock().alloc_handle();
                 self.raw.CreateDepthStencilView(
                     texture.resource.as_mut_ptr(),

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -58,6 +58,19 @@ unsafe extern "system" fn output_debug_string_handler(
         return excpt::EXCEPTION_CONTINUE_SEARCH;
     }
 
+    let dxgi_debug_layer_bug_text1 = "ID3D12CommandQueue::Present";
+    // We currently dont cross command list types, so this text has the
+    // highest chance of being a true positive for this issue.
+    let dxgi_debug_layer_bug_text2 = "resource state on previous Command List type";
+    if level == log::Level::Error
+        && message.contains(dxgi_debug_layer_bug_text1)
+        && message.contains(dxgi_debug_layer_bug_text2)
+    {
+        // This is a bug in the DXGI and D3D12 validation layer when on windows 11.
+        // See https://stackoverflow.com/q/69805245 for more.
+        return excpt::EXCEPTION_CONTINUE_SEARCH;
+    }
+
     let _ = std::panic::catch_unwind(|| {
         log::log!(level, "{}", message);
     });

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -58,7 +58,9 @@ unsafe extern "system" fn output_debug_string_handler(
         return excpt::EXCEPTION_CONTINUE_SEARCH;
     }
 
-    log::log!(level, "{}", message);
+    let _ = std::panic::catch_unwind(|| {
+        log::log!(level, "{}", message);
+    });
 
     if cfg!(debug_assertions) && level == log::Level::Error {
         // Panicking behind FFI is UB, so we just exit.

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -63,8 +63,8 @@ unsafe extern "system" fn output_debug_string_handler(
     });
 
     if cfg!(debug_assertions) && level == log::Level::Error {
-        // Panicking behind FFI is UB, so we just exit.
-        std::process::exit(1);
+        // Set canary and continue
+        crate::VALIDATION_CANARY.set();
     }
 
     excpt::EXCEPTION_CONTINUE_EXECUTION

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -422,6 +422,7 @@ impl Texture {
 #[derive(Debug)]
 pub struct TextureView {
     raw_format: native::Format,
+    format_aspects: crate::FormatAspects, // May explicitly ignore stencil aspect of raw_format!
     target_base: (native::Resource, u32),
     handle_srv: Option<descriptor::Handle>,
     handle_uav: Option<descriptor::Handle>,

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -286,7 +286,7 @@ impl super::Adapter {
 
         let mut features = wgt::Features::empty()
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | wgt::Features::CLEAR_COMMANDS;
+            | wgt::Features::CLEAR_TEXTURE;
         features.set(
             wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER,
             extensions.contains("GL_EXT_texture_border_clamp"),

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -286,7 +286,7 @@ impl super::Adapter {
 
         let mut features = wgt::Features::empty()
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | wgt::Features::CLEAR_TEXTURE;
+            | wgt::Features::CLEAR_COMMANDS;
         features.set(
             wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER,
             extensions.contains("GL_EXT_texture_border_clamp"),

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -259,7 +259,8 @@ fn gl_debug_message_callback(source: u32, gltype: u32, id: u32, severity: u32, m
     });
 
     if cfg!(debug_assertions) && log_severity == log::Level::Error {
-        std::process::exit(1);
+        // Set canary and continue
+        crate::VALIDATION_CANARY.set();
     }
 }
 

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -247,14 +247,16 @@ fn gl_debug_message_callback(source: u32, gltype: u32, id: u32, severity: u32, m
         _ => unreachable!(),
     };
 
-    log::log!(
-        log_severity,
-        "GLES: [{}/{}] ID {} : {}",
-        source_str,
-        type_str,
-        id,
-        message
-    );
+    let _ = std::panic::catch_unwind(|| {
+        log::log!(
+            log_severity,
+            "GLES: [{}/{}] ID {} : {}",
+            source_str,
+            type_str,
+            id,
+            message
+        );
+    });
 
     if cfg!(debug_assertions) && log_severity == log::Level::Error {
         std::process::exit(1);

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -57,7 +57,7 @@ impl super::Queue {
         }
     }
 
-    unsafe fn reset_state(&self, gl: &glow::Context) {
+    unsafe fn reset_state(&mut self, gl: &glow::Context) {
         gl.use_program(None);
         gl.bind_framebuffer(glow::FRAMEBUFFER, None);
         gl.disable(glow::DEPTH_TEST);
@@ -69,6 +69,9 @@ impl super::Queue {
         if self.features.contains(wgt::Features::DEPTH_CLIP_CONTROL) {
             gl.disable(glow::DEPTH_CLAMP);
         }
+
+        gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
+        self.current_index_buffer = None;
     }
 
     unsafe fn set_attachment(

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -84,6 +84,7 @@ use std::{
     num::{NonZeroU32, NonZeroU8},
     ops::{Range, RangeInclusive},
     ptr::NonNull,
+    sync::atomic::AtomicBool,
 };
 
 use bitflags::bitflags;
@@ -1141,6 +1142,39 @@ pub struct RenderPassDescriptor<'a, A: Api> {
 #[derive(Clone, Debug)]
 pub struct ComputePassDescriptor<'a> {
     pub label: Label<'a>,
+}
+
+/// Stores if any API validation error has occurred in this process
+/// since it was last reset.
+///
+/// This is used for internal wgpu testing only and _must not_ be used
+/// as a way to check for errors.
+///
+/// This works as a static because `cargo nextest` runs all of our
+/// tests in separate processes, so each test gets its own canary.
+///
+/// This prevents the issue of one validation error terminating the
+/// entire process.
+pub static VALIDATION_CANARY: ValidationCanary = ValidationCanary {
+    inner: AtomicBool::new(false),
+};
+
+/// Flag for internal testing.
+pub struct ValidationCanary {
+    inner: AtomicBool,
+}
+
+impl ValidationCanary {
+    #[allow(dead_code)] // in some configurations this function is dead
+    fn set(&self) {
+        self.inner.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Returns true if any API validation error has occurred in this process
+    /// since the last call to this function.
+    pub fn get_and_reset(&self) -> bool {
+        self.inner.swap(false, std::sync::atomic::Ordering::SeqCst)
+    }
 }
 
 #[test]

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -906,6 +906,11 @@ impl super::PrivateCapabilities {
             supports_depth_clip_control: device
                 .supports_feature_set(MTLFeatureSet::iOS_GPUFamily4_v1)
                 || os_is_mac,
+            supports_preserve_invariance: if os_is_mac {
+                Self::version_at_least(major, minor, 11, 0)
+            } else {
+                Self::version_at_least(major, minor, 13, 0)
+            },
         }
     }
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -918,6 +918,7 @@ impl super::PrivateCapabilities {
             | F::MAPPABLE_PRIMARY_BUFFERS
             | F::VERTEX_WRITABLE_STORAGE
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
+            | F::PUSH_CONSTANTS
             | F::POLYGON_MODE_LINE
             | F::CLEAR_COMMANDS
             | F::TEXTURE_FORMAT_16BIT_NORM;

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -919,7 +919,7 @@ impl super::PrivateCapabilities {
             | F::VERTEX_WRITABLE_STORAGE
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | F::POLYGON_MODE_LINE
-            | F::CLEAR_COMMANDS
+            | F::CLEAR_TEXTURE
             | F::TEXTURE_FORMAT_16BIT_NORM;
 
         features.set(F::DEPTH_CLIP_CONTROL, self.supports_depth_clip_control);

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -574,7 +574,9 @@ impl super::PrivateCapabilities {
         Self {
             family_check,
             msl_version: if os_is_mac {
-                if Self::version_at_least(major, minor, 10, 15) {
+                if Self::version_at_least(major, minor, 11, 0) {
+                    MTLLanguageVersion::V2_3
+                } else if Self::version_at_least(major, minor, 10, 15) {
                     MTLLanguageVersion::V2_2
                 } else if Self::version_at_least(major, minor, 10, 14) {
                     MTLLanguageVersion::V2_1
@@ -587,6 +589,8 @@ impl super::PrivateCapabilities {
                 } else {
                     MTLLanguageVersion::V1_0
                 }
+            } else if Self::version_at_least(major, minor, 14, 0) {
+                MTLLanguageVersion::V2_3
             } else if Self::version_at_least(major, minor, 13, 0) {
                 MTLLanguageVersion::V2_2
             } else if Self::version_at_least(major, minor, 12, 0) {

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -919,7 +919,7 @@ impl super::PrivateCapabilities {
             | F::VERTEX_WRITABLE_STORAGE
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | F::POLYGON_MODE_LINE
-            | F::CLEAR_TEXTURE
+            | F::CLEAR_COMMANDS
             | F::TEXTURE_FORMAT_16BIT_NORM;
 
         features.set(F::DEPTH_CLIP_CONTROL, self.supports_depth_clip_control);

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -16,6 +16,7 @@ impl Default for super::CommandState {
             stage_infos: Default::default(),
             storage_buffer_length_map: Default::default(),
             work_group_memory_sizes: Vec::new(),
+            push_constants: Vec::new(),
         }
     }
 }
@@ -61,6 +62,7 @@ impl super::CommandState {
         self.stage_infos.fs.clear();
         self.stage_infos.cs.clear();
         self.work_group_memory_sizes.clear();
+        self.push_constants.clear();
     }
 
     fn make_sizes_buffer_update<'a>(
@@ -587,12 +589,41 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 
     unsafe fn set_push_constants(
         &mut self,
-        _layout: &super::PipelineLayout,
-        _stages: wgt::ShaderStages,
-        _offset: u32,
-        _data: &[u32],
+        layout: &super::PipelineLayout,
+        stages: wgt::ShaderStages,
+        offset: u32,
+        data: &[u32],
     ) {
-        //TODO
+        let state_pc = &mut self.state.push_constants;
+        if state_pc.len() < layout.total_push_constants as usize {
+            state_pc.resize(layout.total_push_constants as usize, 0);
+        }
+        assert_eq!(offset as usize % WORD_SIZE, 0);
+
+        let offset = offset as usize / WORD_SIZE;
+        state_pc[offset..offset + data.len()].copy_from_slice(data);
+
+        if stages.contains(wgt::ShaderStages::COMPUTE) {
+            self.state.compute.as_ref().unwrap().set_bytes(
+                layout.push_constants_infos.cs.unwrap().buffer_index as _,
+                (layout.total_push_constants as usize * WORD_SIZE) as _,
+                state_pc.as_ptr() as _,
+            )
+        }
+        if stages.contains(wgt::ShaderStages::VERTEX) {
+            self.state.render.as_ref().unwrap().set_vertex_bytes(
+                layout.push_constants_infos.vs.unwrap().buffer_index as _,
+                (layout.total_push_constants as usize * WORD_SIZE) as _,
+                state_pc.as_ptr() as _,
+            )
+        }
+        if stages.contains(wgt::ShaderStages::FRAGMENT) {
+            self.state.render.as_ref().unwrap().set_fragment_bytes(
+                layout.push_constants_infos.fs.unwrap().buffer_index as _,
+                (layout.total_push_constants as usize * WORD_SIZE) as _,
+                state_pc.as_ptr() as _,
+            )
+        }
     }
 
     unsafe fn insert_debug_marker(&mut self, label: &str) {

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -471,6 +471,7 @@ impl crate::Device<super::Api> for super::Device {
         let mut bind_group_infos = arrayvec::ArrayVec::new();
 
         // First, place the push constants
+        let mut total_push_constants = 0;
         for info in stage_data.iter_mut() {
             for pcr in desc.push_constant_ranges {
                 if pcr.stages.contains(map_naga_stage(info.stage)) {
@@ -492,6 +493,8 @@ impl crate::Device<super::Api> for super::Device {
                 info.pc_buffer = Some(info.counters.buffers);
                 info.counters.buffers += 1;
             }
+
+            total_push_constants = total_push_constants.max(info.pc_limit);
         }
 
         // Second, place the described resources
@@ -641,6 +644,7 @@ impl crate::Device<super::Api> for super::Device {
                     image: naga::proc::BoundsCheckPolicy::ReadZeroSkipWrite,
                 },
             },
+            total_push_constants,
         })
     }
     unsafe fn destroy_pipeline_layout(&self, _pipeline_layout: super::PipelineLayout) {}

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -329,6 +329,8 @@ impl crate::Device<super::Api> for super::Device {
             conv::map_texture_view_dimension(desc.dimension)
         };
 
+        //Note: this doesn't check properly if the mipmap level count or array layer count
+        // is explicitly set to 1.
         let raw = if raw_format == texture.raw_format
             && raw_type == texture.raw_type
             && desc.range == wgt::ImageSubresourceRange::default()

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -76,6 +76,10 @@ impl super::Device {
         let options = mtl::CompileOptions::new();
         options.set_language_version(self.shared.private_caps.msl_version);
 
+        if self.shared.private_caps.supports_preserve_invariance {
+            options.set_preserve_invariance(true);
+        }
+
         let library = self
             .shared
             .device

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -524,6 +524,7 @@ pub struct PipelineLayout {
     bind_group_infos: ArrayVec<BindGroupLayoutInfo, { crate::MAX_BIND_GROUPS }>,
     push_constants_infos: MultiStageData<Option<PushConstantsInfo>>,
     total_counters: MultiStageResourceCounters,
+    total_push_constants: u32,
 }
 
 trait AsNative {
@@ -709,6 +710,7 @@ struct CommandState {
     stage_infos: MultiStageData<PipelineStageInfo>,
     storage_buffer_length_map: fxhash::FxHashMap<naga::ResourceBinding, wgt::BufferSize>,
     work_group_memory_sizes: Vec<u32>,
+    push_constants: Vec<u32>,
 }
 
 pub struct CommandEncoder {

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -226,6 +226,7 @@ struct PrivateCapabilities {
     supports_arrays_of_textures_write: bool,
     supports_mutability: bool,
     supports_depth_clip_control: bool,
+    supports_preserve_invariance: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -708,8 +708,12 @@ impl PhysicalDeviceCapabilities {
             max_storage_buffers_per_shader_stage: max_storage_buffers,
             max_storage_textures_per_shader_stage: max_storage_textures,
             max_uniform_buffers_per_shader_stage: max_uniform_buffers,
-            max_uniform_buffer_binding_size: limits.max_uniform_buffer_range,
-            max_storage_buffer_binding_size: limits.max_storage_buffer_range,
+            max_uniform_buffer_binding_size: limits
+                .max_uniform_buffer_range
+                .min(crate::auxil::MAX_I32_BINDING_SIZE),
+            max_storage_buffer_binding_size: limits
+                .max_storage_buffer_range
+                .min(crate::auxil::MAX_I32_BINDING_SIZE),
             max_vertex_buffers: limits
                 .max_vertex_input_bindings
                 .min(crate::MAX_VERTEX_BUFFERS as u32),

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -332,7 +332,7 @@ impl PhysicalDeviceFeatures {
             | F::TIMESTAMP_QUERY
             | F::PIPELINE_STATISTICS_QUERY
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | F::CLEAR_TEXTURE;
+            | F::CLEAR_COMMANDS;
         let mut dl_flags = Df::all();
 
         dl_flags.set(Df::CUBE_ARRAY_TEXTURES, self.core.image_cube_array != 0);

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1116,8 +1116,8 @@ impl super::Adapter {
         let timeline_semaphore_fn = if enabled_extensions.contains(&khr::TimelineSemaphore::name())
         {
             Some(super::ExtensionFn::Extension(khr::TimelineSemaphore::new(
-                &self.instance.entry,
                 &self.instance.raw,
+                &raw_device,
             )))
         } else if self.phd_capabilities.properties.api_version >= vk::API_VERSION_1_2 {
             Some(super::ExtensionFn::Promoted)

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -332,7 +332,7 @@ impl PhysicalDeviceFeatures {
             | F::TIMESTAMP_QUERY
             | F::PIPELINE_STATISTICS_QUERY
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | F::CLEAR_COMMANDS;
+            | F::CLEAR_TEXTURE;
         let mut dl_flags = Df::all();
 
         dl_flags.set(Df::CUBE_ARRAY_TEXTURES, self.core.image_cube_array != 0);

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -594,9 +594,11 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             .cmd_set_scissor(self.active, 0, &vk_scissors);
     }
     unsafe fn set_stencil_reference(&mut self, value: u32) {
-        self.device
-            .raw
-            .cmd_set_stencil_reference(self.active, vk::StencilFaceFlags::all(), value);
+        self.device.raw.cmd_set_stencil_reference(
+            self.active,
+            vk::StencilFaceFlags::FRONT_AND_BACK,
+            value,
+        );
     }
     unsafe fn set_blend_constants(&mut self, color: &[f32; 4]) {
         self.device.raw.cmd_set_blend_constants(self.active, color);

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -698,14 +698,18 @@ pub fn map_stencil_op(op: wgt::StencilOperation) -> vk::StencilOp {
     }
 }
 
-pub fn map_stencil_face(face: &wgt::StencilFaceState) -> vk::StencilOpState {
+pub fn map_stencil_face(
+    face: &wgt::StencilFaceState,
+    compare_mask: u32,
+    write_mask: u32,
+) -> vk::StencilOpState {
     vk::StencilOpState {
         fail_op: map_stencil_op(face.fail_op),
         pass_op: map_stencil_op(face.pass_op),
         depth_fail_op: map_stencil_op(face.depth_fail_op),
         compare_op: map_comparison(face.compare),
-        compare_mask: !0,
-        write_mask: !0,
+        compare_mask,
+        write_mask,
         reference: 0,
     }
 }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1716,7 +1716,7 @@ impl crate::Device<super::Api> for super::Device {
                     .values(&values);
                 let result = match self.shared.extension_fns.timeline_semaphore {
                     Some(super::ExtensionFn::Extension(ref ext)) => {
-                        ext.wait_semaphores(self.shared.raw.handle(), &vk_info, timeout_us)
+                        ext.wait_semaphores(&vk_info, timeout_us)
                     }
                     Some(super::ExtensionFn::Promoted) => {
                         self.shared.raw.wait_semaphores(&vk_info, timeout_us)

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1462,8 +1462,9 @@ impl crate::Device<super::Api> for super::Device {
                     .depth_compare_op(conv::map_comparison(ds.depth_compare));
             }
             if ds.stencil.is_enabled() {
-                let front = conv::map_stencil_face(&ds.stencil.front);
-                let back = conv::map_stencil_face(&ds.stencil.back);
+                let s = &ds.stencil;
+                let front = conv::map_stencil_face(&s.front, s.read_mask, s.write_mask);
+                let back = conv::map_stencil_face(&s.back, s.read_mask, s.write_mask);
                 vk_depth_stencil = vk_depth_stencil
                     .stencil_test_enable(true)
                     .front(front)

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -208,7 +208,11 @@ impl super::Instance {
             let vk_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
                 .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
                 .message_severity(severity)
-                .message_type(vk::DebugUtilsMessageTypeFlagsEXT::all())
+                .message_type(
+                    vk::DebugUtilsMessageTypeFlagsEXT::GENERAL
+                        | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION
+                        | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE,
+                )
                 .pfn_user_callback(Some(debug_utils_messenger_callback));
             let messenger = extension
                 .create_debug_utils_messenger(&vk_info, None)

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -44,14 +44,16 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         CStr::from_ptr(cd.p_message).to_string_lossy()
     };
 
-    log::log!(
-        level,
-        "{:?} [{} (0x{:x})]\n\t{}",
-        message_type,
-        message_id_name,
-        cd.message_id_number,
-        message,
-    );
+    let _ = std::panic::catch_unwind(|| {
+        log::log!(
+            level,
+            "{:?} [{} (0x{:x})]\n\t{}",
+            message_type,
+            message_id_name,
+            cd.message_id_number,
+            message,
+        );
+    });
 
     if cd.queue_label_count != 0 {
         let labels = slice::from_raw_parts(cd.p_queue_labels, cd.queue_label_count as usize);
@@ -64,7 +66,10 @@ unsafe extern "system" fn debug_utils_messenger_callback(
                     .map(|lbl| CStr::from_ptr(lbl).to_string_lossy())
             })
             .collect::<Vec<_>>();
-        log::log!(level, "\tqueues: {}", names.join(", "));
+
+        let _ = std::panic::catch_unwind(|| {
+            log::log!(level, "\tqueues: {}", names.join(", "));
+        });
     }
 
     if cd.cmd_buf_label_count != 0 {
@@ -78,7 +83,10 @@ unsafe extern "system" fn debug_utils_messenger_callback(
                     .map(|lbl| CStr::from_ptr(lbl).to_string_lossy())
             })
             .collect::<Vec<_>>();
-        log::log!(level, "\tcommand buffers: {}", names.join(", "));
+
+        let _ = std::panic::catch_unwind(|| {
+            log::log!(level, "\tcommand buffers: {}", names.join(", "));
+        });
     }
 
     if cd.object_count != 0 {
@@ -99,7 +107,9 @@ unsafe extern "system" fn debug_utils_messenger_callback(
                 )
             })
             .collect::<Vec<_>>();
-        log::log!(level, "\tobjects: {}", names.join(", "));
+        let _ = std::panic::catch_unwind(|| {
+            log::log!(level, "\tobjects: {}", names.join(", "));
+        });
     }
 
     vk::FALSE

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -442,7 +442,7 @@ impl Drop for super::InstanceShared {
 
 impl crate::Instance<super::Api> for super::Instance {
     unsafe fn init(desc: &crate::InstanceDescriptor) -> Result<Self, crate::InstanceError> {
-        let entry = match ash::Entry::new() {
+        let entry = match ash::Entry::load() {
             Ok(entry) => entry,
             Err(err) => {
                 log::info!("Missing Vulkan entry points: {:?}", err);

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -112,6 +112,11 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         });
     }
 
+    if cfg!(debug_assertions) && level == log::Level::Error {
+        // Set canary and continue
+        crate::VALIDATION_CANARY.set();
+    }
+
     vk::FALSE
 }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -514,9 +514,7 @@ impl Fence {
         match *self {
             Self::TimelineSemaphore(raw) => unsafe {
                 Ok(match *extension.unwrap() {
-                    ExtensionFn::Extension(ref ext) => {
-                        ext.get_semaphore_counter_value(device.handle(), raw)?
-                    }
+                    ExtensionFn::Extension(ref ext) => ext.get_semaphore_counter_value(raw)?,
                     ExtensionFn::Promoted => device.get_semaphore_counter_value(raw)?,
                 })
             },

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -511,7 +511,7 @@ bitflags::bitflags! {
         /// - All
         ///
         /// This is a native only feature.
-        const CLEAR_TEXTURE = 1 << 37;
+        const CLEAR_COMMANDS = 1 << 37;
         /// Enables creating shader modules from SPIR-V binary data (unsafe).
         ///
         /// SPIR-V data is not parsed or interpreted in any way; you can use

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -572,7 +572,7 @@ impl Features {
 /// Represents the sets of limits an adapter/device supports.
 ///
 /// We provide three different defaults.
-/// - [`Limits::downlevel_defaults()`]. This is a set of limits that is guarenteed to work on almost
+/// - [`Limits::downlevel_defaults()`]. This is a set of limits that is guaranteed to work on almost
 ///   all backends, including "downlevel" backends such as OpenGL and D3D11, other than WebGL. For
 ///   most applications we recommend using these limits, assuming they are high enough for your
 ///   application, and you do not intent to support WebGL.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -505,13 +505,13 @@ bitflags::bitflags! {
         ///
         /// This is a native-only feature.
         const VERTEX_WRITABLE_STORAGE = 1 << 36;
-        /// Enables clear to zero for buffers & textures.
+        /// Enables clear to zero for textures.
         ///
         /// Supported platforms:
         /// - All
         ///
         /// This is a native only feature.
-        const CLEAR_COMMANDS = 1 << 37;
+        const CLEAR_TEXTURE = 1 << 37;
         /// Enables creating shader modules from SPIR-V binary data (unsafe).
         ///
         /// SPIR-V data is not parsed or interpreted in any way; you can use

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -628,9 +628,9 @@ pub struct Limits {
     pub max_sampled_textures_per_shader_stage: u32,
     /// Amount of samplers visible in a single shader stage. Defaults to 16. Higher is "better".
     pub max_samplers_per_shader_stage: u32,
-    /// Amount of storage buffers visible in a single shader stage. Defaults to 4. Higher is "better".
+    /// Amount of storage buffers visible in a single shader stage. Defaults to 8. Higher is "better".
     pub max_storage_buffers_per_shader_stage: u32,
-    /// Amount of storage textures visible in a single shader stage. Defaults to 4. Higher is "better".
+    /// Amount of storage textures visible in a single shader stage. Defaults to 8. Higher is "better".
     pub max_storage_textures_per_shader_stage: u32,
     /// Amount of uniform buffers visible in a single shader stage. Defaults to 12. Higher is "better".
     pub max_uniform_buffers_per_shader_stage: u32,
@@ -667,11 +667,13 @@ pub struct Limits {
     /// Defaults to 256. Lower is "better".
     pub min_storage_buffer_offset_alignment: u32,
     /// Maximum allowed number of components (scalars) of input or output locations for
-    /// inter-stage communication (vertex outputs to fragment inputs).
+    /// inter-stage communication (vertex outputs to fragment inputs). Defaults to 60.
     pub max_inter_stage_shader_components: u32,
-    /// Maximum number of bytes used for workgroup memory in a compute entry point.
+    /// Maximum number of bytes used for workgroup memory in a compute entry point. Defaults to
+    /// 16352.
     pub max_compute_workgroup_storage_size: u32,
     /// Maximum value of the product of the `workgroup_size` dimensions for a compute entry-point.
+    /// Defaults to 256.
     pub max_compute_invocations_per_workgroup: u32,
     /// The maximum value of the workgroup_size X dimension for a compute stage `ShaderModule` entry-point.
     /// Defaults to 256.
@@ -680,7 +682,7 @@ pub struct Limits {
     /// Defaults to 256.
     pub max_compute_workgroup_size_y: u32,
     /// The maximum value of the workgroup_size Z dimension for a compute stage `ShaderModule` entry-point.
-    /// Defaults to 256.
+    /// Defaults to 64.
     pub max_compute_workgroup_size_z: u32,
     /// The maximum value for each dimension of a `ComputePass::dispatch(x, y, z)` operation.
     /// Defaults to 65535.

--- a/wgpu/examples/boids/main.rs
+++ b/wgpu/examples/boids/main.rs
@@ -279,7 +279,9 @@ impl framework::Example for Example {
             view,
             resolve_target: None,
             ops: wgpu::Operations {
-                load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                // Not clearing here in order to test wgpu's zero texture initialization on a surface texture.
+                // Users should avoid loading uninitialized memory since this can cause additional overhead.
+                load: wgpu::LoadOp::Load,
                 store: true,
             },
         }];

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1272,21 +1272,25 @@ impl crate::Context for Context {
                 );
                 let spv_module_info = validator.validate(&spv_module).unwrap();
 
-                let wgsl_text = back::wgsl::write_string(&spv_module, &spv_module_info).unwrap();
+                let writer_flags = naga::back::wgsl::WriterFlags::empty();
+                let wgsl_text =
+                    back::wgsl::write_string(&spv_module, &spv_module_info, writer_flags).unwrap();
                 web_sys::GpuShaderModuleDescriptor::new(wgsl_text.as_str())
             }
             #[cfg(feature = "glsl")]
-            ShaderSource::Glsl {
+            crate::ShaderSource::Glsl {
                 ref shader,
                 stage,
                 ref defines,
             } => {
+                use naga::{back, front, valid};
+
                 // Parse the given shader code and store its representation.
-                let options = naga::front::glsl::Options {
+                let options = front::glsl::Options {
                     stage,
                     defines: defines.clone(),
                 };
-                let mut parser = naga::front::glsl::Parser::default();
+                let mut parser = front::glsl::Parser::default();
                 let glsl_module = parser.parse(&options, shader).unwrap();
 
                 let mut validator = valid::Validator::new(
@@ -1295,7 +1299,10 @@ impl crate::Context for Context {
                 );
                 let glsl_module_info = validator.validate(&glsl_module).unwrap();
 
-                let wgsl_text = back::wgsl::write_string(&glsl_module, &glsl_module_info).unwrap();
+                let writer_flags = naga::back::wgsl::WriterFlags::empty();
+                let wgsl_text =
+                    back::wgsl::write_string(&glsl_module, &glsl_module_info, writer_flags)
+                        .unwrap();
                 web_sys::GpuShaderModuleDescriptor::new(wgsl_text.as_str())
             }
             crate::ShaderSource::Wgsl(ref code) => web_sys::GpuShaderModuleDescriptor::new(code),

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2397,7 +2397,7 @@ impl CommandEncoder {
     ///
     /// # Panics
     ///
-    /// - `CLEAR_TEXTURE` extension not enabled
+    /// - `CLEAR_COMMANDS` extension not enabled
     /// - Range is out of bounds
     pub fn clear_texture(&mut self, texture: &Texture, subresource_range: &ImageSubresourceRange) {
         Context::command_encoder_clear_texture(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2388,12 +2388,16 @@ impl CommandEncoder {
 
     /// Clears texture to zero.
     ///
-    /// Where possible it may be significantly more efficient to perform clears via render passes!
+    /// Note that unlike with clear_buffer, `COPY_DST` usage is not required.
+    ///
+    /// # Implementation notes
+    ///
+    /// - implemented either via buffer copies and render/depth target clear, path depends on texture usages
+    /// - behaves like texture zero init, but is performed immediately (clearing is *not* delayed via marking it as uninitialized)
     ///
     /// # Panics
     ///
-    /// - `CLEAR_COMMANDS` extension not enabled
-    /// - Texture does not have `COPY_DST` usage.
+    /// - `CLEAR_TEXTURE` extension not enabled
     /// - Range is out of bounds
     pub fn clear_texture(&mut self, texture: &Texture, subresource_range: &ImageSubresourceRange) {
         Context::command_encoder_clear_texture(

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -210,7 +210,7 @@ fn clear_texture_tests(ctx: &TestingContext, formats: &[wgpu::TextureFormat], su
 #[test]
 fn clear_texture_2d_uncompressed() {
     initialize_test(
-        TestParameters::default().features(wgpu::Features::CLEAR_TEXTURE),
+        TestParameters::default().features(wgpu::Features::CLEAR_COMMANDS),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_UNCOMPRESSED, true);
             clear_texture_tests(&ctx, TEXTURE_FORMATS_DEPTH, false);
@@ -222,7 +222,7 @@ fn clear_texture_2d_uncompressed() {
 fn clear_texture_2d_bc() {
     initialize_test(
         TestParameters::default()
-            .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_BC),
+            .features(wgpu::Features::CLEAR_COMMANDS | wgpu::Features::TEXTURE_COMPRESSION_BC),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_BC, false);
         },
@@ -232,8 +232,9 @@ fn clear_texture_2d_bc() {
 #[test]
 fn clear_texture_2d_astc() {
     initialize_test(
-        TestParameters::default()
-            .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_ASTC_LDR),
+        TestParameters::default().features(
+            wgpu::Features::CLEAR_COMMANDS | wgpu::Features::TEXTURE_COMPRESSION_ASTC_LDR,
+        ),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_ASTC, false);
         },
@@ -244,7 +245,7 @@ fn clear_texture_2d_astc() {
 fn clear_texture_2d_etc2() {
     initialize_test(
         TestParameters::default()
-            .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_ETC2),
+            .features(wgpu::Features::CLEAR_COMMANDS | wgpu::Features::TEXTURE_COMPRESSION_ETC2),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_ETC2, false);
         },


### PR DESCRIPTION
Changed 'guarenteed' to 'guaranteed'. Nothing big, but it irked me a bit!

**Connections**
https://sotrh.github.io/learn-wgpu/beginner/tutorial2-surface/#instance-and-adapter

**Description**
Fixing a misspelled word, this makes the documentation clearer and easier to read.

**Testing**
No tests.
