### PR TITLE
Sync depth/stencil copy restrictions with the spec

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -8,23 +8,27 @@ pub fn is_power_of_two_u32(val: u32) -> bool {
     val != 0 && (val & (val - 1)) == 0
 }
 
-pub fn is_valid_copy_src_texture_format(format: wgt::TextureFormat) -> bool {
+pub fn is_valid_copy_src_texture_format(
+    format: wgt::TextureFormat,
+    aspect: wgt::TextureAspect,
+) -> bool {
+    use wgt::TextureAspect as Ta;
     use wgt::TextureFormat as Tf;
-    match format {
-        Tf::Depth24Plus | Tf::Depth24PlusStencil8 => false,
+    match (format, aspect) {
+        (Tf::Depth24Plus, _) | (Tf::Depth24PlusStencil8, Ta::DepthOnly) => false,
         _ => true,
     }
 }
 
-pub fn is_valid_copy_dst_texture_format(format: wgt::TextureFormat) -> bool {
+pub fn is_valid_copy_dst_texture_format(
+    format: wgt::TextureFormat,
+    aspect: wgt::TextureAspect,
+) -> bool {
+    use wgt::TextureAspect as Ta;
     use wgt::TextureFormat as Tf;
-    match format {
-        //Tf::Stencil8 |
-        Tf::Depth16Unorm
-        | Tf::Depth32Float
-        | Tf::Depth32FloatStencil8
-        | Tf::Depth24Plus
-        | Tf::Depth24PlusStencil8 => false,
+    match (format, aspect) {
+        (Tf::Depth24Plus | Tf::Depth32Float, _)
+        | (Tf::Depth24PlusStencil8 | Tf::Depth32FloatStencil8, Ta::DepthOnly) => false,
         _ => true,
     }
 }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -624,8 +624,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             false,
         )?;
 
-        if !conv::is_valid_copy_dst_texture_format(texture_format) {
-            return Err(TransferError::CopyToForbiddenTextureFormat(texture_format).into());
+        if !conv::is_valid_copy_dst_texture_format(texture_format, destination.aspect) {
+            return Err(TransferError::CopyToForbiddenTextureFormat {
+                format: texture_format,
+                aspect: destination.aspect,
+            }
+            .into());
         }
         let (block_width, block_height) = format_desc.block_dimensions;
         let width_blocks = size.width / block_width as u32;


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**


**Description**
- allow stencil-only `depth24plus-stencil8` to be a copy source
- allow `depth16unorm` to be a copy destination
- allow stencil-only `depth24plus-stencil8` and `depth32float-stencil8` to be copy destinations

see https://gpuweb.github.io/gpuweb/#depth-formats

**Testing**

