### PR TITLE
Fix webgl srgb blit not setting the viewport correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Bottom level categories:
 
 #### GLES
 
-- Surfaces support now `TextureFormat::Rgba8Unorm` and (non-web only) `TextureFormat::Bgra8Unorm`
+- Surfaces support now `TextureFormat::Rgba8Unorm` and (non-web only) `TextureFormat::Bgra8Unorm`. By @Wumpf in [#3070](https://github.com/gfx-rs/wgpu/pull/3070)
 
 ### Bug Fixes
 
@@ -67,6 +67,10 @@ Bottom level categories:
 
 #### WebGPU
 - Use `log` instead of `println` in hello example by @JolifantoBambla in [#2858](https://github.com/gfx-rs/wgpu/pull/2858)
+
+#### GLES
+
+- Fixed WebGL not displaying srgb targets correctly if a non-screen filling viewport was previously set. By @Wumpf in [#3093](https://github.com/gfx-rs/wgpu/pull/3093)
 
 ### Examples
 - Log adapter info in hello example on wasm target by @JolifantoBambla in [#2858](https://github.com/gfx-rs/wgpu/pull/2858)

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -171,6 +171,13 @@ impl Surface {
         ))?;
 
         if swapchain.format.describe().srgb {
+            // Important to set the viewport since we don't know in what state the user left it.
+            gl.viewport(
+                0,
+                0,
+                swapchain.extent.width as _,
+                swapchain.extent.height as _,
+            );
             gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, None);
             gl.bind_sampler(0, None);
             gl.active_texture(glow::TEXTURE0);


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Srgb conversion on webgl assumed the viewport was correctly set. But what if it isn't? This can happen:
![image](https://user-images.githubusercontent.com/1220815/195113952-7d7b271b-6c35-4250-b4ee-d382fc0d5855.png)


**Testing**
manual testing with an egui application