### PR TITLE
allow creating wgpu::Instance from wgpu_core::Instance

### DIFF
--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -918,6 +918,18 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         hal_instance_callback(hal_instance)
     }
 
+    /// # Safety
+    ///
+    /// - The raw handles obtained from the Instance must not be manually destroyed
+    pub unsafe fn from_instance(factory: G, instance: Instance) -> Self {
+        profiling::scope!("new", "Global");
+        Self {
+            instance,
+            surfaces: Registry::without_backend(&factory, "Surface"),
+            hubs: Hubs::new(&factory),
+        }
+    }
+
     pub fn clear_backend<A: HalApi>(&self, _dummy: ()) {
         let mut surface_guard = self.surfaces.data.write();
         let hub = A::hub(self);

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -47,12 +47,20 @@ impl Context {
         ))
     }
 
-    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl2"))]
+    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
     pub unsafe fn instance_as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Instance>) -> R, R>(
         &self,
         hal_instance_callback: F,
     ) -> R {
         self.0.instance_as_hal::<A, F, R>(hal_instance_callback)
+    }
+
+    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
+    pub unsafe fn from_core_instance(core_instance: wgc::instance::Instance) -> Self {
+        Self(wgc::hub::Global::from_instance(
+            wgc::hub::IdentityManagerFactory,
+            core_instance,
+        ))
     }
 
     pub(crate) fn global(&self) -> &wgc::hub::Global<wgc::hub::IdentityManagerFactory> {
@@ -75,7 +83,7 @@ impl Context {
         self.0.create_adapter_from_hal(hal_adapter, PhantomData)
     }
 
-    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl2"))]
+    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
     pub unsafe fn adapter_as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Adapter>) -> R, R>(
         &self,
         adapter: wgc::id::AdapterId,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1638,13 +1638,29 @@ impl Instance {
     /// # Safety
     ///
     /// - The raw handle obtained from the hal Instance must not be manually destroyed
-    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl2"))]
+    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
     pub unsafe fn as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Instance>) -> R, R>(
         &self,
         hal_instance_callback: F,
     ) -> R {
         self.context
             .instance_as_hal::<A, F, R>(hal_instance_callback)
+    }
+
+    /// Create an new instance of wgpu from a wgpu-core instance.
+    ///
+    /// # Arguments
+    ///
+    /// - `core_instance` - wgpu-core instance.
+    ///
+    /// # Safety
+    ///
+    /// Refer to the creation of wgpu-core Instance.
+    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
+    pub unsafe fn from_core(core_instance: wgc::instance::Instance) -> Self {
+        Self {
+            context: Arc::new(C::from_core_instance(core_instance)),
+        }
     }
 
     /// Retrieves all available [`Adapter`]s that match the given [`Backends`].
@@ -1869,7 +1885,7 @@ impl Adapter {
     /// # Safety
     ///
     /// - The raw handle obtained from the hal Adapter must not be manually destroyed
-    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl2"))]
+    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
     pub unsafe fn as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Adapter>) -> R, R>(
         &self,
         hal_adapter_callback: F,


### PR DESCRIPTION
**Description**
When creating custom hal instances, you may want to do so for multiple backends. Since a wgpu_core::Instance may have multiple instance members constructed, that is probably the best spot to deal with multiple custom wgpu_hal backends.

I do this specifically in my wgpu fork to integrate with some Linux specific APIs and want to be able to use EGL and Vulkan adapters.
