### PR TITLE
Add create_texture_error

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3323,6 +3323,18 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         fid.assign_error(label.borrow_or_default(), &mut token);
     }
 
+    /// Assign `id_in` an error with the given `label`.
+    ///
+    /// See `create_buffer_error` for more context and explaination.
+    pub fn create_texture_error<A: HalApi>(&self, id_in: Input<G, id::TextureId>, label: Label) {
+        let hub = A::hub(self);
+        let mut token = Token::root();
+        let fid = hub.textures.prepare(id_in);
+
+        let (_, mut token) = hub.devices.read(&mut token);
+        fid.assign_error(label.borrow_or_default(), &mut token);
+    }
+
     #[cfg(feature = "replay")]
     pub fn device_wait_for_buffer<A: HalApi>(
         &self,


### PR DESCRIPTION
**Description**

Firefox needs it to implement WebGPU's error model (see create_buffer_error). The WebGPU specification allows texture descriptors that are not allowed by wgpu's TextureDescriptor type such as the `usage`  bitfield. Firefox takes care of validating these special cases, however the invalid textures have to be registered which is done via this method. See also `create_buffer_error`. 


**Testing**

None.