### PR TITLE
Don't rename imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ android_system_properties = "0.1.1"
 # DX dependencies
 bit-set = "0.5"
 gpu-allocator = { version = "0.21", default_features = false, features = ["d3d12", "windows", "public-winapi"] }
-native = { package = "d3d12", version = "0.5.0" }
+d3d12 = "0.5.0"
 range-alloc = "0.1"
 winapi = "0.3"
 hassle-rs = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ winapi = "0.3"
 hassle-rs = "0.10.0"
 
 # Gles dependencies
-egl = { package = "khronos-egl", version = "4.1" }
+khronos-egl = "4.1"
 glow = "0.12.1"
 glutin = "0.29.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ winit = "0.27.1"
 # Metal dependencies
 block = "0.1"
 foreign-types = "0.3"
-mtl = { package = "metal", version = "0.24.0" }
+metal = "0.24.0"
 objc = "0.2.5"
 core-graphics-types = "0.1"
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -37,8 +37,8 @@ default = []
 metal = ["naga/msl-out", "block", "foreign-types"]
 vulkan = ["naga/spv-out", "ash", "gpu-alloc", "gpu-descriptor", "libloading", "smallvec"]
 gles = ["naga/glsl-out", "glow", "egl", "libloading"]
-dx11 = ["naga/hlsl-out", "native", "libloading", "winapi/d3d11", "winapi/std", "winapi/d3d11_1", "winapi/d3d11_2", "winapi/d3d11sdklayers", "winapi/dxgi1_6"]
-dx12 = ["naga/hlsl-out", "native", "bit-set", "range-alloc", "winapi/std", "winapi/winbase", "winapi/d3d12", "winapi/d3d12shader", "winapi/d3d12sdklayers", "winapi/dxgi1_6"]
+dx11 = ["naga/hlsl-out", "d3d12", "libloading", "winapi/d3d11", "winapi/std", "winapi/d3d11_1", "winapi/d3d11_2", "winapi/d3d11sdklayers", "winapi/dxgi1_6"]
+dx12 = ["naga/hlsl-out", "d3d12", "bit-set", "range-alloc", "winapi/std", "winapi/winbase", "winapi/d3d12", "winapi/d3d12shader", "winapi/d3d12sdklayers", "winapi/dxgi1_6"]
 # TODO: This is a separate feature until Mozilla okays windows-rs, see https://github.com/gfx-rs/wgpu/issues/3207 for the tracking issue.
 windows_rs = ["gpu-allocator"]
 dxc_shader_compiler = ["hassle-rs"]
