### PR TITLE
Document some wgpu-core resource tracking types

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -224,6 +224,25 @@ impl<A: hal::Api> Resource for Buffer<A> {
     }
 }
 
+/// A temporary buffer, consumed by the command that uses it.
+///
+/// A [`StagingBuffer`] is designed for one-shot uploads of data to the GPU. It
+/// is always created mapped, and the command that uses it destroys the buffer
+/// when it is done.
+///
+/// [`StagingBuffer`]s can be created with [`queue_create_staging_buffer`] and
+/// used with [`queue_write_staging_buffer`]. They are also used internally by
+/// operations like [`queue_write_texture`] that need to upload data to the GPU,
+/// but that don't belong to any particular wgpu command buffer.
+///
+/// Used `StagingBuffer`s are accumulated in [`Device::pending_writes`], to be
+/// freed once their associated operation's queue submission has finished
+/// execution.
+///
+/// [`queue_create_staging_buffer`]: Global::queue_create_staging_buffer
+/// [`queue_write_staging_buffer`]: Global::queue_write_staging_buffer
+/// [`queue_write_texture`]: Global::queue_write_texture
+/// [`Device::pending_writes`]: crate::device::Device
 pub struct StagingBuffer<A: hal::Api> {
     pub(crate) raw: A::Buffer,
     pub(crate) size: wgt::BufferAddress,


### PR DESCRIPTION
Add doc comments for `TempResource`, `PendingWrites`, and `StagingBuffer`.

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] (not relevant) Add change to CHANGELOG.md. See simple instructions inside file.
