### PR TITLE
Implement SHADER_PRIMITIVE_INDEX on all Backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 - Implement `Clone` for `ShaderSource` and `ShaderModuleDescriptor` in `wgpu`. By @daxpedda in [#3086](https://github.com/gfx-rs/wgpu/pull/3086).
 - Add `get_default_config` for `Surface` to simplify user creation of `SurfaceConfiguration`. By @jinleili in [#3034](https://github.com/gfx-rs/wgpu/pull/3034)
 - Native adapters can now use MSAA x2 and x8 if it's supported , previously only x1 and x4 were supported . By @39ali in [3140](https://github.com/gfx-rs/wgpu/pull/3140)
+- Added support for `Features::SHADER_PRIMITIVE_INDEX` on all backends. By @cwfitzgerald in [#3272](https://github.com/gfx-rs/wgpu/pull/3272)
 
 #### GLES
 

--- a/wgpu-hal/examples/halmark/shader.wgsl
+++ b/wgpu-hal/examples/halmark/shader.wgsl
@@ -1,12 +1,17 @@
 struct Globals {
     mvp: mat4x4<f32>,
     size: vec2<f32>,
+    _pad0: u32,
+    _pad1: u32,
 };
 
 struct Locals {
     position: vec2<f32>,
     velocity: vec2<f32>,
     color: u32,
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
 };
 
 @group(0)

--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -123,6 +123,7 @@ impl super::Adapter {
             features |= wgt::Features::DEPTH_CLIP_CONTROL;
             features |= wgt::Features::TIMESTAMP_QUERY;
             features |= wgt::Features::PIPELINE_STATISTICS_QUERY;
+            features |= wgt::Features::SHADER_PRIMITIVE_INDEX;
         }
 
         if feature_level >= FL10_1 {

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -209,7 +209,8 @@ impl super::Adapter {
             | wgt::Features::TEXTURE_COMPRESSION_BC
             | wgt::Features::CLEAR_TEXTURE
             | wgt::Features::TEXTURE_FORMAT_16BIT_NORM
-            | wgt::Features::PUSH_CONSTANTS;
+            | wgt::Features::PUSH_CONSTANTS
+            | wgt::Features::SHADER_PRIMITIVE_INDEX;
         //TODO: in order to expose this, we need to run a compute shader
         // that extract the necessary statistics out of the D3D12 result.
         // Alternatively, we could allocate a buffer for the query set,

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -338,6 +338,10 @@ impl super::Adapter {
             wgt::Features::MULTIVIEW,
             extensions.contains("OVR_multiview2"),
         );
+        features.set(
+            wgt::Features::SHADER_PRIMITIVE_INDEX,
+            ver >= (3, 2) || extensions.contains("OES_geometry_shader"),
+        );
         let gles_bcn_exts = [
             "GL_EXT_texture_compression_s3tc_srgb",
             "GL_EXT_texture_compression_rgtc",

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -726,6 +726,8 @@ impl super::PrivateCapabilities {
             supports_depth_clip_control: os_is_mac
                 || device.supports_feature_set(MTLFeatureSet::iOS_GPUFamily4_v1),
             supports_preserve_invariance: version.at_least((11, 0), (13, 0)),
+            // Metal 2.2 on mac, 2.3 on iOS.
+            supports_shader_primitive_index: version.at_least((10, 15), (14, 0)),
             has_unified_memory: if version.at_least((10, 15), (13, 0)) {
                 Some(device.has_unified_memory())
             } else {
@@ -764,6 +766,10 @@ impl super::PrivateCapabilities {
         features.set(F::TEXTURE_COMPRESSION_ETC2, self.format_eac_etc);
 
         features.set(F::DEPTH_CLIP_CONTROL, self.supports_depth_clip_control);
+        features.set(
+            F::SHADER_PRIMITIVE_INDEX,
+            self.supports_shader_primitive_index,
+        );
 
         features.set(
             F::TEXTURE_BINDING_ARRAY

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -230,6 +230,7 @@ struct PrivateCapabilities {
     supports_mutability: bool,
     supports_depth_clip_control: bool,
     supports_preserve_invariance: bool,
+    supports_shader_primitive_index: bool,
     has_unified_memory: Option<bool>,
 }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Closes #3269

**Description**

Enables SHADER_PRIMITIVE_INDEX where applicable.

**Testing**

Tested locally using the shader-primitive-index test
