### PR TITLE
make Ids a u64 internally

### DIFF
--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -167,6 +167,7 @@ pub(crate) struct Valid<I>(pub I);
 pub trait TypedId: Copy {
     fn zip(index: Index, epoch: Epoch, backend: Backend) -> Self;
     fn unzip(self) -> (Index, Epoch, Backend);
+    fn into_raw(self) -> NonZeroId;
 }
 
 #[allow(trivial_numeric_casts)]
@@ -186,6 +187,10 @@ impl<T> TypedId for Id<T> {
             (((self.0.get() >> INDEX_BITS) as ZippedIndex) & (EPOCH_MASK as ZippedIndex)) as Index,
             self.backend(),
         )
+    }
+
+    fn into_raw(self) -> NonZeroId {
+        self.0
     }
 }
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -76,7 +76,7 @@ name = "water"
 test = true
 
 [features]
-default = ["wgsl"]
+default = ["wgsl", "expose-ids"]
 spirv = ["naga/spv-in"]
 glsl = ["naga/glsl-in"]
 wgsl = ["wgc?/wgsl"]

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -815,46 +815,50 @@ pub(crate) struct CommandEncoder {
     open: bool,
 }
 
-pub(crate) type Id = (u32, u32, wgt::Backend);
-
 impl<T: wgc::id::TypedId> crate::GlobalId for T {
-    fn global_id(&self) -> Id {
-        self.unzip()
+    #[allow(clippy::useless_conversion)] // because not(id32)
+    fn global_id(&self) -> u64 {
+        T::into_raw(*self).get().into()
     }
 }
 
 impl crate::GlobalId for Surface {
-    fn global_id(&self) -> Id {
+    #[allow(clippy::useless_conversion)] // because not(id32)
+    fn global_id(&self) -> u64 {
         use wgc::id::TypedId;
-        self.id.unzip()
+        self.id.into_raw().get().into()
     }
 }
 
 impl crate::GlobalId for Device {
-    fn global_id(&self) -> Id {
+    #[allow(clippy::useless_conversion)] // because not(id32)
+    fn global_id(&self) -> u64 {
         use wgc::id::TypedId;
-        self.id.unzip()
+        self.id.into_raw().get().into()
     }
 }
 
 impl crate::GlobalId for Buffer {
-    fn global_id(&self) -> Id {
+    #[allow(clippy::useless_conversion)] // because not(id32)
+    fn global_id(&self) -> u64 {
         use wgc::id::TypedId;
-        self.id.unzip()
+        self.id.into_raw().get().into()
     }
 }
 
 impl crate::GlobalId for Texture {
-    fn global_id(&self) -> Id {
+    #[allow(clippy::useless_conversion)] // because not(id32)
+    fn global_id(&self) -> u64 {
         use wgc::id::TypedId;
-        self.id.unzip()
+        self.id.into_raw().get().into()
     }
 }
 
 impl crate::GlobalId for CommandEncoder {
-    fn global_id(&self) -> Id {
+    #[allow(clippy::useless_conversion)] // because not(id32)
+    fn global_id(&self) -> u64 {
         use wgc::id::TypedId;
-        self.id.unzip()
+        self.id.into_raw().get().into()
     }
 }
 

--- a/wgpu/src/backend/mod.rs
+++ b/wgpu/src/backend/mod.rs
@@ -1,9 +1,9 @@
 #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
 mod web;
 #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
-pub(crate) use web::{BufferMappedRange, Context, Id, QueueWriteBuffer};
+pub(crate) use web::{BufferMappedRange, Context, QueueWriteBuffer};
 
 #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
 mod direct;
 #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
-pub(crate) use direct::{BufferMappedRange, Context, Id, QueueWriteBuffer};
+pub(crate) use direct::{BufferMappedRange, Context, QueueWriteBuffer};

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -32,17 +32,15 @@ unsafe impl<T> Sync for Identified<T> {}
 
 impl<T> crate::GlobalId for Identified<T> {
     #[cfg(not(feature = "expose-ids"))]
-    fn global_id(&self) -> Id {
+    fn global_id(&self) -> u64 {
         0
     }
 
     #[cfg(feature = "expose-ids")]
-    fn global_id(&self) -> Id {
+    fn global_id(&self) -> u64 {
         self.1
     }
 }
-
-pub(crate) type Id = u64;
 
 #[cfg(feature = "expose-ids")]
 static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -43,7 +43,7 @@ pub use wgt::{
     QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
 };
 
-use backend::{BufferMappedRange, Context as C, Id as BackendId, QueueWriteBuffer};
+use backend::{BufferMappedRange, Context as C, QueueWriteBuffer};
 
 /// Filter for error scopes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
@@ -165,7 +165,7 @@ trait RenderPassInner<Ctx: Context>: RenderInner<Ctx> {
 }
 
 trait GlobalId {
-    fn global_id(&self) -> BackendId;
+    fn global_id(&self) -> u64;
 }
 
 trait Context: Debug + Send + Sized + Sync {
@@ -3805,7 +3805,7 @@ impl Surface {
 #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Id(BackendId);
+pub struct Id(u64);
 
 #[cfg(feature = "expose-ids")]
 impl Adapter {


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
#3051

**Description**
This is going to be needed for future dynamic dispatch work, feature dependent types need to go for this to happen.

cc @TheOnlyMrCat
