### PR TITLE
Remove `emscripten` crate features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,13 +139,13 @@ jobs:
           set -e
 
           # build for Emscripten/WebGL
-          cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-hal --no-default-features --features webgl,emscripten
+          cargo clippy --target ${{ matrix.target }} -p wgpu -p wgpu-hal --no-default-features
 
           # build cube example
-          cargo clippy --target ${{ matrix.target }} --example cube --features webgl,emscripten
+          cargo clippy --target ${{ matrix.target }} --example cube
 
           # build raw-gles example
-          cargo clippy --target ${{ matrix.target }} --example raw-gles --features webgl,emscripten
+          cargo clippy --target ${{ matrix.target }} --example raw-gles
 
       - name: check native
         if: matrix.kind == 'native'

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -35,6 +35,6 @@ workspace = true
 features = ["dx11", "dx12"]
 
 # We want the wgpu-core Vulkan backend on Unix (but not Emscripten) and Windows.
-[target.'cfg(any(windows, all(unix, not(target_arch = "emscripten"))))'.dependencies.wgpu-core]
+[target.'cfg(any(windows, all(unix, not(target_os = "emscripten"))))'.dependencies.wgpu-core]
 workspace = true
 features = ["vulkan"]

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -37,7 +37,7 @@ features = ["metal"]
 workspace = true
 features = ["dx11", "dx12"]
 
-[target.'cfg(any(windows, all(unix, not(target_arch = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
+[target.'cfg(any(windows, all(unix, not(target_os = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
 workspace = true
 features = ["vulkan"]
 

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -35,9 +35,6 @@ dx12 = ["hal/dx12"]
 # https://renderdoc.org/
 renderdoc = ["hal/renderdoc"]
 
-# Compile for the Emscripten POSIX-in-a-web-page emulation environment.
-emscripten = ["hal/emscripten"]
-
 # Apply run-time checks, even in release builds. These are in addition
 # to the validation carried out at public APIs in all builds.
 strict_asserts = ["wgt/strict_asserts"]

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -34,7 +34,7 @@ pub fn is_valid_copy_dst_texture_format(
 }
 
 #[cfg_attr(
-    any(not(target_arch = "wasm32"), feature = "emscripten"),
+    any(not(target_arch = "wasm32"), target_os = "emscripten"),
     allow(unused)
 )]
 pub fn is_valid_external_image_copy_dst_texture_format(format: wgt::TextureFormat) -> bool {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -814,7 +814,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         Ok(())
     }
 
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     pub fn queue_copy_external_image_to_texture<A: HalApi>(
         &self,
         queue_id: id::QueueId,

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -43,7 +43,6 @@ dx12 = ["naga/hlsl-out", "native", "bit-set", "range-alloc", "winapi/std", "wina
 windows_rs = ["gpu-allocator"]
 dxc_shader_compiler = ["hassle-rs"]
 renderdoc = ["libloading", "renderdoc-sys"]
-emscripten = ["gles"]
 
 [[example]]
 name = "halmark"

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -4,7 +4,7 @@
 //! Emscripten build:
 //! 1. install emsdk
 //! 2. build this example with cargo:
-//!    EMCC_CFLAGS="-g -s ERROR_ON_UNDEFINED_SYMBOLS=0 --no-entry -s FULL_ES3=1" cargo build --example raw-gles --target wasm32-unknown-emscripten --features emscripten,webgl
+//!    EMCC_CFLAGS="-g -s ERROR_ON_UNDEFINED_SYMBOLS=0 --no-entry -s FULL_ES3=1" cargo build --example raw-gles --target wasm32-unknown-emscripten
 //! 3. copy raw-gles.em.html into target directory and open it in browser:
 //!    cp wgpu-hal/examples/raw-gles.em.html target/wasm32-unknown-emscripten/debug/examples
 
@@ -66,7 +66,7 @@ fn main() {
     });
 }
 
