### PR TITLE
Add `SHADERINT_16` feature to allow 16bit ints in Vulkan shaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,10 @@ let texture = device.create_texture(&wgpu::TextureDescriptor {
 - Support alpha to coverage. By @Wumpf in [#3156](https://github.com/gfx-rs/wgpu/pull/3156)
 - Support filtering f32 textures. By @expenses in [#3261](https://github.com/gfx-rs/wgpu/pull/3261)
 
+#### Vulkan
+
+- Add `SHADER_INT16` feature to enable the `shaderInt16` VkPhysicalDeviceFeature. By @Elabajaba in [#3401](https://github.com/gfx-rs/wgpu/pull/3401)
+
 #### WebGPU
 
 - Add `MULTISAMPLE_X2`, `MULTISAMPLE_X4` and `MULTISAMPLE_X8` to `TextureFormatFeatureFlags`. By @39ali in [3140](https://github.com/gfx-rs/wgpu/pull/3140)

--- a/deno_webgpu/src/02_idl_types.js
+++ b/deno_webgpu/src/02_idl_types.js
@@ -134,6 +134,7 @@
       "clear-commands",
       "spirv-shader-passthrough",
       "shader-primitive-index",
+      "shader-i16",
     ],
   );
 

--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -164,7 +164,7 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
         return_features.push("indirect-first-instance");
     }
     if features.contains(wgpu_types::Features::SHADER_FLOAT16) {
-        return_features.push("shader-f16")
+        return_features.push("shader-f16");
     }
 
     // extended from spec
@@ -213,6 +213,9 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     }
     if features.contains(wgpu_types::Features::PARTIALLY_BOUND_BINDING_ARRAY) {
         return_features.push("shader-primitive-index");
+    }
+    if features.contains(wgpu_types::Features::SHADER_INT16) {
+        return_features.push("shader-i16");
     }
 
     return_features
@@ -382,7 +385,7 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
         );
         features.set(
             wgpu_types::Features::SHADER_INT16,
-            required_features.0.contains("shader-int16"),
+            required_features.0.contains("shader-i16"),
         );
         features.set(
             wgpu_types::Features::VERTEX_ATTRIBUTE_64BIT,

--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -381,6 +381,10 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
             required_features.0.contains("shader-float64"),
         );
         features.set(
+            wgpu_types::Features::SHADER_INT16,
+            required_features.0.contains("shader-int16"),
+        );
+        features.set(
             wgpu_types::Features::VERTEX_ATTRIBUTE_64BIT,
             required_features.0.contains("vertex-attribute-64bit"),
         );

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -172,7 +172,7 @@ impl PhysicalDeviceFeatures {
                 //.shader_cull_distance(requested_features.contains(wgt::Features::SHADER_CULL_DISTANCE))
                 .shader_float64(requested_features.contains(wgt::Features::SHADER_FLOAT64))
                 //.shader_int64(requested_features.contains(wgt::Features::SHADER_INT64))
-                //.shader_int16(requested_features.contains(wgt::Features::SHADER_INT16))
+                .shader_int16(requested_features.contains(wgt::Features::SHADER_INT16))
                 //.shader_resource_residency(requested_features.contains(wgt::Features::SHADER_RESOURCE_RESIDENCY))
                 .geometry_shader(requested_features.contains(wgt::Features::SHADER_PRIMITIVE_INDEX))
                 .build(),
@@ -409,7 +409,7 @@ impl PhysicalDeviceFeatures {
         //if self.core.shader_cull_distance != 0 {
         features.set(F::SHADER_FLOAT64, self.core.shader_float64 != 0);
         //if self.core.shader_int64 != 0 {
-        //if self.core.shader_int16 != 0 {
+        features.set(F::SHADER_INT16, self.core.shader_int16 != 0);
 
         //if caps.supports_extension(vk::KhrSamplerMirrorClampToEdgeFn::name()) {
         //if caps.supports_extension(vk::ExtSamplerFilterMinmaxFn::name()) {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -674,6 +674,13 @@ bitflags::bitflags! {
         /// - DX12
         /// - Metal (Intel and AMD GPUs)
         const WRITE_TIMESTAMP_INSIDE_PASSES = 1 << 41;
+        /// Allows shaders to acquire the INT16 ability
+        ///
+        /// Supported platforms:
+        /// - Vulkan
+        ///
+        /// This is a native-only feature.
+        const SHADER_INT16 = 1 << 42;
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -674,7 +674,7 @@ bitflags::bitflags! {
         /// - DX12
         /// - Metal (Intel and AMD GPUs)
         const WRITE_TIMESTAMP_INSIDE_PASSES = 1 << 41;
-        /// Allows shaders to use i16. Not currently supported in naga, only available through spirv-passthrough.```
+        /// Allows shaders to use i16. Not currently supported in naga, only available through `spirv-passthrough`.
         ///
         /// Supported platforms:
         /// - Vulkan

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -674,7 +674,7 @@ bitflags::bitflags! {
         /// - DX12
         /// - Metal (Intel and AMD GPUs)
         const WRITE_TIMESTAMP_INSIDE_PASSES = 1 << 41;
-        /// Allows shaders to acquire the INT16 ability
+        /// Allows shaders to use i16. Not currently supported in naga, only available through spirv-passthrough.```
         ///
         /// Supported platforms:
         /// - Vulkan


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Stops Vulkan Validation errors for FSR2 when using https://github.com/JMS55/fsr2_wgpu (currently very much a WIP).

**Description**
This just enables the Vulkan `shader_int16` device feature if the feature is requested. I copied how it seems to be done for `SHADER_FLOAT64`.

According to [the docs](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceFeatures.html), this isn't an extension and is part of vulkan 1.0 `VkPhysicalDeviceFeatures`. ~~I don't know if anything doesn't support this feature, so I'm wondering if it should be enabled by default?~~ Did some more digging on https://vulkan.gpuinfo.org/ and it isn't nearly as universal as I thought.

**Testing**
Tested using bevy+fsr2, it stopped the validation errors about 16bit ints.
