### PR TITLE
Exclude dependencies from documents

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,10 +29,10 @@ jobs:
 
       - name: Build the docs (nightly)
         run: |
-          cargo +nightly doc --lib
+          cargo +nightly doc --no-deps --lib
 
       - name: Build the docs (stable)
-        run: cargo +stable doc --lib
+        run: cargo +stable doc --no-deps --lib
         if: ${{ failure() }}
 
       - name: Deploy the docs


### PR DESCRIPTION
Currently, the document contains dependency crates. If this isn't intentional, is it okay to add `--no-deps` to `cargo doc`?

e.g. https://wgpu.rs/doc/wgpu/struct.RenderPass.html?search=clear