### PR TITLE
use smallvec instead of inplace_it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -490,6 +490,7 @@ DeviceDescriptor {
 - Update parking_lot to 0.12. by @emilio in [#2639](https://github.com/gfx-rs/wgpu/pull/2639)
 - Accept both parking-lot 0.11 and 0.12, to avoid windows-rs. by @jimblandy in [#2660](https://github.com/gfx-rs/wgpu/pull/2660)
 - Update web-sys to 0.3.58, sparse attachments support by @jinleili in [#2813](https://github.com/gfx-rs/wgpu/pull/2813)
+- Remove use of inplace_it by @mockersf in [#2889](https://github.com/gfx-rs/wgpu/pull/2889)
 
 ### deno-webgpu
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,12 +864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inplace_it"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90953f308a79fe6d62a4643e51f848fbfddcd05975a38e69fdf4ab86a7baf7ca"
-
-[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,7 +2127,6 @@ dependencies = [
  "glutin",
  "gpu-alloc",
  "gpu-descriptor",
- "inplace_it",
  "js-sys",
  "khronos-egl",
  "libloading",
@@ -2146,6 +2139,7 @@ dependencies = [
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
+ "smallvec",
  "thiserror",
  "wasm-bindgen",
  "web-sys",

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.59"
 [features]
 default = []
 metal = ["naga/msl-out", "block", "foreign-types"]
-vulkan = ["naga/spv-out", "ash", "gpu-alloc", "gpu-descriptor", "libloading", "inplace_it"]
+vulkan = ["naga/spv-out", "ash", "gpu-alloc", "gpu-descriptor", "libloading", "smallvec"]
 gles = ["naga/glsl-out", "glow", "egl", "libloading"]
 dx11 = ["naga/hlsl-out", "native", "libloading", "winapi/d3d11", "winapi/d3d11_1", "winapi/d3d11_2", "winapi/d3d11sdklayers", "winapi/dxgi1_6"]
 dx12 = ["naga/hlsl-out", "native", "bit-set", "range-alloc", "winapi/d3d12", "winapi/d3d12shader", "winapi/d3d12sdklayers", "winapi/dxgi1_6"]
@@ -51,7 +51,7 @@ foreign-types = { version = "0.3", optional = true }
 ash = { version = "0.37", optional = true }
 gpu-alloc = { version = "0.5", optional = true }
 gpu-descriptor = { version = "0.2", optional = true }
-inplace_it = { version = "0.3.3", optional = true }
+smallvec = { version = "1", optional = true }
 
 # backend: Gles
 glow = { version = "0.11.1", optional = true }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -51,7 +51,7 @@ foreign-types = { version = "0.3", optional = true }
 ash = { version = "0.37", optional = true }
 gpu-alloc = { version = "0.5", optional = true }
 gpu-descriptor = { version = "0.2", optional = true }
-smallvec = { version = "1", optional = true }
+smallvec = { version = "1", optional = true, features = ["union"] }
 
 # backend: Gles
 glow = { version = "0.11.1", optional = true }

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -2,7 +2,6 @@ use super::conv;
 
 use arrayvec::ArrayVec;
 use ash::{extensions::ext, vk};
-use inplace_it::inplace_or_alloc_from_iter;
 
 use std::{mem, ops::Range, slice};
 
@@ -208,11 +207,12 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             size: r.size.get(),
         });
 
-        inplace_or_alloc_from_iter(vk_regions_iter, |vk_regions| {
-            self.device
-                .raw
-                .cmd_copy_buffer(self.active, src.raw, dst.raw, vk_regions)
-        })
+        self.device.raw.cmd_copy_buffer(
+            self.active,
+            src.raw,
+            dst.raw,
+            &smallvec::SmallVec::<[vk::BufferCopy; 32]>::from_iter(vk_regions_iter),
+        );
     }
 
     unsafe fn copy_texture_to_texture<T>(
@@ -244,16 +244,14 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             }
         });
 
-        inplace_or_alloc_from_iter(vk_regions_iter, |vk_regions| {
-            self.device.raw.cmd_copy_image(
-                self.active,
-                src.raw,
-                src_layout,
-                dst.raw,
-                DST_IMAGE_LAYOUT,
-                vk_regions,
-            );
-        });
+        self.device.raw.cmd_copy_image(
+            self.active,
+            src.raw,
+            src_layout,
+            dst.raw,
+            DST_IMAGE_LAYOUT,
+            &smallvec::SmallVec::<[vk::ImageCopy; 32]>::from_iter(vk_regions_iter),
+        );
     }
 
     unsafe fn copy_buffer_to_texture<T>(
@@ -266,15 +264,13 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     {
         let vk_regions_iter = dst.map_buffer_copies(regions);
 
-        inplace_or_alloc_from_iter(vk_regions_iter, |vk_regions| {
-            self.device.raw.cmd_copy_buffer_to_image(
-                self.active,
-                src.raw,
-                dst.raw,
-                DST_IMAGE_LAYOUT,
-                vk_regions,
-            );
-        });
+        self.device.raw.cmd_copy_buffer_to_image(
+            self.active,
+            src.raw,
+            dst.raw,
+            DST_IMAGE_LAYOUT,
+            &smallvec::SmallVec::<[vk::BufferImageCopy; 32]>::from_iter(vk_regions_iter),
+        );
     }
 
     unsafe fn copy_texture_to_buffer<T>(
@@ -289,15 +285,13 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         let src_layout = conv::derive_image_layout(src_usage, src.aspects);
         let vk_regions_iter = src.map_buffer_copies(regions);
 
-        inplace_or_alloc_from_iter(vk_regions_iter, |vk_regions| {
-            self.device.raw.cmd_copy_image_to_buffer(
-                self.active,
-                src.raw,
-                src_layout,
-                dst.raw,
-                vk_regions,
-            );
-        });
+        self.device.raw.cmd_copy_image_to_buffer(
+            self.active,
+            src.raw,
+            src_layout,
+            dst.raw,
+            &smallvec::SmallVec::<[vk::BufferImageCopy; 32]>::from_iter(vk_regions_iter),
+        );
     }
 
     unsafe fn begin_query(&mut self, set: &super::QuerySet, index: u32) {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -2,7 +2,6 @@ use super::conv;
 
 use arrayvec::ArrayVec;
 use ash::{extensions::khr, vk};
-use inplace_it::inplace_or_alloc_from_iter;
 use parking_lot::Mutex;
 
 use std::{
@@ -462,13 +461,16 @@ impl
         layouts: impl ExactSizeIterator<Item = &'a vk::DescriptorSetLayout>,
         sets: &mut impl Extend<vk::DescriptorSet>,
     ) -> Result<(), gpu_descriptor::DeviceAllocationError> {
-        let result = inplace_or_alloc_from_iter(layouts.cloned(), |layouts_slice| {
-            let vk_info = vk::DescriptorSetAllocateInfo::builder()
+        let result = self.raw.allocate_descriptor_sets(
+            &vk::DescriptorSetAllocateInfo::builder()
                 .descriptor_pool(*pool)
-                .set_layouts(layouts_slice)
-                .build();
-            self.raw.allocate_descriptor_sets(&vk_info)
-        });
+                .set_layouts(
+                    &smallvec::SmallVec::<[vk::DescriptorSetLayout; 32]>::from_iter(
+                        layouts.cloned(),
+                    ),
+                )
+                .build(),
+        );
 
         match result {
             Ok(vk_sets) => {
@@ -497,9 +499,10 @@ impl
         pool: &mut vk::DescriptorPool,
         sets: impl Iterator<Item = vk::DescriptorSet>,
     ) {
-        let result = inplace_or_alloc_from_iter(sets, |sets_slice| {
-            self.raw.free_descriptor_sets(*pool, sets_slice)
-        });
+        let result = self.raw.free_descriptor_sets(
+            *pool,
+            &smallvec::SmallVec::<[vk::DescriptorSet; 32]>::from_iter(sets),
+        );
         match result {
             Ok(()) => {}
             Err(err) => log::error!("free_descriptor_sets: {:?}", err),
@@ -827,21 +830,26 @@ impl crate::Device<super::Api> for super::Device {
         I: Iterator<Item = crate::MemoryRange>,
     {
         let vk_ranges = self.shared.make_memory_ranges(buffer, ranges);
-        inplace_or_alloc_from_iter(vk_ranges, |array| {
-            self.shared.raw.flush_mapped_memory_ranges(array).unwrap()
-        });
+
+        self.shared
+            .raw
+            .flush_mapped_memory_ranges(
+                &smallvec::SmallVec::<[vk::MappedMemoryRange; 32]>::from_iter(vk_ranges),
+            )
+            .unwrap();
     }
     unsafe fn invalidate_mapped_ranges<I>(&self, buffer: &super::Buffer, ranges: I)
     where
         I: Iterator<Item = crate::MemoryRange>,
     {
         let vk_ranges = self.shared.make_memory_ranges(buffer, ranges);
-        inplace_or_alloc_from_iter(vk_ranges, |array| {
-            self.shared
-                .raw
-                .invalidate_mapped_memory_ranges(array)
-                .unwrap()
-        });
+
+        self.shared
+            .raw
+            .invalidate_mapped_memory_ranges(
+                &smallvec::SmallVec::<[vk::MappedMemoryRange; 32]>::from_iter(vk_ranges),
+            )
+            .unwrap();
     }
 
     unsafe fn create_texture(
@@ -1123,7 +1131,7 @@ impl crate::Device<super::Api> for super::Device {
             }
         }
 
-        //Note: not bothering with inplace_or_alloc_from_iter her as it's low frequency
+        //Note: not bothering with on stack array here as it's low frequency
         let vk_bindings = desc
             .entries
             .iter()
@@ -1235,7 +1243,7 @@ impl crate::Device<super::Api> for super::Device {
         &self,
         desc: &crate::PipelineLayoutDescriptor<super::Api>,
     ) -> Result<super::PipelineLayout, crate::DeviceError> {
-        //Note: not bothering with inplace_or_alloc_from_iter her as it's low frequency
+        //Note: not bothering with on stack array here as it's low frequency
         let vk_set_layouts = desc
             .bind_group_layouts
             .iter()


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

**Description**
Remove `inplace_it` to use `smallvec` instead. While `inlace_it` tries to be clever with the size of the array used, I just set it to 32 in `smallvec`
On latest nightly, `inplace_it` fails to compile. This will probably be fixed on Rust (https://github.com/rust-lang/rust/pull/99288) or `inplace_it` (https://github.com/NotIntMan/inplace_it/pull/11), but `inplace_it` hasn't been updated in a while.

**Testing**
This is Vulkan only change and I don't have a Vulkan capable machine, so not tested a lot...
