### PR TITLE
Fix dx12 shader validation errors when dxil.dll isn't available in the local scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ Bottom level categories:
 
 ### Bug Fixes
 
+#### DX12
+
+- Fix DXC validation issues when using a custom `dxil_path`. By @Elabajaba in [#3434](https://github.com/gfx-rs/wgpu/pull/3434)
+
 #### General
 
 - `copyTextureToTexture` src/dst aspects must both refer to all aspects of src/dst format. By @teoxoy in [#3431](https://github.com/gfx-rs/wgpu/pull/3431)

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -84,13 +84,12 @@ mod dxc {
     use std::path::PathBuf;
 
     pub(crate) struct DxcContainer {
-        pub compiler: hassle_rs::DxcCompiler,
-        pub library: hassle_rs::DxcLibrary,
+        compiler: hassle_rs::DxcCompiler,
+        library: hassle_rs::DxcLibrary,
         // Has to be held onto for the lifetime of the device otherwise shaders will fail to compile
         _dxc: hassle_rs::Dxc,
-        // Only used when dxil.dll has an explicit path to avoid automatic validation silently failing.
-        pub validator: Option<hassle_rs::DxcValidator>,
-        _dxil: Option<hassle_rs::Dxil>,
+        validator: hassle_rs::DxcValidator,
+        _dxil: hassle_rs::Dxil,
     }
 
     pub(crate) fn get_dxc_container(
@@ -98,37 +97,16 @@ mod dxc {
         dxil_path: Option<PathBuf>,
     ) -> Result<Option<DxcContainer>, crate::DeviceError> {
         // Make sure that dxil.dll exists.
-        let dxil = match hassle_rs::Dxil::new(dxil_path.clone()) {
-            Ok(dxil) => {
-                if dxil_path.is_some() {
-                    Some(dxil)
-                } else {
-                    None
-                }
-            }
+        let dxil = match hassle_rs::Dxil::new(dxil_path) {
+            Ok(dxil) => dxil,
             Err(e) => {
                 log::warn!("Failed to load dxil.dll. Defaulting to Fxc instead: {}", e);
                 return Ok(None);
             }
         };
 
-        // We need to disable implicit validation and do explicit validation if the user is using
-        // a custom path for `dxil.dll`, otherwise it will silently fail to do validation when
-        // calling compile because dxcompiler is looking for `dxil.dll` in the local scope.
-        let validator = if let Some(ref dxil) = dxil {
-            match dxil.create_validator() {
-                Ok(validator) => Some(validator),
-                Err(e) => {
-                    log::warn!(
-                        "Failed to create DXIL validator. Defaulting to Fxc instead: {}",
-                        e
-                    );
-                    return Ok(None);
-                }
-            }
-        } else {
-            None
-        };
+        // Needed for explicit validation.
+        let validator = dxil.create_validator()?;
 
         let dxc = match hassle_rs::Dxc::new(dxc_path) {
             Ok(dxc) => dxc,
@@ -140,13 +118,13 @@ mod dxc {
                 return Ok(None);
             }
         };
-        let dxc_compiler = dxc.create_compiler()?;
-        let dxc_library = dxc.create_library()?;
+        let compiler = dxc.create_compiler()?;
+        let library = dxc.create_library()?;
 
         Ok(Some(DxcContainer {
             _dxc: dxc,
-            compiler: dxc_compiler,
-            library: dxc_library,
+            compiler,
+            library,
             _dxil: dxil,
             validator,
         }))
@@ -167,6 +145,7 @@ mod dxc {
         profiling::scope!("compile_dxc");
         let mut compile_flags = arrayvec::ArrayVec::<&str, 4>::new_const();
         compile_flags.push("-Ges"); // d3dcompiler::D3DCOMPILE_ENABLE_STRICTNESS
+        compile_flags.push("-Vd"); // Disable implicit validation to work around bugs when dxil.dll isn't in the local directory.
         if device
             .private_caps
             .instance_flags
@@ -174,12 +153,6 @@ mod dxc {
         {
             compile_flags.push("-Zi"); // d3dcompiler::D3DCOMPILE_SKIP_OPTIMIZATION
             compile_flags.push("-Od"); // d3dcompiler::D3DCOMPILE_DEBUG
-        }
-
-        // Disable implicit validation if `dxil.dll` isn't available in the local scope, and
-        // do explicit validation instead.
-        if dxc_container.validator.is_some() {
-            compile_flags.push("-Vd");
         }
 
         let blob = match dxc_container
@@ -204,28 +177,19 @@ mod dxc {
         let (result, log_level) = match compiled {
             Ok(dxc_result) => match dxc_result.get_result() {
                 Ok(dxc_blob) => {
-                    // We have a blob, now check if we need to manually validate it or if it
-                    // was automatically validated.
-                    if let Some(ref validator) = dxc_container.validator {
-                        match validator.validate(dxc_blob) {
-                            Ok(validated_blob) => (
-                                Ok(crate::dx12::CompiledShader::Dxc(validated_blob.to_vec())),
-                                log::Level::Info,
-                            ),
-                            Err(e) => (
-                                Err(crate::PipelineError::Linkage(
-                                    stage_bit,
-                                    format!("DXC validation error: {:?}\n{:?}", e.0, e.1),
-                                )),
-                                log::Level::Error,
-                            ),
-                        }
-                    } else {
-                        // Automatically validated by dxc_container.compiler.compile()
-                        (
-                            Ok(crate::dx12::CompiledShader::Dxc(dxc_blob.to_vec())),
+                    // Validate the shader.
+                    match dxc_container.validator.validate(dxc_blob) {
+                        Ok(validated_blob) => (
+                            Ok(crate::dx12::CompiledShader::Dxc(validated_blob.to_vec())),
                             log::Level::Info,
-                        )
+                        ),
+                        Err(e) => (
+                            Err(crate::PipelineError::Linkage(
+                                stage_bit,
+                                format!("DXC validation error: {:?}\n{:?}", e.0, e.1),
+                            )),
+                            log::Level::Error,
+                        ),
                     }
                 }
                 Err(e) => (

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -83,12 +83,14 @@ pub(super) fn compile_fxc(
 mod dxc {
     use std::path::PathBuf;
 
+    // Destructor order should be fine since _dxil and _dxc don't rely on each other.
     pub(crate) struct DxcContainer {
         compiler: hassle_rs::DxcCompiler,
         library: hassle_rs::DxcLibrary,
-        // Has to be held onto for the lifetime of the device otherwise shaders will fail to compile
-        _dxc: hassle_rs::Dxc,
         validator: hassle_rs::DxcValidator,
+        // Has to be held onto for the lifetime of the device otherwise shaders will fail to compile.
+        _dxc: hassle_rs::Dxc,
+        // Also Has to be held onto for the lifetime of the device otherwise shaders will fail to validate.
         _dxil: hassle_rs::Dxil,
     }
 

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -115,7 +115,7 @@ mod dxc {
         // We need to disable implicit validation and do explicit validation if the user is using
         // a custom path for `dxil.dll`, otherwise it will silently fail to do validation when
         // calling compile because dxcompiler is looking for `dxil.dll` in the local scope.
-        let validator = if let Some(dxil) = &dxil {
+        let validator = if let Some(ref dxil) = dxil {
             match dxil.create_validator() {
                 Ok(validator) => Some(validator),
                 Err(e) => {
@@ -206,7 +206,7 @@ mod dxc {
                 Ok(dxc_blob) => {
                     // We have a blob, now check if we need to manually validate it or if it
                     // was automatically validated.
-                    if let Some(validator) = &dxc_container.validator {
+                    if let Some(ref validator) = dxc_container.validator {
                         match validator.validate(dxc_blob) {
                             Ok(validated_blob) => (
                                 Ok(crate::dx12::CompiledShader::Dxc(validated_blob.to_vec())),


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/3433

**Description**
When using a custom path for dxil.dll that isn't in the local scope, dxcompiler's automatic validation will silently fail. This makes it so that if dxil.dll has a custom path, then we disable automatic validation and do manual validation post compilation instead.

**Testing**
Tested against `hello-triangle` with a custom `dxil.dll` path and no `dxil.dll` in the wgpu folder.
