### PR TITLE
Specify an exact wasm-bindgen-cli version in publish.yml.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version=0.2.78
+        run: cargo install wasm-bindgen-cli --version=0.2.81
 
       - name: Build WebGPU examples
         run: cargo build --release --target wasm32-unknown-unknown --examples


### PR DESCRIPTION
The versions of wasm-bindgen-cli run by `.github/workflows/publish.yml` must
exactly match the version of `wasm-bindgen` used by `wgpu`. At the moment,
`wgpu/Cargo.toml` specifies `0.2.81`, and our `Cargo.lock` agrees, so
that is what `publish.yml` should mention.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] **Did not** add change to CHANGELOG.md, because it's trivial.
