### PR TITLE
Move warning to correct location

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -803,18 +803,19 @@ impl crate::Instance<super::Api> for Instance {
             }
             #[cfg(not(feature = "emscripten"))]
             (Rwh::Wayland(_), raw_window_handle::RawDisplayHandle::Wayland(display_handle)) => {
-                /* Wayland displays are not sharable between surfaces so if the
-                 * surface we receive from this handle is from a different
-                 * display, we must re-initialize the context.
-                 *
-                 * See gfx-rs/gfx#3545
-                 */
-                log::warn!("Re-initializing Gles context due to Wayland window");
                 if inner
                     .wl_display
                     .map(|ptr| ptr != display_handle.display)
                     .unwrap_or(true)
                 {
+                    /* Wayland displays are not sharable between surfaces so if the
+                     * surface we receive from this handle is from a different
+                     * display, we must re-initialize the context.
+                     *
+                     * See gfx-rs/gfx#3545
+                     */
+                    log::warn!("Re-initializing Gles context due to Wayland window");
+
                     use std::ops::DerefMut;
                     let display_attributes = [egl::ATTRIB_NONE];
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] ~Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.~ (Resulted in "No back ends enabled in `wgpu-hal`. Enable at least one backend feature."; don't understand why, what I should do about it, and if this is even applicable to my change.)
- [ ] ~Add change to CHANGELOG.md. See simple instructions inside file.~ (Didn't seem worthy of a changelog entry. Please let me know if you disagree, and I'll add it.)

**Connections**
None.

**Description**

The warning I'm moving here is stating that the context was being recreated, but before a check that determined whether this was actually going to be done.

I address this by moving the warning into the `if` block that actually recreates the context.

**Testing**
I didn't test this. My code triggers this warning one way or another. But it jumped out to me as obviously wrong, and the fix seemed obvious. Please review carefully.
