### PR TITLE
Update naga to 0.11.0@git:9742f1616c3e3dd2cc9a5880616fc886c391bb9f

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.11.0"
-source = "git+https://github.com/gfx-rs/naga?rev=58105a06e2bd5aefeb9330984d47976e63c11dc4#58105a06e2bd5aefeb9330984d47976e63c11dc4"
+source = "git+https://github.com/gfx-rs/naga?rev=9742f1616c3e3dd2cc9a5880616fc886c391bb9f#9742f1616c3e3dd2cc9a5880616fc886c391bb9f"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ version = "0.15"
 
 [workspace.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "58105a06e2bd5aefeb9330984d47976e63c11dc4"
+rev = "9742f1616c3e3dd2cc9a5880616fc886c391bb9f"
 version = "0.11.0"
 
 [workspace.dependencies]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -70,7 +70,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "58105a06e2bd5aefeb9330984d47976e63c11dc4"
+rev = "9742f1616c3e3dd2cc9a5880616fc886c391bb9f"
 version = "0.11.0"
 features = ["clone", "span", "validate"]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -119,14 +119,14 @@ android_system_properties = "0.1.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "58105a06e2bd5aefeb9330984d47976e63c11dc4"
+rev = "9742f1616c3e3dd2cc9a5880616fc886c391bb9f"
 version = "0.11.0"
 features = ["clone"]
 
 # DEV dependencies
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "58105a06e2bd5aefeb9330984d47976e63c11dc4"
+rev = "9742f1616c3e3dd2cc9a5880616fc886c391bb9f"
 version = "0.11.0"
 features = ["wgsl-in"]
 

--- a/wgpu/tests/shader/zero_init_workgroup_mem.rs
+++ b/wgpu/tests/shader/zero_init_workgroup_mem.rs
@@ -30,9 +30,7 @@ fn zero_init_workgroup_mem() {
                 Some(6880),
                 Some("SwiftShader"),
                 true,
-            )
-            // TODO: investigate why it fails
-            .specific_failure(Some(Backends::GL), Some(65541), Some("llvmpipe"), false),
+            ),
         zero_init_workgroup_mem_impl,
     );
 }


### PR DESCRIPTION
Another naga update  shortly after the previous one because we'd like to pick up https://github.com/gfx-rs/naga/pull/2259 in Gecko soon.