### PR TITLE
Update `TextureView` validation

### DIFF
--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -408,9 +408,8 @@ fn clear_texture_via_render_passes<A: hal::Api>(
     };
 
     let sample_count = dst_texture.desc.sample_count;
-    let is_3d_texture = dst_texture.desc.dimension == wgt::TextureDimension::D3;
     for mip_level in range.mip_range {
-        let extent = extent_base.mip_level_size(mip_level, is_3d_texture);
+        let extent = extent_base.mip_level_size(mip_level, dst_texture.desc.dimension);
         let layer_or_depth_range = if dst_texture.desc.dimension == wgt::TextureDimension::D3 {
             // TODO: We assume that we're allowed to do clear operations on
             // volume texture slices, this is not properly specified.

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -451,6 +451,8 @@ pub enum RenderPassErrorInner {
     UnsupportedResolveTargetFormat(wgt::TextureFormat),
     #[error("missing color or depth_stencil attachments, at least one is required.")]
     MissingAttachments,
+    #[error("attachment texture view is not renderable")]
+    TextureViewIsNotRenderable,
     #[error("attachments have differing sizes: {previous:?} is followed by {mismatch:?}")]
     AttachmentsDimensionMismatch {
         previous: (&'static str, wgt::Extent3d),
@@ -714,15 +716,18 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
             Ok(())
         };
         let mut add_view = |view: &TextureView<A>, type_name| {
+            let render_extent = view
+                .render_extent
+                .ok_or(RenderPassErrorInner::TextureViewIsNotRenderable)?;
             if let Some(ex) = extent {
-                if ex != view.extent {
+                if ex != render_extent {
                     return Err(RenderPassErrorInner::AttachmentsDimensionMismatch {
                         previous: (attachment_type_name, ex),
-                        mismatch: (type_name, view.extent),
+                        mismatch: (type_name, render_extent),
                     });
                 }
             } else {
-                extent = Some(view.extent);
+                extent = Some(render_extent);
             }
             if sample_count == 0 {
                 sample_count = view.samples;
@@ -910,10 +915,14 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                     .ok_or(RenderPassErrorInner::InvalidAttachment(resolve_target))?;
 
                 check_multiview(resolve_view)?;
-                if color_view.extent != resolve_view.extent {
+
+                let render_extent = resolve_view
+                    .render_extent
+                    .ok_or(RenderPassErrorInner::TextureViewIsNotRenderable)?;
+                if color_view.render_extent.unwrap() != render_extent {
                     return Err(RenderPassErrorInner::AttachmentsDimensionMismatch {
                         previous: (attachment_type_name, extent.unwrap_or_default()),
-                        mismatch: ("resolve", resolve_view.extent),
+                        mismatch: ("resolve", render_extent),
                     });
                 }
                 if color_view.samples == 1 || resolve_view.samples != 1 {
@@ -1071,7 +1080,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
             };
             let desc = hal::RenderPassDescriptor {
                 label: Some("(wgpu internal) Zero init discarded depth/stencil aspect"),
-                extent: view.extent,
+                extent: view.render_extent.unwrap(),
                 sample_count: view.samples,
                 color_attachments: &[],
                 depth_stencil_attachment: Some(hal::DepthStencilAttachment {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -584,7 +584,8 @@ pub struct TextureView<A: hal::Api> {
     //TODO: store device_id for quick access?
     pub(crate) desc: HalTextureViewDescriptor,
     pub(crate) format_features: wgt::TextureFormatFeatures,
-    pub(crate) extent: wgt::Extent3d,
+    /// This is `None` only if the texture view is not renderable
+    pub(crate) render_extent: Option<wgt::Extent3d>,
     pub(crate) samples: u32,
     pub(crate) selector: TextureSelector,
     pub(crate) life_guard: LifeGuard,
@@ -607,6 +608,12 @@ pub enum CreateTextureViewError {
     InvalidCubemapTextureDepth { depth: u32 },
     #[error("Invalid texture depth `{depth}` for texture view of dimension `CubemapArray`. Cubemap views must use images with sizes which are a multiple of 6.")]
     InvalidCubemapArrayTextureDepth { depth: u32 },
+    #[error("Source texture width and height must be equal for a texture view of dimension `Cube`/`CubeArray`")]
+    InvalidCubeTextureViewSize,
+    #[error("mip level count is 0")]
+    ZeroMipLevelCount,
+    #[error("array layer count is 0")]
+    ZeroArrayLayerCount,
     #[error(
         "TextureView mip level count + base mip level {requested} must be <= Texture mip level count {total}"
     )]

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4230,13 +4230,18 @@ impl Extent3d {
 
     /// Calculates the extent at a given mip level.
     /// Does *not* account for memory size being a multiple of block size.
-    pub fn mip_level_size(&self, level: u32, is_3d_texture: bool) -> Extent3d {
-        Extent3d {
+    ///
+    /// https://gpuweb.github.io/gpuweb/#logical-miplevel-specific-texture-extent
+    pub fn mip_level_size(&self, level: u32, dim: TextureDimension) -> Self {
+        Self {
             width: u32::max(1, self.width >> level),
-            height: u32::max(1, self.height >> level),
-            depth_or_array_layers: match is_3d_texture {
-                false => self.depth_or_array_layers,
-                true => u32::max(1, self.depth_or_array_layers >> level),
+            height: match dim {
+                TextureDimension::D1 => 1,
+                _ => u32::max(1, self.height >> level),
+            },
+            depth_or_array_layers: match dim {
+                TextureDimension::D3 => u32::max(1, self.depth_or_array_layers >> level),
+                _ => self.depth_or_array_layers,
             },
         }
     }
@@ -4444,13 +4449,23 @@ impl<L, V: Clone> TextureDescriptor<L, V> {
             return None;
         }
 
-        Some(
-            self.size
-                .mip_level_size(level, self.dimension == TextureDimension::D3),
-        )
+        Some(self.size.mip_level_size(level, self.dimension))
+    }
+
+    /// Computes the render extent of this texture.
+    ///
+    /// https://gpuweb.github.io/gpuweb/#abstract-opdef-compute-render-extent
+    pub fn compute_render_extent(&self, mip_level: u32) -> Extent3d {
+        Extent3d {
+            width: u32::max(1, self.size.width >> mip_level),
+            height: u32::max(1, self.size.height >> mip_level),
+            depth_or_array_layers: 1,
+        }
     }
 
     /// Returns the number of array layers.
+    ///
+    /// https://gpuweb.github.io/gpuweb/#abstract-opdef-array-layer-count
     pub fn array_layer_count(&self) -> u32 {
         match self.dimension {
             TextureDimension::D1 | TextureDimension::D3 => 1,
@@ -5066,7 +5081,7 @@ pub struct ImageCopyTexture<T> {
 
 /// Subresource range within an image
 #[repr(C)]
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]
 pub struct ImageSubresourceRange {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**


**Description**
Update `TextureView` validation according to the WebGPU spec.
I have a follow-up PR to allow creation of depth-only and stencil-only views (according to the spec).

**Testing**

