### PR TITLE
Prevent OpenGL from taking preference over Vulkan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Bottom level categories:
 ## Unreleased
 
 ### Bug Fixes
+- Prefer `DeviceType::DiscreteGpu` over `DeviceType::Other` for `PowerPreference::LowPower` so Vulkan is preferred over OpenGL again by @Craig-Macomber in [#2853](https://github.com/gfx-rs/wgpu/pull/2853)
 
 #### DX12
 - `DownlevelCapabilities::default()` now returns the `ANISOTROPIC_FILTERING` flag set to true so DX12 lists `ANISOTROPIC_FILTERING` as true again by @cwfitzgerald in [#2851](https://github.com/gfx-rs/wgpu/pull/2851)
@@ -127,7 +128,7 @@ is an under-documented area that we hope to improve in the future.
 ```diff
 - let future = buffer.slice(..).map_async(MapMode::Read);
 + buffer.slice(..).map_async(MapMode::Read, || {
-+     // Called when buffer is mapped.  
++     // Called when buffer is mapped.
 + })
 ```
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -786,7 +786,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         let preferred_gpu = match desc.power_preference {
-            PowerPreference::LowPower => integrated.or(other).or(discrete).or(virt).or(cpu),
+            // Since devices of type "Other" might really be "Unknown" and come from APIs like OpenGL that don't specify device type,
+            // Prefer more Specific types over Other.
+            // This means that backends which do provide accurate device types will be preferred
+            // if their device type indicates an actual hardware GPU (integrated or discrete).
+            PowerPreference::LowPower => integrated.or(discrete).or(other).or(virt).or(cpu),
             PowerPreference::HighPerformance => discrete.or(integrated).or(other).or(virt).or(cpu),
         };
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -135,6 +135,11 @@ impl super::Adapter {
         } else if strings_that_imply_cpu.iter().any(|&s| renderer.contains(s)) {
             wgt::DeviceType::Cpu
         } else {
+            // At this point the Device type is Unknown.
+            // It's most likely DiscreteGpu, but we do not know for sure.
+            // Use "Other" to avoid possibly making incorrect assumptions.
+            // Note that if this same device is available under some other API (ex: Vulkan),
+            // It will mostly likely get a different device type (probably DiscreteGpu).
             wgt::DeviceType::Other
         };
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1109,7 +1109,7 @@ pub enum ShaderModel {
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub enum DeviceType {
-    /// Other.
+    /// Other or Unknown.
     Other,
     /// Integrated GPU with shared CPU/GPU memory.
     IntegratedGpu,

--- a/wgpu/examples/hello/README.md
+++ b/wgpu/examples/hello/README.md
@@ -11,6 +11,10 @@ cargo run --example hello
 ## Example output
 
 ```
-# You might see different output as it depends on your graphics card
-AdapterInfo { name: "Intel(R) UHD Graphics 630", vendor: 0, device: 0, device_type: IntegratedGpu, backend: Metal }
+# You might see different output as it depends on your graphics card and drivers
+Available adapters:
+    AdapterInfo { name: "AMD RADV VEGA10", vendor: 4098, device: 26751, device_type: DiscreteGpu, backend: Vulkan }
+    AdapterInfo { name: "llvmpipe (LLVM 12.0.0, 256 bits)", vendor: 65541, device: 0, device_type: Cpu, backend: Vulkan }
+    AdapterInfo { name: "Radeon RX Vega (VEGA10, DRM 3.41.0, 5.13.0-52-generic, LLVM 12.0.0)", vendor: 4098, device: 0, device_type: Other, backend: Gl }
+Selected adapter: AdapterInfo { name: "AMD RADV VEGA10", vendor: 4098, device: 26751, device_type: DiscreteGpu, backend: Vulkan }
 ```

--- a/wgpu/examples/hello/main.rs
+++ b/wgpu/examples/hello/main.rs
@@ -1,13 +1,20 @@
 /// This example shows how to describe the adapter in use.
 async fn run() {
     #[cfg_attr(target_arch = "wasm32", allow(unused_variables))]
-    let adapter = wgpu::Instance::new(wgpu::Backends::all())
-        .request_adapter(&wgpu::RequestAdapterOptions::default())
-        .await
-        .unwrap();
+    let adapter = {
+        let instance = wgpu::Instance::new(wgpu::Backends::all());
+        println!("Available adapters:");
+        for a in instance.enumerate_adapters(wgpu::Backends::all()) {
+            println!("    {:?}", a.get_info())
+        }
+        instance
+            .request_adapter(&wgpu::RequestAdapterOptions::default())
+            .await
+            .unwrap()
+    };
 
     #[cfg(not(target_arch = "wasm32"))]
-    println!("{:?}", adapter.get_info())
+    println!("Selected adapter: {:?}", adapter.get_info())
 }
 
 fn main() {

--- a/wgpu/examples/hello/main.rs
+++ b/wgpu/examples/hello/main.rs
@@ -3,9 +3,12 @@ async fn run() {
     #[cfg_attr(target_arch = "wasm32", allow(unused_variables))]
     let adapter = {
         let instance = wgpu::Instance::new(wgpu::Backends::all());
-        println!("Available adapters:");
-        for a in instance.enumerate_adapters(wgpu::Backends::all()) {
-            println!("    {:?}", a.get_info())
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            println!("Available adapters:");
+            for a in instance.enumerate_adapters(wgpu::Backends::all()) {
+                println!("    {:?}", a.get_info())
+            }
         }
         instance
             .request_adapter(&wgpu::RequestAdapterOptions::default())


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Issue is worked around in https://github.com/Craig-Macomber/rusty-flame/commit/8a20c7f5efb35e437c462ed5d8bc1781109ea1c7#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR115

**Description**

Prefer `DeviceType::DiscreteGpu` over `DeviceType::Other` for `PowerPreference::LowPower` so Vulkan is preferred over OpenGL again.

This change: https://github.com/gfx-rs/wgpu/commit/bfcf5fa513d51f9f4de4318f9627b39b528c8977 caused default configurations (low power, all back-ends) such as the "hello" example to prefer OpenGL over Vulkan for DiscreteGpu devices.

This happens because OpenGL lists the device_type as "Other" when its actually "DiscreteGpu" (but OpenGL does not know this).

Since the OpenGL backend currently never reports any device as DiscreteGpu, it seems like a good idea to make sure "Other" is not preferred over DiscreteGpu: without this GL will get preferred over Vulkan when both are present for the DiscreteGpu.

The low power configuration (which is the default) used to violate this (after the above linked change) which resulted in regressions where GL would get selected over Vulkan, causing reduced feature sets.

This fix is not ideal: it could regress some cases including multi-gpu systems where one of them gets device type Other, and thats actually lower power than the one listed as DiscreteGpu.

It also seems bad to be using "Other" when we mean "Unknown", so I have updated the comment on that device type to clarify its actual usage. 

Another possible fix would be to change the GL backend back to reporting DiscreteGpu instead of Other, or add actual detection support for DiscreteGpu (ex: maybe consider all devices from amd, nvidia or intel not detected as one of the other types as DiscreteGpu?).

**Testing**

My system, which outputs the adapters now listed in the updated readme, now selects the Vulkan version like it did back in wgpu 0.12.
