### PR TITLE
move GL vendor magic numbers to "auxil::db"

### DIFF
--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -5,6 +5,18 @@ pub(super) mod dxgi;
 pub(super) mod renderdoc;
 
 pub mod db {
+    pub mod amd {
+        pub const VENDOR: u32 = 0x1002;
+    }
+    pub mod arm {
+        pub const VENDOR: u32 = 0x13B5;
+    }
+    pub mod broadcom {
+        pub const VENDOR: u32 = 0x14E4;
+    }
+    pub mod imgtec {
+        pub const VENDOR: u32 = 0x1010;
+    }
     pub mod intel {
         pub const VENDOR: u32 = 0x8086;
         pub const DEVICE_KABY_LAKE_MASK: u32 = 0x5900;

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -2,6 +2,8 @@ use glow::HasContext;
 use std::sync::Arc;
 use wgt::AstcChannel;
 
+use crate::auxil::db;
+
 // https://webgl2fundamentals.org/webgl/lessons/webgl-data-textures.html
 
 const GL_UNMASKED_VENDOR_WEBGL: u32 = 0x9245;
@@ -145,26 +147,26 @@ impl super::Adapter {
 
         // source: Sascha Willems at Vulkan
         let vendor_id = if vendor.contains("amd") {
-            0x1002
+            db::amd::VENDOR
         } else if vendor.contains("imgtec") {
-            0x1010
+            db::imgtec::VENDOR
         } else if vendor.contains("nvidia") {
-            0x10DE
+            db::nvidia::VENDOR
         } else if vendor.contains("arm") {
-            0x13B5
+            db::arm::VENDOR
         } else if vendor.contains("qualcomm") {
-            0x5143
+            db::qualcomm::VENDOR
         } else if vendor.contains("intel") {
-            0x8086
+            db::intel::VENDOR
         } else if vendor.contains("broadcom") {
-            0x14e4
+            db::broadcom::VENDOR
         } else {
             0
         };
 
         wgt::AdapterInfo {
             name: renderer_orig,
-            vendor: vendor_id,
+            vendor: vendor_id as usize,
             device: 0,
             device_type: inferred_device_type,
             backend: wgt::Backend::Gl,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Move the GL vendor magic numbers to where all the rest of the vendor magic numbers live.
