### PR TITLE
Raise `wgpu_hal::MAX_COLOR_TARGETS` to 8.

### DIFF
--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -97,7 +97,7 @@ use thiserror::Error;
 pub const MAX_ANISOTROPY: u8 = 16;
 pub const MAX_BIND_GROUPS: usize = 8;
 pub const MAX_VERTEX_BUFFERS: usize = 16;
-pub const MAX_COLOR_TARGETS: usize = 4;
+pub const MAX_COLOR_TARGETS: usize = 8;
 pub const MAX_MIP_LEVELS: u32 = 16;
 /// Size of a single occlusion/timestamp query, when copied into a buffer, in bytes.
 pub const QUERY_SIZE: wgt::BufferAddress = 8;


### PR DESCRIPTION
The WebGPU specification has hard-coded a limit of 8 on the number of color attachments provided in a `GPURenderPassDescriptor`'s `colorAttachments` sequence. It seems to me that `wgpu_hal` must match or exceed that.

The specification doesn't give the limit a name; it just hard-codes `8` in the [valid usage](https://www.w3.org/TR/webgpu/#abstract-opdef-gpurenderpassdescriptor-valid-usage) section for `GPURenderPassDescriptor`.