### PR TITLE
metal: remove PrivateCapabilities's `format_rgb10a2_unorm_surface` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ the same every time it is rendered, we now warn if it is missing.
 #### Metal
 - Add the missing `msg_send![view, retain]` call within `from_view` by @jinleili in [#2976](https://github.com/gfx-rs/wgpu/pull/2976)
 - Fix `max_buffer` `max_texture` and `max_vertex_buffers` limits by @jinleili in [#2978](https://github.com/gfx-rs/wgpu/pull/2978)
+- Remove PrivateCapabilities's `format_rgb10a2_unorm_surface` field by @jinleili in [#2981](https://github.com/gfx-rs/wgpu/pull/2981)
 
 #### Vulkan
 - Fix `astc_hdr` formats support by @jinleili in [#2971]](https://github.com/gfx-rs/wgpu/pull/2971)

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -286,7 +286,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             wgt::TextureFormat::Bgra8UnormSrgb,
             wgt::TextureFormat::Rgba16Float,
         ];
-        if self.shared.private_caps.format_rgb10a2_unorm_surface {
+        if self.shared.private_caps.format_rgb10a2_unorm_all {
             formats.push(wgt::TextureFormat::Rgb10a2Unorm);
         }
 
@@ -580,7 +580,6 @@ impl super::PrivateCapabilities {
             format_rgba8_srgb_no_write: !Self::supports_any(device, RGBA8_SRGB),
             format_rgb10a2_unorm_all: Self::supports_any(device, RGB10A2UNORM_ALL),
             format_rgb10a2_unorm_no_write: !Self::supports_any(device, RGB10A2UNORM_ALL),
-            format_rgb10a2_unorm_surface: os_is_mac,
             format_rgb10a2_uint_color: !Self::supports_any(device, RGB10A2UINT_COLOR_WRITE),
             format_rgb10a2_uint_color_write: Self::supports_any(device, RGB10A2UINT_COLOR_WRITE),
             format_rg11b10_all: Self::supports_any(device, RG11B10FLOAT_ALL),

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -180,7 +180,6 @@ struct PrivateCapabilities {
     format_rgba8_srgb_no_write: bool,
     format_rgb10a2_unorm_all: bool,
     format_rgb10a2_unorm_no_write: bool,
-    format_rgb10a2_unorm_surface: bool,
     format_rgb10a2_uint_color: bool,
     format_rgb10a2_uint_color_write: bool,
     format_rg11b10_all: bool,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**

`Rgb10a2Unorm` is supported above AppleGPUFamily 2, not only macOS. Can use the existing `format_rgb10a2_unorm_all` field instead of `format_rgb10a2_unorm_surface`.
<img width="948" alt="截屏2022-08-23 20 22 15" src="https://user-images.githubusercontent.com/1001342/186156841-8e21a17a-0c4f-4900-bea5-7b9ba23f22e6.png">

**Testing**
Tested on macOS and iOS
