### PR TITLE
Add Aniso to dx12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Bottom level categories:
 
 ## Unreleased
 
+### Bug Fixes
+
+#### DX12
+- `DownlevelCapabilities::default()` now returns the `ANISOTROPIC_FILTERING` flag set to true so DX12 lists `ANISOTROPIC_FILTERING` as true again by @cwfitzgerald in [#2851](https://github.com/gfx-rs/wgpu/pull/2851)
+
 ## wgpu-0.13.1 (2022-07-02)
 
 ### Bug Fixes

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -990,7 +990,7 @@ pub struct DownlevelCapabilities {
 impl Default for DownlevelCapabilities {
     fn default() -> Self {
         Self {
-            flags: DownlevelFlags::compliant(),
+            flags: DownlevelFlags::all(),
             limits: DownlevelLimits::default(),
             shader_model: ShaderModel::Sm5,
         }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

We had DownlevelCaps::default go to a compliant impl, which technically doesn't include aniso - how we use it though means "give me all the flags".
