### PR TITLE
[gles] Handle cubemap copies

### DIFF
--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -327,7 +327,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 dst: dst_raw,
                 dst_target,
                 copy,
-                dst_array_layer_count: dst.array_layer_count,
+                dst_is_cubemap: dst.is_cubemap,
             })
         }
     }

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -327,6 +327,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 dst: dst_raw,
                 dst_target,
                 copy,
+                dst_array_layer_count: dst.array_layer_count,
             })
         }
     }

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1210,6 +1210,7 @@ impl crate::Surface<super::Api> for Surface {
                 height: sc.extent.height,
                 depth: 1,
             },
+            is_cubemap: false,
         };
         Ok(Some(crate::AcquiredSurfaceTexture {
             texture,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -616,6 +616,7 @@ enum Command {
         dst: glow::Texture,
         dst_target: BindTarget,
         copy: crate::TextureCopy,
+        dst_array_layer_count: u32,
     },
     CopyBufferToTexture {
         src: Buffer,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -262,6 +262,7 @@ pub struct Texture {
     #[allow(unused)]
     format_desc: TextureFormatDesc,
     copy_size: crate::CopyExtent,
+    is_cubemap: bool,
 }
 
 impl Texture {
@@ -281,6 +282,7 @@ impl Texture {
                 height: 0,
                 depth: 0,
             },
+            is_cubemap: false,
         }
     }
 }
@@ -616,7 +618,7 @@ enum Command {
         dst: glow::Texture,
         dst_target: BindTarget,
         copy: crate::TextureCopy,
-        dst_array_layer_count: u32,
+        dst_is_cubemap: bool,
     },
     CopyBufferToTexture {
         src: Buffer,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -332,20 +332,10 @@ impl super::Queue {
                     );
                 }
 
+                gl.bind_texture(dst_target, Some(dst));
                 if dst_array_layer_count == 6 {
-                    let cube_map_target = match copy.dst_base.array_layer {
-                        0 => glow::TEXTURE_CUBE_MAP_POSITIVE_X,
-                        1 => glow::TEXTURE_CUBE_MAP_NEGATIVE_X,
-                        2 => glow::TEXTURE_CUBE_MAP_POSITIVE_Y,
-                        3 => glow::TEXTURE_CUBE_MAP_NEGATIVE_Y,
-                        4 => glow::TEXTURE_CUBE_MAP_POSITIVE_Z,
-                        5 => glow::TEXTURE_CUBE_MAP_NEGATIVE_Z,
-                        _ => panic!(),
-                    };
-
-                    gl.bind_texture(cube_map_target, Some(dst));
                     gl.copy_tex_sub_image_2d(
-                        cube_map_target,
+                        CUBEMAP_FACES[copy.dst_base.array_layer as usize],
                         copy.dst_base.mip_level as i32,
                         copy.dst_base.origin.x as i32,
                         copy.dst_base.origin.y as i32,
@@ -355,7 +345,6 @@ impl super::Queue {
                         copy.size.height as i32,
                     );
                 } else if is_layered_target(dst_target) {
-                    gl.bind_texture(dst_target, Some(dst));
                     gl.copy_tex_sub_image_3d(
                         dst_target,
                         copy.dst_base.mip_level as i32,
@@ -368,7 +357,6 @@ impl super::Queue {
                         copy.size.height as i32,
                     );
                 } else {
-                    gl.bind_texture(dst_target, Some(dst));
                     gl.copy_tex_sub_image_2d(
                         dst_target,
                         copy.dst_base.mip_level as i32,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -308,7 +308,7 @@ impl super::Queue {
                 src_target,
                 dst,
                 dst_target,
-                dst_array_layer_count,
+                dst_is_cubemap,
                 ref copy,
             } => {
                 //TODO: handle 3D copies
@@ -333,7 +333,7 @@ impl super::Queue {
                 }
 
                 gl.bind_texture(dst_target, Some(dst));
-                if dst_array_layer_count == 6 {
+                if dst_is_cubemap {
                     gl.copy_tex_sub_image_2d(
                         CUBEMAP_FACES[copy.dst_base.array_layer as usize],
                         copy.dst_base.mip_level as i32,

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -270,6 +270,7 @@ impl crate::Surface<super::Api> for Surface {
                 height: sc.extent.height,
                 depth: 1,
             },
+            is_cubemap: false,
         };
         Ok(Some(crate::AcquiredSurfaceTexture {
             texture,


### PR DESCRIPTION
**Description**

Currently you can't copy a texture to a cubemap in the gles backend because it wrongly uses the `glow::TEXTURE_2D` target. I've pretty hackily set things up so we check how many array layers the target has, and if it has 6 then we write to the correct cubemap face.

**Testing**

Tested in Chrome. ~~I get a `WebGL: INVALID_OPERATION: bindTexture: textures can not be used with multiple targets` error but it functions at least.~~ Fixed that now.