### PR TITLE
vk: create `Sampler` from raw handle

### DIFF
--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -627,6 +627,10 @@ impl super::Device {
         }
     }
 
+    pub unsafe fn sampler_from_raw(raw: vk::Sampler) -> super::Sampler {
+        super::Sampler { raw }
+    }
+
     fn create_shader_module_impl(
         &self,
         spv: &[u32],

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -157,6 +157,45 @@ impl Context {
     }
 
     #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    pub fn create_sampler_from_hal<A: wgc::hub::HalApi>(
+        &self,
+        hal_sampler: Option<A::Sampler>,
+        device: &Device,
+        desc: &SamplerDescriptor,
+    ) -> wgc::id::SamplerId {
+        let descriptor = wgc::resource::SamplerDescriptor {
+            label: desc.label.map(Borrowed),
+            address_modes: [
+                desc.address_mode_u,
+                desc.address_mode_v,
+                desc.address_mode_w,
+            ],
+            mag_filter: desc.mag_filter,
+            min_filter: desc.min_filter,
+            mipmap_filter: desc.mipmap_filter,
+            lod_min_clamp: desc.lod_min_clamp,
+            lod_max_clamp: desc.lod_max_clamp,
+            compare: desc.compare,
+            anisotropy_clamp: desc.anisotropy_clamp,
+            border_color: desc.border_color,
+        };
+
+        let global = &self.0;
+        let (id, error) =
+            global.create_sampler_from_hal::<A>(hal_sampler, device.id, &descriptor, ());
+        if let Some(cause) = error {
+            self.handle_error(
+                &device.error_sink,
+                cause,
+                LABEL,
+                desc.label,
+                "Device::create_sampler",
+            );
+        }
+        id
+    }
+
+    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
     pub unsafe fn device_as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Device>) -> R, R>(
         &self,
         device: &Device,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2278,6 +2278,27 @@ impl Device {
         }
     }
 
+    /// Creates a new [`Sampler`].
+    ///
+    /// # Safety
+    ///
+    /// - `hal_sampler` must be created from this device internal handle
+    /// - `hal_sampler` must be created respecting `desc`
+    /// - `hal_sampler` must be initialized
+    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    pub fn create_sampler_from_hal<A: wgc::hub::HalApi>(
+        &self,
+        hal_sampler: A::Sampler,
+        desc: &SamplerDescriptor,
+    ) -> Sampler {
+        Sampler {
+            context: Arc::clone(&self.context),
+            id: self
+                .context
+                .create_sampler_from_hal::<A>(Some(hal_sampler), &self.id, desc),
+        }
+    }
+
     /// Creates a new [`QuerySet`].
     pub fn create_query_set(&self, desc: &QuerySetDescriptor) -> QuerySet {
         QuerySet {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/gfx-rs/wgpu/issues/274
https://github.com/gfx-rs/wgpu/issues/1733

**Description**
With `xx_from_raw` and `create_xx_from_hal`, wgpu can now create `Texture` from external memory with zero-copy, when the external memory is Android camera data, it is necessary to chain the pNext of `vkSampler` and `vkTextureView` to the `vkSamplerYcbcrConversionInfo` object. 

**Testing**
Tested locally with the following code:

```rust
let (vk_image, vk_sampler) = ac.device.as_hal::<Vulkan, _, _>(|device| {
    let device = device.unwrap().raw_device();
    // ...
    let hal_sampler = create_hal_sampler(device, &external_format, &format_info);
    (image, hal_sampler)
});

let sampler = ac.device.create_sampler_from_hal::<Vulkan>(
    hal_sampler, &wgpu::SamplerDescriptor::default()
);

// ...
unsafe fn create_hal_sampler(
    raw_device: &ash::Device,
    external_format: &ExternalFormatANDROID,
    format_info: &AndroidHardwareBufferFormatPropertiesANDROID,
) -> <Vulkan as Api>::Sampler {
    let conv_info = vk::SamplerYcbcrConversionCreateInfo {
        s_type: StructureType::SAMPLER_YCBCR_CONVERSION_CREATE_INFO,
        p_next: <*const ExternalFormatANDROID>::cast(external_format),
        format: format_info.format,
        ycbcr_model: match format_info.format {
            Format::UNDEFINED => format_info.suggested_ycbcr_model,
            // SD YUV
            _ => vk::SamplerYcbcrModelConversion::YCBCR_601,
        },
        ycbcr_range: format_info.suggested_ycbcr_range,
        components: format_info.sampler_ycbcr_conversion_components,
        x_chroma_offset: format_info.suggested_x_chroma_offset,
        y_chroma_offset: format_info.suggested_y_chroma_offset,
        chroma_filter: vk::Filter::LINEAR,
        force_explicit_reconstruction: vk::Bool32::default(),
    };

    let mut sampler_info = vk::SamplerCreateInfo {
        s_type: StructureType::SAMPLER_CREATE_INFO,
        p_next: std::ptr::null(),
        flags: vk::SamplerCreateFlags::default(),
        mag_filter: vk::Filter::LINEAR,
        min_filter: vk::Filter::LINEAR,
        mipmap_mode: SamplerMipmapMode::default(),
        address_mode_u: SamplerAddressMode::default(),
        address_mode_v: SamplerAddressMode::default(),
        address_mode_w: SamplerAddressMode::default(),
        mip_lod_bias: 0.0,
        anisotropy_enable: Bool32::default(),
        max_anisotropy: 1.0,
        compare_enable: Bool32::default(),
        compare_op: vk::CompareOp::NEVER,
        min_lod: 0.0,
        max_lod: 0.0,
        border_color: vk::BorderColor::default(),
        unnormalized_coordinates: Bool32::default(),
    };

    let conv_sampler_info = vk::SamplerYcbcrConversionInfo {
        s_type: StructureType::SAMPLER_YCBCR_CONVERSION_INFO,
        p_next: ::std::ptr::null(),
        conversion: raw_device
            .create_sampler_ycbcr_conversion(&conv_info, None)
            .expect("Cannot create sampler ycbcr conversion"),
    };

    sampler_info.p_next = <*const vk::SamplerYcbcrConversionInfo>::cast(&conv_sampler_info);

    let vk_sampler = raw_device
        .create_sampler(&sampler_info, None)
        .expect("Cannot create vk sampler");

    <<Vulkan as Api>::Device>::sampler_from_raw(vk_sampler)
}
```