### PR TITLE
Add MULTISAMPLE_X16 texture format feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Bottom level categories:
 
 ### Changes
 
+#### General
+
+- Added `TextureFormatFeatureFlags::MULTISAMPLE_X16`. By @Dinnerbone in [#3454](https://github.com/gfx-rs/wgpu/pull/3454)
+
 #### WebGPU
 
 - Implement `CommandEncoder::clear_buffer`. By @raphlinus in [#3426](https://github.com/gfx-rs/wgpu/pull/3426)

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -811,7 +811,8 @@ impl<A: HalApi> Device<A> {
             if !format_features.flags.intersects(
                 wgt::TextureFormatFeatureFlags::MULTISAMPLE_X4
                     | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X2
-                    | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X8,
+                    | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X8
+                    | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X16,
             ) {
                 return Err(CreateTextureError::InvalidMultisampledFormat(desc.format));
             }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -265,6 +265,10 @@ impl<A: HalApi> Adapter<A> {
             wgt::TextureFormatFeatureFlags::MULTISAMPLE_X8,
             caps.contains(Tfc::MULTISAMPLE_X8),
         );
+        flags.set(
+            wgt::TextureFormatFeatureFlags::MULTISAMPLE_X16,
+            caps.contains(Tfc::MULTISAMPLE_X16),
+        );
 
         flags.set(
             wgt::TextureFormatFeatureFlags::MULTISAMPLE_RESOLVE,

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -492,6 +492,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
         set_sample_count(2, Tfc::MULTISAMPLE_X2);
         set_sample_count(4, Tfc::MULTISAMPLE_X4);
         set_sample_count(8, Tfc::MULTISAMPLE_X8);
+        set_sample_count(16, Tfc::MULTISAMPLE_X16);
 
         caps
     }

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -689,7 +689,12 @@ impl crate::Adapter<super::Api> for super::Adapter {
                     .lock()
                     .get_parameter_i32(glow::MAX_SAMPLES)
             };
-            if max_samples >= 8 {
+            if max_samples >= 16 {
+                Tfc::MULTISAMPLE_X2
+                    | Tfc::MULTISAMPLE_X4
+                    | Tfc::MULTISAMPLE_X8
+                    | Tfc::MULTISAMPLE_X16
+            } else if max_samples >= 8 {
                 Tfc::MULTISAMPLE_X2 | Tfc::MULTISAMPLE_X4 | Tfc::MULTISAMPLE_X8
             } else if max_samples >= 4 {
                 Tfc::MULTISAMPLE_X2 | Tfc::MULTISAMPLE_X4

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -622,14 +622,16 @@ bitflags!(
         const MULTISAMPLE_X4   = 1 << 10;
         /// Format can be multisampled by x8.
         const MULTISAMPLE_X8   = 1 << 11;
+        /// Format can be multisampled by x16.
+        const MULTISAMPLE_X16  = 1 << 12;
 
         /// Format can be used for render pass resolve targets.
-        const MULTISAMPLE_RESOLVE = 1 << 12;
+        const MULTISAMPLE_RESOLVE = 1 << 13;
 
         /// Format can be copied from.
-        const COPY_SRC = 1 << 13;
+        const COPY_SRC = 1 << 14;
         /// Format can be copied to.
-        const COPY_DST = 1 << 14;
+        const COPY_DST = 1 << 15;
     }
 );
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -484,6 +484,9 @@ impl super::PrivateCapabilities {
         if device.supports_texture_sample_count(8) {
             sample_count_mask |= crate::TextureFormatCapabilities::MULTISAMPLE_X8;
         }
+        if device.supports_texture_sample_count(16) {
+            sample_count_mask |= crate::TextureFormatCapabilities::MULTISAMPLE_X16;
+        }
 
         let rw_texture_tier = if version.at_least((10, 13), (11, 0)) {
             device.read_write_texture_support()

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1525,6 +1525,10 @@ impl crate::Adapter<super::Api> for super::Adapter {
             Tfc::MULTISAMPLE_X8,
             sample_flags.contains(vk::SampleCountFlags::TYPE_8),
         );
+        flags.set(
+            Tfc::MULTISAMPLE_X16,
+            sample_flags.contains(vk::SampleCountFlags::TYPE_16),
+        );
 
         flags
     }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1716,17 +1716,19 @@ bitflags::bitflags! {
         const MULTISAMPLE_X4 = 1 << 2 ;
           /// Allows [`TextureDescriptor::sample_count`] to be `8`.
         const MULTISAMPLE_X8 = 1 << 3 ;
+          /// Allows [`TextureDescriptor::sample_count`] to be `16`.
+        const MULTISAMPLE_X16 = 1 << 4;
         /// Allows a texture of this format to back a view passed as `resolve_target`
         /// to a render pass for an automatic driver-implemented resolve.
-        const MULTISAMPLE_RESOLVE = 1 << 4;
+        const MULTISAMPLE_RESOLVE = 1 << 5;
         /// When used as a STORAGE texture, then a texture with this format can be bound with
         /// [`StorageTextureAccess::ReadOnly`] or [`StorageTextureAccess::ReadWrite`].
-        const STORAGE_READ_WRITE = 1 << 5;
+        const STORAGE_READ_WRITE = 1 << 6;
         /// When used as a STORAGE texture, then a texture with this format can be written to with atomics.
         // TODO: No access flag exposed as of writing
-        const STORAGE_ATOMICS = 1 << 6;
+        const STORAGE_ATOMICS = 1 << 7;
         /// If not present, the texture can't be blended into the render target.
-        const BLENDABLE = 1 << 7;
+        const BLENDABLE = 1 << 8;
     }
 }
 
@@ -1742,6 +1744,7 @@ impl TextureFormatFeatureFlags {
             2 => self.contains(tfsc::MULTISAMPLE_X2),
             4 => self.contains(tfsc::MULTISAMPLE_X4),
             8 => self.contains(tfsc::MULTISAMPLE_X8),
+            16 => self.contains(tfsc::MULTISAMPLE_X16),
             _ => false,
         }
     }

--- a/wgpu/examples/msaa-line/main.rs
+++ b/wgpu/examples/msaa-line/main.rs
@@ -134,7 +134,9 @@ impl framework::Example for Example {
         let sample_flags = _adapter.get_texture_format_features(config.format).flags;
 
         let max_sample_count = {
-            if sample_flags.contains(wgpu::TextureFormatFeatureFlags::MULTISAMPLE_X8) {
+            if sample_flags.contains(wgpu::TextureFormatFeatureFlags::MULTISAMPLE_X16) {
+                16
+            } else if sample_flags.contains(wgpu::TextureFormatFeatureFlags::MULTISAMPLE_X8) {
                 8
             } else if sample_flags.contains(wgpu::TextureFormatFeatureFlags::MULTISAMPLE_X4) {
                 4


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
None

**Description**
MSAA x16 is at the limit of what most hardware & backends support, and it's not nearly as common as x4 or x8, but it *is* sometimes supported. We'd like to be able to see and use it when possible, as some of our content unfortunately requests it. This PR adds the flag so we can see when x16 is supported.

**Testing**
Manually tested, and all existing tests pass
