### PR TITLE
fix clippy for rust 1.67

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -494,7 +494,7 @@ pub enum RenderPassErrorInner {
     #[error(transparent)]
     MissingDownlevelFlags(#[from] MissingDownlevelFlags),
     #[error("indirect draw uses bytes {offset}..{end_offset} {} which overruns indirect buffer of size {buffer_size}",
-        count.map_or_else(String::new, |v| format!("(using count {})", v)))]
+        count.map_or_else(String::new, |v| format!("(using count {v})")))]
     IndirectBufferOverrun {
         count: Option<NonZeroU32>,
         offset: u64,

--- a/wgpu-core/src/error.rs
+++ b/wgpu-core/src/error.rs
@@ -13,16 +13,16 @@ pub struct ErrorFormatter<'a> {
 
 impl<'a> ErrorFormatter<'a> {
     pub fn error(&mut self, err: &dyn Error) {
-        writeln!(self.writer, "    {}", err).expect("Error formatting error");
+        writeln!(self.writer, "    {err}").expect("Error formatting error");
     }
 
     pub fn note(&mut self, note: &dyn fmt::Display) {
-        writeln!(self.writer, "      note: {}", note).expect("Error formatting error");
+        writeln!(self.writer, "      note: {note}").expect("Error formatting error");
     }
 
     pub fn label(&mut self, label_key: &str, label_value: &str) {
         if !label_key.is_empty() && !label_value.is_empty() {
-            self.note(&format!("{} = `{}`", label_key, label_value));
+            self.note(&format!("{label_key} = `{label_value}`"));
         }
     }
 

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -392,7 +392,7 @@ impl<T, I: id::TypedId> Storage<T, I> {
         }
         match std::mem::replace(&mut self.map[index], element) {
             Element::Vacant => {}
-            _ => panic!("Index {:?} is already occupied", index),
+            _ => panic!("Index {index:?} is already occupied"),
         }
     }
 

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -24,6 +24,8 @@
     // For some reason `rustc` can warn about these in const generics even
     // though they are required.
     unused_braces,
+    // Clashes with clippy::pattern_type_mismatch
+    clippy::needless_borrowed_reference,
 )]
 #![warn(
     trivial_casts,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -74,7 +74,7 @@ impl fmt::Display for ShaderError<naga::front::wgsl::ParseError> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let label = self.label.as_deref().unwrap_or_default();
         let string = self.inner.emit_to_string(&self.source);
