### PR TITLE
Add `get_default_configure` to simplify user creation of `SurfaceConfiguration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Bottom level categories:
 - Implement `Hash` for `DepthStencilState` and `DepthBiasState`
 - Add the `"wgsl"` feature, to enable WGSL shaders in `wgpu-core` and `wgpu`. Enabled by default in `wgpu`. By @daxpedda in [#2890](https://github.com/gfx-rs/wgpu/pull/2890).
 - Implement `Clone` for `ShaderSource` and `ShaderModuleDescriptor` in `wgpu`. By @daxpedda in [#3086](https://github.com/gfx-rs/wgpu/pull/3086).
+- Add `get_default_config` for `Surface` to simplify user creation of `SurfaceConfiguration`. By @jinleili in [#3034](https://github.com/gfx-rs/wgpu/pull/3034)
 
 #### GLES
 

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -267,14 +267,7 @@ fn start<E: Example>(
     }: Setup,
 ) {
     let spawner = Spawner::new();
-    let mut config = wgpu::SurfaceConfiguration {
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: surface.get_supported_formats(&adapter)[0],
-        width: size.width,
-        height: size.height,
-        present_mode: wgpu::PresentMode::Fifo,
-        alpha_mode: surface.get_supported_alpha_modes(&adapter)[0],
-    };
+    let mut config = surface.get_default_config(&adapter, size.width, size.height);
     surface.configure(&device, &config);
 
     log::info!("Initializing the example...");

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3713,6 +3713,23 @@ impl Surface {
         Context::surface_get_supported_alpha_modes(&*self.context, &self.id, &adapter.id)
     }
 
+    /// Return a default `SurfaceConfiguration` from width and height to use for the [`Surface`] with this adapter.
+    pub fn get_default_config(
+        &self,
+        adapter: &Adapter,
+        width: u32,
+        height: u32,
+    ) -> wgt::SurfaceConfiguration {
+        wgt::SurfaceConfiguration {
+            usage: wgt::TextureUsages::RENDER_ATTACHMENT,
+            format: self.get_supported_formats(adapter)[0],
+            width,
+            height,
+            present_mode: self.get_supported_present_modes(adapter)[0],
+            alpha_mode: wgt::CompositeAlphaMode::Auto,
+        }
+    }
+
     /// Initializes [`Surface`] for presentation.
     ///
     /// # Panics


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Most users don't really need to care about the values of `usage`, `format`, `present_mode`, and possibly `alpha_mode`, `color_space`, etc. when configuring `SurfaceConfiguration`. It is only necessary to understand and specify these fields if the user has a clear need for them. `impl Default`  simplifies the use of users.

`Bgra8UnormSrgb` is set as the default format value because it is the only format supported by all platforms. Although Bgra8Unorm and Rgba8Unorm are defined in the WebGPU spec, metal actually only supports Bgra8Unorm as the texture format for the SwapChain

**Testing**
Tested examples locally
