### PR TITLE
allow gles float textures to be multisampled if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Bottom level categories:
 #### GLES
 
 - Fixed WebGL not displaying srgb targets correctly if a non-screen filling viewport was previously set. By @Wumpf in [#3093](https://github.com/gfx-rs/wgpu/pull/3093)
+- Fix disallowing multisampling for float textures if otherwise supported. By @Wumpf in [#3183](https://github.com/gfx-rs/wgpu/pull/3183)
 
 ### Examples
 - Log adapter info in hello example on wasm target by @JolifantoBambla in [#2858](https://github.com/gfx-rs/wgpu/pull/2858)

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -696,12 +696,18 @@ impl crate::Adapter<super::Api> for super::Adapter {
 
         let half_float_renderable = private_caps_fn(
             super::PrivateCapabilities::COLOR_BUFFER_HALF_FLOAT,
-            Tfc::COLOR_ATTACHMENT | Tfc::COLOR_ATTACHMENT_BLEND,
+            Tfc::COLOR_ATTACHMENT
+                | Tfc::COLOR_ATTACHMENT_BLEND
+                | Tfc::MULTISAMPLE
+                | Tfc::MULTISAMPLE_RESOLVE,
         );
 
         let float_renderable = private_caps_fn(
             super::PrivateCapabilities::COLOR_BUFFER_FLOAT,
-            Tfc::COLOR_ATTACHMENT | Tfc::COLOR_ATTACHMENT_BLEND,
+            Tfc::COLOR_ATTACHMENT
+                | Tfc::COLOR_ATTACHMENT_BLEND
+                | Tfc::MULTISAMPLE
+                | Tfc::MULTISAMPLE_RESOLVE,
         );
 
         match format {

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -718,7 +718,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             super::PrivateCapabilities::COLOR_BUFFER_HALF_FLOAT,
             Tfc::COLOR_ATTACHMENT
                 | Tfc::COLOR_ATTACHMENT_BLEND
-                | Tfc::MULTISAMPLE
+                | sample_count
                 | Tfc::MULTISAMPLE_RESOLVE,
         );
 
@@ -726,7 +726,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             super::PrivateCapabilities::COLOR_BUFFER_FLOAT,
             Tfc::COLOR_ATTACHMENT
                 | Tfc::COLOR_ATTACHMENT_BLEND
-                | Tfc::MULTISAMPLE
+                | sample_count
                 | Tfc::MULTISAMPLE_RESOLVE,
         );
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
n/a

**Description**
Couldn't find any restrictions on render target use for enabled float textures on GLES. It seems MSAA use works just fine iff the respective float extensions are enabled.

**Testing**
Tested rendering to a RGBA32f and RGBA16f target on WebGl. Did not check on resolve