### PR TITLE
vk: improve view_formats setting

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -852,7 +852,7 @@ impl<A: HalApi> Device<A> {
             ));
         }
 
-        let mut hal_view_formats = vec![desc.format];
+        let mut hal_view_formats = vec![];
         for format in desc.view_formats.iter() {
             if desc.format == *format {
                 continue;

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -852,7 +852,7 @@ impl<A: HalApi> Device<A> {
             ));
         }
 
-        let mut allow_different_view_format = false;
+        let mut hal_view_formats = vec![desc.format];
         for format in desc.view_formats.iter() {
             if desc.format == *format {
                 continue;
@@ -860,7 +860,7 @@ impl<A: HalApi> Device<A> {
             if desc.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
                 return Err(CreateTextureError::InvalidViewFormat(*format, desc.format));
             }
-            allow_different_view_format = true;
+            hal_view_formats.push(*format);
         }
 
         // Enforce having COPY_DST/DEPTH_STENCIL_WRIT/COLOR_TARGET otherwise we
@@ -893,7 +893,7 @@ impl<A: HalApi> Device<A> {
             format: desc.format,
             usage: hal_usage,
             memory_flags: hal::MemoryFlags::empty(),
-            allow_different_view_format,
+            view_formats: hal_view_formats,
         };
 
         let raw_texture = unsafe {

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -299,7 +299,7 @@ impl<A: hal::Api> Example<A> {
             format: wgt::TextureFormat::Rgba8UnormSrgb,
             usage: hal::TextureUses::COPY_DST | hal::TextureUses::RESOURCE,
             memory_flags: hal::MemoryFlags::empty(),
-            allow_different_view_format: false,
+            view_formats: vec![],
         };
         let texture = unsafe { device.create_texture(&texture_desc).unwrap() };
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -847,7 +847,7 @@ pub struct TextureDescriptor<'a> {
     pub memory_flags: MemoryFlags,
     /// Allows views of this texture to have a different format
     /// than the this texture does.
-    pub allow_different_view_format: bool,
+    pub view_formats: Vec<wgt::TextureFormat>,
 }
 
 /// TextureView descriptor.

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -846,7 +846,7 @@ pub struct TextureDescriptor<'a> {
     pub usage: TextureUses,
     pub memory_flags: MemoryFlags,
     /// Allows views of this texture to have a different format
-    /// than the this texture does.
+    /// than the texture does.
     pub view_formats: Vec<wgt::TextureFormat>,
 }
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -589,11 +589,14 @@ impl PhysicalDeviceCapabilities {
         }
 
         if self.effective_api_version < vk::API_VERSION_1_2 {
+            // Optional `VK_KHR_image_format_list`
+            if self.supports_extension(vk::KhrImageFormatListFn::name()) {
+                extensions.push(vk::KhrImageFormatListFn::name());
+            }
+
             // Optional `VK_KHR_imageless_framebuffer`
             if self.supports_extension(vk::KhrImagelessFramebufferFn::name()) {
                 extensions.push(vk::KhrImagelessFramebufferFn::name());
-                // Require `VK_KHR_image_format_list` due to it being a dependency
-                extensions.push(vk::KhrImageFormatListFn::name());
                 // Require `VK_KHR_maintenance2` due to it being a dependency
                 if self.effective_api_version < vk::API_VERSION_1_1 {
                     extensions.push(vk::KhrMaintenance2Fn::name());

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -895,11 +895,22 @@ impl crate::Device<super::Api> for super::Device {
             raw_flags |= vk::ImageCreateFlags::CUBE_COMPATIBLE;
         }
 
-        if desc.allow_different_view_format {
+        let mut hal_view_formats: Vec<vk::Format> = vec![];
+        if desc.view_formats.len() > 1 {
             raw_flags |= vk::ImageCreateFlags::MUTABLE_FORMAT;
+            if self
+                .enabled_device_extensions()
+                .contains(&vk::KhrImageFormatListFn::name())
+            {
+                hal_view_formats = desc
+                    .view_formats
+                    .iter()
+                    .map(|f| self.shared.private_caps.map_texture_format(*f))
+                    .collect();
+            }
         }
 
-        let vk_info = vk::ImageCreateInfo::builder()
+        let mut vk_info = vk::ImageCreateInfo::builder()
             .flags(raw_flags)
             .image_type(conv::map_texture_dimension(desc.dimension))
             .format(self.shared.private_caps.map_texture_format(desc.format))
@@ -915,6 +926,15 @@ impl crate::Device<super::Api> for super::Device {
             .usage(conv::map_texture_usage(desc.usage))
             .sharing_mode(vk::SharingMode::EXCLUSIVE)
             .initial_layout(vk::ImageLayout::UNDEFINED);
+
+        let mut format_list_info = if !hal_view_formats.is_empty() {
+            Some(vk::ImageFormatListCreateInfo::builder().view_formats(&hal_view_formats))
+        } else {
+            None
+        };
+        if let Some(list_info) = format_list_info.as_mut() {
+            vk_info = vk_info.push_next(list_info);
+        }
 
         let raw = unsafe { self.shared.raw.create_image(&vk_info, None)? };
         let req = unsafe { self.shared.raw.get_image_memory_requirements(raw) };

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -895,8 +895,9 @@ impl crate::Device<super::Api> for super::Device {
             raw_flags |= vk::ImageCreateFlags::CUBE_COMPATIBLE;
         }
 
+        let original_format = self.shared.private_caps.map_texture_format(desc.format);
         let mut hal_view_formats: Vec<vk::Format> = vec![];
-        if !desc.view_formats.len() > 1 {
+        if !desc.view_formats.is_empty() {
             raw_flags |= vk::ImageCreateFlags::MUTABLE_FORMAT;
             if self.shared_instance().driver_api_version >= vk::API_VERSION_1_2
                 || self
@@ -908,13 +909,14 @@ impl crate::Device<super::Api> for super::Device {
                     .iter()
                     .map(|f| self.shared.private_caps.map_texture_format(*f))
                     .collect();
+                hal_view_formats.push(original_format)
             }
         }
 
         let mut vk_info = vk::ImageCreateInfo::builder()
             .flags(raw_flags)
             .image_type(conv::map_texture_dimension(desc.dimension))
-            .format(self.shared.private_caps.map_texture_format(desc.format))
+            .format(original_format)
             .extent(vk::Extent3D {
                 width: copy_size.width,
                 height: copy_size.height,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -896,7 +896,7 @@ impl crate::Device<super::Api> for super::Device {
         }
 
         let mut hal_view_formats: Vec<vk::Format> = vec![];
-        if !desc.view_formats.is_empty() {
+        if !desc.view_formats.len() > 1 {
             raw_flags |= vk::ImageCreateFlags::MUTABLE_FORMAT;
             if self.shared_instance().driver_api_version >= vk::API_VERSION_1_2
                 || self
@@ -928,13 +928,10 @@ impl crate::Device<super::Api> for super::Device {
             .sharing_mode(vk::SharingMode::EXCLUSIVE)
             .initial_layout(vk::ImageLayout::UNDEFINED);
 
-        let mut format_list_info = if !hal_view_formats.is_empty() {
-            Some(vk::ImageFormatListCreateInfo::builder().view_formats(&hal_view_formats))
-        } else {
-            None
-        };
-        if let Some(list_info) = format_list_info.as_mut() {
-            vk_info = vk_info.push_next(list_info);
+        let mut format_list_info = vk::ImageFormatListCreateInfo::builder();
+        if !hal_view_formats.is_empty() {
+            format_list_info = format_list_info.view_formats(&hal_view_formats);
+            vk_info = vk_info.push_next(&mut format_list_info);
         }
 
         let raw = unsafe { self.shared.raw.create_image(&vk_info, None)? };

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -898,9 +898,10 @@ impl crate::Device<super::Api> for super::Device {
         let mut hal_view_formats: Vec<vk::Format> = vec![];
         if desc.view_formats.len() > 1 {
             raw_flags |= vk::ImageCreateFlags::MUTABLE_FORMAT;
-            if self
-                .enabled_device_extensions()
-                .contains(&vk::KhrImageFormatListFn::name())
+            if self.shared_instance().driver_api_version >= vk::API_VERSION_1_2
+                || self
+                    .enabled_device_extensions()
+                    .contains(&vk::KhrImageFormatListFn::name())
             {
                 hal_view_formats = desc
                     .view_formats

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -896,7 +896,7 @@ impl crate::Device<super::Api> for super::Device {
         }
 
         let mut hal_view_formats: Vec<vk::Format> = vec![];
-        if desc.view_formats.len() > 1 {
+        if !desc.view_formats.is_empty() {
             raw_flags |= vk::ImageCreateFlags::MUTABLE_FORMAT;
             if self.shared_instance().driver_api_version >= vk::API_VERSION_1_2
                 || self


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.

**Connections**
Follow up to https://github.com/gfx-rs/wgpu/pull/3237

**Description**
More efficient view_formats support is described in the [VK_KHR_image_format_list extension](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_image_format_list.html)

**Testing**
Only tested via `--features=vulkan-portability`
