### PR TITLE
Change type of `bytes_per_row` and `rows_per_image` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ By @teoxoy in [#3436](https://github.com/gfx-rs/wgpu/pull/3436)
 
 - Change type of `mip_level_count` and `array_layer_count` (members of `TextureViewDescriptor` and `ImageSubresourceRange`) from `Option<NonZeroU32>` to `Option<u32>`. By @teoxoy in [#3445](https://github.com/gfx-rs/wgpu/pull/3445)
 - All `fxhash` dependencies have been replaced with `rustc-hash`. By @james7132 in [#3502](https://github.com/gfx-rs/wgpu/pull/3502)
+- Change type of `bytes_per_row` and `rows_per_image` (members of `ImageDataLayout`) from `Option<NonZeroU32>` to `Option<u32>`. By @teoxoy in [#3529](https://github.com/gfx-rs/wgpu/pull/3529)
 
 ### Changes
 

--- a/deno_webgpu/src/command_encoder.rs
+++ b/deno_webgpu/src/command_encoder.rs
@@ -8,7 +8,6 @@ use deno_core::ResourceId;
 use serde::Deserialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::num::NonZeroU32;
 
 use super::error::WebGpuResult;
 
@@ -272,8 +271,8 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_texture(
         buffer: source_buffer_resource.0,
         layout: wgpu_types::ImageDataLayout {
             offset: source.offset,
-            bytes_per_row: NonZeroU32::new(source.bytes_per_row.unwrap_or(0)),
-            rows_per_image: NonZeroU32::new(source.rows_per_image.unwrap_or(0)),
+            bytes_per_row: source.bytes_per_row,
+            rows_per_image: source.rows_per_image,
         },
     };
     let destination = wgpu_core::command::ImageCopyTexture {
@@ -320,8 +319,8 @@ pub fn op_webgpu_command_encoder_copy_texture_to_buffer(
         buffer: destination_buffer_resource.0,
         layout: wgpu_types::ImageDataLayout {
             offset: destination.offset,
-            bytes_per_row: NonZeroU32::new(destination.bytes_per_row.unwrap_or(0)),
-            rows_per_image: NonZeroU32::new(destination.rows_per_image.unwrap_or(0)),
+            bytes_per_row: destination.bytes_per_row,
+            rows_per_image: destination.rows_per_image,
         },
     };
     gfx_ok!(command_encoder => instance.command_encoder_copy_texture_to_buffer(

--- a/deno_webgpu/src/queue.rs
+++ b/deno_webgpu/src/queue.rs
@@ -1,7 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use std::num::NonZeroU32;
-
 use deno_core::error::AnyError;
 use deno_core::op;
 use deno_core::OpState;
@@ -54,8 +52,8 @@ impl From<GpuImageDataLayout> for wgpu_types::ImageDataLayout {
     fn from(layout: GpuImageDataLayout) -> Self {
         wgpu_types::ImageDataLayout {
             offset: layout.offset,
-            bytes_per_row: NonZeroU32::new(layout.bytes_per_row.unwrap_or(0)),
-            rows_per_image: NonZeroU32::new(layout.rows_per_image.unwrap_or(0)),
+            bytes_per_row: layout.bytes_per_row,
+            rows_per_image: layout.rows_per_image,
         }
     }
 }

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroU32, ops::Range};
+use std::ops::Range;
 
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;
@@ -363,7 +363,7 @@ fn clear_texture_via_buffer_copies<A: hal::Api>(
                     zero_buffer_copy_regions.push(hal::BufferTextureCopy {
                         buffer_layout: wgt::ImageDataLayout {
                             offset: 0,
-                            bytes_per_row: NonZeroU32::new(bytes_per_row),
+                            bytes_per_row: Some(bytes_per_row),
                             rows_per_image: None,
                         },
                         texture_base: hal::TextureCopyBase {

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -264,7 +264,7 @@ pub(crate) fn validate_linear_texture_data(
     let bytes_in_last_row = width_in_blocks * block_size;
 
     let bytes_per_row = if let Some(bytes_per_row) = layout.bytes_per_row {
-        let bytes_per_row = bytes_per_row.get() as BufferAddress;
+        let bytes_per_row = bytes_per_row as BufferAddress;
         if bytes_per_row < bytes_in_last_row {
             return Err(TransferError::InvalidBytesPerRow);
         }
@@ -276,7 +276,7 @@ pub(crate) fn validate_linear_texture_data(
         0
     };
     let block_rows_per_image = if let Some(rows_per_image) = layout.rows_per_image {
-        let rows_per_image = rows_per_image.get() as BufferAddress;
+        let rows_per_image = rows_per_image as BufferAddress;
         if rows_per_image < height_in_blocks {
             return Err(TransferError::InvalidRowsPerImage);
         }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -18,7 +18,7 @@ use crate::{
 use hal::{CommandEncoder as _, Device as _, Queue as _};
 use parking_lot::Mutex;
 use smallvec::SmallVec;
-use std::{iter, mem, num::NonZeroU32, ptr};
+use std::{iter, mem, ptr};
 use thiserror::Error;
 
 /// Number of command buffers that we generate from the same pool
@@ -649,15 +649,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let width_blocks = size.width / block_width;
         let height_blocks = size.height / block_height;
 
-        let block_rows_per_image = match data_layout.rows_per_image {
-            Some(rows_per_image) => rows_per_image.get(),
-            None => {
-                // doesn't really matter because we need this only if we copy
-                // more than one layer, and then we validate for this being not
-                // None
-                size.height
-            }
-        };
+        let block_rows_per_image = data_layout.rows_per_image.unwrap_or(
+            // doesn't really matter because we need this only if we copy
+            // more than one layer, and then we validate for this being not
+            // None
+            size.height,
+        );
 
         let block_size = dst
             .desc
@@ -738,11 +735,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .as_raw()
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
 
-        let bytes_per_row = if let Some(bytes_per_row) = data_layout.bytes_per_row {
-            bytes_per_row.get()
-        } else {
-            width_blocks * block_size
-        };
+        let bytes_per_row = data_layout
+            .bytes_per_row
+            .unwrap_or(width_blocks * block_size);
 
         // Platform validation requires that the staging buffer always be
         // freed, even if an error occurs. All paths from here must call
@@ -796,8 +791,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     offset: rel_array_layer as u64
                         * block_rows_per_image as u64
                         * stage_bytes_per_row as u64,
-                    bytes_per_row: NonZeroU32::new(stage_bytes_per_row),
-                    rows_per_image: NonZeroU32::new(block_rows_per_image),
+                    bytes_per_row: Some(stage_bytes_per_row),
+                    rows_per_image: Some(block_rows_per_image),
                 },
                 texture_base,
                 size: hal_copy_size,

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -9,9 +9,7 @@ use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 
 use std::{
     borrow::{Borrow, Cow},
-    iter, mem,
-    num::NonZeroU32,
-    ptr,
+    iter, mem, ptr,
     time::Instant,
 };
 
@@ -328,7 +326,7 @@ impl<A: hal::Api> Example<A> {
             let copy = hal::BufferTextureCopy {
                 buffer_layout: wgt::ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: NonZeroU32::new(4),
+                    bytes_per_row: Some(4),
                     rows_per_image: None,
                 },
                 texture_base: hal::TextureCopyBase {

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -33,19 +33,16 @@ impl crate::BufferTextureCopy {
                 Height: self
                     .buffer_layout
                     .rows_per_image
-                    .map_or(self.size.height, |count| count.get() * block_height),
+                    .map_or(self.size.height, |count| count * block_height),
                 Depth: self.size.depth,
                 RowPitch: {
-                    let actual = match self.buffer_layout.bytes_per_row {
-                        Some(count) => count.get(),
+                    let actual = self.buffer_layout.bytes_per_row.unwrap_or_else(|| {
                         // this may happen for single-line updates
-                        None => {
-                            let block_size = format
-                                .block_size(Some(self.texture_base.aspect.map()))
-                                .unwrap();
-                            (self.size.width / block_width) * block_size
-                        }
-                    };
+                        let block_size = format
+                            .block_size(Some(self.texture_base.aspect.map()))
+                            .unwrap();
+                        (self.size.width / block_width) * block_size
+                    });
                     crate::auxil::align_to(actual, d3d12_ty::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT)
                 },
             },

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -597,11 +597,11 @@ impl super::Queue {
                 let row_texels = copy
                     .buffer_layout
                     .bytes_per_row
-                    .map_or(0, |bpr| block_width * bpr.get() / block_size);
+                    .map_or(0, |bpr| block_width * bpr / block_size);
                 let column_texels = copy
                     .buffer_layout
                     .rows_per_image
-                    .map_or(0, |rpi| block_height * rpi.get());
+                    .map_or(0, |rpi| block_height * rpi);
 
                 unsafe { gl.bind_texture(dst_target, Some(dst)) };
                 unsafe { gl.pixel_store_i32(glow::UNPACK_ROW_LENGTH, row_texels as i32) };
@@ -711,13 +711,13 @@ impl super::Queue {
                     let bytes_per_row = copy
                         .buffer_layout
                         .bytes_per_row
-                        .map_or(copy.size.width * block_size, |bpr| bpr.get());
+                        .unwrap_or(copy.size.width * block_size);
                     let minimum_rows_per_image =
                         (copy.size.height + block_height - 1) / block_height;
                     let rows_per_image = copy
                         .buffer_layout
                         .rows_per_image
-                        .map_or(minimum_rows_per_image, |rpi| rpi.get());
+                        .unwrap_or(minimum_rows_per_image);
 
                     let bytes_per_image = bytes_per_row * rows_per_image;
                     let minimum_bytes_per_image = bytes_per_row * minimum_rows_per_image;
@@ -819,11 +819,11 @@ impl super::Queue {
                 let row_texels = copy
                     .buffer_layout
                     .bytes_per_row
-                    .map_or(copy.size.width, |bpr| bpr.get() / block_size);
+                    .map_or(copy.size.width, |bpr| bpr / block_size);
                 let column_texels = copy
                     .buffer_layout
                     .rows_per_image
-                    .map_or(copy.size.height, |bpr| bpr.get());
+                    .unwrap_or(copy.size.height);
 
                 unsafe { gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(self.copy_fbo)) };
 

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -223,14 +223,11 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 .texture_base
                 .max_copy_size(&dst.copy_size)
                 .min(&copy.size);
-            let bytes_per_row = copy
-                .buffer_layout
-                .bytes_per_row
-                .map_or(0, |v| v.get() as u64);
+            let bytes_per_row = copy.buffer_layout.bytes_per_row.unwrap_or(0) as u64;
             let image_byte_stride = if extent.depth > 1 {
                 copy.buffer_layout
                     .rows_per_image
-                    .map_or(0, |v| v.get() as u64 * bytes_per_row)
+                    .map_or(0, |v| v as u64 * bytes_per_row)
             } else {
                 // Don't pass a stride when updating a single layer, otherwise metal validation
                 // fails when updating a subset of the image due to the stride being larger than
@@ -269,14 +266,11 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 .texture_base
                 .max_copy_size(&src.copy_size)
                 .min(&copy.size);
-            let bytes_per_row = copy
-                .buffer_layout
-                .bytes_per_row
-                .map_or(0, |v| v.get() as u64);
+            let bytes_per_row = copy.buffer_layout.bytes_per_row.unwrap_or(0) as u64;
             let bytes_per_image = copy
                 .buffer_layout
                 .rows_per_image
-                .map_or(0, |v| v.get() as u64 * bytes_per_row);
+                .map_or(0, |v| v as u64 * bytes_per_row);
             encoder.copy_from_texture_to_buffer(
                 &src.raw,
                 copy.texture_base.array_layer as u64,

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -25,12 +25,12 @@ impl super::Texture {
                     let block_size = format
                         .block_size(Some(r.texture_base.aspect.map()))
                         .unwrap();
-                    block_width * (bpr.get() / block_size)
+                    block_width * (bpr / block_size)
                 }),
                 buffer_image_height: r
                     .buffer_layout
                     .rows_per_image
-                    .map_or(0, |rpi| rpi.get() * block_height),
+                    .map_or(0, |rpi| rpi * block_height),
                 image_subresource,
                 image_offset,
                 image_extent: conv::map_copy_extent(&extent),

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -5177,7 +5177,7 @@ pub struct ImageDataLayout {
     /// [CEcbtt]: ../wgpu/struct.CommandEncoder.html#method.copy_buffer_to_texture
     /// [CEcttb]: ../wgpu/struct.CommandEncoder.html#method.copy_texture_to_buffer
     /// [Qwt]: ../wgpu/struct.Queue.html#method.write_texture
-    pub bytes_per_row: Option<NonZeroU32>,
+    pub bytes_per_row: Option<u32>,
     /// "Rows" that make up a single "image".
     ///
     /// A row is one row of pixels or of compressed blocks in the x direction.
@@ -5187,7 +5187,7 @@ pub struct ImageDataLayout {
     /// The amount of rows per image may be larger than the actual amount of rows of data.
     ///
     /// Required if there are multiple images (i.e. the depth is more than one).
-    pub rows_per_image: Option<NonZeroU32>,
+    pub rows_per_image: Option<u32>,
 }
 
 /// Specific type of a buffer binding.

--- a/wgpu/examples/bunnymark/main.rs
+++ b/wgpu/examples/bunnymark/main.rs
@@ -159,7 +159,7 @@ impl framework::Example for Example {
                 &buf,
                 wgpu::ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: std::num::NonZeroU32::new(info.width * 4),
+                    bytes_per_row: Some(info.width * 4),
                     rows_per_image: None,
                 },
                 size,

--- a/wgpu/examples/capture/main.rs
+++ b/wgpu/examples/capture/main.rs
@@ -113,10 +113,7 @@ async fn create_red_image_with_dimensions(
                 buffer: &output_buffer,
                 layout: wgpu::ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: Some(
-                        std::num::NonZeroU32::new(buffer_dimensions.padded_bytes_per_row as u32)
-                            .unwrap(),
-                    ),
+                    bytes_per_row: Some(buffer_dimensions.padded_bytes_per_row as u32),
                     rows_per_image: None,
                 },
             },

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -210,7 +210,7 @@ impl framework::Example for Example {
             &texels,
             wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: Some(std::num::NonZeroU32::new(size).unwrap()),
+                bytes_per_row: Some(size),
                 rows_per_image: None,
             },
             texture_extent,

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -504,7 +504,7 @@ pub struct FrameworkRefTest {
 #[cfg(test)]
 #[allow(dead_code)]
 pub fn test<E: Example>(mut params: FrameworkRefTest) {
-    use std::{mem, num::NonZeroU32};
+    use std::mem;
 
     assert_eq!(params.width % 64, 0, "width needs to be aligned 64");
 
@@ -592,7 +592,7 @@ pub fn test<E: Example>(mut params: FrameworkRefTest) {
                     buffer: &dst_buffer,
                     layout: wgpu::ImageDataLayout {
                         offset: 0,
-                        bytes_per_row: NonZeroU32::new(params.width * 4),
+                        bytes_per_row: Some(params.width * 4),
                         rows_per_image: None,
                     },
                 },

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -2,7 +2,7 @@
 mod framework;
 
 use bytemuck::{Pod, Zeroable};
-use std::{borrow::Cow, f32::consts, mem, num::NonZeroU32};
+use std::{borrow::Cow, f32::consts, mem};
 use wgpu::util::DeviceExt;
 
 const TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
@@ -247,7 +247,7 @@ impl framework::Example for Example {
                 buffer: &temp_buf,
                 layout: wgpu::ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: Some(NonZeroU32::new(4 * size).unwrap()),
+                    bytes_per_row: Some(4 * size),
                     rows_per_image: None,
                 },
             },

--- a/wgpu/examples/texture-arrays/main.rs
+++ b/wgpu/examples/texture-arrays/main.rs
@@ -197,7 +197,7 @@ impl framework::Example for Example {
             &red_texture_data,
             wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: Some(NonZeroU32::new(4).unwrap()),
+                bytes_per_row: Some(4),
                 rows_per_image: None,
             },
             wgpu::Extent3d::default(),
@@ -207,7 +207,7 @@ impl framework::Example for Example {
             &green_texture_data,
             wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: Some(NonZeroU32::new(4).unwrap()),
+                bytes_per_row: Some(4),
                 rows_per_image: None,
             },
             wgpu::Extent3d::default(),
@@ -217,7 +217,7 @@ impl framework::Example for Example {
             &blue_texture_data,
             wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: Some(NonZeroU32::new(4).unwrap()),
+                bytes_per_row: Some(4),
                 rows_per_image: None,
             },
             wgpu::Extent3d::default(),
@@ -227,7 +227,7 @@ impl framework::Example for Example {
             &white_texture_data,
             wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: Some(NonZeroU32::new(4).unwrap()),
+                bytes_per_row: Some(4),
                 rows_per_image: None,
             },
             wgpu::Extent3d::default(),

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -460,10 +460,10 @@ fn map_buffer_copy_view(view: crate::ImageCopyBuffer) -> web_sys::GpuImageCopyBu
     let buffer = &<<Context as crate::Context>::BufferId>::from(view.buffer.id).0;
     let mut mapped = web_sys::GpuImageCopyBuffer::new(buffer);
     if let Some(bytes_per_row) = view.layout.bytes_per_row {
-        mapped.bytes_per_row(bytes_per_row.get());
+        mapped.bytes_per_row(bytes_per_row);
     }
     if let Some(rows_per_image) = view.layout.rows_per_image {
-        mapped.rows_per_image(rows_per_image.get());
+        mapped.rows_per_image(rows_per_image);
     }
     mapped.offset(view.layout.offset as f64);
     mapped
@@ -2369,10 +2369,10 @@ impl crate::context::Context for Context {
     ) {
         let mut mapped_data_layout = web_sys::GpuImageDataLayout::new();
         if let Some(bytes_per_row) = data_layout.bytes_per_row {
-            mapped_data_layout.bytes_per_row(bytes_per_row.get());
+            mapped_data_layout.bytes_per_row(bytes_per_row);
         }
         if let Some(rows_per_image) = data_layout.rows_per_image {
-            mapped_data_layout.rows_per_image(rows_per_image.get());
+            mapped_data_layout.rows_per_image(rows_per_image);
         }
         mapped_data_layout.offset(data_layout.offset as f64);
 

--- a/wgpu/src/util/device.rs
+++ b/wgpu/src/util/device.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroU32;
-
 /// Describes a [Buffer](crate::Buffer) when allocating.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BufferInitDescriptor<'a> {
@@ -132,12 +130,8 @@ impl DeviceExt for crate::Device {
                     &data[binary_offset..end_offset],
                     crate::ImageDataLayout {
                         offset: 0,
-                        bytes_per_row: Some(
-                            NonZeroU32::new(bytes_per_row).expect("invalid bytes per row"),
-                        ),
-                        rows_per_image: Some(
-                            NonZeroU32::new(height_blocks).expect("invalid height"),
-                        ),
+                        bytes_per_row: Some(bytes_per_row),
+                        rows_per_image: Some(height_blocks),
                     },
                     mip_physical,
                 );

--- a/wgpu/tests/common/image.rs
+++ b/wgpu/tests/common/image.rs
@@ -2,7 +2,6 @@ use std::{
     borrow::Cow,
     ffi::{OsStr, OsString},
     io,
-    num::NonZeroU32,
     path::Path,
     str::FromStr,
 };
@@ -282,10 +281,8 @@ fn copy_texture_to_buffer_with_aspect(
             },
             layout: ImageDataLayout {
                 offset: 0,
-                bytes_per_row: Some(
-                    NonZeroU32::new((texture.width() / block_width) * block_size).unwrap(),
-                ),
-                rows_per_image: Some(NonZeroU32::new(texture.height() / block_height).unwrap()),
+                bytes_per_row: Some((texture.width() / block_width) * block_size),
+                rows_per_image: Some(texture.height() / block_height),
             },
         },
         texture

--- a/wgpu/tests/external_texture.rs
+++ b/wgpu/tests/external_texture.rs
@@ -1,7 +1,5 @@
 #![cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 
-use std::num::NonZeroU32;
-
 use crate::common::{fail_if, initialize_test, TestParameters};
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
@@ -314,7 +312,7 @@ async fn image_bitmap_import() {
                         buffer: &readback_buffer,
                         layout: wgpu::ImageDataLayout {
                             offset: 0,
-                            bytes_per_row: Some(NonZeroU32::new(256).unwrap()),
+                            bytes_per_row: Some(256),
                             rows_per_image: None,
                         },
                     },

--- a/wgpu/tests/queue_transfer.rs
+++ b/wgpu/tests/queue_transfer.rs
@@ -1,7 +1,5 @@
 //! Tests for buffer copy validation.
 
-use std::num::NonZeroU32;
-
 use crate::common::{fail, initialize_test, TestParameters};
 use wasm_bindgen_test::*;
 
@@ -37,9 +35,9 @@ fn queue_write_texture_overflow() {
                 &data,
                 wgpu::ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: NonZeroU32::new(879161360),
+                    bytes_per_row: Some(879161360),
                     //bytes_per_image: 4294967295,
-                    rows_per_image: NonZeroU32::new(4294967295 / 879161360),
+                    rows_per_image: Some(4294967295 / 879161360),
                 },
                 wgpu::Extent3d {
                     width: 3056263286,

--- a/wgpu/tests/shader_primitive_index/mod.rs
+++ b/wgpu/tests/shader_primitive_index/mod.rs
@@ -1,5 +1,4 @@
 use crate::common::{initialize_test, TestParameters, TestingContext};
-use std::num::NonZeroU32;
 use wasm_bindgen_test::*;
 use wgpu::util::{align_to, DeviceExt};
 
@@ -230,7 +229,7 @@ fn capture_rgba_u8_texture(
             buffer: &output_buffer,
             layout: wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: NonZeroU32::new(bytes_per_row),
+                bytes_per_row: Some(bytes_per_row),
                 rows_per_image: None,
             },
         },

--- a/wgpu/tests/shader_view_format/mod.rs
+++ b/wgpu/tests/shader_view_format/mod.rs
@@ -1,5 +1,4 @@
 use crate::common::{image::calc_difference, initialize_test, TestParameters, TestingContext};
-use std::num::NonZeroU32;
 use wgpu::{util::DeviceExt, DownlevelFlags, Limits, TextureFormat};
 
 #[test]
@@ -166,7 +165,7 @@ fn reinterpret(
             buffer: &read_buffer,
             layout: wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: NonZeroU32::new(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT),
+                bytes_per_row: Some(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT),
                 rows_per_image: None,
             },
         },

--- a/wgpu/tests/texture_bounds.rs
+++ b/wgpu/tests/texture_bounds.rs
@@ -1,7 +1,6 @@
 //! Tests for texture copy bounds checks.
 
 use crate::common::{fail_if, initialize_test, TestParameters};
-use std::num::NonZeroU32;
 use wasm_bindgen_test::*;
 
 #[test]
@@ -112,6 +111,6 @@ const BUFFER_SIZE: u32 = TEXTURE_SIZE.width * TEXTURE_SIZE.height * BYTES_PER_PI
 
 const BUFFER_COPY_LAYOUT: wgpu::ImageDataLayout = wgpu::ImageDataLayout {
     offset: 0,
-    bytes_per_row: NonZeroU32::new(TEXTURE_SIZE.width * BYTES_PER_PIXEL),
+    bytes_per_row: Some(TEXTURE_SIZE.width * BYTES_PER_PIXEL),
     rows_per_image: None,
 };

--- a/wgpu/tests/write_texture.rs
+++ b/wgpu/tests/write_texture.rs
@@ -2,7 +2,6 @@
 
 use crate::common::{initialize_test, TestParameters};
 
-use std::num::NonZeroU32;
 use wasm_bindgen_test::*;
 
 #[test]
@@ -39,8 +38,8 @@ fn write_texture_subset_2d() {
             bytemuck::cast_slice(&data),
             wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: std::num::NonZeroU32::new(size),
-                rows_per_image: std::num::NonZeroU32::new(size),
+                bytes_per_row: Some(size),
+                rows_per_image: Some(size),
             },
             wgpu::Extent3d {
                 width: size,
@@ -73,8 +72,8 @@ fn write_texture_subset_2d() {
                 buffer: &read_buffer,
                 layout: wgpu::ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: NonZeroU32::new(size),
-                    rows_per_image: NonZeroU32::new(size),
+                    bytes_per_row: Some(size),
+                    rows_per_image: Some(size),
                 },
             },
             wgpu::Extent3d {
@@ -135,8 +134,8 @@ fn write_texture_subset_3d() {
             bytemuck::cast_slice(&data),
             wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: std::num::NonZeroU32::new(size),
-                rows_per_image: std::num::NonZeroU32::new(size),
+                bytes_per_row: Some(size),
+                rows_per_image: Some(size),
             },
             wgpu::Extent3d {
                 width: size,
@@ -169,8 +168,8 @@ fn write_texture_subset_3d() {
                 buffer: &read_buffer,
                 layout: wgpu::ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: NonZeroU32::new(size),
-                    rows_per_image: NonZeroU32::new(size),
+                    bytes_per_row: Some(size),
+                    rows_per_image: Some(size),
                 },
             },
             wgpu::Extent3d {

--- a/wgpu/tests/zero_init_texture_after_discard.rs
+++ b/wgpu/tests/zero_init_texture_after_discard.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroU32;
-
 use crate::common::{image::ReadbackBuffers, initialize_test, TestParameters, TestingContext};
 use wasm_bindgen_test::*;
 use wgpu::*;
@@ -184,7 +182,7 @@ impl<'ctx> TestCase<'ctx> {
                 &data,
                 ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: NonZeroU32::new(bytes_per_row),
+                    bytes_per_row: Some(bytes_per_row),
                     rows_per_image: None,
                 },
                 texture.size(),


### PR DESCRIPTION
Change type of `bytes_per_row` and `rows_per_image`  (members of `ImageDataLayout`) from `Option<NonZeroU32>` to `Option<u32>`.

Similar to https://github.com/gfx-rs/wgpu/pull/3445.
