### PR TITLE
Update feature documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,18 @@ Additionally `sample_type` and `block_size` now take an optional `TextureAspect`
 
 By @teoxoy in [#3436](https://github.com/gfx-rs/wgpu/pull/3436)
 
+#### Renamed features
+
+The following `Features` have been renamed.
+
+- `SHADER_FLOAT16` -> `SHADER_F16`
+- `SHADER_FLOAT64` -> `SHADER_F64`
+- `SHADER_INT16` -> `SHADER_I16`
+- `TEXTURE_COMPRESSION_ASTC_LDR` -> `TEXTURE_COMPRESSION_ASTC`
+- `WRITE_TIMESTAMP_INSIDE_PASSES` -> `TIMESTAMP_QUERY_INSIDE_PASSES`
+
+By @teoxoy in [#3534](https://github.com/gfx-rs/wgpu/pull/3534)
+
 #### General
 
 - Change type of `mip_level_count` and `array_layer_count` (members of `TextureViewDescriptor` and `ImageSubresourceRange`) from `Option<NonZeroU32>` to `Option<u32>`. By @teoxoy in [#3445](https://github.com/gfx-rs/wgpu/pull/3445)

--- a/deno_webgpu/src/02_idl_types.js
+++ b/deno_webgpu/src/02_idl_types.js
@@ -105,36 +105,52 @@
   webidl.converters["GPUFeatureName"] = webidl.createEnumConverter(
     "GPUFeatureName",
     [
+      // api
       "depth-clip-control",
+      "timestamp-query",
+      "indirect-first-instance",
+      // shader
+      "shader-f16",
+      // texture formats
       "depth32float-stencil8",
-      "pipeline-statistics-query",
       "texture-compression-bc",
       "texture-compression-etc2",
       "texture-compression-astc",
-      "timestamp-query",
-      "indirect-first-instance",
-      "shader-f16",
+
       // extended from spec
+
+      // texture formats
+      "texture-format-16-bit-norm",
+      "texture-compression-astc-hdr",
+      "texture-adapter-specific-format-features",
+      // api
+      "pipeline-statistics-query",
+      "timestamp-query-inside-passes",
       "mappable-primary-buffers",
       "texture-binding-array",
       "buffer-binding-array",
       "storage-resource-binding-array",
       "sampled-texture-and-storage-buffer-array-non-uniform-indexing",
-      "uniform-buffer-and-storage-buffer-texture-non-uniform-indexing",
-      "unsized-binding-array",
+      "uniform-buffer-and-storage-texture-array-non-uniform-indexing",
+      "partially-bound-binding-array",
       "multi-draw-indirect",
       "multi-draw-indirect-count",
       "push-constants",
+      "address-mode-clamp-to-zero",
       "address-mode-clamp-to-border",
-      "texture-adapter-specific-format-features",
-      "shader-float64",
-      "vertex-attribute-64bit",
+      "polygon-mode-line",
+      "polygon-mode-point",
       "conservative-rasterization",
       "vertex-writable-storage",
-      "clear-commands",
+      "clear-texture",
       "spirv-shader-passthrough",
-      "shader-primitive-index",
+      "multiview",
+      "vertex-attribute-64-bit",
+      // shader
+      "shader-f64",
       "shader-i16",
+      "shader-primitive-index",
+      "shader-early-depth-test",
     ],
   );
 

--- a/deno_webgpu/src/lib.rs
+++ b/deno_webgpu/src/lib.rs
@@ -139,23 +139,9 @@ pub fn init(unstable: bool) -> Extension {
 fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     let mut return_features: Vec<&'static str> = vec![];
 
+    // api
     if features.contains(wgpu_types::Features::DEPTH_CLIP_CONTROL) {
         return_features.push("depth-clip-control");
-    }
-    if features.contains(wgpu_types::Features::DEPTH32FLOAT_STENCIL8) {
-        return_features.push("depth32float-stencil8");
-    }
-    if features.contains(wgpu_types::Features::PIPELINE_STATISTICS_QUERY) {
-        return_features.push("pipeline-statistics-query");
-    }
-    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_BC) {
-        return_features.push("texture-compression-bc");
-    }
-    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ETC2) {
-        return_features.push("texture-compression-etc2");
-    }
-    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC_LDR) {
-        return_features.push("texture-compression-astc");
     }
     if features.contains(wgpu_types::Features::TIMESTAMP_QUERY) {
         return_features.push("timestamp-query");
@@ -163,11 +149,43 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     if features.contains(wgpu_types::Features::INDIRECT_FIRST_INSTANCE) {
         return_features.push("indirect-first-instance");
     }
-    if features.contains(wgpu_types::Features::SHADER_FLOAT16) {
+    // shader
+    if features.contains(wgpu_types::Features::SHADER_F16) {
         return_features.push("shader-f16");
+    }
+    // texture formats
+    if features.contains(wgpu_types::Features::DEPTH32FLOAT_STENCIL8) {
+        return_features.push("depth32float-stencil8");
+    }
+    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_BC) {
+        return_features.push("texture-compression-bc");
+    }
+    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ETC2) {
+        return_features.push("texture-compression-etc2");
+    }
+    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC) {
+        return_features.push("texture-compression-astc");
     }
 
     // extended from spec
+
+    // texture formats
+    if features.contains(wgpu_types::Features::TEXTURE_FORMAT_16BIT_NORM) {
+        return_features.push("texture-format-16-bit-norm");
+    }
+    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC_HDR) {
+        return_features.push("texture-compression-astc-hdr");
+    }
+    if features.contains(wgpu_types::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES) {
+        return_features.push("texture-adapter-specific-format-features");
+    }
+    // api
+    if features.contains(wgpu_types::Features::PIPELINE_STATISTICS_QUERY) {
+        return_features.push("pipeline-statistics-query");
+    }
+    if features.contains(wgpu_types::Features::TIMESTAMP_QUERY_INSIDE_PASSES) {
+        return_features.push("timestamp-query-inside-passes");
+    }
     if features.contains(wgpu_types::Features::MAPPABLE_PRIMARY_BUFFERS) {
         return_features.push("mappable-primary-buffers");
     }
@@ -188,19 +206,34 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     if features.contains(
         wgpu_types::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
     ) {
-        return_features.push("uniform-buffer-and-storage-buffer-texture-non-uniform-indexing");
+        return_features.push("uniform-buffer-and-storage-texture-array-non-uniform-indexing");
+    }
+    if features.contains(wgpu_types::Features::PARTIALLY_BOUND_BINDING_ARRAY) {
+        return_features.push("partially-bound-binding-array");
+    }
+    if features.contains(wgpu_types::Features::MULTI_DRAW_INDIRECT) {
+        return_features.push("multi-draw-indirect");
+    }
+    if features.contains(wgpu_types::Features::MULTI_DRAW_INDIRECT_COUNT) {
+        return_features.push("multi-draw-indirect-count");
+    }
+    if features.contains(wgpu_types::Features::PUSH_CONSTANTS) {
+        return_features.push("push-constants");
+    }
+    if features.contains(wgpu_types::Features::ADDRESS_MODE_CLAMP_TO_ZERO) {
+        return_features.push("address-mode-clamp-to-zero");
     }
     if features.contains(wgpu_types::Features::ADDRESS_MODE_CLAMP_TO_BORDER) {
         return_features.push("address-mode-clamp-to-border");
     }
