### PR TITLE
Add other breaking changes to 0.13 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,52 @@ is an under-documented area that we hope to improve in the future.
 Calling `queue.submit` now returns an opaque submission index that can be used as an argument to
 `device.poll` to say which submission to wait to complete.
 
+### Other Breaking Changes
+
+`Device::create_shader_module` now takes the shader descriptor by value:
+
+```diff
+- device.create_shader_module(&shader_module_descriptor)
++ device.create_shader_module(shader_module_descriptor)
+```
+
+Color attachments can be sparse, so they are now optional:
+
+```diff
+FragmentState {
+-  targets: &[color_target_state]
++  targets: &[Some(color_target_state)]
+  // ..
+}
+```
+
+```diff
+RenderPassDescriptor {
+-  color_attachments: &[render_pass_color_attachment]
++  color_attachments: &[Some(render_pass_color_attachment)]
+  // ..
+}
+```
+
+```diff
+RenderBundleEncoderDescriptor {
+-  color_formats: &[texture_format]
++  color_formats: &[Some(texture_format)]
+  // ..
+}
+```
+
+`Extent3d::max_mips` now requires you to pass a TextureDimension to specify whether or not depth_or_array_layers should be ignored:
+
+```diff
+Extent3d {
+  width: 1920,
+  height: 1080,
+  depth_or_array_layers: 6,
+- }.max_mips()
++ }.max_mips(wgpu::TextureDimension::D3)
+```
+
 ### Added/New Features
 
 #### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ based GPUs, such as mobile devices and Apple's M chips.
 
 `Features::TIMESTAMP_QUERIES` now allows for calling `write_timestamp` only on `CommandEncoder`s.
 
-`Features::WRITE_TIMESTAMP_INSIDE_PASSES` is needed to calling `write_timestamp` on `RenderPassEncoder`s or `ComputePassEncoder`s.
+`Features::WRITE_TIMESTAMP_INSIDE_PASSES` is needed to call `write_timestamp` on `RenderPassEncoder`s or `ComputePassEncoder`s.
 
 #### map_async
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
n/a

**Description**
Added some of the other breaking changes not currently listed on the 0.13 changelog based on the ones I ran into when migrating my project from 0.12. Feel free to reject if it doesn't fit your vision for what the changelog should include!

**Testing**
n/a
