### PR TITLE
Make wgpu-hal resources copyable (Metal and GL only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 - The `strict_assert` family of macros was moved to `wgpu-types`. By @i509VCB in [#3051](https://github.com/gfx-rs/wgpu/pull/3051)
 - Add missing `DEPTH_BIAS_CLAMP` and `FULL_DRAW_INDEX_UINT32` downlevel flags. By @teoxoy in [#3316](https://github.com/gfx-rs/wgpu/pull/3316)
 - Make `ObjectId` structure and invariants idiomatic. By @teoxoy in [#3347](https://github.com/gfx-rs/wgpu/pull/3347)
+- When importing external objects, the `DropGuard` is to be provided to wgpu instead of wgpu-hal. By @kvark in [#3199](https://github.com/gfx-rs/wgpu/pull/3199)
 
 #### WebGPU
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -706,6 +706,7 @@ impl<A: HalApi> Device<A> {
             },
             life_guard: LifeGuard::new(desc.label.borrow_or_default()),
             clear_mode,
+            drop_guard: None,
         }
     }
 
@@ -3789,6 +3790,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         hal_texture: A::Texture,
         device_id: id::DeviceId,
         desc: &resource::TextureDescriptor,
+        drop_guard: Option<resource::DropGuard>,
         id_in: Input<G, id::TextureId>,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
         profiling::scope!("Device::create_texture");
@@ -3837,6 +3839,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             }
 
             texture.initialization_status = TextureInitTracker::new(desc.mip_level_count, 0);
+            texture.drop_guard = drop_guard;
 
             let ref_count = texture.life_guard.add_ref();
 

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -197,6 +197,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         clear_views,
                         is_color: true,
                     },
+                    drop_guard: None,
                 };
 
                 let ref_count = texture.life_guard.add_ref();

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -13,6 +13,9 @@ use thiserror::Error;
 
 use std::{borrow::Borrow, num::NonZeroU8, ops::Range, ptr::NonNull};
 
+/// Drop guard to signal that wgpu is no longer using an externally created object.
+pub type DropGuard = Box<dyn std::any::Any + Send + Sync>;
+
 /// The status code provided to the buffer mapping callback.
 ///
 /// This is very similar to `BufferAccessResult`, except that this is FFI-friendly.
