### PR TITLE
Fix merge compile issues

### DIFF
--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -880,9 +880,10 @@ impl crate::GlobalId for CommandEncoder {
 }
 
 impl crate::GlobalId for Queue {
-    fn global_id(&self) -> Id {
+    #[allow(clippy::useless_conversion)] // because not(id32)
+    fn global_id(&self) -> u64 {
         use wgc::id::TypedId;
-        self.id.unzip()
+        self.id.into_raw().get().into()
     }
 }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

#3178 plus some merge conflicts lead to a fun time