### PR TITLE
Align the validation of Device::create_texture with the WebGPU spec

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -116,14 +116,7 @@ pub fn check_texture_dimension_size(
     use wgt::TextureDimension::*;
 
     let (extent_limits, sample_limit) = match dimension {
-        D1 => (
-            [
-                limits.max_texture_dimension_1d,
-                1,
-                limits.max_texture_array_layers,
-            ],
-            1,
-        ),
+        D1 => ([limits.max_texture_dimension_1d, 1, 1], 1),
         D2 => (
             [
                 limits.max_texture_dimension_2d,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -336,8 +336,22 @@ pub enum TextureDimensionError {
         given: u32,
         limit: u32,
     },
-    #[error("sample count {0} is invalid")]
+    #[error("Sample count {0} is invalid")]
     InvalidSampleCount(u32),
+    #[error("Width {width} is not a multiple of {format:?}'s block width ({block_width})")]
+    NotMultipleOfBlockWidth {
+        width: u32,
+        block_width: u32,
+        format: wgt::TextureFormat,
+    },
+    #[error("Height {height} is not a multiple of {format:?}'s block height ({block_height})")]
+    NotMultipleOfBlockHeight {
+        height: u32,
+        block_height: u32,
+        format: wgt::TextureFormat,
+    },
+    #[error("Multisampled texture depth or array layers must be 1, got {0}")]
+    MultisampledDepthOrArrayLayer(u32),
 }
 
 #[derive(Clone, Debug, Error)]
@@ -360,6 +374,12 @@ pub enum CreateTextureError {
     InvalidFormatUsages(wgt::TextureUsages, wgt::TextureFormat),
     #[error("Texture usages {0:?} are not allowed on a texture of dimensions {1:?}")]
     InvalidDimensionUsages(wgt::TextureUsages, wgt::TextureDimension),
+    #[error("Texture usage STORAGE_BINDING is not allowed for multisampled textures")]
+    InvalidMultisampledStorageBinding,
+    #[error("Format {0:?} does not support multisampling")]
+    InvalidMultisampledFormat(wgt::TextureFormat),
+    #[error("Multisampled textures must have RENDER_ATTACHMENT usage")]
+    MultisampledNotRenderAttachment,
     #[error("Texture format {0:?} can't be used due to missing features.")]
     MissingFeatures(wgt::TextureFormat, #[source] MissingFeatures),
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3306,6 +3306,7 @@ pub struct TextureDescriptor<L> {
     pub format: TextureFormat,
     /// Allowed usages of the texture. If used in other ways, the operation will panic.
     pub usage: TextureUsages,
+    // TODO: missing view_formats https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-viewformats
 }
 
 impl<L> TextureDescriptor<L> {


### PR DESCRIPTION
**Connections**

The [WebGPU specification for createTexture](https://www.w3.org/TR/webgpu/#texture-creation).

**Description**

This PR aligns the validation of create_texture with the steps described in the aforementioned specification. I tried to make sure the validation is at least as strict as the specification, but didn't attempt to remove any existing validation that isn't described in the specification.

There is a tiny bit of reordering so that the validation in the code goes in roughly the same order as the specification (for ease of comparison).

I also found in the process that the method is probably missing a view_formats parameter but if so, it will come in a followup. 

**Testing**

None.