### PR TITLE
Increase max_outliers on wgpu water example reftest.

### DIFF
--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -829,6 +829,6 @@ fn water() {
             .downlevel_flags(wgpu::DownlevelFlags::READ_ONLY_DEPTH_STENCIL)
             .specific_failure(Some(wgpu::Backends::DX12), None, Some("Basic"), false), // WARP has a bug https://github.com/gfx-rs/wgpu/issues/1730
         tolerance: 5,
-        max_outliers: 460, // bounded by DX12, then rpi4 on vk
+        max_outliers: 470, // bounded by DX12, then AMD Radeon Polaris12 on vk linux
     });
 }


### PR DESCRIPTION
The example says:

    Using AMD RADV POLARIS12 (Vulkan)

The test says:

    thread 'water' panicked at 'Image data mismatch! Outlier count 464 over limit 460. Max difference 213', wgpu/examples/water/../../tests/common/image.rs:134:13

I checked the `water-difference.png` file, and it's just a few dots here and there. The example seems to run fine.
