### PR TITLE
Let cts_runner at least start.

### DIFF
--- a/cts_runner/src/bootstrap.js
+++ b/cts_runner/src/bootstrap.js
@@ -219,8 +219,7 @@ delete Object.prototype.__proto__;
     util.immutableDefine(globalThis, "Deno", denoNs);
     Object.freeze(globalThis.Deno);
 
-    core.ops();
-    Error.prepareStackTrace = core.createPrepareStackTrace();
+    Error.prepareStackTrace = core.prepareStackTrace;
   }
 
   ObjectDefineProperties(globalThis, {


### PR DESCRIPTION
The real fix is #3068, but this is enough to run `console.log("Hello, world!");`.

Related: #3164

**Checklist**

- [ ] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
