### PR TITLE
Fix create_device_from_hal not using the provided hal_device's queue

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1783,7 +1783,7 @@ impl Adapter {
                 Queue {
                     context,
                     id: queue.id().into(),
-                    data: Box::new(()),
+                    data: Box::new(queue),
                 },
             )
         })


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable. **I don't know if this is applicable.**
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
None known.

**Description**

I'm wrapping existing Vulkan structures inside `wgpu`, for the purpose of compatibility with [ruffle](https://github.com/ruffle-rs/ruffle)'s `wgpu`-based renderer. While helping me troubleshoot a strange bug, @Dinnerbone noticed that `Adapter::create_device_from_hal` was not using the queue provided by `hal_device`. I made this change on his recommendation.


**Testing**

Before I made the change, the app I'm working on panicked. Now it doesn't.
