### PR TITLE
Provoke VUID-vkDestroyDevice-device-00378 without #3069.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Bug Fixes
+
+#### General
+
+- Bother to free the `hal::Api::CommandBuffer` when a `wgpu_core::command::CommandEncoder` is dropped. By @jimblandy in [#3069](https://github.com/gfx-rs/wgpu/pull/3069).
+
 ## wgpu-0.14.0 (2022-10-05)
 
 ### Major Changes

--- a/wgpu/tests/encoder.rs
+++ b/wgpu/tests/encoder.rs
@@ -1,0 +1,11 @@
+use crate::common::{initialize_test, TestParameters};
+
+#[test]
+fn drop_encoder() {
+    initialize_test(TestParameters::default(), |ctx| {
+        let encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        drop(encoder);
+    })
+}

--- a/wgpu/tests/root.rs
+++ b/wgpu/tests/root.rs
@@ -5,6 +5,7 @@ mod buffer_copy;
 mod buffer_usages;
 mod clear_texture;
 mod device;
+mod encoder;
 mod example_wgsl;
 mod instance;
 mod poll;


### PR DESCRIPTION
This test should have been included in #3069.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
