### PR TITLE
Track depth and stencil writability separately.

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2765,8 +2765,11 @@ impl<A: HalApi> Device<A> {
             if ds.stencil.is_enabled() && ds.stencil.needs_ref_value() {
                 flags |= pipeline::PipelineFlags::STENCIL_REFERENCE;
             }
-            if !ds.is_read_only() {
-                flags |= pipeline::PipelineFlags::WRITES_DEPTH_STENCIL;
+            if !ds.is_depth_read_only() {
+                flags |= pipeline::PipelineFlags::WRITES_DEPTH;
+            }
+            if !ds.is_stencil_read_only() {
+                flags |= pipeline::PipelineFlags::WRITES_STENCIL;
             }
         }
 
@@ -4378,7 +4381,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     desc: trace::new_render_bundle_encoder_descriptor(
                         desc.label.clone(),
                         &bundle_encoder.context,
-                        bundle_encoder.is_ds_read_only,
+                        bundle_encoder.is_depth_read_only,
+                        bundle_encoder.is_stencil_read_only,
                     ),
                     base: bundle_encoder.to_base_pass(),
                 });

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -13,17 +13,17 @@ pub const FILE_NAME: &str = "trace.ron";
 pub(crate) fn new_render_bundle_encoder_descriptor<'a>(
     label: crate::Label<'a>,
     context: &'a super::RenderPassContext,
-    is_ds_read_only: bool,
+    depth_read_only: bool,
+    stencil_read_only: bool,
 ) -> crate::command::RenderBundleEncoderDescriptor<'a> {
     crate::command::RenderBundleEncoderDescriptor {
         label,
         color_formats: Cow::Borrowed(&context.attachments.colors),
         depth_stencil: context.attachments.depth_stencil.map(|format| {
-            let aspects = hal::FormatAspects::from(format);
             wgt::RenderBundleDepthStencil {
                 format,
-                depth_read_only: is_ds_read_only && aspects.contains(hal::FormatAspects::DEPTH),
-                stencil_read_only: is_ds_read_only && aspects.contains(hal::FormatAspects::STENCIL),
+                depth_read_only,
+                stencil_read_only,
             }
         }),
         sample_count: context.sample_count,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -352,7 +352,8 @@ bitflags::bitflags! {
     pub struct PipelineFlags: u32 {
         const BLEND_CONSTANT = 1 << 0;
         const STENCIL_REFERENCE = 1 << 1;
-        const WRITES_DEPTH_STENCIL = 1 << 2;
+        const WRITES_DEPTH = 1 << 2;
+        const WRITES_STENCIL = 1 << 3;
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2419,9 +2419,20 @@ impl DepthStencilState {
     pub fn is_depth_enabled(&self) -> bool {
         self.depth_compare != CompareFunction::Always || self.depth_write_enabled
     }
+
+    /// Returns true if the state doesn't mutate the depth buffer.
+    pub fn is_depth_read_only(&self) -> bool {
+        !self.depth_write_enabled
+    }
+
+    /// Returns true if the state doesn't mutate the stencil.
+    pub fn is_stencil_read_only(&self) -> bool {
+        self.stencil.is_read_only()
+    }
+
     /// Returns true if the state doesn't mutate either depth or stencil of the target.
     pub fn is_read_only(&self) -> bool {
-        !self.depth_write_enabled && self.stencil.is_read_only()
+        self.is_depth_read_only() && self.is_stencil_read_only()
     }
 }
 


### PR DESCRIPTION
Put some plumbing in place to accomodate the latest definition of `GPURenderBundleEncoderDescriptor` in the WebGPU spec, which now has separate `depthReadOnly` and `stencilReadOnly` members.

Rename `RenderPassDepthStencilAttachment::is_read_only` to `depth_stencil_read_only`, and don't skip validation steps due to early returns.
