### PR TITLE
Change get_preferred_format to get_supported_formats

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3013,12 +3013,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .map_err(|_| instance::IsSurfaceSupportedError::InvalidSurface)?;
         Ok(adapter.is_surface_supported(surface))
     }
-    pub fn surface_get_preferred_format<A: HalApi>(
+    pub fn surface_get_supported_formats<A: HalApi>(
         &self,
         surface_id: id::SurfaceId,
         adapter_id: id::AdapterId,
-    ) -> Result<TextureFormat, instance::GetSurfacePreferredFormatError> {
-        profiling::scope!("surface_get_preferred_format");
+    ) -> Result<Vec<TextureFormat>, instance::GetSurfacePreferredFormatError> {
+        profiling::scope!("surface_get_supported_formats");
         let hub = A::hub(self);
         let mut token = Token::root();
 
@@ -3031,7 +3031,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .get(surface_id)
             .map_err(|_| instance::GetSurfacePreferredFormatError::InvalidSurface)?;
 
-        surface.get_preferred_format(adapter)
+        surface.get_supported_formats(adapter)
     }
 
     pub fn device_features<A: HalApi>(

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3018,7 +3018,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         surface_id: id::SurfaceId,
         adapter_id: id::AdapterId,
     ) -> Result<Vec<TextureFormat>, instance::GetSurfacePreferredFormatError> {
-        profiling::scope!("surface_get_supported_formats");
+        profiling::scope!("Surface::get_supported_formats");
         let hub = A::hub(self);
         let mut token = Token::root();
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -156,17 +156,6 @@ impl Surface {
         &self,
         adapter: &Adapter<A>,
     ) -> Result<Vec<wgt::TextureFormat>, GetSurfacePreferredFormatError> {
-        // Check the four formats mentioned in the WebGPU spec.
-        // Also, prefer sRGB over linear as it is better in
-        // representing perceived colors.
-        let candidate_formats = [
-            wgt::TextureFormat::Bgra8UnormSrgb,
-            wgt::TextureFormat::Rgba8UnormSrgb,
-            wgt::TextureFormat::Bgra8Unorm,
-            wgt::TextureFormat::Rgba8Unorm,
-            wgt::TextureFormat::Rgba16Float,
-        ];
-
         let suf = A::get_surface(self);
         let caps = unsafe {
             profiling::scope!("surface_capabilities");

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -166,10 +166,11 @@ impl Surface {
                 .ok_or(GetSurfacePreferredFormatError::UnsupportedQueueFamily)?
         };
 
-        caps.formats
-            .is_empty()
-            .then(|| caps.formats)
-            .ok_or(GetSurfacePreferredFormatError::NotFound)
+        if caps.formats.is_empty() {
+            return Err(GetSurfacePreferredFormatError::NotFound);
+        }
+
+        Ok(caps.formats)
     }
 }
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -177,16 +177,9 @@ impl Surface {
                 .ok_or(GetSurfacePreferredFormatError::UnsupportedQueueFamily)?
         };
 
-        let supported_formats = candidate_formats
-            .iter()
-            .cloned()
-            .filter(|candidate| caps.formats.contains(candidate))
-            .collect::<Vec<wgt::TextureFormat>>();
-
-        // Error if no formats supported
-        supported_formats
+        caps.formats
             .is_empty()
-            .then(|| supported_formats)
+            .then(|| caps.formats)
             .ok_or(GetSurfacePreferredFormatError::NotFound)
     }
 }

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -198,7 +198,11 @@ fn start<E: Example>(
     let spawner = Spawner::new();
     let mut config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: surface.get_preferred_format(&adapter).unwrap(),
+        format: surface
+            .get_supported_formats(&adapter)
+            .unwrap()
+            .pop()
+            .unwrap(),
         width: size.width,
         height: size.height,
         present_mode: wgpu::PresentMode::Mailbox,

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -198,7 +198,7 @@ fn start<E: Example>(
     let spawner = Spawner::new();
     let mut config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: surface
+        format: *surface
             .get_supported_formats(&adapter)
             .unwrap()
             .first()

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -201,7 +201,7 @@ fn start<E: Example>(
         format: surface
             .get_supported_formats(&adapter)
             .unwrap()
-            .pop()
+            .first()
             .unwrap(),
         width: size.width,
         height: size.height,

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -46,7 +46,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         push_constant_ranges: &[],
     });
 
-    let swapchain_format = surface
+    let swapchain_format = *surface
         .get_supported_formats(&adapter)
         .unwrap()
         .first()

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -46,7 +46,11 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         push_constant_ranges: &[],
     });
 
