### PR TITLE
Remove workspace inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,7 +191,6 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 ### Testing/Internal
 
 - Update the `minimum supported rust version` to 1.64
-- Use cargo 1.64 workspace inheritance feature. By @jinleili in [#3107](https://github.com/gfx-rs/wgpu/pull/3107)
 - Move `ResourceMetadata` into its own module. By @jimblandy in [#3213](https://github.com/gfx-rs/wgpu/pull/3213)
 - Add WebAssembly testing infrastructure. By @haraldreingruber in [#3238](https://github.com/gfx-rs/wgpu/pull/3238)
 - Error message when you forget to use cargo-nextest. By @cwfitzgerald in [#3293](https://github.com/gfx-rs/wgpu/pull/3293)

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wgpu-core"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+version = "0.14.0"
+authors = ["wgpu developers"]
+edition = "2021"
 description = "WebGPU core logic on wgpu-hal"
-homepage.workspace = true
-repository.workspace = true
-keywords.workspace = true
-license.workspace = true
+homepage = "https://wgpu.rs/"
+repository = "https://github.com/gfx-rs/wgpu"
+keywords = ["graphics"]
+license = "MIT OR Apache-2.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -51,29 +51,34 @@ vulkan-portability = ["hal/vulkan"]
 portable_features = ["gles", "strict_asserts", "trace", "replay", "serial-pass", "id32", "wgsl"]
 
 [dependencies]
-arrayvec.workspace = true
-bitflags.workspace = true
-bit-vec.workspace = true
-codespan-reporting.workspace = true
-fxhash.workspace = true
-log.workspace = true
-parking_lot.workspace = true
-profiling.workspace = true
-raw-window-handle = { workspace = true, optional = true }
-ron = { workspace = true, optional = true }
-serde = { workspace = true, features = ["serde_derive"], optional = true }
-smallvec.workspace = true
-thiserror.workspace = true
+arrayvec = "0.7"
+bitflags = "1"
+bit-vec = "0.6"
+codespan-reporting = "0.11"
+fxhash = "0.2.1"
+log = "0.4"
+# parking_lot 0.12 switches from `winapi` to `windows`; permit either
+parking_lot = ">=0.11,<0.13"
+profiling = { version = "1", default-features = false }
+raw-window-handle = { version = "0.5", optional = true }
+ron = { version = "0.8", optional = true }
+serde = { version = "1", features = ["serde_derive"], optional = true }
+smallvec = "1"
+thiserror = "1"
 
 [dependencies.naga]
-workspace = true
+git = "https://github.com/gfx-rs/naga"
+rev = "e7fc8e6"
+version = "0.10"
 features = ["clone", "span", "validate"]
 
 [dependencies.wgt]
-workspace = true
+package = "wgpu-types"
+path = "../wgpu-types"
 
 [dependencies.hal]
-workspace = true
+package = "wgpu-hal"
+path = "../wgpu-hal"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-web-sys = { workspace = true, features = ["HtmlCanvasElement", "OffscreenCanvas"] }
+web-sys = { version = "0.3.60", features = ["HtmlCanvasElement", "OffscreenCanvas"] }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wgpu-hal"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+version = "0.14.0"
+authors = ["wgpu developers"]
+edition = "2021"
 description = "WebGPU hardware abstraction layer"
-homepage.workspace = true
-repository.workspace = true
-keywords.workspace = true
-license.workspace = true
+homepage = "https://wgpu.rs/"
+repository = "https://github.com/gfx-rs/wgpu"
+keywords = ["graphics"]
+license = "MIT OR Apache-2.0"
 
 # Override the workspace's `rust-version` key. Firefox uses `cargo vendor` to
 # copy the crates it actually uses out of the workspace, so it's meaningful for
@@ -44,76 +44,81 @@ name = "raw-gles"
 required-features = ["gles"]
 
 [dependencies]
-bitflags.workspace = true
-parking_lot.workspace = true
-profiling.workspace = true
-raw-window-handle.workspace = true
-thiserror.workspace = true
+bitflags = "1"
+parking_lot = ">=0.11,<0.13"
+profiling = { version = "1", default-features = false }
+raw-window-handle = "0.5"
+thiserror = "1"
 
 # backends common
-arrayvec.workspace = true
-fxhash.workspace = true
-log.workspace = true
-renderdoc-sys = { workspace = true, optional = true }
+arrayvec = "0.7"
+fxhash = "0.2.1"
+log = "0.4"
+renderdoc-sys = { version = "0.7.1", optional = true }
 
 # backend: Metal
-block = { workspace = true, optional = true }
-foreign-types = { workspace = true, optional = true }
+block = { version = "0.1", optional = true }
+foreign-types = { version = "0.3", optional = true }
 
 # backend: Vulkan
-ash = { workspace = true, optional = true }
-gpu-alloc = { workspace = true, optional = true }
-gpu-descriptor = { workspace = true, optional = true }
-smallvec = { workspace = true, optional = true, features = ["union"] }
+ash = { version = "0.37.1", optional = true }
+gpu-alloc = { version = "0.5", optional = true }
+gpu-descriptor = { version = "0.2", optional = true }
+smallvec = { version = "1", optional = true, features = ["union"] }
 
 # backend: Gles
-glow = { workspace = true, optional = true }
+glow = { git = "https://github.com/grovesNL/glow", rev = "c8a011fcd57a5c68cc917ed394baa484bdefc909", optional = true }
 
 # backend: Dx12
-bit-set = { workspace = true, optional = true }
-range-alloc = { workspace = true, optional = true }
+bit-set = { version = "0.5", optional = true }
+range-alloc = { version = "0.1", optional = true }
 
 [dependencies.wgt]
-workspace = true
+package = "wgpu-types"
+path = "../wgpu-types"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egl = { workspace = true, features = ["dynamic"], optional = true }
-libloading = { workspace = true, optional = true }
+egl = { package = "khronos-egl", version = "4.1", features = ["dynamic"], optional = true }
+libloading = { version = "0.7", optional = true }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-egl = { workspace = true, features = ["static", "no-pkg-config"] }
+egl = { package = "khronos-egl", version = "4.1", features = ["static", "no-pkg-config"] }
 #Note: it's unused by emscripten, but we keep it to have single code base in egl.rs
-libloading = { workspace = true, optional = true }
+libloading = { version = "0.7", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { workspace = true, features = ["libloaderapi", "windef", "winuser", "dcomp"] }
-native = { workspace = true, features = ["libloading"], optional = true }
+winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser", "dcomp"] }
+native = { package = "d3d12", version = "0.5.0", features = ["libloading"], optional = true }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
-mtl.workspace = true
-objc.workspace = true
-core-graphics-types.workspace = true
+mtl = { package = "metal", version = "0.24.0" }
+objc = "0.2.5"
+core-graphics-types = "0.1"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-wasm-bindgen.workspace = true
-web-sys = { workspace = true, features = ["Window", "HtmlCanvasElement", "WebGl2RenderingContext", "OffscreenCanvas"] }
-js-sys.workspace = true
+wasm-bindgen = "0.2.83"
+web-sys = { version = "0.3.60", features = ["Window", "HtmlCanvasElement", "WebGl2RenderingContext", "OffscreenCanvas"] }
+js-sys = "0.3.60"
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_system_properties.workspace = true
+android_system_properties = "0.1.1"
 
 [dependencies.naga]
-workspace = true
+git = "https://github.com/gfx-rs/naga"
+rev = "e7fc8e6"
+version = "0.10"
 features = ["clone"]
 
 # DEV dependencies
 [dev-dependencies.naga]
-workspace = true
+git = "https://github.com/gfx-rs/naga"
+rev = "e7fc8e6"
+version = "0.10"
 features = ["wgsl-in"]
 
 [dev-dependencies]
-env_logger.workspace = true
-winit.workspace = true      # for "halmark" example
+env_logger = "0.9"
+winit = "0.27.1"      # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-glutin.workspace = true # for "gles" example
+glutin = "0.29.1" # for "gles" example

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wgpu-types"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+version = "0.14.0"
+authors = ["wgpu developers"]
+edition = "2021"
 description = "WebGPU types"
-homepage.workspace = true
-repository.workspace = true
-keywords.workspace = true
-license.workspace = true
+homepage = "https://wgpu.rs/"
+repository = "https://github.com/gfx-rs/wgpu"
+keywords = ["graphics"]
+license = "MIT OR Apache-2.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -20,8 +20,8 @@ trace = ["serde"]
 replay = ["serde"]
 
 [dependencies]
-bitflags.workspace = true
-serde = { workspace = true, features = ["serde_derive"], optional = true }
+bitflags = "1"
+serde = { version = "1", features = ["serde_derive"], optional = true }
 
 [dev-dependencies]
-serde_json.workspace = true
+serde_json = "1.0.85"


### PR DESCRIPTION
This reluctantly reverts #3107. Using workspace inheritance is great, and wgpu should do it - but it makes vendoring impossible because of rust-lang/cargo#11192. Until that's fixed, wgpu will have to hold off on using workspace inheritance.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
