### PR TITLE
Allow creating external texture views and samplers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ Bottom level categories:
 - Add the `"wgsl"` feature, to enable WGSL shaders in `wgpu-core` and `wgpu`. Enabled by default in `wgpu`. By @daxpedda in [#2890](https://github.com/gfx-rs/wgpu/pull/2890).
 - Implement `Clone` for `ShaderSource` and `ShaderModuleDescriptor` in `wgpu`. By @daxpedda in [#3086](https://github.com/gfx-rs/wgpu/pull/3086).
 - Add `get_default_config` for `Surface` to simplify user creation of `SurfaceConfiguration`. By @jinleili in [#3034](https://github.com/gfx-rs/wgpu/pull/3034)
+- Add `create_sampler_from_hal` in `wgpu` for native platforms. By @i509VCB in [#3114](https://github.com/gfx-rs/wgpu/pull/3114)
+- Add `create_texture_view_from_hal` in `wgpu` for native platforms. By @i509VCB in [#3114](https://github.com/gfx-rs/wgpu/pull/3114)
+
+#### Vulkan
+- Add a way to create a sampler from a `vk::Sampler`. By @i509VCB in [#3114](https://github.com/gfx-rs/wgpu/pull/3114)
+- Add a way to create a texture view from a `vk::ImageView`. By @i509VCB in [#3114](https://github.com/gfx-rs/wgpu/pull/3114)
+- Add a way to access the raw `vk::ImageView` from a TextureView. By @i509VCB in [#3114](https://github.com/gfx-rs/wgpu/pull/3114)
 
 #### GLES
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -368,9 +368,17 @@ pub struct TextureView {
     raw: vk::ImageView,
     layers: NonZeroU32,
     attachment: FramebufferAttachment,
+    drop_guard: Option<crate::DropGuard>,
 }
 
 impl TextureView {
+    /// # Safety
+    ///
+    /// - The image view handle must not be manually destroyed
+    pub unsafe fn raw_handle(&self) -> vk::ImageView {
+        self.raw
+    }
+
     fn aspects(&self) -> crate::FormatAspects {
         self.attachment.view_format.into()
     }
@@ -379,6 +387,7 @@ impl TextureView {
 #[derive(Debug)]
 pub struct Sampler {
     raw: vk::Sampler,
+    drop_guard: Option<crate::DropGuard>,
 }
 
 #[derive(Debug)]

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2269,6 +2269,27 @@ impl Device {
         }
     }
 
+    /// Creates a [`Sampler`] from a wgpu-hal Sampler.
+    ///
+    /// # Safety
+    ///
+    /// - `hal_sampler` must be created from this device internal handle
+    /// - `hal_sampler` must be created respecting `desc`
+    /// - `hal_sampler` must be initialized
+    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    pub unsafe fn create_sampler_from_hal<A: wgc::hub::HalApi>(
+        &self,
+        hal_sampler: A::Sampler,
+        desc: &SamplerDescriptor,
+    ) -> Sampler {
+        Sampler {
+            context: Arc::clone(&self.context),
+            id: self
+                .context
+                .create_sampler_from_hal::<A>(hal_sampler, &self.id, desc),
+        }
+    }
+
     /// Creates a new [`QuerySet`].
     pub fn create_query_set(&self, desc: &QuerySetDescriptor) -> QuerySet {
         QuerySet {
@@ -2646,6 +2667,28 @@ impl Texture {
         TextureView {
             context: Arc::clone(&self.context),
             id: Context::texture_create_view(&*self.context, &self.id, desc),
+        }
+    }
+
+    /// Creates a [`TextureView`] from a wgpu-hal TextureView.
+    ///
+    /// # Safety
+    ///
+    /// - `hal_texture_view` must be created from this device internal handle
+    /// - `hal_texture_view` must be created from this texture
+    /// - `hal_texture_view` must be created respecting `desc`
+    /// - `hal_texture_view` must be initialized
+    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    pub unsafe fn create_view_from_hal<A: wgc::hub::HalApi>(
+        &self,
+        hal_texture_view: A::TextureView,
+        desc: &TextureViewDescriptor,
+    ) -> TextureView {
+        TextureView {
+            context: Arc::clone(&self.context),
+            id: self
+                .context
+                .create_texture_view_from_hal::<A>(&self.id, hal_texture_view, desc),
         }
     }
 


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Related to memory import as described in #2320

**Description**
As a part of the work to make external memory function, there needs to be a way to create image views and samplers externally. On Android and Linux, with the VK_EXT_image_drm_modifier and VK_ANDROID_external_memory_android_hardware_buffer extensions, some formats may require a Ycbcr sampler as provided by the VK_KHR_sampler_ycbcr_conversion extension. This sampler type needs to be provided both when creating a Sampler and the TextureViews for which the sampler is used in.

Like any of the prior pull requests, the best way I've seen so far is to expose the logic to allow external mechanisms to create the objects with special extensions outside of wgpu-hal and provide a way to import the handles into wgpu-hal.