### PR TITLE
vk: eliminate duplicate values in SurfaceCapabilities's formats

### DIFF
--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -149,16 +149,22 @@ pub fn map_vk_surface_formats(sf: vk::SurfaceFormatKHR) -> Option<wgt::TextureFo
     use ash::vk::Format as F;
     use wgt::TextureFormat as Tf;
     // List we care about pulled from https://vulkan.gpuinfo.org/listsurfaceformats.php
-    Some(match sf.format {
-        F::B8G8R8A8_UNORM => Tf::Bgra8Unorm,
-        F::B8G8R8A8_SRGB => Tf::Bgra8UnormSrgb,
-        F::R8G8B8A8_SNORM => Tf::Rgba8Snorm,
-        F::R8G8B8A8_UNORM => Tf::Rgba8Unorm,
-        F::R8G8B8A8_SRGB => Tf::Rgba8UnormSrgb,
-        F::R16G16B16A16_SFLOAT => Tf::Rgba16Float,
-        F::R16G16B16A16_SNORM => Tf::Rgba16Snorm,
-        F::R16G16B16A16_UNORM => Tf::Rgba16Unorm,
-        F::A2B10G10R10_UNORM_PACK32 => Tf::Rgb10a2Unorm,
+    Some(match sf.color_space {
+        vk::ColorSpaceKHR::SRGB_NONLINEAR => match sf.format {
+            F::B8G8R8A8_UNORM => Tf::Bgra8Unorm,
+            F::B8G8R8A8_SRGB => Tf::Bgra8UnormSrgb,
+            F::R8G8B8A8_SNORM => Tf::Rgba8Snorm,
+            F::R8G8B8A8_UNORM => Tf::Rgba8Unorm,
+            F::R8G8B8A8_SRGB => Tf::Rgba8UnormSrgb,
+            _ => return None,
+        },
+        vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT => match sf.format {
+            F::R16G16B16A16_SFLOAT => Tf::Rgba16Float,
+            F::R16G16B16A16_SNORM => Tf::Rgba16Snorm,
+            F::R16G16B16A16_UNORM => Tf::Rgba16Unorm,
+            F::A2B10G10R10_UNORM_PACK32 => Tf::Rgb10a2Unorm,
+            _ => return None,
+        },
         _ => return None,
     })
 }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**

`Vec<vk::SurfaceFormatKHR>` obtained by `get_physical_device_surface_formats` contains all supported color spaces and matching formats. Typically, a format appears in multiple color spaces. So currently in the vk backend, `get_supported_formats` will return duplicate `TextureFormat`'s : 
```sh
get_supported_formats: [Bgra8UnormSrgb, Bgra8UnormSrgb, Bgra8UnormSrgb, Bgra8UnormSrgb, Bgra8UnormSrgb, Bgra8UnormSrgb, Bgra8UnormSrgb, Bgra8UnormSrgb, Bgra8UnormSrgb, Bgra8UnormSrgb, Bgra8UnormSrgb, Bgra8UnormSrgb, 
Bgra8Unorm, Rgba16Float, Rgb10a2Unorm, Bgra8Unorm, Rgba16Float, Rgb10a2Unorm, Bgra8Unorm, Rgba16Float, Rgb10a2Unorm, Bgra8Unorm, Rgba16Float, Rgb10a2Unorm, Bgra8Unorm, Rgba16Float, Rgb10a2Unorm, Bgra8Unorm, Rgba16Float, Rgb10a2Unorm, Bgra8Unorm, Rgba16Float, 
Rgb10a2Unorm, Bgra8Unorm, Rgba16Float, Rgb10a2Unorm, Bgra8Unorm, Rgba16Float, Rgb10a2Unorm, Bgra8Unorm, Rgba16Float, Rgb10a2Unorm, Bgra8Unorm, Rgba16Float, Rgb10a2Unorm, Bgra8Unorm, Rgba16Float, Rgb10a2Unorm]
```

Since `TextureFormat` does not derive `Ord` tait,   cannot directly call `sort_xx()` and then `dedup()`, a HashSet is used to help detect uniqueness.

**Testing**
Tested locally
