### PR TITLE
Replace "Intel/Vulkan" w/ "Vulkan on Intel"

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -265,7 +265,7 @@ bitflags::bitflags! {
         /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
         ///
         /// Supported Platforms:
-        /// - Intel/Vulkan
+        /// - Vulkan on Intel
         /// - Mobile (some)
         ///
         /// This is a web and native feature.
@@ -280,7 +280,7 @@ bitflags::bitflags! {
         /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
         ///
         /// Supported Platforms:
-        /// - Intel/Vulkan
+        /// - Vulkan on Intel
         /// - Mobile (some)
         ///
         /// This is a web and native feature.


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

Fixes #3520 
