### PR TITLE
Correct create_surface_from_(offscreen)_canvas docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,13 +100,15 @@ the same every time it is rendered, we now warn if it is missing.
 - Add WGSL examples to complement existing examples written in GLSL by @norepimorphism in [#2888](https://github.com/gfx-rs/wgpu/pull/2888)
 - Document `wgpu_core` resource allocation. @jimb in [#2973](https://github.com/gfx-rs/wgpu/pull/2973)
 
+- Expanded `StagingBelt` documentation by @kpreid in [#2905](https://github.com/gfx-rs/wgpu/pull/2905)
+
+- Fixed documentation for `Instance::create_surface_from_canvas` and
+  `Instance::create_surface_from_offscreen_canvas` regarding their
+  safety contract. These functions are not unsafe. [#2990](https://github.com/gfx-rs/wgpu/pull/2990)
+
 ### Performance
 
 - Made `StagingBelt::write_buffer()` check more thoroughly for reusable memory; by @kpreid in [#2906](https://github.com/gfx-rs/wgpu/pull/2906)
-
-### Documentation
-
-- Expanded `StagingBelt` documentation by @kpreid in [#2905](https://github.com/gfx-rs/wgpu/pull/2905)
 
 ### Build Configuration
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1792,9 +1792,8 @@ impl Instance {
 
     /// Creates a surface from a `web_sys::HtmlCanvasElement`.
     ///
-    /// # Safety
-    ///
-    /// - canvas must be a valid <canvas> element to create a surface upon.
+    /// The `canvas` argument must be a valid `<canvas>` element to
+    /// create a surface upon.
     #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
     pub fn create_surface_from_canvas(&self, canvas: &web_sys::HtmlCanvasElement) -> Surface {
         Surface {
@@ -1805,9 +1804,8 @@ impl Instance {
 
     /// Creates a surface from a `web_sys::OffscreenCanvas`.
     ///
-    /// # Safety
-    ///
-    /// - canvas must be a valid OffscreenCanvas to create a surface upon.
+    /// The `canvas` argument must be a valid `OffscreenCanvas` object
+    /// to create a surface upon.
     #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
     pub fn create_surface_from_offscreen_canvas(
         &self,


### PR DESCRIPTION
The function's does not depend on the `canvas` argument meeting the
given requirements to avoid undefined behavior, so it should just be a
normal contract, not a safety contract.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
