### PR TITLE
Add links for SpirV documents.

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -788,6 +788,8 @@ impl Drop for ShaderModule {
 #[non_exhaustive]
 pub enum ShaderSource<'a> {
     /// SPIR-V module represented as a slice of words.
+    ///
+    /// See also: [`util::make_spirv`], [`include_spirv`]
     #[cfg(feature = "spirv")]
     #[cfg_attr(docsrs, doc(cfg(feature = "spirv")))]
     SpirV(Cow<'a, [u32]>),

--- a/wgpu/src/macros.rs
+++ b/wgpu/src/macros.rs
@@ -44,6 +44,8 @@ fn test_vertex_attr_array() {
 /// Macro to load a SPIR-V module statically.
 ///
 /// It ensures the word alignment as well as the magic number.
+///
+/// Return type: [`crate::ShaderModuleDescriptor`]
 #[macro_export]
 #[cfg(feature = "spirv")]
 macro_rules! include_spirv {


### PR DESCRIPTION
**Connections**

None

**Description**

- **Problem:** It is not obvious for users to create spriv shader modules when consulting docs of `wgpu::ShaderSource::SpirV`. The signature of `SpirV(Cow<'a, [u32]>)` alone doesn't given enough information. And the return type of `include_spirv!` is also not documented. 
- See:
   - https://docs.rs/wgpu/0.12.0/wgpu/enum.ShaderSource.html#variant.SpirV 
   - https://docs.rs/wgpu/0.12.0/wgpu/macro.include_spirv.html

- **Proposed documents enhancement:**
   - Add links of `include_spirv!` and `util::make_spirv`
   - Add return type of `include_spirv!`

**Testing**

Has built documents and checked added links with the following commands:

```shell
 cargo doc --features spirv --open
```
