### PR TITLE
Record that the buffer is mapped when its size is zero.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Bottom level categories:
 - Fix bind group / pipeline deduplication not taking into account RenderBundle execution resetting these values by @shoebe [#2867](https://github.com/gfx-rs/wgpu/pull/2867)
 - Fix panics that occur when using `as_hal` functions when the hal generic type does not match the hub being looked up in by @i509VCB [#2871](https://github.com/gfx-rs/wgpu/pull/2871)
 - Add some validation in map_async by @nical in [#2876](https://github.com/gfx-rs/wgpu/pull/2876)
+- Fix bugs when mapping/unmapping zero-sized buffers and ranges by @nical in [#2877](https://github.com/gfx-rs/wgpu/pull/2877)
 
 #### DX12
 - `DownlevelCapabilities::default()` now returns the `ANISOTROPIC_FILTERING` flag set to true so DX12 lists `ANISOTROPIC_FILTERING` as true again by @cwfitzgerald in [#2851](https://github.com/gfx-rs/wgpu/pull/2851)

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -896,6 +896,11 @@ impl<A: HalApi> LifetimeTracker<A> {
                         }
                     }
                 } else {
+                    buffer.map_state = resource::BufferMapState::Active {
+                        ptr: std::ptr::NonNull::dangling(),
+                        range: mapping.range,
+                        host: mapping.op.host,
+                    };
                     resource::BufferMapAsyncStatus::Success
                 };
                 pending_callbacks.push((mapping.op, status));


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**

This makes buffers behave properly when the user maps and unmaps an empty buffer range. Without this PR, 'unmap' will return an error saying that the buffer is not mapped even though the mapping closure reproted success. 

It's a bit of a ridiculous test cases but fuzzers love this type of input.

The `NonNull::dangling` pointer might be intimidating, thankfully it's used in very few places so it's easy to check that we don't do dangerous things things with it. It can be summed up to the following snipped which I ran under miri  without complaints of undefined behavior:

```rust
    #[test]
    fn it_works() {
        unsafe {
            let nonnul_ptr: std::ptr::NonNull<u8> = std::ptr::NonNull::dangling();
            let actual_ptr = nonnul_ptr.as_ptr();
            let offset = actual_ptr.offset(0);
            let slice = std::slice::from_raw_parts(actual_ptr, 0);
            println!("ok!");
        }
    }
```

**Testing**

No automated tests.