### PR TITLE
Move set_index_buffer FFI functions back into wgpu.

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1219,7 +1219,7 @@ pub mod bundle_ffi {
     use super::{RenderBundleEncoder, RenderCommand};
     use crate::{id, RawString};
     use std::{convert::TryInto, slice};
-    use wgt::{BufferAddress, BufferSize, DynamicOffset};
+    use wgt::{BufferAddress, BufferSize, DynamicOffset, IndexFormat};
 
     /// # Safety
     ///
@@ -1281,6 +1281,17 @@ pub mod bundle_ffi {
             offset,
             size,
         });
+    }
+
+    #[no_mangle]
+    pub extern "C" fn wgpu_render_bundle_set_index_buffer(
+        encoder: &mut RenderBundleEncoder,
+        buffer: id::BufferId,
+        index_format: IndexFormat,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    ) {
+        encoder.set_index_buffer(buffer, index_format, offset, size);
     }
 
     /// # Safety

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2005,7 +2005,7 @@ pub mod render_ffi {
     };
     use crate::{id, RawString};
     use std::{convert::TryInto, ffi, num::NonZeroU32, slice};
-    use wgt::{BufferAddress, BufferSize, Color, DynamicOffset};
+    use wgt::{BufferAddress, BufferSize, Color, DynamicOffset, IndexFormat};
 
     /// # Safety
     ///
@@ -2066,6 +2066,17 @@ pub mod render_ffi {
             offset,
             size,
         });
+    }
+
+    #[no_mangle]
+    pub extern "C" fn wgpu_render_pass_set_index_buffer(
+        pass: &mut RenderPass,
+        buffer: id::BufferId,
+        index_format: IndexFormat,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    ) {
+        pass.set_index_buffer(buffer, index_format, offset, size);
     }
 
     #[no_mangle]


### PR DESCRIPTION
It's very odd to have almost all the render pass and compute pass ffi functions in `wgpu` except for the `set_index_buffer` functions, which live in Firefox. I'd like to remove these from Firefox and put them back next to their companions.

These functions were originally removed from wgpu in #1077, because wgpu-native has its own incompatible version of IndexFormat (see that PR for details). However, with wgpu-native#85, that code was removed, so having these functions in `wgpu` should be no longer be a problem for wgpu-native.
