### PR TITLE
Fix egl only enabled with emscripten feature flag

### DIFF
--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -57,7 +57,7 @@ To address this, we invalidate the vertex buffers based on:
 */
 
 ///cbindgen:ignore
-#[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+#[cfg(any(not(target_arch = "wasm32")))]
 mod egl;
 #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
 mod web;


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
encountered during test attempt for #3070 

**Description**
fixes needing to enable `emscripten` feature flag to use egl (i.e. gles for non-web!)

**Testing**
builds but I don't have a libegl.dylib and I failed building angle so far, so compile only :(