### PR TITLE
Remove some workspace inheritence from wgpu-types/Cargo.toml.

### DIFF
--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -25,8 +25,8 @@ bitflags = "1"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys.workspace = true
-web-sys = { workspace = true, features = [
+js-sys = "0.3.60"
+web-sys = { version = "0.3.60", features = [
     "ImageBitmap",
     "HtmlVideoElement",
     "HtmlCanvasElement",


### PR DESCRIPTION
**Connections**

https://bugzilla.mozilla.org/show_bug.cgi?id=1813547

**Description**

Unfortunately that breaks the cargo vendor stuff in mozilla-central even though it is part of a build configuration that m-c does not use.
