### PR TITLE
Treat `VK_SUBOPTIMAL_KHR` as `VK_SUCCESS` on Android.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@ By @teoxoy in [#3436](https://github.com/gfx-rs/wgpu/pull/3436)
 - `copyTextureToTexture` src/dst aspects must both refer to all aspects of src/dst format. By @teoxoy in [#3431](https://github.com/gfx-rs/wgpu/pull/3431)
 - Validate before extracting texture selectors. By @teoxoy in [#3487](https://github.com/gfx-rs/wgpu/pull/3487)
 
+#### Vulkan
+
+- Treat `VK_SUBOPTIMAL_KHR` as `VK_SUCCESS` on Android. By @James2022-rgb in [#3525](https://github.com/gfx-rs/wgpu/pull/3525)
+
 ## wgpu-0.15.0 (2023-01-25)
 
 ### Major Changes

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -758,6 +758,11 @@ impl crate::Surface<super::Api> for super::Surface {
             sc.functor
                 .acquire_next_image(sc.raw, timeout_ns, vk::Semaphore::null(), sc.fence)
         } {
+            // We treat `VK_SUBOPTIMAL_KHR` as `VK_SUCCESS` on Android.
+            // See the comment in `Queue::present`.
+            #[cfg(target_os = "android")]
+            Ok((index, _)) => (index, false),
+            #[cfg(not(target_os = "android"))]
             Ok(pair) => pair,
             Err(error) => {
                 return match error {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -594,6 +594,11 @@ impl crate::Queue<Api> for Queue {
                 }
             })?
         };
+        // We treat `VK_SUBOPTIMAL_KHR` as `VK_SUCCESS` on Android.
+        // On Android 10+, libvulkan's `vkQueuePresentKHR` implementation returns `VK_SUBOPTIMAL_KHR` if not doing pre-rotation
+        // (i.e `VkSwapchainCreateInfoKHR::preTransform` not being equal to the current device orientation).
+        // This is always the case when the device orientation is anything other than the identity one, as we unconditionally use `VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR`.
+        #[cfg(not(target_os = "android"))]
         if suboptimal {
             log::warn!("Suboptimal present of frame {}", texture.index);
         }

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -594,12 +594,12 @@ impl crate::Queue<Api> for Queue {
                 }
             })?
         };
-        // We treat `VK_SUBOPTIMAL_KHR` as `VK_SUCCESS` on Android.
-        // On Android 10+, libvulkan's `vkQueuePresentKHR` implementation returns `VK_SUBOPTIMAL_KHR` if not doing pre-rotation
-        // (i.e `VkSwapchainCreateInfoKHR::preTransform` not being equal to the current device orientation).
-        // This is always the case when the device orientation is anything other than the identity one, as we unconditionally use `VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR`.
-        #[cfg(not(target_os = "android"))]
         if suboptimal {
+            // We treat `VK_SUBOPTIMAL_KHR` as `VK_SUCCESS` on Android.
+            // On Android 10+, libvulkan's `vkQueuePresentKHR` implementation returns `VK_SUBOPTIMAL_KHR` if not doing pre-rotation
+            // (i.e `VkSwapchainCreateInfoKHR::preTransform` not being equal to the current device orientation).
+            // This is always the case when the device orientation is anything other than the identity one, as we unconditionally use `VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR`.
+            #[cfg(not(target_os = "android"))]
             log::warn!("Suboptimal present of frame {}", texture.index);
         }
         Ok(())


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Addresses issue #3345. 

**Description**
This PR makes is so that `vkQueuePresentKHR`'s `VK_SUBOPTIMAL_KHR` is treated as `VK_SUCCESS` (i.e ignored and not logged) on Android.

On Android 10+, `vkQueuePresentKHR` returns `VK_SUBOPTIMAL_KHR` if the swapchain's `VkSwapchainCreateInfoKHR::preTransform` does not match the device's current orientation.
This is always the case in _wgpu_ when the device orientation is anything other than the identity one,
because we unconditionally use `VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR` when creating the swapchain.

The assumption is that on Android, as discussed in the issue, `VK_SUBOPTIMAL_KHR` is only returned when the device's current orientation doesn't match `VkSwapchainCreateInfoKHR::preTransform`.

https://developer.android.com/games/optimize/vulkan-prerotation#detect_device_orientation_changes
> The most reliable way to detect an orientation change in your application is to verify whether the `vkQueuePresentKHR()` function returns `VK_SUBOPTIMAL_KHR`.

The only code path that returns `VK_SUBOPTIMAL_KHR` in Android libvulkan's `vkQueuePresentKHR` implementation:
https://android.googlesource.com/platform/frameworks/native/+/master/vulkan/libvulkan/swapchain.cpp#2021

More in-detail description of the problem in the connected issue.

**Testing**
Tested on my Galaxy S20 Ultra 5G (Adreno 650), Android 10, that the log spam is no longer exhibited.
