### PR TITLE
Added new  UNRESTRICTED_INDEX_BUFFER downlevel flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Bottom level categories:
 - Convert all `Default` Implementations on Enums to `derive(Default)`
 - Implement `Default` for `CompositeAlphaMode`
 - Improve compute shader validation error message. By @haraldreingruber in [#3139](https://github.com/gfx-rs/wgpu/pull/3139)
-- New downlevel feature `BUFFER_USAGE_COMBINE_VERTEX_INDEX` to indicate support of buffers that have both usages `VERTEX` and `INDEX` (unsupported on WebGL). By @Wumpf in [#3157](https://github.com/gfx-rs/wgpu/pull/3157)
+- New downlevel feature `UNRESTRICTED_INDEX_BUFFER` to indicate support for using `INDEX` together with other non-copy/map usages (unsupported on WebGL). By @Wumpf in [#3157](https://github.com/gfx-rs/wgpu/pull/3157)
 
 #### WebGPU
 - Implement `queue_validate_write_buffer` by @jinleili in [#3098](https://github.com/gfx-rs/wgpu/pull/3098)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Bottom level categories:
 - Convert all `Default` Implementations on Enums to `derive(Default)`
 - Implement `Default` for `CompositeAlphaMode`
 - Improve compute shader validation error message. By @haraldreingruber in [#3139](https://github.com/gfx-rs/wgpu/pull/3139)
+- New downlevel feature `BUFFER_USAGE_COMBINE_VERTEX_INDEX` to indicate support of buffers that have both usages `VERTEX` and `INDEX` (unsupported on WebGL). By @Wumpf in [#3157](https://github.com/gfx-rs/wgpu/pull/3157)
 
 #### WebGPU
 - Implement `queue_validate_write_buffer` by @jinleili in [#3098](https://github.com/gfx-rs/wgpu/pull/3098)

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -601,15 +601,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .downlevel
             .flags
             .contains(wgt::DownlevelFlags::UNRESTRICTED_INDEX_BUFFER)
-            && (src_buffer.usage.contains(BufferUsages::INDEX)
-                || dst_buffer.usage.contains(BufferUsages::INDEX))
+            && (src_buffer.usage.contains(wgt::BufferUsages::INDEX)
+                || dst_buffer.usage.contains(wgt::BufferUsages::INDEX))
         {
-            let non_index_non_copy_buffer_usages = wgt::BufferUsages::VERTEX
+            let forbidden_usages = wgt::BufferUsages::VERTEX
                 | wgt::BufferUsages::UNIFORM
                 | wgt::BufferUsages::INDIRECT
                 | wgt::BufferUsages::STORAGE;
-            if src_buffer.usage.contains(non_index_non_copy_buffer_usages)
-                || dst_buffer.usage.contains(non_index_non_copy_buffer_usages)
+            if src_buffer.usage.intersects(forbidden_usages)
+                || dst_buffer.usage.intersects(forbidden_usages)
             {
                 return Err(TransferError::MissingDownlevelFlags(MissingDownlevelFlags(
                     wgt::DownlevelFlags::UNRESTRICTED_INDEX_BUFFER,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -590,11 +590,15 @@ impl<A: HalApi> Device<A> {
             });
         }
 
-        if desc
-            .usage
-            .contains(wgt::BufferUsages::VERTEX | wgt::BufferUsages::INDEX)
+        if desc.usage.contains(wgt::BufferUsages::INDEX)
+            && desc.usage.contains(
+                wgt::BufferUsages::VERTEX
+                    | wgt::BufferUsages::UNIFORM
+                    | wgt::BufferUsages::INDIRECT
+                    | wgt::BufferUsages::STORAGE,
+            )
         {
-            self.require_downlevel_flags(wgt::DownlevelFlags::BUFFER_USAGE_COMBINE_VERTEX_INDEX)?;
+            self.require_downlevel_flags(wgt::DownlevelFlags::UNRESTRICTED_INDEX_BUFFER)?;
         }
 
         let mut usage = conv::map_buffer_usage(desc.usage);

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -590,6 +590,13 @@ impl<A: HalApi> Device<A> {
             });
         }
 
+        if desc
+            .usage
+            .contains(wgt::BufferUsages::VERTEX | wgt::BufferUsages::INDEX)
+        {
+            self.require_downlevel_flags(wgt::DownlevelFlags::BUFFER_USAGE_COMBINE_VERTEX_INDEX)?;
+        }
+
         let mut usage = conv::map_buffer_usage(desc.usage);
 
         if desc.usage.is_empty() {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1,5 +1,5 @@
 use crate::{
-    device::{DeviceError, HostMap, MissingFeatures},
+    device::{DeviceError, HostMap, MissingDownlevelFlags, MissingFeatures},
     hub::{Global, GlobalIdentityHandlerFactory, HalApi, Resource, Token},
     id::{AdapterId, DeviceId, SurfaceId, TextureId, Valid},
     init_tracker::{BufferInitTracker, TextureInitTracker},
@@ -248,6 +248,8 @@ pub enum CreateBufferError {
     UsageMismatch(wgt::BufferUsages),
     #[error("Buffer size {requested} is greater than the maximum buffer size ({maximum})")]
     MaxBufferSize { requested: u64, maximum: u64 },
+    #[error(transparent)]
+    MissingDownlevelFlags(#[from] MissingDownlevelFlags),
 }
 
 impl<A: hal::Api> Resource for Buffer<A> {

--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -91,8 +91,9 @@ impl super::Adapter {
             | wgt::Features::CLEAR_TEXTURE
             | wgt::Features::TEXTURE_FORMAT_16BIT_NORM
             | wgt::Features::ADDRESS_MODE_CLAMP_TO_ZERO;
-        let mut downlevel =
-            wgt::DownlevelFlags::BASE_VERTEX | wgt::DownlevelFlags::READ_ONLY_DEPTH_STENCIL;
+        let mut downlevel = wgt::DownlevelFlags::BASE_VERTEX
+            | wgt::DownlevelFlags::READ_ONLY_DEPTH_STENCIL
+            | wgt::DownlevelFlags::BUFFER_USAGE_COMBINE_VERTEX_INDEX;
 
         // Features from queries
         downlevel.set(

--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -93,7 +93,7 @@ impl super::Adapter {
             | wgt::Features::ADDRESS_MODE_CLAMP_TO_ZERO;
         let mut downlevel = wgt::DownlevelFlags::BASE_VERTEX
             | wgt::DownlevelFlags::READ_ONLY_DEPTH_STENCIL
-            | wgt::DownlevelFlags::BUFFER_USAGE_COMBINE_VERTEX_INDEX;
+            | wgt::DownlevelFlags::UNRESTRICTED_INDEX_BUFFER;
 
         // Features from queries
         downlevel.set(

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -312,6 +312,12 @@ impl super::Adapter {
             wgt::DownlevelFlags::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED,
             !(cfg!(target_arch = "wasm32") || is_angle),
         );
+        // https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.5
+        // "A given WebGLBuffer object may only be bound to one of the ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target in its lifetime."
+        downlevel_flags.set(
+            wgt::DownlevelFlags::BUFFER_USAGE_COMBINE_VERTEX_INDEX,
+            !cfg!(target_arch = "wasm32"),
+        );
 
         let mut features = wgt::Features::empty()
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -312,10 +312,9 @@ impl super::Adapter {
             wgt::DownlevelFlags::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED,
             !(cfg!(target_arch = "wasm32") || is_angle),
         );
-        // https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.5
-        // "A given WebGLBuffer object may only be bound to one of the ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target in its lifetime."
+        // see https://registry.khronos.org/webgl/specs/latest/2.0/#BUFFER_OBJECT_BINDING
         downlevel_flags.set(
-            wgt::DownlevelFlags::BUFFER_USAGE_COMBINE_VERTEX_INDEX,
+            wgt::DownlevelFlags::UNRESTRICTED_INDEX_BUFFER,
             !cfg!(target_arch = "wasm32"),
         );
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1063,7 +1063,7 @@ bitflags::bitflags! {
 
         /// Supports samplers with anisotropic filtering. Note this isn't actually required by
         /// WebGPU, the implementation is allowed to completely ignore aniso clamp. This flag is
-        /// here for native backends so they can communi    cate to the user of aniso is enabled.
+        /// here for native backends so they can communicate to the user of aniso is enabled.
         ///
         /// All backends and all devices support anisotropic filtering.
         const ANISOTROPIC_FILTERING = 1 << 10;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1088,10 +1088,12 @@ bitflags::bitflags! {
         /// WebGL doesn't support this.
         const BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED = 1 << 15;
 
-        /// Supports buffers that have both [`BufferUsages::INDEX`] and [`BufferUsages::VERTEX`] set.
+        /// Supports buffers to combine [`BufferUsages::INDEX`] with usages other than [`BufferUsages::COPY_DST`] and [`BufferUsages::COPY_SRC`].
+        /// Furthermore, in absence of this feature it is not allowed to copy index buffers from/to buffers with usages other than
+        /// [`BufferUsages::INDEX`]/[`BufferUsages::COPY_DST`]/[`BufferUsages::COPY_SRC`].
         ///
         /// WebGL doesn't support this.
-        const BUFFER_USAGE_COMBINE_VERTEX_INDEX = 1 << 16;
+        const UNRESTRICTED_INDEX_BUFFER = 1 << 16;
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1063,7 +1063,7 @@ bitflags::bitflags! {
 
         /// Supports samplers with anisotropic filtering. Note this isn't actually required by
         /// WebGPU, the implementation is allowed to completely ignore aniso clamp. This flag is
-        /// here for native backends so they can comunicate to the user of aniso is enabled.
+        /// here for native backends so they can communi    cate to the user of aniso is enabled.
         ///
         /// All backends and all devices support anisotropic filtering.
         const ANISOTROPIC_FILTERING = 1 << 10;
@@ -1089,8 +1089,8 @@ bitflags::bitflags! {
         const BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED = 1 << 15;
 
         /// Supports buffers to combine [`BufferUsages::INDEX`] with usages other than [`BufferUsages::COPY_DST`] and [`BufferUsages::COPY_SRC`].
-        /// Furthermore, in absence of this feature it is not allowed to copy index buffers from/to buffers with usages other than
-        /// [`BufferUsages::INDEX`]/[`BufferUsages::COPY_DST`]/[`BufferUsages::COPY_SRC`].
+        /// Furthermore, in absence of this feature it is not allowed to copy index buffers from/to buffers with a set of usage flags containing
+         /// [`BufferUsages::VERTEX`]/[`BufferUsages::UNIFORM`]/[`BufferUsages::STORAGE`] or [`BufferUsages::INDIRECT`].
         ///
         /// WebGL doesn't support this.
         const UNRESTRICTED_INDEX_BUFFER = 1 << 16;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1087,6 +1087,11 @@ bitflags::bitflags! {
         ///
         /// WebGL doesn't support this.
         const BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED = 1 << 15;
+
+        /// Supports buffers that have both [`BufferUsages::INDEX`] and [`BufferUsages::VERTEX`] set.
+        ///
+        /// WebGL doesn't support this.
+        const BUFFER_USAGE_COMBINE_VERTEX_INDEX = 1 << 16;
     }
 }
 


### PR DESCRIPTION

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
n/a

**Description**

WebGL doesn't support buffers that are are used both as vertex and index buffer. This introduces a new downlevel feature to check for this.

**Testing**
Tested same application in browser and desktop (Metal). Browser now correctly logs an error:

```
panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_buffer
      note: label = `rerun logo`
    Downlevel flags BUFFER_USAGE_COMBINE_VERTEX_INDEX are required but not supported on the device.
This is not an invalid use of WebGPU: the underlying API or device does not support enough features to be a fully compliant implementation. A subset of the features can still be used. If you are running this program on native and not in a browser and wish to work around this issue, call Adapter::downlevel_properties or Device::downlevel_properties to get a listing of the features the current platform supports.
```
not super expressive but good enough I reckon