### PR TITLE
Make `ObjectId` structure and invariants idiomatic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 - Dereferencing a buffer view is now marked inline. By @Wumpf in [#3307](https://github.com/gfx-rs/wgpu/pull/3307)
 - The `strict_assert` family of macros was moved to `wgpu-types`. By @i509VCB in [#3051](https://github.com/gfx-rs/wgpu/pull/3051)
 - Add missing `DEPTH_BIAS_CLAMP` and `FULL_DRAW_INDEX_UINT32` downlevel flags. By @teoxoy in [#3316](https://github.com/gfx-rs/wgpu/pull/3316)
+- Make `ObjectId` structure and invariants idiomatic. By @teoxoy in [#3347](https://github.com/gfx-rs/wgpu/pull/3347)
 
 #### WebGPU
 

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -172,7 +172,6 @@ pub(crate) struct Valid<I>(pub I);
 /// need to construct `Id` values directly, or access their components, like the
 /// WGPU recording player, may use this trait to do so.
 pub trait TypedId: Copy {
-    fn as_raw(&self) -> NonZeroId;
     fn zip(index: Index, epoch: Epoch, backend: Backend) -> Self;
     fn unzip(self) -> (Index, Epoch, Backend);
     fn into_raw(self) -> NonZeroId;
@@ -180,10 +179,6 @@ pub trait TypedId: Copy {
 
 #[allow(trivial_numeric_casts)]
 impl<T> TypedId for Id<T> {
-    fn as_raw(&self) -> NonZeroId {
-        self.0
-    }
-
     fn zip(index: Index, epoch: Epoch, backend: Backend) -> Self {
         assert_eq!(0, epoch >> EPOCH_BITS);
         assert_eq!(0, (index as IdType) >> INDEX_BITS);

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -80,7 +80,7 @@ name = "stencil-triangles"
 test = true
 
 [features]
-default = ["wgsl", "expose-ids"]
+default = ["wgsl"]
 # Apply run-time checks, even in release builds. These are in addition
 # to the validation carried out at public APIs in all builds.
 strict_asserts = ["wgc?/strict_asserts", "wgt/strict_asserts"]

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -2885,22 +2885,21 @@ impl crate::Context for Context {
 }
 
 impl<T> From<ObjectId> for wgc::id::Id<T> {
-    // If the id32 feature is enabled, this conversion is not useless.
-    #[allow(clippy::useless_conversion)]
     fn from(id: ObjectId) -> Self {
-        let raw = std::num::NonZeroU128::from(id);
-        // If the id32 feature is enabled, this will truncate the id to a NonZeroU32.
-        let id = raw.try_into().expect("Id exceeded 32-bits");
-        // FIXME: This is not safe
+        // If the id32 feature is enabled in wgpu-core, this will make sure that the id fits in a NonZeroU32.
+        #[allow(clippy::useless_conversion)]
+        let id = id.id().try_into().expect("Id exceeded 32-bits");
+        // SAFETY: The id was created via the impl below
         unsafe { Self::from_raw(id) }
     }
 }
 
 impl<T> From<wgc::id::Id<T>> for ObjectId {
-    // If the id32 feature is enabled, this conversion is not useless.
-    #[allow(clippy::useless_conversion)]
     fn from(id: wgc::id::Id<T>) -> Self {
-        ObjectId::from(std::num::NonZeroU128::from(id.as_raw()))
+        // If the id32 feature is enabled in wgpu-core, the conversion is not useless
+        #[allow(clippy::useless_conversion)]
+        let id = id.into_raw().into();
+        Self::from_global_id(id)
     }
 }
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -6,7 +6,6 @@ use std::{
     cell::RefCell,
     fmt,
     future::Future,
-    num::NonZeroU128,
     ops::Range,
     pin::Pin,
     rc::Rc,
@@ -26,10 +25,11 @@ use crate::{
 fn create_identified<T>(value: T) -> Identified<T> {
     cfg_if::cfg_if! {
         if #[cfg(feature = "expose-ids")] {
-            static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-            Identified(value, NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
+            static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+            let id = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Identified(value, crate::Id(core::num::NonZeroU64::new(id).unwrap()))
         } else {
-            Identified(value, 0)
+            Identified(value)
         }
     }
 }
@@ -44,25 +44,30 @@ fn create_identified<T>(value: T) -> Identified<T> {
 
 impl<T: FromWasmAbi<Abi = u32> + JsCast> From<ObjectId> for Identified<T> {
     fn from(id: ObjectId) -> Self {
-        let raw = std::num::NonZeroU128::from(id);
-        let global_id = (raw.get() >> 64) as u64;
-
+        let id = id.id().get() as u32;
         // SAFETY: wasm_bindgen says an ABI representation may only be cast to a wrapper type if it was created
         // using into_abi.
         //
         // This assumption we sadly have to assume to prevent littering the code with unsafe blocks.
-        let wasm = unsafe { JsValue::from_abi(raw.get() as u32) };
+        let wasm = unsafe { JsValue::from_abi(id) };
         wgt::strict_assert!(wasm.is_instance_of::<T>());
         // SAFETY: The ABI of the type must be a u32, and strict asserts ensure the right type is used.
-        Self(wasm.unchecked_into(), global_id)
+        Self(
+            wasm.unchecked_into(),
+            #[cfg(feature = "expose-ids")]
+            id.global_id(),
+        )
     }
 }
 
 impl<T: IntoWasmAbi<Abi = u32>> From<Identified<T>> for ObjectId {
     fn from(id: Identified<T>) -> Self {
-        let abi = id.0.into_abi();
-        let id = abi as u128 | ((id.1 as u128) << 64);
-        Self::from(NonZeroU128::new(id).unwrap())
+        let id = core::num::NonZeroU64::new(id.0.into_abi() as u64).unwrap();
+        Self::new(
+            id,
+            #[cfg(feature = "expose-ids")]
+            id.1,
+        )
     }
 }
 
@@ -72,7 +77,7 @@ unsafe impl<T> Send for Sendable<T> {}
 unsafe impl<T> Sync for Sendable<T> {}
 
 #[derive(Clone, Debug)]
-pub(crate) struct Identified<T>(T, #[cfg(feature = "expose-ids")] u64);
+pub(crate) struct Identified<T>(T, #[cfg(feature = "expose-ids")] crate::Id);
 unsafe impl<T> Send for Identified<T> {}
 unsafe impl<T> Sync for Identified<T> {}
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4027,7 +4027,7 @@ impl Surface {
 #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Id(u64);
+pub struct Id(core::num::NonZeroU64);
 
 #[cfg(feature = "expose-ids")]
 impl Adapter {
@@ -4037,7 +4037,7 @@ impl Adapter {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4049,7 +4049,7 @@ impl Device {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4061,7 +4061,7 @@ impl Queue {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4073,7 +4073,7 @@ impl ShaderModule {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4085,7 +4085,7 @@ impl BindGroupLayout {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4097,7 +4097,7 @@ impl BindGroup {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4109,7 +4109,7 @@ impl TextureView {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4121,7 +4121,7 @@ impl Sampler {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4133,7 +4133,7 @@ impl Buffer {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4145,7 +4145,7 @@ impl Texture {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4157,7 +4157,7 @@ impl QuerySet {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4169,7 +4169,7 @@ impl PipelineLayout {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4181,7 +4181,7 @@ impl RenderPipeline {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4193,7 +4193,7 @@ impl ComputePipeline {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4205,7 +4205,7 @@ impl RenderBundle {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 
@@ -4217,7 +4217,7 @@ impl Surface {
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id {
-        Id(self.id.global_id())
+        self.id.global_id()
     }
 }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

**Description**
- disable the `expose-ids` feature by default (also fix compilation errors)
- make `ObjectId` structure and invariants idiomatic
- fix `global_id` always being 0 with the direct backend

**Testing**