-    if features.contains(wgpu_types::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES) {
-        return_features.push("texture-adapter-specific-format-features");
+    if features.contains(wgpu_types::Features::POLYGON_MODE_LINE) {
+        return_features.push("polygon-mode-line");
     }
-    if features.contains(wgpu_types::Features::SHADER_FLOAT64) {
-        return_features.push("shader-float64");
+    if features.contains(wgpu_types::Features::POLYGON_MODE_POINT) {
+        return_features.push("polygon-mode-point");
     }
-    if features.contains(wgpu_types::Features::VERTEX_ATTRIBUTE_64BIT) {
-        return_features.push("vertex-attribute-64bit");
+    if features.contains(wgpu_types::Features::CONSERVATIVE_RASTERIZATION) {
+        return_features.push("conservative-rasterization");
     }
     if features.contains(wgpu_types::Features::VERTEX_WRITABLE_STORAGE) {
         return_features.push("vertex-writable-storage");
@@ -208,14 +241,27 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     if features.contains(wgpu_types::Features::CLEAR_TEXTURE) {
         return_features.push("clear-texture");
     }
+    if features.contains(wgpu_types::Features::SPIRV_SHADER_PASSTHROUGH) {
+        return_features.push("spirv-shader-passthrough");
+    }
+    if features.contains(wgpu_types::Features::MULTIVIEW) {
+        return_features.push("multiview");
+    }
+    if features.contains(wgpu_types::Features::VERTEX_ATTRIBUTE_64BIT) {
+        return_features.push("vertex-attribute-64-bit");
+    }
+    // shader
+    if features.contains(wgpu_types::Features::SHADER_F64) {
+        return_features.push("shader-f64");
+    }
+    if features.contains(wgpu_types::Features::SHADER_I16) {
+        return_features.push("shader-i16");
+    }
     if features.contains(wgpu_types::Features::SHADER_PRIMITIVE_INDEX) {
         return_features.push("shader-primitive-index");
     }
-    if features.contains(wgpu_types::Features::PARTIALLY_BOUND_BINDING_ARRAY) {
-        return_features.push("shader-primitive-index");
-    }
-    if features.contains(wgpu_types::Features::SHADER_INT16) {
-        return_features.push("shader-i16");
+    if features.contains(wgpu_types::Features::SHADER_EARLY_DEPTH_TEST) {
+        return_features.push("shader-early-depth-test");
     }
 
     return_features
@@ -301,17 +347,28 @@ pub struct GpuRequiredFeatures(HashSet<String>);
 impl From<GpuRequiredFeatures> for wgpu_types::Features {
     fn from(required_features: GpuRequiredFeatures) -> wgpu_types::Features {
         let mut features: wgpu_types::Features = wgpu_types::Features::empty();
+        // api
         features.set(
             wgpu_types::Features::DEPTH_CLIP_CONTROL,
             required_features.0.contains("depth-clip-control"),
         );
         features.set(
-            wgpu_types::Features::DEPTH32FLOAT_STENCIL8,
-            required_features.0.contains("depth32float-stencil8"),
+            wgpu_types::Features::TIMESTAMP_QUERY,
+            required_features.0.contains("timestamp-query"),
         );
         features.set(
-            wgpu_types::Features::PIPELINE_STATISTICS_QUERY,
-            required_features.0.contains("pipeline-statistics-query"),
+            wgpu_types::Features::INDIRECT_FIRST_INSTANCE,
+            required_features.0.contains("indirect-first-instance"),
+        );
+        // shader
+        features.set(
+            wgpu_types::Features::SHADER_F16,
+            required_features.0.contains("shader-f16"),
+        );
+        // texture formats
+        features.set(
+            wgpu_types::Features::DEPTH32FLOAT_STENCIL8,
+            required_features.0.contains("depth32float-stencil8"),
         );
         features.set(
             wgpu_types::Features::TEXTURE_COMPRESSION_BC,
@@ -322,23 +379,38 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
             required_features.0.contains("texture-compression-etc2"),
         );
         features.set(
-            wgpu_types::Features::TEXTURE_COMPRESSION_ASTC_LDR,
+            wgpu_types::Features::TEXTURE_COMPRESSION_ASTC,
             required_features.0.contains("texture-compression-astc"),
-        );
-        features.set(
-            wgpu_types::Features::TIMESTAMP_QUERY,
-            required_features.0.contains("timestamp-query"),
-        );
-        features.set(
-            wgpu_types::Features::INDIRECT_FIRST_INSTANCE,
-            required_features.0.contains("indirect-first-instance"),
-        );
-        features.set(
-            wgpu_types::Features::SHADER_FLOAT16,
-            required_features.0.contains("shader-f16"),
         );
 
         // extended from spec
+
+        // texture formats
+        features.set(
+            wgpu_types::Features::TEXTURE_FORMAT_16BIT_NORM,
+            required_features.0.contains("texture-format-16-bit-norm"),
+        );
+        features.set(
+            wgpu_types::Features::TEXTURE_COMPRESSION_ASTC_HDR,
+            required_features.0.contains("texture-compression-astc-hdr"),
+        );
+        features.set(
+            wgpu_types::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
+            required_features
+                .0
+                .contains("texture-adapter-specific-format-features"),
+        );
+        // api
+        features.set(
+            wgpu_types::Features::PIPELINE_STATISTICS_QUERY,
+            required_features.0.contains("pipeline-statistics-query"),
+        );
+        features.set(
+            wgpu_types::Features::TIMESTAMP_QUERY_INSIDE_PASSES,
+            required_features
+                .0
+                .contains("timestamp-query-inside-passes"),
+        );
         features.set(
             wgpu_types::Features::MAPPABLE_PRIMARY_BUFFERS,
             required_features.0.contains("mappable-primary-buffers"),
@@ -367,29 +439,45 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
             wgpu_types::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
             required_features
                 .0
-                .contains("uniform-buffer-and-storage-buffer-texture-non-uniform-indexing"),
+                .contains("uniform-buffer-and-storage-texture-array-non-uniform-indexing"),
+        );
+        features.set(
+            wgpu_types::Features::PARTIALLY_BOUND_BINDING_ARRAY,
+            required_features
+                .0
+                .contains("partially-bound-binding-array"),
+        );
+        features.set(
+            wgpu_types::Features::MULTI_DRAW_INDIRECT,
+            required_features.0.contains("multi-draw-indirect"),
+        );
+        features.set(
+            wgpu_types::Features::MULTI_DRAW_INDIRECT_COUNT,
+            required_features.0.contains("multi-draw-indirect-count"),
+        );
+        features.set(
+            wgpu_types::Features::PUSH_CONSTANTS,
+            required_features.0.contains("push-constants"),
+        );
+        features.set(
+            wgpu_types::Features::ADDRESS_MODE_CLAMP_TO_ZERO,
+            required_features.0.contains("address-mode-clamp-to-zero"),
         );
         features.set(
             wgpu_types::Features::ADDRESS_MODE_CLAMP_TO_BORDER,
             required_features.0.contains("address-mode-clamp-to-border"),
         );
         features.set(
-            wgpu_types::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
-            required_features
-                .0
-                .contains("texture-adapter-specific-format-features"),
+            wgpu_types::Features::POLYGON_MODE_LINE,
+            required_features.0.contains("polygon-mode-line"),
         );
         features.set(
-            wgpu_types::Features::SHADER_FLOAT64,
-            required_features.0.contains("shader-float64"),
+            wgpu_types::Features::POLYGON_MODE_POINT,
+            required_features.0.contains("polygon-mode-point"),
         );
         features.set(
-            wgpu_types::Features::SHADER_INT16,
-            required_features.0.contains("shader-i16"),
-        );
-        features.set(
-            wgpu_types::Features::VERTEX_ATTRIBUTE_64BIT,
-            required_features.0.contains("vertex-attribute-64bit"),
+            wgpu_types::Features::CONSERVATIVE_RASTERIZATION,
+            required_features.0.contains("conservative-rasterization"),
         );
         features.set(
             wgpu_types::Features::VERTEX_WRITABLE_STORAGE,
@@ -397,17 +485,36 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
         );
         features.set(
             wgpu_types::Features::CLEAR_TEXTURE,
-            required_features.0.contains("clear-commands"),
+            required_features.0.contains("clear-texture"),
+        );
+        features.set(
+            wgpu_types::Features::SPIRV_SHADER_PASSTHROUGH,
+            required_features.0.contains("spirv-shader-passthrough"),
+        );
+        features.set(
+            wgpu_types::Features::MULTIVIEW,
+            required_features.0.contains("multiview"),
+        );
+        features.set(
+            wgpu_types::Features::VERTEX_ATTRIBUTE_64BIT,
+            required_features.0.contains("vertex-attribute-64-bit"),
+        );
+        // shader
+        features.set(
+            wgpu_types::Features::SHADER_F64,
+            required_features.0.contains("shader-f64"),
+        );
+        features.set(
+            wgpu_types::Features::SHADER_I16,
+            required_features.0.contains("shader-i16"),
         );
         features.set(
             wgpu_types::Features::SHADER_PRIMITIVE_INDEX,
             required_features.0.contains("shader-primitive-index"),
         );
         features.set(
-            wgpu_types::Features::PARTIALLY_BOUND_BINDING_ARRAY,
-            required_features
-                .0
-                .contains("partially-bound-binding-array"),
+            wgpu_types::Features::SHADER_EARLY_DEPTH_TEST,
+            required_features.0.contains("shader-early-depth-test"),
         );
 
         features

--- a/deno_webgpu/webgpu.idl
+++ b/deno_webgpu/webgpu.idl
@@ -88,14 +88,52 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
 };
 
 enum GPUFeatureName {
+    // api
     "depth-clip-control",
+    "timestamp-query",
+    "indirect-first-instance",
+    // shader
+    "shader-f16",
+    // texture formats
     "depth32float-stencil8",
     "texture-compression-bc",
     "texture-compression-etc2",
     "texture-compression-astc",
-    "timestamp-query",
-    "indirect-first-instance",
-    "shader-f16",
+
+    // extended from spec
+
+    // texture formats
+    "texture-format-16-bit-norm",
+    "texture-compression-astc-hdr",
+    "texture-adapter-specific-format-features",
+    // api
+    "pipeline-statistics-query",
+    "timestamp-query-inside-passes",
+    "mappable-primary-buffers",
+    "texture-binding-array",
+    "buffer-binding-array",
+    "storage-resource-binding-array",
+    "sampled-texture-and-storage-buffer-array-non-uniform-indexing",
+    "uniform-buffer-and-storage-texture-array-non-uniform-indexing",
+    "partially-bound-binding-array",
+    "multi-draw-indirect",
+    "multi-draw-indirect-count",
+    "push-constants",
+    "address-mode-clamp-to-zero",
+    "address-mode-clamp-to-border",
+    "polygon-mode-line",
+    "polygon-mode-point",
+    "conservative-rasterization",
+    "vertex-writable-storage",
+    "clear-texture",
+    "spirv-shader-passthrough",
+    "multiview",
+    "vertex-attribute-64-bit",
+    // shader
+    "shader-f64",
+    "shader-i16",
+    "shader-primitive-index",
+    "shader-early-depth-test",
 };
 
 [Exposed=(Window, DedicatedWorker), SecureContext]

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -633,7 +633,7 @@ impl RenderBundleEncoder {
                 RenderCommand::PushDebugGroup { color: _, len: _ } => unimplemented!(),
                 RenderCommand::InsertDebugMarker { color: _, len: _ } => unimplemented!(),
                 RenderCommand::PopDebugGroup => unimplemented!(),
-                RenderCommand::WriteTimestamp { .. } // Must check the WRITE_TIMESTAMP_INSIDE_PASSES feature
+                RenderCommand::WriteTimestamp { .. } // Must check the TIMESTAMP_QUERY_INSIDE_PASSES feature
                 | RenderCommand::BeginPipelineStatisticsQuery { .. }
                 | RenderCommand::EndPipelineStatisticsQuery => unimplemented!(),
                 RenderCommand::ExecuteBundle(_)

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -714,7 +714,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     let scope = PassErrorScope::WriteTimestamp;
 
                     device
-                        .require_features(wgt::Features::WRITE_TIMESTAMP_INSIDE_PASSES)
+                        .require_features(wgt::Features::TIMESTAMP_QUERY_INSIDE_PASSES)
                         .map_pass_err(scope)?;
 
                     let query_set: &resource::QuerySet<A> = cmd_buf

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1928,7 +1928,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         let scope = PassErrorScope::WriteTimestamp;
 
                         device
-                            .require_features(wgt::Features::WRITE_TIMESTAMP_INSIDE_PASSES)
+                            .require_features(wgt::Features::TIMESTAMP_QUERY_INSIDE_PASSES)
                             .map_pass_err(scope)?;
 
                         let query_set: &resource::QuerySet<A> = cmd_buf

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1357,7 +1357,7 @@ impl<A: HalApi> Device<A> {
         );
         caps.set(
             Caps::FLOAT64,
-            self.features.contains(wgt::Features::SHADER_FLOAT64),
+            self.features.contains(wgt::Features::SHADER_F64),
         );
         caps.set(
             Caps::PRIMITIVE_INDEX,

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -206,7 +206,7 @@ impl super::Adapter {
             | wgt::Features::VERTEX_WRITABLE_STORAGE
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | wgt::Features::TIMESTAMP_QUERY
-            | wgt::Features::WRITE_TIMESTAMP_INSIDE_PASSES
+            | wgt::Features::TIMESTAMP_QUERY_INSIDE_PASSES
             | wgt::Features::TEXTURE_COMPRESSION_BC
             | wgt::Features::CLEAR_TEXTURE
             | wgt::Features::TEXTURE_FORMAT_16BIT_NORM

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -396,11 +396,11 @@ impl super::Adapter {
         if extensions.contains("WEBGL_compressed_texture_astc")
             || extensions.contains("GL_OES_texture_compression_astc")
         {
-            features.insert(wgt::Features::TEXTURE_COMPRESSION_ASTC_LDR);
+            features.insert(wgt::Features::TEXTURE_COMPRESSION_ASTC);
             features.insert(wgt::Features::TEXTURE_COMPRESSION_ASTC_HDR);
         } else {
             features.set(
-                wgt::Features::TEXTURE_COMPRESSION_ASTC_LDR,
+                wgt::Features::TEXTURE_COMPRESSION_ASTC,
                 extensions.contains("GL_KHR_texture_compression_astc_ldr"),
             );
             features.set(
@@ -743,7 +743,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
 
         let bcn_features = feature_fn(wgt::Features::TEXTURE_COMPRESSION_BC, filterable);
         let etc2_features = feature_fn(wgt::Features::TEXTURE_COMPRESSION_ETC2, filterable);
-        let astc_features = feature_fn(wgt::Features::TEXTURE_COMPRESSION_ASTC_LDR, filterable);
+        let astc_features = feature_fn(wgt::Features::TEXTURE_COMPRESSION_ASTC, filterable);
         let astc_hdr_features = feature_fn(wgt::Features::TEXTURE_COMPRESSION_ASTC_HDR, filterable);
 
         let private_caps_fn = |f, caps| {

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -761,11 +761,11 @@ impl super::PrivateCapabilities {
             | F::POLYGON_MODE_LINE
             | F::CLEAR_TEXTURE
             | F::TEXTURE_FORMAT_16BIT_NORM
-            | F::SHADER_FLOAT16
+            | F::SHADER_F16
             | F::DEPTH32FLOAT_STENCIL8
             | F::MULTI_DRAW_INDIRECT;
 
-        features.set(F::TEXTURE_COMPRESSION_ASTC_LDR, self.format_astc);
+        features.set(F::TEXTURE_COMPRESSION_ASTC, self.format_astc);
         features.set(F::TEXTURE_COMPRESSION_ASTC_HDR, self.format_astc_hdr);
         features.set(F::TEXTURE_COMPRESSION_BC, self.format_bc);
         features.set(F::TEXTURE_COMPRESSION_ETC2, self.format_eac_etc);

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -140,7 +140,7 @@ impl PhysicalDeviceFeatures {
                     requested_features.contains(wgt::Features::TEXTURE_COMPRESSION_ETC2),
                 )
                 .texture_compression_astc_ldr(
-                    requested_features.contains(wgt::Features::TEXTURE_COMPRESSION_ASTC_LDR),
+                    requested_features.contains(wgt::Features::TEXTURE_COMPRESSION_ASTC),
                 )
                 .texture_compression_bc(
                     requested_features.contains(wgt::Features::TEXTURE_COMPRESSION_BC),
@@ -174,9 +174,9 @@ impl PhysicalDeviceFeatures {
                 //.shader_storage_image_array_dynamic_indexing(
                 //.shader_clip_distance(requested_features.contains(wgt::Features::SHADER_CLIP_DISTANCE))
                 //.shader_cull_distance(requested_features.contains(wgt::Features::SHADER_CULL_DISTANCE))
-                .shader_float64(requested_features.contains(wgt::Features::SHADER_FLOAT64))
+                .shader_float64(requested_features.contains(wgt::Features::SHADER_F64))
                 //.shader_int64(requested_features.contains(wgt::Features::SHADER_INT64))
-                .shader_int16(requested_features.contains(wgt::Features::SHADER_INT16))
+                .shader_int16(requested_features.contains(wgt::Features::SHADER_I16))
                 //.shader_resource_residency(requested_features.contains(wgt::Features::SHADER_RESOURCE_RESIDENCY))
                 .geometry_shader(requested_features.contains(wgt::Features::SHADER_PRIMITIVE_INDEX))
                 .build(),
@@ -278,7 +278,7 @@ impl PhysicalDeviceFeatures {
             } else {
                 None
             },
-            shader_float16: if requested_features.contains(wgt::Features::SHADER_FLOAT16) {
+            shader_float16: if requested_features.contains(wgt::Features::SHADER_F16) {
                 Some((
                     vk::PhysicalDeviceShaderFloat16Int8Features::builder()
                         .shader_float16(true)
@@ -322,7 +322,7 @@ impl PhysicalDeviceFeatures {
             | F::ADDRESS_MODE_CLAMP_TO_BORDER
             | F::ADDRESS_MODE_CLAMP_TO_ZERO
             | F::TIMESTAMP_QUERY
-            | F::WRITE_TIMESTAMP_INSIDE_PASSES
+            | F::TIMESTAMP_QUERY_INSIDE_PASSES
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | F::CLEAR_TEXTURE;
 
@@ -374,7 +374,7 @@ impl PhysicalDeviceFeatures {
             self.core.texture_compression_etc2 != 0,
         );
         features.set(
-            F::TEXTURE_COMPRESSION_ASTC_LDR,
+            F::TEXTURE_COMPRESSION_ASTC,
             self.core.texture_compression_astc_ldr != 0,
         );
         features.set(
@@ -418,9 +418,9 @@ impl PhysicalDeviceFeatures {
         //if self.core.shader_storage_image_array_dynamic_indexing != 0 {
         //if self.core.shader_clip_distance != 0 {
         //if self.core.shader_cull_distance != 0 {
-        features.set(F::SHADER_FLOAT64, self.core.shader_float64 != 0);
+        features.set(F::SHADER_F64, self.core.shader_float64 != 0);
         //if self.core.shader_int64 != 0 {
-        features.set(F::SHADER_INT16, self.core.shader_int16 != 0);
+        features.set(F::SHADER_I16, self.core.shader_int16 != 0);
 
         //if caps.supports_extension(vk::KhrSamplerMirrorClampToEdgeFn::name()) {
         //if caps.supports_extension(vk::ExtSamplerFilterMinmaxFn::name()) {
@@ -494,7 +494,7 @@ impl PhysicalDeviceFeatures {
 
         if let Some((ref f16_i8, ref bit16)) = self.shader_float16 {
             features.set(
-                F::SHADER_FLOAT16,
+                F::SHADER_F16,
                 f16_i8.shader_float16 != 0
                     && bit16.storage_buffer16_bit_access != 0
                     && bit16.uniform_and_storage_buffer16_bit_access != 0,
@@ -647,7 +647,7 @@ impl PhysicalDeviceCapabilities {
             }
 
             // Require `VK_KHR_shader_float16_int8` and `VK_KHR_16bit_storage` if the associated feature was requested
-            if requested_features.contains(wgt::Features::SHADER_FLOAT16) {
+            if requested_features.contains(wgt::Features::SHADER_F16) {
                 extensions.push(vk::KhrShaderFloat16Int8Fn::name());
                 // `VK_KHR_16bit_storage` requires `VK_KHR_storage_buffer_storage_class`, however we require that one already
                 if self.effective_api_version < vk::API_VERSION_1_1 {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -220,6 +220,8 @@ bitflags::bitflags! {
         // WebGPU features:
         //
 
+        // API:
+
         /// By default, polygon depth is clipped to 0-1 range before/during rasterization.
         /// Anything outside of that range is rejected, and respective fragments are not touched.
         ///
@@ -232,68 +234,6 @@ bitflags::bitflags! {
         ///
         /// This is a web and native feature.
         const DEPTH_CLIP_CONTROL = 1 << 0;
-        /// Allows for explicit creation of textures of format [`TextureFormat::Depth32FloatStencil8`]
-        ///
-        /// Supported platforms:
-        /// - Vulkan (mostly)
-        /// - DX12
-        /// - Metal
-        ///
-        /// This is a web and native feature.
-        const DEPTH32FLOAT_STENCIL8 = 1 << 2;
-        /// Enables BCn family of compressed textures. All BCn textures use 4x4 pixel blocks
-        /// with 8 or 16 bytes per block.
-        ///
-        /// Compressed textures sacrifice some quality in exchange for significantly reduced
-        /// bandwidth usage.
-        ///
-        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING`] for BCn formats.
-        /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
-        ///
-        /// Supported Platforms:
-        /// - desktops
-        ///
-        /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_BC = 1 << 3;
-        /// Enables ETC family of compressed textures. All ETC textures use 4x4 pixel blocks.
-        /// ETC2 RGB and RGBA1 are 8 bytes per block. RTC2 RGBA8 and EAC are 16 bytes per block.
-        ///
-        /// Compressed textures sacrifice some quality in exchange for significantly reduced
-        /// bandwidth usage.
-        ///
-        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING`] for ETC2 formats.
-        /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
-        ///
-        /// Supported Platforms:
-        /// - Vulkan on Intel
-        /// - Mobile (some)
-        ///
-        /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_ETC2 = 1 << 4;
-        /// Enables ASTC family of compressed textures. ASTC textures use pixel blocks varying from 4x4 to 12x12.
-        /// Blocks are always 16 bytes.
-        ///
-        /// Compressed textures sacrifice some quality in exchange for significantly reduced
-        /// bandwidth usage.
-        ///
-        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING`] for ASTC formats.
-        /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
-        ///
-        /// Supported Platforms:
-        /// - Vulkan on Intel
-        /// - Mobile (some)
-        ///
-        /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_ASTC_LDR = 1 << 5;
-        /// Allows non-zero value for the "first instance" in indirect draw calls.
-        ///
-        /// Supported Platforms:
-        /// - Vulkan (mostly)
-        /// - DX12
-        /// - Metal
-        ///
-        /// This is a web and native feature.
-        const INDIRECT_FIRST_INSTANCE = 1 << 6;
         /// Enables use of Timestamp Queries. These queries tell the current gpu timestamp when
         /// all work before the query is finished. Call [`CommandEncoder::write_timestamp`],
         /// [`RenderPassEncoder::write_timestamp`], or [`ComputePassEncoder::write_timestamp`] to
@@ -311,7 +251,154 @@ bitflags::bitflags! {
         /// This is currently unimplemented on Metal.
         ///
         /// This is a web and native feature.
-        const TIMESTAMP_QUERY = 1 << 7;
+        const TIMESTAMP_QUERY = 1 << 1;
+        /// Allows non-zero value for the "first instance" in indirect draw calls.
+        ///
+        /// Supported Platforms:
+        /// - Vulkan (mostly)
+        /// - DX12
+        /// - Metal
+        ///
+        /// This is a web and native feature.
+        const INDIRECT_FIRST_INSTANCE = 1 << 2;
+
+        // 3..8 available
+
+        // Shader:
+
+        /// Allows shaders to acquire the FP16 ability
+        ///
+        /// Note: this is not supported in naga yet，only through spir-v passthrough right now.
+        ///
+        /// Supported Platforms:
+        /// - Vulkan
+        /// - Metal
+        ///
+        /// This is a web and native feature.
+        const SHADER_F16 = 1 << 8;
+
+        // 9..14 available
+
+        // Texture Formats:
+
+        // ? const FORMATS_TIER_1 = 1 << 14; (https://github.com/gpuweb/gpuweb/issues/3837)
+        // ? const RW_STORAGE_TEXTURE_TIER_1 = 1 << 15; (https://github.com/gpuweb/gpuweb/issues/3838)
+        // TODO const BGRA8UNORM_STORAGE = 1 << 16;
+        // ? const NORM16_FILTERABLE = 1 << 17; (https://github.com/gpuweb/gpuweb/issues/3839)
+        // ? const NORM16_RESOLVE = 1 << 18; (https://github.com/gpuweb/gpuweb/issues/3839)
+        // TODO const FLOAT32_FILTERABLE = 1 << 19;
+        // ? const FLOAT32_BLENDABLE = 1 << 20; (https://github.com/gpuweb/gpuweb/issues/3556)
+        // ? const 32BIT_FORMAT_MULTISAMPLE = 1 << 21; (https://github.com/gpuweb/gpuweb/issues/3844)
+        // ? const 32BIT_FORMAT_RESOLVE = 1 << 22; (https://github.com/gpuweb/gpuweb/issues/3844)
+        // TODO const RG11B10UFLOAT_RENDERABLE = 1 << 23;
+
+        /// Allows for explicit creation of textures of format [`TextureFormat::Depth32FloatStencil8`]
+        ///
+        /// Supported platforms:
+        /// - Vulkan (mostly)
+        /// - DX12
+        /// - Metal
+        ///
+        /// This is a web and native feature.
+        const DEPTH32FLOAT_STENCIL8 = 1 << 24;
+        /// Enables BCn family of compressed textures. All BCn textures use 4x4 pixel blocks
+        /// with 8 or 16 bytes per block.
+        ///
+        /// Compressed textures sacrifice some quality in exchange for significantly reduced
+        /// bandwidth usage.
+        ///
+        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING`] for BCn formats.
+        /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
+        ///
+        /// Supported Platforms:
+        /// - desktops
+        ///
+        /// This is a web and native feature.
+        const TEXTURE_COMPRESSION_BC = 1 << 25;
+        /// Enables ETC family of compressed textures. All ETC textures use 4x4 pixel blocks.
+        /// ETC2 RGB and RGBA1 are 8 bytes per block. RTC2 RGBA8 and EAC are 16 bytes per block.
+        ///
+        /// Compressed textures sacrifice some quality in exchange for significantly reduced
+        /// bandwidth usage.
+        ///
+        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING`] for ETC2 formats.
+        /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
+        ///
+        /// Supported Platforms:
+        /// - Vulkan on Intel
+        /// - Mobile (some)
+        ///
+        /// This is a web and native feature.
+        const TEXTURE_COMPRESSION_ETC2 = 1 << 26;
+        /// Enables ASTC family of compressed textures. ASTC textures use pixel blocks varying from 4x4 to 12x12.
+        /// Blocks are always 16 bytes.
+        ///
+        /// Compressed textures sacrifice some quality in exchange for significantly reduced
+        /// bandwidth usage.
+        ///
+        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING`] for ASTC formats.
+        /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
+        ///
+        /// Supported Platforms:
+        /// - Vulkan on Intel
+        /// - Mobile (some)
+        ///
+        /// This is a web and native feature.
+        const TEXTURE_COMPRESSION_ASTC = 1 << 27;
+
+        // ? const TEXTURE_COMPRESSION_ASTC_HDR = 1 << 28; (https://github.com/gpuweb/gpuweb/issues/3856)
+
+        // 29..32 should be available but are for now occupied by native only texture related features
+        // TEXTURE_FORMAT_16BIT_NORM & TEXTURE_COMPRESSION_ASTC_HDR will most likely become web features as well
+        // TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES might not be necessary if we have all the texture features implemented
+
+        //
+        // ---- Restart Numbering for Native Features ---
+        //
+        // Native Features:
+        //
+
+        // Texture Formats:
+
+        /// Enables normalized `16-bit` texture formats.
+        ///
+        /// Supported platforms:
+        /// - Vulkan
+        /// - DX12
+        /// - Metal
+        ///
+        /// This is a native only feature.
+        const TEXTURE_FORMAT_16BIT_NORM = 1 << 29;
+        /// Enables ASTC HDR family of compressed textures.
+        ///
+        /// Compressed textures sacrifice some quality in exchange for significantly reduced
+        /// bandwidth usage.
+        ///
+        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING`] for BCn formats.
+        /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
+        ///
+        /// Supported Platforms:
+        /// - Metal
+        /// - Vulkan
+        /// - OpenGL
+        ///
+        /// This is a native only feature.
+        const TEXTURE_COMPRESSION_ASTC_HDR = 1 << 30;
+        /// Enables device specific texture format features.
+        ///
+        /// See `TextureFormatFeatures` for a listing of the features in question.
+        ///
+        /// By default only texture format properties as defined by the WebGPU specification are allowed.
+        /// Enabling this feature flag extends the features of each format to the ones supported by the current device.
+        /// Note that without this flag, read/write storage access is not allowed at all.
+        ///
+        /// This extension does not enable additional formats.
+        ///
+        /// This is a native only feature.
+        const TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 1 << 31;
+
+        // API:
+
         /// Enables use of Pipeline Statistics Queries. These queries tell the count of various operations
         /// performed between the start and stop call. Call [`RenderPassEncoder::begin_pipeline_statistics_query`] to start
         /// a query, then call [`RenderPassEncoder::end_pipeline_statistics_query`] to stop one.
@@ -323,25 +410,21 @@ bitflags::bitflags! {
         /// - Vulkan
         /// - DX12
         ///
-        /// This is a web and native feature.
-        const PIPELINE_STATISTICS_QUERY = 1 << 8;
-        /// Allows shaders to acquire the FP16 ability
+        /// This is a native only feature with a [proposal](https://github.com/gpuweb/gpuweb/blob/0008bd30da2366af88180b511a5d0d0c1dffbc36/proposals/pipeline-statistics-query.md) for the web.
+        const PIPELINE_STATISTICS_QUERY = 1 << 32;
+        /// Allows for timestamp queries inside render passes.
         ///
-        /// Note: this is not supported in naga yet，only through spir-v passthrough right now.
+        /// Implies [`Features::TIMESTAMP_QUERY`] is supported.
         ///
-        /// Supported Platforms:
+        /// Supported platforms:
         /// - Vulkan
-        /// - Metal
+        /// - DX12
         ///
-        /// This is a web and native feature.
-        const SHADER_FLOAT16 = 1 << 9;
-
-        //
-        // ---- Restart Numbering for Native Features ---
-        //
-        // Native Features:
-        //
-
+        /// This is currently unimplemented on Metal.
+        /// When implemented, it will be supported on Metal on AMD and Intel GPUs, but not Apple GPUs.
+        ///
+        /// This is a native only feature with a [proposal](https://github.com/gpuweb/gpuweb/blob/0008bd30da2366af88180b511a5d0d0c1dffbc36/proposals/timestamp-query-inside-passes.md) for the web.
+        const TIMESTAMP_QUERY_INSIDE_PASSES = 1 << 33;
         /// Webgpu only allows the MAP_READ and MAP_WRITE buffer usage to be matched with
         /// COPY_DST and COPY_SRC respectively. This removes this requirement.
         ///
@@ -355,7 +438,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const MAPPABLE_PRIMARY_BUFFERS = 1 << 16;
+        const MAPPABLE_PRIMARY_BUFFERS = 1 << 34;
         /// Allows the user to create uniform arrays of textures in shaders:
         ///
         /// ex.
@@ -378,7 +461,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const TEXTURE_BINDING_ARRAY = 1 << 17;
+        const TEXTURE_BINDING_ARRAY = 1 << 35;
         /// Allows the user to create arrays of buffers in shaders:
         ///
         /// ex.
@@ -400,7 +483,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const BUFFER_BINDING_ARRAY = 1 << 18;
+        const BUFFER_BINDING_ARRAY = 1 << 36;
         /// Allows the user to create uniform arrays of storage buffers or textures in shaders,
         /// if resp. [`Features::BUFFER_BINDING_ARRAY`] or [`Features::TEXTURE_BINDING_ARRAY`]
         /// is supported.
@@ -413,7 +496,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const STORAGE_RESOURCE_BINDING_ARRAY = 1 << 19;
+        const STORAGE_RESOURCE_BINDING_ARRAY = 1 << 37;
         /// Allows shaders to index sampled texture and storage buffer resource arrays with dynamically non-uniform values:
         ///
         /// ex. `texture_array[vertex_data]`
@@ -438,7 +521,7 @@ bitflags::bitflags! {
         /// - Vulkan 1.2+ (or VK_EXT_descriptor_indexing)'s shaderSampledImageArrayNonUniformIndexing & shaderStorageBufferArrayNonUniformIndexing feature)
         ///
         /// This is a native only feature.
-        const SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING = 1 << 20;
+        const SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING = 1 << 38;
         /// Allows shaders to index uniform buffer and storage texture resource arrays with dynamically non-uniform values:
         ///
         /// ex. `texture_array[vertex_data]`
@@ -463,11 +546,11 @@ bitflags::bitflags! {
         /// - Vulkan 1.2+ (or VK_EXT_descriptor_indexing)'s shaderUniformBufferArrayNonUniformIndexing & shaderStorageTextureArrayNonUniformIndexing feature)
         ///
         /// This is a native only feature.
-        const UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING = 1 << 21;
+        const UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING = 1 << 39;
         /// Allows the user to create bind groups continaing arrays with less bindings than the BindGroupLayout.
         ///
         /// This is a native only feature.
-        const PARTIALLY_BOUND_BINDING_ARRAY = 1 << 22;
+        const PARTIALLY_BOUND_BINDING_ARRAY = 1 << 40;
         /// Allows the user to call [`RenderPass::multi_draw_indirect`] and [`RenderPass::multi_draw_indexed_indirect`].
         ///
         /// Allows multiple indirect calls to be dispatched from a single buffer.
@@ -481,7 +564,7 @@ bitflags::bitflags! {
         ///
         /// [`RenderPass::multi_draw_indirect`]: ../wgpu/struct.RenderPass.html#method.multi_draw_indirect
         /// [`RenderPass::multi_draw_indexed_indirect`]: ../wgpu/struct.RenderPass.html#method.multi_draw_indexed_indirect
-        const MULTI_DRAW_INDIRECT = 1 << 23;
+        const MULTI_DRAW_INDIRECT = 1 << 41;
         /// Allows the user to call [`RenderPass::multi_draw_indirect_count`] and [`RenderPass::multi_draw_indexed_indirect_count`].
         ///
         /// This allows the use of a buffer containing the actual number of draw calls.
@@ -494,7 +577,7 @@ bitflags::bitflags! {
         ///
         /// [`RenderPass::multi_draw_indirect_count`]: ../wgpu/struct.RenderPass.html#method.multi_draw_indirect_count
         /// [`RenderPass::multi_draw_indexed_indirect_count`]: ../wgpu/struct.RenderPass.html#method.multi_draw_indexed_indirect_count
-        const MULTI_DRAW_INDIRECT_COUNT = 1 << 24;
+        const MULTI_DRAW_INDIRECT_COUNT = 1 << 42;
         /// Allows the use of push constants: small, fast bits of memory that can be updated
         /// inside a [`RenderPass`].
         ///
@@ -515,7 +598,19 @@ bitflags::bitflags! {
         /// [`RenderPass`]: ../wgpu/struct.RenderPass.html
         /// [`PipelineLayoutDescriptor`]: ../wgpu/struct.PipelineLayoutDescriptor.html
         /// [`RenderPass::set_push_constants`]: ../wgpu/struct.RenderPass.html#method.set_push_constants
-        const PUSH_CONSTANTS = 1 << 25;
+        const PUSH_CONSTANTS = 1 << 43;
+        /// Allows the use of [`AddressMode::ClampToBorder`] with a border color
+        /// of [`SamplerBorderColor::Zero`].
+        ///
+        /// Supported platforms:
+        /// - DX12
+        /// - Vulkan
+        /// - Metal
+        /// - DX11
+        /// - OpenGL
+        ///
+        /// This is a native only feature.
+        const ADDRESS_MODE_CLAMP_TO_ZERO = 1 << 44;
         /// Allows the use of [`AddressMode::ClampToBorder`] with a border color
         /// other than [`SamplerBorderColor::Zero`].
         ///
@@ -526,8 +621,8 @@ bitflags::bitflags! {
         /// - DX11
         /// - OpenGL
         ///
-        /// This is a web and native feature.
-        const ADDRESS_MODE_CLAMP_TO_BORDER = 1 << 26;
+        /// This is a native only feature.
+        const ADDRESS_MODE_CLAMP_TO_BORDER = 1 << 45;
         /// Allows the user to set [`PolygonMode::Line`] in [`PrimitiveState::polygon_mode`]
         ///
         /// This allows drawing polygons/triangles as lines (wireframe) instead of filled
@@ -538,7 +633,7 @@ bitflags::bitflags! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const POLYGON_MODE_LINE = 1 << 27;
+        const POLYGON_MODE_LINE = 1 << 46;
         /// Allows the user to set [`PolygonMode::Point`] in [`PrimitiveState::polygon_mode`]
         ///
         /// This allows only drawing the vertices of polygons/triangles instead of filled
@@ -548,37 +643,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const POLYGON_MODE_POINT = 1 << 28;
-        /// Enables device specific texture format features.
-        ///
-        /// See `TextureFormatFeatures` for a listing of the features in question.
-        ///
-        /// By default only texture format properties as defined by the WebGPU specification are allowed.
-        /// Enabling this feature flag extends the features of each format to the ones supported by the current device.
-        /// Note that without this flag, read/write storage access is not allowed at all.
-        ///
-        /// This extension does not enable additional formats.
-        ///
-        /// This is a native-only feature.
-        const TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 1 << 29;
-        /// Enables 64-bit floating point types in SPIR-V shaders.
-        ///
-        /// Note: even when supported by GPU hardware, 64-bit floating point operations are
-        /// frequently between 16 and 64 _times_ slower than equivalent operations on 32-bit floats.
-        ///
-        /// Supported Platforms:
-        /// - Vulkan
-        ///
-        /// This is a native-only feature.
-        const SHADER_FLOAT64 = 1 << 30;
-        /// Enables using 64-bit types for vertex attributes.
-        ///
-        /// Requires SHADER_FLOAT64.
-        ///
-        /// Supported Platforms: N/A
-        ///
-        /// This is a native-only feature.
-        const VERTEX_ATTRIBUTE_64BIT = 1 << 31;
+        const POLYGON_MODE_POINT = 1 << 47;
         /// Allows the user to set a overestimation-conservative-rasterization in [`PrimitiveState::conservative`]
         ///
         /// Processing of degenerate triangles/lines is hardware specific.
@@ -588,7 +653,7 @@ bitflags::bitflags! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const CONSERVATIVE_RASTERIZATION = 1 << 32;
+        const CONSERVATIVE_RASTERIZATION = 1 << 48;
         /// Enables bindings of writable storage buffers and textures visible to vertex shaders.
         ///
         /// Note: some (tiled-based) platforms do not support vertex shaders with any side-effects.
@@ -596,15 +661,15 @@ bitflags::bitflags! {
         /// Supported Platforms:
         /// - All
         ///
-        /// This is a native-only feature.
-        const VERTEX_WRITABLE_STORAGE = 1 << 33;
+        /// This is a native only feature.
+        const VERTEX_WRITABLE_STORAGE = 1 << 49;
         /// Enables clear to zero for textures.
         ///
         /// Supported platforms:
         /// - All
         ///
         /// This is a native only feature.
-        const CLEAR_TEXTURE = 1 << 34;
+        const CLEAR_TEXTURE = 1 << 50;
         /// Enables creating shader modules from SPIR-V binary data (unsafe).
         ///
         /// SPIR-V data is not parsed or interpreted in any way; you can use
@@ -616,7 +681,45 @@ bitflags::bitflags! {
         /// Vulkan implementation.
         ///
         /// This is a native only feature.
-        const SPIRV_SHADER_PASSTHROUGH = 1 << 35;
+        const SPIRV_SHADER_PASSTHROUGH = 1 << 51;
+        /// Enables multiview render passes and `builtin(view_index)` in vertex shaders.
+        ///
+        /// Supported platforms:
+        /// - Vulkan
+        /// - OpenGL (web only)
+        ///
+        /// This is a native only feature.
+        const MULTIVIEW = 1 << 52;
+        /// Enables using 64-bit types for vertex attributes.
+        ///
+        /// Requires SHADER_FLOAT64.
+        ///
+        /// Supported Platforms: N/A
+        ///
+        /// This is a native only feature.
+        const VERTEX_ATTRIBUTE_64BIT = 1 << 53;
+
+        // 54..59 available
+
+        // Shader:
+
+        /// Enables 64-bit floating point types in SPIR-V shaders.
+        ///
+        /// Note: even when supported by GPU hardware, 64-bit floating point operations are
+        /// frequently between 16 and 64 _times_ slower than equivalent operations on 32-bit floats.
+        ///
+        /// Supported Platforms:
+        /// - Vulkan
+        ///
+        /// This is a native only feature.
+        const SHADER_F64 = 1 << 59;
+        /// Allows shaders to use i16. Not currently supported in naga, only available through `spirv-passthrough`.
+        ///
+        /// Supported platforms:
+        /// - Vulkan
+        ///
+        /// This is a native only feature.
+        const SHADER_I16 = 1 << 60;
         /// Enables `builtin(primitive_index)` in fragment shaders.
         ///
         /// Note: enables geometry processing for pipelines using the builtin.
@@ -631,76 +734,16 @@ bitflags::bitflags! {
         /// - OpenGL (some)
         ///
         /// This is a native only feature.
-        const SHADER_PRIMITIVE_INDEX = 1 << 36;
-        /// Enables multiview render passes and `builtin(view_index)` in vertex shaders.
-        ///
-        /// Supported platforms:
-        /// - Vulkan
-        /// - OpenGL (web only)
-        ///
-        /// This is a native only feature.
-        const MULTIVIEW = 1 << 37;
-        /// Enables normalized `16-bit` texture formats.
-        ///
-        /// Supported platforms:
-        /// - Vulkan
-        /// - DX12
-        /// - Metal
-        ///
-        /// This is a native only feature.
-        const TEXTURE_FORMAT_16BIT_NORM = 1 << 38;
-        /// Allows the use of [`AddressMode::ClampToBorder`] with a border color
-        /// of [`SamplerBorderColor::Zero`].
-        ///
-        /// Supported platforms:
-        /// - DX12
-        /// - Vulkan
-        /// - Metal
-        /// - DX11
-        /// - OpenGL
-        ///
-        /// This is a native only feature.
-        const ADDRESS_MODE_CLAMP_TO_ZERO = 1 << 39;
-        /// Enables ASTC HDR family of compressed textures.
-        ///
-        /// Compressed textures sacrifice some quality in exchange for significantly reduced
-        /// bandwidth usage.
-        ///
-        /// Support for this feature guarantees availability of [`TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING`] for BCn formats.
-        /// [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] may enable additional usages.
-        ///
-        /// Supported Platforms:
-        /// - Metal
-        /// - Vulkan
-        /// - OpenGL
-        ///
-        /// This is a native-only feature.
-        const TEXTURE_COMPRESSION_ASTC_HDR = 1 << 40;
-        /// Allows for timestamp queries inside render passes.
-        ///
-        /// Implies [`Features::TIMESTAMP_QUERIES`] is supported.
-        ///
-        /// Supported platforms:
-        /// - Vulkan
-        /// - DX12
-        ///
-        /// This is currently unimplemented on Metal.
-        /// When implemented, it will be supported on Metal on AMD and Intel GPUs, but not Apple GPUs.
-        const WRITE_TIMESTAMP_INSIDE_PASSES = 1 << 41;
-        /// Allows shaders to use i16. Not currently supported in naga, only available through `spirv-passthrough`.
-        ///
-        /// Supported platforms:
-        /// - Vulkan
-        ///
-        /// This is a native-only feature.
-        const SHADER_INT16 = 1 << 42;
+        const SHADER_PRIMITIVE_INDEX = 1 << 61;
         /// Allows shaders to use the `early_depth_test` attribute.
         ///
         /// Supported platforms:
         /// - GLES 3.1+
         ///
-        /// This is a native-only feature.
-        const SHADER_EARLY_DEPTH_TEST = 1 << 43;
+        /// This is a native only feature.
+        const SHADER_EARLY_DEPTH_TEST = 1 << 62;
+
+        // 62..64 available
     }
 }
 
@@ -1825,11 +1868,11 @@ pub enum AstcBlock {
 pub enum AstcChannel {
     /// 8 bit integer RGBA, [0, 255] converted to/from linear-color float [0, 1] in shader.
     ///
-    /// [`Features::TEXTURE_COMPRESSION_ASTC_LDR`] must be enabled to use this channel.
+    /// [`Features::TEXTURE_COMPRESSION_ASTC`] must be enabled to use this channel.
     Unorm,
     /// 8 bit integer RGBA, Srgb-color [0, 255] converted to/from linear-color float [0, 1] in shader.
     ///
-    /// [`Features::TEXTURE_COMPRESSION_ASTC_LDR`] must be enabled to use this channel.
+    /// [`Features::TEXTURE_COMPRESSION_ASTC`] must be enabled to use this channel.
     UnormSrgb,
     /// floating-point RGBA, linear-color float can be outside of the [0, 1] range.
     ///
@@ -2118,10 +2161,10 @@ pub enum TextureFormat {
     EacRg11Snorm,
     /// block compressed texture. 16 bytes per block.
     ///
-    /// Features [`TEXTURE_COMPRESSION_ASTC_LDR`] or [`TEXTURE_COMPRESSION_ASTC_HDR`]
+    /// Features [`TEXTURE_COMPRESSION_ASTC`] or [`TEXTURE_COMPRESSION_ASTC_HDR`]
     /// must be enabled to use this texture format.
     ///
-    /// [`TEXTURE_COMPRESSION_ASTC_LDR`]: Features::TEXTURE_COMPRESSION_ASTC_LDR
+    /// [`TEXTURE_COMPRESSION_ASTC`]: Features::TEXTURE_COMPRESSION_ASTC
     /// [`TEXTURE_COMPRESSION_ASTC_HDR`]: Features::TEXTURE_COMPRESSION_ASTC_HDR
     Astc {
         /// compressed block dimensions
@@ -2646,9 +2689,7 @@ impl TextureFormat {
 
             Self::Astc { channel, .. } => match channel {
                 AstcChannel::Hdr => Features::TEXTURE_COMPRESSION_ASTC_HDR,
-                AstcChannel::Unorm | AstcChannel::UnormSrgb => {
-                    Features::TEXTURE_COMPRESSION_ASTC_LDR
-                }
+                AstcChannel::Unorm | AstcChannel::UnormSrgb => Features::TEXTURE_COMPRESSION_ASTC,
             },
         }
     }
@@ -4095,13 +4136,13 @@ pub enum VertexFormat {
     Sint32x3 = 28,
     /// Four signed ints (i32). `ivec4` in shaders.
     Sint32x4 = 29,
-    /// One double-precision float (f64). `double` in shaders. Requires VERTEX_ATTRIBUTE_64BIT features.
+    /// One double-precision float (f64). `double` in shaders. Requires [`Features::VERTEX_ATTRIBUTE_64BIT`].
     Float64 = 30,
-    /// Two double-precision floats (f64). `dvec2` in shaders. Requires VERTEX_ATTRIBUTE_64BIT features.
+    /// Two double-precision floats (f64). `dvec2` in shaders. Requires [`Features::VERTEX_ATTRIBUTE_64BIT`].
     Float64x2 = 31,
-    /// Three double-precision floats (f64). `dvec3` in shaders. Requires VERTEX_ATTRIBUTE_64BIT features.
+    /// Three double-precision floats (f64). `dvec3` in shaders. Requires [`Features::VERTEX_ATTRIBUTE_64BIT`].
     Float64x3 = 32,
-    /// Four double-precision floats (f64). `dvec4` in shaders. Requires VERTEX_ATTRIBUTE_64BIT features.
+    /// Four double-precision floats (f64). `dvec4` in shaders. Requires [`Features::VERTEX_ATTRIBUTE_64BIT`].
     Float64x4 = 33,
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -281,6 +281,10 @@ bitflags::bitflags! {
 
         // Texture Formats:
 
+        // The features starting with a ? are features that might become part of the spec or
+        // at the very least we can implement as native features; since they should cover all
+        // possible formats and capabilities across backends.
+        //
         // ? const FORMATS_TIER_1 = 1 << 14; (https://github.com/gpuweb/gpuweb/issues/3837)
         // ? const RW_STORAGE_TEXTURE_TIER_1 = 1 << 15; (https://github.com/gpuweb/gpuweb/issues/3838)
         // TODO const BGRA8UNORM_STORAGE = 1 << 16;

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -202,7 +202,7 @@ impl framework::Example for Example {
     fn optional_features() -> wgpu::Features {
         wgpu::Features::TIMESTAMP_QUERY
             | wgpu::Features::PIPELINE_STATISTICS_QUERY
-            | wgpu::Features::WRITE_TIMESTAMP_INSIDE_PASSES
+            | wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES
     }
 
     fn init(
@@ -329,7 +329,7 @@ impl framework::Example for Example {
         let query_sets = if device.features().contains(
             wgpu::Features::TIMESTAMP_QUERY
                 | wgpu::Features::PIPELINE_STATISTICS_QUERY
-                | wgpu::Features::WRITE_TIMESTAMP_INSIDE_PASSES,
+                | wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES,
         ) {
             // For N total mips, it takes N - 1 passes to generate them, and we're measuring those.
             let mip_passes = MIP_LEVEL_COUNT - 1;

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -269,7 +269,7 @@ impl framework::Example for Skybox {
         let device_features = device.features();
 
         let skybox_format = if device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_ASTC) {
-            log::info!("Using ASTC_LDR");
+            log::info!("Using ASTC");
             wgpu::TextureFormat::Astc {
                 block: AstcBlock::B4x4,
                 channel: AstcChannel::UnormSrgb,

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -94,7 +94,7 @@ impl Skybox {
 
 impl framework::Example for Skybox {
     fn optional_features() -> wgpu::Features {
-        wgpu::Features::TEXTURE_COMPRESSION_ASTC_LDR
+        wgpu::Features::TEXTURE_COMPRESSION_ASTC
             | wgpu::Features::TEXTURE_COMPRESSION_ETC2
             | wgpu::Features::TEXTURE_COMPRESSION_BC
     }
@@ -268,23 +268,22 @@ impl framework::Example for Skybox {
 
         let device_features = device.features();
 
-        let skybox_format =
-            if device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_ASTC_LDR) {
-                log::info!("Using ASTC_LDR");
-                wgpu::TextureFormat::Astc {
-                    block: AstcBlock::B4x4,
-                    channel: AstcChannel::UnormSrgb,
-                }
-            } else if device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_ETC2) {
-                log::info!("Using ETC2");
-                wgpu::TextureFormat::Etc2Rgb8UnormSrgb
-            } else if device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_BC) {
-                log::info!("Using BC");
-                wgpu::TextureFormat::Bc1RgbaUnormSrgb
-            } else {
-                log::info!("Using plain");
-                wgpu::TextureFormat::Bgra8UnormSrgb
-            };
+        let skybox_format = if device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_ASTC) {
+            log::info!("Using ASTC_LDR");
+            wgpu::TextureFormat::Astc {
+                block: AstcBlock::B4x4,
+                channel: AstcChannel::UnormSrgb,
+            }
+        } else if device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_ETC2) {
+            log::info!("Using ETC2");
+            wgpu::TextureFormat::Etc2Rgb8UnormSrgb
+        } else if device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_BC) {
+            log::info!("Using BC");
+            wgpu::TextureFormat::Bc1RgbaUnormSrgb
+        } else {
+            log::info!("Using plain");
+            wgpu::TextureFormat::Bgra8UnormSrgb
+        };
 
         let size = wgpu::Extent3d {
             width: IMAGE_SIZE,
@@ -523,7 +522,7 @@ fn skybox_astc() {
         image_path: "/examples/skybox/screenshot-astc.png",
         width: 1024,
         height: 768,
-        optional_features: wgpu::Features::TEXTURE_COMPRESSION_ASTC_LDR,
+        optional_features: wgpu::Features::TEXTURE_COMPRESSION_ASTC,
         base_test_parameters: framework::test_common::TestParameters::default(), // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
         tolerance: 5,
         max_outliers: 300, // Bounded by rp4 on vk

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -568,7 +568,7 @@ const FEATURES_MAPPING: [(wgt::Features, web_sys::GpuFeatureName); 8] = [
         web_sys::GpuFeatureName::TextureCompressionEtc2,
     ),
     (
-        wgt::Features::TEXTURE_COMPRESSION_ASTC_LDR,
+        wgt::Features::TEXTURE_COMPRESSION_ASTC,
         web_sys::GpuFeatureName::TextureCompressionAstc,
     ),
     (
@@ -580,7 +580,7 @@ const FEATURES_MAPPING: [(wgt::Features, web_sys::GpuFeatureName); 8] = [
         web_sys::GpuFeatureName::IndirectFirstInstance,
     ),
     (
-        wgt::Features::SHADER_FLOAT16,
+        wgt::Features::SHADER_F16,
         web_sys::GpuFeatureName::ShaderF16,
     ),
 ];
@@ -2520,7 +2520,7 @@ impl crate::context::Context for Context {
         _query_set_data: &Self::QuerySetData,
         _query_index: u32,
     ) {
-        panic!("WRITE_TIMESTAMP_INSIDE_PASSES feature must be enabled to call write_timestamp in a compute pass")
+        panic!("TIMESTAMP_QUERY_INSIDE_PASSES feature must be enabled to call write_timestamp in a compute pass")
     }
 
     fn compute_pass_begin_pipeline_statistics_query(
@@ -3073,7 +3073,7 @@ impl crate::context::Context for Context {
         _query_set_data: &Self::QuerySetData,
         _query_index: u32,
     ) {
-        panic!("WRITE_TIMESTAMP_INSIDE_PASSES feature must be enabled to call write_timestamp in a compute pass")
+        panic!("TIMESTAMP_QUERY_INSIDE_PASSES feature must be enabled to call write_timestamp in a compute pass")
     }
 
     fn render_pass_begin_pipeline_statistics_query(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3426,7 +3426,7 @@ impl<'a> RenderPass<'a> {
     }
 }
 
-/// [`Features::WRITE_TIMESTAMP_INSIDE_PASSES`] must be enabled on the device in order to call these functions.
+/// [`Features::TIMESTAMP_QUERY_INSIDE_PASSES`] must be enabled on the device in order to call these functions.
 impl<'a> RenderPass<'a> {
     /// Issue a timestamp command at this point in the queue. The
     /// timestamp will be written to the specified query set, at the specified index.
@@ -3605,7 +3605,7 @@ impl<'a> ComputePass<'a> {
     }
 }
 
-/// [`Features::WRITE_TIMESTAMP_INSIDE_PASSES`] must be enabled on the device in order to call these functions.
+/// [`Features::TIMESTAMP_QUERY_INSIDE_PASSES`] must be enabled on the device in order to call these functions.
 impl<'a> ComputePass<'a> {
     /// Issue a timestamp command at this point in the queue. The timestamp will be written to the specified query set, at the specified index.
     ///

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -83,7 +83,7 @@ static TEXTURE_FORMATS_ETC2: &[wgpu::TextureFormat] = &[
     wgpu::TextureFormat::EacRg11Snorm,
 ];
 
-// needs TEXTURE_COMPRESSION_ASTC_LDR
+// needs TEXTURE_COMPRESSION_ASTC
 use wgpu::{AstcBlock, AstcChannel};
 static TEXTURE_FORMATS_ASTC: &[wgpu::TextureFormat] = &[
     wgpu::TextureFormat::Astc {
@@ -397,7 +397,7 @@ fn clear_texture_bc() {
 fn clear_texture_astc() {
     initialize_test(
         TestParameters::default()
-            .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_ASTC_LDR)
+            .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_ASTC)
             .limits(wgpu::Limits {
                 max_texture_dimension_2d: wgpu::COPY_BYTES_PER_ROW_ALIGNMENT * 12,
                 ..wgpu::Limits::downlevel_defaults()


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
closes https://github.com/gfx-rs/wgpu/issues/3266

**Description**
- Update feature documentation
- Update/fix deno's feature related bindings
- Rename the following features to be in line with the spec:

  - `SHADER_FLOAT16` -> `SHADER_F16`
  - `SHADER_FLOAT64` -> `SHADER_F64`
  - `SHADER_INT16` -> `SHADER_I16`
  - `TEXTURE_COMPRESSION_ASTC_LDR` -> `TEXTURE_COMPRESSION_ASTC`
  - `WRITE_TIMESTAMP_INSIDE_PASSES` -> `TIMESTAMP_QUERY_INSIDE_PASSES`

**Testing**
N/A
