### PR TITLE
deref/deref_mut methods on buffer-views inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 - Combine `Surface::get_supported_formats`, `Surface::get_supported_present_modes`, and `Surface::get_supported_alpha_modes` into `Surface::get_capabilities` and `SurfaceCapabilities`. By @cwfitzgerald in [#3157](https://github.com/gfx-rs/wgpu/pull/3157)
 - Make `Surface::get_default_config` return an Option to prevent panics. By @cwfitzgerald in [#3157](https://github.com/gfx-rs/wgpu/pull/3157)
 - Lower the `max_buffer_size` limit value for compatibility with Apple2 and WebGPU compliance. By @jinleili in [#3255](https://github.com/gfx-rs/wgpu/pull/3255)
+- Dereferencing a buffer view is now marked inline. By @Wumpf in [#3307](https://github.com/gfx-rs/wgpu/pull/3307)
 
 #### WebGPU
 

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -2501,6 +2501,7 @@ impl std::ops::Deref for QueueWriteBuffer {
 }
 
 impl std::ops::DerefMut for QueueWriteBuffer {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         use crate::BufferMappedRangeSlice;
         self.mapping.slice_mut()
@@ -2517,10 +2518,12 @@ unsafe impl Send for BufferMappedRange {}
 unsafe impl Sync for BufferMappedRange {}
 
 impl crate::BufferMappedRangeSlice for BufferMappedRange {
+    #[inline]
     fn slice(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.ptr, self.size) }
     }
 
+    #[inline]
     fn slice_mut(&mut self) -> &mut [u8] {
         unsafe { slice::from_raw_parts_mut(self.ptr, self.size) }
     }

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -2530,6 +2530,7 @@ impl std::ops::Deref for QueueWriteBuffer {
 }
 
 impl std::ops::DerefMut for QueueWriteBuffer {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -2542,10 +2543,12 @@ pub struct BufferMappedRange {
 }
 
 impl crate::BufferMappedRangeSlice for BufferMappedRange {
+    #[inline]
     fn slice(&self) -> &[u8] {
         &self.temporary_mapping
     }
 
+    #[inline]
     fn slice_mut(&mut self) -> &mut [u8] {
         &mut self.temporary_mapping
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2508,6 +2508,7 @@ pub struct BufferViewMut<'a> {
 impl std::ops::Deref for BufferView<'_> {
     type Target = [u8];
 
+    #[inline]
     fn deref(&self) -> &[u8] {
         self.data.slice()
     }
@@ -2516,6 +2517,7 @@ impl std::ops::Deref for BufferView<'_> {
 impl std::ops::Deref for BufferViewMut<'_> {
     type Target = [u8];
 
+    #[inline]
     fn deref(&self) -> &[u8] {
         assert!(
             self.readable,
@@ -2527,18 +2529,21 @@ impl std::ops::Deref for BufferViewMut<'_> {
 }
 
 impl std::ops::DerefMut for BufferViewMut<'_> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.data.slice_mut()
     }
 }
 
 impl AsRef<[u8]> for BufferView<'_> {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         self.data.slice()
     }
 }
 
 impl AsMut<[u8]> for BufferViewMut<'_> {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         self.data.slice_mut()
     }
@@ -3608,6 +3613,7 @@ impl<'a> std::ops::Deref for QueueWriteBufferView<'a> {
 }
 
 impl<'a> std::ops::DerefMut for QueueWriteBufferView<'a> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
n/a

**Description**
If no link time optimizations are enabled, each access to a buffer view incurs an opaque function call. When iterating over bytes directly on the mapped buffer, this can be a significant overhead!

**Testing**
it compiles ;)