### PR TITLE
Make crate features no-op on incompatible targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,16 @@ jobs:
 
           # build for WebGPU
           cargo clippy --target ${{ matrix.target }} -p wgpu --tests --features glsl,spirv
+          cargo doc --target ${{ matrix.target }} -p wgpu --no-deps --features glsl,spirv
 
           # build for WebGL
           cargo clippy --target ${{ matrix.target }} -p wgpu --tests --features webgl,glsl,spirv
+          cargo doc --target ${{ matrix.target }} -p wgpu --no-deps --features webgl,glsl,spirv
 
-          # build docs
-          cargo doc --target ${{ matrix.target }} -p wgpu --no-deps --features glsl,spirv
+          # all features
+          cargo clippy --target ${{ matrix.target }} -p wgpu-hal --tests --all-features
+          cargo clippy --target ${{ matrix.target }} -p wgpu --tests --all-features
+          cargo doc --target ${{ matrix.target }} -p wgpu --no-deps --all-features
 
       - name: check em
         if: matrix.kind == 'em'
@@ -138,7 +142,7 @@ jobs:
         run: |
           set -e
 
-          # build for Emscripten/WebGL
+          # build for Emscripten
           cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-hal --no-default-features
 
           # build cube example
@@ -146,6 +150,10 @@ jobs:
 
           # build raw-gles example
           cargo clippy --target ${{ matrix.target }} --example raw-gles
+
+          # all features
+          cargo clippy --target ${{ matrix.target }} -p wgpu-hal --all-features
+          cargo clippy --target ${{ matrix.target }} -p wgpu --all-features
 
       - name: check native
         if: matrix.kind == 'native'
@@ -159,8 +167,9 @@ jobs:
           # Check with all features.
           # (But watch out for backend-selection features in wgpu-core; some of
           # those only build on the right platforms.)
-          cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-info -p player --tests --all-features
+          cargo clippy --target ${{ matrix.target }} -p wgpu-hal --tests --all-features
           cargo clippy --target ${{ matrix.target }} -p wgpu-core --tests --all-features
+          cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-info -p player --tests --all-features
 
           # build docs
           # (Watch out for backend-selection features in wgpu-core; some of

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,13 +127,8 @@ jobs:
           cargo clippy --target ${{ matrix.target }} -p wgpu --tests --features glsl,spirv
           cargo doc --target ${{ matrix.target }} -p wgpu --no-deps --features glsl,spirv
 
-          # build for WebGL
-          cargo clippy --target ${{ matrix.target }} -p wgpu --tests --features webgl,glsl,spirv
-          cargo doc --target ${{ matrix.target }} -p wgpu --no-deps --features webgl,glsl,spirv
-
           # all features
-          cargo clippy --target ${{ matrix.target }} -p wgpu-hal --tests --all-features
-          cargo clippy --target ${{ matrix.target }} -p wgpu --tests --all-features
+          cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-hal --tests --all-features
           cargo doc --target ${{ matrix.target }} -p wgpu --no-deps --all-features
 
       - name: check em
@@ -165,17 +160,10 @@ jobs:
           cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-core -p wgpu-info -p player --no-default-features
 
           # Check with all features.
-          # (But watch out for backend-selection features in wgpu-core; some of
-          # those only build on the right platforms.)
-          cargo clippy --target ${{ matrix.target }} -p wgpu-hal --tests --all-features
-          cargo clippy --target ${{ matrix.target }} -p wgpu-core --tests --all-features
-          cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-info -p player --tests --all-features
+          cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-info -p player -p wgpu-core -p wgpu-hal --tests --all-features
 
           # build docs
-          # (Watch out for backend-selection features in wgpu-core; some of
-          # those only build on the right platforms.)
-          cargo doc --target ${{ matrix.target }} -p wgpu -p wgpu-info -p player --all-features --no-deps
-          cargo doc --target ${{ matrix.target }} -p wgpu-core --no-deps --all-features
+          cargo doc --target ${{ matrix.target }} -p wgpu -p wgpu-info -p player -p wgpu-core -p wgpu-hal --all-features --no-deps
 
   wasm-test:
     name: Test WebAssembly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,13 +160,13 @@ jobs:
           # (But watch out for backend-selection features in wgpu-core; some of
           # those only build on the right platforms.)
           cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-info -p player --tests --all-features
