### PR TITLE
Update to Naga b209d911 (2022-9-1).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,11 @@ the same every time it is rendered, we now warn if it is missing.
 - Add the missing `msg_send![view, retain]` call within `from_view` by @jinleili in [#2976](https://github.com/gfx-rs/wgpu/pull/2976)
 
 #### Vulkan
-
 - Fix `astc_hdr` formats support by @jinleili in [#2971]](https://github.com/gfx-rs/wgpu/pull/2971)
+- Update to Naga b209d911 (2022-9-1) to avoid generating SPIR-V that
+  violates Vulkan valid usage rules `VUID-StandaloneSpirv-Flat-06202`
+  and `VUID-StandaloneSpirv-Flat-04744`. By @jimblandy in
+  [#3008](https://github.com/gfx-rs/wgpu/pull/3008)
 
 ### Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,8 +1194,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f50357e1167a3ab92d6b3c7f4bf5f7fd13fde3f4b28bf0d5ea07b5100fdb6c0"
+source = "git+https://github.com/gfx-rs/naga?rev=b209d911#b209d911681c4ef563f7d9048623667743e6248f"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -44,8 +44,8 @@ smallvec = "1"
 thiserror = "1"
 
 [dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
+git = "https://github.com/gfx-rs/naga"
+rev = "b209d911"
 version = "0.9"
 features = ["span", "validate", "wgsl-in"]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -95,16 +95,15 @@ js-sys = { version = "0.3" }
 android_system_properties = "0.1.1"
 
 [dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
+git = "https://github.com/gfx-rs/naga"
+rev = "b209d911"
 version = "0.9"
 
 # DEV dependencies
 
 [dev-dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
-version = "0.9"
+git = "https://github.com/gfx-rs/naga"
+rev = "b209d911"
 features = ["wgsl-in"]
 
 [dev-dependencies]

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1061,6 +1061,7 @@ impl crate::Device<super::Api> for super::Device {
                 binding_map,
                 fake_missing_bindings: false,
                 special_constants_binding,
+                push_constants_target: None,
             },
         })
     }

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -139,21 +139,21 @@ pollster = "0.2"
 env_logger = "0.9"
 
 [dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
+git = "https://github.com/gfx-rs/naga"
+rev = "b209d911"
 version = "0.9"
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
+git = "https://github.com/gfx-rs/naga"
+rev = "b209d911"
 version = "0.9"
 features = ["wgsl-in"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.naga]
-#git = "https://github.com/gfx-rs/naga"
-#rev = "27d38aae"
+git = "https://github.com/gfx-rs/naga"
+rev = "b209d911"
 version = "0.9"
 features = ["wgsl-out"]
 

--- a/wgpu/tests/shader_primitive_index/mod.rs
+++ b/wgpu/tests/shader_primitive_index/mod.rs
@@ -51,14 +51,7 @@ fn draw() {
     initialize_test(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::SHADER_PRIMITIVE_INDEX)
-            // https://github.com/gfx-rs/wgpu/issues/2751
-            .specific_failure(
-                Some(wgt::Backends::VULKAN),
-                Some(0x1002), // AMD
-                Some("AMD RADV"),
-                false,
-            ),
+            .features(wgpu::Features::SHADER_PRIMITIVE_INDEX),
         |ctx| {
             pulling_common(ctx, &expected, |rpass| {
                 rpass.draw(0..6, 0..1);
@@ -82,14 +75,7 @@ fn draw_indexed() {
     initialize_test(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::SHADER_PRIMITIVE_INDEX)
-            // https://github.com/gfx-rs/wgpu/issues/2751
-            .specific_failure(
-                Some(wgt::Backends::VULKAN),
-                Some(0x1002), // AMD
-                Some("AMD RADV"),
-                false,
-            ),
+            .features(wgpu::Features::SHADER_PRIMITIVE_INDEX),
         |ctx| {
             pulling_common(ctx, &expected, |rpass| {
                 rpass.draw_indexed(0..6, 0, 0..1);


### PR DESCRIPTION
This removes an expected failure on AMD RADV. I guess #2751 was our
bug all along.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
