### PR TITLE
reuse equivalent samplers in dx12 to help stay under the limit of 2048

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ By @teoxoy in [#3436](https://github.com/gfx-rs/wgpu/pull/3436)
 #### DX12
 
 - Fix DXC validation issues when using a custom `dxil_path`. By @Elabajaba in [#3434](https://github.com/gfx-rs/wgpu/pull/3434)
+- Reuse equivalent samplers in dx12 to help stay under the limit of 2048 per heap. By @Davidster in [#3499](https://github.com/gfx-rs/wgpu/pull/3499)
 
 #### GLES
 

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -853,7 +853,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         if info.tables.contains(super::TableTypes::SAMPLERS) {
             log::trace!("\tBind element[{}] = sampler", root_index);
             self.pass.root_elements[root_index] =
-                super::RootElement::Table(group.handle_samplers.unwrap().gpu);
+                super::RootElement::Table(group.handle_samplers.as_ref().unwrap().0.gpu);
             root_index += 1;
         }
 

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -852,9 +852,10 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         // Bind Sampler descriptor tables.
         if info.tables.contains(super::TableTypes::SAMPLERS) {
             log::trace!("\tBind element[{}] = sampler", root_index);
-            self.pass.root_elements[root_index] =
-                super::RootElement::Table(group.handle_samplers.as_ref().unwrap().0.gpu);
-            root_index += 1;
+            for &(ref sampler_handle, _) in &group.handle_samplers {
+                self.pass.root_elements[root_index] = super::RootElement::Table(sampler_handle.gpu);
+                root_index += 1;
+            }
         }
 
         // Bind root descriptors

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -627,7 +627,7 @@ impl crate::Device<super::Api> for super::Device {
 
         let hash = {
             let mut state = std::collections::hash_map::DefaultHasher::new();
-            desc.hash(&mut state);
+            hash_sampler_descriptor(desc, &mut state);
             state.finish()
         };
 
@@ -1639,4 +1639,23 @@ impl crate::Device<super::Api> for super::Device {
                 .end_frame_capture(self.raw.as_mut_ptr() as *mut _, ptr::null_mut())
         }
     }
+}
+
+fn hash_sampler_descriptor<H: Hasher>(
+    sampler_descriptor: &crate::SamplerDescriptor<'_>,
+    state: &mut H,
+) {
+    sampler_descriptor.address_modes.hash(state);
+    sampler_descriptor.mag_filter.hash(state);
+    sampler_descriptor.min_filter.hash(state);
+    sampler_descriptor.mipmap_filter.hash(state);
+    sampler_descriptor.compare.hash(state);
+    sampler_descriptor.anisotropy_clamp.hash(state);
+    sampler_descriptor.border_color.hash(state);
+
+    let hashable_lod_clamp = sampler_descriptor
+        .lod_clamp
+        .as_ref()
+        .map(|lod_clamp| (lod_clamp.start.to_bits(), lod_clamp.end.to_bits()));
+    hashable_lod_clamp.hash(state);
 }

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -244,6 +244,8 @@ impl DeviceShared {
     }
 }
 
+type SamplerHash = u64;
+
 pub struct Device {
     raw: native::Device,
     present_queue: native::CommandQueue,
@@ -262,7 +264,7 @@ pub struct Device {
     null_rtv_handle: descriptor::Handle,
     mem_allocator: Option<Mutex<suballocation::GpuAllocatorWrapper>>,
     dxc_container: Option<shader_compilation::DxcContainer>,
-    uploaded_sampler_handles: Mutex<HashMap<u64, (descriptor::DualHandle, usize)>>,
+    uploaded_sampler_handles: Mutex<HashMap<SamplerHash, Arc<descriptor::DualHandle>>>,
 }
 
 unsafe impl Send for Device {}
@@ -514,7 +516,7 @@ enum BufferViewKind {
 #[derive(Debug)]
 pub struct BindGroup {
     handle_views: Option<descriptor::DualHandle>,
-    handle_samplers: Vec<(descriptor::DualHandle, u64)>,
+    handle_samplers: Vec<(Arc<descriptor::DualHandle>, SamplerHash)>,
     dynamic_buffers: Vec<native::GpuAddress>,
 }
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -47,7 +47,7 @@ use crate::auxil::{self, dxgi::result::HResult as _};
 
 use arrayvec::ArrayVec;
 use parking_lot::Mutex;
-use std::{ffi, fmt, mem, num::NonZeroU32, sync::Arc};
+use std::{collections::HashMap, ffi, fmt, mem, num::NonZeroU32, sync::Arc};
 use winapi::{
     shared::{dxgi, dxgi1_4, dxgitype, windef, winerror},
     um::{d3d12, dcomp, synchapi, winbase, winnt},
@@ -262,6 +262,7 @@ pub struct Device {
     null_rtv_handle: descriptor::Handle,
     mem_allocator: Option<Mutex<suballocation::GpuAllocatorWrapper>>,
     dxc_container: Option<shader_compilation::DxcContainer>,
+    uploaded_sampler_handles: Mutex<HashMap<Vec<u64>, (descriptor::DualHandle, usize)>>,
 }
 
 unsafe impl Send for Device {}
@@ -472,6 +473,7 @@ unsafe impl Sync for TextureView {}
 #[derive(Debug)]
 pub struct Sampler {
     handle: descriptor::Handle,
+    hash: u64,
 }
 
 unsafe impl Send for Sampler {}
@@ -512,7 +514,7 @@ enum BufferViewKind {
 #[derive(Debug)]
 pub struct BindGroup {
     handle_views: Option<descriptor::DualHandle>,
-    handle_samplers: Option<descriptor::DualHandle>,
+    handle_samplers: Option<(descriptor::DualHandle, Vec<u64>)>,
     dynamic_buffers: Vec<native::GpuAddress>,
 }
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -262,7 +262,7 @@ pub struct Device {
     null_rtv_handle: descriptor::Handle,
     mem_allocator: Option<Mutex<suballocation::GpuAllocatorWrapper>>,
     dxc_container: Option<shader_compilation::DxcContainer>,
-    uploaded_sampler_handles: Mutex<HashMap<Vec<u64>, (descriptor::DualHandle, usize)>>,
+    uploaded_sampler_handles: Mutex<HashMap<u64, (descriptor::DualHandle, usize)>>,
 }
 
 unsafe impl Send for Device {}
@@ -514,7 +514,7 @@ enum BufferViewKind {
 #[derive(Debug)]
 pub struct BindGroup {
     handle_views: Option<descriptor::DualHandle>,
-    handle_samplers: Option<(descriptor::DualHandle, Vec<u64>)>,
+    handle_samplers: Vec<(descriptor::DualHandle, u64)>,
     dynamic_buffers: Vec<native::GpuAddress>,
 }
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -101,6 +101,7 @@ pub mod api {
 use std::{
     borrow::{Borrow, Cow},
     fmt,
+    hash::{Hash, Hasher},
     num::{NonZeroU32, NonZeroU8},
     ops::{Range, RangeInclusive},
     ptr::NonNull,
@@ -937,6 +938,25 @@ pub struct SamplerDescriptor<'a> {
     pub compare: Option<wgt::CompareFunction>,
     pub anisotropy_clamp: Option<NonZeroU8>,
     pub border_color: Option<wgt::SamplerBorderColor>,
+}
+
+impl Hash for SamplerDescriptor<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.label.hash(state);
+        self.address_modes.hash(state);
+        self.mag_filter.hash(state);
+        self.min_filter.hash(state);
+        self.mipmap_filter.hash(state);
+        self.compare.hash(state);
+        self.anisotropy_clamp.hash(state);
+        self.border_color.hash(state);
+
+        let hashable_lod_clamp = self
+            .lod_clamp
+            .as_ref()
+            .map(|lod_clamp| (lod_clamp.start.to_bits(), lod_clamp.end.to_bits()));
+        hashable_lod_clamp.hash(state);
+    }
 }
 
 /// BindGroupLayout descriptor.

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -942,7 +942,6 @@ pub struct SamplerDescriptor<'a> {
 
 impl Hash for SamplerDescriptor<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.label.hash(state);
         self.address_modes.hash(state);
         self.mag_filter.hash(state);
         self.min_filter.hash(state);

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -101,7 +101,7 @@ pub mod api {
 use std::{
     borrow::{Borrow, Cow},
     fmt,
-    hash::{Hash, Hasher},
+    hash::Hash,
     num::{NonZeroU32, NonZeroU8},
     ops::{Range, RangeInclusive},
     ptr::NonNull,
@@ -938,24 +938,6 @@ pub struct SamplerDescriptor<'a> {
     pub compare: Option<wgt::CompareFunction>,
     pub anisotropy_clamp: Option<NonZeroU8>,
     pub border_color: Option<wgt::SamplerBorderColor>,
-}
-
-impl Hash for SamplerDescriptor<'_> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.address_modes.hash(state);
-        self.mag_filter.hash(state);
-        self.min_filter.hash(state);
-        self.mipmap_filter.hash(state);
-        self.compare.hash(state);
-        self.anisotropy_clamp.hash(state);
-        self.border_color.hash(state);
-
-        let hashable_lod_clamp = self
-            .lod_clamp
-            .as_ref()
-            .map(|lod_clamp| (lod_clamp.start.to_bits(), lod_clamp.end.to_bits()));
-        hashable_lod_clamp.hash(state);
-    }
 }
 
 /// BindGroupLayout descriptor.


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
#3350

**Description**
As mentioned in the linked issue, the sampler count is limited to 2048 in dx12 and will throw an out of memory error if exceeded. I encountered this in my project when loading a lot of textures. My current approach to solving it is to hash the samplers as they're created, and keep a hash map of which sets of samplers have been uploaded to the gpu (including a ref count) so they're only uploaded once and reused across different bind groups if the hashes match.

**Testing**
I tested it by wiring it up to my project and verifying that the out of memory error no longer occurred. I also double-checked that `uploaded_sampler_handles` gets completely emptied when the user of wgpu drops all of their bind groups.
