### PR TITLE
Check that all vertex outputs are consumed by the fragment shader

### DIFF
--- a/wgpu/examples/cube/shader.wgsl
+++ b/wgpu/examples/cube/shader.wgsl
@@ -30,6 +30,6 @@ fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
 }
 
 @fragment
-fn fs_wire() -> @location(0) vec4<f32> {
+fn fs_wire(vertex: VertexOutput) -> @location(0) vec4<f32> {
     return vec4<f32>(0.0, 0.5, 0.0, 0.5);
 }


### PR DESCRIPTION
**Connections**

https://github.com/gfx-rs/naga/issues/1945 only happens when this rule is violated. 

**Description**

We never checked that all vertex outputs are consumed by the fragment shader.

**Testing**

Ran tests, it actually caught a violation in our tests.
