### PR TITLE
web: implement `queue_validate_write_buffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ Bottom level categories:
 - Convert all `Default` Implementations on Enums to `derive(Default)`
 - Implement `Default` for `CompositeAlphaMode`
 
+#### WebGPU
+- Implement `queue_validate_write_buffer` by @jinleili in [#3098](https://github.com/gfx-rs/wgpu/pull/3098)
+
 ### Added/New Features
 
 #### General


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Closes https://github.com/gfx-rs/wgpu/issues/3085

**Testing**
There is no suitable test environment. Firefox Nightly's wgpu seams too old, Chrome Canary used it's own validation internally.
