### PR TITLE
Implement missing PrettyError impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ SurfaceConfiguration {
   enabled. By @imberflur in [#3023](https://github.com/gfx-rs/wgpu/pull/3023)
 - Fixed `CommandEncoder` not being `Send` and `Sync` on web by @i509VCB in [#3025](https://github.com/gfx-rs/wgpu/pull/3025)
 - Document meaning of `vendor` in `AdapterInfo` if the vendor has no PCI id.
+- Fix missing resource labels from some Errors by @scoopr in [#3066](https://github.com/gfx-rs/wgpu/pull/3066)
 
 #### Metal
 - Add the missing `msg_send![view, retain]` call within `from_view` by @jinleili in [#2976](https://github.com/gfx-rs/wgpu/pull/2976)

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -112,6 +112,18 @@ pub enum QueryError {
     InvalidQuerySet(id::QuerySetId),
 }
 
+impl crate::error::PrettyError for QueryError {
+    fn fmt_pretty(&self, fmt: &mut crate::error::ErrorFormatter) {
+        fmt.error(self);
+        match *self {
+            Self::InvalidBuffer(id) => fmt.buffer_label(&id),
+            Self::InvalidQuerySet(id) => fmt.query_set_label(&id),
+
+            _ => {}
+        }
+    }
+}
+
 /// Error encountered while trying to use queries
 #[derive(Clone, Debug, Error)]
 pub enum QueryUseError {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4759,6 +4759,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .push(id::Valid(query_set_id));
     }
 
+    pub fn query_set_label<A: HalApi>(&self, id: id::QuerySetId) -> String {
+        A::hub(self).query_sets.label_for_resource(id)
+    }
+
     pub fn device_create_render_pipeline<A: HalApi>(
         &self,
         device_id: id::DeviceId,

--- a/wgpu-core/src/error.rs
+++ b/wgpu-core/src/error.rs
@@ -91,6 +91,12 @@ impl<'a> ErrorFormatter<'a> {
         let label = gfx_select!(id => global.command_buffer_label(*id));
         self.label("command buffer", &label);
     }
+
+    pub fn query_set_label(&mut self, id: &crate::id::QuerySetId) {
+        let global = self.global;
+        let label = gfx_select!(id => global.query_set_label(*id));
+        self.label("query set", &label);
+    }
 }
 
 pub trait PrettyError: Error + Sized {
@@ -140,6 +146,15 @@ pub fn format_pretty_any(
         return pretty_err.fmt_pretty(&mut fmt);
     }
     if let Some(pretty_err) = error.downcast_ref::<crate::command::TransferError>() {
+        return pretty_err.fmt_pretty(&mut fmt);
+    }
+    if let Some(pretty_err) = error.downcast_ref::<crate::command::PassErrorScope>() {
+        return pretty_err.fmt_pretty(&mut fmt);
+    }
+    if let Some(pretty_err) = error.downcast_ref::<crate::track::UsageConflict>() {
+        return pretty_err.fmt_pretty(&mut fmt);
+    }
+    if let Some(pretty_err) = error.downcast_ref::<crate::command::QueryError>() {
         return pretty_err.fmt_pretty(&mut fmt);
     }
 

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -240,16 +240,16 @@ fn iterate_bitvec_indices(ownership: &BitVec<usize>) -> impl Iterator<Item = usi
 
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum UsageConflict {
-    #[error("Attempted to use buffer {id:?} which is invalid.")]
+    #[error("Attempted to use invalid buffer")]
     BufferInvalid { id: id::BufferId },
-    #[error("Attempted to use texture {id:?} which is invalid.")]
+    #[error("Attempted to use invalid texture")]
     TextureInvalid { id: id::TextureId },
-    #[error("Attempted to use buffer {id:?} with {invalid_use}.")]
+    #[error("Attempted to use buffer with {invalid_use}.")]
     Buffer {
         id: id::BufferId,
         invalid_use: InvalidUse<hal::BufferUses>,
     },
-    #[error("Attempted to use a texture {id:?} mips {mip_levels:?} layers {array_layers:?} with {invalid_use}.")]
+    #[error("Attempted to use a texture (mips {mip_levels:?} layers {array_layers:?}) with {invalid_use}.")]
     Texture {
         id: id::TextureId,
         mip_levels: ops::Range<u32>,
@@ -257,6 +257,7 @@ pub enum UsageConflict {
         invalid_use: InvalidUse<hal::TextureUses>,
     },
 }
+
 impl UsageConflict {
     fn from_buffer(
         id: id::BufferId,
@@ -286,6 +287,26 @@ impl UsageConflict {
                 current_state,
                 new_state,
             },
+        }
+    }
+}
+
+impl crate::error::PrettyError for UsageConflict {
+    fn fmt_pretty(&self, fmt: &mut crate::error::ErrorFormatter) {
+        fmt.error(self);
+        match *self {
+            Self::BufferInvalid { id } => {
+                fmt.buffer_label(&id);
+            }
+            Self::TextureInvalid { id } => {
+                fmt.texture_label(&id);
+            }
+            Self::Buffer { id, .. } => {
+                fmt.buffer_label(&id);
+            }
+            Self::Texture { id, .. } => {
+                fmt.texture_label(&id);
+            }
         }
     }
 }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Closes #3061 

**Description**
Some of the Error impls that refer to the resource ids were not formatting the labels for the resources

**Testing**
I must confess that I only compile-tested. Inducing or synthesizing the error conditions are a bit difficult.
