### PR TITLE
Update winit to 0.27.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ smallvec = "1"
 static_assertions = "1.1.0"
 thiserror = "1"
 wgpu = { version = "0.15", path = "./wgpu" }
-winit = "0.27.1"
+winit = "0.27.5"
 
 # Metal dependencies
 block = "0.1"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -127,7 +127,7 @@ features = ["wgsl-in"]
 
 [dev-dependencies]
 env_logger = "0.9"
-winit = "0.27.1"      # for "halmark" example
+winit = "0.27.5"      # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 glutin = "0.29.1" # for "gles" example


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.

**Description**
Update to `winit` 0.28 is not suitable, because `objc2` has been used in this version.

**Testing**
Tested on macOS and Windows 11 ARM64
