### PR TITLE
Allow tests to be captured and replayed in xcode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,6 +3028,7 @@ dependencies = [
  "image",
  "js-sys",
  "log",
+ "metal",
  "naga",
  "nanorand",
  "noise",

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -176,6 +176,9 @@ nanorand = { workspace = true, features = ["wyrand"] }
 wasm-bindgen-test.workspace = true
 winit.workspace = true # for "halmark" example
 
+[target.'cfg(any(target_os="macos", target_os="ios"))'.dev-dependencies]
+mtl = { package = "metal", version = "0.24.0" }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 async-executor.workspace = true
 


### PR DESCRIPTION
**Checklist**

- [ ] Run `cargo clippy`. (I'd love to but I need https://github.com/gfx-rs/wgpu/pull/3505 for that to work)

**Description**

I recently had to debug a failing test on mac and being able to capture/replay a test run in xcode was very useful. It took some fiddling to get it to work, here is the patch that allowed me to do it.

Obviously calling into metal directly from the test framework isn't great. We would benefit a lot from this being lifted into wgpu proper with solutions for other backends. However I am going to be unavailable for a while starting soon so I wanted to put this here in a less than ideal but working state. It could either be merged as is or just exist here as a reference for anyone in need of troubleshooting a test failure on mac or to build a better solution upon.
