### PR TITLE
[BREAKING] Make `Shader(Module)Source::Wgsl` optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,9 @@ jobs:
       - name: check web
         if: matrix.kind == 'web'
         run: |
+          # build with no features
+          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu --no-default-features
+
           # build examples
           cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu --examples
 
@@ -194,7 +197,7 @@ jobs:
         if: matrix.kind == 'em'
         run: |
           # build for Emscripten/WebGL
-          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu -p wgpu-hal --features webgl,emscripten
+          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu -p wgpu-hal --no-default-features --features webgl,emscripten
 
           # build raw-gles example
           cargo ${{matrix.tool}} --target ${{ matrix.target }} --example raw-gles --features webgl,emscripten
@@ -203,7 +206,7 @@ jobs:
         if: matrix.kind == 'local' || matrix.kind == 'other'
         run: |
           # check with no features
-          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu -p wgpu-core -p wgpu-info -p player
+          cargo ${{matrix.tool}} --target ${{ matrix.target }} -p wgpu -p wgpu-core -p wgpu-info -p player --no-default-features
 
           # check with all features
           # explicitly don't mention wgpu-hal so that --all-features don't apply to it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ Bottom level categories:
 - Convert all `Default` Implementations on Enums to `derive(Default)`
 - Implement `Default` for `CompositeAlphaMode`
 
+### Added/New Features
+
+Add the `"wgsl"` feature, to enable WGSL shaders in `wgpu-core` and `wgpu`. Enabled by default in `wgpu`. By @daxpedda in [#2890](https://github.com/gfx-rs/wgpu/pull/2890).
+
 ### Bug Fixes
 
 #### General

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -14,5 +14,5 @@ description = "WebGPU implementation for Deno"
 deno_core = "0.151.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.19", features = ["full"] }
-wgpu-core = { path = "../wgpu-core", features = ["trace", "replay", "serde", "strict_asserts"] }
+wgpu-core = { path = "../wgpu-core", features = ["trace", "replay", "serde", "strict_asserts", "wgsl"] }
 wgpu-types = { path = "../wgpu-types", features = ["trace", "replay", "serde"] }

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -29,7 +29,7 @@ features = ["replay"]
 [dependencies.wgc]
 path = "../wgpu-core"
 package = "wgpu-core"
-features = ["replay", "raw-window-handle", "strict_asserts"]
+features = ["replay", "raw-window-handle", "strict_asserts", "wgsl"]
 
 [dev-dependencies]
 serde = "1"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -24,6 +24,8 @@ replay = ["serde", "wgt/replay", "arrayvec/serde", "naga/deserialize"]
 # Enable serializable compute/render passes, and bundle encoders.
 serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
 id32 = []
+# Enable `ShaderModuleSource::Wgsl`
+wgsl = ["naga/wgsl-in"]
 vulkan-portability = ["hal/vulkan"]
 
 [dependencies]
@@ -46,7 +48,7 @@ thiserror = "1"
 git = "https://github.com/gfx-rs/naga"
 rev = "c52d9102"
 version = "0.10"
-features = ["clone", "span", "validate", "wgsl-in"]
+features = ["clone", "span", "validate"]
 
 [dependencies.wgt]
 path = "../wgpu-types"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/gfx-rs/wgpu"
 repository = "https://github.com/gfx-rs/wgpu"
 keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [lib]
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -76,9 +76,10 @@ name = "water"
 test = true
 
 [features]
-default = []
+default = ["wgsl"]
 spirv = ["naga/spv-in"]
 glsl = ["naga/glsl-in"]
+wgsl = ["wgc?/wgsl"]
 trace = ["serde", "wgc/trace"]
 replay = ["serde", "wgc/replay"]
 angle = ["wgc/angle"]

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1094,6 +1094,15 @@ impl crate::Context for Context {
         }
     }
 
+    #[cfg_attr(
+        not(any(
+            feature = "spirv",
+            feature = "glsl",
+            feature = "wgsl",
+            feature = "naga"
+        )),
+        allow(unreachable_code, unused_variables)
+    )]
     fn device_create_shader_module(
         &self,
         device: &Self::DeviceId,
@@ -1134,9 +1143,11 @@ impl crate::Context for Context {
 
                 wgc::pipeline::ShaderModuleSource::Naga(std::borrow::Cow::Owned(module))
             }
+            #[cfg(feature = "wgsl")]
             ShaderSource::Wgsl(ref code) => wgc::pipeline::ShaderModuleSource::Wgsl(Borrowed(code)),
             #[cfg(feature = "naga")]
             ShaderSource::Naga(module) => wgc::pipeline::ShaderModuleSource::Naga(module),
+            ShaderSource::Dummy(_) => panic!("found `ShaderSource::Dummy`"),
         };
         let (id, error) = wgc::gfx_select!(
             device.id => global.device_create_shader_module(device.id, &descriptor, source, ())

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -858,11 +858,17 @@ pub enum ShaderSource<'a> {
         defines: naga::FastHashMap<String, String>,
     },
     /// WGSL module as a string slice.
+    #[cfg(feature = "wgsl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "wgsl")))]
     Wgsl(Cow<'a, str>),
     /// Naga module.
     #[cfg(feature = "naga")]
     #[cfg_attr(docsrs, doc(cfg(feature = "naga")))]
     Naga(Cow<'static, naga::Module>),
+    /// Dummy variant because `Naga` doesn't have a lifetime and without enough active features it
+    /// could be the last one active.
+    #[doc(hidden)]
+    Dummy(PhantomData<&'a ()>),
 }
 static_assertions::assert_impl_all!(ShaderSource: Send, Sync);
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Discussed in Matrix.

**Description**
This is totally a breaking change! It also might turn out entirely unnecessary if the compile-time savings aren't worth the added complexity.

At the moment the `naga` `wgsl-in` crate feature is active even when completely unnecessary. This addresses it by gating `Shader(Module)Source::Wgsl` behind a new `wgsl` crate feature, like with `ShaderSource::Glsl` for example. The added `wgsl` crate feature is also active by default.

Code quality is definitely a bit worse with all of these `#[cfg(...)]` now. CI time is increased because `--no-default-features` has to be tested.

I also didn't know what to do about `Shader(Module)Source`s lifetime, at the moment the lifetime is not present when the only active variant is `Naga`, which I consider very user unfriendly and could only be fixed by either stop using `Cow` or adding a dummy lifetime to the `Naga` variant. ~~This could also be solved by #2903, so maybe we should merge that first.~~ (can't bind `'a` to the `'static` in `Cow`)

I also had to increase the MSRV to 1.60 to not unnecessarily pull in `wgpu-core` on WASM by using the weak dependency feature.

**Testing**
Added additional runs with `--no-default-features` in the CI.