-    let swapchain_format = surface.get_preferred_format(&adapter).unwrap();
+    let swapchain_format = surface
+        .get_supported_formats(&adapter)
+        .unwrap()
+        .pop()
+        .unwrap();
 
     let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: None,

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -49,7 +49,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
     let swapchain_format = surface
         .get_supported_formats(&adapter)
         .unwrap()
-        .pop()
+        .first()
         .unwrap();
 
     let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -33,7 +33,12 @@ impl ViewportDesc {
 
         let config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format: self.surface.get_preferred_format(adapter).unwrap(),
+            format: self
+                .surface
+                .get_supported_formats(adapter)
+                .unwrap()
+                .pop()
+                .unwrap(),
             width: size.width,
             height: size.height,
             present_mode: wgpu::PresentMode::Fifo,

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -33,7 +33,7 @@ impl ViewportDesc {
 
         let config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format: self
+            format: *self
                 .surface
                 .get_supported_formats(adapter)
                 .unwrap()

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -37,7 +37,7 @@ impl ViewportDesc {
                 .surface
                 .get_supported_formats(adapter)
                 .unwrap()
-                .pop()
+                .first()
                 .unwrap(),
             width: size.width,
             height: size.height,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -932,17 +932,17 @@ impl crate::Context for Context {
         }
     }
 
-    fn surface_get_preferred_format(
+    fn surface_get_supported_formats(
         &self,
         surface: &Self::SurfaceId,
         adapter: &Self::AdapterId,
-    ) -> Option<TextureFormat> {
+    ) -> Option<Vec<TextureFormat>> {
         let global = &self.0;
-        match wgc::gfx_select!(adapter => global.surface_get_preferred_format(surface.id, *adapter))
+        match wgc::gfx_select!(adapter => global.surface_get_supported_formats(surface.id, *adapter))
         {
-            Ok(format) => Some(format),
+            Ok(formats) => Some(formats),
             Err(wgc::instance::GetSurfacePreferredFormatError::UnsupportedQueueFamily) => None,
-            Err(err) => self.handle_error_fatal(err, "Surface::get_preferred_format"),
+            Err(err) => self.handle_error_fatal(err, "Surface::get_supported_formats"),
         }
     }
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1188,12 +1188,12 @@ impl crate::Context for Context {
         format.describe().guaranteed_format_features
     }
 
-    fn surface_get_preferred_format(
+    fn surface_get_supported_formats(
         &self,
         surface: &Self::SurfaceId,
         adapter: &Self::AdapterId,
-    ) -> Option<wgt::TextureFormat> {
-        let format = map_texture_format_from_web_sys(surface.0.get_preferred_format(&adapter.0));
+    ) -> Option<Vec<wgt::TextureFormat>> {
+        let format = map_texture_format_from_web_sys(surface.0.get_supported_formats(&adapter.0));
         Some(format)
     }
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -553,7 +553,7 @@ fn map_texture_format(texture_format: wgt::TextureFormat) -> web_sys::GpuTexture
     }
 }
 
-fn map_texture_format_from_web_sys(
+fn _map_texture_format_from_web_sys(
     texture_format: web_sys::GpuTextureFormat,
 ) -> wgt::TextureFormat {
     use web_sys::GpuTextureFormat as tf;
@@ -1190,11 +1190,16 @@ impl crate::Context for Context {
 
     fn surface_get_supported_formats(
         &self,
-        surface: &Self::SurfaceId,
-        adapter: &Self::AdapterId,
+        _surface: &Self::SurfaceId,
+        _adapter: &Self::AdapterId,
     ) -> Option<Vec<wgt::TextureFormat>> {
-        let format = map_texture_format_from_web_sys(surface.0.get_supported_formats(&adapter.0));
-        Some(format)
+        // https://gpuweb.github.io/gpuweb/#supported-context-formats
+        let formats = vec![
+            wgt::TextureFormat::Bgra8Unorm,
+            wgt::TextureFormat::Rgba8Unorm,
+            wgt::TextureFormat::Rgba16Float,
+        ];
+        Some(formats)
     }
 
     fn surface_configure(

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -553,56 +553,6 @@ fn map_texture_format(texture_format: wgt::TextureFormat) -> web_sys::GpuTexture
     }
 }
 
-fn _map_texture_format_from_web_sys(
-    texture_format: web_sys::GpuTextureFormat,
-) -> wgt::TextureFormat {
-    use web_sys::GpuTextureFormat as tf;
-    use wgt::TextureFormat;
-    match texture_format {
-        tf::R8unorm => TextureFormat::R8Unorm,
-        tf::R8snorm => TextureFormat::R8Snorm,
-        tf::R8uint => TextureFormat::R8Uint,
-        tf::R8sint => TextureFormat::R8Sint,
-        tf::R16uint => TextureFormat::R16Uint,
-        tf::R16sint => TextureFormat::R16Sint,
-        tf::R16float => TextureFormat::R16Float,
-        tf::Rg8unorm => TextureFormat::Rg8Unorm,
-        tf::Rg8snorm => TextureFormat::Rg8Snorm,
-        tf::Rg8uint => TextureFormat::Rg8Uint,
-        tf::Rg8sint => TextureFormat::Rg8Sint,
-        tf::R32uint => TextureFormat::R32Uint,
-        tf::R32sint => TextureFormat::R32Sint,
-        tf::R32float => TextureFormat::R32Float,
-        tf::Rg16uint => TextureFormat::Rg16Uint,
-        tf::Rg16sint => TextureFormat::Rg16Sint,
-        tf::Rg16float => TextureFormat::Rg16Float,
-        tf::Rgba8unorm => TextureFormat::Rgba8Unorm,
-        tf::Rgba8unormSrgb => TextureFormat::Rgba8UnormSrgb,
-        tf::Rgba8snorm => TextureFormat::Rgba8Snorm,
-        tf::Rgba8uint => TextureFormat::Rgba8Uint,
-        tf::Rgba8sint => TextureFormat::Rgba8Sint,
-        tf::Bgra8unorm => TextureFormat::Bgra8Unorm,
-        tf::Bgra8unormSrgb => TextureFormat::Bgra8UnormSrgb,
-        tf::Rgb10a2unorm => TextureFormat::Rgb10a2Unorm,
-        tf::Rg11b10ufloat => TextureFormat::Rg11b10Float,
-        tf::Rg32uint => TextureFormat::Rg32Uint,
-        tf::Rg32sint => TextureFormat::Rg32Sint,
-        tf::Rg32float => TextureFormat::Rg32Float,
-        tf::Rgba16uint => TextureFormat::Rgba16Uint,
-        tf::Rgba16sint => TextureFormat::Rgba16Sint,
-        tf::Rgba16float => TextureFormat::Rgba16Float,
-        tf::Rgba32uint => TextureFormat::Rgba32Uint,
-        tf::Rgba32sint => TextureFormat::Rgba32Sint,
-        tf::Rgba32float => TextureFormat::Rgba32Float,
-        tf::Depth32float => TextureFormat::Depth32Float,
-        tf::Depth32floatStencil8 => TextureFormat::Depth32FloatStencil8,
-        tf::Depth24plus => TextureFormat::Depth24Plus,
-        tf::Depth24plusStencil8 => TextureFormat::Depth24PlusStencil8,
-        tf::Depth24unormStencil8 => TextureFormat::Depth24UnormStencil8,
-        _ => unimplemented!(),
-    }
-}
-
 fn map_texture_component_type(
     sample_type: wgt::TextureSampleType,
 ) -> web_sys::GpuTextureSampleType {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3435,7 +3435,8 @@ impl Drop for SurfaceTexture {
 }
 
 impl Surface {
-    /// Returns an optimal texture format to use for the [`Surface`] with this adapter.
+    /// Returns a vec of supported texture formats to use for the [`Surface`] with this adapter.
+    /// Note: The first format in the vector is preferred
     ///
     /// Returns None if the surface is incompatible with the adapter.
     pub fn get_supported_formats(&self, adapter: &Adapter) -> Option<Vec<TextureFormat>> {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -225,11 +225,11 @@ trait Context: Debug + Send + Sized + Sync {
         format: TextureFormat,
     ) -> TextureFormatFeatures;
 
-    fn surface_get_preferred_format(
+    fn surface_get_supported_formats(
         &self,
         surface: &Self::SurfaceId,
         adapter: &Self::AdapterId,
-    ) -> Option<TextureFormat>;
+    ) -> Option<Vec<TextureFormat>>;
     fn surface_configure(
         &self,
         surface: &Self::SurfaceId,
@@ -3438,8 +3438,8 @@ impl Surface {
     /// Returns an optimal texture format to use for the [`Surface`] with this adapter.
     ///
     /// Returns None if the surface is incompatible with the adapter.
-    pub fn get_preferred_format(&self, adapter: &Adapter) -> Option<TextureFormat> {
-        Context::surface_get_preferred_format(&*self.context, &self.id, &adapter.id)
+    pub fn get_supported_formats(&self, adapter: &Adapter) -> Option<Vec<TextureFormat>> {
+        Context::surface_get_supported_formats(&*self.context, &self.id, &adapter.id)
     }
 
     /// Initializes [`Surface`] for presentation.


### PR DESCRIPTION
**Connections**
Closes #2718

**Description**
Converted everything related to `get_preferred_format -> Option<TextureFormat>` to `get_supported_formats -> Option<Vec<TextureFormat>>`

Converted the web version to return the set of texture formats defined by https://gpuweb.github.io/gpuweb/#supported-context-formats

**Testing**
I ran `cargo nextest run --no-fail-fast`
