### PR TITLE
fix(deno): cleanup resources when closed

### DIFF
--- a/deno_webgpu/src/command_encoder.rs
+++ b/deno_webgpu/src/command_encoder.rs
@@ -9,20 +9,39 @@ use serde::Deserialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::num::NonZeroU32;
+use std::rc::Rc;
 
 use super::error::WebGpuResult;
 
-pub(crate) struct WebGpuCommandEncoder(pub(crate) wgpu_core::id::CommandEncoderId);
+pub(crate) struct WebGpuCommandEncoder(
+    pub(crate) super::Instance,
+    pub(crate) wgpu_core::id::CommandEncoderId, // TODO: should maybe be option?
+);
 impl Resource for WebGpuCommandEncoder {
     fn name(&self) -> Cow<str> {
         "webGPUCommandEncoder".into()
     }
+
+    fn close(self: Rc<Self>) {
+        let instance = &self.0;
+        gfx_select!(self.1 => instance.command_encoder_drop(self.1));
+    }
 }
 
-pub(crate) struct WebGpuCommandBuffer(pub(crate) wgpu_core::id::CommandBufferId);
+pub(crate) struct WebGpuCommandBuffer(
+    pub(crate) super::Instance,
+    pub(crate) RefCell<Option<wgpu_core::id::CommandBufferId>>,
+);
 impl Resource for WebGpuCommandBuffer {
     fn name(&self) -> Cow<str> {
         "webGPUCommandBuffer".into()
+    }
+
+    fn close(self: Rc<Self>) {
+        if let Some(id) = *self.1.borrow() {
+            let instance = &self.0;
+            gfx_select!(id => instance.command_buffer_drop(id));
+        }
     }
 }
 
@@ -36,7 +55,7 @@ pub fn op_webgpu_create_command_encoder(
     let device_resource = state
         .resource_table
         .get::<super::WebGpuDevice>(device_rid)?;
-    let device = device_resource.0;
+    let device = device_resource.1;
 
     let descriptor = wgpu_types::CommandEncoderDescriptor {
         label: label.map(Cow::from),
@@ -101,10 +120,10 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
                             .get::<super::texture::WebGpuTextureView>(rid)
                     })
                     .transpose()?
