### PR TITLE
get_supported_formats: sort like the old get_preferred_format and simplify return type

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -342,8 +342,6 @@ pub enum IsSurfaceSupportedError {
 
 #[derive(Clone, Debug, Error)]
 pub enum GetSurfacePreferredFormatError {
-    #[error("no suitable format found")]
-    NotFound,
     #[error("invalid adapter")]
     InvalidAdapter,
     #[error("invalid surface")]

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -157,7 +157,7 @@ impl Surface {
         adapter: &Adapter<A>,
     ) -> Result<Vec<wgt::TextureFormat>, GetSurfacePreferredFormatError> {
         let suf = A::get_surface(self);
-        let caps = unsafe {
+        let mut caps = unsafe {
             profiling::scope!("surface_capabilities");
             adapter
                 .raw
@@ -166,9 +166,8 @@ impl Surface {
                 .ok_or(GetSurfacePreferredFormatError::UnsupportedQueueFamily)?
         };
 
-        if caps.formats.is_empty() {
-            return Err(GetSurfacePreferredFormatError::NotFound);
-        }
+        // TODO: maybe remove once we support texture view changing srgb-ness
+        caps.formats.sort_by_key(|f| !f.describe().srgb);
 
         Ok(caps.formats)
     }

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -269,11 +269,7 @@ fn start<E: Example>(
     let spawner = Spawner::new();
     let mut config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: *surface
-            .get_supported_formats(&adapter)
-            .unwrap()
-            .first()
-            .unwrap(),
+        format: surface.get_supported_formats(&adapter)[0],
         width: size.width,
         height: size.height,
         present_mode: wgpu::PresentMode::Mailbox,

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -46,11 +46,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         push_constant_ranges: &[],
     });
 
-    let swapchain_format = *surface
-        .get_supported_formats(&adapter)
-        .unwrap()
-        .first()
-        .unwrap();
+    let swapchain_format = surface.get_supported_formats(&adapter)[0];
 
     let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: None,

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -33,12 +33,7 @@ impl ViewportDesc {
 
         let config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format: *self
-                .surface
-                .get_supported_formats(adapter)
-                .unwrap()
-                .first()
-                .unwrap(),
+            format: self.surface.get_supported_formats(adapter)[0],
             width: size.width,
             height: size.height,
             present_mode: wgpu::PresentMode::Fifo,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -962,12 +962,12 @@ impl crate::Context for Context {
         &self,
         surface: &Self::SurfaceId,
         adapter: &Self::AdapterId,
-    ) -> Option<Vec<TextureFormat>> {
+    ) -> Vec<TextureFormat> {
         let global = &self.0;
         match wgc::gfx_select!(adapter => global.surface_get_supported_formats(surface.id, *adapter))
         {
-            Ok(formats) => Some(formats),
-            Err(wgc::instance::GetSurfacePreferredFormatError::UnsupportedQueueFamily) => None,
+            Ok(formats) => formats,
+            Err(wgc::instance::GetSurfacePreferredFormatError::UnsupportedQueueFamily) => vec![],
             Err(err) => self.handle_error_fatal(err, "Surface::get_supported_formats"),
         }
     }

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1142,14 +1142,13 @@ impl crate::Context for Context {
         &self,
         _surface: &Self::SurfaceId,
         _adapter: &Self::AdapterId,
-    ) -> Option<Vec<wgt::TextureFormat>> {
+    ) -> Vec<wgt::TextureFormat> {
         // https://gpuweb.github.io/gpuweb/#supported-context-formats
-        let formats = vec![
+        vec![
             wgt::TextureFormat::Bgra8Unorm,
             wgt::TextureFormat::Rgba8Unorm,
             wgt::TextureFormat::Rgba16Float,
-        ];
-        Some(formats)
+        ]
     }
 
     fn surface_configure(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -229,7 +229,7 @@ trait Context: Debug + Send + Sized + Sync {
         &self,
         surface: &Self::SurfaceId,
         adapter: &Self::AdapterId,
-    ) -> Option<Vec<TextureFormat>>;
+    ) -> Vec<TextureFormat>;
     fn surface_configure(
         &self,
         surface: &Self::SurfaceId,
@@ -3449,8 +3449,8 @@ impl Surface {
     /// Returns a vec of supported texture formats to use for the [`Surface`] with this adapter.
     /// Note: The first format in the vector is preferred
     ///
-    /// Returns None if the surface is incompatible with the adapter.
-    pub fn get_supported_formats(&self, adapter: &Adapter) -> Option<Vec<TextureFormat>> {
+    /// Returns an empty vector if the surface is incompatible with the adapter.
+    pub fn get_supported_formats(&self, adapter: &Adapter) -> Vec<TextureFormat> {
         Context::surface_get_supported_formats(&*self.context, &self.id, &adapter.id)
     }
 


### PR DESCRIPTION
**Connections**
Follow up to #2783 . Alternative to #2785 .

**Description**
Makes the first returned format the same as the old get_preferred_format. Simplifies the return type, and consequently the examples/

**Testing**
Ran some examples.