### PR TITLE
vk: fix `astc_hdr` formats support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ the same every time it is rendered, we now warn if it is missing.
 #### Metal
 - Add the missing `msg_send![view, retain]` call within `from_view` by @jinleili in [#2976](https://github.com/gfx-rs/wgpu/pull/2976)
 
+#### Vulkan
+
+- Fix `astc_hdr` formats support by @jinleili in [#2971]](https://github.com/gfx-rs/wgpu/pull/2971)
+
 ### Changes
 
 #### General

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -624,6 +624,7 @@ bitflags::bitflags! {
         ///
         /// Supported Platforms:
         /// - Metal
+        /// - Vulkan
         ///
         /// This is a native-only feature.
         const TEXTURE_COMPRESSION_ASTC_HDR = 1 << 40;


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/gfx-rs/wgpu/issues/2969

**Testing**
Tested on Android 12 (OnePlus Ace Pro) via [wgpu-on-app](https://github.com/jinleili/wgpu-on-app)
