### PR TITLE
Move `ResourceMetadata` into its own module, and give it a proper interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Bottom level categories:
 
 - Update the `minimum supported rust version` to 1.65
 - Use cargo 1.64 workspace inheritance feature. By @jinleili in [#3107](https://github.com/gfx-rs/wgpu/pull/3107)
+- Move `ResourceMetadata` into its own module. By @jimblandy in [#3213](https://github.com/gfx-rs/wgpu/pull/3213)
 
 #### Vulkan
 

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -529,7 +529,7 @@ impl<A: hub::HalApi> BufferTracker<A> {
         let (index32, epoch, _) = id.0.unzip();
         let index = index32 as usize;
 
-        if index > self.metadata.owned.len() {
+        if index > self.metadata.size() {
             return false;
         }
 

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -720,11 +720,7 @@ unsafe fn insert<A: hub::HalApi>(
         *current_states.get_unchecked_mut(index) = new_end_state;
 
         let (epoch, ref_count) = metadata_provider.get_own(life_guard, index);
-
-        resource_metadata.owned.set(index, true);
-
-        *resource_metadata.epochs.get_unchecked_mut(index) = epoch;
-        *resource_metadata.ref_counts.get_unchecked_mut(index) = Some(ref_count);
+        resource_metadata.insert(index, epoch, ref_count);
     }
 }
 

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -514,7 +514,7 @@ impl<A: hub::HalApi> BufferTracker<A> {
                 )
             };
 
-            unsafe { scope.metadata.reset(index) };
+            unsafe { scope.metadata.remove(index) };
         }
     }
 
