### PR TITLE
When a command encoder is dropped, destroy its hal command buffer.

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -4575,6 +4575,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         if let Some(cmdbuf) = cmdbuf {
             let device = &mut device_guard[cmdbuf.device_id.value];
             device.untrack::<G>(hub, &cmdbuf.trackers, &mut token);
+            device.destroy_command_buffer(cmdbuf);
         }
     }
 


### PR DESCRIPTION
Fixes #2965.

I'm suspicious that it's this simple, but `CommandBuffer`s are not reference-counted, and we have taken ownership of it by calling `unregister`, just like `queue_submit` would, so this *seems* okay. I guess CI will educate me.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.
