### PR TITLE
Fix formatting of `TextureDimensionError::LimitExceeded`.

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -330,7 +330,7 @@ pub enum TextureErrorDimension {
 pub enum TextureDimensionError {
     #[error("Dimension {0:?} is zero")]
     Zero(TextureErrorDimension),
-    #[error("Dimension {0:?} value {given} exceeds the limit of {limit}")]
+    #[error("Dimension {dim:?} value {given} exceeds the limit of {limit}")]
     LimitExceeded {
         dim: TextureErrorDimension,
         given: u32,


### PR DESCRIPTION
**Description**
in the thiserror error format string, `{0:?}` ends up referring to the first named argument, not the first struct field or a compile error, so the error was incorrectly

>    Dimension 32768 value 32768 exceeds the limit of 16384

instead of

>    Dimension X value 32768 exceeds the limit of 16384

I did not find any other occurrences of this mistake in the source code.

**Testing**
Manually tested by modifying an example to throw this error. I did not notice any other error message tests, so I didn't add one, but I'm happy to do so if that would be desired.
