### PR TITLE
Introduce boxes and vectors to reduce Result sizes.

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,0 @@
-large-error-threshold = 225 # bytes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Bottom level categories:
 - Avoid panicking in some interactions with invalid resources by @nical in (#3094)[https://github.com/gfx-rs/wgpu/pull/3094]
 - Remove `wgpu_types::Features::DEPTH24PLUS_STENCIL8`, making `wgpu::TextureFormat::Depth24PlusStencil8` available on all backends. By @Healthire in (#3151)[https://github.com/gfx-rs/wgpu/pull/3151]
 - Fix an integer overflow in `queue_write_texture` by @nical in (#3146)[https://github.com/gfx-rs/wgpu/pull/3146]
+- Make `RenderPassCompatibilityError` and `CreateShaderModuleError` not so huge. By @jimblandy in (#3226)[https://github.com/gfx-rs/wgpu/pull/3226]
 
 #### WebGPU
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -66,7 +66,7 @@ impl<A: hal::Api> Resource for ShaderModule<A> {
 pub struct ShaderError<E> {
     pub source: String,
     pub label: Option<String>,
-    pub inner: E,
+    pub inner: Box<E>,
 }
 #[cfg(feature = "wgsl")]
 impl fmt::Display for ShaderError<naga::front::wgsl::ParseError> {


### PR DESCRIPTION
The following error variants were large enough to trip Clippy's `result_large_err` lint:

- RenderPassCompatibilityError::IncompatibleColorAttachment
- CreateShaderModuleError::Validation

Large error types are a problem, because they make the `Result` type large, requiring the program to copy around large numbers of bytes even in the success case. Since the failure case is rare, it's usually not a problem to just heap-allocate the contents to keep the `Ok` case small.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
