### PR TITLE
Return an error instead of panicking when canvas context is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 + let config = surface.get_default_config(&adapter).expect("Surface unsupported by adapter");
 ```
 
+#### Fallible surface creation
+
+`Instance::create_surface()` now returns `Result<Surface, CreateSurfaceError>` instead of `Surface`. This allows an error to be returned instead of panicking if the given window is a HTML canvas and obtaining a WebGPU or WebGL 2 context fails. (No other platforms currently report any errors through this path.) By @kpreid in [#3052](https://github.com/gfx-rs/wgpu/pull/3052/)
+
 ### Changes
 
 #### General

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -83,7 +83,7 @@ wgsl = ["wgc?/wgsl"]
 trace = ["serde", "wgc/trace"]
 replay = ["serde", "wgc/replay"]
 angle = ["wgc/angle"]
-webgl = ["wgc"]
+webgl = ["hal", "wgc"]
 emscripten = ["webgl"]
 vulkan-portability = ["wgc/vulkan-portability"]
 expose-ids = []
@@ -100,8 +100,12 @@ optional = true
 [dependencies.wgt]
 workspace = true
 
-[target.'cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))'.dependencies.hal]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.hal]
 workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.hal]
+workspace = true
+optional = true
 
 [dependencies]
 arrayvec.workspace = true

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -164,7 +164,7 @@ async fn setup<E: Example>(title: &str) -> Setup {
         let size = window.inner_size();
 
         #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
-        let surface = instance.create_surface(&window);
+        let surface = instance.create_surface(&window).unwrap();
         #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
         let surface = {
             if let Some(offscreen_canvas_setup) = &offscreen_canvas_setup {
@@ -174,7 +174,8 @@ async fn setup<E: Example>(title: &str) -> Setup {
             } else {
                 instance.create_surface(&window)
             }
-        };
+        }
+        .unwrap();
 
         (size, surface)
     };

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -8,7 +8,7 @@ use winit::{
 async fn run(event_loop: EventLoop<()>, window: Window) {
     let size = window.inner_size();
     let instance = wgpu::Instance::new(wgpu::Backends::all());
-    let surface = unsafe { instance.create_surface(&window) };
+    let surface = unsafe { instance.create_surface(&window) }.unwrap();
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::default(),

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -20,7 +20,7 @@ struct Viewport {
 
 impl ViewportDesc {
     fn new(window: Window, background: wgpu::Color, instance: &wgpu::Instance) -> Self {
-        let surface = unsafe { instance.create_surface(&window) };
+        let surface = unsafe { instance.create_surface(&window) }.unwrap();
         Self {
             window,
             background,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -219,24 +219,30 @@ impl Context {
     pub fn instance_create_surface_from_canvas(
         self: &Arc<Self>,
         canvas: &web_sys::HtmlCanvasElement,
-    ) -> Surface {
-        let id = self.0.create_surface_webgl_canvas(canvas, ());
-        Surface {
+    ) -> Result<Surface, crate::CreateSurfaceError> {
+        let id = self
+            .0
+            .create_surface_webgl_canvas(canvas, ())
+            .map_err(|hal::InstanceError| crate::CreateSurfaceError {})?;
+        Ok(Surface {
             id,
             configured_device: Mutex::default(),
-        }
+        })
     }
 
     #[cfg(all(target_arch = "wasm32", feature = "webgl", not(feature = "emscripten")))]
     pub fn instance_create_surface_from_offscreen_canvas(
         self: &Arc<Self>,
         canvas: &web_sys::OffscreenCanvas,
-    ) -> Surface {
-        let id = self.0.create_surface_webgl_offscreen_canvas(canvas, ());
-        Surface {
+    ) -> Result<Surface, crate::CreateSurfaceError> {
+        let id = self
+            .0
+            .create_surface_webgl_offscreen_canvas(canvas, ())
+            .map_err(|hal::InstanceError| crate::CreateSurfaceError {})?;
+        Ok(Surface {
             id,
             configured_device: Mutex::default(),
-        }
+        })
     }
 
     #[cfg(target_os = "windows")]
@@ -943,13 +949,13 @@ impl crate::Context for Context {
         &self,
         display_handle: raw_window_handle::RawDisplayHandle,
         window_handle: raw_window_handle::RawWindowHandle,
-    ) -> Self::SurfaceId {
-        Surface {
+    ) -> Result<Self::SurfaceId, crate::CreateSurfaceError> {
+        Ok(Surface {
             id: self
                 .0
                 .instance_create_surface(display_handle, window_handle, ()),
             configured_device: Mutex::new(None),
-        }
+        })
     }
 
     fn instance_request_adapter(

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1027,22 +1027,52 @@ impl Context {
         &self,
         canvas: &web_sys::HtmlCanvasElement,
     ) -> <Self as crate::Context>::SurfaceId {
-        let context: wasm_bindgen::JsValue = match canvas.get_context("webgpu") {
-            Ok(Some(ctx)) => ctx.into(),
-            _ => panic!("expected to get context from canvas"),
-        };
-        create_identified(context.into())
+        self.create_surface_from_context(canvas.get_context("webgpu"))
+            .unwrap()
     }
 
     pub fn instance_create_surface_from_offscreen_canvas(
         &self,
         canvas: &web_sys::OffscreenCanvas,
     ) -> <Self as crate::Context>::SurfaceId {
-        let context: wasm_bindgen::JsValue = match canvas.get_context("webgpu") {
-            Ok(Some(ctx)) => ctx.into(),
-            _ => panic!("expected to get context from canvas"),
+        self.create_surface_from_context(canvas.get_context("webgpu"))
+            .unwrap()
+    }
+
+    /// Common portion of public `instance_create_surface_from_*` functions.
+    ///
+    /// Note: Analogous code also exists in the WebGL 2 backend at
+    /// `wgpu_hal::gles::web::Instance`.
+    fn create_surface_from_context(
+        &self,
+        context_result: Result<Option<js_sys::Object>, wasm_bindgen::JsValue>,
+    ) -> Result<<Self as crate::Context>::SurfaceId, ()> {
+        let context: js_sys::Object = match context_result {
+            Ok(Some(context)) => context,
+            Ok(None) => {
+                // <https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-getcontext-dev>
+                // A getContext() call “returns null if contextId is not supported, or if the
+                // canvas has already been initialized with another context type”. Additionally,
+                // “not supported” could include “insufficient GPU resources” or “the GPU process
+                // previously crashed”. So, we must return it as an `Err` since it could occur
+                // for circumstances outside the application author's control.
+                return Err(());
+            }
+            Err(js_error) => {
+                // <https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-getcontext>
+                // A thrown exception indicates misuse of the canvas state. Ideally we wouldn't
+                // panic in this case ... TODO
+                panic!("canvas.getContext() threw {js_error:?}")
+            }
         };
-        create_identified(context.into())
+
+        // Not returning this error because it is a type error that shouldn't happen unless
+        // the browser, JS builtin objects, or wasm bindings are misbehaving somehow.
+        let context: web_sys::GpuCanvasContext = context
+            .dyn_into()
+            .expect("canvas context is not a GPUCanvasContext");
+
+        Ok(create_identified(context))
     }
 
     pub fn queue_copy_external_image_to_texture(


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #3017 "WebGL and WebGPU backends should not panic if canvas context is unavailable".

**Description**
- Add a `Result` return value to `wgpu::Instance::create_surface()` and related functions.
- Add `wgpu::CreateSurfaceError`.
- Expand documentation of `create_surface()`.

**Testing**
There is no current way to run automated tests under WASM, but I ran `cargo check` with and without the `webgl` feature; `cargo nextest run`; and some `run-wasm` examples.

**Further notes and concerns**

* This is a breaking change (changing return types to be `Result<Surface>` instead of `Surface`) — is there anything to improve about the new API?
* It would be really nice to have more details from the error, so that it is diagnosable rather than “Sorry, something wrong happened”. The main obstacle to that is the non-specificity of `wgpu_hal::InstanceError`. However, this PR doesn't strictly need that, and it can be enhanced later without `wgpu` API changes.
* The docs for `create_surface()` say more things than they used to. I think they're better, but since this is an `unsafe fn`, everything it says is important. Particularly, I moved the remark about panicking on Metal from Safety to Panics on the assumption that if it's a panic it's not unsound (and therefore should not be in the Safety section), but perhaps that's wrong.

* ~~**This is a draft because some changes are missing for `features = ["webgl"]`.** I discovered that `wgpu_hal` is not depended on directly from `wgpu` (when the target is wasm32) even though it is indirectly depended on, so `wgpu_hal::InstanceError` isn't usable for communicating errors from `wgpu_core` to `wgpu` in the WebGL backend's context creation. So, a different error type will be needed, or that dependency added, or a reexport. I'm posting this PR anyway (as a draft) because it's mostly complete from an API and docs perspective.~~ Resolved.