### PR TITLE
vk: fix PIPELINE_STATISTICS_QUERY feature support

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -360,7 +360,6 @@ impl PhysicalDeviceFeatures {
             | F::ADDRESS_MODE_CLAMP_TO_BORDER
             | F::ADDRESS_MODE_CLAMP_TO_ZERO
             | F::TIMESTAMP_QUERY
-            | F::PIPELINE_STATISTICS_QUERY
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | F::CLEAR_TEXTURE;
         let mut dl_flags = Df::all();
@@ -397,8 +396,10 @@ impl PhysicalDeviceFeatures {
             F::TEXTURE_COMPRESSION_BC,
             self.core.texture_compression_bc != 0,
         );
-        //if self.core.occlusion_query_precise != 0 {
-        //if self.core.pipeline_statistics_query != 0 { //TODO
+        features.set(
+            F::PIPELINE_STATISTICS_QUERY,
+            self.core.pipeline_statistics_query != 0,
+        );
         features.set(
             F::VERTEX_WRITABLE_STORAGE,
             self.core.vertex_pipeline_stores_and_atomics != 0,


### PR DESCRIPTION
**Description**
`PIPELINE_STATISTICS_QUERY` feature not supported by all vk devices,  running `mipmap` on vk backend on M1 Mac caused error:
```sh
[2022-06-08T04:24:38Z ERROR wgpu_hal::vulkan::instance]         objects: (type: INSTANCE, hndl: 0x14d872a00, name: ?)
[mvk-error] VK_ERROR_FEATURE_NOT_PRESENT: vkCreateDevice(): Requested feature is not available on this device.
[2022-06-08T04:24:38Z ERROR wgpu_hal::vulkan::instance] GENERAL | VALIDATION | PERFORMANCE | 1111111111111111111111111111000 [ (0x0)]
        VK_ERROR_FEATURE_NOT_PRESENT: vkCreateDevice(): Requested feature is not available on this device.
[2022-06-08T04:24:38Z ERROR wgpu_hal::vulkan::instance]         objects: (type: DEVICE, hndl: 0x13c02da18, name: ?)
[2022-06-08T04:24:38Z ERROR wgpu_hal::vulkan::instance] GENERAL [Loader Message (0x0)]
        terminator_CreateDevice: Failed in ICD /usr/local/share/vulkan/icd.d/../../../lib/libMoltenVK.dylib vkCreateDevice call
[2022-06-08T04:24:38Z ERROR wgpu_hal::vulkan::instance]         objects: (type: INSTANCE, hndl: 0x14d872a00, name: ?)
[2022-06-08T04:24:38Z ERROR wgpu_hal::vulkan::instance] GENERAL [Loader Message (0x0)]
        vkCreateDevice:  Failed to create device chain.
[2022-06-08T04:24:38Z ERROR wgpu_hal::vulkan::instance]         objects: (type: INSTANCE, hndl: 0x14d872a00, name: ?)
[2022-06-08T04:24:38Z ERROR wgpu::backend::direct] Error in Adapter::request_device: connection to device was lost during initialization
```

**Testing**
Tested mipmap example on vk backend.