### PR TITLE
Better error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Bottom level categories:
 -->
 
 ## Unreleased
+- Better error message for non-aligned shaders in WebGL [#3099](https://github.com/gfx-rs/wgpu/pull/3099)
 
 ### Changes
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2854,11 +2854,18 @@ impl<A: HalApi> Device<A> {
             self.require_features(wgt::Features::MULTIVIEW)?;
         }
 
-        for size in shader_binding_sizes.values() {
-            if size.get() % 16 != 0 {
-                self.require_downlevel_flags(
-                    wgt::DownlevelFlags::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED,
-                )?;
+        if !self
+            .downlevel
+            .flags
+            .contains(wgt::DownlevelFlags::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED)
+        {
+            for (binding, size) in shader_binding_sizes.iter() {
+                if size.get() % 16 != 0 {
+                    return Err(pipeline::CreateRenderPipelineError::UnalignedShader {
+                        binding: binding.binding,
+                        group: binding.group,
+                    });
+                }
             }
         }
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -371,6 +371,8 @@ pub enum CreateRenderPipelineError {
         stage: wgt::ShaderStages,
         error: String,
     },
+    #[error("shader group {group} binding {binding} must be 16bit aligned as device does not support DownlevelFlags `BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED`")]
+    UnalignedShader { group: u32, binding: u32 },
 }
 
 bitflags::bitflags! {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Closes https://github.com/gfx-rs/wgpu/issues/2832

**Description**
Previous error message was the generic downflags error message for `BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED` that didn't highlight that if it was 16 bit aligned then this *is* supported. But it wasn't clear which shader group / bind was not aligned.

New error message:
```
In Device::create_render_pipeline
      note: label = `cuboids_pipeline`
    shader group 1 binding 1 must be 16bit aligned as device does not support DownlevelFlags `BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED`
```

Also have switched the code around to check the flag once as if it's set then we can skip the check entirely.

**Testing**
I've tested that I get the updated error locally in the browser.
