### PR TITLE
Expand documentation of `Queue::write_texture`.

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3596,13 +3596,23 @@ impl Queue {
         }
     }
 
-    /// Schedule a data write into `texture`.
+    /// Schedule a write of some data into a texture.
+    ///
+    /// * `data` contains the texels to be written, which must be in
+    ///   [the same format as the texture](TextureFormat).
+    /// * `data_layout` describes the memory layout of `data`, which does not necessarily
+    ///   have to have tightly packed rows.
+    /// * `texture` specifies the texture to write into, and the location within the
+    ///   texture (coordinate offset, mip level) that will be overwritten.
+    /// * `size` is the size, in texels, of the region to be written.
     ///
     /// This method is intended to have low performance costs.
     /// As such, the write is not immediately submitted, and instead enqueued
     /// internally to happen at the start of the next `submit()` call.
+    /// However, `data` will be immediately copied into staging memory; so the caller may
+    /// discard it any time after this call completes.
     ///
-    /// This method fails if `data` overruns the size of fragment of `texture` specified with `size`.
+    /// This method fails if `size` overruns the size of `texture`, or if `data` is too short.
     pub fn write_texture(
         &self,
         texture: ImageCopyTexture,
@@ -3613,7 +3623,7 @@ impl Queue {
         Context::queue_write_texture(&*self.context, &self.id, texture, data, data_layout, size)
     }
 
-    /// Schedule a copy of data from `image` into `texture`
+    /// Schedule a copy of data from `image` into `texture`.
     #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
     pub fn copy_external_image_to_texture(
         &self,


### PR DESCRIPTION
* Explain which of the source and destination each parameter applies to.
* Clarify that just because this “schedules” a write doesn't mean that the slice has to be kept alive (this is “obvious” from the lifetimes but I have heard of it being confusing).

Inspired by <https://github.com/gfx-rs/wgpu/discussions/3172>

----

P.S. I have intentionally not bothered to update the changelog because this is a trivial documentation update and I would really like to make contributing this as simple as possible. If it is project policy that all PRs must also include changelog entries, … well, please reconsider that, but if so, I will.