### PR TITLE
wgpu spell checking

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -658,9 +658,9 @@ impl Features {
 /// - [`Limits::downlevel_webgl2_defaults()`] This is a set of limits that is lower even than the
 ///   [`downlevel_defaults()`], configured to be low enough to support running in the browser using
 ///   WebGL2.
-/// - [`Limits::default()`]. This is the set of limits that is guarenteed to work on all modern
-///   backends and is guarenteed to be supported by WebGPU. Applications needing more modern
-///   features can use this as a reasonable set of limits if they are targetting only desktop and
+/// - [`Limits::default()`]. This is the set of limits that is guaranteed to work on all modern
+///   backends and is guaranteed to be supported by WebGPU. Applications needing more modern
+///   features can use this as a reasonable set of limits if they are targeting only desktop and
 ///   modern mobile devices.
 ///
 /// We recommend starting with the most restrictive limits you can and manually increasing the
@@ -773,7 +773,7 @@ pub struct Limits {
     pub max_compute_workgroups_per_dimension: u32,
     /// A limit above which buffer allocations are guaranteed to fail.
     ///
-    /// Buffer allocations below the maximum buffer size may not succed depending on available memory,
+    /// Buffer allocations below the maximum buffer size may not succeed depending on available memory,
     /// fragmentation and other factors.
     pub max_buffer_size: u64,
 }
@@ -815,7 +815,7 @@ impl Default for Limits {
 }
 
 impl Limits {
-    /// These default limits are guarenteed to be compatible with GLES-3.1, and D3D11
+    /// These default limits are guaranteed to be compatible with GLES-3.1, and D3D11
     pub fn downlevel_defaults() -> Self {
         Self {
             max_texture_dimension_1d: 2048,
@@ -850,7 +850,7 @@ impl Limits {
         }
     }
 
-    /// These default limits are guarenteed to be compatible with GLES-3.0, and D3D11, and WebGL2
+    /// These default limits are guaranteed to be compatible with GLES-3.0, and D3D11, and WebGL2
     pub fn downlevel_webgl2_defaults() -> Self {
         Self {
             max_uniform_buffers_per_shader_stage: 11,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -620,7 +620,7 @@ bitflags::bitflags! {
         ///
         /// This is a native-only feature.
         const TEXTURE_COMPRESSION_ASTC_HDR = 1 << 40;
-        /// Allows for timestamp queries inside renderpasses. Metal does not allow this
+        /// Allows for timestamp queries inside render passes. Metal does not allow this
         /// on Apple GPUs.
         ///
         /// Implies [`Features::TIMESTAMP_QUERIES`] is supported.
@@ -3841,7 +3841,7 @@ bitflags::bitflags! {
         const TEXTURE_BINDING = 1 << 2;
         /// Allows a texture to be a [`BindingType::StorageTexture`] in a bind group.
         const STORAGE_BINDING = 1 << 3;
-        /// Allows a texture to be an output attachment of a renderpass.
+        /// Allows a texture to be an output attachment of a render pass.
         const RENDER_ATTACHMENT = 1 << 4;
     }
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1179,7 +1179,7 @@ pub struct DeviceDescriptor<L> {
 }
 
 impl<L> DeviceDescriptor<L> {
-    ///
+    /// Takes a closure and maps the label of the device descriptor into another.
     pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> DeviceDescriptor<K> {
         DeviceDescriptor {
             label: fun(&self.label),
@@ -2049,7 +2049,7 @@ pub enum TextureFormat {
     Astc {
         /// compressed block dimensions
         block: AstcBlock,
-        ///
+        /// astc RGBA channel
         channel: AstcChannel,
     },
 }
@@ -3672,7 +3672,7 @@ pub struct BufferDescriptor<L> {
 }
 
 impl<L> BufferDescriptor<L> {
-    ///
+    /// Takes a closure and maps the label of the buffer descriptor into another.
     pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> BufferDescriptor<K> {
         BufferDescriptor {
             label: fun(&self.label),
@@ -3697,7 +3697,7 @@ pub struct CommandEncoderDescriptor<L> {
 }
 
 impl<L> CommandEncoderDescriptor<L> {
-    ///
+    /// Takes a closure and maps the label of the command encoder descriptor into another.
     pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> CommandEncoderDescriptor<K> {
         CommandEncoderDescriptor {
             label: fun(&self.label),
@@ -3900,13 +3900,13 @@ pub enum SurfaceStatus {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Color {
-    ///
+    /// red component of the color
     pub r: f64,
-    ///
+    /// green component of the color
     pub g: f64,
-    ///
+    /// blue component of the color
     pub b: f64,
-    ///
+    /// alpha component of the color
     pub a: f64,
 }
 
@@ -3980,11 +3980,11 @@ pub enum TextureDimension {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Origin3d {
-    ///
+    /// x position of the origin
     pub x: u32,
-    ///
+    /// y position of the origin
     pub y: u32,
-    ///
+    /// z position of the origin
     pub z: u32,
 }
 
@@ -4009,11 +4009,11 @@ impl Default for Origin3d {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Extent3d {
-    ///
+    /// height of the extent
     pub width: u32,
-    ///
+    /// width of the extent
     pub height: u32,
-    ///
+    /// the depth of the extent or the number of array layers
     #[cfg_attr(feature = "serde", serde(default = "default_depth"))]
     pub depth_or_array_layers: u32,
 }
@@ -4218,7 +4218,7 @@ pub struct TextureDescriptor<L> {
 }
 
 impl<L> TextureDescriptor<L> {
-    ///
+    /// Takes a closure and maps the label of the texture descriptor into another.
     pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> TextureDescriptor<K> {
         TextureDescriptor {
             label: fun(&self.label),
@@ -4380,7 +4380,7 @@ pub struct CommandBufferDescriptor<L> {
 }
 
 impl<L> CommandBufferDescriptor<L> {
-    ///
+    /// Takes a closure and maps the label of the command buffer descriptor into another.
     pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> CommandBufferDescriptor<K> {
         CommandBufferDescriptor {
             label: fun(&self.label),
@@ -4419,7 +4419,7 @@ pub struct RenderBundleDescriptor<L> {
 }
 
 impl<L> RenderBundleDescriptor<L> {
-    ///
+    /// Takes a closure and maps the label of the render bundle descriptor into another.
     pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> RenderBundleDescriptor<K> {
         RenderBundleDescriptor {
             label: fun(&self.label),
@@ -4971,7 +4971,7 @@ pub struct QuerySetDescriptor<L> {
 }
 
 impl<L> QuerySetDescriptor<L> {
-    ///
+    /// Takes a closure and maps the label of the query set descriptor into another.
     pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> QuerySetDescriptor<K> {
         QuerySetDescriptor {
             label: fun(&self.label),

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2049,7 +2049,7 @@ pub enum TextureFormat {
     Astc {
         /// compressed block dimensions
         block: AstcBlock,
-        /// astc RGBA channel
+        /// ASTC RGBA channel
         channel: AstcChannel,
     },
 }
@@ -3900,13 +3900,13 @@ pub enum SurfaceStatus {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Color {
-    /// red component of the color
+    /// Red component of the color
     pub r: f64,
-    /// green component of the color
+    /// Green component of the color
     pub g: f64,
-    /// blue component of the color
+    /// Blue component of the color
     pub b: f64,
-    /// alpha component of the color
+    /// Alpha component of the color
     pub a: f64,
 }
 
@@ -3980,11 +3980,11 @@ pub enum TextureDimension {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Origin3d {
-    /// x position of the origin
+    /// X position of the origin
     pub x: u32,
-    /// y position of the origin
+    /// Y position of the origin
     pub y: u32,
-    /// z position of the origin
+    /// Z position of the origin
     pub z: u32,
 }
 
@@ -4009,11 +4009,11 @@ impl Default for Origin3d {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Extent3d {
-    /// height of the extent
+    /// Width of the extent
     pub width: u32,
-    /// width of the extent
+    /// Height of the extent
     pub height: u32,
-    /// the depth of the extent or the number of array layers
+    /// The depth of the extent or the number of array layers
     #[cfg_attr(feature = "serde", serde(default = "default_depth"))]
     pub depth_or_array_layers: u32,
 }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3118,7 +3118,7 @@ impl<'a> RenderPass<'a> {
 
 /// [`Features::MULTI_DRAW_INDIRECT_COUNT`] must be enabled on the device in order to call these functions.
 impl<'a> RenderPass<'a> {
-    /// Disptaches multiple draw calls from the active vertex buffer(s) based on the contents of the `indirect_buffer`.
+    /// Dispatches multiple draw calls from the active vertex buffer(s) based on the contents of the `indirect_buffer`.
     /// The count buffer is read to determine how many draws to issue.
     ///
     /// The indirect buffer must be long enough to account for `max_count` draws, however only `count` will

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1201,7 +1201,7 @@ pub struct BufferBinding<'a> {
 }
 static_assertions::assert_impl_all!(BufferBinding: Send, Sync);
 
-/// Operation to perform to the output attachment at the start of a renderpass.
+/// Operation to perform to the output attachment at the start of a render pass.
 ///
 /// The render target must be cleared at least once before its content is loaded.
 ///
@@ -1659,13 +1659,13 @@ pub struct RenderBundleEncoderDescriptor<'a> {
     /// Debug label of the render bundle encoder. This will show up in graphics debuggers for easy identification.
     pub label: Label<'a>,
     /// The formats of the color attachments that this render bundle is capable to rendering to. This
-    /// must match the formats of the color attachments in the renderpass this render bundle is executed in.
+    /// must match the formats of the color attachments in the render pass this render bundle is executed in.
     pub color_formats: &'a [Option<TextureFormat>],
     /// Information about the depth attachment that this render bundle is capable to rendering to. This
-    /// must match the format of the depth attachments in the renderpass this render bundle is executed in.
+    /// must match the format of the depth attachments in the render pass this render bundle is executed in.
     pub depth_stencil: Option<RenderBundleDepthStencil>,
     /// Sample count this render bundle is capable of rendering to. This must match the pipelines and
-    /// the renderpasses it is used in.
+    /// the render passes it is used in.
     pub sample_count: u32,
     /// If this render bundle will rendering to multiple array layers in the attachments at the same time.
     pub multiview: Option<NonZeroU32>,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4023,14 +4023,14 @@ impl<T> UncapturedErrorHandler for T where T: Fn(Error) + Send + 'static {}
 pub enum Error {
     /// Out of memory error
     OutOfMemory {
-        ///
+        /// Lower level source of the error.
         source: Box<dyn error::Error + Send + 'static>,
     },
     /// Validation error, signifying a bug in code or data
     Validation {
-        ///
+        /// Lower level source of the error.
         source: Box<dyn error::Error + Send + 'static>,
-        ///
+        /// Description of the validation error.
         description: String,
     },
 }


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
A clippy lint has been proposed to help prevent empty doc comments in the future: https://github.com/rust-lang/rust-clippy/issues/9931

**Description**
Probably best reviewed one commit at a time.

Fixes a few spelling errors

Changes instances of `renderpass` to `render pass` to match `compute pass` and the webgpu spec using `render pass`.

Fills in empty doc comments in wgpu-types and wgpu.