### PR TITLE
Fix documentation comments for Rust 1.66.

### DIFF
--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -814,7 +814,7 @@ enum TextureStateProvider<'a> {
     TextureSet { set: &'a TextureStateSet },
 }
 impl<'a> TextureStateProvider<'a> {
-    /// Convenience function turning Option<Selector> into this enum.
+    /// Convenience function turning `Option<Selector>` into this enum.
     fn from_option(selector: Option<TextureSelector>, state: TextureUses) -> Self {
         match selector {
             Some(selector) => Self::Selector { selector, state },


### PR DESCRIPTION
Somewhere after 1.64 but by 1.66, `rustdoc` started checking for unmatched HTML tags in doc strings, meaning that text like

    /// Convenience function turning Option<Selector> into this enum.

causes problems, since `rustdoc` will pass through `<Selector>` as HTML tag, which browsers displaying the output will misunderstand.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- (unnecessary) Add change to CHANGELOG.md. See simple instructions inside file.
