### PR TITLE
Use fully qualified syntax for some calls.

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -309,8 +309,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (device_guard, mut token) = hub.devices.read(&mut token);
 
         let (mut cmd_buf_guard, mut token) = hub.command_buffers.write(&mut token);
-        let cmd_buf = CommandBuffer::get_encoder_mut(&mut *cmd_buf_guard, encoder_id)
-            .map_pass_err(init_scope)?;
+        // Spell out the type, to placate rust-analyzer.
+        // https://github.com/rust-lang/rust-analyzer/issues/12247
+        let cmd_buf: &mut CommandBuffer<A> =
+            CommandBuffer::get_encoder_mut(&mut *cmd_buf_guard, encoder_id)
+                .map_pass_err(init_scope)?;
         // will be reset to true if recording is done without errors
         cmd_buf.status = CommandEncoderStatus::Error;
         let raw = cmd_buf.encoder.open();

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1050,8 +1050,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (trackers, query_reset_state, pending_discard_init_fixups) = {
             let (mut cmb_guard, mut token) = hub.command_buffers.write(&mut token);
 
-            let cmd_buf = CommandBuffer::get_encoder_mut(&mut *cmb_guard, encoder_id)
-                .map_pass_err(init_scope)?;
+            // Spell out the type, to placate rust-analyzer.
+            // https://github.com/rust-lang/rust-analyzer/issues/12247
+            let cmd_buf: &mut CommandBuffer<A> =
+                CommandBuffer::get_encoder_mut(&mut *cmb_guard, encoder_id)
+                    .map_pass_err(init_scope)?;
             // close everything while the new command encoder is filled
             cmd_buf.encoder.close();
             // will be reset to true if recording is done without errors


### PR DESCRIPTION
Without this change, rust-analyzer cannot determine the type of
cmd_buf.

The rust-analyzer bug is reported as rust-lang/rust-analyzer#12247.