### PR TITLE
Replace android-properties with android_system_properties.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,16 +35,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-properties"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
-
-[[package]]
 name = "android_glue"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40906ab18de39e789f964079c6cee50adfb8290fc17bc87f4df76057edc47368"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anyhow"
@@ -2112,7 +2115,7 @@ dependencies = [
 name = "wgpu-hal"
 version = "0.12.0"
 dependencies = [
- "android-properties",
+ "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -91,7 +91,7 @@ web-sys = { version = "0.3", features = ["Window", "HtmlCanvasElement", "WebGl2R
 js-sys = { version = "0.3" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android-properties = "0.2"
+android_system_properties = "0.1.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -573,9 +573,9 @@ impl crate::Instance<super::Api> for super::Instance {
 
         #[cfg(target_os = "android")]
         let android_sdk_version = {
+            let properties = android_system_properties::AndroidSystemProperties::new();
             // See: https://developer.android.com/reference/android/os/Build.VERSION_CODES
-            let mut prop = android_properties::getprop("ro.build.version.sdk");
-            if let Some(val) = prop.value() {
+            if let Some(val) = properties.get("ro.build.version.sdk") {
                 match val.parse::<u32>() {
                     Ok(sdk_ver) => sdk_ver,
                     Err(err) => {


### PR DESCRIPTION
Fixes #2805.

**Description**

`android-properties` use statically linked Android libc symbols while `android_system_properties` loads them dynamically. This is required to support old and new versions of Android with the same binary. It unblocks updating wgpu in Gecko.

In its current version, `android_system_properties` supports exactly what wgpu needs and nothing more, which makes it easy to audit, don't hesitate to give it a critical look: https://github.com/nical/android_system_properties/blob/00c55a5a871e3fc6d9b133f96bf6d74c8e1927cf/src/lib.rs and report concerns here or in an issue on the repo.

I heared back from the `android-properties` crate author yet in my PR their repo and I can't afford to wait for too long as this blocks a lot of work on the Firefox side. So I ended up putting together an alternative crate (the PR was already pretty much an entire rewrite). I'll be happy to move wgpu back to `android_properties` if/when things can be resolved there (and yank the whole `android_system_properties` crate.

**Testing**

I tested it manually on a device, however it is a bit hard to automate. This doesn't change the test coverage as far as wgpu is concerned.

