### PR TITLE
Increase GL MAX_PUSH_CONSTANTS from 16 to 64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 #### GLES
 
 - Browsers that support `OVR_multiview2` now report the `MULTIVIEW` feature by @expenses in [#3121](https://github.com/gfx-rs/wgpu/pull/3121).
+- `Limits::max_push_constant_size` on GLES is now 256 by @Dinnerbone in [#3374](https://github.com/gfx-rs/wgpu/pull/3374).
 
 #### Vulkan
 

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -372,7 +372,8 @@ impl super::Device {
             }
         }
 
-        let mut uniforms: [super::UniformDesc; super::MAX_PUSH_CONSTANTS] = Default::default();
+        let mut uniforms: [super::UniformDesc; super::MAX_PUSH_CONSTANTS] =
+            [None; super::MAX_PUSH_CONSTANTS].map(|_: Option<()>| Default::default());
         let count = unsafe { gl.get_active_uniforms(program) };
         let mut offset = 0;
 

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -95,7 +95,7 @@ const MAX_TEXTURE_SLOTS: usize = 16;
 const MAX_SAMPLERS: usize = 16;
 const MAX_VERTEX_ATTRIBUTES: usize = 16;
 const ZERO_BUFFER_SIZE: usize = 256 << 10;
-const MAX_PUSH_CONSTANTS: usize = 16;
+const MAX_PUSH_CONSTANTS: usize = 64;
 
 impl crate::Api for Api {
     type Instance = Instance;

--- a/wgpu/tests/shader/struct_layout.rs
+++ b/wgpu/tests/shader/struct_layout.rs
@@ -221,7 +221,8 @@ fn push_constant_input() {
             .limits(Limits {
                 max_push_constant_size: MAX_BUFFER_SIZE as u32,
                 ..Limits::downlevel_defaults()
-            }),
+            })
+            .backend_failure(Backends::GL),
         |ctx| {
             shader_input_output_test(
                 ctx,


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
None.

**Description**
I've found that using the emulated push constants is significantly faster than buffer juggling on our own on the webgl backend. However, it's limited to 16*4 bytes right now, which is too small for our needs.

I can't find any rationale behind it behind just 16*4, it's possible it was a naga limitation but it doesn't seem to be the case anymore? The docs for `Limits::max_push_constant_size` suggest it should be 256 on GLES so this increases it to that, which can hold a couple of matrices nicely.

If I'm wrong and there's a limitation I missed somewhere and this *doesn't* actually work somehow, then okay, nevermind! But I've tested this out on Ruffle and it seems to work perfect and performant for us.

**Testing**
Manually tested and it works fine, not sure it deserves its own unit test.
