### PR TITLE
Split Blendability and Filterability into Two Different TextureFormatFeatureFlags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ the same every time it is rendered, we now warn if it is missing.
 ### Added/New Features
 
 - Add `Buffer::size()` and `Buffer::usage()`; by @kpreid in [#2923](https://github.com/gfx-rs/wgpu/pull/2923)
+- Split Blendability and Filterability into Two Different TextureFormatFeatureFlags; by @stakka in [#3012](https://github.com/gfx-rs/wgpu/pull/3012)
 
 ### Bug Fixes
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2610,7 +2610,15 @@ impl<A: HalApi> Device<A> {
                     {
                         break Some(pipeline::ColorStateError::FormatNotRenderable(cs.format));
                     }
-                    if cs.blend.is_some() && !format_features.flags.contains(Tfff::FILTERABLE) {
+                    if cs.blend.is_some()
+                        && (!format_features.flags.contains(Tfff::BLENDABLE)
+                            ||
+                            // according to WebGPU specifications the texture needs to be [`TextureFormatFeatureFlags::FILTERABLE`] 
+                            // if blending is set - use [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] to elude this limitation
+                            (!self.features.contains(wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES)
+                             && !format_features.flags.contains(Tfff::FILTERABLE)
+                            ))
+                    {
                         break Some(pipeline::ColorStateError::FormatNotBlendable(cs.format));
                     }
                     if !hal::FormatAspects::from(cs.format).contains(hal::FormatAspects::COLOR) {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2611,15 +2611,14 @@ impl<A: HalApi> Device<A> {
                     {
                         break Some(pipeline::ColorStateError::FormatNotRenderable(cs.format));
                     }
-                    if cs.blend.is_some()
-                        && (!format_features.flags.contains(Tfff::BLENDABLE)
-                            ||
-                            // according to WebGPU specifications the texture needs to be [`TextureFormatFeatureFlags::FILTERABLE`] 
-                            // if blending is set - use [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] to elude this limitation
-                            (!self.features.contains(wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES)
-                             && !format_features.flags.contains(Tfff::FILTERABLE)
-                            ))
-                    {
+                    let blendable = format_features.flags.contains(Tfff::BLENDABLE);
+                    let filterable = format_features.flags.contains(Tfff::FILTERABLE);
+                    let adapter_specific = self
+                        .features
+                        .contains(wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES);
+                    // according to WebGPU specifications the texture needs to be [`TextureFormatFeatureFlags::FILTERABLE`]
+                    // if blending is set - use [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] to elude this limitation
+                    if cs.blend.is_some() && (!blendable || (!filterable && !adapter_specific)) {
                         break Some(pipeline::ColorStateError::FormatNotBlendable(cs.format));
                     }
                     if !hal::FormatAspects::from(cs.format).contains(hal::FormatAspects::COLOR) {

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -242,14 +242,14 @@ impl<A: HalApi> Adapter<A> {
             caps.contains(Tfc::STORAGE_READ_WRITE),
         );
 
-        // We are currently taking the filtering and blending together,
-        // but we may reconsider this in the future if there are formats
-        // in the wild for which these two capabilities do not match.
         flags.set(
             wgt::TextureFormatFeatureFlags::FILTERABLE,
-            caps.contains(Tfc::SAMPLED_LINEAR)
-                && (!caps.contains(Tfc::COLOR_ATTACHMENT)
-                    || caps.contains(Tfc::COLOR_ATTACHMENT_BLEND)),
+            caps.contains(Tfc::SAMPLED_LINEAR),
+        );
+
+        flags.set(
+            wgt::TextureFormatFeatureFlags::BLENDABLE,
+            caps.contains(Tfc::COLOR_ATTACHMENT_BLEND),
         );
 
         flags.set(

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2293,9 +2293,14 @@ impl TextureFormat {
         };
 
         let mut flags = msaa_flags;
+        let filterable_sample_type = sample_type == TextureSampleType::Float { filterable: true };
         flags.set(
             TextureFormatFeatureFlags::FILTERABLE,
-            sample_type == TextureSampleType::Float { filterable: true },
+            filterable_sample_type,
+        );
+        flags.set(
+            TextureFormatFeatureFlags::BLENDABLE,
+            filterable_sample_type,
         );
 
         TextureFormatInfo {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1655,6 +1655,8 @@ bitflags::bitflags! {
         /// When used as a STORAGE texture, then a texture with this format can be written to with atomics.
         // TODO: No access flag exposed as of writing
         const STORAGE_ATOMICS = 1 << 4;
+        /// If not present, the texture can't be blended into the render target.
+        const BLENDABLE = 1 << 5;
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2298,10 +2298,7 @@ impl TextureFormat {
             TextureFormatFeatureFlags::FILTERABLE,
             filterable_sample_type,
         );
-        flags.set(
-            TextureFormatFeatureFlags::BLENDABLE,
-            filterable_sample_type,
-        );
+        flags.set(TextureFormatFeatureFlags::BLENDABLE, filterable_sample_type);
 
         TextureFormatInfo {
             required_features,


### PR DESCRIPTION
…FeatureFlags

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
 Split Blendability and Filterability into Two Different TextureFormatFeatureFlags [#2943](https://github.com/gfx-rs/wgpu/issues/2943) 

**Description**
By splitting up Blendability and Filterablity in the texture format feature flags, it is now possible to elude the limitation enforced by [WebGPU](https://www.w3.org/TR/webgpu/#fragment-state) to have a filterable texture format when blending is set on the color state of the render pipeline by using `Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`.

**Testing**
Tested on
backend = Metal
iOS: 15.6 (both real device and simulator)
device: iPad Pro 2021 12.9"
using the feature flag and the RG32Float format according to the issue described [here](https://github.com/gfx-rs/wgpu/issues/2943).