### PR TITLE
Request the `gles` feature in `wgpu`, not `wgpu-core`.

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -60,17 +60,15 @@ workspace = true
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
 web-sys = { workspace = true, features = ["HtmlCanvasElement", "OffscreenCanvas"] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-hal = { workspace = true, features = ["gles"] }
-
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
 hal = { workspace = true, features = ["metal"] }
 #Note: could also enable "vulkan" for Vulkan Portability
 
+# Non-Apple, non-wasm Unix
 [target.'cfg(all(not(target_arch = "wasm32"), unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
-hal = { workspace = true, features = ["vulkan", "gles", "renderdoc"] }
+hal = { workspace = true, features = ["vulkan", "renderdoc"] }
 
-[target.'cfg(all(not(target_arch = "wasm32"), windows))'.dependencies]
+[target.'cfg(windows)'.dependencies]
 hal = { workspace = true, features = ["vulkan", "dx12", "dx11", "renderdoc"] }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -27,7 +27,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [lib]
 
 [features]
-default = ["gles"]
+default = []
 metal = ["naga/msl-out", "block", "foreign-types"]
 vulkan = ["naga/spv-out", "ash", "gpu-alloc", "gpu-descriptor", "libloading", "smallvec"]
 gles = ["naga/glsl-out", "glow", "egl", "libloading"]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -102,6 +102,7 @@ workspace = true
 
 [target.'cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))'.dependencies.hal]
 workspace = true
+features = ["gles"]
 
 [dependencies]
 arrayvec.workspace = true


### PR DESCRIPTION
The selection of backends should be left to higher-level crates, not `wgpu-core`.

**Checklist**

- [ ] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
