### PR TITLE
Add DEPTH24UNORM_STENCIL8 feature

### DIFF
--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -128,6 +128,9 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     if features.contains(wgpu_types::Features::DEPTH_CLIP_CONTROL) {
         return_features.push("depth-clip-control");
     }
+    if features.contains(wgpu_types::Features::DEPTH24UNORM_STENCIL8) {
+        return_features.push("depth24unorm-stencil8");
+    }
     if features.contains(wgpu_types::Features::DEPTH32FLOAT_STENCIL8) {
         return_features.push("depth32float-stencil8");
     }
@@ -284,6 +287,10 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
         features.set(
             wgpu_types::Features::DEPTH_CLIP_CONTROL,
             required_features.0.contains("depth-clip-control"),
+        );
+         features.set(
+            wgpu_types::Features::DEPTH24UNORM_STENCIL8,
+            required_features.0.contains("depth24unorm-stencil8"),
         );
         features.set(
             wgpu_types::Features::DEPTH32FLOAT_STENCIL8,

--- a/player/tests/data/pipeline-statistics-query.ron
+++ b/player/tests/data/pipeline-statistics-query.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0000_0000_0000_0080, // PIPELINE_STATISTICS_QUERY
+    features: 0x0000_0000_0000_0100, // PIPELINE_STATISTICS_QUERY
     expectations: [
         (
             name: "Queried number of compute invocations is correct",

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -313,7 +313,8 @@ pub(crate) fn validate_texture_copy_range(
         wgt::TextureFormat::Depth32Float
         | wgt::TextureFormat::Depth32FloatStencil8
         | wgt::TextureFormat::Depth24Plus
-        | wgt::TextureFormat::Depth24PlusStencil8 => {
+        | wgt::TextureFormat::Depth24PlusStencil8
+        | wgt::TextureFormat::Depth24UnormStencil8 => {
             if *copy_size != extent {
                 return Err(TransferError::InvalidDepthTextureExtent);
             }

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -19,9 +19,11 @@ pub fn is_valid_copy_src_texture_format(format: wgt::TextureFormat) -> bool {
 pub fn is_valid_copy_dst_texture_format(format: wgt::TextureFormat) -> bool {
     use wgt::TextureFormat as Tf;
     match format {
-        Tf::Depth32Float | Tf::Depth32FloatStencil8 | Tf::Depth24Plus | Tf::Depth24PlusStencil8 => {
-            false
-        }
+        Tf::Depth32Float
+        | Tf::Depth32FloatStencil8
+        | Tf::Depth24Plus
+        | Tf::Depth24PlusStencil8
+        | Tf::Depth24UnormStencil8 => false,
         _ => true,
     }
 }

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -705,7 +705,8 @@ impl NumericType {
             Tf::Depth32Float
             | Tf::Depth32FloatStencil8
             | Tf::Depth24Plus
-            | Tf::Depth24PlusStencil8 => {
+            | Tf::Depth24PlusStencil8
+            | Tf::Depth24UnormStencil8 => {
                 panic!("Unexpected depth format")
             }
             Tf::Rgb9e5Ufloat => (NumericDimension::Vector(Vs::Tri), Sk::Float),

--- a/wgpu-hal/src/auxil/dxgi/conv.rs
+++ b/wgpu-hal/src/auxil/dxgi/conv.rs
@@ -49,7 +49,7 @@ pub fn map_texture_format(format: wgt::TextureFormat) -> dxgiformat::DXGI_FORMAT
         Tf::Depth32Float => DXGI_FORMAT_D32_FLOAT,
         Tf::Depth32FloatStencil8 => DXGI_FORMAT_D32_FLOAT_S8X24_UINT,
         Tf::Depth24Plus => DXGI_FORMAT_D24_UNORM_S8_UINT,
-        Tf::Depth24PlusStencil8 => DXGI_FORMAT_D24_UNORM_S8_UINT,
+        Tf::Depth24PlusStencil8 | Tf::Depth24UnormStencil8 => DXGI_FORMAT_D24_UNORM_S8_UINT,
         Tf::Rgb9e5Ufloat => DXGI_FORMAT_R9G9B9E5_SHAREDEXP,
         Tf::Bc1RgbaUnorm => DXGI_FORMAT_BC1_UNORM,
         Tf::Bc1RgbaUnormSrgb => DXGI_FORMAT_BC1_UNORM_SRGB,
@@ -100,9 +100,9 @@ pub fn map_texture_format_nodepth(format: wgt::TextureFormat) -> dxgiformat::DXG
         wgt::TextureFormat::Depth32FloatStencil8 => {
             dxgiformat::DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS
         }
-        wgt::TextureFormat::Depth24Plus | wgt::TextureFormat::Depth24PlusStencil8 => {
-            dxgiformat::DXGI_FORMAT_R24_UNORM_X8_TYPELESS
-        }
+        wgt::TextureFormat::Depth24Plus
+        | wgt::TextureFormat::Depth24PlusStencil8
+        | wgt::TextureFormat::Depth24UnormStencil8 => dxgiformat::DXGI_FORMAT_R24_UNORM_X8_TYPELESS,
         _ => {
             assert_eq!(
                 crate::FormatAspects::from(format),
@@ -117,9 +117,9 @@ pub fn map_texture_format_depth_typeless(format: wgt::TextureFormat) -> dxgiform
     match format {
         wgt::TextureFormat::Depth32Float => dxgiformat::DXGI_FORMAT_R32_TYPELESS,
         wgt::TextureFormat::Depth32FloatStencil8 => dxgiformat::DXGI_FORMAT_R32G8X24_TYPELESS,
-        wgt::TextureFormat::Depth24Plus | wgt::TextureFormat::Depth24PlusStencil8 => {
-            dxgiformat::DXGI_FORMAT_R24G8_TYPELESS
-        }
+        wgt::TextureFormat::Depth24Plus
+        | wgt::TextureFormat::Depth24PlusStencil8
+        | wgt::TextureFormat::Depth24UnormStencil8 => dxgiformat::DXGI_FORMAT_R24G8_TYPELESS,
         _ => unreachable!(),
     }
 }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -185,6 +185,7 @@ impl super::Adapter {
 
         let mut features = wgt::Features::empty()
             | wgt::Features::DEPTH_CLIP_CONTROL
+            | wgt::Features::DEPTH24UNORM_STENCIL8
             | wgt::Features::DEPTH32FLOAT_STENCIL8
             | wgt::Features::INDIRECT_FIRST_INSTANCE
             | wgt::Features::MAPPABLE_PRIMARY_BUFFERS

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -662,7 +662,8 @@ impl crate::Adapter<super::Api> for super::Adapter {
             Tf::Depth32Float
             | Tf::Depth32FloatStencil8
             | Tf::Depth24Plus
-            | Tf::Depth24PlusStencil8 => depth,
+            | Tf::Depth24PlusStencil8
+            | Tf::Depth24UnormStencil8 => depth,
             Tf::Rgb9e5Ufloat
             | Tf::Bc1RgbaUnorm
             | Tf::Bc1RgbaUnormSrgb

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -65,7 +65,7 @@ impl super::AdapterShared {
                 glow::DEPTH_COMPONENT,
                 glow::UNSIGNED_NORMALIZED,
             ),
-            Tf::Depth24PlusStencil8 => (
+            Tf::Depth24PlusStencil8 | Tf::Depth24UnormStencil8 => (
                 glow::DEPTH24_STENCIL8,
                 glow::DEPTH_COMPONENT,
                 glow::UNSIGNED_INT,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -602,9 +602,9 @@ impl From<wgt::TextureFormat> for FormatAspects {
     fn from(format: wgt::TextureFormat) -> Self {
         match format {
             wgt::TextureFormat::Depth32Float | wgt::TextureFormat::Depth24Plus => Self::DEPTH,
-            wgt::TextureFormat::Depth32FloatStencil8 | wgt::TextureFormat::Depth24PlusStencil8 => {
-                Self::DEPTH | Self::STENCIL
-            }
+            wgt::TextureFormat::Depth32FloatStencil8
+            | wgt::TextureFormat::Depth24PlusStencil8
+            | wgt::TextureFormat::Depth24UnormStencil8 => Self::DEPTH | Self::STENCIL,
             _ => Self::COLOR,
         }
     }

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -200,6 +200,12 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 }
                 flags
             }
+            Tf::Depth24UnormStencil8 => {
+                Tfc::DEPTH_STENCIL_ATTACHMENT
+                    | Tfc::SAMPLED_LINEAR
+                    | Tfc::MULTISAMPLE
+                    | Tfc::MULTISAMPLE_RESOLVE
+            }
             Tf::Rgb9e5Ufloat => {
                 if pc.msaa_apple3 {
                     all_caps
@@ -762,6 +768,7 @@ impl super::PrivateCapabilities {
         features.set(F::TEXTURE_COMPRESSION_ETC2, self.format_eac_etc);
 
         features.set(F::DEPTH_CLIP_CONTROL, self.supports_depth_clip_control);
+        features.set(F::DEPTH24UNORM_STENCIL8, self.format_depth24_stencil8);
 
         features.set(
             F::TEXTURE_BINDING_ARRAY
@@ -909,6 +916,7 @@ impl super::PrivateCapabilities {
                     Depth32Float_Stencil8
                 }
             }
+            Tf::Depth24UnormStencil8 => Depth24Unorm_Stencil8,
             Tf::Rgb9e5Ufloat => RGB9E5Float,
             Tf::Bc1RgbaUnorm => BC1_RGBA,
             Tf::Bc1RgbaUnormSrgb => BC1_RGBA_sRGB,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -566,9 +566,16 @@ impl PhysicalDeviceFeatures {
             caps.supports_format(
                 vk::Format::D32_SFLOAT_S8_UINT,
                 vk::ImageTiling::OPTIMAL,
-                vk::FormatFeatureFlags::DEPTH_STENCIL_ATTACHMENT
-                    | vk::FormatFeatureFlags::SAMPLED_IMAGE
-                    | vk::FormatFeatureFlags::TRANSFER_SRC,
+                vk::FormatFeatureFlags::DEPTH_STENCIL_ATTACHMENT,
+            ),
+        );
+
+        features.set(
+            F::DEPTH24UNORM_STENCIL8,
+            caps.supports_format(
+                vk::Format::D24_UNORM_S8_UINT,
+                vk::ImageTiling::OPTIMAL,
+                vk::FormatFeatureFlags::DEPTH_STENCIL_ATTACHMENT,
             ),
         );
 

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -64,6 +64,7 @@ impl super::PrivateCapabilities {
                     F::D32_SFLOAT_S8_UINT
                 }
             }
+            Tf::Depth24UnormStencil8 => F::D24_UNORM_S8_UINT,
             Tf::Rgb9e5Ufloat => F::E5B9G9R9_UFLOAT_PACK32,
             Tf::Bc1RgbaUnorm => F::BC1_RGBA_UNORM_BLOCK,
             Tf::Bc1RgbaUnormSrgb => F::BC1_RGBA_SRGB_BLOCK,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -185,6 +185,15 @@ bitflags::bitflags! {
         ///
         /// This is a web and native feature.
         const DEPTH_CLIP_CONTROL = 1 << 0;
+        /// Allows for explicit creation of textures of format [`TextureFormat::Depth24UnormStencil8`]
+        ///
+        /// Supported platforms:
+        /// - Vulkan (some)
+        /// - DX12
+        /// - Metal (Macs with amd GPUs)
+        ///
+        /// This is a web and native feature.
+        const DEPTH24UNORM_STENCIL8 = 1 << 1;
         /// Allows for explicit creation of textures of format [`TextureFormat::Depth32FloatStencil8`]
         ///
         /// Supported platforms:
@@ -193,7 +202,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a web and native feature.
-        const DEPTH32FLOAT_STENCIL8 = 1 << 1;
+        const DEPTH32FLOAT_STENCIL8 = 1 << 2;
         /// Enables BCn family of compressed textures. All BCn textures use 4x4 pixel blocks
         /// with 8 or 16 bytes per block.
         ///
@@ -207,7 +216,7 @@ bitflags::bitflags! {
         /// - desktops
         ///
         /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_BC = 1 << 2;
+        const TEXTURE_COMPRESSION_BC = 1 << 3;
         /// Enables ETC family of compressed textures. All ETC textures use 4x4 pixel blocks.
         /// ETC2 RGB and RGBA1 are 8 bytes per block. RTC2 RGBA8 and EAC are 16 bytes per block.
         ///
@@ -222,7 +231,7 @@ bitflags::bitflags! {
         /// - Mobile (some)
         ///
         /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_ETC2 = 1 << 3;
+        const TEXTURE_COMPRESSION_ETC2 = 1 << 4;
         /// Enables ASTC family of compressed textures. ASTC textures use pixel blocks varying from 4x4 to 12x12.
         /// Blocks are always 16 bytes.
         ///
@@ -237,7 +246,7 @@ bitflags::bitflags! {
         /// - Mobile (some)
         ///
         /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_ASTC_LDR = 1 << 4;
+        const TEXTURE_COMPRESSION_ASTC_LDR = 1 << 5;
         /// Allows non-zero value for the "first instance" in indirect draw calls.
         ///
         /// Supported Platforms:
@@ -246,7 +255,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a web and native feature.
-        const INDIRECT_FIRST_INSTANCE = 1 << 5;
+        const INDIRECT_FIRST_INSTANCE = 1 << 6;
         /// Enables use of Timestamp Queries. These queries tell the current gpu timestamp when
         /// all work before the query is finished. Call [`CommandEncoder::write_timestamp`],
         /// [`RenderPassEncoder::write_timestamp`], or [`ComputePassEncoder::write_timestamp`] to
@@ -264,7 +273,7 @@ bitflags::bitflags! {
         /// - DX12 (works)
         ///
         /// This is a web and native feature.
-        const TIMESTAMP_QUERY = 1 << 6;
+        const TIMESTAMP_QUERY = 1 << 7;
         /// Enables use of Pipeline Statistics Queries. These queries tell the count of various operations
         /// performed between the start and stop call. Call [`RenderPassEncoder::begin_pipeline_statistics_query`] to start
         /// a query, then call [`RenderPassEncoder::end_pipeline_statistics_query`] to stop one.
@@ -279,7 +288,7 @@ bitflags::bitflags! {
         /// - DX12 (works)
         ///
         /// This is a web and native feature.
-        const PIPELINE_STATISTICS_QUERY = 1 << 7;
+        const PIPELINE_STATISTICS_QUERY = 1 << 8;
         /// Allows shaders to acquire the FP16 ability
         ///
         /// Note: this is not supported in naga yet，only through spir-v passthrough right now.
@@ -289,7 +298,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a web and native feature.
-        const SHADER_FLOAT16 = 1 << 8;
+        const SHADER_FLOAT16 = 1 << 9;
         /// Webgpu only allows the MAP_READ and MAP_WRITE buffer usage to be matched with
         /// COPY_DST and COPY_SRC respectively. This removes this requirement.
         ///
@@ -1856,6 +1865,9 @@ pub enum TextureFormat {
     /// Special depth/stencil format with at least 24 bit integer depth and 8 bits integer stencil.
     #[cfg_attr(feature = "serde", serde(rename = "depth24plus-stencil8"))]
     Depth24PlusStencil8,
+    /// Special depth/stencil format with 24 bit integer depth and 8 bits integer stencil.
+    #[cfg_attr(feature = "serde", serde(rename = "depth24unorm-stencil8"))]
+    Depth24UnormStencil8,
 
     // Packed uncompressed texture formats
     /// Packed unsigned float with 9 bits mantisa for each RGB component, then a common 5 bits exponent
@@ -2059,6 +2071,7 @@ impl TextureFormat {
         let astc_hdr = Features::TEXTURE_COMPRESSION_ASTC_HDR;
         let norm16bit = Features::TEXTURE_FORMAT_16BIT_NORM;
         let d32_s8 = Features::DEPTH32FLOAT_STENCIL8;
+        let d24_s8 = Features::DEPTH24UNORM_STENCIL8;
 
         // Sample Types
         let uint = TextureSampleType::Uint;
@@ -2151,6 +2164,7 @@ impl TextureFormat {
             Self::Depth32FloatStencil8 =>(   d32_s8,   depth,    linear,         msaa, (1, 1),  4, attachment, 2),
             Self::Depth24Plus =>         (   native,   depth,    linear,         msaa, (1, 1),  4, attachment, 1),
             Self::Depth24PlusStencil8 => (   native,   depth,    linear,         msaa, (1, 1),  4, attachment, 2),
+            Self::Depth24UnormStencil8 => (  d24_s8,   depth,    linear,         msaa, (1, 1),  4, attachment, 2),
 
             // Packed uncompressed  
             Self::Rgb9e5Ufloat =>        (   native,   float,    linear,         noaa, (1, 1),  4,      basic, 3),

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -546,6 +546,7 @@ fn map_texture_format(texture_format: wgt::TextureFormat) -> web_sys::GpuTexture
         TextureFormat::Depth32FloatStencil8 => tf::Depth32floatStencil8,
         TextureFormat::Depth24Plus => tf::Depth24plus,
         TextureFormat::Depth24PlusStencil8 => tf::Depth24plusStencil8,
+        TextureFormat::Depth24UnormStencil8 => tf::Depth24unormStencil8,
         _ => unimplemented!(),
     }
 }
@@ -595,6 +596,7 @@ fn map_texture_format_from_web_sys(
         tf::Depth32floatStencil8 => TextureFormat::Depth32FloatStencil8,
         tf::Depth24plus => TextureFormat::Depth24Plus,
         tf::Depth24plusStencil8 => TextureFormat::Depth24PlusStencil8,
+        tf::Depth24unormStencil8 => TextureFormat::Depth24UnormStencil8,
         _ => unimplemented!(),
     }
 }
@@ -1091,8 +1093,14 @@ impl crate::Context for Context {
         let possible_features = [
             //TODO: update the name
             (wgt::Features::DEPTH_CLIP_CONTROL, Gfn::DepthClamping),
-            // TODO (_, Gfn::Depth24unormStencil8),
-            // TODO (_, Gfn::Depth32floatStencil8),
+            (
+                wgt::Features::DEPTH24UNORM_STENCIL8,
+                Gfn::Depth24unormStencil8,
+            ),
+            (
+                wgt::Features::DEPTH32FLOAT_STENCIL8,
+                Gfn::Depth32floatStencil8,
+            ),
             (
                 wgt::Features::PIPELINE_STATISTICS_QUERY,
                 Gfn::PipelineStatisticsQuery,

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -333,6 +333,22 @@ fn clear_texture_d32_s8() {
 }
 
 #[test]
+fn clear_texture_d24_s8() {
+    initialize_test(
+        TestParameters::default()
+            .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::DEPTH24UNORM_STENCIL8),
+        |ctx| {
+            clear_texture_tests(
+                &ctx,
+                &[wgpu::TextureFormat::Depth24UnormStencil8],
+                false,
+                false,
+            );
+        },
+    )
+}
+
+#[test]
 fn clear_texture_2d_bc() {
     initialize_test(
         TestParameters::default()


### PR DESCRIPTION
WebGPU spec: https://gpuweb.github.io/gpuweb/#depth24unorm-stencil8

**Testing**
Tested on metal vk(--features=vulkan-portability) an dx12 backends