### PR TITLE
Expect shader_primitive_index tests to fail on AMD RADV POLARIS12.

### DIFF
--- a/wgpu/tests/shader_primitive_index/mod.rs
+++ b/wgpu/tests/shader_primitive_index/mod.rs
@@ -51,7 +51,14 @@ fn draw() {
     initialize_test(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::SHADER_PRIMITIVE_INDEX),
+            .features(wgpu::Features::SHADER_PRIMITIVE_INDEX)
+            // https://github.com/gfx-rs/wgpu/issues/2751
+            .specific_failure(
+                Some(wgt::Backends::VULKAN),
+                Some(0x1002), // AMD
+                Some("AMD RADV"),
+                false,
+            ),
         |ctx| {
             pulling_common(ctx, &expected, |rpass| {
                 rpass.draw(0..6, 0..1);
@@ -75,7 +82,14 @@ fn draw_indexed() {
     initialize_test(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::SHADER_PRIMITIVE_INDEX),
+            .features(wgpu::Features::SHADER_PRIMITIVE_INDEX)
+            // https://github.com/gfx-rs/wgpu/issues/2751
+            .specific_failure(
+                Some(wgt::Backends::VULKAN),
+                Some(0x1002), // AMD
+                Some("AMD RADV"),
+                false,
+            ),
         |ctx| {
             pulling_common(ctx, &expected, |rpass| {
                 rpass.draw_indexed(0..6, 0, 0..1);


### PR DESCRIPTION
On Fedora, mesa-vulkan-drivers 22.0.3 AMD RADV POLARIS12 just colors both the NE and SW corners red. There's no blue. (NW and SE are white, as expected.) I suspect this means that the primitive ID is always being passed as zero.

This is probably not just due to a difference in rasterization: I tried enlarging the texture to 4x4 and shifting the triangles to ensure that there was a pixel in each quadrant that was fully covered.

With Vulkan "llvmpipe (LLVM 14.0.0, 256 bits)", the unmodified test passes.

This is probably limited to Linux, but `wgpu_tests::common::TestParameters` doesn't have a slot for that.

Fixes #2751.
