### PR TITLE
Add create_surface_from_surface_handle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,8 +498,7 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 [[package]]
 name = "d3d12"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827914e1f53b1e0e025ecd3d967a7836b7bcb54520f90e21ef8df7b4d88a2759"
+source = "git+https://github.com/xiaopengli89/d3d12-rs?branch=factory-media#bd2290f4acb9a6793b909c1e4ce0838075084f24"
 dependencies = [
  "bitflags",
  "libloading",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 [[package]]
 name = "d3d12"
 version = "0.5.0"
-source = "git+https://github.com/xiaopengli89/d3d12-rs?branch=factory-media#bd2290f4acb9a6793b909c1e4ce0838075084f24"
+source = "git+https://github.com/gfx-rs/d3d12-rs?rev=a990c93#a990c93ec64eeab78f2292763d0715da9dba1d59"
 dependencies = [
  "bitflags",
  "libloading",

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -592,7 +592,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id.0
     }
 
-    #[cfg(dx12)]
+    #[cfg(feature = "dx12")]
     /// # Safety
     ///
     /// The surface_handle must be valid and able to be used to make a swapchain with.
@@ -605,13 +605,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let surface = Surface {
             presentation: None,
-            #[cfg(vulkan)]
+            #[cfg(feature = "vulkan")]
             vulkan: None,
             dx12: self.instance.dx12.as_ref().map(|inst| HalSurface {
                 raw: unsafe { inst.create_surface_from_surface_handle(surface_handle) },
             }),
             dx11: None,
-            #[cfg(gl)]
+            #[cfg(feature = "gles")]
             gl: None,
         };
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -592,6 +592,34 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id.0
     }
 
+    #[cfg(dx12)]
+    /// # Safety
+    ///
+    /// The surface_handle must be valid and able to be used to make a swapchain with.
+    pub unsafe fn instance_create_surface_from_surface_handle(
+        &self,
+        surface_handle: *mut std::ffi::c_void,
+        id_in: Input<G, SurfaceId>,
+    ) -> SurfaceId {
+        profiling::scope!("Instance::instance_create_surface_from_surface_handle");
+
+        let surface = Surface {
+            presentation: None,
+            #[cfg(vulkan)]
+            vulkan: None,
+            dx12: self.instance.dx12.as_ref().map(|inst| HalSurface {
+                raw: unsafe { inst.create_surface_from_surface_handle(surface_handle) },
+            }),
+            dx11: None,
+            #[cfg(gl)]
+            gl: None,
+        };
+
+        let mut token = Token::root();
+        let id = self.surfaces.prepare(id_in).assign(surface, &mut token);
+        id.0
+    }
+
     pub fn surface_drop(&self, id: SurfaceId) {
         profiling::scope!("Surface::drop");
         let mut token = Token::root();

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -93,7 +93,7 @@ libloading = { version = "0.7", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["profileapi", "libloaderapi", "windef", "winuser", "dcomp"] }
-native = { package = "d3d12", git = "https://github.com/gfx-rs/d3d12-rs", rev = "a990c93", features = ["libloading"], optional = true }
+native = { package = "d3d12", version = "0.5.0", git = "https://github.com/gfx-rs/d3d12-rs", rev = "a990c93", features = ["libloading"], optional = true }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
 mtl = { package = "metal", version = "0.24.0" }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -93,7 +93,7 @@ libloading = { version = "0.7", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["profileapi", "libloaderapi", "windef", "winuser", "dcomp"] }
-native = { package = "d3d12", version = "0.5.0", features = ["libloading"], optional = true }
+native = { package = "d3d12", git = "https://github.com/gfx-rs/d3d12-rs", rev = "a990c93", features = ["libloading"], optional = true }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
 mtl = { package = "metal", version = "0.24.0" }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -515,7 +515,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
                         None
                     }
                 }
