### PR TITLE
metal: fix Depth24Plus | Depth24PlusStencil8 capabilities

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -181,20 +181,24 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 flags
             }
             Tf::Depth32Float | Tf::Depth32FloatStencil8 => {
-                let mut flats =
+                let mut flags =
                     Tfc::DEPTH_STENCIL_ATTACHMENT | Tfc::MULTISAMPLE | msaa_resolve_apple3x_if;
                 if pc.format_depth32float_filter {
-                    flats |= Tfc::SAMPLED_LINEAR
+                    flags |= Tfc::SAMPLED_LINEAR
                 }
-                flats
+                flags
             }
-            Tf::Depth24Plus => Tfc::empty(),
-            Tf::Depth24PlusStencil8 => {
-                if pc.msaa_desktop {
-                    Tfc::DEPTH_STENCIL_ATTACHMENT | Tfc::SAMPLED_LINEAR | Tfc::MULTISAMPLE
+            Tf::Depth24Plus | Tf::Depth24PlusStencil8 => {
+                let mut flags = Tfc::DEPTH_STENCIL_ATTACHMENT | Tfc::MULTISAMPLE;
+                if pc.format_depth24_stencil8 {
+                    flags |= Tfc::SAMPLED_LINEAR | Tfc::MULTISAMPLE_RESOLVE
                 } else {
-                    Tfc::empty()
+                    flags |= msaa_resolve_apple3x_if;
+                    if pc.format_depth32float_filter {
+                        flags |= Tfc::SAMPLED_LINEAR
+                    }
                 }
+                flags
             }
             Tf::Rgb9e5Ufloat => {
                 if pc.msaa_apple3 {


### PR DESCRIPTION
**Description**
Since `Depth24Plus`  `Depth24PlusStencil8` always map to `Depth24Unorm_Stencil8 || Depth32Float` and `Depth24Unorm_Stencil8 || Depth32Float_Stencil8` respectively, 
https://github.com/gfx-rs/wgpu/blob/84efe2b18b31de5cad1e554d1c8db5baf8beef59/wgpu-hal/src/metal/adapter.rs#L894-L907
so capabilities also need map to too:
<img width="1090" alt="截屏2022-05-22 14 00 53" src="https://user-images.githubusercontent.com/1001342/169681874-c55be1ef-a7c9-4389-a324-5a2fa7bf1715.png">