-#[cfg(feature = "emscripten")]
+#[cfg(target_os = "emscripten")]
 fn main() {
     env_logger::init();
 
@@ -116,7 +116,7 @@ fn main() {
     fill_screen(&exposed, 640, 400);
 }
 
-#[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 fn main() {}
 
 fn fill_screen(exposed: &hal::ExposedAdapter<hal::api::Gles>, width: u32, height: u32) {

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -264,7 +264,7 @@ impl crate::CommandEncoder<Api> for Encoder {
 
     unsafe fn copy_buffer_to_buffer<T>(&mut self, src: &Resource, dst: &Resource, regions: T) {}
 
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     unsafe fn copy_external_image_to_texture<T>(
         &mut self,
         src: &wgt::ImageCopyExternalImage,

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -309,7 +309,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         }
     }
 
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     unsafe fn copy_external_image_to_texture<T>(
         &mut self,
         src: &wgt::ImageCopyExternalImage,

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -94,7 +94,7 @@ impl super::Device {
     /// - If `drop_guard` is [`None`], wgpu-hal will take ownership of the texture. If `drop_guard` is
     ///   [`Some`], the texture must be valid until the drop implementation
     ///   of the drop guard is called.
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn texture_from_raw(
         &self,
         name: std::num::NonZeroU32,
@@ -125,7 +125,7 @@ impl super::Device {
     /// - If `drop_guard` is [`None`], wgpu-hal will take ownership of the renderbuffer. If `drop_guard` is
     ///   [`Some`], the renderbuffer must be valid until the drop implementation
     ///   of the drop guard is called.
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn texture_from_raw_renderbuffer(
         &self,
         name: std::num::NonZeroU32,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -57,9 +57,9 @@ To address this, we invalidate the vertex buffers based on:
 */
 
 ///cbindgen:ignore
-#[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 mod egl;
-#[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 mod web;
 
 mod adapter;
@@ -70,14 +70,14 @@ mod queue;
 
 use crate::{CopyExtent, TextureDescriptor};
 
-#[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 pub use self::egl::{AdapterContext, AdapterContextLock};
-#[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 use self::egl::{Instance, Surface};
 
-#[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 pub use self::web::AdapterContext;
-#[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 use self::web::{Instance, Surface};
 
 use arrayvec::ArrayVec;
@@ -680,7 +680,7 @@ enum Command {
         dst_target: BindTarget,
         copy: crate::BufferCopy,
     },
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     CopyExternalImageToTexture {
         src: wgt::ImageCopyExternalImage,
         dst: glow::Texture,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -379,7 +379,7 @@ impl super::Queue {
                     unsafe { gl.bind_buffer(copy_dst_target, None) };
                 }
             }
-            #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+            #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             C::CopyExternalImageToTexture {
                 ref src,
                 dst,
@@ -1509,10 +1509,10 @@ impl crate::Queue<super::Api> for super::Queue {
         surface: &mut super::Surface,
         texture: super::Texture,
     ) -> Result<(), crate::SurfaceError> {
-        #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+        #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
         let gl = unsafe { &self.shared.context.get_without_egl_lock() };
 
-        #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+        #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
         let gl = &self.shared.context.glow_context;
 
         unsafe { surface.present(texture, gl) }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -407,7 +407,7 @@ pub trait CommandEncoder<A: Api>: Send + Sync + fmt::Debug {
     /// Works with a single array layer.
     /// Note: `dst` current usage has to be `TextureUses::COPY_DST`.
     /// Note: the copy extent is in physical size (rounded to the block size)
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     unsafe fn copy_external_image_to_texture<T>(
         &mut self,
         src: &wgt::ImageCopyExternalImage,

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -97,7 +97,6 @@ trace = ["serde", "wgc/trace"]
 replay = ["serde", "wgc/replay"]
 angle = ["wgc/angle"]
 webgl = ["hal", "wgc"]
-emscripten = ["webgl"]
 vulkan-portability = ["wgc/vulkan"]
 expose-ids = []
 
@@ -128,13 +127,9 @@ workspace = true
 features = ["dx11", "dx12"]
 
 # We want the wgpu-core Vulkan backend on Unix (but not Emscripten) and Windows.
-[target.'cfg(any(windows, all(unix, not(target_arch = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
+[target.'cfg(any(windows, all(unix, not(target_os = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
 workspace = true
 features = ["vulkan"]
-
-[target.'cfg(target_os = "emscripten")'.dependencies.wgc]
-workspace = true
-features = ["emscripten"]
 
 [dependencies.wgt]
 workspace = true

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -41,7 +41,7 @@ impl fmt::Debug for Context {
 }
 
 impl Context {
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn from_hal_instance<A: wgc::hub::HalApi>(hal_instance: A::Instance) -> Self {
         Self(unsafe {
             wgc::hub::Global::from_hal_instance::<A>(
@@ -69,13 +69,13 @@ impl Context {
         &self.0
     }
 
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub fn enumerate_adapters(&self, backends: wgt::Backends) -> Vec<wgc::id::AdapterId> {
         self.0
             .enumerate_adapters(wgc::instance::AdapterInputs::Mask(backends, |_| ()))
     }
 
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn create_adapter_from_hal<A: wgc::hub::HalApi>(
         &self,
         hal_adapter: hal::ExposedAdapter<A>,
@@ -94,7 +94,7 @@ impl Context {
         }
     }
 
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn create_device_from_hal<A: wgc::hub::HalApi>(
         &self,
         adapter: &wgc::id::AdapterId,
@@ -128,7 +128,11 @@ impl Context {
         Ok((device, queue))
     }
 
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten", feature = "webgl"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        target_os = "emscripten",
+        feature = "webgl"
+    ))]
     pub unsafe fn create_texture_from_hal<A: wgc::hub::HalApi>(
         &self,
         hal_texture: A::Texture,
@@ -154,7 +158,7 @@ impl Context {
         }
     }
 
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn device_as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Device>) -> R, R>(
         &self,
         device: &Device,
@@ -166,7 +170,7 @@ impl Context {
         }
     }
 
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn surface_as_hal_mut<
         A: wgc::hub::HalApi,
         F: FnOnce(Option<&mut A::Surface>) -> R,
@@ -182,7 +186,7 @@ impl Context {
         }
     }
 
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn texture_as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Texture>)>(
         &self,
         texture: &Texture,
@@ -194,7 +198,7 @@ impl Context {
         }
     }
 
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub fn generate_report(&self) -> wgc::hub::GlobalReport {
         self.0.generate_report()
     }
@@ -211,7 +215,11 @@ impl Context {
         }
     }
 
-    #[cfg(all(target_arch = "wasm32", feature = "webgl", not(feature = "emscripten")))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        feature = "webgl",
+        not(target_os = "emscripten")
+    ))]
     pub fn instance_create_surface_from_canvas(
         &self,
         canvas: &web_sys::HtmlCanvasElement,
@@ -226,7 +234,11 @@ impl Context {
         })
     }
 
-    #[cfg(all(target_arch = "wasm32", feature = "webgl", not(feature = "emscripten")))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        feature = "webgl",
+        not(target_os = "emscripten")
+    ))]
     pub fn instance_create_surface_from_offscreen_canvas(
         &self,
         canvas: &web_sys::OffscreenCanvas,
@@ -353,7 +365,7 @@ fn map_texture_copy_view(view: crate::ImageCopyTexture) -> wgc::command::ImageCo
 }
 
 #[cfg_attr(
-    any(not(target_arch = "wasm32"), feature = "emscripten"),
+    any(not(target_arch = "wasm32"), target_os = "emscripten"),
     allow(unused)
 )]
 fn map_texture_tagged_copy_view(
@@ -1408,7 +1420,7 @@ impl crate::Context for Context {
     fn device_drop(&self, device: &Self::DeviceId, _device_data: &Self::DeviceData) {
         let global = &self.0;
 
-        #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+        #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
         {
             match wgc::gfx_select!(device => global.device_poll(*device, wgt::Maintain::Wait)) {
                 Ok(_) => (),
@@ -2219,7 +2231,7 @@ impl crate::Context for Context {
         }
     }
 
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     fn queue_copy_external_image_to_texture(
         &self,
         queue: &Self::QueueId,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -128,11 +128,6 @@ impl Context {
         Ok((device, queue))
     }
 
-    #[cfg(any(
-        not(target_arch = "wasm32"),
-        target_os = "emscripten",
-        feature = "webgl"
-    ))]
     pub unsafe fn create_texture_from_hal<A: wgc::hub::HalApi>(
         &self,
         hal_texture: A::Texture,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -41,7 +41,6 @@ impl fmt::Debug for Context {
 }
 
 impl Context {
-    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn from_hal_instance<A: wgc::hub::HalApi>(hal_instance: A::Instance) -> Self {
         Self(unsafe {
             wgc::hub::Global::from_hal_instance::<A>(

--- a/wgpu/src/backend/mod.rs
+++ b/wgpu/src/backend/mod.rs
@@ -1,9 +1,23 @@
-#[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
+#[cfg(all(
+    target_arch = "wasm32",
+    not(any(target_os = "emscripten", feature = "webgl"))
+))]
 mod web;
-#[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
+#[cfg(all(
+    target_arch = "wasm32",
+    not(any(target_os = "emscripten", feature = "webgl"))
+))]
 pub(crate) use web::Context;
 
-#[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    target_os = "emscripten",
+    feature = "webgl"
+))]
 mod direct;
-#[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    target_os = "emscripten",
+    feature = "webgl"
+))]
 pub(crate) use direct::Context;

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -2394,7 +2394,6 @@ impl crate::context::Context for Context {
             );
     }
 
