### PR TITLE
README.md: Update "Get started" link to "Running the examples".

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ files, producing 1.63-compatible files.
 
 ### Rust
 
-Rust examples can be found at `wgpu/examples`. You can run the examples with `cargo run --example name`. See the [list of examples](wgpu/examples). For detailed instructions, look at our [Get Started](https://github.com/gfx-rs/wgpu/wiki/Getting-Started) wiki.
+Rust examples can be found at `wgpu/examples`. You can run the examples with `cargo run --example name`. See the [list of examples](wgpu/examples). For detailed instructions, look at [Running the examples](https://github.com/gfx-rs/wgpu/wiki/Running-the-examples) on the wiki.
 
 If you are looking for a wgpu tutorial, look at the following:
 - https://sotrh.github.io/learn-wgpu/


### PR DESCRIPTION
The "Get started" wiki page has been moved to "Running the examples", but the link in `README.md` wasn't updated.

(did not follow the checklist, because trivial)