### PR TITLE
Add blit shader comment

### DIFF
--- a/wgpu/examples/mipmap/blit.wgsl
+++ b/wgpu/examples/mipmap/blit.wgsl
@@ -3,6 +3,24 @@ struct VertexOutput {
     @location(0) tex_coords: vec2<f32>,
 };
 
+// meant to be called with 3 vertex indices: 0, 1, 2
+// draws one large triangle over the clip space like this:
+// (the asterisks represent the clip space bounds)
+//-1,1           1,1
+// ---------------------------------
+// |              *              .
+// |              *           .
+// |              *        .
+// |              *      .
+// |              *    . 
+// |              * .
+// |***************
+// |            . 1,-1 
+// |          .
+// |       .
+// |     .
+// |   .
+// |.
 @vertex
 fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     var result: VertexOutput;


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
This is just a little comment I added on this same shader when I copied it into my project, I figured it might be helpful for others to explain how the vertex shader works. I know that comments generally become outdated over time so I'd understand if this isn't wanted in the project.

**Testing**
Tested locally
