### PR TITLE
Remove the default features from wgpu-info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
         shell: bash
         run: |
           # run wgpu-info
-          cargo run --bin wgpu-info
+          cargo run --bin wgpu-info --features angle,vulkan-portability
           # run unit and player tests
           cargo nextest run -p wgpu-types -p wgpu-hal -p wgpu-core -p player --no-fail-fast
           # run native tests

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -9,10 +9,6 @@ repository = "https://github.com/gfx-rs/wgpu"
 keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 
-# Even if you aren't actually building `wgpu-info`,
-# enabling the `angle` and `vulkan-portability` features of wgpu enables them for everything built in this workspace.
-# This includes the web examples, which fail to compile when Vulkan is enabled,
-# so disable that on web (by just disabling everything, since this won't compile for wasm anyway).
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[dependencies]
 env_logger = "0.9"
-wgpu = { version = "0.12", path = "../wgpu", features = ["angle", "vulkan-portability"] }
+wgpu = { version = "0.12", path = "../wgpu" }

--- a/wgpu-info/README.md
+++ b/wgpu-info/README.md
@@ -6,7 +6,7 @@ This is a command line utility that does two different functions.
 
 When called with no arguments, wgpu-info will list all adapters visible to wgpu and all the information about them we have.
 
-For gl in non Linux add the angle feature, for vk on macOS add the vulkan-portability feature.
+For OpenGL on platforms other than Linux add the `angle` feature, for Vulkan on macOS add the `vulkan-portability` feature.
 
 ```
 cargo run --bin wgpu-info

--- a/wgpu-info/README.md
+++ b/wgpu-info/README.md
@@ -6,6 +6,8 @@ This is a command line utility that does two different functions.
 
 When called with no arguments, wgpu-info will list all adapters visible to wgpu and all the information about them we have.
 
+For gl in non Linux add the angle feature, for vk on macOS add the vulkan-portability feature.
+
 ```
 cargo run --bin wgpu-info
 ```


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/pull/2730

**Description**
Keep the results of running the examples consistent between from the workspace root and wgpu package directory without specifying `WGPU_BACKEND`. 

**Testing**
Tested examples at the workspace root and wgpu package directory.