-                    .map(|texture| texture.0);
+                    .map(|texture| texture.1);
 
                 Some(wgpu_core::command::RenderPassColorAttachment {
-                    view: texture_view_resource.0,
+                    view: texture_view_resource.1,
                     resolve_target,
                     channel: wgpu_core::command::PassChannel {
                         load_op: at.load_op,
@@ -129,7 +148,7 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
 
         processed_depth_stencil_attachment =
             Some(wgpu_core::command::RenderPassDepthStencilAttachment {
-                view: texture_view_resource.0,
+                view: texture_view_resource.1,
                 depth: wgpu_core::command::PassChannel {
                     load_op: attachment
                         .depth_load_op
@@ -159,7 +178,7 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
         depth_stencil_attachment: processed_depth_stencil_attachment.as_ref(),
     };
 
-    let render_pass = wgpu_core::command::RenderPass::new(command_encoder_resource.0, &descriptor);
+    let render_pass = wgpu_core::command::RenderPass::new(command_encoder_resource.1, &descriptor);
 
     let rid = state
         .resource_table
@@ -185,7 +204,7 @@ pub fn op_webgpu_command_encoder_begin_compute_pass(
     };
 
     let compute_pass =
-        wgpu_core::command::ComputePass::new(command_encoder_resource.0, &descriptor);
+        wgpu_core::command::ComputePass::new(command_encoder_resource.1, &descriptor);
 
     let rid = state
         .resource_table
@@ -210,15 +229,15 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_buffer(
     let command_encoder_resource = state
         .resource_table
         .get::<WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
     let source_buffer_resource = state
         .resource_table
         .get::<super::buffer::WebGpuBuffer>(source)?;
-    let source_buffer = source_buffer_resource.0;
+    let source_buffer = source_buffer_resource.1;
     let destination_buffer_resource = state
         .resource_table
         .get::<super::buffer::WebGpuBuffer>(destination)?;
-    let destination_buffer = destination_buffer_resource.0;
+    let destination_buffer = destination_buffer_resource.1;
 
     gfx_ok!(command_encoder => instance.command_encoder_copy_buffer_to_buffer(
       command_encoder,
@@ -260,7 +279,7 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_texture(
     let command_encoder_resource = state
         .resource_table
         .get::<WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
     let source_buffer_resource = state
         .resource_table
         .get::<super::buffer::WebGpuBuffer>(source.buffer)?;
@@ -269,7 +288,7 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_texture(
         .get::<super::texture::WebGpuTexture>(destination.texture)?;
 
     let source = wgpu_core::command::ImageCopyBuffer {
-        buffer: source_buffer_resource.0,
+        buffer: source_buffer_resource.1,
         layout: wgpu_types::ImageDataLayout {
             offset: source.offset,
             bytes_per_row: NonZeroU32::new(source.bytes_per_row.unwrap_or(0)),
@@ -277,7 +296,7 @@ pub fn op_webgpu_command_encoder_copy_buffer_to_texture(
         },
     };
     let destination = wgpu_core::command::ImageCopyTexture {
-        texture: destination_texture_resource.0,
+        texture: destination_texture_resource.id,
         mip_level: destination.mip_level,
         origin: destination.origin,
         aspect: destination.aspect,
@@ -302,7 +321,7 @@ pub fn op_webgpu_command_encoder_copy_texture_to_buffer(
     let command_encoder_resource = state
         .resource_table
         .get::<WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
     let source_texture_resource = state
         .resource_table
         .get::<super::texture::WebGpuTexture>(source.texture)?;
@@ -311,13 +330,13 @@ pub fn op_webgpu_command_encoder_copy_texture_to_buffer(
         .get::<super::buffer::WebGpuBuffer>(destination.buffer)?;
 
     let source = wgpu_core::command::ImageCopyTexture {
-        texture: source_texture_resource.0,
+        texture: source_texture_resource.id,
         mip_level: source.mip_level,
         origin: source.origin,
         aspect: source.aspect,
     };
     let destination = wgpu_core::command::ImageCopyBuffer {
-        buffer: destination_buffer_resource.0,
+        buffer: destination_buffer_resource.1,
         layout: wgpu_types::ImageDataLayout {
             offset: destination.offset,
             bytes_per_row: NonZeroU32::new(destination.bytes_per_row.unwrap_or(0)),
@@ -344,7 +363,7 @@ pub fn op_webgpu_command_encoder_copy_texture_to_texture(
     let command_encoder_resource = state
         .resource_table
         .get::<WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
     let source_texture_resource = state
         .resource_table
         .get::<super::texture::WebGpuTexture>(source.texture)?;
@@ -353,13 +372,13 @@ pub fn op_webgpu_command_encoder_copy_texture_to_texture(
         .get::<super::texture::WebGpuTexture>(destination.texture)?;
 
     let source = wgpu_core::command::ImageCopyTexture {
-        texture: source_texture_resource.0,
+        texture: source_texture_resource.id,
         mip_level: source.mip_level,
         origin: source.origin,
         aspect: source.aspect,
     };
     let destination = wgpu_core::command::ImageCopyTexture {
-        texture: destination_texture_resource.0,
+        texture: destination_texture_resource.id,
         mip_level: destination.mip_level,
         origin: destination.origin,
         aspect: destination.aspect,
@@ -384,14 +403,14 @@ pub fn op_webgpu_command_encoder_clear_buffer(
     let command_encoder_resource = state
         .resource_table
         .get::<WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
     let destination_resource = state
         .resource_table
         .get::<super::buffer::WebGpuBuffer>(buffer_rid)?;
 
     gfx_ok!(command_encoder => instance.command_encoder_clear_buffer(
       command_encoder,
-      destination_resource.0,
+      destination_resource.1,
       offset,
       std::num::NonZeroU64::new(size)
     ))
@@ -407,7 +426,7 @@ pub fn op_webgpu_command_encoder_push_debug_group(
     let command_encoder_resource = state
         .resource_table
         .get::<WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
 
     gfx_ok!(command_encoder => instance.command_encoder_push_debug_group(command_encoder, &group_label))
 }
@@ -421,7 +440,7 @@ pub fn op_webgpu_command_encoder_pop_debug_group(
     let command_encoder_resource = state
         .resource_table
         .get::<WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
 
     gfx_ok!(command_encoder => instance.command_encoder_pop_debug_group(command_encoder))
 }
@@ -436,7 +455,7 @@ pub fn op_webgpu_command_encoder_insert_debug_marker(
     let command_encoder_resource = state
         .resource_table
         .get::<WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
 
     gfx_ok!(command_encoder => instance.command_encoder_insert_debug_marker(
       command_encoder,
@@ -455,14 +474,14 @@ pub fn op_webgpu_command_encoder_write_timestamp(
     let command_encoder_resource = state
         .resource_table
         .get::<WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
     let query_set_resource = state
         .resource_table
         .get::<super::WebGpuQuerySet>(query_set)?;
 
     gfx_ok!(command_encoder => instance.command_encoder_write_timestamp(
       command_encoder,
-      query_set_resource.0,
+      query_set_resource.1,
       query_index
     ))
 }
@@ -481,7 +500,7 @@ pub fn op_webgpu_command_encoder_resolve_query_set(
     let command_encoder_resource = state
         .resource_table
         .get::<WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
     let query_set_resource = state
         .resource_table
         .get::<super::WebGpuQuerySet>(query_set)?;
@@ -491,10 +510,10 @@ pub fn op_webgpu_command_encoder_resolve_query_set(
 
     gfx_ok!(command_encoder => instance.command_encoder_resolve_query_set(
       command_encoder,
-      query_set_resource.0,
+      query_set_resource.1,
       first_query,
       query_count,
-      destination_resource.0,
+      destination_resource.1,
       destination_offset
     ))
 }
@@ -508,15 +527,22 @@ pub fn op_webgpu_command_encoder_finish(
     let command_encoder_resource = state
         .resource_table
         .take::<WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
     let instance = state.borrow::<super::Instance>();
 
     let descriptor = wgpu_types::CommandBufferDescriptor {
         label: label.map(Cow::from),
     };
 
-    gfx_put!(command_encoder => instance.command_encoder_finish(
-    command_encoder,
-    &descriptor
-  ) => state, WebGpuCommandBuffer)
+    let (val, maybe_err) = gfx_select!(command_encoder => instance.command_encoder_finish(
+      command_encoder,
+      &descriptor
+    ));
+
+    let rid = state.resource_table.add(WebGpuCommandBuffer(
+        instance.clone(),
+        RefCell::new(Some(val)),
+    ));
+
+    Ok(WebGpuResult::rid_err(rid, maybe_err))
 }

--- a/deno_webgpu/src/compute_pass.rs
+++ b/deno_webgpu/src/compute_pass.rs
@@ -33,7 +33,7 @@ pub fn op_webgpu_compute_pass_set_pipeline(
 
     wgpu_core::command::compute_ffi::wgpu_compute_pass_set_pipeline(
         &mut compute_pass_resource.0.borrow_mut(),
-        compute_pipeline_resource.0,
+        compute_pipeline_resource.1,
     );
 
     Ok(WebGpuResult::empty())
@@ -77,7 +77,7 @@ pub fn op_webgpu_compute_pass_dispatch_workgroups_indirect(
 
     wgpu_core::command::compute_ffi::wgpu_compute_pass_dispatch_workgroups_indirect(
         &mut compute_pass_resource.0.borrow_mut(),
-        buffer_resource.0,
+        buffer_resource.1,
         indirect_offset,
     );
 
@@ -100,7 +100,7 @@ pub fn op_webgpu_compute_pass_begin_pipeline_statistics_query(
 
     wgpu_core::command::compute_ffi::wgpu_compute_pass_begin_pipeline_statistics_query(
         &mut compute_pass_resource.0.borrow_mut(),
-        query_set_resource.0,
+        query_set_resource.1,
         query_index,
     );
 
@@ -139,7 +139,7 @@ pub fn op_webgpu_compute_pass_write_timestamp(
 
     wgpu_core::command::compute_ffi::wgpu_compute_pass_write_timestamp(
         &mut compute_pass_resource.0.borrow_mut(),
-        query_set_resource.0,
+        query_set_resource.1,
         query_index,
     );
 
@@ -156,7 +156,7 @@ pub fn op_webgpu_compute_pass_end(
         state
             .resource_table
             .get::<super::command_encoder::WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
     let compute_pass_resource = state
         .resource_table
         .take::<WebGpuComputePass>(compute_pass_rid)?;
@@ -209,7 +209,7 @@ pub fn op_webgpu_compute_pass_set_bind_group(
         wgpu_core::command::compute_ffi::wgpu_compute_pass_set_bind_group(
             &mut compute_pass_resource.0.borrow_mut(),
             index,
-            bind_group_resource.0,
+            bind_group_resource.1,
             dynamic_offsets_data.as_ptr(),
             dynamic_offsets_data.len(),
         );

--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -52,7 +52,7 @@ mod macros {
     macro_rules! gfx_put {
     ($id:expr => $global:ident.$method:ident( $($param:expr),* ) => $state:expr, $rc:expr) => {{
       let (val, maybe_err) = gfx_select!($id => $global.$method($($param),*));
-      let rid = $state.resource_table.add($rc(val));
+      let rid = $state.resource_table.add($rc($global.clone(), val));
       Ok(WebGpuResult::rid_err(rid, maybe_err))
     }};
   }
@@ -93,26 +93,41 @@ fn check_unstable(state: &OpState, api_name: &str) {
     }
 }
 
-pub type Instance = wgpu_core::hub::Global<wgpu_core::hub::IdentityManagerFactory>;
+pub type Instance = std::sync::Arc<wgpu_core::hub::Global<wgpu_core::hub::IdentityManagerFactory>>;
 
-struct WebGpuAdapter(wgpu_core::id::AdapterId);
+struct WebGpuAdapter(Instance, wgpu_core::id::AdapterId);
 impl Resource for WebGpuAdapter {
     fn name(&self) -> Cow<str> {
         "webGPUAdapter".into()
     }
+
+    fn close(self: Rc<Self>) {
+        let instance = &self.0;
+        gfx_select!(self.1 => instance.adapter_drop(self.1));
+    }
 }
 
-struct WebGpuDevice(wgpu_core::id::DeviceId);
+struct WebGpuDevice(Instance, wgpu_core::id::DeviceId);
 impl Resource for WebGpuDevice {
     fn name(&self) -> Cow<str> {
         "webGPUDevice".into()
     }
+
+    fn close(self: Rc<Self>) {
+        let instance = &self.0;
+        gfx_select!(self.1 => instance.device_drop(self.1));
+    }
 }
 
-struct WebGpuQuerySet(wgpu_core::id::QuerySetId);
+struct WebGpuQuerySet(Instance, wgpu_core::id::QuerySetId);
 impl Resource for WebGpuQuerySet {
     fn name(&self) -> Cow<str> {
         "webGPUQuerySet".into()
+    }
+
+    fn close(self: Rc<Self>) {
+        let instance = &self.0;
+        gfx_select!(self.1 => instance.query_set_drop(self.1));
     }
 }
 
@@ -252,14 +267,14 @@ pub async fn op_webgpu_request_adapter(
     let instance = if let Some(instance) = state.try_borrow::<Instance>() {
         instance
     } else {
-        state.put(wgpu_core::hub::Global::new(
+        state.put(std::sync::Arc::new(wgpu_core::hub::Global::new(
             "webgpu",
             wgpu_core::hub::IdentityManagerFactory,
             wgpu_types::InstanceDescriptor {
                 backends,
                 dx12_shader_compiler: wgpu_types::Dx12Compiler::Fxc,
             },
-        ));
+        )));
         state.borrow::<Instance>()
     };
 
@@ -285,7 +300,9 @@ pub async fn op_webgpu_request_adapter(
     let features = deserialize_features(&adapter_features);
     let adapter_limits = gfx_select!(adapter => instance.adapter_limits(adapter))?;
 
-    let rid = state.resource_table.add(WebGpuAdapter(adapter));
+    let instance = instance.clone();
+
+    let rid = state.resource_table.add(WebGpuAdapter(instance, adapter));
 
     Ok(GpuAdapterDeviceOrErr::Features(GpuAdapterDevice {
         rid,
@@ -424,7 +441,7 @@ pub async fn op_webgpu_request_device(
 ) -> Result<GpuAdapterDevice, AnyError> {
     let mut state = state.borrow_mut();
     let adapter_resource = state.resource_table.get::<WebGpuAdapter>(adapter_rid)?;
-    let adapter = adapter_resource.0;
+    let adapter = adapter_resource.1;
     let instance = state.borrow::<Instance>();
 
     let descriptor = wgpu_types::DeviceDescriptor {
@@ -447,7 +464,8 @@ pub async fn op_webgpu_request_device(
     let features = deserialize_features(&device_features);
     let limits = gfx_select!(device => instance.device_limits(device))?;
 
-    let rid = state.resource_table.add(WebGpuDevice(device));
+    let instance = instance.clone();
+    let rid = state.resource_table.add(WebGpuDevice(instance, device));
 
     Ok(GpuAdapterDevice {
         rid,
@@ -474,7 +492,7 @@ pub async fn op_webgpu_request_adapter_info(
 ) -> Result<GPUAdapterInfo, AnyError> {
     let state = state.borrow_mut();
     let adapter_resource = state.resource_table.get::<WebGpuAdapter>(adapter_rid)?;
-    let adapter = adapter_resource.0;
+    let adapter = adapter_resource.1;
     let instance = state.borrow::<Instance>();
 
     let info = gfx_select!(adapter => instance.adapter_get_info(adapter))?;
@@ -548,8 +566,8 @@ pub fn op_webgpu_create_query_set(
     args: CreateQuerySetArgs,
 ) -> Result<WebGpuResult, AnyError> {
     let device_resource = state.resource_table.get::<WebGpuDevice>(args.device_rid)?;
-    let device = device_resource.0;
-    let instance = &state.borrow::<Instance>();
+    let device = device_resource.1;
+    let instance = state.borrow::<Instance>();
 
     let descriptor = wgpu_types::QuerySetDescriptor {
         label: args.label.map(Cow::from),

--- a/deno_webgpu/src/queue.rs
+++ b/deno_webgpu/src/queue.rs
@@ -21,7 +21,7 @@ pub fn op_webgpu_queue_submit(
 ) -> Result<WebGpuResult, AnyError> {
     let instance = state.borrow::<super::Instance>();
     let queue_resource = state.resource_table.get::<WebGpuQueue>(queue_rid)?;
-    let queue = queue_resource.0;
+    let queue = queue_resource.1;
 
     let ids = command_buffers
         .iter()
@@ -29,7 +29,8 @@ pub fn op_webgpu_queue_submit(
             let buffer_resource = state
                 .resource_table
                 .get::<super::command_encoder::WebGpuCommandBuffer>(*rid)?;
-            Ok(buffer_resource.0)
+            let mut id = buffer_resource.1.borrow_mut();
+            Ok(id.take().unwrap())
         })
         .collect::<Result<Vec<_>, AnyError>>()?;
 
@@ -74,9 +75,9 @@ pub fn op_webgpu_write_buffer(
     let buffer_resource = state
         .resource_table
         .get::<super::buffer::WebGpuBuffer>(buffer)?;
-    let buffer = buffer_resource.0;
+    let buffer = buffer_resource.1;
     let queue_resource = state.resource_table.get::<WebGpuQueue>(queue_rid)?;
-    let queue = queue_resource.0;
+    let queue = queue_resource.1;
 
     let data = match size {
         Some(size) => &buf[data_offset..(data_offset + size)],
@@ -107,10 +108,10 @@ pub fn op_webgpu_write_texture(
         .resource_table
         .get::<super::texture::WebGpuTexture>(destination.texture)?;
     let queue_resource = state.resource_table.get::<WebGpuQueue>(queue_rid)?;
-    let queue = queue_resource.0;
+    let queue = queue_resource.1;
 
     let destination = wgpu_core::command::ImageCopyTexture {
-        texture: texture_resource.0,
+        texture: texture_resource.id,
         mip_level: destination.mip_level,
         origin: destination.origin,
         aspect: destination.aspect,

--- a/deno_webgpu/src/render_pass.rs
+++ b/deno_webgpu/src/render_pass.rs
@@ -130,7 +130,7 @@ pub fn op_webgpu_render_pass_begin_pipeline_statistics_query(
 
     wgpu_core::command::render_ffi::wgpu_render_pass_begin_pipeline_statistics_query(
         &mut render_pass_resource.0.borrow_mut(),
-        query_set_resource.0,
+        query_set_resource.1,
         query_index,
     );
 
@@ -169,7 +169,7 @@ pub fn op_webgpu_render_pass_write_timestamp(
 
     wgpu_core::command::render_ffi::wgpu_render_pass_write_timestamp(
         &mut render_pass_resource.0.borrow_mut(),
-        query_set_resource.0,
+        query_set_resource.1,
         query_index,
     );
 
@@ -188,7 +188,7 @@ pub fn op_webgpu_render_pass_execute_bundles(
             let render_bundle_resource = state
                 .resource_table
                 .get::<super::bundle::WebGpuRenderBundle>(*rid)?;
-            Ok(render_bundle_resource.0)
+            Ok(render_bundle_resource.1)
         })
         .collect::<Result<Vec<_>, AnyError>>()?;
 
@@ -219,7 +219,7 @@ pub fn op_webgpu_render_pass_end(
         state
             .resource_table
             .get::<super::command_encoder::WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.0;
+    let command_encoder = command_encoder_resource.1;
     let render_pass_resource = state
         .resource_table
         .take::<WebGpuRenderPass>(render_pass_rid)?;
@@ -269,7 +269,7 @@ pub fn op_webgpu_render_pass_set_bind_group(
         wgpu_core::command::render_ffi::wgpu_render_pass_set_bind_group(
             &mut render_pass_resource.0.borrow_mut(),
             index,
-            bind_group_resource.0,
+            bind_group_resource.1,
             dynamic_offsets_data.as_ptr(),
             dynamic_offsets_data.len(),
         );
@@ -357,7 +357,7 @@ pub fn op_webgpu_render_pass_set_pipeline(
 
     wgpu_core::command::render_ffi::wgpu_render_pass_set_pipeline(
         &mut render_pass_resource.0.borrow_mut(),
-        render_pipeline_resource.0,
+        render_pipeline_resource.1,
     );
 
     Ok(WebGpuResult::empty())
@@ -389,7 +389,7 @@ pub fn op_webgpu_render_pass_set_index_buffer(
     };
 
     render_pass_resource.0.borrow_mut().set_index_buffer(
-        buffer_resource.0,
+        buffer_resource.1,
         index_format,
         offset,
         size,
@@ -426,7 +426,7 @@ pub fn op_webgpu_render_pass_set_vertex_buffer(
     wgpu_core::command::render_ffi::wgpu_render_pass_set_vertex_buffer(
         &mut render_pass_resource.0.borrow_mut(),
         slot,
-        buffer_resource.0,
+        buffer_resource.1,
         offset,
         size,
     );
@@ -500,7 +500,7 @@ pub fn op_webgpu_render_pass_draw_indirect(
 
     wgpu_core::command::render_ffi::wgpu_render_pass_draw_indirect(
         &mut render_pass_resource.0.borrow_mut(),
-        buffer_resource.0,
+        buffer_resource.1,
         indirect_offset,
     );
 
@@ -523,7 +523,7 @@ pub fn op_webgpu_render_pass_draw_indexed_indirect(
 
     wgpu_core::command::render_ffi::wgpu_render_pass_draw_indexed_indirect(
         &mut render_pass_resource.0.borrow_mut(),
-        buffer_resource.0,
+        buffer_resource.1,
         indirect_offset,
     );
 

--- a/deno_webgpu/src/texture.rs
+++ b/deno_webgpu/src/texture.rs
@@ -102,11 +102,8 @@ pub struct CreateTextureViewArgs {
     label: Option<String>,
     format: Option<wgpu_types::TextureFormat>,
     dimension: Option<wgpu_types::TextureViewDimension>,
-    aspect: wgpu_types::TextureAspect,
-    base_mip_level: u32,
-    mip_level_count: Option<u32>,
-    base_array_layer: u32,
-    array_layer_count: Option<u32>,
+    #[serde(flatten)]
+    range: wgpu_types::ImageSubresourceRange,
 }
 
 #[op]

--- a/deno_webgpu/src/texture.rs
+++ b/deno_webgpu/src/texture.rs
@@ -7,19 +7,40 @@ use deno_core::Resource;
 use deno_core::ResourceId;
 use serde::Deserialize;
 use std::borrow::Cow;
+use std::rc::Rc;
 
 use super::error::WebGpuResult;
-pub(crate) struct WebGpuTexture(pub(crate) wgpu_core::id::TextureId);
+pub(crate) struct WebGpuTexture {
+    pub(crate) instance: crate::Instance,
+    pub(crate) id: wgpu_core::id::TextureId,
+    pub(crate) owned: bool,
+}
+
 impl Resource for WebGpuTexture {
     fn name(&self) -> Cow<str> {
         "webGPUTexture".into()
     }
+
+    fn close(self: Rc<Self>) {
+        if self.owned {
+            let instance = &self.instance;
+            gfx_select!(self.id => instance.texture_drop(self.id, true));
+        }
+    }
 }
 
-pub(crate) struct WebGpuTextureView(pub(crate) wgpu_core::id::TextureViewId);
+pub(crate) struct WebGpuTextureView(
+    pub(crate) crate::Instance,
+    pub(crate) wgpu_core::id::TextureViewId,
+);
 impl Resource for WebGpuTextureView {
     fn name(&self) -> Cow<str> {
         "webGPUTextureView".into()
+    }
+
+    fn close(self: Rc<Self>) {
+        let instance = &self.0;
+        gfx_select!(self.1 => instance.texture_view_drop(self.1, true)).unwrap();
     }
 }
 
@@ -46,7 +67,7 @@ pub fn op_webgpu_create_texture(
     let device_resource = state
         .resource_table
         .get::<super::WebGpuDevice>(args.device_rid)?;
-    let device = device_resource.0;
+    let device = device_resource.1;
 
     let descriptor = wgpu_core::resource::TextureDescriptor {
         label: args.label.map(Cow::from),
@@ -59,11 +80,19 @@ pub fn op_webgpu_create_texture(
         view_formats: args.view_formats,
     };
 
-    gfx_put!(device => instance.device_create_texture(
-    device,
-    &descriptor,
-    ()
-  ) => state, WebGpuTexture)
+    let (val, maybe_err) = gfx_select!(device => instance.device_create_texture(
+      device,
+      &descriptor,
+      ()
+    ));
+
+    let rid = state.resource_table.add(WebGpuTexture {
+        instance: instance.clone(),
+        id: val,
+        owned: true,
+    });
+
+    Ok(WebGpuResult::rid_err(rid, maybe_err))
 }
 
 #[derive(Deserialize)]
@@ -73,8 +102,11 @@ pub struct CreateTextureViewArgs {
     label: Option<String>,
     format: Option<wgpu_types::TextureFormat>,
     dimension: Option<wgpu_types::TextureViewDimension>,
-    #[serde(flatten)]
-    range: wgpu_types::ImageSubresourceRange,
+    aspect: wgpu_types::TextureAspect,
+    base_mip_level: u32,
+    mip_level_count: Option<u32>,
+    base_array_layer: u32,
+    array_layer_count: Option<u32>,
 }
 
 #[op]
@@ -86,7 +118,7 @@ pub fn op_webgpu_create_texture_view(
     let texture_resource = state
         .resource_table
         .get::<WebGpuTexture>(args.texture_rid)?;
-    let texture = texture_resource.0;
+    let texture = texture_resource.id;
 
     let descriptor = wgpu_core::resource::TextureViewDescriptor {
         label: args.label.map(Cow::from),


### PR DESCRIPTION
This implements resource cleanup similar to the drop handlers used in https://github.com/gfx-rs/wgpu/blob/master/wgpu/src/lib.rs, as currently none of resources clean up and causes massive memory leaks.

Please review carefully as I potentially replaced some unrelated changes