### PR TITLE
Fixed buffer sizes encoding on Metal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ SurfaceConfiguration {
 - Add the missing `msg_send![view, retain]` call within `from_view` by @jinleili in [#2976](https://github.com/gfx-rs/wgpu/pull/2976)
 - Fix `max_buffer` `max_texture` and `max_vertex_buffers` limits by @jinleili in [#2978](https://github.com/gfx-rs/wgpu/pull/2978)
 - Remove PrivateCapabilities's `format_rgb10a2_unorm_surface` field by @jinleili in [#2981](https://github.com/gfx-rs/wgpu/pull/2981)
+- Fix `_buffer_sizes` encoding by @dtiselice in [#3047](https://github.com/gfx-rs/wgpu/pull/3047)
 
 #### Vulkan
 - Fix `astc_hdr` formats support by @jinleili in [#2971]](https://github.com/gfx-rs/wgpu/pull/2971)

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -76,13 +76,12 @@ impl super::CommandState {
         let slot = stage_info.sizes_slot?;
 
         result_sizes.clear();
-        result_sizes.extend(
-            stage_info
-                .sized_bindings
-                .iter()
-                .filter_map(|br| self.storage_buffer_length_map.get(br))
-                .map(|size| size.get().min(!0u32 as u64) as u32),
-        );
+        result_sizes.extend(stage_info.sized_bindings.iter().map(|br| {
+            self.storage_buffer_length_map
+                .get(br)
+                .map(|size| u32::try_from(size.get()).unwrap_or(u32::MAX))
+                .unwrap_or_default()
+        }));
 
         if !result_sizes.is_empty() {
             Some((slot as _, result_sizes))


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Metal validation layers were complaining that the Naga-generated `_buffer_sizes` argument was not properly encoded in the cases where only a part of the buffers declared in the shader file was used by one entry. Thus, the size buffer would only be partially written.

This patch writes 0s in the case of unused buffer's sizes.

**Testing**
Tested locally. Validation reports no errors.
