### PR TITLE
RenderPassDescriptor: make label lifetime match doc, and make names descriptive.

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1170,11 +1170,11 @@ impl<V: Default> Default for Operations<V> {
 /// Corresponds to [WebGPU `GPURenderPassColorAttachment`](
 /// https://gpuweb.github.io/gpuweb/#color-attachments).
 #[derive(Clone, Debug)]
-pub struct RenderPassColorAttachment<'a> {
+pub struct RenderPassColorAttachment<'tex> {
     /// The view to use as an attachment.
-    pub view: &'a TextureView,
+    pub view: &'tex TextureView,
     /// The view that will receive the resolved output if multisampling is used.
-    pub resolve_target: Option<&'a TextureView>,
+    pub resolve_target: Option<&'tex TextureView>,
     /// What operations will be performed on this color attachment.
     pub ops: Operations<Color>,
 }
@@ -1186,9 +1186,9 @@ pub struct RenderPassColorAttachment<'a> {
 /// Corresponds to [WebGPU `GPURenderPassDepthStencilAttachment`](
 /// https://gpuweb.github.io/gpuweb/#depth-stencil-attachments).
 #[derive(Clone, Debug)]
-pub struct RenderPassDepthStencilAttachment<'a> {
+pub struct RenderPassDepthStencilAttachment<'tex> {
     /// The view to use as an attachment.
-    pub view: &'a TextureView,
+    pub view: &'tex TextureView,
     /// What operations will be performed on the depth part of the attachment.
     pub depth_ops: Option<Operations<f32>>,
     /// What operations will be performed on the stencil part of the attachment.
@@ -1389,19 +1389,19 @@ pub struct BindGroupDescriptor<'a> {
 ///
 /// For use with [`CommandEncoder::begin_render_pass`].
 ///
-/// Note: separate lifetimes are needed because the texture views
-/// have to live as long as the pass is recorded, while everything else doesn't.
+/// Note: separate lifetimes are needed because the texture views (`'tex`)
+/// have to live as long as the pass is recorded, while everything else (`'desc`) doesn't.
 ///
 /// Corresponds to [WebGPU `GPURenderPassDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpassdescriptor).
 #[derive(Clone, Debug, Default)]
-pub struct RenderPassDescriptor<'a, 'b> {
+pub struct RenderPassDescriptor<'tex, 'desc> {
     /// Debug label of the render pass. This will show up in graphics debuggers for easy identification.
-    pub label: Label<'a>,
+    pub label: Label<'desc>,
     /// The color attachments of the render pass.
-    pub color_attachments: &'b [RenderPassColorAttachment<'a>],
+    pub color_attachments: &'desc [RenderPassColorAttachment<'tex>],
     /// The depth and stencil attachment of the render pass, if any.
-    pub depth_stencil_attachment: Option<RenderPassDepthStencilAttachment<'a>>,
+    pub depth_stencil_attachment: Option<RenderPassDepthStencilAttachment<'tex>>,
 }
 
 /// Describes how the vertex buffer is interpreted.
@@ -2490,10 +2490,10 @@ impl CommandEncoder {
     /// Begins recording of a render pass.
     ///
     /// This function returns a [`RenderPass`] object which records a single render pass.
-    pub fn begin_render_pass<'a>(
-        &'a mut self,
-        desc: &RenderPassDescriptor<'a, '_>,
-    ) -> RenderPass<'a> {
+    pub fn begin_render_pass<'pass>(
+        &'pass mut self,
+        desc: &RenderPassDescriptor<'pass, '_>,
+    ) -> RenderPass<'pass> {
         let id = self.id.as_ref().unwrap();
         RenderPass {
             id: Context::command_encoder_begin_render_pass(&*self.context, id, desc),


### PR DESCRIPTION
**Description**
Lifetime names like `<'a, 'b>` mean that the reader must look at how they are used to understand them. By changing them to `'tex` (lifetime of borrows of the texture views the documentation describes) and `'desc` (everything else), and mentioning them in the documentation, it's more obvious which role each one plays.

For consistency, I also changed `begin_render_pass()`, `RenderPassColorAttachment`, and `RenderPassDepthStencilAttachment` to use matching lifetime names.

Also, this made it clear that the `Label` had the wrong lifetime -- the docs say that the texture views have a different lifetime from “everything else”, but the `Label` in fact had the same lifetime as the texture views, so I changed it to the `'desc` (formerly `'b`) lifetime. (On review of change history, this mismatch was previously introduced in commit 632f828eda9af1f6f18c74398b5f40644cf02f03.) This change is definitely safe because I followed the data flow down to `BasePass::new` which promptly calls `to_string()` on the label, thus converting it to owned data.

**Testing**
As this only weakens lifetimes (which cannot change run-time behavior or stop a program from compiling) and renames them (which is not an API surface change) it should not have any effect other than allowing some programs with short-lived labels to compile when they would not have otherwise. That said, I ran `cargo nextest run --no-fail-fast` and all tests passed except for `example/shadow` which always fails on my machine.
