### PR TITLE
Remove unnecessary mutability from ResourceMetadata field uses.

### DIFF
--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -533,11 +533,11 @@ impl<A: hub::HalApi> BufferTracker<A> {
 
         unsafe {
             if self.metadata.owned.get(index).unwrap_unchecked() {
-                let existing_epoch = self.metadata.epochs.get_unchecked_mut(index);
-                let existing_ref_count = self.metadata.ref_counts.get_unchecked_mut(index);
+                let existing_epoch = self.metadata.epochs.get_unchecked(index);
+                let existing_ref_count = self.metadata.ref_counts.get_unchecked(index);
 
                 if *existing_epoch == epoch
-                    && existing_ref_count.as_mut().unwrap_unchecked().load() == 1
+                    && existing_ref_count.as_ref().unwrap_unchecked().load() == 1
                 {
                     self.metadata.reset(index);
 

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -191,11 +191,11 @@ impl<A: hub::HalApi, T: hub::Resource, Id: TypedId> StatelessTracker<A, T, Id> {
 
         unsafe {
             if self.metadata.owned.get(index).unwrap_unchecked() {
-                let existing_epoch = self.metadata.epochs.get_unchecked_mut(index);
-                let existing_ref_count = self.metadata.ref_counts.get_unchecked_mut(index);
+                let existing_epoch = self.metadata.epochs.get_unchecked(index);
+                let existing_ref_count = self.metadata.ref_counts.get_unchecked(index);
 
                 if *existing_epoch == epoch
-                    && existing_ref_count.as_mut().unwrap_unchecked().load() == 1
+                    && existing_ref_count.as_ref().unwrap_unchecked().load() == 1
                 {
                     self.metadata.reset(index);
 

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -750,11 +750,11 @@ impl<A: hub::HalApi> TextureTracker<A> {
 
         unsafe {
             if self.metadata.owned.get(index).unwrap_unchecked() {
-                let existing_epoch = self.metadata.epochs.get_unchecked_mut(index);
-                let existing_ref_count = self.metadata.ref_counts.get_unchecked_mut(index);
+                let existing_epoch = self.metadata.epochs.get_unchecked(index);
+                let existing_ref_count = self.metadata.ref_counts.get_unchecked(index);
 
                 if *existing_epoch == epoch
-                    && existing_ref_count.as_mut().unwrap_unchecked().load() == 1
+                    && existing_ref_count.as_ref().unwrap_unchecked().load() == 1
                 {
                     self.start_set.complex.remove(&index32);
                     self.end_set.complex.remove(&index32);


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] (unneeded) Add change to CHANGELOG.md. See simple instructions inside file.
