### PR TITLE
Fix panic in the GLES backend when creating a pipeline with opaque ty…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,7 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 
 - Fixed WebGL not displaying srgb targets correctly if a non-screen filling viewport was previously set. By @Wumpf in [#3093](https://github.com/gfx-rs/wgpu/pull/3093)
 - Fix disallowing multisampling for float textures if otherwise supported. By @Wumpf in [#3183](https://github.com/gfx-rs/wgpu/pull/3183)
+- Fix a panic when creating a pipeline with opaque types other than samplers (images and atomic counters). By @James2022-rgb in [#3361](https://github.com/gfx-rs/wgpu/pull/3361)
 
 #### Vulkan
 

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -439,6 +439,52 @@ pub(super) fn is_sampler(glsl_uniform_type: u32) -> bool {
     }
 }
 
+pub(super) fn is_image(glsl_uniform_type: u32) -> bool {
+    match glsl_uniform_type {
+        glow::INT_IMAGE_1D
+        | glow::INT_IMAGE_1D_ARRAY
+        | glow::INT_IMAGE_2D
+        | glow::INT_IMAGE_2D_ARRAY
+        | glow::INT_IMAGE_2D_MULTISAMPLE
+        | glow::INT_IMAGE_2D_MULTISAMPLE_ARRAY
+        | glow::INT_IMAGE_2D_RECT
+        | glow::INT_IMAGE_3D
+        | glow::INT_IMAGE_CUBE
+        | glow::INT_IMAGE_CUBE_MAP_ARRAY
+        | glow::UNSIGNED_INT_IMAGE_1D
+        | glow::UNSIGNED_INT_IMAGE_1D_ARRAY
+        | glow::UNSIGNED_INT_IMAGE_2D
+        | glow::UNSIGNED_INT_IMAGE_2D_ARRAY
+        | glow::UNSIGNED_INT_IMAGE_2D_MULTISAMPLE
+        | glow::UNSIGNED_INT_IMAGE_2D_MULTISAMPLE_ARRAY
+        | glow::UNSIGNED_INT_IMAGE_2D_RECT
+        | glow::UNSIGNED_INT_IMAGE_3D
+        | glow::UNSIGNED_INT_IMAGE_CUBE
+        | glow::UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY
+        | glow::IMAGE_1D
+        | glow::IMAGE_1D_ARRAY
+        | glow::IMAGE_2D
+        | glow::IMAGE_2D_ARRAY
+        | glow::IMAGE_2D_MULTISAMPLE
+        | glow::IMAGE_2D_MULTISAMPLE_ARRAY
+        | glow::IMAGE_2D_RECT
+        | glow::IMAGE_3D
+        | glow::IMAGE_CUBE
+        | glow::IMAGE_CUBE_MAP_ARRAY => true,
+        _ => false,
+    }
+}
+
+pub(super) fn is_atomic_counter(glsl_uniform_type: u32) -> bool {
+    glsl_uniform_type == glow::UNSIGNED_INT_ATOMIC_COUNTER
+}
+
+pub(super) fn is_opaque_type(glsl_uniform_type: u32) -> bool {
+    is_sampler(glsl_uniform_type)
+        || is_image(glsl_uniform_type)
+        || is_atomic_counter(glsl_uniform_type)
+}
+
 pub(super) fn uniform_byte_size(glsl_uniform_type: u32) -> u32 {
     match glsl_uniform_type {
         glow::FLOAT | glow::INT => 4,
@@ -448,6 +494,6 @@ pub(super) fn uniform_byte_size(glsl_uniform_type: u32) -> u32 {
         glow::FLOAT_MAT2 => 16,
         glow::FLOAT_MAT3 => 36,
         glow::FLOAT_MAT4 => 64,
-        _ => panic!("Unsupported uniform datatype!"),
+        _ => panic!("Unsupported uniform datatype! {glsl_uniform_type:#X}"),
     }
 }

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -380,7 +380,7 @@ impl super::Device {
             let glow::ActiveUniform { utype, name, .. } =
                 unsafe { gl.get_active_uniform(program, uniform) }.unwrap();
 
-            if conv::is_sampler(utype) {
+            if conv::is_opaque_type(utype) {
                 continue;
             }
 


### PR DESCRIPTION
…pes other than samplers.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
  Done, with `--feature gles`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes issue #3337

**Description**
`wgpu_hal::gles::device::Device::create_pipeline` was taking into account sampler types when collecting `UniformDesc`s, but not other opaque types such as images and atomic counters,
which led to the `panic!` here:
https://github.com/gfx-rs/wgpu/blob/a06ef71fd773914f7bd68773054a1a2222d70f98/wgpu-hal/src/gles/conv.rs#L442-L453

This PR adds checks for these other opaque types in addition to samplers.

**Testing**
Tested locally on my Galaxy S20 Ultra 5G, confirming the result of the `textureStore` in the `glDispatchCompute` with RenderDoc.
