### PR TITLE
Fix texture view creation with full-resource views when using an explicit `mip_level_count` or `array_layer_count`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
         run: |
           set -e
 
-          cargo test --doc
+          cargo test --doc -p wgpu -p wgpu-core -p wgpu-hal -p wgpu-types
 
   fmt:
     name: Format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,9 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 - Evaluate `gfx_select!`'s `#[cfg]` conditions at the right time. By @jimblandy in [#3253](https://github.com/gfx-rs/wgpu/pull/3253)
 - Improve error messages when binding bind group with dynamic offsets. By @cwfitzgerald in [#3294](https://github.com/gfx-rs/wgpu/pull/3294)
 
+#### Metal
+- Fix texture view creation with full-resource views when using an explicit `mip_level_count` or `array_layer_count`. By @cwfitzgerald in [#3323](https://github.com/gfx-rs/wgpu/pull/3323)
+
 #### WebGPU
 
 - Use `log` instead of `println` in hello example by @JolifantoBambla in [#2858](https://github.com/gfx-rs/wgpu/pull/2858)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
     "run-wasm"
 ]
 exclude = []
-default-members = ["wgpu", "wgpu-hal", "wgpu-info"]
+default-members = ["wgpu", "wgpu-hal", "wgpu-info", "wgpu-types"]
 
 [workspace.package]
 edition = "2021"

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -81,7 +81,7 @@ This allows us to compose the operations to form the various kinds of tracker me
 that need to happen in the codebase. For each resource in the given merger, the following
 operation applies:
 
-```
+```text
 UsageScope <- Resource = insert(scope, usage) OR merge(scope, usage)
 UsageScope <- UsageScope = insert(scope, scope) OR merge(scope, scope)
 CommandBuffer <- UsageScope = insert(buffer.start, buffer.end, scope)

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -358,12 +358,13 @@ impl crate::Device<super::Api> for super::Device {
             conv::map_texture_view_dimension(desc.dimension)
         };
 
-        //Note: this doesn't check properly if the mipmap level count or array layer count
-        // is explicitly set to 1.
-        let raw = if raw_format == texture.raw_format
-            && raw_type == texture.raw_type
-            && desc.range == wgt::ImageSubresourceRange::default()
-        {
+        let format_equal = raw_format == texture.raw_format;
+        let type_equal = raw_type == texture.raw_type;
+        let range_full_resource = desc
+            .range
+            .is_full_resource(texture.mip_levels, texture.array_layers);
+
+        let raw = if format_equal && type_equal && range_full_resource {
             // Some images are marked as framebuffer-only, and we can't create aliases of them.
             // Also helps working around Metal bugs with aliased array textures.
             texture.raw.to_owned()

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -25,4 +25,5 @@ bitflags = "1"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 
 [dev-dependencies]
+serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1.0.85"

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -9,7 +9,7 @@
 )]
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 
-#[cfg(feature = "serde")]
+#[cfg(any(feature = "serde", test))]
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 use std::{num::NonZeroU32, ops::Range};
@@ -2103,7 +2103,7 @@ pub enum TextureFormat {
     },
 }
 
-#[cfg(feature = "serde")]
+#[cfg(any(feature = "serde", test))]
 impl<'de> Deserialize<'de> for TextureFormat {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -2239,7 +2239,7 @@ impl<'de> Deserialize<'de> for TextureFormat {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(any(feature = "serde", test))]
 impl Serialize for TextureFormat {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**

Two standalone commits:
- Make doctests and tests run wgpu-types' tests.
- Fix issue where explicitly spelled out full-resource views would not work correctly, causing metal validation to get mad when the surface texture was used this way.

**Testing**

Tested against rend3, and with explicit doctests.
