### PR TITLE
Improve write_buffer_with Spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,6 +2913,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "png",
  "pollster",
+ "profiling",
  "raw-window-handle 0.5.0",
  "serde",
  "smallvec",

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -389,6 +389,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_size: wgt::BufferSize,
         id_in: Input<G, id::StagingBufferId>,
     ) -> Result<(id::StagingBufferId, *mut u8), QueueWriteError> {
+        profiling::scope!("Queue::create_staging_buffer");
         let hub = A::hub(self);
         let root_token = &mut Token::root();
 
@@ -413,8 +414,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_offset: wgt::BufferAddress,
         staging_buffer_id: id::StagingBufferId,
     ) -> Result<(), QueueWriteError> {
-        profiling::scope!("Queue::write_buffer_with");
-
+        profiling::scope!("Queue::write_staging_buffer");
         let hub = A::hub(self);
         let root_token = &mut Token::root();
 
@@ -457,6 +457,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_offset: u64,
         buffer_size: u64,
     ) -> Result<(), QueueWriteError> {
+        profiling::scope!("Queue::validate_write_buffer");
         let hub = A::hub(self);
         let root_token = &mut Token::root();
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -151,6 +151,7 @@ optional = true
 arrayvec.workspace = true
 log.workspace = true
 parking_lot.workspace = true
+profiling.workspace = true
 raw-window-handle.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
 smallvec.workspace = true

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3853,6 +3853,7 @@ impl Queue {
         offset: BufferAddress,
         size: BufferSize,
     ) -> Option<QueueWriteBufferView<'a>> {
+        profiling::scope!("Queue::write_buffer_with");
         DynContext::queue_validate_write_buffer(
             &*self.context,
             &self.id,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
**Description**

Improves the profiling spans for write_buffer_with to avoid un-spanned sections

**Testing**

None needed
