### PR TITLE
Update publish.yml workflow's wasm-bindgen version to 0.2.83.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version=0.2.81
+        run: cargo install wasm-bindgen-cli --version=0.2.83
 
       - name: Build WebGPU examples
         run: cargo build --release --target wasm32-unknown-unknown --examples


### PR DESCRIPTION
In order to update wgpu.rs, the version of wasm-bindgen specified in `.github/workflows/publish.yml` must exactly match that in the main `Cargo.lock` file. This is currently 0.2.83.
