### PR TITLE
Avoid integer overflow on multiplication in write_texture.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Bottom level categories:
 - Fixed the mipmap example by adding the missing WRITE_TIMESTAMP_INSIDE_PASSES feature. By @Olaroll in [#3081](https://github.com/gfx-rs/wgpu/pull/3081).
 - Avoid panicking in some interactions with invalid resources by @nical in (#3094)[https://github.com/gfx-rs/wgpu/pull/3094]
 - Remove `wgpu_types::Features::DEPTH24PLUS_STENCIL8`, making `wgpu::TextureFormat::Depth24PlusStencil8` available on all backends. By @Healthire in (#3151)[https://github.com/gfx-rs/wgpu/pull/3151]
+- Fix an integer overflow in `queue_write_texture` by @nical in (#3146)[https://github.com/gfx-rs/wgpu/pull/3146]
 
 #### WebGPU
 - Use `log` instead of `println` in hello example by @JolifantoBambla in [#2858](https://github.com/gfx-rs/wgpu/pull/2858)

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -219,7 +219,10 @@ pub(crate) fn validate_linear_texture_data(
     copy_size: &Extent3d,
     need_copy_aligned_rows: bool,
 ) -> Result<(BufferAddress, BufferAddress), TransferError> {
-    // Convert all inputs to BufferAddress (u64) to prevent overflow issues
+    // Convert all inputs to BufferAddress (u64) to avoid some of the overflow issues
+    // Note: u64 is not always enough to prevent overflow, especially when multiplying
+    // something with a potentially large depth value, so it is preferrable to validate
+    // the copy size before calling this function (for example via `validate_texture_copy_range`).
     let copy_width = copy_size.width as BufferAddress;
     let copy_height = copy_size.height as BufferAddress;
     let copy_depth = copy_size.depth_or_array_layers as BufferAddress;

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -600,6 +600,19 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (selector, dst_base, texture_format) =
             extract_texture_selector(destination, size, &*texture_guard)?;
         let format_desc = texture_format.describe();
+
+        let dst = texture_guard.get_mut(destination.texture).unwrap();
+        if !dst.desc.usage.contains(wgt::TextureUsages::COPY_DST) {
+            return Err(
+                TransferError::MissingCopyDstUsageFlag(None, Some(destination.texture)).into(),
+            );
+        }
+
+        // Note: Doing the copy range validation early is important because ensures that the
+        // dimensions are not going to cause overflow in other parts of the validation.
+        let (hal_copy_size, array_layer_count) =
+            validate_texture_copy_range(destination, &dst.desc, CopySide::Destination, size)?;
+
         // Note: `_source_bytes_per_array_layer` is ignored since we
         // have a staging copy, and it can have a different value.
         let (_, _source_bytes_per_array_layer) = validate_linear_texture_data(
@@ -641,13 +654,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let block_rows_in_copy =
             (size.depth_or_array_layers - 1) * block_rows_per_image + height_blocks;
         let stage_size = stage_bytes_per_row as u64 * block_rows_in_copy as u64;
-
-        let dst = texture_guard.get_mut(destination.texture).unwrap();
-        if !dst.desc.usage.contains(wgt::TextureUsages::COPY_DST) {
-            return Err(
-                TransferError::MissingCopyDstUsageFlag(None, Some(destination.texture)).into(),
-            );
-        }
 
         let mut trackers = device.trackers.lock();
         let encoder = device.pending_writes.activate();
@@ -702,8 +708,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             )
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
 
-        let (hal_copy_size, array_layer_count) =
-            validate_texture_copy_range(destination, &dst.desc, CopySide::Destination, size)?;
         dst.life_guard.use_at(device.active_submission_index + 1);
 
         let dst_raw = dst

--- a/wgpu/tests/queue_transfer.rs
+++ b/wgpu/tests/queue_transfer.rs
@@ -1,0 +1,49 @@
+//! Tests for buffer copy validation.
+
+use std::num::NonZeroU32;
+
+use crate::common::{fail, initialize_test, TestParameters};
+
+#[test]
+fn queue_write_texture_overflow() {
+    initialize_test(TestParameters::default(), |ctx| {
+        let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            size: wgpu::Extent3d {
+                width: 146,
+                height: 25,
+                depth_or_array_layers: 192,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba32Float,
+            usage: wgpu::TextureUsages::COPY_DST,
+        });
+
+        let data = vec![255; 128];
+
+        fail(&ctx.device, || {
+            ctx.queue.write_texture(
+                wgpu::ImageCopyTexture {
+                    texture: &texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                &data,
+                wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: NonZeroU32::new(879161360),
+                    //bytes_per_image: 4294967295,
+                    rows_per_image: NonZeroU32::new(4294967295 / 879161360),
+                },
+                wgpu::Extent3d {
+                    width: 3056263286,
+                    height: 64,
+                    depth_or_array_layers: 1144576469,
+                },
+            );
+        });
+    });
+}

--- a/wgpu/tests/root.rs
+++ b/wgpu/tests/root.rs
@@ -9,6 +9,7 @@ mod encoder;
 mod example_wgsl;
 mod instance;
 mod poll;
+mod queue_transfer;
 mod resource_descriptor_accessor;
 mod resource_error;
 mod shader;


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Found by 

https://bugzilla.mozilla.org/show_bug.cgi?id=1791809

**Description**

With large depth values in `copy_size`, `validate_linear_texture_data` can run into integer overflows.
This is avoided by validating the copy depth before calling `validate_linear_texture_data` in `queue_write_texture`.
The other two `validate_linear_texture_data` call sites already have the copy size validated beforehand.


**Testing**

I can add a test when I come back from vacation a week from now.