### PR TITLE
Fixed misspelling in documentation

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -581,7 +581,7 @@ impl Features {
 /// Represents the sets of limits an adapter/device supports.
 ///
 /// We provide three different defaults.
-/// - [`Limits::downlevel_defaults()`]. This is a set of limits that is guarenteed to work on almost
+/// - [`Limits::downlevel_defaults()`]. This is a set of limits that is guaranteed to work on almost
 ///   all backends, including "downlevel" backends such as OpenGL and D3D11, other than WebGL. For
 ///   most applications we recommend using these limits, assuming they are high enough for your
 ///   application, and you do not intent to support WebGL.


### PR DESCRIPTION
Changed 'guarenteed' to 'guaranteed'. Nothing big, but it irked me a bit!

Connections
https://sotrh.github.io/learn-wgpu/beginner/tutorial2-surface/#instance-and-adapter

Description
Fixing a misspelled word, this makes the documentation clearer and easier to read.

Testing
No tests.
