### PR TITLE
Change `get_metal_layer()` visiability to pub(crate)

### DIFF
--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -98,7 +98,7 @@ impl super::Surface {
     }
 
     /// If not called on the main thread, this will panic.
-    pub unsafe fn get_metal_layer(
+    pub(crate) unsafe fn get_metal_layer(
         view: *mut Object,
         delegate: Option<&HalManagedMetalLayerDelegate>,
     ) -> *mut Object {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/gfx-rs/wgpu/issues/3190

**Description**

I think we need to keep things simple, because on both Mac and iOS, layer can add sublayers  and keep nesting that way, and it is possible for a CAMetalLayer to be added as a sublayer's sublayer  of a layer by the user, but that is not a best practice.  
  
Also checked the approach of detecting CAMetalLayer within `winit`, although the implementation is a bit different, the code is equivalent: it only detects if the main layer is a CAMetalLayer.  
https://github.com/rust-windowing/winit/blob/08f9e374e0111168c282d0cfffbcd469dd8fdcb0/src/platform_impl/ios/window.rs#L432-L434
  
The reason why CAMetalLayer is added via sub layer on the iOS side when does not exist is that the main layer in iOS UIView can only be overridden by class method, and the main layer of the UIView instance cannot be replaced at runtime.  

**Testing**

Tested locally on Metal and Vulkan(vulkan-portability)