### PR TITLE
Avoid overflow in check texture copy bounds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,8 @@ jobs:
           for backend in ${{ matrix.backends }}; do
             echo "======= NATIVE TESTS $backend ======";
             WGPU_BACKEND=$backend cargo nextest run -p wgpu --no-fail-fast
+            # Test that we catch overflows in `--release` builds too.
+            WGPU_BACKEND=$backend cargo nextest run --release -p wgpu --no-fail-fast
           done
 
   fmt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ the same every time it is rendered, we now warn if it is missing.
 
 #### General
 - Free `StagingBuffers` even when an error occurs in the operation that consumes them. By @jimblandy in [#2961](https://github.com/gfx-rs/wgpu/pull/2961)
+- Avoid overflow when checking that texture copies fall within bounds. By @jimblandy in [#2963](https://github.com/gfx-rs/wgpu/pull/2963)
 - Improve the validation and error reporting of buffer mappings by @nical in [#2848](https://github.com/gfx-rs/wgpu/pull/2848)
 - Fix compilation errors when using wgpu-core in isolation while targetting `wasm32-unknown-unknown` by @Seamooo in [#2922](https://github.com/gfx-rs/wgpu/pull/2922)
 - Fixed opening of RenderDoc library by @abuffseagull in [#2930](https://github.com/gfx-rs/wgpu/pull/2930)

--- a/wgpu/tests/texture_bounds.rs
+++ b/wgpu/tests/texture_bounds.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroU32;
 
 #[test]
 fn bad_copy_origin() {
-    fn try_origin(origin: wgpu::Origin3d, should_panic: bool) {
+    fn try_origin(origin: wgpu::Origin3d, size: wgpu::Extent3d, should_panic: bool) {
         let mut parameters = TestParameters::default();
         if should_panic {
             parameters = parameters.failure();
@@ -23,15 +23,68 @@ fn bad_copy_origin() {
                 },
                 &data,
                 BUFFER_COPY_LAYOUT,
-                TEXTURE_SIZE,
+                size,
             );
         });
     }
 
-    try_origin(wgpu::Origin3d { x: 0, y: 0, z: 0 }, false);
-    try_origin(wgpu::Origin3d { x: 1, y: 0, z: 0 }, true);
-    try_origin(wgpu::Origin3d { x: 0, y: 1, z: 0 }, true);
-    try_origin(wgpu::Origin3d { x: 0, y: 0, z: 1 }, true);
+    try_origin(wgpu::Origin3d { x: 0, y: 0, z: 0 }, TEXTURE_SIZE, false);
+    try_origin(wgpu::Origin3d { x: 1, y: 0, z: 0 }, TEXTURE_SIZE, true);
+    try_origin(wgpu::Origin3d { x: 0, y: 1, z: 0 }, TEXTURE_SIZE, true);
+    try_origin(wgpu::Origin3d { x: 0, y: 0, z: 1 }, TEXTURE_SIZE, true);
+
+    try_origin(
+        wgpu::Origin3d {
+            x: TEXTURE_SIZE.width - 1,
+            y: TEXTURE_SIZE.height - 1,
+            z: TEXTURE_SIZE.depth_or_array_layers - 1,
+        },
+        wgpu::Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        false,
+    );
+    try_origin(
+        wgpu::Origin3d {
+            x: u32::MAX,
+            y: 0,
+            z: 0,
+        },
+        wgpu::Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        true,
+    );
+    try_origin(
+        wgpu::Origin3d {
+            x: u32::MAX,
+            y: 0,
+            z: 0,
+        },
+        wgpu::Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        true,
+    );
+    try_origin(
+        wgpu::Origin3d {
+            x: u32::MAX,
+            y: 0,
+            z: 0,
+        },
+        wgpu::Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        true,
+    );
 }
 
 const TEXTURE_SIZE: wgpu::Extent3d = wgpu::Extent3d {


### PR DESCRIPTION
Fixes #2962. Includes new tests.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.