### PR TITLE
Expose naga span location helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.8.0"
-source = "git+https://github.com/gfx-rs/naga?rev=571302e#571302e3ff09cb856f63a3683da308159872b7cc"
+source = "git+https://github.com/gfx-rs/naga?rev=89bed99#89bed99bcc995bc5068c9c112fd9b7d7896bb148"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -42,7 +42,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "571302e"
+rev = "89bed99"
 #version = "0.8"
 features = ["span", "validate", "wgsl-in"]
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -126,6 +126,16 @@ pub enum CreateShaderModuleError {
     MissingFeatures(#[from] MissingFeatures),
 }
 
+impl CreateShaderModuleError {
+    pub fn location(&self, source: &str) -> Option<naga::SourceLocation> {
+        match *self {
+            CreateShaderModuleError::Parsing(ref err) => err.inner.location(source),
+            CreateShaderModuleError::Validation(ref err) => err.inner.location(source),
+            _ => None,
+        }
+    }
+}
+
 /// Describes a programmable pipeline stage.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -95,14 +95,14 @@ android-properties = "0.2"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "571302e"
+rev = "89bed99"
 #version = "0.8"
 
 # DEV dependencies
 
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "571302e"
+rev = "89bed99"
 #version = "0.8"
 features = ["wgsl-in"]
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -140,20 +140,20 @@ env_logger = "0.9"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "571302e"
+rev = "89bed99"
 #version = "0.8"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "571302e"
+rev = "89bed99"
 #version = "0.8"
 features = ["wgsl-in"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "571302e"
+rev = "89bed99"
 #version = "0.8"
 features = ["wgsl-out"]
 


### PR DESCRIPTION
**Description**

This exposes the `location` method from naga errors. The idea is to let the user obtain an `Option<naga::SourceLocation>` out of `CreateShaderModuleError` without matching on the internal error types.

This PR also bumps the naga dependency to a more recent revision since the `location` methods were added recently. Note that the glsl backend recently got bounds check for image loads in https://github.com/gfx-rs/naga/pull/1889, I left the extra parameter disabled in this PR to get the code to build.

**Testing**

None (the location method has a test in naga).