-        write!(f, "\nShader '{}' parsing {}", label, string)
+        write!(f, "\nShader '{label}' parsing {string}")
     }
 }
 impl fmt::Display for ShaderError<naga::WithSpan<naga::valid::ValidationError>> {

--- a/wgpu-hal/src/auxil/renderdoc.rs
+++ b/wgpu-hal/src/auxil/renderdoc.rs
@@ -62,8 +62,7 @@ impl RenderDoc {
             Err(e) => {
                 return RenderDoc::NotAvailable {
                     reason: format!(
-                        "Unable to load renderdoc library '{}': {:?}",
-                        renderdoc_filename, e
+                        "Unable to load renderdoc library '{renderdoc_filename}': {e:?}"
                     ),
                 }
             }
@@ -75,8 +74,7 @@ impl RenderDoc {
                 Err(e) => {
                     return RenderDoc::NotAvailable {
                         reason: format!(
-                            "Unable to get RENDERDOC_GetAPI from renderdoc library '{}': {:?}",
-                            renderdoc_filename, e
+                            "Unable to get RENDERDOC_GetAPI from renderdoc library '{renderdoc_filename}': {e:?}"
                         ),
                     }
                 }
@@ -91,8 +89,7 @@ impl RenderDoc {
             },
             return_value => RenderDoc::NotAvailable {
                 reason: format!(
-                    "Unable to get API from renderdoc library '{}': {}",
-                    renderdoc_filename, return_value
+                    "Unable to get API from renderdoc library '{renderdoc_filename}': {return_value}"
                 ),
             },
         }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -214,7 +214,7 @@ impl super::Device {
             profiling::scope!("naga::back::hlsl::write");
             writer
                 .write(module, &stage.module.naga.info)
-                .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("HLSL: {:?}", e)))?
+                .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("HLSL: {e:?}")))?
         };
 
         let full_stage = format!(
@@ -231,7 +231,7 @@ impl super::Device {
 
         let raw_ep = reflection_info.entry_point_names[ep_index]
             .as_ref()
-            .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("{}", e)))?;
+            .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("{e}")))?;
 
         let source_name = stage
             .module

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -56,7 +56,7 @@ pub(super) fn compile_fxc(
             log::Level::Info,
         ),
         Err(e) => {
-            let mut full_msg = format!("FXC D3DCompile error ({})", e);
+            let mut full_msg = format!("FXC D3DCompile error ({e})");
             if !error.is_null() {
                 use std::fmt::Write as _;
                 let message = unsafe {
@@ -150,7 +150,7 @@ mod dxc {
         let blob = match dxc_container
             .library
             .create_blob_with_encoding_from_str(source)
-            .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("DXC blob error: {}", e)))
+            .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("DXC blob error: {e}")))
         {
             Ok(blob) => blob,
             Err(e) => return (Err(e), log::Level::Error),
@@ -176,7 +176,7 @@ mod dxc {
                 Err(e) => (
                     Err(crate::PipelineError::Linkage(
                         stage_bit,
-                        format!("DXC compile error: {}", e),
+                        format!("DXC compile error: {e}"),
                     )),
                     log::Level::Error,
                 ),
@@ -184,7 +184,7 @@ mod dxc {
             Err(e) => (
                 Err(crate::PipelineError::Linkage(
                     stage_bit,
-                    format!("DXC compile error: {:?}", e),
+                    format!("DXC compile error: {e:?}"),
                 )),
                 log::Level::Error,
             ),

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -153,7 +153,7 @@ mod allocation {
         match allocator.lock().allocator.free(allocation.allocation) {
             Ok(_) => (),
             // TODO: Don't panic here
-            Err(e) => panic!("Failed to destroy dx12 buffer, {}", e),
+            Err(e) => panic!("Failed to destroy dx12 buffer, {e}"),
         };
     }
 
@@ -164,7 +164,7 @@ mod allocation {
         match allocator.lock().allocator.free(allocation.allocation) {
             Ok(_) => (),
             // TODO: Don't panic here
-            Err(e) => panic!("Failed to destroy dx12 texture, {}", e),
+            Err(e) => panic!("Failed to destroy dx12 texture, {e}"),
         };
     }
 

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -247,12 +247,12 @@ impl super::Device {
             policies,
         )
         .map_err(|e| {
-            let msg = format!("{}", e);
+            let msg = format!("{e}");
             crate::PipelineError::Linkage(map_naga_stage(naga_stage), msg)
         })?;
 
         let reflection_info = writer.write().map_err(|e| {
-            let msg = format!("{}", e);
+            let msg = format!("{e}");
             crate::PipelineError::Linkage(map_naga_stage(naga_stage), msg)
         })?;
 
@@ -358,7 +358,7 @@ impl super::Device {
 
         // Create empty fragment shader if only vertex shader is present
         if has_stages == wgt::ShaderStages::VERTEX {
-            let shader_src = format!("#version {} es \n void main(void) {{}}", glsl_version,);
+            let shader_src = format!("#version {glsl_version} es \n void main(void) {{}}",);
             log::info!("Only vertex shader is present. Creating an empty fragment shader",);
             let shader = unsafe {
                 Self::compile_shader(
@@ -1248,7 +1248,7 @@ impl crate::Device<super::Api> for super::Device {
 
                 if let Some(label) = desc.label {
                     temp_string.clear();
-                    let _ = write!(temp_string, "{}[{}]", label, i);
+                    let _ = write!(temp_string, "{label}[{i}]");
                     let name = unsafe { mem::transmute(query) };
                     unsafe { gl.object_label(glow::QUERY, name, Some(&temp_string)) };
                 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -38,6 +38,8 @@
     clippy::non_send_fields_in_send_ty,
     // TODO!
     clippy::missing_safety_doc,
+    // Clashes with clippy::pattern_type_mismatch
+    clippy::needless_borrowed_reference,
 )]
 #![warn(
     trivial_casts,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -321,7 +321,7 @@ impl gpu_alloc::MemoryDevice<vk::DeviceMemory> for super::DeviceShared {
                 Err(gpu_alloc::OutOfMemory::OutOfHostMemory)
             }
             Err(vk::Result::ERROR_TOO_MANY_OBJECTS) => panic!("Too many objects"),
-            Err(err) => panic!("Unexpected Vulkan error: `{}`", err),
+            Err(err) => panic!("Unexpected Vulkan error: `{err}`"),
         }
     }
 
@@ -348,7 +348,7 @@ impl gpu_alloc::MemoryDevice<vk::DeviceMemory> for super::DeviceShared {
                 Err(gpu_alloc::DeviceMapError::OutOfHostMemory)
             }
             Err(vk::Result::ERROR_MEMORY_MAP_FAILED) => Err(gpu_alloc::DeviceMapError::MapFailed),
-            Err(err) => panic!("Unexpected Vulkan error: `{}`", err),
+            Err(err) => panic!("Unexpected Vulkan error: `{err}`"),
         }
     }
 
@@ -707,7 +707,7 @@ impl super::Device {
                         Some(&pipeline_options),
                     )
                 }
-                .map_err(|e| crate::PipelineError::Linkage(stage_flags, format!("{}", e)))?;
+                .map_err(|e| crate::PipelineError::Linkage(stage_flags, format!("{e}")))?;
                 self.create_shader_module_impl(&spv)?
             }
         };
