### PR TITLE
remove copyless

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -31,7 +31,6 @@ arrayvec = "0.7"
 bitflags = "1.0"
 bit-vec = "0.6"
 codespan-reporting = "0.11"
-copyless = "0.1"
 fxhash = "0.2"
 log = "0.4"
 # parking_lot 0.12 switches from `winapi` to `windows`; permit either

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use smallvec::SmallVec;
 
-use copyless::VecHelper as _;
 use hal::Device as _;
 use parking_lot::Mutex;
 use thiserror::Error;
@@ -339,7 +338,7 @@ impl<A: hal::Api> LifetimeTracker<A> {
             }
         }
 
-        self.active.alloc().init(ActiveSubmission {
+        self.active.push(ActiveSubmission {
             index,
             last_resources,
             mapped: Vec::new(),

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -18,7 +18,6 @@ use crate::{
 };
 
 use arrayvec::ArrayVec;
-use copyless::VecHelper as _;
 use hal::{CommandEncoder as _, Device as _};
 use parking_lot::{Mutex, MutexGuard};
 use smallvec::SmallVec;
@@ -2518,7 +2517,7 @@ impl<A: HalApi> Device<A> {
         let mut vertex_buffers = Vec::with_capacity(desc.vertex.buffers.len());
         let mut total_attributes = 0;
         for (i, vb_state) in desc.vertex.buffers.iter().enumerate() {
-            vertex_steps.alloc().init(pipeline::VertexStep {
+            vertex_steps.push(pipeline::VertexStep {
                 stride: vb_state.array_stride,
                 mode: vb_state.step_mode,
             });
@@ -2538,7 +2537,7 @@ impl<A: HalApi> Device<A> {
                     stride: vb_state.array_stride,
                 });
             }
-            vertex_buffers.alloc().init(hal::VertexBufferLayout {
+            vertex_buffers.push(hal::VertexBufferLayout {
                 array_stride: vb_state.array_stride,
                 step_mode: vb_state.step_mode,
                 attributes: vb_state.attributes.as_ref(),


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
copyless apparently isn't needed anymore to prevent extraneous memcopies and therefore got deprecated:
https://github.com/kvark/copyless/issues/22

**Description**
Removes copyless