### PR TITLE
Alpha to coverage support for GLES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Bottom level categories:
 #### GLES
 
 - Surfaces support now `TextureFormat::Rgba8Unorm` and (non-web only) `TextureFormat::Bgra8Unorm`. By @Wumpf in [#3070](https://github.com/gfx-rs/wgpu/pull/3070)
+- Support alpha to coverage. By @Wumpf in [#3156](https://github.com/gfx-rs/wgpu/pull/3156)
 
 ### Bug Fixes
 

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -20,6 +20,7 @@ pub(super) struct State {
     color_targets: ArrayVec<super::ColorTargetDesc, { crate::MAX_COLOR_ATTACHMENTS }>,
     stencil: super::StencilState,
     depth_bias: wgt::DepthBiasState,
+    alpha_to_coverage_enabled: bool,
     samplers: [Option<glow::Sampler>; super::MAX_SAMPLERS],
     texture_slots: [TextureSlotDesc; super::MAX_TEXTURE_SLOTS],
     render_size: wgt::Extent3d,
@@ -794,6 +795,14 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         self.cmd_buffer
             .commands
             .push(C::ConfigureDepthStencil(aspects));
+
+        // set multisampling state
+        if pipeline.alpha_to_coverage_enabled != self.state.alpha_to_coverage_enabled {
+            self.state.alpha_to_coverage_enabled = pipeline.alpha_to_coverage_enabled;
+            self.cmd_buffer
+                .commands
+                .push(C::SetAlphaToCoverage(pipeline.alpha_to_coverage_enabled));
+        }
 
         // set blend states
         if self.state.color_targets[..] != pipeline.color_targets[..] {

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1090,6 +1090,7 @@ impl crate::Device<super::Api> for super::Device {
                 .depth_stencil
                 .as_ref()
                 .map(|ds| conv::map_stencil(&ds.stencil)),
+            alpha_to_coverage_enabled: desc.multisample.alpha_to_coverage_enabled,
         })
     }
     unsafe fn destroy_render_pipeline(&self, pipeline: super::RenderPipeline) {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -502,6 +502,7 @@ pub struct RenderPipeline {
     depth: Option<DepthState>,
     depth_bias: wgt::DepthBiasState,
     stencil: Option<StencilState>,
+    alpha_to_coverage_enabled: bool,
 }
 
 // SAFE: WASM doesn't have threads
@@ -742,6 +743,7 @@ enum Command {
     SetDepth(DepthState),
     SetDepthBias(wgt::DepthBiasState),
     ConfigureDepthStencil(crate::FormatAspects),
+    SetAlphaToCoverage(bool),
     SetVertexAttribute {
         buffer: Option<glow::Buffer>,
         buffer_desc: VertexBufferDesc,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -992,6 +992,13 @@ impl super::Queue {
                     gl.disable(glow::STENCIL_TEST);
                 }
             }
+            C::SetAlphaToCoverage(enabled) => {
+                if enabled {
+                    gl.enable(glow::SAMPLE_ALPHA_TO_COVERAGE);
+                } else {
+                    gl.disable(glow::SAMPLE_ALPHA_TO_COVERAGE);
+                }
+            }
             C::SetProgram(program) => {
                 gl.use_program(Some(program));
             }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixed float multisample target support in #3183 

**Description**
MSAA alpha to coverage support for GLES!

**Testing**
Tested on WebGL:

after/before
![image](https://user-images.githubusercontent.com/1220815/200418394-52aea8fb-0289-42a0-be68-dd8f1d3a2073.png)

(these are sphere faking quads with analytic pixel coverage in their alpha channel the same way as performed here https://www.shadertoy.com/view/MsSSWV)