@@ -1489,7 +1489,7 @@ impl crate::Device<super::Api> for super::Device {
                         &naga_options,
                         None,
                     )
-                    .map_err(|e| crate::ShaderError::Compilation(format!("{}", e)))?,
+                    .map_err(|e| crate::ShaderError::Compilation(format!("{e}")))?,
                 )
             }
             crate::ShaderInput::SpirV(spv) => Cow::Borrowed(spv),

--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -133,7 +133,7 @@ mod inner {
         let features = adapter.features();
         let limits = adapter.limits();
 
-        println!("Adapter {}:", idx);
+        println!("Adapter {idx}:");
         println!("\t   Backend: {:?}", info.backend);
         println!("\t      Name: {:?}", info.name);
         println!("\t  VendorID: {:?}", info.vendor);
@@ -147,7 +147,7 @@ mod inner {
             let bit = wgpu::Features::from_bits(1 << i as u64);
             if let Some(bit) = bit {
                 if wgpu::Features::all().contains(bit) {
-                    println!("\t\t{:>63} {}", format!("{:?}:", bit), features.contains(bit));
+                    println!("\t\t{:>63} {}", format!("{bit:?}:"), features.contains(bit));
                 }
             }
         }
@@ -184,35 +184,35 @@ mod inner {
             max_compute_workgroup_size_z,
             max_compute_workgroups_per_dimension,
         } = limits;
-        println!("\t\t                        Max Texture Dimension 1d: {}", max_texture_dimension_1d);
-        println!("\t\t                        Max Texture Dimension 2d: {}", max_texture_dimension_2d);
-        println!("\t\t                        Max Texture Dimension 3d: {}", max_texture_dimension_3d);
-        println!("\t\t                        Max Texture Array Layers: {}", max_texture_array_layers);
-        println!("\t\t                                 Max Bind Groups: {}", max_bind_groups);
-        println!("\t\t                     Max Bindings Per Bind Group: {}", max_bindings_per_bind_group);
-        println!("\t\t Max Dynamic Uniform Buffers Per Pipeline Layout: {}", max_dynamic_uniform_buffers_per_pipeline_layout);
-        println!("\t\t Max Dynamic Storage Buffers Per Pipeline Layout: {}", max_dynamic_storage_buffers_per_pipeline_layout);
-        println!("\t\t           Max Sampled Textures Per Shader Stage: {}", max_sampled_textures_per_shader_stage);
-        println!("\t\t                   Max Samplers Per Shader Stage: {}", max_samplers_per_shader_stage);
-        println!("\t\t            Max Storage Buffers Per Shader Stage: {}", max_storage_buffers_per_shader_stage);
-        println!("\t\t           Max Storage Textures Per Shader Stage: {}", max_storage_textures_per_shader_stage);
-        println!("\t\t            Max Uniform Buffers Per Shader Stage: {}", max_uniform_buffers_per_shader_stage);
-        println!("\t\t                 Max Uniform Buffer Binding Size: {}", max_uniform_buffer_binding_size);
-        println!("\t\t                 Max Storage Buffer Binding Size: {}", max_storage_buffer_binding_size);
-        println!("\t\t                                 Max Buffer Size: {}", max_buffer_size);
-        println!("\t\t                              Max Vertex Buffers: {}", max_vertex_buffers);
-        println!("\t\t                           Max Vertex Attributes: {}", max_vertex_attributes);
-        println!("\t\t                  Max Vertex Buffer Array Stride: {}", max_vertex_buffer_array_stride);
-        println!("\t\t                          Max Push Constant Size: {}", max_push_constant_size);
-        println!("\t\t             Min Uniform Buffer Offset Alignment: {}", min_uniform_buffer_offset_alignment);
-        println!("\t\t             Min Storage Buffer Offset Alignment: {}", min_storage_buffer_offset_alignment);
-        println!("\t\t                Max Inter-Stage Shader Component: {}", max_inter_stage_shader_components);
-        println!("\t\t              Max Compute Workgroup Storage Size: {}", max_compute_workgroup_storage_size);
-        println!("\t\t           Max Compute Invocations Per Workgroup: {}", max_compute_invocations_per_workgroup);
-        println!("\t\t                    Max Compute Workgroup Size X: {}", max_compute_workgroup_size_x);
-        println!("\t\t                    Max Compute Workgroup Size Y: {}", max_compute_workgroup_size_y);
-        println!("\t\t                    Max Compute Workgroup Size Z: {}", max_compute_workgroup_size_z);
-        println!("\t\t            Max Compute Workgroups Per Dimension: {}", max_compute_workgroups_per_dimension);
+        println!("\t\t                        Max Texture Dimension 1d: {max_texture_dimension_1d}");
+        println!("\t\t                        Max Texture Dimension 2d: {max_texture_dimension_2d}");
+        println!("\t\t                        Max Texture Dimension 3d: {max_texture_dimension_3d}");
+        println!("\t\t                        Max Texture Array Layers: {max_texture_array_layers}");
+        println!("\t\t                                 Max Bind Groups: {max_bind_groups}");
+        println!("\t\t                     Max Bindings Per Bind Group: {max_bindings_per_bind_group}");
+        println!("\t\t Max Dynamic Uniform Buffers Per Pipeline Layout: {max_dynamic_uniform_buffers_per_pipeline_layout}");
+        println!("\t\t Max Dynamic Storage Buffers Per Pipeline Layout: {max_dynamic_storage_buffers_per_pipeline_layout}");
+        println!("\t\t           Max Sampled Textures Per Shader Stage: {max_sampled_textures_per_shader_stage}");
+        println!("\t\t                   Max Samplers Per Shader Stage: {max_samplers_per_shader_stage}");
+        println!("\t\t            Max Storage Buffers Per Shader Stage: {max_storage_buffers_per_shader_stage}");
+        println!("\t\t           Max Storage Textures Per Shader Stage: {max_storage_textures_per_shader_stage}");
+        println!("\t\t            Max Uniform Buffers Per Shader Stage: {max_uniform_buffers_per_shader_stage}");
+        println!("\t\t                 Max Uniform Buffer Binding Size: {max_uniform_buffer_binding_size}");
+        println!("\t\t                 Max Storage Buffer Binding Size: {max_storage_buffer_binding_size}");
+        println!("\t\t                                 Max Buffer Size: {max_buffer_size}");
+        println!("\t\t                              Max Vertex Buffers: {max_vertex_buffers}");
+        println!("\t\t                           Max Vertex Attributes: {max_vertex_attributes}");
+        println!("\t\t                  Max Vertex Buffer Array Stride: {max_vertex_buffer_array_stride}");
+        println!("\t\t                          Max Push Constant Size: {max_push_constant_size}");
+        println!("\t\t             Min Uniform Buffer Offset Alignment: {min_uniform_buffer_offset_alignment}");
+        println!("\t\t             Min Storage Buffer Offset Alignment: {min_storage_buffer_offset_alignment}");
+        println!("\t\t                Max Inter-Stage Shader Component: {max_inter_stage_shader_components}");
+        println!("\t\t              Max Compute Workgroup Storage Size: {max_compute_workgroup_storage_size}");
+        println!("\t\t           Max Compute Invocations Per Workgroup: {max_compute_invocations_per_workgroup}");
+        println!("\t\t                    Max Compute Workgroup Size X: {max_compute_workgroup_size_x}");
+        println!("\t\t                    Max Compute Workgroup Size Y: {max_compute_workgroup_size_y}");
+        println!("\t\t                    Max Compute Workgroup Size Z: {max_compute_workgroup_size_z}");
+        println!("\t\t            Max Compute Workgroups Per Dimension: {max_compute_workgroups_per_dimension}");
 
         println!("\tDownlevel Properties:");
         let wgpu::DownlevelCapabilities {
@@ -220,12 +220,12 @@ mod inner {
             limits: _,
             flags,
         } = downlevel;
-        println!("\t\t                       Shader Model: {:?}", shader_model);
+        println!("\t\t                       Shader Model: {shader_model:?}");
         for i in 0..(size_of::<wgpu::DownlevelFlags>() * 8) {
             let bit = wgpu::DownlevelFlags::from_bits(1 << i as u64);
             if let Some(bit) = bit {
                 if wgpu::DownlevelFlags::all().contains(bit) {
-                    println!("\t\t{:>37} {}", format!("{:?}:", bit), flags.contains(bit));
+                    println!("\t\t{:>37} {}", format!("{bit:?}:"), flags.contains(bit));
                 }
             }
         }
@@ -241,7 +241,7 @@ mod inner {
                     format!("{format:?}:")
                 }
             };
-            print!("\t\t{:>21}", format_name);
+            print!("\t\t{format_name:>21}");
             for i in 0..(size_of::<wgpu::TextureUsages>() * 8) {
                 let bit = wgpu::TextureUsages::from_bits(1 << i as u32);
                 if let Some(bit) = bit {
@@ -339,8 +339,7 @@ mod inner {
             let all_time = all_start.elapsed().as_secs_f32();
 
             println!(
-                "=========== {} adapters PASSED in {:.3}s ===========",
-                adapter_count, all_time
+                "=========== {adapter_count} adapters PASSED in {all_time:.3}s ==========="
             );
         }
     }

--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -338,9 +338,7 @@ mod inner {
 
             let all_time = all_start.elapsed().as_secs_f32();
 
-            println!(
-                "=========== {adapter_count} adapters PASSED in {all_time:.3}s ==========="
-            );
+            println!("=========== {adapter_count} adapters PASSED in {all_time:.3}s ===========");
         }
     }
 }

