### PR TITLE
Add missing `DEPTH_BIAS_CLAMP` and `FULL_DRAW_INDEX_UINT32` downlevel flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 - Lower the `max_buffer_size` limit value for compatibility with Apple2 and WebGPU compliance. By @jinleili in [#3255](https://github.com/gfx-rs/wgpu/pull/3255)
 - Dereferencing a buffer view is now marked inline. By @Wumpf in [#3307](https://github.com/gfx-rs/wgpu/pull/3307)
 - The `strict_assert` family of macros was moved to `wgpu-types`. By @i509VCB in [#3051](https://github.com/gfx-rs/wgpu/pull/3051)
+- Add missing `DEPTH_BIAS_CLAMP` and `FULL_DRAW_INDEX_UINT32` downlevel flags. By @teoxoy in [#3316](https://github.com/gfx-rs/wgpu/pull/3316)
 
 #### WebGPU
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2738,6 +2738,15 @@ impl<A: HalApi> Device<A> {
             if let Some(e) = error {
                 return Err(pipeline::CreateRenderPipelineError::DepthStencilState(e));
             }
+
+            if ds.bias.clamp != 0.0
+                && !self
+                    .shared
+                    .downlevel_flags
+                    .contains(wgt::DownlevelFlags::DEPTH_BIAS_CLAMP)
+            {
+                return Err(MissingDownlevelFlags(wgt::DownlevelFlags::DEPTH_BIAS_CLAMP).into());
+            }
         }
 
         if desc.layout.is_none() {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2739,13 +2739,8 @@ impl<A: HalApi> Device<A> {
                 return Err(pipeline::CreateRenderPipelineError::DepthStencilState(e));
             }
 
-            if ds.bias.clamp != 0.0
-                && !self
-                    .shared
-                    .downlevel_flags
-                    .contains(wgt::DownlevelFlags::DEPTH_BIAS_CLAMP)
-            {
-                return Err(MissingDownlevelFlags(wgt::DownlevelFlags::DEPTH_BIAS_CLAMP).into());
+            if ds.bias.clamp != 0.0 {
+                self.require_downlevel_flags(wgt::DownlevelFlags::DEPTH_BIAS_CLAMP)?;
             }
         }
 

--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -110,6 +110,8 @@ impl super::Adapter {
             downlevel |= wgt::DownlevelFlags::INDEPENDENT_BLEND;
             // formally FL9_1 supports aniso 2, but we don't support that level of distinction
             downlevel |= wgt::DownlevelFlags::ANISOTROPIC_FILTERING;
+            // this is actually the first FL that supports u32 at all
+            downlevel |= wgt::DownlevelFlags::FULL_DRAW_INDEX_UINT32;
         }
 
         if feature_level >= FL9_3 {
@@ -120,6 +122,7 @@ impl super::Adapter {
             downlevel |= wgt::DownlevelFlags::INDEPENDENT_BLEND;
             downlevel |= wgt::DownlevelFlags::FRAGMENT_STORAGE;
             downlevel |= wgt::DownlevelFlags::FRAGMENT_WRITABLE_STORAGE;
+            downlevel |= wgt::DownlevelFlags::DEPTH_BIAS_CLAMP;
             features |= wgt::Features::DEPTH_CLIP_CONTROL;
             features |= wgt::Features::TIMESTAMP_QUERY;
             features |= wgt::Features::PIPELINE_STATISTICS_QUERY;

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -255,6 +255,7 @@ impl super::Adapter {
         } else {
             0
         };
+        let max_element_index = unsafe { gl.get_parameter_i32(glow::MAX_ELEMENT_INDEX) } as u32;
 
         // WORKAROUND: In order to work around an issue with GL on RPI4 and similar, we ignore a
         // zero vertex ssbo count if there are vertex sstos. (more info:
@@ -315,6 +316,10 @@ impl super::Adapter {
         downlevel_flags.set(
             wgt::DownlevelFlags::UNRESTRICTED_INDEX_BUFFER,
             !cfg!(target_arch = "wasm32"),
+        );
+        downlevel_flags.set(
+            wgt::DownlevelFlags::FULL_DRAW_INDEX_UINT32,
+            max_element_index == u32::MAX,
         );
 
         let mut features = wgt::Features::empty()

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -316,7 +316,18 @@ impl PhysicalDeviceFeatures {
             | F::WRITE_TIMESTAMP_INSIDE_PASSES
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | F::CLEAR_TEXTURE;
-        let mut dl_flags = Df::all();
+
+        let mut dl_flags = Df::COMPUTE_SHADERS
+            | Df::BASE_VERTEX
+            | Df::READ_ONLY_DEPTH_STENCIL
+            | Df::NON_POWER_OF_TWO_MIPMAPPED_TEXTURES
+            | Df::COMPARISON_SAMPLERS
+            | Df::VERTEX_STORAGE
+            | Df::FRAGMENT_STORAGE
+            | Df::DEPTH_TEXTURE_AND_BUFFER_COPIES
+            | Df::WEBGPU_TEXTURE_FORMAT_SUPPORT
+            | Df::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED
+            | Df::UNRESTRICTED_INDEX_BUFFER;
 
         dl_flags.set(Df::CUBE_ARRAY_TEXTURES, self.core.image_cube_array != 0);
         dl_flags.set(Df::ANISOTROPIC_FILTERING, self.core.sampler_anisotropy != 0);
@@ -326,6 +337,11 @@ impl PhysicalDeviceFeatures {
         );
         dl_flags.set(Df::MULTISAMPLED_SHADING, self.core.sample_rate_shading != 0);
         dl_flags.set(Df::INDEPENDENT_BLEND, self.core.independent_blend != 0);
+        dl_flags.set(
+            Df::FULL_DRAW_INDEX_UINT32,
+            self.core.full_draw_index_uint32 != 0,
+        );
+        dl_flags.set(Df::DEPTH_BIAS_CLAMP, self.core.depth_bias_clamp != 0);
 
         features.set(
             F::INDIRECT_FIRST_INSTANCE,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1129,6 +1129,16 @@ bitflags::bitflags! {
         ///
         /// WebGL doesn't support this.
         const UNRESTRICTED_INDEX_BUFFER = 1 << 16;
+
+        /// Supports full 32-bit range indices (2^32-1 as opposed to 2^24-1 without this flag)
+        ///
+        /// Corresponds to Vulkan's `VkPhysicalDeviceFeatures.fullDrawIndexUint32`
+        const FULL_DRAW_INDEX_UINT32 = 1 << 17;
+
+        /// Supports depth bias clamping
+        ///
+        /// Corresponds to Vulkan's `VkPhysicalDeviceFeatures.depthBiasClamp`
+        const DEPTH_BIAS_CLAMP = 1 << 18;
     }
 }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

**Description**
Added missing Vulkan/GLES downlevel flags.
Do note that we don't validate `FULL_DRAW_INDEX_UINT32` because we'd have to go through all values in the index buffers and check them.

**Testing**