-                SurfaceTarget::Visual(_) => None,
+                SurfaceTarget::Visual(_) | SurfaceTarget::SurfaceHandle(_) => None,
             }
         };
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -89,6 +89,7 @@ const ZERO_BUFFER_SIZE: wgt::BufferAddress = 256 << 10;
 
 pub struct Instance {
     factory: native::DxgiFactory,
+    factory_media: Option<native::FactoryMedia>,
     library: Arc<native::D3D12Lib>,
     supports_allow_tearing: bool,
     _lib_dxgi: native::DxgiLib,
@@ -103,6 +104,7 @@ impl Instance {
     ) -> Surface {
         Surface {
             factory: self.factory,
+            factory_media: self.factory_media,
             target: SurfaceTarget::Visual(unsafe { native::WeakPtr::from_raw(visual) }),
             supports_allow_tearing: self.supports_allow_tearing,
             swap_chain: None,
@@ -115,6 +117,7 @@ impl Instance {
     ) -> Surface {
         Surface {
             factory: self.factory,
+            factory_media: self.factory_media,
             target: SurfaceTarget::SurfaceHandle(surface_handle),
             supports_allow_tearing: self.supports_allow_tearing,
             swap_chain: None,
@@ -145,6 +148,7 @@ enum SurfaceTarget {
 
 pub struct Surface {
     factory: native::DxgiFactory,
+    factory_media: Option<native::FactoryMedia>,
     target: SurfaceTarget,
     supports_allow_tearing: bool,
     swap_chain: Option<SwapChain>,
@@ -694,8 +698,8 @@ impl crate::Surface<Api> for Surface {
                             .into_result()
                     }
                     SurfaceTarget::SurfaceHandle(handle) => self
-                        .factory
-                        .unwrap_factory_media()
+                        .factory_media
+                        .unwrap()
                         .create_swapchain_for_composition_surface_handle(
                             device.present_queue.as_mut_ptr() as *mut _,
                             handle,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -702,7 +702,7 @@ impl crate::Surface<Api> for Surface {
                             "IDXGIFactoryMedia::CreateSwapChainForCompositionSurfaceHandle"
                         );
                         self.factory_media
-                            .unwrap()
+                            .ok_or(crate::SurfaceError::Other("IDXGIFactoryMedia not found"))?
                             .create_swapchain_for_composition_surface_handle(
                                 device.present_queue.as_mut_ptr() as *mut _,
                                 handle,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -697,15 +697,19 @@ impl crate::Surface<Api> for Surface {
                             )
                             .into_result()
                     }
-                    SurfaceTarget::SurfaceHandle(handle) => self
-                        .factory_media
-                        .unwrap()
-                        .create_swapchain_for_composition_surface_handle(
-                            device.present_queue.as_mut_ptr() as *mut _,
-                            handle,
-                            &desc,
-                        )
-                        .into_result(),
+                    SurfaceTarget::SurfaceHandle(handle) => {
+                        profiling::scope!(
+                            "IDXGIFactoryMedia::CreateSwapChainForCompositionSurfaceHandle"
+                        );
+                        self.factory_media
+                            .unwrap()
+                            .create_swapchain_for_composition_surface_handle(
+                                device.present_queue.as_mut_ptr() as *mut _,
+                                handle,
+                                &desc,
+                            )
+                            .into_result()
+                    }
                     SurfaceTarget::WndHandle(hwnd) => {
                         profiling::scope!("IDXGIFactory4::CreateSwapChainForHwnd");
                         self.factory

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -250,6 +250,24 @@ impl Context {
         }
     }
 
+    #[cfg(target_os = "windows")]
+    pub unsafe fn create_surface_from_surface_handle(
+        self: &Arc<Self>,
+        surface_handle: *mut std::ffi::c_void,
+    ) -> crate::Surface {
+        let id = unsafe {
+            self.0
+                .instance_create_surface_from_surface_handle(surface_handle, ())
+        };
+        crate::Surface {
+            context: Arc::clone(self),
+            id: Surface {
+                id,
+                configured_device: Mutex::default(),
+            },
+        }
+    }
+
     fn handle_error(
         &self,
         sink_mutex: &Mutex<ErrorSinkRaw>,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -252,19 +252,16 @@ impl Context {
 
     #[cfg(target_os = "windows")]
     pub unsafe fn create_surface_from_surface_handle(
-        self: &Arc<Self>,
+        &self,
         surface_handle: *mut std::ffi::c_void,
-    ) -> crate::Surface {
+    ) -> Surface {
         let id = unsafe {
             self.0
                 .instance_create_surface_from_surface_handle(surface_handle, ())
         };
-        crate::Surface {
-            context: Arc::clone(self),
-            id: Surface {
-                id,
-                configured_device: Mutex::default(),
-            },
+        Surface {
+            id,
+            configured_device: Mutex::default(),
         }
     }
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1517,6 +1517,22 @@ impl Instance {
         }
     }
 
+    /// Creates a surface from `SurfaceHandle`.
+    ///
+    /// # Safety
+    ///
+    /// - surface_handle must be a valid SurfaceHandle to create a surface upon.
+    #[cfg(target_os = "windows")]
+    pub unsafe fn create_surface_from_surface_handle(
+        &self,
+        surface_handle: *mut std::ffi::c_void,
+    ) -> Surface {
+        unsafe {
+            self.context
+                .create_surface_from_surface_handle(surface_handle)
+        }
+    }
+
     /// Creates a surface from a `web_sys::HtmlCanvasElement`.
     ///
     /// The `canvas` argument must be a valid `<canvas>` element to

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1527,9 +1527,18 @@ impl Instance {
         &self,
         surface_handle: *mut std::ffi::c_void,
     ) -> Surface {
-        unsafe {
+        let surface = unsafe {
             self.context
+                .as_any()
+                .downcast_ref::<crate::backend::Context>()
+                .unwrap()
                 .create_surface_from_surface_handle(surface_handle)
+        };
+        Surface {
+            context: Arc::clone(&self.context),
+            id: ObjectId::from(surface.id()),
+            data: Box::new(surface),
+            config: Mutex::new(None),
         }
     }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
gfx-rs/d3d12-rs#40

**Description**
Support creating surface from a [DirectComposition](https://learn.microsoft.com/en-us/windows/desktop/directcomp/reference) surface handle, the handle can be shared between processes.

