### PR TITLE
Don't use a callback to return backend instance handles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ the same every time it is rendered, we now warn if it is missing.
 ### Changes
 
 #### General
+- Changed `Instance::as_hal<A>` to just return an `Option<&A::Instance>` rather than taking a callback. By @jimb in [#2991](https://github.com/gfx-rs/wgpu/pull/2991)
 - Added downlevel restriction error message for `InvalidFormatUsages` error by @Seamooo in [#2886](https://github.com/gfx-rs/wgpu/pull/2886)
 - Add warning when using CompareFunction::*Equal with vertex shader that is missing @invariant tag by @cwfitzgerald in [#2887](https://github.com/gfx-rs/wgpu/pull/2887)
 - Update Winit to version 0.27 and raw-window-handle to 0.5 by @wyatt-herkamp in  [#2918](https://github.com/gfx-rs/wgpu/pull/2918)

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -1135,13 +1135,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     /// # Safety
     ///
-    /// - The raw handle obtained from the hal Instance must not be manually destroyed
-    pub unsafe fn instance_as_hal<A: HalApi, F: FnOnce(Option<&A::Instance>) -> R, R>(
-        &self,
-        hal_instance_callback: F,
-    ) -> R {
-        let hal_instance = A::instance_as_hal(&self.instance);
-        hal_instance_callback(hal_instance)
+    /// - The raw instance handle returned must not be manually destroyed.
+    pub unsafe fn instance_as_hal<A: HalApi>(&self) -> Option<&A::Instance> {
+        A::instance_as_hal(&self.instance)
     }
 
     /// # Safety

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -47,11 +47,11 @@ impl Context {
         ))
     }
 
-    pub unsafe fn instance_as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Instance>) -> R, R>(
-        &self,
-        hal_instance_callback: F,
-    ) -> R {
-        self.0.instance_as_hal::<A, F, R>(hal_instance_callback)
+    /// # Safety
+    ///
+    /// - The raw instance handle returned must not be manually destroyed.
+    pub unsafe fn instance_as_hal<A: wgc::hub::HalApi>(&self) -> Option<&A::Instance> {
+        self.0.instance_as_hal::<A>()
     }
 
     pub unsafe fn from_core_instance(core_instance: wgc::instance::Instance) -> Self {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1671,19 +1671,19 @@ impl Instance {
         }
     }
 
-    /// Returns the inner hal Instance using a callback. The hal instance will be `None` if the
-    /// backend type argument does not match with this wgpu Instance
+    /// Return a reference to a specific backend instance, if available.
+    ///
+    /// If this `Instance` has a wgpu-hal [`Instance`] for backend
+    /// `A`, return a reference to it. Otherwise, return `None`.
     ///
     /// # Safety
     ///
-    /// - The raw handle obtained from the hal Instance must not be manually destroyed
+    /// - The raw instance handle returned must not be manually destroyed.
+    ///
+    /// [`Instance`]: hal::Api::Instance
     #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
-    pub unsafe fn as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Instance>) -> R, R>(
-        &self,
-        hal_instance_callback: F,
-    ) -> R {
-        self.context
-            .instance_as_hal::<A, F, R>(hal_instance_callback)
+    pub unsafe fn as_hal<A: wgc::hub::HalApi>(&self) -> Option<&A::Instance> {
+        self.context.instance_as_hal::<A>()
     }
 
     /// Create an new instance of wgpu from a wgpu-core instance.


### PR DESCRIPTION
Change `Instance::as_hal<A>` to simply return an
`Option<&A::Instance>`, rather than passing it to a callback. We're
just borrowing a reference to some `wgpu_hal::Api::Instance` owned by
the `wgpu_core::instance::Instance`, so there's no special scoping or
locking magic required here.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
