### PR TITLE
fix panic with as_hal functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Bottom level categories:
 - `get_texture_format_features` only lists the COPY_* usages if the adapter actually supports that usage by @cwfitzgerald in [#2856](https://github.com/gfx-rs/wgpu/pull/2856)
 - Improve the validation and error reporting of buffer mappings by @nical in [#2848](https://github.com/gfx-rs/wgpu/pull/2848)
 - Fix bind group / pipeline deduplication not taking into account RenderBundle execution resetting these values by @shoebe [#2867](https://github.com/gfx-rs/wgpu/pull/2867)
+- Fix panics that occur when using `as_hal` functions when the hal generic type does not match the hub being looked up in by @i509VCB [#2871](https://github.com/gfx-rs/wgpu/pull/2871)
 
 #### DX12
 - `DownlevelCapabilities::default()` now returns the `ANISOTROPIC_FILTERING` flag set to true so DX12 lists `ANISOTROPIC_FILTERING` as true again by @cwfitzgerald in [#2851](https://github.com/gfx-rs/wgpu/pull/2851)

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -326,7 +326,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let hub = A::hub(self);
         let mut token = Token::root();
         let (guard, _) = hub.textures.read(&mut token);
-        let texture = guard.get(id).ok();
+        let texture = guard.try_get(id).ok().flatten();
         let hal_texture = texture.map(|tex| tex.inner.as_raw().unwrap());
 
         hal_texture_callback(hal_texture);
@@ -346,7 +346,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut token = Token::root();
 
         let (guard, _) = hub.adapters.read(&mut token);
-        let adapter = guard.get(id).ok();
+        let adapter = guard.try_get(id).ok().flatten();
         let hal_adapter = adapter.map(|adapter| &adapter.raw.adapter);
 
         hal_adapter_callback(hal_adapter)
@@ -365,7 +365,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let hub = A::hub(self);
         let mut token = Token::root();
         let (guard, _) = hub.devices.read(&mut token);
-        let device = guard.get(id).ok();
+        let device = guard.try_get(id).ok().flatten();
         let hal_device = device.map(|device| &device.raw);
 
         hal_device_callback(hal_device)


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #2862

**Description**
The `as_hal` family of functions will invoke the callback with `None` if the wrong api is used as the generic type. This is because the `HalApi` generic performs lookup in a different hub. However the `get` function in the storage will fail if the id used for lookup is not in the storage (because you specified the wrong generic type) and therefore panic.

To solve this, a `try_get` function is used for all `as_hal` functions to ensure that `as_hal` will actually return `None` instead of panicking.