### PR TITLE
Properly Barrier Compute Indirect Buffers

### DIFF
--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -715,7 +715,7 @@ impl<A: hub::HalApi> Tracker<A> {
         bind_group: &BindGroupStates<A>,
     ) {
         self.buffers
-            .set_and_remove_from_usage_scope_sparse(&mut scope.buffers, &bind_group.buffers);
+            .set_and_remove_from_usage_scope_sparse(&mut scope.buffers, bind_group.buffers.used());
         self.textures.set_and_remove_from_usage_scope_sparse(
             textures,
             &mut scope.textures,


### PR DESCRIPTION
**Connections**

Fixes #2728

**Description**

Just never issues the transition for the indirect buffer if it wasn't used in a bind group too.

**Testing**

Against DX12 validation layers.
