### PR TITLE
vk: add external memory extensions for Android

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -600,6 +600,17 @@ impl PhysicalDeviceCapabilities {
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         extensions.push(vk::KhrPortabilitySubsetFn::name());
 
+        #[cfg(target_os = "android")]
+        {
+            extensions.append(&mut vec![
+                vk::KhrBindMemory2Fn::name(),
+                vk::KhrExternalMemoryFn::name(),
+                vk::KhrGetMemoryRequirements2Fn::name(),
+                vk::ExtQueueFamilyForeignFn::name(),
+                vk::AndroidExternalMemoryAndroidHardwareBufferFn::name(),
+            ]);
+        }
+
         if requested_features.contains(wgt::Features::TEXTURE_COMPRESSION_ASTC_HDR) {
             extensions.push(vk::ExtTextureCompressionAstcHdrFn::name());
         }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/gfx-rs/wgpu/issues/274

**Description**
To implement zero-copy external memory access on Android devices, need to use [AHardwareBuffer](https://developer.android.com/ndk/reference/group/a-hardware-buffer) to create `vk::Image`, and to use AHardwareBuffer, `VK_ANDROID_external_memory_android_hardware_buffer` and related extensions are required.

I looked at some official Google examples, and these extensions should be supported by all Android devices:
https://github.com/android/renderscript-samples/blob/08d5130faeae4d21005b0f043959243b85c73d89/RenderScriptMigrationSample/app/src/main/cpp/VulkanContext.cpp#L157-L163

**Testing**
Tested on Android 10.0 and Android 12.1.1
