### PR TITLE
added texture metadata

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -228,14 +228,7 @@ pub struct Texture {
     id: ObjectId,
     data: Box<Data>,
     owned: bool,
-    width: u32,
-    height: u32,
-    depth_or_array_layers: u32,
-    mip_level_count: u32,
-    sample_count: u32,
-    dimension: TextureDimension,
-    format: TextureFormat,
-    usage: TextureUsages,
+    descriptor: TextureDescriptor<'static>,
 }
 static_assertions::assert_impl_all!(Texture: Send, Sync);
 
@@ -291,6 +284,7 @@ pub struct Surface {
     context: Arc<C>,
     id: ObjectId,
     data: Box<Data>,
+    // config: SurfaceConfiguration,
 }
 static_assertions::assert_impl_all!(Surface: Send, Sync);
 
@@ -2047,14 +2041,10 @@ impl Device {
             id,
             data,
             owned: true,
-            width: desc.size.width,
-            height: desc.size.height,
-            depth_or_array_layers: desc.size.depth_or_array_layers,
-            mip_level_count: desc.mip_level_count,
-            sample_count: desc.sample_count,
-            dimension: desc.dimension,
-            format: desc.format,
-            usage: desc.usage,
+            descriptor: TextureDescriptor {
+                label: None,
+                ..desc.clone()
+            },
         }
     }
 
@@ -2087,14 +2077,10 @@ impl Device {
             id: ObjectId::from(texture.id()),
             data: Box::new(texture),
             owned: true,
-            width: desc.size.width,
-            height: desc.size.height,
-            depth_or_array_layers: desc.size.depth_or_array_layers,
-            mip_level_count: desc.mip_level_count,
-            sample_count: desc.sample_count,
-            dimension: desc.dimension,
-            format: desc.format,
-            usage: desc.usage,
+            descriptor: TextureDescriptor {
+                label: None,
+                ..desc.clone()
+            },
         }
     }
 
@@ -2548,60 +2534,67 @@ impl Texture {
         }
     }
 
+    /// Returns the size of this `Texture`.
+    ///
+    /// This is always equal to the `size` that was specified when creating the texture.
+    pub fn size(&self) -> Extent3d {
+        self.descriptor.size
+    }
+
     /// Returns the width of this `Texture`.
     ///
     /// This is always equal to the `size.width` that was specified when creating the texture.
     pub fn width(&self) -> u32 {
-        self.width
+        self.descriptor.size.width
     }
 
     /// Returns the height of this `Texture`.
     ///
     /// This is always equal to the `size.height` that was specified when creating the texture.
     pub fn height(&self) -> u32 {
-        self.height
+        self.descriptor.size.height
     }
 
     /// Returns the depth or layer count of this `Texture`.
     ///
     /// This is always equal to the `size.depth_or_array_layers` that was specified when creating the texture.
     pub fn depth_or_array_layers(&self) -> u32 {
-        self.depth_or_array_layers
+        self.descriptor.size.depth_or_array_layers
     }
 
     /// Returns the mip_level_count of this `Texture`.
     ///
     /// This is always equal to the `mip_level_count` that was specified when creating the texture.
     pub fn mip_level_count(&self) -> u32 {
-        self.mip_level_count
+        self.descriptor.mip_level_count
     }
 
     /// Returns the sample_count of this `Texture`.
     ///
     /// This is always equal to the `sample_count` that was specified when creating the texture.
     pub fn sample_count(&self) -> u32 {
-        self.sample_count
+        self.descriptor.sample_count
     }
 
     /// Returns the dimension of this `Texture`.
     ///
     /// This is always equal to the `dimension` that was specified when creating the texture.
     pub fn dimension(&self) -> TextureDimension {
-        self.dimension
+        self.descriptor.dimension
     }
 
     /// Returns the format of this `Texture`.
     ///
     /// This is always equal to the `format` that was specified when creating the texture.
     pub fn format(&self) -> TextureFormat {
-        self.format
+        self.descriptor.format
     }
 
     /// Returns the allowed usages of this `Texture`.
     ///
     /// This is always equal to the `usage` that was specified when creating the texture.
     pub fn usage(&self) -> TextureUsages {
-        self.usage
+        self.descriptor.usage
     }
 }
 
@@ -4074,15 +4067,21 @@ impl Surface {
 
                     // Todo: how do we specify these values correctly?
                     // they are part of the `SurfaceConfiguration`, which is not available here
-                    width: 0,
-                    height: 0,
-                    format: TextureFormat::R8Unorm,
-                    usage: TextureUsages::RENDER_ATTACHMENT,
+                    descriptor: TextureDescriptor {
+                        label: None,
+                        size: Extent3d {
+                            width: 0,
+                            height: 0,
+                            depth_or_array_layers: 1,
+                        },
 
-                    depth_or_array_layers: 1,
-                    mip_level_count: 1,
-                    sample_count: 1,
-                    dimension: TextureDimension::D2,
+                        format: TextureFormat::R8Unorm,
+                        usage: TextureUsages::RENDER_ATTACHMENT,
+
+                        mip_level_count: 1,
+                        sample_count: 1,
+                        dimension: TextureDimension::D2,
+                    },
                 },
                 suboptimal,
                 presented: false,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4070,9 +4070,9 @@ impl Surface {
             SurfaceStatus::Lost => return Err(SurfaceError::Lost),
         };
 
