### PR TITLE
Set `COPY_SRC`/`COPY_DST` only based on Vulkan's `TRANSFER_SRC`/`TRANSFER_DST`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,10 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 
 - Browsers that support `OVR_multiview2` now report the `MULTIVIEW` feature by @expenses in [#3121](https://github.com/gfx-rs/wgpu/pull/3121).
 
+#### Vulkan
+
+- Set `COPY_SRC`/`COPY_DST` only based on Vulkan's `TRANSFER_SRC`/`TRANSFER_DST` by @teoxoy in [#3366](https://github.com/gfx-rs/wgpu/pull/3366).
+
 ### Added/New Features
 
 #### General

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1476,15 +1476,11 @@ impl crate::Adapter<super::Api> for super::Adapter {
         );
         flags.set(
             Tfc::COPY_SRC,
-            features.intersects(
-                vk::FormatFeatureFlags::TRANSFER_SRC | vk::FormatFeatureFlags::BLIT_SRC,
-            ),
+            features.intersects(vk::FormatFeatureFlags::TRANSFER_SRC),
         );
         flags.set(
             Tfc::COPY_DST,
-            features.intersects(
-                vk::FormatFeatureFlags::TRANSFER_DST | vk::FormatFeatureFlags::BLIT_DST,
-            ),
+            features.intersects(vk::FormatFeatureFlags::TRANSFER_DST),
         );
         // Vulkan is very permissive about MSAA
         flags.set(Tfc::MULTISAMPLE_RESOLVE, !format.describe().is_compressed());


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**


**Description**
We don't use `vkCmdBlitImage` at all and

```
r8snorm
rg8snorm
rgba8snorm
rg11b10ufloat
rgb9e5ufloat
```

formats don't have `VK_FORMAT_FEATURE_BLIT_DST_BIT` but should be copyable.

**Testing**

