### PR TITLE
Allow vulkan to change view formats

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -852,6 +852,7 @@ impl<A: HalApi> Device<A> {
             ));
         }
 
+        let mut allow_different_view_format = false;
         for format in desc.view_formats.iter() {
             if desc.format == *format {
                 continue;
@@ -859,6 +860,7 @@ impl<A: HalApi> Device<A> {
             if desc.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
                 return Err(CreateTextureError::InvalidViewFormat(*format, desc.format));
             }
+            allow_different_view_format = true;
         }
 
         // Enforce having COPY_DST/DEPTH_STENCIL_WRIT/COLOR_TARGET otherwise we
@@ -891,6 +893,7 @@ impl<A: HalApi> Device<A> {
             format: desc.format,
             usage: hal_usage,
             memory_flags: hal::MemoryFlags::empty(),
+            allow_different_view_format,
         };
 
         let raw_texture = unsafe {

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -299,6 +299,7 @@ impl<A: hal::Api> Example<A> {
             format: wgt::TextureFormat::Rgba8UnormSrgb,
             usage: hal::TextureUses::COPY_DST | hal::TextureUses::RESOURCE,
             memory_flags: hal::MemoryFlags::empty(),
+            allow_different_view_format: false,
         };
         let texture = unsafe { device.create_texture(&texture_desc).unwrap() };
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -848,6 +848,9 @@ pub struct TextureDescriptor<'a> {
     pub format: wgt::TextureFormat,
     pub usage: TextureUses,
     pub memory_flags: MemoryFlags,
+    /// Allows views of this texture to have a different format
+    /// than the this texture does.
+    pub allow_different_view_format: bool,
 }
 
 /// TextureView descriptor.

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -331,7 +331,8 @@ impl PhysicalDeviceFeatures {
             | Df::DEPTH_TEXTURE_AND_BUFFER_COPIES
             | Df::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED
             | Df::UNRESTRICTED_INDEX_BUFFER
-            | Df::INDIRECT_EXECUTION;
+            | Df::INDIRECT_EXECUTION
+            | Df::VIEW_FORMATS;
 
         dl_flags.set(Df::CUBE_ARRAY_TEXTURES, self.core.image_cube_array != 0);
         dl_flags.set(Df::ANISOTROPIC_FILTERING, self.core.sampler_anisotropy != 0);

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -895,6 +895,10 @@ impl crate::Device<super::Api> for super::Device {
             raw_flags |= vk::ImageCreateFlags::CUBE_COMPATIBLE;
         }
 
+        if desc.allow_different_view_format {
+            raw_flags |= vk::ImageCreateFlags::MUTABLE_FORMAT;
+        }
+
         let vk_info = vk::ImageCreateInfo::builder()
             .flags(raw_flags)
             .image_type(conv::map_texture_dimension(desc.dimension))


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.

**Connections**

Follow up to #3237

cc @jinleili

**Description**

Adding view format changing as a downlevel flag was missed on the original PR, so an extra bit of data wasn't passed down to vulkan.

**Testing**

Tested using the view format aliasing test, thanks for that test!
