### PR TITLE
Add WGPU_BACKEND_VALIDATION environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Added/New Features
+
+#### General
+
+- Add `WGPU_BACKEND_VALIDATION` env var to control validation by @cwfitzgerald in [#2881](https://github.com/gfx-rs/wgpu/pull/2881)
+
 ### Bug Fixes
 
 #### General

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ All testing and example infrastructure shares the same set of environment variab
 
 When running the CTS, use the variables `DENO_WEBGPU_ADAPTER_NAME`, `DENO_WEBGPU_BACKEND`, `DENO_WEBGPU_POWER_PREFERENCE`.
 
+When running in the wild, you can enable or disable backend validation layers at runtime using the following flag
+
+- `WGPU_BACKEND_VALIDATION` set to `ENABLED` or `1` to force on validation, `DISABLED` or `0` to force off. The variable being unset
+  or set to another value will result in validation being on in debug mode and off in release.
+
 ## Testing
 
 We have multiple methods of testing, each of which tests different qualities about wgpu. We automatically run our tests on CI if possible. The current state of CI testing:


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Part of #2316 

**Description**

This adds an env var which turns on backend validation no matter if we're in debug or release. This is useful for both forcing it on in release and forcing it off in debug.

**Testing**
None
