### PR TITLE
Improve vk format msaa capabilities detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Bottom level categories:
 
 - Implement `CommandEncoder::clear_buffer`. By @raphlinus in [#3426](https://github.com/gfx-rs/wgpu/pull/3426)
 
+#### Vulkan
+
+- Improve format MSAA capabilities detection. By @jinleili in [#3429](https://github.com/gfx-rs/wgpu/pull/3429)
+
 ## wgpu-0.15.0 (2023-01-25)
 
 ### Major Changes

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1509,7 +1509,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 wgt::TextureSampleType::Sint | wgt::TextureSampleType::Uint => {
                     limits.sampled_image_integer_sample_counts
                 }
-                _ => unimplemented!(),
+                _ => unreachable!(),
             }
         };
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1493,22 +1493,23 @@ impl crate::Adapter<super::Api> for super::Adapter {
         let format_aspect = crate::FormatAspects::from(format);
         let limits = self.phd_capabilities.properties.limits;
 
-        let sample_flags = if format_aspect.contains(crate::FormatAspects::DEPTH) {
-            limits
-                .framebuffer_depth_sample_counts
-                .min(limits.sampled_image_depth_sample_counts)
+        let limits_counts = if format_aspect.contains(crate::FormatAspects::DEPTH) {
+            limits.sampled_image_depth_sample_counts
         } else if format_aspect.contains(crate::FormatAspects::STENCIL) {
-            limits
-                .framebuffer_stencil_sample_counts
-                .min(limits.sampled_image_stencil_sample_counts)
+            limits.sampled_image_stencil_sample_counts
         } else {
-            limits
-                .framebuffer_color_sample_counts
-                .min(limits.sampled_image_color_sample_counts)
-                .min(limits.sampled_image_integer_sample_counts)
-                .min(limits.storage_image_sample_counts)
+            match format.describe().sample_type {
+                wgt::TextureSampleType::Float { filterable: _ } => {
+                    limits.sampled_image_color_sample_counts
+                }
+                wgt::TextureSampleType::Sint | wgt::TextureSampleType::Uint => {
+                    limits.sampled_image_integer_sample_counts
+                }
+                _ => limits.storage_image_sample_counts,
+            }
         };
 
+        let sample_flags = limits.framebuffer_color_sample_counts.min(limits_counts);
         flags.set(
             Tfc::MULTISAMPLE_X2,
             sample_flags.contains(vk::SampleCountFlags::TYPE_2),
@@ -1517,7 +1518,6 @@ impl crate::Adapter<super::Api> for super::Adapter {
             Tfc::MULTISAMPLE_X4,
             sample_flags.contains(vk::SampleCountFlags::TYPE_4),
         );
-
         flags.set(
             Tfc::MULTISAMPLE_X8,
             sample_flags.contains(vk::SampleCountFlags::TYPE_8),


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
MSAA with a sample count greater than 1 (e.g., 4) will result in the following validation error on the vk backend：
```log
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
    color state [0] is invalid
    format Rgba8UnormSrgb can't be multisampled
```
Here are the relevant fields defined in [vk Limits](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceLimits.html)：
> **sampledImageColorSampleCounts** is a bitmask1 of [VkSampleCountFlagBits](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSampleCountFlagBits.html) indicating the sample counts supported for all 2D images created with VK_IMAGE_TILING_OPTIMAL, usage containing VK_IMAGE_USAGE_SAMPLED_BIT, and a non-integer color format.
> **sampledImageIntegerSampleCounts** is a bitmask1 of [VkSampleCountFlagBits](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSampleCountFlagBits.html) indicating the sample counts supported for all 2D images created with VK_IMAGE_TILING_OPTIMAL, usage containing VK_IMAGE_USAGE_SAMPLED_BIT, and an integer color format.
> **storageImageSampleCounts** is a bitmask1 of [VkSampleCountFlagBits](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSampleCountFlagBits.html) indicating the sample counts supported for all 2D images created with VK_IMAGE_TILING_OPTIMAL, and usage containing VK_IMAGE_USAGE_STORAGE_BIT.

On my test devices, `storageImageSampleCounts` always equal to `SampleCountFlags::TYPE_1`.

**Testing**
Tested on Android 13 and macOS (--features=vulkan-portability) via [wgpu-in-app](https://github.com/jinleili/wgpu-in-app)
