### PR TITLE
vk: fix surface view formats validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Bottom level categories:
 #### Vulkan
 
 - Improve format MSAA capabilities detection. By @jinleili in [#3429](https://github.com/gfx-rs/wgpu/pull/3429)
+- Fix surface view formats validation error. By @jinleili in [#3432](https://github.com/gfx-rs/wgpu/pull/3432)
 
 ## wgpu-0.15.0 (2023-01-25)
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -217,20 +217,32 @@ impl super::DeviceShared {
                     .iter()
                     .map(|at| self.private_caps.map_texture_format(at.view_format))
                     .collect::<ArrayVec<_, { super::MAX_TOTAL_ATTACHMENTS }>>();
+                let vk_view_formats_list = e
+                    .key()
+                    .attachments
+                    .iter()
+                    .map(|at| at.raw_view_formats.clone())
+                    .collect::<ArrayVec<_, { super::MAX_TOTAL_ATTACHMENTS }>>();
+
                 let vk_image_infos = e
                     .key()
                     .attachments
                     .iter()
                     .enumerate()
                     .map(|(i, at)| {
-                        vk::FramebufferAttachmentImageInfo::builder()
+                        let mut info = vk::FramebufferAttachmentImageInfo::builder()
                             .usage(conv::map_texture_usage(at.view_usage))
                             .flags(at.raw_image_flags)
                             .width(e.key().extent.width)
                             .height(e.key().extent.height)
-                            .layer_count(e.key().extent.depth_or_array_layers)
-                            .view_formats(&vk_view_formats[i..i + 1])
-                            .build()
+                            .layer_count(e.key().extent.depth_or_array_layers);
+                        // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkRenderPassBeginInfo.html#VUID-VkRenderPassBeginInfo-framebuffer-03214
+                        if vk_view_formats_list[i].is_empty() {
+                            info = info.view_formats(&vk_view_formats[i..i + 1]);
+                        } else {
+                            info = info.view_formats(&vk_view_formats_list[i]);
+                        };
+                        info.build()
                     })
                     .collect::<ArrayVec<_, { super::MAX_TOTAL_ATTACHMENTS }>>();
 
@@ -550,6 +562,7 @@ impl super::Device {
         let original_format = self.shared.private_caps.map_texture_format(config.format);
         let mut raw_flags = vk::SwapchainCreateFlagsKHR::empty();
         let mut raw_view_formats: Vec<vk::Format> = vec![];
+        let mut wgt_view_formats = vec![];
         if !config.view_formats.is_empty() {
             raw_flags |= vk::SwapchainCreateFlagsKHR::MUTABLE_FORMAT;
             raw_view_formats = config
@@ -558,6 +571,9 @@ impl super::Device {
                 .map(|f| self.shared.private_caps.map_texture_format(*f))
                 .collect();
             raw_view_formats.push(original_format);
+
+            wgt_view_formats = config.view_formats.clone();
+            wgt_view_formats.push(config.format);
         }
 
         let mut info = vk::SwapchainCreateInfoKHR::builder()
@@ -617,11 +633,13 @@ impl super::Device {
 
         Ok(super::Swapchain {
             raw,
+            raw_flags,
             functor,
             device: Arc::clone(&self.shared),
             fence,
             images,
             config: config.clone(),
+            view_formats: wgt_view_formats,
         })
     }
 
@@ -630,11 +648,26 @@ impl super::Device {
     /// - `vk_image` must be created respecting `desc`
     /// - If `drop_guard` is `Some`, the application must manually destroy the image handle. This
     ///   can be done inside the `Drop` impl of `drop_guard`.
+    /// - If the `ImageCreateFlags` does not contain `MUTABLE_FORMAT`, the `view_formats` of `desc` must be empty.
     pub unsafe fn texture_from_raw(
         vk_image: vk::Image,
         desc: &crate::TextureDescriptor,
         drop_guard: Option<crate::DropGuard>,
     ) -> super::Texture {
+        let mut raw_flags = vk::ImageCreateFlags::empty();
+        let mut view_formats = vec![];
+        for tf in desc.view_formats.iter() {
+            if *tf == desc.format {
+                continue;
+            }
+            view_formats.push(*tf);
+        }
+        if !view_formats.is_empty() {
+            raw_flags |=
+                vk::ImageCreateFlags::MUTABLE_FORMAT | vk::ImageCreateFlags::EXTENDED_USAGE;
+            view_formats.push(desc.format)
+        }
+
         super::Texture {
             raw: vk_image,
             drop_guard,
@@ -644,6 +677,7 @@ impl super::Device {
             format_info: desc.format.describe(),
             raw_flags: vk::ImageCreateFlags::empty(),
             copy_size: crate::CopyExtent::map_extent_to_copy_size(&desc.size, desc.dimension),
+            view_formats,
         }
     }
 
@@ -916,20 +950,24 @@ impl crate::Device<super::Api> for super::Device {
         }
 
         let original_format = self.shared.private_caps.map_texture_format(desc.format);
-        let mut hal_view_formats: Vec<vk::Format> = vec![];
+        let mut vk_view_formats = vec![];
+        let mut wgt_view_formats = vec![];
         if !desc.view_formats.is_empty() {
             raw_flags |= vk::ImageCreateFlags::MUTABLE_FORMAT;
+            wgt_view_formats = desc.view_formats.clone();
+            wgt_view_formats.push(desc.format);
+
             if self.shared_instance().driver_api_version >= vk::API_VERSION_1_2
                 || self
                     .enabled_device_extensions()
                     .contains(&vk::KhrImageFormatListFn::name())
             {
-                hal_view_formats = desc
+                vk_view_formats = desc
                     .view_formats
                     .iter()
                     .map(|f| self.shared.private_caps.map_texture_format(*f))
                     .collect();
-                hal_view_formats.push(original_format)
+                vk_view_formats.push(original_format)
             }
         }
 
@@ -951,8 +989,8 @@ impl crate::Device<super::Api> for super::Device {
             .initial_layout(vk::ImageLayout::UNDEFINED);
 
         let mut format_list_info = vk::ImageFormatListCreateInfo::builder();
-        if !hal_view_formats.is_empty() {
-            format_list_info = format_list_info.view_formats(&hal_view_formats);
+        if !vk_view_formats.is_empty() {
+            format_list_info = format_list_info.view_formats(&vk_view_formats);
             vk_info = vk_info.push_next(&mut format_list_info);
         }
 
@@ -993,6 +1031,7 @@ impl crate::Device<super::Api> for super::Device {
             format_info: desc.format.describe(),
             raw_flags,
             copy_size,
+            view_formats: wgt_view_formats,
         })
     }
     unsafe fn destroy_texture(&self, texture: super::Texture) {
@@ -1048,6 +1087,11 @@ impl crate::Device<super::Api> for super::Device {
             raw_image_flags: texture.raw_flags,
             view_usage,
             view_format: desc.format,
+            raw_view_formats: texture
+                .view_formats
+                .iter()
+                .map(|tf| self.shared.private_caps.map_texture_format(*tf))
+                .collect(),
         };
 
         Ok(super::TextureView {

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -784,6 +784,16 @@ impl crate::Surface<super::Api> for super::Surface {
             .map_err(crate::DeviceError::from)?;
         unsafe { sc.device.raw.reset_fences(fences) }.map_err(crate::DeviceError::from)?;
 
+        // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkRenderPassBeginInfo.html#VUID-VkRenderPassBeginInfo-framebuffer-03209
+        let raw_flags = if sc
+            .raw_flags
+            .contains(vk::SwapchainCreateFlagsKHR::MUTABLE_FORMAT)
+        {
+            vk::ImageCreateFlags::MUTABLE_FORMAT | vk::ImageCreateFlags::EXTENDED_USAGE
+        } else {
+            vk::ImageCreateFlags::empty()
+        };
+
         let texture = super::SurfaceTexture {
             index,
             texture: super::Texture {
@@ -793,11 +803,12 @@ impl crate::Surface<super::Api> for super::Surface {
                 usage: sc.config.usage,
                 aspects: crate::FormatAspects::COLOR,
                 format_info: sc.config.format.describe(),
-                raw_flags: vk::ImageCreateFlags::empty(),
+                raw_flags,
                 copy_size: conv::map_extent_to_copy_size(
                     &sc.config.extent,
                     wgt::TextureDimension::D2,
                 ),
+                view_formats: sc.view_formats.clone(),
             },
         };
         Ok(Some(crate::AcquiredSurfaceTexture {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -96,11 +96,13 @@ pub struct Instance {
 
 struct Swapchain {
     raw: vk::SwapchainKHR,
+    raw_flags: vk::SwapchainCreateFlagsKHR,
     functor: khr::Swapchain,
     device: Arc<DeviceShared>,
     fence: vk::Fence,
     images: Vec<vk::Image>,
     config: crate::SurfaceConfiguration,
+    view_formats: Vec<wgt::TextureFormat>,
 }
 
 pub struct Surface {
@@ -225,6 +227,7 @@ struct FramebufferAttachment {
     raw_image_flags: vk::ImageCreateFlags,
     view_usage: crate::TextureUses,
     view_format: wgt::TextureFormat,
+    raw_view_formats: Vec<vk::Format>,
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -294,6 +297,7 @@ pub struct Texture {
     format_info: wgt::TextureFormatInfo,
     raw_flags: vk::ImageCreateFlags,
     copy_size: crate::CopyExtent,
+    view_formats: Vec<wgt::TextureFormat>,
 }
 
 impl Texture {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
From Matrix:
> Elabajaba: vulkan is very unhappy with my attempts to use view_formats
```log
93 API High Miscellaneous 3725809774 Validation Error: [ VUID-VkRenderPassBeginInfo-framebuffer-03209 ] Object 0: handle = Render Pass 428, type = VK_OBJECT_TYPE_RENDER_PASS; | MessageID = 0xde13586e | vkCmdBeginRenderPass: Image view #0 created from an image with flags set as 0x108, but image info #0 used to create the framebuffer had flags set as 0x0 The Vulkan spec states: If framebuffer was created with a VkFramebufferCreateInfo::flags value that included VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT, each element of the pAttachments member of a VkRenderPassAttachmentBeginInfo structure included in the pNext chain must be a VkImageView of an image created with a value of VkImageCreateInfo::flags equal to the flags member of the corresponding element of VkFramebufferAttachmentsCreateInfo::pAttachmentImageInfos used to create framebuffer (https://vulkan.lunarg.com/doc/view/1.3.236.0/windows/1.3-extensions/vkspec.html#VUID-VkRenderPassBeginInfo-framebuffer-03209)

93 API High Miscellaneous 1246532502 Validation Error: [ VUID-VkRenderPassBeginInfo-framebuffer-03214 ] Object 0: handle = Render Pass 428, type = VK_OBJECT_TYPE_RENDER_PASS; | MessageID = 0x4a4c9396 | VkRenderPassBeginInfo: Image view #0 created with an image with a viewFormatCount of 2, but image info #0 used to create the framebuffer had viewFormatCount set as 1 The Vulkan spec states: If framebuffer was created with a VkFramebufferCreateInfo::flags value that included VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT, each element of the pAttachments member of a VkRenderPassAttachmentBeginInfo structure included in the pNext chain must be a VkImageView of an image created with a value of VkImageFormatListCreateInfo::viewFormatCount equal to the viewFormatCount member of the corresponding element of VkFramebufferAttachmentsCreateInfo::pAttachmentImageInfos used to create framebuffer (https://vulkan.lunarg.com/doc/view/1.3.236.0/windows/1.3-extensions/vkspec.html#VUID-VkRenderPassBeginInfo-framebuffer-03214)

93 API High Miscellaneous 2112405535 Validation Error: [ VUID-VkRenderPassBeginInfo-framebuffer-03215 ] Object 0: handle = Render Pass 428, type = VK_OBJECT_TYPE_RENDER_PASS; | MessageID = 0x7de8c01f | VkRenderPassBeginInfo: Image view #0 created with an image including the format VK_FORMAT_R8G8B8A8_UNORM in its view format list, but image info #0 used to create the framebuffer does not include this format The Vulkan spec states: If framebuffer was created with a VkFramebufferCreateInfo::flags value that included VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT, each element of the pAttachments member of a VkRenderPassAttachmentBeginInfo structure included in the pNext chain must be a VkImageView of an image created with a set of elements in VkImageFormatListCreateInfo::pViewFormats equal to the set of elements in the pViewFormats member of the corresponding element of VkFramebufferAttachmentsCreateInfo::pAttachmentImageInfos used to create framebuffer (https://vulkan.lunarg.com/doc/view/1.3.236.0/windows/1.3-extensions/vkspec.html#VUID-VkRenderPassBeginInfo-framebuffer-03215)
```

**Description**
Maybe it's better to set the type of the `view_formats` field in `hal/vk/Texture` to `Vec<vk::Format>`, but I can't call `private_caps.map_texture_format()` instance function in `texture_from_raw()` to implement format mapping.

**Testing**
Tested locally
