### PR TITLE
fix(wgpu-info): s/driver/&_info for `DriverInfo` line

### DIFF
--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -132,7 +132,7 @@ mod inner {
         let downlevel = adapter.get_downlevel_capabilities();
         let features = adapter.features();
         let limits = adapter.limits();
-    
+
         println!("Adapter {}:", idx);
         println!("\t   Backend: {:?}", info.backend);
         println!("\t      Name: {:?}", info.name);
@@ -151,7 +151,7 @@ mod inner {
                 }
             }
         }
-    
+
         println!("\tLimits:");
         let wgpu::Limits {
             max_texture_dimension_1d,
@@ -213,7 +213,7 @@ mod inner {
         println!("\t\t                    Max Compute Workgroup Size Y: {}", max_compute_workgroup_size_y);
         println!("\t\t                    Max Compute Workgroup Size Z: {}", max_compute_workgroup_size_z);
         println!("\t\t            Max Compute Workgroups Per Dimension: {}", max_compute_workgroups_per_dimension);
-    
+
         println!("\tDownlevel Properties:");
         let wgpu::DownlevelCapabilities {
             shader_model,

--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -140,7 +140,7 @@ mod inner {
         println!("\t  DeviceID: {:?}", info.device);
         println!("\t      Type: {:?}", info.device_type);
         println!("\t    Driver: {:?}", info.driver);
-        println!("\tDriverInfo: {:?}", info.driver);
+        println!("\tDriverInfo: {:?}", info.driver_info);
         println!("\t Compliant: {:?}", downlevel.is_webgpu_compliant());
         println!("\tFeatures:");
         for i in 0..(size_of::<wgpu::Features>() * 8) {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

Using the `driver` member instead of the `driver_info` member looks like a mistake here; we already print `driver` on the line right above, and the current line differs with a `DriverInfo` prepend.

**Testing**
_Explain how this change is tested._