-    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     fn queue_copy_external_image_to_texture(
         &self,
         queue: &Self::QueueId,

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -2394,7 +2394,7 @@ impl crate::context::Context for Context {
             );
     }
 
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     fn queue_copy_external_image_to_texture(
         &self,
         queue: &Self::QueueId,

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -561,7 +561,7 @@ pub trait Context: Debug + Send + Sized + Sync {
         data_layout: ImageDataLayout,
         size: Extent3d,
     );
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     fn queue_copy_external_image_to_texture(
         &self,
         queue: &Self::QueueId,
@@ -1488,7 +1488,7 @@ pub(crate) trait DynContext: Debug + Send + Sync {
         data_layout: ImageDataLayout,
         size: Extent3d,
     );
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     fn queue_copy_external_image_to_texture(
         &self,
         queue: &ObjectId,
@@ -2884,7 +2884,7 @@ where
         Context::queue_write_texture(self, &queue, queue_data, texture, data, data_layout, size)
     }
 
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     fn queue_copy_external_image_to_texture(
         &self,
         queue: &ObjectId,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1341,7 +1341,11 @@ impl Instance {
     /// # Safety
     ///
     /// Refer to the creation of wgpu-hal Instance for every backend.
-    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        target_os = "emscripten",
+        feature = "webgl"
+    ))]
     pub unsafe fn from_hal<A: wgc::hub::HalApi>(hal_instance: A::Instance) -> Self {
         Self {
             context: Arc::new(unsafe {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -49,9 +49,9 @@ pub use wgt::{
 
 // wasm-only types, we try to keep as many types non-platform
 // specific, but these need to depend on web-sys.
-#[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 pub use wgt::{ExternalImageSource, ImageCopyExternalImage};
-#[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 static_assertions::assert_impl_all!(ExternalImageSource: Send, Sync);
 
 /// Filter for error scopes.
@@ -1341,7 +1341,7 @@ impl Instance {
     /// # Safety
     ///
     /// Refer to the creation of wgpu-hal Instance for every backend.
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn from_hal<A: wgc::hub::HalApi>(hal_instance: A::Instance) -> Self {
         Self {
             context: Arc::new(unsafe {
@@ -1360,7 +1360,11 @@ impl Instance {
     /// - The raw instance handle returned must not be manually destroyed.
     ///
     /// [`Instance`]: hal::Api::Instance
-    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        target_os = "emscripten",
+        feature = "webgl"
+    ))]
     pub unsafe fn as_hal<A: wgc::hub::HalApi>(&self) -> Option<&A::Instance> {
         unsafe {
             self.context
@@ -1380,7 +1384,11 @@ impl Instance {
     /// # Safety
     ///
     /// Refer to the creation of wgpu-core Instance.
-    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        target_os = "emscripten",
+        feature = "webgl"
+    ))]
     pub unsafe fn from_core(core_instance: wgc::instance::Instance) -> Self {
         Self {
             context: Arc::new(unsafe {
@@ -1394,7 +1402,7 @@ impl Instance {
     /// # Arguments
     ///
     /// - `backends` - Backends from which to enumerate adapters.
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub fn enumerate_adapters(&self, backends: Backends) -> impl Iterator<Item = Adapter> {
         let context = Arc::clone(&self.context);
         self.context
@@ -1433,7 +1441,7 @@ impl Instance {
     /// # Safety
     ///
     /// `hal_adapter` must be created from this instance internal handle.
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn create_adapter_from_hal<A: wgc::hub::HalApi>(
         &self,
         hal_adapter: hal::ExposedAdapter<A>,
@@ -1575,7 +1583,7 @@ impl Instance {
     ///
     /// - On WebGL2: Will return an error if the browser does not support WebGL2,
     ///   or declines to provide GPU access (such as due to a resource shortage).
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     pub fn create_surface_from_canvas(
         &self,
         canvas: &web_sys::HtmlCanvasElement,
@@ -1611,7 +1619,7 @@ impl Instance {
     ///
     /// - On WebGL2: Will return an error if the browser does not support WebGL2,
     ///   or declines to provide GPU access (such as due to a resource shortage).
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     pub fn create_surface_from_offscreen_canvas(
         &self,
         canvas: &web_sys::OffscreenCanvas,
@@ -1659,7 +1667,7 @@ impl Instance {
     }
 
     /// Generates memory report.
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub fn generate_report(&self) -> wgc::hub::GlobalReport {
         self.context
             .as_any()
@@ -1730,7 +1738,7 @@ impl Adapter {
     ///
     /// - `hal_device` must be created from this adapter internal handle.
     /// - `desc.features` must be a subset of `hal_device` features.
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn create_device_from_hal<A: wgc::hub::HalApi>(
         &self,
         hal_device: hal::OpenDevice<A>,
@@ -1780,7 +1788,11 @@ impl Adapter {
     /// - The raw handle passed to the callback must not be manually destroyed.
     ///
     /// [`A::Adapter`]: hal::Api::Adapter
-    #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        target_os = "emscripten",
+        feature = "webgl"
+    ))]
     pub unsafe fn as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Adapter>) -> R, R>(
         &self,
         hal_adapter_callback: F,
@@ -2125,7 +2137,11 @@ impl Device {
     /// - `hal_texture` must be created from this device internal handle
     /// - `hal_texture` must be created respecting `desc`
     /// - `hal_texture` must be initialized
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten", feature = "webgl"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        target_os = "emscripten",
+        feature = "webgl"
+    ))]
     pub unsafe fn create_texture_from_hal<A: wgc::hub::HalApi>(
         &self,
         hal_texture: A::Texture,
@@ -2226,7 +2242,7 @@ impl Device {
     /// - The raw handle passed to the callback must not be manually destroyed.
     ///
     /// [`A::Device`]: hal::Api::Device
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Device>) -> R, R>(
         &self,
         hal_device_callback: F,
@@ -2564,7 +2580,7 @@ impl Texture {
     /// # Safety
     ///
     /// - The raw handle obtained from the hal Texture must not be manually destroyed
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn as_hal<A: wgc::hub::HalApi, F: FnOnce(Option<&A::Texture>)>(
         &self,
         hal_texture_callback: F,
@@ -3973,7 +3989,7 @@ impl Queue {
     }
 
     /// Schedule a copy of data from `image` into `texture`.
-    #[cfg(all(target_arch = "wasm32", not(feature = "emscripten")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     pub fn copy_external_image_to_texture(
         &self,
         source: &wgt::ImageCopyExternalImage,
@@ -4185,7 +4201,7 @@ impl Surface {
     /// # Safety
     ///
     /// - The raw handle obtained from the hal Surface must not be manually destroyed
-    #[cfg(any(not(target_arch = "wasm32"), feature = "emscripten"))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
     pub unsafe fn as_hal_mut<A: wgc::hub::HalApi, F: FnOnce(Option<&mut A::Surface>) -> R, R>(
         &mut self,
         hal_surface_callback: F,

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -340,12 +340,18 @@ fn initialize_adapter() -> (Adapter, SurfaceGuard) {
     let surface_guard;
     let compatible_surface;
 
-    #[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
+    #[cfg(not(all(
+        target_arch = "wasm32",
+        any(target_os = "emscripten", feature = "webgl")
+    )))]
     {
         surface_guard = SurfaceGuard {};
         compatible_surface = None;
     }
-    #[cfg(all(target_arch = "wasm32", feature = "webgl"))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        any(target_os = "emscripten", feature = "webgl")
+    ))]
     {
         // On wasm, append a canvas to the document body for initializing the adapter
         let canvas = create_html_canvas();
@@ -371,14 +377,17 @@ fn initialize_adapter() -> (Adapter, SurfaceGuard) {
 }
 
 struct SurfaceGuard {
-    #[cfg(all(target_arch = "wasm32", feature = "webgl"))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        any(target_os = "emscripten", feature = "webgl")
+    ))]
     canvas: web_sys::HtmlCanvasElement,
 }
 
 impl SurfaceGuard {
     fn check_for_unreported_errors(&self) -> bool {
         cfg_if::cfg_if! {
-            if #[cfg(all(target_arch = "wasm32", feature = "webgl"))] {
+            if #[cfg(all(target_arch = "wasm32", any(target_os = "emscripten", feature = "webgl")))] {
                 use wasm_bindgen::JsCast;
 
                 self.canvas
@@ -396,14 +405,20 @@ impl SurfaceGuard {
     }
 }
 
-#[cfg(all(target_arch = "wasm32", feature = "webgl"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    any(target_os = "emscripten", feature = "webgl")
+))]
 impl Drop for SurfaceGuard {
     fn drop(&mut self) {
         delete_html_canvas();
     }
 }
 
-#[cfg(all(target_arch = "wasm32", feature = "webgl"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    any(target_os = "emscripten", feature = "webgl")
+))]
 fn create_html_canvas() -> web_sys::HtmlCanvasElement {
     use wasm_bindgen::JsCast;
 
@@ -419,7 +434,10 @@ fn create_html_canvas() -> web_sys::HtmlCanvasElement {
         .expect("couldn't append canvas to document body")
 }
 
-#[cfg(all(target_arch = "wasm32", feature = "webgl"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    any(target_os = "emscripten", feature = "webgl")
+))]
 fn delete_html_canvas() {
     if let Some(document) = web_sys::window().and_then(|win| win.document()) {
         if let Some(element) = document.get_element_by_id(CANVAS_ID) {

--- a/wgpu/tests/external_texture.rs
+++ b/wgpu/tests/external_texture.rs
@@ -1,4 +1,4 @@
-#![cfg(all(target_arch = "wasm32", not(features = "emscripten")))]
+#![cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 
 use std::num::NonZeroU32;
 


### PR DESCRIPTION
This removes the `emscripten` crate feature from all crates and replaces necessary guards with `target_os = "emscripten"`.
`wgpu` will activate `wgpu-hal/gles` by default for the emscripten target and guards that were in place for `feature = "webgl"` for Emscripten were adjusted.

Requires careful review, it was a lot of search & replace and copy & paste.

See #3466.