### PR TITLE
DXC Integration in DX12 Backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "com-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1138,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hassle-rs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90601c6189668c7345fc53842cb3f3a3d872203d523be1b3cb44a36a3e62fb85"
+dependencies = [
+ "bitflags",
+ "com-rs",
+ "libc",
+ "libloading",
+ "thiserror",
+ "widestring",
+ "winapi",
 ]
 
 [[package]]
@@ -2864,6 +2885,7 @@ dependencies = [
  "glutin",
  "gpu-alloc",
  "gpu-descriptor",
+ "hassle-rs",
  "js-sys",
  "khronos-egl",
  "libloading",
@@ -2913,6 +2935,12 @@ dependencies = [
  "libc",
  "once_cell",
 ]
+
+[[package]]
+name = "widestring"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ bit-set = "0.5"
 native = { package = "d3d12", version = "0.5.0" }
 range-alloc = "0.1"
 winapi = "0.3"
+hassle-rs = "0.9.0"
 
 # Gles dependencies
 egl = { package = "khronos-egl", version = "4.1" }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -27,7 +27,7 @@ metal = ["naga/msl-out", "block", "foreign-types"]
 vulkan = ["naga/spv-out", "ash", "gpu-alloc", "gpu-descriptor", "libloading", "smallvec"]
 gles = ["naga/glsl-out", "glow", "egl", "libloading"]
 dx11 = ["naga/hlsl-out", "native", "libloading", "winapi/d3d11", "winapi/d3d11_1", "winapi/d3d11_2", "winapi/d3d11sdklayers", "winapi/dxgi1_6"]
-dx12 = ["naga/hlsl-out", "native", "bit-set", "range-alloc", "winapi/d3d12", "winapi/d3d12shader", "winapi/d3d12sdklayers", "winapi/dxgi1_6"]
+dx12 = ["naga/hlsl-out", "native", "bit-set", "range-alloc", "winapi/d3d12", "winapi/d3d12shader", "winapi/d3d12sdklayers", "winapi/dxgi1_6", "hassle-rs"]
 renderdoc = ["libloading", "renderdoc-sys"]
 emscripten = ["gles"]
 
@@ -67,6 +67,7 @@ glow = { workspace = true, optional = true }
 # backend: Dx12
 bit-set = { workspace = true, optional = true }
 range-alloc = { workspace = true, optional = true }
+hassle-rs = { workspace = true, optional = true } 
 
 [dependencies.wgt]
 workspace = true

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -239,6 +239,9 @@ impl super::Device {
             compile_flags.push("-Od"); /* d3dcompiler::D3DCOMPILE_DEBUG */
         }
 
+        // This closure gets called if `hassle_rs::compile_hlsl() fails due to a `hassle_rs::HassleError::LoadLibraryError`,
+        //
+        //  This usually means that `dxcompiler.dll` and/or `dxil.dll` could not be found in the current execution environment.
         let load_shader_fxc = || {
             let mut shader_data = native::Blob::null();
             let mut compile_flags = d3dcompiler::D3DCOMPILE_ENABLE_STRICTNESS;
@@ -262,22 +265,22 @@ impl super::Device {
             let hr = unsafe {
                 profiling::scope!("d3dcompiler::D3DCompile");
                 d3dcompiler::D3DCompile(
-                    source.as_ptr() as *const _,
+                    source.as_ptr().cast(),
                     source.len(),
-                    source_name.as_ptr() as *const i8,
+                    source_name.as_ptr().cast(),
                     ptr::null(),
                     ptr::null_mut(),
                     raw_ep.as_ptr(),
-                    full_stage.as_ptr() as *const i8,
+                    full_stage.as_ptr().cast(),
                     compile_flags,
                     0,
-                    shader_data.mut_void() as *mut *mut _,
-                    error.mut_void() as *mut *mut _,
+                    shader_data.mut_void().cast(),
+                    error.mut_void().cast(),
                 )
             };
 
             match hr.into_result() {
-                Ok(()) => (Ok(super::ShaderDXIL::FXC(shader_data)), log::Level::Info),
+                Ok(()) => (Ok(super::ShaderDXIL::Fxc(shader_data)), log::Level::Info),
                 Err(e) => {
                     let mut full_msg = format!("D3DCompile error ({})", e);
                     if !error.is_null() {
@@ -311,10 +314,10 @@ impl super::Device {
                 raw_ep.to_str().unwrap(),
                 &full_stage,
                 &compile_flags,
-                &vec![],
+                &[],
             )
         }) {
-            Ok(dxil) => (Ok(super::ShaderDXIL::DXC(dxil)), log::Level::Info),
+            Ok(dxil) => (Ok(super::ShaderDXIL::Dxc(dxil)), log::Level::Info),
             Err(err) => match err {
                 hassle_rs::HassleError::Win32Error(err) => {
                     let err_str = i32::into_result(err.0).unwrap_err();
@@ -1385,7 +1388,7 @@ impl crate::Device<super::Api> for super::Device {
                 shader_stages |= wgt::ShaderStages::FRAGMENT;
                 self.load_shader(stage, desc.layout, naga::ShaderStage::Fragment)?
             }
-            None => crate::dx12::ShaderDXIL::DXC(vec![]),
+            None => crate::dx12::ShaderDXIL::Dxc(vec![]),
         };
 
         let mut vertex_strides = [None; crate::MAX_VERTEX_BUFFERS];
@@ -1459,12 +1462,12 @@ impl crate::Device<super::Api> for super::Device {
         let raw_desc = d3d12::D3D12_GRAPHICS_PIPELINE_STATE_DESC {
             pRootSignature: desc.layout.shared.signature.as_mut_ptr(),
             VS: match blob_vs {
-                super::ShaderDXIL::DXC(ref blob_vs) => *native::Shader::from_raw(&blob_vs),
-                super::ShaderDXIL::FXC(blob_vs) => *native::Shader::from_blob(blob_vs),
+                super::ShaderDXIL::Dxc(ref blob_vs) => *native::Shader::from_raw(blob_vs),
+                super::ShaderDXIL::Fxc(blob_vs) => *native::Shader::from_blob(blob_vs),
             },
             PS: match blob_fs {
-                super::ShaderDXIL::DXC(ref blob_fs) => *native::Shader::from_raw(&blob_fs),
-                super::ShaderDXIL::FXC(blob_fs) => {
+                super::ShaderDXIL::Dxc(ref blob_fs) => *native::Shader::from_raw(blob_fs),
+                super::ShaderDXIL::Fxc(blob_fs) => {
                     if blob_fs.is_null() {
                         *native::Shader::null()
                     } else {
@@ -1543,8 +1546,7 @@ impl crate::Device<super::Api> for super::Device {
             )
         };
 
-        if let super::ShaderDXIL::FXC(vs_fxc) = &blob_vs {
-            vs_fxc.destroy();
+        if let super::ShaderDXIL::Fxc(vs_fxc) = blob_vs {
             if !vs_fxc.is_null() {
                 vs_fxc.destroy();
             }
@@ -1580,8 +1582,8 @@ impl crate::Device<super::Api> for super::Device {
             self.raw.create_compute_pipeline_state(
                 desc.layout.shared.signature,
                 match blob_cs {
-                    crate::dx12::ShaderDXIL::DXC(ref blob_cs) => native::Shader::from_raw(&blob_cs),
-                    crate::dx12::ShaderDXIL::FXC(blob_cs) => native::Shader::from_blob(blob_cs),
+                    crate::dx12::ShaderDXIL::Dxc(ref blob_cs) => native::Shader::from_raw(blob_cs),
+                    crate::dx12::ShaderDXIL::Fxc(blob_cs) => native::Shader::from_blob(blob_cs),
                 },
                 0,
                 native::CachedPSO::null(),
@@ -1589,7 +1591,7 @@ impl crate::Device<super::Api> for super::Device {
             )
         };
 
-        if let super::ShaderDXIL::FXC(cs_fxc) = blob_cs {
+        if let super::ShaderDXIL::Fxc(cs_fxc) = blob_cs {
             cs_fxc.destroy();
         }
 

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -222,11 +222,12 @@ impl super::Device {
             .map(|name| ffi::CString::new(name.as_str()).unwrap())
             .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("{}", e)))?;
 
-        let empty_str = "";
-        let source_name = match stage.module.raw_name {
-            Some(ref cstr) => cstr.to_str().unwrap_or(empty_str),
-            None => empty_str,
-        };
+        let source_name = stage
+            .module
+            .raw_name
+            .as_ref()
+            .and_then(|cstr| cstr.to_str().ok())
+            .unwrap_or_default();
 
         let mut compile_flags = vec!["-Ges"]/* d3dcompiler::D3DCOMPILE_ENABLE_STRICTNESS */;
         if self
@@ -302,15 +303,17 @@ impl super::Device {
 
         // hassle_rs doesn't check for `dxil.dll` if you only call `hassle_rs::compile_hlsl` but calling hassle_rs::Dxil::new will .
         profiling::scope!("hassle_rs::compile_hlsl");
-        let (result, log_level) = match hassle_rs::Dxil::new(None).and(hassle_rs::compile_hlsl(
-            source_name,
-            &source,
-            /*this is safe because `raw_ep` was converted from `String`*/
-            raw_ep.to_str().unwrap(),
-            &full_stage,
-            &compile_flags,
-            &vec![],
-        )) {
+        let (result, log_level) = match hassle_rs::Dxil::new(None).and_then(|_| {
+            hassle_rs::compile_hlsl(
+                source_name,
+                &source,
+                /*this is safe because `raw_ep` was converted from `String`*/
+                raw_ep.to_str().unwrap(),
+                &full_stage,
+                &compile_flags,
+                &vec![],
+            )
+        }) {
             Ok(dxil) => (Ok(super::ShaderDXIL::DXC(dxil)), log::Level::Info),
             Err(err) => match err {
                 hassle_rs::HassleError::Win32Error(err) => {

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -228,6 +228,16 @@ impl super::Device {
             None => empty_str,
         };
 
+        let mut compile_flags = vec!["-Ges"]/* d3dcompiler::D3DCOMPILE_ENABLE_STRICTNESS */;
+        if self
+            .private_caps
+            .instance_flags
+            .contains(crate::InstanceFlags::DEBUG)
+        {
+            compile_flags.push("-Zi"); /* d3dcompiler::D3DCOMPILE_SKIP_OPTIMIZATION */
+            compile_flags.push("-Od"); /* d3dcompiler::D3DCOMPILE_DEBUG */
+        }
+
         let load_shader_fxc = || {
             let mut shader_data = native::Blob::null();
             let mut compile_flags = d3dcompiler::D3DCOMPILE_ENABLE_STRICTNESS;
@@ -298,7 +308,7 @@ impl super::Device {
             /*this is safe because `raw_ep` was converted from `String`*/
             raw_ep.to_str().unwrap(),
             &full_stage,
-            &vec![],
+            &compile_flags,
             &vec![],
         )) {
             Ok(dxil) => (Ok(super::ShaderDXIL::DXC(dxil)), log::Level::Info),

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -528,8 +528,8 @@ pub struct ShaderModule {
 }
 
 enum ShaderDXIL {
-    DXC(Vec<u8>),
-    FXC(native::Blob),
+    Dxc(Vec<u8>),
+    Fxc(native::Blob),
 }
 
 pub struct RenderPipeline {

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -527,6 +527,11 @@ pub struct ShaderModule {
     raw_name: Option<ffi::CString>,
 }
 
+enum ShaderDXIL {
+    DXC(Vec<u8>),
+    FXC(native::Blob),
+}
+
 pub struct RenderPipeline {
     raw: native::PipelineState,
     layout: PipelineLayoutShared,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
[https://github.com/gfx-rs/wgpu/issues/2722](https://github.com/gfx-rs/wgpu/issues/2722)

**Description**
DXC will be the default shader compiler for the d3d12 backend , I'm not sure about the addition of `enum ShaderDXIL` , the other solution would be to convert the `ID3DBlob` to `Vec<u8>` which would require a malloc+copy and freeing the blob .  

**Testing**
_Explain how this change is tested._
