### PR TITLE
Expose and enforce a maximum buffer size.

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3180,6 +3180,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     .add(trace::Action::CreateBuffer(fid.id(), desc));
             }
 
+            let max_size = device.limits.max_buffer_size as BufferAddress;
+            if desc.size > max_size {
+                break resource::CreateBufferError::MaxBufferSize {
+                    requested: desc.size,
+                    maximum: max_size,
+                };
+            }
+
             let mut buffer = match device.create_buffer(device_id, desc, false) {
                 Ok(buffer) => buffer,
                 Err(e) => break e,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -174,6 +174,11 @@ pub enum CreateBufferError {
     EmptyUsage,
     #[error("`MAP` usage can only be combined with the opposite `COPY`, requested {0:?}")]
     UsageMismatch(wgt::BufferUsages),
+    #[error("Buffer size {requested} is larger than the maximum buffer size ({maximum})")]
+    MaxBufferSize {
+        requested: wgt::BufferAddress,
+        maximum: wgt::BufferAddress,
+    },
 }
 
 impl<A: hal::Api> Resource for Buffer<A> {

--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -220,6 +220,7 @@ impl super::Adapter {
             max_compute_workgroup_size_y: max_workgroup_size_xy,
             max_compute_workgroup_size_z: max_workgroup_size_z,
             max_compute_workgroups_per_dimension,
+            max_buffer_size: std::i32::MAX as u32,
         };
 
         //

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -282,6 +282,7 @@ impl super::Adapter {
                     max_compute_workgroup_size_z: d3d12::D3D12_CS_THREAD_GROUP_MAX_Z,
                     max_compute_workgroups_per_dimension:
                         d3d12::D3D12_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION,
+                    max_buffer_size: std::i32::MAX as u32,
                 },
                 alignments: crate::Alignments {
                     buffer_copy_offset: wgt::BufferSize::new(

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -461,6 +461,7 @@ impl super::Adapter {
                 0
             },
             max_compute_workgroups_per_dimension,
+            max_buffer_size: std::i32::MAX as u32,
         };
 
         let mut workarounds = super::Workarounds::empty();

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -847,6 +847,7 @@ impl super::PrivateCapabilities {
                 max_compute_workgroup_size_y: self.max_threads_per_group,
                 max_compute_workgroup_size_z: self.max_threads_per_group,
                 max_compute_workgroups_per_dimension: 0xFFFF,
+                max_buffer_size: self.max_buffer_size as u32,
             },
             alignments: crate::Alignments {
                 buffer_copy_offset: wgt::BufferSize::new(self.buffer_alignment).unwrap(),

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -768,6 +768,10 @@ impl PhysicalDeviceCapabilities {
             .min(limits.max_compute_work_group_count[1])
             .min(limits.max_compute_work_group_count[2]);
 
+        // Vulkan does not expose a maximum size for buffers, however some drivers run into integer
+        // overflows with sizes larger than what fits 32 bits integers.
+        let max_buffer_size = std::i32::MAX as u32;
+
         wgt::Limits {
             max_texture_dimension_1d: limits.max_image_dimension1_d,
             max_texture_dimension_2d: limits.max_image_dimension2_d,
@@ -808,6 +812,7 @@ impl PhysicalDeviceCapabilities {
             max_compute_workgroup_size_y: max_compute_workgroup_sizes[1],
             max_compute_workgroup_size_z: max_compute_workgroup_sizes[2],
             max_compute_workgroups_per_dimension,
+            max_buffer_size,
         }
     }
 

--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -60,6 +60,7 @@ mod inner {
             max_compute_workgroup_size_y,
             max_compute_workgroup_size_z,
             max_compute_workgroups_per_dimension,
+            max_buffer_size,
         } = limits;
         println!("\t\tMax Texture Dimension 1d:                        {}", max_texture_dimension_1d);
         println!("\t\tMax Texture Dimension 2d:                        {}", max_texture_dimension_2d);
@@ -72,6 +73,7 @@ mod inner {
         println!("\t\tMax Samplers Per Shader Stage:                   {}", max_samplers_per_shader_stage);
         println!("\t\tMax Storage Buffers Per Shader Stage:            {}", max_storage_buffers_per_shader_stage);
         println!("\t\tMax Storage Textures Per Shader Stage:           {}", max_storage_textures_per_shader_stage);
+        println!("\t\tMax buffer size:                                 {}", max_buffer_size);
         println!("\t\tMax Uniform Buffers Per Shader Stage:            {}", max_uniform_buffers_per_shader_stage);
         println!("\t\tMax Uniform Buffer Binding Size:                 {}", max_uniform_buffer_binding_size);
         println!("\t\tMax Storage Buffer Binding Size:                 {}", max_storage_buffer_binding_size);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -737,6 +737,8 @@ pub struct Limits {
     /// The maximum value for each dimension of a `ComputePass::dispatch(x, y, z)` operation.
     /// Defaults to 65535.
     pub max_compute_workgroups_per_dimension: u32,
+    /// The maximum size of a buffer
+    pub max_buffer_size: u32,
 }
 
 impl Default for Limits {
@@ -769,6 +771,8 @@ impl Default for Limits {
             max_compute_workgroup_size_y: 256,
             max_compute_workgroup_size_z: 64,
             max_compute_workgroups_per_dimension: 65535,
+            // Some drivers run into overflows when manipulating larger buffer sizes.
+            max_buffer_size: std::i32::MAX as u32,
         }
     }
 }
@@ -804,6 +808,7 @@ impl Limits {
             max_compute_workgroup_size_y: 256,
             max_compute_workgroup_size_z: 64,
             max_compute_workgroups_per_dimension: 65535,
+            max_buffer_size: 134_217_728, // 128MB is the guaranteed supported SSBO size in GL
         }
     }
 
@@ -921,6 +926,7 @@ impl Limits {
         compare!(max_compute_workgroup_size_y, Less);
         compare!(max_compute_workgroup_size_z, Less);
         compare!(max_compute_workgroups_per_dimension, Less);
+        compare!(max_buffer_size, Less);
     }
 }
 


### PR DESCRIPTION
**Connections**

WebGPU spec discussion: https://github.com/gpuweb/gpuweb/issues/1371

**Description**

A maximum buffer size will be exposed in the WebGPU specification. This is mostly because of metal which is officially restrictive in that area while other APIs (as far as I know), don't expose limits on the maximum buffer size and only limit the maximum binding size.

However in practice drivers have bugs. Mesa/lavapipe for example runs into trouble with sizes that don't fit into a signed 32 bit integer, and more generally my experience is that allocating gpu buffers and textures in the order of multiple gigabytes is a very good way to find driver bugs, in particular the kind that bring the OS on the mid/low end of the hardware ecosystem.

This PR exposes metal's maximum buffer size in Limits and sets the max buffer size to i32::MAX for all other backends.

I realize that the i32::MAX global limit might be controversial. It's very likely that the browser will override it with something even more conservative but on the native side, some might find it limiting.

The limit could depend on the hardware and driver with some more work.


**Testing**

None.