### PR TITLE
Vulkan Command pool optimization

### DIFF
--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -98,7 +98,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         let _ = self
             .device
             .raw
-            .reset_command_pool(self.raw, vk::CommandPoolResetFlags::RELEASE_RESOURCES);
+            .reset_command_pool(self.raw, vk::CommandPoolResetFlags::default());
     }
 
     unsafe fn transition_buffers<'a, T>(&mut self, barriers: T)

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1059,6 +1059,7 @@ impl crate::Device<super::Api> for super::Device {
     ) -> Result<super::CommandEncoder, crate::DeviceError> {
         let vk_info = vk::CommandPoolCreateInfo::builder()
             .queue_family_index(desc.queue.family_index)
+            .flags(vk::CommandPoolCreateFlags::TRANSIENT)
             .build();
         let raw = self.shared.raw.create_command_pool(&vk_info, None)?;
 


### PR DESCRIPTION
Looking at Vulkan Samples and other Vulkan materials even on mobile it seems that the right way to manage command pools in a transient way as they are used by wgpu should be enabling the right flag and resetting it without any flags.

Vulkan Samples:
https://github.com/KhronosGroup/Vulkan-Samples/blob/master/framework/core/command_pool.cpp

Arm Mobile developer:
https://arm-software.github.io/vulkan_best_practice_for_mobile_developers/samples/performance/command_buffer_usage/command_buffer_usage_tutorial.html

In my local profilings in my proto engine we're passing from around 9ms to around 800μs (more than 10x speedup)
No warning on leaks from validation layers is appearing in RenderDoc on my side too.
