### PR TITLE
Add `Features::MULTI_DRAW_INDIRECT` to Metal

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -760,7 +760,8 @@ impl super::PrivateCapabilities {
             | F::CLEAR_TEXTURE
             | F::TEXTURE_FORMAT_16BIT_NORM
             | F::SHADER_FLOAT16
-            | F::DEPTH32FLOAT_STENCIL8;
+            | F::DEPTH32FLOAT_STENCIL8
+            | F::MULTI_DRAW_INDIRECT;
 
         features.set(F::TEXTURE_COMPRESSION_ASTC_LDR, self.format_astc);
         features.set(F::TEXTURE_COMPRESSION_ASTC_HDR, self.format_astc_hdr);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -422,6 +422,7 @@ bitflags::bitflags! {
         /// Supported platforms:
         /// - DX12
         /// - Vulkan
+        /// - Metal (Emulated on top of `draw_indirect` and `draw_indexed_indirect`)
         ///
         /// This is a native only feature.
         const MULTI_DRAW_INDIRECT = 1 << 23;


### PR DESCRIPTION
**Description**

We currently emulate MDI in Metal on top of `draw_primitives_indirect`:

https://github.com/gfx-rs/wgpu/blob/a3b241857df53dba7891580c61eb33921f859ff3/wgpu-hal/src/metal/command.rs#L847-L850

Therefore we might as well expose the feature as long as it's clear that it's emulated and not natively supported.

**Testing**

I don't have my Macbook on me at the moment but I can test it on that when I get home.
