### PR TITLE
Make `make_spirv_raw` and `make_spirv` handle big-endian binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,7 @@ let texture = device.create_texture(&wgpu::TextureDescriptor {
 - Validate texture ids in `Global::queue_texture_write`. By @jimblandy in [#3378](https://github.com/gfx-rs/wgpu/pull/3378).
 - Don't panic on mapped buffer in queue_submit. By @crowlKats in [#3364](https://github.com/gfx-rs/wgpu/pull/3364).
 - Fix being able to sample a depth texture with a filtering sampler. By @teoxoy in [#3394](https://github.com/gfx-rs/wgpu/pull/3394).
+- Make `make_spirv_raw` and `make_spirv` handle big-endian binaries. By @1e1001 in [#3411](https://github.com/gfx-rs/wgpu/pull/3411).
 
 #### Metal
 - Fix texture view creation with full-resource views when using an explicit `mip_level_count` or `array_layer_count`. By @cwfitzgerald in [#3323](https://github.com/gfx-rs/wgpu/pull/3323)

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -66,7 +66,8 @@ pub fn make_spirv_raw(data: &[u8]) -> Cow<[u32]> {
         Cow::from(words)
     };
 
-    // swap if that corrects the magic
+    // Before checking if the data starts with the magic, check if it starts
+    // with the magic in non-native endianness, own & swap the data if so.
     if words[0] == MAGIC_NUMBER.swap_bytes() {
         for word in Cow::to_mut(&mut words) {
             *word = word.swap_bytes();

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -48,10 +48,11 @@ pub fn make_spirv_raw(data: &[u8]) -> Cow<[u32]> {
         0,
         "data size is not a multiple of 4"
     );
+    assert_ne!(data.len(), 0, "data size must be larger than zero");
 
     //If the data happens to be aligned, directly use the byte array,
     // otherwise copy the byte array in an owned vector and use that instead.
-    let words = if data.as_ptr().align_offset(align_of::<u32>()) == 0 {
+    let mut words = if data.as_ptr().align_offset(align_of::<u32>()) == 0 {
         let (pre, words, post) = unsafe { data.align_to::<u32>() };
         debug_assert!(pre.is_empty());
         debug_assert!(post.is_empty());
@@ -63,6 +64,13 @@ pub fn make_spirv_raw(data: &[u8]) -> Cow<[u32]> {
         }
         Cow::from(words)
     };
+
+    // swap if that corrects the magic
+    if words[0] == MAGIC_NUMBER.swap_bytes() {
+        for word in Cow::to_mut(&mut words) {
+            *word = word.swap_bytes();
+        }
+    }
 
     assert_eq!(
         words[0], MAGIC_NUMBER,

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -31,6 +31,7 @@ pub use init::*;
 ///
 /// - Input length isn't multiple of 4
 /// - Input is longer than [`usize::max_value`]
+/// - Input is empty
 /// - SPIR-V magic number is missing from beginning of stream
 #[cfg(feature = "spirv")]
 pub fn make_spirv(data: &[u8]) -> super::ShaderSource {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #3408.

**Description**
Swaps the words if that makes the first word match the magic. Also adds a check that the input isn't empty, not sure if it's needed but I think the better error message would be useful.

**Testing**
Locally tested by flipping a spir-v binary and comparing the result, if I need to add an actual test I will.
