### PR TITLE
In IntelliJ Rust plugin, Declarative macro expansion of bitflags! fails when a backslash is present in rustdoc.

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -360,14 +360,14 @@ bitflags::bitflags! {
         /// Allows the user to create uniform arrays of textures in shaders:
         ///
         /// ex.
-        /// `var textures: binding_array<texture_2d<f32>, 10>` (WGSL)\
+        /// `var textures: binding_array<texture_2d<f32>, 10>` (WGSL)
         /// `uniform texture2D textures[10]` (GLSL)
         ///
         /// If [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] is supported as well as this, the user
         /// may also create uniform arrays of storage textures.
         ///
         /// ex.
-        /// `var textures: array<texture_storage_2d<f32, write>, 10>` (WGSL)\
+        /// `var textures: array<texture_storage_2d<f32, write>, 10>` (WGSL)
         /// `uniform image2D textures[10]` (GLSL)
         ///
         /// This capability allows them to exist and to be indexed by dynamically uniform
@@ -383,7 +383,7 @@ bitflags::bitflags! {
         /// Allows the user to create arrays of buffers in shaders:
         ///
         /// ex.
-        /// `var<uniform> buffer_array: array<MyBuffer, 10>` (WGSL)\
+        /// `var<uniform> buffer_array: array<MyBuffer, 10>` (WGSL)
         /// `uniform myBuffer { ... } buffer_array[10]` (GLSL)
         ///
         /// This capability allows them to exist and to be indexed by dynamically uniform
@@ -393,7 +393,7 @@ bitflags::bitflags! {
         /// may also create arrays of storage buffers.
         ///
         /// ex.
-        /// `var<storage> buffer_array: array<MyBuffer, 10>` (WGSL)\
+        /// `var<storage> buffer_array: array<MyBuffer, 10>` (WGSL)
         /// `buffer myBuffer { ... } buffer_array[10]` (GLSL)
         ///
         /// Supported platforms:


### PR DESCRIPTION

**Checklist**
No check was performed, this only changed the comment.
- [ ] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
This is because of the problem of intellij-rust. Until this problem is solved, avoiding it may temporarily improve the user experience.
https://github.com/intellij-rust/intellij-rust/issues/9843#issue-1475060423

**Description**
Due to a problem with intellij-rust, deleting these backslashes will enable the macro to expand correctly, thus improving the code experience.

**Testing**
No test was performed, this only changed the comment.
