### PR TITLE
Add `Buffer::size()` and `Buffer::usage()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ the same every time it is rendered, we now warn if it is missing.
 +fn vert_main(v_in: VertexInput) -> @builtin(position) @invariant vec4<f32> {...}
 ```
 
+### Added/New Features
+
+- Add `Buffer::size()` and `Buffer::usage()`
+
 ### Bug Fixes
 
 #### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ the same every time it is rendered, we now warn if it is missing.
 
 ### Added/New Features
 
-- Add `Buffer::size()` and `Buffer::usage()`
+- Add `Buffer::size()` and `Buffer::usage()`; by @kpreid in [#2923](https://github.com/gfx-rs/wgpu/pull/2923)
 
 ### Bug Fixes
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -659,6 +659,7 @@ pub struct Buffer {
     context: Arc<C>,
     id: <C as Context>::BufferId,
     map_context: Mutex<MapContext>,
+    size: wgt::BufferAddress,
     usage: BufferUsages,
 }
 
@@ -2129,6 +2130,7 @@ impl Device {
             context: Arc::clone(&self.context),
             id: Context::device_create_buffer(&*self.context, &self.id, desc),
             map_context: Mutex::new(map_context),
+            size: desc.size,
             usage: desc.usage,
         }
     }
@@ -2425,6 +2427,20 @@ impl Buffer {
     /// Destroy the associated native resources as soon as possible.
     pub fn destroy(&self) {
         Context::buffer_destroy(&*self.context, &self.id);
+    }
+
+    /// Returns the length of the buffer allocation in bytes.
+    ///
+    /// This is always equal to the `size` that was specified when creating the buffer.
+    pub fn size(&self) -> wgt::BufferAddress {
+        self.size
+    }
+
+    /// Returns the allowed usages for this `Buffer`.
+    ///
+    /// This is always equal to the `usage` that was specified when creating the buffer.
+    pub fn usage(&self) -> BufferUsages {
+        self.usage
     }
 }
 

--- a/wgpu/tests/buffer.rs
+++ b/wgpu/tests/buffer.rs
@@ -1,0 +1,19 @@
+use crate::common::{initialize_test, TestParameters};
+
+#[test]
+fn buffer_size_and_usage_get() {
+    initialize_test(TestParameters::default(), |ctx| {
+        let buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 1234,
+            usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        assert_eq!(buffer.size(), 1234);
+        assert_eq!(
+            buffer.usage(),
+            wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST
+        );
+    })
+}

--- a/wgpu/tests/resource_descriptor_accessor.rs
+++ b/wgpu/tests/resource_descriptor_accessor.rs
@@ -1,7 +1,8 @@
 use crate::common::{initialize_test, TestParameters};
 
+/// Buffer's size and usage can be read back.
 #[test]
-fn buffer_size_and_usage_get() {
+fn buffer_size_and_usage() {
     initialize_test(TestParameters::default(), |ctx| {
         let buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
             label: None,

--- a/wgpu/tests/root.rs
+++ b/wgpu/tests/root.rs
@@ -1,6 +1,7 @@
 // All files containing tests
 mod common;
 
+mod buffer;
 mod clear_texture;
 mod device;
 mod example_wgsl;

--- a/wgpu/tests/root.rs
+++ b/wgpu/tests/root.rs
@@ -1,12 +1,12 @@
 // All files containing tests
 mod common;
 
-mod buffer;
 mod clear_texture;
 mod device;
 mod example_wgsl;
 mod instance;
 mod poll;
+mod resource_descriptor_accessor;
 mod shader_primitive_index;
 mod vertex_indices;
 mod zero_init_texture_after_discard;


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #2904

**Description**
Implements `size` and `usage` from https://gpuweb.github.io/gpuweb/#buffer-interface

**Testing**
Added a unit test and ran the test suite. Since this does not interact with the backend at all, there should be no platform-specific testing needed.
