### PR TITLE
metal: add the missing `msg_send![view, retain]` call within `from_view`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ the same every time it is rendered, we now warn if it is missing.
 - Fix compilation errors when using wgpu-core in isolation while targetting `wasm32-unknown-unknown` by @Seamooo in [#2922](https://github.com/gfx-rs/wgpu/pull/2922)
 - Fixed opening of RenderDoc library by @abuffseagull in [#2930](https://github.com/gfx-rs/wgpu/pull/2930)
 
+#### Metal
+- Add the missing `msg_send![view, retain]` call within `from_view` by @jinleili in [#2976](https://github.com/gfx-rs/wgpu/pull/2976)
+
 ### Changes
 
 #### General

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -86,6 +86,7 @@ impl super::Surface {
         let render_layer =
             mem::transmute::<_, &mtl::MetalLayerRef>(Self::get_metal_layer(view, delegate))
                 .to_owned();
+        let _: *mut c_void = msg_send![view, retain];
         Self::new(NonNull::new(view), render_layer)
     }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/gfx-rs/wgpu/issues/2974

**Testing**
Tested on macOS and iOS
