### PR TITLE
Add `expose-ids` feature

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -86,6 +86,7 @@ angle = ["wgc/angle"]
 webgl = ["wgc"]
 emscripten = ["webgl"]
 vulkan-portability = ["wgc/vulkan-portability"]
+expose-ids = []
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
 package = "wgpu-core"

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -803,42 +803,42 @@ pub(crate) struct CommandEncoder {
 
 pub(crate) type Id = (u32, u32, wgt::Backend);
 
-impl<T: wgc::id::TypedId> crate::BikeshedBackendId for T {
-    fn id(&self) -> Id {
+impl<T: wgc::id::TypedId> crate::GlobalId for T {
+    fn global_id(&self) -> Id {
         self.unzip()
     }
 }
 
-impl crate::BikeshedBackendId for Surface {
-    fn id(&self) -> Id {
+impl crate::GlobalId for Surface {
+    fn global_id(&self) -> Id {
         use wgc::id::TypedId;
         self.id.unzip()
     }
 }
 
-impl crate::BikeshedBackendId for Device {
-    fn id(&self) -> Id {
+impl crate::GlobalId for Device {
+    fn global_id(&self) -> Id {
         use wgc::id::TypedId;
         self.id.unzip()
     }
 }
 
-impl crate::BikeshedBackendId for Buffer {
-    fn id(&self) -> Id {
+impl crate::GlobalId for Buffer {
+    fn global_id(&self) -> Id {
         use wgc::id::TypedId;
         self.id.unzip()
     }
 }
 
-impl crate::BikeshedBackendId for Texture {
-    fn id(&self) -> Id {
+impl crate::GlobalId for Texture {
+    fn global_id(&self) -> Id {
         use wgc::id::TypedId;
         self.id.unzip()
     }
 }
 
-impl crate::BikeshedBackendId for CommandEncoder {
-    fn id(&self) -> Id {
+impl crate::GlobalId for CommandEncoder {
+    fn global_id(&self) -> Id {
         use wgc::id::TypedId;
         self.id.unzip()
     }

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -801,6 +801,49 @@ pub(crate) struct CommandEncoder {
     open: bool,
 }
 
+pub(crate) type Id = (u32, u32, wgt::Backend);
+
+impl<T: wgc::id::TypedId> crate::BikeshedBackendId for T {
+    fn id(&self) -> Id {
+        self.unzip()
+    }
+}
+
+impl crate::BikeshedBackendId for Surface {
+    fn id(&self) -> Id {
+        use wgc::id::TypedId;
+        self.id.unzip()
+    }
+}
+
+impl crate::BikeshedBackendId for Device {
+    fn id(&self) -> Id {
+        use wgc::id::TypedId;
+        self.id.unzip()
+    }
+}
+
+impl crate::BikeshedBackendId for Buffer {
+    fn id(&self) -> Id {
+        use wgc::id::TypedId;
+        self.id.unzip()
+    }
+}
+
+impl crate::BikeshedBackendId for Texture {
+    fn id(&self) -> Id {
+        use wgc::id::TypedId;
+        self.id.unzip()
+    }
+}
+
+impl crate::BikeshedBackendId for CommandEncoder {
+    fn id(&self) -> Id {
+        use wgc::id::TypedId;
+        self.id.unzip()
+    }
+}
+
 impl crate::Context for Context {
     type AdapterId = wgc::id::AdapterId;
     type DeviceId = Device;

--- a/wgpu/src/backend/mod.rs
+++ b/wgpu/src/backend/mod.rs
@@ -1,9 +1,9 @@
 #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
 mod web;
 #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
-pub(crate) use web::{BufferMappedRange, Context, QueueWriteBuffer};
+pub(crate) use web::{BufferMappedRange, Context, Id, QueueWriteBuffer};
 
 #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
 mod direct;
 #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
-pub(crate) use direct::{BufferMappedRange, Context, QueueWriteBuffer};
+pub(crate) use direct::{BufferMappedRange, Context, Id, QueueWriteBuffer};

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1,8 +1,6 @@
 #![allow(clippy::type_complexity)]
 
 use js_sys::Promise;
-#[cfg(feature = "expose-ids")]
-use std::sync::atomic::{self, AtomicU64};
 use std::{
     cell::RefCell,
     fmt,
@@ -47,7 +45,7 @@ impl<T> crate::GlobalId for Identified<T> {
 pub(crate) type Id = u64;
 
 #[cfg(feature = "expose-ids")]
-static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 #[cfg(not(feature = "expose-ids"))]
 fn create_identified<T>(value: T) -> Identified<T> {
@@ -56,7 +54,10 @@ fn create_identified<T>(value: T) -> Identified<T> {
 
 #[cfg(feature = "expose-ids")]
 fn create_identified<T>(value: T) -> Identified<T> {
-    Identified(value, NEXT_ID.fetch_add(1, atomic::Ordering::Relaxed))
+    Identified(
+        value,
+        NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+    )
 }
 
 pub(crate) struct Context(web_sys::Gpu);

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -25,21 +25,21 @@ pub(crate) struct Sendable<T>(T, #[cfg(feature = "expose-ids")] u64);
 unsafe impl<T> Send for Sendable<T> {}
 unsafe impl<T> Sync for Sendable<T> {}
 
-impl<T> crate::BikeshedBackendId for Sendable<T> {
+impl<T> crate::GlobalId for Sendable<T> {
     #[cfg(not(feature = "expose-ids"))]
-    fn id(&self) -> Id {
+    fn global_id(&self) -> Id {
         0
     }
 
     #[cfg(feature = "expose-ids")]
-    fn id(&self) -> Id {
+    fn global_id(&self) -> Id {
         self.1
     }
 }
 
 // For QuerySetId
-impl crate::BikeshedBackendId for () {
-    fn id(&self) -> Id {
+impl crate::GlobalId for () {
+    fn global_id(&self) -> Id {
         0
     }
 }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -164,32 +164,32 @@ trait RenderPassInner<Ctx: Context>: RenderInner<Ctx> {
     );
 }
 
-trait BikeshedBackendId {
-    fn id(&self) -> BackendId;
+trait GlobalId {
+    fn global_id(&self) -> BackendId;
 }
 
 trait Context: Debug + Send + Sized + Sync {
-    type AdapterId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type DeviceId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type QueueId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type ShaderModuleId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type BindGroupLayoutId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type BindGroupId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type TextureViewId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type SamplerId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type BufferId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type TextureId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type QuerySetId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type PipelineLayoutId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type RenderPipelineId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type ComputePipelineId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type CommandEncoderId: BikeshedBackendId + Debug;
+    type AdapterId: GlobalId + Debug + Send + Sync + 'static;
+    type DeviceId: GlobalId + Debug + Send + Sync + 'static;
+    type QueueId: GlobalId + Debug + Send + Sync + 'static;
+    type ShaderModuleId: GlobalId + Debug + Send + Sync + 'static;
+    type BindGroupLayoutId: GlobalId + Debug + Send + Sync + 'static;
+    type BindGroupId: GlobalId + Debug + Send + Sync + 'static;
+    type TextureViewId: GlobalId + Debug + Send + Sync + 'static;
+    type SamplerId: GlobalId + Debug + Send + Sync + 'static;
+    type BufferId: GlobalId + Debug + Send + Sync + 'static;
+    type TextureId: GlobalId + Debug + Send + Sync + 'static;
+    type QuerySetId: GlobalId + Debug + Send + Sync + 'static;
+    type PipelineLayoutId: GlobalId + Debug + Send + Sync + 'static;
+    type RenderPipelineId: GlobalId + Debug + Send + Sync + 'static;
+    type ComputePipelineId: GlobalId + Debug + Send + Sync + 'static;
+    type CommandEncoderId: Debug;
     type ComputePassId: Debug + ComputePassInner<Self>;
     type RenderPassId: Debug + RenderPassInner<Self>;
-    type CommandBufferId: BikeshedBackendId + Debug + Send + Sync;
+    type CommandBufferId: Debug + Send + Sync;
     type RenderBundleEncoderId: Debug + RenderInner<Self>;
-    type RenderBundleId: BikeshedBackendId + Debug + Send + Sync + 'static;
-    type SurfaceId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type RenderBundleId: GlobalId + Debug + Send + Sync + 'static;
+    type SurfaceId: GlobalId + Debug + Send + Sync + 'static;
 
     type SurfaceOutputDetail: Send;
     type SubmissionIndex: Debug + Copy + Clone + Send + 'static;
@@ -596,10 +596,6 @@ pub struct Device {
     id: <C as Context>::DeviceId,
 }
 static_assertions::assert_impl_all!(Device: Send, Sync);
-
-/// Opaque globally-unique identifier
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Id(BackendId);
 
 /// Identifier for a particular call to [`Queue::submit`]. Can be used
 /// as part of an argument to [`Device::poll`] to block for a particular
@@ -3780,6 +3776,188 @@ impl Surface {
                 detail,
             })
             .ok_or(SurfaceError::Lost)
+    }
+}
+
+/// Opaque globally-unique identifier
+#[cfg(feature = "expose-ids")]
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Id(BackendId);
+
+#[cfg(feature = "expose-ids")]
+impl Adapter {
+    /// Returns a globally-unique identifier for this `Adapter`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl Device {
+    /// Returns a globally-unique identifier for this `Device`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl Queue {
+    /// Returns a globally-unique identifier for this `Queue`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl ShaderModule {
+    /// Returns a globally-unique identifier for this `ShaderModule`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl BindGroupLayout {
+    /// Returns a globally-unique identifier for this `BindGroupLayout`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl BindGroup {
+    /// Returns a globally-unique identifier for this `BindGroup`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl TextureView {
+    /// Returns a globally-unique identifier for this `TextureView`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl Sampler {
+    /// Returns a globally-unique identifier for this `Sampler`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl Buffer {
+    /// Returns a globally-unique identifier for this `Buffer`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl Texture {
+    /// Returns a globally-unique identifier for this `Texture`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl QuerySet {
+    /// Returns a globally-unique identifier for this `QuerySet`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl PipelineLayout {
+    /// Returns a globally-unique identifier for this `PipelineLayout`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl RenderPipeline {
+    /// Returns a globally-unique identifier for this `RenderPipeline`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl ComputePipeline {
+    /// Returns a globally-unique identifier for this `ComputePipeline`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl RenderBundle {
+    /// Returns a globally-unique identifier for this `RenderBundle`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl Surface {
+    /// Returns a globally-unique identifier for this `Surface`.
+    ///
+    /// Calling this method multiple times on the same object will always return the same value.
+    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    pub fn global_id(&self) -> Id {
+        Id(self.id.global_id())
     }
 }
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3781,6 +3781,7 @@ impl Surface {
 
 /// Opaque globally-unique identifier
 #[cfg(feature = "expose-ids")]
+#[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Id(BackendId);
@@ -3791,6 +3792,7 @@ impl Adapter {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3802,6 +3804,7 @@ impl Device {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3813,6 +3816,7 @@ impl Queue {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3824,6 +3828,7 @@ impl ShaderModule {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3835,6 +3840,7 @@ impl BindGroupLayout {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3846,6 +3852,7 @@ impl BindGroup {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3857,6 +3864,7 @@ impl TextureView {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3868,6 +3876,7 @@ impl Sampler {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3879,6 +3888,7 @@ impl Buffer {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3890,6 +3900,7 @@ impl Texture {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3901,6 +3912,7 @@ impl QuerySet {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3912,6 +3924,7 @@ impl PipelineLayout {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3923,6 +3936,7 @@ impl RenderPipeline {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3934,6 +3948,7 @@ impl ComputePipeline {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3945,6 +3960,7 @@ impl RenderBundle {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }
@@ -3956,6 +3972,7 @@ impl Surface {
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
         Id(self.id.global_id())
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -43,7 +43,7 @@ pub use wgt::{
     QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
 };
 
-use backend::{BufferMappedRange, Context as C, QueueWriteBuffer};
+use backend::{BufferMappedRange, Context as C, Id as BackendId, QueueWriteBuffer};
 
 /// Filter for error scopes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
@@ -164,28 +164,32 @@ trait RenderPassInner<Ctx: Context>: RenderInner<Ctx> {
     );
 }
 
+trait BikeshedBackendId {
+    fn id(&self) -> BackendId;
+}
+
 trait Context: Debug + Send + Sized + Sync {
-    type AdapterId: Debug + Send + Sync + 'static;
-    type DeviceId: Debug + Send + Sync + 'static;
-    type QueueId: Debug + Send + Sync + 'static;
-    type ShaderModuleId: Debug + Send + Sync + 'static;
-    type BindGroupLayoutId: Debug + Send + Sync + 'static;
-    type BindGroupId: Debug + Send + Sync + 'static;
-    type TextureViewId: Debug + Send + Sync + 'static;
-    type SamplerId: Debug + Send + Sync + 'static;
-    type BufferId: Debug + Send + Sync + 'static;
-    type TextureId: Debug + Send + Sync + 'static;
-    type QuerySetId: Debug + Send + Sync + 'static;
-    type PipelineLayoutId: Debug + Send + Sync + 'static;
-    type RenderPipelineId: Debug + Send + Sync + 'static;
-    type ComputePipelineId: Debug + Send + Sync + 'static;
-    type CommandEncoderId: Debug;
+    type AdapterId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type DeviceId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type QueueId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type ShaderModuleId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type BindGroupLayoutId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type BindGroupId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type TextureViewId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type SamplerId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type BufferId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type TextureId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type QuerySetId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type PipelineLayoutId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type RenderPipelineId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type ComputePipelineId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type CommandEncoderId: BikeshedBackendId + Debug;
     type ComputePassId: Debug + ComputePassInner<Self>;
     type RenderPassId: Debug + RenderPassInner<Self>;
-    type CommandBufferId: Debug + Send + Sync;
+    type CommandBufferId: BikeshedBackendId + Debug + Send + Sync;
     type RenderBundleEncoderId: Debug + RenderInner<Self>;
-    type RenderBundleId: Debug + Send + Sync + 'static;
-    type SurfaceId: Debug + Send + Sync + 'static;
+    type RenderBundleId: BikeshedBackendId + Debug + Send + Sync + 'static;
+    type SurfaceId: BikeshedBackendId + Debug + Send + Sync + 'static;
 
     type SurfaceOutputDetail: Send;
     type SubmissionIndex: Debug + Copy + Clone + Send + 'static;
@@ -592,6 +596,10 @@ pub struct Device {
     id: <C as Context>::DeviceId,
 }
 static_assertions::assert_impl_all!(Device: Send, Sync);
+
+/// Opaque globally-unique identifier
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Id(BackendId);
 
 /// Identifier for a particular call to [`Queue::submit`]. Can be used
 /// as part of an argument to [`Device::poll`] to block for a particular


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Discussed in matrix

**Description**
Adds the `expose-ids` feature, which allows API users to compare and store the identity of GPU objects through an opaque `Id` type. On native, `Id` wraps an unzipped `wgc::TypedId`; on web, `Id` wraps a manually-generated unique `u64`.

Most types with an `id` field now expose a feature-gated `global_id` method.

**Testing**
Not functionally tested yet, only typechecked

**Unresolved Questions**
- Should `Id`s be type-tagged, and if so, should there still be an untyped option?
- Should global atomics be used to guarantee uniqueness between multiple `Context`s on native?
