### PR TITLE
Improve InvalidScissorRect error message

### DIFF
--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -89,8 +89,8 @@ pub enum RenderCommandError {
     PushConstants(#[from] PushConstantUploadError),
     #[error("Invalid Viewport parameters")]
     InvalidViewport,
-    #[error("Invalid ScissorRect parameters")]
-    InvalidScissorRect,
+    #[error("Scissor {0:?} is not contained in the render target {1:?}")]
+    InvalidScissorRect(Rect<u32>, wgt::Extent3d),
     #[error("Support for {0} is not implemented yet")]
     Unimplemented(&'static str),
 }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1510,7 +1510,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             || rect.x + rect.w > info.extent.width
                             || rect.y + rect.h > info.extent.height
                         {
-                            return Err(RenderCommandError::InvalidScissorRect).map_pass_err(scope);
+                            return Err(RenderCommandError::InvalidScissorRect(*rect, info.extent))
+                                .map_pass_err(scope);
                         }
                         let r = hal::Rect {
                             x: rect.x,


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/2676

**Testing**
Calling RenderPass `set_scissor_rect` with illegal arguments will output the following error message:
```sh
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In a RenderPass
      note: encoder = `<CommandBuffer-(0, 1, Metal)>`
    In a set_scissor_rect command
    Scissor Rect { x: 1000, y: 1000, w: 601, h: 200 } is not contained in the render target Extent3d { width: 1600, height: 1200, depth_or_array_layers: 1 }

```
