### PR TITLE
Work around a clippy error

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -485,8 +485,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id.0
     }
 
+    /// # Safety
+    ///
+    /// `layer` must be a valid pointer.
     #[cfg(feature = "metal")]
-    pub fn instance_create_surface_metal(
+    pub unsafe fn instance_create_surface_metal(
         &self,
         layer: *mut std::ffi::c_void,
         id_in: Input<G, SurfaceId>,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -195,7 +195,7 @@ impl Context {
         &self,
         layer: *mut std::ffi::c_void,
     ) -> Surface {
-        let id = self.0.instance_create_surface_metal(layer, ());
+        let id = unsafe { self.0.instance_create_surface_metal(layer, ()) };
         Surface {
             id,
             configured_device: Mutex::default(),


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.

**Description**

I was hitting this error on mac when running clippy:

```
error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> wgpu-core/src/instance.rs:502:81
    |
502 |                     inst.create_surface_from_layer(unsafe { std::mem::transmute(layer) })
    |                                                                                 ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref
    = note: `#[deny(clippy::not_unsafe_ptr_arg_deref)]` on by default
```

The simplest fix is to mark the function as unsafe. Clippy was then warning that its only caller `create_surface_from_core_animation_layer`, while being unsafe itself, should still have unsafe blocks around whatever unsafe functions it calls, and that a public unsafe function should have a `# Safety` section in its doc, so I continued obeying the machine.

Clippy is quiet now.