### PR TITLE
egl: recreate Wayland context if X surface is supplied

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -764,6 +764,7 @@ impl crate::Instance<super::Api> for Instance {
         let mut inner = self.inner.lock();
 
         match raw_window_handle {
+            #[cfg(not(feature = "emscripten"))]
             Rwh::Xlib(handle) => {
                 // If Wayland EGLDisplay was created, but we got an X window, recreate the context
                 // https://github.com/gfx-rs/wgpu/issues/2762

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -790,9 +790,7 @@ impl crate::Instance<super::Api> for Instance {
                         display,
                         WindowSystemInterface {
                             kind: WindowKind::X11,
-                            library: libloading::Library::new("libX11.so")
-                                .ok()
-                                .map(|x| Arc::new(x)),
+                            library: libloading::Library::new("libX11.so").ok().map(Arc::new),
                         },
                     )
                     .map_err(|_| crate::InstanceError)?;


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_
Fixes #2762

**Description**
_Describe what problem this is solving, and how it's solved._
When user has libwayland and WAYLAND_DISPLAY, wgpu creates EGLDisplay using EGL_PLATFORM_WAYLAND_KHR, which is incompatible with X windows. However, application might use X in Wayland environment, and so its surface will have incompatible type thus leading to panic. In this case reinitialize the EGLDisplay with EGL_PLATFORM_X11_KHR.

**Testing**
_Explain how this change is tested._
WINIT_UNIX_BACKEND=x11