### PR TITLE
Allow unchecked shader modules to also skip (naga's) uniformity checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Bottom level categories:
 - Add the `"wgsl"` feature, to enable WGSL shaders in `wgpu-core` and `wgpu`. Enabled by default in `wgpu`. By @daxpedda in [#2890](https://github.com/gfx-rs/wgpu/pull/2890).
 - Implement `Clone` for `ShaderSource` and `ShaderModuleDescriptor` in `wgpu`. By @daxpedda in [#3086](https://github.com/gfx-rs/wgpu/pull/3086).
 - Add `get_default_config` for `Surface` to simplify user creation of `SurfaceConfiguration`. By @jinleili in [#3034](https://github.com/gfx-rs/wgpu/pull/3034)
+- Add `create_shader_module_non_uniform` to `Device` to allow disabling naga's uniform control flow validation for a single shader. By @DJMcNab in [#notyetassigned](https://github.com/gfx-rs/wgpu/pull/notyetassigned)
 
 #### GLES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Bottom level categories:
 - Convert all `Default` Implementations on Enums to `derive(Default)`
 - Implement `Default` for `CompositeAlphaMode`
 - Improve compute shader validation error message. By @haraldreingruber in [#3139](https://github.com/gfx-rs/wgpu/pull/3139)
+- `Device::create_shader_module_unchecked` now no longer validates control flow uniformity. By @DJMcNab in [#notyetassigned](https://github.com/gfx-rs/wgpu/pull/notyetassigned)
 
 #### WebGPU
 - Implement `queue_validate_write_buffer` by @jinleili in [#3098](https://github.com/gfx-rs/wgpu/pull/3098)
@@ -63,7 +64,7 @@ Bottom level categories:
 - Add the `"wgsl"` feature, to enable WGSL shaders in `wgpu-core` and `wgpu`. Enabled by default in `wgpu`. By @daxpedda in [#2890](https://github.com/gfx-rs/wgpu/pull/2890).
 - Implement `Clone` for `ShaderSource` and `ShaderModuleDescriptor` in `wgpu`. By @daxpedda in [#3086](https://github.com/gfx-rs/wgpu/pull/3086).
 - Add `get_default_config` for `Surface` to simplify user creation of `SurfaceConfiguration`. By @jinleili in [#3034](https://github.com/gfx-rs/wgpu/pull/3034)
-- Add `create_shader_module_non_uniform` to `Device` to allow disabling naga's uniform control flow validation for a single shader. By @DJMcNab in [#notyetassigned](https://github.com/gfx-rs/wgpu/pull/notyetassigned)
+- Add `create_shader_module_non_uniform` to `Device` to allow not validating control flow uniformity for a single shader. By @DJMcNab in [#notyetassigned](https://github.com/gfx-rs/wgpu/pull/notyetassigned)
 
 #### GLES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Bottom level categories:
 - Convert all `Default` Implementations on Enums to `derive(Default)`
 - Implement `Default` for `CompositeAlphaMode`
 - Improve compute shader validation error message. By @haraldreingruber in [#3139](https://github.com/gfx-rs/wgpu/pull/3139)
-- `Device::create_shader_module_unchecked` now no longer validates control flow uniformity. By @DJMcNab in [#3175](https://github.com/gfx-rs/wgpu/pull/3175)
+- `Device::create_shader_module_unchecked` now accepts a `ShaderBoundChecks` to specify which checks can be skipped. By @DJMcNab in [#3175](https://github.com/gfx-rs/wgpu/pull/3175)
 
 #### WebGPU
 - Implement `queue_validate_write_buffer` by @jinleili in [#3098](https://github.com/gfx-rs/wgpu/pull/3098)
@@ -64,7 +64,6 @@ Bottom level categories:
 - Add the `"wgsl"` feature, to enable WGSL shaders in `wgpu-core` and `wgpu`. Enabled by default in `wgpu`. By @daxpedda in [#2890](https://github.com/gfx-rs/wgpu/pull/2890).
 - Implement `Clone` for `ShaderSource` and `ShaderModuleDescriptor` in `wgpu`. By @daxpedda in [#3086](https://github.com/gfx-rs/wgpu/pull/3086).
 - Add `get_default_config` for `Surface` to simplify user creation of `SurfaceConfiguration`. By @jinleili in [#3034](https://github.com/gfx-rs/wgpu/pull/3034)
-- Add `create_shader_module_non_uniform` to `Device` to allow not validating control flow uniformity for a single shader. By @DJMcNab in [#3175](https://github.com/gfx-rs/wgpu/pull/3175)
 
 #### GLES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Bottom level categories:
 - Convert all `Default` Implementations on Enums to `derive(Default)`
 - Implement `Default` for `CompositeAlphaMode`
 - Improve compute shader validation error message. By @haraldreingruber in [#3139](https://github.com/gfx-rs/wgpu/pull/3139)
-- `Device::create_shader_module_unchecked` now no longer validates control flow uniformity. By @DJMcNab in [#notyetassigned](https://github.com/gfx-rs/wgpu/pull/notyetassigned)
+- `Device::create_shader_module_unchecked` now no longer validates control flow uniformity. By @DJMcNab in [#3175](https://github.com/gfx-rs/wgpu/pull/3175)
 
 #### WebGPU
 - Implement `queue_validate_write_buffer` by @jinleili in [#3098](https://github.com/gfx-rs/wgpu/pull/3098)
@@ -64,7 +64,7 @@ Bottom level categories:
 - Add the `"wgsl"` feature, to enable WGSL shaders in `wgpu-core` and `wgpu`. Enabled by default in `wgpu`. By @daxpedda in [#2890](https://github.com/gfx-rs/wgpu/pull/2890).
 - Implement `Clone` for `ShaderSource` and `ShaderModuleDescriptor` in `wgpu`. By @daxpedda in [#3086](https://github.com/gfx-rs/wgpu/pull/3086).
 - Add `get_default_config` for `Surface` to simplify user creation of `SurfaceConfiguration`. By @jinleili in [#3034](https://github.com/gfx-rs/wgpu/pull/3034)
-- Add `create_shader_module_non_uniform` to `Device` to allow not validating control flow uniformity for a single shader. By @DJMcNab in [#notyetassigned](https://github.com/gfx-rs/wgpu/pull/notyetassigned)
+- Add `create_shader_module_non_uniform` to `Device` to allow not validating control flow uniformity for a single shader. By @DJMcNab in [#3175](https://github.com/gfx-rs/wgpu/pull/3175)
 
 #### GLES
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1280,7 +1280,14 @@ impl<A: HalApi> Device<A> {
                 wgt::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
             ),
         );
-        let info = naga::valid::Validator::new(naga::valid::ValidationFlags::all(), caps)
+        use naga::valid::ValidationFlags;
+
+        let mut validation = ValidationFlags::all();
+        validation.set(
+            ValidationFlags::CONTROL_FLOW_UNIFORMITY,
+            desc.shader_bound_checks.uniformity_validation(),
+        );
+        let info = naga::valid::Validator::new(validation, caps)
             .validate(&module)
             .map_err(|inner| {
                 pipeline::CreateShaderModuleError::Validation(pipeline::ShaderError {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -5067,9 +5067,16 @@ pub struct DispatchIndirectArgs {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[non_exhaustive]
 pub struct ShaderBoundChecks {
-    runtime_checks: bool,
-    uniformity_validation: bool,
+    /// Whether to the shader should be bounds checked
+    /// You MUST ensure that all shaders built with this configuration don't perform any
+    /// out of bounds reads or writes.
+    pub runtime_checks: bool,
+    /// Whether to run uniformity validation on the shader
+    /// The caller MUST ensure that all shaders built with this configuration don't perform any
+    /// invalid non-uniform operation.
+    pub uniformity_validation: bool,
 }
 
 impl ShaderBoundChecks {
@@ -5086,34 +5093,14 @@ impl ShaderBoundChecks {
     /// # Safety
     /// The caller MUST ensure that all shaders built with this configuration don't perform any
     /// out of bounds reads or writes.
-    pub unsafe fn unchecked() -> Self {
+    pub fn unchecked() -> Self {
         ShaderBoundChecks {
             runtime_checks: false,
-            uniformity_validation: false,
+            // Disabling `uniformity_validation` is only a small effect on startup performance,
+            // whereas `runtime_checks` may have a larger effect on startup performance.
+            // Don't provide an example using it
+            uniformity_validation: true,
         }
-    }
-
-    /// Creates a new configuration where the shader doesn't have bound checking.
-    ///
-    /// # Safety
-    /// The caller MUST ensure that all shaders built with this configuration don't perform any
-    /// invalid non-uniform operation. This should be used if the wgsl validation is too strict
-    /// for your use case.
-    pub unsafe fn allows_non_uniform() -> Self {
-        ShaderBoundChecks {
-            runtime_checks: true,
-            uniformity_validation: false,
-        }
-    }
-
-    /// Query whether runtime bound checks are enabled in this configuration
-    pub fn runtime_checks(&self) -> bool {
-        self.runtime_checks
-    }
-
-    /// Query whether uniformity analysis is enabled in this configuration
-    pub fn uniformity_validation(&self) -> bool {
-        self.uniformity_validation
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -5069,6 +5069,7 @@ pub struct DispatchIndirectArgs {
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub struct ShaderBoundChecks {
     runtime_checks: bool,
+    uniformity_validation: bool,
 }
 
 impl ShaderBoundChecks {
@@ -5076,6 +5077,7 @@ impl ShaderBoundChecks {
     pub fn new() -> Self {
         ShaderBoundChecks {
             runtime_checks: true,
+            uniformity_validation: true,
         }
     }
 
@@ -5087,12 +5089,31 @@ impl ShaderBoundChecks {
     pub unsafe fn unchecked() -> Self {
         ShaderBoundChecks {
             runtime_checks: false,
+            uniformity_validation: false,
+        }
+    }
+
+    /// Creates a new configuration where the shader doesn't have bound checking.
+    ///
+    /// # Safety
+    /// The caller MUST ensure that all shaders built with this configuration don't perform any
+    /// invalid non-uniform operation. This should be used if the wgsl validation is too strict
+    /// for your use case.
+    pub unsafe fn allows_non_uniform() -> Self {
+        ShaderBoundChecks {
+            runtime_checks: true,
+            uniformity_validation: false,
         }
     }
 
     /// Query whether runtime bound checks are enabled in this configuration
     pub fn runtime_checks(&self) -> bool {
         self.runtime_checks
+    }
+
+    /// Query whether uniformity analysis is enabled in this configuration
+    pub fn uniformity_validation(&self) -> bool {
+        self.uniformity_validation
     }
 }
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2124,6 +2124,31 @@ impl Device {
         }
     }
 
+    /// Creates a shader module from either SPIR-V or WGSL source code without uniformity checks.
+    ///
+    /// # Safety
+    /// In contrast with [`create_shader_module`](Self::create_shader_module) this function
+    /// creates a shader module without unifromity checks which allows shaders to perform
+    /// operations which can lead to undefined behavior like data races, thus it's
+    /// the caller responsibility to pass a shader which doesn't perform any of these
+    /// operations.
+    ///
+    /// This is equivalent to `create_shader_module` effect on web.
+    pub unsafe fn create_shader_module_non_uniform(
+        &self,
+        desc: ShaderModuleDescriptor,
+    ) -> ShaderModule {
+        ShaderModule {
+            context: Arc::clone(&self.context),
+            id: Context::device_create_shader_module(
+                &*self.context,
+                &self.id,
+                desc,
+                wgt::ShaderBoundChecks::allows_non_uniform(),
+            ),
+        }
+    }
+
     /// Creates a shader module from SPIR-V binary directly.
     ///
     /// # Safety


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy` 
   Ran but couldn't find any non-pre-existing errors. Didn't do a complete diff as that felt like a waste of time.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
   I think not applicable, but ran anyway - no warnings. Please clarify what "if applicable" means here.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Modelled after https://github.com/gfx-rs/wgpu/pull/1978, using the same struct this already created.
Fixes https://github.com/gfx-rs/wgpu/issues/3135
The changes might be removable after https://github.com/gpuweb/gpuweb/issues/3479 is resolved and filters through

**Description**
When using shaders with `wgpu`, it may be necessary to work around https://github.com/gpuweb/gpuweb/issues/3479.
To allow this, `Device::create_shader_module_unchecked` has gained a parameter for configuration. This allows This disabling [`ValidationFlags::CONTROL_FLOW_UNIFORMITY`](https://docs.rs/naga/latest/naga/valid/struct.ValidationFlags.html#associatedconstant.CONTROL_FLOW_UNIFORMITY) when used, but may allow maintaining bounds checks.

**Testing**
I don't believe that we should expect much use of this API; it should primarily be used for exploratory work.

TODO, awaiting results from @raphlinus