### PR TITLE
Implement `clear_buffer` on web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ Bottom level categories:
 - Hal
 -->
 
+## Unreleased
+
+### Changes
+
+#### WebGPU
+
+- Implement `CommandEncoder::clear_buffer`. By @raphlinus in [#3426](https://github.com/gfx-rs/wgpu/pull/3426)
+
 ## wgpu-0.15.0 (2023-01-25)
 
 ### Major Changes

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -2187,13 +2187,21 @@ impl crate::context::Context for Context {
 
     fn command_encoder_clear_buffer(
         &self,
-        _encoder: &Self::CommandEncoderId,
+        encoder: &Self::CommandEncoderId,
         _encoder_data: &Self::CommandEncoderData,
-        _buffer: &crate::Buffer,
-        _offset: wgt::BufferAddress,
-        _size: Option<wgt::BufferSize>,
+        buffer: &crate::Buffer,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
     ) {
-        //TODO
+        let buffer_id = &<<Context as crate::Context>::BufferId>::from(buffer.id).0;
+        match size {
+            Some(size) => {
+                encoder
+                    .0
+                    .clear_buffer_with_f64_and_f64(buffer_id, offset as f64, size.get() as f64)
+            }
+            None => encoder.0.clear_buffer_with_f64(buffer_id, offset as f64),
+        }
     }
 
     fn command_encoder_insert_debug_marker(


### PR DESCRIPTION
This was "TODO" but would be very nice to have.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
There's a workaround for this in https://github.com/linebender/vello/issues/267

**Description**
The ` clear_buffer()` method is an empty TODO on the web back-end. This patch fills in the obvious implementation.

**Testing**
It's not carefully tested just yet, but we do plan to soon. Necessary steps will be landing vello#267, updating vello to wgpu 0.15 (vello#263 is the PR in progress for that), removing the hacky workaround, and verifying that it works in Chrome Canary.