### PR TITLE
Use cargo 1.64 workspace inheritance feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  RUST_VERSION: 1.62
+  RUST_VERSION: 1.64
   PKG_CONFIG_ALLOW_CROSS: 1 # allow android to work
   RUSTFLAGS: --cfg=web_sys_unstable_apis -D warnings
   RUSTDOCFLAGS: -Dwarnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Bottom level categories:
 ### Testing/Internal
 
 - Update the `minimum supported rust version` to 1.62
+- Use cargo 1.64 workspace inheritance feature. By @jinleili in [#3107](https://github.com/gfx-rs/wgpu/pull/3107)
 
 #### Vulkan
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dummy"
-version = "0.1.0"
+version = "0.14.0"
 dependencies = [
  "wgpu-core",
 ]
@@ -1697,7 +1697,7 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "player"
-version = "0.1.0"
+version = "0.14.0"
 dependencies = [
  "env_logger",
  "log",
@@ -1905,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "run-wasm"
-version = "0.1.0"
+version = "0.14.0"
 dependencies = [
  "cargo-run-wasm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,122 @@ members = [
     "wgpu-hal",
     "wgpu-info",
     "wgpu-types",
-    "run-wasm",
+    "run-wasm"
 ]
-exclude = [
-]
+exclude = []
 default-members = ["wgpu", "wgpu-hal", "wgpu-info"]
+
+[workspace.package]
+edition = "2021"
+rust-version = "1.64"
+keywords = ["graphics"]
+license = "MIT OR Apache-2.0"
+homepage = "https://wgpu.rs/"
+repository = "https://github.com/gfx-rs/wgpu"
+version = "0.14.0"
+authors = ["wgpu developers"]
+
+[workspace.dependencies.wgc]
+package = "wgpu-core"
+path = "./wgpu-core"
+
+[workspace.dependencies.wgt]
+package = "wgpu-types"
+path = "./wgpu-types"
+
+[workspace.dependencies.hal]
+package = "wgpu-hal"
+path = "./wgpu-hal"
+
+[workspace.dependencies.naga]
+git = "https://github.com/gfx-rs/naga"
+rev = "c52d9102"
+version = "0.10"
+
+[workspace.dependencies]
+arrayvec = "0.7"
+async-executor = "1.0"
+bitflags = "1"
+bitflags_serde_shim = "0.2"
+bit-vec = "0.6"
+bytemuck = "1.4"
+cargo-run-wasm = "0.2.0"
+cfg_aliases = "0.1"
+cfg-if = "1"
+codespan-reporting = "0.11"
+ddsfile = "0.5"
+env_logger = "0.9"
+futures-intrusive = "0.4"
+fxhash = "0.2.1"
+glam = "0.21.3"
+libloading = "0.7"
+log = "0.4"
+nanorand = { version = "0.7", default-features = false }
+# Opt out of noise's "default-features" to avoid "image" feature as a dependency count optimization.
+# This will not be required in the next release since it has been removed from the default feature in https://github.com/Razaekel/noise-rs/commit/1af9e1522236b2c584fb9a02150c9c67a5e6bb04#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542
+noise = { version = "0.7", default-features = false }
+obj = "0.10"
+# parking_lot 0.12 switches from `winapi` to `windows`; permit either
+parking_lot = ">=0.11,<0.13"
+png = "0.17.5"
+pollster = "0.2"
+profiling = { version = "1", default-features = false }
+raw-window-handle = "0.5"
+renderdoc-sys = "0.7.1"
+ron = "0.8"
+serde = "1"
+serde_json = "1.0.85"
+smallvec = "1"
+static_assertions = "1.1.0"
+thiserror = "1"
+wgpu = { version = "0.14", path = "./wgpu" }
+winit = "0.27.1"
+
+# Metal dependencies
+block = "0.1"
+foreign-types = "0.3"
+mtl = { package = "metal", version = "0.24.0" }
+objc = "0.2.5"
+core-graphics-types = "0.1"
+
+# Vulkan dependencies
+ash = "0.37"
+gpu-alloc = "0.5"
+gpu-descriptor = "0.2"
+android_system_properties = "0.1.1"
+
+# DX dependencies
+bit-set = "0.5"
+native = { package = "d3d12", version = "0.5.0" }
+range-alloc = "0.1"
+winapi = "0.3"
+
+# Gles dependencies
+egl = { package = "khronos-egl", version = "4.1" }
+# glow = { version = "0.11.2", optional = true }
+# TODO: New glow release
+glow = { git = "https://github.com/grovesNL/glow/", rev = "c8a011fcd57a5c68cc917ed394baa484bdefc909" }
+glutin = "0.29.1"
+
+# wasm32 dependencies
+console_error_panic_hook = "0.1.7"
+console_log = "0.2"
+js-sys = "0.3.60"
+wasm-bindgen = "0.2.83"
+wasm-bindgen-futures = "0.4.33"
+web-sys = "0.3.60"
+
+# deno dependencies
+deno_console = "0.69.0"
+deno_core = "0.151.0"
+deno_url = "0.69.0"
+deno_web = "0.100.0"
+deno_webidl = "0.69.0"
+deno_webgpu = { path = "./deno_webgpu" }
+tokio = "1.19.0"
+termcolor = "1.1.2"
+wgpu-core = { path = "./wgpu-core" }
+wgpu-types = { path = "./wgpu-types" }
 
 [patch."https://github.com/gfx-rs/naga"]
 #naga = { path = "../naga" }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For an overview of all the components in the gfx-rs ecosystem, see [the big pict
 
 ### MSRV policy
 
-Minimum Supported Rust Version is **1.62**.
+Minimum Supported Rust Version is **1.64**.
 It is enforced on CI (in "/.github/workflows/ci.yml") with `RUST_VERSION` variable.
 This version can only be upgraded in breaking releases.
 

--- a/cts_runner/Cargo.toml
+++ b/cts_runner/Cargo.toml
@@ -2,20 +2,20 @@
 name = "cts_runner"
 version = "0.1.0"
 authors = [
-	"Luca Casonato <hello@lcas.dev>",
+	"Luca Casonato <hello@lcas.dev>"
 ]
-edition = "2021"
+edition.workspace = true
 description = "CTS runner for wgpu"
-license = "MIT OR Apache-2.0"
+license.workspace = true
 publish = false
 resolver = "2"
 
 [dependencies]
-deno_console = "0.69.0"
-deno_core = "0.151.0"
-deno_url = "0.69.0"
-deno_web = "0.100.0"
-deno_webidl = "0.69.0"
-deno_webgpu = { path = "../deno_webgpu" }
-tokio = { version = "1.19.0", features = ["full"] }
-termcolor = "1.1.2"
+deno_console.workspace = true
+deno_core.workspace = true
+deno_url.workspace = true
+deno_web.workspace = true
+deno_webidl.workspace = true
+deno_webgpu.workspace = true
+tokio = { workspace = true, features = ["full"] }
+termcolor.workspace = true

--- a/cts_runner/Cargo.toml
+++ b/cts_runner/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 description = "CTS runner for wgpu"
 license.workspace = true
 publish = false
-resolver = "2"
 
 [dependencies]
 deno_console.workspace = true

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -4,15 +4,15 @@
 name = "deno_webgpu"
 version = "0.63.0"
 authors = ["the Deno authors"]
-edition = "2021"
+edition.workspace = true
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/gfx-rs/wgpu"
+repository.workspace = true
 description = "WebGPU implementation for Deno"
 
 [dependencies]
-deno_core = "0.151.0"
-serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.19", features = ["full"] }
-wgpu-core = { path = "../wgpu-core", features = ["trace", "replay", "serde", "strict_asserts", "wgsl"] }
-wgpu-types = { path = "../wgpu-types", features = ["trace", "replay", "serde"] }
+deno_core.workspace = true
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["full"] }
+wgpu-core = { workspace = true, features = ["trace", "replay", "serde", "strict_asserts", "wgsl"] }
+wgpu-types = { workspace = true, features = ["trace", "replay", "serde"] }

--- a/dummy/Cargo.toml
+++ b/dummy/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
 name = "dummy"
-version = "0.1.0"
-authors = [
-    "Dzmitry Malyshau <kvark@mozilla.com>",
-]
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [features]
 
 [dependencies.wgc]
-path = "../wgpu-core"
-package = "wgpu-core"
+workspace = true
 features = ["serial-pass", "trace"]

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
 name = "player"
-version = "0.1.0"
-authors = [
-	"Dzmitry Malyshau <kvark@mozilla.com>",
-]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "WebGPU trace player"
-homepage = "https://github.com/gfx-rs/wgpu"
-repository = "https://github.com/gfx-rs/wgpu"
-keywords = ["graphics"]
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
 publish = false
 
 [features]
@@ -17,21 +15,19 @@ angle = ["wgc/angle"]
 vulkan-portability = ["wgc/vulkan-portability"]
 
 [dependencies]
-env_logger = "0.9"
-log = "0.4"
-raw-window-handle = "0.5"
-ron = "0.8"
-winit = { version = "0.27", optional = true }
+env_logger.workspace = true
+log.workspace = true
+raw-window-handle.workspace = true
+ron.workspace = true
+winit = { workspace = true, optional = true }
 
 [dependencies.wgt]
-path = "../wgpu-types"
-package = "wgpu-types"
+workspace = true
 features = ["replay"]
 
 [dependencies.wgc]
-path = "../wgpu-core"
-package = "wgpu-core"
+workspace = true
 features = ["replay", "raw-window-handle", "strict_asserts", "wgsl"]
 
 [dev-dependencies]
-serde = "1"
+serde.workspace = true

--- a/run-wasm/Cargo.toml
+++ b/run-wasm/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "run-wasm"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo-run-wasm = "0.2.0"
+cargo-run-wasm.workspace = true

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wgpu-core"
-version = "0.14.0"
-authors = ["wgpu developers"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "WebGPU core logic on wgpu-hal"
-homepage = "https://github.com/gfx-rs/wgpu"
-repository = "https://github.com/gfx-rs/wgpu"
-keywords = ["graphics"]
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
 
 [lib]
 
@@ -29,55 +29,48 @@ wgsl = ["naga/wgsl-in"]
 vulkan-portability = ["hal/vulkan"]
 
 [dependencies]
-arrayvec = "0.7"
-bitflags = "1.0"
-bit-vec = "0.6"
-codespan-reporting = "0.11"
-fxhash = "0.2"
-log = "0.4"
-# parking_lot 0.12 switches from `winapi` to `windows`; permit either
-parking_lot = ">=0.11,<0.13"
-profiling = { version = "1", default-features = false }
-raw-window-handle = { version = "0.5", optional = true }
-ron = { version = "0.8", optional = true }
-serde = { version = "1.0", features = ["serde_derive"], optional = true }
-smallvec = "1"
-thiserror = "1"
+arrayvec.workspace = true
+bitflags.workspace = true
+bit-vec.workspace = true
+codespan-reporting.workspace = true
+fxhash.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+profiling.workspace = true
+raw-window-handle = { workspace = true, optional = true }
+ron = { workspace = true, optional = true }
+serde = { workspace = true, features = ["serde_derive"], optional = true }
+smallvec.workspace = true
+thiserror.workspace = true
 
 [dependencies.naga]
-git = "https://github.com/gfx-rs/naga"
-rev = "c52d9102"
-version = "0.10"
+workspace = true
 features = ["clone", "span", "validate"]
 
 [dependencies.wgt]
-path = "../wgpu-types"
-package = "wgpu-types"
-version = "0.14"
+workspace = true
 
 [dependencies.hal]
-path = "../wgpu-hal"
-package = "wgpu-hal"
-version = "0.14"
+workspace = true
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-web-sys = { version = "0.3", features = ["HtmlCanvasElement", "OffscreenCanvas"] }
+web-sys = { workspace = true, features = ["HtmlCanvasElement", "OffscreenCanvas"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-hal = { path = "../wgpu-hal", package = "wgpu-hal", version = "0.14", features = ["gles"] }
+hal = { workspace = true, features = ["gles"] }
 
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
-hal = { path = "../wgpu-hal", package = "wgpu-hal", version = "0.14", features = ["metal"] }
+hal = { workspace = true, features = ["metal"] }
 #Note: could also enable "vulkan" for Vulkan Portability
 
 [target.'cfg(all(not(target_arch = "wasm32"), unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
-hal = { path = "../wgpu-hal", package = "wgpu-hal", version = "0.14", features = ["vulkan", "gles", "renderdoc"] }
+hal = { workspace = true, features = ["vulkan", "gles", "renderdoc"] }
 
 [target.'cfg(all(not(target_arch = "wasm32"), windows))'.dependencies]
-hal = { path = "../wgpu-hal", package = "wgpu-hal", version = "0.14", features = ["vulkan", "dx12", "dx11", "renderdoc"] }
+hal = { workspace = true, features = ["vulkan", "dx12", "dx11", "renderdoc"] }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-hal = { path = "../wgpu-hal", package = "wgpu-hal", version = "0.14", features = ["emscripten"] }
+hal = { workspace = true, features = ["emscripten"] }
 
 [build-dependencies]
-cfg_aliases = "0.1"
+cfg_aliases.workspace = true

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "wgpu-hal"
-version = "0.14.0"
-authors = ["wgpu developers"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "WebGPU hardware abstraction layer"
-homepage = "https://github.com/gfx-rs/wgpu"
-repository = "https://github.com/gfx-rs/wgpu"
-keywords = ["graphics"]
-license = "MIT OR Apache-2.0"
-rust-version = "1.60"
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
+rust-version.workspace = true
 
 [lib]
 
@@ -30,88 +30,76 @@ name = "raw-gles"
 required-features = ["gles"]
 
 [dependencies]
-bitflags = "1.0"
-# parking_lot 0.12 switches from `winapi` to `windows`; permit either
-parking_lot = ">=0.11,<0.13"
-profiling = { version = "1", default-features = false }
-raw-window-handle = "0.5"
-thiserror = "1"
+bitflags.workspace = true
+parking_lot.workspace = true
+profiling.workspace = true
+raw-window-handle.workspace = true
+thiserror.workspace = true
 
 # backends common
-arrayvec = "0.7"
-fxhash = "0.2.1"
-log = "0.4"
-renderdoc-sys = { version = "0.7.1", optional = true }
+arrayvec.workspace = true
+fxhash.workspace = true
+log.workspace = true
+renderdoc-sys = { workspace = true, optional = true }
 
 # backend: Metal
-block = { version = "0.1", optional = true }
-foreign-types = { version = "0.3", optional = true }
+block = { workspace = true, optional = true }
+foreign-types = { workspace = true, optional = true }
 
 # backend: Vulkan
-ash = { version = "0.37", optional = true }
-gpu-alloc = { version = "0.5", optional = true }
-gpu-descriptor = { version = "0.2", optional = true }
-smallvec = { version = "1", optional = true, features = ["union"] }
+ash = { workspace = true, optional = true }
+gpu-alloc = { workspace = true, optional = true }
+gpu-descriptor = { workspace = true, optional = true }
+smallvec = { workspace = true, optional = true, features = ["union"] }
 
 # backend: Gles
-#glow = { version = "0.11.2", optional = true }
-# TODO: New glow release
-glow = { git = "https://github.com/grovesNL/glow/", rev = "c8a011fcd57a5c68cc917ed394baa484bdefc909", optional = true }
+glow = { workspace = true, optional = true }
 
 # backend: Dx12
-bit-set = { version = "0.5", optional = true }
-range-alloc = { version = "0.1", optional = true }
+bit-set = { workspace = true, optional = true }
+range-alloc = { workspace = true, optional = true }
 
 [dependencies.wgt]
-package = "wgpu-types"
-path = "../wgpu-types"
-version = "0.14"
+workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egl = { package = "khronos-egl", version = "4.1", features = ["dynamic"], optional = true }
-#Note: it's only unused on Apple platforms
-libloading = { version = "0.7", optional = true }
+egl = { workspace = true, features = ["dynamic"], optional = true }
+libloading = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-egl = { package = "khronos-egl", version = "4.1", features = ["static", "no-pkg-config"] }
+egl = { workspace = true, features = ["static", "no-pkg-config"] }
 #Note: it's unused by emscripten, but we keep it to have single code base in egl.rs
-libloading = { version = "0.7", optional = true }
+libloading = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser", "dcomp"] }
-native = { package = "d3d12", version = "0.5.0", features = ["libloading"], optional = true }
-# native = { package = "d3d12", git = "https://github.com/gfx-rs/d3d12-rs.git", rev = "ffe5e261da0a6cb85332b82ab310abd2a7e849f6", features = ["libloading"], optional = true }
+winapi = { workspace = true, features = ["libloaderapi", "windef", "winuser", "dcomp"] }
+native = { workspace = true, features = ["libloading"], optional = true }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
-mtl = { package = "metal", version = "0.24.0" }
-# mtl = { package = "metal", git = "https://github.com/gfx-rs/metal-rs", rev = "1aaa903" }
-objc = "0.2.5"
-core-graphics-types = "0.1"
+mtl.workspace = true
+objc.workspace = true
+core-graphics-types.workspace = true
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-wasm-bindgen = { version = "0.2" }
-web-sys = { version = "=0.3.60", features = ["Window", "HtmlCanvasElement", "WebGl2RenderingContext", "OffscreenCanvas"] }
-js-sys = { version = "0.3" }
+wasm-bindgen.workspace = true
+web-sys = { workspace = true, features = ["Window", "HtmlCanvasElement", "WebGl2RenderingContext", "OffscreenCanvas"] }
+js-sys.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_system_properties = "0.1.1"
+android_system_properties.workspace = true
 
 [dependencies.naga]
-git = "https://github.com/gfx-rs/naga"
-rev = "c52d9102"
-version = "0.10"
+workspace = true
 features = ["clone"]
 
 # DEV dependencies
-
 [dev-dependencies.naga]
-git = "https://github.com/gfx-rs/naga"
-rev = "c52d9102"
+workspace = true
 features = ["wgsl-in"]
 
 [dev-dependencies]
-env_logger = "0.9"
-winit = "0.27.1"     # for "halmark" example
+env_logger.workspace = true
+winit.workspace = true      # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-glutin = "0.29.1" # for "gles" example
+glutin.workspace = true # for "gles" example

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "wgpu-info"
-version = "0.14.0"
-authors = ["wgpu developers"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "Adapter information and per-adapter test program"
-homepage = "https://github.com/gfx-rs/wgpu"
-repository = "https://github.com/gfx-rs/wgpu"
-keywords = ["graphics"]
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
 
 [dependencies]
-env_logger = "0.9"
-wgpu = { version = "0.14", path = "../wgpu" }
+env_logger.workspace = true
+wgpu.workspace = true

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wgpu-types"
-version = "0.14.0"
-authors = ["wgpu developers"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "WebGPU types"
-homepage = "https://github.com/gfx-rs/wgpu"
-repository = "https://github.com/gfx-rs/wgpu"
-keywords = ["graphics"]
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
 
 [lib]
 
@@ -16,9 +16,9 @@ trace = ["serde", "bitflags_serde_shim"]
 replay = ["serde", "bitflags_serde_shim"]
 
 [dependencies]
-bitflags = "1.0"
-serde = { version = "1.0", features = ["serde_derive"], optional = true }
-bitflags_serde_shim = { version = "0.2", optional = true }
+bitflags.workspace = true
+serde = { workspace = true, features = ["serde_derive"], optional = true }
+bitflags_serde_shim = { workspace = true, optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.85"
+serde_json.workspace = true

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wgpu"
-version = "0.14.0"
-authors = ["wgpu developers"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "Rusty WebGPU API wrapper"
-homepage = "https://wgpu.rs/"
-repository = "https://github.com/gfx-rs/wgpu/tree/v0.13"
-keywords = ["graphics"]
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
 exclude = [
     "etc/**/*",
     "examples/**/*.png",  # Image comparison test
@@ -88,81 +88,64 @@ emscripten = ["webgl"]
 vulkan-portability = ["wgc/vulkan-portability"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
-package = "wgpu-core"
-path = "../wgpu-core"
-version = "0.14"
+workspace = true
 features = ["raw-window-handle"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.wgc]
-package = "wgpu-core"
-path = "../wgpu-core"
-version = "0.14"
+workspace = true
 features = ["raw-window-handle"]
 optional = true
 
 [dependencies.wgt]
-package = "wgpu-types"
-path = "../wgpu-types"
-version = "0.14"
+workspace = true
 
 [target.'cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))'.dependencies.hal]
-package = "wgpu-hal"
-path = "../wgpu-hal"
-version = "0.14"
+workspace = true
 
 [dependencies]
-arrayvec = "0.7"
-log = "0.4"
-# parking_lot 0.12 switches from `winapi` to `windows`; permit either
-parking_lot = ">=0.11,<0.13"
-raw-window-handle = "0.5"
-serde = { version = "1", features = ["derive"], optional = true }
-smallvec = "1"
-static_assertions = "1.1.0"
+arrayvec.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+raw-window-handle.workspace = true
+serde = { workspace = true, features = ["derive"], optional = true }
+smallvec.workspace = true
+static_assertions.workspace = true
 
 [dev-dependencies]
-bitflags = "1"
-bytemuck = { version = "1.4", features = ["derive"] }
-cfg-if = "1"
-glam = "0.21.3"
-ddsfile = "0.5"
-futures-intrusive = "0.4"
-env_logger = "0.9"
-log = "0.4"
-# Opt out of noise's "default-features" to avoid "image" feature as a dependency count optimization.
-# This will not be required in the next release since it has been removed from the default feature in https://github.com/Razaekel/noise-rs/commit/1af9e1522236b2c584fb9a02150c9c67a5e6bb04#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542
-noise = { version = "0.7", default-features = false }
-obj = "0.10"
-pollster = "0.2"
-png = "0.17"
-nanorand = { version = "0.7", default-features = false, features = ["wyrand"] }
-winit = "0.27.1"                                                                # for "halmark" example
+bitflags.workspace = true
+cfg-if.workspace = true
+bytemuck = { workspace = true, features = ["derive"] }
+glam.workspace = true
+ddsfile.workspace = true
+futures-intrusive.workspace = true
+env_logger.workspace = true
+log.workspace = true
+noise = { workspace = true }
+obj.workspace = true
+pollster.workspace = true
+png.workspace = true
+nanorand = { workspace = true, features = ["wyrand"] }
+winit.workspace = true                                 # for "halmark" example                                                        # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-async-executor = "1.0"
+async-executor.workspace = true
 
 [dependencies.naga]
-git = "https://github.com/gfx-rs/naga"
-rev = "c52d9102"
-version = "0.10"
+workspace = true
 features = ["clone"]
 optional = true
 
 # used to test all the example shaders
 [dev-dependencies.naga]
-git = "https://github.com/gfx-rs/naga"
-rev = "c52d9102"
-version = "0.10"
+workspace = true
 features = ["wgsl-in"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.naga]
-git = "https://github.com/gfx-rs/naga"
-rev = "c52d9102"
-version = "0.10"
+workspace = true
 features = ["wgsl-out"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3.60", features = [
+web-sys = { workspace = true, features = [
     "Document",
     "Navigator",
     "Node",
@@ -291,17 +274,16 @@ web-sys = { version = "0.3.60", features = [
     "WorkerGlobalScope",
     "WorkerNavigator"
 ] }
-wasm-bindgen = "0.2.83"
-js-sys = "0.3.60"
-wasm-bindgen-futures = "0.4.33"
-# parking_lot 0.12 switches from `winapi` to `windows`; permit either
-parking_lot = ">=0.11,<0.13"
+wasm-bindgen.workspace = true
+js-sys.workspace = true
+wasm-bindgen-futures.workspace = true
+parking_lot.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-console_error_panic_hook = "0.1.7"
-console_log = "0.2"
+console_error_panic_hook.workspace = true
+console_log.workspace = true
 # We need these features in the framework examples
-web-sys = { version = "0.3.60", features = [
+web-sys = { workspace = true, features = [
     "Location",
     "Blob",
     "RequestInit",


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Now, dependencies used by more than one package use inheritance instead.

In the `[package]` table, three fields of `name`, `description`, and `version` remain independent. Although each crate `version` is now synchronized, they should be able to upgrade the version separately, in dummy, player two crates, the authors value is not the same, so it also remains independent.
    - In `dummy`, `player` crates, the `authors` field value are not the same, so they remain independent.
    - The value of  `homepage` field is "https://wgpu.rs/" in  wgpu crate and "https://github.com/gfx-rs/wgpu" in  other crate, I'm not sure if this is intentional or not, but now it is inherited as  "https://wgpu.rs/" value

`deno_webgpu` and `cts_runner` are not workspace members, so inheritance cannot be used.

**Testing**
Tested locally on macOS, Windows11 and Android 12.