### PR TITLE
Set the new naga capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ By @teoxoy in [#3436](https://github.com/gfx-rs/wgpu/pull/3436)
 
 - Added `TextureFormatFeatureFlags::MULTISAMPLE_X16`. By @Dinnerbone in [#3454](https://github.com/gfx-rs/wgpu/pull/3454)
 - Support stencil-only views and copying to/from combined depth-stencil textures. By @teoxoy in [#3436](https://github.com/gfx-rs/wgpu/pull/3436)
+- Added `Features::SHADER_EARLY_DEPTH_TEST`. By @teoxoy in [#3494](https://github.com/gfx-rs/wgpu/pull/3494)
 
 #### WebGPU
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.11.0"
-source = "git+https://github.com/gfx-rs/naga?rev=568d7c4c136dada369ef7f59ee8414a263d6c7b2#568d7c4c136dada369ef7f59ee8414a263d6c7b2"
+source = "git+https://github.com/gfx-rs/naga?rev=7422ace934b7ed51c1e061eb1d36de8259b5f619#7422ace934b7ed51c1e061eb1d36de8259b5f619"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ version = "0.15"
 
 [workspace.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "568d7c4c136dada369ef7f59ee8414a263d6c7b2"
+rev = "7422ace934b7ed51c1e061eb1d36de8259b5f619"
 version = "0.11.0"
 
 [workspace.dependencies]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -70,7 +70,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "568d7c4c136dada369ef7f59ee8414a263d6c7b2"
+rev = "7422ace934b7ed51c1e061eb1d36de8259b5f619"
 version = "0.11.0"
 features = ["clone", "span", "validate"]
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1388,6 +1388,21 @@ impl<A: HalApi> Device<A> {
             self.features
                 .contains(wgt::Features::TEXTURE_FORMAT_16BIT_NORM),
         );
+        caps.set(
+            Caps::MULTIVIEW,
+            self.features.contains(wgt::Features::MULTIVIEW),
+        );
+        caps.set(
+            Caps::EARLY_DEPTH_TEST,
+            self.features
+                .contains(wgt::Features::SHADER_EARLY_DEPTH_TEST),
+        );
+        caps.set(
+            Caps::MULTISAMPLED_SHADING,
+            self.downlevel
+                .flags
+                .contains(wgt::DownlevelFlags::MULTISAMPLED_SHADING),
+        );
 
         let info = naga::valid::Validator::new(naga::valid::ValidationFlags::all(), caps)
             .validate(&module)

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -119,14 +119,14 @@ android_system_properties = "0.1.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "568d7c4c136dada369ef7f59ee8414a263d6c7b2"
+rev = "7422ace934b7ed51c1e061eb1d36de8259b5f619"
 version = "0.11.0"
 features = ["clone"]
 
 # DEV dependencies
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "568d7c4c136dada369ef7f59ee8414a263d6c7b2"
+rev = "7422ace934b7ed51c1e061eb1d36de8259b5f619"
 version = "0.11.0"
 features = ["wgsl-in"]
 

--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -135,6 +135,7 @@ impl super::Adapter {
 
         if feature_level >= FL10_1 {
             downlevel |= wgt::DownlevelFlags::CUBE_ARRAY_TEXTURES;
+            downlevel |= wgt::DownlevelFlags::MULTISAMPLED_SHADING;
         }
 
         if feature_level >= FL11_0 {

--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -124,7 +124,6 @@ impl super::Adapter {
         }
 
         if feature_level >= FL10_0 {
-            downlevel |= wgt::DownlevelFlags::INDEPENDENT_BLEND;
             downlevel |= wgt::DownlevelFlags::FRAGMENT_STORAGE;
             downlevel |= wgt::DownlevelFlags::FRAGMENT_WRITABLE_STORAGE;
             downlevel |= wgt::DownlevelFlags::DEPTH_BIAS_CLAMP;

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -355,6 +355,7 @@ impl super::Adapter {
             wgt::Features::SHADER_PRIMITIVE_INDEX,
             ver >= (3, 2) || extensions.contains("OES_geometry_shader"),
         );
+        features.set(wgt::Features::SHADER_EARLY_DEPTH_TEST, ver >= (3, 1));
         let gles_bcn_exts = [
             "GL_EXT_texture_compression_s3tc_srgb",
             "GL_EXT_texture_compression_rgtc",

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -325,6 +325,10 @@ impl super::Adapter {
             wgt::DownlevelFlags::FULL_DRAW_INDEX_UINT32,
             max_element_index == u32::MAX,
         );
+        downlevel_flags.set(
+            wgt::DownlevelFlags::MULTISAMPLED_SHADING,
+            ver >= (3, 2) || extensions.contains("OES_sample_variables"),
+        );
 
         let mut features = wgt::Features::empty()
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -681,6 +681,13 @@ bitflags::bitflags! {
         ///
         /// This is a native-only feature.
         const SHADER_INT16 = 1 << 42;
+        /// Allows shaders to use the `early_depth_test` attribute.
+        ///
+        /// Supported platforms:
+        /// - GLES 3.1+
+        ///
+        /// This is a native-only feature.
+        const SHADER_EARLY_DEPTH_TEST = 1 << 43;
     }
 }
 

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -269,10 +269,6 @@ impl Example {
 }
 
 impl framework::Example for Example {
-    fn required_features() -> wgpu::Features {
-        wgpu::Features::SHADER_EARLY_DEPTH_TEST
-    }
-
     fn init(
         config: &wgpu::SurfaceConfiguration,
         _adapter: &wgpu::Adapter,

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -269,6 +269,10 @@ impl Example {
 }
 
 impl framework::Example for Example {
+    fn required_features() -> wgpu::Features {
+        wgpu::Features::SHADER_EARLY_DEPTH_TEST
+    }
+
     fn init(
         config: &wgpu::SurfaceConfiguration,
         _adapter: &wgpu::Adapter,

--- a/wgpu/examples/water/terrain.wgsl
+++ b/wgpu/examples/water/terrain.wgsl
@@ -37,7 +37,6 @@ fn vs_main(
 }
 
 @fragment
-@early_depth_test
 fn fs_main(
     vertex: VertexOutput,
 ) -> @location(0) vec4<f32> {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**


**Description**
- set the right naga capabilities
- add `Features::SHADER_EARLY_DEPTH_TEST`
- set the `MULTISAMPLED_SHADING` downlevel flag for gles and dx11

**Testing**
