### PR TITLE
Update naga to 0.11.0@git:568d7c4c136dada369ef7f59ee8414a263d6c7b2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.11.0"
-source = "git+https://github.com/gfx-rs/naga?rev=4b796b157cb2b67b0ab166a2238fe4e9473bfd52#4b796b157cb2b67b0ab166a2238fe4e9473bfd52"
+source = "git+https://github.com/gfx-rs/naga?rev=568d7c4c136dada369ef7f59ee8414a263d6c7b2#568d7c4c136dada369ef7f59ee8414a263d6c7b2"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ version = "0.15"
 
 [workspace.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "4b796b157cb2b67b0ab166a2238fe4e9473bfd52"
+rev = "568d7c4c136dada369ef7f59ee8414a263d6c7b2"
 version = "0.11.0"
 
 [workspace.dependencies]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -70,7 +70,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "4b796b157cb2b67b0ab166a2238fe4e9473bfd52"
+rev = "568d7c4c136dada369ef7f59ee8414a263d6c7b2"
 version = "0.11.0"
 features = ["clone", "span", "validate"]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -119,14 +119,14 @@ android_system_properties = "0.1.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "4b796b157cb2b67b0ab166a2238fe4e9473bfd52"
+rev = "568d7c4c136dada369ef7f59ee8414a263d6c7b2"
 version = "0.11.0"
 features = ["clone"]
 
 # DEV dependencies
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "4b796b157cb2b67b0ab166a2238fe4e9473bfd52"
+rev = "568d7c4c136dada369ef7f59ee8414a263d6c7b2"
 version = "0.11.0"
 features = ["wgsl-in"]
 

--- a/wgpu/tests/common/copy_texture_to_buffer.wgsl
+++ b/wgpu/tests/common/copy_texture_to_buffer.wgsl
@@ -6,11 +6,11 @@ var<storage, read_write> output: array<{{type}}>;
 
 @compute @workgroup_size(1)
 fn copy_texture_to_buffer() {
-    let layers = textureNumLayers(texture);
+    let layers = i32(textureNumLayers(texture));
     let dim = textureDimensions(texture);
     for (var l = 0; l < layers; l++) {
-        for (var y = 0; y < dim.y; y++) {
-            for (var x = 0; x < dim.x; x++) {
+        for (var y = 0u; y < dim.y; y++) {
+            for (var x = 0u; x < dim.x; x++) {
                 output[x + y * dim.x] = textureLoad(texture, vec2(x, y), l, 0).x;
             }
         }


### PR DESCRIPTION
**Checklist**

- [ ] Run `cargo clippy`.


**Description**

Routine naga update.

I was a tad confused by the error I was getting in `copy_texture_to_buffer.wgsl` for some `textureLoad` parameters that expected, quoting the error message "an integer scalar"  while the parameter was `u32` (Fixed by passing a `i32` instead).