### PR TITLE
Use concrete `Future` types in public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ the same every time it is rendered, we now warn if it is missing.
 - Added downlevel restriction error message for `InvalidFormatUsages` error by @Seamooo in [#2886](https://github.com/gfx-rs/wgpu/pull/2886)
 - Add warning when using CompareFunction::*Equal with vertex shader that is missing @invariant tag by @cwfitzgerald in [#2887](https://github.com/gfx-rs/wgpu/pull/2887)
 - Update Winit to version 0.27 and raw-window-handle to 0.5 by @wyatt-herkamp in  [#2918](https://github.com/gfx-rs/wgpu/pull/2918)
+- Used concrete `Future` types for `Instance::request_adapter()` and `Adapter::request_device()` in [#2970](https://github.com/gfx-rs/wgpu/pull/2970)
 
 #### Metal
 - Extract the generic code into `get_metal_layer` by @jinleili in [#2826](https://github.com/gfx-rs/wgpu/pull/2826)


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
None.

**Description**
I am trying to implement a render state that can be polled to finish `request_adapter` and `request_device` instead of using `await`. This has come up because of https://github.com/rust-windowing/winit/issues/2051, now we have to call  `request_adapter` and `request_device` inside the event loop, which isn't allowed to block.

**Testing**
Actually quiet well tested by the existing infrastructure.
