### PR TITLE
Force binding sizes to be multiples of 16 on webgl

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2807,6 +2807,14 @@ impl<A: HalApi> Device<A> {
             self.require_features(wgt::Features::MULTIVIEW)?;
         }
 
+        for size in shader_binding_sizes.values() {
+            if size.get() % 16 != 0 {
+                self.require_downlevel_flags(
+                    wgt::DownlevelFlags::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED,
+                )?;
+            }
+        }
+
         let late_sized_buffer_groups =
             Device::make_late_sized_buffer_groups(&shader_binding_sizes, layout, &*bgl_guard);
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -212,6 +212,9 @@ impl super::Adapter {
             naga::back::glsl::Version::Embedded(value)
         };
 
+        // ANGLE provides renderer strings like: "ANGLE (Apple, Apple M1 Pro, OpenGL 4.1)"
+        let is_angle = renderer.contains("ANGLE");
+
         let vertex_shader_storage_blocks = if supports_storage {
             gl.get_parameter_i32(glow::MAX_VERTEX_SHADER_STORAGE_BLOCKS) as u32
         } else {
@@ -288,6 +291,10 @@ impl super::Adapter {
         downlevel_flags.set(
             wgt::DownlevelFlags::ANISOTROPIC_FILTERING,
             extensions.contains("EXT_texture_filter_anisotropic"),
+        );
+        downlevel_flags.set(
+            wgt::DownlevelFlags::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED,
+            !(cfg!(target_arch = "wasm32") || is_angle),
         );
 
         let is_ext_color_buffer_float_supported = extensions.contains("EXT_color_buffer_float");

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1039,6 +1039,11 @@ bitflags::bitflags! {
         /// Supports all the texture usages described in WebGPU. If this isn't supported, you
         /// should call `get_texture_format_features` to get how you can use textures of a given format
         const WEBGPU_TEXTURE_FORMAT_SUPPORT = 1 << 14;
+
+        /// Supports buffer bindings with sizes that aren't a multiple of 16.
+        ///
+        /// WebGL doesn't support this.
+        const BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED = 1 << 15;
     }
 }
 


### PR DESCRIPTION
**Connections**

Fixes #2072 
Fixes #2573 

**Description**

This adds a down level feature that forces all sizes in buffers.

**Testing**

Untested
