### PR TITLE
Add validation in accordance with WebGPU `GPUSamplerDescriptor` valid…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 - The `strict_assert` family of macros was moved to `wgpu-types`. By @i509VCB in [#3051](https://github.com/gfx-rs/wgpu/pull/3051)
 - Add missing `DEPTH_BIAS_CLAMP` and `FULL_DRAW_INDEX_UINT32` downlevel flags. By @teoxoy in [#3316](https://github.com/gfx-rs/wgpu/pull/3316)
 - Make `ObjectId` structure and invariants idiomatic. By @teoxoy in [#3347](https://github.com/gfx-rs/wgpu/pull/3347)
+- Add validation in accordance with WebGPU `GPUSamplerDescriptor` valid usage for `lodMinClamp` and `lodMaxClamp`. By @James2022-rgb in [#3353](https://github.com/gfx-rs/wgpu/pull/3353)
 
 #### WebGPU
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1170,6 +1170,10 @@ impl<A: HalApi> Device<A> {
             self.require_features(wgt::Features::ADDRESS_MODE_CLAMP_TO_ZERO)?;
         }
 
+        if desc.lod_min_clamp < 0.0 || desc.lod_max_clamp < desc.lod_min_clamp {
+            return Err(resource::CreateSamplerError::InvalidLodClamp(desc.lod_min_clamp..desc.lod_max_clamp));
+        }
+
         let lod_clamp = if desc.lod_min_clamp > 0.0 || desc.lod_max_clamp < 32.0 {
             Some(desc.lod_min_clamp..desc.lod_max_clamp)
         } else {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1171,7 +1171,9 @@ impl<A: HalApi> Device<A> {
         }
 
         if desc.lod_min_clamp < 0.0 || desc.lod_max_clamp < desc.lod_min_clamp {
-            return Err(resource::CreateSamplerError::InvalidLodClamp(desc.lod_min_clamp..desc.lod_max_clamp));
+            return Err(resource::CreateSamplerError::InvalidLodClamp(
+                desc.lod_min_clamp..desc.lod_max_clamp,
+            ));
         }
 
         let lod_clamp = if desc.lod_min_clamp > 0.0 || desc.lod_max_clamp < 32.0 {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -701,6 +701,8 @@ pub struct Sampler<A: hal::Api> {
 pub enum CreateSamplerError {
     #[error(transparent)]
     Device(#[from] DeviceError),
+    #[error("invalid lod clamp lod_min_clamp:{} lod_max_clamp:{}, must satisfy lod_min_clamp >= 0 and lod_max_clamp >= lod_min_clamp ", .0.start, .0.end)]
+    InvalidLodClamp(Range<f32>),
     #[error("invalid anisotropic clamp {0}, must be one of 1, 2, 4, 8 or 16")]
     InvalidClamp(u8),
     #[error("cannot create any more samplers")]


### PR DESCRIPTION
… usage for `lodMinClamp` and `lodMaxClamp`.

`lodMinClamp` must not be negative, and `lodMaxClamp` must be >= `lodMinClamp`

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
       Done just in case, with `--feature gles`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
For `wgpu::SamplerDescriptor`, it was possible to use values for `lod_min_clamp` and `lod_max_clamp` such that:
- `lod_min_clamp` is negative
- `lod_max_clamp` < `lod_min_clamp`

both of which are in violation of the valid usage defined for `GPUSamplerDescriptor` in the WebGPU spec:
> descriptor.[lodMinClamp](https://gpuweb.github.io/gpuweb/#dom-gpusamplerdescriptor-lodminclamp) ≥ 0.
> descriptor.[lodMaxClamp](https://gpuweb.github.io/gpuweb/#dom-gpusamplerdescriptor-lodmaxclamp) ≥ descriptor.[lodMinClamp](https://gpuweb.github.io/gpuweb/#dom-gpusamplerdescriptor-lodminclamp).

This PR adds `InvalidLodClamp` to `CreateSamplerError`, inspired by the already-existing `InvalidClamp`, and uses that if the validation fails.

**Testing**
Tested locally.