### PR TITLE
Update present_mode docs as most of them don't automatically fall back to Fifo anymore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ Bottom level categories:
 #### DX12
 - `DownlevelCapabilities::default()` now returns the `ANISOTROPIC_FILTERING` flag set to true so DX12 lists `ANISOTROPIC_FILTERING` as true again by @cwfitzgerald in [#2851](https://github.com/gfx-rs/wgpu/pull/2851)
 
+### Documentation
+
+- Update present_mode docs as most of them don't automatically fall back to Fifo anymore. by @Elabajaba in [#2855](https://github.com/gfx-rs/wgpu/pull/2855)
+
+
 ## wgpu-0.13.1 (2022-07-02)
 
 ### Bug Fixes

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3067,7 +3067,7 @@ pub struct SurfaceConfiguration {
     pub height: u32,
     /// Presentation mode of the swap chain. Fifo is the only mode guaranteed to be supported.
     /// FifoRelaxed, Immediate, and Mailbox will crash if unsupported, while AutoVsync and
-    /// AutoNoVsync will gracefully fall back to Fifo without crashing if their primary modes are
+    /// AutoNoVsync will gracefully do a designed sets of fallbacks if their primary modes are
     /// unsupported.
     pub present_mode: PresentMode,
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2994,7 +2994,7 @@ pub enum PresentMode {
     ///
     /// Tearing can be observed.
     ///
-    /// Supported on most platforms except older DX12.
+    /// Supported on most platforms except older DX12 and Wayland.
     ///
     /// This is traditionally called "Vsync Off".
     Immediate = 4,
@@ -3065,8 +3065,10 @@ pub struct SurfaceConfiguration {
     pub width: u32,
     /// Height of the swap chain. Must be the same size as the surface.
     pub height: u32,
-    /// Presentation mode of the swap chain. FIFO is the only guaranteed to be supported, though
-    /// other formats will automatically fall back to FIFO.
+    /// Presentation mode of the swap chain. Fifo is the only mode guaranteed to be supported.
+    /// FifoRelaxed, Immediate, and Mailbox will crash if unsupported, while AutoVsync and
+    /// AutoNoVsync will gracefully fall back to Fifo without crashing if their primary modes are
+    /// unsupported.
     pub present_mode: PresentMode,
 }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**

PresentMode docs on the SurfaceConfiguration struct were outdated due to #2803, so I updated them. I also added Wayland as a common platform that Immediate mode doesn't work on.