### PR TITLE
Implement Hash for DepthStencilState and DepthBiasState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Bottom level categories:
 
 #### General
 
-- Implement `Hash` for `DepthStencilState` and `DepthBiasState` in `wgpu-types`.
+- Implement `Hash` for `DepthStencilState` and `DepthBiasState`
 - Add the `"wgsl"` feature, to enable WGSL shaders in `wgpu-core` and `wgpu`. Enabled by default in `wgpu`. By @daxpedda in [#2890](https://github.com/gfx-rs/wgpu/pull/2890).
 - Implement `Clone` for `ShaderSource` and `ShaderModuleDescriptor` in `wgpu`. By @daxpedda in [#3086](https://github.com/gfx-rs/wgpu/pull/3086).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Bottom level categories:
 
 #### General
 
+- Implement `Hash` for `DepthStencilState` and `DepthBiasState` in `wgpu-types`.
 - Add the `"wgsl"` feature, to enable WGSL shaders in `wgpu-core` and `wgpu`. Enabled by default in `wgpu`. By @daxpedda in [#2890](https://github.com/gfx-rs/wgpu/pull/2890).
 - Implement `Clone` for `ShaderSource` and `ShaderModuleDescriptor` in `wgpu`. By @daxpedda in [#3086](https://github.com/gfx-rs/wgpu/pull/3086).
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3183,8 +3183,8 @@ impl Hash for DepthBiasState {
 impl PartialEq for DepthBiasState {
     fn eq(&self, other: &Self) -> bool {
         (self.constant == other.constant)
-            & (self.slope_scale == other.slope_scale)
-            & (self.clamp == other.clamp)
+            && (self.slope_scale.to_bits() == other.slope_scale.to_bits())
+            && (self.clamp.to_bits() == other.clamp.to_bits())
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3153,7 +3153,7 @@ impl StencilState {
 /// Corresponds to a portion of [WebGPU `GPUDepthStencilState`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpudepthstencilstate).
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct DepthBiasState {
@@ -3177,6 +3177,12 @@ impl Hash for DepthBiasState {
         self.constant.hash(state);
         self.slope_scale.to_bits().hash(state);
         self.clamp.to_bits().hash(state);
+    }
+}
+
+impl PartialEq for DepthBiasState {
+    fn eq(&self, other: &Self) -> bool {
+        (self.constant == other.constant) & (self.slope_scale == other.slope_scale) & (self.clamp == other.clamp)
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3182,7 +3182,9 @@ impl Hash for DepthBiasState {
 
 impl PartialEq for DepthBiasState {
     fn eq(&self, other: &Self) -> bool {
-        (self.constant == other.constant) & (self.slope_scale == other.slope_scale) & (self.clamp == other.clamp)
+        (self.constant == other.constant)
+            & (self.slope_scale == other.slope_scale)
+            & (self.clamp == other.clamp)
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -10,6 +10,7 @@
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
 use std::{num::NonZeroU32, ops::Range};
 
 /// Integral type used for buffer offsets.
@@ -3171,12 +3172,20 @@ impl DepthBiasState {
     }
 }
 
+impl Hash for DepthBiasState {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.constant.hash(state);
+        self.slope_scale.to_bits().hash(state);
+        self.clamp.to_bits().hash(state);
+    }
+}
+
 /// Describes the depth/stencil state in a render pipeline.
 ///
 /// Corresponds to [WebGPU `GPUDepthStencilState`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpudepthstencilstate).
 #[repr(C)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct DepthStencilState {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Hopefully, a simple solution for this issue : closes #3087 

**Description**
As described in the question `DepthStencilState` and `DepthBiasState` doesn't have a Hash implementation, I tried to manage the implementation manually. I've never done this before, so it may not be perfect, but I'm interested in your opinion on this.

**Testing**
Cargo fmt / test / clippy.
