### PR TITLE
Fix default backends selection when running examples at the workspace root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
         shell: bash
         run: |
           # run wgpu-info
-          cargo run --bin wgpu-info
+          cargo run -p wgpu-info
           # run unit and player tests
           cargo nextest run -p wgpu-types -p wgpu-hal -p wgpu-core -p player --no-fail-fast
           # run native tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ members = [
     "wgpu-hal",
     "wgpu-info",
     "wgpu-types",
-    "run-wasm",
+    "run-wasm"
 ]
 exclude = [
     "cts_runner",
-    "deno_webgpu",
+    "deno_webgpu"
 ]
-default-members = ["wgpu", "wgpu-hal", "wgpu-info"]
+default-members = ["wgpu", "wgpu-hal"]
 
 [patch."https://github.com/gfx-rs/naga"]
 #naga = { path = "../naga" }

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ cargo nextest run --no-fail-fast
 `wgpu-info` can run the tests once for each adapter on your system.
 
 ```
-cargo run --bin wgpu-info -- cargo nextest run --no-fail-fast
+cargo run -p wgpu-info -- cargo nextest run --no-fail-fast
 ```
 
 Then to run an example's image comparison tests, run:

--- a/wgpu-info/README.md
+++ b/wgpu-info/README.md
@@ -7,7 +7,7 @@ This is a command line utility that does two different functions.
 When called with no arguments, wgpu-info will list all adapters visible to wgpu and all the information about them we have.
 
 ```
-cargo run --bin wgpu-info
+cargo run -p wgpu-info
 ```
 
 #### Running Test on many Adapters


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/2540

**Description**
Since wgpu-info as a workspace  `default-members`  item depends on wgpu and enabled `angle`  `vulkan-portability` features, it causes  `#[cfg(vulkan)]` `#[cfg(gl)]`  compile conditions alway pass when  run examples at the workspace root .
https://github.com/gfx-rs/wgpu/blob/9e3cd08e5913bbb22e4d5b1f3fd30dccbf4ba9c7/wgpu-core/build.rs#L10-L19

**Testing**
Tested examples at the workspace root and `wgpu` package directory
