### PR TITLE
Implement `Clone` for `ShaderModuleDescriptor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,8 +1043,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f50357e1167a3ab92d6b3c7f4bf5f7fd13fde3f4b28bf0d5ea07b5100fdb6c0"
+source = "git+https://github.com/gfx-rs/naga?rev=48e79388#48e79388b506535d668df4f6c7be4e681812ab81"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -41,9 +41,9 @@ smallvec = "1"
 thiserror = "1"
 
 [dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
-version = "0.9"
+git = "https://github.com/gfx-rs/naga"
+rev = "48e79388"
+#version = "0.9"
 features = ["span", "validate", "wgsl-in"]
 
 [dependencies.wgt]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -95,16 +95,16 @@ js-sys = { version = "0.3" }
 android_system_properties = "0.1.1"
 
 [dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
-version = "0.9"
+git = "https://github.com/gfx-rs/naga"
+rev = "48e79388"
+#version = "0.9"
 
 # DEV dependencies
 
 [dev-dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
-version = "0.9"
+git = "https://github.com/gfx-rs/naga"
+rev = "48e79388"
+#version = "0.9"
 features = ["wgsl-in"]
 
 [dev-dependencies]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -139,22 +139,23 @@ pollster = "0.2"
 env_logger = "0.9"
 
 [dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
-version = "0.9"
+git = "https://github.com/gfx-rs/naga"
+rev = "48e79388"
+#version = "0.9"
+features = ["clone"]
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
-version = "0.9"
+git = "https://github.com/gfx-rs/naga"
+rev = "48e79388"
+#version = "0.9"
 features = ["wgsl-in"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
-version = "0.9"
+git = "https://github.com/gfx-rs/naga"
+rev = "48e79388"
+#version = "0.9"
 features = ["wgsl-out"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -814,6 +814,7 @@ impl Drop for ShaderModule {
 ///
 /// Any necessary shader translation (e.g. from WGSL to SPIR-V or vice versa)
 /// will be done internally by wgpu.
+#[derive(Clone)]
 #[non_exhaustive]
 pub enum ShaderSource<'a> {
     /// SPIR-V module represented as a slice of words.
@@ -847,6 +848,7 @@ pub enum ShaderSource<'a> {
 ///
 /// Corresponds to [WebGPU `GPUShaderModuleDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpushadermoduledescriptor).
+#[derive(Clone)]
 pub struct ShaderModuleDescriptor<'a> {
     /// Debug label of the shader module. This will show up in graphics debuggers for easy identification.
     pub label: Label<'a>,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Depends on https://github.com/gfx-rs/naga/pull/2013.

**Description**
I am playing around with pre-compiled shaders and encountered an issue with storing them in `static`s, `ShaderSource::Naga` needs to own it, so cloning solves the problem.

**Testing**
None.