@@ -95,7 +95,7 @@ gpu-allocator = { version = "0.22", default_features = false, features = ["d3d12
 hassle-rs = { version = "0.10", optional = true }
 
 winapi = { version = "0.3", features = ["profileapi", "libloaderapi", "windef", "winuser", "dcomp"] }
-native = { package = "d3d12", version = "0.6.0", git = "https://github.com/gfx-rs/d3d12-rs", rev = "b940b1d71", features = ["libloading"], optional = true }
+d3d12 = { version = "0.6.0", git = "https://github.com/gfx-rs/d3d12-rs", rev = "b940b1d71", features = ["libloading"], optional = true }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
 # backend: Metal

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -36,7 +36,7 @@ targets = [
 default = []
 metal = ["naga/msl-out", "block", "foreign-types"]
 vulkan = ["naga/spv-out", "ash", "gpu-alloc", "gpu-descriptor", "libloading", "smallvec"]
-gles = ["naga/glsl-out", "glow", "egl", "libloading"]
+gles = ["naga/glsl-out", "glow", "khronos-egl", "libloading"]
 dx11 = ["naga/hlsl-out", "d3d12", "libloading", "winapi/d3d11", "winapi/std", "winapi/d3d11_1", "winapi/d3d11_2", "winapi/d3d11sdklayers", "winapi/dxgi1_6"]
 dx12 = ["naga/hlsl-out", "d3d12", "bit-set", "range-alloc", "winapi/std", "winapi/winbase", "winapi/d3d12", "winapi/d3d12shader", "winapi/d3d12sdklayers", "winapi/dxgi1_6"]
 # TODO: This is a separate feature until Mozilla okays windows-rs, see https://github.com/gfx-rs/wgpu/issues/3207 for the tracking issue.
@@ -78,12 +78,12 @@ gpu-alloc = { version = "0.5", optional = true }
 gpu-descriptor = { version = "0.2", optional = true }
 smallvec = { version = "1", optional = true, features = ["union"] }
 
-egl = { package = "khronos-egl", version = "4.1", features = ["dynamic"], optional = true }
+khronos-egl = { version = "4.1", features = ["dynamic"], optional = true }
 libloading = { version = "0.7", optional = true }
 renderdoc-sys = { version = "1.0.0", optional = true }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-egl = { package = "khronos-egl", version = "4.1", features = ["static", "no-pkg-config"] }
+khronos-egl = { version = "4.1", features = ["static", "no-pkg-config"] }
 #Note: it's unused by emscripten, but we keep it to have single code base in egl.rs
 libloading = { version = "0.7", optional = true }
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -102,7 +102,7 @@ native = { package = "d3d12", version = "0.6.0", git = "https://github.com/gfx-r
 block = { version = "0.1", optional = true }
 foreign-types = { version = "0.3", optional = true }
 
-mtl = { package = "metal", version = "0.24.0" }
+metal = "0.24.0"
 objc = "0.2.5"
 core-graphics-types = "0.1"
 

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -71,19 +71,19 @@ fn main() {
     env_logger::init();
 
     println!("Initializing external GL context");
-    let egl = egl::Instance::new(egl::Static);
-    let display = egl.get_display(egl::DEFAULT_DISPLAY).unwrap();
+    let egl = khronos_egl::Instance::new(khronos_egl::Static);
+    let display = egl.get_display(khronos_egl::DEFAULT_DISPLAY).unwrap();
     egl.initialize(display)
         .expect("unable to initialize display");
 
     let attributes = [
-        egl::RED_SIZE,
+        khronos_egl::RED_SIZE,
         8,
-        egl::GREEN_SIZE,
+        khronos_egl::GREEN_SIZE,
         8,
-        egl::BLUE_SIZE,
+        khronos_egl::BLUE_SIZE,
         8,
-        egl::NONE,
+        khronos_egl::NONE,
     ];
 
     let config = egl
@@ -96,7 +96,7 @@ fn main() {
     }
     .expect("unable to create surface");
 
-    let context_attributes = [egl::CONTEXT_CLIENT_VERSION, 3, egl::NONE];
+    let context_attributes = [khronos_egl::CONTEXT_CLIENT_VERSION, 3, khronos_egl::NONE];
 
     let gl_context = egl
         .create_context(display, config, None, &context_attributes)

--- a/wgpu-hal/src/auxil/dxgi/conv.rs
+++ b/wgpu-hal/src/auxil/dxgi/conv.rs
@@ -223,6 +223,6 @@ pub fn map_vertex_format(format: wgt::VertexFormat) -> dxgiformat::DXGI_FORMAT {
     }
 }
 
-pub fn map_acomposite_alpha_mode(_mode: wgt::CompositeAlphaMode) -> native::AlphaMode {
-    native::AlphaMode::Ignore
+pub fn map_acomposite_alpha_mode(_mode: wgt::CompositeAlphaMode) -> d3d12::AlphaMode {
+    d3d12::AlphaMode::Ignore
 }

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -13,14 +13,14 @@ pub enum DxgiFactoryType {
     Factory6,
 }
 
-pub fn enumerate_adapters(factory: native::DxgiFactory) -> Vec<native::DxgiAdapter> {
+pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter> {
     let mut adapters = Vec::with_capacity(8);
 
     for cur_index in 0.. {
         if let Some(factory6) = factory.as_factory6() {
             profiling::scope!("IDXGIFactory6::EnumAdapterByGpuPreference");
             // We're already at dxgi1.6, we can grab IDXGIAdapater4 directly
-            let mut adapter4 = native::WeakPtr::<dxgi1_6::IDXGIAdapter4>::null();
+            let mut adapter4 = d3d12::WeakPtr::<dxgi1_6::IDXGIAdapter4>::null();
             let hr = unsafe {
                 factory6.EnumAdapterByGpuPreference(
                     cur_index,
@@ -38,12 +38,12 @@ pub fn enumerate_adapters(factory: native::DxgiFactory) -> Vec<native::DxgiAdapt
                 break;
             }
 
-            adapters.push(native::DxgiAdapter::Adapter4(adapter4));
+            adapters.push(d3d12::DxgiAdapter::Adapter4(adapter4));
             continue;
         }
 
         profiling::scope!("IDXGIFactory1::EnumAdapters1");
-        let mut adapter1 = native::WeakPtr::<dxgi::IDXGIAdapter1>::null();
+        let mut adapter1 = d3d12::WeakPtr::<dxgi::IDXGIAdapter1>::null();
         let hr = unsafe { factory.EnumAdapters1(cur_index, adapter1.mut_void() as *mut *mut _) };
 
         if hr == winerror::DXGI_ERROR_NOT_FOUND {
@@ -61,7 +61,7 @@ pub fn enumerate_adapters(factory: native::DxgiFactory) -> Vec<native::DxgiAdapt
             match adapter1.cast::<dxgi1_4::IDXGIAdapter3>().into_result() {
                 Ok(adapter3) => {
                     adapter1.destroy();
-                    adapters.push(native::DxgiAdapter::Adapter3(adapter3));
+                    adapters.push(d3d12::DxgiAdapter::Adapter3(adapter3));
                     continue;
                 }
                 Err(err) => {
@@ -75,7 +75,7 @@ pub fn enumerate_adapters(factory: native::DxgiFactory) -> Vec<native::DxgiAdapt
             match adapter1.cast::<dxgi1_2::IDXGIAdapter2>().into_result() {
                 Ok(adapter2) => {
                     adapter1.destroy();
-                    adapters.push(native::DxgiAdapter::Adapter2(adapter2));
+                    adapters.push(d3d12::DxgiAdapter::Adapter2(adapter2));
                     continue;
                 }
                 Err(err) => {
@@ -84,7 +84,7 @@ pub fn enumerate_adapters(factory: native::DxgiFactory) -> Vec<native::DxgiAdapt
             }
         }
 
-        adapters.push(native::DxgiAdapter::Adapter1(adapter1));
+        adapters.push(d3d12::DxgiAdapter::Adapter1(adapter1));
     }
 
     adapters
@@ -96,10 +96,10 @@ pub fn enumerate_adapters(factory: native::DxgiFactory) -> Vec<native::DxgiAdapt
 pub fn create_factory(
     required_factory_type: DxgiFactoryType,
     instance_flags: crate::InstanceFlags,
-) -> Result<(native::DxgiLib, native::DxgiFactory), crate::InstanceError> {
-    let lib_dxgi = native::DxgiLib::new().map_err(|_| crate::InstanceError)?;
+) -> Result<(d3d12::DxgiLib, d3d12::DxgiFactory), crate::InstanceError> {
+    let lib_dxgi = d3d12::DxgiLib::new().map_err(|_| crate::InstanceError)?;
 
-    let mut factory_flags = native::FactoryCreationFlags::empty();
+    let mut factory_flags = d3d12::FactoryCreationFlags::empty();
 
     if instance_flags.contains(crate::InstanceFlags::VALIDATION) {
         // The `DXGI_CREATE_FACTORY_DEBUG` flag is only allowed to be passed to
@@ -109,7 +109,7 @@ pub fn create_factory(
             Ok(pair) => match pair.into_result() {
                 Ok(debug_controller) => {
                     unsafe { debug_controller.destroy() };
-                    factory_flags |= native::FactoryCreationFlags::DEBUG;
+                    factory_flags |= d3d12::FactoryCreationFlags::DEBUG;
                 }
                 Err(err) => {
                     log::warn!("Unable to enable DXGI debug interface: {}", err);
@@ -154,7 +154,7 @@ pub fn create_factory(
                 unsafe {
                     factory4.destroy();
                 }
-                return Ok((lib_dxgi, native::DxgiFactory::Factory6(factory6)));
+                return Ok((lib_dxgi, d3d12::DxgiFactory::Factory6(factory6)));
             }
             // If we require factory6, hard error.
             Err(err) if required_factory_type == DxgiFactoryType::Factory6 => {
@@ -164,7 +164,7 @@ pub fn create_factory(
             // If we don't print it to info.
             Err(err) => {
                 log::info!("Failed to cast IDXGIFactory4 to IDXGIFactory6: {:?}", err);
-                return Ok((lib_dxgi, native::DxgiFactory::Factory4(factory4)));
+                return Ok((lib_dxgi, d3d12::DxgiFactory::Factory4(factory4)));
             }
         }
     }
@@ -192,7 +192,7 @@ pub fn create_factory(
             unsafe {
                 factory1.destroy();
             }
-            return Ok((lib_dxgi, native::DxgiFactory::Factory2(factory2)));
+            return Ok((lib_dxgi, d3d12::DxgiFactory::Factory2(factory2)));
         }
         // If we require factory2, hard error.
         Err(err) if required_factory_type == DxgiFactoryType::Factory2 => {
@@ -206,5 +206,5 @@ pub fn create_factory(
     }
 
     // We tried to create 4 and 2, but only succeeded with 1.
-    Ok((lib_dxgi, native::DxgiFactory::Factory1(factory1)))
+    Ok((lib_dxgi, d3d12::DxgiFactory::Factory1(factory1)))
 }

--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -33,7 +33,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
 impl super::Adapter {
     pub(super) fn expose(
         instance: &super::library::D3D11Lib,
-        adapter: native::DxgiAdapter,
+        adapter: d3d12::DxgiAdapter,
     ) -> Option<crate::ExposedAdapter<super::Api>> {
         use d3dcommon::{
             D3D_FEATURE_LEVEL_10_0 as FL10_0, D3D_FEATURE_LEVEL_10_1 as FL10_1,

--- a/wgpu-hal/src/dx11/library.rs
+++ b/wgpu-hal/src/dx11/library.rs
@@ -22,7 +22,7 @@ type D3D11CreateDeviceFun = unsafe extern "system" fn(
     *mut *mut d3d11::ID3D11Device,
     *mut d3dcommon::D3D_FEATURE_LEVEL,
     *mut *mut d3d11::ID3D11DeviceContext,
-) -> native::HRESULT;
+) -> d3d12::HRESULT;
 
 pub(super) struct D3D11Lib {
     // We use the os specific symbol to drop the lifetime parameter.
@@ -51,7 +51,7 @@ impl D3D11Lib {
 
     pub fn create_device(
         &self,
-        adapter: native::DxgiAdapter,
+        adapter: d3d12::DxgiAdapter,
     ) -> Option<(super::D3D11Device, d3dcommon::D3D_FEATURE_LEVEL)> {
         let feature_levels = [
             d3dcommon::D3D_FEATURE_LEVEL_11_1,
@@ -63,7 +63,7 @@ impl D3D11Lib {
             d3dcommon::D3D_FEATURE_LEVEL_9_1,
         ];
 
-        let mut device = native::WeakPtr::<d3d11::ID3D11Device>::null();
+        let mut device = d3d12::WeakPtr::<d3d11::ID3D11Device>::null();
         let mut feature_level: d3dcommon::D3D_FEATURE_LEVEL = 0;
 
         // We need to try this twice. If the first time fails due to E_INVALIDARG

--- a/wgpu-hal/src/dx11/mod.rs
+++ b/wgpu-hal/src/dx11/mod.rs
@@ -40,8 +40,8 @@ impl crate::Api for Api {
 
 pub struct Instance {
     lib_d3d11: library::D3D11Lib,
-    lib_dxgi: native::DxgiLib,
-    factory: native::DxgiFactory,
+    lib_dxgi: d3d12::DxgiLib,
+    factory: d3d12::DxgiFactory,
 }
 
 unsafe impl Send for Instance {}
@@ -56,7 +56,7 @@ pub struct Adapter {
 unsafe impl Send for Adapter {}
 unsafe impl Sync for Adapter {}
 
-native::weak_com_inheritance_chain! {
+d3d12::weak_com_inheritance_chain! {
     #[derive(Debug, Copy, Clone, PartialEq)]
     enum D3D11Device {
         Device(d3d11::ID3D11Device), from_device, as_device, device;

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -5,7 +5,7 @@ use crate::{
 use std::{mem, ptr, sync::Arc, thread};
 use winapi::{
     shared::{dxgi, dxgi1_2, minwindef::DWORD, windef, winerror},
-    um::{d3d12, d3d12sdklayers, winuser},
+    um::{d3d12 as d3d12_ty, d3d12sdklayers, winuser},
 };
 
 impl Drop for super::Adapter {
@@ -43,21 +43,21 @@ impl super::Adapter {
         }
     }
 
-    pub fn raw_adapter(&self) -> &native::DxgiAdapter {
+    pub fn raw_adapter(&self) -> &d3d12::DxgiAdapter {
         &self.raw
     }
 
     #[allow(trivial_casts)]
     pub(super) fn expose(
-        adapter: native::DxgiAdapter,
-        library: &Arc<native::D3D12Lib>,
+        adapter: d3d12::DxgiAdapter,
+        library: &Arc<d3d12::D3D12Lib>,
         instance_flags: crate::InstanceFlags,
         dx12_shader_compiler: &wgt::Dx12Compiler,
     ) -> Option<crate::ExposedAdapter<super::Api>> {
         // Create the device so that we can get the capabilities.
         let device = {
             profiling::scope!("ID3D12Device::create_device");
-            match library.create_device(*adapter, native::FeatureLevel::L11_0) {
+            match library.create_device(*adapter, d3d12::FeatureLevel::L11_0) {
                 Ok(pair) => match pair.into_result() {
                     Ok(device) => device,
                     Err(err) => {
@@ -88,25 +88,25 @@ impl super::Adapter {
             name.to_string_lossy().into_owned()
         };
 
-        let mut features_architecture: d3d12::D3D12_FEATURE_DATA_ARCHITECTURE =
+        let mut features_architecture: d3d12_ty::D3D12_FEATURE_DATA_ARCHITECTURE =
             unsafe { mem::zeroed() };
         assert_eq!(0, unsafe {
             device.CheckFeatureSupport(
-                d3d12::D3D12_FEATURE_ARCHITECTURE,
+                d3d12_ty::D3D12_FEATURE_ARCHITECTURE,
                 &mut features_architecture as *mut _ as *mut _,
-                mem::size_of::<d3d12::D3D12_FEATURE_DATA_ARCHITECTURE>() as _,
+                mem::size_of::<d3d12_ty::D3D12_FEATURE_DATA_ARCHITECTURE>() as _,
             )
         });
 
-        let mut shader_model_support: d3d12::D3D12_FEATURE_DATA_SHADER_MODEL =
-            d3d12::D3D12_FEATURE_DATA_SHADER_MODEL {
-                HighestShaderModel: d3d12::D3D_SHADER_MODEL_6_0,
+        let mut shader_model_support: d3d12_ty::D3D12_FEATURE_DATA_SHADER_MODEL =
+            d3d12_ty::D3D12_FEATURE_DATA_SHADER_MODEL {
+                HighestShaderModel: d3d12_ty::D3D_SHADER_MODEL_6_0,
             };
         assert_eq!(0, unsafe {
             device.CheckFeatureSupport(
-                d3d12::D3D12_FEATURE_SHADER_MODEL,
+                d3d12_ty::D3D12_FEATURE_SHADER_MODEL,
                 &mut shader_model_support as *mut _ as *mut _,
-                mem::size_of::<d3d12::D3D12_FEATURE_DATA_SHADER_MODEL>() as _,
+                mem::size_of::<d3d12_ty::D3D12_FEATURE_DATA_SHADER_MODEL>() as _,
             )
         });
 
@@ -129,22 +129,23 @@ impl super::Adapter {
             driver_info: String::new(),
         };
 
-        let mut options: d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS = unsafe { mem::zeroed() };
+        let mut options: d3d12_ty::D3D12_FEATURE_DATA_D3D12_OPTIONS = unsafe { mem::zeroed() };
         assert_eq!(0, unsafe {
             device.CheckFeatureSupport(
-                d3d12::D3D12_FEATURE_D3D12_OPTIONS,
+                d3d12_ty::D3D12_FEATURE_D3D12_OPTIONS,
                 &mut options as *mut _ as *mut _,
-                mem::size_of::<d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS>() as _,
+                mem::size_of::<d3d12_ty::D3D12_FEATURE_DATA_D3D12_OPTIONS>() as _,
             )
         });
 
         let _depth_bounds_test_supported = {
-            let mut features2: d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS2 = unsafe { mem::zeroed() };
+            let mut features2: d3d12_ty::D3D12_FEATURE_DATA_D3D12_OPTIONS2 =
+                unsafe { mem::zeroed() };
             let hr = unsafe {
                 device.CheckFeatureSupport(
-                    d3d12::D3D12_FEATURE_D3D12_OPTIONS2,
+                    d3d12_ty::D3D12_FEATURE_D3D12_OPTIONS2,
                     &mut features2 as *mut _ as *mut _,
-                    mem::size_of::<d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS2>() as _,
+                    mem::size_of::<d3d12_ty::D3D12_FEATURE_DATA_D3D12_OPTIONS2>() as _,
                 )
             };
             hr == 0 && features2.DepthBoundsTestSupported != 0
@@ -156,7 +157,7 @@ impl super::Adapter {
         let private_caps = super::PrivateCapabilities {
             instance_flags,
             heterogeneous_resource_heaps: options.ResourceHeapTier
-                != d3d12::D3D12_RESOURCE_HEAP_TIER_1,
+                != d3d12_ty::D3D12_RESOURCE_HEAP_TIER_1,
             memory_architecture: if features_architecture.UMA != 0 {
                 super::MemoryArchitecture::Unified {
                     cache_coherent: features_architecture.CacheCoherentUMA != 0,
@@ -171,22 +172,22 @@ impl super::Adapter {
         let tier3_practical_descriptor_limit = 1 << 20;
 
         let (full_heap_count, _uav_count) = match options.ResourceBindingTier {
-            d3d12::D3D12_RESOURCE_BINDING_TIER_1 => (
-                d3d12::D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1,
+            d3d12_ty::D3D12_RESOURCE_BINDING_TIER_1 => (
+                d3d12_ty::D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1,
                 8, // conservative, is 64 on feature level 11.1
             ),
-            d3d12::D3D12_RESOURCE_BINDING_TIER_2 => (
-                d3d12::D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_2,
+            d3d12_ty::D3D12_RESOURCE_BINDING_TIER_2 => (
+                d3d12_ty::D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_2,
                 64,
             ),
-            d3d12::D3D12_RESOURCE_BINDING_TIER_3 => (
+            d3d12_ty::D3D12_RESOURCE_BINDING_TIER_3 => (
                 tier3_practical_descriptor_limit,
                 tier3_practical_descriptor_limit,
             ),
             other => {
                 log::warn!("Unknown resource binding tier {}", other);
                 (
-                    d3d12::D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1,
+                    d3d12_ty::D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1,
                     8,
                 )
             }
@@ -221,14 +222,14 @@ impl super::Adapter {
         features.set(
             wgt::Features::CONSERVATIVE_RASTERIZATION,
             options.ConservativeRasterizationTier
-                != d3d12::D3D12_CONSERVATIVE_RASTERIZATION_TIER_NOT_SUPPORTED,
+                != d3d12_ty::D3D12_CONSERVATIVE_RASTERIZATION_TIER_NOT_SUPPORTED,
         );
 
         features.set(
             wgt::Features::TEXTURE_BINDING_ARRAY
                 | wgt::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING
                 | wgt::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
-            shader_model_support.HighestShaderModel >= d3d12::D3D_SHADER_MODEL_5_1,
+            shader_model_support.HighestShaderModel >= d3d12_ty::D3D_SHADER_MODEL_5_1,
         );
 
         // TODO: Determine if IPresentationManager is supported
@@ -250,11 +251,11 @@ impl super::Adapter {
             features,
             capabilities: crate::Capabilities {
                 limits: wgt::Limits {
-                    max_texture_dimension_1d: d3d12::D3D12_REQ_TEXTURE1D_U_DIMENSION,
-                    max_texture_dimension_2d: d3d12::D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION
-                        .min(d3d12::D3D12_REQ_TEXTURECUBE_DIMENSION),
-                    max_texture_dimension_3d: d3d12::D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION,
-                    max_texture_array_layers: d3d12::D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION,
+                    max_texture_dimension_1d: d3d12_ty::D3D12_REQ_TEXTURE1D_U_DIMENSION,
+                    max_texture_dimension_2d: d3d12_ty::D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION
+                        .min(d3d12_ty::D3D12_REQ_TEXTURECUBE_DIMENSION),
+                    max_texture_dimension_3d: d3d12_ty::D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION,
+                    max_texture_array_layers: d3d12_ty::D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION,
                     max_bind_groups: crate::MAX_BIND_GROUPS as u32,
                     max_bindings_per_bind_group: 65535,
                     // dynamic offsets take a root constant, so we expose the minimum here
@@ -263,25 +264,25 @@ impl super::Adapter {
                     max_dynamic_storage_buffers_per_pipeline_layout: base
                         .max_dynamic_storage_buffers_per_pipeline_layout,
                     max_sampled_textures_per_shader_stage: match options.ResourceBindingTier {
-                        d3d12::D3D12_RESOURCE_BINDING_TIER_1 => 128,
+                        d3d12_ty::D3D12_RESOURCE_BINDING_TIER_1 => 128,
                         _ => full_heap_count,
                     },
                     max_samplers_per_shader_stage: match options.ResourceBindingTier {
-                        d3d12::D3D12_RESOURCE_BINDING_TIER_1 => 16,
-                        _ => d3d12::D3D12_MAX_SHADER_VISIBLE_SAMPLER_HEAP_SIZE,
+                        d3d12_ty::D3D12_RESOURCE_BINDING_TIER_1 => 16,
+                        _ => d3d12_ty::D3D12_MAX_SHADER_VISIBLE_SAMPLER_HEAP_SIZE,
                     },
                     // these both account towards `uav_count`, but we can't express the limit as as sum
                     max_storage_buffers_per_shader_stage: base.max_storage_buffers_per_shader_stage,
                     max_storage_textures_per_shader_stage: base
                         .max_storage_textures_per_shader_stage,
                     max_uniform_buffers_per_shader_stage: full_heap_count,
-                    max_uniform_buffer_binding_size: d3d12::D3D12_REQ_CONSTANT_BUFFER_ELEMENT_COUNT
-                        * 16,
+                    max_uniform_buffer_binding_size:
+                        d3d12_ty::D3D12_REQ_CONSTANT_BUFFER_ELEMENT_COUNT * 16,
                     max_storage_buffer_binding_size: crate::auxil::MAX_I32_BINDING_SIZE,
-                    max_vertex_buffers: d3d12::D3D12_VS_INPUT_REGISTER_COUNT
+                    max_vertex_buffers: d3d12_ty::D3D12_VS_INPUT_REGISTER_COUNT
                         .min(crate::MAX_VERTEX_BUFFERS as u32),
-                    max_vertex_attributes: d3d12::D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT,
-                    max_vertex_buffer_array_stride: d3d12::D3D12_SO_BUFFER_MAX_STRIDE_IN_BYTES,
+                    max_vertex_attributes: d3d12_ty::D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT,
+                    max_vertex_buffer_array_stride: d3d12_ty::D3D12_SO_BUFFER_MAX_STRIDE_IN_BYTES,
                     // The push constants are part of the root signature which
                     // has a limit of 64 DWORDS (256 bytes), but other resources
                     // also share the root signature:
@@ -302,26 +303,26 @@ impl super::Adapter {
                     // Source: https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signature-limits#memory-limits-and-costs
                     max_push_constant_size: 128,
                     min_uniform_buffer_offset_alignment:
-                        d3d12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT,
+                        d3d12_ty::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT,
                     min_storage_buffer_offset_alignment: 4,
                     max_inter_stage_shader_components: base.max_inter_stage_shader_components,
                     max_compute_workgroup_storage_size: base.max_compute_workgroup_storage_size, //TODO?
                     max_compute_invocations_per_workgroup:
-                        d3d12::D3D12_CS_4_X_THREAD_GROUP_MAX_THREADS_PER_GROUP,
-                    max_compute_workgroup_size_x: d3d12::D3D12_CS_THREAD_GROUP_MAX_X,
-                    max_compute_workgroup_size_y: d3d12::D3D12_CS_THREAD_GROUP_MAX_Y,
-                    max_compute_workgroup_size_z: d3d12::D3D12_CS_THREAD_GROUP_MAX_Z,
+                        d3d12_ty::D3D12_CS_4_X_THREAD_GROUP_MAX_THREADS_PER_GROUP,
+                    max_compute_workgroup_size_x: d3d12_ty::D3D12_CS_THREAD_GROUP_MAX_X,
+                    max_compute_workgroup_size_y: d3d12_ty::D3D12_CS_THREAD_GROUP_MAX_Y,
+                    max_compute_workgroup_size_z: d3d12_ty::D3D12_CS_THREAD_GROUP_MAX_Z,
                     max_compute_workgroups_per_dimension:
-                        d3d12::D3D12_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION,
+                        d3d12_ty::D3D12_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION,
                     max_buffer_size: u64::MAX,
                 },
                 alignments: crate::Alignments {
                     buffer_copy_offset: wgt::BufferSize::new(
-                        d3d12::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as u64,
+                        d3d12_ty::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as u64,
                     )
                     .unwrap(),
                     buffer_copy_pitch: wgt::BufferSize::new(
-                        d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as u64,
+                        d3d12_ty::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as u64,
                     )
                     .unwrap(),
                 },
@@ -341,9 +342,9 @@ impl crate::Adapter<super::Api> for super::Adapter {
             profiling::scope!("ID3D12Device::CreateCommandQueue");
             self.device
                 .create_command_queue(
-                    native::CmdListType::Direct,
-                    native::Priority::Normal,
-                    native::CommandQueueFlags::empty(),
+                    d3d12::CmdListType::Direct,
+                    d3d12::Priority::Normal,
+                    d3d12::CommandQueueFlags::empty(),
                     0,
                 )
                 .into_device_result("Queue creation")?
@@ -390,33 +391,33 @@ impl crate::Adapter<super::Api> for super::Adapter {
         }
         .unwrap();
 
-        let mut data = d3d12::D3D12_FEATURE_DATA_FORMAT_SUPPORT {
+        let mut data = d3d12_ty::D3D12_FEATURE_DATA_FORMAT_SUPPORT {
             Format: raw_format,
             Support1: unsafe { mem::zeroed() },
             Support2: unsafe { mem::zeroed() },
         };
         assert_eq!(winerror::S_OK, unsafe {
             self.device.CheckFeatureSupport(
-                d3d12::D3D12_FEATURE_FORMAT_SUPPORT,
+                d3d12_ty::D3D12_FEATURE_FORMAT_SUPPORT,
                 &mut data as *mut _ as *mut _,
-                mem::size_of::<d3d12::D3D12_FEATURE_DATA_FORMAT_SUPPORT>() as _,
+                mem::size_of::<d3d12_ty::D3D12_FEATURE_DATA_FORMAT_SUPPORT>() as _,
             )
         });
 
         // Because we use a different format for SRV and UAV views of depth textures, we need to check
         // the features that use SRV/UAVs using the no-depth format.
-        let mut data_srv_uav = d3d12::D3D12_FEATURE_DATA_FORMAT_SUPPORT {
+        let mut data_srv_uav = d3d12_ty::D3D12_FEATURE_DATA_FORMAT_SUPPORT {
             Format: srv_uav_format,
-            Support1: d3d12::D3D12_FORMAT_SUPPORT1_NONE,
-            Support2: d3d12::D3D12_FORMAT_SUPPORT2_NONE,
+            Support1: d3d12_ty::D3D12_FORMAT_SUPPORT1_NONE,
+            Support2: d3d12_ty::D3D12_FORMAT_SUPPORT2_NONE,
         };
         if raw_format != srv_uav_format {
             // Only-recheck if we're using a different format
             assert_eq!(winerror::S_OK, unsafe {
                 self.device.CheckFeatureSupport(
-                    d3d12::D3D12_FEATURE_FORMAT_SUPPORT,
+                    d3d12_ty::D3D12_FEATURE_FORMAT_SUPPORT,
                     ptr::addr_of_mut!(data_srv_uav).cast(),
-                    DWORD::try_from(mem::size_of::<d3d12::D3D12_FEATURE_DATA_FORMAT_SUPPORT>())
+                    DWORD::try_from(mem::size_of::<d3d12_ty::D3D12_FEATURE_DATA_FORMAT_SUPPORT>())
                         .unwrap(),
                 )
             });
@@ -427,61 +428,62 @@ impl crate::Adapter<super::Api> for super::Adapter {
 
         let mut caps = Tfc::COPY_SRC | Tfc::COPY_DST;
         let is_texture = data.Support1
-            & (d3d12::D3D12_FORMAT_SUPPORT1_TEXTURE1D
-                | d3d12::D3D12_FORMAT_SUPPORT1_TEXTURE2D
-                | d3d12::D3D12_FORMAT_SUPPORT1_TEXTURE3D
-                | d3d12::D3D12_FORMAT_SUPPORT1_TEXTURECUBE)
+            & (d3d12_ty::D3D12_FORMAT_SUPPORT1_TEXTURE1D
+                | d3d12_ty::D3D12_FORMAT_SUPPORT1_TEXTURE2D
+                | d3d12_ty::D3D12_FORMAT_SUPPORT1_TEXTURE3D
+                | d3d12_ty::D3D12_FORMAT_SUPPORT1_TEXTURECUBE)
             != 0;
         // SRVs use srv_uav_format
         caps.set(
             Tfc::SAMPLED,
-            is_texture && data_srv_uav.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_SHADER_LOAD != 0,
+            is_texture && data_srv_uav.Support1 & d3d12_ty::D3D12_FORMAT_SUPPORT1_SHADER_LOAD != 0,
         );
         caps.set(
             Tfc::SAMPLED_LINEAR,
-            data_srv_uav.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_SHADER_SAMPLE != 0,
+            data_srv_uav.Support1 & d3d12_ty::D3D12_FORMAT_SUPPORT1_SHADER_SAMPLE != 0,
         );
         caps.set(
             Tfc::COLOR_ATTACHMENT,
-            data.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_RENDER_TARGET != 0,
+            data.Support1 & d3d12_ty::D3D12_FORMAT_SUPPORT1_RENDER_TARGET != 0,
         );
         caps.set(
             Tfc::COLOR_ATTACHMENT_BLEND,
-            data.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_BLENDABLE != 0,
+            data.Support1 & d3d12_ty::D3D12_FORMAT_SUPPORT1_BLENDABLE != 0,
         );
         caps.set(
             Tfc::DEPTH_STENCIL_ATTACHMENT,
-            data.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_DEPTH_STENCIL != 0,
+            data.Support1 & d3d12_ty::D3D12_FORMAT_SUPPORT1_DEPTH_STENCIL != 0,
         );
         // UAVs use srv_uav_format
         caps.set(
             Tfc::STORAGE,
-            data_srv_uav.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_TYPED_UNORDERED_ACCESS_VIEW != 0,
+            data_srv_uav.Support1 & d3d12_ty::D3D12_FORMAT_SUPPORT1_TYPED_UNORDERED_ACCESS_VIEW
+                != 0,
         );
         caps.set(
             Tfc::STORAGE_READ_WRITE,
-            data_srv_uav.Support2 & d3d12::D3D12_FORMAT_SUPPORT2_UAV_TYPED_LOAD != 0,
+            data_srv_uav.Support2 & d3d12_ty::D3D12_FORMAT_SUPPORT2_UAV_TYPED_LOAD != 0,
         );
 
         // We load via UAV/SRV so use srv_uav_format
         let no_msaa_load = caps.contains(Tfc::SAMPLED)
-            && data_srv_uav.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_MULTISAMPLE_LOAD == 0;
+            && data_srv_uav.Support1 & d3d12_ty::D3D12_FORMAT_SUPPORT1_MULTISAMPLE_LOAD == 0;
 
         let no_msaa_target = data.Support1
-            & (d3d12::D3D12_FORMAT_SUPPORT1_RENDER_TARGET
-                | d3d12::D3D12_FORMAT_SUPPORT1_DEPTH_STENCIL)
+            & (d3d12_ty::D3D12_FORMAT_SUPPORT1_RENDER_TARGET
+                | d3d12_ty::D3D12_FORMAT_SUPPORT1_DEPTH_STENCIL)
             != 0
-            && data.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_MULTISAMPLE_RENDERTARGET == 0;
+            && data.Support1 & d3d12_ty::D3D12_FORMAT_SUPPORT1_MULTISAMPLE_RENDERTARGET == 0;
 
         caps.set(
             Tfc::MULTISAMPLE_RESOLVE,
-            data.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_MULTISAMPLE_RESOLVE != 0,
+            data.Support1 & d3d12_ty::D3D12_FORMAT_SUPPORT1_MULTISAMPLE_RESOLVE != 0,
         );
 
-        let mut ms_levels = d3d12::D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS {
+        let mut ms_levels = d3d12_ty::D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS {
             Format: raw_format,
             SampleCount: 0,
-            Flags: d3d12::D3D12_MULTISAMPLE_QUALITY_LEVELS_FLAG_NONE,
+            Flags: d3d12_ty::D3D12_MULTISAMPLE_QUALITY_LEVELS_FLAG_NONE,
             NumQualityLevels: 0,
         };
 
@@ -490,9 +492,9 @@ impl crate::Adapter<super::Api> for super::Adapter {
 
             if unsafe {
                 self.device.CheckFeatureSupport(
-                    d3d12::D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
+                    d3d12_ty::D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
                     <*mut _>::cast(&mut ms_levels),
-                    mem::size_of::<d3d12::D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS>() as _,
+                    mem::size_of::<d3d12_ty::D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS>() as _,
                 )
             } == winerror::S_OK
                 && ms_levels.NumQualityLevels != 0

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -2,10 +2,10 @@ use crate::auxil::{self, dxgi::result::HResult as _};
 
 use super::conv;
 use std::{mem, ops::Range, ptr};
-use winapi::um::d3d12;
+use winapi::um::d3d12 as d3d12_ty;
 
-fn make_box(origin: &wgt::Origin3d, size: &crate::CopyExtent) -> d3d12::D3D12_BOX {
-    d3d12::D3D12_BOX {
+fn make_box(origin: &wgt::Origin3d, size: &crate::CopyExtent) -> d3d12_ty::D3D12_BOX {
+    d3d12_ty::D3D12_BOX {
         left: origin.x,
         top: origin.y,
         right: origin.x + size.width,
@@ -19,11 +19,11 @@ impl crate::BufferTextureCopy {
     fn to_subresource_footprint(
         &self,
         format: wgt::TextureFormat,
-    ) -> d3d12::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
+    ) -> d3d12_ty::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
         let (block_width, block_height) = format.block_dimensions();
-        d3d12::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
+        d3d12_ty::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
             Offset: self.buffer_layout.offset,
-            Footprint: d3d12::D3D12_SUBRESOURCE_FOOTPRINT {
+            Footprint: d3d12_ty::D3D12_SUBRESOURCE_FOOTPRINT {
                 Format: auxil::dxgi::conv::map_texture_format_for_copy(
                     format,
                     self.texture_base.aspect,
@@ -46,7 +46,7 @@ impl crate::BufferTextureCopy {
                             (self.size.width / block_width) * block_size
                         }
                     };
-                    crate::auxil::align_to(actual, d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT)
+                    crate::auxil::align_to(actual, d3d12_ty::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT)
                 },
             },
         }
@@ -235,7 +235,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         let list = loop {
             if let Some(list) = self.free_lists.pop() {
                 let reset_result = list
-                    .reset(self.allocator, native::PipelineState::null())
+                    .reset(self.allocator, d3d12::PipelineState::null())
                     .into_result();
                 if reset_result.is_ok() {
                     break Some(list);
@@ -254,9 +254,9 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         } else {
             self.device
                 .create_graphics_command_list(
-                    native::CmdListType::Direct,
+                    d3d12::CmdListType::Direct,
                     self.allocator,
-                    native::PipelineState::null(),
+                    d3d12::PipelineState::null(),
                     0,
                 )
                 .into_device_result("Create command list")?
@@ -318,28 +318,28 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             let s0 = conv::map_buffer_usage_to_state(barrier.usage.start);
             let s1 = conv::map_buffer_usage_to_state(barrier.usage.end);
             if s0 != s1 {
-                let mut raw = d3d12::D3D12_RESOURCE_BARRIER {
-                    Type: d3d12::D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
-                    Flags: d3d12::D3D12_RESOURCE_BARRIER_FLAG_NONE,
+                let mut raw = d3d12_ty::D3D12_RESOURCE_BARRIER {
+                    Type: d3d12_ty::D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
+                    Flags: d3d12_ty::D3D12_RESOURCE_BARRIER_FLAG_NONE,
                     u: unsafe { mem::zeroed() },
                 };
                 unsafe {
-                    *raw.u.Transition_mut() = d3d12::D3D12_RESOURCE_TRANSITION_BARRIER {
+                    *raw.u.Transition_mut() = d3d12_ty::D3D12_RESOURCE_TRANSITION_BARRIER {
                         pResource: barrier.buffer.resource.as_mut_ptr(),
-                        Subresource: d3d12::D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+                        Subresource: d3d12_ty::D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
                         StateBefore: s0,
                         StateAfter: s1,
                     }
                 };
                 self.temp.barriers.push(raw);
             } else if barrier.usage.start == crate::BufferUses::STORAGE_READ_WRITE {
-                let mut raw = d3d12::D3D12_RESOURCE_BARRIER {
-                    Type: d3d12::D3D12_RESOURCE_BARRIER_TYPE_UAV,
-                    Flags: d3d12::D3D12_RESOURCE_BARRIER_FLAG_NONE,
+                let mut raw = d3d12_ty::D3D12_RESOURCE_BARRIER {
+                    Type: d3d12_ty::D3D12_RESOURCE_BARRIER_TYPE_UAV,
+                    Flags: d3d12_ty::D3D12_RESOURCE_BARRIER_FLAG_NONE,
                     u: unsafe { mem::zeroed() },
                 };
                 unsafe {
-                    *raw.u.UAV_mut() = d3d12::D3D12_RESOURCE_UAV_BARRIER {
+                    *raw.u.UAV_mut() = d3d12_ty::D3D12_RESOURCE_UAV_BARRIER {
                         pResource: barrier.buffer.resource.as_mut_ptr(),
                     }
                 };
@@ -374,15 +374,15 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             let s0 = conv::map_texture_usage_to_state(barrier.usage.start);
             let s1 = conv::map_texture_usage_to_state(barrier.usage.end);
             if s0 != s1 {
-                let mut raw = d3d12::D3D12_RESOURCE_BARRIER {
-                    Type: d3d12::D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
-                    Flags: d3d12::D3D12_RESOURCE_BARRIER_FLAG_NONE,
+                let mut raw = d3d12_ty::D3D12_RESOURCE_BARRIER {
+                    Type: d3d12_ty::D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
+                    Flags: d3d12_ty::D3D12_RESOURCE_BARRIER_FLAG_NONE,
                     u: unsafe { mem::zeroed() },
                 };
                 unsafe {
-                    *raw.u.Transition_mut() = d3d12::D3D12_RESOURCE_TRANSITION_BARRIER {
+                    *raw.u.Transition_mut() = d3d12_ty::D3D12_RESOURCE_TRANSITION_BARRIER {
                         pResource: barrier.texture.resource.as_mut_ptr(),
-                        Subresource: d3d12::D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+                        Subresource: d3d12_ty::D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
                         StateBefore: s0,
                         StateAfter: s1,
                     }
@@ -428,13 +428,13 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     }
                 }
             } else if barrier.usage.start == crate::TextureUses::STORAGE_READ_WRITE {
-                let mut raw = d3d12::D3D12_RESOURCE_BARRIER {
-                    Type: d3d12::D3D12_RESOURCE_BARRIER_TYPE_UAV,
-                    Flags: d3d12::D3D12_RESOURCE_BARRIER_FLAG_NONE,
+                let mut raw = d3d12_ty::D3D12_RESOURCE_BARRIER {
+                    Type: d3d12_ty::D3D12_RESOURCE_BARRIER_TYPE_UAV,
+                    Flags: d3d12_ty::D3D12_RESOURCE_BARRIER_FLAG_NONE,
                     u: unsafe { mem::zeroed() },
                 };
                 unsafe {
-                    *raw.u.UAV_mut() = d3d12::D3D12_RESOURCE_UAV_BARRIER {
+                    *raw.u.UAV_mut() = d3d12_ty::D3D12_RESOURCE_UAV_BARRIER {
                         pResource: barrier.texture.resource.as_mut_ptr(),
                     }
                 };
@@ -501,14 +501,14 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         T: Iterator<Item = crate::TextureCopy>,
     {
         let list = self.list.unwrap();
-        let mut src_location = d3d12::D3D12_TEXTURE_COPY_LOCATION {
+        let mut src_location = d3d12_ty::D3D12_TEXTURE_COPY_LOCATION {
             pResource: src.resource.as_mut_ptr(),
-            Type: d3d12::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
+            Type: d3d12_ty::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
             u: unsafe { mem::zeroed() },
         };
-        let mut dst_location = d3d12::D3D12_TEXTURE_COPY_LOCATION {
+        let mut dst_location = d3d12_ty::D3D12_TEXTURE_COPY_LOCATION {
             pResource: dst.resource.as_mut_ptr(),
-            Type: d3d12::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
+            Type: d3d12_ty::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
             u: unsafe { mem::zeroed() },
         };
 
@@ -543,14 +543,14 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         T: Iterator<Item = crate::BufferTextureCopy>,
     {
         let list = self.list.unwrap();
-        let mut src_location = d3d12::D3D12_TEXTURE_COPY_LOCATION {
+        let mut src_location = d3d12_ty::D3D12_TEXTURE_COPY_LOCATION {
             pResource: src.resource.as_mut_ptr(),
-            Type: d3d12::D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT,
+            Type: d3d12_ty::D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT,
             u: unsafe { mem::zeroed() },
         };
-        let mut dst_location = d3d12::D3D12_TEXTURE_COPY_LOCATION {
+        let mut dst_location = d3d12_ty::D3D12_TEXTURE_COPY_LOCATION {
             pResource: dst.resource.as_mut_ptr(),
-            Type: d3d12::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
+            Type: d3d12_ty::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
             u: unsafe { mem::zeroed() },
         };
         for r in regions {
@@ -585,14 +585,14 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         T: Iterator<Item = crate::BufferTextureCopy>,
     {
         let list = self.list.unwrap();
-        let mut src_location = d3d12::D3D12_TEXTURE_COPY_LOCATION {
+        let mut src_location = d3d12_ty::D3D12_TEXTURE_COPY_LOCATION {
             pResource: src.resource.as_mut_ptr(),
-            Type: d3d12::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
+            Type: d3d12_ty::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
             u: unsafe { mem::zeroed() },
         };
-        let mut dst_location = d3d12::D3D12_TEXTURE_COPY_LOCATION {
+        let mut dst_location = d3d12_ty::D3D12_TEXTURE_COPY_LOCATION {
             pResource: dst.resource.as_mut_ptr(),
-            Type: d3d12::D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT,
+            Type: d3d12_ty::D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT,
             u: unsafe { mem::zeroed() },
         };
         for r in regions {
@@ -626,7 +626,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         unsafe {
             self.list.unwrap().EndQuery(
                 set.raw.as_mut_ptr(),
-                d3d12::D3D12_QUERY_TYPE_TIMESTAMP,
+                d3d12_ty::D3D12_QUERY_TYPE_TIMESTAMP,
                 index,
             )
         };
@@ -658,7 +658,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 
     unsafe fn begin_render_pass(&mut self, desc: &crate::RenderPassDescriptor<super::Api>) {
         unsafe { self.begin_pass(super::PassKind::Render, desc.label) };
-        let mut color_views = [native::CpuDescriptor { ptr: 0 }; crate::MAX_COLOR_ATTACHMENTS];
+        let mut color_views = [d3d12::CpuDescriptor { ptr: 0 }; crate::MAX_COLOR_ATTACHMENTS];
         for (rtv, cat) in color_views.iter_mut().zip(desc.color_attachments.iter()) {
             if let Some(cat) = cat.as_ref() {
                 *rtv = cat.target.view.handle_rtv.unwrap().raw;
@@ -711,17 +711,17 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         }
 
         if let Some(ref ds) = desc.depth_stencil_attachment {
-            let mut flags = native::ClearFlags::empty();
+            let mut flags = d3d12::ClearFlags::empty();
             let aspects = ds.target.view.aspects;
             if !ds.depth_ops.contains(crate::AttachmentOps::LOAD)
                 && aspects.contains(crate::FormatAspects::DEPTH)
             {
-                flags |= native::ClearFlags::DEPTH;
+                flags |= d3d12::ClearFlags::DEPTH;
             }
             if !ds.stencil_ops.contains(crate::AttachmentOps::LOAD)
                 && aspects.contains(crate::FormatAspects::STENCIL)
             {
-                flags |= native::ClearFlags::STENCIL;
+                flags |= d3d12::ClearFlags::STENCIL;
             }
 
             if !ds_view.is_null() && !flags.is_empty() {
@@ -735,7 +735,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             }
         }
 
-        let raw_vp = d3d12::D3D12_VIEWPORT {
+        let raw_vp = d3d12_ty::D3D12_VIEWPORT {
             TopLeftX: 0.0,
             TopLeftY: 0.0,
             Width: desc.extent.width as f32,
@@ -743,7 +743,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             MinDepth: 0.0,
             MaxDepth: 1.0,
         };
-        let raw_rect = d3d12::D3D12_RECT {
+        let raw_rect = d3d12_ty::D3D12_RECT {
             left: 0,
             top: 0,
             right: desc.extent.width as i32,
@@ -761,28 +761,28 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             // All the targets are expected to be in `COLOR_TARGET` state,
             // but D3D12 has special source/destination states for the resolves.
             for resolve in self.pass.resolves.iter() {
-                let mut barrier = d3d12::D3D12_RESOURCE_BARRIER {
-                    Type: d3d12::D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
-                    Flags: d3d12::D3D12_RESOURCE_BARRIER_FLAG_NONE,
+                let mut barrier = d3d12_ty::D3D12_RESOURCE_BARRIER {
+                    Type: d3d12_ty::D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
+                    Flags: d3d12_ty::D3D12_RESOURCE_BARRIER_FLAG_NONE,
                     u: unsafe { mem::zeroed() },
                 };
                 //Note: this assumes `D3D12_RESOURCE_STATE_RENDER_TARGET`.
                 // If it's not the case, we can include the `TextureUses` in `PassResove`.
                 unsafe {
-                    *barrier.u.Transition_mut() = d3d12::D3D12_RESOURCE_TRANSITION_BARRIER {
+                    *barrier.u.Transition_mut() = d3d12_ty::D3D12_RESOURCE_TRANSITION_BARRIER {
                         pResource: resolve.src.0.as_mut_ptr(),
                         Subresource: resolve.src.1,
-                        StateBefore: d3d12::D3D12_RESOURCE_STATE_RENDER_TARGET,
-                        StateAfter: d3d12::D3D12_RESOURCE_STATE_RESOLVE_SOURCE,
+                        StateBefore: d3d12_ty::D3D12_RESOURCE_STATE_RENDER_TARGET,
+                        StateAfter: d3d12_ty::D3D12_RESOURCE_STATE_RESOLVE_SOURCE,
                     }
                 };
                 self.temp.barriers.push(barrier);
                 unsafe {
-                    *barrier.u.Transition_mut() = d3d12::D3D12_RESOURCE_TRANSITION_BARRIER {
+                    *barrier.u.Transition_mut() = d3d12_ty::D3D12_RESOURCE_TRANSITION_BARRIER {
                         pResource: resolve.dst.0.as_mut_ptr(),
                         Subresource: resolve.dst.1,
-                        StateBefore: d3d12::D3D12_RESOURCE_STATE_RENDER_TARGET,
-                        StateAfter: d3d12::D3D12_RESOURCE_STATE_RESOLVE_DEST,
+                        StateBefore: d3d12_ty::D3D12_RESOURCE_STATE_RENDER_TARGET,
+                        StateAfter: d3d12_ty::D3D12_RESOURCE_STATE_RESOLVE_DEST,
                     }
                 };
                 self.temp.barriers.push(barrier);
@@ -867,7 +867,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             log::trace!("\tBind element[{}] = dynamic", root_index);
             self.pass.root_elements[root_index] = super::RootElement::DynamicOffsetBuffer {
                 kind,
-                address: gpu_base + offset as native::GpuAddress,
+                address: gpu_base + offset as d3d12::GpuAddress,
             };
             root_index += 1;
         }
@@ -972,7 +972,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     }
 
     unsafe fn set_viewport(&mut self, rect: &crate::Rect<f32>, depth_range: Range<f32>) {
-        let raw_vp = d3d12::D3D12_VIEWPORT {
+        let raw_vp = d3d12_ty::D3D12_VIEWPORT {
             TopLeftX: rect.x,
             TopLeftY: rect.y,
             Width: rect.w,
@@ -983,7 +983,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         unsafe { self.list.unwrap().RSSetViewports(1, &raw_vp) };
     }
     unsafe fn set_scissor_rect(&mut self, rect: &crate::Rect<u32>) {
-        let raw_rect = d3d12::D3D12_RECT {
+        let raw_rect = d3d12_ty::D3D12_RECT {
             left: rect.x as i32,
             top: rect.y as i32,
             right: (rect.x + rect.w) as i32,

--- a/wgpu-hal/src/dx12/conv.rs
+++ b/wgpu-hal/src/dx12/conv.rs
@@ -1,77 +1,79 @@
 use std::iter;
 use winapi::{
     shared::minwindef::BOOL,
-    um::{d3d12, d3dcommon},
+    um::{d3d12 as d3d12_ty, d3dcommon},
 };
 
-pub fn map_buffer_usage_to_resource_flags(usage: crate::BufferUses) -> d3d12::D3D12_RESOURCE_FLAGS {
+pub fn map_buffer_usage_to_resource_flags(
+    usage: crate::BufferUses,
+) -> d3d12_ty::D3D12_RESOURCE_FLAGS {
     let mut flags = 0;
     if usage.contains(crate::BufferUses::STORAGE_READ_WRITE) {
-        flags |= d3d12::D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+        flags |= d3d12_ty::D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     }
     flags
 }
 
-pub fn map_texture_dimension(dim: wgt::TextureDimension) -> d3d12::D3D12_RESOURCE_DIMENSION {
+pub fn map_texture_dimension(dim: wgt::TextureDimension) -> d3d12_ty::D3D12_RESOURCE_DIMENSION {
     match dim {
-        wgt::TextureDimension::D1 => d3d12::D3D12_RESOURCE_DIMENSION_TEXTURE1D,
-        wgt::TextureDimension::D2 => d3d12::D3D12_RESOURCE_DIMENSION_TEXTURE2D,
-        wgt::TextureDimension::D3 => d3d12::D3D12_RESOURCE_DIMENSION_TEXTURE3D,
+        wgt::TextureDimension::D1 => d3d12_ty::D3D12_RESOURCE_DIMENSION_TEXTURE1D,
+        wgt::TextureDimension::D2 => d3d12_ty::D3D12_RESOURCE_DIMENSION_TEXTURE2D,
+        wgt::TextureDimension::D3 => d3d12_ty::D3D12_RESOURCE_DIMENSION_TEXTURE3D,
     }
 }
 
 pub fn map_texture_usage_to_resource_flags(
     usage: crate::TextureUses,
-) -> d3d12::D3D12_RESOURCE_FLAGS {
+) -> d3d12_ty::D3D12_RESOURCE_FLAGS {
     let mut flags = 0;
 
     if usage.contains(crate::TextureUses::COLOR_TARGET) {
-        flags |= d3d12::D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+        flags |= d3d12_ty::D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
     }
     if usage.intersects(
         crate::TextureUses::DEPTH_STENCIL_READ | crate::TextureUses::DEPTH_STENCIL_WRITE,
     ) {
-        flags |= d3d12::D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
+        flags |= d3d12_ty::D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
         if !usage.contains(crate::TextureUses::RESOURCE) {
-            flags |= d3d12::D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE;
+            flags |= d3d12_ty::D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE;
         }
     }
     if usage.contains(crate::TextureUses::STORAGE_READ_WRITE) {
-        flags |= d3d12::D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+        flags |= d3d12_ty::D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     }
 
     flags
 }
 
-pub fn map_address_mode(mode: wgt::AddressMode) -> d3d12::D3D12_TEXTURE_ADDRESS_MODE {
+pub fn map_address_mode(mode: wgt::AddressMode) -> d3d12_ty::D3D12_TEXTURE_ADDRESS_MODE {
     use wgt::AddressMode as Am;
     match mode {
-        Am::Repeat => d3d12::D3D12_TEXTURE_ADDRESS_MODE_WRAP,
-        Am::MirrorRepeat => d3d12::D3D12_TEXTURE_ADDRESS_MODE_MIRROR,
-        Am::ClampToEdge => d3d12::D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
-        Am::ClampToBorder => d3d12::D3D12_TEXTURE_ADDRESS_MODE_BORDER,
-        //Am::MirrorClamp => d3d12::D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE,
+        Am::Repeat => d3d12_ty::D3D12_TEXTURE_ADDRESS_MODE_WRAP,
+        Am::MirrorRepeat => d3d12_ty::D3D12_TEXTURE_ADDRESS_MODE_MIRROR,
+        Am::ClampToEdge => d3d12_ty::D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
+        Am::ClampToBorder => d3d12_ty::D3D12_TEXTURE_ADDRESS_MODE_BORDER,
+        //Am::MirrorClamp => d3d12_ty::D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE,
     }
 }
 
-pub fn map_filter_mode(mode: wgt::FilterMode) -> d3d12::D3D12_FILTER_TYPE {
+pub fn map_filter_mode(mode: wgt::FilterMode) -> d3d12_ty::D3D12_FILTER_TYPE {
     match mode {
-        wgt::FilterMode::Nearest => d3d12::D3D12_FILTER_TYPE_POINT,
-        wgt::FilterMode::Linear => d3d12::D3D12_FILTER_TYPE_LINEAR,
+        wgt::FilterMode::Nearest => d3d12_ty::D3D12_FILTER_TYPE_POINT,
+        wgt::FilterMode::Linear => d3d12_ty::D3D12_FILTER_TYPE_LINEAR,
     }
 }
 
-pub fn map_comparison(func: wgt::CompareFunction) -> d3d12::D3D12_COMPARISON_FUNC {
+pub fn map_comparison(func: wgt::CompareFunction) -> d3d12_ty::D3D12_COMPARISON_FUNC {
     use wgt::CompareFunction as Cf;
     match func {
-        Cf::Never => d3d12::D3D12_COMPARISON_FUNC_NEVER,
-        Cf::Less => d3d12::D3D12_COMPARISON_FUNC_LESS,
-        Cf::LessEqual => d3d12::D3D12_COMPARISON_FUNC_LESS_EQUAL,
-        Cf::Equal => d3d12::D3D12_COMPARISON_FUNC_EQUAL,
-        Cf::GreaterEqual => d3d12::D3D12_COMPARISON_FUNC_GREATER_EQUAL,
-        Cf::Greater => d3d12::D3D12_COMPARISON_FUNC_GREATER,
-        Cf::NotEqual => d3d12::D3D12_COMPARISON_FUNC_NOT_EQUAL,
-        Cf::Always => d3d12::D3D12_COMPARISON_FUNC_ALWAYS,
+        Cf::Never => d3d12_ty::D3D12_COMPARISON_FUNC_NEVER,
+        Cf::Less => d3d12_ty::D3D12_COMPARISON_FUNC_LESS,
+        Cf::LessEqual => d3d12_ty::D3D12_COMPARISON_FUNC_LESS_EQUAL,
+        Cf::Equal => d3d12_ty::D3D12_COMPARISON_FUNC_EQUAL,
+        Cf::GreaterEqual => d3d12_ty::D3D12_COMPARISON_FUNC_GREATER_EQUAL,
+        Cf::Greater => d3d12_ty::D3D12_COMPARISON_FUNC_GREATER,
+        Cf::NotEqual => d3d12_ty::D3D12_COMPARISON_FUNC_NOT_EQUAL,
+        Cf::Always => d3d12_ty::D3D12_COMPARISON_FUNC_ALWAYS,
     }
 }
 
@@ -84,32 +86,32 @@ pub fn map_border_color(border_color: Option<wgt::SamplerBorderColor>) -> [f32; 
     }
 }
 
-pub fn map_visibility(visibility: wgt::ShaderStages) -> native::ShaderVisibility {
+pub fn map_visibility(visibility: wgt::ShaderStages) -> d3d12::ShaderVisibility {
     match visibility {
-        wgt::ShaderStages::VERTEX => native::ShaderVisibility::VS,
-        wgt::ShaderStages::FRAGMENT => native::ShaderVisibility::PS,
-        _ => native::ShaderVisibility::All,
+        wgt::ShaderStages::VERTEX => d3d12::ShaderVisibility::VS,
+        wgt::ShaderStages::FRAGMENT => d3d12::ShaderVisibility::PS,
+        _ => d3d12::ShaderVisibility::All,
     }
 }
 
-pub fn map_binding_type(ty: &wgt::BindingType) -> native::DescriptorRangeType {
+pub fn map_binding_type(ty: &wgt::BindingType) -> d3d12::DescriptorRangeType {
     use wgt::BindingType as Bt;
     match *ty {
-        Bt::Sampler { .. } => native::DescriptorRangeType::Sampler,
+        Bt::Sampler { .. } => d3d12::DescriptorRangeType::Sampler,
         Bt::Buffer {
             ty: wgt::BufferBindingType::Uniform,
             ..
-        } => native::DescriptorRangeType::CBV,
+        } => d3d12::DescriptorRangeType::CBV,
         Bt::Buffer {
             ty: wgt::BufferBindingType::Storage { read_only: true },
             ..
         }
-        | Bt::Texture { .. } => native::DescriptorRangeType::SRV,
+        | Bt::Texture { .. } => d3d12::DescriptorRangeType::SRV,
         Bt::Buffer {
             ty: wgt::BufferBindingType::Storage { read_only: false },
             ..
         }
-        | Bt::StorageTexture { .. } => native::DescriptorRangeType::UAV,
+        | Bt::StorageTexture { .. } => d3d12::DescriptorRangeType::UAV,
     }
 }
 
@@ -117,37 +119,37 @@ pub fn map_label(name: &str) -> Vec<u16> {
     name.encode_utf16().chain(iter::once(0)).collect()
 }
 
-pub fn map_buffer_usage_to_state(usage: crate::BufferUses) -> d3d12::D3D12_RESOURCE_STATES {
+pub fn map_buffer_usage_to_state(usage: crate::BufferUses) -> d3d12_ty::D3D12_RESOURCE_STATES {
     use crate::BufferUses as Bu;
-    let mut state = d3d12::D3D12_RESOURCE_STATE_COMMON;
+    let mut state = d3d12_ty::D3D12_RESOURCE_STATE_COMMON;
 
     if usage.intersects(Bu::COPY_SRC) {
-        state |= d3d12::D3D12_RESOURCE_STATE_COPY_SOURCE;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_COPY_SOURCE;
     }
     if usage.intersects(Bu::COPY_DST) {
-        state |= d3d12::D3D12_RESOURCE_STATE_COPY_DEST;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_COPY_DEST;
     }
     if usage.intersects(Bu::INDEX) {
-        state |= d3d12::D3D12_RESOURCE_STATE_INDEX_BUFFER;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_INDEX_BUFFER;
     }
     if usage.intersects(Bu::VERTEX | Bu::UNIFORM) {
-        state |= d3d12::D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
     }
     if usage.intersects(Bu::STORAGE_READ_WRITE) {
-        state |= d3d12::D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
     } else if usage.intersects(Bu::STORAGE_READ) {
-        state |= d3d12::D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
-            | d3d12::D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
+            | d3d12_ty::D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
     }
     if usage.intersects(Bu::INDIRECT) {
-        state |= d3d12::D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;
     }
     state
 }
 
-pub fn map_texture_usage_to_state(usage: crate::TextureUses) -> d3d12::D3D12_RESOURCE_STATES {
+pub fn map_texture_usage_to_state(usage: crate::TextureUses) -> d3d12_ty::D3D12_RESOURCE_STATES {
     use crate::TextureUses as Tu;
-    let mut state = d3d12::D3D12_RESOURCE_STATE_COMMON;
+    let mut state = d3d12_ty::D3D12_RESOURCE_STATE_COMMON;
     //Note: `RESOLVE_SOURCE` and `RESOLVE_DEST` are not used here
     //Note: `PRESENT` is the same as `COMMON`
     if usage == crate::TextureUses::UNINITIALIZED {
@@ -155,26 +157,26 @@ pub fn map_texture_usage_to_state(usage: crate::TextureUses) -> d3d12::D3D12_RES
     }
 
     if usage.intersects(Tu::COPY_SRC) {
-        state |= d3d12::D3D12_RESOURCE_STATE_COPY_SOURCE;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_COPY_SOURCE;
     }
     if usage.intersects(Tu::COPY_DST) {
-        state |= d3d12::D3D12_RESOURCE_STATE_COPY_DEST;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_COPY_DEST;
     }
     if usage.intersects(Tu::RESOURCE) {
-        state |= d3d12::D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
-            | d3d12::D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
+            | d3d12_ty::D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
     }
     if usage.intersects(Tu::COLOR_TARGET) {
-        state |= d3d12::D3D12_RESOURCE_STATE_RENDER_TARGET;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_RENDER_TARGET;
     }
     if usage.intersects(Tu::DEPTH_STENCIL_READ) {
-        state |= d3d12::D3D12_RESOURCE_STATE_DEPTH_READ;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_DEPTH_READ;
     }
     if usage.intersects(Tu::DEPTH_STENCIL_WRITE) {
-        state |= d3d12::D3D12_RESOURCE_STATE_DEPTH_WRITE;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_DEPTH_WRITE;
     }
     if usage.intersects(Tu::STORAGE_READ | Tu::STORAGE_READ_WRITE) {
-        state |= d3d12::D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+        state |= d3d12_ty::D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
     }
     state
 }
@@ -182,70 +184,70 @@ pub fn map_texture_usage_to_state(usage: crate::TextureUses) -> d3d12::D3D12_RES
 pub fn map_topology(
     topology: wgt::PrimitiveTopology,
 ) -> (
-    d3d12::D3D12_PRIMITIVE_TOPOLOGY_TYPE,
-    d3d12::D3D12_PRIMITIVE_TOPOLOGY,
+    d3d12_ty::D3D12_PRIMITIVE_TOPOLOGY_TYPE,
+    d3d12_ty::D3D12_PRIMITIVE_TOPOLOGY,
 ) {
     match topology {
         wgt::PrimitiveTopology::PointList => (
-            d3d12::D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT,
+            d3d12_ty::D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT,
             d3dcommon::D3D_PRIMITIVE_TOPOLOGY_POINTLIST,
         ),
         wgt::PrimitiveTopology::LineList => (
-            d3d12::D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE,
+            d3d12_ty::D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE,
             d3dcommon::D3D_PRIMITIVE_TOPOLOGY_LINELIST,
         ),
         wgt::PrimitiveTopology::LineStrip => (
-            d3d12::D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE,
+            d3d12_ty::D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE,
             d3dcommon::D3D_PRIMITIVE_TOPOLOGY_LINESTRIP,
         ),
         wgt::PrimitiveTopology::TriangleList => (
-            d3d12::D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
+            d3d12_ty::D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
             d3dcommon::D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST,
         ),
         wgt::PrimitiveTopology::TriangleStrip => (
-            d3d12::D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
+            d3d12_ty::D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
             d3dcommon::D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
         ),
     }
 }
 
-pub fn map_polygon_mode(mode: wgt::PolygonMode) -> d3d12::D3D12_FILL_MODE {
+pub fn map_polygon_mode(mode: wgt::PolygonMode) -> d3d12_ty::D3D12_FILL_MODE {
     match mode {
         wgt::PolygonMode::Point => {
             log::error!("Point rasterization is not supported");
-            d3d12::D3D12_FILL_MODE_WIREFRAME
+            d3d12_ty::D3D12_FILL_MODE_WIREFRAME
         }
-        wgt::PolygonMode::Line => d3d12::D3D12_FILL_MODE_WIREFRAME,
-        wgt::PolygonMode::Fill => d3d12::D3D12_FILL_MODE_SOLID,
+        wgt::PolygonMode::Line => d3d12_ty::D3D12_FILL_MODE_WIREFRAME,
+        wgt::PolygonMode::Fill => d3d12_ty::D3D12_FILL_MODE_SOLID,
     }
 }
 
-fn map_blend_factor(factor: wgt::BlendFactor, is_alpha: bool) -> d3d12::D3D12_BLEND {
+fn map_blend_factor(factor: wgt::BlendFactor, is_alpha: bool) -> d3d12_ty::D3D12_BLEND {
     use wgt::BlendFactor as Bf;
     match factor {
-        Bf::Zero => d3d12::D3D12_BLEND_ZERO,
-        Bf::One => d3d12::D3D12_BLEND_ONE,
-        Bf::Src if is_alpha => d3d12::D3D12_BLEND_SRC_ALPHA,
-        Bf::Src => d3d12::D3D12_BLEND_SRC_COLOR,
-        Bf::OneMinusSrc if is_alpha => d3d12::D3D12_BLEND_INV_SRC_ALPHA,
-        Bf::OneMinusSrc => d3d12::D3D12_BLEND_INV_SRC_COLOR,
-        Bf::Dst if is_alpha => d3d12::D3D12_BLEND_DEST_ALPHA,
-        Bf::Dst => d3d12::D3D12_BLEND_DEST_COLOR,
-        Bf::OneMinusDst if is_alpha => d3d12::D3D12_BLEND_INV_DEST_ALPHA,
-        Bf::OneMinusDst => d3d12::D3D12_BLEND_INV_DEST_COLOR,
-        Bf::SrcAlpha => d3d12::D3D12_BLEND_SRC_ALPHA,
-        Bf::OneMinusSrcAlpha => d3d12::D3D12_BLEND_INV_SRC_ALPHA,
-        Bf::DstAlpha => d3d12::D3D12_BLEND_DEST_ALPHA,
-        Bf::OneMinusDstAlpha => d3d12::D3D12_BLEND_INV_DEST_ALPHA,
-        Bf::Constant => d3d12::D3D12_BLEND_BLEND_FACTOR,
-        Bf::OneMinusConstant => d3d12::D3D12_BLEND_INV_BLEND_FACTOR,
-        Bf::SrcAlphaSaturated => d3d12::D3D12_BLEND_SRC_ALPHA_SAT,
-        //Bf::Src1Color if is_alpha => d3d12::D3D12_BLEND_SRC1_ALPHA,
-        //Bf::Src1Color => d3d12::D3D12_BLEND_SRC1_COLOR,
-        //Bf::OneMinusSrc1Color if is_alpha => d3d12::D3D12_BLEND_INV_SRC1_ALPHA,
-        //Bf::OneMinusSrc1Color => d3d12::D3D12_BLEND_INV_SRC1_COLOR,
-        //Bf::Src1Alpha => d3d12::D3D12_BLEND_SRC1_ALPHA,
-        //Bf::OneMinusSrc1Alpha => d3d12::D3D12_BLEND_INV_SRC1_ALPHA,
+        Bf::Zero => d3d12_ty::D3D12_BLEND_ZERO,
+        Bf::One => d3d12_ty::D3D12_BLEND_ONE,
+        Bf::Src if is_alpha => d3d12_ty::D3D12_BLEND_SRC_ALPHA,
+        Bf::Src => d3d12_ty::D3D12_BLEND_SRC_COLOR,
+        Bf::OneMinusSrc if is_alpha => d3d12_ty::D3D12_BLEND_INV_SRC_ALPHA,
+        Bf::OneMinusSrc => d3d12_ty::D3D12_BLEND_INV_SRC_COLOR,
+        Bf::Dst if is_alpha => d3d12_ty::D3D12_BLEND_DEST_ALPHA,
+        Bf::Dst => d3d12_ty::D3D12_BLEND_DEST_COLOR,
+        Bf::OneMinusDst if is_alpha => d3d12_ty::D3D12_BLEND_INV_DEST_ALPHA,
+        Bf::OneMinusDst => d3d12_ty::D3D12_BLEND_INV_DEST_COLOR,
+        Bf::SrcAlpha => d3d12_ty::D3D12_BLEND_SRC_ALPHA,
+        Bf::OneMinusSrcAlpha => d3d12_ty::D3D12_BLEND_INV_SRC_ALPHA,
+        Bf::DstAlpha => d3d12_ty::D3D12_BLEND_DEST_ALPHA,
+        Bf::OneMinusDstAlpha => d3d12_ty::D3D12_BLEND_INV_DEST_ALPHA,
+        Bf::Constant => d3d12_ty::D3D12_BLEND_BLEND_FACTOR,
+        Bf::OneMinusConstant => d3d12_ty::D3D12_BLEND_INV_BLEND_FACTOR,
+        Bf::SrcAlphaSaturated => d3d12_ty::D3D12_BLEND_SRC_ALPHA_SAT,
+        //Bf::Src1Color if is_alpha => d3d12_ty::D3D12_BLEND_SRC1_ALPHA,
+        //Bf::Src1Color => d3d12_ty::D3D12_BLEND_SRC1_COLOR,
+        //Bf::OneMinusSrc1Color if is_alpha => d3d12_ty::D3D12_BLEND_INV_SRC1_ALPHA,
+        //Bf::OneMinusSrc1Color => d3d12_ty::D3D12_BLEND_INV_SRC1_COLOR,
+        //Bf::Src1Alpha => d3d12_ty::D3D12_BLEND_SRC1_ALPHA,
+        //Bf::OneMinusSrc1Alpha => d3d12_ty::D3D12_BLEND_INV_SRC1_ALPHA,
     }
 }
 
@@ -253,16 +255,16 @@ fn map_blend_component(
     component: &wgt::BlendComponent,
     is_alpha: bool,
 ) -> (
-    d3d12::D3D12_BLEND_OP,
-    d3d12::D3D12_BLEND,
-    d3d12::D3D12_BLEND,
+    d3d12_ty::D3D12_BLEND_OP,
+    d3d12_ty::D3D12_BLEND,
+    d3d12_ty::D3D12_BLEND,
 ) {
     let raw_op = match component.operation {
-        wgt::BlendOperation::Add => d3d12::D3D12_BLEND_OP_ADD,
-        wgt::BlendOperation::Subtract => d3d12::D3D12_BLEND_OP_SUBTRACT,
-        wgt::BlendOperation::ReverseSubtract => d3d12::D3D12_BLEND_OP_REV_SUBTRACT,
-        wgt::BlendOperation::Min => d3d12::D3D12_BLEND_OP_MIN,
-        wgt::BlendOperation::Max => d3d12::D3D12_BLEND_OP_MAX,
+        wgt::BlendOperation::Add => d3d12_ty::D3D12_BLEND_OP_ADD,
+        wgt::BlendOperation::Subtract => d3d12_ty::D3D12_BLEND_OP_SUBTRACT,
+        wgt::BlendOperation::ReverseSubtract => d3d12_ty::D3D12_BLEND_OP_REV_SUBTRACT,
+        wgt::BlendOperation::Min => d3d12_ty::D3D12_BLEND_OP_MIN,
+        wgt::BlendOperation::Max => d3d12_ty::D3D12_BLEND_OP_MAX,
     };
     let raw_src = map_blend_factor(component.src_factor, is_alpha);
     let raw_dst = map_blend_factor(component.dst_factor, is_alpha);
@@ -271,21 +273,21 @@ fn map_blend_component(
 
 pub fn map_render_targets(
     color_targets: &[Option<wgt::ColorTargetState>],
-) -> [d3d12::D3D12_RENDER_TARGET_BLEND_DESC; d3d12::D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT as usize]
-{
-    let dummy_target = d3d12::D3D12_RENDER_TARGET_BLEND_DESC {
+) -> [d3d12_ty::D3D12_RENDER_TARGET_BLEND_DESC;
+       d3d12_ty::D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT as usize] {
+    let dummy_target = d3d12_ty::D3D12_RENDER_TARGET_BLEND_DESC {
         BlendEnable: 0,
         LogicOpEnable: 0,
-        SrcBlend: d3d12::D3D12_BLEND_ZERO,
-        DestBlend: d3d12::D3D12_BLEND_ZERO,
-        BlendOp: d3d12::D3D12_BLEND_OP_ADD,
-        SrcBlendAlpha: d3d12::D3D12_BLEND_ZERO,
-        DestBlendAlpha: d3d12::D3D12_BLEND_ZERO,
-        BlendOpAlpha: d3d12::D3D12_BLEND_OP_ADD,
-        LogicOp: d3d12::D3D12_LOGIC_OP_CLEAR,
+        SrcBlend: d3d12_ty::D3D12_BLEND_ZERO,
+        DestBlend: d3d12_ty::D3D12_BLEND_ZERO,
+        BlendOp: d3d12_ty::D3D12_BLEND_OP_ADD,
+        SrcBlendAlpha: d3d12_ty::D3D12_BLEND_ZERO,
+        DestBlendAlpha: d3d12_ty::D3D12_BLEND_ZERO,
+        BlendOpAlpha: d3d12_ty::D3D12_BLEND_OP_ADD,
+        LogicOp: d3d12_ty::D3D12_LOGIC_OP_CLEAR,
         RenderTargetWriteMask: 0,
     };
-    let mut raw_targets = [dummy_target; d3d12::D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT as usize];
+    let mut raw_targets = [dummy_target; d3d12_ty::D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT as usize];
 
     for (raw, ct) in raw_targets.iter_mut().zip(color_targets.iter()) {
         if let Some(ct) = ct.as_ref() {
@@ -307,22 +309,22 @@ pub fn map_render_targets(
     raw_targets
 }
 
-fn map_stencil_op(op: wgt::StencilOperation) -> d3d12::D3D12_STENCIL_OP {
+fn map_stencil_op(op: wgt::StencilOperation) -> d3d12_ty::D3D12_STENCIL_OP {
     use wgt::StencilOperation as So;
     match op {
-        So::Keep => d3d12::D3D12_STENCIL_OP_KEEP,
-        So::Zero => d3d12::D3D12_STENCIL_OP_ZERO,
-        So::Replace => d3d12::D3D12_STENCIL_OP_REPLACE,
-        So::IncrementClamp => d3d12::D3D12_STENCIL_OP_INCR_SAT,
-        So::IncrementWrap => d3d12::D3D12_STENCIL_OP_INCR,
-        So::DecrementClamp => d3d12::D3D12_STENCIL_OP_DECR_SAT,
-        So::DecrementWrap => d3d12::D3D12_STENCIL_OP_DECR,
-        So::Invert => d3d12::D3D12_STENCIL_OP_INVERT,
+        So::Keep => d3d12_ty::D3D12_STENCIL_OP_KEEP,
+        So::Zero => d3d12_ty::D3D12_STENCIL_OP_ZERO,
+        So::Replace => d3d12_ty::D3D12_STENCIL_OP_REPLACE,
+        So::IncrementClamp => d3d12_ty::D3D12_STENCIL_OP_INCR_SAT,
+        So::IncrementWrap => d3d12_ty::D3D12_STENCIL_OP_INCR,
+        So::DecrementClamp => d3d12_ty::D3D12_STENCIL_OP_DECR_SAT,
+        So::DecrementWrap => d3d12_ty::D3D12_STENCIL_OP_DECR,
+        So::Invert => d3d12_ty::D3D12_STENCIL_OP_INVERT,
     }
 }
 
-fn map_stencil_face(face: &wgt::StencilFaceState) -> d3d12::D3D12_DEPTH_STENCILOP_DESC {
-    d3d12::D3D12_DEPTH_STENCILOP_DESC {
+fn map_stencil_face(face: &wgt::StencilFaceState) -> d3d12_ty::D3D12_DEPTH_STENCILOP_DESC {
+    d3d12_ty::D3D12_DEPTH_STENCILOP_DESC {
         StencilFailOp: map_stencil_op(face.fail_op),
         StencilDepthFailOp: map_stencil_op(face.depth_fail_op),
         StencilPassOp: map_stencil_op(face.pass_op),
@@ -330,13 +332,13 @@ fn map_stencil_face(face: &wgt::StencilFaceState) -> d3d12::D3D12_DEPTH_STENCILO
     }
 }
 
-pub fn map_depth_stencil(ds: &wgt::DepthStencilState) -> d3d12::D3D12_DEPTH_STENCIL_DESC {
-    d3d12::D3D12_DEPTH_STENCIL_DESC {
+pub fn map_depth_stencil(ds: &wgt::DepthStencilState) -> d3d12_ty::D3D12_DEPTH_STENCIL_DESC {
+    d3d12_ty::D3D12_DEPTH_STENCIL_DESC {
         DepthEnable: BOOL::from(ds.is_depth_enabled()),
         DepthWriteMask: if ds.depth_write_enabled {
-            d3d12::D3D12_DEPTH_WRITE_MASK_ALL
+            d3d12_ty::D3D12_DEPTH_WRITE_MASK_ALL
         } else {
-            d3d12::D3D12_DEPTH_WRITE_MASK_ZERO
+            d3d12_ty::D3D12_DEPTH_WRITE_MASK_ZERO
         },
         DepthFunc: map_comparison(ds.depth_compare),
         StencilEnable: BOOL::from(ds.stencil.is_enabled()),

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -5,7 +5,7 @@ use parking_lot::Mutex;
 use std::{ffi, mem, num::NonZeroU32, ptr, sync::Arc};
 use winapi::{
     shared::{dxgiformat, dxgitype, minwindef::BOOL, winerror},
-    um::{d3d12, synchapi, winbase},
+    um::{d3d12 as d3d12_ty, synchapi, winbase},
     Interface,
 };
 
@@ -14,10 +14,10 @@ const NAGA_LOCATION_SEMANTIC: &[u8] = b"LOC\0";
 
 impl super::Device {
     pub(super) fn new(
-        raw: native::Device,
-        present_queue: native::CommandQueue,
+        raw: d3d12::Device,
+        present_queue: d3d12::CommandQueue,
         private_caps: super::PrivateCapabilities,
-        library: &Arc<native::D3D12Lib>,
+        library: &Arc<d3d12::D3D12Lib>,
         dx12_shader_compiler: wgt::Dx12Compiler,
     ) -> Result<Self, crate::DeviceError> {
         let mem_allocator = super::suballocation::create_allocator_wrapper(&raw)?;
@@ -30,22 +30,22 @@ impl super::Device {
             wgt::Dx12Compiler::Fxc => None,
         };
 
-        let mut idle_fence = native::Fence::null();
+        let mut idle_fence = d3d12::Fence::null();
         let hr = unsafe {
             profiling::scope!("ID3D12Device::CreateFence");
             raw.CreateFence(
                 0,
-                d3d12::D3D12_FENCE_FLAG_NONE,
-                &d3d12::ID3D12Fence::uuidof(),
+                d3d12_ty::D3D12_FENCE_FLAG_NONE,
+                &d3d12_ty::ID3D12Fence::uuidof(),
                 idle_fence.mut_void(),
             )
         };
         hr.into_device_result("Idle fence creation")?;
 
-        let mut zero_buffer = native::Resource::null();
+        let mut zero_buffer = d3d12::Resource::null();
         unsafe {
-            let raw_desc = d3d12::D3D12_RESOURCE_DESC {
-                Dimension: d3d12::D3D12_RESOURCE_DIMENSION_BUFFER,
+            let raw_desc = d3d12_ty::D3D12_RESOURCE_DESC {
+                Dimension: d3d12_ty::D3D12_RESOURCE_DIMENSION_BUFFER,
                 Alignment: 0,
                 Width: super::ZERO_BUFFER_SIZE,
                 Height: 1,
@@ -56,16 +56,16 @@ impl super::Device {
                     Count: 1,
                     Quality: 0,
                 },
-                Layout: d3d12::D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
-                Flags: d3d12::D3D12_RESOURCE_FLAG_NONE,
+                Layout: d3d12_ty::D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+                Flags: d3d12_ty::D3D12_RESOURCE_FLAG_NONE,
             };
 
-            let heap_properties = d3d12::D3D12_HEAP_PROPERTIES {
-                Type: d3d12::D3D12_HEAP_TYPE_CUSTOM,
-                CPUPageProperty: d3d12::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE,
+            let heap_properties = d3d12_ty::D3D12_HEAP_PROPERTIES {
+                Type: d3d12_ty::D3D12_HEAP_TYPE_CUSTOM,
+                CPUPageProperty: d3d12_ty::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE,
                 MemoryPoolPreference: match private_caps.memory_architecture {
-                    super::MemoryArchitecture::Unified { .. } => d3d12::D3D12_MEMORY_POOL_L0,
-                    super::MemoryArchitecture::NonUnified => d3d12::D3D12_MEMORY_POOL_L1,
+                    super::MemoryArchitecture::Unified { .. } => d3d12_ty::D3D12_MEMORY_POOL_L0,
+                    super::MemoryArchitecture::NonUnified => d3d12_ty::D3D12_MEMORY_POOL_L1,
                 },
                 CreationNodeMask: 0,
                 VisibleNodeMask: 0,
@@ -74,11 +74,11 @@ impl super::Device {
             profiling::scope!("Zero Buffer Allocation");
             raw.CreateCommittedResource(
                 &heap_properties,
-                d3d12::D3D12_HEAP_FLAG_NONE,
+                d3d12_ty::D3D12_HEAP_FLAG_NONE,
                 &raw_desc,
-                d3d12::D3D12_RESOURCE_STATE_COMMON,
+                d3d12_ty::D3D12_RESOURCE_STATE_COMMON,
                 ptr::null(),
-                &d3d12::ID3D12Resource::uuidof(),
+                &d3d12_ty::ID3D12Resource::uuidof(),
                 zero_buffer.mut_void(),
             )
             .into_device_result("Zero buffer creation")?;
@@ -96,24 +96,24 @@ impl super::Device {
             cmd_signatures: super::CommandSignatures {
                 draw: raw
                     .create_command_signature(
-                        native::RootSignature::null(),
-                        &[native::IndirectArgument::draw()],
+                        d3d12::RootSignature::null(),
+                        &[d3d12::IndirectArgument::draw()],
                         mem::size_of::<wgt::DrawIndirectArgs>() as u32,
                         0,
                     )
                     .into_device_result("Command (draw) signature creation")?,
                 draw_indexed: raw
                     .create_command_signature(
-                        native::RootSignature::null(),
-                        &[native::IndirectArgument::draw_indexed()],
+                        d3d12::RootSignature::null(),
+                        &[d3d12::IndirectArgument::draw_indexed()],
                         mem::size_of::<wgt::DrawIndexedIndirectArgs>() as u32,
                         0,
                     )
                     .into_device_result("Command (draw_indexed) signature creation")?,
                 dispatch: raw
                     .create_command_signature(
-                        native::RootSignature::null(),
-                        &[native::IndirectArgument::dispatch()],
+                        d3d12::RootSignature::null(),
+                        &[d3d12::IndirectArgument::dispatch()],
                         mem::size_of::<wgt::DispatchIndirectArgs>() as u32,
                         0,
                     )
@@ -121,23 +121,23 @@ impl super::Device {
             },
             heap_views: descriptor::GeneralHeap::new(
                 raw,
-                native::DescriptorHeapType::CbvSrvUav,
+                d3d12::DescriptorHeapType::CbvSrvUav,
                 capacity_views,
             )?,
             heap_samplers: descriptor::GeneralHeap::new(
                 raw,
-                native::DescriptorHeapType::Sampler,
+                d3d12::DescriptorHeapType::Sampler,
                 capacity_samplers,
             )?,
         };
 
-        let mut rtv_pool = descriptor::CpuPool::new(raw, native::DescriptorHeapType::Rtv);
+        let mut rtv_pool = descriptor::CpuPool::new(raw, d3d12::DescriptorHeapType::Rtv);
         let null_rtv_handle = rtv_pool.alloc_handle();
         // A null pResource is used to initialize a null descriptor,
         // which guarantees D3D11-like null binding behavior (reading 0s, writes are discarded)
         raw.create_render_target_view(
-            native::WeakPtr::null(),
-            &native::RenderTargetViewDesc::texture_2d(
+            d3d12::WeakPtr::null(),
+            &d3d12::RenderTargetViewDesc::texture_2d(
                 winapi::shared::dxgiformat::DXGI_FORMAT_R8G8B8A8_UNORM,
                 0,
                 0,
@@ -150,22 +150,22 @@ impl super::Device {
             present_queue,
             idler: super::Idler {
                 fence: idle_fence,
-                event: native::Event::create(false, false),
+                event: d3d12::Event::create(false, false),
             },
             private_caps,
             shared: Arc::new(shared),
             rtv_pool: Mutex::new(rtv_pool),
             dsv_pool: Mutex::new(descriptor::CpuPool::new(
                 raw,
-                native::DescriptorHeapType::Dsv,
+                d3d12::DescriptorHeapType::Dsv,
             )),
             srv_uav_pool: Mutex::new(descriptor::CpuPool::new(
                 raw,
-                native::DescriptorHeapType::CbvSrvUav,
+                d3d12::DescriptorHeapType::CbvSrvUav,
             )),
             sampler_pool: Mutex::new(descriptor::CpuPool::new(
                 raw,
-                native::DescriptorHeapType::Sampler,
+                d3d12::DescriptorHeapType::Sampler,
             )),
             library: Arc::clone(library),
             #[cfg(feature = "renderdoc")]
@@ -269,16 +269,16 @@ impl super::Device {
         result
     }
 
-    pub fn raw_device(&self) -> &native::Device {
+    pub fn raw_device(&self) -> &d3d12::Device {
         &self.raw
     }
 
-    pub fn raw_queue(&self) -> &native::CommandQueue {
+    pub fn raw_queue(&self) -> &d3d12::CommandQueue {
         &self.present_queue
     }
 
     pub unsafe fn texture_from_raw(
-        resource: native::Resource,
+        resource: d3d12::Resource,
         format: wgt::TextureFormat,
         dimension: wgt::TextureDimension,
         size: wgt::Extent3d,
@@ -314,15 +314,15 @@ impl crate::Device<super::Api> for super::Device {
         &self,
         desc: &crate::BufferDescriptor,
     ) -> Result<super::Buffer, crate::DeviceError> {
-        let mut resource = native::Resource::null();
+        let mut resource = d3d12::Resource::null();
         let mut size = desc.size;
         if desc.usage.contains(crate::BufferUses::UNIFORM) {
-            let align_mask = d3d12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT as u64 - 1;
+            let align_mask = d3d12_ty::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT as u64 - 1;
             size = ((size - 1) | align_mask) + 1;
         }
 
-        let raw_desc = d3d12::D3D12_RESOURCE_DESC {
-            Dimension: d3d12::D3D12_RESOURCE_DIMENSION_BUFFER,
+        let raw_desc = d3d12_ty::D3D12_RESOURCE_DESC {
+            Dimension: d3d12_ty::D3D12_RESOURCE_DIMENSION_BUFFER,
             Alignment: 0,
             Width: size,
             Height: 1,
@@ -333,7 +333,7 @@ impl crate::Device<super::Api> for super::Device {
                 Count: 1,
                 Quality: 0,
             },
-            Layout: d3d12::D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+            Layout: d3d12_ty::D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
             Flags: conv::map_buffer_usage_to_resource_flags(desc.usage),
         };
 
@@ -397,9 +397,9 @@ impl crate::Device<super::Api> for super::Device {
     ) -> Result<super::Texture, crate::DeviceError> {
         use super::suballocation::create_texture_resource;
 
-        let mut resource = native::Resource::null();
+        let mut resource = d3d12::Resource::null();
 
-        let raw_desc = d3d12::D3D12_RESOURCE_DESC {
+        let raw_desc = d3d12_ty::D3D12_RESOURCE_DESC {
             Dimension: conv::map_texture_dimension(desc.dimension),
             Alignment: 0,
             Width: desc.size.width as u64,
@@ -424,7 +424,7 @@ impl crate::Device<super::Api> for super::Device {
                 Count: desc.sample_count,
                 Quality: 0,
             },
-            Layout: d3d12::D3D12_TEXTURE_LAYOUT_UNKNOWN,
+            Layout: d3d12_ty::D3D12_TEXTURE_LAYOUT_UNKNOWN,
             Flags: conv::map_texture_usage_to_resource_flags(desc.usage),
         };
 
@@ -588,16 +588,16 @@ impl crate::Device<super::Api> for super::Device {
         let handle = self.sampler_pool.lock().alloc_handle();
 
         let reduction = match desc.compare {
-            Some(_) => d3d12::D3D12_FILTER_REDUCTION_TYPE_COMPARISON,
-            None => d3d12::D3D12_FILTER_REDUCTION_TYPE_STANDARD,
+            Some(_) => d3d12_ty::D3D12_FILTER_REDUCTION_TYPE_COMPARISON,
+            None => d3d12_ty::D3D12_FILTER_REDUCTION_TYPE_STANDARD,
         };
-        let filter = conv::map_filter_mode(desc.min_filter) << d3d12::D3D12_MIN_FILTER_SHIFT
-            | conv::map_filter_mode(desc.mag_filter) << d3d12::D3D12_MAG_FILTER_SHIFT
-            | conv::map_filter_mode(desc.mipmap_filter) << d3d12::D3D12_MIP_FILTER_SHIFT
-            | reduction << d3d12::D3D12_FILTER_REDUCTION_TYPE_SHIFT
+        let filter = conv::map_filter_mode(desc.min_filter) << d3d12_ty::D3D12_MIN_FILTER_SHIFT
+            | conv::map_filter_mode(desc.mag_filter) << d3d12_ty::D3D12_MAG_FILTER_SHIFT
+            | conv::map_filter_mode(desc.mipmap_filter) << d3d12_ty::D3D12_MIP_FILTER_SHIFT
+            | reduction << d3d12_ty::D3D12_FILTER_REDUCTION_TYPE_SHIFT
             | desc
                 .anisotropy_clamp
-                .map_or(0, |_| d3d12::D3D12_FILTER_ANISOTROPIC);
+                .map_or(0, |_| d3d12_ty::D3D12_FILTER_ANISOTROPIC);
 
         let border_color = conv::map_border_color(desc.border_color);
 
@@ -628,7 +628,7 @@ impl crate::Device<super::Api> for super::Device {
     ) -> Result<super::CommandEncoder, crate::DeviceError> {
         let allocator = self
             .raw
-            .create_command_allocator(native::CmdListType::Direct)
+            .create_command_allocator(d3d12::CmdListType::Direct)
             .into_device_result("Command allocator creation")?;
 
         if let Some(label) = desc.label {
@@ -684,7 +684,7 @@ impl crate::Device<super::Api> for super::Device {
             cpu_heap_views: if num_views != 0 {
                 let heap = descriptor::CpuHeap::new(
                     self.raw,
-                    native::DescriptorHeapType::CbvSrvUav,
+                    d3d12::DescriptorHeapType::CbvSrvUav,
                     num_views,
                 )?;
                 Some(heap)
@@ -694,7 +694,7 @@ impl crate::Device<super::Api> for super::Device {
             cpu_heap_samplers: if num_samplers != 0 {
                 let heap = descriptor::CpuHeap::new(
                     self.raw,
-                    native::DescriptorHeapType::Sampler,
+                    d3d12::DescriptorHeapType::Sampler,
                     num_samplers,
                 )?;
                 Some(heap)
@@ -748,8 +748,8 @@ impl crate::Device<super::Api> for super::Device {
         // Currently impossible because wgpu-core only re-binds the descriptor sets based
         // on Vulkan-like layout compatibility rules.
 
-        fn native_binding(bt: &hlsl::BindTarget) -> native::Binding {
-            native::Binding {
+        fn native_binding(bt: &hlsl::BindTarget) -> d3d12::Binding {
+            d3d12::Binding {
                 space: bt.space as u32,
                 register: bt.register,
             }
@@ -787,8 +787,8 @@ impl crate::Device<super::Api> for super::Device {
                 parameter_index,
                 size,
             );
-            parameters.push(native::RootParameter::constants(
-                native::ShaderVisibility::All,
+            parameters.push(d3d12::RootParameter::constants(
+                d3d12::ShaderVisibility::All,
                 native_binding(&bind_cbv),
                 size,
             ));
@@ -855,10 +855,10 @@ impl crate::Device<super::Api> for super::Device {
                     ref other => conv::map_binding_type(other),
                 };
                 let bt = match range_ty {
-                    native::DescriptorRangeType::CBV => &mut bind_cbv,
-                    native::DescriptorRangeType::SRV => &mut bind_srv,
-                    native::DescriptorRangeType::UAV => &mut bind_uav,
-                    native::DescriptorRangeType::Sampler => continue,
+                    d3d12::DescriptorRangeType::CBV => &mut bind_cbv,
+                    d3d12::DescriptorRangeType::SRV => &mut bind_srv,
+                    d3d12::DescriptorRangeType::UAV => &mut bind_uav,
+                    d3d12::DescriptorRangeType::Sampler => continue,
                 };
 
                 binding_map.insert(
@@ -871,11 +871,11 @@ impl crate::Device<super::Api> for super::Device {
                         ..bt.clone()
                     },
                 );
-                ranges.push(native::DescriptorRange::new(
+                ranges.push(d3d12::DescriptorRange::new(
                     range_ty,
                     entry.count.map_or(1, |count| count.get()),
                     native_binding(bt),
-                    d3d12::D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND,
+                    d3d12_ty::D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND,
                 ));
                 bt.register += entry.count.map(NonZeroU32::get).unwrap_or(1);
             }
@@ -886,7 +886,7 @@ impl crate::Device<super::Api> for super::Device {
                     visibility_view_static,
                     ranges.len() - range_base,
                 );
-                parameters.push(native::RootParameter::descriptor_table(
+                parameters.push(d3d12::RootParameter::descriptor_table(
                     conv::map_visibility(visibility_view_static),
                     &ranges[range_base..],
                 ));
@@ -897,7 +897,7 @@ impl crate::Device<super::Api> for super::Device {
             range_base = ranges.len();
             for entry in bgl.entries.iter() {
                 let range_ty = match entry.ty {
-                    wgt::BindingType::Sampler { .. } => native::DescriptorRangeType::Sampler,
+                    wgt::BindingType::Sampler { .. } => d3d12::DescriptorRangeType::Sampler,
                     _ => continue,
                 };
                 binding_map.insert(
@@ -910,11 +910,11 @@ impl crate::Device<super::Api> for super::Device {
                         ..bind_sampler.clone()
                     },
                 );
-                ranges.push(native::DescriptorRange::new(
+                ranges.push(d3d12::DescriptorRange::new(
                     range_ty,
                     entry.count.map_or(1, |count| count.get()),
                     native_binding(&bind_sampler),
-                    d3d12::D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND,
+                    d3d12_ty::D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND,
                 ));
                 bind_sampler.register += entry.count.map(NonZeroU32::get).unwrap_or(1);
             }
@@ -925,7 +925,7 @@ impl crate::Device<super::Api> for super::Device {
                     visibility_sampler,
                     ranges.len() - range_base,
                 );
-                parameters.push(native::RootParameter::descriptor_table(
+                parameters.push(d3d12::RootParameter::descriptor_table(
                     conv::map_visibility(visibility_sampler),
                     &ranges[range_base..],
                 ));
@@ -947,17 +947,17 @@ impl crate::Device<super::Api> for super::Device {
                 let (kind, parameter_ty, bt) = match buffer_ty {
                     wgt::BufferBindingType::Uniform => (
                         super::BufferViewKind::Constant,
-                        d3d12::D3D12_ROOT_PARAMETER_TYPE_CBV,
+                        d3d12_ty::D3D12_ROOT_PARAMETER_TYPE_CBV,
                         &mut bind_cbv,
                     ),
                     wgt::BufferBindingType::Storage { read_only: true } => (
                         super::BufferViewKind::ShaderResource,
-                        d3d12::D3D12_ROOT_PARAMETER_TYPE_SRV,
+                        d3d12_ty::D3D12_ROOT_PARAMETER_TYPE_SRV,
                         &mut bind_srv,
                     ),
                     wgt::BufferBindingType::Storage { read_only: false } => (
                         super::BufferViewKind::UnorderedAccess,
-                        d3d12::D3D12_ROOT_PARAMETER_TYPE_UAV,
+                        d3d12_ty::D3D12_ROOT_PARAMETER_TYPE_UAV,
                         &mut bind_uav,
                     ),
                 };
@@ -980,7 +980,7 @@ impl crate::Device<super::Api> for super::Device {
                     buffer_ty,
                     dynamic_buffers_visibility,
                 );
-                parameters.push(native::RootParameter::descriptor(
+                parameters.push(d3d12::RootParameter::descriptor(
                     parameter_ty,
                     dynamic_buffers_visibility,
                     native_binding(bt),
@@ -1001,8 +1001,8 @@ impl crate::Device<super::Api> for super::Device {
         ) {
             let parameter_index = parameters.len();
             log::debug!("\tParam[{}] = special", parameter_index);
-            parameters.push(native::RootParameter::constants(
-                native::ShaderVisibility::All, // really needed for VS and CS only
+            parameters.push(d3d12::RootParameter::constants(
+                d3d12::ShaderVisibility::All, // really needed for VS and CS only
                 native_binding(&bind_cbv),
                 3, // 0 = base vertex, 1 = base instance, 2 = other
             ));
@@ -1019,10 +1019,10 @@ impl crate::Device<super::Api> for super::Device {
         let (blob, error) = self
             .library
             .serialize_root_signature(
-                native::RootSignatureVersion::V1_0,
+                d3d12::RootSignatureVersion::V1_0,
                 &parameters,
                 &[],
-                native::RootSignatureFlags::ALLOW_IA_INPUT_LAYOUT,
+                d3d12::RootSignatureFlags::ALLOW_IA_INPUT_LAYOUT,
             )
             .map_err(|e| {
                 log::error!("Unable to find serialization function: {:?}", e);
@@ -1125,27 +1125,27 @@ impl crate::Device<super::Api> for super::Device {
                         match ty {
                             wgt::BufferBindingType::Uniform => {
                                 let size_mask =
-                                    d3d12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1;
-                                let raw_desc = d3d12::D3D12_CONSTANT_BUFFER_VIEW_DESC {
+                                    d3d12_ty::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1;
+                                let raw_desc = d3d12_ty::D3D12_CONSTANT_BUFFER_VIEW_DESC {
                                     BufferLocation: gpu_address,
                                     SizeInBytes: ((size - 1) | size_mask) + 1,
                                 };
                                 unsafe { self.raw.CreateConstantBufferView(&raw_desc, handle) };
                             }
                             wgt::BufferBindingType::Storage { read_only: true } => {
-                                let mut raw_desc = d3d12::D3D12_SHADER_RESOURCE_VIEW_DESC {
+                                let mut raw_desc = d3d12_ty::D3D12_SHADER_RESOURCE_VIEW_DESC {
                                     Format: dxgiformat::DXGI_FORMAT_R32_TYPELESS,
                                     Shader4ComponentMapping:
                                         view::D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
-                                    ViewDimension: d3d12::D3D12_SRV_DIMENSION_BUFFER,
+                                    ViewDimension: d3d12_ty::D3D12_SRV_DIMENSION_BUFFER,
                                     u: unsafe { mem::zeroed() },
                                 };
                                 unsafe {
-                                    *raw_desc.u.Buffer_mut() = d3d12::D3D12_BUFFER_SRV {
+                                    *raw_desc.u.Buffer_mut() = d3d12_ty::D3D12_BUFFER_SRV {
                                         FirstElement: data.offset / 4,
                                         NumElements: size / 4,
                                         StructureByteStride: 0,
-                                        Flags: d3d12::D3D12_BUFFER_SRV_FLAG_RAW,
+                                        Flags: d3d12_ty::D3D12_BUFFER_SRV_FLAG_RAW,
                                     }
                                 };
                                 unsafe {
@@ -1157,18 +1157,18 @@ impl crate::Device<super::Api> for super::Device {
                                 };
                             }
                             wgt::BufferBindingType::Storage { read_only: false } => {
-                                let mut raw_desc = d3d12::D3D12_UNORDERED_ACCESS_VIEW_DESC {
+                                let mut raw_desc = d3d12_ty::D3D12_UNORDERED_ACCESS_VIEW_DESC {
                                     Format: dxgiformat::DXGI_FORMAT_R32_TYPELESS,
-                                    ViewDimension: d3d12::D3D12_UAV_DIMENSION_BUFFER,
+                                    ViewDimension: d3d12_ty::D3D12_UAV_DIMENSION_BUFFER,
                                     u: unsafe { mem::zeroed() },
                                 };
                                 unsafe {
-                                    *raw_desc.u.Buffer_mut() = d3d12::D3D12_BUFFER_UAV {
+                                    *raw_desc.u.Buffer_mut() = d3d12_ty::D3D12_BUFFER_UAV {
                                         FirstElement: data.offset / 4,
                                         NumElements: size / 4,
                                         StructureByteStride: 0,
                                         CounterOffsetInBytes: 0,
-                                        Flags: d3d12::D3D12_BUFFER_UAV_FLAG_RAW,
+                                        Flags: d3d12_ty::D3D12_BUFFER_UAV_FLAG_RAW,
                                     }
                                 };
                                 unsafe {
@@ -1298,14 +1298,14 @@ impl crate::Device<super::Api> for super::Device {
             *stride = NonZeroU32::new(vbuf.array_stride as u32);
             let (slot_class, step_rate) = match vbuf.step_mode {
                 wgt::VertexStepMode::Vertex => {
-                    (d3d12::D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0)
+                    (d3d12_ty::D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0)
                 }
                 wgt::VertexStepMode::Instance => {
-                    (d3d12::D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA, 1)
+                    (d3d12_ty::D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA, 1)
                 }
             };
             for attribute in vbuf.attributes {
-                input_element_descs.push(d3d12::D3D12_INPUT_ELEMENT_DESC {
+                input_element_descs.push(d3d12_ty::D3D12_INPUT_ELEMENT_DESC {
                     SemanticName: NAGA_LOCATION_SEMANTIC.as_ptr() as *const _,
                     SemanticIndex: attribute.shader_location,
                     Format: auxil::dxgi::conv::map_vertex_format(attribute.format),
@@ -1318,7 +1318,7 @@ impl crate::Device<super::Api> for super::Device {
         }
 
         let mut rtv_formats = [dxgiformat::DXGI_FORMAT_UNKNOWN;
-            d3d12::D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT as usize];
+            d3d12_ty::D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT as usize];
         for (rtv_format, ct) in rtv_formats.iter_mut().zip(desc.color_targets) {
             if let Some(ct) = ct.as_ref() {
                 *rtv_format = auxil::dxgi::conv::map_texture_format(ct.format);
@@ -1331,12 +1331,12 @@ impl crate::Device<super::Api> for super::Device {
             .map(|ds| ds.bias)
             .unwrap_or_default();
 
-        let raw_rasterizer = d3d12::D3D12_RASTERIZER_DESC {
+        let raw_rasterizer = d3d12_ty::D3D12_RASTERIZER_DESC {
             FillMode: conv::map_polygon_mode(desc.primitive.polygon_mode),
             CullMode: match desc.primitive.cull_mode {
-                None => d3d12::D3D12_CULL_MODE_NONE,
-                Some(wgt::Face::Front) => d3d12::D3D12_CULL_MODE_FRONT,
-                Some(wgt::Face::Back) => d3d12::D3D12_CULL_MODE_BACK,
+                None => d3d12_ty::D3D12_CULL_MODE_NONE,
+                Some(wgt::Face::Front) => d3d12_ty::D3D12_CULL_MODE_FRONT,
+                Some(wgt::Face::Back) => d3d12_ty::D3D12_CULL_MODE_BACK,
             },
             FrontCounterClockwise: match desc.primitive.front_face {
                 wgt::FrontFace::Cw => 0,
@@ -1350,30 +1350,30 @@ impl crate::Device<super::Api> for super::Device {
             ForcedSampleCount: 0,
             AntialiasedLineEnable: 0,
             ConservativeRaster: if desc.primitive.conservative {
-                d3d12::D3D12_CONSERVATIVE_RASTERIZATION_MODE_ON
+                d3d12_ty::D3D12_CONSERVATIVE_RASTERIZATION_MODE_ON
             } else {
-                d3d12::D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF
+                d3d12_ty::D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF
             },
         };
 
-        let raw_desc = d3d12::D3D12_GRAPHICS_PIPELINE_STATE_DESC {
+        let raw_desc = d3d12_ty::D3D12_GRAPHICS_PIPELINE_STATE_DESC {
             pRootSignature: desc.layout.shared.signature.as_mut_ptr(),
             VS: *blob_vs.create_native_shader(),
             PS: match blob_fs {
                 Some(ref shader) => *shader.create_native_shader(),
-                None => *native::Shader::null(),
+                None => *d3d12::Shader::null(),
             },
-            GS: *native::Shader::null(),
-            DS: *native::Shader::null(),
-            HS: *native::Shader::null(),
-            StreamOutput: d3d12::D3D12_STREAM_OUTPUT_DESC {
+            GS: *d3d12::Shader::null(),
+            DS: *d3d12::Shader::null(),
+            HS: *d3d12::Shader::null(),
+            StreamOutput: d3d12_ty::D3D12_STREAM_OUTPUT_DESC {
                 pSODeclaration: ptr::null(),
                 NumEntries: 0,
                 pBufferStrides: ptr::null(),
                 NumStrides: 0,
                 RasterizedStream: 0,
             },
-            BlendState: d3d12::D3D12_BLEND_DESC {
+            BlendState: d3d12_ty::D3D12_BLEND_DESC {
                 AlphaToCoverageEnable: BOOL::from(desc.multisample.alpha_to_coverage_enabled),
                 IndependentBlendEnable: 1,
                 RenderTarget: conv::map_render_targets(desc.color_targets),
@@ -1384,7 +1384,7 @@ impl crate::Device<super::Api> for super::Device {
                 Some(ref ds) => conv::map_depth_stencil(ds),
                 None => unsafe { mem::zeroed() },
             },
-            InputLayout: d3d12::D3D12_INPUT_LAYOUT_DESC {
+            InputLayout: d3d12_ty::D3D12_INPUT_LAYOUT_DESC {
                 pInputElementDescs: if input_element_descs.is_empty() {
                     ptr::null()
                 } else {
@@ -1393,11 +1393,13 @@ impl crate::Device<super::Api> for super::Device {
                 NumElements: input_element_descs.len() as u32,
             },
             IBStripCutValue: match desc.primitive.strip_index_format {
-                Some(wgt::IndexFormat::Uint16) => d3d12::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFF,
-                Some(wgt::IndexFormat::Uint32) => {
-                    d3d12::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFFFFFF
+                Some(wgt::IndexFormat::Uint16) => {
+                    d3d12_ty::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFF
                 }
-                None => d3d12::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_DISABLED,
+                Some(wgt::IndexFormat::Uint32) => {
+                    d3d12_ty::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFFFFFF
+                }
+                None => d3d12_ty::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_DISABLED,
             },
             PrimitiveTopologyType: topology_class,
             NumRenderTargets: desc.color_targets.len() as u32,
@@ -1413,20 +1415,20 @@ impl crate::Device<super::Api> for super::Device {
                 Quality: 0,
             },
             NodeMask: 0,
-            CachedPSO: d3d12::D3D12_CACHED_PIPELINE_STATE {
+            CachedPSO: d3d12_ty::D3D12_CACHED_PIPELINE_STATE {
                 pCachedBlob: ptr::null(),
                 CachedBlobSizeInBytes: 0,
             },
-            Flags: d3d12::D3D12_PIPELINE_STATE_FLAG_NONE,
+            Flags: d3d12_ty::D3D12_PIPELINE_STATE_FLAG_NONE,
         };
 
-        let mut raw = native::PipelineState::null();
+        let mut raw = d3d12::PipelineState::null();
         let hr = {
             profiling::scope!("ID3D12Device::CreateGraphicsPipelineState");
             unsafe {
                 self.raw.CreateGraphicsPipelineState(
                     &raw_desc,
-                    &d3d12::ID3D12PipelineState::uuidof(),
+                    &d3d12_ty::ID3D12PipelineState::uuidof(),
                     raw.mut_void(),
                 )
             }
@@ -1468,8 +1470,8 @@ impl crate::Device<super::Api> for super::Device {
                 desc.layout.shared.signature,
                 blob_cs.create_native_shader(),
                 0,
-                native::CachedPSO::null(),
-                native::PipelineStateFlags::empty(),
+                d3d12::CachedPSO::null(),
+                d3d12::PipelineStateFlags::empty(),
             )
         };
 
@@ -1499,16 +1501,16 @@ impl crate::Device<super::Api> for super::Device {
     ) -> Result<super::QuerySet, crate::DeviceError> {
         let (heap_ty, raw_ty) = match desc.ty {
             wgt::QueryType::Occlusion => (
-                native::QueryHeapType::Occlusion,
-                d3d12::D3D12_QUERY_TYPE_BINARY_OCCLUSION,
+                d3d12::QueryHeapType::Occlusion,
+                d3d12_ty::D3D12_QUERY_TYPE_BINARY_OCCLUSION,
             ),
             wgt::QueryType::PipelineStatistics(_) => (
-                native::QueryHeapType::PipelineStatistics,
-                d3d12::D3D12_QUERY_TYPE_PIPELINE_STATISTICS,
+                d3d12::QueryHeapType::PipelineStatistics,
+                d3d12_ty::D3D12_QUERY_TYPE_PIPELINE_STATISTICS,
             ),
             wgt::QueryType::Timestamp => (
-                native::QueryHeapType::Timestamp,
-                d3d12::D3D12_QUERY_TYPE_TIMESTAMP,
+                d3d12::QueryHeapType::Timestamp,
+                d3d12_ty::D3D12_QUERY_TYPE_TIMESTAMP,
             ),
         };
 
@@ -1529,12 +1531,12 @@ impl crate::Device<super::Api> for super::Device {
     }
 
     unsafe fn create_fence(&self) -> Result<super::Fence, crate::DeviceError> {
-        let mut raw = native::Fence::null();
+        let mut raw = d3d12::Fence::null();
         let hr = unsafe {
             self.raw.CreateFence(
                 0,
-                d3d12::D3D12_FENCE_FLAG_NONE,
-                &d3d12::ID3D12Fence::uuidof(),
+                d3d12_ty::D3D12_FENCE_FLAG_NONE,
+                &d3d12_ty::ID3D12Fence::uuidof(),
                 raw.mut_void(),
             )
         };

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -13,7 +13,7 @@ impl Drop for super::Instance {
 
 impl crate::Instance<super::Api> for super::Instance {
     unsafe fn init(desc: &crate::InstanceDescriptor) -> Result<Self, crate::InstanceError> {
-        let lib_main = native::D3D12Lib::new().map_err(|_| crate::InstanceError)?;
+        let lib_main = d3d12::D3D12Lib::new().map_err(|_| crate::InstanceError)?;
 
         if desc.flags.contains(crate::InstanceFlags::VALIDATION) {
             // Enable debug layer

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -50,7 +50,7 @@ use parking_lot::Mutex;
 use std::{ffi, fmt, mem, num::NonZeroU32, sync::Arc};
 use winapi::{
     shared::{dxgi, dxgi1_4, dxgitype, windef, winerror},
-    um::{d3d12, dcomp, synchapi, winbase, winnt},
+    um::{d3d12 as d3d12_ty, dcomp, synchapi, winbase, winnt},
     Interface as _,
 };
 
@@ -88,11 +88,11 @@ const MAX_ROOT_ELEMENTS: usize = 64;
 const ZERO_BUFFER_SIZE: wgt::BufferAddress = 256 << 10;
 
 pub struct Instance {
-    factory: native::DxgiFactory,
-    factory_media: Option<native::FactoryMedia>,
-    library: Arc<native::D3D12Lib>,
+    factory: d3d12::DxgiFactory,
+    factory_media: Option<d3d12::FactoryMedia>,
+    library: Arc<d3d12::D3D12Lib>,
     supports_allow_tearing: bool,
-    _lib_dxgi: native::DxgiLib,
+    _lib_dxgi: d3d12::DxgiLib,
     flags: crate::InstanceFlags,
     dx12_shader_compiler: wgt::Dx12Compiler,
 }
@@ -105,7 +105,7 @@ impl Instance {
         Surface {
             factory: self.factory,
             factory_media: self.factory_media,
-            target: SurfaceTarget::Visual(unsafe { native::WeakPtr::from_raw(visual) }),
+            target: SurfaceTarget::Visual(unsafe { d3d12::WeakPtr::from_raw(visual) }),
             supports_allow_tearing: self.supports_allow_tearing,
             swap_chain: None,
         }
@@ -129,10 +129,10 @@ unsafe impl Send for Instance {}
 unsafe impl Sync for Instance {}
 
 struct SwapChain {
-    raw: native::WeakPtr<dxgi1_4::IDXGISwapChain3>,
+    raw: d3d12::WeakPtr<dxgi1_4::IDXGISwapChain3>,
     // need to associate raw image pointers with the swapchain so they can be properly released
     // when the swapchain is destroyed
-    resources: Vec<native::Resource>,
+    resources: Vec<d3d12::Resource>,
     waitable: winnt::HANDLE,
     acquired_count: usize,
     present_mode: wgt::PresentMode,
@@ -142,13 +142,13 @@ struct SwapChain {
 
 enum SurfaceTarget {
     WndHandle(windef::HWND),
-    Visual(native::WeakPtr<dcomp::IDCompositionVisual>),
+    Visual(d3d12::WeakPtr<dcomp::IDCompositionVisual>),
     SurfaceHandle(winnt::HANDLE),
 }
 
 pub struct Surface {
-    factory: native::DxgiFactory,
-    factory_media: Option<native::FactoryMedia>,
+    factory: d3d12::DxgiFactory,
+    factory_media: Option<d3d12::FactoryMedia>,
     target: SurfaceTarget,
     supports_allow_tearing: bool,
     swap_chain: Option<SwapChain>,
@@ -184,9 +184,9 @@ struct Workarounds {
 }
 
 pub struct Adapter {
-    raw: native::DxgiAdapter,
-    device: native::Device,
-    library: Arc<native::D3D12Lib>,
+    raw: d3d12::DxgiAdapter,
+    device: d3d12::Device,
+    library: Arc<d3d12::D3D12Lib>,
     private_caps: PrivateCapabilities,
     presentation_timer: auxil::dxgi::time::PresentationTimer,
     //Note: this isn't used right now, but we'll need it later.
@@ -200,8 +200,8 @@ unsafe impl Sync for Adapter {}
 
 /// Helper structure for waiting for GPU.
 struct Idler {
-    fence: native::Fence,
-    event: native::Event,
+    fence: d3d12::Fence,
+    event: d3d12::Event,
 }
 
 impl Idler {
@@ -211,9 +211,9 @@ impl Idler {
 }
 
 struct CommandSignatures {
-    draw: native::CommandSignature,
-    draw_indexed: native::CommandSignature,
-    dispatch: native::CommandSignature,
+    draw: d3d12::CommandSignature,
+    draw_indexed: d3d12::CommandSignature,
+    dispatch: d3d12::CommandSignature,
 }
 
 impl CommandSignatures {
@@ -227,7 +227,7 @@ impl CommandSignatures {
 }
 
 struct DeviceShared {
-    zero_buffer: native::Resource,
+    zero_buffer: d3d12::Resource,
     cmd_signatures: CommandSignatures,
     heap_views: descriptor::GeneralHeap,
     heap_samplers: descriptor::GeneralHeap,
@@ -245,8 +245,8 @@ impl DeviceShared {
 }
 
 pub struct Device {
-    raw: native::Device,
-    present_queue: native::CommandQueue,
+    raw: d3d12::Device,
+    present_queue: d3d12::CommandQueue,
     idler: Idler,
     private_caps: PrivateCapabilities,
     shared: Arc<DeviceShared>,
@@ -256,7 +256,7 @@ pub struct Device {
     srv_uav_pool: Mutex<descriptor::CpuPool>,
     sampler_pool: Mutex<descriptor::CpuPool>,
     // library
-    library: Arc<native::D3D12Lib>,
+    library: Arc<d3d12::D3D12Lib>,
     #[cfg(feature = "renderdoc")]
     render_doc: crate::auxil::renderdoc::RenderDoc,
     null_rtv_handle: descriptor::Handle,
@@ -268,8 +268,8 @@ unsafe impl Send for Device {}
 unsafe impl Sync for Device {}
 
 pub struct Queue {
-    raw: native::CommandQueue,
-    temp_lists: Vec<native::CommandList>,
+    raw: d3d12::CommandQueue,
+    temp_lists: Vec<d3d12::CommandList>,
 }
 
 unsafe impl Send for Queue {}
@@ -278,7 +278,7 @@ unsafe impl Sync for Queue {}
 #[derive(Default)]
 struct Temp {
     marker: Vec<u16>,
-    barriers: Vec<d3d12::D3D12_RESOURCE_BARRIER>,
+    barriers: Vec<d3d12_ty::D3D12_RESOURCE_BARRIER>,
 }
 
 impl Temp {
@@ -289,9 +289,9 @@ impl Temp {
 }
 
 struct PassResolve {
-    src: (native::Resource, u32),
-    dst: (native::Resource, u32),
-    format: native::Format,
+    src: (d3d12::Resource, u32),
+    dst: (d3d12::Resource, u32),
+    format: d3d12::Format,
 }
 
 #[derive(Clone, Copy)]
@@ -304,11 +304,11 @@ enum RootElement {
         other: u32,
     },
     /// Descriptor table.
-    Table(native::GpuDescriptor),
+    Table(d3d12::GpuDescriptor),
     /// Descriptor for a buffer that has dynamic offset.
     DynamicOffsetBuffer {
         kind: BufferViewKind,
-        address: native::GpuAddress,
+        address: d3d12::GpuAddress,
     },
 }
 
@@ -326,7 +326,7 @@ struct PassState {
     root_elements: [RootElement; MAX_ROOT_ELEMENTS],
     constant_data: [u32; MAX_ROOT_ELEMENTS],
     dirty_root_elements: u64,
-    vertex_buffers: [d3d12::D3D12_VERTEX_BUFFER_VIEW; crate::MAX_VERTEX_BUFFERS],
+    vertex_buffers: [d3d12_ty::D3D12_VERTEX_BUFFER_VIEW; crate::MAX_VERTEX_BUFFERS],
     dirty_vertex_buffers: usize,
     kind: PassKind,
 }
@@ -342,7 +342,7 @@ impl PassState {
             has_label: false,
             resolves: ArrayVec::new(),
             layout: PipelineLayoutShared {
-                signature: native::RootSignature::null(),
+                signature: d3d12::RootSignature::null(),
                 total_root_elements: 0,
                 special_constants_root_index: None,
                 root_constant_info: None,
@@ -363,12 +363,12 @@ impl PassState {
 }
 
 pub struct CommandEncoder {
-    allocator: native::CommandAllocator,
-    device: native::Device,
+    allocator: d3d12::CommandAllocator,
+    device: d3d12::Device,
     shared: Arc<DeviceShared>,
     null_rtv_handle: descriptor::Handle,
-    list: Option<native::GraphicsCommandList>,
-    free_lists: Vec<native::GraphicsCommandList>,
+    list: Option<d3d12::GraphicsCommandList>,
+    free_lists: Vec<d3d12::GraphicsCommandList>,
     pass: PassState,
     temp: Temp,
 }
@@ -387,7 +387,7 @@ impl fmt::Debug for CommandEncoder {
 
 #[derive(Debug)]
 pub struct CommandBuffer {
-    raw: native::GraphicsCommandList,
+    raw: d3d12::GraphicsCommandList,
     closed: bool,
 }
 
@@ -396,7 +396,7 @@ unsafe impl Sync for CommandBuffer {}
 
 #[derive(Debug)]
 pub struct Buffer {
-    resource: native::Resource,
+    resource: d3d12::Resource,
     size: wgt::BufferAddress,
     allocation: Option<suballocation::AllocationWrapper>,
 }
@@ -419,7 +419,7 @@ impl crate::BufferBinding<'_, Api> {
 
 #[derive(Debug)]
 pub struct Texture {
-    resource: native::Resource,
+    resource: d3d12::Resource,
     format: wgt::TextureFormat,
     dimension: wgt::TextureDimension,
     size: wgt::Extent3d,
@@ -456,9 +456,9 @@ impl Texture {
 
 #[derive(Debug)]
 pub struct TextureView {
-    raw_format: native::Format,
+    raw_format: d3d12::Format,
     aspects: crate::FormatAspects,
-    target_base: (native::Resource, u32),
+    target_base: (d3d12::Resource, u32),
     handle_srv: Option<descriptor::Handle>,
     handle_uav: Option<descriptor::Handle>,
     handle_rtv: Option<descriptor::Handle>,
@@ -479,8 +479,8 @@ unsafe impl Sync for Sampler {}
 
 #[derive(Debug)]
 pub struct QuerySet {
-    raw: native::QueryHeap,
-    raw_ty: d3d12::D3D12_QUERY_TYPE,
+    raw: d3d12::QueryHeap,
+    raw_ty: d3d12_ty::D3D12_QUERY_TYPE,
 }
 
 unsafe impl Send for QuerySet {}
@@ -488,7 +488,7 @@ unsafe impl Sync for QuerySet {}
 
 #[derive(Debug)]
 pub struct Fence {
-    raw: native::Fence,
+    raw: d3d12::Fence,
 }
 
 unsafe impl Send for Fence {}
@@ -513,7 +513,7 @@ enum BufferViewKind {
 pub struct BindGroup {
     handle_views: Option<descriptor::DualHandle>,
     handle_samplers: Option<descriptor::DualHandle>,
-    dynamic_buffers: Vec<native::GpuAddress>,
+    dynamic_buffers: Vec<d3d12::GpuAddress>,
 }
 
 bitflags::bitflags! {
@@ -540,7 +540,7 @@ struct RootConstantInfo {
 
 #[derive(Clone)]
 struct PipelineLayoutShared {
-    signature: native::RootSignature,
+    signature: d3d12::RootSignature,
     total_root_elements: RootIndex,
     special_constants_root_index: Option<RootIndex>,
     root_constant_info: Option<RootConstantInfo>,
@@ -566,14 +566,14 @@ pub struct ShaderModule {
 pub(super) enum CompiledShader {
     #[allow(unused)]
     Dxc(Vec<u8>),
-    Fxc(native::Blob),
+    Fxc(d3d12::Blob),
 }
 
 impl CompiledShader {
-    fn create_native_shader(&self) -> native::Shader {
+    fn create_native_shader(&self) -> d3d12::Shader {
         match *self {
-            CompiledShader::Dxc(ref shader) => native::Shader::from_raw(shader),
-            CompiledShader::Fxc(shader) => native::Shader::from_blob(shader),
+            CompiledShader::Dxc(ref shader) => d3d12::Shader::from_raw(shader),
+            CompiledShader::Fxc(shader) => d3d12::Shader::from_blob(shader),
         }
     }
 
@@ -588,9 +588,9 @@ impl CompiledShader {
 }
 
 pub struct RenderPipeline {
-    raw: native::PipelineState,
+    raw: d3d12::PipelineState,
     layout: PipelineLayoutShared,
-    topology: d3d12::D3D12_PRIMITIVE_TOPOLOGY,
+    topology: d3d12_ty::D3D12_PRIMITIVE_TOPOLOGY,
     vertex_strides: [Option<NonZeroU32>; crate::MAX_VERTEX_BUFFERS],
 }
 
@@ -598,7 +598,7 @@ unsafe impl Send for RenderPipeline {}
 unsafe impl Sync for RenderPipeline {}
 
 pub struct ComputePipeline {
-    raw: native::PipelineState,
+    raw: d3d12::PipelineState,
     layout: PipelineLayoutShared,
 }
 
@@ -606,7 +606,7 @@ unsafe impl Send for ComputePipeline {}
 unsafe impl Sync for ComputePipeline {}
 
 impl SwapChain {
-    unsafe fn release_resources(self) -> native::WeakPtr<dxgi1_4::IDXGISwapChain3> {
+    unsafe fn release_resources(self) -> d3d12::WeakPtr<dxgi1_4::IDXGISwapChain3> {
         for resource in self.resources {
             unsafe { resource.destroy() };
         }
@@ -672,7 +672,7 @@ impl crate::Surface<Api> for Surface {
                 raw
             }
             None => {
-                let desc = native::SwapchainDesc {
+                let desc = d3d12::SwapchainDesc {
                     alpha_mode: auxil::dxgi::conv::map_acomposite_alpha_mode(
                         config.composite_alpha_mode,
                     ),
@@ -680,14 +680,14 @@ impl crate::Surface<Api> for Surface {
                     height: config.extent.height,
                     format: non_srgb_format,
                     stereo: false,
-                    sample: native::SampleDesc {
+                    sample: d3d12::SampleDesc {
                         count: 1,
                         quality: 0,
                     },
                     buffer_usage: dxgitype::DXGI_USAGE_RENDER_TARGET_OUTPUT,
                     buffer_count: config.swap_chain_size,
-                    scaling: native::Scaling::Stretch,
-                    swap_effect: native::SwapEffect::FlipDiscard,
+                    scaling: d3d12::Scaling::Stretch,
+                    swap_effect: d3d12::SwapEffect::FlipDiscard,
                     flags,
                 };
                 let swap_chain1 = match self.target {
@@ -781,10 +781,10 @@ impl crate::Surface<Api> for Surface {
         unsafe { swap_chain.SetMaximumFrameLatency(config.swap_chain_size) };
         let waitable = unsafe { swap_chain.GetFrameLatencyWaitableObject() };
 
-        let mut resources = vec![native::Resource::null(); config.swap_chain_size as usize];
+        let mut resources = vec![d3d12::Resource::null(); config.swap_chain_size as usize];
         for (i, res) in resources.iter_mut().enumerate() {
             unsafe {
-                swap_chain.GetBuffer(i as _, &d3d12::ID3D12Resource::uuidof(), res.mut_void())
+                swap_chain.GetBuffer(i as _, &d3d12_ty::ID3D12Resource::uuidof(), res.mut_void())
             };
         }
 

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -23,7 +23,7 @@ pub(super) fn compile_fxc(
     log::Level,
 ) {
     profiling::scope!("compile_fxc");
-    let mut shader_data = native::Blob::null();
+    let mut shader_data = d3d12::Blob::null();
     let mut compile_flags = d3dcompiler::D3DCOMPILE_ENABLE_STRICTNESS;
     if device
         .private_caps
@@ -32,7 +32,7 @@ pub(super) fn compile_fxc(
     {
         compile_flags |= d3dcompiler::D3DCOMPILE_DEBUG | d3dcompiler::D3DCOMPILE_SKIP_OPTIMIZATION;
     }
-    let mut error = native::Blob::null();
+    let mut error = d3d12::Blob::null();
     let hr = unsafe {
         profiling::scope!("d3dcompiler::D3DCompile");
         d3dcompiler::D3DCompile(

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -11,13 +11,13 @@ pub(crate) use allocation::{
 // This is the fast path using gpu_allocator to suballocate buffers and textures.
 #[cfg(feature = "windows_rs")]
 mod allocation {
-    use native::WeakPtr;
+    use d3d12::WeakPtr;
     use parking_lot::Mutex;
     use std::ptr;
     use wgt::assertions::StrictAssertUnwrapExt;
     use winapi::{
         um::{
-            d3d12::{self, ID3D12Resource},
+            d3d12::{self as d3d12_ty, ID3D12Resource},
             winnt::HRESULT,
         },
         Interface,
@@ -39,7 +39,7 @@ mod allocation {
     }
 
     pub(crate) fn create_allocator_wrapper(
-        raw: &native::Device,
+        raw: &d3d12::Device,
     ) -> Result<Option<Mutex<GpuAllocatorWrapper>>, crate::DeviceError> {
         let device = raw.as_ptr();
 
@@ -58,7 +58,7 @@ mod allocation {
     pub(crate) fn create_buffer_resource(
         device: &crate::dx12::Device,
         desc: &crate::BufferDescriptor,
-        raw_desc: d3d12::D3D12_RESOURCE_DESC,
+        raw_desc: d3d12_ty::D3D12_RESOURCE_DESC,
         resource: &mut WeakPtr<ID3D12Resource>,
     ) -> Result<(HRESULT, Option<AllocationWrapper>), crate::DeviceError> {
         let is_cpu_read = desc.usage.contains(crate::BufferUses::MAP_READ);
@@ -95,9 +95,9 @@ mod allocation {
                 allocation.heap().as_winapi() as *mut _,
                 allocation.offset(),
                 &raw_desc,
-                d3d12::D3D12_RESOURCE_STATE_COMMON,
+                d3d12_ty::D3D12_RESOURCE_STATE_COMMON,
                 ptr::null(),
-                &d3d12::ID3D12Resource::uuidof(),
+                &d3d12_ty::ID3D12Resource::uuidof(),
                 resource.mut_void(),
             )
         };
@@ -108,7 +108,7 @@ mod allocation {
     pub(crate) fn create_texture_resource(
         device: &crate::dx12::Device,
         desc: &crate::TextureDescriptor,
-        raw_desc: d3d12::D3D12_RESOURCE_DESC,
+        raw_desc: d3d12_ty::D3D12_RESOURCE_DESC,
         resource: &mut WeakPtr<ID3D12Resource>,
     ) -> Result<(HRESULT, Option<AllocationWrapper>), crate::DeviceError> {
         let location = MemoryLocation::GpuOnly;
@@ -136,9 +136,9 @@ mod allocation {
                 allocation.heap().as_winapi() as *mut _,
                 allocation.offset(),
                 &raw_desc,
-                d3d12::D3D12_RESOURCE_STATE_COMMON,
+                d3d12_ty::D3D12_RESOURCE_STATE_COMMON,
                 ptr::null(), // clear value
-                &d3d12::ID3D12Resource::uuidof(),
+                &d3d12_ty::ID3D12Resource::uuidof(),
                 resource.mut_void(),
             )
         };
@@ -205,18 +205,18 @@ mod allocation {
 // Tracking issue for when it can be removed: https://github.com/gfx-rs/wgpu/issues/3207
 #[cfg(not(feature = "windows_rs"))]
 mod allocation {
-    use native::WeakPtr;
+    use d3d12::WeakPtr;
     use parking_lot::Mutex;
     use std::ptr;
     use winapi::{
         um::{
-            d3d12::{self, ID3D12Resource},
+            d3d12_ty::{self, ID3D12Resource},
             winnt::HRESULT,
         },
         Interface,
     };
 
-    const D3D12_HEAP_FLAG_CREATE_NOT_ZEROED: u32 = d3d12::D3D12_HEAP_FLAG_NONE; // TODO: find the exact value
+    const D3D12_HEAP_FLAG_CREATE_NOT_ZEROED: u32 = d3d12_ty::D3D12_HEAP_FLAG_NONE; // TODO: find the exact value
 
     // Allocator isn't needed when not suballocating with gpu_allocator
     #[derive(Debug)]
@@ -227,7 +227,7 @@ mod allocation {
     pub(crate) struct AllocationWrapper {}
 
     pub(crate) fn create_allocator_wrapper(
-        _raw: &native::Device,
+        _raw: &d3d12::Device,
     ) -> Result<Option<Mutex<GpuAllocatorWrapper>>, crate::DeviceError> {
         Ok(None)
     }
@@ -235,26 +235,26 @@ mod allocation {
     pub(crate) fn create_buffer_resource(
         device: &crate::dx12::Device,
         desc: &crate::BufferDescriptor,
-        raw_desc: d3d12::D3D12_RESOURCE_DESC,
+        raw_desc: d3d12_ty::D3D12_RESOURCE_DESC,
         resource: &mut WeakPtr<ID3D12Resource>,
     ) -> Result<(HRESULT, Option<AllocationWrapper>), crate::DeviceError> {
         let is_cpu_read = desc.usage.contains(crate::BufferUses::MAP_READ);
         let is_cpu_write = desc.usage.contains(crate::BufferUses::MAP_WRITE);
 
-        let heap_properties = d3d12::D3D12_HEAP_PROPERTIES {
-            Type: d3d12::D3D12_HEAP_TYPE_CUSTOM,
+        let heap_properties = d3d12_ty::D3D12_HEAP_PROPERTIES {
+            Type: d3d12_ty::D3D12_HEAP_TYPE_CUSTOM,
             CPUPageProperty: if is_cpu_read {
-                d3d12::D3D12_CPU_PAGE_PROPERTY_WRITE_BACK
+                d3d12_ty::D3D12_CPU_PAGE_PROPERTY_WRITE_BACK
             } else if is_cpu_write {
-                d3d12::D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE
+                d3d12_ty::D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE
             } else {
-                d3d12::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE
+                d3d12_ty::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE
             },
             MemoryPoolPreference: match device.private_caps.memory_architecture {
                 crate::dx12::MemoryArchitecture::NonUnified if !is_cpu_read && !is_cpu_write => {
-                    d3d12::D3D12_MEMORY_POOL_L1
+                    d3d12_ty::D3D12_MEMORY_POOL_L1
                 }
-                _ => d3d12::D3D12_MEMORY_POOL_L0,
+                _ => d3d12_ty::D3D12_MEMORY_POOL_L0,
             },
             CreationNodeMask: 0,
             VisibleNodeMask: 0,
@@ -266,12 +266,12 @@ mod allocation {
                 if device.private_caps.heap_create_not_zeroed {
                     D3D12_HEAP_FLAG_CREATE_NOT_ZEROED
                 } else {
-                    d3d12::D3D12_HEAP_FLAG_NONE
+                    d3d12_ty::D3D12_HEAP_FLAG_NONE
                 },
                 &raw_desc,
-                d3d12::D3D12_RESOURCE_STATE_COMMON,
+                d3d12_ty::D3D12_RESOURCE_STATE_COMMON,
                 ptr::null(),
-                &d3d12::ID3D12Resource::uuidof(),
+                &d3d12_ty::ID3D12Resource::uuidof(),
                 resource.mut_void(),
             )
         };
@@ -282,15 +282,15 @@ mod allocation {
     pub(crate) fn create_texture_resource(
         device: &crate::dx12::Device,
         _desc: &crate::TextureDescriptor,
-        raw_desc: d3d12::D3D12_RESOURCE_DESC,
+        raw_desc: d3d12_ty::D3D12_RESOURCE_DESC,
         resource: &mut WeakPtr<ID3D12Resource>,
     ) -> Result<(HRESULT, Option<AllocationWrapper>), crate::DeviceError> {
-        let heap_properties = d3d12::D3D12_HEAP_PROPERTIES {
-            Type: d3d12::D3D12_HEAP_TYPE_CUSTOM,
-            CPUPageProperty: d3d12::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE,
+        let heap_properties = d3d12_ty::D3D12_HEAP_PROPERTIES {
+            Type: d3d12_ty::D3D12_HEAP_TYPE_CUSTOM,
+            CPUPageProperty: d3d12_ty::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE,
             MemoryPoolPreference: match device.private_caps.memory_architecture {
-                crate::dx12::MemoryArchitecture::NonUnified => d3d12::D3D12_MEMORY_POOL_L1,
-                crate::dx12::MemoryArchitecture::Unified { .. } => d3d12::D3D12_MEMORY_POOL_L0,
+                crate::dx12::MemoryArchitecture::NonUnified => d3d12_ty::D3D12_MEMORY_POOL_L1,
+                crate::dx12::MemoryArchitecture::Unified { .. } => d3d12_ty::D3D12_MEMORY_POOL_L0,
             },
             CreationNodeMask: 0,
             VisibleNodeMask: 0,
@@ -302,12 +302,12 @@ mod allocation {
                 if device.private_caps.heap_create_not_zeroed {
                     D3D12_HEAP_FLAG_CREATE_NOT_ZEROED
                 } else {
-                    d3d12::D3D12_HEAP_FLAG_NONE
+                    d3d12_ty::D3D12_HEAP_FLAG_NONE
                 },
                 &raw_desc,
-                d3d12::D3D12_RESOURCE_STATE_COMMON,
+                d3d12_ty::D3D12_RESOURCE_STATE_COMMON,
                 ptr::null(), // clear value
-                &d3d12::ID3D12Resource::uuidof(),
+                &d3d12_ty::ID3D12Resource::uuidof(),
                 resource.mut_void(),
             )
         };

--- a/wgpu-hal/src/dx12/view.rs
+++ b/wgpu-hal/src/dx12/view.rs
@@ -1,14 +1,14 @@
 use crate::auxil;
 use std::mem;
-use winapi::um::d3d12;
+use winapi::um::d3d12 as d3d12_ty;
 
 pub(crate) const D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING: u32 = 0x1688;
 
 pub(super) struct ViewDescriptor {
     dimension: wgt::TextureViewDimension,
     pub aspects: crate::FormatAspects,
-    pub rtv_dsv_format: native::Format,
-    srv_uav_format: Option<native::Format>,
+    pub rtv_dsv_format: d3d12::Format,
+    srv_uav_format: Option<d3d12::Format>,
     multisampled: bool,
     array_layer_base: u32,
     array_layer_count: u32,
@@ -35,8 +35,8 @@ impl crate::TextureViewDescriptor<'_> {
 }
 
 impl ViewDescriptor {
-    pub(crate) unsafe fn to_srv(&self) -> Option<d3d12::D3D12_SHADER_RESOURCE_VIEW_DESC> {
-        let mut desc = d3d12::D3D12_SHADER_RESOURCE_VIEW_DESC {
+    pub(crate) unsafe fn to_srv(&self) -> Option<d3d12_ty::D3D12_SHADER_RESOURCE_VIEW_DESC> {
+        let mut desc = d3d12_ty::D3D12_SHADER_RESOURCE_VIEW_DESC {
             Format: self.srv_uav_format?,
             ViewDimension: 0,
             Shader4ComponentMapping: D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
@@ -45,9 +45,9 @@ impl ViewDescriptor {
 
         match self.dimension {
             wgt::TextureViewDimension::D1 => {
-                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE1D;
+                desc.ViewDimension = d3d12_ty::D3D12_SRV_DIMENSION_TEXTURE1D;
                 unsafe {
-                    *desc.u.Texture1D_mut() = d3d12::D3D12_TEX1D_SRV {
+                    *desc.u.Texture1D_mut() = d3d12_ty::D3D12_TEX1D_SRV {
                         MostDetailedMip: self.mip_level_base,
                         MipLevels: self.mip_level_count,
                         ResourceMinLODClamp: 0.0,
@@ -56,8 +56,8 @@ impl ViewDescriptor {
             }
             /*
             wgt::TextureViewDimension::D1Array => {
-                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE1DARRAY;
-                *desc.u.Texture1DArray_mut() = d3d12::D3D12_TEX1D_ARRAY_SRV {
+                desc.ViewDimension = d3d12_ty::D3D12_SRV_DIMENSION_TEXTURE1DARRAY;
+                *desc.u.Texture1DArray_mut() = d3d12_ty::D3D12_TEX1D_ARRAY_SRV {
                     MostDetailedMip: self.mip_level_base,
                     MipLevels: self.mip_level_count,
                     FirstArraySlice: self.array_layer_base,
@@ -66,17 +66,17 @@ impl ViewDescriptor {
                 }
             }*/
             wgt::TextureViewDimension::D2 if self.multisampled && self.array_layer_base == 0 => {
-                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE2DMS;
+                desc.ViewDimension = d3d12_ty::D3D12_SRV_DIMENSION_TEXTURE2DMS;
                 unsafe {
-                    *desc.u.Texture2DMS_mut() = d3d12::D3D12_TEX2DMS_SRV {
+                    *desc.u.Texture2DMS_mut() = d3d12_ty::D3D12_TEX2DMS_SRV {
                         UnusedField_NothingToDefine: 0,
                     }
                 }
             }
             wgt::TextureViewDimension::D2 if self.array_layer_base == 0 => {
-                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE2D;
+                desc.ViewDimension = d3d12_ty::D3D12_SRV_DIMENSION_TEXTURE2D;
                 unsafe {
-                    *desc.u.Texture2D_mut() = d3d12::D3D12_TEX2D_SRV {
+                    *desc.u.Texture2D_mut() = d3d12_ty::D3D12_TEX2D_SRV {
                         MostDetailedMip: self.mip_level_base,
                         MipLevels: self.mip_level_count,
                         PlaneSlice: 0,
@@ -87,18 +87,18 @@ impl ViewDescriptor {
             wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array
                 if self.multisampled =>
             {
-                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY;
+                desc.ViewDimension = d3d12_ty::D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY;
                 unsafe {
-                    *desc.u.Texture2DMSArray_mut() = d3d12::D3D12_TEX2DMS_ARRAY_SRV {
+                    *desc.u.Texture2DMSArray_mut() = d3d12_ty::D3D12_TEX2DMS_ARRAY_SRV {
                         FirstArraySlice: self.array_layer_base,
                         ArraySize: self.array_layer_count,
                     }
                 }
             }
             wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array => {
-                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
+                desc.ViewDimension = d3d12_ty::D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
                 unsafe {
-                    *desc.u.Texture2DArray_mut() = d3d12::D3D12_TEX2D_ARRAY_SRV {
+                    *desc.u.Texture2DArray_mut() = d3d12_ty::D3D12_TEX2D_ARRAY_SRV {
                         MostDetailedMip: self.mip_level_base,
                         MipLevels: self.mip_level_count,
                         FirstArraySlice: self.array_layer_base,
@@ -109,9 +109,9 @@ impl ViewDescriptor {
                 }
             }
             wgt::TextureViewDimension::D3 => {
-                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE3D;
+                desc.ViewDimension = d3d12_ty::D3D12_SRV_DIMENSION_TEXTURE3D;
                 unsafe {
-                    *desc.u.Texture3D_mut() = d3d12::D3D12_TEX3D_SRV {
+                    *desc.u.Texture3D_mut() = d3d12_ty::D3D12_TEX3D_SRV {
                         MostDetailedMip: self.mip_level_base,
                         MipLevels: self.mip_level_count,
                         ResourceMinLODClamp: 0.0,
@@ -119,9 +119,9 @@ impl ViewDescriptor {
                 }
             }
             wgt::TextureViewDimension::Cube if self.array_layer_base == 0 => {
-                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURECUBE;
+                desc.ViewDimension = d3d12_ty::D3D12_SRV_DIMENSION_TEXTURECUBE;
                 unsafe {
-                    *desc.u.TextureCube_mut() = d3d12::D3D12_TEXCUBE_SRV {
+                    *desc.u.TextureCube_mut() = d3d12_ty::D3D12_TEXCUBE_SRV {
                         MostDetailedMip: self.mip_level_base,
                         MipLevels: self.mip_level_count,
                         ResourceMinLODClamp: 0.0,
@@ -129,9 +129,9 @@ impl ViewDescriptor {
                 }
             }
             wgt::TextureViewDimension::Cube | wgt::TextureViewDimension::CubeArray => {
-                desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURECUBEARRAY;
+                desc.ViewDimension = d3d12_ty::D3D12_SRV_DIMENSION_TEXTURECUBEARRAY;
                 unsafe {
-                    *desc.u.TextureCubeArray_mut() = d3d12::D3D12_TEXCUBE_ARRAY_SRV {
+                    *desc.u.TextureCubeArray_mut() = d3d12_ty::D3D12_TEXCUBE_ARRAY_SRV {
                         MostDetailedMip: self.mip_level_base,
                         MipLevels: self.mip_level_count,
                         First2DArrayFace: self.array_layer_base,
@@ -149,8 +149,8 @@ impl ViewDescriptor {
         Some(desc)
     }
 
-    pub(crate) unsafe fn to_uav(&self) -> Option<d3d12::D3D12_UNORDERED_ACCESS_VIEW_DESC> {
-        let mut desc = d3d12::D3D12_UNORDERED_ACCESS_VIEW_DESC {
+    pub(crate) unsafe fn to_uav(&self) -> Option<d3d12_ty::D3D12_UNORDERED_ACCESS_VIEW_DESC> {
+        let mut desc = d3d12_ty::D3D12_UNORDERED_ACCESS_VIEW_DESC {
             Format: self.srv_uav_format?,
             ViewDimension: 0,
             u: unsafe { mem::zeroed() },
@@ -158,35 +158,35 @@ impl ViewDescriptor {
 
         match self.dimension {
             wgt::TextureViewDimension::D1 => {
-                desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE1D;
+                desc.ViewDimension = d3d12_ty::D3D12_UAV_DIMENSION_TEXTURE1D;
                 unsafe {
-                    *desc.u.Texture1D_mut() = d3d12::D3D12_TEX1D_UAV {
+                    *desc.u.Texture1D_mut() = d3d12_ty::D3D12_TEX1D_UAV {
                         MipSlice: self.mip_level_base,
                     }
                 }
             }
             /*
             wgt::TextureViewDimension::D1Array => {
-                desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE1DARRAY;
-                *desc.u.Texture1DArray_mut() = d3d12::D3D12_TEX1D_ARRAY_UAV {
+                desc.ViewDimension = d3d12_ty::D3D12_UAV_DIMENSION_TEXTURE1DARRAY;
+                *desc.u.Texture1DArray_mut() = d3d12_ty::D3D12_TEX1D_ARRAY_UAV {
                     MipSlice: self.mip_level_base,
                     FirstArraySlice: self.array_layer_base,
                     ArraySize,
                 }
             }*/
             wgt::TextureViewDimension::D2 if self.array_layer_base == 0 => {
-                desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE2D;
+                desc.ViewDimension = d3d12_ty::D3D12_UAV_DIMENSION_TEXTURE2D;
                 unsafe {
-                    *desc.u.Texture2D_mut() = d3d12::D3D12_TEX2D_UAV {
+                    *desc.u.Texture2D_mut() = d3d12_ty::D3D12_TEX2D_UAV {
                         MipSlice: self.mip_level_base,
                         PlaneSlice: 0,
                     }
                 }
             }
             wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array => {
-                desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
+                desc.ViewDimension = d3d12_ty::D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
                 unsafe {
-                    *desc.u.Texture2DArray_mut() = d3d12::D3D12_TEX2D_ARRAY_UAV {
+                    *desc.u.Texture2DArray_mut() = d3d12_ty::D3D12_TEX2D_ARRAY_UAV {
                         MipSlice: self.mip_level_base,
                         FirstArraySlice: self.array_layer_base,
                         ArraySize: self.array_layer_count,
@@ -195,9 +195,9 @@ impl ViewDescriptor {
                 }
             }
             wgt::TextureViewDimension::D3 => {
-                desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE3D;
+                desc.ViewDimension = d3d12_ty::D3D12_UAV_DIMENSION_TEXTURE3D;
                 unsafe {
-                    *desc.u.Texture3D_mut() = d3d12::D3D12_TEX3D_UAV {
+                    *desc.u.Texture3D_mut() = d3d12_ty::D3D12_TEX3D_UAV {
                         MipSlice: self.mip_level_base,
                         FirstWSlice: self.array_layer_base,
                         WSize: self.array_layer_count,
@@ -212,8 +212,8 @@ impl ViewDescriptor {
         Some(desc)
     }
 
-    pub(crate) unsafe fn to_rtv(&self) -> d3d12::D3D12_RENDER_TARGET_VIEW_DESC {
-        let mut desc = d3d12::D3D12_RENDER_TARGET_VIEW_DESC {
+    pub(crate) unsafe fn to_rtv(&self) -> d3d12_ty::D3D12_RENDER_TARGET_VIEW_DESC {
+        let mut desc = d3d12_ty::D3D12_RENDER_TARGET_VIEW_DESC {
             Format: self.rtv_dsv_format,
             ViewDimension: 0,
             u: unsafe { mem::zeroed() },
@@ -221,34 +221,34 @@ impl ViewDescriptor {
 
         match self.dimension {
             wgt::TextureViewDimension::D1 => {
-                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE1D;
+                desc.ViewDimension = d3d12_ty::D3D12_RTV_DIMENSION_TEXTURE1D;
                 unsafe {
-                    *desc.u.Texture1D_mut() = d3d12::D3D12_TEX1D_RTV {
+                    *desc.u.Texture1D_mut() = d3d12_ty::D3D12_TEX1D_RTV {
                         MipSlice: self.mip_level_base,
                     }
                 }
             }
             /*
             wgt::TextureViewDimension::D1Array => {
-                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE1DARRAY;
-                *desc.u.Texture1DArray_mut() = d3d12::D3D12_TEX1D_ARRAY_RTV {
+                desc.ViewDimension = d3d12_ty::D3D12_RTV_DIMENSION_TEXTURE1DARRAY;
+                *desc.u.Texture1DArray_mut() = d3d12_ty::D3D12_TEX1D_ARRAY_RTV {
                     MipSlice: self.mip_level_base,
                     FirstArraySlice: self.array_layer_base,
                     ArraySize,
                 }
             }*/
             wgt::TextureViewDimension::D2 if self.multisampled && self.array_layer_base == 0 => {
-                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE2DMS;
+                desc.ViewDimension = d3d12_ty::D3D12_RTV_DIMENSION_TEXTURE2DMS;
                 unsafe {
-                    *desc.u.Texture2DMS_mut() = d3d12::D3D12_TEX2DMS_RTV {
+                    *desc.u.Texture2DMS_mut() = d3d12_ty::D3D12_TEX2DMS_RTV {
                         UnusedField_NothingToDefine: 0,
                     }
                 }
             }
             wgt::TextureViewDimension::D2 if self.array_layer_base == 0 => {
-                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE2D;
+                desc.ViewDimension = d3d12_ty::D3D12_RTV_DIMENSION_TEXTURE2D;
                 unsafe {
-                    *desc.u.Texture2D_mut() = d3d12::D3D12_TEX2D_RTV {
+                    *desc.u.Texture2D_mut() = d3d12_ty::D3D12_TEX2D_RTV {
                         MipSlice: self.mip_level_base,
                         PlaneSlice: 0,
                     }
@@ -257,18 +257,18 @@ impl ViewDescriptor {
             wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array
                 if self.multisampled =>
             {
-                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY;
+                desc.ViewDimension = d3d12_ty::D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY;
                 unsafe {
-                    *desc.u.Texture2DMSArray_mut() = d3d12::D3D12_TEX2DMS_ARRAY_RTV {
+                    *desc.u.Texture2DMSArray_mut() = d3d12_ty::D3D12_TEX2DMS_ARRAY_RTV {
                         FirstArraySlice: self.array_layer_base,
                         ArraySize: self.array_layer_count,
                     }
                 }
             }
             wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array => {
-                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
+                desc.ViewDimension = d3d12_ty::D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
                 unsafe {
-                    *desc.u.Texture2DArray_mut() = d3d12::D3D12_TEX2D_ARRAY_RTV {
+                    *desc.u.Texture2DArray_mut() = d3d12_ty::D3D12_TEX2D_ARRAY_RTV {
                         MipSlice: self.mip_level_base,
                         FirstArraySlice: self.array_layer_base,
                         ArraySize: self.array_layer_count,
@@ -277,9 +277,9 @@ impl ViewDescriptor {
                 }
             }
             wgt::TextureViewDimension::D3 => {
-                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE3D;
+                desc.ViewDimension = d3d12_ty::D3D12_RTV_DIMENSION_TEXTURE3D;
                 unsafe {
-                    *desc.u.Texture3D_mut() = d3d12::D3D12_TEX3D_RTV {
+                    *desc.u.Texture3D_mut() = d3d12_ty::D3D12_TEX3D_RTV {
                         MipSlice: self.mip_level_base,
                         FirstWSlice: self.array_layer_base,
                         WSize: self.array_layer_count,
@@ -294,18 +294,18 @@ impl ViewDescriptor {
         desc
     }
 
-    pub(crate) unsafe fn to_dsv(&self, read_only: bool) -> d3d12::D3D12_DEPTH_STENCIL_VIEW_DESC {
-        let mut desc = d3d12::D3D12_DEPTH_STENCIL_VIEW_DESC {
+    pub(crate) unsafe fn to_dsv(&self, read_only: bool) -> d3d12_ty::D3D12_DEPTH_STENCIL_VIEW_DESC {
+        let mut desc = d3d12_ty::D3D12_DEPTH_STENCIL_VIEW_DESC {
             Format: self.rtv_dsv_format,
             ViewDimension: 0,
             Flags: {
-                let mut flags = d3d12::D3D12_DSV_FLAG_NONE;
+                let mut flags = d3d12_ty::D3D12_DSV_FLAG_NONE;
                 if read_only {
                     if self.aspects.contains(crate::FormatAspects::DEPTH) {
-                        flags |= d3d12::D3D12_DSV_FLAG_READ_ONLY_DEPTH;
+                        flags |= d3d12_ty::D3D12_DSV_FLAG_READ_ONLY_DEPTH;
                     }
                     if self.aspects.contains(crate::FormatAspects::STENCIL) {
-                        flags |= d3d12::D3D12_DSV_FLAG_READ_ONLY_STENCIL;
+                        flags |= d3d12_ty::D3D12_DSV_FLAG_READ_ONLY_STENCIL;
                     }
                 }
                 flags
@@ -315,34 +315,34 @@ impl ViewDescriptor {
 
         match self.dimension {
             wgt::TextureViewDimension::D1 => {
-                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE1D;
+                desc.ViewDimension = d3d12_ty::D3D12_DSV_DIMENSION_TEXTURE1D;
                 unsafe {
-                    *desc.u.Texture1D_mut() = d3d12::D3D12_TEX1D_DSV {
+                    *desc.u.Texture1D_mut() = d3d12_ty::D3D12_TEX1D_DSV {
                         MipSlice: self.mip_level_base,
                     }
                 }
             }
             /*
             wgt::TextureViewDimension::D1Array => {
-                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE1DARRAY;
-                *desc.u.Texture1DArray_mut() = d3d12::D3D12_TEX1D_ARRAY_DSV {
+                desc.ViewDimension = d3d12_ty::D3D12_DSV_DIMENSION_TEXTURE1DARRAY;
+                *desc.u.Texture1DArray_mut() = d3d12_ty::D3D12_TEX1D_ARRAY_DSV {
                     MipSlice: self.mip_level_base,
                     FirstArraySlice: self.array_layer_base,
                     ArraySize,
                 }
             }*/
             wgt::TextureViewDimension::D2 if self.multisampled && self.array_layer_base == 0 => {
-                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE2DMS;
+                desc.ViewDimension = d3d12_ty::D3D12_DSV_DIMENSION_TEXTURE2DMS;
                 unsafe {
-                    *desc.u.Texture2DMS_mut() = d3d12::D3D12_TEX2DMS_DSV {
+                    *desc.u.Texture2DMS_mut() = d3d12_ty::D3D12_TEX2DMS_DSV {
                         UnusedField_NothingToDefine: 0,
                     }
                 }
             }
             wgt::TextureViewDimension::D2 if self.array_layer_base == 0 => {
-                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE2D;
+                desc.ViewDimension = d3d12_ty::D3D12_DSV_DIMENSION_TEXTURE2D;
                 unsafe {
-                    *desc.u.Texture2D_mut() = d3d12::D3D12_TEX2D_DSV {
+                    *desc.u.Texture2D_mut() = d3d12_ty::D3D12_TEX2D_DSV {
                         MipSlice: self.mip_level_base,
                     }
                 }
@@ -350,18 +350,18 @@ impl ViewDescriptor {
             wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array
                 if self.multisampled =>
             {
-                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE2DMSARRAY;
+                desc.ViewDimension = d3d12_ty::D3D12_DSV_DIMENSION_TEXTURE2DMSARRAY;
                 unsafe {
-                    *desc.u.Texture2DMSArray_mut() = d3d12::D3D12_TEX2DMS_ARRAY_DSV {
+                    *desc.u.Texture2DMSArray_mut() = d3d12_ty::D3D12_TEX2DMS_ARRAY_DSV {
                         FirstArraySlice: self.array_layer_base,
                         ArraySize: self.array_layer_count,
                     }
                 }
             }
             wgt::TextureViewDimension::D2 | wgt::TextureViewDimension::D2Array => {
-                desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
+                desc.ViewDimension = d3d12_ty::D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
                 unsafe {
-                    *desc.u.Texture2DArray_mut() = d3d12::D3D12_TEX2D_ARRAY_DSV {
+                    *desc.u.Texture2DArray_mut() = d3d12_ty::D3D12_TEX2D_ARRAY_DSV {
                         MipSlice: self.mip_level_base,
                         FirstArraySlice: self.array_layer_base,
                         ArraySize: self.array_layer_count,

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -27,10 +27,10 @@ type WlDisplayConnectFun =
 type WlDisplayDisconnectFun = unsafe extern "system" fn(display: *const raw::c_void);
 
 #[cfg(not(target_os = "emscripten"))]
-type EglInstance = egl::DynamicInstance<egl::EGL1_4>;
+type EglInstance = khronos_egl::DynamicInstance<khronos_egl::EGL1_4>;
 
 #[cfg(target_os = "emscripten")]
-type EglInstance = egl::Instance<egl::Static>;
+type EglInstance = khronos_egl::Instance<khronos_egl::Static>;
 
 type WlEglWindowCreateFun = unsafe extern "system" fn(
     surface: *const raw::c_void,
@@ -63,7 +63,7 @@ type EglLabel = *const raw::c_void;
 #[allow(clippy::upper_case_acronyms)]
 type EGLDEBUGPROCKHR = Option<
     unsafe extern "system" fn(
-        error: egl::Enum,
+        error: khronos_egl::Enum,
         command: *const raw::c_char,
         message_type: u32,
         thread_label: EglLabel,
@@ -77,11 +77,13 @@ const EGL_DEBUG_MSG_ERROR_KHR: u32 = 0x33BA;
 const EGL_DEBUG_MSG_WARN_KHR: u32 = 0x33BB;
 const EGL_DEBUG_MSG_INFO_KHR: u32 = 0x33BC;
 
-type EglDebugMessageControlFun =
-    unsafe extern "system" fn(proc: EGLDEBUGPROCKHR, attrib_list: *const egl::Attrib) -> raw::c_int;
+type EglDebugMessageControlFun = unsafe extern "system" fn(
+    proc: EGLDEBUGPROCKHR,
+    attrib_list: *const khronos_egl::Attrib,
+) -> raw::c_int;
 
 unsafe extern "system" fn egl_debug_proc(
-    error: egl::Enum,
+    error: khronos_egl::Enum,
     command_raw: *const raw::c_char,
     message_type: u32,
     _thread_label: EglLabel,
@@ -161,25 +163,28 @@ enum SrgbFrameBufferKind {
 /// Choose GLES framebuffer configuration.
 fn choose_config(
     egl: &EglInstance,
-    display: egl::Display,
+    display: khronos_egl::Display,
     srgb_kind: SrgbFrameBufferKind,
-) -> Result<(egl::Config, bool), crate::InstanceError> {
+) -> Result<(khronos_egl::Config, bool), crate::InstanceError> {
     //TODO: EGL_SLOW_CONFIG
     let tiers = [
         (
             "off-screen",
             &[
-                egl::SURFACE_TYPE,
-                egl::PBUFFER_BIT,
-                egl::RENDERABLE_TYPE,
-                egl::OPENGL_ES2_BIT,
+                khronos_egl::SURFACE_TYPE,
+                khronos_egl::PBUFFER_BIT,
+                khronos_egl::RENDERABLE_TYPE,
+                khronos_egl::OPENGL_ES2_BIT,
             ][..],
         ),
-        ("presentation", &[egl::SURFACE_TYPE, egl::WINDOW_BIT][..]),
+        (
+            "presentation",
+            &[khronos_egl::SURFACE_TYPE, khronos_egl::WINDOW_BIT][..],
+        ),
         #[cfg(not(target_os = "android"))]
         (
             "native-render",
-            &[egl::NATIVE_RENDERABLE, egl::TRUE as _][..],
+            &[khronos_egl::NATIVE_RENDERABLE, khronos_egl::TRUE as _][..],
         ),
     ];
 
@@ -196,11 +201,11 @@ fn choose_config(
         match srgb_kind {
             SrgbFrameBufferKind::None => {}
             _ => {
-                attributes.push(egl::ALPHA_SIZE);
+                attributes.push(khronos_egl::ALPHA_SIZE);
                 attributes.push(8);
             }
         }
-        attributes.push(egl::NONE);
+        attributes.push(khronos_egl::NONE);
 
         match egl.choose_first_config(display, &attributes) {
             Ok(Some(config)) => {
@@ -282,9 +287,9 @@ fn gl_debug_message_callback(source: u32, gltype: u32, id: u32, severity: u32, m
 struct EglContext {
     instance: Arc<EglInstance>,
     version: (i32, i32),
-    display: egl::Display,
-    raw: egl::Context,
-    pbuffer: Option<egl::Surface>,
+    display: khronos_egl::Display,
+    raw: khronos_egl::Context,
+    pbuffer: Option<khronos_egl::Surface>,
 }
 
 impl EglContext {
@@ -325,7 +330,7 @@ impl AdapterContext {
     /// Returns the EGLDisplay corresponding to the adapter context.
     ///
     /// Returns [`None`] if the adapter was externally created.
-    pub fn raw_display(&self) -> Option<&egl::Display> {
+    pub fn raw_display(&self) -> Option<&khronos_egl::Display> {
         self.egl.as_ref().map(|egl| &egl.display)
     }
 
@@ -346,7 +351,7 @@ impl AdapterContext {
 
 struct EglContextLock<'a> {
     instance: &'a Arc<EglInstance>,
-    display: egl::Display,
+    display: khronos_egl::Display,
 }
 
 /// A guard containing a lock to an [`AdapterContext`]
@@ -422,7 +427,7 @@ struct Inner {
     #[allow(unused)]
     version: (i32, i32),
     supports_native_window: bool,
-    config: egl::Config,
+    config: khronos_egl::Config,
     #[cfg_attr(target_os = "emscripten", allow(dead_code))]
     wl_display: Option<*mut raw::c_void>,
     /// Method by which the framebuffer should support srgb
@@ -433,12 +438,14 @@ impl Inner {
     fn create(
         flags: crate::InstanceFlags,
         egl: Arc<EglInstance>,
-        display: egl::Display,
+        display: khronos_egl::Display,
     ) -> Result<Self, crate::InstanceError> {
         let version = egl.initialize(display).map_err(|_| crate::InstanceError)?;
-        let vendor = egl.query_string(Some(display), egl::VENDOR).unwrap();
+        let vendor = egl
+            .query_string(Some(display), khronos_egl::VENDOR)
+            .unwrap();
         let display_extensions = egl
-            .query_string(Some(display), egl::EXTENSIONS)
+            .query_string(Some(display), khronos_egl::EXTENSIONS)
             .unwrap()
             .to_string_lossy();
         log::info!("Display vendor {:?}, version {:?}", vendor, version,);
@@ -465,17 +472,17 @@ impl Inner {
             egl.get_configs(display, &mut configurations).unwrap();
             for &config in configurations.iter() {
                 log::trace!("\tCONFORMANT=0x{:X}, RENDERABLE=0x{:X}, NATIVE_RENDERABLE=0x{:X}, SURFACE_TYPE=0x{:X}, ALPHA_SIZE={}",
-                    egl.get_config_attrib(display, config, egl::CONFORMANT).unwrap(),
-                    egl.get_config_attrib(display, config, egl::RENDERABLE_TYPE).unwrap(),
-                    egl.get_config_attrib(display, config, egl::NATIVE_RENDERABLE).unwrap(),
-                    egl.get_config_attrib(display, config, egl::SURFACE_TYPE).unwrap(),
-                    egl.get_config_attrib(display, config, egl::ALPHA_SIZE).unwrap(),
+                    egl.get_config_attrib(display, config, khronos_egl::CONFORMANT).unwrap(),
+                    egl.get_config_attrib(display, config, khronos_egl::RENDERABLE_TYPE).unwrap(),
+                    egl.get_config_attrib(display, config, khronos_egl::NATIVE_RENDERABLE).unwrap(),
+                    egl.get_config_attrib(display, config, khronos_egl::SURFACE_TYPE).unwrap(),
+                    egl.get_config_attrib(display, config, khronos_egl::ALPHA_SIZE).unwrap(),
                 );
             }
         }
 
         let (config, supports_native_window) = choose_config(&egl, display, srgb_kind)?;
-        egl.bind_api(egl::OPENGL_ES_API).unwrap();
+        egl.bind_api(khronos_egl::OPENGL_ES_API).unwrap();
 
         let needs_robustness = true;
         let mut khr_context_flags = 0;
@@ -483,14 +490,14 @@ impl Inner {
 
         //TODO: make it so `Device` == EGL Context
         let mut context_attributes = vec![
-            egl::CONTEXT_CLIENT_VERSION,
+            khronos_egl::CONTEXT_CLIENT_VERSION,
             3, // Request GLES 3.0 or higher
         ];
         if flags.contains(crate::InstanceFlags::DEBUG) {
             if version >= (1, 5) {
                 log::info!("\tEGL context: +debug");
-                context_attributes.push(egl::CONTEXT_OPENGL_DEBUG);
-                context_attributes.push(egl::TRUE as _);
+                context_attributes.push(khronos_egl::CONTEXT_OPENGL_DEBUG);
+                context_attributes.push(khronos_egl::TRUE as _);
             } else if supports_khr_context {
                 log::info!("\tEGL context: +debug KHR");
                 khr_context_flags |= EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR;
@@ -504,25 +511,25 @@ impl Inner {
             // In fact, Angle does precisely that awful behavior, so we don't try it there.
             if version >= (1, 5) && !display_extensions.contains("EGL_ANGLE_") {
                 log::info!("\tEGL context: +robust access");
-                context_attributes.push(egl::CONTEXT_OPENGL_ROBUST_ACCESS);
-                context_attributes.push(egl::TRUE as _);
+                context_attributes.push(khronos_egl::CONTEXT_OPENGL_ROBUST_ACCESS);
+                context_attributes.push(khronos_egl::TRUE as _);
             } else if display_extensions.contains("EGL_EXT_create_context_robustness") {
                 log::info!("\tEGL context: +robust access EXT");
                 context_attributes.push(EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT);
-                context_attributes.push(egl::TRUE as _);
+                context_attributes.push(khronos_egl::TRUE as _);
             } else {
                 //Note: we aren't trying `EGL_CONTEXT_OPENGL_ROBUST_ACCESS_BIT_KHR`
                 // because it's for desktop GL only, not GLES.
                 log::warn!("\tEGL context: -robust access");
             }
 
-            //TODO do we need `egl::CONTEXT_OPENGL_NOTIFICATION_STRATEGY_EXT`?
+            //TODO do we need `khronos_egl::CONTEXT_OPENGL_NOTIFICATION_STRATEGY_EXT`?
         }
         if khr_context_flags != 0 {
             context_attributes.push(EGL_CONTEXT_FLAGS_KHR);
             context_attributes.push(khr_context_flags);
         }
-        context_attributes.push(egl::NONE);
+        context_attributes.push(khronos_egl::NONE);
         let context = match egl.create_context(display, config, None, &context_attributes) {
             Ok(context) => context,
             Err(e) => {
@@ -540,7 +547,13 @@ impl Inner {
             log::info!("\tEGL context: +surfaceless");
             None
         } else {
-            let attributes = [egl::WIDTH, 1, egl::HEIGHT, 1, egl::NONE];
+            let attributes = [
+                khronos_egl::WIDTH,
+                1,
+                khronos_egl::HEIGHT,
+                1,
+                khronos_egl::NONE,
+            ];
             egl.create_pbuffer_surface(display, config, &attributes)
                 .map(Some)
                 .map_err(|e| {
@@ -602,7 +615,7 @@ pub struct Instance {
 }
 
 impl Instance {
-    pub fn raw_display(&self) -> egl::Display {
+    pub fn raw_display(&self) -> khronos_egl::Display {
         self.inner
             .try_lock()
             .expect("Could not lock instance. This is most-likely a deadlock.")
@@ -625,19 +638,24 @@ unsafe impl Sync for Instance {}
 impl crate::Instance<super::Api> for Instance {
     unsafe fn init(desc: &crate::InstanceDescriptor) -> Result<Self, crate::InstanceError> {
         #[cfg(target_os = "emscripten")]
-        let egl_result: Result<EglInstance, egl::Error> = Ok(egl::Instance::new(egl::Static));
+        let egl_result: Result<EglInstance, khronos_egl::Error> =
+            Ok(khronos_egl::Instance::new(khronos_egl::Static));
 
         #[cfg(not(target_os = "emscripten"))]
         let egl_result = if cfg!(windows) {
             unsafe {
-                egl::DynamicInstance::<egl::EGL1_4>::load_required_from_filename("libEGL.dll")
+                khronos_egl::DynamicInstance::<khronos_egl::EGL1_4>::load_required_from_filename(
+                    "libEGL.dll",
+                )
             }
         } else if cfg!(any(target_os = "macos", target_os = "ios")) {
             unsafe {
-                egl::DynamicInstance::<egl::EGL1_4>::load_required_from_filename("libEGL.dylib")
+                khronos_egl::DynamicInstance::<khronos_egl::EGL1_4>::load_required_from_filename(
+                    "libEGL.dylib",
+                )
             }
         } else {
-            unsafe { egl::DynamicInstance::<egl::EGL1_4>::load_required() }
+            unsafe { khronos_egl::DynamicInstance::<khronos_egl::EGL1_4>::load_required() }
         };
         let egl = match egl_result {
             Ok(egl) => Arc::new(egl),
@@ -647,7 +665,7 @@ impl crate::Instance<super::Api> for Instance {
             }
         };
 
-        let client_extensions = egl.query_string(None, egl::EXTENSIONS);
+        let client_extensions = egl.query_string(None, khronos_egl::EXTENSIONS);
 
         let client_ext_str = match client_extensions {
             Ok(ext) => ext.to_string_lossy().into_owned(),
@@ -675,7 +693,7 @@ impl crate::Instance<super::Api> for Instance {
         };
 
         #[cfg(not(target_os = "emscripten"))]
-        let egl1_5 = egl.upcast::<egl::EGL1_5>();
+        let egl1_5 = egl.upcast::<khronos_egl::EGL1_5>();
 
         #[cfg(target_os = "emscripten")]
         let egl1_5: Option<&Arc<EglInstance>> = Some(&egl);
@@ -684,18 +702,18 @@ impl crate::Instance<super::Api> for Instance {
             (wayland_library, egl1_5)
         {
             log::info!("Using Wayland platform");
-            let display_attributes = [egl::ATTRIB_NONE];
+            let display_attributes = [khronos_egl::ATTRIB_NONE];
             let display = egl
                 .get_platform_display(
                     EGL_PLATFORM_WAYLAND_KHR,
-                    egl::DEFAULT_DISPLAY,
+                    khronos_egl::DEFAULT_DISPLAY,
                     &display_attributes,
                 )
                 .unwrap();
             (display, Some(Arc::new(library)), WindowKind::Wayland)
         } else if let (Some((display, library)), Some(egl)) = (x11_display_library, egl1_5) {
             log::info!("Using X11 platform");
-            let display_attributes = [egl::ATTRIB_NONE];
+            let display_attributes = [khronos_egl::ATTRIB_NONE];
             let display = egl
                 .get_platform_display(EGL_PLATFORM_X11_KHR, display.as_ptr(), &display_attributes)
                 .unwrap();
@@ -703,11 +721,11 @@ impl crate::Instance<super::Api> for Instance {
         } else if let (Some((display, library)), Some(egl)) = (angle_x11_display_library, egl1_5) {
             log::info!("Using Angle platform with X11");
             let display_attributes = [
-                EGL_PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE as egl::Attrib,
-                EGL_PLATFORM_X11_KHR as egl::Attrib,
-                EGL_PLATFORM_ANGLE_DEBUG_LAYERS_ENABLED as egl::Attrib,
+                EGL_PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE as khronos_egl::Attrib,
+                EGL_PLATFORM_X11_KHR as khronos_egl::Attrib,
+                EGL_PLATFORM_ANGLE_DEBUG_LAYERS_ENABLED as khronos_egl::Attrib,
                 usize::from(desc.flags.contains(crate::InstanceFlags::VALIDATION)),
-                egl::ATTRIB_NONE,
+                khronos_egl::ATTRIB_NONE,
             ];
             let display = egl
                 .get_platform_display(
@@ -724,13 +742,13 @@ impl crate::Instance<super::Api> for Instance {
                 .get_platform_display(
                     EGL_PLATFORM_SURFACELESS_MESA,
                     std::ptr::null_mut(),
-                    &[egl::ATTRIB_NONE],
+                    &[khronos_egl::ATTRIB_NONE],
                 )
                 .unwrap();
             (display, None, WindowKind::Unknown)
         } else {
             log::info!("EGL_MESA_platform_surfaceless not available. Using default platform");
-            let display = egl.get_display(egl::DEFAULT_DISPLAY).unwrap();
+            let display = egl.get_display(khronos_egl::DEFAULT_DISPLAY).unwrap();
             (display, None, WindowKind::Unknown)
         };
 
@@ -743,15 +761,15 @@ impl crate::Instance<super::Api> for Instance {
                 unsafe { std::mem::transmute(addr) }
             };
             let attributes = [
-                EGL_DEBUG_MSG_CRITICAL_KHR as egl::Attrib,
+                EGL_DEBUG_MSG_CRITICAL_KHR as khronos_egl::Attrib,
                 1,
-                EGL_DEBUG_MSG_ERROR_KHR as egl::Attrib,
+                EGL_DEBUG_MSG_ERROR_KHR as khronos_egl::Attrib,
                 1,
-                EGL_DEBUG_MSG_WARN_KHR as egl::Attrib,
+                EGL_DEBUG_MSG_WARN_KHR as khronos_egl::Attrib,
                 1,
-                EGL_DEBUG_MSG_INFO_KHR as egl::Attrib,
+                EGL_DEBUG_MSG_INFO_KHR as khronos_egl::Attrib,
                 1,
-                egl::ATTRIB_NONE,
+                khronos_egl::ATTRIB_NONE,
             ];
             unsafe { (function)(Some(egl_debug_proc), attributes.as_ptr()) };
         }
@@ -792,7 +810,11 @@ impl crate::Instance<super::Api> for Instance {
                 let format = inner
                     .egl
                     .instance
-                    .get_config_attrib(inner.egl.display, inner.config, egl::NATIVE_VISUAL_ID)
+                    .get_config_attrib(
+                        inner.egl.display,
+                        inner.config,
+                        khronos_egl::NATIVE_VISUAL_ID,
+                    )
                     .unwrap();
 
                 let ret = unsafe {
@@ -820,12 +842,12 @@ impl crate::Instance<super::Api> for Instance {
                     log::warn!("Re-initializing Gles context due to Wayland window");
 
                     use std::ops::DerefMut;
-                    let display_attributes = [egl::ATTRIB_NONE];
+                    let display_attributes = [khronos_egl::ATTRIB_NONE];
 
                     let display = inner
                         .egl
                         .instance
-                        .upcast::<egl::EGL1_5>()
+                        .upcast::<khronos_egl::EGL1_5>()
                         .unwrap()
                         .get_platform_display(
                             EGL_PLATFORM_WAYLAND_KHR,
@@ -939,7 +961,7 @@ impl super::Device {
 
 #[derive(Debug)]
 pub struct Swapchain {
-    surface: egl::Surface,
+    surface: khronos_egl::Surface,
     wl_window: Option<*mut raw::c_void>,
     framebuffer: glow::Framebuffer,
     renderbuffer: glow::Renderbuffer,
@@ -955,7 +977,7 @@ pub struct Swapchain {
 pub struct Surface {
     egl: EglContext,
     wsi: WindowSystemInterface,
-    config: egl::Config,
+    config: khronos_egl::Config,
     pub(super) presentable: bool,
     raw_window_handle: raw_window_handle::RawWindowHandle,
     swapchain: Option<Swapchain>,
@@ -1031,7 +1053,7 @@ impl Surface {
     unsafe fn unconfigure_impl(
         &mut self,
         device: &super::Device,
-    ) -> Option<(egl::Surface, Option<*mut raw::c_void>)> {
+    ) -> Option<(khronos_egl::Surface, Option<*mut raw::c_void>)> {
         let gl = &device.shared.context.lock();
         match self.swapchain.take() {
             Some(sc) => {
@@ -1117,7 +1139,7 @@ impl crate::Surface<super::Api> for Surface {
                 };
 
                 let mut attributes = vec![
-                    egl::RENDER_BUFFER,
+                    khronos_egl::RENDER_BUFFER,
                     // We don't want any of the buffering done by the driver, because we
                     // manage a swapchain on our side.
                     // Some drivers just fail on surface creation seeing `EGL_SINGLE_BUFFER`.
@@ -1125,26 +1147,26 @@ impl crate::Surface<super::Api> for Surface {
                         || cfg!(windows)
                         || self.wsi.kind == WindowKind::AngleX11
                     {
-                        egl::BACK_BUFFER
+                        khronos_egl::BACK_BUFFER
                     } else {
-                        egl::SINGLE_BUFFER
+                        khronos_egl::SINGLE_BUFFER
                     },
                 ];
                 match self.srgb_kind {
                     SrgbFrameBufferKind::None => {}
                     SrgbFrameBufferKind::Core => {
-                        attributes.push(egl::GL_COLORSPACE);
-                        attributes.push(egl::GL_COLORSPACE_SRGB);
+                        attributes.push(khronos_egl::GL_COLORSPACE);
+                        attributes.push(khronos_egl::GL_COLORSPACE_SRGB);
                     }
                     SrgbFrameBufferKind::Khr => {
                         attributes.push(EGL_GL_COLORSPACE_KHR as i32);
                         attributes.push(EGL_GL_COLORSPACE_SRGB_KHR as i32);
                     }
                 }
-                attributes.push(egl::ATTRIB_NONE as i32);
+                attributes.push(khronos_egl::ATTRIB_NONE as i32);
 
                 #[cfg(not(target_os = "emscripten"))]
-                let egl1_5 = self.egl.instance.upcast::<egl::EGL1_5>();
+                let egl1_5 = self.egl.instance.upcast::<khronos_egl::EGL1_5>();
 
                 #[cfg(target_os = "emscripten")]
                 let egl1_5: Option<&Arc<EglInstance>> = Some(&self.egl.instance);

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1,4 +1,4 @@
-use mtl::{MTLFeatureSet, MTLGPUFamily, MTLLanguageVersion, MTLReadWriteTextureTier};
+use metal::{MTLFeatureSet, MTLGPUFamily, MTLLanguageVersion, MTLReadWriteTextureTier};
 use objc::{class, msg_send, sel, sel_impl};
 use parking_lot::Mutex;
 use wgt::{AstcBlock, AstcChannel};
@@ -50,9 +50,9 @@ impl crate::Adapter<super::Api> for super::Adapter {
         // https://developer.apple.com/documentation/metal/mtlreadwritetexturetier/mtlreadwritetexturetier1?language=objc
         // https://developer.apple.com/documentation/metal/mtlreadwritetexturetier/mtlreadwritetexturetier2?language=objc
         let (read_write_tier1_if, read_write_tier2_if) = match pc.read_write_texture_tier {
-            mtl::MTLReadWriteTextureTier::TierNone => (Tfc::empty(), Tfc::empty()),
-            mtl::MTLReadWriteTextureTier::Tier1 => (Tfc::STORAGE_READ_WRITE, Tfc::empty()),
-            mtl::MTLReadWriteTextureTier::Tier2 => {
+            metal::MTLReadWriteTextureTier::TierNone => (Tfc::empty(), Tfc::empty()),
+            metal::MTLReadWriteTextureTier::Tier1 => (Tfc::STORAGE_READ_WRITE, Tfc::empty()),
+            metal::MTLReadWriteTextureTier::Tier2 => {
                 (Tfc::STORAGE_READ_WRITE, Tfc::STORAGE_READ_WRITE)
             }
         };
@@ -437,14 +437,14 @@ const DEPTH_CLIP_MODE: &[MTLFeatureSet] = &[
 const OS_NOT_SUPPORT: (usize, usize) = (10000, 0);
 
 impl super::PrivateCapabilities {
-    fn supports_any(raw: &mtl::DeviceRef, features_sets: &[MTLFeatureSet]) -> bool {
+    fn supports_any(raw: &metal::DeviceRef, features_sets: &[MTLFeatureSet]) -> bool {
         features_sets
             .iter()
             .cloned()
             .any(|x| raw.supports_feature_set(x))
     }
 
-    pub fn new(device: &mtl::Device) -> Self {
+    pub fn new(device: &metal::Device) -> Self {
         #[repr(C)]
         #[derive(Clone, Copy, Debug)]
         #[allow(clippy::upper_case_acronyms)]
@@ -628,7 +628,7 @@ impl super::PrivateCapabilities {
             buffer_alignment: if os_is_mac { 256 } else { 64 },
             max_buffer_size: if version.at_least((10, 14), (12, 0)) {
                 // maxBufferLength available on macOS 10.14+ and iOS 12.0+
-                let buffer_size: mtl::NSInteger =
+                let buffer_size: metal::NSInteger =
                     unsafe { msg_send![device.as_ref(), maxBufferLength] };
                 buffer_size as _
             } else if os_is_mac {
@@ -863,8 +863,8 @@ impl super::PrivateCapabilities {
         }
     }
 
-    pub fn map_format(&self, format: wgt::TextureFormat) -> mtl::MTLPixelFormat {
-        use mtl::MTLPixelFormat::*;
+    pub fn map_format(&self, format: wgt::TextureFormat) -> metal::MTLPixelFormat {
+        use metal::MTLPixelFormat::*;
         use wgt::TextureFormat as Tf;
         match format {
             Tf::R8Unorm => R8Unorm,
@@ -1008,9 +1008,9 @@ impl super::PrivateCapabilities {
         &self,
         format: wgt::TextureFormat,
         aspects: crate::FormatAspects,
-    ) -> mtl::MTLPixelFormat {
+    ) -> metal::MTLPixelFormat {
         use crate::FormatAspects as Fa;
-        use mtl::MTLPixelFormat::*;
+        use metal::MTLPixelFormat::*;
         use wgt::TextureFormat as Tf;
         match (format, aspects) {
             // map combined depth-stencil format to their stencil-only format
@@ -1030,7 +1030,7 @@ impl super::PrivateCapabilities {
 }
 
 impl super::PrivateDisabilities {
-    pub fn new(device: &mtl::Device) -> Self {
+    pub fn new(device: &metal::Device) -> Self {
         let is_intel = device.name().starts_with("Intel");
         Self {
             broken_viewport_near_depth: is_intel

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -10,9 +10,9 @@ impl Default for super::CommandState {
             blit: None,
             render: None,
             compute: None,
-            raw_primitive_type: mtl::MTLPrimitiveType::Point,
+            raw_primitive_type: metal::MTLPrimitiveType::Point,
             index: None,
-            raw_wg_size: mtl::MTLSize::new(0, 0, 0),
+            raw_wg_size: metal::MTLSize::new(0, 0, 0),
             stage_infos: Default::default(),
             storage_buffer_length_map: Default::default(),
             work_group_memory_sizes: Vec::new(),
@@ -22,7 +22,7 @@ impl Default for super::CommandState {
 }
 
 impl super::CommandEncoder {
-    fn enter_blit(&mut self) -> &mtl::BlitCommandEncoderRef {
+    fn enter_blit(&mut self) -> &metal::BlitCommandEncoderRef {
         if self.state.blit.is_none() {
             debug_assert!(self.state.render.is_none() && self.state.compute.is_none());
             objc::rc::autoreleasepool(|| {
@@ -39,7 +39,7 @@ impl super::CommandEncoder {
         }
     }
 
-    fn enter_any(&mut self) -> Option<&mtl::CommandEncoderRef> {
+    fn enter_any(&mut self) -> Option<&metal::CommandEncoderRef> {
         if let Some(ref encoder) = self.state.render {
             Some(encoder)
         } else if let Some(ref encoder) = self.state.compute {
@@ -300,7 +300,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     .as_ref()
                     .unwrap()
                     .set_visibility_result_mode(
-                        mtl::MTLVisibilityResultMode::Boolean,
+                        metal::MTLVisibilityResultMode::Boolean,
                         index as u64 * crate::QUERY_SIZE,
                     );
             }
@@ -314,7 +314,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     .render
                     .as_ref()
                     .unwrap()
-                    .set_visibility_result_mode(mtl::MTLVisibilityResultMode::Disabled, 0);
+                    .set_visibility_result_mode(metal::MTLVisibilityResultMode::Disabled, 0);
             }
             _ => {}
         }
@@ -322,7 +322,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     unsafe fn write_timestamp(&mut self, _set: &super::QuerySet, _index: u32) {}
     unsafe fn reset_queries(&mut self, set: &super::QuerySet, range: Range<u32>) {
         let encoder = self.enter_blit();
-        let raw_range = mtl::NSRange {
+        let raw_range = metal::NSRange {
             location: range.start as u64 * crate::QUERY_SIZE,
             length: (range.end - range.start) as u64 * crate::QUERY_SIZE,
         };
@@ -354,7 +354,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         self.state.index = None;
 
         objc::rc::autoreleasepool(|| {
-            let descriptor = mtl::RenderPassDescriptor::new();
+            let descriptor = metal::RenderPassDescriptor::new();
             //TODO: set visibility results buffer
 
             for (i, at) in desc.color_attachments.iter().enumerate() {
@@ -366,10 +366,10 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                         at_descriptor.set_resolve_texture(Some(&resolve.view.raw));
                     }
                     let load_action = if at.ops.contains(crate::AttachmentOps::LOAD) {
-                        mtl::MTLLoadAction::Load
+                        metal::MTLLoadAction::Load
                     } else {
                         at_descriptor.set_clear_color(conv::map_clear_color(&at.clear_value));
-                        mtl::MTLLoadAction::Clear
+                        metal::MTLLoadAction::Clear
                     };
                     let store_action = conv::map_store_action(
                         at.ops.contains(crate::AttachmentOps::STORE),
@@ -386,15 +386,15 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     at_descriptor.set_texture(Some(&at.target.view.raw));
 
                     let load_action = if at.depth_ops.contains(crate::AttachmentOps::LOAD) {
-                        mtl::MTLLoadAction::Load
+                        metal::MTLLoadAction::Load
                     } else {
                         at_descriptor.set_clear_depth(at.clear_value.0 as f64);
-                        mtl::MTLLoadAction::Clear
+                        metal::MTLLoadAction::Clear
                     };
                     let store_action = if at.depth_ops.contains(crate::AttachmentOps::STORE) {
-                        mtl::MTLStoreAction::Store
+                        metal::MTLStoreAction::Store
                     } else {
-                        mtl::MTLStoreAction::DontCare
+                        metal::MTLStoreAction::DontCare
                     };
                     at_descriptor.set_load_action(load_action);
                     at_descriptor.set_store_action(store_action);
@@ -409,15 +409,15 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     at_descriptor.set_texture(Some(&at.target.view.raw));
 
                     let load_action = if at.stencil_ops.contains(crate::AttachmentOps::LOAD) {
-                        mtl::MTLLoadAction::Load
+                        metal::MTLLoadAction::Load
                     } else {
                         at_descriptor.set_clear_stencil(at.clear_value.1);
-                        mtl::MTLLoadAction::Clear
+                        metal::MTLLoadAction::Clear
                     };
                     let store_action = if at.stencil_ops.contains(crate::AttachmentOps::STORE) {
-                        mtl::MTLStoreAction::Store
+                        metal::MTLStoreAction::Store
                     } else {
-                        mtl::MTLStoreAction::DontCare
+                        metal::MTLStoreAction::DontCare
                     };
                     at_descriptor.set_load_action(load_action);
                     at_descriptor.set_store_action(store_action);
@@ -713,8 +713,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         format: wgt::IndexFormat,
     ) {
         let (stride, raw_type) = match format {
-            wgt::IndexFormat::Uint16 => (2, mtl::MTLIndexType::UInt16),
-            wgt::IndexFormat::Uint32 => (4, mtl::MTLIndexType::UInt32),
+            wgt::IndexFormat::Uint16 => (2, metal::MTLIndexType::UInt16),
+            wgt::IndexFormat::Uint32 => (4, metal::MTLIndexType::UInt32),
         };
         self.state.index = Some(super::IndexState {
             buffer_ptr: AsNative::from(binding.buffer.raw.as_ref()),
@@ -741,7 +741,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             depth_range.end
         };
         let encoder = self.state.render.as_ref().unwrap();
-        encoder.set_viewport(mtl::MTLViewport {
+        encoder.set_viewport(metal::MTLViewport {
             originX: rect.x as _,
             originY: rect.y as _,
             width: rect.w as _,
@@ -752,7 +752,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     }
     unsafe fn set_scissor_rect(&mut self, rect: &crate::Rect<u32>) {
         //TODO: support empty scissors by modifying the viewport
-        let scissor = mtl::MTLScissorRect {
+        let scissor = metal::MTLScissorRect {
             x: rect.x as _,
             y: rect.y as _,
             width: rect.w as _,
@@ -957,7 +957,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
 
     unsafe fn dispatch(&mut self, count: [u32; 3]) {
         let encoder = self.state.compute.as_ref().unwrap();
-        let raw_count = mtl::MTLSize {
+        let raw_count = metal::MTLSize {
             width: count[0] as u64,
             height: count[1] as u64,
             depth: count[2] as u64,

--- a/wgpu-hal/src/metal/conv.rs
+++ b/wgpu-hal/src/metal/conv.rs
@@ -1,37 +1,37 @@
 pub fn map_texture_usage(
     format: wgt::TextureFormat,
     usage: crate::TextureUses,
-) -> mtl::MTLTextureUsage {
+) -> metal::MTLTextureUsage {
     use crate::TextureUses as Tu;
 
-    let mut mtl_usage = mtl::MTLTextureUsage::Unknown;
+    let mut mtl_usage = metal::MTLTextureUsage::Unknown;
 
     mtl_usage.set(
-        mtl::MTLTextureUsage::RenderTarget,
+        metal::MTLTextureUsage::RenderTarget,
         usage.intersects(Tu::COLOR_TARGET | Tu::DEPTH_STENCIL_READ | Tu::DEPTH_STENCIL_WRITE),
     );
     mtl_usage.set(
-        mtl::MTLTextureUsage::ShaderRead,
+        metal::MTLTextureUsage::ShaderRead,
         usage.intersects(
             Tu::RESOURCE | Tu::DEPTH_STENCIL_READ | Tu::STORAGE_READ | Tu::STORAGE_READ_WRITE,
         ),
     );
     mtl_usage.set(
-        mtl::MTLTextureUsage::ShaderWrite,
+        metal::MTLTextureUsage::ShaderWrite,
         usage.intersects(Tu::STORAGE_READ_WRITE),
     );
     // needed for combined depth/stencil formats since we might
     // create a stencil-only view from them
     mtl_usage.set(
-        mtl::MTLTextureUsage::PixelFormatView,
+        metal::MTLTextureUsage::PixelFormatView,
         format.is_combined_depth_stencil_format(),
     );
 
     mtl_usage
 }
 
-pub fn map_texture_view_dimension(dim: wgt::TextureViewDimension) -> mtl::MTLTextureType {
-    use mtl::MTLTextureType::*;
+pub fn map_texture_view_dimension(dim: wgt::TextureViewDimension) -> metal::MTLTextureType {
+    use metal::MTLTextureType::*;
     use wgt::TextureViewDimension as Tvd;
     match dim {
         Tvd::D1 => D1,
@@ -43,8 +43,8 @@ pub fn map_texture_view_dimension(dim: wgt::TextureViewDimension) -> mtl::MTLTex
     }
 }
 
-pub fn map_compare_function(fun: wgt::CompareFunction) -> mtl::MTLCompareFunction {
-    use mtl::MTLCompareFunction::*;
+pub fn map_compare_function(fun: wgt::CompareFunction) -> metal::MTLCompareFunction {
+    use metal::MTLCompareFunction::*;
     use wgt::CompareFunction as Cf;
     match fun {
         Cf::Never => Never,
@@ -58,16 +58,16 @@ pub fn map_compare_function(fun: wgt::CompareFunction) -> mtl::MTLCompareFunctio
     }
 }
 
-pub fn map_filter_mode(filter: wgt::FilterMode) -> mtl::MTLSamplerMinMagFilter {
-    use mtl::MTLSamplerMinMagFilter::*;
+pub fn map_filter_mode(filter: wgt::FilterMode) -> metal::MTLSamplerMinMagFilter {
+    use metal::MTLSamplerMinMagFilter::*;
     match filter {
         wgt::FilterMode::Nearest => Nearest,
         wgt::FilterMode::Linear => Linear,
     }
 }
 
-pub fn map_address_mode(address: wgt::AddressMode) -> mtl::MTLSamplerAddressMode {
-    use mtl::MTLSamplerAddressMode::*;
+pub fn map_address_mode(address: wgt::AddressMode) -> metal::MTLSamplerAddressMode {
+    use metal::MTLSamplerAddressMode::*;
     use wgt::AddressMode as Fm;
     match address {
         Fm::Repeat => Repeat,
@@ -78,8 +78,8 @@ pub fn map_address_mode(address: wgt::AddressMode) -> mtl::MTLSamplerAddressMode
     }
 }
 
-pub fn map_border_color(border_color: wgt::SamplerBorderColor) -> mtl::MTLSamplerBorderColor {
-    use mtl::MTLSamplerBorderColor::*;
+pub fn map_border_color(border_color: wgt::SamplerBorderColor) -> metal::MTLSamplerBorderColor {
+    use metal::MTLSamplerBorderColor::*;
     match border_color {
         wgt::SamplerBorderColor::TransparentBlack => TransparentBlack,
         wgt::SamplerBorderColor::OpaqueBlack => OpaqueBlack,
@@ -90,53 +90,53 @@ pub fn map_border_color(border_color: wgt::SamplerBorderColor) -> mtl::MTLSample
 
 pub fn map_primitive_topology(
     topology: wgt::PrimitiveTopology,
-) -> (mtl::MTLPrimitiveTopologyClass, mtl::MTLPrimitiveType) {
+) -> (metal::MTLPrimitiveTopologyClass, metal::MTLPrimitiveType) {
     use wgt::PrimitiveTopology as Pt;
     match topology {
         Pt::PointList => (
-            mtl::MTLPrimitiveTopologyClass::Point,
-            mtl::MTLPrimitiveType::Point,
+            metal::MTLPrimitiveTopologyClass::Point,
+            metal::MTLPrimitiveType::Point,
         ),
         Pt::LineList => (
-            mtl::MTLPrimitiveTopologyClass::Line,
-            mtl::MTLPrimitiveType::Line,
+            metal::MTLPrimitiveTopologyClass::Line,
+            metal::MTLPrimitiveType::Line,
         ),
         Pt::LineStrip => (
-            mtl::MTLPrimitiveTopologyClass::Line,
-            mtl::MTLPrimitiveType::LineStrip,
+            metal::MTLPrimitiveTopologyClass::Line,
+            metal::MTLPrimitiveType::LineStrip,
         ),
         Pt::TriangleList => (
-            mtl::MTLPrimitiveTopologyClass::Triangle,
-            mtl::MTLPrimitiveType::Triangle,
+            metal::MTLPrimitiveTopologyClass::Triangle,
+            metal::MTLPrimitiveType::Triangle,
         ),
         Pt::TriangleStrip => (
-            mtl::MTLPrimitiveTopologyClass::Triangle,
-            mtl::MTLPrimitiveType::TriangleStrip,
+            metal::MTLPrimitiveTopologyClass::Triangle,
+            metal::MTLPrimitiveType::TriangleStrip,
         ),
     }
 }
 
-pub fn map_color_write(mask: wgt::ColorWrites) -> mtl::MTLColorWriteMask {
-    let mut raw_mask = mtl::MTLColorWriteMask::empty();
+pub fn map_color_write(mask: wgt::ColorWrites) -> metal::MTLColorWriteMask {
+    let mut raw_mask = metal::MTLColorWriteMask::empty();
 
     if mask.contains(wgt::ColorWrites::RED) {
-        raw_mask |= mtl::MTLColorWriteMask::Red;
+        raw_mask |= metal::MTLColorWriteMask::Red;
     }
     if mask.contains(wgt::ColorWrites::GREEN) {
-        raw_mask |= mtl::MTLColorWriteMask::Green;
+        raw_mask |= metal::MTLColorWriteMask::Green;
     }
     if mask.contains(wgt::ColorWrites::BLUE) {
-        raw_mask |= mtl::MTLColorWriteMask::Blue;
+        raw_mask |= metal::MTLColorWriteMask::Blue;
     }
     if mask.contains(wgt::ColorWrites::ALPHA) {
-        raw_mask |= mtl::MTLColorWriteMask::Alpha;
+        raw_mask |= metal::MTLColorWriteMask::Alpha;
     }
 
     raw_mask
 }
 
-pub fn map_blend_factor(factor: wgt::BlendFactor) -> mtl::MTLBlendFactor {
-    use mtl::MTLBlendFactor::*;
+pub fn map_blend_factor(factor: wgt::BlendFactor) -> metal::MTLBlendFactor {
+    use metal::MTLBlendFactor::*;
     use wgt::BlendFactor as Bf;
 
     match factor {
@@ -162,8 +162,8 @@ pub fn map_blend_factor(factor: wgt::BlendFactor) -> mtl::MTLBlendFactor {
     }
 }
 
-pub fn map_blend_op(operation: wgt::BlendOperation) -> mtl::MTLBlendOperation {
-    use mtl::MTLBlendOperation::*;
+pub fn map_blend_op(operation: wgt::BlendOperation) -> metal::MTLBlendOperation {
+    use metal::MTLBlendOperation::*;
     use wgt::BlendOperation as Bo;
 
     match operation {
@@ -178,9 +178,9 @@ pub fn map_blend_op(operation: wgt::BlendOperation) -> mtl::MTLBlendOperation {
 pub fn map_blend_component(
     component: &wgt::BlendComponent,
 ) -> (
-    mtl::MTLBlendOperation,
-    mtl::MTLBlendFactor,
-    mtl::MTLBlendFactor,
+    metal::MTLBlendOperation,
+    metal::MTLBlendFactor,
+    metal::MTLBlendFactor,
 ) {
     (
         map_blend_op(component.operation),
@@ -189,8 +189,8 @@ pub fn map_blend_component(
     )
 }
 
-pub fn map_vertex_format(format: wgt::VertexFormat) -> mtl::MTLVertexFormat {
-    use mtl::MTLVertexFormat::*;
+pub fn map_vertex_format(format: wgt::VertexFormat) -> metal::MTLVertexFormat {
+    use metal::MTLVertexFormat::*;
     use wgt::VertexFormat as Vf;
 
     match format {
@@ -228,15 +228,15 @@ pub fn map_vertex_format(format: wgt::VertexFormat) -> mtl::MTLVertexFormat {
     }
 }
 
-pub fn map_step_mode(mode: wgt::VertexStepMode) -> mtl::MTLVertexStepFunction {
+pub fn map_step_mode(mode: wgt::VertexStepMode) -> metal::MTLVertexStepFunction {
     match mode {
-        wgt::VertexStepMode::Vertex => mtl::MTLVertexStepFunction::PerVertex,
-        wgt::VertexStepMode::Instance => mtl::MTLVertexStepFunction::PerInstance,
+        wgt::VertexStepMode::Vertex => metal::MTLVertexStepFunction::PerVertex,
+        wgt::VertexStepMode::Instance => metal::MTLVertexStepFunction::PerInstance,
     }
 }
 
-pub fn map_stencil_op(op: wgt::StencilOperation) -> mtl::MTLStencilOperation {
-    use mtl::MTLStencilOperation::*;
+pub fn map_stencil_op(op: wgt::StencilOperation) -> metal::MTLStencilOperation {
+    use metal::MTLStencilOperation::*;
     use wgt::StencilOperation as So;
 
     match op {
@@ -251,46 +251,46 @@ pub fn map_stencil_op(op: wgt::StencilOperation) -> mtl::MTLStencilOperation {
     }
 }
 
-pub fn map_winding(winding: wgt::FrontFace) -> mtl::MTLWinding {
+pub fn map_winding(winding: wgt::FrontFace) -> metal::MTLWinding {
     match winding {
-        wgt::FrontFace::Cw => mtl::MTLWinding::Clockwise,
-        wgt::FrontFace::Ccw => mtl::MTLWinding::CounterClockwise,
+        wgt::FrontFace::Cw => metal::MTLWinding::Clockwise,
+        wgt::FrontFace::Ccw => metal::MTLWinding::CounterClockwise,
     }
 }
 
-pub fn map_cull_mode(face: Option<wgt::Face>) -> mtl::MTLCullMode {
+pub fn map_cull_mode(face: Option<wgt::Face>) -> metal::MTLCullMode {
     match face {
-        None => mtl::MTLCullMode::None,
-        Some(wgt::Face::Front) => mtl::MTLCullMode::Front,
-        Some(wgt::Face::Back) => mtl::MTLCullMode::Back,
+        None => metal::MTLCullMode::None,
+        Some(wgt::Face::Front) => metal::MTLCullMode::Front,
+        Some(wgt::Face::Back) => metal::MTLCullMode::Back,
     }
 }
 
-pub fn map_range(range: &crate::MemoryRange) -> mtl::NSRange {
-    mtl::NSRange {
+pub fn map_range(range: &crate::MemoryRange) -> metal::NSRange {
+    metal::NSRange {
         location: range.start,
         length: range.end - range.start,
     }
 }
 
-pub fn map_copy_extent(extent: &crate::CopyExtent) -> mtl::MTLSize {
-    mtl::MTLSize {
+pub fn map_copy_extent(extent: &crate::CopyExtent) -> metal::MTLSize {
+    metal::MTLSize {
         width: extent.width as u64,
         height: extent.height as u64,
         depth: extent.depth as u64,
     }
 }
 
-pub fn map_origin(origin: &wgt::Origin3d) -> mtl::MTLOrigin {
-    mtl::MTLOrigin {
+pub fn map_origin(origin: &wgt::Origin3d) -> metal::MTLOrigin {
+    metal::MTLOrigin {
         x: origin.x as u64,
         y: origin.y as u64,
         z: origin.z as u64,
     }
 }
 
-pub fn map_store_action(store: bool, resolve: bool) -> mtl::MTLStoreAction {
-    use mtl::MTLStoreAction::*;
+pub fn map_store_action(store: bool, resolve: bool) -> metal::MTLStoreAction {
+    use metal::MTLStoreAction::*;
     match (store, resolve) {
         (true, true) => StoreAndMultisampleResolve,
         (false, true) => MultisampleResolve,
@@ -299,8 +299,8 @@ pub fn map_store_action(store: bool, resolve: bool) -> mtl::MTLStoreAction {
     }
 }
 
-pub fn map_clear_color(color: &wgt::Color) -> mtl::MTLClearColor {
-    mtl::MTLClearColor {
+pub fn map_clear_color(color: &wgt::Color) -> metal::MTLClearColor {
+    metal::MTLClearColor {
         red: color.r,
         green: color.g,
         blue: color.b,
@@ -311,14 +311,14 @@ pub fn map_clear_color(color: &wgt::Color) -> mtl::MTLClearColor {
 pub fn get_blit_option(
     format: wgt::TextureFormat,
     aspect: crate::FormatAspects,
-) -> mtl::MTLBlitOption {
+) -> metal::MTLBlitOption {
     if format.is_combined_depth_stencil_format() {
         match aspect {
-            crate::FormatAspects::DEPTH => mtl::MTLBlitOption::DepthFromDepthStencil,
-            crate::FormatAspects::STENCIL => mtl::MTLBlitOption::StencilFromDepthStencil,
+            crate::FormatAspects::DEPTH => metal::MTLBlitOption::DepthFromDepthStencil,
+            crate::FormatAspects::STENCIL => metal::MTLBlitOption::StencilFromDepthStencil,
             _ => unreachable!(),
         }
     } else {
-        mtl::MTLBlitOption::None
+        metal::MTLBlitOption::None
     }
 }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -67,7 +67,7 @@ pub struct Instance {
 }
 
 impl Instance {
-    pub fn create_surface_from_layer(&self, layer: &mtl::MetalLayerRef) -> Surface {
+    pub fn create_surface_from_layer(&self, layer: &metal::MetalLayerRef) -> Surface {
         unsafe { Surface::from_layer(layer) }
     }
 }
@@ -104,7 +104,7 @@ impl crate::Instance<Api> for Instance {
     }
 
     unsafe fn enumerate_adapters(&self) -> Vec<crate::ExposedAdapter<Api>> {
-        let devices = mtl::Device::all();
+        let devices = metal::Device::all();
         let mut adapters: Vec<crate::ExposedAdapter<Api>> = devices
             .into_iter()
             .map(|dev| {
@@ -140,9 +140,9 @@ impl crate::Instance<Api> for Instance {
 #[derive(Clone, Debug)]
 struct PrivateCapabilities {
     family_check: bool,
-    msl_version: mtl::MTLLanguageVersion,
+    msl_version: metal::MTLLanguageVersion,
     fragment_rw_storage: bool,
-    read_write_texture_tier: mtl::MTLReadWriteTextureTier,
+    read_write_texture_tier: metal::MTLReadWriteTextureTier,
     msaa_desktop: bool,
     msaa_apple3: bool,
     msaa_apple7: bool,
@@ -250,7 +250,7 @@ struct Settings {
 }
 
 struct AdapterShared {
-    device: Mutex<mtl::Device>,
+    device: Mutex<metal::Device>,
     disabilities: PrivateDisabilities,
     private_caps: PrivateCapabilities,
     settings: Settings,
@@ -261,7 +261,7 @@ unsafe impl Send for AdapterShared {}
 unsafe impl Sync for AdapterShared {}
 
 impl AdapterShared {
-    fn new(device: mtl::Device) -> Self {
+    fn new(device: metal::Device) -> Self {
         let private_caps = PrivateCapabilities::new(&device);
         log::debug!("{:#?}", private_caps);
 
@@ -280,14 +280,14 @@ pub struct Adapter {
 }
 
 pub struct Queue {
-    raw: Arc<Mutex<mtl::CommandQueue>>,
+    raw: Arc<Mutex<metal::CommandQueue>>,
 }
 
 unsafe impl Send for Queue {}
 unsafe impl Sync for Queue {}
 
 impl Queue {
-    pub unsafe fn queue_from_raw(raw: mtl::CommandQueue) -> Self {
+    pub unsafe fn queue_from_raw(raw: metal::CommandQueue) -> Self {
         Self {
             raw: Arc::new(Mutex::new(raw)),
         }
@@ -300,7 +300,7 @@ pub struct Device {
 
 pub struct Surface {
     view: Option<NonNull<objc::runtime::Object>>,
-    render_layer: Mutex<mtl::MetalLayer>,
+    render_layer: Mutex<metal::MetalLayer>,
     swapchain_format: Option<wgt::TextureFormat>,
     extent: wgt::Extent3d,
     main_thread_id: thread::ThreadId,
@@ -315,7 +315,7 @@ unsafe impl Sync for Surface {}
 #[derive(Debug)]
 pub struct SurfaceTexture {
     texture: Texture,
-    drawable: mtl::MetalDrawable,
+    drawable: metal::MetalDrawable,
     present_with_transaction: bool,
 }
 
@@ -409,7 +409,7 @@ impl crate::Queue<Api> for Queue {
 
 #[derive(Debug)]
 pub struct Buffer {
-    raw: mtl::Buffer,
+    raw: metal::Buffer,
     size: wgt::BufferAddress,
 }
 
@@ -424,9 +424,9 @@ impl Buffer {
 
 #[derive(Debug)]
 pub struct Texture {
-    raw: mtl::Texture,
+    raw: metal::Texture,
     format: wgt::TextureFormat,
-    raw_type: mtl::MTLTextureType,
+    raw_type: metal::MTLTextureType,
     array_layers: u32,
     mip_levels: u32,
     copy_size: crate::CopyExtent,
@@ -437,7 +437,7 @@ unsafe impl Sync for Texture {}
 
 #[derive(Debug)]
 pub struct TextureView {
-    raw: mtl::Texture,
+    raw: metal::Texture,
     aspects: crate::FormatAspects,
 }
 
@@ -452,7 +452,7 @@ impl TextureView {
 
 #[derive(Debug)]
 pub struct Sampler {
-    raw: mtl::SamplerState,
+    raw: metal::SamplerState,
 }
 
 unsafe impl Send for Sampler {}
@@ -549,12 +549,12 @@ trait AsNative {
     fn as_native(&self) -> &Self::Native;
 }
 
-type BufferPtr = NonNull<mtl::MTLBuffer>;
-type TexturePtr = NonNull<mtl::MTLTexture>;
-type SamplerPtr = NonNull<mtl::MTLSamplerState>;
+type BufferPtr = NonNull<metal::MTLBuffer>;
+type TexturePtr = NonNull<metal::MTLTexture>;
+type SamplerPtr = NonNull<metal::MTLSamplerState>;
 
 impl AsNative for BufferPtr {
-    type Native = mtl::BufferRef;
+    type Native = metal::BufferRef;
     #[inline]
     fn from(native: &Self::Native) -> Self {
         unsafe { NonNull::new_unchecked(native.as_ptr()) }
@@ -566,7 +566,7 @@ impl AsNative for BufferPtr {
 }
 
 impl AsNative for TexturePtr {
-    type Native = mtl::TextureRef;
+    type Native = metal::TextureRef;
     #[inline]
     fn from(native: &Self::Native) -> Self {
         unsafe { NonNull::new_unchecked(native.as_ptr()) }
@@ -578,7 +578,7 @@ impl AsNative for TexturePtr {
 }
 
 impl AsNative for SamplerPtr {
-    type Native = mtl::SamplerStateRef;
+    type Native = metal::SamplerStateRef;
     #[inline]
     fn from(native: &Self::Native) -> Self {
         unsafe { NonNull::new_unchecked(native.as_ptr()) }
@@ -655,30 +655,30 @@ impl PipelineStageInfo {
 }
 
 pub struct RenderPipeline {
-    raw: mtl::RenderPipelineState,
+    raw: metal::RenderPipelineState,
     #[allow(dead_code)]
-    vs_lib: mtl::Library,
+    vs_lib: metal::Library,
     #[allow(dead_code)]
-    fs_lib: Option<mtl::Library>,
+    fs_lib: Option<metal::Library>,
     vs_info: PipelineStageInfo,
     fs_info: PipelineStageInfo,
-    raw_primitive_type: mtl::MTLPrimitiveType,
-    raw_triangle_fill_mode: mtl::MTLTriangleFillMode,
-    raw_front_winding: mtl::MTLWinding,
-    raw_cull_mode: mtl::MTLCullMode,
-    raw_depth_clip_mode: Option<mtl::MTLDepthClipMode>,
-    depth_stencil: Option<(mtl::DepthStencilState, wgt::DepthBiasState)>,
+    raw_primitive_type: metal::MTLPrimitiveType,
+    raw_triangle_fill_mode: metal::MTLTriangleFillMode,
+    raw_front_winding: metal::MTLWinding,
+    raw_cull_mode: metal::MTLCullMode,
+    raw_depth_clip_mode: Option<metal::MTLDepthClipMode>,
+    depth_stencil: Option<(metal::DepthStencilState, wgt::DepthBiasState)>,
 }
 
 unsafe impl Send for RenderPipeline {}
 unsafe impl Sync for RenderPipeline {}
 
 pub struct ComputePipeline {
-    raw: mtl::ComputePipelineState,
+    raw: metal::ComputePipelineState,
     #[allow(dead_code)]
-    cs_lib: mtl::Library,
+    cs_lib: metal::Library,
     cs_info: PipelineStageInfo,
-    work_group_size: mtl::MTLSize,
+    work_group_size: metal::MTLSize,
     work_group_memory_sizes: Vec<u32>,
 }
 
@@ -687,7 +687,7 @@ unsafe impl Sync for ComputePipeline {}
 
 #[derive(Debug)]
 pub struct QuerySet {
-    raw_buffer: mtl::Buffer,
+    raw_buffer: metal::Buffer,
     ty: wgt::QueryType,
 }
 
@@ -698,7 +698,7 @@ unsafe impl Sync for QuerySet {}
 pub struct Fence {
     completed_value: Arc<atomic::AtomicU64>,
     /// The pending fence values have to be ascending.
-    pending_command_buffers: Vec<(crate::FenceValue, mtl::CommandBuffer)>,
+    pending_command_buffers: Vec<(crate::FenceValue, metal::CommandBuffer)>,
 }
 
 unsafe impl Send for Fence {}
@@ -708,7 +708,7 @@ impl Fence {
     fn get_latest(&self) -> crate::FenceValue {
         let mut max_value = self.completed_value.load(atomic::Ordering::Acquire);
         for &(value, ref cmd_buf) in self.pending_command_buffers.iter() {
-            if cmd_buf.status() == mtl::MTLCommandBufferStatus::Completed {
+            if cmd_buf.status() == metal::MTLCommandBufferStatus::Completed {
                 max_value = value;
             }
         }
@@ -726,7 +726,7 @@ struct IndexState {
     buffer_ptr: BufferPtr,
     offset: wgt::BufferAddress,
     stride: wgt::BufferAddress,
-    raw_type: mtl::MTLIndexType,
+    raw_type: metal::MTLIndexType,
 }
 
 #[derive(Default)]
@@ -735,12 +735,12 @@ struct Temp {
 }
 
 struct CommandState {
-    blit: Option<mtl::BlitCommandEncoder>,
-    render: Option<mtl::RenderCommandEncoder>,
-    compute: Option<mtl::ComputeCommandEncoder>,
-    raw_primitive_type: mtl::MTLPrimitiveType,
+    blit: Option<metal::BlitCommandEncoder>,
+    render: Option<metal::RenderCommandEncoder>,
+    compute: Option<metal::ComputeCommandEncoder>,
+    raw_primitive_type: metal::MTLPrimitiveType,
     index: Option<IndexState>,
-    raw_wg_size: mtl::MTLSize,
+    raw_wg_size: metal::MTLSize,
     stage_infos: MultiStageData<PipelineStageInfo>,
 
     /// Sizes of currently bound [`wgt::BufferBindingType::Storage`] buffers.
@@ -770,8 +770,8 @@ struct CommandState {
 
 pub struct CommandEncoder {
     shared: Arc<AdapterShared>,
-    raw_queue: Arc<Mutex<mtl::CommandQueue>>,
-    raw_cmd_buf: Option<mtl::CommandBuffer>,
+    raw_queue: Arc<Mutex<metal::CommandQueue>>,
+    raw_cmd_buf: Option<metal::CommandBuffer>,
     state: CommandState,
     temp: Temp,
 }
@@ -790,7 +790,7 @@ unsafe impl Sync for CommandEncoder {}
 
 #[derive(Debug)]
 pub struct CommandBuffer {
-    raw: mtl::CommandBuffer,
+    raw: metal::CommandBuffer,
 }
 
 unsafe impl Send for CommandBuffer {}

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -59,7 +59,7 @@ impl HalManagedMetalLayerDelegate {
 }
 
 impl super::Surface {
-    fn new(view: Option<NonNull<Object>>, layer: mtl::MetalLayer) -> Self {
+    fn new(view: Option<NonNull<Object>>, layer: metal::MetalLayer) -> Self {
         Self {
             view,
             render_layer: Mutex::new(layer),
@@ -85,14 +85,14 @@ impl super::Surface {
         let view = view as *mut Object;
         let render_layer = {
             let layer = unsafe { Self::get_metal_layer(view, delegate) };
-            unsafe { mem::transmute::<_, &mtl::MetalLayerRef>(layer) }
+            unsafe { mem::transmute::<_, &metal::MetalLayerRef>(layer) }
         }
         .to_owned();
         let _: *mut c_void = msg_send![view, retain];
         Self::new(NonNull::new(view), render_layer)
     }
 
-    pub unsafe fn from_layer(layer: &mtl::MetalLayerRef) -> Self {
+    pub unsafe fn from_layer(layer: &metal::MetalLayerRef) -> Self {
         let class = class!(CAMetalLayer);
         let proper_kind: BOOL = msg_send![layer, isKindOfClass: class];
         assert_eq!(proper_kind, YES);
@@ -255,7 +255,7 @@ impl crate::Surface<super::Api> for super::Surface {
             texture: super::Texture {
                 raw: texture,
                 format: self.swapchain_format.unwrap(),
-                raw_type: mtl::MTLTextureType::D2,
+                raw_type: metal::MTLTextureType::D2,
                 array_layers: 1,
                 mip_levels: 1,
                 copy_size: crate::CopyExtent {


### PR DESCRIPTION
I think renaming imports is not a great idea; it took me a bit to find out that `native` = `d3d12`.