### PR TITLE
Silence `clippy::let_unit_value` false positives on `objc::msg_send` calls.

### DIFF
--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::let_unit_value)] // `let () =` being used to constrain result type
+
 use std::{mem, os::raw::c_void, ptr::NonNull, sync::Once, thread};
 
 use core_graphics_types::{


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] ~~Add change to CHANGELOG.md.~~ Not a user-visible change.

**Description**
The `let_unit_value` lint is new in Rust 1.62, and warns on all of our `let () = msg_send![]` calls.
https://github.com/rust-lang/rust-clippy/pull/9056 might quiet it next release, though, so this may or may not be worth doing.

**Testing**
`cargo clippy` is now silent on macOS.
