### PR TITLE
Vulkan: Allow creating hal Instance and OpenDevice with additional extensions

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1360,18 +1360,18 @@ impl super::Adapter {
 
         Ok(crate::OpenDevice { device, queue })
     }
-}
 
-impl crate::Adapter<super::Api> for super::Adapter {
-    unsafe fn open(
+    unsafe fn open_with_extensions(
         &self,
         features: wgt::Features,
         limits: &wgt::Limits,
+        additional_extensions: &[&'static CStr],
     ) -> Result<crate::OpenDevice<super::Api>, crate::DeviceError> {
         let phd_limits = &self.phd_capabilities.properties.limits;
         let uab_types = super::UpdateAfterBindTypes::from_limits(limits, phd_limits);
 
-        let enabled_extensions = self.required_device_extensions(features);
+        let mut enabled_extensions = self.required_device_extensions(features);
+        enabled_extensions.extend(additional_extensions);
         let mut enabled_phd_features =
             self.physical_device_features(&enabled_extensions, features, uab_types);
 
@@ -1410,6 +1410,16 @@ impl crate::Adapter<super::Api> for super::Adapter {
             family_info.queue_family_index,
             0,
         )
+    }
+}
+
+impl crate::Adapter<super::Api> for super::Adapter {
+    unsafe fn open(
+        &self,
+        features: wgt::Features,
+        limits: &wgt::Limits,
+    ) -> Result<crate::OpenDevice<super::Api>, crate::DeviceError> {
+        self.open_with_extensions(features, limits, &[])
     }
 
     unsafe fn texture_format_capabilities(


### PR DESCRIPTION
**Description**
Vulkan being a very explicit graphics API gates functionality behind extensions that must be enabled when an instance or device is created.

Out of tree wgpu extension libraries may want to enable extensions without duplicating a bunch of wgpu-hal code (which would have to be done with creating a raw device). This adds two functions to Vulkan's wgpu-hal types, `Instance::init_with_extensions` and `Adapter::open_with_extensions` as alternatives to wgpu-hal's `Instance::init` and `Adapter::open` that allow specifying additional Vulkan extensions to enable when creating an Instance or Device.
