### PR TITLE
Allow fragment stage to have more outputs than the pipeline has

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2774,16 +2774,14 @@ impl<A: HalApi> Device<A> {
                             },
                         )?;
                     }
-                    Some(&None) => {
-                        return Err(
-                            pipeline::CreateRenderPipelineError::InvalidFragmentOutputLocation(*i),
-                        );
-                    }
                     _ => {
-                        return Err(pipeline::CreateRenderPipelineError::ColorState(
-                            *i as u8,
-                            pipeline::ColorStateError::Missing,
-                        ));
+                        log::info!(
+                            "The fragment stage {:?} output @location({}) values are ignored",
+                            fragment_stage
+                                .as_ref()
+                                .map_or("", |stage| stage.entry_point),
+                            i
+                        );
                     }
                 }
             }

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -280,8 +280,6 @@ pub struct RenderPipelineDescriptor<'a> {
 
 #[derive(Clone, Debug, Error)]
 pub enum ColorStateError {
-    #[error("output is missing")]
-    Missing,
     #[error("format {0:?} is not renderable")]
     FormatNotRenderable(wgt::TextureFormat),
     #[error("format {0:?} is not blendable")]
@@ -317,8 +315,6 @@ pub enum CreateRenderPipelineError {
     Device(#[from] DeviceError),
     #[error("pipeline layout is invalid")]
     InvalidLayout,
-    #[error("fragment output @location({0}) is invalid")]
-    InvalidFragmentOutputLocation(u32),
     #[error("unable to derive an implicit layout")]
     Implicit(#[from] ImplicitLayoutError),
     #[error("color state [{0}] is invalid")]


### PR DESCRIPTION
**Connections**
Follow https://github.com/gfx-rs/wgpu/issues/2469
WebGPU Spec: https://gpuweb.github.io/gpuweb/#fragment-state

**Testing**
Tested on metal, gl, vulkan, dx12 backends.
wasm target can not running on Chrome Canary because Dawn's validation failure:
```sh
Color target has no corresponding fragment stage output but writeMask (ColorWriteMask::(Red|Green|Blue|Alpha)) is not zero.
 - While validating targets[0].
 - While validating fragment state.
 - While calling [Device].CreateRenderPipeline([RenderPipelineDescriptor]).
localhost/:1 [Invalid RenderPipeline] is invalid.
 - While encoding [RenderPassEncoder].SetPipeline([Invalid RenderPipeline]).
```
