### PR TITLE
Clearing a non-color attachment should be unreachable

### DIFF
--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -525,7 +525,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                             color: [c.r as f32, c.g as f32, c.b as f32, c.a as f32],
                             is_srgb: cat.target.view.format.describe().srgb,
                         },
-                        wgt::TextureSampleType::Depth => unimplemented!(),
+                        wgt::TextureSampleType::Depth => unreachable!(),
                         wgt::TextureSampleType::Uint => C::ClearColorU(
                             i as u32,
                             [c.r as u32, c.g as u32, c.b as u32, c.a as u32],

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -203,17 +203,16 @@ impl crate::ColorAttachment<'_, super::Api> {
             .describe()
             .sample_type
         {
-            wgt::TextureSampleType::Float { .. } | wgt::TextureSampleType::Depth => {
-                vk::ClearColorValue {
-                    float32: [cv.r as f32, cv.g as f32, cv.b as f32, cv.a as f32],
-                }
-            }
+            wgt::TextureSampleType::Float { .. } => vk::ClearColorValue {
+                float32: [cv.r as f32, cv.g as f32, cv.b as f32, cv.a as f32],
+            },
             wgt::TextureSampleType::Sint => vk::ClearColorValue {
                 int32: [cv.r as i32, cv.g as i32, cv.b as i32, cv.a as i32],
             },
             wgt::TextureSampleType::Uint => vk::ClearColorValue {
                 uint32: [cv.r as u32, cv.g as u32, cv.b as u32, cv.a as u32],
             },
+            wgt::TextureSampleType::Depth => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

**Description**
Clearing a depth/stencil texture bound as a color attachment should be unreachable.

**Testing**
