### PR TITLE
[BREAKING] Wrap `ShaderSource::Naga` in `Cow<'static>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ the same every time it is rendered, we now warn if it is missing.
 - Update Winit to version 0.27 and raw-window-handle to 0.5 by @wyatt-herkamp in  [#2918](https://github.com/gfx-rs/wgpu/pull/2918)
 - Address Clippy 0.1.63 complaints. By @jimblandy in [#2977](https://github.com/gfx-rs/wgpu/pull/2977)
 - Don't use `PhantomData` for `IdentityManager`'s `Input` type. By @jimblandy in [#2972](https://github.com/gfx-rs/wgpu/pull/2972)
+- Changed Naga variant in ShaderSource to `Cow<'static, Module>`, to allow loading global variables by @daxpedda in [#2903](https://github.com/gfx-rs/wgpu/pull/2903)
 
 #### Metal
 - Extract the generic code into `get_metal_layer` by @jinleili in [#2826](https://github.com/gfx-rs/wgpu/pull/2826)

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -47,7 +47,7 @@ thiserror = "1"
 git = "https://github.com/gfx-rs/naga"
 rev = "b209d911"
 version = "0.9"
-features = ["span", "validate", "wgsl-in"]
+features = ["clone", "span", "validate", "wgsl-in"]
 
 [dependencies.wgt]
 path = "../wgpu-types"

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1201,7 +1201,7 @@ impl<A: HalApi> Device<A> {
                         inner,
                     })
                 })?;
-                (module, code.into_owned())
+                (Cow::Owned(module), code.into_owned())
             }
             pipeline::ShaderModuleSource::Naga(module) => (module, String::new()),
         };

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -21,7 +21,7 @@ pub(crate) struct LateSizedBufferGroup {
 #[allow(clippy::large_enum_variant)]
 pub enum ShaderModuleSource<'a> {
     Wgsl(Cow<'a, str>),
-    Naga(naga::Module),
+    Naga(Cow<'static, naga::Module>),
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -98,6 +98,7 @@ android_system_properties = "0.1.1"
 git = "https://github.com/gfx-rs/naga"
 rev = "b209d911"
 version = "0.9"
+features = ["clone"]
 
 # DEV dependencies
 

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -6,7 +6,13 @@ use hal::{
     Adapter as _, CommandEncoder as _, Device as _, Instance as _, Queue as _, Surface as _,
 };
 
-use std::{borrow::Borrow, iter, mem, num::NonZeroU32, ptr, time::Instant};
+use std::{
+    borrow::{Borrow, Cow},
+    iter, mem,
+    num::NonZeroU32,
+    ptr,
+    time::Instant,
+};
 
 const MAX_BUNNIES: usize = 1 << 20;
 const BUNNY_SIZE: f32 = 0.15 * 256.0;
@@ -143,7 +149,10 @@ impl<A: hal::Api> Example<A> {
             )
             .validate(&module)
             .unwrap();
-            hal::NagaShader { module, info }
+            hal::NagaShader {
+                module: Cow::Owned(module),
+                info,
+            }
         };
         let shader_desc = hal::ShaderModuleDescriptor {
             label: None,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -83,7 +83,7 @@ pub mod api {
 pub use vulkan::UpdateAfterBindTypes;
 
 use std::{
-    borrow::Borrow,
+    borrow::{Borrow, Cow},
     fmt,
     num::{NonZeroU32, NonZeroU8},
     ops::{Range, RangeInclusive},
@@ -939,7 +939,7 @@ pub struct CommandEncoderDescriptor<'a, A: Api> {
 /// Naga shader module.
 pub struct NagaShader {
     /// Shader module IR.
-    pub module: naga::Module,
+    pub module: Cow<'static, naga::Module>,
     /// Analysis information of the module.
     pub info: naga::valid::ModuleInfo,
 }

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -142,6 +142,7 @@ env_logger = "0.9"
 git = "https://github.com/gfx-rs/naga"
 rev = "b209d911"
 version = "0.9"
+features = ["clone"]
 optional = true
 
 # used to test all the example shaders

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1097,7 +1097,7 @@ impl crate::Context for Context {
                 };
                 let parser = naga::front::spv::Parser::new(spv.iter().cloned(), &options);
                 let module = parser.parse().unwrap();
-                wgc::pipeline::ShaderModuleSource::Naga(module)
+                wgc::pipeline::ShaderModuleSource::Naga(std::borrow::Cow::Owned(module))
             }
             #[cfg(feature = "glsl")]
             ShaderSource::Glsl {
@@ -1113,7 +1113,7 @@ impl crate::Context for Context {
                 let mut parser = naga::front::glsl::Parser::default();
                 let module = parser.parse(&options, shader).unwrap();
 
-                wgc::pipeline::ShaderModuleSource::Naga(module)
+                wgc::pipeline::ShaderModuleSource::Naga(std::borrow::Cow::Owned(module))
             }
             ShaderSource::Wgsl(ref code) => wgc::pipeline::ShaderModuleSource::Wgsl(Borrowed(code)),
             #[cfg(feature = "naga")]

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -815,6 +815,7 @@ impl Drop for ShaderModule {
 ///
 /// Any necessary shader translation (e.g. from WGSL to SPIR-V or vice versa)
 /// will be done internally by wgpu.
+#[cfg_attr(feature = "naga", allow(clippy::large_enum_variant))]
 #[non_exhaustive]
 pub enum ShaderSource<'a> {
     /// SPIR-V module represented as a slice of words.
@@ -841,7 +842,7 @@ pub enum ShaderSource<'a> {
     /// Naga module.
     #[cfg(feature = "naga")]
     #[cfg_attr(docsrs, doc(cfg(feature = "naga")))]
-    Naga(naga::Module),
+    Naga(Cow<'static, naga::Module>),
 }
 
 /// Descriptor for use with [`Device::create_shader_module`].


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Depends on https://github.com/gfx-rs/naga/pull/2013.

**Description**
I'm currently pre-compiling shaders and storing them as `const`, but `ShaderSource::Naga` wants to own `naga::Module`s, as far as I understand, for good reasons, because it stores them, so not owning them would be problematic. Using `Cow<'static, Module>`, solves this, even if it looks strange.

**Testing**
None.
