### PR TITLE
Map bounds check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,8 @@ the same every time it is rendered, we now warn if it is missing.
 - Fix bugs when mapping/unmapping zero-sized buffers and ranges by @nical in [#2877](https://github.com/gfx-rs/wgpu/pull/2877)
 - Fix out-of-bound write in `map_buffer` with non-zero offset by @nical in [#2916](https://github.com/gfx-rs/wgpu/pull/2916)
 - Validate the number of color attachments in `create_render_pipeline` by @nical in [#2913](https://github.com/gfx-rs/wgpu/pull/2913)
-- Validate against the maximum binding index in `create_bind_group_layout` by @nical in [#2892]
+- Validate against the maximum binding index in `create_bind_group_layout` by @nical in [#2892](https://github.com/gfx-rs/wgpu/pull/2892)
+- Validate that map_async's range is not negative by @nical in [#2938](https://github.com/gfx-rs/wgpu/pull/2938)
 
 #### DX12
 - `DownlevelCapabilities::default()` now returns the `ANISOTROPIC_FILTERING` flag set to true so DX12 lists `ANISOTROPIC_FILTERING` as true again by @cwfitzgerald in [#2851](https://github.com/gfx-rs/wgpu/pull/2851)

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -5403,9 +5403,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     BufferMapAsyncStatus::InvalidAlignment
                 }
                 &BufferAccessError::OutOfBoundsUnderrun { .. }
-                | &BufferAccessError::OutOfBoundsOverrun { .. } => {
-                    BufferMapAsyncStatus::InvalidRange
-                }
+                | &BufferAccessError::OutOfBoundsOverrun { .. }
+                | &BufferAccessError::NegativeRange { .. } => BufferMapAsyncStatus::InvalidRange,
                 _ => BufferMapAsyncStatus::Error,
             };
 
@@ -5456,6 +5455,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 return Err((op, e.into()));
             }
 
+            if range.start > range.end {
+                return Err((
+                    op,
+                    BufferAccessError::NegativeRange {
+                        start: range.start,
+                        end: range.end,
+                    },
+                ));
+            }
             if range.end > buffer.size {
                 return Err((
                     op,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -173,6 +173,11 @@ pub enum BufferAccessError {
         index: wgt::BufferAddress,
         max: wgt::BufferAddress,
     },
+    #[error("buffer map range start {start} is greater than end {end}")]
+    NegativeRange {
+        start: wgt::BufferAddress,
+        end: wgt::BufferAddress,
+    },
 }
 
 pub(crate) struct BufferPendingMapping {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Fixes #2935.

**Description**

The range is not entirely bounds checked in buffer_map_async. It uses unsigned integers guaranteeing that the range can't underflow the buffer, and the range's end is also checked against the size of the buffer, but a user calling into wgpu_core directly (such as Firefox), could pass a negative range which is invalid and also would allow the start offset to be outside of the bounds of the buffer.

The fix is simply to validate that the range is not negative. Since the end of the range is already validated against the buffer size, it means the buffer start isn't allowed to overflow the buffer.

**Testing**

None.