### PR TITLE
Fix calculation/validation of layer/mip ranges in create_texture_view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ the same every time it is rendered, we now warn if it is missing.
 - Validate the number of color attachments in `create_render_pipeline` by @nical in [#2913](https://github.com/gfx-rs/wgpu/pull/2913)
 - Validate against the maximum binding index in `create_bind_group_layout` by @nical in [#2892](https://github.com/gfx-rs/wgpu/pull/2892)
 - Validate that map_async's range is not negative by @nical in [#2938](https://github.com/gfx-rs/wgpu/pull/2938)
+- Fix calculation/validation of layer/mip ranges in create_texture_view by @nical in [#2955](https://github.com/gfx-rs/wgpu/pull/2955)
 
 #### DX12
 - `DownlevelCapabilities::default()` now returns the `ANISOTROPIC_FILTERING` flag set to true so DX12 lists `ANISOTROPIC_FILTERING` as true again by @cwfitzgerald in [#2851](https://github.com/gfx-rs/wgpu/pull/2851)

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -948,18 +948,21 @@ impl<A: HalApi> Device<A> {
             },
         };
 
-        let required_level_count =
-            desc.range.base_mip_level + desc.range.mip_level_count.map_or(1, |count| count.get());
+        let mip_count = desc.range.mip_level_count.map_or(1, |count| count.get());
+        let required_level_count = desc.range.base_mip_level.saturating_add(mip_count);
+
         let required_layer_count = match desc.range.array_layer_count {
-            Some(count) => desc.range.base_array_layer + count.get(),
+            Some(count) => desc.range.base_array_layer.saturating_add(count.get()),
             None => match view_dim {
                 wgt::TextureViewDimension::D1
                 | wgt::TextureViewDimension::D2
                 | wgt::TextureViewDimension::D3 => 1,
                 wgt::TextureViewDimension::Cube => 6,
                 _ => texture.desc.array_layer_count(),
-            },
+            }
+            .max(desc.range.base_array_layer.saturating_add(1)),
         };
+
         let level_end = texture.full_range.mips.end;
         let layer_end = texture.full_range.layers.end;
         if required_level_count > level_end {


### PR DESCRIPTION
Back with some more validation fixes.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

https://bugzilla.mozilla.org/show_bug.cgi?id=1780057

**Description**

The previous code was doing "selector.layers = base_layer .. count" instead of "base_layer .. base_layer + count" which looked dubious. Same thing for the mip range. It was also not taking the base layer count when in requested_layer_count when the texture was not a texture array which led to invalid ranges and underflow when asking for a non-zero base layer with a (non-array) 2d texture.

The fix consists in:
 - writing the ranges as `base .. base + count`
 - always taking the provided base layer into account in the requested layer count even where it doesn't make sense (since it will ensure validation catches the error).


**Testing**

None