### PR TITLE
fix BufferMapCallbackC & SubmittedWorkDoneClosureC

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -30,8 +30,8 @@ const WRITE_COMMAND_BUFFERS_PER_POOL: usize = 64;
 
 #[repr(C)]
 pub struct SubmittedWorkDoneClosureC {
-    callback: unsafe extern "C" fn(user_data: *mut u8),
-    user_data: *mut u8,
+    pub callback: unsafe extern "C" fn(user_data: *mut u8),
+    pub user_data: *mut u8,
 }
 
 unsafe impl Send for SubmittedWorkDoneClosureC {}

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -47,8 +47,8 @@ unsafe impl<A: hal::Api> Sync for BufferMapState<A> {}
 
 #[repr(C)]
 pub struct BufferMapCallbackC {
-    callback: unsafe extern "C" fn(status: BufferMapAsyncStatus, user_data: *mut u8),
-    user_data: *mut u8,
+    pub callback: unsafe extern "C" fn(status: BufferMapAsyncStatus, user_data: *mut u8),
+    pub user_data: *mut u8,
 }
 
 unsafe impl Send for BufferMapCallbackC {}


### PR DESCRIPTION
**Description**
Trivial changes,  makes `BufferMapCallbackC` & `SubmittedWorkDoneClosureC` usable


**Testing**
tested locally with `wgpu-native`
