### PR TITLE
expose some underlying types in Vulkan hal

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1113,6 +1113,10 @@ impl super::Instance {
 }
 
 impl super::Adapter {
+    pub fn raw_physical_device(&self) -> ash::vk::PhysicalDevice {
+        self.raw
+    }
+
     pub fn required_device_extensions(&self, features: wgt::Features) -> Vec<&'static CStr> {
         let (supported_extensions, unsupported_extensions) = self
             .phd_capabilities

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -133,6 +133,22 @@ impl super::Swapchain {
 }
 
 impl super::Instance {
+    pub fn entry(&self) -> &ash::Entry {
+        &self.shared.entry
+    }
+
+    pub fn raw_instance(&self) -> &ash::Instance {
+        &self.shared.raw
+    }
+
+    pub fn driver_api_version(&self) -> u32 {
+        self.shared.driver_api_version
+    }
+
+    pub fn extensions(&self) -> &[&'static CStr] {
+        &self.extensions[..]
+    }
+
     pub fn required_extensions(
         entry: &ash::Entry,
         flags: crate::InstanceFlags,
@@ -266,6 +282,7 @@ impl super::Instance {
                 get_physical_device_properties,
                 entry,
                 has_nv_optimus,
+                driver_api_version,
             }),
             extensions,
         })

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -87,6 +87,7 @@ struct InstanceShared {
     get_physical_device_properties: Option<khr::GetPhysicalDeviceProperties2>,
     entry: ash::Entry,
     has_nv_optimus: bool,
+    driver_api_version: u32,
 }
 
 pub struct Instance {


### PR DESCRIPTION
**Description**
In order to use some of the `as_hal` functions exposed in the Vulkan hal to their full potential, a few things need to be exposed.

This makes the following things accessible:
* Underlying `ash::Instance` and `ash::Entry` from Instance
* Underlying `ash::vk::PhysicalDevice` from Adapter
* The driver api version of the Instance
* The enabled extensions of the Instance