### PR TITLE
Move surface view formats to a vec

### DIFF
--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -547,7 +547,7 @@ pub fn test<E: Example>(mut params: FrameworkRefTest) {
                     height: params.height,
                     present_mode: wgpu::PresentMode::Fifo,
                     alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                    view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
+                    view_formats: vec![wgpu::TextureFormat::Rgba8Unorm],
                 },
                 &ctx.adapter,
                 &ctx.device,

--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -77,7 +77,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         height: size.height,
         present_mode: wgpu::PresentMode::Fifo,
         alpha_mode: swapchain_capabilities.alpha_modes[0],
-        view_formats: &[],
+        view_formats: vec![],
     };
 
     surface.configure(&device, &config);

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -15,7 +15,7 @@ struct ViewportDesc {
 
 struct Viewport {
     desc: ViewportDesc,
-    config: wgpu::SurfaceConfiguration<'static>,
+    config: wgpu::SurfaceConfiguration,
 }
 
 impl ViewportDesc {
@@ -39,7 +39,7 @@ impl ViewportDesc {
             height: size.height,
             present_mode: wgpu::PresentMode::Fifo,
             alpha_mode: caps.alpha_modes[0],
-            view_formats: &[],
+            view_formats: vec![],
         };
 
         self.surface.configure(device, &config);

--- a/wgpu/examples/msaa-line/main.rs
+++ b/wgpu/examples/msaa-line/main.rs
@@ -31,7 +31,7 @@ struct Example {
     vertex_count: u32,
     sample_count: u32,
     rebuild_bundle: bool,
-    config: wgpu::SurfaceConfiguration<'static>,
+    config: wgpu::SurfaceConfiguration,
     max_sample_count: u32,
 }
 
@@ -204,10 +204,7 @@ impl framework::Example for Example {
             sample_count,
             max_sample_count,
             rebuild_bundle: false,
-            config: wgpu::SurfaceConfiguration {
-                view_formats: &[],
-                ..config.clone()
-            },
+            config: config.clone(),
         }
     }
 
@@ -245,10 +242,7 @@ impl framework::Example for Example {
         device: &wgpu::Device,
         _queue: &wgpu::Queue,
     ) {
-        self.config = wgpu::SurfaceConfiguration {
-            view_formats: &[],
-            ..config.clone()
-        };
+        self.config = config.clone();
         self.multisampled_framebuffer =
             Example::create_multisampled_framebuffer(device, config, self.sample_count);
     }

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -737,7 +737,7 @@ impl crate::Context for Context {
         config: &crate::SurfaceConfiguration,
     ) {
         let global = &self.0;
-        let error = wgc::gfx_select!(device => global.surface_configure(*surface, *device, &config.map_view_formats(|v| v.to_vec())));
+        let error = wgc::gfx_select!(device => global.surface_configure(*surface, *device, config));
         if let Some(e) = error {
             self.handle_error_fatal(e, "Surface::configure");
         } else {

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -162,7 +162,7 @@ pub trait Context: Debug + Send + Sized + Sync {
         surface_data: &Self::SurfaceData,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        config: &crate::SurfaceConfiguration<'_>,
+        config: &crate::SurfaceConfiguration,
     );
     #[allow(clippy::type_complexity)]
     fn surface_get_current_texture(
@@ -1139,7 +1139,7 @@ pub(crate) trait DynContext: Debug + Send + Sync {
         surface_data: &crate::Data,
         device: &ObjectId,
         device_data: &crate::Data,
-        config: &crate::SurfaceConfiguration<'_>,
+        config: &crate::SurfaceConfiguration,
     );
     fn surface_get_current_texture(
         &self,
@@ -2044,7 +2044,7 @@ where
         surface_data: &crate::Data,
         device: &ObjectId,
         device_data: &crate::Data,
-        config: &crate::SurfaceConfiguration<'_>,
+        config: &crate::SurfaceConfiguration,
     ) {
         let surface = <T::SurfaceId>::from(*surface);
         let surface_data = downcast_ref(surface_data);

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -284,7 +284,7 @@ impl Drop for Sampler {
 ///
 /// Corresponds to [WebGPU `GPUCanvasConfiguration`](
 /// https://gpuweb.github.io/gpuweb/#canvas-configuration).
-pub type SurfaceConfiguration<'a> = wgt::SurfaceConfiguration<&'a [TextureFormat]>;
+pub type SurfaceConfiguration = wgt::SurfaceConfiguration<Vec<TextureFormat>>;
 static_assertions::assert_impl_all!(SurfaceConfiguration: Send, Sync);
 
 /// Handle to a presentable surface.
@@ -306,7 +306,7 @@ pub struct Surface {
     // Because the `Surface::configure` method operates on an immutable reference this type has to
     // be wrapped in a mutex and since the configuration is only supplied after the surface has
     // been created is is additionally wrapped in an option.
-    config: Mutex<Option<SurfaceConfiguration<'static>>>,
+    config: Mutex<Option<SurfaceConfiguration>>,
 }
 static_assertions::assert_impl_all!(Surface: Send, Sync);
 
@@ -4090,7 +4090,7 @@ impl Surface {
         adapter: &Adapter,
         width: u32,
         height: u32,
-    ) -> Option<SurfaceConfiguration<'static>> {
+    ) -> Option<SurfaceConfiguration> {
         let caps = self.get_capabilities(adapter);
         Some(SurfaceConfiguration {
             usage: wgt::TextureUsages::RENDER_ATTACHMENT,
@@ -4099,7 +4099,7 @@ impl Surface {
             height,
             present_mode: *caps.present_modes.get(0)?,
             alpha_mode: wgt::CompositeAlphaMode::Auto,
-            view_formats: &[],
+            view_formats: vec![],
         })
     }
 
@@ -4109,7 +4109,7 @@ impl Surface {
     ///
     /// - A old [`SurfaceTexture`] is still alive referencing an old surface.
     /// - Texture format requested is unsupported on the surface.
-    pub fn configure(&self, device: &Device, config: &SurfaceConfiguration<'static>) {
+    pub fn configure(&self, device: &Device, config: &SurfaceConfiguration) {
         DynContext::surface_configure(
             &*self.context,
             &self.id,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.

**Connections**

Follow up to #3409 

**Description**
The 'static bound was extremely limiting, let's move to a vector.
