### PR TITLE
Buffer usages mismatch check and documentation for mapped_at_creation size requirement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ the same every time it is rendered, we now warn if it is missing.
 - Improve the validation and error reporting of buffer mappings by @nical in [#2848](https://github.com/gfx-rs/wgpu/pull/2848)
 - Fix compilation errors when using wgpu-core in isolation while targetting `wasm32-unknown-unknown` by @Seamooo in [#2922](https://github.com/gfx-rs/wgpu/pull/2922)
 - Fixed opening of RenderDoc library by @abuffseagull in [#2930](https://github.com/gfx-rs/wgpu/pull/2930)
+- Added missing validation for `BufferUsages` mismatches when `Features::MAPPABLE_PRIMARY_BUFFERS` is not
+  enabled. By @imberflur in [#3023](https://github.com/gfx-rs/wgpu/pull/3023)
 
 #### Metal
 - Add the missing `msg_send![view, retain]` call within `from_view` by @jinleili in [#2976](https://github.com/gfx-rs/wgpu/pull/2976)

--- a/player/tests/data/buffer-copy.ron
+++ b/player/tests/data/buffer-copy.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0,
+    features: 0x1_0000,
     expectations: [
         (
             name: "basic",

--- a/player/tests/data/clear-buffer-texture.ron
+++ b/player/tests/data/clear-buffer-texture.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0000_0004_0000_0000,
+    features: 0x0000_0004_0001_0000,
     expectations: [
         (
             name: "Quad",

--- a/player/tests/data/zero-init-buffer.ron
+++ b/player/tests/data/zero-init-buffer.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0,
+    features: 0x1_0000,
     expectations: [
         // Ensuring that mapping zero-inits buffers.
         (

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -588,6 +588,20 @@ impl<A: HalApi> Device<A> {
             return Err(resource::CreateBufferError::EmptyUsage);
         }
 
+        if !self
+            .features
+            .contains(wgt::Features::MAPPABLE_PRIMARY_BUFFERS)
+        {
+            use wgt::BufferUsages as Bu;
+            let write_mismatch = desc.usage.contains(Bu::MAP_WRITE)
+                && !(Bu::MAP_WRITE | Bu::COPY_SRC).contains(desc.usage);
+            let read_mismatch = desc.usage.contains(Bu::MAP_READ)
+                && !(Bu::MAP_READ | Bu::COPY_DST).contains(desc.usage);
+            if write_mismatch || read_mismatch {
+                return Err(resource::CreateBufferError::UsageMismatch(desc.usage));
+            }
+        }
+
         if desc.mapped_at_creation {
             if desc.size % wgt::COPY_BUFFER_ALIGNMENT != 0 {
                 return Err(resource::CreateBufferError::UnalignedSize);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2913,6 +2913,9 @@ pub struct BufferDescriptor<L> {
     pub usage: BufferUsages,
     /// Allows a buffer to be mapped immediately after they are made. It does not have to be [`BufferUsages::MAP_READ`] or
     /// [`BufferUsages::MAP_WRITE`], all buffers are allowed to be mapped at creation.
+    ///
+    /// If this is `true`, [`size`](#structfield.size) must be a multiple of
+    /// [`COPY_BUFFER_ALIGNMENT`].
     pub mapped_at_creation: bool,
 }
 

--- a/wgpu/tests/buffer_usages.rs
+++ b/wgpu/tests/buffer_usages.rs
@@ -1,0 +1,74 @@
+//! Tests for buffer usages validation.
+
+use wgt::BufferAddress;
+
+use crate::common::{initialize_test, TestParameters};
+
+#[test]
+fn buffer_usage() {
+    fn try_create(
+        usage: wgpu::BufferUsages,
+        enable_mappable_primary_buffers: bool,
+        should_panic: bool,
+    ) {
+        let mut parameters = TestParameters::default();
+        if enable_mappable_primary_buffers {
+            parameters = parameters.features(wgpu::Features::MAPPABLE_PRIMARY_BUFFERS);
+        }
+        if should_panic {
+            parameters = parameters.failure();
+        }
+
+        initialize_test(parameters, |ctx| {
+            let _buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+                label: None,
+                size: BUFFER_SIZE,
+                usage,
+                mapped_at_creation: false,
+            });
+        });
+    }
+
+    use wgpu::BufferUsages as Bu;
+
+    // These are always valid
+    [
+        Bu::MAP_READ,
+        Bu::MAP_WRITE,
+        Bu::MAP_READ | Bu::COPY_DST,
+        Bu::MAP_WRITE | Bu::COPY_SRC,
+    ]
+    .into_iter()
+    .for_each(|usages| {
+        // Should only pass validation when MAPPABLE_PRIMARY_BUFFERS is enabled.
+        try_create(usages, false, false);
+        try_create(usages, true, false);
+    });
+
+    // MAP_READ can only be paired with COPY_DST and MAP_WRITE can only be paired with COPY_SRC
+    // (unless Features::MAPPABlE_PRIMARY_BUFFERS is enabled).
+    [
+        Bu::MAP_READ | Bu::COPY_DST | Bu::COPY_SRC,
+        Bu::MAP_WRITE | Bu::COPY_SRC | Bu::COPY_DST,
+        Bu::MAP_READ | Bu::MAP_WRITE,
+        Bu::MAP_WRITE | Bu::MAP_READ,
+        Bu::MAP_READ | Bu::COPY_DST | Bu::STORAGE,
+        Bu::MAP_WRITE | Bu::COPY_SRC | Bu::STORAGE,
+        wgpu::BufferUsages::all(),
+    ]
+    .into_iter()
+    .for_each(|usages| {
+        // Only valid when MAPPABLE_PRIMARY_BUFFERS is enabled.
+        try_create(usages, false, true);
+        try_create(usages, true, false);
+    });
+
+    // Buffers cannot have empty usage flags
+    [Bu::empty()].into_iter().for_each(|usages| {
+        // Should always fail
+        try_create(usages, false, true);
+        try_create(usages, true, true);
+    });
+}
+
+const BUFFER_SIZE: BufferAddress = 1234;

--- a/wgpu/tests/buffer_usages.rs
+++ b/wgpu/tests/buffer_usages.rs
@@ -7,7 +7,7 @@ use crate::common::{initialize_test, TestParameters};
 #[test]
 fn buffer_usage() {
     fn try_create(
-        usage: wgpu::BufferUsages,
+        usages: &[wgpu::BufferUsages],
         enable_mappable_primary_buffers: bool,
         should_panic: bool,
     ) {
@@ -20,34 +20,28 @@ fn buffer_usage() {
         }
 
         initialize_test(parameters, |ctx| {
-            let _buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
-                label: None,
-                size: BUFFER_SIZE,
-                usage,
-                mapped_at_creation: false,
-            });
+            for usage in usages.iter().copied() {
+                let _buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+                    label: None,
+                    size: BUFFER_SIZE,
+                    usage,
+                    mapped_at_creation: false,
+                });
+            }
         });
     }
 
     use wgpu::BufferUsages as Bu;
 
-    // These are always valid
-    [
+    let always_valid = [
         Bu::MAP_READ,
         Bu::MAP_WRITE,
         Bu::MAP_READ | Bu::COPY_DST,
         Bu::MAP_WRITE | Bu::COPY_SRC,
-    ]
-    .into_iter()
-    .for_each(|usages| {
-        // Should only pass validation when MAPPABLE_PRIMARY_BUFFERS is enabled.
-        try_create(usages, false, false);
-        try_create(usages, true, false);
-    });
-
+    ];
     // MAP_READ can only be paired with COPY_DST and MAP_WRITE can only be paired with COPY_SRC
     // (unless Features::MAPPABlE_PRIMARY_BUFFERS is enabled).
-    [
+    let needs_mappable_primary_buffers = [
         Bu::MAP_READ | Bu::COPY_DST | Bu::COPY_SRC,
         Bu::MAP_WRITE | Bu::COPY_SRC | Bu::COPY_DST,
         Bu::MAP_READ | Bu::MAP_WRITE,
@@ -55,20 +49,17 @@ fn buffer_usage() {
         Bu::MAP_READ | Bu::COPY_DST | Bu::STORAGE,
         Bu::MAP_WRITE | Bu::COPY_SRC | Bu::STORAGE,
         wgpu::BufferUsages::all(),
-    ]
-    .into_iter()
-    .for_each(|usages| {
-        // Only valid when MAPPABLE_PRIMARY_BUFFERS is enabled.
-        try_create(usages, false, true);
-        try_create(usages, true, false);
-    });
+    ];
+    let always_fail = [Bu::empty()];
 
-    // Buffers cannot have empty usage flags
-    [Bu::empty()].into_iter().for_each(|usages| {
-        // Should always fail
-        try_create(usages, false, true);
-        try_create(usages, true, true);
-    });
+    try_create(&always_valid, false, false);
+    try_create(&always_valid, true, false);
+
+    try_create(&needs_mappable_primary_buffers, false, true);
+    try_create(&needs_mappable_primary_buffers, true, false);
+
+    try_create(&always_fail, false, true);
+    try_create(&always_fail, true, true);
 }
 
 const BUFFER_SIZE: BufferAddress = 1234;

--- a/wgpu/tests/root.rs
+++ b/wgpu/tests/root.rs
@@ -2,6 +2,7 @@
 mod common;
 
 mod buffer_copy;
+mod buffer_usages;
 mod clear_texture;
 mod device;
 mod example_wgsl;


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] ~~Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.~~
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
I based this on the documented validation behavior:
* <https://docs.rs/wgpu/0.13.1/wgpu/struct.BufferUsages.html>
* <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>

**Description**
Buffer usage mismatch validation was lost to a refactor. Specifically, this is the check needed when one of the `MAP_*` usages is enabled. This re-adds the check.

I also added some documentation on the the validation of the buffer size when `mapped_at_creation` is `true`.

**Testing**
A test was added at `wgpu/tests/buffer_usage.rs`. I confirmed that improper combinations were being allowed via this test and that with the changes they now fail validation. 