### PR TITLE
Expand StagingBelt documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ the same every time it is rendered, we now warn if it is missing.
 #### General
 - Added downlevel restriction error message for `InvalidFormatUsages` error by @Seamooo in [#2886](https://github.com/gfx-rs/wgpu/pull/2886)
 
+### Documentation
+
+- Expanded `StagingBelt` documentation by @kpreid in [#2905](https://github.com/gfx-rs/wgpu/pull/2905)
+
 ## wgpu-0.13.2 (2022-07-13)
 
 ### Bug Fixes


### PR DESCRIPTION
**Checklist**
- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Expand StagingBelt documentation:

* Give advice on the *minimum* `chunk_size`, for more efficient memory usage.
* Explain the state transitions and valid call sequences in more detail.
* More intra-doc links.
