### PR TITLE
Add InvalidGroupIndex validation at create_shader_module

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1189,6 +1189,18 @@ impl<A: HalApi> Device<A> {
             }
             pipeline::ShaderModuleSource::Naga(module) => (module, String::new()),
         };
+        for (_, var) in module.global_variables.iter() {
+            match var.binding {
+                Some(ref br) if br.group >= self.limits.max_bind_groups => {
+                    return Err(pipeline::CreateShaderModuleError::InvalidGroupIndex {
+                        bind: br.clone(),
+                        group: br.group,
+                        limit: self.limits.max_bind_groups,
+                    });
+                }
+                _ => continue,
+            };
+        }
 
         use naga::valid::Capabilities as Caps;
         profiling::scope!("naga::validate");

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -124,6 +124,14 @@ pub enum CreateShaderModuleError {
     Validation(#[from] ShaderError<naga::WithSpan<naga::valid::ValidationError>>),
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
+    #[error(
+        "shader global {bind:?} uses a group index {group} that exceeds the max_bind_groups limit of {limit}."
+    )]
+    InvalidGroupIndex {
+        bind: naga::ResourceBinding,
+        group: u32,
+        limit: u32,
+    },
 }
 
 impl CreateShaderModuleError {


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/2526

**Testing**
Tested locally, now, if an invalid group index is used, the following validation message will be output:
```sh
Caused by:
    In Device::create_shader_module
    shader global ResourceBinding { group: 4, binding: 0 } uses a group index 4 that exceeds the max_bind_groups limit of 4.
```