### PR TITLE
Add test for writing a 3D texture

### DIFF
--- a/wgpu/tests/write_texture.rs
+++ b/wgpu/tests/write_texture.rs
@@ -7,7 +7,7 @@ use wasm_bindgen_test::*;
 
 #[test]
 #[wasm_bindgen_test]
-fn write_texture_subset() {
+fn write_texture_subset_2d() {
     let size = 256;
     let parameters = TestParameters::default().backend_failure(wgpu::Backends::DX12);
     initialize_test(parameters, |ctx| {
@@ -95,6 +95,103 @@ fn write_texture_subset() {
             assert_eq!(*byte, 1);
         }
         for byte in &data[(size as usize * 2)..] {
+            assert_eq!(*byte, 0);
+        }
+    });
+}
+
+
+#[test]
+#[wasm_bindgen_test]
+fn write_texture_subset_3d() {
+    let size = 256;
+    let depth = 4;
+    let parameters = TestParameters::default().backend_failure(wgpu::Backends::DX12);
+    initialize_test(parameters, |ctx| {
+        let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size: wgpu::Extent3d {
+                width: size,
+                height: size,
+                depth_or_array_layers: depth,
+            },
+            format: wgpu::TextureFormat::R8Uint,
+            usage: wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            mip_level_count: 1,
+            sample_count: 1,
+            view_formats: &[],
+        });
+        let data = vec![1u8; (size*size) as usize * 2];
+        // Write the first two slices
+        ctx.queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &tex,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            bytemuck::cast_slice(&data),
+            wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: std::num::NonZeroU32::new(size),
+                rows_per_image: std::num::NonZeroU32::new(size),
+            },
+            wgpu::Extent3d {
+                width: size,
+                height: size,
+                depth_or_array_layers: 2,
+            },
+        );
+
+        ctx.queue.submit(None);
+
+        let read_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: (size * size * depth) as u64,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+        encoder.copy_texture_to_buffer(
+            wgpu::ImageCopyTexture {
+                texture: &tex,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::ImageCopyBuffer {
+                buffer: &read_buffer,
+                layout: wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: NonZeroU32::new(size),
+                    rows_per_image: NonZeroU32::new(size),
+                },
+            },
+            wgpu::Extent3d {
+                width: size,
+                height: size,
+                depth_or_array_layers: depth,
+            },
+        );
+
+        ctx.queue.submit(Some(encoder.finish()));
+
+        let slice = read_buffer.slice(..);
+        slice.map_async(wgpu::MapMode::Read, |_| ());
+        ctx.device.poll(wgpu::Maintain::Wait);
+        let data: Vec<u8> = slice.get_mapped_range().to_vec();
+
+        for byte in &data[..((size*size) as usize * 2)] {
+            assert_eq!(*byte, 1);
+        }
+        for byte in &data[((size*size) as usize * 2)..] {
             assert_eq!(*byte, 0);
         }
     });

--- a/wgpu/tests/write_texture.rs
+++ b/wgpu/tests/write_texture.rs
@@ -100,7 +100,6 @@ fn write_texture_subset_2d() {
     });
 }
 
-
 #[test]
 #[wasm_bindgen_test]
 fn write_texture_subset_3d() {
@@ -124,7 +123,7 @@ fn write_texture_subset_3d() {
             sample_count: 1,
             view_formats: &[],
         });
-        let data = vec![1u8; (size*size) as usize * 2];
+        let data = vec![1u8; (size * size) as usize * 2];
         // Write the first two slices
         ctx.queue.write_texture(
             wgpu::ImageCopyTexture {
@@ -188,10 +187,10 @@ fn write_texture_subset_3d() {
         ctx.device.poll(wgpu::Maintain::Wait);
         let data: Vec<u8> = slice.get_mapped_range().to_vec();
 
-        for byte in &data[..((size*size) as usize * 2)] {
+        for byte in &data[..((size * size) as usize * 2)] {
             assert_eq!(*byte, 1);
         }
-        for byte in &data[((size*size) as usize * 2)..] {
+        for byte in &data[((size * size) as usize * 2)..] {
             assert_eq!(*byte, 0);
         }
     });

--- a/wgpu/tests/write_texture.rs
+++ b/wgpu/tests/write_texture.rs
@@ -105,7 +105,6 @@ fn write_texture_subset_2d() {
 fn write_texture_subset_3d() {
     let size = 256;
     let depth = 4;
-    let parameters = TestParameters::default().backend_failure(wgpu::Backends::DX12);
     initialize_test(parameters, |ctx| {
         let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,

--- a/wgpu/tests/write_texture.rs
+++ b/wgpu/tests/write_texture.rs
@@ -105,6 +105,7 @@ fn write_texture_subset_2d() {
 fn write_texture_subset_3d() {
     let size = 256;
     let depth = 4;
+    let parameters = TestParameters::default();
     initialize_test(parameters, |ctx| {
         let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,


### PR DESCRIPTION
While search for [a problem related to uploading 3D tex data](https://github.com/gfx-rs/wgpu-native/pull/238) I wrote a test to see whether the problem was perhaps in wgpu-core. It was not. But the test might still be useful 😄.

