### PR TITLE
Move minimum supported rust version (MSRV) from 1.65 back to 1.64.

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,0 @@
-large-error-threshold = 225 # bytes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  RUST_VERSION: 1.65
+  RUST_VERSION: 1.64
   PKG_CONFIG_ALLOW_CROSS: 1 # allow android to work
   RUSTFLAGS: --cfg=web_sys_unstable_apis -D warnings
   RUSTDOCFLAGS: -Dwarnings

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  RUST_VERSION: 1.65
+  RUST_VERSION: 1.64
 
 jobs:
   cts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Bottom level categories:
 - Avoid panicking in some interactions with invalid resources by @nical in (#3094)[https://github.com/gfx-rs/wgpu/pull/3094]
 - Remove `wgpu_types::Features::DEPTH24PLUS_STENCIL8`, making `wgpu::TextureFormat::Depth24PlusStencil8` available on all backends. By @Healthire in (#3151)[https://github.com/gfx-rs/wgpu/pull/3151]
 - Fix an integer overflow in `queue_write_texture` by @nical in (#3146)[https://github.com/gfx-rs/wgpu/pull/3146]
+- Make `RenderPassCompatibilityError` and `CreateShaderModuleError` not so huge. By @jimblandy in (#3226)[https://github.com/gfx-rs/wgpu/pull/3226]
 
 #### WebGPU
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ Bottom level categories:
 
 ### Testing/Internal
 
-- Update the `minimum supported rust version` to 1.65
+- Update the `minimum supported rust version` to 1.64
 - Use cargo 1.64 workspace inheritance feature. By @jinleili in [#3107](https://github.com/gfx-rs/wgpu/pull/3107)
 
 #### Vulkan

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-members = ["wgpu", "wgpu-hal", "wgpu-info"]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.64"
 keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 homepage = "https://wgpu.rs/"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ Minimum Supported Rust Version is **1.64**.
 It is enforced on CI (in "/.github/workflows/ci.yml") with `RUST_VERSION` variable.
 This version can only be upgraded in breaking releases.
 
+The `wgpu-core`, `wgpu-hal`, and `wgpu-types` crates should never
+require an MSRV ahead of Firefox's MSRV for nightly builds, as
+determined by the value of `MINIMUM_RUST_VERSION` in
+[`python/mozboot/mozboot/util.py`][util]. However, Firefox uses `cargo
+vendor` to extract only those crates it actually uses, so the
+workspace's other crates can have more recent MSRVs.
+
+*Note for Rust 1.64*: The workspace itself can even use a newer MSRV
+than Firefox, as long as the vendoring step's `Cargo.toml` rewriting
+removes any features Firefox's MSRV couldn't handle. For example,
+`wgpu` can use manifest key inheritance, added in Rust 1.64, even
+before Firefox reaches that MSRV, because `cargo vendor` copies
+inherited values directly into the individual crates' `Cargo.toml`
+files, producing 1.63-compatible files.
+
+[util]: https://searchfox.org/mozilla-central/source/python/mozboot/mozboot/util.py
+
 ## Getting Started
 
 ### Rust

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For an overview of all the components in the gfx-rs ecosystem, see [the big pict
 
 ### MSRV policy
 
-Minimum Supported Rust Version is **1.65**.
+Minimum Supported Rust Version is **1.64**.
 It is enforced on CI (in "/.github/workflows/ci.yml") with `RUST_VERSION` variable.
 This version can only be upgraded in breaking releases.
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -66,7 +66,7 @@ impl<A: hal::Api> Resource for ShaderModule<A> {
 pub struct ShaderError<E> {
     pub source: String,
     pub label: Option<String>,
-    pub inner: E,
+    pub inner: Box<E>,
 }
 #[cfg(feature = "wgsl")]
 impl fmt::Display for ShaderError<naga::front::wgsl::ParseError> {

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -8,7 +8,12 @@ homepage.workspace = true
 repository.workspace = true
 keywords.workspace = true
 license.workspace = true
-rust-version.workspace = true
+
+# Override the workspace's `rust-version` key. Firefox uses `cargo vendor` to
+# copy the crates it actually uses out of the workspace, so it's meaningful for
+# them to have less restrictive MSRVs individually than the workspace as a
+# whole, if their code permits. See `../README.md` for details.
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 # Ideally we would enable all the features.


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
