### PR TITLE
Placate Clippy 0.1.63.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ the same every time it is rendered, we now warn if it is missing.
 - Added downlevel restriction error message for `InvalidFormatUsages` error by @Seamooo in [#2886](https://github.com/gfx-rs/wgpu/pull/2886)
 - Add warning when using CompareFunction::*Equal with vertex shader that is missing @invariant tag by @cwfitzgerald in [#2887](https://github.com/gfx-rs/wgpu/pull/2887)
 - Update Winit to version 0.27 and raw-window-handle to 0.5 by @wyatt-herkamp in  [#2918](https://github.com/gfx-rs/wgpu/pull/2918)
-
+- Address Clippy 0.1.63 complaints. By @jimb in [#2977](https://github.com/gfx-rs/wgpu/pull/2977)
 #### Metal
 - Extract the generic code into `get_metal_layer` by @jinleili in [#2826](https://github.com/gfx-rs/wgpu/pull/2826)
 

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -648,7 +648,7 @@ impl<A: hal::Api> Resource for PipelineLayout<A> {
 }
 
 #[repr(C)]
-#[derive(Clone, Debug, Hash, PartialEq)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct BufferBinding {
@@ -784,7 +784,7 @@ pub enum GetBindGroupLayoutError {
     InvalidGroupIndex(u32),
 }
 
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
 #[error("Buffer is bound with size {bound_size} where the shader expects {shader_size} in group[{group_index}] compact index {compact_index}")]
 pub struct LateMinBufferBindingSizeMismatch {
     pub group_index: u32,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -136,7 +136,7 @@ pub struct ComputePassDescriptor<'a> {
     pub label: Label<'a>,
 }
 
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum DispatchError {
     #[error("compute pipeline must be set")]
     MissingPipeline,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -14,7 +14,7 @@ use std::num::NonZeroU32;
 use thiserror::Error;
 
 /// Error validating a draw call.
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum DrawError {
     #[error("blend constant needs to be set")]
     MissingBlendConstant,

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -149,7 +149,7 @@ impl<A: HalApi> CommandBuffer<A> {
 
         base.buffers.set_from_tracker(&head.buffers);
         base.textures
-            .set_from_tracker(&*texture_guard, &head.textures);
+            .set_from_tracker(texture_guard, &head.textures);
 
         Self::drain_barriers(raw, base, buffer_guard, texture_guard);
     }
@@ -165,7 +165,7 @@ impl<A: HalApi> CommandBuffer<A> {
 
         base.buffers.set_from_usage_scope(&head.buffers);
         base.textures
-            .set_from_usage_scope(&*texture_guard, &head.textures);
+            .set_from_usage_scope(texture_guard, &head.textures);
 
         Self::drain_barriers(raw, base, buffer_guard, texture_guard);
     }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -71,7 +71,7 @@ pub enum StoreOp {
 
 /// Describes an individual channel within a render pass, such as color, depth, or stencil.
 #[repr(C)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(feature = "serial-pass", feature = "trace"), derive(Serialize))]
 #[cfg_attr(any(feature = "serial-pass", feature = "replay"), derive(Deserialize))]
 pub struct PassChannel<V> {
@@ -737,7 +737,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
             let view: &TextureView<A> = cmd_buf
                 .trackers
                 .views
-                .add_single(&*view_guard, at.view)
+                .add_single(view_guard, at.view)
                 .ok_or(RenderPassErrorInner::InvalidAttachment(at.view))?;
             check_multiview(view)?;
             add_view(view, "depth")?;
@@ -853,7 +853,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
             let color_view: &TextureView<A> = cmd_buf
                 .trackers
                 .views
-                .add_single(&*view_guard, at.view)
+                .add_single(view_guard, at.view)
                 .ok_or(RenderPassErrorInner::InvalidAttachment(at.view))?;
             check_multiview(color_view)?;
             add_view(color_view, "color")?;
@@ -883,7 +883,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 let resolve_view: &TextureView<A> = cmd_buf
                     .trackers
                     .views
-                    .add_single(&*view_guard, resolve_target)
+                    .add_single(view_guard, resolve_target)
                     .ok_or(RenderPassErrorInner::InvalidAttachment(resolve_target))?;
 
                 check_multiview(resolve_view)?;
@@ -1015,7 +1015,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 self.usage_scope
                     .textures
                     .merge_single(
-                        &*texture_guard,
+                        texture_guard,
                         ra.texture_id.value,
                         Some(ra.selector.clone()),
                         &ra.texture_id.ref_count,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -46,7 +46,7 @@ const EP_FAILURE: &str = "EP is invalid";
 pub type DeviceDescriptor<'a> = wgt::DeviceDescriptor<Label<'a>>;
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub enum HostMap {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -479,7 +479,7 @@ impl<A: hal::Api> Borrow<TextureSelector> for Texture<A> {
 }
 
 /// Describes a [`TextureView`].
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize), serde(default))]
 pub struct TextureViewDescriptor<'a> {

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -238,7 +238,7 @@ fn iterate_bitvec_indices(ownership: &BitVec<usize>) -> impl Iterator<Item = usi
         })
 }
 
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum UsageConflict {
     #[error("Attempted to use buffer {id:?} which is invalid.")]
     BufferInvalid { id: id::BufferId },
@@ -291,7 +291,7 @@ impl UsageConflict {
 }
 
 /// Pretty print helper that shows helpful descriptions of a conflicting usage.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InvalidUse<T> {
     current_state: T,
     new_state: T,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -106,7 +106,7 @@ pub type Label<'a> = Option<&'a str>;
 pub type MemoryRange = Range<wgt::BufferAddress>;
 pub type FenceValue = u64;
 
-#[derive(Clone, Debug, PartialEq, Error)]
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
 pub enum DeviceError {
     #[error("out of memory")]
     OutOfMemory,
@@ -114,7 +114,7 @@ pub enum DeviceError {
     Lost,
 }
 
-#[derive(Clone, Debug, PartialEq, Error)]
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
 pub enum ShaderError {
     #[error("compilation failed: {0:?}")]
     Compilation(String),
@@ -122,7 +122,7 @@ pub enum ShaderError {
     Device(#[from] DeviceError),
 }
 
-#[derive(Clone, Debug, PartialEq, Error)]
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
 pub enum PipelineError {
     #[error("linkage failed for stage {0:?}: {1}")]
     Linkage(wgt::ShaderStages, String),
@@ -132,7 +132,7 @@ pub enum PipelineError {
     Device(#[from] DeviceError),
 }
 
-#[derive(Clone, Debug, PartialEq, Error)]
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
 pub enum SurfaceError {
     #[error("surface is lost")]
     Lost,
@@ -144,7 +144,7 @@ pub enum SurfaceError {
     Other(&'static str),
 }
 
-#[derive(Clone, Debug, PartialEq, Error)]
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
 #[error("Not supported")]
 pub struct InstanceError;
 
@@ -1032,7 +1032,7 @@ pub struct RenderPipelineDescriptor<'a, A: Api> {
 
 /// Specifies how the alpha channel of the textures should be handled during (martin mouv i step)
 /// compositing.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum CompositeAlphaMode {
     /// The alpha channel, if it exists, of the textures is ignored in the
     /// compositing process. Instead, the textures is treated as if it has a

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1113,7 +1113,7 @@ pub enum ShaderModel {
 
 /// Supported physical device types.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub enum DeviceType {
@@ -1132,7 +1132,7 @@ pub enum DeviceType {
 //TODO: convert `vendor` and `device` to `u32`
 
 /// Information about an adapter.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub struct AdapterInfo {
@@ -4115,7 +4115,7 @@ pub struct ImageCopyTexture<T> {
 
 /// Subresource range within an image
 #[repr(C)]
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub struct ImageSubresourceRange {

--- a/wgpu/examples/water/point_gen.rs
+++ b/wgpu/examples/water/point_gen.rs
@@ -40,7 +40,7 @@ pub struct TerrainVertexAttributes {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Pod, Zeroable)]
 pub struct WaterVertexAttributes {
     position: [i16; 2],
     offsets: [i8; 4],

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -46,7 +46,7 @@ pub use wgt::{
 use backend::{BufferMappedRange, Context as C, QueueWriteBuffer};
 
 /// Filter for error scopes.
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 pub enum ErrorFilter {
     /// Catch only out-of-memory errors.
     OutOfMemory,
@@ -1295,7 +1295,7 @@ pub type Maintain = wgt::Maintain<SubmissionIndex>;
 ///
 /// Corresponds to [WebGPU `GPUTextureViewDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gputextureviewdescriptor).
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct TextureViewDescriptor<'a> {
     /// Debug label of the texture view. This will show up in graphics debuggers for easy identification.
     pub label: Label<'a>,
@@ -2262,7 +2262,7 @@ impl Display for BufferAsyncError {
 impl error::Error for BufferAsyncError {}
 
 /// Type of buffer mapping.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum MapMode {
     /// Map only for reading
     Read,

--- a/wgpu/tests/common/image.rs
+++ b/wgpu/tests/common/image.rs
@@ -62,7 +62,7 @@ fn write_png(
 }
 
 fn calc_difference(lhs: u8, rhs: u8) -> u8 {
-    (lhs as i16 - rhs as i16).abs() as u8
+    (lhs as i16 - rhs as i16).unsigned_abs() as u8
 }
 
 pub fn compare_image_output(

--- a/wgpu/tests/example_wgsl.rs
+++ b/wgpu/tests/example_wgsl.rs
@@ -28,7 +28,7 @@ fn parse_example_wgsl() {
         for file_entry in read_files {
             let shader = match file_entry {
                 Ok(entry) => match entry.path().extension() {
-                    Some(ostr) if &*ostr == "wgsl" => {
+                    Some(ostr) if ostr == "wgsl" => {
                         println!("Validating {:?}", entry.path());
                         fs::read_to_string(entry.path()).unwrap_or_default()
                     }

--- a/wgpu/tests/zero_init_texture_after_discard.rs
+++ b/wgpu/tests/zero_init_texture_after_discard.rs
@@ -67,6 +67,7 @@ fn discarding_color_target_resets_texture_init_state_check_visible_on_copy_in_sa
 }
 
 #[test]
+#[allow(clippy::single_element_loop)]
 fn discarding_depth_target_resets_texture_init_state_check_visible_on_copy_in_same_encoder() {
     initialize_test(
         TestParameters::default()


### PR DESCRIPTION
- Derive `Eq` where possible.

- Remove some needless `&*` circumlocution.

- Use `unsigned_abs` where appropriate.

- #[allow] some extraneous Clippy complaints in tests.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
