### PR TITLE
validate the number of color_attachments in `begin_render_pass`

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -81,8 +81,8 @@ index format changes.
 use crate::{
     binding_model::{self, buffer_binding_type_alignment},
     command::{
-        BasePass, BindGroupStateChange, DrawError, MapPassErr, PassErrorScope, RenderCommand,
-        RenderCommandError, StateChange,
+        BasePass, BindGroupStateChange, ColorAttachmentError, DrawError, MapPassErr,
+        PassErrorScope, RenderCommand, RenderCommandError, StateChange,
     },
     conv,
     device::{
@@ -179,7 +179,12 @@ impl RenderBundleEncoder {
             context: RenderPassContext {
                 attachments: AttachmentData {
                     colors: if desc.color_formats.len() > hal::MAX_COLOR_ATTACHMENTS {
-                        return Err(CreateRenderBundleError::TooManyColorAttachments);
+                        return Err(CreateRenderBundleError::ColorAttachment(
+                            ColorAttachmentError::TooMany {
+                                given: desc.color_formats.len(),
+                                limit: hal::MAX_COLOR_ATTACHMENTS,
+                            },
+                        ));
                     } else {
                         desc.color_formats.iter().cloned().collect()
                     },
@@ -691,10 +696,10 @@ impl RenderBundleEncoder {
 /// Error type returned from `RenderBundleEncoder::new` if the sample count is invalid.
 #[derive(Clone, Debug, Error)]
 pub enum CreateRenderBundleError {
+    #[error(transparent)]
+    ColorAttachment(#[from] ColorAttachmentError),
     #[error("invalid number of samples {0}")]
     InvalidSampleCount(u32),
-    #[error("number of color attachments exceeds the limit")]
-    TooManyColorAttachments,
 }
 
 /// Error type returned from `RenderBundleEncoder::new` if the sample count is invalid.

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2611,12 +2611,12 @@ impl<A: HalApi> Device<A> {
 
         let num_attachments = desc.fragment.as_ref().map(|f| f.targets.len()).unwrap_or(0);
         if num_attachments > hal::MAX_COLOR_ATTACHMENTS {
-            return Err(
-                pipeline::CreateRenderPipelineError::TooManyColorAttachments {
-                    given: num_attachments as u32,
-                    limit: hal::MAX_COLOR_ATTACHMENTS as u32,
+            return Err(pipeline::CreateRenderPipelineError::ColorAttachment(
+                command::ColorAttachmentError::TooMany {
+                    given: num_attachments,
+                    limit: hal::MAX_COLOR_ATTACHMENTS,
                 },
-            );
+            ));
         }
 
         let color_targets = desc

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -1,5 +1,6 @@
 use crate::{
     binding_model::{CreateBindGroupLayoutError, CreatePipelineLayoutError},
+    command::ColorAttachmentError,
     device::{DeviceError, MissingDownlevelFlags, MissingFeatures, RenderPassContext},
     hub::Resource,
     id::{DeviceId, PipelineLayoutId, ShaderModuleId},
@@ -322,6 +323,8 @@ pub enum DepthStencilStateError {
 #[derive(Clone, Debug, Error)]
 pub enum CreateRenderPipelineError {
     #[error(transparent)]
+    ColorAttachment(#[from] ColorAttachmentError),
+    #[error(transparent)]
     Device(#[from] DeviceError),
     #[error("pipeline layout is invalid")]
     InvalidLayout,
@@ -333,8 +336,6 @@ pub enum CreateRenderPipelineError {
     DepthStencilState(#[from] DepthStencilStateError),
     #[error("invalid sample count {0}")]
     InvalidSampleCount(u32),
-    #[error("the number of color attachments {given} exceeds the limit {limit}")]
-    TooManyColorAttachments { given: u32, limit: u32 },
     #[error("the number of vertex buffers {given} exceeds the limit {limit}")]
     TooManyVertexBuffers { given: u32, limit: u32 },
     #[error("the total number of vertex attributes {given} exceeds the limit {limit}")]

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1860,6 +1860,15 @@ impl crate::Context for Context {
         _encoder_data: &Self::CommandEncoderData,
         desc: &crate::RenderPassDescriptor<'a, '_>,
     ) -> (Self::RenderPassId, Self::RenderPassData) {
+        if desc.color_attachments.len() > wgc::MAX_COLOR_ATTACHMENTS {
+            self.handle_error_fatal(
+                wgc::command::ColorAttachmentError::TooMany {
+                    given: desc.color_attachments.len(),
+                    limit: wgc::MAX_COLOR_ATTACHMENTS,
+                },
+                "CommandEncoder::begin_render_pass",
+            );
+        }
         let colors = desc
             .color_attachments
             .iter()


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Fix a crash when the number of color_attachments in `begin_render_pass` exceeds the limit of `MAX_COLOR_ATTACHMENTS`
```log
thread 'main' panicked at 'ArrayVec: capacity exceeded in extend/from_iter', /Users/lijinlei/.cargo/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/src/arrayvec.rs:1025:5
```
In the [WebGPU spec](https://gpuweb.github.io/gpuweb/#render-pass-encoder-creation), this validation is also required.

**Testing**
Tested locally
