### PR TITLE
expose egl display in gles Instance hal

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -580,6 +580,24 @@ pub struct Instance {
     inner: Mutex<Inner>,
 }
 
+impl Instance {
+    pub fn raw_display(&self) -> egl::Display {
+        self.inner
+            .try_lock()
+            .expect("Could not lock instance. This is most-likely a deadlock.")
+            .egl
+            .display
+    }
+
+    /// Returns the version of the EGL display.
+    pub fn egl_version(&self) -> (i32, i32) {
+        self.inner
+            .try_lock()
+            .expect("Could not lock instance. This is most-likely a deadlock.")
+            .version
+    }
+}
+
 unsafe impl Send for Instance {}
 unsafe impl Sync for Instance {}
 


### PR DESCRIPTION
**Description**
Exposes some parts of egl's Instance.

The display and the egl version are made public.

The former is needed for using some extensions such as `EGL_EXT_image_dma_buf_import`. The version is also useful for extensions where a specific version of EGL is required. 

## Questions

~~Because the internals of the display are guarded by a mutex, is returning a guard the best solution for access to the display?~~ The raw display is copy, no mutex guard needed.