### PR TITLE
Implement `view_formats` for `SurfaceConfiguration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,15 @@ let texture = device.create_texture(&wgpu::TextureDescriptor {
 });
 ```
 
+```diff
+let config = wgpu::SurfaceConfiguration {
+  // ...
+  format: TextureFormat::Rgba8Unorm,
++ view_formats: &[wgpu::TextureFormat::Rgba8UnormSrgb],
+};
+surface.configure(&device, &config);
+```
+
 ### Changes
 
 #### General
@@ -183,9 +192,10 @@ let texture = device.create_texture(&wgpu::TextureDescriptor {
 - Make `ObjectId` structure and invariants idiomatic. By @teoxoy in [#3347](https://github.com/gfx-rs/wgpu/pull/3347)
 - Add validation in accordance with WebGPU `GPUSamplerDescriptor` valid usage for `lodMinClamp` and `lodMaxClamp`. By @James2022-rgb in [#3353](https://github.com/gfx-rs/wgpu/pull/3353)
 - Remove panics in `Deref` implementations for `QueueWriteBufferView` and `BufferViewMut`. Instead, warnings are logged, since reading from these types is not recommended. By @botahamec in [#3336]
-- Implement `view_formats` in TextureDescriptor to match the WebGPU spec. By @jinleili in [#3237](https://github.com/gfx-rs/wgpu/pull/3237)
+- Implement `view_formats` in the TextureDescriptor to match the WebGPU spec. By @jinleili in [#3237](https://github.com/gfx-rs/wgpu/pull/3237)
 - Show more information in error message for non-aligned buffer bindings in WebGL [#3414](https://github.com/gfx-rs/wgpu/pull/3414)
 - Update `TextureView` validation according to the WebGPU spec. By @teoxoy in [#3410](https://github.com/gfx-rs/wgpu/pull/3410)
+- Implement `view_formats` in the SurfaceConfiguration to match the WebGPU spec. By @jinleili in [#3409](https://github.com/gfx-rs/wgpu/pull/3409)
 
 #### WebGPU
 

--- a/deno_webgpu/src/04_surface_idl_types.js
+++ b/deno_webgpu/src/04_surface_idl_types.js
@@ -68,6 +68,15 @@
       converter: webidl.converters["long"],
       required: true,
     },
+    {
+      key: "viewFormats",
+      converter: webidl.createSequenceConverter(
+        webidl.converters["GPUTextureFormat"],
+      ),
+      get defaultValue() {
+        return [];
+      },
+    },
   ];
   webidl.converters["GPUCanvasConfiguration"] = webidl
     .createDictionaryConverter(

--- a/deno_webgpu/src/surface.rs
+++ b/deno_webgpu/src/surface.rs
@@ -54,6 +54,7 @@ pub struct SurfaceConfigureArgs {
     height: u32,
     present_mode: Option<wgpu_types::PresentMode>,
     alpha_mode: wgpu_types::CompositeAlphaMode,
+    view_formats: Vec<wgpu_types::TextureFormat>,
 }
 
 #[op]
@@ -71,13 +72,14 @@ pub fn op_webgpu_surface_configure(
         .get::<WebGpuSurface>(args.surface_rid)?;
     let surface = surface_resource.0;
 
-    let conf = wgpu_types::SurfaceConfiguration {
+    let conf = wgpu_types::SurfaceConfiguration::<Vec<wgpu_types::TextureFormat>> {
         usage: wgpu_types::TextureUsages::from_bits_truncate(args.usage),
         format: args.format,
         width: args.width,
         height: args.height,
         present_mode: args.present_mode.unwrap_or_default(),
         alpha_mode: args.alpha_mode,
+        view_formats: args.view_formats,
     };
 
     let err = gfx_select!(device => instance.surface_configure(surface, device, &conf));

--- a/deno_webgpu/webgpu.idl
+++ b/deno_webgpu/webgpu.idl
@@ -1085,6 +1085,7 @@ dictionary GPUCanvasConfiguration {
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
     GPUCanvasAlphaMode alphaMode = "opaque";
+    sequence<GPUTextureFormat> viewFormats = [];
 };
 
 enum GPUDeviceLostReason {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -5354,6 +5354,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 hal_view_formats.push(*format);
             }
 
+            if !hal_view_formats.is_empty() {
+                if let Err(missing_flag) = device
+                    .require_downlevel_flags(wgt::DownlevelFlags::SURFACE_CONFIGURE_VIEW_FORMATS)
+                {
+                    break 'outter E::MissingDownlevelFlags(missing_flag);
+                }
+            }
+
             let num_frames = present::DESIRED_NUM_FRAMES
                 .clamp(*caps.swap_chain_sizes.start(), *caps.swap_chain_sizes.end());
             let mut hal_config = hal::SurfaceConfiguration {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -5337,7 +5337,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 }
             };
 
-            let mut hal_view_formats = vec![config.format];
+            let mut hal_view_formats = vec![];
             for format in config.view_formats.iter() {
                 if *format == config.format {
                     continue;

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -5355,8 +5355,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             }
 
             if !hal_view_formats.is_empty() {
-                if let Err(missing_flag) = device
-                    .require_downlevel_flags(wgt::DownlevelFlags::SURFACE_CONFIGURE_VIEW_FORMATS)
+                if let Err(missing_flag) =
+                    device.require_downlevel_flags(wgt::DownlevelFlags::SURFACE_VIEW_FORMATS)
                 {
                     break 'outter E::MissingDownlevelFlags(missing_flag);
                 }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -5188,7 +5188,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         &self,
         surface_id: id::SurfaceId,
         device_id: id::DeviceId,
-        config: &wgt::SurfaceConfiguration,
+        config: &wgt::SurfaceConfiguration<Vec<TextureFormat>>,
     ) -> Option<present::ConfigureSurfaceError> {
         use hal::{Adapter as _, Surface as _};
         use present::ConfigureSurfaceError as E;

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -5311,7 +5311,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (adapter_guard, mut token) = hub.adapters.read(&mut token);
         let (device_guard, _token) = hub.devices.read(&mut token);
 
-        let error = 'outter: loop {
+        let error = 'outer: loop {
             let device = match device_guard.get(device_id) {
                 Ok(device) => device,
                 Err(_) => break DeviceError::Invalid.into(),
@@ -5343,13 +5343,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     continue;
                 }
                 if !caps.formats.contains(&config.format) {
-                    break 'outter E::UnsupportedFormat {
+                    break 'outer E::UnsupportedFormat {
                         requested: config.format,
                         available: caps.formats.clone(),
                     };
                 }
                 if config.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
-                    break 'outter E::InvalidViewFormat(*format, config.format);
+                    break 'outer E::InvalidViewFormat(*format, config.format);
                 }
                 hal_view_formats.push(*format);
             }
@@ -5358,7 +5358,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 if let Err(missing_flag) =
                     device.require_downlevel_flags(wgt::DownlevelFlags::SURFACE_VIEW_FORMATS)
                 {
-                    break 'outter E::MissingDownlevelFlags(missing_flag);
+                    break 'outer E::MissingDownlevelFlags(missing_flag);
                 }
             }
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -5311,7 +5311,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (adapter_guard, mut token) = hub.adapters.read(&mut token);
         let (device_guard, _token) = hub.devices.read(&mut token);
 
-        let error = loop {
+        let error = 'outter: loop {
             let device = match device_guard.get(device_id) {
                 Ok(device) => device,
                 Err(_) => break DeviceError::Invalid.into(),
@@ -5327,6 +5327,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Ok(surface) => surface,
                 Err(_) => break E::InvalidSurface,
             };
+
+            for format in config.view_formats.iter() {
+                if config.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
+                    break 'outter E::InvalidViewFormat(*format, config.format);
+                }
+            }
 
             let caps = unsafe {
                 let suf = A::get_surface(surface);

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -40,7 +40,10 @@ pub enum Action<'a> {
         desc: crate::device::DeviceDescriptor<'a>,
         backend: wgt::Backend,
     },
-    ConfigureSurface(id::SurfaceId, wgt::SurfaceConfiguration),
+    ConfigureSurface(
+        id::SurfaceId,
+        wgt::SurfaceConfiguration<Vec<wgt::TextureFormat>>,
+    ),
     CreateBuffer(id::BufferId, crate::resource::BufferDescriptor<'a>),
     FreeBuffer(id::BufferId),
     DestroyBuffer(id::BufferId),

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -64,6 +64,8 @@ pub enum ConfigureSurfaceError {
     Device(#[from] DeviceError),
     #[error("invalid surface")]
     InvalidSurface,
+    #[error("The view format {0:?} is not compatible with texture format {1:?}, only changing srgb-ness is allowed.")]
+    InvalidViewFormat(wgt::TextureFormat, wgt::TextureFormat),
     #[error("`SurfaceOutput` must be dropped before a new `Surface` is made")]
     PreviousOutputExists,
     #[error("Both `Surface` width and height must be non-zero. Wait to recreate the `Surface` until the window has non-zero area.")]

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -32,7 +32,7 @@ pub const DESIRED_NUM_FRAMES: u32 = 3;
 #[derive(Debug)]
 pub(crate) struct Presentation {
     pub(crate) device_id: Stored<DeviceId>,
-    pub(crate) config: wgt::SurfaceConfiguration,
+    pub(crate) config: wgt::SurfaceConfiguration<Vec<wgt::TextureFormat>>,
     #[allow(unused)]
     pub(crate) num_frames: u32,
     pub(crate) acquired_texture: Option<Stored<TextureId>>,
@@ -180,7 +180,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         format: config.format,
                         dimension: wgt::TextureDimension::D2,
                         usage: config.usage,
-                        view_formats: vec![],
+                        view_formats: config.view_formats,
                     },
                     hal_usage: conv::map_texture_usage(config.usage, config.format.into()),
                     format_features: wgt::TextureFormatFeatures {

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -15,7 +15,7 @@ use std::borrow::Borrow;
 use crate::device::trace::Action;
 use crate::{
     conv,
-    device::DeviceError,
+    device::{DeviceError, MissingDownlevelFlags},
     hub::{Global, GlobalIdentityHandlerFactory, HalApi, Input, Token},
     id::{DeviceId, SurfaceId, TextureId, Valid},
     init_tracker::TextureInitTracker,
@@ -66,6 +66,8 @@ pub enum ConfigureSurfaceError {
     InvalidSurface,
     #[error("The view format {0:?} is not compatible with texture format {1:?}, only changing srgb-ness is allowed.")]
     InvalidViewFormat(wgt::TextureFormat, wgt::TextureFormat),
+    #[error(transparent)]
+    MissingDownlevelFlags(#[from] MissingDownlevelFlags),
     #[error("`SurfaceOutput` must be dropped before a new `Surface` is made")]
     PreviousOutputExists,
     #[error("Both `Surface` width and height must be non-zero. Wait to recreate the `Surface` until the window has non-zero area.")]

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -139,6 +139,7 @@ impl<A: hal::Api> Example<A> {
                 depth_or_array_layers: 1,
             },
             usage: hal::TextureUses::COLOR_TARGET,
+            view_formats: vec![],
         };
         unsafe {
             surface.configure(&device, &surface_config).unwrap();

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1113,6 +1113,9 @@ pub struct SurfaceConfiguration {
     pub extent: wgt::Extent3d,
     /// Allowed usage of surface textures,
     pub usage: TextureUses,
+    /// Allows views of swapchain texture to have a different format
+    /// than the texture does.
+    pub view_formats: Vec<wgt::TextureFormat>,
 }
 
 #[derive(Debug, Clone)]

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -565,6 +565,9 @@ impl PhysicalDeviceCapabilities {
 
         // Require `VK_KHR_swapchain`
         extensions.push(vk::KhrSwapchainFn::name());
+        // `KhrSwapchainMutableFormatFn` extension is requires support for Vulkan 1.0:
+        // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_swapchain_mutable_format.html
+        extensions.push(vk::KhrSwapchainMutableFormatFn::name());
 
         if self.effective_api_version < vk::API_VERSION_1_1 {
             // Require either `VK_KHR_maintenance1` or `VK_AMD_negative_viewport_height`

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -320,7 +320,8 @@ impl PhysicalDeviceFeatures {
             | Df::UNRESTRICTED_INDEX_BUFFER
             | Df::INDIRECT_EXECUTION
             | Df::VIEW_FORMATS
-            | Df::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES;
+            | Df::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES
+            | Df::SURFACE_CONFIGURE_VIEW_FORMATS;
 
         dl_flags.set(Df::CUBE_ARRAY_TEXTURES, self.core.image_cube_array != 0);
         dl_flags.set(Df::ANISOTROPIC_FILTERING, self.core.sampler_anisotropy != 0);

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -565,9 +565,6 @@ impl PhysicalDeviceCapabilities {
 
         // Require `VK_KHR_swapchain`
         extensions.push(vk::KhrSwapchainFn::name());
-        // `KhrSwapchainMutableFormatFn` extension is requires support for Vulkan 1.0:
-        // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_swapchain_mutable_format.html
-        extensions.push(vk::KhrSwapchainMutableFormatFn::name());
 
         if self.effective_api_version < vk::API_VERSION_1_1 {
             // Require either `VK_KHR_maintenance1` or `VK_AMD_negative_viewport_height`
@@ -644,6 +641,15 @@ impl PhysicalDeviceCapabilities {
             // Optional `VK_EXT_image_robustness`
             if self.supports_extension(vk::ExtImageRobustnessFn::name()) {
                 extensions.push(vk::ExtImageRobustnessFn::name());
+            }
+        }
+
+        if self.effective_api_version >= vk::API_VERSION_1_2
+            || self.supports_extension(vk::KhrImageFormatListFn::name())
+        {
+            // Optional `VK_KHR_swapchain_mutable_format`
+            if self.supports_extension(vk::KhrSwapchainMutableFormatFn::name()) {
+                extensions.push(vk::KhrSwapchainMutableFormatFn::name());
             }
         }
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -321,7 +321,7 @@ impl PhysicalDeviceFeatures {
             | Df::INDIRECT_EXECUTION
             | Df::VIEW_FORMATS
             | Df::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES
-            | Df::SURFACE_CONFIGURE_VIEW_FORMATS;
+            | Df::SURFACE_VIEW_FORMATS;
 
         dl_flags.set(Df::CUBE_ARRAY_TEXTURES, self.core.image_cube_array != 0);
         dl_flags.set(Df::ANISOTROPIC_FILTERING, self.core.sampler_anisotropy != 0);

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -644,13 +644,9 @@ impl PhysicalDeviceCapabilities {
             }
         }
 
-        if self.effective_api_version >= vk::API_VERSION_1_2
-            || self.supports_extension(vk::KhrImageFormatListFn::name())
-        {
-            // Optional `VK_KHR_swapchain_mutable_format`
-            if self.supports_extension(vk::KhrSwapchainMutableFormatFn::name()) {
-                extensions.push(vk::KhrSwapchainMutableFormatFn::name());
-            }
+        // Optional `VK_KHR_swapchain_mutable_format`
+        if self.supports_extension(vk::KhrSwapchainMutableFormatFn::name()) {
+            extensions.push(vk::KhrSwapchainMutableFormatFn::name());
         }
 
         // Optional `VK_EXT_robustness2`

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -320,9 +320,12 @@ impl PhysicalDeviceFeatures {
             | Df::UNRESTRICTED_INDEX_BUFFER
             | Df::INDIRECT_EXECUTION
             | Df::VIEW_FORMATS
-            | Df::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES
-            | Df::SURFACE_VIEW_FORMATS;
+            | Df::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES;
 
+        dl_flags.set(
+            Df::SURFACE_VIEW_FORMATS,
+            caps.supports_extension(vk::KhrSwapchainMutableFormatFn::name()),
+        );
         dl_flags.set(Df::CUBE_ARRAY_TEXTURES, self.core.image_cube_array != 0);
         dl_flags.set(Df::ANISOTROPIC_FILTERING, self.core.sampler_anisotropy != 0);
         dl_flags.set(

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -550,11 +550,7 @@ impl super::Device {
         let original_format = self.shared.private_caps.map_texture_format(config.format);
         let mut raw_flags = vk::SwapchainCreateFlagsKHR::empty();
         let mut raw_view_formats: Vec<vk::Format> = vec![];
-        if !config.view_formats.is_empty()
-            && self
-                .enabled_device_extensions()
-                .contains(&vk::KhrSwapchainMutableFormatFn::name())
-        {
+        if !config.view_formats.is_empty() {
             raw_flags |= vk::SwapchainCreateFlagsKHR::MUTABLE_FORMAT;
             raw_view_formats = config
                 .view_formats

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4007,7 +4007,7 @@ impl Default for SurfaceCapabilities {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct SurfaceConfiguration {
+pub struct SurfaceConfiguration<V> {
     /// The usage of the swap chain. The only supported usage is `RENDER_ATTACHMENT`.
     pub usage: TextureUsages,
     /// The texture format of the swap chain. The only formats that are guaranteed are
@@ -4024,6 +4024,27 @@ pub struct SurfaceConfiguration {
     pub present_mode: PresentMode,
     /// Specifies how the alpha channel of the textures should be handled during compositing.
     pub alpha_mode: CompositeAlphaMode,
+    /// Specifies what view formats will be allowed when calling create_view() on texture returned by get_current_texture().
+    ///
+    /// View formats of the same format as the texture are always allowed.
+    ///
+    /// Note: currently, only the srgb-ness is allowed to change. (ex: Rgba8Unorm texture + Rgba8UnormSrgb view)
+    pub view_formats: V,
+}
+
+impl<V: Clone> SurfaceConfiguration<V> {
+    /// Map view_formats of the texture descriptor into another.
+    pub fn map_view_formats<M>(&self, fun: impl FnOnce(V) -> M) -> SurfaceConfiguration<M> {
+        SurfaceConfiguration {
+            usage: self.usage,
+            format: self.format,
+            width: self.width,
+            height: self.height,
+            present_mode: self.present_mode,
+            alpha_mode: self.alpha_mode,
+            view_formats: fun(self.view_formats.clone()),
+        }
+    }
 }
 
 /// Status of the recieved surface image.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1159,6 +1159,11 @@ bitflags::bitflags! {
         ///
         /// WebGL doesn't support this. WebGPU does.
         const UNRESTRICTED_EXTERNAL_TEXTURE_COPIES = 1 << 20;
+
+        /// Supports specifying which view formats are allowed when calling create_view on the texture returned by get_current_texture.
+        ///
+        /// The GLES/WebGL and Vulkan on Android doesn't support this.
+        const SURFACE_CONFIGURE_VIEW_FORMATS = 1 << 21;
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1163,7 +1163,7 @@ bitflags::bitflags! {
         /// Supports specifying which view formats are allowed when calling create_view on the texture returned by get_current_texture.
         ///
         /// The GLES/WebGL and Vulkan on Android doesn't support this.
-        const SURFACE_CONFIGURE_VIEW_FORMATS = 1 << 21;
+        const SURFACE_VIEW_FORMATS = 1 << 21;
     }
 }
 

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -547,6 +547,7 @@ pub fn test<E: Example>(mut params: FrameworkRefTest) {
                     height: params.height,
                     present_mode: wgpu::PresentMode::Fifo,
                     alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                    view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
                 },
                 &ctx.adapter,
                 &ctx.device,

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -77,6 +77,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         height: size.height,
         present_mode: wgpu::PresentMode::Fifo,
         alpha_mode: swapchain_capabilities.alpha_modes[0],
+        view_formats: &[],
     };
 
     surface.configure(&device, &config);

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -15,7 +15,7 @@ struct ViewportDesc {
 
 struct Viewport {
     desc: ViewportDesc,
-    config: wgpu::SurfaceConfiguration,
+    config: wgpu::SurfaceConfiguration<'static>,
 }
 
 impl ViewportDesc {
@@ -39,6 +39,7 @@ impl ViewportDesc {
             height: size.height,
             present_mode: wgpu::PresentMode::Fifo,
             alpha_mode: caps.alpha_modes[0],
+            view_formats: &[],
         };
 
         self.surface.configure(device, &config);

--- a/wgpu/examples/msaa-line/main.rs
+++ b/wgpu/examples/msaa-line/main.rs
@@ -31,7 +31,7 @@ struct Example {
     vertex_count: u32,
     sample_count: u32,
     rebuild_bundle: bool,
-    config: wgpu::SurfaceConfiguration,
+    config: wgpu::SurfaceConfiguration<'static>,
     max_sample_count: u32,
 }
 
@@ -204,7 +204,10 @@ impl framework::Example for Example {
             sample_count,
             max_sample_count,
             rebuild_bundle: false,
-            config: config.clone(),
+            config: wgpu::SurfaceConfiguration {
+                view_formats: &[],
+                ..config.clone()
+            },
         }
     }
 
@@ -242,7 +245,10 @@ impl framework::Example for Example {
         device: &wgpu::Device,
         _queue: &wgpu::Queue,
     ) {
-        self.config = config.clone();
+        self.config = wgpu::SurfaceConfiguration {
+            view_formats: &[],
+            ..config.clone()
+        };
         self.multisampled_framebuffer =
             Example::create_multisampled_framebuffer(device, config, self.sample_count);
     }

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -734,10 +734,10 @@ impl crate::Context for Context {
         surface_data: &Self::SurfaceData,
         device: &Self::DeviceId,
         _device_data: &Self::DeviceData,
-        config: &wgt::SurfaceConfiguration,
+        config: &crate::SurfaceConfiguration,
     ) {
         let global = &self.0;
-        let error = wgc::gfx_select!(device => global.surface_configure(*surface, *device, config));
+        let error = wgc::gfx_select!(device => global.surface_configure(*surface, *device, &config.map_view_formats(|v| v.to_vec())));
         if let Some(e) = error {
             self.handle_error_fatal(e, "Surface::configure");
         } else {

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1050,7 +1050,7 @@ impl crate::context::Context for Context {
         _surface_data: &Self::SurfaceData,
         device: &Self::DeviceId,
         _device_data: &Self::DeviceData,
-        config: &wgt::SurfaceConfiguration,
+        config: &crate::SurfaceConfiguration,
     ) {
         if let wgt::PresentMode::Mailbox | wgt::PresentMode::Immediate = config.present_mode {
             panic!("Only FIFO/Auto* is supported on web");
@@ -1068,7 +1068,7 @@ impl crate::context::Context for Context {
             web_sys::GpuCanvasConfiguration::new(&device.0, map_texture_format(config.format));
         mapped.usage(config.usage.bits());
         mapped.alpha_mode(alpha_mode);
-        let mapped_view_formats = desc
+        let mapped_view_formats = config
             .view_formats
             .iter()
             .map(|format| JsValue::from(map_texture_format(*format)))

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1068,6 +1068,12 @@ impl crate::context::Context for Context {
             web_sys::GpuCanvasConfiguration::new(&device.0, map_texture_format(config.format));
         mapped.usage(config.usage.bits());
         mapped.alpha_mode(alpha_mode);
+        let mapped_view_formats = desc
+            .view_formats
+            .iter()
+            .map(|format| JsValue::from(map_texture_format(*format)))
+            .collect::<js_sys::Array>();
+        mapped.view_formats(&mapped_view_formats);
         surface.0.configure(&mapped);
     }
 

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -3,8 +3,8 @@ use std::{any::Any, fmt::Debug, future::Future, num::NonZeroU64, ops::Range, pin
 use wgt::{
     strict_assert, strict_assert_eq, AdapterInfo, BufferAddress, BufferSize, Color,
     DownlevelCapabilities, DynamicOffset, Extent3d, Features, ImageDataLayout,
-    ImageSubresourceRange, IndexFormat, Limits, ShaderStages, SurfaceConfiguration, SurfaceStatus,
-    TextureFormat, TextureFormatFeatures,
+    ImageSubresourceRange, IndexFormat, Limits, ShaderStages, SurfaceStatus, TextureFormat,
+    TextureFormatFeatures,
 };
 
 use crate::{
@@ -162,7 +162,7 @@ pub trait Context: Debug + Send + Sized + Sync {
         surface_data: &Self::SurfaceData,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        config: &SurfaceConfiguration,
+        config: &crate::SurfaceConfiguration<'_>,
     );
     #[allow(clippy::type_complexity)]
     fn surface_get_current_texture(
@@ -1139,7 +1139,7 @@ pub(crate) trait DynContext: Debug + Send + Sync {
         surface_data: &crate::Data,
         device: &ObjectId,
         device_data: &crate::Data,
-        config: &SurfaceConfiguration,
+        config: &crate::SurfaceConfiguration<'_>,
     );
     fn surface_get_current_texture(
         &self,
@@ -2044,7 +2044,7 @@ where
         surface_data: &crate::Data,
         device: &ObjectId,
         device_data: &crate::Data,
-        config: &SurfaceConfiguration,
+        config: &crate::SurfaceConfiguration<'_>,
     ) {
         let surface = <T::SurfaceId>::from(*surface);
         let surface_data = downcast_ref(surface_data);


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Follow up to https://github.com/gfx-rs/wgpu/pull/3237


**Testing**
Tested locally except deno part