### PR TITLE
Fix surface creation cfgs in example framework.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,11 @@ jobs:
           set -e
 
           # build for Emscripten/WebGL
-          cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-hal --no-default-features --features webgl,emscripten
+          cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-hal \
+                       --no-default-features --features webgl,emscripten
+
+          # build cube example
+          cargo clippy --target ${{ matrix.target }} --example cube --features webgl,emscripten
 
           # build raw-gles example
           cargo clippy --target ${{ matrix.target }} --example raw-gles --features webgl,emscripten

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,10 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
   zero, rather than treating that as "until the end of the buffer".
   By @jimblandy in [#3171](https://github.com/gfx-rs/wgpu/pull/3171)
 
+#### Emscripten
+
+- Let the wgpu examples `framework.rs` compile again under Emscripten. By @jimblandy in [#3246](https://github.com/gfx-rs/wgpu/pull/3246)
+
 ### Examples
 
 - Log adapter info in hello example on wasm target by @JolifantoBambla in [#2858](https://github.com/gfx-rs/wgpu/pull/2858)

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -163,9 +163,9 @@ async fn setup<E: Example>(title: &str) -> Setup {
     let (size, surface) = unsafe {
         let size = window.inner_size();
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
         let surface = instance.create_surface(&window);
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
         let surface = {
             if let Some(offscreen_canvas_setup) = &offscreen_canvas_setup {
                 log::info!("Creating surface from OffscreenCanvas");


### PR DESCRIPTION
Expand CI coverage so that we try building `wgpu/examples/framework.rs` on Emscripten.

The `framework.rs` library used to check:

    #[cfg(not(target_arch = "wasm32"))]

to decide whether to call `instance.create_surface` or attempt to support creating a surface from an offscreen canvas. This is not correct: `emscripten` should be be treated as a non-web target; the instance doesn't have a `create_surface_from_offscreen_canvas` method.

Instead, `framework.rs` should check:

    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]

to treat the Emscripten target like a native target.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
