### PR TITLE
fix: oops, remove `gles` feature from `wgpu-hal`'s `default`s

### DIFF
--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -27,7 +27,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [lib]
 
 [features]
-default = ["gles"]
+default = []
 metal = ["naga/msl-out", "block", "foreign-types"]
 vulkan = ["naga/spv-out", "ash", "gpu-alloc", "gpu-descriptor", "libloading", "smallvec"]
 gles = ["naga/glsl-out", "glow", "egl", "libloading"]


### PR DESCRIPTION
Totally my bad; this should not have landed. I was using it while chasing down files to change in #3044. :<

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] ~~Add change to CHANGELOG.md. See simple instructions inside file.~~

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._

Prompted by @jimblandy after he pointed out that I made this mistake in #3044. Sorry, everyone!