### PR TITLE
expose vulkan physical device capabilities, enabled device extensions

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -600,7 +600,11 @@ unsafe impl Send for PhysicalDeviceCapabilities {}
 unsafe impl Sync for PhysicalDeviceCapabilities {}
 
 impl PhysicalDeviceCapabilities {
-    fn supports_extension(&self, extension: &CStr) -> bool {
+    pub fn properties(&self) -> vk::PhysicalDeviceProperties {
+        self.properties
+    }
+
+    pub fn supports_extension(&self, extension: &CStr) -> bool {
         self.supported_extensions
             .iter()
             .any(|ep| unsafe { CStr::from_ptr(ep.extension_name.as_ptr()) } == extension)
@@ -1117,6 +1121,14 @@ impl super::Adapter {
         self.raw
     }
 
+    pub fn physical_device_capabilities(&self) -> &PhysicalDeviceCapabilities {
+        &self.phd_capabilities
+    }
+
+    pub fn shared_instance(&self) -> &super::InstanceShared {
+        &self.instance
+    }
+
     pub fn required_device_extensions(&self, features: wgt::Features) -> Vec<&'static CStr> {
         let (supported_extensions, unsupported_extensions) = self
             .phd_capabilities
@@ -1287,6 +1299,8 @@ impl super::Adapter {
             raw: raw_device,
             handle_is_owned,
             instance: Arc::clone(&self.instance),
+            physical_device: self.raw,
+            enabled_extensions: enabled_extensions.into(),
             extension_fns: super::DeviceExtensionFunctions {
                 draw_indirect_count: indirect_count_fn,
                 timeline_semaphore: timeline_semaphore_fn,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -8,7 +8,7 @@ use parking_lot::Mutex;
 use std::{
     borrow::Cow,
     collections::{hash_map::Entry, BTreeMap},
-    ffi::CString,
+    ffi::{CStr, CString},
     num::NonZeroU32,
     ptr,
     sync::Arc,
@@ -21,8 +21,6 @@ impl super::DeviceShared {
         object: impl vk::Handle,
         name: &str,
     ) {
-        use std::ffi::CStr;
-
         let extension = match self.instance.debug_utils {
             Some(ref debug_utils) => &debug_utils.extension,
             None => return,
@@ -698,6 +696,18 @@ impl super::Device {
 
     pub fn raw_device(&self) -> &ash::Device {
         &self.shared.raw
+    }
+
+    pub fn raw_physical_device(&self) -> ash::vk::PhysicalDevice {
+        self.shared.physical_device
+    }
+
+    pub fn enabled_device_extensions(&self) -> &[&'static CStr] {
+        &self.shared.enabled_extensions
+    }
+
+    pub fn shared_instance(&self) -> &super::InstanceShared {
+        &self.shared.instance
     }
 }
 

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -132,21 +132,27 @@ impl super::Swapchain {
     }
 }
 
-impl super::Instance {
+impl super::InstanceShared {
     pub fn entry(&self) -> &ash::Entry {
-        &self.shared.entry
+        &self.entry
     }
 
     pub fn raw_instance(&self) -> &ash::Instance {
-        &self.shared.raw
+        &self.raw
     }
 
     pub fn driver_api_version(&self) -> u32 {
-        self.shared.driver_api_version
+        self.driver_api_version
     }
 
     pub fn extensions(&self) -> &[&'static CStr] {
         &self.extensions[..]
+    }
+}
+
+impl super::Instance {
+    pub fn shared_instance(&self) -> &super::InstanceShared {
+        &self.shared
     }
 
     pub fn required_extensions(
@@ -276,6 +282,7 @@ impl super::Instance {
         Ok(Self {
             shared: Arc::new(super::InstanceShared {
                 raw: raw_instance,
+                extensions,
                 drop_guard,
                 flags,
                 debug_utils,
@@ -284,7 +291,6 @@ impl super::Instance {
                 has_nv_optimus,
                 driver_api_version,
             }),
-            extensions,
         })
     }
 
@@ -294,7 +300,7 @@ impl super::Instance {
         dpy: *mut vk::Display,
         window: vk::Window,
     ) -> super::Surface {
-        if !self.extensions.contains(&khr::XlibSurface::name()) {
+        if !self.shared.extensions.contains(&khr::XlibSurface::name()) {
             panic!("Vulkan driver does not support VK_KHR_XLIB_SURFACE");
         }
 
@@ -318,7 +324,7 @@ impl super::Instance {
         connection: *mut vk::xcb_connection_t,
         window: vk::xcb_window_t,
     ) -> super::Surface {
-        if !self.extensions.contains(&khr::XcbSurface::name()) {
+        if !self.shared.extensions.contains(&khr::XcbSurface::name()) {
             panic!("Vulkan driver does not support VK_KHR_XCB_SURFACE");
         }
 
@@ -342,7 +348,11 @@ impl super::Instance {
         display: *mut c_void,
         surface: *mut c_void,
     ) -> super::Surface {
-        if !self.extensions.contains(&khr::WaylandSurface::name()) {
+        if !self
+            .shared
+            .extensions
+            .contains(&khr::WaylandSurface::name())
+        {
             panic!("Vulkan driver does not support VK_KHR_WAYLAND_SURFACE");
         }
 
@@ -379,7 +389,7 @@ impl super::Instance {
         hinstance: *mut c_void,
         hwnd: *mut c_void,
     ) -> super::Surface {
-        if !self.extensions.contains(&khr::Win32Surface::name()) {
+        if !self.shared.extensions.contains(&khr::Win32Surface::name()) {
             panic!("Vulkan driver does not support VK_KHR_WIN32_SURFACE");
         }
 
@@ -598,16 +608,21 @@ impl crate::Instance<super::Api> for super::Instance {
 
         match has_handle.raw_window_handle() {
             RawWindowHandle::Wayland(handle)
-                if self.extensions.contains(&khr::WaylandSurface::name()) =>
+                if self
+                    .shared
+                    .extensions
+                    .contains(&khr::WaylandSurface::name()) =>
             {
                 Ok(self.create_surface_from_wayland(handle.display, handle.surface))
             }
             RawWindowHandle::Xlib(handle)
-                if self.extensions.contains(&khr::XlibSurface::name()) =>
+                if self.shared.extensions.contains(&khr::XlibSurface::name()) =>
             {
                 Ok(self.create_surface_from_xlib(handle.display as *mut _, handle.window))
             }
-            RawWindowHandle::Xcb(handle) if self.extensions.contains(&khr::XcbSurface::name()) => {
+            RawWindowHandle::Xcb(handle)
+                if self.shared.extensions.contains(&khr::XcbSurface::name()) =>
+            {
                 Ok(self.create_surface_from_xcb(handle.connection, handle.window))
             }
             RawWindowHandle::AndroidNdk(handle) => {
@@ -622,13 +637,13 @@ impl crate::Instance<super::Api> for super::Instance {
             }
             #[cfg(target_os = "macos")]
             RawWindowHandle::AppKit(handle)
-                if self.extensions.contains(&ext::MetalSurface::name()) =>
+                if self.shared.extensions.contains(&ext::MetalSurface::name()) =>
             {
                 Ok(self.create_surface_from_view(handle.ns_view))
             }
             #[cfg(target_os = "ios")]
             RawWindowHandle::UiKit(handle)
-                if self.extensions.contains(&ext::MetalSurface::name()) =>
+                if self.shared.extensions.contains(&ext::MetalSurface::name()) =>
             {
                 Ok(self.create_surface_from_view(handle.ui_view))
             }

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -79,8 +79,9 @@ struct DebugUtils {
     messenger: vk::DebugUtilsMessengerEXT,
 }
 
-struct InstanceShared {
+pub struct InstanceShared {
     raw: ash::Instance,
+    extensions: Vec<&'static CStr>,
     drop_guard: Option<DropGuard>,
     flags: crate::InstanceFlags,
     debug_utils: Option<DebugUtils>,
@@ -92,7 +93,6 @@ struct InstanceShared {
 
 pub struct Instance {
     shared: Arc<InstanceShared>,
-    extensions: Vec<&'static CStr>,
 }
 
 struct Swapchain {
@@ -313,6 +313,8 @@ struct DeviceShared {
     raw: ash::Device,
     handle_is_owned: bool,
     instance: Arc<InstanceShared>,
+    physical_device: ash::vk::PhysicalDevice,
+    enabled_extensions: Vec<&'static CStr>,
     extension_fns: DeviceExtensionFunctions,
     vendor_id: u32,
     timestamp_period: f32,


### PR DESCRIPTION
**Description**
Well this pull request expanded a bit as you can see in the edits.

- Expose physical device properties and PhysicalDeviceCapabilities from Vulkan's Adapter
- For Vulkan's Device, expose the following
  - Enabled device extensions
  - Raw physical device (needed for getting data associated with a device that is too varied to calculate at creation time).
  - The instance the device is from (for getting said physical device data)
  - Version of the instance on the device (For above)
  - Enabled instance extensions (Also for above)
- For Vulkan's Adapter, expose the following
  - The instance
  - The version of the instance
  - Enabled instance extensions