### PR TITLE
Report invalid pipelines in render bundles as errors, not panics.

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -271,7 +271,8 @@ impl RenderBundleEncoder {
                         .trackers
                         .render_pipes
                         .use_extend(&*pipeline_guard, pipeline_id, (), ())
-                        .unwrap();
+                        .map_err(|_| RenderCommandError::InvalidPipeline(pipeline_id))
+                        .map_pass_err(scope)?;
 
                     self.context
                         .check_compatible(&pipeline.pass_context)


### PR DESCRIPTION
Fixes #2665.

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1759242