### PR TITLE
Add `SHADER_FLOAT16` feature

### DIFF
--- a/deno_webgpu/02_idl_types.js
+++ b/deno_webgpu/02_idl_types.js
@@ -120,6 +120,7 @@
       "texture-compression-astc",
       "timestamp-query",
       "indirect-first-instance",
+      "shader-f16",
       // extended from spec
       "mappable-primary-buffers",
       "texture-binding-array",

--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -146,6 +146,9 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     if features.contains(wgpu_types::Features::INDIRECT_FIRST_INSTANCE) {
         return_features.push("indirect-first-instance");
     }
+    if features.contains(wgpu_types::Features::SHADER_FLOAT16) {
+        return_features.push("shader-f16")
+    }
 
     // extended from spec
     if features.contains(wgpu_types::Features::MAPPABLE_PRIMARY_BUFFERS) {
@@ -305,6 +308,10 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
         features.set(
             wgpu_types::Features::INDIRECT_FIRST_INSTANCE,
             required_features.0.contains("indirect-first-instance"),
+        );
+        features.set(
+            wgpu_types::Features::SHADER_FLOAT16,
+            required_features.0.contains("shader-f16"),
         );
 
         // extended from spec

--- a/deno_webgpu/webgpu.idl
+++ b/deno_webgpu/webgpu.idl
@@ -90,6 +90,7 @@ enum GPUFeatureName {
     "texture-compression-astc",
     "timestamp-query",
     "indirect-first-instance",
+    "shader-f16",
 };
 
 [Exposed=(Window, DedicatedWorker), SecureContext]

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -751,7 +751,8 @@ impl super::PrivateCapabilities {
             | F::PUSH_CONSTANTS
             | F::POLYGON_MODE_LINE
             | F::CLEAR_TEXTURE
-            | F::TEXTURE_FORMAT_16BIT_NORM;
+            | F::TEXTURE_FORMAT_16BIT_NORM
+            | F::SHADER_FLOAT16;
 
         features.set(F::TEXTURE_COMPRESSION_ASTC_LDR, self.format_astc);
         features.set(F::TEXTURE_COMPRESSION_ASTC_HDR, self.format_astc_hdr);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -232,6 +232,16 @@ bitflags::bitflags! {
         ///
         /// This is a web and native feature.
         const PIPELINE_STATISTICS_QUERY = 1 << 4;
+        /// Allows shaders to acquire the FP16 ability
+        ///
+        /// Note: this is not supported in naga yet，only through spir-v passthrough right now.
+        ///
+        /// Supported Platforms:
+        /// - Vulkan
+        /// - Metal
+        ///
+        /// This is a web and native feature.
+        const SHADER_FLOAT16 = 1 << 5;
         /// Webgpu only allows the MAP_READ and MAP_WRITE buffer usage to be matched with
         /// COPY_DST and COPY_SRC respectively. This removes this requirement.
         ///


### PR DESCRIPTION
**Connections**
[WebGPU spec](https://gpuweb.github.io/gpuweb/#shader-f16)
https://github.com/gfx-rs/naga/issues/1884

**Description**
Dx12 need to check `D3D12_FEATURE_DATA_D3D12_OPTIONS4::Native16BitShaderOpsSupported` and `D3D_SHADER_MODEL_6_2` to comform whether  supports true FP16 which `winapi` currently don't defined, maybe one more reason to replace `winapi` with `windows-rs`?

**Testing**
Tested on metal and vk backend.