### PR TITLE
expose context and display from adapter and device for egl gles hal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Bottom level categories:
 #### Hal
 
 - Allow access to queue family index in Vulkan hal by @i509VCB in [#2859](https://github.com/gfx-rs/wgpu/pull/2859)
+- Allow access to the EGLDisplay and EGLContext pointer in Gles hal Adapter and Device by @i509VCB in [#2860](https://github.com/gfx-rs/wgpu/pull/2860)
 
 ### Documentation
 - Update present_mode docs as most of them don't automatically fall back to Fifo anymore. by @Elabajaba in [#2855](https://github.com/gfx-rs/wgpu/pull/2855)

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -282,6 +282,7 @@ fn gl_debug_message_callback(source: u32, gltype: u32, id: u32, severity: u32, m
 #[derive(Clone, Debug)]
 struct EglContext {
     instance: Arc<EglInstance>,
+    version: (i32, i32),
     display: egl::Display,
     raw: egl::Context,
     pbuffer: Option<egl::Surface>,
@@ -315,7 +316,27 @@ impl AdapterContext {
         self.egl.is_some()
     }
 
-    #[cfg(feature = "renderdoc")]
+    /// Returns the EGL instance.
+    ///
+    /// This provides access to EGL functions and the ability to load GL and EGL extension functions.
+    pub fn egl_instance(&self) -> Option<&EglInstance> {
+        self.egl.as_ref().map(|egl| &*egl.instance)
+    }
+
+    /// Returns the EGLDisplay corresponding to the adapter context.
+    ///
+    /// Returns [`None`] if the adapter was externally created.
+    pub fn raw_display(&self) -> Option<&egl::Display> {
+        self.egl.as_ref().map(|egl| &egl.display)
+    }
+
+    /// Returns the EGL version the adapter context was created with.
+    ///
+    /// Returns [`None`] if the adapter was externally created.
+    pub fn egl_version(&self) -> Option<(i32, i32)> {
+        self.egl.as_ref().map(|egl| egl.version)
+    }
+
     pub fn raw_context(&self) -> *mut raw::c_void {
         match self.egl {
             Some(ref egl) => egl.raw.as_ptr(),
@@ -535,6 +556,7 @@ impl Inner {
                 display,
                 raw: context,
                 pbuffer,
+                version,
             },
             version,
             supports_native_window,
@@ -880,6 +902,17 @@ impl super::Adapter {
             glow: Mutex::new(glow::Context::from_loader_function(fun)),
             egl: None,
         })
+    }
+
+    pub fn adapter_context(&self) -> &AdapterContext {
+        &self.shared.context
+    }
+}
+
+impl super::Device {
+    /// Returns the underlying EGL context.
+    pub fn context(&self) -> &AdapterContext {
+        &self.shared.context
     }
 }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
For extensions to wgpu to be able to interface with EGL, the EGLDisplay, EGLContext and version of EGL need to be available from the adapter and device in the gles hal.

This means the existing `AdapterContext::raw_context` function is now exposed without needing renderdoc to be enabled.

This function also provides access to `get_proc_address` via exposing `EGLInstance`.