### PR TITLE
WebGL2 multiview support via OVR_multiview2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Bottom level categories:
 #### WebGPU
 - Implement `queue_validate_write_buffer` by @jinleili in [#3098](https://github.com/gfx-rs/wgpu/pull/3098)
 
+#### GLES
+
+- Browsers that support `OVR_multiview2` now report the `MULTIVIEW` feature by @expenses in [#3121](https://github.com/gfx-rs/wgpu/pull/3121).
+
 ### Added/New Features
 
 #### General

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -330,6 +330,10 @@ impl super::Adapter {
             downlevel_flags.contains(wgt::DownlevelFlags::VERTEX_STORAGE)
                 && vertex_shader_storage_textures != 0,
         );
+        features.set(
+            wgt::Features::MULTIVIEW,
+            extensions.contains("OVR_multiview2"),
+        );
         let gles_bcn_exts = [
             "GL_EXT_texture_compression_s3tc_srgb",
             "GL_EXT_texture_compression_rgtc",

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -89,7 +89,18 @@ impl super::Queue {
             }
             super::TextureInner::DefaultRenderbuffer => panic!("Unexpected default RBO"),
             super::TextureInner::Texture { raw, target } => {
-                if is_layered_target(target) {
+                let num_layers = view.array_layers.end - view.array_layers.start;
+                if num_layers > 1 {
+                    #[cfg(target_arch = "wasm32")]
+                    gl.framebuffer_texture_multiview_ovr(
+                        fbo_target,
+                        attachment,
+                        Some(raw),
+                        view.mip_levels.start as i32,
+                        view.array_layers.start as i32,
+                        num_layers as i32,
+                    );
+                } else if is_layered_target(target) {
                     gl.framebuffer_texture_layer(
                         fbo_target,
                         attachment,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -91,7 +91,7 @@ impl super::Queue {
             super::TextureInner::Texture { raw, target } => {
                 let num_layers = view.array_layers.end - view.array_layers.start;
                 if num_layers > 1 {
-                    #[cfg(target_arch = "wasm32")]
+                    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
                     gl.framebuffer_texture_multiview_ovr(
                         fbo_target,
                         attachment,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -586,6 +586,7 @@ bitflags::bitflags! {
         ///
         /// Supported platforms:
         /// - Vulkan
+        /// - OpenGL (web only)
         ///
         /// This is a native only feature.
         const MULTIVIEW = 1 << 37;


### PR DESCRIPTION
**Checklist**

Built on top of https://github.com/gfx-rs/naga/pull/1933.

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

- https://github.com/gfx-rs/naga/pull/1933
- https://github.com/grovesNL/glow/pull/220
- https://github.com/rustwasm/wasm-bindgen/pull/2903

**Testing**

I've been using it extensively in my own code.
