### PR TITLE
Add missing validation in copy_texture_to-Buffer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ the same every time it is rendered, we now warn if it is missing.
 - Validate the number of color attachments in `create_render_pipeline` by @nical in [#2913](https://github.com/gfx-rs/wgpu/pull/2913)
 - Validate against the maximum binding index in `create_bind_group_layout` by @nical in [#2892](https://github.com/gfx-rs/wgpu/pull/2892)
 - Validate that map_async's range is not negative by @nical in [#2938](https://github.com/gfx-rs/wgpu/pull/2938)
+- Validate the sample count and mip level in `copy_texture_to_buffer` by @nical in [#2958](https://github.com/gfx-rs/wgpu/pull/2958)
 
 #### DX12
 - `DownlevelCapabilities::default()` now returns the `ANISOTROPIC_FILTERING` flag set to true so DX12 lists `ANISOTROPIC_FILTERING` as true again by @cwfitzgerald in [#2851](https://github.com/gfx-rs/wgpu/pull/2851)


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Spec: https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copytexturetobuffer
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1774456

**Description**

Another missing validation found by fuzzers.

Per WebGPU spec:
 - The source sample count must be 1
 - the requested mip level must be < mip level count.
