### PR TITLE
core: restrict hal::TextureUses::COLOR_TARGET condition within create_texture

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -818,8 +818,8 @@ impl<A: HalApi> Device<A> {
                 if format_features
                     .allowed_usages
                     .contains(wgt::TextureUsages::RENDER_ATTACHMENT)
-                    && desc.dimension != wgt::TextureDimension::D3
-                // Render targets into 3D textures are not
+                    && desc.dimension == wgt::TextureDimension::D2
+                // Render targets dimension must be 2d
                 {
                     hal::TextureUses::COLOR_TARGET
                 } else {


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/2794

**Description**
The WebGPU Spec says:
> A [GPUTextureView](https://gpuweb.github.io/gpuweb/#gputextureview) view is a renderable texture view if the following requirements are met:
view.[[[texture]]](https://gpuweb.github.io/gpuweb/#dom-gputextureview-texture-slot).[usage](https://gpuweb.github.io/gpuweb/#dom-gputexture-usage) must contain [RENDER_ATTACHMENT](https://gpuweb.github.io/gpuweb/#dom-gputextureusage-render_attachment).
descriptor.[dimension](https://gpuweb.github.io/gpuweb/#dom-gputextureviewdescriptor-dimension) must be ["2d"](https://gpuweb.github.io/gpuweb/#dom-gputextureviewdimension-2d).

So that failure was more about alignment with spec.

**Testing**
Tested on macOS with `METAL_DEVICE_WRAPPER_TYPE=1 cargo nextest run --all --no-fail-fast`