### PR TITLE
Fixes #2840

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,7 @@ DeviceDescriptor {
 
 #### General
 
+- AutoNoVSync now correctly falls back to Fifo @simbleau in [#2842](https://github.com/gfx-rs/wgpu/pull/2842)
 - Fix trac(y/ing) compile issue by @cwfitzgerald in [#2333](https://github.com/gfx-rs/wgpu/pull/2333)
 - Improve detection and validation of cubemap views by @kvark in [#2331](https://github.com/gfx-rs/wgpu/pull/2331)
 - Don't create array layer trackers for 3D textures. by @ElectronicRU in [#2348](https://github.com/gfx-rs/wgpu/pull/2348)

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4995,6 +4995,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             if caps.present_modes.contains(&wgt::PresentMode::Mailbox) {
                                 break wgt::PresentMode::Mailbox;
                             }
+                            if caps.present_modes.contains(&wgt::PresentMode::Fifo) {
+                                break wgt::PresentMode::Fifo;
+                            }
                         }
                         _ => {}
                     }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
This fixes #2840 

**Description**
AutoNoVSync should fall back on Fifo as a last resort. This is important for Web, since Web only has Fifo. [Documentation already shows this should use Fifo](https://docs.rs/wgpu/latest/wgpu/enum.PresentMode.html#variant.AutoNoVsync), but it was missing.
