### PR TITLE
Update workspace Cargo.lock for new deno_webgpu version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webgpu"
-version = "0.63.0"
+version = "0.81.0"
 dependencies = [
  "deno_core",
  "serde",


### PR DESCRIPTION
Trivial.