### PR TITLE
Create gles buffers with DYNAMIC_DRAW instead of STATIC_DRAW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 - Fixed WebGL not displaying srgb targets correctly if a non-screen filling viewport was previously set. By @Wumpf in [#3093](https://github.com/gfx-rs/wgpu/pull/3093)
 - Fix disallowing multisampling for float textures if otherwise supported. By @Wumpf in [#3183](https://github.com/gfx-rs/wgpu/pull/3183)
 - Fix a panic when creating a pipeline with opaque types other than samplers (images and atomic counters). By @James2022-rgb in [#3361](https://github.com/gfx-rs/wgpu/pull/3361)
+- Fix uniform buffers being empty on some vendors. By @Dinnerbone in [#3391](https://github.com/gfx-rs/wgpu/pull/3391)
 
 #### Vulkan
 

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -499,7 +499,10 @@ impl crate::Device<super::Api> for super::Device {
                     glow::DYNAMIC_DRAW
                 }
             } else {
-                glow::STATIC_DRAW
+                // Even if the usage doesn't contain SRC_READ, we update it internally at least once
+                // Some vendors take usage very literally and STATIC_DRAW will freeze us with an empty buffer
+                // https://github.com/gfx-rs/wgpu/issues/3371
+                glow::DYNAMIC_DRAW
             };
             unsafe { gl.buffer_data_size(target, raw_size, usage) };
         }


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
This fixes #3371.

**Description**
wgpu currently creates buffers with `STATIC_DRAW`, but it actually updates the buffer once after creation to copy in the data from a staging buffer.
Some vendors take this usage hint literally, and freeze the buffer at the data it was created with - leaving it empty and unusable.

In an ideal world we'd be able to populate the data here in the constructor and keep it `STATIC_DRAW` for all but `BufferUsage::COPY_DST`, perhaps using a specialized path from `create_buffer_init`, but we don't live in that ideal world right now and have to pay the penalty of `DYNAMIC_DRAW`.

**Testing**
It passes all of the existing tests, and is confirmed to fix #3371 on affected devices.