@@ -345,6 +348,7 @@ pub struct Texture<A: hal::Api> {
     pub(crate) full_range: TextureSelector,
     pub(crate) life_guard: LifeGuard,
     pub(crate) clear_mode: TextureClearMode<A>,
+    pub(crate) drop_guard: Option<DropGuard>,
 }
 
 impl<A: hal::Api> Texture<A> {

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -7,7 +7,7 @@ pub struct Api;
 pub struct Context;
 #[derive(Debug)]
 pub struct Encoder;
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Resource;
 
 type DeviceResult<T> = Result<T, crate::DeviceError>;

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -279,7 +279,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 
     unsafe fn clear_buffer(&mut self, buffer: &super::Buffer, range: crate::MemoryRange) {
         self.cmd_buffer.commands.push(C::ClearBuffer {
-            dst: buffer.clone(),
+            dst: *buffer,
             dst_target: buffer.target,
             range,
         });
@@ -300,9 +300,9 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         };
         for copy in regions {
             self.cmd_buffer.commands.push(C::CopyBufferToBuffer {
-                src: src.clone(),
+                src: *src,
                 src_target,
-                dst: dst.clone(),
+                dst: *dst,
                 dst_target,
                 copy,
             })
@@ -346,7 +346,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         for mut copy in regions {
             copy.clamp_size_to_virtual(&dst.copy_size);
             self.cmd_buffer.commands.push(C::CopyBufferToTexture {
-                src: src.clone(),
+                src: *src,
                 src_target: src.target,
                 dst: dst_raw,
                 dst_target,
@@ -372,7 +372,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 src: src_raw,
                 src_target,
                 src_format: src.format,
-                dst: dst.clone(),
+                dst: *dst,
                 dst_target: dst.target,
                 copy,
             })
@@ -409,7 +409,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         let query_range = start as u32..self.cmd_buffer.queries.len() as u32;
         self.cmd_buffer.commands.push(C::CopyQueryResults {
             query_range,
-            dst: buffer.clone(),
+            dst: *buffer,
             dst_target: buffer.target,
             dst_offset: offset,
         });
@@ -450,12 +450,10 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                         let attachment = glow::COLOR_ATTACHMENT0 + i as u32;
                         self.cmd_buffer.commands.push(C::BindAttachment {
                             attachment,
-                            view: cat.target.view.clone(),
+                            view: *cat.target.view,
                         });
                         if let Some(ref rat) = cat.resolve_target {
-                            self.state
-                                .resolve_attachments
-                                .push((attachment, rat.view.clone()));
+                            self.state.resolve_attachments.push((attachment, *rat.view));
                         }
                         if !cat.ops.contains(crate::AttachmentOps::STORE) {
                             self.state.invalidate_attachments.push(attachment);
@@ -471,7 +469,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     };
                     self.cmd_buffer.commands.push(C::BindAttachment {
                         attachment,
-                        view: dsat.target.view.clone(),
+                        view: *dsat.target.view,
                     });
                     if aspects.contains(crate::FormatAspects::DEPTH)
                         && !dsat.depth_ops.contains(crate::AttachmentOps::STORE)

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1257,7 +1257,7 @@ impl crate::Surface<super::Api> for Surface {
             inner: super::TextureInner::Renderbuffer {
                 raw: sc.renderbuffer,
             },
-            drop_guard: None,
+            externally_owned: false,
             array_layer_count: 1,
             mip_level_count: 1,
             format: sc.format,

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1259,9 +1259,8 @@ impl crate::Surface<super::Api> for Surface {
             },
             externally_owned: false,
             array_layer_count: 1,
-            mip_level_count: 1,
             format: sc.format,
-            format_desc: sc.format_desc.clone(),
+            format_desc: sc.format_desc,
             copy_size: crate::CopyExtent {
                 width: sc.extent.width,
                 height: sc.extent.height,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -183,7 +183,7 @@ impl Default for VertexAttribKind {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 struct TextureFormatDesc {
     internal: u32,
     external: u32,
@@ -240,7 +240,7 @@ pub struct Buffer {
 unsafe impl Sync for Buffer {}
 unsafe impl Send for Buffer {}
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 enum TextureInner {
     Renderbuffer {
         raw: glow::Renderbuffer,
@@ -263,10 +263,10 @@ impl TextureInner {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Texture {
     inner: TextureInner,
-    drop_guard: Option<crate::DropGuard>,
+    externally_owned: bool,
     mip_level_count: u32,
     array_layer_count: u32,
     format: wgt::TextureFormat,
@@ -280,7 +280,7 @@ impl Texture {
     pub fn default_framebuffer(format: wgt::TextureFormat) -> Self {
         Self {
             inner: TextureInner::DefaultRenderbuffer,
-            drop_guard: None,
+            externally_owned: false,
             mip_level_count: 1,
             array_layer_count: 1,
             format,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -84,7 +84,7 @@ use arrayvec::ArrayVec;
 
 use glow::HasContext;
 
-use std::{fmt, ops::Range, sync::Arc};
+use std::{fmt, ops::Range, ptr::NonNull, sync::Arc};
 
 #[derive(Clone)]
 pub struct Api;
@@ -228,19 +228,16 @@ pub struct Queue {
     current_index_buffer: Option<glow::Buffer>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Buffer {
     raw: Option<glow::Buffer>,
     target: BindTarget,
     size: wgt::BufferAddress,
     map_flags: u32,
-    data: Option<Arc<std::sync::Mutex<Vec<u8>>>>,
+    data: Option<NonNull<u8>>,
 }
 
-// Safe: WASM doesn't have threads
-#[cfg(target_arch = "wasm32")]
 unsafe impl Sync for Buffer {}
-#[cfg(target_arch = "wasm32")]
 unsafe impl Send for Buffer {}
 
 #[derive(Clone, Debug)]
@@ -345,7 +342,7 @@ pub struct TextureView {
     format: wgt::TextureFormat,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Sampler {
     raw: glow::Sampler,
 }

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -267,7 +267,6 @@ impl TextureInner {
 pub struct Texture {
     inner: TextureInner,
     externally_owned: bool,
-    mip_level_count: u32,
     array_layer_count: u32,
     format: wgt::TextureFormat,
     #[allow(unused)]
@@ -281,7 +280,6 @@ impl Texture {
         Self {
             inner: TextureInner::DefaultRenderbuffer,
             externally_owned: false,
-            mip_level_count: 1,
             array_layer_count: 1,
             format,
             format_desc: TextureFormatDesc {
@@ -332,13 +330,14 @@ impl Texture {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct TextureView {
     inner: TextureInner,
     sample_type: wgt::TextureSampleType,
     aspects: crate::FormatAspects,
-    mip_levels: Range<u32>,
-    array_layers: Range<u32>,
+    base_mip_level: u32,
+    base_array_layer: u32,
+    array_layer_count: u32,
     format: wgt::TextureFormat,
 }
 

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -98,17 +98,16 @@ impl super::Queue {
             }
             super::TextureInner::DefaultRenderbuffer => panic!("Unexpected default RBO"),
             super::TextureInner::Texture { raw, target } => {
-                let num_layers = view.array_layers.end - view.array_layers.start;
-                if num_layers > 1 {
+                if view.array_layer_count > 1 {
                     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
                     unsafe {
                         gl.framebuffer_texture_multiview_ovr(
                             fbo_target,
                             attachment,
                             Some(raw),
-                            view.mip_levels.start as i32,
-                            view.array_layers.start as i32,
-                            num_layers as i32,
+                            view.base_mip_level as i32,
+                            view.base_array_layer as i32,
+                            view.array_layer_count as i32,
                         )
                     };
                 } else if is_layered_target(target) {
@@ -117,8 +116,8 @@ impl super::Queue {
                             fbo_target,
                             attachment,
                             Some(raw),
-                            view.mip_levels.start as i32,
-                            view.array_layers.start as i32,
+                            view.base_mip_level as i32,
+                            view.base_array_layer as i32,
                         )
                     };
                 } else if target == glow::TEXTURE_CUBE_MAP {
@@ -126,9 +125,9 @@ impl super::Queue {
                         gl.framebuffer_texture_2d(
                             fbo_target,
                             attachment,
-                            CUBEMAP_FACES[view.array_layers.start as usize],
+                            CUBEMAP_FACES[view.base_array_layer as usize],
                             Some(raw),
-                            view.mip_levels.start as i32,
+                            view.base_mip_level as i32,
                         )
                     };
                 } else {
@@ -138,7 +137,7 @@ impl super::Queue {
                             attachment,
                             target,
                             Some(raw),
-                            view.mip_levels.start as i32,
+                            view.base_mip_level as i32,
                         )
                     };
                 }

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -356,7 +356,7 @@ impl crate::Surface<super::Api> for Surface {
                 raw: self.texture.unwrap(),
                 target: glow::TEXTURE_2D,
             },
-            drop_guard: None,
+            externally_owned: false,
             array_layer_count: 1,
             mip_level_count: 1,
             format: sc.format,

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -358,9 +358,8 @@ impl crate::Surface<super::Api> for Surface {
             },
             externally_owned: false,
             array_layer_count: 1,
-            mip_level_count: 1,
             format: sc.format,
-            format_desc: sc.format_desc.clone(),
+            format_desc: sc.format_desc,
             copy_size: crate::CopyExtent {
                 width: sc.extent.width,
                 height: sc.extent.height,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -117,9 +117,6 @@ pub type Label<'a> = Option<&'a str>;
 pub type MemoryRange = Range<wgt::BufferAddress>;
 pub type FenceValue = u64;
 
-/// Drop guard to signal wgpu-hal is no longer using an externally created object.
-pub type DropGuard = Box<dyn std::any::Any + Send + Sync>;
-
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
 pub enum DeviceError {
     #[error("out of memory")]

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -79,8 +79,8 @@ struct DebugUtils {
 
 pub struct InstanceShared {
     raw: ash::Instance,
+    externally_owned: bool,
     extensions: Vec<&'static CStr>,
-    drop_guard: Option<crate::DropGuard>,
     flags: crate::InstanceFlags,
     debug_utils: Option<DebugUtils>,
     get_physical_device_properties: Option<khr::GetPhysicalDeviceProperties2>,
@@ -346,7 +346,7 @@ pub struct Buffer {
 #[derive(Debug)]
 pub struct Texture {
     raw: vk::Image,
-    drop_guard: Option<crate::DropGuard>,
+    externally_owned: bool,
     block: Option<gpu_alloc::MemoryBlock<vk::DeviceMemory>>,
     usage: crate::TextureUses,
     aspects: crate::FormatAspects,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -134,6 +134,7 @@ impl Context {
         hal_texture: A::Texture,
         device: &Device,
         desc: &TextureDescriptor,
+        drop_guard: Option<wgc::resource::DropGuard>,
     ) -> Texture {
         let global = &self.0;
         let (id, error) = unsafe {
@@ -141,6 +142,7 @@ impl Context {
                 hal_texture,
                 device.id,
                 &desc.map_label(|l| l.map(Borrowed)),
+                drop_guard,
                 (),
             )
         };

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -28,6 +28,8 @@ use std::{
 use context::{Context, DeviceRequest, DynContext, ObjectId};
 use parking_lot::Mutex;
 
+#[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+pub use wgc::resource::DropGuard;
 pub use wgt::{
     AdapterInfo, AddressMode, AstcBlock, AstcChannel, Backend, Backends, BindGroupLayoutEntry,
     BindingType, BlendComponent, BlendFactor, BlendOperation, BlendState, BufferAddress,
@@ -2071,6 +2073,7 @@ impl Device {
         &self,
         hal_texture: A::Texture,
         desc: &TextureDescriptor,
+        drop_guard: Option<DropGuard>,
     ) -> Texture {
         let texture = unsafe {
             self.context
@@ -2081,6 +2084,7 @@ impl Device {
                     hal_texture,
                     self.data.as_ref().downcast_ref().unwrap(),
                     desc,
+                    drop_guard,
                 )
         };
         Texture {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Closes #3195

**Description**
See #3195

**Testing**
Examples.
