### PR TITLE
Add `cargo-deny`  to CI

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -1,0 +1,13 @@
+[licenses]
+allow = [
+	"Apache-2.0",
+	"Apache-2.0 WITH LLVM-exception",
+	"BSD-2-Clause",
+	"BSD-3-Clause",
+	"CC0-1.0",
+	"ISC",
+	"MIT",
+	"MPL-2.0",
+	"Unicode-DFS-2016",
+	"Zlib",
+]

--- a/.deny.toml
+++ b/.deny.toml
@@ -11,3 +11,16 @@ allow = [
 	"Unicode-DFS-2016",
 	"Zlib",
 ]
+
+[sources]
+allow-git = [
+	"https://github.com/grovesNL/glow",
+]
+unknown-registry = "deny"
+unknown-git = "deny"
+required-git-spec = "rev"
+
+[sources.allow-org]
+github = [
+	"gfx-rs"
+]

--- a/.deny.toml
+++ b/.deny.toml
@@ -1,3 +1,14 @@
+[bans]
+multiple-versions = "deny"
+skip-tree = [
+	{ name = "cts_runner" },
+	{ name = "dummy" },
+	{ name = "player" },
+	{ name = "run-wasm" },
+	{ name = "wgpu-info" },
+]
+wildcards = "deny"
+
 [licenses]
 allow = [
 	"Apache-2.0",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,3 +352,16 @@ jobs:
       - name: build Deno
         run: |
           cargo clippy --manifest-path cts_runner/Cargo.toml
+
+  cargo-deny:
+    name: "Run `cargo deny check`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v3
+
+      - name: Run `cargo deny check`
+        uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          arguments: --all-features --workspace
+          rust-version: ${{ env.RUST_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,21 @@ jobs:
         run: |
           cargo clippy --manifest-path cts_runner/Cargo.toml
 
-  cargo-deny:
+  cargo-deny-check-advisories:
+    name: "Run `cargo deny check advisories`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v3
+
+      - name: Run `cargo deny check`
+        uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check advisories
+          arguments: --all-features --workspace
+          rust-version: ${{ env.RUST_VERSION }}
+
+  cargo-deny-check-rest:
     name: "Run `cargo deny check`"
     runs-on: ubuntu-latest
     steps:
@@ -363,5 +377,6 @@ jobs:
       - name: Run `cargo deny check`
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
+          command: check bans licenses sources
           arguments: --all-features --workspace
           rust-version: ${{ env.RUST_VERSION }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
 [[package]]
 name = "glow"
 version = "0.11.2"
-source = "git+https://github.com/grovesNL/glow/?rev=c8a011fcd57a5c68cc917ed394baa484bdefc909#c8a011fcd57a5c68cc917ed394baa484bdefc909"
+source = "git+https://github.com/grovesNL/glow?rev=c8a011fcd57a5c68cc917ed394baa484bdefc909#c8a011fcd57a5c68cc917ed394baa484bdefc909"
 dependencies = [
  "js-sys",
  "slotmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ winapi = "0.3"
 egl = { package = "khronos-egl", version = "4.1" }
 # glow = { version = "0.11.2", optional = true }
 # TODO: New glow release
-glow = { git = "https://github.com/grovesNL/glow/", rev = "c8a011fcd57a5c68cc917ed394baa484bdefc909" }
+glow = { git = "https://github.com/grovesNL/glow", rev = "c8a011fcd57a5c68cc917ed394baa484bdefc909" }
 glutin = "0.29.1"
 
 # wasm32 dependencies

--- a/run-wasm/Cargo.toml
+++ b/run-wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "run-wasm"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 keywords.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 env_logger.workspace = true


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] ~Add change to CHANGELOG.md. See simple instructions inside file.~ Not sure if this is worth doing for downstream, skipping for now.
- [ ] Ensure that `codecov` is happy.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

None, AFAIK!

**Description**
_Describe what problem this is solving, and how it's solved._

Right now, `wgpu`'s CI doesn't take advantage of nice tooling to audit dependencies. `cargo-deny` is a fantastic suite of dependency checks that's relatively popular in the Rust community. Add an invocation of `cargo deny check` as a step in the `ci` workflow; create configuration; adjust `run-wasm`'s licensing so that it passes.

**Testing**
_Explain how this change is tested._

TODO: Waiting to see how CI handles this.

There are some duplicate dependencies noted, but I doubt it's a problem that will be interesting to tackle except as occasional maintenance, rather than a hard CI check. Leaving as a warning for now.
