### PR TITLE
Allow non-filtering integer texture sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 - Check for invalid bitflag bits in wgpu-core and allow them to be captured/replayed by @nical in (#3229)[https://github.com/gfx-rs/wgpu/pull/3229]
 - Evaluate `gfx_select!`'s `#[cfg]` conditions at the right time. By @jimblandy in [#3253](https://github.com/gfx-rs/wgpu/pull/3253)
 - Improve error messages when binding bind group with dynamic offsets. By @cwfitzgerald in [#3294](https://github.com/gfx-rs/wgpu/pull/3294)
+- Allow non-filtering sampling of integer textures. By @JMS55 in [#3362](https://github.com/gfx-rs/wgpu/pull/3362).
 
 #### Metal
 - Fix texture view creation with full-resource views when using an explicit `mip_level_count` or `array_layer_count`. By @cwfitzgerald in [#3323](https://github.com/gfx-rs/wgpu/pull/3323)


### PR DESCRIPTION
**Checklist**
- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
- Closes https://github.com/gfx-rs/wgpu/issues/3303
- Requires https://github.com/gfx-rs/wgpu/pull/3352
- Context: https://github.com/gfx-rs/naga/issues/2135
- Context: https://github.com/bevyengine/bevy/pull/7070

**Description**
Allow using textureGather on integer textures, by allowing non-filtered integer texture sampling.

**Testing**
Ran my bevy fork with this patch applied. Modify bevy/Cargo.toml to patch wgpu/naga, then run `cargo run --example ssao`.