-          cargo clippy --target ${{ matrix.target }} -p wgpu-core --tests --features="portable_features"
+          cargo clippy --target ${{ matrix.target }} -p wgpu-core --tests --all-features
 
           # build docs
           # (Watch out for backend-selection features in wgpu-core; some of
           # those only build on the right platforms.)
           cargo doc --target ${{ matrix.target }} -p wgpu -p wgpu-info -p player --all-features --no-deps
-          cargo doc --target ${{ matrix.target }} -p wgpu-core --no-deps --features="portable_features"
+          cargo doc --target ${{ matrix.target }} -p wgpu-core --no-deps --all-features
 
   wasm-test:
     name: Test WebAssembly

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -49,9 +49,6 @@ id32 = []
 # Enable `ShaderModuleSource::Wgsl`
 wgsl = ["naga/wgsl-in"]
 
-# Features that are intended to work on all platforms.
-portable_features = ["gles", "strict_asserts", "trace", "replay", "serial-pass", "id32", "wgsl"]
-
 [dependencies]
 arrayvec = "0.7"
 bitflags = "1"

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -5560,22 +5560,22 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut closures = UserClosures::default();
         let mut all_queue_empty = true;
 
-        #[cfg(feature = "vulkan")]
+        #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
         {
             all_queue_empty = self.poll_devices::<hal::api::Vulkan>(force_wait, &mut closures)?
                 && all_queue_empty;
         }
-        #[cfg(feature = "metal")]
+        #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
         {
             all_queue_empty =
                 self.poll_devices::<hal::api::Metal>(force_wait, &mut closures)? && all_queue_empty;
         }
-        #[cfg(feature = "dx12")]
+        #[cfg(all(feature = "dx12", windows))]
         {
             all_queue_empty =
                 self.poll_devices::<hal::api::Dx12>(force_wait, &mut closures)? && all_queue_empty;
         }
