### PR TITLE
Don't dirty the vertex buffer for stride/rate changes on bundles.

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1203,11 +1203,8 @@ impl<A: HalApi> State<A> {
         self.index.pipeline_format = index_format;
 
         for (vs, &(stride, step_mode)) in self.vertex.iter_mut().zip(vertex_strides) {
-            if vs.stride != stride || vs.rate != step_mode {
-                vs.stride = stride;
-                vs.rate = step_mode;
-                vs.is_dirty = true;
-            }
+            vs.stride = stride;
+            vs.rate = step_mode;
         }
 
         let push_constants_changed = self


### PR DESCRIPTION
`wgpu_core::command::bundle::State::set_pipeline` marks a vertex buffer slot dirty if the pipeline's stride or step mode for that vertex buffer slot differs from what had been previously established. The effect of marking the slot dirty is to ensure that a new `SetVertexBuffer` command is inserted before the next draw command that uses that vertex buffer. However, this is unnecessary: `wgpu_hal::CommandEncoder::set_vertex_buffer` does not need to be called simply because the stride or rate has changed.
