### PR TITLE
Use numeric constants to define `wgpu_types::Features` values.

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -174,7 +174,7 @@ bitflags::bitflags! {
     #[derive(Default)]
     pub struct Features: u64 {
         //
-        // ---- Start numbering at 1 << 0, each one defined in terms of the last ----
+        // ---- Start numbering at 1 << 0 ----
         //
         // WebGPU features:
         //
@@ -199,7 +199,7 @@ bitflags::bitflags! {
         /// - Metal (Macs with amd GPUs)
         ///
         /// This is a web and native feature.
-        const DEPTH24UNORM_STENCIL8 = Self::DEPTH_CLIP_CONTROL.bits << 1;
+        const DEPTH24UNORM_STENCIL8 = 1 << 1;
         /// Allows for explicit creation of textures of format [`TextureFormat::Depth32FloatStencil8`]
         ///
         /// Supported platforms:
@@ -208,7 +208,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a web and native feature.
-        const DEPTH32FLOAT_STENCIL8 = Self::DEPTH24UNORM_STENCIL8.bits << 1;
+        const DEPTH32FLOAT_STENCIL8 = 1 << 2;
         /// Enables BCn family of compressed textures. All BCn textures use 4x4 pixel blocks
         /// with 8 or 16 bytes per block.
         ///
@@ -222,7 +222,7 @@ bitflags::bitflags! {
         /// - desktops
         ///
         /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_BC = Self::DEPTH32FLOAT_STENCIL8.bits << 1;
+        const TEXTURE_COMPRESSION_BC = 1 << 3;
         /// Enables ETC family of compressed textures. All ETC textures use 4x4 pixel blocks.
         /// ETC2 RGB and RGBA1 are 8 bytes per block. RTC2 RGBA8 and EAC are 16 bytes per block.
         ///
@@ -237,7 +237,7 @@ bitflags::bitflags! {
         /// - Mobile (some)
         ///
         /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_ETC2 = Self::TEXTURE_COMPRESSION_BC.bits << 1;
+        const TEXTURE_COMPRESSION_ETC2 = 1 << 4;
         /// Enables ASTC family of compressed textures. ASTC textures use pixel blocks varying from 4x4 to 12x12.
         /// Blocks are always 16 bytes.
         ///
@@ -252,7 +252,7 @@ bitflags::bitflags! {
         /// - Mobile (some)
         ///
         /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_ASTC_LDR = Self::TEXTURE_COMPRESSION_ETC2.bits << 1;
+        const TEXTURE_COMPRESSION_ASTC_LDR = 1 << 5;
         /// Allows non-zero value for the "first instance" in indirect draw calls.
         ///
         /// Supported Platforms:
@@ -261,7 +261,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a web and native feature.
-        const INDIRECT_FIRST_INSTANCE = Self::TEXTURE_COMPRESSION_ASTC_LDR.bits << 1;
+        const INDIRECT_FIRST_INSTANCE = 1 << 6;
         /// Enables use of Timestamp Queries. These queries tell the current gpu timestamp when
         /// all work before the query is finished. Call [`CommandEncoder::write_timestamp`],
         /// [`RenderPassEncoder::write_timestamp`], or [`ComputePassEncoder::write_timestamp`] to
@@ -279,7 +279,7 @@ bitflags::bitflags! {
         /// - DX12 (works)
         ///
         /// This is a web and native feature.
-        const TIMESTAMP_QUERY = Self::INDIRECT_FIRST_INSTANCE.bits << 1;
+        const TIMESTAMP_QUERY = 1 << 7;
         /// Enables use of Pipeline Statistics Queries. These queries tell the count of various operations
         /// performed between the start and stop call. Call [`RenderPassEncoder::begin_pipeline_statistics_query`] to start
         /// a query, then call [`RenderPassEncoder::end_pipeline_statistics_query`] to stop one.
@@ -294,7 +294,7 @@ bitflags::bitflags! {
         /// - DX12 (works)
         ///
         /// This is a web and native feature.
-        const PIPELINE_STATISTICS_QUERY = Self::TIMESTAMP_QUERY.bits << 1;
+        const PIPELINE_STATISTICS_QUERY = 1 << 8;
         /// Allows shaders to acquire the FP16 ability
         ///
         /// Note: this is not supported in naga yet，only through spir-v passthrough right now.
@@ -304,7 +304,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a web and native feature.
-        const SHADER_FLOAT16 = Self::PIPELINE_STATISTICS_QUERY.bits << 1;
+        const SHADER_FLOAT16 = 1 << 9;
 
         //
         // ---- Restart Numbering for Native Features ---
@@ -342,7 +342,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const TEXTURE_BINDING_ARRAY = Self::MAPPABLE_PRIMARY_BUFFERS.bits << 1;
+        const TEXTURE_BINDING_ARRAY = 1 << 17;
         /// Allows the user to create arrays of buffers in shaders:
         ///
         /// eg. `uniform myBuffer { .... } buffer_array[10]`.
@@ -360,7 +360,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const BUFFER_BINDING_ARRAY = Self::TEXTURE_BINDING_ARRAY.bits << 1;
+        const BUFFER_BINDING_ARRAY = 1 << 18;
         /// Allows the user to create uniform arrays of storage buffers or textures in shaders,
         /// if resp. [`Features::BUFFER_BINDING_ARRAY`] or [`Features::TEXTURE_BINDING_ARRAY`]
         /// is supported.
@@ -373,7 +373,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const STORAGE_RESOURCE_BINDING_ARRAY = Self::BUFFER_BINDING_ARRAY.bits << 1;
+        const STORAGE_RESOURCE_BINDING_ARRAY = 1 << 19;
         /// Allows shaders to index sampled texture and storage buffer resource arrays with dynamically non-uniform values:
         ///
         /// eg. `texture_array[vertex_data]`
@@ -398,7 +398,7 @@ bitflags::bitflags! {
         /// - Vulkan 1.2+ (or VK_EXT_descriptor_indexing)'s shaderSampledImageArrayNonUniformIndexing & shaderStorageBufferArrayNonUniformIndexing feature)
         ///
         /// This is a native only feature.
-        const SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING = Self::STORAGE_RESOURCE_BINDING_ARRAY.bits << 1;
+        const SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING = 1 << 20;
         /// Allows shaders to index uniform buffer and storage texture resource arrays with dynamically non-uniform values:
         ///
         /// eg. `texture_array[vertex_data]`
@@ -423,11 +423,11 @@ bitflags::bitflags! {
         /// - Vulkan 1.2+ (or VK_EXT_descriptor_indexing)'s shaderUniformBufferArrayNonUniformIndexing & shaderStorageTextureArrayNonUniformIndexing feature)
         ///
         /// This is a native only feature.
-        const UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING = Self::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING.bits << 1;
+        const UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING = 1 << 21;
         /// Allows the user to create bind groups continaing arrays with less bindings than the BindGroupLayout.
         ///
         /// This is a native only feature.
-        const PARTIALLY_BOUND_BINDING_ARRAY = Self::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING.bits << 1;
+        const PARTIALLY_BOUND_BINDING_ARRAY = 1 << 22;
         /// Allows the user to call [`RenderPass::multi_draw_indirect`] and [`RenderPass::multi_draw_indexed_indirect`].
         ///
         /// Allows multiple indirect calls to be dispatched from a single buffer.
@@ -438,7 +438,7 @@ bitflags::bitflags! {
         /// - Metal (Emulated on top of `draw_indirect` and `draw_indexed_indirect`)
         ///
         /// This is a native only feature.
-        const MULTI_DRAW_INDIRECT = Self::PARTIALLY_BOUND_BINDING_ARRAY.bits << 1;
+        const MULTI_DRAW_INDIRECT = 1 << 23;
         /// Allows the user to call [`RenderPass::multi_draw_indirect_count`] and [`RenderPass::multi_draw_indexed_indirect_count`].
         ///
         /// This allows the use of a buffer containing the actual number of draw calls.
@@ -448,7 +448,7 @@ bitflags::bitflags! {
         /// - Vulkan 1.2+ (or VK_KHR_draw_indirect_count)
         ///
         /// This is a native only feature.
-        const MULTI_DRAW_INDIRECT_COUNT = Self::MULTI_DRAW_INDIRECT.bits << 1;
+        const MULTI_DRAW_INDIRECT_COUNT = 1 << 24;
         /// Allows the use of push constants: small, fast bits of memory that can be updated
         /// inside a [`RenderPass`].
         ///
@@ -465,7 +465,7 @@ bitflags::bitflags! {
         /// - OpenGL (emulated with uniforms)
         ///
         /// This is a native only feature.
-        const PUSH_CONSTANTS = Self::MULTI_DRAW_INDIRECT_COUNT.bits << 1;
+        const PUSH_CONSTANTS = 1 << 25;
         /// Allows the use of [`AddressMode::ClampToBorder`] with a border color
         /// other than [`SamplerBorderColor::Zero`].
         ///
@@ -477,7 +477,7 @@ bitflags::bitflags! {
         /// - OpenGL
         ///
         /// This is a web and native feature.
-        const ADDRESS_MODE_CLAMP_TO_BORDER = Self::PUSH_CONSTANTS.bits << 1;
+        const ADDRESS_MODE_CLAMP_TO_BORDER = 1 << 26;
         /// Allows the user to set [`PolygonMode::Line`] in [`PrimitiveState::polygon_mode`]
         ///
         /// This allows drawing polygons/triangles as lines (wireframe) instead of filled
@@ -488,7 +488,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const POLYGON_MODE_LINE = Self::ADDRESS_MODE_CLAMP_TO_BORDER.bits << 1;
+        const POLYGON_MODE_LINE = 1 << 27;
         /// Allows the user to set [`PolygonMode::Point`] in [`PrimitiveState::polygon_mode`]
         ///
         /// This allows only drawing the vertices of polygons/triangles instead of filled
@@ -498,7 +498,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const POLYGON_MODE_POINT = Self::POLYGON_MODE_LINE.bits << 1;
+        const POLYGON_MODE_POINT = 1 << 28;
         /// Enables device specific texture format features.
         ///
         /// See `TextureFormatFeatures` for a listing of the features in question.
@@ -510,7 +510,7 @@ bitflags::bitflags! {
         /// This extension does not enable additional formats.
         ///
         /// This is a native-only feature.
-        const TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = Self::POLYGON_MODE_POINT.bits << 1;
+        const TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 1 << 29;
         /// Enables 64-bit floating point types in SPIR-V shaders.
         ///
         /// Note: even when supported by GPU hardware, 64-bit floating point operations are
@@ -520,7 +520,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native-only feature.
-        const SHADER_FLOAT64 = Self::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES.bits << 1;
+        const SHADER_FLOAT64 = 1 << 30;
         /// Enables using 64-bit types for vertex attributes.
         ///
         /// Requires SHADER_FLOAT64.
@@ -528,7 +528,7 @@ bitflags::bitflags! {
         /// Supported Platforms: N/A
         ///
         /// This is a native-only feature.
-        const VERTEX_ATTRIBUTE_64BIT = Self::SHADER_FLOAT64.bits << 1;
+        const VERTEX_ATTRIBUTE_64BIT = 1 << 31;
         /// Allows the user to set a overestimation-conservative-rasterization in [`PrimitiveState::conservative`]
         ///
         /// Processing of degenerate triangles/lines is hardware specific.
@@ -538,7 +538,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const CONSERVATIVE_RASTERIZATION = Self::VERTEX_ATTRIBUTE_64BIT.bits << 1;
+        const CONSERVATIVE_RASTERIZATION = 1 << 32;
         /// Enables bindings of writable storage buffers and textures visible to vertex shaders.
         ///
         /// Note: some (tiled-based) platforms do not support vertex shaders with any side-effects.
@@ -547,14 +547,14 @@ bitflags::bitflags! {
         /// - All
         ///
         /// This is a native-only feature.
-        const VERTEX_WRITABLE_STORAGE = Self::CONSERVATIVE_RASTERIZATION.bits << 1;
+        const VERTEX_WRITABLE_STORAGE = 1 << 33;
         /// Enables clear to zero for textures.
         ///
         /// Supported platforms:
         /// - All
         ///
         /// This is a native only feature.
-        const CLEAR_TEXTURE = Self::VERTEX_WRITABLE_STORAGE.bits << 1;
+        const CLEAR_TEXTURE = 1 << 34;
         /// Enables creating shader modules from SPIR-V binary data (unsafe).
         ///
         /// SPIR-V data is not parsed or interpreted in any way; you can use
@@ -566,7 +566,7 @@ bitflags::bitflags! {
         /// Vulkan implementation.
         ///
         /// This is a native only feature.
-        const SPIRV_SHADER_PASSTHROUGH = Self::CLEAR_TEXTURE.bits << 1;
+        const SPIRV_SHADER_PASSTHROUGH = 1 << 35;
         /// Enables `builtin(primitive_index)` in fragment shaders.
         ///
         /// Note: enables geometry processing for pipelines using the builtin.
@@ -577,14 +577,14 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const SHADER_PRIMITIVE_INDEX = Self::SPIRV_SHADER_PASSTHROUGH.bits << 1;
+        const SHADER_PRIMITIVE_INDEX = 1 << 36;
         /// Enables multiview render passes and `builtin(view_index)` in vertex shaders.
         ///
         /// Supported platforms:
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const MULTIVIEW = Self::SHADER_PRIMITIVE_INDEX.bits << 1;
+        const MULTIVIEW = 1 << 37;
         /// Enables normalized `16-bit` texture formats.
         ///
         /// Supported platforms:
@@ -593,7 +593,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const TEXTURE_FORMAT_16BIT_NORM = Self::MULTIVIEW.bits << 1;
+        const TEXTURE_FORMAT_16BIT_NORM = 1 << 38;
         /// Allows the use of [`AddressMode::ClampToBorder`] with a border color
         /// of [`SamplerBorderColor::Zero`].
         ///
@@ -605,7 +605,7 @@ bitflags::bitflags! {
         /// - OpenGL
         ///
         /// This is a native only feature.
-        const ADDRESS_MODE_CLAMP_TO_ZERO = Self::TEXTURE_FORMAT_16BIT_NORM.bits << 1;
+        const ADDRESS_MODE_CLAMP_TO_ZERO = 1 << 39;
         /// Enables ASTC HDR family of compressed textures.
         ///
         /// Compressed textures sacrifice some quality in exchange for significantly reduced
@@ -618,7 +618,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a native-only feature.
-        const TEXTURE_COMPRESSION_ASTC_HDR = Self::ADDRESS_MODE_CLAMP_TO_ZERO.bits << 1;
+        const TEXTURE_COMPRESSION_ASTC_HDR = 1 << 40;
         /// Allows for timestamp queries inside renderpasses. Metal does not allow this
         /// on Apple GPUs.
         ///
@@ -628,7 +628,7 @@ bitflags::bitflags! {
         /// - Vulkan
         /// - DX12
         /// - Metal (Intel and AMD GPUs)
-        const WRITE_TIMESTAMP_INSIDE_PASSES = Self::TEXTURE_COMPRESSION_ASTC_HDR.bits << 1;
+        const WRITE_TIMESTAMP_INSIDE_PASSES = 1 << 41;
     }
 }
 


### PR DESCRIPTION
As an incidental change, wgpu#2802 (de5fe90f2) changed the definitions of the bitflags in `wgpu_types::Features` from looking like this:

    const DEPTH24UNORM_STENCIL8 = 1 << 1;

to this:

    const DEPTH24UNORM_STENCIL8 = Self::DEPTH_CLIP_CONTROL.bits << 1;

The intention was to make it easier to insert new flags at a logical point in the list, and have the numbers automatically update themselves.

Unfortunately, `cbindgen` can't cope with the new style of definition. It produces definitions for these flags that look like this:

    #define WGPUFeatures_DEPTH24UNORM_STENCIL8 (uint64_t)((WGPUFeatures_DEPTH_CLIP_CONTROL).bits << 1)

These are integer values, so the `.bits` field access is bogus.

This commit changes the definitions back to using direct numbering, which `cbindgen` doesn't choke on.
