### PR TITLE
Adapter and Instance as_hal functions

### DIFF
--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -47,6 +47,14 @@ impl Context {
         ))
     }
 
+    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl2"))]
+    pub unsafe fn instance_as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Instance>) -> R, R>(
+        &self,
+        hal_instance_callback: F,
+    ) -> R {
+        self.0.instance_as_hal::<A, F, R>(hal_instance_callback)
+    }
+
     pub(crate) fn global(&self) -> &wgc::hub::Global<wgc::hub::IdentityManagerFactory> {
         &self.0
     }
@@ -65,6 +73,16 @@ impl Context {
         hal_adapter: hal::ExposedAdapter<A>,
     ) -> wgc::id::AdapterId {
         self.0.create_adapter_from_hal(hal_adapter, PhantomData)
+    }
+
+    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl2"))]
+    pub unsafe fn adapter_as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Adapter>) -> R, R>(
+        &self,
+        adapter: wgc::id::AdapterId,
+        hal_adapter_callback: F,
+    ) -> R {
+        self.0
+            .adapter_as_hal::<A, F, R>(adapter, hal_adapter_callback)
     }
 
     #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1632,6 +1632,21 @@ impl Instance {
         }
     }
 
+    /// Returns the inner hal Instance using a callback. The hal instance will be `None` if the
+    /// backend type argument does not match with this wgpu Instance
+    ///
+    /// # Safety
+    ///
+    /// - The raw handle obtained from the hal Instance must not be manually destroyed
+    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl2"))]
+    pub unsafe fn as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Instance>) -> R, R>(
+        &self,
+        hal_instance_callback: F,
+    ) -> R {
+        self.context
+            .instance_as_hal::<A, F, R>(hal_instance_callback)
+    }
+
     /// Retrieves all available [`Adapter`]s that match the given [`Backends`].
     ///
     /// # Arguments
@@ -1846,6 +1861,21 @@ impl Adapter {
                     },
                 )
             })
+    }
+
+    /// Returns the inner hal Adapter using a callback. The hal adapter will be `None` if the
+    /// backend type argument does not match with this wgpu Adapter
+    ///
+    /// # Safety
+    ///
+    /// - The raw handle obtained from the hal Adapter must not be manually destroyed
+    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl2"))]
+    pub unsafe fn as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Adapter>) -> R, R>(
+        &self,
+        hal_adapter_callback: F,
+    ) -> R {
+        self.context
+            .adapter_as_hal::<A, F, R>(self.id, hal_adapter_callback)
     }
 
     /// Returns whether this adapter may present to the passed surface.


### PR DESCRIPTION
**Description**
At the moment the inner hal type for Instance and Adapter are not possible to access. This adds `as_hal` functions to Instance and Adapter.

HalApi does gain a new function (`instance_as_hal`) to implement `as_hal` for Instance without resorting to a `Instance::as_(backend)` function for every backend.
