### PR TITLE
Small typo fix in `TextureViewDescriptor` docs

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -551,9 +551,9 @@ pub struct TextureViewDescriptor<'a> {
     pub format: Option<wgt::TextureFormat>,
     /// The dimension of the texture view.
     ///
-    /// - For 1D textures, this must be `1D`.
+    /// - For 1D textures, this must be `D1`.
     /// - For 2D textures it must be one of `D2`, `D2Array`, `Cube`, or `CubeArray`.
-    /// - For 3D textures it must be `3D`.
+    /// - For 3D textures it must be `D3`.
     pub dimension: Option<wgt::TextureViewDimension>,
     /// Range within the texture that is accessible via this view.
     pub range: wgt::ImageSubresourceRange,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1364,8 +1364,8 @@ pub struct TextureViewDescriptor<'a> {
     pub label: Label<'a>,
     /// Format of the texture view. At this time, it must be the same as the underlying format of the texture.
     pub format: Option<TextureFormat>,
-    /// The dimension of the texture view. For 1D textures, this must be `1D`. For 2D textures it must be one of
-    /// `D2`, `D2Array`, `Cube`, and `CubeArray`. For 3D textures it must be `3D`
+    /// The dimension of the texture view. For 1D textures, this must be `D1`. For 2D textures it must be one of
+    /// `D2`, `D2Array`, `Cube`, and `CubeArray`. For 3D textures it must be `D3`
     pub dimension: Option<TextureViewDimension>,
     /// Aspect of the texture. Color textures must be [`TextureAspect::All`].
     pub aspect: TextureAspect,


### PR DESCRIPTION
**Checklist**

- [ ] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Fixed a small docs typo I noticed.
