### PR TITLE
Clarify about breaking max_buffer_size in Limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,15 @@ Extent3d {
 + }.max_mips(wgpu::TextureDimension::D3)
 ```
 
+`Limits` has a new field, [`max_buffer_size`](https://docs.rs/wgpu/0.13.0/wgpu/struct.Limits.html#structfield.max_buffer_size) (not an issue if you don't define limits manually):
+
+```diff
+Limits {
+  // ...
++ max_buffer_size: 256 * 1024 * 1024, // adjust as you see fit
+}
+```
+
 ### Added/New Features
 
 #### General


### PR DESCRIPTION
**Checklist**

~~- [ ] Run `cargo clippy`.~~
~~- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.~~
- [X] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

https://matrix.to/#/!FZyQrssSlHEZqrYcOb:matrix.org/$ajf5IpIcU8NQfGFNfG6SpTBIKchgP62dWQqIhZgE7Bs?via=matrix.org&via=mozilla.org&via=kde.org

**Description**
_Describe what problem this is solving, and how it's solved._

The changelog didn't list in before that `max_buffer_size` was added to `Limits`, though it's actually a new field. It's simply documented with an acceptable value.

**Testing**
_Explain how this change is tested._

Not at all.