### PR TITLE
Fix documentation claiming shader entry points must return void

### DIFF
--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -151,8 +151,8 @@ impl CreateShaderModuleError {
 pub struct ProgrammableStageDescriptor<'a> {
     /// The compiled shader module for this stage.
     pub module: ShaderModuleId,
-    /// The name of the entry point in the compiled shader. There must be a function that returns
-    /// void with this name in the shader.
+    /// The name of the entry point in the compiled shader. There must be a function with this name
+    /// in the shader.
     pub entry_point: Cow<'a, str>,
 }
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -969,8 +969,8 @@ pub struct ShaderModuleDescriptor<'a> {
 pub struct ProgrammableStage<'a, A: Api> {
     /// The compiled shader module for this stage.
     pub module: &'a A::ShaderModule,
-    /// The name of the entry point in the compiled shader. There must be a function that returns
-    /// void with this name in the shader.
+    /// The name of the entry point in the compiled shader. There must be a function with this name
+    ///  in the shader.
     pub entry_point: &'a str,
 }
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1468,8 +1468,8 @@ pub struct VertexBufferLayout<'a> {
 pub struct VertexState<'a> {
     /// The compiled shader module for this stage.
     pub module: &'a ShaderModule,
-    /// The name of the entry point in the compiled shader. There must be a function that returns
-    /// void with this name in the shader.
+    /// The name of the entry point in the compiled shader. There must be a function with this name
+    /// in the shader.
     pub entry_point: &'a str,
     /// The format of any vertex buffers used with this pipeline.
     pub buffers: &'a [VertexBufferLayout<'a>],
@@ -1485,8 +1485,8 @@ pub struct VertexState<'a> {
 pub struct FragmentState<'a> {
     /// The compiled shader module for this stage.
     pub module: &'a ShaderModule,
-    /// The name of the entry point in the compiled shader. There must be a function that returns
-    /// void with this name in the shader.
+    /// The name of the entry point in the compiled shader. There must be a function with this name
+    /// in the shader.
     pub entry_point: &'a str,
     /// The color state of the render targets.
     pub targets: &'a [Option<ColorTargetState>],
@@ -1545,8 +1545,8 @@ pub struct ComputePipelineDescriptor<'a> {
     pub layout: Option<&'a PipelineLayout>,
     /// The compiled shader module for this stage.
     pub module: &'a ShaderModule,
-    /// The name of the entry point in the compiled shader. There must be a function that returns
-    /// void with this name in the shader.
+    /// The name of the entry point in the compiled shader. There must be a function with this name
+    /// and no return value in the shader.
     pub entry_point: &'a str,
 }
 


### PR DESCRIPTION
While following https://sotrh.github.io/learn-wgpu/beginner/tutorial3-pipeline/ I was confused that the documentation for the shader entry point states that the function must return void when this was [not the case](https://github.com/sotrh/learn-wgpu/blob/1220dfa70ba9c85f2a3d078914ae811a6a63c5ad/code/beginner/tutorial3-pipeline/src/shader.wgsl) in the article.

As far as I can tell no such restriction exists.