### PR TITLE
vk: find the supported wide color gamut color space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ the same every time it is rendered, we now warn if it is missing.
 #### Metal
 - Extract the generic code into `get_metal_layer` by @jinleili in [#2826](https://github.com/gfx-rs/wgpu/pull/2826)
 
+#### Vulkan
+- Find the supported wide color gamut color space by @jinleili in [#2980](https://github.com/gfx-rs/wgpu/pull/2980)
+
 ### Documentation
 
 #### General


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Prefer `BT2020_LINEAR_EXT` color space, followed by `EXTENDED_SRGB_LINEAR_EXT`,  linear color space maybe easier to implement tone mapping.

Referenced document [Enhance graphics with wide color content](https://developer.android.com/training/wide-color-gamut)

**Testing**
Tested on macOS(--features=vulkan-portability) and Android 12(OnePlus Ace Pro)