### PR TITLE
Make GLES DeviceType unknown by default

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -735,7 +735,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let preferred_gpu = match desc.power_preference {
             PowerPreference::LowPower => integrated.or(other).or(discrete).or(virt).or(cpu),
-            PowerPreference::HighPerformance => discrete.or(other).or(integrated).or(virt).or(cpu),
+            PowerPreference::HighPerformance => discrete.or(integrated).or(other).or(virt).or(cpu),
         };
 
         let mut selected = preferred_gpu.unwrap_or(0);

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -134,7 +134,7 @@ impl super::Adapter {
         } else if strings_that_imply_cpu.iter().any(|&s| renderer.contains(s)) {
             wgt::DeviceType::Cpu
         } else {
-            wgt::DeviceType::DiscreteGpu
+            wgt::DeviceType::Other
         };
 
         // source: Sascha Willems at Vulkan

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -98,6 +98,7 @@ impl super::Adapter {
         // opengl has no way to discern device_type, so we can try to infer it from the renderer string
         let strings_that_imply_integrated = [
             " xpress", // space here is on purpose so we don't match express
+            "amd renoir",
             "radeon hd 4200",
             "radeon hd 4250",
             "radeon hd 4290",


### PR DESCRIPTION
I just found out that my integrated GPU is not on `wgp-hal` list.

Thanks to that I realized that when I request `HighPerformance` adapter GLES one will always be selected instead of Vulkan one, because Vulkan reports `IntegratedGpu` properly, so it gets filtered out in favor of GLES `DiscreteGpu`(that in reality is not discrete).

I could just add it to the list, but I don't think that's the right solution, it's an endless fight, and we will never have all integrated gpus on the list no matter what.

So I think the right solution is to just admit that we don't know what is the device type. So `DeviceType::Other` should be used, maybe the name does not fit the case well, but it directly maps to `WGPUAdapterType_Unknown` in `webgpu-native` so I think it's right to use it for this.