### PR TITLE
[README] Remove Repo specific link

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ WGSL is always supported by default, but GLSL and SPIR-V need features enabled t
 
 Note that the WGSL specification is still under development,
 so the [draft specification][wgsl spec] does not exactly describe what `wgpu` supports.
-See [below](https://github.com/jimblandy/wgpu/tree/doc-wgsl-version#tracking-the-webgpu-and-wgsl-draft-specifications) for details.
+See [below](#tracking-the-webgpu-and-wgsl-draft-specifications) for details.
 
 To enable SPIR-V shaders, enable the `spirv` feature of wgpu.  
 To enable GLSL shaders, enable the `glsl` feature of wgpu.


### PR DESCRIPTION


**Checklist**

- [](not applicable) Run `cargo clippy`.
- [](not applicable) Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [](not applicable) Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
#3005 #3009 #2994

**Description**
#3009 vastly improves upon #3005 in terms of writing, but introduced one regression, it links to the repo by the person that created the MR. This should always link inside the repo, AFAIK this form of relative linking is fairly widely supported, at least github, gitlab, gitea, vscode and intellij support it.

**Testing**
_Explain how this change is tested._
