### PR TITLE
Expose the vk::Queue in the Vulkan hal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ the same every time it is rendered, we now warn if it is missing.
 
 #### Vulkan
 - Remove use of Vulkan12Features/Properties types. By @i509VCB in [#2936](https://github.com/gfx-rs/wgpu/pull/2936)
+- Provide a means for `wgpu` users to access `vk::Queue` and the queue index. By @anlumo in [#2950](https://github.com/gfx-rs/wgpu/pull/2950)
 
 ### Documentation
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1181,6 +1181,8 @@ impl super::Adapter {
         let shared = Arc::new(super::DeviceShared {
             raw: raw_device,
             family_index,
+            queue_index,
+            raw_queue,
             handle_is_owned,
             instance: Arc::clone(&self.instance),
             physical_device: self.raw,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -714,12 +714,20 @@ impl super::Device {
         self.shared.family_index
     }
 
+    pub fn queue_index(&self) -> u32 {
+        self.shared.queue_index
+    }
+
     pub fn raw_device(&self) -> &ash::Device {
         &self.shared.raw
     }
 
     pub fn raw_physical_device(&self) -> ash::vk::PhysicalDevice {
         self.shared.physical_device
+    }
+
+    pub fn raw_queue(&self) -> ash::vk::Queue {
+        self.shared.raw_queue
     }
 
     pub fn enabled_device_extensions(&self) -> &[&'static CStr] {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -296,6 +296,8 @@ impl UpdateAfterBindTypes {
 struct DeviceShared {
     raw: ash::Device,
     family_index: u32,
+    queue_index: u32,
+    raw_queue: ash::vk::Queue,
     handle_is_owned: bool,
     instance: Arc<InstanceShared>,
     physical_device: ash::vk::PhysicalDevice,


### PR DESCRIPTION
**Connections**

Followup to #2667.

**Description**

Allows users of wgpu to access `vk::Queue` using a simple accessor in the Vulkan backend.