### PR TITLE
added downlevel restriction error message for InvalidFormatUsages error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ Bottom level categories:
 #### Metal
 - Extract the generic code into `get_metal_layer` by @jinleili in [#2826](https://github.com/gfx-rs/wgpu/pull/2826)
 
+#### General
+- Added downlevel restriction error message for `InvalidFormatUsages` error by @Seamooo in [#2886](https://github.com/gfx-rs/wgpu/pull/2886)
+
 ## wgpu-0.13.2 (2022-07-13)
 
 ### Bug Fixes

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -800,9 +800,17 @@ impl<A: HalApi> Device<A> {
 
         let missing_allowed_usages = desc.usage - format_features.allowed_usages;
         if !missing_allowed_usages.is_empty() {
+            // detect downlevel incompatibilities
+            let wgpu_allowed_usages = desc
+                .format
+                .describe()
+                .guaranteed_format_features
+                .allowed_usages;
+            let wgpu_missing_usages = desc.usage - wgpu_allowed_usages;
             return Err(CreateTextureError::InvalidFormatUsages(
                 missing_allowed_usages,
                 desc.format,
+                wgpu_missing_usages.is_empty(),
             ));
         }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -423,8 +423,11 @@ pub enum CreateTextureError {
         "Texture descriptor mip level count {requested} is invalid, maximum allowed is {maximum}"
     )]
     InvalidMipLevelCount { requested: u32, maximum: u32 },
-    #[error("Texture usages {0:?} are not allowed on a texture of type {1:?}")]
-    InvalidFormatUsages(wgt::TextureUsages, wgt::TextureFormat),
+    #[error(
+        "Texture usages {0:?} are not allowed on a texture of type {1:?}{}",
+        if *.2 { " due to downlevel restrictions" } else { "" }
+    )]
+    InvalidFormatUsages(wgt::TextureUsages, wgt::TextureFormat, bool),
     #[error("Texture usages {0:?} are not allowed on a texture of dimensions {1:?}")]
     InvalidDimensionUsages(wgt::TextureUsages, wgt::TextureDimension),
     #[error("Texture usage STORAGE_BINDING is not allowed for multisampled textures")]


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
[link to issue](https://github.com/gfx-rs/wgpu/issues/2837)

**Description**
As mentioned in the issue, texture format usages that are not possible due to downlevel incompatibility have the same error message as if a usage incompatible with the WebGPU specification is specified. This PR adds a third parameter to the InvalidFormatUsages error, specifying if the error was due to a downlevel incompatibility. Additionally this third parameter is populated by checking against the webgpu allowed usages for the texture format in question. 

**Testing**
This PR was tested by running
```rust
device.create_texture(&wgpu::TextureDescriptor {
    label: None,
    size: wgpu::Extent3d {
        width: 1,
        height: 1,
        depth_or_array_layers: 1,
    },
    mip_level_count: 1,
    sample_count: 1,
    dimension: wgpu::TextureDimension::D2,
    format: wgpu::TextureFormat::Rg32Uint,
    usage: wgpu::TextureUsages::STORAGE_BINDING,
});
```
where device is of type wgpu::Device.
This is within the specification, and within the format features [table](https://github.com/gfx-rs/wgpu/blob/48325f1aaa1a26744e328112254a299e5509b9f1/wgpu-types/src/lib.rs#L2163), however unsupported by the hardware I'm running.
The observed error message is
```
thread 'tests::test_create_texture' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_texture
    Texture usages STORAGE_BINDING are not allowed on a texture of type Rg32Uint due to downlevel restrictions

', wgpu/wgpu/src/backend/direct.rs:2391:5
```
Additionally to assert that the original error message without downlevel restrictions is behaving correctly the below snippet was run
```rust
device.create_texture(&wgpu::TextureDescriptor {
    label: None,
    size: wgpu::Extent3d {
        width: 1,
        height: 1,
        depth_or_array_layers: 1,
    },
    mip_level_count: 1,
    sample_count: 1,
    dimension: wgpu::TextureDimension::D2,
    format: wgpu::TextureFormat::R16Uint,
    usage: wgpu::TextureUsages::STORAGE_BINDING,
});
```
This is both outside the specification and the table referenced. The error observed in this case is
```
thread 'tests::test_create_texture' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_texture
    Texture usages STORAGE_BINDING are not allowed on a texture of type R16Uint

', wgpu/wgpu/src/backend/direct.rs:2391:5
```