-        let config = self
-            .config
-            .lock()
+        let guard = self.config.lock();
+        let config = guard
+            .as_ref()
             .expect("This surface has not been configured yet.");
 
         let descriptor = TextureDescriptor {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -284,6 +284,12 @@ pub struct Surface {
     context: Arc<C>,
     id: ObjectId,
     data: Box<Data>,
+    // Stores the latest `SurfaceConfiguration` that was set using `Surface::configure`.
+    // It is required to set the attributes of the `SurfaceTexture` in the
+    // `Surface::get_current_texture` method.
+    // Because the `Surface::configure` method operates on an immutable reference this type has to
+    // be wrapped in a mutex and since the configuration is only supplied after the surface has
+    // been created is is additionally wrapped in an option.
     config: Mutex<Option<SurfaceConfiguration>>,
 }
 static_assertions::assert_impl_all!(Surface: Send, Sync);
@@ -1534,7 +1540,6 @@ impl Instance {
             id: ObjectId::from(surface),
             #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
             data: Box::new(()),
-            #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
             config: Mutex::new(None),
         })
     }
@@ -1571,7 +1576,6 @@ impl Instance {
             id: ObjectId::from(surface),
             #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
             data: Box::new(()),
-            #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
             config: Mutex::new(None),
         })
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -197,6 +197,7 @@ pub struct Buffer {
     map_context: Mutex<MapContext>,
     size: wgt::BufferAddress,
     usage: BufferUsages,
+    // Todo: missing map_state https://www.w3.org/TR/webgpu/#dom-gpubuffer-mapstate
 }
 static_assertions::assert_impl_all!(Buffer: Send, Sync);
 
@@ -227,6 +228,14 @@ pub struct Texture {
     id: ObjectId,
     data: Box<Data>,
     owned: bool,
+    width: u32,
+    height: u32,
+    depth_or_array_layers: u32,
+    mip_level_count: u32,
+    sample_count: u32,
+    dimension: TextureDimension,
+    format: TextureFormat,
+    usage: TextureUsages,
 }
 static_assertions::assert_impl_all!(Texture: Send, Sync);
 
@@ -2038,6 +2047,14 @@ impl Device {
             id,
             data,
             owned: true,
+            width: desc.size.width,
+            height: desc.size.height,
+            depth_or_array_layers: desc.size.depth_or_array_layers,
+            mip_level_count: desc.mip_level_count,
+            sample_count: desc.sample_count,
+            dimension: desc.dimension,
+            format: desc.format,
+            usage: desc.usage,
         }
     }
 
@@ -2070,6 +2087,14 @@ impl Device {
             id: ObjectId::from(texture.id()),
             data: Box::new(texture),
             owned: true,
+            width: desc.size.width,
+            height: desc.size.height,
+            depth_or_array_layers: desc.size.depth_or_array_layers,
+            mip_level_count: desc.mip_level_count,
+            sample_count: desc.sample_count,
+            dimension: desc.dimension,
+            format: desc.format,
+            usage: desc.usage,
         }
     }
 
@@ -2386,7 +2411,7 @@ impl Buffer {
     /// Returns the length of the buffer allocation in bytes.
     ///
     /// This is always equal to the `size` that was specified when creating the buffer.
-    pub fn size(&self) -> wgt::BufferAddress {
+    pub fn size(&self) -> BufferAddress {
         self.size
     }
 
@@ -2521,6 +2546,62 @@ impl Texture {
             origin: Origin3d::ZERO,
             aspect: TextureAspect::All,
         }
+    }
+
+    /// Returns the width of this `Texture`.
+    ///
+    /// This is always equal to the `size.width` that was specified when creating the texture.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Returns the height of this `Texture`.
+    ///
+    /// This is always equal to the `size.height` that was specified when creating the texture.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Returns the depth or layer count of this `Texture`.
+    ///
+    /// This is always equal to the `size.depth_or_array_layers` that was specified when creating the texture.
+    pub fn depth_or_array_layers(&self) -> u32 {
+        self.depth_or_array_layers
+    }
+
+    /// Returns the mip_level_count of this `Texture`.
+    ///
+    /// This is always equal to the `mip_level_count` that was specified when creating the texture.
+    pub fn mip_level_count(&self) -> u32 {
+        self.mip_level_count
+    }
+
+    /// Returns the sample_count of this `Texture`.
+    ///
+    /// This is always equal to the `sample_count` that was specified when creating the texture.
+    pub fn sample_count(&self) -> u32 {
+        self.sample_count
+    }
+
+    /// Returns the dimension of this `Texture`.
+    ///
+    /// This is always equal to the `dimension` that was specified when creating the texture.
+    pub fn dimension(&self) -> TextureDimension {
+        self.dimension
+    }
+
+    /// Returns the format of this `Texture`.
+    ///
+    /// This is always equal to the `format` that was specified when creating the texture.
+    pub fn format(&self) -> TextureFormat {
+        self.format
+    }
+
+    /// Returns the allowed usages of this `Texture`.
+    ///
+    /// This is always equal to the `usage` that was specified when creating the texture.
+    pub fn usage(&self) -> TextureUsages {
+        self.usage
     }
 }
 
@@ -3990,6 +4071,18 @@ impl Surface {
                     id,
                     data,
                     owned: false,
+
+                    // Todo: how do we specify these values correctly?
+                    // they are part of the `SurfaceConfiguration`, which is not available here
+                    width: 0,
+                    height: 0,
+                    format: TextureFormat::R8Unorm,
+                    usage: TextureUsages::RENDER_ATTACHMENT,
+
+                    depth_or_array_layers: 1,
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: TextureDimension::D2,
                 },
                 suboptimal,
                 presented: false,


### PR DESCRIPTION
**Description**

This PR exposes the metadata/attributes of a `Texture`, according to the WebGpu spec: https://www.w3.org/TR/webgpu/#gputexture.

This is a draft because I am unsure how to set those attributes for the `SurfaceTexture`s (see the Todo).
I would appreciate any guidance you can give me.