@@ -543,7 +543,7 @@ impl<A: hub::HalApi> BufferTracker<A> {
                 if *existing_epoch == epoch
                     && existing_ref_count.as_ref().unwrap_unchecked().load() == 1
                 {
-                    self.metadata.reset(index);
+                    self.metadata.remove(index);
 
                     return true;
                 }

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -537,14 +537,11 @@ impl<A: hub::HalApi> BufferTracker<A> {
 
         unsafe {
             if self.metadata.contains_unchecked(index) {
-                let existing_epoch = self.metadata.epochs.get_unchecked(index);
-                let existing_ref_count = self.metadata.ref_counts.get_unchecked(index);
+                let existing_epoch = self.metadata.get_epoch_unchecked(index);
+                let existing_ref_count = self.metadata.get_ref_count_unchecked(index);
 
-                if *existing_epoch == epoch
-                    && existing_ref_count.as_ref().unwrap_unchecked().load() == 1
-                {
+                if existing_epoch == epoch && existing_ref_count.load() == 1 {
                     self.metadata.remove(index);
-
                     return true;
                 }
             }

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -316,7 +316,7 @@ impl<A: hub::HalApi> BufferTracker<A> {
         self.tracker_assert_in_bounds(index);
 
         unsafe {
-            let currently_owned = self.metadata.owned.get(index).unwrap_unchecked();
+            let currently_owned = self.metadata.contains_unchecked(index);
 
             if currently_owned {
                 panic!("Tried to insert buffer already tracked");
@@ -492,7 +492,7 @@ impl<A: hub::HalApi> BufferTracker<A> {
 
             scope.tracker_assert_in_bounds(index);
 
-            if unsafe { !scope.metadata.owned.get(index).unwrap_unchecked() } {
+            if unsafe { !scope.metadata.contains_unchecked(index) } {
                 continue;
             }
             unsafe {
@@ -536,7 +536,7 @@ impl<A: hub::HalApi> BufferTracker<A> {
         self.tracker_assert_in_bounds(index);
 
         unsafe {
-            if self.metadata.owned.get(index).unwrap_unchecked() {
+            if self.metadata.contains_unchecked(index) {
                 let existing_epoch = self.metadata.epochs.get_unchecked(index);
                 let existing_ref_count = self.metadata.ref_counts.get_unchecked(index);
 
@@ -600,7 +600,7 @@ unsafe fn insert_or_merge<A: hub::HalApi>(
     state_provider: BufferStateProvider<'_>,
     metadata_provider: ResourceMetadataProvider<'_, A>,
 ) -> Result<(), UsageConflict> {
-    let currently_owned = unsafe { resource_metadata.owned.get(index).unwrap_unchecked() };
+    let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
 
     if !currently_owned {
         unsafe {
@@ -659,7 +659,7 @@ unsafe fn insert_or_barrier_update<A: hub::HalApi>(
     metadata_provider: ResourceMetadataProvider<'_, A>,
     barriers: &mut Vec<PendingTransition<BufferUses>>,
 ) {
-    let currently_owned = unsafe { resource_metadata.owned.get(index).unwrap_unchecked() };
+    let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
 
     if !currently_owned {
         unsafe {

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -124,7 +124,7 @@ impl<A: hub::HalApi> BufferUsageScope<A> {
 
     /// Returns a list of all buffers tracked.
     pub fn used(&self) -> impl Iterator<Item = Valid<BufferId>> + '_ {
-        self.metadata.used()
+        self.metadata.owned_ids()
     }
 
     /// Merge the list of buffer states in the given bind group into this usage scope.
@@ -293,7 +293,7 @@ impl<A: hub::HalApi> BufferTracker<A> {
 
     /// Returns a list of all buffers tracked.
     pub fn used(&self) -> impl Iterator<Item = Valid<BufferId>> + '_ {
-        self.metadata.used()
+        self.metadata.owned_ids()
     }
 
     /// Drains all currently pending transitions.

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -13,8 +13,8 @@ use crate::{
     id::{BufferId, TypedId, Valid},
     resource::Buffer,
     track::{
-        invalid_resource_state, iterate_bitvec_indices, skip_barrier, ResourceMetadata,
-        ResourceMetadataProvider, ResourceUses, UsageConflict,
+        invalid_resource_state, skip_barrier, ResourceMetadata, ResourceMetadataProvider,
+        ResourceUses, UsageConflict,
     },
     LifeGuard, RefCount,
 };
@@ -180,7 +180,7 @@ impl<A: hub::HalApi> BufferUsageScope<A> {
             self.set_size(incoming_size);
         }
 
-        for index in iterate_bitvec_indices(&scope.metadata.owned) {
+        for index in scope.metadata.owned_indices() {
             self.tracker_assert_in_bounds(index);
             scope.tracker_assert_in_bounds(index);
 
@@ -394,7 +394,7 @@ impl<A: hub::HalApi> BufferTracker<A> {
             self.set_size(incoming_size);
         }
 
-        for index in iterate_bitvec_indices(&tracker.metadata.owned) {
+        for index in tracker.metadata.owned_indices() {
             self.tracker_assert_in_bounds(index);
             tracker.tracker_assert_in_bounds(index);
             unsafe {
@@ -434,7 +434,7 @@ impl<A: hub::HalApi> BufferTracker<A> {
             self.set_size(incoming_size);
         }
 
-        for index in iterate_bitvec_indices(&scope.metadata.owned) {
+        for index in scope.metadata.owned_indices() {
             self.tracker_assert_in_bounds(index);
             scope.tracker_assert_in_bounds(index);
             unsafe {

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -1,0 +1,247 @@
+//! The `ResourceMetadata` type.
+
+use crate::{
+    hub,
+    id::{self, TypedId},
+    Epoch, LifeGuard, RefCount,
+};
+use bit_vec::BitVec;
+use std::{borrow::Cow, marker::PhantomData, mem};
+
+/// SOA container for storing metadata of a resource.
+///
+/// This contains the ownership bitvec, the refcount of
+/// the resource, and the epoch of the object's full ID.
+#[derive(Debug)]
+pub(super) struct ResourceMetadata<A: hub::HalApi> {
+    owned: BitVec<usize>,
+    ref_counts: Vec<Option<RefCount>>,
+    epochs: Vec<Epoch>,
+
+    _phantom: PhantomData<A>,
+}
+
+impl<A: hub::HalApi> ResourceMetadata<A> {
+    pub(super) fn new() -> Self {
+        Self {
+            owned: BitVec::default(),
+            ref_counts: Vec::new(),
+            epochs: Vec::new(),
+
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Returns the number of indices we can accommodate.
+    pub(super) fn size(&self) -> usize {
+        self.owned.len()
+    }
+
+    pub(super) fn set_size(&mut self, size: usize) {
+        self.ref_counts.resize(size, None);
+        self.epochs.resize(size, u32::MAX);
+
+        resize_bitvec(&mut self.owned, size);
+    }
+
+    /// Ensures a given index is in bounds for all arrays and does
+    /// sanity checks of the presence of a refcount.
+    ///
+    /// In release mode this function is completely empty and is removed.
+    #[cfg_attr(not(feature = "strict_asserts"), allow(unused_variables))]
+    pub(super) fn tracker_assert_in_bounds(&self, index: usize) {
+        strict_assert!(index < self.owned.len());
+        strict_assert!(index < self.ref_counts.len());
+        strict_assert!(index < self.epochs.len());
+
+        strict_assert!(if self.contains(index) {
+            self.ref_counts[index].is_some()
+        } else {
+            true
+        });
+    }
+
+    /// Returns true if the tracker owns no resources.
+    ///
+    /// This is a O(n) operation.
+    pub(super) fn is_empty(&self) -> bool {
+        !self.owned.any()
+    }
+
+    /// Returns true if the set contains the resource with the given index.
+    pub(super) fn contains(&self, index: usize) -> bool {
+        self.owned[index]
+    }
+
+    /// Returns true if the set contains the resource with the given index.
+    ///
+    /// # Safety
+    ///
+    /// The given `index` must be in bounds for this `ResourceMetadata`'s
+    /// existing tables. See `tracker_assert_in_bounds`.
+    #[inline(always)]
+    pub(super) unsafe fn contains_unchecked(&self, index: usize) -> bool {
+        unsafe { self.owned.get(index).unwrap_unchecked() }
+    }
+
+    /// Insert a resource into the set.
+    ///
+    /// Add the resource with the given index, epoch, and reference count to the
+    /// set.
+    ///
+    /// # Safety
+    ///
+    /// The given `index` must be in bounds for this `ResourceMetadata`'s
+    /// existing tables. See `tracker_assert_in_bounds`.
+    #[inline(always)]
+    pub(super) unsafe fn insert(&mut self, index: usize, epoch: Epoch, ref_count: RefCount) {
+        self.owned.set(index, true);
+        unsafe {
+            *self.epochs.get_unchecked_mut(index) = epoch;
+            *self.ref_counts.get_unchecked_mut(index) = Some(ref_count);
+        }
+    }
+
+    #[inline(always)]
+    pub(super) unsafe fn get_ref_count_unchecked(&self, index: usize) -> &RefCount {
+        unsafe {
+            self.ref_counts
+                .get_unchecked(index)
+                .as_ref()
+                .unwrap_unchecked()
+        }
+    }
+
+    #[inline(always)]
+    pub(super) unsafe fn get_epoch_unchecked(&self, index: usize) -> Epoch {
+        unsafe { *self.epochs.get_unchecked(index) }
+    }
+
+    /// Returns an iterator over the ids for all resources owned by `self`.
+    pub(super) fn owned_ids<Id: TypedId>(&self) -> impl Iterator<Item = id::Valid<Id>> + '_ {
+        if !self.owned.is_empty() {
+            self.tracker_assert_in_bounds(self.owned.len() - 1)
+        };
+        iterate_bitvec_indices(&self.owned).map(move |index| {
+            let epoch = unsafe { *self.epochs.get_unchecked(index) };
+            id::Valid(Id::zip(index as u32, epoch, A::VARIANT))
+        })
+    }
+
+    /// Returns an iterator over the indices of all resources owned by `self`.
+    pub(super) fn owned_indices(&self) -> impl Iterator<Item = usize> + '_ {
+        if !self.owned.is_empty() {
+            self.tracker_assert_in_bounds(self.owned.len() - 1)
+        };
+        iterate_bitvec_indices(&self.owned)
+    }
+
+    /// Remove the resource with the given index from the set.
+    pub(super) unsafe fn remove(&mut self, index: usize) {
+        unsafe {
+            *self.ref_counts.get_unchecked_mut(index) = None;
+            *self.epochs.get_unchecked_mut(index) = u32::MAX;
+        }
+        self.owned.set(index, false);
+    }
+}
+
+/// A source of resource metadata.
+///
+/// This is used to abstract over the various places
+/// trackers can get new resource metadata from.
+pub(super) enum ResourceMetadataProvider<'a, A: hub::HalApi> {
+    /// Comes directly from explicit values.
+    Direct {
+        epoch: Epoch,
+        ref_count: Cow<'a, RefCount>,
+    },
+    /// Comes from another metadata tracker.
+    Indirect { metadata: &'a ResourceMetadata<A> },
+    /// The epoch is given directly, but the life count comes from the resource itself.
+    Resource { epoch: Epoch },
+}
+impl<A: hub::HalApi> ResourceMetadataProvider<'_, A> {
+    /// Get the epoch and an owned refcount from this.
+    ///
+    /// # Safety
+    ///
+    /// - The index must be in bounds of the metadata tracker if this uses an indirect source.
+    /// - life_guard must be Some if this uses a Resource source.
+    #[inline(always)]
+    pub(super) unsafe fn get_own(
+        self,
+        life_guard: Option<&LifeGuard>,
+        index: usize,
+    ) -> (Epoch, RefCount) {
+        match self {
+            ResourceMetadataProvider::Direct { epoch, ref_count } => {
+                (epoch, ref_count.into_owned())
+            }
+            ResourceMetadataProvider::Indirect { metadata } => {
+                metadata.tracker_assert_in_bounds(index);
+                (unsafe { *metadata.epochs.get_unchecked(index) }, {
+                    let ref_count = unsafe { metadata.ref_counts.get_unchecked(index) };
+                    unsafe { ref_count.clone().unwrap_unchecked() }
+                })
+            }
+            ResourceMetadataProvider::Resource { epoch } => {
+                strict_assert!(life_guard.is_some());
+                (epoch, unsafe { life_guard.unwrap_unchecked() }.add_ref())
+            }
+        }
+    }
+    /// Get the epoch from this.
+    ///
+    /// # Safety
+    ///
+    /// - The index must be in bounds of the metadata tracker if this uses an indirect source.
+    #[inline(always)]
+    pub(super) unsafe fn get_epoch(self, index: usize) -> Epoch {
+        match self {
+            ResourceMetadataProvider::Direct { epoch, .. }
+            | ResourceMetadataProvider::Resource { epoch, .. } => epoch,
+            ResourceMetadataProvider::Indirect { metadata } => {
+                metadata.tracker_assert_in_bounds(index);
+                unsafe { *metadata.epochs.get_unchecked(index) }
+            }
+        }
+    }
+}
+
+/// Resizes the given bitvec to the given size. I'm not sure why this is hard to do but it is.
+fn resize_bitvec<B: bit_vec::BitBlock>(vec: &mut BitVec<B>, size: usize) {
+    let owned_size_to_grow = size.checked_sub(vec.len());
+    if let Some(delta) = owned_size_to_grow {
+        if delta != 0 {
+            vec.grow(delta, false);
+        }
+    } else {
+        vec.truncate(size);
+    }
+}
+
+/// Produces an iterator that yields the indexes of all bits that are set in the bitvec.
+///
+/// Will skip entire usize's worth of bits if they are all false.
+fn iterate_bitvec_indices(ownership: &BitVec<usize>) -> impl Iterator<Item = usize> + '_ {
+    const BITS_PER_BLOCK: usize = mem::size_of::<usize>() * 8;
+
+    let size = ownership.len();
+
+    ownership
+        .blocks()
+        .enumerate()
+        .filter(|&(_, word)| word != 0)
+        .flat_map(move |(word_index, mut word)| {
+            let bit_start = word_index * BITS_PER_BLOCK;
+            let bit_end = (bit_start + BITS_PER_BLOCK).min(size);
+
+            (bit_start..bit_end).filter(move |_| {
+                let active = word & 0b1 != 0;
+                word >>= 1;
+
+                active
+            })
+        })
+}

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -396,6 +396,24 @@ impl<A: hub::HalApi> ResourceMetadata<A> {
         !self.owned.any()
     }
 
+    /// Insert a resource into the set.
+    ///
+    /// Add the resource with the given index, epoch, and reference count to the
+    /// set.
+    ///
+    /// # Safety
+    ///
+    /// The given `index` must be in bounds for this `ResourceMetadata`'s
+    /// existing tables. See `tracker_assert_in_bounds`.
+    #[inline(always)]
+    pub(super) unsafe fn insert(&mut self, index: usize, epoch: Epoch, ref_count: RefCount) {
+        self.owned.set(index, true);
+        unsafe {
+            *self.epochs.get_unchecked_mut(index) = epoch;
+            *self.ref_counts.get_unchecked_mut(index) = Some(ref_count);
+        }
+    }
+
     /// Returns ids for all resources we own.
     fn used<Id: TypedId>(&self) -> impl Iterator<Item = id::Valid<Id>> + '_ {
         if !self.owned.is_empty() {

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -431,7 +431,7 @@ impl<A: hub::HalApi> ResourceMetadata<A> {
     }
 
     /// Returns ids for all resources we own.
-    fn used<Id: TypedId>(&self) -> impl Iterator<Item = id::Valid<Id>> + '_ {
+    fn owned_ids<Id: TypedId>(&self) -> impl Iterator<Item = id::Valid<Id>> + '_ {
         if !self.owned.is_empty() {
             self.tracker_assert_in_bounds(self.owned.len() - 1)
         };

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -435,6 +435,21 @@ impl<A: hub::HalApi> ResourceMetadata<A> {
         }
     }
 
+    #[inline(always)]
+    pub unsafe fn get_ref_count_unchecked(&self, index: usize) -> &RefCount {
+        unsafe {
+            self.ref_counts
+                .get_unchecked(index)
+                .as_ref()
+                .unwrap_unchecked()
+        }
+    }
+
+    #[inline(always)]
+    pub unsafe fn get_epoch_unchecked(&self, index: usize) -> Epoch {
+        unsafe { *self.epochs.get_unchecked(index) }
+    }
+
     /// Returns an iterator over the ids for all resources owned by `self`.
     fn owned_ids<Id: TypedId>(&self) -> impl Iterator<Item = id::Valid<Id>> + '_ {
         if !self.owned.is_empty() {

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -94,6 +94,7 @@ Device <- CommandBuffer = insert(device.start, device.end, buffer.start, buffer.
 */
 
 mod buffer;
+mod metadata;
 mod range;
 mod stateless;
 mod texture;
@@ -101,14 +102,14 @@ mod texture;
 use crate::{
     binding_model, command, conv, hub,
     id::{self, TypedId},
-    pipeline, resource, Epoch, LifeGuard, RefCount,
+    pipeline, resource,
 };
 
-use bit_vec::BitVec;
-use std::{borrow::Cow, fmt, marker::PhantomData, mem, num::NonZeroU32, ops};
+use std::{fmt, num::NonZeroU32, ops};
 use thiserror::Error;
 
 pub(crate) use buffer::{BufferBindGroupState, BufferTracker, BufferUsageScope};
+use metadata::{ResourceMetadata, ResourceMetadataProvider};
 pub(crate) use stateless::{StatelessBindGroupSate, StatelessTracker};
 pub(crate) use texture::{
     TextureBindGroupState, TextureSelector, TextureTracker, TextureUsageScope,
@@ -203,43 +204,6 @@ fn skip_barrier<T: ResourceUses>(old_state: T, new_state: T) -> bool {
     // If the state didn't change and all the usages are ordered, the hardware
     // will guarentee the order of accesses, so we do not need to issue a barrier at all
     old_state == new_state && old_state.all_ordered()
-}
-
-/// Resizes the given bitvec to the given size. I'm not sure why this is hard to do but it is.
-fn resize_bitvec<B: bit_vec::BitBlock>(vec: &mut BitVec<B>, size: usize) {
-    let owned_size_to_grow = size.checked_sub(vec.len());
-    if let Some(delta) = owned_size_to_grow {
-        if delta != 0 {
-            vec.grow(delta, false);
-        }
-    } else {
-        vec.truncate(size);
-    }
-}
-
-/// Produces an iterator that yields the indexes of all bits that are set in the bitvec.
-///
-/// Will skip entire usize's worth of bits if they are all false.
-fn iterate_bitvec_indices(ownership: &BitVec<usize>) -> impl Iterator<Item = usize> + '_ {
-    const BITS_PER_BLOCK: usize = mem::size_of::<usize>() * 8;
-
-    let size = ownership.len();
-
-    ownership
-        .blocks()
-        .enumerate()
-        .filter(|&(_, word)| word != 0)
-        .flat_map(move |(word_index, mut word)| {
-            let bit_start = word_index * BITS_PER_BLOCK;
-            let bit_end = (bit_start + BITS_PER_BLOCK).min(size);
-
-            (bit_start..bit_end).filter(move |_| {
-                let active = word & 0b1 != 0;
-                word >>= 1;
-
-                active
-            })
-        })
 }
 
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
@@ -339,202 +303,6 @@ impl<T: ResourceUses> fmt::Display for InvalidUse<T> {
             {exclusive:?} is an exclusive usage and cannot be used with any other\
             usages within the usage scope (renderpass or compute dispatch)"
         )
-    }
-}
-
-/// SOA container for storing metadata of a resource.
-///
-/// This contins the ownership bitvec, the refcount of
-/// the resource, and the epoch of the object's full ID.
-#[derive(Debug)]
-pub(crate) struct ResourceMetadata<A: hub::HalApi> {
-    owned: BitVec<usize>,
-    ref_counts: Vec<Option<RefCount>>,
-    epochs: Vec<Epoch>,
-
-    _phantom: PhantomData<A>,
-}
-impl<A: hub::HalApi> ResourceMetadata<A> {
-    pub fn new() -> Self {
-        Self {
-            owned: BitVec::default(),
-            ref_counts: Vec::new(),
-            epochs: Vec::new(),
-
-            _phantom: PhantomData,
-        }
-    }
-
-    /// Returns the number of indices we can accommodate.
-    pub fn size(&self) -> usize {
-        self.owned.len()
-    }
-
-    pub fn set_size(&mut self, size: usize) {
-        self.ref_counts.resize(size, None);
-        self.epochs.resize(size, u32::MAX);
-
-        resize_bitvec(&mut self.owned, size);
-    }
-
-    /// Ensures a given index is in bounds for all arrays and does
-    /// sanity checks of the presence of a refcount.
-    ///
-    /// In release mode this function is completely empty and is removed.
-    #[cfg_attr(not(feature = "strict_asserts"), allow(unused_variables))]
-    fn tracker_assert_in_bounds(&self, index: usize) {
-        strict_assert!(index < self.owned.len());
-        strict_assert!(index < self.ref_counts.len());
-        strict_assert!(index < self.epochs.len());
-
-        strict_assert!(if self.contains(index) {
-            self.ref_counts[index].is_some()
-        } else {
-            true
-        });
-    }
-
-    /// Returns true if the tracker owns no resources.
-    ///
-    /// This is a O(n) operation.
-    fn is_empty(&self) -> bool {
-        !self.owned.any()
-    }
-
-    /// Returns true if the set contains the resource with the given index.
-    pub(super) fn contains(&self, index: usize) -> bool {
-        self.owned[index]
-    }
-
-    /// Returns true if the set contains the resource with the given index.
-    ///
-    /// # Safety
-    ///
-    /// The given `index` must be in bounds for this `ResourceMetadata`'s
-    /// existing tables. See `tracker_assert_in_bounds`.
-    #[inline(always)]
-    pub(super) unsafe fn contains_unchecked(&self, index: usize) -> bool {
-        unsafe { self.owned.get(index).unwrap_unchecked() }
-    }
-
-    /// Insert a resource into the set.
-    ///
-    /// Add the resource with the given index, epoch, and reference count to the
-    /// set.
-    ///
-    /// # Safety
-    ///
-    /// The given `index` must be in bounds for this `ResourceMetadata`'s
-    /// existing tables. See `tracker_assert_in_bounds`.
-    #[inline(always)]
-    pub(super) unsafe fn insert(&mut self, index: usize, epoch: Epoch, ref_count: RefCount) {
-        self.owned.set(index, true);
-        unsafe {
-            *self.epochs.get_unchecked_mut(index) = epoch;
-            *self.ref_counts.get_unchecked_mut(index) = Some(ref_count);
-        }
-    }
-
-    #[inline(always)]
-    pub unsafe fn get_ref_count_unchecked(&self, index: usize) -> &RefCount {
-        unsafe {
-            self.ref_counts
-                .get_unchecked(index)
-                .as_ref()
-                .unwrap_unchecked()
-        }
-    }
-
-    #[inline(always)]
-    pub unsafe fn get_epoch_unchecked(&self, index: usize) -> Epoch {
-        unsafe { *self.epochs.get_unchecked(index) }
-    }
-
-    /// Returns an iterator over the ids for all resources owned by `self`.
-    fn owned_ids<Id: TypedId>(&self) -> impl Iterator<Item = id::Valid<Id>> + '_ {
-        if !self.owned.is_empty() {
-            self.tracker_assert_in_bounds(self.owned.len() - 1)
-        };
-        iterate_bitvec_indices(&self.owned).map(move |index| {
-            let epoch = unsafe { *self.epochs.get_unchecked(index) };
-            id::Valid(Id::zip(index as u32, epoch, A::VARIANT))
-        })
-    }
-
-    /// Returns an iterator over the indices of all resources owned by `self`.
-    fn owned_indices(&self) -> impl Iterator<Item = usize> + '_ {
-        if !self.owned.is_empty() {
-            self.tracker_assert_in_bounds(self.owned.len() - 1)
-        };
-        iterate_bitvec_indices(&self.owned)
-    }
-
-    /// Remove the resource with the given index from the set.
-    unsafe fn remove(&mut self, index: usize) {
-        unsafe {
-            *self.ref_counts.get_unchecked_mut(index) = None;
-            *self.epochs.get_unchecked_mut(index) = u32::MAX;
-        }
-        self.owned.set(index, false);
-    }
-}
-
-/// A source of resource metadata.
-///
-/// This is used to abstract over the various places
-/// trackers can get new resource metadata from.
-enum ResourceMetadataProvider<'a, A: hub::HalApi> {
-    /// Comes directly from explicit values.
-    Direct {
-        epoch: Epoch,
-        ref_count: Cow<'a, RefCount>,
-    },
-    /// Comes from another metadata tracker.
-    Indirect { metadata: &'a ResourceMetadata<A> },
-    /// The epoch is given directly, but the life count comes from the resource itself.
-    Resource { epoch: Epoch },
-}
-impl<A: hub::HalApi> ResourceMetadataProvider<'_, A> {
-    /// Get the epoch and an owned refcount from this.
-    ///
-    /// # Safety
-    ///
-    /// - The index must be in bounds of the metadata tracker if this uses an indirect source.
-    /// - life_guard must be Some if this uses a Resource source.
-    #[inline(always)]
-    unsafe fn get_own(self, life_guard: Option<&LifeGuard>, index: usize) -> (Epoch, RefCount) {
-        match self {
-            ResourceMetadataProvider::Direct { epoch, ref_count } => {
-                (epoch, ref_count.into_owned())
-            }
-            ResourceMetadataProvider::Indirect { metadata } => {
-                metadata.tracker_assert_in_bounds(index);
-                (unsafe { *metadata.epochs.get_unchecked(index) }, {
-                    let ref_count = unsafe { metadata.ref_counts.get_unchecked(index) };
-                    unsafe { ref_count.clone().unwrap_unchecked() }
-                })
-            }
-            ResourceMetadataProvider::Resource { epoch } => {
-                strict_assert!(life_guard.is_some());
-                (epoch, unsafe { life_guard.unwrap_unchecked() }.add_ref())
-            }
-        }
-    }
-    /// Get the epoch from this.
-    ///
-    /// # Safety
-    ///
-    /// - The index must be in bounds of the metadata tracker if this uses an indirect source.
-    #[inline(always)]
-    unsafe fn get_epoch(self, index: usize) -> Epoch {
-        match self {
-            ResourceMetadataProvider::Direct { epoch, .. }
-            | ResourceMetadataProvider::Resource { epoch, .. } => epoch,
-            ResourceMetadataProvider::Indirect { metadata } => {
-                metadata.tracker_assert_in_bounds(index);
-                unsafe { *metadata.epochs.get_unchecked(index) }
-            }
-        }
     }
 }
 

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -442,9 +442,11 @@ impl<A: hub::HalApi> ResourceMetadata<A> {
     }
 
     /// Remove the resource with the given index from the set.
-    unsafe fn reset(&mut self, index: usize) {
-        unsafe { *self.ref_counts.get_unchecked_mut(index) = None };
-        unsafe { *self.epochs.get_unchecked_mut(index) = u32::MAX };
+    unsafe fn remove(&mut self, index: usize) {
+        unsafe {
+            *self.ref_counts.get_unchecked_mut(index) = None;
+            *self.epochs.get_unchecked_mut(index) = u32::MAX;
+        }
         self.owned.set(index, false);
     }
 }

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -430,7 +430,7 @@ impl<A: hub::HalApi> ResourceMetadata<A> {
         }
     }
 
-    /// Returns ids for all resources we own.
+    /// Returns an iterator over the ids for all resources owned by `self`.
     fn owned_ids<Id: TypedId>(&self) -> impl Iterator<Item = id::Valid<Id>> + '_ {
         if !self.owned.is_empty() {
             self.tracker_assert_in_bounds(self.owned.len() - 1)
@@ -439,6 +439,14 @@ impl<A: hub::HalApi> ResourceMetadata<A> {
             let epoch = unsafe { *self.epochs.get_unchecked(index) };
             id::Valid(Id::zip(index as u32, epoch, A::VARIANT))
         })
+    }
+
+    /// Returns an iterator over the indices of all resources owned by `self`.
+    fn owned_indices(&self) -> impl Iterator<Item = usize> + '_ {
+        if !self.owned.is_empty() {
+            self.tracker_assert_in_bounds(self.owned.len() - 1)
+        };
+        iterate_bitvec_indices(&self.owned)
     }
 
     /// Remove the resource with the given index from the set.

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -365,6 +365,11 @@ impl<A: hub::HalApi> ResourceMetadata<A> {
         }
     }
 
+    /// Returns the number of indices we can accommodate.
+    pub fn size(&self) -> usize {
+        self.owned.len()
+    }
+
     pub fn set_size(&mut self, size: usize) {
         self.ref_counts.resize(size, None);
         self.epochs.resize(size, u32::MAX);

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -84,7 +84,7 @@ impl<A: hub::HalApi, T: hub::Resource, Id: TypedId> StatelessTracker<A, T, Id> {
 
     /// Extend the vectors to let the given index be valid.
     fn allow_index(&mut self, index: usize) {
-        if index >= self.metadata.owned.len() {
+        if index >= self.metadata.size() {
             self.set_size(index + 1);
         }
     }
@@ -140,8 +140,8 @@ impl<A: hub::HalApi, T: hub::Resource, Id: TypedId> StatelessTracker<A, T, Id> {
     /// If the ID is higher than the length of internal vectors,
     /// the vectors will be extended. A call to set_size is not needed.
     pub fn add_from_tracker(&mut self, other: &Self) {
-        let incoming_size = other.metadata.owned.len();
-        if incoming_size > self.metadata.owned.len() {
+        let incoming_size = other.metadata.size();
+        if incoming_size > self.metadata.size() {
             self.set_size(incoming_size);
         }
 
@@ -176,7 +176,7 @@ impl<A: hub::HalApi, T: hub::Resource, Id: TypedId> StatelessTracker<A, T, Id> {
         let (index32, epoch, _) = id.0.unzip();
         let index = index32 as usize;
 
-        if index > self.metadata.owned.len() {
+        if index > self.metadata.size() {
             return false;
         }
 

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 use crate::{
     hub,
     id::{TypedId, Valid},
-    track::{iterate_bitvec_indices, ResourceMetadata},
+    track::ResourceMetadata,
     RefCount,
 };
 
@@ -145,7 +145,7 @@ impl<A: hub::HalApi, T: hub::Resource, Id: TypedId> StatelessTracker<A, T, Id> {
             self.set_size(incoming_size);
         }
 
-        for index in iterate_bitvec_indices(&other.metadata.owned) {
+        for index in other.metadata.owned_indices() {
             self.tracker_assert_in_bounds(index);
             other.tracker_assert_in_bounds(index);
             unsafe {

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -152,14 +152,9 @@ impl<A: hub::HalApi, T: hub::Resource, Id: TypedId> StatelessTracker<A, T, Id> {
                 let previously_owned = self.metadata.contains_unchecked(index);
 
                 if !previously_owned {
-                    let other_ref_count = other
-                        .metadata
-                        .ref_counts
-                        .get_unchecked(index)
-                        .clone()
-                        .unwrap_unchecked();
-                    let epoch = *other.metadata.epochs.get_unchecked(index);
-                    self.metadata.insert(index, epoch, other_ref_count);
+                    let epoch = other.metadata.get_epoch_unchecked(index);
+                    let other_ref_count = other.metadata.get_ref_count_unchecked(index);
+                    self.metadata.insert(index, epoch, other_ref_count.clone());
                 }
             }
         }
@@ -184,14 +179,11 @@ impl<A: hub::HalApi, T: hub::Resource, Id: TypedId> StatelessTracker<A, T, Id> {
 
         unsafe {
             if self.metadata.contains_unchecked(index) {
-                let existing_epoch = self.metadata.epochs.get_unchecked(index);
-                let existing_ref_count = self.metadata.ref_counts.get_unchecked(index);
+                let existing_epoch = self.metadata.get_epoch_unchecked(index);
+                let existing_ref_count = self.metadata.get_ref_count_unchecked(index);
 
-                if *existing_epoch == epoch
-                    && existing_ref_count.as_ref().unwrap_unchecked().load() == 1
-                {
+                if existing_epoch == epoch && existing_ref_count.load() == 1 {
                     self.metadata.remove(index);
-
                     return true;
                 }
             }

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -91,7 +91,7 @@ impl<A: hub::HalApi, T: hub::Resource, Id: TypedId> StatelessTracker<A, T, Id> {
 
     /// Returns a list of all resources tracked.
     pub fn used(&self) -> impl Iterator<Item = Valid<Id>> + '_ {
-        self.metadata.used()
+        self.metadata.owned_ids()
     }
 
     /// Inserts a single resource into the resource tracker.

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -149,7 +149,7 @@ impl<A: hub::HalApi, T: hub::Resource, Id: TypedId> StatelessTracker<A, T, Id> {
             self.tracker_assert_in_bounds(index);
             other.tracker_assert_in_bounds(index);
             unsafe {
-                let previously_owned = self.metadata.owned.get(index).unwrap_unchecked();
+                let previously_owned = self.metadata.contains_unchecked(index);
 
                 if !previously_owned {
                     let other_ref_count = other
@@ -183,7 +183,7 @@ impl<A: hub::HalApi, T: hub::Resource, Id: TypedId> StatelessTracker<A, T, Id> {
         self.tracker_assert_in_bounds(index);
 
         unsafe {
-            if self.metadata.owned.get(index).unwrap_unchecked() {
+            if self.metadata.contains_unchecked(index) {
                 let existing_epoch = self.metadata.epochs.get_unchecked(index);
                 let existing_ref_count = self.metadata.ref_counts.get_unchecked(index);
 

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -190,7 +190,7 @@ impl<A: hub::HalApi, T: hub::Resource, Id: TypedId> StatelessTracker<A, T, Id> {
                 if *existing_epoch == epoch
                     && existing_ref_count.as_ref().unwrap_unchecked().load() == 1
                 {
-                    self.metadata.reset(index);
+                    self.metadata.remove(index);
 
                     return true;
                 }

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -25,8 +25,8 @@ use crate::{
     id::{TextureId, TypedId, Valid},
     resource::Texture,
     track::{
-        invalid_resource_state, iterate_bitvec_indices, skip_barrier, ResourceMetadata,
-        ResourceMetadataProvider, ResourceUses, UsageConflict,
+        invalid_resource_state, skip_barrier, ResourceMetadata, ResourceMetadataProvider,
+        ResourceUses, UsageConflict,
     },
     LifeGuard, RefCount,
 };
@@ -285,7 +285,7 @@ impl<A: hub::HalApi> TextureUsageScope<A> {
             self.set_size(incoming_size);
         }
 
-        for index in iterate_bitvec_indices(&scope.metadata.owned) {
+        for index in scope.metadata.owned_indices() {
             let index32 = index as u32;
 
             self.tracker_assert_in_bounds(index);
@@ -573,7 +573,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
             self.set_size(incoming_size);
         }
 
-        for index in iterate_bitvec_indices(&tracker.metadata.owned) {
+        for index in tracker.metadata.owned_indices() {
             let index32 = index as u32;
 
             self.tracker_assert_in_bounds(index);
@@ -619,7 +619,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
             self.set_size(incoming_size);
         }
 
-        for index in iterate_bitvec_indices(&scope.metadata.owned) {
+        for index in scope.metadata.owned_indices() {
             let index32 = index as u32;
 
             self.tracker_assert_in_bounds(index);

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -1092,12 +1092,11 @@ unsafe fn insert<A: hub::HalApi>(
         }
     }
 
-    let (epoch, ref_count) =
-        unsafe { metadata_provider.get_own(texture_data.map(|(life_guard, _)| life_guard), index) };
-
-    resource_metadata.owned.set(index, true);
-    unsafe { *resource_metadata.epochs.get_unchecked_mut(index) = epoch };
-    unsafe { *resource_metadata.ref_counts.get_unchecked_mut(index) = Some(ref_count) };
+    unsafe {
+        let (epoch, ref_count) =
+            metadata_provider.get_own(texture_data.map(|(life_guard, _)| life_guard), index);
+        resource_metadata.insert(index, epoch, ref_count);
+    }
 }
 
 #[inline(always)]

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -698,7 +698,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
                 )
             };
 
-            unsafe { scope.metadata.reset(index) };
+            unsafe { scope.metadata.remove(index) };
         }
     }
 
@@ -726,7 +726,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
                 self.start_set.complex.remove(&index32);
                 self.end_set.complex.remove(&index32);
 
-                self.metadata.reset(index);
+                self.metadata.remove(index);
 
                 return true;
             }
@@ -763,7 +763,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
                     self.start_set.complex.remove(&index32);
                     self.end_set.complex.remove(&index32);
 
-                    self.metadata.reset(index);
+                    self.metadata.remove(index);
 
                     return true;
                 }

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -469,8 +469,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
 
         self.tracker_assert_in_bounds(index);
 
-        let ref_count = unsafe { self.metadata.ref_counts.get_unchecked(index) };
-        unsafe { ref_count.as_ref().unwrap_unchecked() }
+        unsafe { self.metadata.get_ref_count_unchecked(index) }
     }
 
     /// Inserts a single texture and a state into the resource tracker.
@@ -720,7 +719,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
 
         unsafe {
             if self.metadata.contains_unchecked(index) {
-                let existing_epoch = *self.metadata.epochs.get_unchecked_mut(index);
+                let existing_epoch = self.metadata.get_epoch_unchecked(index);
                 assert_eq!(existing_epoch, epoch);
 
                 self.start_set.complex.remove(&index32);
@@ -754,12 +753,10 @@ impl<A: hub::HalApi> TextureTracker<A> {
 
         unsafe {
             if self.metadata.contains_unchecked(index) {
-                let existing_epoch = self.metadata.epochs.get_unchecked(index);
-                let existing_ref_count = self.metadata.ref_counts.get_unchecked(index);
+                let existing_epoch = self.metadata.get_epoch_unchecked(index);
+                let existing_ref_count = self.metadata.get_ref_count_unchecked(index);
 
-                if *existing_epoch == epoch
-                    && existing_ref_count.as_ref().unwrap_unchecked().load() == 1
-                {
+                if existing_epoch == epoch && existing_ref_count.load() == 1 {
                     self.start_set.complex.remove(&index32);
                     self.end_set.complex.remove(&index32);
 

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -258,7 +258,7 @@ impl<A: hub::HalApi> TextureUsageScope<A> {
 
     /// Returns a list of all textures tracked.
     pub fn used(&self) -> impl Iterator<Item = Valid<TextureId>> + '_ {
-        self.metadata.used()
+        self.metadata.owned_ids()
     }
 
     /// Returns true if the tracker owns no resources.
@@ -447,7 +447,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
 
     /// Returns a list of all textures tracked.
     pub fn used(&self) -> impl Iterator<Item = Valid<TextureId>> + '_ {
-        self.metadata.used()
+        self.metadata.owned_ids()
     }
 
     /// Drains all currently pending transitions.

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -712,7 +712,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
         let (index32, epoch, _) = id.0.unzip();
         let index = index32 as usize;
 
-        if index > self.metadata.owned.len() {
+        if index > self.metadata.size() {
             return false;
         }
 
@@ -746,7 +746,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
         let (index32, epoch, _) = id.0.unzip();
         let index = index32 as usize;
 
-        if index > self.metadata.owned.len() {
+        if index > self.metadata.size() {
             return false;
         }
 

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -238,7 +238,7 @@ impl<A: hub::HalApi> TextureUsageScope<A> {
 
         strict_assert!(index < self.set.simple.len());
 
-        strict_assert!(if self.metadata.owned.get(index).unwrap()
+        strict_assert!(if self.metadata.contains(index)
             && self.set.simple[index] == TextureUses::COMPLEX
         {
             self.set.complex.contains_key(&(index as u32))
@@ -411,14 +411,14 @@ impl<A: hub::HalApi> TextureTracker<A> {
         strict_assert!(index < self.start_set.simple.len());
         strict_assert!(index < self.end_set.simple.len());
 
-        strict_assert!(if self.metadata.owned.get(index).unwrap()
+        strict_assert!(if self.metadata.contains(index)
             && self.start_set.simple[index] == TextureUses::COMPLEX
         {
             self.start_set.complex.contains_key(&(index as u32))
         } else {
             true
         });
-        strict_assert!(if self.metadata.owned.get(index).unwrap()
+        strict_assert!(if self.metadata.contains(index)
             && self.end_set.simple[index] == TextureUses::COMPLEX
         {
             self.end_set.complex.contains_key(&(index as u32))
@@ -488,7 +488,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
         self.tracker_assert_in_bounds(index);
 
         unsafe {
-            let currently_owned = self.metadata.owned.get(index).unwrap_unchecked();
+            let currently_owned = self.metadata.contains_unchecked(index);
 
             if currently_owned {
                 panic!("Tried to insert texture already tracked");
@@ -677,7 +677,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
             let index = index32 as usize;
             scope.tracker_assert_in_bounds(index);
 
-            if unsafe { !scope.metadata.owned.get(index).unwrap_unchecked() } {
+            if unsafe { !scope.metadata.contains_unchecked(index) } {
                 continue;
             }
             let texture_data = unsafe { texture_data_from_texture(storage, index32) };
@@ -719,7 +719,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
         self.tracker_assert_in_bounds(index);
 
         unsafe {
-            if self.metadata.owned.get(index).unwrap_unchecked() {
+            if self.metadata.contains_unchecked(index) {
                 let existing_epoch = *self.metadata.epochs.get_unchecked_mut(index);
                 assert_eq!(existing_epoch, epoch);
 
@@ -753,7 +753,7 @@ impl<A: hub::HalApi> TextureTracker<A> {
         self.tracker_assert_in_bounds(index);
 
         unsafe {
-            if self.metadata.owned.get(index).unwrap_unchecked() {
+            if self.metadata.contains_unchecked(index) {
                 let existing_epoch = self.metadata.epochs.get_unchecked(index);
                 let existing_ref_count = self.metadata.ref_counts.get_unchecked(index);
 
@@ -906,7 +906,7 @@ unsafe fn insert_or_merge<A: hub::HalApi>(
     state_provider: TextureStateProvider<'_>,
     metadata_provider: ResourceMetadataProvider<'_, A>,
 ) -> Result<(), UsageConflict> {
-    let currently_owned = unsafe { resource_metadata.owned.get(index).unwrap_unchecked() };
+    let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
 
     if !currently_owned {
         unsafe {
@@ -967,7 +967,7 @@ unsafe fn insert_or_barrier_update<A: hub::HalApi>(
     metadata_provider: ResourceMetadataProvider<'_, A>,
     barriers: &mut Vec<PendingTransition<TextureUses>>,
 ) {
-    let currently_owned = unsafe { resource_metadata.owned.get(index).unwrap_unchecked() };
+    let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
 
     if !currently_owned {
         unsafe {


### PR DESCRIPTION
Populating and removing `ResourceMetadata` elements should affect all three parallel arrays simultaneously. This is easiest to ensure (and show to readers) by making the members private and using a method for insertion. Accesses look cleaner with methods, too.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
