### PR TITLE
Fix opening of renderdoc lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ the same every time it is rendered, we now warn if it is missing.
 
 #### General
 - Improve the validation and error reporting of buffer mappings by @nical in [#2848](https://github.com/gfx-rs/wgpu/pull/2848)
+- Fixed opening of RenderDoc library by @abuffseagull in [#2930](https://github.com/gfx-rs/wgpu/pull/2930)
 
 ### Changes
 

--- a/wgpu-hal/src/auxil/renderdoc.rs
+++ b/wgpu-hal/src/auxil/renderdoc.rs
@@ -29,6 +29,7 @@ pub enum RenderDoc {
 }
 
 // TODO: replace with libloading API once supported
+#[cfg(unix)]
 const RTLD_NOLOAD: i32 = 0x4;
 
 impl RenderDoc {

--- a/wgpu-hal/src/auxil/renderdoc.rs
+++ b/wgpu-hal/src/auxil/renderdoc.rs
@@ -28,6 +28,9 @@ pub enum RenderDoc {
     },
 }
 
+// TODO: replace with libloading API once supported
+const RTLD_NOLOAD: i32 = 0x4;
+
 impl RenderDoc {
     pub unsafe fn new() -> Self {
         type GetApiFn = unsafe extern "C" fn(version: u32, out: *mut *mut ffi::c_void) -> i32;
@@ -39,7 +42,20 @@ impl RenderDoc {
         #[cfg(target_os = "android")]
         let renderdoc_filename = "libVkLayer_GLES_RenderDoc.so";
 
-        let renderdoc_lib = match libloading::Library::new(renderdoc_filename) {
+        #[cfg(unix)]
+        let renderdoc_result: Result<libloading::Library, libloading::Error> =
+            libloading::os::unix::Library::open(
+                Some(renderdoc_filename),
+                libloading::os::unix::RTLD_NOW | RTLD_NOLOAD,
+            )
+            .map(|lib| lib.into());
+
+        #[cfg(windows)]
+        let renderdoc_result: Result<libloading::Library, libloading::Error> =
+            libloading::os::windows::Library::open_already_loaded(renderdoc_filename)
+                .map(|lib| lib.into());
+
+        let renderdoc_lib = match renderdoc_result {
             Ok(lib) => lib,
             Err(e) => {
                 return RenderDoc::NotAvailable {


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Same issue in ebkalderon/renderdoc-rs#128
Fixes #2793

**Description**
Renderdoc needs to not be opened by us, but instead open the existing copy.
This currently requires OS specific flags for opening and `libloading` doesn't have full API coverage.

**Testing**
The examples didn't work before, now they work fine.
Although I was just able to test Linux only, so anyone who wants to make a quick test with RenderDoc on Windows and Mac would be great.
