### PR TITLE
fix: panic in `Storage::get`

### DIFF
--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -150,12 +150,8 @@ impl<T, I: id::TypedId> Storage<T, I> {
     pub(crate) fn contains(&self, id: I) -> bool {
         let (index, epoch, _) = id.unzip();
         match self.map.get(index as usize) {
-            Some(element) => match *element {
-                Element::Vacant => false,
-                Element::Occupied(_, storage_epoch) | Element::Error(storage_epoch, ..) => {
-                    epoch == storage_epoch
-                }
-            },
+            Some(&Element::Vacant) => false,
+            Some(&Element::Occupied(_, storage_epoch) | &Element::Error(storage_epoch, _)) => storage_epoch == epoch,
             None => false,
         }
     }
@@ -164,44 +160,42 @@ impl<T, I: id::TypedId> Storage<T, I> {
     /// Panics if there is an epoch mismatch, or the entry is empty.
     pub(crate) fn get(&self, id: I) -> Result<&T, InvalidId> {
         let (index, epoch, _) = id.unzip();
-        match self.map.get(index as usize) {
-            Some(element) => {
-                let (result, storage_epoch) = match *element {
-                    Element::Occupied(ref v, epoch) => (Ok(v), epoch),
-                    Element::Vacant => panic!("{}[{}] does not exist", self.kind, index),
-                    Element::Error(epoch, ..) => (Err(InvalidId), epoch),
-                };
-                assert_eq!(
-                    epoch, storage_epoch,
-                    "{}[{}] is no longer alive",
-                    self.kind, index
-                );
-                result
-            }
-            None => Err(InvalidId),
-        }
+        let element = match self.map.get(index as usize) {
+            Some(element) => element,
+            None => return Err(InvalidId),
+        };
+        let (result, storage_epoch) = match *element {
+            Element::Occupied(ref v, epoch) => (Ok(v), epoch),
+            Element::Vacant => panic!("{}[{}] does not exist", self.kind, index),
+            Element::Error(epoch, ..) => (Err(InvalidId), epoch),
+        };
+        assert_eq!(
+            epoch, storage_epoch,
+            "{}[{}] is no longer alive",
+            self.kind, index
+        );
+        result
     }
 
     /// Get a mutable reference to an item behind a potentially invalid ID.
     /// Panics if there is an epoch mismatch, or the entry is empty.
     pub(crate) fn get_mut(&mut self, id: I) -> Result<&mut T, InvalidId> {
         let (index, epoch, _) = id.unzip();
-        match self.map.get_mut(index as usize) {
-            Some(element) => {
-                let (result, storage_epoch) = match *element {
-                    Element::Occupied(ref mut v, epoch) => (Ok(v), epoch),
-                    Element::Vacant => panic!("{}[{}] does not exist", self.kind, index),
-                    Element::Error(epoch, ..) => (Err(InvalidId), epoch),
-                };
-                assert_eq!(
-                    epoch, storage_epoch,
-                    "{}[{}] is no longer alive",
-                    self.kind, index
-                );
-                result
-            }
-            None => Err(InvalidId),
-        }
+        let element = match self.map.get_mut(index as usize) {
+            Some(element) => element,
+            None => return Err(InvalidId),
+        };
+        let (result, storage_epoch) = match *element {
+            Element::Occupied(ref mut v, epoch) => (Ok(v), epoch),
+            Element::Vacant => panic!("{}[{}] does not exist", self.kind, index),
+            Element::Error(epoch, ..) => (Err(InvalidId), epoch),
+        };
+        assert_eq!(
+            epoch, storage_epoch,
+            "{}[{}] is no longer alive",
+            self.kind, index
+        );
+        result
     }
 
     pub(crate) fn label_for_invalid_id(&self, id: I) -> &str {

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -155,8 +155,8 @@ impl<T, I: id::TypedId> Storage<T, I> {
                 Element::Occupied(_, storage_epoch) | Element::Error(storage_epoch, ..) => {
                     epoch == storage_epoch
                 }
-            }
-            None => false
+            },
+            None => false,
         }
     }
 

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -151,7 +151,9 @@ impl<T, I: id::TypedId> Storage<T, I> {
         let (index, epoch, _) = id.unzip();
         match self.map.get(index as usize) {
             Some(&Element::Vacant) => false,
-            Some(&Element::Occupied(_, storage_epoch) | &Element::Error(storage_epoch, _)) => storage_epoch == epoch,
+            Some(&Element::Occupied(_, storage_epoch) | &Element::Error(storage_epoch, _)) => {
+                storage_epoch == epoch
+            }
             None => false,
         }
     }

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -196,8 +196,8 @@ impl<T, I: id::TypedId> Storage<T, I> {
 
     pub(crate) fn label_for_invalid_id(&self, id: I) -> &str {
         let (index, _, _) = id.unzip();
-        match self.map[index as usize] {
-            Element::Error(_, ref label) => label,
+        match self.map.get(index as usize) {
+            Some(&Element::Error(_, ref label)) => label,
             _ => "",
         }
     }


### PR DESCRIPTION
**Description**
When an `Id` with `Index` out of bounds of `self.map` is given to `Storage::contains`, `Storage::get`, or `Storage::get_mut`, it panics due to directly indexing the Vec. This PR fixes that, and makes `contains` return false, and `get*` return `Err(InvalidId)` like they should.

This also indirectly fixes a panic when `Device::as_hal` is invoked with an API that is *not* being used at the time.

**Testing**
This was tested by creating a device with `Backends::Vulkan`, and trying to get a `Dx12` backend (`Device::as_hal::<Dx12, _, _>`) from it. It correctly gives the closure a None, instead of panicking as it did earlier.
