### PR TITLE
allow access to queue family index in vulkan hal device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ Bottom level categories:
 - Fix depth stencil texture format capability by @jinleili in [#2854](https://github.com/gfx-rs/wgpu/pull/2854)
 - `get_texture_format_features` now only returns usages for formats it actually supports by @cwfitzgerald in [#2856](https://github.com/gfx-rs/wgpu/pull/2856)
 
+#### Hal
+
+- Allow access to queue family index in Vulkan hal by @i509VCB in [#2859](https://github.com/gfx-rs/wgpu/pull/2859)
+
 ### Documentation
 - Update present_mode docs as most of them don't automatically fall back to Fifo anymore. by @Elabajaba in [#2855](https://github.com/gfx-rs/wgpu/pull/2855)
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1316,6 +1316,7 @@ impl super::Adapter {
 
         let shared = Arc::new(super::DeviceShared {
             raw: raw_device,
+            family_index,
             handle_is_owned,
             instance: Arc::clone(&self.instance),
             physical_device: self.raw,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -702,6 +702,15 @@ impl super::Device {
         })
     }
 
+    /// Returns the queue family index of the device's internal queue.
+    ///
+    /// This is useful for constructing memory barriers needed for queue family ownership transfer when
+    /// external memory is involved (from/to `VK_QUEUE_FAMILY_EXTERNAL_KHR` and `VK_QUEUE_FAMILY_FOREIGN_EXT`
+    /// for example).
+    pub fn queue_family_index(&self) -> u32 {
+        self.shared.family_index
+    }
+
     pub fn raw_device(&self) -> &ash::Device {
         &self.shared.raw
     }

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -312,6 +312,7 @@ impl UpdateAfterBindTypes {
 
 struct DeviceShared {
     raw: ash::Device,
+    family_index: u32,
     handle_is_owned: bool,
     instance: Arc<InstanceShared>,
     physical_device: ash::vk::PhysicalDevice,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Allows users to access the queue family index of the queue used by the Vulkan hal device. This is needed if custom memory barriers need to be created for queue family ownership transfer.
