### PR TITLE
Remove SwiftShader failure from zero init test

### DIFF
--- a/wgpu/tests/shader/zero_init_workgroup_mem.rs
+++ b/wgpu/tests/shader/zero_init_workgroup_mem.rs
@@ -23,13 +23,6 @@ fn zero_init_workgroup_mem() {
                 Some(5140),
                 Some("Microsoft Basic Render Driver"),
                 true,
-            )
-            // this one is flakey
-            .specific_failure(
-                Some(Backends::VULKAN),
-                Some(6880),
-                Some("SwiftShader"),
-                true,
             ),
         zero_init_workgroup_mem_impl,
     );


### PR DESCRIPTION
We fixed this in naga. See https://github.com/gfx-rs/wgpu/pull/3512 and https://github.com/gfx-rs/wgpu/issues/3492.