### PR TITLE
Update naga to 0.11.0@git:4b796b157cb2b67b0ab166a2238fe4e9473bfd52

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.11.0"
-source = "git+https://github.com/gfx-rs/naga?rev=f0edae8#f0edae8ce9e55eeef489fc53b10dc95fb79561cc"
+source = "git+https://github.com/gfx-rs/naga?rev=4b796b157cb2b67b0ab166a2238fe4e9473bfd52#4b796b157cb2b67b0ab166a2238fe4e9473bfd52"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ version = "0.15"
 
 [workspace.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f0edae8"
-version = "0.11"
+rev = "4b796b157cb2b67b0ab166a2238fe4e9473bfd52"
+version = "0.11.0"
 
 [workspace.dependencies]
 arrayvec = "0.7"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -67,8 +67,8 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f0edae8"
-version = "0.11"
+rev = "4b796b157cb2b67b0ab166a2238fe4e9473bfd52"
+version = "0.11.0"
 features = ["clone", "span", "validate"]
 
 [dependencies.wgt]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -114,15 +114,15 @@ android_system_properties = "0.1.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f0edae8"
-version = "0.11"
+rev = "4b796b157cb2b67b0ab166a2238fe4e9473bfd52"
+version = "0.11.0"
 features = ["clone"]
 
 # DEV dependencies
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f0edae8"
-version = "0.11"
+rev = "4b796b157cb2b67b0ab166a2238fe4e9473bfd52"
+version = "0.11.0"
 features = ["wgsl-in"]
 
 [dev-dependencies]

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -151,7 +151,7 @@ impl<A: hal::Api> Example<A> {
                 .join("halmark")
                 .join("shader.wgsl");
             let source = std::fs::read_to_string(shader_file).unwrap();
-            let module = naga::front::wgsl::Parser::new().parse(&source).unwrap();
+            let module = naga::front::wgsl::Frontend::new().parse(&source).unwrap();
             let info = naga::valid::Validator::new(
                 naga::valid::ValidationFlags::all(),
                 naga::valid::Capabilities::empty(),

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -869,7 +869,7 @@ impl crate::Context for Context {
                     strict_capabilities: true,
                     block_ctx_dump_prefix: None,
                 };
-                let parser = naga::front::spv::Parser::new(spv.iter().cloned(), &options);
+                let parser = naga::front::spv::Frontend::new(spv.iter().cloned(), &options);
                 let module = parser.parse().unwrap();
                 wgc::pipeline::ShaderModuleSource::Naga(Owned(module))
             }
@@ -884,7 +884,7 @@ impl crate::Context for Context {
                     stage,
                     defines: defines.clone(),
                 };
-                let mut parser = naga::front::glsl::Parser::default();
+                let mut parser = naga::front::glsl::Frontend::default();
                 let module = parser.parse(&options, shader).unwrap();
 
                 wgc::pipeline::ShaderModuleSource::Naga(Owned(module))

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1175,7 +1175,7 @@ impl crate::context::Context for Context {
                     strict_capabilities: true,
                     block_ctx_dump_prefix: None,
                 };
-                let spv_parser = front::spv::Parser::new(spv.iter().cloned(), &options);
+                let spv_parser = front::spv::Frontend::new(spv.iter().cloned(), &options);
                 let spv_module = spv_parser.parse().unwrap();
 
                 let mut validator = valid::Validator::new(
@@ -1202,7 +1202,7 @@ impl crate::context::Context for Context {
                     stage,
                     defines: defines.clone(),
                 };
-                let mut parser = front::glsl::Parser::default();
+                let mut parser = front::glsl::Frontend::default();
                 let glsl_module = parser.parse(&options, shader).unwrap();
 
                 let mut validator = valid::Validator::new(


### PR DESCRIPTION
- [x] Run `cargo clippy`.

**Description**

Routine naga update.

This commit was mostly generated by [a script](https://github.com/nical/moz-wgpu-update#updating-naga-in-wgpu) Although I had to make a small manual adjustment to account for an API change.

**Testing**

Ran `cargo nextest run`.