### PR TITLE
export `AdapterContext` in Gles hal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Bottom level categories:
 #### Hal
 
 - Document safety requirements for `Adapter::from_external` in gles hal by @i509VCB in [#2863](https://github.com/gfx-rs/wgpu/pull/2863)
+- Make `AdapterContext` a publicly accessible type in the gles hal by @i509VCB in [#2870](https://github.com/gfx-rs/wgpu/pull/2870)
 
 ## wgpu-0.13.1 (2022-07-02)
 

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -69,10 +69,14 @@ mod device;
 mod queue;
 
 #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
-use self::egl::{AdapterContext, Instance, Surface};
+pub use self::egl::{AdapterContext, AdapterContextLock};
+#[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+use self::egl::{Instance, Surface};
 
 #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
-use self::web::{AdapterContext, Instance, Surface};
+pub use self::web::AdapterContext;
+#[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+use self::web::{Instance, Surface};
 
 use arrayvec::ArrayVec;
 


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
External users of wgpu-hal have a much easier time interfacing with Gles if AdapterContext (and it's Lock type for EGL) are publicly accessible.
