### PR TITLE
For wgpu web backend, use a real type for submission indices.

### DIFF
--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -972,6 +972,12 @@ impl Context {
     }
 }
 
+// The web doesn't provide any way to identify specific queue
+// submissions. But Clippy gets concerned if we pass around `()` as if
+// it were meaningful.
+#[derive(Debug, Clone, Copy)]
+pub struct SubmissionIndex;
+
 impl crate::Context for Context {
     type AdapterId = Sendable<web_sys::GpuAdapter>;
     type DeviceId = Sendable<web_sys::GpuDevice>;
@@ -996,7 +1002,7 @@ impl crate::Context for Context {
     type SurfaceId = Sendable<web_sys::GpuCanvasContext>;
 
     type SurfaceOutputDetail = SurfaceOutputDetail;
-    type SubmissionIndex = ();
+    type SubmissionIndex = SubmissionIndex;
 
     type RequestAdapterFuture = MakeSendFuture<
         wasm_bindgen_futures::JsFuture,
@@ -2280,7 +2286,7 @@ impl crate::Context for Context {
 
         queue.0.submit(&temp_command_buffers);
 
-        // SubmissionIndex is (), so just let this function end
+        SubmissionIndex
     }
 
     fn queue_get_timestamp_period(&self, _queue: &Self::QueueId) -> f32 {


### PR DESCRIPTION
The wgpu web backend uses `()` as `Context::SubmissionIndex`, which is fine --- WebGPU provides no way to identify individual queue submissions --- except that Clippy is concerned about us passing around `()` in the front end as if it were a real value. Instead, define a new zero-size `wgpu::backend::web::SubmissionIndex` type for this use.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] **Did not** add change to CHANGELOG.md, since it's trivial.
