### PR TITLE
Test and doc tweaks

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -317,7 +317,9 @@ bitflags::bitflags! {
         /// the consequences.
         ///
         /// Supported platforms:
-        /// - All
+        /// - Vulkan
+        /// - DX12
+        /// - Metal
         ///
         /// This is a native only feature.
         const MAPPABLE_PRIMARY_BUFFERS = 1 << 16;

--- a/wgpu/tests/buffer_usages.rs
+++ b/wgpu/tests/buffer_usages.rs
@@ -1,39 +1,49 @@
 //! Tests for buffer usages validation.
 
+use crate::common::{fail, initialize_test, valid, TestParameters};
 use wgt::BufferAddress;
 
-use crate::common::{initialize_test, TestParameters};
+const BUFFER_SIZE: BufferAddress = 1234;
 
 #[test]
 fn buffer_usage() {
-    fn try_create(
-        usages: &[wgpu::BufferUsages],
-        enable_mappable_primary_buffers: bool,
-        should_panic: bool,
-    ) {
+    fn try_create(enable_mappable_primary_buffers: bool, usages: &[(bool, &[wgpu::BufferUsages])]) {
         let mut parameters = TestParameters::default();
         if enable_mappable_primary_buffers {
             parameters = parameters.features(wgpu::Features::MAPPABLE_PRIMARY_BUFFERS);
         }
-        if should_panic {
-            parameters = parameters.failure();
-        }
 
         initialize_test(parameters, |ctx| {
-            for usage in usages.iter().copied() {
-                let _buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
-                    label: None,
-                    size: BUFFER_SIZE,
-                    usage,
-                    mapped_at_creation: false,
-                });
+            for (expect_validation_error, usage) in
+                usages
+                    .iter()
+                    .flat_map(|&(expect_validation_error, usages)| {
+                        usages
+                            .iter()
+                            .copied()
+                            .map(move |u| (expect_validation_error, u))
+                    })
+            {
+                let create_buffer = || {
+                    let _buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+                        label: None,
+                        size: BUFFER_SIZE,
+                        usage,
+                        mapped_at_creation: false,
+                    });
+                };
+                if expect_validation_error {
+                    fail(&ctx.device, create_buffer);
+                } else {
+                    valid(&ctx.device, create_buffer);
+                }
             }
         });
     }
 
     use wgpu::BufferUsages as Bu;
 
-    let always_valid = [
+    let always_valid = &[
         Bu::MAP_READ,
         Bu::MAP_WRITE,
         Bu::MAP_READ | Bu::COPY_DST,
@@ -41,25 +51,31 @@ fn buffer_usage() {
     ];
     // MAP_READ can only be paired with COPY_DST and MAP_WRITE can only be paired with COPY_SRC
     // (unless Features::MAPPABlE_PRIMARY_BUFFERS is enabled).
-    let needs_mappable_primary_buffers = [
+    let needs_mappable_primary_buffers = &[
         Bu::MAP_READ | Bu::COPY_DST | Bu::COPY_SRC,
         Bu::MAP_WRITE | Bu::COPY_SRC | Bu::COPY_DST,
         Bu::MAP_READ | Bu::MAP_WRITE,
         Bu::MAP_WRITE | Bu::MAP_READ,
         Bu::MAP_READ | Bu::COPY_DST | Bu::STORAGE,
         Bu::MAP_WRITE | Bu::COPY_SRC | Bu::STORAGE,
-        wgpu::BufferUsages::all(),
+        Bu::all(),
     ];
-    let always_fail = [Bu::empty()];
+    let always_fail = &[Bu::empty()];
 
-    try_create(&always_valid, false, false);
-    try_create(&always_valid, true, false);
-
-    try_create(&needs_mappable_primary_buffers, false, true);
-    try_create(&needs_mappable_primary_buffers, true, false);
-
-    try_create(&always_fail, false, true);
-    try_create(&always_fail, true, true);
+    try_create(
+        false,
+        &[
+            (false, always_valid),
+            (true, needs_mappable_primary_buffers),
+            (true, always_fail),
+        ],
+    );
+    try_create(
+        true,
+        &[
+            (false, always_valid),
+            (false, needs_mappable_primary_buffers),
+            (true, always_fail),
+        ],
+    );
 }
-
-const BUFFER_SIZE: BufferAddress = 1234;

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -177,7 +177,7 @@ pub fn initialize_test(parameters: TestParameters, test_function: impl FnOnce(Te
         backend_bits,
         None,
     ))
-    .expect("could not find sutable adapter on the system");
+    .expect("could not find suitable adapter on the system");
 
     let adapter_info = adapter.get_info();
     let adapter_lowercase_name = adapter_info.name.to_lowercase();

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -331,3 +331,13 @@ pub fn valid<T>(device: &wgpu::Device, callback: impl FnOnce() -> T) -> T {
 
     result
 }
+
+// Run some code in an error scope and assert that validation succeeds or fails depending on the
+// provided `should_fail` boolean.
+pub fn fail_if<T>(device: &wgpu::Device, should_fail: bool, callback: impl FnOnce() -> T) -> T {
+    if should_fail {
+        fail(device, callback)
+    } else {
+        valid(device, callback)
+    }
+}


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] ~~Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.~~
- [ ] ~~Add change to CHANGELOG.md. See simple instructions inside file.~~

**Connections**
This fixes a bug I noticed in a test I added in a previous PR: see this comment <https://github.com/gfx-rs/wgpu/pull/3023#issuecomment-1251244469>

**Description**
Instead of using panics to catch validation errors, the buffer usage test now uses error scopes. This is more amenable to not re-creating the whole context for each test case that is intended to fail.

This PR also modifies the docs of `Feature::MAPPABLE_PRIMARY_BUFFER` to indicate that it is only available on Vulkan, DX12, and Metal.