### PR TITLE
Use () instead of PhantomData as IdentityManager's Input type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ the same every time it is rendered, we now warn if it is missing.
 - Added downlevel restriction error message for `InvalidFormatUsages` error by @Seamooo in [#2886](https://github.com/gfx-rs/wgpu/pull/2886)
 - Add warning when using CompareFunction::*Equal with vertex shader that is missing @invariant tag by @cwfitzgerald in [#2887](https://github.com/gfx-rs/wgpu/pull/2887)
 - Update Winit to version 0.27 and raw-window-handle to 0.5 by @wyatt-herkamp in  [#2918](https://github.com/gfx-rs/wgpu/pull/2918)
-
+- Don't use `PhantomData` for `IdentityManager`'s `Input` type. By @jimblandy in [#2972](https://github.com/gfx-rs/wgpu/pull/2972)
 #### Metal
 - Extract the generic code into `get_metal_layer` by @jinleili in [#2826](https://github.com/gfx-rs/wgpu/pull/2826)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,8 @@ the same every time it is rendered, we now warn if it is missing.
 - Added downlevel restriction error message for `InvalidFormatUsages` error by @Seamooo in [#2886](https://github.com/gfx-rs/wgpu/pull/2886)
 - Add warning when using CompareFunction::*Equal with vertex shader that is missing @invariant tag by @cwfitzgerald in [#2887](https://github.com/gfx-rs/wgpu/pull/2887)
 - Update Winit to version 0.27 and raw-window-handle to 0.5 by @wyatt-herkamp in  [#2918](https://github.com/gfx-rs/wgpu/pull/2918)
+- Address Clippy 0.1.63 complaints. By @jimblandy in [#2977](https://github.com/gfx-rs/wgpu/pull/2977)
 - Don't use `PhantomData` for `IdentityManager`'s `Input` type. By @jimblandy in [#2972](https://github.com/gfx-rs/wgpu/pull/2972)
-- Address Clippy 0.1.63 complaints. By @jimb in [#2977](https://github.com/gfx-rs/wgpu/pull/2977)
 #### Metal
 - Extract the generic code into `get_metal_layer` by @jinleili in [#2826](https://github.com/gfx-rs/wgpu/pull/2826)
 

--- a/deno_webgpu/src/binding.rs
+++ b/deno_webgpu/src/binding.rs
@@ -192,7 +192,7 @@ pub fn op_webgpu_create_bind_group_layout(
     gfx_put!(device => instance.device_create_bind_group_layout(
     device,
     &descriptor,
-    std::marker::PhantomData
+    ()
   ) => state, WebGpuBindGroupLayout)
 }
 
@@ -226,7 +226,7 @@ pub fn op_webgpu_create_pipeline_layout(
     gfx_put!(device => instance.device_create_pipeline_layout(
     device,
     &descriptor,
-    std::marker::PhantomData
+    ()
   ) => state, super::pipeline::WebGpuPipelineLayout)
 }
 
@@ -304,6 +304,6 @@ pub fn op_webgpu_create_bind_group(
     gfx_put!(device => instance.device_create_bind_group(
     device,
     &descriptor,
-    std::marker::PhantomData
+    ()
   ) => state, WebGpuBindGroup)
 }

--- a/deno_webgpu/src/buffer.rs
+++ b/deno_webgpu/src/buffer.rs
@@ -57,7 +57,7 @@ pub fn op_webgpu_create_buffer(
     gfx_put!(device => instance.device_create_buffer(
     device,
     &descriptor,
-    std::marker::PhantomData
+    ()
   ) => state, WebGpuBuffer)
 }
 

--- a/deno_webgpu/src/bundle.rs
+++ b/deno_webgpu/src/bundle.rs
@@ -104,7 +104,7 @@ pub fn op_webgpu_render_bundle_encoder_finish(
     &wgpu_core::command::RenderBundleDescriptor {
       label: label.map(Cow::from),
     },
-    std::marker::PhantomData
+    ()
   ) => state, WebGpuRenderBundle)
 }
 

--- a/deno_webgpu/src/command_encoder.rs
+++ b/deno_webgpu/src/command_encoder.rs
@@ -45,7 +45,7 @@ pub fn op_webgpu_create_command_encoder(
     gfx_put!(device => instance.device_create_command_encoder(
     device,
     &descriptor,
-    std::marker::PhantomData
+    ()
   ) => state, WebGpuCommandEncoder)
 }
 

--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -250,7 +250,7 @@ pub async fn op_webgpu_request_adapter(
     };
     let res = instance.request_adapter(
         &descriptor,
-        wgpu_core::instance::AdapterInputs::Mask(backends, |_| std::marker::PhantomData),
+        wgpu_core::instance::AdapterInputs::Mask(backends, |_| ()),
     );
 
     let adapter = match res {
@@ -413,7 +413,7 @@ pub async fn op_webgpu_request_device(
       adapter,
       &descriptor,
       std::env::var("DENO_WEBGPU_TRACE").ok().as_ref().map(std::path::Path::new),
-      std::marker::PhantomData
+      ()
     ));
     if let Some(err) = maybe_err {
         return Err(DomExceptionOperationError::new(&err.to_string()).into());
@@ -536,7 +536,7 @@ pub fn op_webgpu_create_query_set(
     gfx_put!(device => instance.device_create_query_set(
     device,
     &descriptor,
-    std::marker::PhantomData
+    ()
   ) => state, WebGpuQuerySet)
 }
 

--- a/deno_webgpu/src/pipeline.rs
+++ b/deno_webgpu/src/pipeline.rs
@@ -95,8 +95,8 @@ pub fn op_webgpu_create_compute_pipeline(
         GPUPipelineLayoutOrGPUAutoLayoutMode::Layout(_) => None,
         GPUPipelineLayoutOrGPUAutoLayoutMode::Auto(GPUAutoLayoutMode::Auto) => {
             Some(wgpu_core::device::ImplicitPipelineIds {
-                root_id: std::marker::PhantomData,
-                group_ids: &[std::marker::PhantomData; MAX_BIND_GROUPS],
+                root_id: (),
+                group_ids: &[(); MAX_BIND_GROUPS],
             })
         }
     };
@@ -104,7 +104,7 @@ pub fn op_webgpu_create_compute_pipeline(
     let (compute_pipeline, maybe_err) = gfx_select!(device => instance.device_create_compute_pipeline(
       device,
       &descriptor,
-      std::marker::PhantomData,
+      (),
       implicit_pipelines
     ));
 
@@ -135,7 +135,7 @@ pub fn op_webgpu_compute_pipeline_get_bind_group_layout(
         .get::<WebGpuComputePipeline>(compute_pipeline_rid)?;
     let compute_pipeline = compute_pipeline_resource.0;
 
-    let (bind_group_layout, maybe_err) = gfx_select!(compute_pipeline => instance.compute_pipeline_get_bind_group_layout(compute_pipeline, index, std::marker::PhantomData));
+    let (bind_group_layout, maybe_err) = gfx_select!(compute_pipeline => instance.compute_pipeline_get_bind_group_layout(compute_pipeline, index, ()));
 
     let label =
         gfx_select!(bind_group_layout => instance.bind_group_layout_label(bind_group_layout));
@@ -364,8 +364,8 @@ pub fn op_webgpu_create_render_pipeline(
         GPUPipelineLayoutOrGPUAutoLayoutMode::Layout(_) => None,
         GPUPipelineLayoutOrGPUAutoLayoutMode::Auto(GPUAutoLayoutMode::Auto) => {
             Some(wgpu_core::device::ImplicitPipelineIds {
-                root_id: std::marker::PhantomData,
-                group_ids: &[std::marker::PhantomData; MAX_BIND_GROUPS],
+                root_id: (),
+                group_ids: &[(); MAX_BIND_GROUPS],
             })
         }
     };
@@ -373,7 +373,7 @@ pub fn op_webgpu_create_render_pipeline(
     let (render_pipeline, maybe_err) = gfx_select!(device => instance.device_create_render_pipeline(
       device,
       &descriptor,
-      std::marker::PhantomData,
+      (),
       implicit_pipelines
     ));
 
@@ -396,7 +396,7 @@ pub fn op_webgpu_render_pipeline_get_bind_group_layout(
         .get::<WebGpuRenderPipeline>(render_pipeline_rid)?;
     let render_pipeline = render_pipeline_resource.0;
 
-    let (bind_group_layout, maybe_err) = gfx_select!(render_pipeline => instance.render_pipeline_get_bind_group_layout(render_pipeline, index, std::marker::PhantomData));
+    let (bind_group_layout, maybe_err) = gfx_select!(render_pipeline => instance.render_pipeline_get_bind_group_layout(render_pipeline, index, ()));
 
     let label =
         gfx_select!(bind_group_layout => instance.bind_group_layout_label(bind_group_layout));

--- a/deno_webgpu/src/sampler.rs
+++ b/deno_webgpu/src/sampler.rs
@@ -65,6 +65,6 @@ pub fn op_webgpu_create_sampler(
     gfx_put!(device => instance.device_create_sampler(
     device,
     &descriptor,
-    std::marker::PhantomData
+    ()
   ) => state, WebGpuSampler)
 }

--- a/deno_webgpu/src/shader.rs
+++ b/deno_webgpu/src/shader.rs
@@ -40,6 +40,6 @@ pub fn op_webgpu_create_shader_module(
     device,
     &descriptor,
     source,
-    std::marker::PhantomData
+    ()
   ) => state, WebGpuShaderModule)
 }

--- a/deno_webgpu/src/texture.rs
+++ b/deno_webgpu/src/texture.rs
@@ -60,7 +60,7 @@ pub fn op_webgpu_create_texture(
     gfx_put!(device => instance.device_create_texture(
     device,
     &descriptor,
-    std::marker::PhantomData
+    ()
   ) => state, WebGpuTexture)
 }
 
@@ -105,6 +105,6 @@ pub fn op_webgpu_create_texture_view(
     gfx_put!(texture => instance.texture_create_view(
     texture,
     &descriptor,
-    std::marker::PhantomData
+    ()
   ) => state, WebGpuTextureView)
 }

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -438,7 +438,7 @@ pub trait IdentityHandler<I>: Debug {
 }
 
 impl<I: id::TypedId + Debug> IdentityHandler<I> for Mutex<IdentityManager> {
-    type Input = PhantomData<I>;
+    type Input = ();
     fn process(&self, _id: Self::Input, backend: Backend) -> I {
         self.lock().alloc(backend)
     }

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -15,7 +15,6 @@ use std::{
     error::Error,
     fmt,
     future::{ready, Ready},
-    marker::PhantomData,
     ops::Range,
     slice,
     sync::Arc,
@@ -69,9 +68,7 @@ impl Context {
     #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
     pub fn enumerate_adapters(&self, backends: wgt::Backends) -> Vec<wgc::id::AdapterId> {
         self.0
-            .enumerate_adapters(wgc::instance::AdapterInputs::Mask(backends, |_| {
-                PhantomData
-            }))
+            .enumerate_adapters(wgc::instance::AdapterInputs::Mask(backends, |_| ()))
     }
 
     #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
@@ -79,7 +76,7 @@ impl Context {
         &self,
         hal_adapter: hal::ExposedAdapter<A>,
     ) -> wgc::id::AdapterId {
-        self.0.create_adapter_from_hal(hal_adapter, PhantomData)
+        self.0.create_adapter_from_hal(hal_adapter, ())
     }
 
     pub unsafe fn adapter_as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Adapter>) -> R, R>(
@@ -105,7 +102,7 @@ impl Context {
             hal_device,
             &desc.map_label(|l| l.map(Borrowed)),
             trace_dir,
-            PhantomData,
+            (),
         );
         if let Some(err) = error {
             self.handle_error_fatal(err, "Adapter::create_device_from_hal");
@@ -130,7 +127,7 @@ impl Context {
             hal_texture,
             device.id,
             &desc.map_label(|l| l.map(Borrowed)),
-            PhantomData,
+            (),
         );
         if let Some(cause) = error {
             self.handle_error(
@@ -177,7 +174,7 @@ impl Context {
         self: &Arc<Self>,
         layer: *mut std::ffi::c_void,
     ) -> crate::Surface {
-        let id = self.0.instance_create_surface_metal(layer, PhantomData);
+        let id = self.0.instance_create_surface_metal(layer, ());
         crate::Surface {
             context: Arc::clone(self),
             id: Surface {
@@ -192,7 +189,7 @@ impl Context {
         self: &Arc<Self>,
         canvas: &web_sys::HtmlCanvasElement,
     ) -> Surface {
-        let id = self.0.create_surface_webgl_canvas(canvas, PhantomData);
+        let id = self.0.create_surface_webgl_canvas(canvas, ());
         Surface {
             id,
             configured_device: Mutex::default(),
@@ -204,9 +201,7 @@ impl Context {
         self: &Arc<Self>,
         canvas: &web_sys::OffscreenCanvas,
     ) -> Surface {
-        let id = self
-            .0
-            .create_surface_webgl_offscreen_canvas(canvas, PhantomData);
+        let id = self.0.create_surface_webgl_offscreen_canvas(canvas, ());
         Surface {
             id,
             configured_device: Mutex::default(),
@@ -218,9 +213,7 @@ impl Context {
         self: &Arc<Self>,
         visual: *mut std::ffi::c_void,
     ) -> crate::Surface {
-        let id = self
-            .0
-            .instance_create_surface_from_visual(visual, PhantomData);
+        let id = self.0.instance_create_surface_from_visual(visual, ());
         crate::Surface {
             context: Arc::clone(self),
             id: Surface {
@@ -853,7 +846,7 @@ impl crate::Context for Context {
         handle: &(impl raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRawDisplayHandle),
     ) -> Self::SurfaceId {
         Surface {
-            id: self.0.instance_create_surface(handle, PhantomData),
+            id: self.0.instance_create_surface(handle, ()),
             configured_device: Mutex::new(None),
         }
     }
@@ -868,7 +861,7 @@ impl crate::Context for Context {
                 force_fallback_adapter: options.force_fallback_adapter,
                 compatible_surface: options.compatible_surface.map(|surface| surface.id.id),
             },
-            wgc::instance::AdapterInputs::Mask(wgt::Backends::all(), |_| PhantomData),
+            wgc::instance::AdapterInputs::Mask(wgt::Backends::all(), |_| ()),
         );
         ready(id.ok())
     }
@@ -892,7 +885,7 @@ impl crate::Context for Context {
             *adapter,
             &desc.map_label(|l| l.map(Borrowed)),
             trace_dir,
-            PhantomData
+            ()
         ));
         if let Some(err) = error {
             log::error!("Error in Adapter::request_device: {}", err);
@@ -1022,7 +1015,7 @@ impl crate::Context for Context {
             .lock()
             .expect("Surface was not configured?");
         match wgc::gfx_select!(
-            device_id => global.surface_get_current_texture(surface.id, PhantomData)
+            device_id => global.surface_get_current_texture(surface.id, ())
         ) {
             Ok(wgc::present::SurfaceOutput { status, texture_id }) => (
                 texture_id.map(|id| Texture {
@@ -1127,7 +1120,7 @@ impl crate::Context for Context {
             ShaderSource::Naga(module) => wgc::pipeline::ShaderModuleSource::Naga(module),
         };
         let (id, error) = wgc::gfx_select!(
-            device.id => global.device_create_shader_module(device.id, &descriptor, source, PhantomData)
+            device.id => global.device_create_shader_module(device.id, &descriptor, source, ())
         );
         if let Some(cause) = error {
             self.handle_error(
@@ -1154,7 +1147,7 @@ impl crate::Context for Context {
             shader_bound_checks: wgt::ShaderBoundChecks::unchecked(),
         };
         let (id, error) = wgc::gfx_select!(
-            device.id => global.device_create_shader_module_spirv(device.id, &descriptor, Borrowed(&desc.source), PhantomData)
+            device.id => global.device_create_shader_module_spirv(device.id, &descriptor, Borrowed(&desc.source), ())
         );
         if let Some(cause) = error {
             self.handle_error(
@@ -1179,7 +1172,7 @@ impl crate::Context for Context {
             entries: Borrowed(desc.entries),
         };
         let (id, error) = wgc::gfx_select!(
-            device.id => global.device_create_bind_group_layout(device.id, &descriptor, PhantomData)
+            device.id => global.device_create_bind_group_layout(device.id, &descriptor, ())
         );
         if let Some(cause) = error {
             self.handle_error(
@@ -1280,7 +1273,7 @@ impl crate::Context for Context {
         let (id, error) = wgc::gfx_select!(device.id => global.device_create_bind_group(
             device.id,
             &descriptor,
-            PhantomData
+            ()
         ));
         if let Some(cause) = error {
             self.handle_error(
@@ -1323,7 +1316,7 @@ impl crate::Context for Context {
         let (id, error) = wgc::gfx_select!(device.id => global.device_create_pipeline_layout(
             device.id,
             &descriptor,
-            PhantomData
+            ()
         ));
         if let Some(cause) = error {
             self.handle_error(
@@ -1358,8 +1351,8 @@ impl crate::Context for Context {
         let implicit_pipeline_ids = match desc.layout {
             Some(_) => None,
             None => Some(wgc::device::ImplicitPipelineIds {
-                root_id: PhantomData,
-                group_ids: &[PhantomData; wgc::MAX_BIND_GROUPS],
+                root_id: (),
+                group_ids: &[(); wgc::MAX_BIND_GROUPS],
             }),
         };
         let descriptor = pipe::RenderPipelineDescriptor {
@@ -1389,7 +1382,7 @@ impl crate::Context for Context {
         let (id, error) = wgc::gfx_select!(device.id => global.device_create_render_pipeline(
             device.id,
             &descriptor,
-            PhantomData,
+            (),
             implicit_pipeline_ids
         ));
         if let Some(cause) = error {
@@ -1418,8 +1411,8 @@ impl crate::Context for Context {
         let implicit_pipeline_ids = match desc.layout {
             Some(_) => None,
             None => Some(wgc::device::ImplicitPipelineIds {
-                root_id: PhantomData,
-                group_ids: &[PhantomData; wgc::MAX_BIND_GROUPS],
+                root_id: (),
+                group_ids: &[(); wgc::MAX_BIND_GROUPS],
             }),
         };
         let descriptor = pipe::ComputePipelineDescriptor {
@@ -1435,7 +1428,7 @@ impl crate::Context for Context {
         let (id, error) = wgc::gfx_select!(device.id => global.device_create_compute_pipeline(
             device.id,
             &descriptor,
-            PhantomData,
+            (),
             implicit_pipeline_ids
         ));
         if let Some(cause) = error {
@@ -1467,7 +1460,7 @@ impl crate::Context for Context {
         let (id, error) = wgc::gfx_select!(device.id => global.device_create_buffer(
             device.id,
             &desc.map_label(|l| l.map(Borrowed)),
-            PhantomData
+            ()
         ));
         if let Some(cause) = error {
             self.handle_error(
@@ -1493,7 +1486,7 @@ impl crate::Context for Context {
         let (id, error) = wgc::gfx_select!(device.id => global.device_create_texture(
             device.id,
             &desc.map_label(|l| l.map(Borrowed)),
-            PhantomData
+            ()
         ));
         if let Some(cause) = error {
             self.handle_error(
@@ -1536,7 +1529,7 @@ impl crate::Context for Context {
         let (id, error) = wgc::gfx_select!(device.id => global.device_create_sampler(
             device.id,
             &descriptor,
-            PhantomData
+            ()
         ));
         if let Some(cause) = error {
             self.handle_error(
@@ -1559,7 +1552,7 @@ impl crate::Context for Context {
         let (id, error) = wgc::gfx_select!(device.id => global.device_create_query_set(
             device.id,
             &desc.map_label(|l| l.map(Borrowed)),
-            PhantomData
+            ()
         ));
         if let Some(cause) = error {
             self.handle_error_nolabel(&device.error_sink, cause, "Device::create_query_set");
@@ -1576,7 +1569,7 @@ impl crate::Context for Context {
         let (id, error) = wgc::gfx_select!(device.id => global.device_create_command_encoder(
             device.id,
             &desc.map_label(|l| l.map(Borrowed)),
-            PhantomData
+            ()
         ));
         if let Some(cause) = error {
             self.handle_error(
@@ -1742,7 +1735,7 @@ impl crate::Context for Context {
         };
         let global = &self.0;
         let (id, error) = wgc::gfx_select!(
-            texture.id => global.texture_create_view(texture.id, &descriptor, PhantomData)
+            texture.id => global.texture_create_view(texture.id, &descriptor, ())
         );
         if let Some(cause) = error {
             self.handle_error(
@@ -1848,7 +1841,7 @@ impl crate::Context for Context {
         index: u32,
     ) -> Self::BindGroupLayoutId {
         let global = &self.0;
-        let (id, error) = wgc::gfx_select!(*pipeline => global.compute_pipeline_get_bind_group_layout(*pipeline, index, PhantomData));
+        let (id, error) = wgc::gfx_select!(*pipeline => global.compute_pipeline_get_bind_group_layout(*pipeline, index, ()));
         if let Some(err) = error {
             panic!("Error reflecting bind group {}: {}", index, err);
         }
@@ -1860,7 +1853,7 @@ impl crate::Context for Context {
         index: u32,
     ) -> Self::BindGroupLayoutId {
         let global = &self.0;
-        let (id, error) = wgc::gfx_select!(*pipeline => global.render_pipeline_get_bind_group_layout(*pipeline, index, PhantomData));
+        let (id, error) = wgc::gfx_select!(*pipeline => global.render_pipeline_get_bind_group_layout(*pipeline, index, ()));
         if let Some(err) = error {
             panic!("Error reflecting bind group {}: {}", index, err);
         }
@@ -2183,7 +2176,7 @@ impl crate::Context for Context {
         let (id, error) = wgc::gfx_select!(encoder.parent() => global.render_bundle_encoder_finish(
             encoder,
             &desc.map_label(|l| l.map(Borrowed)),
-            PhantomData
+            ()
         ));
         if let Some(err) = error {
             self.handle_error_fatal(err, "RenderBundleEncoder::finish");
@@ -2230,7 +2223,7 @@ impl crate::Context for Context {
     ) -> QueueWriteBuffer {
         let global = &self.0;
         match wgc::gfx_select!(
-            *queue => global.queue_create_staging_buffer(*queue, size, PhantomData)
+            *queue => global.queue_create_staging_buffer(*queue, size, ())
         ) {
             Ok((buffer_id, ptr)) => QueueWriteBuffer {
                 buffer_id,


### PR DESCRIPTION
PhantomData suggests that there's some sort of persuasion required for lifetime variance inference or other sorts of arcana, but it doesn't seem to be necessary at all. `()` works just fine.

I'm a little worried about this on [Chesterton's Fence](https://en.wikipedia.org/wiki/G._K._Chesterton#Chesterton's_fence) grounds, but there's only one way to find out!

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
