### PR TITLE
Resolve Rust 1.66 `clippy` lints

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -5252,8 +5252,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let num_frames = present::DESIRED_NUM_FRAMES
-                .max(*caps.swap_chain_sizes.start())
-                .min(*caps.swap_chain_sizes.end());
+                .clamp(*caps.swap_chain_sizes.start(), *caps.swap_chain_sizes.end());
             let mut hal_config = hal::SurfaceConfiguration {
                 swap_chain_size: num_frames,
                 present_mode: config.present_mode,

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -124,9 +124,10 @@ impl<A: hal::Api> Example<A> {
 
         let window_size: (u32, u32) = window.inner_size().into();
         let surface_config = hal::SurfaceConfiguration {
-            swap_chain_size: DESIRED_FRAMES
-                .max(*surface_caps.swap_chain_sizes.start())
-                .min(*surface_caps.swap_chain_sizes.end()),
+            swap_chain_size: DESIRED_FRAMES.clamp(
+                *surface_caps.swap_chain_sizes.start(),
+                *surface_caps.swap_chain_sizes.end(),
+            ),
             present_mode: wgt::PresentMode::Fifo,
             composite_alpha_mode: wgt::CompositeAlphaMode::Opaque,
             format: wgt::TextureFormat::Bgra8UnormSrgb,

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -322,7 +322,7 @@ impl framework::Example for Skybox {
             queue,
             &wgpu::TextureDescriptor {
                 size,
-                mip_level_count: max_mips as u32,
+                mip_level_count: max_mips,
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: skybox_format,

--- a/wgpu/src/util/device.rs
+++ b/wgpu/src/util/device.rs
@@ -117,7 +117,7 @@ impl DeviceExt for crate::Device {
                 queue.write_texture(
                     crate::ImageCopyTexture {
                         texture: &texture,
-                        mip_level: mip as u32,
+                        mip_level: mip,
                         origin: crate::Origin3d {
                             x: 0,
                             y: 0,

--- a/wgpu/tests/common/image.rs
+++ b/wgpu/tests/common/image.rs
@@ -124,7 +124,7 @@ pub fn compare_image_output(
 
             write_png(actual_path, width, height, data, png::Compression::Fast);
             write_png(
-                &difference_path,
+                difference_path,
                 width,
                 height,
                 &difference_data,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] ~Add change to CHANGELOG.md. See simple instructions inside file.~ Didn't do this, pretty sure it doesn't matter for this.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
