### PR TITLE
Fix incorrect offset in get_mapped_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,14 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 
 - Don't use a pointer to a local copy of a `PhysicalDeviceDriverProperties` struct after it has gone out of scope. In fact, don't make a local copy at all. Introduce a helper function for building `CStr`s from C character arrays, and remove some `unsafe` blocks. By @jimblandy in [#3076](https://github.com/gfx-rs/wgpu/pull/3076).
 
+
+## wgpu-0.14.2 (2022-11-28)
+
+### Bug Fixes
+
+- Fix incorrect offset in `get_mapped_range` by @nical in [#3233](https://github.com/gfx-rs/wgpu/pull/3233)
+
+
 ## wgpu-0.14.1 (2022-11-02)
 
 ### Bug Fixes

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -5677,7 +5677,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         max: range.end,
                     });
                 }
-                unsafe { Ok((ptr.as_ptr().offset(offset as isize), range_size)) }
+                // ptr points to the beginning of the range we mapped in map_async
+                // rather thant the beginning of the buffer.
+                let relative_offset = (offset - range.start) as isize;
+                unsafe { Ok((ptr.as_ptr().offset(relative_offset), range_size)) }
             }
             resource::BufferMapState::Idle | resource::BufferMapState::Waiting(_) => {
                 Err(BufferAccessError::NotMapped)

--- a/wgpu/tests/root.rs
+++ b/wgpu/tests/root.rs
@@ -1,6 +1,7 @@
 // All files containing tests
 mod common;
 
+mod buffer;
 mod buffer_copy;
 mod buffer_usages;
 mod clear_texture;


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Found the issue while fuzzing Gecko's WebGPU integration.

**Description**

This one is kind of serious.

`get_mapped_range` ([spec](https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange)) takes a range that is relative to the beginning of the buffer. The implementation in webgpu seems to want to agree judging by how the validation checks that the range is contained in the mapped one. However internally the `ptr` stored in  `BufferMapState::Active` is actually relative to the beginning of the mapped range (rather than beginning of the buffer). This means that we have to subtract the mapped offset to the one provided in `get_mapped_range`, otherwise seriously scary things happen.

**Testing**

Added a simple test.

Note that in the process of adding the test I found out that tests/buffer.rs was not run (oops!). I hadn't finished it when it landed a little while ago, it was not quite working yet because of how wgpu does not accept empty slices, I had put it on hold for a bit and when it landed anyway without breaking the build I didn't think too much of it but the version that landed was not part of the build. So this commit puts the file back in the build with a #[ignore] slapped on it, and of course it got reformatted in the process.