### PR TITLE
Make Water Visible in Water Example on WebGL

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -289,6 +289,9 @@ impl super::Adapter {
             wgt::DownlevelFlags::ANISOTROPIC_FILTERING,
             extensions.contains("EXT_texture_filter_anisotropic"),
         );
+        if cfg!(not(target_arch = "wasm32")) {
+            downlevel_flags.set(wgt::DownlevelFlags::READ_ONLY_DEPTH_STENCIL, true);
+        }
 
         let mut features = wgt::Features::empty()
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES

--- a/wgpu/examples/water/water.wgsl
+++ b/wgpu/examples/water/water.wgsl
@@ -250,3 +250,20 @@ fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
 
     return vec4<f32>(depth_colour, clamped * (1.0 - vertex.f_Fresnel));
 }
+
+// This is the same as fs_main above, but with the depth calculation removed, because it is
+// unsupported for some adapters.
+@fragment
+fn fs_without_depth_read(vertex: VertexOutput) -> @location(0) vec4<f32> {
+    let reflection_colour = textureSample(reflection, colour_sampler, vertex.f_WaterScreenPos.xy).xyz;
+    let normalized_coords = vertex.position.xy / vec2<f32>(uniforms.time_size_width.w, uniforms.viewport_height);
+
+    let dist = 1.5;
+    let clamped = pow(smoothstep(0.0, 1.5, dist), 4.8);
+
+    let final_colour = vertex.f_Light + reflection_colour;
+    let t = smoothstep(1.0, 5.0, dist) * 0.2; //TODO: splat for mix()?
+    let depth_colour = mix(final_colour, water_colour, vec3<f32>(t, t, t));
+
+    return vec4<f32>(depth_colour, clamped * (1.0 - vertex.f_Fresnel));
+}


### PR DESCRIPTION
Uses a separate entrypoint for the water fragment shader on WebGL to
avoid the unsupported depth calculation.

**Connections**
Addresses #2032

**Description**
Uses an alternate fragment shader entrypoint on for the water example on WebGL. Looks slightly worse, but actually renders the water.

This should mean we could put this example on the website with the others.

**Testing**
Tested in my browser: `Brave Browser 97.1.34.80 unknown` ( a Chrome derivative )

![image](https://user-images.githubusercontent.com/25393315/172025768-593e37bb-65e1-42d3-b588-87726e57ae5b.png)

Tested on Ubuntu 20.04 Vulkan that the example still works normally after the change.

---

BTW, love the new `cargo run-wasm` utility, and the cleaner `@binding` syntax for WGSL. :)