### PR TITLE
metal: fix `Rgb9e5Ufloat` capabilities and `sampler_lod_average` support

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -202,7 +202,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 } else if pc.msaa_desktop {
                     Tfc::SAMPLED_LINEAR
                 } else {
-                    Tfc::STORAGE
+                    Tfc::SAMPLED_LINEAR
                         | Tfc::COLOR_ATTACHMENT
                         | Tfc::COLOR_ATTACHMENT_BLEND
                         | Tfc::MULTISAMPLE
@@ -523,10 +523,7 @@ impl super::PrivateCapabilities {
                 MUTABLE_COMPARISON_SAMPLER_SUPPORT,
             ),
             sampler_clamp_to_border: Self::supports_any(device, SAMPLER_CLAMP_TO_BORDER_SUPPORT),
-            sampler_lod_average: {
-                // TODO: Clarify minimum macOS version with Apple (43707452)
-                version.at_least((10, 13), (9, 0))
-            },
+            sampler_lod_average: { version.at_least((11, 0), (9, 0)) },
             base_instance: Self::supports_any(device, BASE_INSTANCE_SUPPORT),
             base_vertex_instance_drawing: Self::supports_any(device, BASE_VERTEX_INSTANCE_SUPPORT),
             dual_source_blending: Self::supports_any(device, DUAL_SOURCE_BLEND_SUPPORT),

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -261,7 +261,7 @@ impl AdapterShared {
 
         Self {
             disabilities: PrivateDisabilities::new(&device),
-            private_caps: PrivateCapabilities::new(&device),
+            private_caps,
             device: Mutex::new(device),
             settings: Settings::default(),
         }


### PR DESCRIPTION
**Description**
`Rgb9e5Ufloat` capabilities table:
<img width="1169" alt="截屏2022-05-14 08 36 15" src="https://user-images.githubusercontent.com/1001342/168404548-7f9a4204-696e-469d-b41d-41cd7e90af52.png">

Apple `lodAverage` doc: https://developer.apple.com/documentation/metal/mtlsamplerdescriptor/1615844-lodaverage

