### PR TITLE
Improve compute shader validation error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Bottom level categories:
 
 - Convert all `Default` Implementations on Enums to `derive(Default)`
 - Implement `Default` for `CompositeAlphaMode`
-- Improve compute shader validation error message
+- Improve compute shader validation error message. By @haraldreingruber in [#3139](https://github.com/gfx-rs/wgpu/pull/3139)
 
 #### WebGPU
 - Implement `queue_validate_write_buffer` by @jinleili in [#3098](https://github.com/gfx-rs/wgpu/pull/3098)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Bottom level categories:
 - DX11
 - GLES
 - WebGPU
-- Enscripten
+- Emscripten
 - Hal
 -->
 
@@ -46,6 +46,7 @@ Bottom level categories:
 
 - Convert all `Default` Implementations on Enums to `derive(Default)`
 - Implement `Default` for `CompositeAlphaMode`
+- Improve compute shader validation error message
 
 #### WebGPU
 - Implement `queue_validate_write_buffer` by @jinleili in [#3098](https://github.com/gfx-rs/wgpu/pull/3098)

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -236,10 +236,11 @@ pub enum StageError {
     #[error("shader module is invalid")]
     InvalidModule,
     #[error(
-        "shader entry point current workgroup size {current:?} must be less or equal to {limit:?} of total {total}"
+        "shader entry point current workgroup size {current:?} of total {current_total} must be less or equal to {limit:?} and of total {total}"
     )]
     InvalidWorkgroupSize {
         current: [u32; 3],
+        current_total: u32,
         limit: [u32; 3],
         total: u32,
     },
@@ -1098,6 +1099,7 @@ impl Interface {
             {
                 return Err(StageError::InvalidWorkgroupSize {
                     current: entry_point.workgroup_size,
+                    current_total: total_invocations,
                     limit: max_workgroup_size_limits,
                     total: self.limits.max_compute_invocations_per_workgroup,
                 });

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -236,7 +236,7 @@ pub enum StageError {
     #[error("shader module is invalid")]
     InvalidModule,
     #[error(
-        "shader entry point current workgroup size {current:?} of total {current_total} must be less or equal to {limit:?} and of total {total}"
+        "shader entry point's workgroup size {current:?} ({current_total} total invocations) must be less or equal to the per-dimension limit {limit:?} and the total invocation limit {total}"
     )]
     InvalidWorkgroupSize {
         current: [u32; 3],


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Potential improvement for #2985 

**Description**
The previous error message was easily misunderstood, as it didn't say explicitly that each dimension and the total number must be below the bounds.

For example, instead of:

    shader entry point current workgroup size [8, 8, 8] must be less or equal to [256, 256, 64] of total 256

after applying this PR the error is:

    shader entry point current workgroup size [8, 8, 8] of total 512 must be less or equal to [256, 256, 64] and of total 256

Thanks to @mwalczyk for the original improvement idea 🙏

**Testing**
In `shader.wgsl` of the `hello-compute` example, I've changed the `@workgroup_size(1)` to `@workgroup_size(8, 8, 8)`
