### PR TITLE
Flip span labels to work better with tools

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -328,7 +328,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         base: BasePassRef<ComputeCommand>,
     ) -> Result<(), ComputePassError> {
-        profiling::scope!("run_compute_pass", "CommandEncoder");
+        profiling::scope!("CommandEncoder::run_compute_pass");
         let init_scope = PassErrorScope::Pass(encoder_id);
 
         let hub = A::hub(self);

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -341,7 +341,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         _desc: &wgt::CommandBufferDescriptor<Label>,
     ) -> (id::CommandBufferId, Option<CommandEncoderError>) {
-        profiling::scope!("finish", "CommandEncoder");
+        profiling::scope!("CommandEncoder::finish");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -374,7 +374,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) -> Result<(), CommandEncoderError> {
-        profiling::scope!("push_debug_group", "CommandEncoder");
+        profiling::scope!("CommandEncoder::push_debug_group");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -399,7 +399,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) -> Result<(), CommandEncoderError> {
-        profiling::scope!("insert_debug_marker", "CommandEncoder");
+        profiling::scope!("CommandEncoder::insert_debug_marker");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -423,7 +423,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         encoder_id: id::CommandEncoderId,
     ) -> Result<(), CommandEncoderError> {
-        profiling::scope!("pop_debug_marker", "CommandEncoder");
+        profiling::scope!("CommandEncoder::pop_debug_marker");
 
         let hub = A::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -653,7 +653,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
         buffer_guard: &'a Storage<Buffer<A>, id::BufferId>,
         texture_guard: &'a Storage<Texture<A>, id::TextureId>,
     ) -> Result<Self, RenderPassErrorInner> {
-        profiling::scope!("start", "RenderPassInfo");
+        profiling::scope!("RenderPassInfo::start");
 
         // We default to false intentionally, even if depth-stencil isn't used at all.
         // This allows us to use the primary raw pipeline in `RenderPipeline`,
@@ -998,7 +998,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
         raw: &mut A::CommandEncoder,
         texture_guard: &Storage<Texture<A>, id::TextureId>,
     ) -> Result<(UsageScope<A>, SurfacesInDiscardState), RenderPassErrorInner> {
-        profiling::scope!("finish", "RenderPassInfo");
+        profiling::scope!("RenderPassInfo::finish");
         unsafe {
             raw.end_render_pass();
         }
@@ -1091,7 +1091,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         color_attachments: &[Option<RenderPassColorAttachment>],
         depth_stencil_attachment: Option<&RenderPassDepthStencilAttachment>,
     ) -> Result<(), RenderPassError> {
-        profiling::scope!("run_render_pass", "CommandEncoder");
+        profiling::scope!("CommandEncoder::run_render_pass");
         let init_scope = PassErrorScope::Pass(encoder_id);
 
         let hub = A::hub(self);

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -493,7 +493,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination_offset: BufferAddress,
         size: BufferAddress,
     ) -> Result<(), CopyError> {
-        profiling::scope!("copy_buffer_to_buffer", "CommandEncoder");
+        profiling::scope!("CommandEncoder::copy_buffer_to_buffer");
 
         if source == destination {
             return Err(TransferError::SameSourceDestinationBuffer.into());
@@ -617,7 +617,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &ImageCopyTexture,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
-        profiling::scope!("copy_buffer_to_texture", "CommandEncoder");
+        profiling::scope!("CommandEncoder::copy_buffer_to_texture");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -744,7 +744,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &ImageCopyBuffer,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
-        profiling::scope!("copy_texture_to_buffer", "CommandEncoder");
+        profiling::scope!("CommandEncoder::copy_texture_to_buffer");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -888,7 +888,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         destination: &ImageCopyTexture,
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
-        profiling::scope!("copy_texture_to_texture", "CommandEncoder");
+        profiling::scope!("CommandEncoder::copy_texture_to_texture");
 
         let hub = A::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -417,7 +417,7 @@ impl<A: hal::Api> LifetimeTracker<A> {
     }
 
     pub fn cleanup(&mut self, device: &A::Device) {
-        profiling::scope!("cleanup", "LifetimeTracker");
+        profiling::scope!("LifetimeTracker::cleanup");
         unsafe {
             self.free_resources.clean(device);
         }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -445,7 +445,7 @@ impl<A: HalApi> Device<A> {
         maintain: wgt::Maintain<queue::WrappedSubmissionIndex>,
         token: &mut Token<'token, Self>,
     ) -> Result<(UserClosures, bool), WaitIdleError> {
-        profiling::scope!("maintain", "Device");
+        profiling::scope!("Device::maintain");
         let mut life_tracker = self.lock_life(token);
 
         // Normally, `temp_suspected` exists only to save heap
@@ -3195,7 +3195,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &resource::BufferDescriptor,
         id_in: Input<G, id::BufferId>,
     ) -> (id::BufferId, Option<resource::CreateBufferError>) {
-        profiling::scope!("create_buffer", "Device");
+        profiling::scope!("Device::create_buffer");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -3393,7 +3393,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         data: &[u8],
     ) -> Result<(), resource::BufferAccessError> {
-        profiling::scope!("set_buffer_sub_data", "Device");
+        profiling::scope!("Device::set_buffer_sub_data");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -3450,7 +3450,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         data: &mut [u8],
     ) -> Result<(), resource::BufferAccessError> {
-        profiling::scope!("get_buffer_sub_data", "Device");
+        profiling::scope!("Device::get_buffer_sub_data");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -3496,7 +3496,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         buffer_id: id::BufferId,
     ) -> Result<(), resource::DestroyError> {
-        profiling::scope!("destroy", "Buffer");
+        profiling::scope!("Buffer::destroy");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -3537,7 +3537,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn buffer_drop<A: HalApi>(&self, buffer_id: id::BufferId, wait: bool) {
-        profiling::scope!("drop", "Buffer");
+        profiling::scope!("Buffer::drop");
         log::debug!("buffer {:?} is dropped", buffer_id);
 
         let hub = A::hub(self);
@@ -3590,7 +3590,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &resource::TextureDescriptor,
         id_in: Input<G, id::TextureId>,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
-        profiling::scope!("create_texture", "Device");
+        profiling::scope!("Device::create_texture");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -3645,7 +3645,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &resource::TextureDescriptor,
         id_in: Input<G, id::TextureId>,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
-        profiling::scope!("create_texture", "Device");
+        profiling::scope!("Device::create_texture");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -3717,7 +3717,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         texture_id: id::TextureId,
     ) -> Result<(), resource::DestroyError> {
-        profiling::scope!("destroy", "Texture");
+        profiling::scope!("Texture::destroy");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -3775,7 +3775,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn texture_drop<A: HalApi>(&self, texture_id: id::TextureId, wait: bool) {
-        profiling::scope!("drop", "Texture");
+        profiling::scope!("Texture::drop");
         log::debug!("texture {:?} is dropped", texture_id);
 
         let hub = A::hub(self);
@@ -3829,7 +3829,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &resource::TextureViewDescriptor,
         id_in: Input<G, id::TextureViewId>,
     ) -> (id::TextureViewId, Option<resource::CreateTextureViewError>) {
-        profiling::scope!("create_view", "Texture");
+        profiling::scope!("Texture::create_view");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -3876,7 +3876,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         texture_view_id: id::TextureViewId,
         wait: bool,
     ) -> Result<(), resource::TextureViewDestroyError> {
-        profiling::scope!("drop", "TextureView");
+        profiling::scope!("TextureView::drop");
         log::debug!("texture view {:?} is dropped", texture_view_id);
 
         let hub = A::hub(self);
@@ -3926,7 +3926,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &resource::SamplerDescriptor,
         id_in: Input<G, id::SamplerId>,
     ) -> (id::SamplerId, Option<resource::CreateSamplerError>) {
-        profiling::scope!("create_sampler", "Device");
+        profiling::scope!("Device::create_sampler");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -3966,7 +3966,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn sampler_drop<A: HalApi>(&self, sampler_id: id::SamplerId) {
-        profiling::scope!("drop", "Sampler");
+        profiling::scope!("Sampler::drop");
         log::debug!("sampler {:?} is dropped", sampler_id);
 
         let hub = A::hub(self);
@@ -4004,7 +4004,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::BindGroupLayoutId,
         Option<binding_model::CreateBindGroupLayoutError>,
     ) {
-        profiling::scope!("create_bind_group_layout", "Device");
+        profiling::scope!("Device::create_bind_group_layout");
 
         let mut token = Token::root();
         let hub = A::hub(self);
@@ -4066,7 +4066,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn bind_group_layout_drop<A: HalApi>(&self, bind_group_layout_id: id::BindGroupLayoutId) {
-        profiling::scope!("drop", "BindGroupLayout");
+        profiling::scope!("BindGroupLayout::drop");
         log::debug!("bind group layout {:?} is dropped", bind_group_layout_id);
 
         let hub = A::hub(self);
@@ -4100,7 +4100,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::PipelineLayoutId,
         Option<binding_model::CreatePipelineLayoutError>,
     ) {
-        profiling::scope!("create_pipeline_layout", "Device");
+        profiling::scope!("Device::create_pipeline_layout");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -4140,7 +4140,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn pipeline_layout_drop<A: HalApi>(&self, pipeline_layout_id: id::PipelineLayoutId) {
-        profiling::scope!("drop", "PipelineLayout");
+        profiling::scope!("PipelineLayout::drop");
         log::debug!("pipeline layout {:?} is dropped", pipeline_layout_id);
 
         let hub = A::hub(self);
@@ -4177,7 +4177,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &binding_model::BindGroupDescriptor,
         id_in: Input<G, id::BindGroupId>,
     ) -> (id::BindGroupId, Option<binding_model::CreateBindGroupError>) {
-        profiling::scope!("create_bind_group", "Device");
+        profiling::scope!("Device::create_bind_group");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -4230,7 +4230,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn bind_group_drop<A: HalApi>(&self, bind_group_id: id::BindGroupId) {
-        profiling::scope!("drop", "BindGroup");
+        profiling::scope!("BindGroup::drop");
         log::debug!("bind group {:?} is dropped", bind_group_id);
 
         let hub = A::hub(self);
@@ -4269,7 +4269,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::ShaderModuleId,
         Option<pipeline::CreateShaderModuleError>,
     ) {
-        profiling::scope!("create_shader_module", "Device");
+        profiling::scope!("Device::create_shader_module");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -4329,7 +4329,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::ShaderModuleId,
         Option<pipeline::CreateShaderModuleError>,
     ) {
-        profiling::scope!("create_shader_module", "Device");
+        profiling::scope!("Device::create_shader_module");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -4371,7 +4371,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn shader_module_drop<A: HalApi>(&self, shader_module_id: id::ShaderModuleId) {
-        profiling::scope!("drop", "ShaderModule");
+        profiling::scope!("ShaderModule::drop");
         log::debug!("shader module {:?} is dropped", shader_module_id);
 
         let hub = A::hub(self);
@@ -4398,7 +4398,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &wgt::CommandEncoderDescriptor<Label>,
         id_in: Input<G, id::CommandEncoderId>,
     ) -> (id::CommandEncoderId, Option<DeviceError>) {
-        profiling::scope!("create_command_encoder", "Device");
+        profiling::scope!("Device::create_command_encoder");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -4446,7 +4446,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_encoder_drop<A: HalApi>(&self, command_encoder_id: id::CommandEncoderId) {
-        profiling::scope!("drop", "CommandEncoder");
+        profiling::scope!("CommandEncoder::drop");
         log::debug!("command encoder {:?} is dropped", command_encoder_id);
 
         let hub = A::hub(self);
@@ -4463,7 +4463,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn command_buffer_drop<A: HalApi>(&self, command_buffer_id: id::CommandBufferId) {
-        profiling::scope!("drop", "CommandBuffer");
+        profiling::scope!("CommandBuffer::drop");
         log::debug!("command buffer {:?} is dropped", command_buffer_id);
         self.command_encoder_drop::<A>(command_buffer_id)
     }
@@ -4476,7 +4476,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::RenderBundleEncoderId,
         Option<command::CreateRenderBundleError>,
     ) {
-        profiling::scope!("create_render_bundle_encoder", "Device");
+        profiling::scope!("Device::create_render_bundle_encoder");
         let (encoder, error) = match command::RenderBundleEncoder::new(desc, device_id, None) {
             Ok(encoder) => (encoder, None),
             Err(e) => (command::RenderBundleEncoder::dummy(device_id), Some(e)),
@@ -4490,7 +4490,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &command::RenderBundleDescriptor,
         id_in: Input<G, id::RenderBundleId>,
     ) -> (id::RenderBundleId, Option<command::RenderBundleError>) {
-        profiling::scope!("finish", "RenderBundleEncoder");
+        profiling::scope!("RenderBundleEncoder::finish");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -4538,7 +4538,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn render_bundle_drop<A: HalApi>(&self, render_bundle_id: id::RenderBundleId) {
-        profiling::scope!("drop", "RenderBundle");
+        profiling::scope!("RenderBundle::drop");
         log::debug!("render bundle {:?} is dropped", render_bundle_id);
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -4572,7 +4572,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &resource::QuerySetDescriptor,
         id_in: Input<G, id::QuerySetId>,
     ) -> (id::QuerySetId, Option<resource::CreateQuerySetError>) {
-        profiling::scope!("create_query_set", "Device");
+        profiling::scope!("Device::create_query_set");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -4614,7 +4614,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn query_set_drop<A: HalApi>(&self, query_set_id: id::QuerySetId) {
-        profiling::scope!("drop", "QuerySet");
+        profiling::scope!("QuerySet::drop");
         log::debug!("query set {:?} is dropped", query_set_id);
 
         let hub = A::hub(self);
@@ -4654,7 +4654,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::RenderPipelineId,
         Option<pipeline::CreateRenderPipelineError>,
     ) {
-        profiling::scope!("create_render_pipeline", "Device");
+        profiling::scope!("Device::create_render_pipeline");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -4756,7 +4756,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn render_pipeline_drop<A: HalApi>(&self, render_pipeline_id: id::RenderPipelineId) {
-        profiling::scope!("drop", "RenderPipeline");
+        profiling::scope!("RenderPipeline::drop");
         log::debug!("render pipeline {:?} is dropped", render_pipeline_id);
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -4798,7 +4798,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id::ComputePipelineId,
         Option<pipeline::CreateComputePipelineError>,
     ) {
-        profiling::scope!("create_compute_pipeline", "Device");
+        profiling::scope!("Device::create_compute_pipeline");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -4896,7 +4896,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn compute_pipeline_drop<A: HalApi>(&self, compute_pipeline_id: id::ComputePipelineId) {
-        profiling::scope!("drop", "ComputePipeline");
+        profiling::scope!("ComputePipeline::drop");
         log::debug!("compute pipeline {:?} is dropped", compute_pipeline_id);
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -5232,7 +5232,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_drop<A: HalApi>(&self, device_id: id::DeviceId) {
-        profiling::scope!("drop", "Device");
+        profiling::scope!("Device::drop");
         log::debug!("device {:?} is dropped", device_id);
 
         let hub = A::hub(self);
@@ -5285,7 +5285,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         range: Range<BufferAddress>,
         op: resource::BufferMapOperation,
     ) -> Result<(), resource::BufferAccessError> {
-        profiling::scope!("map_async", "Buffer");
+        profiling::scope!("Buffer::map_async");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -5352,7 +5352,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         size: Option<BufferAddress>,
     ) -> Result<(*mut u8, u64), resource::BufferAccessError> {
-        profiling::scope!("get_mapped_range", "Buffer");
+        profiling::scope!("Buffer::get_mapped_range");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -5412,7 +5412,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         buffer_id: id::BufferId,
     ) -> Result<Option<BufferMapPendingClosure>, resource::BufferAccessError> {
-        profiling::scope!("unmap", "Buffer");
+        profiling::scope!("Buffer::unmap");
 
         let hub = A::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -295,7 +295,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_offset: wgt::BufferAddress,
         data: &[u8],
     ) -> Result<(), QueueWriteError> {
-        profiling::scope!("write_buffer", "Queue");
+        profiling::scope!("Queue::write_buffer");
 
         let hub = A::hub(self);
         let root_token = &mut Token::root();
@@ -371,7 +371,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_offset: wgt::BufferAddress,
         staging_buffer_id: id::StagingBufferId,
     ) -> Result<(), QueueWriteError> {
-        profiling::scope!("write_buffer_with", "Queue");
+        profiling::scope!("Queue::write_buffer_with");
 
         let hub = A::hub(self);
         let root_token = &mut Token::root();
@@ -518,7 +518,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         data_layout: &wgt::ImageDataLayout,
         size: &wgt::Extent3d,
     ) -> Result<(), QueueWriteError> {
-        profiling::scope!("write_texture", "Queue");
+        profiling::scope!("Queue::write_texture");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -737,7 +737,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         queue_id: id::QueueId,
         command_buffer_ids: &[id::CommandBufferId],
     ) -> Result<WrappedSubmissionIndex, QueueSubmitError> {
-        profiling::scope!("submit", "Queue");
+        profiling::scope!("Queue::submit");
 
         let (submit_index, callbacks) = {
             let hub = A::hub(self);

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -899,7 +899,7 @@ pub struct Global<G: GlobalIdentityHandlerFactory> {
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn new(name: &str, factory: G, backends: wgt::Backends) -> Self {
-        profiling::scope!("new", "Global");
+        profiling::scope!("Global::new");
         Self {
             instance: Instance::new(name, backends),
             surfaces: Registry::without_backend(&factory, "Surface"),
@@ -915,7 +915,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         factory: G,
         hal_instance: A::Instance,
     ) -> Self {
-        profiling::scope!("new", "Global");
+        profiling::scope!("Global::new");
         Self {
             instance: A::create_instance_from_hal(name, hal_instance),
             surfaces: Registry::without_backend(&factory, "Surface"),
@@ -938,7 +938,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     ///
     /// - The raw handles obtained from the Instance must not be manually destroyed
     pub unsafe fn from_instance(factory: G, instance: Instance) -> Self {
-        profiling::scope!("new", "Global");
+        profiling::scope!("Global::new");
         Self {
             instance,
             surfaces: Registry::without_backend(&factory, "Surface"),
@@ -992,7 +992,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
 impl<G: GlobalIdentityHandlerFactory> Drop for Global<G> {
     fn drop(&mut self) {
-        profiling::scope!("drop", "Global");
+        profiling::scope!("Global::drop");
         log::info!("Dropping Global");
         let mut surface_guard = self.surfaces.data.write();
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -408,7 +408,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         handle: &impl raw_window_handle::HasRawWindowHandle,
         id_in: Input<G, SurfaceId>,
     ) -> SurfaceId {
-        profiling::scope!("create_surface", "Instance");
+        profiling::scope!("Instance::create_surface");
 
         //Note: using a dummy argument to work around the following error:
         //> cannot provide explicit generic arguments when `impl Trait` is used in argument position
@@ -456,7 +456,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         layer: *mut std::ffi::c_void,
         id_in: Input<G, SurfaceId>,
     ) -> SurfaceId {
-        profiling::scope!("create_surface_metal", "Instance");
+        profiling::scope!("Instance::create_surface_metal");
 
         let surface = Surface {
             presentation: None,
@@ -485,7 +485,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         canvas: &web_sys::HtmlCanvasElement,
         id_in: Input<G, SurfaceId>,
     ) -> SurfaceId {
-        profiling::scope!("create_surface_webgl_canvas", "Instance");
+        profiling::scope!("Instance::create_surface_webgl_canvas");
 
         let surface = Surface {
             presentation: None,
@@ -508,7 +508,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         canvas: &web_sys::OffscreenCanvas,
         id_in: Input<G, SurfaceId>,
     ) -> SurfaceId {
-        profiling::scope!("create_surface_webgl_offscreen_canvas", "Instance");
+        profiling::scope!("Instance::create_surface_webgl_offscreen_canvas");
 
         let surface = Surface {
             presentation: None,
@@ -534,7 +534,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         visual: *mut std::ffi::c_void,
         id_in: Input<G, SurfaceId>,
     ) -> SurfaceId {
-        profiling::scope!("instance_create_surface_from_visual", "Instance");
+        profiling::scope!("Instance::instance_create_surface_from_visual");
 
         let surface = Surface {
             presentation: None,
@@ -554,7 +554,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn surface_drop(&self, id: SurfaceId) {
-        profiling::scope!("drop", "Surface");
+        profiling::scope!("Surface::drop");
         let mut token = Token::root();
         let (surface, _) = self.surfaces.unregister(id, &mut token);
         self.instance.destroy_surface(surface.unwrap());
@@ -593,7 +593,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn enumerate_adapters(&self, inputs: AdapterInputs<Input<G, AdapterId>>) -> Vec<AdapterId> {
-        profiling::scope!("enumerate_adapters", "Instance");
+        profiling::scope!("Instance::enumerate_adapters");
 
         let mut adapters = Vec::new();
 
@@ -650,7 +650,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &RequestAdapterOptions,
         inputs: AdapterInputs<Input<G, AdapterId>>,
     ) -> Result<AdapterId, RequestAdapterError> {
-        profiling::scope!("pick_adapter", "Instance");
+        profiling::scope!("Instance::pick_adapter");
 
         fn gather<A: HalApi, I: Clone>(
             _: A,
@@ -808,7 +808,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         hal_adapter: hal::ExposedAdapter<A>,
         input: Input<G, AdapterId>,
     ) -> AdapterId {
-        profiling::scope!("create_adapter_from_hal", "Instance");
+        profiling::scope!("Instance::create_adapter_from_hal");
 
         let mut token = Token::root();
         let fid = A::hub(self).adapters.prepare(input);
@@ -895,7 +895,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn adapter_drop<A: HalApi>(&self, adapter_id: AdapterId) {
-        profiling::scope!("drop", "Adapter");
+        profiling::scope!("Adapter::drop");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -920,7 +920,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         trace_path: Option<&std::path::Path>,
         id_in: Input<G, DeviceId>,
     ) -> (DeviceId, Option<RequestDeviceError>) {
-        profiling::scope!("request_device", "Adapter");
+        profiling::scope!("Adapter::request_device");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -956,7 +956,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         trace_path: Option<&std::path::Path>,
         id_in: Input<G, DeviceId>,
     ) -> (DeviceId, Option<RequestDeviceError>) {
-        profiling::scope!("create_device_from_hal", "Adapter");
+        profiling::scope!("Adapter::create_device_from_hal");
 
         let hub = A::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -92,7 +92,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         surface_id: SurfaceId,
         texture_id_in: Input<G, TextureId>,
     ) -> Result<SurfaceOutput, SurfaceError> {
-        profiling::scope!("get_next_texture", "SwapChain");
+        profiling::scope!("SwapChain::get_next_texture");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -240,7 +240,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         surface_id: SurfaceId,
     ) -> Result<Status, SurfaceError> {
-        profiling::scope!("present", "SwapChain");
+        profiling::scope!("SwapChain::present");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -334,7 +334,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         surface_id: SurfaceId,
     ) -> Result<(), SurfaceError> {
-        profiling::scope!("discard", "SwapChain");
+        profiling::scope!("SwapChain::discard");
 
         let hub = A::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -288,7 +288,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id: TextureId,
         hal_texture_callback: F,
     ) {
-        profiling::scope!("as_hal", "Texture");
+        profiling::scope!("Texture::as_hal");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -307,7 +307,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id: AdapterId,
         hal_adapter_callback: F,
     ) -> R {
-        profiling::scope!("as_hal", "Adapter");
+        profiling::scope!("Adapter::as_hal");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -327,7 +327,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id: DeviceId,
         hal_device_callback: F,
     ) -> R {
-        profiling::scope!("as_hal", "Device");
+        profiling::scope!("Device::as_hal");
 
         let hub = A::hub(self);
         let mut token = Token::root();


### PR DESCRIPTION
**Description**

Tools like tracy are used to working with spans that look like module paths `A::B::C` but often hide extra information. This uses the module style, which we've been slowly adopting on new spans.

**Testing**
Looked at it.