### PR TITLE
StagingBelt: check for free chunks in the `receiver` as well as `free_chunks`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ the same every time it is rendered, we now warn if it is missing.
 #### General
 - Added downlevel restriction error message for `InvalidFormatUsages` error by @Seamooo in [#2886](https://github.com/gfx-rs/wgpu/pull/2886)
 
+### Performance
+
+- Made `StagingBelt::write_buffer()` check more thoroughly for reusable memory; by @kpreid in [#2906](https://github.com/gfx-rs/wgpu/pull/2906)
+
 ### Documentation
 
 - Expanded `StagingBelt` documentation by @kpreid in [#2905](https://github.com/gfx-rs/wgpu/pull/2905)


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md.

**Description**
Previously, chunks would only be taken from the GPU callback receiver and put on `free_chunks` during `finish()`. So, there might be chunks that are actually available for use but wouldn't be used.

Now, we consult the receiver whenever we're about to consult the `free_chunks`, so the reuse of chunks will be as good as possible (given the application's uses of operations that trigger `map_async` callbacks).

**Testing**
StagingBelt has no automated tests, so I ran the `examples/skybox` and my own application that uses `StagingBelt`, and confirmed that there were no errors or noticeable negative performance consequences.

I don't have any proof that this is ever a performance improvement in practice; it just feels like low-hanging fruit.
