### PR TITLE
Fixed missing device feature in mipmap example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Bottom level categories:
 #### General
 
 - Bother to free the `hal::Api::CommandBuffer` when a `wgpu_core::command::CommandEncoder` is dropped. By @jimblandy in [#3069](https://github.com/gfx-rs/wgpu/pull/3069).
+- Fixed the mipmap example by adding the missing WRITE_TIMESTAMP_INSIDE_PASSES feature. By @Olaroll in [#3081](https://github.com/gfx-rs/wgpu/pull/3081).
 
 ## wgpu-0.14.0 (2022-10-05)
 

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -200,7 +200,9 @@ impl Example {
 
 impl framework::Example for Example {
     fn optional_features() -> wgpu::Features {
-        wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::PIPELINE_STATISTICS_QUERY | wgpu::Features::WRITE_TIMESTAMP_INSIDE_PASSES
+        wgpu::Features::TIMESTAMP_QUERY
+            | wgpu::Features::PIPELINE_STATISTICS_QUERY
+            | wgpu::Features::WRITE_TIMESTAMP_INSIDE_PASSES
     }
 
     fn init(

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -200,7 +200,7 @@ impl Example {
 
 impl framework::Example for Example {
     fn optional_features() -> wgpu::Features {
-        wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::PIPELINE_STATISTICS_QUERY
+        wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::PIPELINE_STATISTICS_QUERY | wgpu::Features::WRITE_TIMESTAMP_INSIDE_PASSES
     }
 
     fn init(

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -325,10 +325,11 @@ impl framework::Example for Example {
         });
 
         // If both kinds of query are supported, use queries
-        let query_sets = if device
-            .features()
-            .contains(wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::PIPELINE_STATISTICS_QUERY)
-        {
+        let query_sets = if device.features().contains(
+            wgpu::Features::TIMESTAMP_QUERY
+                | wgpu::Features::PIPELINE_STATISTICS_QUERY
+                | wgpu::Features::WRITE_TIMESTAMP_INSIDE_PASSES,
+        ) {
             // For N total mips, it takes N - 1 passes to generate them, and we're measuring those.
             let mip_passes = MIP_LEVEL_COUNT - 1;
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
None

**Description**
I'm currently learning wgpu and noticed that the mipmap example didn't work. I added the feature indicated in the error to the appropriate place and now it works. The feature in question is `WRITE_TIMESTAMP_INSIDE_PASSES`.

**Testing**
Ran the example and it worked.
