### PR TITLE
changed websys features in core and hal to align with used features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ the same every time it is rendered, we now warn if it is missing.
 
 #### General
 - Improve the validation and error reporting of buffer mappings by @nical in [#2848](https://github.com/gfx-rs/wgpu/pull/2848)
+- Fix compilation errors when using wgpu-core in isolation while targetting `wasm32-unknown-unknown` by @Seamooo in [#2922](https://github.com/gfx-rs/wgpu/pull/2922)
 
 ### Changes
 

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -56,9 +56,11 @@ path = "../wgpu-hal"
 package = "wgpu-hal"
 version = "0.13"
 
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+web-sys = { version = "0.3", features = ["HtmlCanvasElement", "OffscreenCanvas"] }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 hal = { path = "../wgpu-hal", package = "wgpu-hal", version = "0.13", features = ["gles"] }
-web-sys = { version = "0.3", features = ["HtmlCanvasElement"] }
 
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
 hal = { path = "../wgpu-hal", package = "wgpu-hal", version = "0.13", features = ["metal"] }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -88,7 +88,7 @@ core-graphics-types = "0.1"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
 wasm-bindgen = { version = "0.2" }
-web-sys = { version = "0.3", features = ["Window", "HtmlCanvasElement", "WebGl2RenderingContext"] }
+web-sys = { version = "0.3", features = ["Window", "HtmlCanvasElement", "WebGl2RenderingContext", "OffscreenCanvas"] }
 js-sys = { version = "0.3" }
 
 [target.'cfg(target_os = "android")'.dependencies]


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
addresses https://github.com/gfx-rs/wgpu/issues/2894 

**Description**
if using wgpu-core or wgpu-hal as a dependency with target `wasm32-unknown-unknown` without specifying the web-sys feature: `OffscreenCanvas` in the dependencies, both wgpu-core and wgpu-hal would fail to compile (wgpu-hal only when using the gles feature which is effectively implied by the target). The trivial fix to this is adding `OffscreenCanvas` to the web-sys features in wgpu-hal, as wgpu-core also depends on it whenever needing to use web-sys, however, for semantics sake, the feature is in use in wgpu-core as well, so has been added, however behind a more restrictive target as that's the only time web-sys is in use.

**Testing**
inside wgpu/wgpu-core:
- `cargo build --target wasm32-unknown-unknown`
- `cargo build --target wasm32-unknown-emscripten`

inside wgpu/wgpu-hal
- `cargo build --target wasm32-unknown-unknown --features gles`
- `cargo build --target wasm32-unknown-emscripten --features emscripten`

all builds succeed, whereas previously the wasm32-unknown-unknown target builds would fail
