### PR TITLE
Backport #3151 Without Breaking Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+## wgpu-0.14.1 (2022-11-02)
+
+### Bug Fixes
+
+- Make `wgpu::TextureFormat::Depth24PlusStencil8` available on all backends by making the feature unconditionally available and the feature unneeded to use the format. By @Healthire and @cwfitzgerald in [#3151](https://github.com/gfx-rs/wgpu/pull/3151)
+
 ## wgpu-0.14.0 (2022-10-05)
 
 ### Major Changes

--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -86,6 +86,7 @@ impl super::Adapter {
         // TODO(cwfitzgerald): Needed downlevel features: 3D dispatch
 
         let mut features = wgt::Features::DEPTH_CLIP_CONTROL
+            | wgt::Features::DEPTH24PLUS_STENCIL8 // workaround #3112
             | wgt::Features::PUSH_CONSTANTS
             | wgt::Features::POLYGON_MODE_LINE
             | wgt::Features::CLEAR_TEXTURE

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -191,7 +191,7 @@ impl super::Adapter {
 
         let mut features = wgt::Features::empty()
             | wgt::Features::DEPTH_CLIP_CONTROL
-            | wgt::Features::DEPTH24PLUS_STENCIL8
+            | wgt::Features::DEPTH24PLUS_STENCIL8 // workaround #3112
             | wgt::Features::DEPTH32FLOAT_STENCIL8
             | wgt::Features::INDIRECT_FIRST_INSTANCE
             | wgt::Features::MAPPABLE_PRIMARY_BUFFERS

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -314,6 +314,7 @@ impl super::Adapter {
         );
 
         let mut features = wgt::Features::empty()
+            | wgt::Features::DEPTH24PLUS_STENCIL8 // workaround #3112
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | wgt::Features::CLEAR_TEXTURE
             | wgt::Features::PUSH_CONSTANTS;

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -760,6 +760,7 @@ impl super::PrivateCapabilities {
         use wgt::Features as F;
 
         let mut features = F::empty()
+            | F::DEPTH24PLUS_STENCIL8 // workaround #3112
             | F::INDIRECT_FIRST_INSTANCE
             | F::MAPPABLE_PRIMARY_BUFFERS
             | F::VERTEX_WRITABLE_STORAGE
@@ -778,7 +779,6 @@ impl super::PrivateCapabilities {
         features.set(F::TEXTURE_COMPRESSION_ETC2, self.format_eac_etc);
 
         features.set(F::DEPTH_CLIP_CONTROL, self.supports_depth_clip_control);
-        features.set(F::DEPTH24PLUS_STENCIL8, self.format_depth24_stencil8);
 
         features.set(
             F::TEXTURE_BINDING_ARRAY

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -307,6 +307,7 @@ impl PhysicalDeviceFeatures {
         use crate::auxil::db;
         use wgt::{DownlevelFlags as Df, Features as F};
         let mut features = F::empty()
+            | F::DEPTH24PLUS_STENCIL8 // workaround #3112
             | F::SPIRV_SHADER_PASSTHROUGH
             | F::MAPPABLE_PRIMARY_BUFFERS
             | F::PUSH_CONSTANTS
@@ -476,17 +477,6 @@ impl PhysicalDeviceFeatures {
                 instance,
                 phd,
                 vk::Format::D32_SFLOAT_S8_UINT,
-                vk::ImageTiling::OPTIMAL,
-                vk::FormatFeatureFlags::DEPTH_STENCIL_ATTACHMENT,
-            ),
-        );
-
-        features.set(
-            F::DEPTH24PLUS_STENCIL8,
-            supports_format(
-                instance,
-                phd,
-                vk::Format::D24_UNORM_S8_UINT,
                 vk::ImageTiling::OPTIMAL,
                 vk::FormatFeatureFlags::DEPTH_STENCIL_ATTACHMENT,
             ),

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -191,12 +191,10 @@ bitflags::bitflags! {
         ///
         /// This is a web and native feature.
         const DEPTH_CLIP_CONTROL = 1 << 0;
-        /// Allows for explicit creation of textures of format [`TextureFormat::Depth24PlusStencil8`]
+        /// Does nothing.
         ///
         /// Supported platforms:
-        /// - Vulkan (some)
-        /// - DX12
-        /// - Metal (Macs with amd GPUs)
+        /// - All platforms. This being a feature was a bug. See [#3112](https://github.com/gfx-rs/wgpu/issues/3112)
         ///
         /// This is a web and native feature.
         const DEPTH24PLUS_STENCIL8 = 1 << 1;
@@ -2314,7 +2312,6 @@ impl TextureFormat {
         let astc_hdr = Features::TEXTURE_COMPRESSION_ASTC_HDR;
         let norm16bit = Features::TEXTURE_FORMAT_16BIT_NORM;
         let d32_s8 = Features::DEPTH32FLOAT_STENCIL8;
-        let d24_s8 = Features::DEPTH24PLUS_STENCIL8;
 
         // Sample Types
         let uint = TextureSampleType::Uint;
@@ -2399,7 +2396,7 @@ impl TextureFormat {
             // Depth-stencil textures
             Self::Depth16Unorm =>        (   native,   depth,    linear,         msaa, (1, 1),  2, attachment, 1),
             Self::Depth24Plus =>         (   native,   depth,    linear,         msaa, (1, 1),  4, attachment, 1),
-            Self::Depth24PlusStencil8 => (   d24_s8,   depth,    linear,         msaa, (1, 1),  4, attachment, 2),
+            Self::Depth24PlusStencil8 => (   native,   depth,    linear,         msaa, (1, 1),  4, attachment, 2),
             Self::Depth32Float =>        (   native,   depth,    linear,         msaa, (1, 1),  4, attachment, 1),
             Self::Depth32FloatStencil8 =>(   d32_s8,   depth,    linear,         msaa, (1, 1),  4, attachment, 2),
             // Packed uncompressed

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -44,6 +44,7 @@ static TEXTURE_FORMATS_DEPTH: &[wgpu::TextureFormat] = &[
     //wgpu::TextureFormat::Stencil8,
     wgpu::TextureFormat::Depth16Unorm,
     wgpu::TextureFormat::Depth24Plus,
+    wgpu::TextureFormat::Depth24PlusStencil8,
 ];
 
 // needs TEXTURE_COMPRESSION_BC
@@ -322,22 +323,6 @@ fn clear_texture_d32_s8() {
             clear_texture_tests(
                 &ctx,
                 &[wgpu::TextureFormat::Depth32FloatStencil8],
-                false,
-                false,
-            );
-        },
-    )
-}
-
-#[test]
-fn clear_texture_d24_s8() {
-    initialize_test(
-        TestParameters::default()
-            .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::DEPTH24PLUS_STENCIL8),
-        |ctx| {
-            clear_texture_tests(
-                &ctx,
-                &[wgpu::TextureFormat::Depth24PlusStencil8],
                 false,
                 false,
             );

--- a/wgpu/tests/zero_init_texture_after_discard.rs
+++ b/wgpu/tests/zero_init_texture_after_discard.rs
@@ -110,58 +110,55 @@ fn discarding_depth_target_resets_texture_init_state_check_visible_on_copy_in_sa
 
 #[test]
 fn discarding_either_depth_or_stencil_aspect() {
-    initialize_test(
-        TestParameters::default().features(wgpu::Features::DEPTH24PLUS_STENCIL8),
-        |ctx| {
-            let (texture, _) = create_white_texture_and_readback_buffer(
-                &ctx,
-                wgpu::TextureFormat::Depth24PlusStencil8,
-            );
-            // TODO: How do we test this other than "doesn't crash"? We can't copy the texture to/from buffers, so we would need to do a copy in a shader
-            {
-                let mut encoder = ctx
-                    .device
-                    .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("Depth Discard, Stencil Load"),
-                    color_attachments: &[],
-                    depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
-                        view: &texture.create_view(&wgpu::TextureViewDescriptor::default()),
-                        depth_ops: Some(wgpu::Operations {
-                            load: wgpu::LoadOp::Load,
-                            store: false, // discard!
-                        }),
-                        stencil_ops: Some(wgpu::Operations {
-                            load: wgpu::LoadOp::Clear(0),
-                            store: true,
-                        }),
+    initialize_test(TestParameters::default(), |ctx| {
+        let (texture, _) = create_white_texture_and_readback_buffer(
+            &ctx,
+            wgpu::TextureFormat::Depth24PlusStencil8,
+        );
+        // TODO: How do we test this other than "doesn't crash"? We can't copy the texture to/from buffers, so we would need to do a copy in a shader
+        {
+            let mut encoder = ctx
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Depth Discard, Stencil Load"),
+                color_attachments: &[],
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                    view: &texture.create_view(&wgpu::TextureViewDescriptor::default()),
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: false, // discard!
                     }),
-                });
-                ctx.queue.submit([encoder.finish()]);
-            }
-            {
-                let mut encoder = ctx
-                    .device
-                    .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("Depth Load, Stencil Discard"),
-                    color_attachments: &[],
-                    depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
-                        view: &texture.create_view(&wgpu::TextureViewDescriptor::default()),
-                        depth_ops: Some(wgpu::Operations {
-                            load: wgpu::LoadOp::Clear(0.0),
-                            store: true,
-                        }),
-                        stencil_ops: Some(wgpu::Operations {
-                            load: wgpu::LoadOp::Load,
-                            store: false, // discard!
-                        }),
+                    stencil_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(0),
+                        store: true,
                     }),
-                });
-                ctx.queue.submit([encoder.finish()]);
-            }
-        },
-    );
+                }),
+            });
+            ctx.queue.submit([encoder.finish()]);
+        }
+        {
+            let mut encoder = ctx
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Depth Load, Stencil Discard"),
+                color_attachments: &[],
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                    view: &texture.create_view(&wgpu::TextureViewDescriptor::default()),
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(0.0),
+                        store: true,
+                    }),
+                    stencil_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: false, // discard!
+                    }),
+                }),
+            });
+            ctx.queue.submit([encoder.finish()]);
+        }
+    });
 }
 
 const TEXTURE_SIZE: wgpu::Extent3d = wgpu::Extent3d {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Fixes #3112 

**Description**

Makes `wgpu::TextureFormat::Depth24PlusStencil8` available on all backends by making the feature unconditionally available and the feature unneeded to use the format.

**Testing**

Local tests were run.
