### PR TITLE
Check for webgl2 validation errors and catch issues

### DIFF
--- a/wgpu/examples/boids/main.rs
+++ b/wgpu/examples/boids/main.rs
@@ -329,7 +329,10 @@ fn main() {
     framework::run::<Example>("boids");
 }
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn boids() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/boids/screenshot.png",

--- a/wgpu/examples/bunnymark/main.rs
+++ b/wgpu/examples/bunnymark/main.rs
@@ -357,7 +357,10 @@ fn main() {
     framework::run::<Example>("bunnymark");
 }
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn bunnymark() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/bunnymark/screenshot.png",

--- a/wgpu/examples/capture/main.rs
+++ b/wgpu/examples/capture/main.rs
@@ -225,7 +225,10 @@ mod tests {
     use super::*;
     use wgpu::BufferView;
 
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn ensure_generated_data_matches_expected() {
         assert_generated_data_matches_expected();
     }

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -314,7 +314,10 @@ fn main() {
     framework::run::<Example>("conservative-raster");
 }
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn conservative_raster() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/conservative-raster/screenshot.png",

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -406,7 +406,10 @@ fn main() {
     framework::run::<Example>("cube");
 }
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn cube() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/cube/screenshot.png",
@@ -420,6 +423,7 @@ fn cube() {
 }
 
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn cube_lines() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/cube/screenshot-lines.png",

--- a/wgpu/examples/hello-compute/tests.rs
+++ b/wgpu/examples/hello-compute/tests.rs
@@ -6,7 +6,10 @@ use std::sync::Arc;
 use super::*;
 use common::{initialize_test, TestParameters};
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn test_compute_1() {
     initialize_test(
         TestParameters::default()
@@ -27,6 +30,7 @@ fn test_compute_1() {
 }
 
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn test_compute_2() {
     initialize_test(
         TestParameters::default()
@@ -47,6 +51,7 @@ fn test_compute_2() {
 }
 
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn test_compute_overflow() {
     initialize_test(
         TestParameters::default()
@@ -66,6 +71,7 @@ fn test_compute_overflow() {
 }
 
 #[test]
+// Wasm doesn't support threads
 fn test_multithreaded_compute() {
     initialize_test(
         TestParameters::default()

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -487,7 +487,10 @@ fn main() {
     framework::run::<Example>("mipmap");
 }
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn mipmap() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/mipmap/screenshot.png",

--- a/wgpu/examples/msaa-line/main.rs
+++ b/wgpu/examples/msaa-line/main.rs
@@ -310,7 +310,10 @@ fn main() {
     framework::run::<Example>("msaa-line");
 }
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn msaa_line() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/msaa-line/screenshot.png",

--- a/wgpu/examples/shadow/main.rs
+++ b/wgpu/examples/shadow/main.rs
@@ -841,7 +841,10 @@ fn main() {
     framework::run::<Example>("shadow");
 }
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn shadow() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/shadow/screenshot.png",
@@ -850,6 +853,7 @@ fn shadow() {
         optional_features: wgpu::Features::default(),
         base_test_parameters: framework::test_common::TestParameters::default()
             .downlevel_flags(wgpu::DownlevelFlags::COMPARISON_SAMPLERS)
+            .specific_failure(Some(wgpu::Backends::GL), None, Some("ANGLE"), false)
             // rpi4 on VK doesn't work: https://gitlab.freedesktop.org/mesa/mesa/-/issues/3916
             .specific_failure(Some(wgpu::Backends::VULKAN), None, Some("V3D"), false)
             // llvmpipe versions in CI are flaky: https://github.com/gfx-rs/wgpu/issues/2594

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -465,20 +465,29 @@ fn main() {
     framework::run::<Skybox>("skybox");
 }
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn skybox() {
     framework::test::<Skybox>(framework::FrameworkRefTest {
         image_path: "/examples/skybox/screenshot.png",
         width: 1024,
         height: 768,
         optional_features: wgpu::Features::default(),
-        base_test_parameters: framework::test_common::TestParameters::default(),
+        base_test_parameters: framework::test_common::TestParameters::default().specific_failure(
+            Some(wgpu::Backends::GL),
+            None,
+            Some("ANGLE"),
+            false,
+        ),
         tolerance: 3,
         max_outliers: 207, // bounded by swiftshader
     });
 }
 
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn skybox_bc1() {
     framework::test::<Skybox>(framework::FrameworkRefTest {
         image_path: "/examples/skybox/screenshot-bc1.png",
@@ -492,6 +501,7 @@ fn skybox_bc1() {
 }
 
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn skybox_etc2() {
     framework::test::<Skybox>(framework::FrameworkRefTest {
         image_path: "/examples/skybox/screenshot-etc2.png",
@@ -505,6 +515,7 @@ fn skybox_etc2() {
 }
 
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn skybox_astc() {
     framework::test::<Skybox>(framework::FrameworkRefTest {
         image_path: "/examples/skybox/screenshot-astc.png",

--- a/wgpu/examples/texture-arrays/main.rs
+++ b/wgpu/examples/texture-arrays/main.rs
@@ -406,7 +406,10 @@ fn main() {
     framework::run::<Example>("texture-arrays");
 }
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn texture_arrays_uniform() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/texture-arrays/screenshot.png",
@@ -420,6 +423,7 @@ fn texture_arrays_uniform() {
 }
 
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn texture_arrays_non_uniform() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/texture-arrays/screenshot.png",

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -818,7 +818,10 @@ fn main() {
     framework::run::<Example>("water");
 }
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn water() {
     framework::test::<Example>(framework::FrameworkRefTest {
         image_path: "/examples/water/screenshot.png",

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -494,12 +494,12 @@ trait Context: Debug + Send + Sized + Sync {
         buffer: &Self::BufferId,
         offset: wgt::BufferAddress,
         size: wgt::BufferSize,
-    );
+    ) -> Option<()>;
     fn queue_create_staging_buffer(
         &self,
         queue: &Self::QueueId,
         size: BufferSize,
-    ) -> QueueWriteBuffer;
+    ) -> Option<QueueWriteBuffer>;
     fn queue_write_staging_buffer(
         &self,
         queue: &Self::QueueId,
@@ -3656,15 +3656,15 @@ impl Queue {
         buffer: &'a Buffer,
         offset: BufferAddress,
         size: BufferSize,
-    ) -> QueueWriteBufferView<'a> {
-        Context::queue_validate_write_buffer(&*self.context, &self.id, &buffer.id, offset, size);
-        let staging_buffer = Context::queue_create_staging_buffer(&*self.context, &self.id, size);
-        QueueWriteBufferView {
+    ) -> Option<QueueWriteBufferView<'a>> {
+        Context::queue_validate_write_buffer(&*self.context, &self.id, &buffer.id, offset, size)?;
+        let staging_buffer = Context::queue_create_staging_buffer(&*self.context, &self.id, size)?;
+        Some(QueueWriteBufferView {
             queue: self,
             buffer,
             offset,
             inner: staging_buffer,
-        }
+        })
     }
 
     /// Schedule a write of some data into a texture.

--- a/wgpu/tests/buffer_copy.rs
+++ b/wgpu/tests/buffer_copy.rs
@@ -1,21 +1,20 @@
 //! Tests for buffer copy validation.
 
+use wasm_bindgen_test::wasm_bindgen_test;
 use wgt::BufferAddress;
 
-use crate::common::{initialize_test, TestParameters};
+use crate::common::{fail_if, initialize_test, TestParameters};
 
 #[test]
+#[wasm_bindgen_test]
 fn copy_alignment() {
-    fn try_copy(offset: BufferAddress, size: BufferAddress, should_panic: bool) {
-        let mut parameters = TestParameters::default();
-        if should_panic {
-            parameters = parameters.failure();
-        }
-
-        initialize_test(parameters, |ctx| {
+    fn try_copy(offset: BufferAddress, size: BufferAddress, should_fail: bool) {
+        initialize_test(TestParameters::default(), |ctx| {
             let buffer = ctx.device.create_buffer(&BUFFER_DESCRIPTOR);
             let data = vec![255; size as usize];
-            ctx.queue.write_buffer(&buffer, offset, &data);
+            fail_if(&ctx.device, should_fail, || {
+                ctx.queue.write_buffer(&buffer, offset, &data)
+            });
         });
     }
 

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -307,9 +307,12 @@ fn clear_texture_tests(
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn clear_texture_2d_uncompressed() {
     initialize_test(
-        TestParameters::default().features(wgpu::Features::CLEAR_TEXTURE),
+        TestParameters::default()
+            .webgl2_failure()
+            .features(wgpu::Features::CLEAR_TEXTURE),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_UNCOMPRESSED, true, true);
             clear_texture_tests(&ctx, TEXTURE_FORMATS_DEPTH, false, false);

--- a/wgpu/tests/common/image.rs
+++ b/wgpu/tests/common/image.rs
@@ -1,7 +1,6 @@
 use std::{
     ffi::{OsStr, OsString},
-    fs::File,
-    io::{BufWriter, Cursor},
+    io,
     path::Path,
     str::FromStr,
 };
@@ -18,7 +17,7 @@ fn read_png(path: impl AsRef<Path>, width: u32, height: u32) -> Option<Vec<u8>> 
             return None;
         }
     };
-    let decoder = png::Decoder::new(Cursor::new(data));
+    let decoder = png::Decoder::new(io::Cursor::new(data));
     let mut reader = decoder.read_info().ok()?;
 
     let mut buffer = vec![0; reader.output_buffer_size()];
@@ -43,6 +42,7 @@ fn read_png(path: impl AsRef<Path>, width: u32, height: u32) -> Option<Vec<u8>> 
     Some(buffer)
 }
 
+#[allow(unused_variables)]
 fn write_png(
     path: impl AsRef<Path>,
     width: u32,
@@ -50,15 +50,18 @@ fn write_png(
     data: &[u8],
     compression: png::Compression,
 ) {
-    let file = BufWriter::new(File::create(path).unwrap());
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let file = io::BufWriter::new(std::fs::File::create(path).unwrap());
 
-    let mut encoder = png::Encoder::new(file, width, height);
-    encoder.set_color(png::ColorType::Rgba);
-    encoder.set_depth(png::BitDepth::Eight);
-    encoder.set_compression(compression);
-    let mut writer = encoder.write_header().unwrap();
+        let mut encoder = png::Encoder::new(file, width, height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        encoder.set_compression(compression);
+        let mut writer = encoder.write_header().unwrap();
 
-    writer.write_image_data(data).unwrap();
+        writer.write_image_data(data).unwrap();
+    }
 }
 
 fn calc_difference(lhs: u8, rhs: u8) -> u8 {

--- a/wgpu/tests/zero_init_texture_after_discard.rs
+++ b/wgpu/tests/zero_init_texture_after_discard.rs
@@ -7,7 +7,7 @@ use wasm_bindgen_test::*;
 #[test]
 #[wasm_bindgen_test]
 fn discarding_color_target_resets_texture_init_state_check_visible_on_copy_after_submit() {
-    initialize_test(TestParameters::default(), |ctx| {
+    initialize_test(TestParameters::default().webgl2_failure(), |ctx| {
         let (texture, readback_buffer) =
             create_white_texture_and_readback_buffer(&ctx, wgpu::TextureFormat::Rgba8UnormSrgb);
         {
@@ -43,7 +43,7 @@ fn discarding_color_target_resets_texture_init_state_check_visible_on_copy_after
 #[test]
 #[wasm_bindgen_test]
 fn discarding_color_target_resets_texture_init_state_check_visible_on_copy_in_same_encoder() {
-    initialize_test(TestParameters::default(), |ctx| {
+    initialize_test(TestParameters::default().webgl2_failure(), |ctx| {
         let (texture, readback_buffer) =
             create_white_texture_and_readback_buffer(&ctx, wgpu::TextureFormat::Rgba8UnormSrgb);
         {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Helps with https://github.com/gfx-rs/wgpu/issues/3282

**Description**



**Testing**
_Explain how this change is tested._
