### PR TITLE
Add WGSL examples to documentation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,22 @@ Bottom level categories:
 ### Bug Fixes
 
 #### General
+- Improve the validation and error reporting of buffer mappings by @nical in [#2848](https://github.com/gfx-rs/wgpu/pull/2848)
+
+### Changes
+
+#### Metal
+- Extract the generic code into `get_metal_layer` by @jinleili in [#2826](https://github.com/gfx-rs/wgpu/pull/2826)
+
+## wgpu-0.13.2 (2022-07-13)
+
+### Bug Fixes
+
+#### General
 - Prefer `DeviceType::DiscreteGpu` over `DeviceType::Other` for `PowerPreference::LowPower` so Vulkan is preferred over OpenGL again by @Craig-Macomber in [#2853](https://github.com/gfx-rs/wgpu/pull/2853)
 - Allow running `get_texture_format_features` on unsupported texture formats (returning no flags) by @cwfitzgerald in [#2856](https://github.com/gfx-rs/wgpu/pull/2856)
 - Allow multi-sampled textures that are supported by the device but not WebGPU if `TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES` is enabled by @cwfitzgerald in [#2856](https://github.com/gfx-rs/wgpu/pull/2856)
 - `get_texture_format_features` only lists the COPY_* usages if the adapter actually supports that usage by @cwfitzgerald in [#2856](https://github.com/gfx-rs/wgpu/pull/2856)
-- Improve the validation and error reporting of buffer mappings by @nical in [#2848](https://github.com/gfx-rs/wgpu/pull/2848)
 - Fix bind group / pipeline deduplication not taking into account RenderBundle execution resetting these values by @shoebe [#2867](https://github.com/gfx-rs/wgpu/pull/2867)
 - Fix panics that occur when using `as_hal` functions when the hal generic type does not match the hub being looked up in by @i509VCB [#2871](https://github.com/gfx-rs/wgpu/pull/2871)
 - Add some validation in map_async by @nical in [#2876](https://github.com/gfx-rs/wgpu/pull/2876)
@@ -72,11 +83,6 @@ Bottom level categories:
 #### Hal
 
 - Document safety requirements for `Adapter::from_external` in gles hal by @i509VCB in [#2863](https://github.com/gfx-rs/wgpu/pull/2863)
-
-### Changes
-
-#### Metal
-- Extract the generic code into `get_metal_layer` by @jinleili in [#2826](https://github.com/gfx-rs/wgpu/pull/2826)
 
 ## wgpu-0.13.1 (2022-07-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ Bottom level categories:
 #### Metal
 - Extract the generic code into `get_metal_layer` by @jinleili in [#2826](https://github.com/gfx-rs/wgpu/pull/2826)
 
+### Documentation
+
+#### General
+- Add WGSL examples to complement existing examples written in GLSL by @norepimorphism in [#2888](https://github.com/gfx-rs/wgpu/pull/2888)
+
 ## wgpu-0.13.2 (2022-07-13)
 
 ### Bug Fixes

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -326,15 +326,16 @@ bitflags::bitflags! {
         const MAPPABLE_PRIMARY_BUFFERS = 1 << 16;
         /// Allows the user to create uniform arrays of textures in shaders:
         ///
-        /// ex. 
+        /// ex.  
         /// `var textures: binding_array<texture_2d<f32>, 10>` (WGSL)  
         /// `uniform texture2D textures[10]` (GLSL)
         ///
         /// If [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] is supported as well as this, the user
         /// may also create uniform arrays of storage textures.
         ///
-        /// eg. `var textures: array<texture_storage_2d<f32, write>, 10>` (WGSL),
-        /// `uniform image2D textures[10]` (GLSL).
+        /// ex.  
+        /// `var textures: array<texture_storage_2d<f32, write>, 10>` (WGSL)  
+        /// `uniform image2D textures[10]` (GLSL)
         ///
         /// This capability allows them to exist and to be indexed by dynamically uniform
         /// values.
@@ -348,8 +349,9 @@ bitflags::bitflags! {
         const TEXTURE_BINDING_ARRAY = 1 << 17;
         /// Allows the user to create arrays of buffers in shaders:
         ///
-        /// eg. `var<uniform> buffer_array: array<MyBuffer, 10>` (WGSL),
-        /// `uniform myBuffer { ... } buffer_array[10]` (GLSL).
+        /// ex.  
+        /// `var<uniform> buffer_array: array<MyBuffer, 10>` (WGSL)  
+        /// `uniform myBuffer { ... } buffer_array[10]` (GLSL)
         ///
         /// This capability allows them to exist and to be indexed by dynamically uniform
         /// values.
@@ -357,8 +359,9 @@ bitflags::bitflags! {
         /// If [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] is supported as well as this, the user
         /// may also create arrays of storage buffers.
         ///
-        /// eg. `var<storage> buffer_array: array<MyBuffer, 10>` (WGSL),
-        /// `buffer myBuffer { ... } buffer_array[10]` (GLSL).
+        /// ex.  
+        /// `var<storage> buffer_array: array<MyBuffer, 10>` (WGSL)  
+        /// `buffer myBuffer { ... } buffer_array[10]` (GLSL)
         ///
         /// Supported platforms:
         /// - DX12
@@ -381,7 +384,7 @@ bitflags::bitflags! {
         const STORAGE_RESOURCE_BINDING_ARRAY = 1 << 19;
         /// Allows shaders to index sampled texture and storage buffer resource arrays with dynamically non-uniform values:
         ///
-        /// eg. `texture_array[vertex_data]`
+        /// ex. `texture_array[vertex_data]`
         ///
         /// In order to use this capability, the corresponding GLSL extension must be enabled like so:
         ///
@@ -389,11 +392,11 @@ bitflags::bitflags! {
         ///
         /// and then used either as `nonuniformEXT` qualifier in variable declaration:
         ///
-        /// eg. `layout(location = 0) nonuniformEXT flat in int vertex_data;`
+        /// ex. `layout(location = 0) nonuniformEXT flat in int vertex_data;`
         ///
         /// or as `nonuniformEXT` constructor:
         ///
-        /// eg. `texture_array[nonuniformEXT(vertex_data)]`
+        /// ex. `texture_array[nonuniformEXT(vertex_data)]`
         ///
         /// WGSL and HLSL do not need any extension.
         ///
@@ -406,7 +409,7 @@ bitflags::bitflags! {
         const SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING = 1 << 20;
         /// Allows shaders to index uniform buffer and storage texture resource arrays with dynamically non-uniform values:
         ///
-        /// eg. `texture_array[vertex_data]`
+        /// ex. `texture_array[vertex_data]`
         ///
         /// In order to use this capability, the corresponding GLSL extension must be enabled like so:
         ///
@@ -414,11 +417,11 @@ bitflags::bitflags! {
         ///
         /// and then used either as `nonuniformEXT` qualifier in variable declaration:
         ///
-        /// eg. `layout(location = 0) nonuniformEXT flat in int vertex_data;`
+        /// ex. `layout(location = 0) nonuniformEXT flat in int vertex_data;`
         ///
         /// or as `nonuniformEXT` constructor:
         ///
-        /// eg. `texture_array[nonuniformEXT(vertex_data)]`
+        /// ex. `texture_array[nonuniformEXT(vertex_data)]`
         ///
         /// WGSL and HLSL do not need any extension.
         ///

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3854,15 +3854,27 @@ impl Default for TextureSampleType {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum StorageTextureAccess {
-    /// The texture can only be written in the shader and it must be annotated with `writeonly`.
+    /// The texture can only be written in the shader and it must be annotated with
+    /// `writeonly` (GLSL).
+    ///
+    /// This is not expressible in WGSL.
     ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(set=0, binding=0, r32f) writeonly uniform image2D myStorageImage;
     /// ```
     WriteOnly,
-    /// The texture can only be read in the shader and it must be annotated with `readonly`.
-    /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] must be enabled to use this access mode,
+    /// The texture can only be read in the shader and it:
+    /// - may or may not be annotated with `read` (WGSL).
+    /// - must be annotated with `readonly` (GLSL).
+    ///
+    /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] must be enabled to use this access mode.
+    ///
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// @group(0) @binding(0)
+    /// var<read> my_storage_image: texture_storage_2d<f32>;
+    /// ```
     ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
@@ -3871,6 +3883,8 @@ pub enum StorageTextureAccess {
     ReadOnly,
     /// The texture can be both read and written in the shader.
     /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] must be enabled to use this access mode.
+    ///
+    /// This is not expressible in WGSL.
     ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
@@ -3935,10 +3949,16 @@ pub enum BindingType {
     },
     /// A sampler that can be used to sample a texture.
     ///
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// @group(0) @binding(0)
+    /// var s: sampler;
+    /// ```
+    ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// uniform sampler s;
+    /// readonly uniform sampler s;
     /// ```
     ///
     /// Corresponds to [WebGPU `GPUSamplerBindingLayout`](
@@ -3946,10 +3966,16 @@ pub enum BindingType {
     Sampler(SamplerBindingType),
     /// A texture binding.
     ///
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// @group(0) @binding(0)
+    /// var t: texture_2d<f32>;
+    /// ```
+    ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// uniform texture2D t;
+    /// readonly uniform texture2D t;
     /// ```
     ///
     /// Corresponds to [WebGPU `GPUTextureBindingLayout`](
@@ -3966,9 +3992,15 @@ pub enum BindingType {
     },
     /// A storage texture.
     ///
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// @group(0) @binding(0)
+    /// var my_storage_image: texture_storage_2d<f32>;
+    /// ```
+    ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
-    /// layout(set=0, binding=0, r32f) uniform image2D myStorageImage;
+    /// layout(set=0, binding=0, r32f) readonly uniform image2D myStorageImage;
     /// ```
     /// Note that the texture format must be specified in the shader as well.
     /// A list of valid formats can be found in the specification here: <https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.60.html#layout-qualifiers>

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -394,7 +394,7 @@ bitflags::bitflags! {
         ///
         /// eg. `texture_array[nonuniformEXT(vertex_data)]`
         ///
-        /// HLSL does not need any extension.
+        /// WGSL and HLSL do not need any extension.
         ///
         /// Supported platforms:
         /// - DX12
@@ -419,7 +419,7 @@ bitflags::bitflags! {
         ///
         /// eg. `texture_array[nonuniformEXT(vertex_data)]`
         ///
-        /// HLSL does not need any extension.
+        /// WGSL and HLSL do not need any extension.
         ///
         /// Supported platforms:
         /// - DX12

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3714,7 +3714,7 @@ pub enum BufferBindingType {
     /// ```rust,ignore
     /// struct Globals {
     ///     a_uniform: vec2<f32>,
-    ///     another_uniform: vec2<f32>
+    ///     another_uniform: vec2<f32>,
     /// }
     /// @group(0) @binding(0)
     /// var<uniform> globals: Globals;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3861,7 +3861,7 @@ pub enum StorageTextureAccess {
     /// Example WGSL syntax:
     /// ```rust,ignore
     /// @group(0) @binding(0)
-    /// var<write> my_storage_image: texture_storage_2d<f32>;
+    /// var my_storage_image: texture_storage_2d<f32, write>;
     /// ```
     ///
     /// Example GLSL syntax:
@@ -3878,7 +3878,7 @@ pub enum StorageTextureAccess {
     /// Example WGSL syntax:
     /// ```rust,ignore
     /// @group(0) @binding(0)
-    /// var<read> my_storage_image: texture_storage_2d<f32>;
+    /// var my_storage_image: texture_storage_2d<f32, read>;
     /// ```
     ///
     /// Example GLSL syntax:
@@ -3895,7 +3895,7 @@ pub enum StorageTextureAccess {
     /// Example WGSL syntax:
     /// ```rust,ignore
     /// @group(0) @binding(0)
-    /// var<read_write> my_storage_image: texture_storage_2d<f32>;
+    /// var my_storage_image: texture_storage_2d<f32, read_write>;
     /// ```
     ///
     /// Example GLSL syntax:
@@ -4007,7 +4007,7 @@ pub enum BindingType {
     /// Example WGSL syntax:
     /// ```rust,ignore
     /// @group(0) @binding(0)
-    /// var my_storage_image: texture_storage_2d<f32>;
+    /// var my_storage_image: texture_storage_2d<f32, write>;
     /// ```
     ///
     /// Example GLSL syntax:

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1206,22 +1206,22 @@ bitflags_serde_shim::impl_serde_for_bitflags!(ShaderStages);
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub enum TextureViewDimension {
-    /// A one dimensional texture. `texture1D` in glsl shaders.
+    /// A one dimensional texture. `texture_1d` in WGSL and `texture1D` in GLSL.
     #[cfg_attr(feature = "serde", serde(rename = "1d"))]
     D1,
-    /// A two dimensional texture. `texture2D` in glsl shaders.
+    /// A two dimensional texture. `texture_2d` in WGSL and `texture2D` in GLSL.
     #[cfg_attr(feature = "serde", serde(rename = "2d"))]
     D2,
-    /// A two dimensional array texture. `texture2DArray` in glsl shaders.
+    /// A two dimensional array texture. `texture_2d_array` in WGSL and `texture2DArray` in GLSL.
     #[cfg_attr(feature = "serde", serde(rename = "2d-array"))]
     D2Array,
-    /// A cubemap texture. `textureCube` in glsl shaders.
+    /// A cubemap texture. `texture_cube` in WGSL and `textureCube` in GLSL.
     #[cfg_attr(feature = "serde", serde(rename = "cube"))]
     Cube,
-    /// A cubemap array texture. `textureCubeArray` in glsl shaders.
+    /// A cubemap array texture. `texture_cube_array` in WGSL and `textureCubeArray` in GLSL.
     #[cfg_attr(feature = "serde", serde(rename = "cube-array"))]
     CubeArray,
-    /// A three dimensional texture. `texture3D` in glsl shaders.
+    /// A three dimensional texture. `texture_3d` in WGSL and `texture3D` in GLSL.
     #[cfg_attr(feature = "serde", serde(rename = "3d"))]
     D3,
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3786,7 +3786,7 @@ pub enum TextureSampleType {
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// readonly uniform texture2D t;
+    /// uniform texture2D t;
     /// ```
     Float {
         /// If `filterable` is false, the texture can't be sampled with
@@ -3804,7 +3804,7 @@ pub enum TextureSampleType {
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// readonly uniform texture2DShadow t;
+    /// uniform texture2DShadow t;
     /// ```
     Depth,
     /// Sampling returns signed integers.
@@ -3818,7 +3818,7 @@ pub enum TextureSampleType {
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// readonly uniform itexture2D t;
+    /// uniform itexture2D t;
     /// ```
     Sint,
     /// Sampling returns unsigned integers.
@@ -3832,7 +3832,7 @@ pub enum TextureSampleType {
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// readonly uniform utexture2D t;
+    /// uniform utexture2D t;
     /// ```
     Uint,
 }
@@ -3854,21 +3854,26 @@ impl Default for TextureSampleType {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum StorageTextureAccess {
-    /// The texture can only be written in the shader and it must be annotated with
-    /// `writeonly` (GLSL).
+    /// The texture can only be written in the shader and it:
+    /// - may or may not be annotated with `write` (WGSL).
+    /// - must be annotated with `writeonly` (GLSL).
     ///
-    /// This is not expressible in WGSL.
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// @group(0) @binding(0)
+    /// var<write> my_storage_image: texture_storage_2d<f32>;
+    /// ```
     ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(set=0, binding=0, r32f) writeonly uniform image2D myStorageImage;
     /// ```
     WriteOnly,
-    /// The texture can only be read in the shader and it:
-    /// - may or may not be annotated with `read` (WGSL).
-    /// - must be annotated with `readonly` (GLSL).
+    /// The texture can only be read in the shader and it must be annotated with `read` (WGSL) or
+    /// `readonly` (GLSL).
     ///
-    /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] must be enabled to use this access mode.
+    /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] must be enabled to use this access
+    /// mode. This is a nonstandard, native-only extension.
     ///
     /// Example WGSL syntax:
     /// ```rust,ignore
@@ -3881,10 +3886,17 @@ pub enum StorageTextureAccess {
     /// layout(set=0, binding=0, r32f) readonly uniform image2D myStorageImage;
     /// ```
     ReadOnly,
-    /// The texture can be both read and written in the shader.
-    /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] must be enabled to use this access mode.
+    /// The texture can be both read and written in the shader and must be annotated with
+    /// `read_write` in WGSL.
     ///
-    /// This is not expressible in WGSL.
+    /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] must be enabled to use this access
+    /// mode.  This is a nonstandard, native-only extension.
+    ///
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// @group(0) @binding(0)
+    /// var<read_write> my_storage_image: texture_storage_2d<f32>;
+    /// ```
     ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
@@ -3958,7 +3970,7 @@ pub enum BindingType {
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// readonly uniform sampler s;
+    /// uniform sampler s;
     /// ```
     ///
     /// Corresponds to [WebGPU `GPUSamplerBindingLayout`](
@@ -3975,7 +3987,7 @@ pub enum BindingType {
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// readonly uniform texture2D t;
+    /// uniform texture2D t;
     /// ```
     ///
     /// Corresponds to [WebGPU `GPUTextureBindingLayout`](
@@ -4000,7 +4012,7 @@ pub enum BindingType {
     ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
-    /// layout(set=0, binding=0, r32f) readonly uniform image2D myStorageImage;
+    /// layout(set=0, binding=0, r32f) writeonly uniform image2D myStorageImage;
     /// ```
     /// Note that the texture format must be specified in the shader as well.
     /// A list of valid formats can be found in the specification here: <https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.60.html#layout-qualifiers>

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -326,15 +326,15 @@ bitflags::bitflags! {
         const MAPPABLE_PRIMARY_BUFFERS = 1 << 16;
         /// Allows the user to create uniform arrays of textures in shaders:
         ///
-        /// ex.  
-        /// `var textures: binding_array<texture_2d<f32>, 10>` (WGSL)  
+        /// ex.
+        /// `var textures: binding_array<texture_2d<f32>, 10>` (WGSL)\
         /// `uniform texture2D textures[10]` (GLSL)
         ///
         /// If [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] is supported as well as this, the user
         /// may also create uniform arrays of storage textures.
         ///
-        /// ex.  
-        /// `var textures: array<texture_storage_2d<f32, write>, 10>` (WGSL)  
+        /// ex.
+        /// `var textures: array<texture_storage_2d<f32, write>, 10>` (WGSL)\
         /// `uniform image2D textures[10]` (GLSL)
         ///
         /// This capability allows them to exist and to be indexed by dynamically uniform
@@ -349,8 +349,8 @@ bitflags::bitflags! {
         const TEXTURE_BINDING_ARRAY = 1 << 17;
         /// Allows the user to create arrays of buffers in shaders:
         ///
-        /// ex.  
-        /// `var<uniform> buffer_array: array<MyBuffer, 10>` (WGSL)  
+        /// ex.
+        /// `var<uniform> buffer_array: array<MyBuffer, 10>` (WGSL)\
         /// `uniform myBuffer { ... } buffer_array[10]` (GLSL)
         ///
         /// This capability allows them to exist and to be indexed by dynamically uniform
@@ -359,8 +359,8 @@ bitflags::bitflags! {
         /// If [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] is supported as well as this, the user
         /// may also create arrays of storage buffers.
         ///
-        /// ex.  
-        /// `var<storage> buffer_array: array<MyBuffer, 10>` (WGSL)  
+        /// ex.
+        /// `var<storage> buffer_array: array<MyBuffer, 10>` (WGSL)\
         /// `buffer myBuffer { ... } buffer_array[10]` (GLSL)
         ///
         /// Supported platforms:

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3741,7 +3741,9 @@ pub enum BufferBindingType {
     /// ```
     Storage {
         /// If `true`, the buffer can only be read in the shader,
-        /// and it must be annotated with `readonly`.
+        /// and it:
+        /// - may or may not be annotated with `read` (WGSL).
+        /// - must be annotated with `readonly` (GLSL).
         ///
         /// Example WGSL syntax:
         /// ```rust,ignore
@@ -3784,7 +3786,7 @@ pub enum TextureSampleType {
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// uniform texture2D t;
+    /// readonly uniform texture2D t;
     /// ```
     Float {
         /// If `filterable` is false, the texture can't be sampled with
@@ -3802,7 +3804,7 @@ pub enum TextureSampleType {
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// uniform texture2DShadow t;
+    /// readonly uniform texture2DShadow t;
     /// ```
     Depth,
     /// Sampling returns signed integers.
@@ -3816,7 +3818,7 @@ pub enum TextureSampleType {
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// uniform itexture2D t;
+    /// readonly uniform itexture2D t;
     /// ```
     Sint,
     /// Sampling returns unsigned integers.
@@ -3830,7 +3832,7 @@ pub enum TextureSampleType {
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
-    /// uniform utexture2D t;
+    /// readonly uniform utexture2D t;
     /// ```
     Uint,
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2195,7 +2195,7 @@ impl TextureFormat {
             Self::Rgb10a2Unorm =>        (   native,   float,    linear, msaa_resolve, (1, 1),  4, attachment, 4),
             Self::Rg11b10Float =>        (   native,   float,    linear,         msaa, (1, 1),  4,      basic, 3),
 
-            // Packed 32 bit textures  
+            // Packed 32 bit textures
             Self::Rg32Uint =>            (   native,    uint,    linear,         noaa, (1, 1),  8,  all_flags, 2),
             Self::Rg32Sint =>            (   native,    sint,    linear,         noaa, (1, 1),  8,  all_flags, 2),
             Self::Rg32Float =>           (   native, nearest,    linear,         noaa, (1, 1),  8,  all_flags, 2),
@@ -2203,7 +2203,7 @@ impl TextureFormat {
             Self::Rgba16Sint =>          (   native,    sint,    linear,         msaa, (1, 1),  8,  all_flags, 4),
             Self::Rgba16Float =>         (   native,   float,    linear, msaa_resolve, (1, 1),  8,  all_flags, 4),
 
-            // Packed 32 bit textures  
+            // Packed 32 bit textures
             Self::Rgba32Uint =>          (   native,    uint,    linear,         noaa, (1, 1), 16,  all_flags, 4),
             Self::Rgba32Sint =>          (   native,    sint,    linear,         noaa, (1, 1), 16,  all_flags, 4),
             Self::Rgba32Float =>         (   native, nearest,    linear,         noaa, (1, 1), 16,  all_flags, 4),
@@ -2215,7 +2215,7 @@ impl TextureFormat {
             Self::Depth24PlusStencil8 => (   native,   depth,    linear,         msaa, (1, 1),  4, attachment, 2),
             Self::Depth24UnormStencil8 => (  d24_s8,   depth,    linear,         msaa, (1, 1),  4, attachment, 2),
 
-            // Packed uncompressed  
+            // Packed uncompressed
             Self::Rgb9e5Ufloat =>        (   native,   float,    linear,         noaa, (1, 1),  4,      basic, 3),
 
             // Optional normalized 16-bit-per-channel formats
@@ -3706,6 +3706,16 @@ pub struct ImageDataLayout {
 pub enum BufferBindingType {
     /// A buffer for uniform values.
     ///
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// struct Globals {
+    ///     a_uniform: vec2<f32>,
+    ///     another_uniform: vec2<f32>
+    /// }
+    /// @group(0) @binding(0)
+    /// var<uniform> globals: Globals;
+    /// ```
+    ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(std140, binding = 0)
@@ -3717,6 +3727,12 @@ pub enum BufferBindingType {
     Uniform,
     /// A storage buffer.
     ///
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// @group(0) @binding(0)
+    /// var<storage, read_write> my_element: array<vec4<f32>>;
+    /// ```
+    ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout (set=0, binding=0) buffer myStorageBuffer {
@@ -3726,6 +3742,12 @@ pub enum BufferBindingType {
     Storage {
         /// If `true`, the buffer can only be read in the shader,
         /// and it must be annotated with `readonly`.
+        ///
+        /// Example WGSL syntax:
+        /// ```rust,ignore
+        /// @group(0) @binding(0)
+        /// var<storage, read> my_element: array<vec4<f32>>;
+        /// ```
         ///
         /// Example GLSL syntax:
         /// ```cpp,ignore
@@ -3753,6 +3775,12 @@ impl Default for BufferBindingType {
 pub enum TextureSampleType {
     /// Sampling returns floats.
     ///
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// @group(0) @binding(0)
+    /// var t: texure_2d<f32>;
+    /// ```
+    ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
@@ -3765,6 +3793,12 @@ pub enum TextureSampleType {
     },
     /// Sampling does the depth reference comparison.
     ///
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// @group(0) @binding(0)
+    /// var t: texture_depth_2d;
+    /// ```
+    ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
@@ -3773,6 +3807,12 @@ pub enum TextureSampleType {
     Depth,
     /// Sampling returns signed integers.
     ///
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// @group(0) @binding(0)
+    /// var t: texture_2d<i32>;
+    /// ```
+    ///
     /// Example GLSL syntax:
     /// ```cpp,ignore
     /// layout(binding = 0)
@@ -3780,6 +3820,12 @@ pub enum TextureSampleType {
     /// ```
     Sint,
     /// Sampling returns unsigned integers.
+    ///
+    /// Example WGSL syntax:
+    /// ```rust,ignore
+    /// @group(0) @binding(0)
+    /// var t: texture_2d<u32>;
+    /// ```
     ///
     /// Example GLSL syntax:
     /// ```cpp,ignore

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -326,12 +326,14 @@ bitflags::bitflags! {
         const MAPPABLE_PRIMARY_BUFFERS = 1 << 16;
         /// Allows the user to create uniform arrays of textures in shaders:
         ///
-        /// eg. `uniform texture2D textures[10]`.
+        /// eg. `var textures: array<texture_2d<f32>, 10>` (WGPU), `uniform texture2D textures[10]`
+        /// (GLSL).
         ///
         /// If [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] is supported as well as this, the user
         /// may also create uniform arrays of storage textures.
         ///
-        /// eg. `uniform image2D textures[10]`.
+        /// eg. `var textures: array<texture_storage_2d<f32, write>, 10>` (WGSL),
+        /// `uniform image2D textures[10]` (GLSL).
         ///
         /// This capability allows them to exist and to be indexed by dynamically uniform
         /// values.
@@ -345,7 +347,8 @@ bitflags::bitflags! {
         const TEXTURE_BINDING_ARRAY = 1 << 17;
         /// Allows the user to create arrays of buffers in shaders:
         ///
-        /// eg. `uniform myBuffer { .... } buffer_array[10]`.
+        /// eg. `var<uniform> buffer_array: array<MyBuffer, 10>` (WGSL),
+        /// `uniform myBuffer { ... } buffer_array[10]` (GLSL).
         ///
         /// This capability allows them to exist and to be indexed by dynamically uniform
         /// values.
@@ -353,7 +356,8 @@ bitflags::bitflags! {
         /// If [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] is supported as well as this, the user
         /// may also create arrays of storage buffers.
         ///
-        /// eg. `buffer myBuffer { ... } buffer_array[10]`
+        /// eg. `var<storage> buffer_array: array<MyBuffer, 10>` (WGSL),
+        /// `buffer myBuffer { ... } buffer_array[10]` (GLSL).
         ///
         /// Supported platforms:
         /// - DX12

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -326,8 +326,9 @@ bitflags::bitflags! {
         const MAPPABLE_PRIMARY_BUFFERS = 1 << 16;
         /// Allows the user to create uniform arrays of textures in shaders:
         ///
-        /// eg. `var textures: array<texture_2d<f32>, 10>` (WGPU), `uniform texture2D textures[10]`
-        /// (GLSL).
+        /// ex. 
+        /// `var textures: binding_array<texture_2d<f32>, 10>` (WGSL)  
+        /// `uniform texture2D textures[10]` (GLSL)
         ///
         /// If [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] is supported as well as this, the user
         /// may also create uniform arrays of storage textures.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3877,7 +3877,7 @@ pub enum StorageTextureAccess {
     /// `readonly` (GLSL).
     ///
     /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] must be enabled to use this access
-    /// mode. This is a nonstandard, native-only extension.
+    /// mode. This is a native-only extension.
     ///
     /// Example WGSL syntax:
     /// ```rust,ignore


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
- [x] Add `Features` example(s).
- [x] Add `BufferBindingType` example(s).
- [x] Add `BindingType` example(s).
- [x] Add `StorageTextureAccess` example(s).
- [x] Add `TextureSampleType` example(s).
- [x] Add `TextureViewDimension` example(s).

**Connections**
Partly addresses #2849.

**Description**
Adds WGSL examples to *wgpu* documentation to complement the existing examples written in GLSL.

**Testing**
Run `cargo doc` to observe that the documentation is updated, and compile the WGSL examples (e.g. with *naga*) to confirm they are valid.
