### PR TITLE
vulkan: Don't use pointer to dropped PhysicalDeviceDriverProperties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Bottom level categories:
 
 #### Vulkan
 
-- Don't use a pointer to a local copy of a `PhysicalDeviceDriverProperties` struct after it has gone out of scope. In fact, don't make a local copy at all. By @jimblandy in [#3076](https://github.com/gfx-rs/wgpu/pull/3076).
+- Don't use a pointer to a local copy of a `PhysicalDeviceDriverProperties` struct after it has gone out of scope. In fact, don't make a local copy at all. Introduce a helper function for building `CStr`s from C character arrays, and remove some `unsafe` blocks. By @jimblandy in [#3076](https://github.com/gfx-rs/wgpu/pull/3076).
 
 ## wgpu-0.14.0 (2022-10-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ Bottom level categories:
 
 - Update the `minimum supported rust version` to 1.62
 
+#### Vulkan
+
+- Don't use a pointer to a local copy of a `PhysicalDeviceDriverProperties` struct after it has gone out of scope. In fact, don't make a local copy at all. By @jimblandy in [#3076](https://github.com/gfx-rs/wgpu/pull/3076).
+
 ## wgpu-0.14.0 (2022-10-05)
 
 ### Major Changes

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -125,7 +125,7 @@ impl crate::TextureCopy {
 /// This can be removed when `CStr::from_bytes_until_nul` is stabilized.
 /// ([#95027](https://github.com/rust-lang/rust/issues/95027))
 #[allow(dead_code)]
-pub(crate) fn cstr_from_bytes_until_nul(bytes: &[std::ffi::c_char]) -> Option<&std::ffi::CStr> {
+pub(crate) fn cstr_from_bytes_until_nul(bytes: &[std::os::raw::c_char]) -> Option<&std::ffi::CStr> {
     if bytes.contains(&0) {
         // Safety for `CStr::from_ptr`:
         // - We've ensured that the slice does contain a null terminator.

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -115,3 +115,24 @@ impl crate::TextureCopy {
         self.size = self.size.min(&max_src_size).min(&max_dst_size);
     }
 }
+
+/// Construct a `CStr` from a byte slice, up to the first zero byte.
+///
+/// Return a `CStr` extending from the start of `bytes` up to and
+/// including the first zero byte. If there is no zero byte in
+/// `bytes`, return `None`.
+///
+/// This can be removed when `CStr::from_bytes_until_nul` is stabilized.
+/// ([#95027](https://github.com/rust-lang/rust/issues/95027))
+#[allow(dead_code)]
+pub(crate) fn cstr_from_bytes_until_nul(bytes: &[std::ffi::c_char]) -> Option<&std::ffi::CStr> {
+    if bytes.contains(&0) {
+        // Safety for `CStr::from_ptr`:
+        // - We've ensured that the slice does contain a null terminator.
+        // - The range is valid to read, because the slice covers it.
+        // - The memory won't be changed, because the slice borrows it.
+        unsafe { Some(std::ffi::CStr::from_ptr(bytes.as_ptr())) }
+    } else {
+        None
+    }
+}

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -538,9 +538,10 @@ impl PhysicalDeviceCapabilities {
     }
 
     pub fn supports_extension(&self, extension: &CStr) -> bool {
+        use crate::auxil::cstr_from_bytes_until_nul;
         self.supported_extensions
             .iter()
-            .any(|ep| unsafe { CStr::from_ptr(ep.extension_name.as_ptr()) } == extension)
+            .any(|ep| cstr_from_bytes_until_nul(&ep.extension_name) == Some(extension))
     }
 
     /// Map `requested_features` to the list of Vulkan extension strings required to create the logical device.
@@ -885,14 +886,15 @@ impl super::Instance {
         &self,
         phd: vk::PhysicalDevice,
     ) -> Option<crate::ExposedAdapter<super::Api>> {
+        use crate::auxil::cstr_from_bytes_until_nul;
         use crate::auxil::db;
 
         let (phd_capabilities, phd_features) = self.shared.inspect(phd);
 
         let info = wgt::AdapterInfo {
-            name: unsafe {
-                CStr::from_ptr(phd_capabilities.properties.device_name.as_ptr())
-                    .to_str()
+            name: {
+                cstr_from_bytes_until_nul(&phd_capabilities.properties.device_name)
+                    .and_then(|info| info.to_str().ok())
                     .unwrap_or("?")
                     .to_owned()
             },
@@ -906,23 +908,23 @@ impl super::Instance {
                 ash::vk::PhysicalDeviceType::CPU => wgt::DeviceType::Cpu,
                 _ => wgt::DeviceType::Other,
             },
-            driver: unsafe {
-                let driver_name = if let Some(ref driver) = phd_capabilities.driver {
-                    CStr::from_ptr(driver.driver_name.as_ptr()).to_str().ok()
-                } else {
-                    None
-                };
-
-                driver_name.unwrap_or("?").to_owned()
+            driver: {
+                phd_capabilities
+                    .driver
+                    .as_ref()
+                    .and_then(|driver| cstr_from_bytes_until_nul(&driver.driver_name))
+                    .and_then(|name| name.to_str().ok())
+                    .unwrap_or("?")
+                    .to_owned()
             },
-            driver_info: unsafe {
-                let driver_info = if let Some(ref driver) = phd_capabilities.driver {
-                    CStr::from_ptr(driver.driver_info.as_ptr()).to_str().ok()
-                } else {
-                    None
-                };
-
-                driver_info.unwrap_or("?").to_owned()
+            driver_info: {
+                phd_capabilities
+                    .driver
+                    .as_ref()
+                    .and_then(|driver| cstr_from_bytes_until_nul(&driver.driver_info))
+                    .and_then(|name| name.to_str().ok())
+                    .unwrap_or("?")
+                    .to_owned()
             },
             backend: wgt::Backend::Vulkan,
         };

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -907,7 +907,7 @@ impl super::Instance {
                 _ => wgt::DeviceType::Other,
             },
             driver: unsafe {
-                let driver_name = if let Some(driver) = phd_capabilities.driver {
+                let driver_name = if let Some(ref driver) = phd_capabilities.driver {
                     CStr::from_ptr(driver.driver_name.as_ptr()).to_str().ok()
                 } else {
                     None
@@ -916,7 +916,7 @@ impl super::Instance {
                 driver_name.unwrap_or("?").to_owned()
             },
             driver_info: unsafe {
-                let driver_info = if let Some(driver) = phd_capabilities.driver {
+                let driver_info = if let Some(ref driver) = phd_capabilities.driver {
                     CStr::from_ptr(driver.driver_info.as_ptr()).to_str().ok()
                 } else {
                     None


### PR DESCRIPTION
Detected by ASAN, but seems impossible to exploit.

Since `ash::vk::definitions::PhysicalDeviceDriverProperties` is `Copy`, the statement

    if let Some(driver) = phd_capabilities.driver { ... }

actually makes `driver` a local copy of the struct. The code uses `as_ptr` to create a pointer to the `driver_name` field of this local copy, and then tries to use that pointer outside the `if let`, when the local copy has gone out of scope. This is UB.

Taking a reference to the properties struct is correct and more efficient.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
