### PR TITLE
[dxgi] fix `depth16Unorm` formats for nodepth and typeless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,10 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 
 - Update ash to 0.37.1+1.3.235 to fix CI breaking by changing a call to the deprecated `debug_utils_set_object_name()` function to `set_debug_utils_object_name()` by @elabajaba in [#3273](https://github.com/gfx-rs/wgpu/pull/3273)
 
+#### DX12
+
+- Fix `depth16Unorm` formats by @teoxoy in [#3313](https://github.com/gfx-rs/wgpu/pull/3313)
+
 ### Examples
 
 - Log adapter info in hello example on wasm target by @JolifantoBambla in [#2858](https://github.com/gfx-rs/wgpu/pull/2858)

--- a/wgpu-hal/src/auxil/dxgi/conv.rs
+++ b/wgpu-hal/src/auxil/dxgi/conv.rs
@@ -47,7 +47,7 @@ pub fn map_texture_format_failable(format: wgt::TextureFormat) -> Option<dxgifor
         Tf::Rgba32Uint => DXGI_FORMAT_R32G32B32A32_UINT,
         Tf::Rgba32Sint => DXGI_FORMAT_R32G32B32A32_SINT,
         Tf::Rgba32Float => DXGI_FORMAT_R32G32B32A32_FLOAT,
-        //Tf::Stencil8 => DXGI_FORMAT_R8_UNORM,
+        // Tf::Stencil8 => DXGI_FORMAT_D24_UNORM_S8_UINT,
         Tf::Depth16Unorm => DXGI_FORMAT_D16_UNORM,
         Tf::Depth24Plus => DXGI_FORMAT_D24_UNORM_S8_UINT,
         Tf::Depth24PlusStencil8 => DXGI_FORMAT_D24_UNORM_S8_UINT,
@@ -101,12 +101,10 @@ pub fn map_texture_format_nosrgb(format: wgt::TextureFormat) -> dxgiformat::DXGI
     }
 }
 
-//Note: SRV and UAV can't use the depth formats directly
-//TODO: stencil views?
+// Note: SRV and UAV can't use the depth formats directly
 pub fn map_texture_format_nodepth(format: wgt::TextureFormat) -> dxgiformat::DXGI_FORMAT {
     match format {
-        //wgt::TextureFormat::Stencil8 => dxgiformat::DXGI_FORMAT_R8_UNORM,
-        wgt::TextureFormat::Depth16Unorm => dxgiformat::DXGI_FORMAT_D16_UNORM,
+        wgt::TextureFormat::Depth16Unorm => dxgiformat::DXGI_FORMAT_R16_UNORM,
         wgt::TextureFormat::Depth32Float => dxgiformat::DXGI_FORMAT_R32_FLOAT,
         wgt::TextureFormat::Depth32FloatStencil8 => {
             dxgiformat::DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS
@@ -126,8 +124,7 @@ pub fn map_texture_format_nodepth(format: wgt::TextureFormat) -> dxgiformat::DXG
 
 pub fn map_texture_format_depth_typeless(format: wgt::TextureFormat) -> dxgiformat::DXGI_FORMAT {
     match format {
-        //wgt::TextureFormat::Stencil8 => dxgiformat::DXGI_FORMAT_R8_UNORM,
-        wgt::TextureFormat::Depth16Unorm => dxgiformat::DXGI_FORMAT_D16_UNORM,
+        wgt::TextureFormat::Depth16Unorm => dxgiformat::DXGI_FORMAT_R16_TYPELESS,
         wgt::TextureFormat::Depth32Float => dxgiformat::DXGI_FORMAT_R32_TYPELESS,
         wgt::TextureFormat::Depth32FloatStencil8 => dxgiformat::DXGI_FORMAT_R32G8X24_TYPELESS,
         wgt::TextureFormat::Depth24Plus | wgt::TextureFormat::Depth24PlusStencil8 => {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**


**Description**
We were using the wrong formats for `depth16Unorm`.
Also updated the commented `stencil8` format since [`DXGI_FORMAT_R8_UNORM`](https://github.com/MicrosoftDocs/win32/blob/63f1e8026b3be57072a3918d87b2d06992b28af6/desktop-src/direct3ddxgi/format-support-for-direct3d-11-0-feature-level-hardware.md?plain=1#L3216) doesn't support being a "Depth/Stencil Target" but [`DXGI_FORMAT_D24_UNORM_S8_UINT`](https://github.com/MicrosoftDocs/win32/blob/63f1e8026b3be57072a3918d87b2d06992b28af6/desktop-src/direct3ddxgi/format-support-for-direct3d-11-0-feature-level-hardware.md?plain=1#L2400) does.

**Testing**

