### PR TITLE
Validate against the maximum binding index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ the same every time it is rendered, we now warn if it is missing.
 - Add some validation in map_async by @nical in [#2876](https://github.com/gfx-rs/wgpu/pull/2876)
 - Fix bugs when mapping/unmapping zero-sized buffers and ranges by @nical in [#2877](https://github.com/gfx-rs/wgpu/pull/2877)
 - Validate the number of color attachments in `create_render_pipeline` by @nical in [#2913](https://github.com/gfx-rs/wgpu/pull/2913)
+- Validate against the maximum binding index in `create_bind_group_layout` by @nical in [#2892]
 
 #### DX12
 - `DownlevelCapabilities::default()` now returns the `ANISOTROPIC_FILTERING` flag set to true so DX12 lists `ANISOTROPIC_FILTERING` as true again by @cwfitzgerald in [#2851](https://github.com/gfx-rs/wgpu/pull/2851)

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -48,6 +48,8 @@ pub enum CreateBindGroupLayoutError {
     },
     #[error(transparent)]
     TooManyBindings(BindingTypeMaxCountError),
+    #[error("Binding index {binding} is greater than the maximum index {maximum}")]
+    InvalidBindingIndex { binding: u32, maximum: u32 },
 }
 
 //TODO: refactor this to move out `enum BindingError`.

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -31,6 +31,9 @@ pub mod queue;
 #[cfg(any(feature = "trace", feature = "replay"))]
 pub mod trace;
 
+// Per WebGPU specification.
+pub const MAX_BINDING_INDEX: u32 = 65535;
+
 pub const SHADER_STAGE_COUNT: usize = 3;
 // Should be large enough for the largest possible texture row. This value is enough for a 16k texture with float4 format.
 pub(crate) const ZERO_BUFFER_SIZE: BufferAddress = 512 << 10;
@@ -4090,6 +4093,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let mut entry_map = FastHashMap::default();
             for entry in desc.entries.iter() {
+                if entry.binding > MAX_BINDING_INDEX {
+                    break 'outer binding_model::CreateBindGroupLayoutError::InvalidBindingIndex {
+                        binding: entry.binding,
+                        maximum: MAX_BINDING_INDEX,
+                    };
+                }
                 if entry_map.insert(entry.binding, *entry).is_some() {
                     break 'outer binding_model::CreateBindGroupLayoutError::ConflictBinding(
                         entry.binding,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

WebGPU spec: https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbindgrouplayout

**Description**

This PR validates that binding indices in `create_bind_group_layout` aren't larger than the maximum binding index from teh WebGPU specification, so it's another baby step towards WebGPU compliance.

This also sort of mitigates driver issues with very large binding indices on vulkan. The vulkan spec is made with the expectation that the driver allocates a contiguous buffer of descriptors at least as large as the maximum binding index. Binding indices are expected to be small, and some drivers don't expect that allocation to fail (which is fairly easy to trigger by repeatedly creating bind group layouts with enormous binding indices.

Note that Dawn internally renames all binding indices to compact them, including in their vulkan backend. That's a much stronger mitigation against that source of driver issues.

**Testing**

None