### PR TITLE
Don't try to build the entire workspace on wasm32.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         run: cargo install wasm-bindgen-cli --version=0.2.83
 
       - name: Build WebGPU examples
-        run: cargo build --release --target wasm32-unknown-unknown --examples
+        run: cargo build --package wgpu --release --target wasm32-unknown-unknown --examples
 
       - name: Generate JS bindings for WebGPU examples
         run: |


### PR DESCRIPTION
When building for WebAssembly using the WebGPU backend, don't try to build the entire workspace. wgpu-hal isn't meant to be used in this case, and since #3254, it complains if no backends have been explicitly selected.

Instead, pass `--package wgpu` when doing the WebGPU-backend build.
