### PR TITLE
Build for WASM on docs.rs

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -12,6 +12,12 @@ license = "MIT OR Apache-2.0"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "wasm32-unknown-unknown",
+]
 
 [lib]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -23,6 +23,12 @@ rust-version = "1.60"
 # with the dx11 and dx12 features.
 features = ["vulkan", "gles", "renderdoc"]
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "wasm32-unknown-unknown",
+]
 
 [lib]
 

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -12,6 +12,12 @@ license = "MIT OR Apache-2.0"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "wasm32-unknown-unknown",
+]
 
 [lib]
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -24,6 +24,12 @@ autotests = false
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "wasm32-unknown-unknown",
+]
 
 [lib]
 


### PR DESCRIPTION
I noticed that on docs.rs the WASM target isn't available, which made it hard to search for some functions.

This PR explicitly defines which targets to build, I threw out the 32-bit targets and added `wasm32-unknown-unknown`.
It might not be useful to build all three main targets, Linux, MacOS and Windows for all crates, any feedback is welcome.

@cwfitzgerald it would be nice to get this in before v0.15.1 (https://github.com/gfx-rs/wgpu/pull/3461).