### PR TITLE
Vendor id clarification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ SurfaceConfiguration {
 - Added missing validation for `BufferUsages` mismatches when `Features::MAPPABLE_PRIMARY_BUFFERS` is not
   enabled. By @imberflur in [#3023](https://github.com/gfx-rs/wgpu/pull/3023)
 - Fixed `CommandEncoder` not being `Send` and `Sync` on web by @i509VCB in [#3025](https://github.com/gfx-rs/wgpu/pull/3025)
+- Document meaning of `vendor` in `AdapterInfo` if the vendor has no PCI id.
 
 #### Metal
 - Add the missing `msg_send![view, retain]` call within `from_view` by @jinleili in [#2976](https://github.com/gfx-rs/wgpu/pull/2976)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,8 @@ SurfaceConfiguration {
   [#3008](https://github.com/gfx-rs/wgpu/pull/3008)
 
 #### Gles
-- Report vendor id for Mesa and Apple GPUs. By @i509VCB [#3036](https://github.com/gfx-rs/wgpu/pull/3036).
+- Report vendor id for Mesa and Apple GPUs. By @i509VCB [#3036](https://github.com/gfx-rs/wgpu/pull/3036)
+- Report Apple M2 gpu as integrated. By @i509VCB [#3036](https://github.com/gfx-rs/wgpu/pull/3036)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ SurfaceConfiguration {
   and `VUID-StandaloneSpirv-Flat-04744`. By @jimblandy in
   [#3008](https://github.com/gfx-rs/wgpu/pull/3008)
 
+#### Gles
+- Report vendor id for Mesa and Apple GPUs. By @i509VCB [#3036](https://github.com/gfx-rs/wgpu/pull/3036).
+
 ### Changes
 
 #### General

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -8,6 +8,9 @@ pub mod db {
     pub mod amd {
         pub const VENDOR: u32 = 0x1002;
     }
+    pub mod apple {
+        pub const VENDOR: u32 = 0x106B;
+    }
     pub mod arm {
         pub const VENDOR: u32 = 0x13B5;
     }
@@ -21,6 +24,13 @@ pub mod db {
         pub const VENDOR: u32 = 0x8086;
         pub const DEVICE_KABY_LAKE_MASK: u32 = 0x5900;
         pub const DEVICE_SKY_LAKE_MASK: u32 = 0x1900;
+    }
+    pub mod mesa {
+        // Mesa does not actually have a PCI vendor id.
+        //
+        // To match Vulkan, we use the VkVendorId for Mesa in the gles backend so that lavapipe (Vulkan) and
+        // llvmpipe (OpenGL) have the same vendor id.
+        pub const VENDOR: u32 = 0x10005;
     }
     pub mod nvidia {
         pub const VENDOR: u32 = 0x10DE;

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -160,6 +160,10 @@ impl super::Adapter {
             db::intel::VENDOR
         } else if vendor.contains("broadcom") {
             db::broadcom::VENDOR
+        } else if vendor.contains("mesa") {
+            db::mesa::VENDOR
+        } else if vendor.contains("apple") {
+            db::apple::VENDOR
         } else {
             0
         };

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -122,7 +122,7 @@ impl super::Adapter {
             "mali",
             "intel",
             "v3d",
-            "apple m1",
+            "apple m", // all apple m are integrated
         ];
         let strings_that_imply_cpu = ["mesa offscreen", "swiftshader", "llvmpipe"];
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1140,6 +1140,9 @@ pub struct AdapterInfo {
     /// Adapter name
     pub name: String,
     /// Vendor PCI id of the adapter
+    ///
+    /// If the vendor has no PCI id, then this value will be the backend's vendor id equivalent. On Vulkan,
+    /// Mesa would have a vendor id equivalent to it's `VkVendorId` value.
     pub vendor: usize,
     /// PCI id of the adapter
     pub device: usize,


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Each commit does what it says on the tin:
1. Set the `AdapterInfo::vendor` for Apple GPUs and Mesa vendored implementations.
2. Ensure M2 gpu is marked as Integrated
3. Document what `AdapterInfo::vendor` means if the vendor has no PCI id.