### PR TITLE
[Gles] Fix clearing depth and stencil at the same time

### DIFF
--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -520,12 +520,19 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             }
         }
         if let Some(ref dsat) = desc.depth_stencil_attachment {
-            if !dsat.depth_ops.contains(crate::AttachmentOps::LOAD) {
+            let clear_depth = !dsat.depth_ops.contains(crate::AttachmentOps::LOAD);
+            let clear_stencil = !dsat.stencil_ops.contains(crate::AttachmentOps::LOAD);
+
+            if clear_depth && clear_stencil {
+                self.cmd_buffer.commands.push(C::ClearDepthAndStencil(
+                    dsat.clear_value.0,
+                    dsat.clear_value.1,
+                ));
+            } else if clear_depth {
                 self.cmd_buffer
                     .commands
                     .push(C::ClearDepth(dsat.clear_value.0));
-            }
-            if !dsat.stencil_ops.contains(crate::AttachmentOps::LOAD) {
+            } else if clear_stencil {
                 self.cmd_buffer
                     .commands
                     .push(C::ClearStencil(dsat.clear_value.1));

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -667,6 +667,7 @@ enum Command {
     ClearColorI(u32, [i32; 4]),
     ClearDepth(f32),
     ClearStencil(u32),
+    ClearDepthAndStencil(f32, u32),
     BufferBarrier(glow::Buffer, crate::BufferUses),
     TextureBarrier(crate::TextureUses),
     SetViewport {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -667,6 +667,10 @@ enum Command {
     ClearColorI(u32, [i32; 4]),
     ClearDepth(f32),
     ClearStencil(u32),
+    // Clearing both the depth and stencil buffer individually appears to
+    // result in the stencil buffer failing to clear, atleast in WebGL.
+    // It is also more efficient to emit a single command instead of two for
+    // this.
     ClearDepthAndStencil(f32, u32),
     BufferBarrier(glow::Buffer, crate::BufferUses),
     TextureBarrier(crate::TextureUses),

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -758,6 +758,9 @@ impl super::Queue {
             C::ClearStencil(value) => {
                 gl.clear_buffer_i32_slice(glow::STENCIL, 0, &[value as i32]);
             }
+            C::ClearDepthAndStencil(depth, stencil_value) => {
+                gl.clear_buffer_depth_stencil(glow::DEPTH_STENCIL, 0, depth, stencil_value as i32);
+            }
             C::BufferBarrier(raw, usage) => {
                 let mut flags = 0;
                 if usage.contains(crate::BufferUses::VERTEX) {


### PR DESCRIPTION
**Description**

Currently in the gles backend, if a depth+stencil buffer with a format like `TextureFormat::Depth24FloatPlusStencil8` is attached to a render pass with both the depth and stencil set to clear, only the depth is cleared. I'm not sure if this happens with native gl, but it certainly does with webgl.

**Testing**

This fixed a problem I had in my project. Here's a before and after of using a stencil buffer for a mirror:

![mirror_before_and_after](https://user-images.githubusercontent.com/13566135/169354879-de5f9338-0097-4fb3-8148-3295ccc17c89.png)
