### PR TITLE
Update to ash 0.37.1 to replace deprecated function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,10 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 
 - Let the wgpu examples `framework.rs` compile again under Emscripten. By @jimblandy in [#3246](https://github.com/gfx-rs/wgpu/pull/3246)
 
+#### Vulkan
+
+- Update ash to 0.37.1+1.3.235 to fix CI breaking by changing a call to the deprecated `debug_utils_set_object_name()` function to `set_debug_utils_object_name()` by @elabajaba in [#3273](https://github.com/gfx-rs/wgpu/pull/3273)
+
 ### Examples
 
 - Log adapter info in hello example on wasm target by @JolifantoBambla in [#2858](https://github.com/gfx-rs/wgpu/pull/2858)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.37.0+1.3.209"
+version = "0.37.1+1.3.235"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006ca68e0f2b03f22d6fa9f2860f85aed430d257fec20f8879b2145e7c7ae1a6"
+checksum = "911015c962d56e2e4052f40182ca5462ba60a3d2ff04e827c365a0ab3d65726d"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ objc = "0.2.5"
 core-graphics-types = "0.1"
 
 # Vulkan dependencies
-ash = "0.37"
+ash = ">=0.37.1,<0.38"
 gpu-alloc = "0.5"
 gpu-descriptor = "0.2"
 android_system_properties = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ objc = "0.2.5"
 core-graphics-types = "0.1"
 
 # Vulkan dependencies
-ash = ">=0.37.1,<0.38"
+ash = "0.37.1"
 gpu-alloc = "0.5"
 gpu-descriptor = "0.2"
 android_system_properties = "0.1.1"

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -52,7 +52,7 @@ impl super::DeviceShared {
         let name = unsafe { CStr::from_bytes_with_nul_unchecked(name_bytes) };
 
         let _result = unsafe {
-            extension.debug_utils_set_object_name(
+            extension.set_debug_utils_object_name(
                 self.raw.handle(),
                 &vk::DebugUtilsObjectNameInfoEXT::builder()
                     .object_type(object_type)


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
CI was breaking for me in #3163 after running `cargo update` due to `debug_utils_set_object_name()` being deprecated and replaced with `set_debug_utils_object_name()`