--- a/wgpu/examples/boids/main.rs
+++ b/wgpu/examples/boids/main.rs
@@ -197,7 +197,7 @@ impl framework::Example for Example {
         for i in 0..2 {
             particle_buffers.push(
                 device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                    label: Some(&format!("Particle Buffer {}", i)),
+                    label: Some(&format!("Particle Buffer {i}")),
                     contents: bytemuck::cast_slice(&initial_particle_data),
                     usage: wgpu::BufferUsages::VERTEX
                         | wgpu::BufferUsages::STORAGE

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -99,7 +99,7 @@ impl<F: Future<Output = Option<wgpu::Error>>> Future for ErrorFuture<F> {
         let inner = unsafe { self.map_unchecked_mut(|me| &mut me.inner) };
         inner.poll(cx).map(|error| {
             if let Some(e) = error {
-                panic!("Rendering {}", e);
+                panic!("Rendering {e}");
             }
         })
     }

--- a/wgpu/examples/hello-compute/main.rs
+++ b/wgpu/examples/hello-compute/main.rs
@@ -7,7 +7,7 @@ const OVERFLOW: u32 = 0xffffffff;
 async fn run() {
     let numbers = if std::env::args().len() <= 1 {
         let default = vec![1, 2, 3, 4];
-        println!("No numbers were provided, defaulting to {:?}", default);
+        println!("No numbers were provided, defaulting to {default:?}");
         default
     } else {
         std::env::args()

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -172,7 +172,7 @@ fn main() {
         for row in 0..ROWS {
             for column in 0..COLUMNS {
                 let window = winit::window::WindowBuilder::new()
-                    .with_title(format!("x{}y{}", column, row))
+                    .with_title(format!("x{column}y{row}"))
                     .with_inner_size(winit::dpi::PhysicalSize::new(WINDOW_SIZE, WINDOW_SIZE))
                     .build(&event_loop)
                     .unwrap();

--- a/wgpu/examples/texture-arrays/main.rs
+++ b/wgpu/examples/texture-arrays/main.rs
@@ -125,7 +125,7 @@ impl framework::Example for Example {
             &base_shader_module
         };
 
-        println!("Using fragment entry point '{}'", fragment_entry_point);
+        println!("Using fragment entry point '{fragment_entry_point}'");
 
         let vertex_size = std::mem::size_of::<Vertex>();
         let vertex_data = create_vertices();

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1854,11 +1854,11 @@ impl crate::Context for Context {
         }
     }
 
-    fn command_encoder_begin_render_pass<'a>(
+    fn command_encoder_begin_render_pass(
         &self,
         encoder: &Self::CommandEncoderId,
         _encoder_data: &Self::CommandEncoderData,
-        desc: &crate::RenderPassDescriptor<'a, '_>,
+        desc: &crate::RenderPassDescriptor<'_, '_>,
     ) -> (Self::RenderPassId, Self::RenderPassData) {
         if desc.color_attachments.len() > wgc::MAX_COLOR_ATTACHMENTS {
             self.handle_error_fatal(

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -313,7 +313,7 @@ impl Context {
         cause: impl Error + Send + Sync + 'static,
         string: &'static str,
     ) -> ! {
-        panic!("Error in {}: {}", string, cause);
+        panic!("Error in {string}: {cause}");
     }
 
     fn format_error(&self, err: &(impl Error + 'static)) -> String {
@@ -1401,7 +1401,7 @@ impl crate::Context for Context {
         };
         match wgc::command::RenderBundleEncoder::new(&descriptor, *device, None) {
             Ok(encoder) => (Unused, encoder),
-            Err(e) => panic!("Error in Device::create_render_bundle_encoder: {}", e),
+            Err(e) => panic!("Error in Device::create_render_bundle_encoder: {e}"),
         }
     }
     #[cfg_attr(target_arch = "wasm32", allow(unused))]
@@ -1698,7 +1698,7 @@ impl crate::Context for Context {
         let global = &self.0;
         let (id, error) = wgc::gfx_select!(*pipeline => global.compute_pipeline_get_bind_group_layout(*pipeline, index, ()));
         if let Some(err) = error {
-            panic!("Error reflecting bind group {}: {}", index, err);
+            panic!("Error reflecting bind group {index}: {err}");
         }
         (id, ())
     }
@@ -1712,7 +1712,7 @@ impl crate::Context for Context {
         let global = &self.0;
         let (id, error) = wgc::gfx_select!(*pipeline => global.render_pipeline_get_bind_group_layout(*pipeline, index, ()));
         if let Some(err) = error {
-            panic!("Error reflecting bind group {}: {}", index, err);
+            panic!("Error reflecting bind group {index}: {err}");
         }
         (id, ())
     }
@@ -3021,7 +3021,7 @@ impl fmt::Debug for ErrorSinkRaw {
 
 fn default_error_handler(err: crate::Error) {
     log::error!("Handling wgpu errors as fatal by default");
-    panic!("wgpu error: {}\n", err);
+    panic!("wgpu error: {err}\n");
 }
 
 #[derive(Debug)]

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -837,7 +837,7 @@ impl crate::context::Context for Context {
         let canvas_node: wasm_bindgen::JsValue = web_sys::window()
             .and_then(|win| win.document())
             .and_then(|doc| {
-                doc.query_selector_all(&format!("[data-raw-handle=\"{}\"]", canvas_attribute))
+                doc.query_selector_all(&format!("[data-raw-handle=\"{canvas_attribute}\"]"))
                     .ok()
             })
             .and_then(|nodes| nodes.get(0))
@@ -2052,11 +2052,11 @@ impl crate::context::Context for Context {
         pass.0.end();
     }
 
-    fn command_encoder_begin_render_pass<'a>(
+    fn command_encoder_begin_render_pass(
         &self,
         encoder: &Self::CommandEncoderId,
         _encoder_data: &Self::CommandEncoderData,
-        desc: &crate::RenderPassDescriptor<'a, '_>,
+        desc: &crate::RenderPassDescriptor<'_, '_>,
     ) -> (Self::RenderPassId, Self::RenderPassData) {
         let mapped_color_attachments = desc
             .color_attachments

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -438,11 +438,11 @@ pub trait Context: Debug + Send + Sized + Sync {
         pass: &mut Self::ComputePassId,
         pass_data: &mut Self::ComputePassData,
     );
-    fn command_encoder_begin_render_pass<'a>(
+    fn command_encoder_begin_render_pass(
         &self,
         encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        desc: &RenderPassDescriptor<'a, '_>,
+        desc: &RenderPassDescriptor<'_, '_>,
     ) -> (Self::RenderPassId, Self::RenderPassData);
     fn command_encoder_end_render_pass(
         &self,
@@ -1369,11 +1369,11 @@ pub(crate) trait DynContext: Debug + Send + Sync {
         pass: &mut ObjectId,
         pass_data: &mut crate::Data,
     );
-    fn command_encoder_begin_render_pass<'a>(
+    fn command_encoder_begin_render_pass(
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        desc: &RenderPassDescriptor<'a, '_>,
+        desc: &RenderPassDescriptor<'_, '_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn command_encoder_end_render_pass(
         &self,
@@ -2633,11 +2633,11 @@ where
         )
     }
 
-    fn command_encoder_begin_render_pass<'a>(
+    fn command_encoder_begin_render_pass(
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        desc: &RenderPassDescriptor<'a, '_>,
+        desc: &RenderPassDescriptor<'_, '_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let encoder = <T::CommandEncoderId>::from(*encoder);
         let encoder_data = downcast_ref(encoder_data);

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -167,8 +167,7 @@ impl MapContext {
         for sub in self.sub_ranges.iter() {
             assert!(
                 end <= sub.start || offset >= sub.end,
-                "Intersecting map range with {:?}",
-                sub
+                "Intersecting map range with {sub:?}"
             );
         }
         self.sub_ranges.push(offset..end);

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -211,7 +211,7 @@ fn single_texture_clear_test(
     );
 
     let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
-        label: Some(&format!("texture {:?}", format)),
+        label: Some(&format!("texture {format:?}")),
         size,
         mip_level_count: if dimension == wgpu::TextureDimension::D1 {
             1

--- a/wgpu/tests/common/image.rs
+++ b/wgpu/tests/common/image.rs
@@ -138,9 +138,7 @@ pub fn compare_image_output(
                 "Image data mismatch! Outlier count {outliers} over limit {max_outliers}. Max difference {max_difference}"
             )
         } else {
-            println!(
-                "{outliers} outliers over max difference {max_difference}"
-            );
+            println!("{outliers} outliers over max difference {max_difference}");
         }
     } else {
         write_png(&path, width, height, data, png::Compression::Best);

--- a/wgpu/tests/common/image.rs
+++ b/wgpu/tests/common/image.rs
@@ -135,13 +135,11 @@ pub fn compare_image_output(
             );
 
             panic!(
-                "Image data mismatch! Outlier count {} over limit {}. Max difference {}",
-                outliers, max_outliers, max_difference
+                "Image data mismatch! Outlier count {outliers} over limit {max_outliers}. Max difference {max_difference}"
             )
         } else {
             println!(
-                "{} outliers over max difference {}",
-                outliers, max_difference
+                "{outliers} outliers over max difference {max_difference}"
             );
         }
     } else {

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -29,7 +29,7 @@ async fn initialize_device(
 
     match bundle {
         Ok(b) => b,
-        Err(e) => panic!("Failed to initialize device: {}", e),
+        Err(e) => panic!("Failed to initialize device: {e}"),
     }
 }
 
@@ -324,9 +324,9 @@ pub fn initialize_test(parameters: TestParameters, test_function: impl FnOnce(Te
         }
     } else if let Some((reason, _)) = expected_failure_reason {
         // We expected to fail, but things passed
-        panic!("UNEXPECTED TEST PASS: {:?}", reason);
+        panic!("UNEXPECTED TEST PASS: {reason:?}");
     } else {
-        panic!("UNEXPECTED TEST FAILURE DUE TO {}", failure_cause)
+        panic!("UNEXPECTED TEST FAILURE DUE TO {failure_cause}")
     }
 }
 

--- a/wgpu/tests/shader/zero_init_workgroup_mem.rs
+++ b/wgpu/tests/shader/zero_init_workgroup_mem.rs
@@ -165,7 +165,7 @@ fn zero_init_workgroup_mem_impl(ctx: TestingContext) {
 
     let mapped = mapping_buffer.slice(..).get_mapped_range();
 
-    let typed: &[u32] = bytemuck::cast_slice(&*mapped);
+    let typed: &[u32] = bytemuck::cast_slice(&mapped);
 
     // -- Check results --
 
@@ -174,8 +174,7 @@ fn zero_init_workgroup_mem_impl(ctx: TestingContext) {
 
     assert!(
         num_disptaches_failed == 0,
-        "Zero-initialization of workgroup memory failed ({:.0}% of disptaches failed).",
-        ratio
+        "Zero-initialization of workgroup memory failed ({ratio:.0}% of disptaches failed)."
     );
 
     drop(mapped);


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
New rust version, new clippy lints.

**Testing**

Water example runs.