### PR TITLE
Introduce `VertexStep`: a stride and a step mode.

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -367,7 +367,7 @@ impl RenderBundleEncoder {
                     pipeline_layout_id = Some(pipeline.layout_id.value);
 
                     state.set_pipeline(
-                        &pipeline.vertex_strides,
+                        &pipeline.vertex_steps,
                         &layout.bind_group_layout_ids,
                         &layout.push_constant_ranges,
                     );
@@ -981,8 +981,7 @@ impl IndexState {
 struct VertexState {
     buffer: Option<id::BufferId>,
     range: Range<wgt::BufferAddress>,
-    stride: wgt::BufferAddress,
-    rate: wgt::VertexStepMode,
+    step: pipeline::VertexStep,
     is_dirty: bool,
 }
 
@@ -993,8 +992,7 @@ impl VertexState {
         Self {
             buffer: None,
             range: 0..0,
-            stride: 0,
-            rate: wgt::VertexStepMode::Vertex,
+            step: pipeline::VertexStep::default(),
             is_dirty: false,
         }
     }
@@ -1122,11 +1120,11 @@ impl<A: HalApi> State<A> {
             instance_limit_slot: 0,
         };
         for (idx, vbs) in self.vertex.iter().enumerate() {
-            if vbs.stride == 0 {
+            if vbs.step.stride == 0 {
                 continue;
             }
-            let limit = ((vbs.range.end - vbs.range.start) / vbs.stride) as u32;
-            match vbs.rate {
+            let limit = ((vbs.range.end - vbs.range.start) / vbs.step.stride) as u32;
+            match vbs.step.mode {
                 wgt::VertexStepMode::Vertex => {
                     if limit < vert_state.vertex_limit {
                         vert_state.vertex_limit = limit;
@@ -1184,13 +1182,12 @@ impl<A: HalApi> State<A> {
 
     fn set_pipeline(
         &mut self,
-        vertex_strides: &[(wgt::BufferAddress, wgt::VertexStepMode)],
+        attributes: &[pipeline::VertexStep],
         layout_ids: &[id::Valid<id::BindGroupLayoutId>],
         push_constant_layouts: &[wgt::PushConstantRange],
     ) {
-        for (vs, &(stride, step_mode)) in self.vertex.iter_mut().zip(vertex_strides) {
-            vs.stride = stride;
-            vs.rate = step_mode;
+        for (vs, &step) in self.vertex.iter_mut().zip(attributes) {
+            vs.step = step;
         }
 
         let push_constants_changed = self

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2396,13 +2396,14 @@ impl<A: HalApi> Device<A> {
         let mut io = validation::StageIo::default();
         let mut validated_stages = wgt::ShaderStages::empty();
 
-        let mut vertex_strides = Vec::with_capacity(desc.vertex.buffers.len());
+        let mut vertex_steps = Vec::with_capacity(desc.vertex.buffers.len());
         let mut vertex_buffers = Vec::with_capacity(desc.vertex.buffers.len());
         let mut total_attributes = 0;
         for (i, vb_state) in desc.vertex.buffers.iter().enumerate() {
-            vertex_strides
-                .alloc()
-                .init((vb_state.array_stride, vb_state.step_mode));
+            vertex_steps.alloc().init(pipeline::VertexStep {
+                stride: vb_state.array_stride,
+                mode: vb_state.step_mode,
+            });
             if vb_state.attributes.is_empty() {
                 continue;
             }
@@ -2800,7 +2801,7 @@ impl<A: HalApi> Device<A> {
             pass_context,
             flags,
             strip_index_format: desc.primitive.strip_index_format,
-            vertex_strides,
+            vertex_steps,
             late_sized_buffer_groups,
             life_guard: LifeGuard::new(desc.label.borrow_or_default()),
         };

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -357,6 +357,25 @@ bitflags::bitflags! {
     }
 }
 
+/// How a render pipeline will retrieve attributes from a particular vertex buffer.
+#[derive(Clone, Copy, Debug)]
+pub struct VertexStep {
+    /// The byte stride in the buffer between one attribute value and the next.
+    pub stride: wgt::BufferAddress,
+
+    /// Whether the buffer is indexed by vertex number or instance number.
+    pub mode: wgt::VertexStepMode,
+}
+
+impl Default for VertexStep {
+    fn default() -> Self {
+        Self {
+            stride: 0,
+            mode: wgt::VertexStepMode::Vertex,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct RenderPipeline<A: hal::Api> {
     pub(crate) raw: A::RenderPipeline,
@@ -365,7 +384,7 @@ pub struct RenderPipeline<A: hal::Api> {
     pub(crate) pass_context: RenderPassContext,
     pub(crate) flags: PipelineFlags,
     pub(crate) strip_index_format: Option<wgt::IndexFormat>,
-    pub(crate) vertex_strides: Vec<(wgt::BufferAddress, wgt::VertexStepMode)>,
+    pub(crate) vertex_steps: Vec<VertexStep>,
     pub(crate) late_sized_buffer_groups: ArrayVec<LateSizedBufferGroup, { hal::MAX_BIND_GROUPS }>,
     pub(crate) life_guard: LifeGuard,
 }


### PR DESCRIPTION
This is used in various places around render pipelines, passes, and
bundles.

The public `wgpu_core::pipeline::VertexBufferLayout` could use
`VertexStep` as well, but I think it's best to let that continue to
resemble `GPUVertexBufferLayout`.
