### PR TITLE
use debug_assert_** with not(feature = "strict_asserts")

### DIFF
--- a/wgpu-core/src/assertions.rs
+++ b/wgpu-core/src/assertions.rs
@@ -12,6 +12,7 @@
 //! in both debug and release builds.
 
 #[cfg(feature = "strict_asserts")]
+#[macro_export]
 macro_rules! strict_assert {
     ( $( $arg:tt )* ) => {
         assert!( $( $arg )* )
@@ -19,6 +20,7 @@ macro_rules! strict_assert {
 }
 
 #[cfg(feature = "strict_asserts")]
+#[macro_export]
 macro_rules! strict_assert_eq {
     ( $( $arg:tt )* ) => {
         assert_eq!( $( $arg )* )
@@ -26,6 +28,7 @@ macro_rules! strict_assert_eq {
 }
 
 #[cfg(feature = "strict_asserts")]
+#[macro_export]
 macro_rules! strict_assert_ne {
     ( $( $arg:tt )* ) => {
         assert_ne!( $( $arg )* )
@@ -41,6 +44,7 @@ macro_rules! strict_assert {
 }
 
 #[cfg(not(feature = "strict_asserts"))]
+#[macro_export]
 macro_rules! strict_assert_eq {
     ( $( $arg:tt )* ) => {
         debug_assert_eq!( $( $arg )* )
@@ -48,6 +52,7 @@ macro_rules! strict_assert_eq {
 }
 
 #[cfg(not(feature = "strict_asserts"))]
+#[macro_export]
 macro_rules! strict_assert_ne {
     ( $( $arg:tt )* ) => {
         debug_assert_ne!( $( $arg )* )

--- a/wgpu-core/src/assertions.rs
+++ b/wgpu-core/src/assertions.rs
@@ -35,15 +35,21 @@ macro_rules! strict_assert_ne {
 #[cfg(not(feature = "strict_asserts"))]
 #[macro_export]
 macro_rules! strict_assert {
-    ( $( $arg:tt )* ) => {};
+    ( $( $arg:tt )* ) => {
+        debug_assert!( $( $arg )* )
+    };
 }
 
 #[cfg(not(feature = "strict_asserts"))]
 macro_rules! strict_assert_eq {
-    ( $( $arg:tt )* ) => {};
+    ( $( $arg:tt )* ) => {
+        debug_assert_eq!( $( $arg )* )
+    };
 }
 
 #[cfg(not(feature = "strict_asserts"))]
 macro_rules! strict_assert_ne {
-    ( $( $arg:tt )* ) => {};
+    ( $( $arg:tt )* ) => {
+        debug_assert_ne!( $( $arg )* )
+    };
 }


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
`strict_asserts` should at least validate with the debug_assert_** family of macros in debug builds. Otherwise undefined behavior can sneak by.