### PR TITLE
note PresentMode::Mailbox support for Wayland

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3020,7 +3020,7 @@ pub enum PresentMode {
     ///
     /// No tearing will be observed.
     ///
-    /// Supported on DX11/12 on Windows 10, and NVidia on Vulkan.
+    /// Supported on DX11/12 on Windows 10, NVidia on Vulkan and Wayland on Vulkan.
     ///
     /// This is traditionally called "Fast Vsync"
     Mailbox = 5,


### PR DESCRIPTION
Wayland is inherently a mailbox system and hence should be noted as always supporting Mailbox (at least on Vulkan where it's explicitly known, the Wayland EGL platform isn't too clear about the present mode).

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Note support for the `Mailbox` present mode on Wayland on Vulkan. Wayland is inherently a mailbox system and therefore all Vulkan implementations must report the mailbox present mode.
