### PR TITLE
[gles] fix: Set `FORCE_POINT_SIZE` if it is vertex shader with mesh consist of point list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ Bottom level categories:
 
 - Fix DXC validation issues when using a custom `dxil_path`. By @Elabajaba in [#3434](https://github.com/gfx-rs/wgpu/pull/3434)
 
+#### GLES
+
+- [gles] fix: Set FORCE_POINT_SIZE if it is vertex shader with mesh consist of point list. By @REASY in [3440](https://github.com/gfx-rs/wgpu/pull/3440)
+
 #### General
 
 - `copyTextureToTexture` src/dst aspects must both refer to all aspects of src/dst format. By @teoxoy in [#3431](https://github.com/gfx-rs/wgpu/pull/3431)

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -331,6 +331,7 @@ impl super::Device {
         Ok(program)
     }
 
+    #[allow(clippy::too_many_arguments)]
     unsafe fn create_program<'a>(
         gl: &glow::Context,
         shaders: ArrayVec<ShaderStage<'a>, 3>,

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -192,10 +192,8 @@ impl super::Device {
         naga_stage: naga::ShaderStage,
         stage: &crate::ProgrammableStage<super::Api>,
         context: CompilationContext,
-        primitive_topology: Option<wgt::PrimitiveTopology>,
     ) -> Result<glow::Shader, crate::PipelineError> {
         use naga::back::glsl;
-
         let pipeline_options = glsl::PipelineOptions {
             shader_stage: naga_stage,
             entry_point: stage.entry_point.to_string(),
@@ -227,31 +225,12 @@ impl super::Device {
             binding_array: BoundsCheckPolicy::Unchecked,
         };
 
-        let update_naga_options = primitive_topology == Some(wgt::PrimitiveTopology::PointList)
-            && naga_stage == naga::ShaderStage::Vertex;
-        // Update naga options if mesh consist of point list and it is vertex shader
-        let naga_options = if update_naga_options {
-            let mut wrt_flags = context.layout.naga_options.writer_flags;
-            wrt_flags.set(glsl::WriterFlags::FORCE_POINT_SIZE, true);
-            glsl::Options {
-                version: context.layout.naga_options.version,
-                writer_flags: wrt_flags,
-                binding_map: context.layout.naga_options.binding_map.clone(),
-                zero_initialize_workgroup_memory: context
-                    .layout
-                    .naga_options
-                    .zero_initialize_workgroup_memory,
-            }
-        } else {
-            context.layout.naga_options.clone()
-        };
-
         let mut output = String::new();
         let mut writer = glsl::Writer::new(
             &mut output,
             &shader.module,
             &shader.info,
-            &naga_options,
+            &context.layout.naga_options,
             &pipeline_options,
             policies,
         )
@@ -283,7 +262,6 @@ impl super::Device {
         layout: &super::PipelineLayout,
         #[cfg_attr(target_arch = "wasm32", allow(unused))] label: Option<&str>,
         multiview: Option<std::num::NonZeroU32>,
-        primitive_topology: Option<wgt::PrimitiveTopology>,
     ) -> Result<Arc<super::PipelineInner>, crate::PipelineError> {
         let mut program_stages = ArrayVec::new();
         let mut group_to_binding_to_slot = Vec::with_capacity(layout.group_infos.len());
@@ -322,7 +300,6 @@ impl super::Device {
                     multiview,
                     glsl_version,
                     self.shared.private_caps,
-                    primitive_topology,
                 )
             })
             .to_owned()?;
@@ -331,7 +308,6 @@ impl super::Device {
         Ok(program)
     }
 
-    #[allow(clippy::too_many_arguments)]
     unsafe fn create_program<'a>(
         gl: &glow::Context,
         shaders: ArrayVec<ShaderStage<'a>, 3>,
@@ -340,7 +316,6 @@ impl super::Device {
         multiview: Option<std::num::NonZeroU32>,
         glsl_version: u16,
         private_caps: super::PrivateCapabilities,
-        primitive_topology: Option<wgt::PrimitiveTopology>,
     ) -> Result<Arc<super::PipelineInner>, crate::PipelineError> {
         let program = unsafe { gl.create_program() }.unwrap();
         #[cfg(not(target_arch = "wasm32"))]
@@ -365,7 +340,7 @@ impl super::Device {
                 multiview,
             };
 
-            let shader = Self::create_shader(gl, naga_stage, stage, context, primitive_topology)?;
+            let shader = Self::create_shader(gl, naga_stage, stage, context)?;
             shaders_to_delete.push(shader);
         }
 
@@ -977,6 +952,9 @@ impl crate::Device<super::Api> for super::Device {
                 .private_caps
                 .contains(super::PrivateCapabilities::SHADER_TEXTURE_SHADOW_LOD),
         );
+        // We always force point size to be written and it will be ignored by the driver if it's not a point list primitive.
+        // https://github.com/gfx-rs/wgpu/pull/3440/files#r1095726950
+        writer_flags.set(glsl::WriterFlags::FORCE_POINT_SIZE, true);
         let mut binding_map = glsl::BindingMap::default();
 
         for (group_index, bg_layout) in desc.bind_group_layouts.iter().enumerate() {
@@ -1122,16 +1100,8 @@ impl crate::Device<super::Api> for super::Device {
         if let Some(ref fs) = desc.fragment_stage {
             shaders.push((naga::ShaderStage::Fragment, fs));
         }
-        let inner = unsafe {
-            self.create_pipeline(
-                gl,
-                shaders,
-                desc.layout,
-                desc.label,
-                desc.multiview,
-                Some(desc.primitive.topology),
-            )
-        }?;
+        let inner =
+            unsafe { self.create_pipeline(gl, shaders, desc.layout, desc.label, desc.multiview) }?;
 
         let (vertex_buffers, vertex_attributes) = {
             let mut buffers = Vec::new();
@@ -1212,8 +1182,7 @@ impl crate::Device<super::Api> for super::Device {
         let gl = &self.shared.context.lock();
         let mut shaders = ArrayVec::new();
         shaders.push((naga::ShaderStage::Compute, &desc.stage));
-        let inner =
-            unsafe { self.create_pipeline(gl, shaders, desc.layout, desc.label, None, None) }?;
+        let inner = unsafe { self.create_pipeline(gl, shaders, desc.layout, desc.label, None) }?;
 
         Ok(super::ComputePipeline { inner })
     }


### PR DESCRIPTION
# fix: Set `FORCE_POINT_SIZE` if it is vertex shader with mesh consist of point list
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/3179
Blocked by https://github.com/gfx-rs/naga/pull/2223

**Description**
PrimitiveTopology::PointList does not render on WebGL on Windows OS.

It is because gl_PointSize is not set. According to https://registry.khronos.org/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.html#built-in-language-variables
> The variable gl_PointSize is intended for a shader to write the size of the point to be rasterized. It is measured in pixels. If gl_PointSize is not written to, its value is _undefined_ in subsequent pipe stages.

**Testing**
I'm pointing WGPU to use fixed version of naga from https://github.com/gfx-rs/naga/pull/2223. Then I run hello-triangle 
```bash
cargo run-wasm --example hello-triangle --features webgl --port 18000
```
And expect to see 64 red pixels as in the screenshot below:
![image](https://user-images.githubusercontent.com/5107562/216190588-b35f6320-f6d3-4d36-9a72-285d9c0d6e15.png)

