### PR TITLE
tracking for EXTERNAL texture use

### DIFF
--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -378,6 +378,16 @@ impl<T, I: id::TypedId> Storage<T, I> {
         }
     }
 
+    pub(crate) unsafe fn get_valid_unchecked(&self, id: u32, backend: Backend) -> id::Valid<I> {
+        let epoch = match self.map[id as usize] {
+            Element::Occupied(_, epoch) => epoch,
+            Element::Vacant => panic!("{}[{}] does not exist", self.kind, id),
+            Element::Error(_, _) => panic!(""),
+        };
+
+        id::Valid(I::zip(id, epoch, backend))
+    }
+
     pub(crate) fn label_for_invalid_id(&self, id: I) -> &str {
         let (index, _, _) = id.unzip();
         match self.map.get(index as usize) {

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -119,7 +119,7 @@ use wgt::strict_assert_ne;
 /// A structure containing all the information about a particular resource
 /// transition. User code should be able to generate a pipeline barrier
 /// based on the contents.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct PendingTransition<S: ResourceUses> {
     pub id: u32,
     pub selector: S::Selector,

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -451,6 +451,11 @@ impl<A: hub::HalApi> TextureTracker<A> {
         self.metadata.owned_ids()
     }
 
+    /// Returns all currently pending transitions.
+    pub fn pending(&self) -> impl DoubleEndedIterator<Item = &PendingTransition<TextureUses>> + '_ {
+        self.temp.iter()
+    }
+
     /// Drains all currently pending transitions.
     pub fn drain(&mut self) -> Drain<PendingTransition<TextureUses>> {
         self.temp.drain(..)

--- a/wgpu-hal/src/dx11/device.rs
+++ b/wgpu-hal/src/dx11/device.rs
@@ -224,6 +224,12 @@ impl crate::Queue<super::Api> for super::Queue {
     }
 }
 
+impl crate::Texture<super::Api> for super::Texture {
+    fn is_external(&self) -> bool {
+        false
+    }
+}
+
 impl super::D3D11Device {
     #[allow(trivial_casts)] // come on
     pub unsafe fn check_feature_support<T>(&self, feature: d3d11::D3D11_FEATURE) -> T {

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -900,3 +900,9 @@ impl crate::Queue<Api> for Queue {
         (1_000_000_000.0 / frequency as f64) as f32
     }
 }
+
+impl crate::Texture<Api> for Texture {
+    fn is_external(&self) -> bool {
+        false
+    }
+}

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -411,3 +411,9 @@ impl crate::CommandEncoder<Api> for Encoder {
     unsafe fn dispatch(&mut self, count: [u32; 3]) {}
     unsafe fn dispatch_indirect(&mut self, buffer: &Resource, offset: wgt::BufferAddress) {}
 }
+
+impl crate::Texture<Api> for Resource {
+    fn is_external(&self) -> bool {
+        false
+    }
+}

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1321,6 +1321,12 @@ impl crate::Device<super::Api> for super::Device {
     }
 }
 
+impl crate::Texture<super::Api> for super::Texture {
+    fn is_external(&self) -> bool {
+        false
+    }
+}
+
 // SAFE: WASM doesn't have threads
 #[cfg(target_arch = "wasm32")]
 unsafe impl Sync for super::Device {}

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -164,7 +164,7 @@ pub trait Api: Clone + Sized {
     type CommandBuffer: Send + Sync + fmt::Debug;
 
     type Buffer: fmt::Debug + Send + Sync + 'static;
-    type Texture: fmt::Debug + Send + Sync + 'static;
+    type Texture: Texture<Self> + 'static;
     type SurfaceTexture: fmt::Debug + Send + Sync + Borrow<Self::Texture>;
     type TextureView: fmt::Debug + Send + Sync;
     type Sampler: fmt::Debug + Send + Sync;
@@ -550,6 +550,13 @@ pub trait CommandEncoder<A: Api>: Send + Sync + fmt::Debug {
     unsafe fn dispatch_indirect(&mut self, buffer: &A::Buffer, offset: wgt::BufferAddress);
 }
 
+pub trait Texture<A: Api>: fmt::Debug + Send + Sync {
+    /// Whether this texture originates from external memory.
+    ///
+    /// This indicates whether the texture may have the `EXTERNAL` usage.
+    fn is_external(&self) -> bool;
+}
+
 bitflags!(
     /// Instance initialization flags.
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -765,9 +772,16 @@ bitflags::bitflags! {
 
         /// Flag used by the wgpu-core texture tracker to say a texture is in different states for every sub-resource
         const COMPLEX = 1 << 10;
+
+        /// Flag used by the wgpu-core texture tracker to say a texture was imported from external memory.
+        ///
+        /// In the Vulkan backend, this indicates the texture needs to be transferred from an external queue
+        /// family to the graphics queue family.
+        const EXTERNAL = 1 << 11;
+
         /// Flag used by the wgpu-core texture tracker to say that the tracker does not know the state of the sub-resource.
         /// This is different from UNINITIALIZED as that says the tracker does know, but the texture has not been initialized.
-        const UNKNOWN = 1 << 11;
+        const UNKNOWN = 1 << 12;
     }
 }
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -406,6 +406,12 @@ impl crate::Queue<Api> for Queue {
     }
 }
 
+impl crate::Texture<Api> for Texture {
+    fn is_external(&self) -> bool {
+        false
+    }
+}
+
 #[derive(Debug)]
 pub struct Buffer {
     raw: metal::Buffer,

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -820,6 +820,7 @@ impl crate::Surface<super::Api> for super::Surface {
                     depth: 1,
                 },
                 view_formats: sc.view_formats.clone(),
+                external_queue_family_index: None,
             },
         };
         Ok(Some(crate::AcquiredSurfaceTexture {


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Resolves #2948

**Description**
This pull request adds tracking for a new `EXTERNAL` texture use. In the Vulkan hal, a new parameter for `texture_from_raw` to specify the owning foreign queue of the texture is added and logic changes to transition external textures to and from the external queue.

**Testing**
An example needs to be created to use an image that would have an EXTERNAL texture use.

I will write an example to test this. It will probably be an example using kernel mode setting (KMS).

Regarding testing on CI, I am not certain how we could approach that.