### PR TITLE
metal: check if in the main thread when calling `create_surface`

### DIFF
--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -9,7 +9,7 @@ use objc::{
     declare::ClassDecl,
     msg_send,
     rc::autoreleasepool,
-    runtime::{Class, Object, Sel, BOOL, YES},
+    runtime::{Class, Object, Sel, BOOL, NO, YES},
     sel, sel_impl,
 };
 use parking_lot::Mutex;
@@ -74,6 +74,7 @@ impl super::Surface {
         }
     }
 
+    /// If not called on the main thread, this will panic.
     #[allow(clippy::transmute_ptr_to_ref)]
     pub unsafe fn from_view(
         view: *mut c_void,
@@ -82,6 +83,11 @@ impl super::Surface {
         let view = view as *mut Object;
         if view.is_null() {
             panic!("window does not have a valid contentView");
+        }
+
+        let is_main_thread: BOOL = msg_send![class!(NSThread), isMainThread];
+        if is_main_thread == NO {
+            panic!("create_surface cannot be called in non-ui thread.");
         }
 
         let main_layer: *mut Object = msg_send![view, layer];

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1708,6 +1708,7 @@ impl Instance {
     ///
     /// - Raw Window Handle must be a valid object to create a surface upon and
     ///   must remain valid for the lifetime of the returned surface.
+    /// - If not called on the main thread, metal backend will panic.
     pub unsafe fn create_surface<W: raw_window_handle::HasRawWindowHandle>(
         &self,
         window: &W,


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/2727

**Description**
On macOS and iOS platforms, calling UI APIs in non-ui thread will cause unexpected results. Tell the user exactly what the problem is by checking if it is in the main thread.

Also tried using Objective-C GCD to specify the main thread to execute the code, but `view: *mut c_void` is not a thread-safe object, and I don't think actively jumping threads is something wgpu should do.

**Testing**
Tested on macOS and iOS.