### PR TITLE
vulkan feature exclude macOS and iOS by default

### DIFF
--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [features]
 angle = ["wgc/angle"]
-vulkan-portability = ["wgc/vulkan-portability"]
+vulkan-portability = ["wgc/vulkan"]
 
 [dependencies]
 env_logger.workspace = true
@@ -28,6 +28,18 @@ features = ["replay"]
 [dependencies.wgc]
 workspace = true
 features = ["replay", "raw-window-handle", "strict_asserts", "wgsl"]
+
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.wgc]
+workspace = true
+features = ["metal"]
+
+[target.'cfg(windows)'.dependencies.wgc]
+workspace = true
+features = ["dx11", "dx12"]
+
+[target.'cfg(any(windows, all(unix, not(target_arch = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
+workspace = true
+features = ["vulkan"]
 
 [dev-dependencies]
 serde.workspace = true

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -45,7 +45,6 @@ serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
 id32 = []
 # Enable `ShaderModuleSource::Wgsl`
 wgsl = ["naga/wgsl-in"]
-vulkan-portability = ["hal/vulkan"]
 
 # Features that are intended to work on all platforms.
 portable_features = ["gles", "strict_asserts", "trace", "replay", "serial-pass", "id32", "wgsl"]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -85,7 +85,7 @@ replay = ["serde", "wgc/replay"]
 angle = ["wgc/angle"]
 webgl = ["hal", "wgc"]
 emscripten = ["webgl"]
-vulkan-portability = ["wgc/vulkan-portability"]
+vulkan-portability = ["wgc/vulkan"]
 expose-ids = []
 
 # wgpu-core is always available as an optional dependency, "wgc".
@@ -115,7 +115,7 @@ workspace = true
 features = ["dx11", "dx12"]
 
 # We want the wgpu-core Vulkan backend on Unix (but not Emscripten) and Windows.
-[target.'cfg(any(windows, all(unix, not(target_arch = "emscripten"))))'.dependencies.wgc]
+[target.'cfg(any(windows, all(unix, not(target_arch = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
 workspace = true
 features = ["vulkan"]
 
@@ -164,7 +164,7 @@ pollster.workspace = true
 png.workspace = true
 nanorand = { workspace = true, features = ["wyrand"] }
 wasm-bindgen-test.workspace = true
-winit.workspace = true # for "halmark" example
+winit.workspace = true                                 # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 async-executor.workspace = true

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -164,7 +164,7 @@ pollster.workspace = true
 png.workspace = true
 nanorand = { workspace = true, features = ["wyrand"] }
 wasm-bindgen-test.workspace = true
-winit.workspace = true                                 # for "halmark" example
+winit.workspace = true # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 async-executor.workspace = true


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Closes https://github.com/gfx-rs/wgpu/issues/3287

**Description**
- `vulkan` feature exclude macOS and iOS by default, users can use `vulkan-portability` feature to enable vk backend.
- player can be re-runnable locally.

Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` will cause error, but this is another issue:
```log
error: No back ends enabled in `wgpu-hal`. Enable at least one backend feature.
  --> wgpu-hal/src/lib.rs:59:1
   |
59 | compile_error!("No back ends enabled in `wgpu-hal`. Enable at least one backend feature.");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `wgpu-hal` due to previous error
```

**Testing**
Tested locally