-        #[cfg(feature = "dx11")]
+        #[cfg(all(feature = "dx11", windows))]
         {
             all_queue_empty =
                 self.poll_devices::<hal::api::Dx11>(force_wait, &mut closures)? && all_queue_empty;

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -1057,13 +1057,13 @@ impl<A: HalApi, F: GlobalIdentityHandlerFactory> Hub<A, F> {
 }
 
 pub struct Hubs<F: GlobalIdentityHandlerFactory> {
-    #[cfg(feature = "vulkan")]
+    #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
     vulkan: Hub<hal::api::Vulkan, F>,
-    #[cfg(feature = "metal")]
+    #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
     metal: Hub<hal::api::Metal, F>,
-    #[cfg(feature = "dx12")]
+    #[cfg(all(feature = "dx12", windows))]
     dx12: Hub<hal::api::Dx12, F>,
-    #[cfg(feature = "dx11")]
+    #[cfg(all(feature = "dx11", windows))]
     dx11: Hub<hal::api::Dx11, F>,
     #[cfg(feature = "gles")]
     gl: Hub<hal::api::Gles, F>,
@@ -1072,13 +1072,13 @@ pub struct Hubs<F: GlobalIdentityHandlerFactory> {
 impl<F: GlobalIdentityHandlerFactory> Hubs<F> {
     fn new(factory: &F) -> Self {
         Self {
-            #[cfg(feature = "vulkan")]
+            #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
             vulkan: Hub::new(factory),
-            #[cfg(feature = "metal")]
+            #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
             metal: Hub::new(factory),
-            #[cfg(feature = "dx12")]
+            #[cfg(all(feature = "dx12", windows))]
             dx12: Hub::new(factory),
-            #[cfg(feature = "dx11")]
+            #[cfg(all(feature = "dx11", windows))]
             dx11: Hub::new(factory),
             #[cfg(feature = "gles")]
             gl: Hub::new(factory),
@@ -1089,13 +1089,13 @@ impl<F: GlobalIdentityHandlerFactory> Hubs<F> {
 #[derive(Debug)]
 pub struct GlobalReport {
     pub surfaces: StorageReport,
-    #[cfg(feature = "vulkan")]
+    #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
     pub vulkan: Option<HubReport>,
-    #[cfg(feature = "metal")]
+    #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
     pub metal: Option<HubReport>,
-    #[cfg(feature = "dx12")]
+    #[cfg(all(feature = "dx12", windows))]
     pub dx12: Option<HubReport>,
-    #[cfg(feature = "dx11")]
+    #[cfg(all(feature = "dx11", windows))]
     pub dx11: Option<HubReport>,
     #[cfg(feature = "gles")]
     pub gl: Option<HubReport>,
@@ -1162,25 +1162,25 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn generate_report(&self) -> GlobalReport {
         GlobalReport {
             surfaces: self.surfaces.data.read().generate_report(),
-            #[cfg(feature = "vulkan")]
+            #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
             vulkan: if self.instance.vulkan.is_some() {
                 Some(self.hubs.vulkan.generate_report())
             } else {
                 None
             },
-            #[cfg(feature = "metal")]
+            #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
             metal: if self.instance.metal.is_some() {
                 Some(self.hubs.metal.generate_report())
             } else {
                 None
             },
-            #[cfg(feature = "dx12")]
+            #[cfg(all(feature = "dx12", windows))]
             dx12: if self.instance.dx12.is_some() {
                 Some(self.hubs.dx12.generate_report())
             } else {
                 None
             },
-            #[cfg(feature = "dx11")]
+            #[cfg(all(feature = "dx11", windows))]
             dx11: if self.instance.dx11.is_some() {
                 Some(self.hubs.dx11.generate_report())
             } else {
@@ -1203,19 +1203,19 @@ impl<G: GlobalIdentityHandlerFactory> Drop for Global<G> {
         let mut surface_guard = self.surfaces.data.write();
 
         // destroy hubs before the instance gets dropped
-        #[cfg(feature = "vulkan")]
+        #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
         {
             self.hubs.vulkan.clear(&mut surface_guard, true);
         }
-        #[cfg(feature = "metal")]
+        #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
         {
             self.hubs.metal.clear(&mut surface_guard, true);
         }
-        #[cfg(feature = "dx12")]
+        #[cfg(all(feature = "dx12", windows))]
         {
             self.hubs.dx12.clear(&mut surface_guard, true);
         }
-        #[cfg(feature = "dx11")]
+        #[cfg(all(feature = "dx11", windows))]
         {
             self.hubs.dx11.clear(&mut surface_guard, true);
         }
@@ -1261,7 +1261,7 @@ impl HalApi for hal::api::Empty {
     }
 }
 
-#[cfg(feature = "vulkan")]
+#[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
 impl HalApi for hal::api::Vulkan {
     const VARIANT: Backend = Backend::Vulkan;
     fn create_instance_from_hal(name: &str, hal_instance: Self::Instance) -> Instance {
@@ -1285,7 +1285,7 @@ impl HalApi for hal::api::Vulkan {
     }
 }
 
-#[cfg(feature = "metal")]
+#[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
 impl HalApi for hal::api::Metal {
     const VARIANT: Backend = Backend::Metal;
     fn create_instance_from_hal(name: &str, hal_instance: Self::Instance) -> Instance {
@@ -1309,7 +1309,7 @@ impl HalApi for hal::api::Metal {
     }
 }
 
-#[cfg(feature = "dx12")]
+#[cfg(all(feature = "dx12", windows))]
 impl HalApi for hal::api::Dx12 {
     const VARIANT: Backend = Backend::Dx12;
     fn create_instance_from_hal(name: &str, hal_instance: Self::Instance) -> Instance {
@@ -1333,7 +1333,7 @@ impl HalApi for hal::api::Dx12 {
     }
 }
 
-#[cfg(feature = "dx11")]
+#[cfg(all(feature = "dx11", windows))]
 impl HalApi for hal::api::Dx11 {
     const VARIANT: Backend = Backend::Dx11;
     fn create_instance_from_hal(name: &str, hal_instance: Self::Instance) -> Instance {

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -54,13 +54,13 @@ fn downlevel_default_limits_less_than_default_limits() {
 pub struct Instance {
     #[allow(dead_code)]
     pub name: String,
-    #[cfg(feature = "vulkan")]
+    #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
     pub vulkan: Option<HalInstance<hal::api::Vulkan>>,
-    #[cfg(feature = "metal")]
+    #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
     pub metal: Option<HalInstance<hal::api::Metal>>,
-    #[cfg(feature = "dx12")]
+    #[cfg(all(feature = "dx12", windows))]
     pub dx12: Option<HalInstance<hal::api::Dx12>>,
-    #[cfg(feature = "dx11")]
+    #[cfg(all(feature = "dx11", windows))]
     pub dx11: Option<HalInstance<hal::api::Dx11>>,
     #[cfg(feature = "gles")]
     pub gl: Option<HalInstance<hal::api::Gles>>,
@@ -88,13 +88,13 @@ impl Instance {
 
         Self {
             name: name.to_string(),
-            #[cfg(feature = "vulkan")]
+            #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
             vulkan: init(hal::api::Vulkan, &instance_desc),
-            #[cfg(feature = "metal")]
+            #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
             metal: init(hal::api::Metal, &instance_desc),
-            #[cfg(feature = "dx12")]
+            #[cfg(all(feature = "dx12", windows))]
             dx12: init(hal::api::Dx12, &instance_desc),
-            #[cfg(feature = "dx11")]
+            #[cfg(all(feature = "dx11", windows))]
             dx11: init(hal::api::Dx11, &instance_desc),
             #[cfg(feature = "gles")]
             gl: init(hal::api::Gles, &instance_desc),
@@ -113,13 +113,13 @@ impl Instance {
                 }
             }
         }
-        #[cfg(feature = "vulkan")]
+        #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
         destroy(hal::api::Vulkan, &self.vulkan, surface.vulkan);
-        #[cfg(feature = "metal")]
+        #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
         destroy(hal::api::Metal, &self.metal, surface.metal);
-        #[cfg(feature = "dx12")]
+        #[cfg(all(feature = "dx12", windows))]
         destroy(hal::api::Dx12, &self.dx12, surface.dx12);
-        #[cfg(feature = "dx11")]
+        #[cfg(all(feature = "dx11", windows))]
         destroy(hal::api::Dx11, &self.dx11, surface.dx11);
         #[cfg(feature = "gles")]
         destroy(hal::api::Gles, &self.gl, surface.gl);
@@ -128,13 +128,13 @@ impl Instance {
 
 pub struct Surface {
     pub(crate) presentation: Option<Presentation>,
-    #[cfg(feature = "vulkan")]
+    #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
     pub vulkan: Option<HalSurface<hal::api::Vulkan>>,
-    #[cfg(feature = "metal")]
+    #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
     pub metal: Option<HalSurface<hal::api::Metal>>,
-    #[cfg(feature = "dx12")]
+    #[cfg(all(feature = "dx12", windows))]
     pub dx12: Option<HalSurface<hal::api::Dx12>>,
-    #[cfg(feature = "dx11")]
+    #[cfg(all(feature = "dx11", windows))]
     pub dx11: Option<HalSurface<hal::api::Dx11>>,
     #[cfg(feature = "gles")]
     pub gl: Option<HalSurface<hal::api::Gles>>,
@@ -468,13 +468,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let surface = Surface {
             presentation: None,
-            #[cfg(feature = "vulkan")]
+            #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
             vulkan: init::<hal::api::Vulkan>(&self.instance.vulkan, display_handle, window_handle),
-            #[cfg(feature = "metal")]
+            #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
             metal: init::<hal::api::Metal>(&self.instance.metal, display_handle, window_handle),
-            #[cfg(feature = "dx12")]
+            #[cfg(all(feature = "dx12", windows))]
             dx12: init::<hal::api::Dx12>(&self.instance.dx12, display_handle, window_handle),
-            #[cfg(feature = "dx11")]
+            #[cfg(all(feature = "dx11", windows))]
             dx11: init::<hal::api::Dx11>(&self.instance.dx11, display_handle, window_handle),
             #[cfg(feature = "gles")]
             gl: init::<hal::api::Gles>(&self.instance.gl, display_handle, window_handle),
@@ -488,7 +488,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     /// # Safety
     ///
     /// `layer` must be a valid pointer.
-    #[cfg(feature = "metal")]
+    #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
     pub unsafe fn instance_create_surface_metal(
         &self,
         layer: *mut std::ffi::c_void,
@@ -506,7 +506,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 },
                 //acquired_texture: None,
             }),
-            #[cfg(feature = "vulkan")]
+            #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
             vulkan: None,
             #[cfg(feature = "gles")]
             gl: None,
@@ -571,7 +571,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         Ok(id.0)
     }
 
-    #[cfg(feature = "dx12")]
+    #[cfg(all(feature = "dx12", windows))]
     /// # Safety
     ///
     /// The visual must be valid and able to be used to make a swapchain with.
@@ -584,7 +584,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let surface = Surface {
             presentation: None,
-            #[cfg(feature = "vulkan")]
+            #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
             vulkan: None,
             dx12: self.instance.dx12.as_ref().map(|inst| HalSurface {
                 raw: unsafe { inst.create_surface_from_visual(visual as _) },
@@ -599,7 +599,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id.0
     }
 
-    #[cfg(feature = "dx12")]
+    #[cfg(all(feature = "dx12", windows))]
     /// # Safety
     ///
     /// The surface_handle must be valid and able to be used to make a swapchain with.
@@ -612,7 +612,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let surface = Surface {
             presentation: None,
-            #[cfg(feature = "vulkan")]
+            #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
             vulkan: None,
             dx12: self.instance.dx12.as_ref().map(|inst| HalSurface {
                 raw: unsafe { inst.create_surface_from_surface_handle(surface_handle) },
@@ -671,23 +671,23 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let mut adapters = Vec::new();
 
-        #[cfg(feature = "vulkan")]
+        #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
         self.enumerate(
             hal::api::Vulkan,
             &self.instance.vulkan,
             &inputs,
             &mut adapters,
         );
-        #[cfg(feature = "metal")]
+        #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
         self.enumerate(
             hal::api::Metal,
             &self.instance.metal,
             &inputs,
             &mut adapters,
         );
-        #[cfg(feature = "dx12")]
+        #[cfg(all(feature = "dx12", windows))]
         self.enumerate(hal::api::Dx12, &self.instance.dx12, &inputs, &mut adapters);
-        #[cfg(feature = "dx11")]
+        #[cfg(all(feature = "dx11", windows))]
         self.enumerate(hal::api::Dx11, &self.instance.dx11, &inputs, &mut adapters);
         #[cfg(feature = "gles")]
         self.enumerate(hal::api::Gles, &self.instance.gl, &inputs, &mut adapters);
@@ -772,7 +772,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .transpose()?;
         let mut device_types = Vec::new();
 
-        #[cfg(feature = "vulkan")]
+        #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
         let (id_vulkan, adapters_vk) = gather(
             hal::api::Vulkan,
             self.instance.vulkan.as_ref(),
@@ -781,7 +781,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             desc.force_fallback_adapter,
             &mut device_types,
         );
-        #[cfg(feature = "metal")]
+        #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
         let (id_metal, adapters_metal) = gather(
             hal::api::Metal,
             self.instance.metal.as_ref(),
@@ -790,7 +790,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             desc.force_fallback_adapter,
             &mut device_types,
         );
-        #[cfg(feature = "dx12")]
+        #[cfg(all(feature = "dx12", windows))]
         let (id_dx12, adapters_dx12) = gather(
             hal::api::Dx12,
             self.instance.dx12.as_ref(),
@@ -799,7 +799,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             desc.force_fallback_adapter,
             &mut device_types,
         );
-        #[cfg(feature = "dx11")]
+        #[cfg(all(feature = "dx11", windows))]
         let (id_dx11, adapters_dx11) = gather(
             hal::api::Dx11,
             self.instance.dx11.as_ref(),
@@ -861,19 +861,19 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         };
 
         let mut selected = preferred_gpu.unwrap_or(0);
-        #[cfg(feature = "vulkan")]
+        #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
         if let Some(id) = self.select(&mut selected, id_vulkan, adapters_vk) {
             return Ok(id);
         }
-        #[cfg(feature = "metal")]
+        #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
         if let Some(id) = self.select(&mut selected, id_metal, adapters_metal) {
             return Ok(id);
         }
-        #[cfg(feature = "dx12")]
+        #[cfg(all(feature = "dx12", windows))]
         if let Some(id) = self.select(&mut selected, id_dx12, adapters_dx12) {
             return Ok(id);
         }
-        #[cfg(feature = "dx11")]
+        #[cfg(all(feature = "dx11", windows))]
         if let Some(id) = self.select(&mut selected, id_dx11, adapters_dx11) {
             return Ok(id);
         }
@@ -901,13 +901,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let fid = A::hub(self).adapters.prepare(input);
 
         match A::VARIANT {
-            #[cfg(feature = "vulkan")]
+            #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
             Backend::Vulkan => fid.assign(Adapter::new(hal_adapter), &mut token).0,
-            #[cfg(feature = "metal")]
+            #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
             Backend::Metal => fid.assign(Adapter::new(hal_adapter), &mut token).0,
-            #[cfg(feature = "dx12")]
+            #[cfg(all(feature = "dx12", windows))]
             Backend::Dx12 => fid.assign(Adapter::new(hal_adapter), &mut token).0,
-            #[cfg(feature = "dx11")]
+            #[cfg(all(feature = "dx11", windows))]
             Backend::Dx11 => fid.assign(Adapter::new(hal_adapter), &mut token).0,
             #[cfg(feature = "gles")]
             Backend::Gl => fid.assign(Adapter::new(hal_adapter), &mut token).0,

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -295,14 +295,14 @@ platform supports.";
 /// private name, which is never used outside this macro. For details:
 /// <https://github.com/rust-lang/rust/pull/52234#issuecomment-976702997>
 macro_rules! define_backend_caller {
-    { $public:ident, $private:ident if $feature:literal } => {
-        #[cfg(feature = $feature )]
+    { $public:ident, $private:ident, $feature:literal if $cfg:meta } => {
+        #[cfg($cfg)]
         #[macro_export]
         macro_rules! $private {
             ( $call:expr ) => ( $call )
         }
 
-        #[cfg(not(feature = $feature ))]
+        #[cfg(not($cfg))]
         #[macro_export]
         macro_rules! $private {
             ( $call:expr ) => (
@@ -321,11 +321,11 @@ macro_rules! define_backend_caller {
 //
 // expands to `expr` if the `"vulkan"` feature is enabled, or to a panic
 // otherwise.
-define_backend_caller! { gfx_if_vulkan, gfx_if_vulkan_hidden if "vulkan" }
-define_backend_caller! { gfx_if_metal, gfx_if_metal_hidden if "metal" }
-define_backend_caller! { gfx_if_dx12, gfx_if_dx12_hidden if "dx12" }
-define_backend_caller! { gfx_if_dx11, gfx_if_dx11_hidden if "dx11" }
-define_backend_caller! { gfx_if_gles, gfx_if_gles_hidden if "gles" }
+define_backend_caller! { gfx_if_vulkan, gfx_if_vulkan_hidden, "vulkan" if all(feature = "vulkan", not(target_arch = "wasm32")) }
+define_backend_caller! { gfx_if_metal, gfx_if_metal_hidden, "metal" if all(feature = "metal", any(target_os = "macos", target_os = "ios")) }
+define_backend_caller! { gfx_if_dx12, gfx_if_dx12_hidden, "dx12" if all(feature = "dx12", windows) }
+define_backend_caller! { gfx_if_dx11, gfx_if_dx11_hidden, "dx11" if all(feature = "dx11", windows) }
+define_backend_caller! { gfx_if_gles, gfx_if_gles_hidden, "gles" if feature = "gles" }
 
 /// Dispatch on an [`Id`]'s backend to a backend-generic method.
 ///

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -62,7 +62,6 @@ thiserror = "1"
 arrayvec = "0.7"
 fxhash = "0.2.1"
 log = "0.4"
-renderdoc-sys = { version = "1.0.0", optional = true }
 
 # backend: Gles
 glow = { version = "0.12.1", optional = true }
@@ -81,6 +80,7 @@ smallvec = { version = "1", optional = true, features = ["union"] }
 
 egl = { package = "khronos-egl", version = "4.1", features = ["dynamic"], optional = true }
 libloading = { version = "0.7", optional = true }
+renderdoc-sys = { version = "1.0.0", optional = true }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
 egl = { package = "khronos-egl", version = "4.1", features = ["static", "no-pkg-config"] }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -64,24 +64,8 @@ fxhash = "0.2.1"
 log = "0.4"
 renderdoc-sys = { version = "1.0.0", optional = true }
 
-# backend: Metal
-block = { version = "0.1", optional = true }
-foreign-types = { version = "0.3", optional = true }
-
-# backend: Vulkan
-ash = { version = "0.37.2", optional = true }
-gpu-alloc = { version = "0.5", optional = true }
-gpu-descriptor = { version = "0.2", optional = true }
-smallvec = { version = "1", optional = true, features = ["union"] }
-
 # backend: Gles
 glow = { version = "0.12.1", optional = true }
-
-# backend: Dx12
-bit-set = { version = "0.5", optional = true }
-range-alloc = { version = "0.1", optional = true }
-gpu-allocator = { version = "0.22", default_features = false, features = ["d3d12", "windows", "public-winapi"], optional = true }
-hassle-rs = { version = "0.10", optional = true }
 
 [dependencies.wgt]
 package = "wgpu-types"
@@ -89,6 +73,12 @@ path = "../wgpu-types"
 version = "0.15"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# backend: Vulkan
+ash = { version = "0.37.2", optional = true }
+gpu-alloc = { version = "0.5", optional = true }
+gpu-descriptor = { version = "0.2", optional = true }
+smallvec = { version = "1", optional = true, features = ["union"] }
+
 egl = { package = "khronos-egl", version = "4.1", features = ["dynamic"], optional = true }
 libloading = { version = "0.7", optional = true }
 
@@ -98,10 +88,20 @@ egl = { package = "khronos-egl", version = "4.1", features = ["static", "no-pkg-
 libloading = { version = "0.7", optional = true }
 
 [target.'cfg(windows)'.dependencies]
+# backend: Dx12
+bit-set = { version = "0.5", optional = true }
+range-alloc = { version = "0.1", optional = true }
+gpu-allocator = { version = "0.22", default_features = false, features = ["d3d12", "windows", "public-winapi"], optional = true }
+hassle-rs = { version = "0.10", optional = true }
+
 winapi = { version = "0.3", features = ["profileapi", "libloaderapi", "windef", "winuser", "dcomp"] }
 native = { package = "d3d12", version = "0.6.0", git = "https://github.com/gfx-rs/d3d12-rs", rev = "b940b1d71", features = ["libloading"], optional = true }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
+# backend: Metal
+block = { version = "0.1", optional = true }
+foreign-types = { version = "0.3", optional = true }
+
 mtl = { package = "metal", version = "0.24.0" }
 objc = "0.2.5"
 core-graphics-types = "0.1"

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(all(any(feature = "dx11", feature = "dx12"), windows))]
 pub(super) mod dxgi;
 
-#[cfg(feature = "renderdoc")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
 pub(super) mod renderdoc;
 
 pub mod db {

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "dx11", feature = "dx12"))]
+#[cfg(all(any(feature = "dx11", feature = "dx12"), windows))]
 pub(super) mod dxgi;
 
 #[cfg(feature = "renderdoc")]

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -27,7 +27,7 @@ and [`crate::CommandEncoder::set_render_pipeline`] with
 [`crate::CommandEncoder::set_compute_pipeline`].
 
 For this reason, in order avoid repeating the binding code,
-we are binding everything in [`CommandEncoder::update_root_elements`].
+we are binding everything in `CommandEncoder::update_root_elements`.
 When the pipeline layout is changed, we reset all bindings.
 Otherwise, we pass a range corresponding only to the current bind group.
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -660,7 +660,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             device: super::Device {
                 shared: Arc::clone(&self.shared),
                 main_vao,
-                #[cfg(feature = "renderdoc")]
+                #[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
                 render_doc: Default::default(),
             },
             queue: super::Queue {

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1301,7 +1301,7 @@ impl crate::Device<super::Api> for super::Device {
     }
 
     unsafe fn start_capture(&self) -> bool {
-        #[cfg(feature = "renderdoc")]
+        #[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
         return unsafe {
             self.render_doc
                 .start_frame_capture(self.shared.context.raw_context(), ptr::null_mut())
@@ -1310,7 +1310,7 @@ impl crate::Device<super::Api> for super::Device {
         false
     }
     unsafe fn stop_capture(&self) {
-        #[cfg(feature = "renderdoc")]
+        #[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
         unsafe {
             self.render_doc
                 .end_frame_capture(ptr::null_mut(), ptr::null_mut())

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -211,7 +211,7 @@ pub struct Adapter {
 pub struct Device {
     shared: Arc<AdapterShared>,
     main_vao: glow::VertexArray,
-    #[cfg(feature = "renderdoc")]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
     render_doc: crate::auxil::renderdoc::RenderDoc,
 }
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -51,20 +51,6 @@
     clippy::pattern_type_mismatch,
 )]
 
-#[cfg(not(any(
-    feature = "dx11",
-    feature = "dx12",
-    feature = "gles",
-    feature = "metal",
-    feature = "vulkan"
-)))]
-compile_error!("No back ends enabled in `wgpu-hal`. Enable at least one backend feature.");
-
-#[cfg(all(feature = "metal", not(any(target_os = "macos", target_os = "ios"))))]
-compile_error!("Metal API enabled on non-Apple OS. If your project is not using resolver=\"2\" in Cargo.toml, it should.");
-#[cfg(all(feature = "dx12", not(windows)))]
-compile_error!("DX12 API enabled on non-Windows OS. If your project is not using resolver=\"2\" in Cargo.toml, it should.");
-
 /// DirectX11 API internals.
 #[cfg(all(feature = "dx11", windows))]
 pub mod dx11;
@@ -77,24 +63,24 @@ pub mod empty;
 #[cfg(all(feature = "gles"))]
 pub mod gles;
 /// Metal API internals.
-#[cfg(all(feature = "metal"))]
+#[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
 pub mod metal;
 /// Vulkan API internals.
-#[cfg(feature = "vulkan")]
+#[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
 pub mod vulkan;
 
 pub mod auxil;
 pub mod api {
-    #[cfg(feature = "dx11")]
+    #[cfg(all(feature = "dx11", windows))]
     pub use super::dx11::Api as Dx11;
-    #[cfg(feature = "dx12")]
+    #[cfg(all(feature = "dx12", windows))]
     pub use super::dx12::Api as Dx12;
     pub use super::empty::Api as Empty;
     #[cfg(feature = "gles")]
     pub use super::gles::Api as Gles;
-    #[cfg(feature = "metal")]
+    #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
     pub use super::metal::Api as Metal;
-    #[cfg(feature = "vulkan")]
+    #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
     pub use super::vulkan::Api as Vulkan;
 }
 


### PR DESCRIPTION
This changes crate features to be no-op on incompatible targets instead of not compiling.

- Vulkan is no-op on WASM
- DirectX12 and DirectX11 is no-op on everything but Windows
- Metal is no-op on everything but MacOS and iOS

As far as I'm aware Vulkan is needed on MacOS for Vulkan Portability.
I saw a feature called `portable_features` that is used for testing purposes. I believe I can actually remove this now?

~~Depends on #3467.~~

Fixes #3463 (only WASM).
Fixes #3465.