### PR TITLE
Update cargo-run-wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-run-wasm"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504f8305a43320764724b4faddba9acc3ac94750049e8265ae3f6c338d69fdaa"
+checksum = "611b811fad83eebfcdcf47ae1e425c82d1249608bc571d537448d706be08cf27"
 dependencies = [
  "devserver_lib",
  "pico-args",
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "pico-args"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"

--- a/run-wasm/Cargo.toml
+++ b/run-wasm/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo-run-wasm = "0.1.1"
+cargo-run-wasm = "0.2.0"

--- a/run-wasm/src/main.rs
+++ b/run-wasm/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    cargo_run_wasm::run_wasm();
+    cargo_run_wasm::run_wasm_with_css("body { margin: 0px; }");
 }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

**Description**

This PR updates cargo-run-wasm to the latest release.

A common request I have received is to remove the `<h1></h1>` from the page and give easy access to custom css.
To accommodate that I have reworked the API a little and changed the format of the page.
I have used the `body { margin: 0px; }` css which is the recommended default css to use as with `cargo run-wasm` as it gives the wasm app more space to work with by removing the pointless margin.

**Testing**
Locally running the examples
