### PR TITLE
Fix instruction to run example test in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ cargo run --bin wgpu-info -- cargo nextest run --no-fail-fast
 Then to run an example's image comparison tests, run:
 
 ```
-cargo nextest run --example <example-name> --no-fail-fast
+cargo nextest run <example-test-name> --no-fail-fast
 ```
 
 Or run a part of the integration test suite:


### PR DESCRIPTION
**Description**
The provided command to run example tests in the README returns `error: Found argument '--example' which wasn't expected, or isn't valid in this context`. This corrects the documented command.

**Testing**
Run prior and new commands (e.g. `cargo nextest run --example water --no-fail-fast` and `cargo nextest run water --no-fail-fast`), confirm the first fails to run and the latter succeeds.