### PR TITLE
enable debug extension on emscripten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ By @teoxoy in [#3436](https://github.com/gfx-rs/wgpu/pull/3436)
 #### GLES
 
 - [gles] fix: Set FORCE_POINT_SIZE if it is vertex shader with mesh consist of point list. By @REASY in [3440](https://github.com/gfx-rs/wgpu/pull/3440)
+- [gles] fix: enable `WEBGL_debug_renderer_info` before querying unmasked vendor/renderer to avoid crashing on emscripten in [#3519](https://github.com/gfx-rs/wgpu/pull/3519)
 
 #### General
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -186,14 +186,15 @@ impl super::Adapter {
         let extensions = gl.supported_extensions();
 
         let (vendor_const, renderer_const) = if extensions.contains("WEBGL_debug_renderer_info") {
-            // context must be current
+            // emscripten doesn't enable "WEBGL_debug_renderer_info" extension by default. so, we do it manually.
+            // See https://github.com/gfx-rs/wgpu/issues/3245 for context
             #[cfg(target_os = "emscripten")]
             if unsafe { super::emscripten::enable_extension("WEBGL_debug_renderer_info\0") } {
                 (GL_UNMASKED_VENDOR_WEBGL, GL_UNMASKED_RENDERER_WEBGL)
             } else {
                 (glow::VENDOR, glow::RENDERER)
             }
-            // glow enables WEBGL_debug_renderer_info on w-u-u target.
+            // glow already enables WEBGL_debug_renderer_info on wasm32-unknown-unknown target by default.
             #[cfg(not(target_os = "emscripten"))]
             (GL_UNMASKED_VENDOR_WEBGL, GL_UNMASKED_RENDERER_WEBGL)
         } else {

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -8,7 +8,14 @@ use crate::auxil::db;
 
 const GL_UNMASKED_VENDOR_WEBGL: u32 = 0x9245;
 const GL_UNMASKED_RENDERER_WEBGL: u32 = 0x9246;
-
+extern "C" {
+    /// returns 1 if success. 0 if failure. extension name must be null terminated
+    pub fn emscripten_webgl_enable_extension(
+        context: std::ffi::c_int,
+        extension: *const std::ffi::c_char,
+    ) -> std::ffi::c_int;
+    pub fn emscripten_webgl_get_current_context() -> std::ffi::c_int;
+}
 impl super::Adapter {
     /// According to the OpenGL specification, the version information is
     /// expected to follow the following syntax:
@@ -184,8 +191,18 @@ impl super::Adapter {
     ) -> Option<crate::ExposedAdapter<super::Api>> {
         let gl = context.lock();
         let extensions = gl.supported_extensions();
-
-        let (vendor_const, renderer_const) = if extensions.contains("WEBGL_debug_renderer_info") {
+        // if emscripten, has debug extension and if we can enable it -> use unmasked vendor/renderer
+        // https://github.com/gfx-rs/wgpu/issues/3245
+        let (vendor_const, renderer_const) = if cfg!(target_os = "emscripten")
+            && extensions.contains("WEBGL_debug_renderer_info")
+            && unsafe {
+                emscripten_webgl_enable_extension(
+                    emscripten_webgl_get_current_context(),
+                    "WEBGL_debug_renderer_info\0".as_ptr() as _,
+                )
+            } == 1
+        {
+            // if we try querying unmasked constants without enabling extension, we crash on emscripten.
             (GL_UNMASKED_VENDOR_WEBGL, GL_UNMASKED_RENDERER_WEBGL)
         } else {
             (glow::VENDOR, glow::RENDERER)

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -6,16 +6,6 @@ use crate::auxil::db;
 
 // https://webgl2fundamentals.org/webgl/lessons/webgl-data-textures.html
 
-const GL_UNMASKED_VENDOR_WEBGL: u32 = 0x9245;
-const GL_UNMASKED_RENDERER_WEBGL: u32 = 0x9246;
-extern "C" {
-    /// returns 1 if success. 0 if failure. extension name must be null terminated
-    pub fn emscripten_webgl_enable_extension(
-        context: std::ffi::c_int,
-        extension: *const std::ffi::c_char,
-    ) -> std::ffi::c_int;
-    pub fn emscripten_webgl_get_current_context() -> std::ffi::c_int;
-}
 impl super::Adapter {
     /// According to the OpenGL specification, the version information is
     /// expected to follow the following syntax:
@@ -191,22 +181,13 @@ impl super::Adapter {
     ) -> Option<crate::ExposedAdapter<super::Api>> {
         let gl = context.lock();
         let extensions = gl.supported_extensions();
-        // if emscripten, has debug extension and if we can enable it -> use unmasked vendor/renderer
-        // https://github.com/gfx-rs/wgpu/issues/3245
-        let (vendor_const, renderer_const) = if cfg!(target_os = "emscripten")
-            && extensions.contains("WEBGL_debug_renderer_info")
-            && unsafe {
-                emscripten_webgl_enable_extension(
-                    emscripten_webgl_get_current_context(),
-                    "WEBGL_debug_renderer_info\0".as_ptr() as _,
-                )
-            } == 1
-        {
-            // if we try querying unmasked constants without enabling extension, we crash on emscripten.
-            (GL_UNMASKED_VENDOR_WEBGL, GL_UNMASKED_RENDERER_WEBGL)
-        } else {
-            (glow::VENDOR, glow::RENDERER)
-        };
+
+        #[cfg(target_os = "emscripten")]
+        let (vendor_const, renderer_const) =
+            unsafe { super::emscripten::get_vendor_renderer_constants(extensions) }; // context must be current
+        #[cfg(not(target_os = "emscripten"))]
+        let (vendor_const, renderer_const) = (glow::VENDOR, glow::RENDERER);
+
         let (vendor, renderer) = {
             let vendor = unsafe { gl.get_parameter_string(vendor_const) };
             let renderer = unsafe { gl.get_parameter_string(renderer_const) };

--- a/wgpu-hal/src/gles/emscripten.rs
+++ b/wgpu-hal/src/gles/emscripten.rs
@@ -1,0 +1,32 @@
+const GL_UNMASKED_VENDOR_WEBGL: u32 = 0x9245;
+const GL_UNMASKED_RENDERER_WEBGL: u32 = 0x9246;
+
+extern "C" {
+    /// returns 1 if success. 0 if failure. extension name must be null terminated
+    fn emscripten_webgl_enable_extension(
+        context: std::ffi::c_int,
+        extension: *const std::ffi::c_char,
+    ) -> std::ffi::c_int;
+    fn emscripten_webgl_get_current_context() -> std::ffi::c_int;
+}
+/// if we have debug extension and if we can enable it -> use unmasked vendor/renderer
+/// https://github.com/gfx-rs/wgpu/issues/3245
+/// # Safety:
+/// opengl context MUST BE current
+pub unsafe fn get_vendor_renderer_constants(
+    extensions: &std::collections::HashSet<String>,
+) -> (u32, u32) {
+    if extensions.contains("WEBGL_debug_renderer_info")
+        && unsafe {
+            emscripten_webgl_enable_extension(
+                emscripten_webgl_get_current_context(),
+                "WEBGL_debug_renderer_info\0".as_ptr() as _,
+            )
+        } == 1
+    {
+        // if we try querying unmasked constants without enabling extension, we crash on emscripten.
+        (GL_UNMASKED_VENDOR_WEBGL, GL_UNMASKED_RENDERER_WEBGL)
+    } else {
+        (glow::VENDOR, glow::RENDERER)
+    }
+}

--- a/wgpu-hal/src/gles/emscripten.rs
+++ b/wgpu-hal/src/gles/emscripten.rs
@@ -6,12 +6,16 @@ extern "C" {
     ) -> std::ffi::c_int;
     fn emscripten_webgl_get_current_context() -> std::ffi::c_int;
 }
-/// if we have debug extension and if we can enable it -> use unmasked vendor/renderer
-/// https://github.com/gfx-rs/wgpu/issues/3245
+/// Webgl requires extensions to be enabled before using them.
+/// This function can be used to enable webgl extension on emscripten target.
+///
 /// returns true on success
+///
 /// # Safety:
-/// opengl context MUST BE current
-/// extension_name_null_terminated argument must be a valid string with null terminator.
+///
+/// - opengl context MUST BE current
+/// - extension_name_null_terminated argument must be a valid string with null terminator.
+/// - extension must be present. check `glow_context.supported_extensions()`
 pub unsafe fn enable_extension(extension_name_null_terminated: &str) -> bool {
     unsafe {
         emscripten_webgl_enable_extension(

--- a/wgpu-hal/src/gles/emscripten.rs
+++ b/wgpu-hal/src/gles/emscripten.rs
@@ -1,6 +1,3 @@
-const GL_UNMASKED_VENDOR_WEBGL: u32 = 0x9245;
-const GL_UNMASKED_RENDERER_WEBGL: u32 = 0x9246;
-
 extern "C" {
     /// returns 1 if success. 0 if failure. extension name must be null terminated
     fn emscripten_webgl_enable_extension(
@@ -11,22 +8,15 @@ extern "C" {
 }
 /// if we have debug extension and if we can enable it -> use unmasked vendor/renderer
 /// https://github.com/gfx-rs/wgpu/issues/3245
+/// returns true on success
 /// # Safety:
 /// opengl context MUST BE current
-pub unsafe fn get_vendor_renderer_constants(
-    extensions: &std::collections::HashSet<String>,
-) -> (u32, u32) {
-    if extensions.contains("WEBGL_debug_renderer_info")
-        && unsafe {
-            emscripten_webgl_enable_extension(
-                emscripten_webgl_get_current_context(),
-                "WEBGL_debug_renderer_info\0".as_ptr() as _,
-            )
-        } == 1
-    {
-        // if we try querying unmasked constants without enabling extension, we crash on emscripten.
-        (GL_UNMASKED_VENDOR_WEBGL, GL_UNMASKED_RENDERER_WEBGL)
-    } else {
-        (glow::VENDOR, glow::RENDERER)
+/// extension_name_null_terminated argument must be a valid string with null terminator.
+pub unsafe fn enable_extension(extension_name_null_terminated: &str) -> bool {
+    unsafe {
+        emscripten_webgl_enable_extension(
+            emscripten_webgl_get_current_context(),
+            extension_name_null_terminated.as_ptr() as _,
+        ) == 1
     }
 }

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -59,6 +59,8 @@ To address this, we invalidate the vertex buffers based on:
 ///cbindgen:ignore
 #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 mod egl;
+#[cfg(target_os = "emscripten")]
+mod emscripten;
 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 mod web;
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/gfx-rs/wgpu/issues/3245

**Description**
we check if `WEBGL_debug_renderer_info` extension is available on emscripten and if it is, we query for unmasked vendor/renderer strings. 
but on webgl, we need to enable the extension before using it. but emscripten avoids enabling this particular extension by default. 
so, we use emscripten's extern functions defined in https://github.com/emscripten-core/emscripten/blob/4d864df0a57024d667e8db171aab2c3385d04c30/system/include/emscripten/html5_webgl.h#L61 to manually enable the extension if it is found on emscripten target. or fallback to  vendor/renderer constants instead of the unmasked variants.

**Testing**
wgpu-hal's gles html example used for testing. 

I believe the wiki needs to be updated https://github.com/gfx-rs/wgpu/wiki/Running-on-the-web-with-Emscripten 
