### PR TITLE
Improve RenderPass related errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ By @teoxoy in [#3436](https://github.com/gfx-rs/wgpu/pull/3436)
 - Added `TextureFormatFeatureFlags::MULTISAMPLE_X16`. By @Dinnerbone in [#3454](https://github.com/gfx-rs/wgpu/pull/3454)
 - Support stencil-only views and copying to/from combined depth-stencil textures. By @teoxoy in [#3436](https://github.com/gfx-rs/wgpu/pull/3436)
 - Added `Features::SHADER_EARLY_DEPTH_TEST`. By @teoxoy in [#3494](https://github.com/gfx-rs/wgpu/pull/3494)
+- Improve attachment related errors. By @cwfitzgerald in [#3549](https://github.com/gfx-rs/wgpu/pull/3549)
+- Make error descriptions all upper case. By @cwfitzgerald in [#3549](https://github.com/gfx-rs/wgpu/pull/3549)
 
 #### WebGPU
 

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -22,11 +22,11 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]
 pub enum BindGroupLayoutEntryError {
-    #[error("cube dimension is not expected for texture storage")]
+    #[error("Cube dimension is not expected for texture storage")]
     StorageTextureCube,
     #[error("Read-write and read-only storage textures are not allowed by webgpu, they require the native only feature TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES")]
     StorageTextureReadWrite,
-    #[error("arrays of bindings unsupported for this type of binding")]
+    #[error("Arrays of bindings unsupported for this type of binding")]
     ArrayUnsupported,
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
@@ -38,9 +38,9 @@ pub enum BindGroupLayoutEntryError {
 pub enum CreateBindGroupLayoutError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("conflicting binding at index {0}")]
+    #[error("Conflicting binding at index {0}")]
     ConflictBinding(u32),
-    #[error("binding {binding} entry is invalid")]
+    #[error("Binding {binding} entry is invalid")]
     Entry {
         binding: u32,
         #[source]
@@ -60,63 +60,63 @@ pub enum CreateBindGroupLayoutError {
 pub enum CreateBindGroupError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("bind group layout is invalid")]
+    #[error("Bind group layout is invalid")]
     InvalidLayout,
-    #[error("buffer {0:?} is invalid or destroyed")]
+    #[error("Buffer {0:?} is invalid or destroyed")]
     InvalidBuffer(BufferId),
-    #[error("texture view {0:?} is invalid")]
+    #[error("Texture view {0:?} is invalid")]
     InvalidTextureView(TextureViewId),
-    #[error("texture {0:?} is invalid")]
+    #[error("Texture {0:?} is invalid")]
     InvalidTexture(TextureId),
-    #[error("sampler {0:?} is invalid")]
+    #[error("Sampler {0:?} is invalid")]
     InvalidSampler(SamplerId),
     #[error(
-        "binding count declared with at most {expected} items, but {actual} items were provided"
+        "Binding count declared with at most {expected} items, but {actual} items were provided"
     )]
     BindingArrayPartialLengthMismatch { actual: usize, expected: usize },
     #[error(
-        "binding count declared with exactly {expected} items, but {actual} items were provided"
+        "Binding count declared with exactly {expected} items, but {actual} items were provided"
     )]
     BindingArrayLengthMismatch { actual: usize, expected: usize },
-    #[error("array binding provided zero elements")]
+    #[error("Array binding provided zero elements")]
     BindingArrayZeroLength,
-    #[error("bound buffer range {range:?} does not fit in buffer of size {size}")]
+    #[error("Bound buffer range {range:?} does not fit in buffer of size {size}")]
     BindingRangeTooLarge {
         buffer: BufferId,
         range: Range<wgt::BufferAddress>,
         size: u64,
     },
-    #[error("buffer binding size {actual} is less than minimum {min}")]
+    #[error("Buffer binding size {actual} is less than minimum {min}")]
     BindingSizeTooSmall {
         buffer: BufferId,
         actual: u64,
         min: u64,
     },
-    #[error("buffer binding size is zero")]
+    #[error("Buffer binding size is zero")]
     BindingZeroSize(BufferId),
-    #[error("number of bindings in bind group descriptor ({actual}) does not match the number of bindings defined in the bind group layout ({expected})")]
+    #[error("Number of bindings in bind group descriptor ({actual}) does not match the number of bindings defined in the bind group layout ({expected})")]
     BindingsNumMismatch { actual: usize, expected: usize },
-    #[error("binding {0} is used at least twice in the descriptor")]
+    #[error("Binding {0} is used at least twice in the descriptor")]
     DuplicateBinding(u32),
-    #[error("unable to find a corresponding declaration for the given binding {0}")]
+    #[error("Unable to find a corresponding declaration for the given binding {0}")]
     MissingBindingDeclaration(u32),
     #[error(transparent)]
     MissingBufferUsage(#[from] MissingBufferUsageError),
     #[error(transparent)]
     MissingTextureUsage(#[from] MissingTextureUsageError),
-    #[error("binding declared as a single item, but bind group is using it as an array")]
+    #[error("Binding declared as a single item, but bind group is using it as an array")]
     SingleBindingExpected,
-    #[error("buffer offset {0} does not respect device's requested `{1}` limit {2}")]
+    #[error("Buffer offset {0} does not respect device's requested `{1}` limit {2}")]
     UnalignedBufferOffset(wgt::BufferAddress, &'static str, u32),
     #[error(
-        "buffer binding {binding} range {given} exceeds `max_*_buffer_binding_size` limit {limit}"
+        "Buffer binding {binding} range {given} exceeds `max_*_buffer_binding_size` limit {limit}"
     )]
     BufferRangeTooLarge {
         binding: u32,
         given: u32,
         limit: u32,
     },
-    #[error("binding {binding} has a different type ({actual:?}) than the one in the layout ({expected:?})")]
+    #[error("Binding {binding} has a different type ({actual:?}) than the one in the layout ({expected:?})")]
     WrongBindingType {
         // Index of the binding
         binding: u32,
@@ -125,47 +125,47 @@ pub enum CreateBindGroupError {
         // Human-readable description of expected types
         expected: &'static str,
     },
-    #[error("texture binding {binding} expects multisampled = {layout_multisampled}, but given a view with samples = {view_samples}")]
+    #[error("Texture binding {binding} expects multisampled = {layout_multisampled}, but given a view with samples = {view_samples}")]
     InvalidTextureMultisample {
         binding: u32,
         layout_multisampled: bool,
         view_samples: u32,
     },
-    #[error("texture binding {binding} expects sample type = {layout_sample_type:?}, but given a view with format = {view_format:?}")]
+    #[error("Texture binding {binding} expects sample type = {layout_sample_type:?}, but given a view with format = {view_format:?}")]
     InvalidTextureSampleType {
         binding: u32,
         layout_sample_type: wgt::TextureSampleType,
         view_format: wgt::TextureFormat,
     },
-    #[error("texture binding {binding} expects dimension = {layout_dimension:?}, but given a view with dimension = {view_dimension:?}")]
+    #[error("Texture binding {binding} expects dimension = {layout_dimension:?}, but given a view with dimension = {view_dimension:?}")]
     InvalidTextureDimension {
         binding: u32,
         layout_dimension: wgt::TextureViewDimension,
         view_dimension: wgt::TextureViewDimension,
     },
-    #[error("storage texture binding {binding} expects format = {layout_format:?}, but given a view with format = {view_format:?}")]
+    #[error("Storage texture binding {binding} expects format = {layout_format:?}, but given a view with format = {view_format:?}")]
     InvalidStorageTextureFormat {
         binding: u32,
         layout_format: wgt::TextureFormat,
         view_format: wgt::TextureFormat,
     },
-    #[error("storage texture bindings must have a single mip level, but given a view with mip_level_count = {mip_level_count:?} at binding {binding}")]
+    #[error("Storage texture bindings must have a single mip level, but given a view with mip_level_count = {mip_level_count:?} at binding {binding}")]
     InvalidStorageTextureMipLevelCount { binding: u32, mip_level_count: u32 },
-    #[error("sampler binding {binding} expects comparison = {layout_cmp}, but given a sampler with comparison = {sampler_cmp}")]
+    #[error("Sampler binding {binding} expects comparison = {layout_cmp}, but given a sampler with comparison = {sampler_cmp}")]
     WrongSamplerComparison {
         binding: u32,
         layout_cmp: bool,
         sampler_cmp: bool,
     },
-    #[error("sampler binding {binding} expects filtering = {layout_flt}, but given a sampler with filtering = {sampler_flt}")]
+    #[error("Sampler binding {binding} expects filtering = {layout_flt}, but given a sampler with filtering = {sampler_flt}")]
     WrongSamplerFiltering {
         binding: u32,
         layout_flt: bool,
         sampler_flt: bool,
     },
-    #[error("bound texture views can not have both depth and stencil aspects enabled")]
+    #[error("Bound texture views can not have both depth and stencil aspects enabled")]
     DepthStencilAspect,
-    #[error("the adapter does not support read access for storages texture of format {0:?}")]
+    #[error("The adapter does not support read access for storages texture of format {0:?}")]
     StorageReadNotSupported(wgt::TextureFormat),
     #[error(transparent)]
     ResourceUsageConflict(#[from] UsageConflict),
@@ -200,14 +200,14 @@ impl PrettyError for CreateBindGroupError {
 
 #[derive(Clone, Debug, Error)]
 pub enum BindingZone {
-    #[error("stage {0:?}")]
+    #[error("Stage {0:?}")]
     Stage(wgt::ShaderStages),
-    #[error("whole pipeline")]
+    #[error("Whole pipeline")]
     Pipeline,
 }
 
 #[derive(Clone, Debug, Error)]
-#[error("too many bindings of type {kind:?} in {zone}, limit is {limit}, count was {count}")]
+#[error("Too many bindings of type {kind:?} in {zone}, limit is {limit}, count was {count}")]
 pub struct BindingTypeMaxCountError {
     pub kind: BindingTypeMaxCountErrorKind,
     pub zone: BindingZone,
@@ -470,22 +470,22 @@ impl<A: hal::Api> Resource for BindGroupLayout<A> {
 pub enum CreatePipelineLayoutError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("bind group layout {0:?} is invalid")]
+    #[error("Bind group layout {0:?} is invalid")]
     InvalidBindGroupLayout(BindGroupLayoutId),
     #[error(
-        "push constant at index {index} has range bound {bound} not aligned to {}",
+        "Push constant at index {index} has range bound {bound} not aligned to {}",
         wgt::PUSH_CONSTANT_ALIGNMENT
     )]
     MisalignedPushConstantRange { index: usize, bound: u32 },
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
-    #[error("push constant range (index {index}) provides for stage(s) {provided:?} but there exists another range that provides stage(s) {intersected:?}. Each stage may only be provided by one range")]
+    #[error("Push constant range (index {index}) provides for stage(s) {provided:?} but there exists another range that provides stage(s) {intersected:?}. Each stage may only be provided by one range")]
     MoreThanOnePushConstantRangePerStage {
         index: usize,
         provided: wgt::ShaderStages,
         intersected: wgt::ShaderStages,
     },
-    #[error("push constant at index {index} has range {}..{} which exceeds device push constant size limit 0..{max}", range.start, range.end)]
+    #[error("Push constant at index {index} has range {}..{} which exceeds device push constant size limit 0..{max}", range.start, range.end)]
     PushConstantRangeTooLarge {
         index: usize,
         range: Range<u32>,
@@ -493,7 +493,7 @@ pub enum CreatePipelineLayoutError {
     },
     #[error(transparent)]
     TooManyBindings(BindingTypeMaxCountError),
-    #[error("bind group layout count {actual} exceeds device bind group limit {max}")]
+    #[error("Bind group layout count {actual} exceeds device bind group limit {max}")]
     TooManyGroups { actual: usize, max: usize },
 }
 
@@ -508,31 +508,31 @@ impl PrettyError for CreatePipelineLayoutError {
 
 #[derive(Clone, Debug, Error)]
 pub enum PushConstantUploadError {
-    #[error("provided push constant with indices {offset}..{end_offset} overruns matching push constant range at index {idx}, with stage(s) {:?} and indices {:?}", range.stages, range.range)]
+    #[error("Provided push constant with indices {offset}..{end_offset} overruns matching push constant range at index {idx}, with stage(s) {:?} and indices {:?}", range.stages, range.range)]
     TooLarge {
         offset: u32,
         end_offset: u32,
         idx: usize,
         range: wgt::PushConstantRange,
     },
-    #[error("provided push constant is for stage(s) {actual:?}, stage with a partial match found at index {idx} with stage(s) {matched:?}, however push constants must be complete matches")]
+    #[error("Provided push constant is for stage(s) {actual:?}, stage with a partial match found at index {idx} with stage(s) {matched:?}, however push constants must be complete matches")]
     PartialRangeMatch {
         actual: wgt::ShaderStages,
         idx: usize,
         matched: wgt::ShaderStages,
     },
-    #[error("provided push constant is for stage(s) {actual:?}, but intersects a push constant range (at index {idx}) with stage(s) {missing:?}. Push constants must provide the stages for all ranges they intersect")]
+    #[error("Provided push constant is for stage(s) {actual:?}, but intersects a push constant range (at index {idx}) with stage(s) {missing:?}. Push constants must provide the stages for all ranges they intersect")]
     MissingStages {
         actual: wgt::ShaderStages,
         idx: usize,
         missing: wgt::ShaderStages,
     },
-    #[error("provided push constant is for stage(s) {actual:?}, however the pipeline layout has no push constant range for the stage(s) {unmatched:?}")]
+    #[error("Provided push constant is for stage(s) {actual:?}, however the pipeline layout has no push constant range for the stage(s) {unmatched:?}")]
     UnmatchedStages {
         actual: wgt::ShaderStages,
         unmatched: wgt::ShaderStages,
     },
-    #[error("provided push constant offset {0} does not respect `PUSH_CONSTANT_ALIGNMENT`")]
+    #[error("Provided push constant offset {0} does not respect `PUSH_CONSTANT_ALIGNMENT`")]
     Unaligned(u32),
 }
 
@@ -829,9 +829,9 @@ impl<A: HalApi> Resource for BindGroup<A> {
 
 #[derive(Clone, Debug, Error)]
 pub enum GetBindGroupLayoutError {
-    #[error("pipeline is invalid")]
+    #[error("Pipeline is invalid")]
     InvalidPipeline,
-    #[error("invalid group index {0}")]
+    #[error("Invalid group index {0}")]
     InvalidGroupIndex(u32),
 }
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -86,8 +86,8 @@ use crate::{
     },
     conv,
     device::{
-        AttachmentData, Device, DeviceError, MissingDownlevelFlags, RenderPassContext,
-        SHADER_STAGE_COUNT,
+        AttachmentData, Device, DeviceError, MissingDownlevelFlags,
+        RenderPassCompatibilityCheckType, RenderPassContext, SHADER_STAGE_COUNT,
     },
     error::{ErrorFormatter, PrettyError},
     hub::{GlobalIdentityHandlerFactory, HalApi, Hub, Resource, Storage, Token},
@@ -367,7 +367,7 @@ impl RenderBundleEncoder {
                         .map_pass_err(scope)?;
 
                     self.context
-                        .check_compatible(&pipeline.pass_context)
+                        .check_compatible(&pipeline.pass_context, RenderPassCompatibilityCheckType::RenderPipeline)
                         .map_err(RenderCommandError::IncompatiblePipelineTargets)
                         .map_pass_err(scope)?;
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -698,16 +698,16 @@ impl RenderBundleEncoder {
 pub enum CreateRenderBundleError {
     #[error(transparent)]
     ColorAttachment(#[from] ColorAttachmentError),
-    #[error("invalid number of samples {0}")]
+    #[error("Invalid number of samples {0}")]
     InvalidSampleCount(u32),
 }
 
 /// Error type returned from `RenderBundleEncoder::new` if the sample count is invalid.
 #[derive(Clone, Debug, Error)]
 pub enum ExecutionError {
-    #[error("buffer {0:?} is destroyed")]
+    #[error("Buffer {0:?} is destroyed")]
     DestroyedBuffer(id::BufferId),
-    #[error("using {0} in a render bundle is not implemented")]
+    #[error("Using {0} in a render bundle is not implemented")]
     Unimplemented(&'static str),
 }
 impl PrettyError for ExecutionError {
@@ -1377,7 +1377,7 @@ impl<A: HalApi> State<A> {
 /// Error encountered when finishing recording a render bundle.
 #[derive(Clone, Debug, Error)]
 pub(super) enum RenderBundleErrorInner {
-    #[error("resource is not valid to use with this render bundle because the resource and the bundle come from different devices")]
+    #[error("Resource is not valid to use with this render bundle because the resource and the bundle come from different devices")]
     NotValidToUse,
     #[error(transparent)]
     Device(#[from] DeviceError),

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -19,43 +19,43 @@ use wgt::{BufferAddress, BufferSize, BufferUsages, ImageSubresourceRange, Textur
 /// Error encountered while attempting a clear.
 #[derive(Clone, Debug, Error)]
 pub enum ClearError {
-    #[error("to use clear_texture the CLEAR_TEXTURE feature needs to be enabled")]
+    #[error("To use clear_texture the CLEAR_TEXTURE feature needs to be enabled")]
     MissingClearTextureFeature,
-    #[error("command encoder {0:?} is invalid")]
+    #[error("Command encoder {0:?} is invalid")]
     InvalidCommandEncoder(CommandEncoderId),
-    #[error("device {0:?} is invalid")]
+    #[error("Device {0:?} is invalid")]
     InvalidDevice(DeviceId),
-    #[error("buffer {0:?} is invalid or destroyed")]
+    #[error("Buffer {0:?} is invalid or destroyed")]
     InvalidBuffer(BufferId),
-    #[error("texture {0:?} is invalid or destroyed")]
+    #[error("Texture {0:?} is invalid or destroyed")]
     InvalidTexture(TextureId),
-    #[error("texture {0:?} can not be cleared")]
+    #[error("Texture {0:?} can not be cleared")]
     NoValidTextureClearMode(TextureId),
-    #[error("buffer clear size {0:?} is not a multiple of `COPY_BUFFER_ALIGNMENT`")]
+    #[error("Buffer clear size {0:?} is not a multiple of `COPY_BUFFER_ALIGNMENT`")]
     UnalignedFillSize(BufferSize),
-    #[error("buffer offset {0:?} is not a multiple of `COPY_BUFFER_ALIGNMENT`")]
+    #[error("Buffer offset {0:?} is not a multiple of `COPY_BUFFER_ALIGNMENT`")]
     UnalignedBufferOffset(BufferAddress),
-    #[error("clear of {start_offset}..{end_offset} would end up overrunning the bounds of the buffer of size {buffer_size}")]
+    #[error("Clear of {start_offset}..{end_offset} would end up overrunning the bounds of the buffer of size {buffer_size}")]
     BufferOverrun {
         start_offset: BufferAddress,
         end_offset: BufferAddress,
         buffer_size: BufferAddress,
     },
-    #[error("destination buffer is missing the `COPY_DST` usage flag")]
+    #[error("Destination buffer is missing the `COPY_DST` usage flag")]
     MissingCopyDstUsageFlag(Option<BufferId>, Option<TextureId>),
-    #[error("texture lacks the aspects that were specified in the image subresource range. Texture with format {texture_format:?}, specified was {subresource_range_aspects:?}")]
+    #[error("Texture lacks the aspects that were specified in the image subresource range. Texture with format {texture_format:?}, specified was {subresource_range_aspects:?}")]
     MissingTextureAspect {
         texture_format: wgt::TextureFormat,
         subresource_range_aspects: TextureAspect,
     },
-    #[error("image subresource level range is outside of the texture's level range. texture range is {texture_level_range:?},  \
+    #[error("Image subresource level range is outside of the texture's level range. texture range is {texture_level_range:?},  \
 whereas subesource range specified start {subresource_base_mip_level} and count {subresource_mip_level_count:?}")]
     InvalidTextureLevelRange {
         texture_level_range: Range<u32>,
         subresource_base_mip_level: u32,
         subresource_mip_level_count: Option<u32>,
     },
-    #[error("image subresource layer range is outside of the texture's layer range. texture range is {texture_layer_range:?},  \
+    #[error("Image subresource layer range is outside of the texture's layer range. texture range is {texture_layer_range:?},  \
 whereas subesource range specified start {subresource_base_array_layer} and count {subresource_array_layer_count:?}")]
     InvalidTextureLayerRange {
         texture_layer_range: Range<u32>,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -138,16 +138,16 @@ pub struct ComputePassDescriptor<'a> {
 
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum DispatchError {
-    #[error("compute pipeline must be set")]
+    #[error("Compute pipeline must be set")]
     MissingPipeline,
-    #[error("the pipeline layout, associated with the current compute pipeline, contains a bind group layout at index {index} which is incompatible with the bind group layout associated with the bind group at {index}")]
+    #[error("The pipeline layout, associated with the current compute pipeline, contains a bind group layout at index {index} which is incompatible with the bind group layout associated with the bind group at {index}")]
     IncompatibleBindGroup {
         index: u32,
         //expected: BindGroupLayoutId,
         //provided: Option<(BindGroupLayoutId, BindGroupId)>,
     },
     #[error(
-        "each current dispatch group size dimension ({current:?}) must be less or equal to {limit}"
+        "Each current dispatch group size dimension ({current:?}) must be less or equal to {limit}"
     )]
     InvalidGroupSize { current: [u32; 3], limit: u32 },
     #[error(transparent)]
@@ -159,29 +159,29 @@ pub enum DispatchError {
 pub enum ComputePassErrorInner {
     #[error(transparent)]
     Encoder(#[from] CommandEncoderError),
-    #[error("bind group {0:?} is invalid")]
+    #[error("Bind group {0:?} is invalid")]
     InvalidBindGroup(id::BindGroupId),
-    #[error("bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
+    #[error("Bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
     BindGroupIndexOutOfRange { index: u8, max: u32 },
-    #[error("compute pipeline {0:?} is invalid")]
+    #[error("Compute pipeline {0:?} is invalid")]
     InvalidPipeline(id::ComputePipelineId),
     #[error("QuerySet {0:?} is invalid")]
     InvalidQuerySet(id::QuerySetId),
-    #[error("indirect buffer {0:?} is invalid or destroyed")]
+    #[error("Indirect buffer {0:?} is invalid or destroyed")]
     InvalidIndirectBuffer(id::BufferId),
-    #[error("indirect buffer uses bytes {offset}..{end_offset} which overruns indirect buffer of size {buffer_size}")]
+    #[error("Indirect buffer uses bytes {offset}..{end_offset} which overruns indirect buffer of size {buffer_size}")]
     IndirectBufferOverrun {
         offset: u64,
         end_offset: u64,
         buffer_size: u64,
     },
-    #[error("buffer {0:?} is invalid or destroyed")]
+    #[error("Buffer {0:?} is invalid or destroyed")]
     InvalidBuffer(id::BufferId),
     #[error(transparent)]
     ResourceUsageConflict(#[from] UsageConflict),
     #[error(transparent)]
     MissingBufferUsage(#[from] MissingBufferUsageError),
-    #[error("cannot pop debug group, because number of pushed debug groups is zero")]
+    #[error("Cannot pop debug group, because number of pushed debug groups is zero")]
     InvalidPopDebugGroup,
     #[error(transparent)]
     Dispatch(#[from] DispatchError),

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -16,36 +16,36 @@ use thiserror::Error;
 /// Error validating a draw call.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum DrawError {
-    #[error("blend constant needs to be set")]
+    #[error("Blend constant needs to be set")]
     MissingBlendConstant,
-    #[error("render pipeline must be set")]
+    #[error("Render pipeline must be set")]
     MissingPipeline,
-    #[error("vertex buffer {index} must be set")]
+    #[error("Vertex buffer {index} must be set")]
     MissingVertexBuffer { index: u32 },
-    #[error("index buffer must be set")]
+    #[error("Index buffer must be set")]
     MissingIndexBuffer,
-    #[error("the pipeline layout, associated with the current render pipeline, contains a bind group layout at index {index} which is incompatible with the bind group layout associated with the bind group at {index}")]
+    #[error("The pipeline layout, associated with the current render pipeline, contains a bind group layout at index {index} which is incompatible with the bind group layout associated with the bind group at {index}")]
     IncompatibleBindGroup {
         index: u32,
         //expected: BindGroupLayoutId,
         //provided: Option<(BindGroupLayoutId, BindGroupId)>,
     },
-    #[error("vertex {last_vertex} extends beyond limit {vertex_limit} imposed by the buffer in slot {slot}. Did you bind the correct `Vertex` step-rate vertex buffer?")]
+    #[error("Vertex {last_vertex} extends beyond limit {vertex_limit} imposed by the buffer in slot {slot}. Did you bind the correct `Vertex` step-rate vertex buffer?")]
     VertexBeyondLimit {
         last_vertex: u32,
         vertex_limit: u32,
         slot: u32,
     },
-    #[error("instance {last_instance} extends beyond limit {instance_limit} imposed by the buffer in slot {slot}. Did you bind the correct `Instance` step-rate vertex buffer?")]
+    #[error("Instance {last_instance} extends beyond limit {instance_limit} imposed by the buffer in slot {slot}. Did you bind the correct `Instance` step-rate vertex buffer?")]
     InstanceBeyondLimit {
         last_instance: u32,
         instance_limit: u32,
         slot: u32,
     },
-    #[error("index {last_index} extends beyond limit {index_limit}. Did you bind the correct index buffer?")]
+    #[error("Index {last_index} extends beyond limit {index_limit}. Did you bind the correct index buffer?")]
     IndexBeyondLimit { last_index: u32, index_limit: u32 },
     #[error(
-        "pipeline index format ({pipeline:?}) and buffer index format ({buffer:?}) do not match"
+        "Pipeline index format ({pipeline:?}) and buffer index format ({buffer:?}) do not match"
     )]
     UnmatchedIndexFormats {
         pipeline: wgt::IndexFormat,
@@ -59,27 +59,27 @@ pub enum DrawError {
 /// This is the shared error set between render bundles and passes.
 #[derive(Clone, Debug, Error)]
 pub enum RenderCommandError {
-    #[error("bind group {0:?} is invalid")]
+    #[error("Bind group {0:?} is invalid")]
     InvalidBindGroup(id::BindGroupId),
-    #[error("render bundle {0:?} is invalid")]
+    #[error("Render bundle {0:?} is invalid")]
     InvalidRenderBundle(id::RenderBundleId),
-    #[error("bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
+    #[error("Bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
     BindGroupIndexOutOfRange { index: u8, max: u32 },
-    #[error("dynamic buffer offset {0} does not respect device's requested `{1}` limit {2}")]
+    #[error("Dynamic buffer offset {0} does not respect device's requested `{1}` limit {2}")]
     UnalignedBufferOffset(u64, &'static str, u32),
-    #[error("number of buffer offsets ({actual}) does not match the number of dynamic bindings ({expected})")]
+    #[error("Number of buffer offsets ({actual}) does not match the number of dynamic bindings ({expected})")]
     InvalidDynamicOffsetCount { actual: usize, expected: usize },
-    #[error("render pipeline {0:?} is invalid")]
+    #[error("Render pipeline {0:?} is invalid")]
     InvalidPipeline(id::RenderPipelineId),
     #[error("QuerySet {0:?} is invalid")]
     InvalidQuerySet(id::QuerySetId),
     #[error("Render pipeline targets are incompatible with render pass")]
     IncompatiblePipelineTargets(#[from] crate::device::RenderPassCompatibilityError),
-    #[error("pipeline writes to depth/stencil, while the pass has read-only depth/stencil")]
+    #[error("Pipeline writes to depth/stencil, while the pass has read-only depth/stencil")]
     IncompatiblePipelineRods,
     #[error(transparent)]
     UsageConflict(#[from] UsageConflict),
-    #[error("buffer {0:?} is destroyed")]
+    #[error("Buffer {0:?} is destroyed")]
     DestroyedBuffer(id::BufferId),
     #[error(transparent)]
     MissingBufferUsage(#[from] MissingBufferUsageError),

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -329,9 +329,9 @@ impl<C: Clone> BasePass<C> {
 
 #[derive(Clone, Debug, Error)]
 pub enum CommandEncoderError {
-    #[error("command encoder is invalid")]
+    #[error("Command encoder is invalid")]
     Invalid,
-    #[error("command encoder must be active")]
+    #[error("Command encoder must be active")]
     NotRecording,
 }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     device::{
         AttachmentData, Device, MissingDownlevelFlags, MissingFeatures,
-        RenderPassCompatibilityError, RenderPassContext,
+        RenderPassCompatibilityCheckType, RenderPassCompatibilityError, RenderPassContext,
     },
     error::{ErrorFormatter, PrettyError},
     hub::{Global, GlobalIdentityHandlerFactory, HalApi, Storage, Token},
@@ -1320,7 +1320,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .map_pass_err(scope)?;
 
                         info.context
-                            .check_compatible(&pipeline.pass_context)
+                            .check_compatible(
+                                &pipeline.pass_context,
+                                RenderPassCompatibilityCheckType::RenderPipeline,
+                            )
                             .map_err(RenderCommandError::IncompatiblePipelineTargets)
                             .map_pass_err(scope)?;
 
@@ -1986,7 +1989,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .map_pass_err(scope)?;
 
                         info.context
-                            .check_compatible(&bundle.context)
+                            .check_compatible(
+                                &bundle.context,
+                                RenderPassCompatibilityCheckType::RenderBundle,
+                            )
                             .map_err(RenderPassErrorInner::IncompatibleBundleTargets)
                             .map_pass_err(scope)?;
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -466,9 +466,9 @@ impl fmt::Display for AttachmentErrorLocation {
 
 #[derive(Clone, Debug, Error)]
 pub enum ColorAttachmentError {
-    #[error("attachment format {0:?} is not a color format")]
+    #[error("Attachment format {0:?} is not a color format")]
     InvalidFormat(wgt::TextureFormat),
-    #[error("the number of color attachments {given} exceeds the limit {limit}")]
+    #[error("The number of color attachments {given} exceeds the limit {limit}")]
     TooMany { given: usize, limit: usize },
 }
 
@@ -479,66 +479,66 @@ pub enum RenderPassErrorInner {
     ColorAttachment(#[from] ColorAttachmentError),
     #[error(transparent)]
     Encoder(#[from] CommandEncoderError),
-    #[error("attachment texture view {0:?} is invalid")]
+    #[error("Attachment texture view {0:?} is invalid")]
     InvalidAttachment(id::TextureViewId),
-    #[error("the format of the depth-stencil attachment ({0:?}) is not a depth-stencil format")]
+    #[error("The format of the depth-stencil attachment ({0:?}) is not a depth-stencil format")]
     InvalidDepthStencilAttachmentFormat(wgt::TextureFormat),
-    #[error("the format of the {location} ({format:?}) is not resolvable")]
+    #[error("The format of the {location} ({format:?}) is not resolvable")]
     UnsupportedResolveTargetFormat {
         location: AttachmentErrorLocation,
         format: wgt::TextureFormat,
     },
-    #[error("no color attachments or depth attachments were provided, at least one attachment of any kind must be provided")]
+    #[error("No color attachments or depth attachments were provided, at least one attachment of any kind must be provided")]
     MissingAttachments,
-    #[error("the {location} is not renderable:")]
+    #[error("The {location} is not renderable:")]
     TextureViewIsNotRenderable {
         location: AttachmentErrorLocation,
         #[source]
         reason: TextureViewNotRenderableReason,
     },
-    #[error("attachments have differing sizes: the {expected_location} has extent {expected_extent:?} but is followed by the {actual_location} which has {actual_extent:?}")]
+    #[error("Attachments have differing sizes: the {expected_location} has extent {expected_extent:?} but is followed by the {actual_location} which has {actual_extent:?}")]
     AttachmentsDimensionMismatch {
         expected_location: AttachmentErrorLocation,
         expected_extent: wgt::Extent3d,
         actual_location: AttachmentErrorLocation,
         actual_extent: wgt::Extent3d,
     },
-    #[error("attachments have differing sample counts: the {expected_location} has count {expected_samples:?} but is followed by the {actual_location} which has count {actual_samples:?}")]
+    #[error("Attachments have differing sample counts: the {expected_location} has count {expected_samples:?} but is followed by the {actual_location} which has count {actual_samples:?}")]
     AttachmentSampleCountMismatch {
         expected_location: AttachmentErrorLocation,
         expected_samples: u32,
         actual_location: AttachmentErrorLocation,
         actual_samples: u32,
     },
-    #[error("the resolve source, {location}, must be multi-sampled (has {src} samples) while the resolve destination must not be multisampled (has {dst} samples)")]
+    #[error("The resolve source, {location}, must be multi-sampled (has {src} samples) while the resolve destination must not be multisampled (has {dst} samples)")]
     InvalidResolveSampleCounts {
         location: AttachmentErrorLocation,
         src: u32,
         dst: u32,
     },
     #[error(
-        "resource source, {location}, format ({src:?}) must match the resolve destination format ({dst:?})"
+        "Resource source, {location}, format ({src:?}) must match the resolve destination format ({dst:?})"
     )]
     MismatchedResolveTextureFormat {
         location: AttachmentErrorLocation,
         src: wgt::TextureFormat,
         dst: wgt::TextureFormat,
     },
-    #[error("surface texture is dropped before the render pass is finished")]
+    #[error("Surface texture is dropped before the render pass is finished")]
     SurfaceTextureDropped,
-    #[error("not enough memory left")]
+    #[error("Not enough memory left")]
     OutOfMemory,
-    #[error("unable to clear non-present/read-only depth")]
+    #[error("Unable to clear non-present/read-only depth")]
     InvalidDepthOps,
-    #[error("unable to clear non-present/read-only stencil")]
+    #[error("Unable to clear non-present/read-only stencil")]
     InvalidStencilOps,
-    #[error("setting `values_offset` to be `None` is only for internal use in render bundles")]
+    #[error("Setting `values_offset` to be `None` is only for internal use in render bundles")]
     InvalidValuesOffset,
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
     #[error(transparent)]
     MissingDownlevelFlags(#[from] MissingDownlevelFlags),
-    #[error("indirect draw uses bytes {offset}..{end_offset} {} which overruns indirect buffer of size {buffer_size}",
+    #[error("Indirect draw uses bytes {offset}..{end_offset} {} which overruns indirect buffer of size {buffer_size}",
         count.map_or_else(String::new, |v| format!("(using count {v})")))]
     IndirectBufferOverrun {
         count: Option<NonZeroU32>,
@@ -546,20 +546,20 @@ pub enum RenderPassErrorInner {
         end_offset: u64,
         buffer_size: u64,
     },
-    #[error("indirect draw uses bytes {begin_count_offset}..{end_count_offset} which overruns indirect buffer of size {count_buffer_size}")]
+    #[error("Indirect draw uses bytes {begin_count_offset}..{end_count_offset} which overruns indirect buffer of size {count_buffer_size}")]
     IndirectCountBufferOverrun {
         begin_count_offset: u64,
         end_count_offset: u64,
         count_buffer_size: u64,
     },
-    #[error("cannot pop debug group, because number of pushed debug groups is zero")]
+    #[error("Cannot pop debug group, because number of pushed debug groups is zero")]
     InvalidPopDebugGroup,
     #[error(transparent)]
     ResourceUsageConflict(#[from] UsageConflict),
-    #[error("render bundle has incompatible targets, {0}")]
+    #[error("Render bundle has incompatible targets, {0}")]
     IncompatibleBundleTargets(#[from] RenderPassCompatibilityError),
     #[error(
-        "render bundle has incompatible read-only flags: \
+        "Render bundle has incompatible read-only flags: \
              bundle has flags depth = {bundle_depth} and stencil = {bundle_stencil}, \
              while the pass has flags depth = {pass_depth} and stencil = {pass_stencil}. \
              Read-only renderpasses are only compatible with read-only bundles for that aspect."
@@ -578,10 +578,10 @@ pub enum RenderPassErrorInner {
     Bind(#[from] BindError),
     #[error(transparent)]
     QueryUse(#[from] QueryUseError),
-    #[error("multiview layer count must match")]
+    #[error("Multiview layer count must match")]
     MultiViewMismatch,
     #[error(
-        "multiview pass texture views with more than one array layer must have D2Array dimension"
+        "Multiview pass texture views with more than one array layer must have D2Array dimension"
     )]
     MultiViewDimensionMismatch,
 }

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -35,26 +35,26 @@ pub enum CopySide {
 /// Error encountered while attempting a data transfer.
 #[derive(Clone, Debug, Error)]
 pub enum TransferError {
-    #[error("buffer {0:?} is invalid or destroyed")]
+    #[error("Buffer {0:?} is invalid or destroyed")]
     InvalidBuffer(BufferId),
-    #[error("texture {0:?} is invalid or destroyed")]
+    #[error("Texture {0:?} is invalid or destroyed")]
     InvalidTexture(TextureId),
     #[error("Source and destination cannot be the same buffer")]
     SameSourceDestinationBuffer,
-    #[error("source buffer/texture is missing the `COPY_SRC` usage flag")]
+    #[error("Source buffer/texture is missing the `COPY_SRC` usage flag")]
     MissingCopySrcUsageFlag,
-    #[error("destination buffer/texture is missing the `COPY_DST` usage flag")]
+    #[error("Destination buffer/texture is missing the `COPY_DST` usage flag")]
     MissingCopyDstUsageFlag(Option<BufferId>, Option<TextureId>),
-    #[error("destination texture is missing the `RENDER_ATTACHMENT` usage flag")]
+    #[error("Destination texture is missing the `RENDER_ATTACHMENT` usage flag")]
     MissingRenderAttachmentUsageFlag(TextureId),
-    #[error("copy of {start_offset}..{end_offset} would end up overrunning the bounds of the {side:?} buffer of size {buffer_size}")]
+    #[error("Copy of {start_offset}..{end_offset} would end up overrunning the bounds of the {side:?} buffer of size {buffer_size}")]
     BufferOverrun {
         start_offset: BufferAddress,
         end_offset: BufferAddress,
         buffer_size: BufferAddress,
         side: CopySide,
     },
-    #[error("copy of {dimension:?} {start_offset}..{end_offset} would end up overrunning the bounds of the {side:?} texture of {dimension:?} size {texture_size}")]
+    #[error("Copy of {dimension:?} {start_offset}..{end_offset} would end up overrunning the bounds of the {side:?} texture of {dimension:?} size {texture_size}")]
     TextureOverrun {
         start_offset: u32,
         end_offset: u32,
@@ -62,65 +62,65 @@ pub enum TransferError {
         dimension: TextureErrorDimension,
         side: CopySide,
     },
-    #[error("unable to select texture aspect {aspect:?} from fromat {format:?}")]
+    #[error("Unable to select texture aspect {aspect:?} from fromat {format:?}")]
     InvalidTextureAspect {
         format: wgt::TextureFormat,
         aspect: wgt::TextureAspect,
     },
-    #[error("unable to select texture mip level {level} out of {total}")]
+    #[error("Unable to select texture mip level {level} out of {total}")]
     InvalidTextureMipLevel { level: u32, total: u32 },
-    #[error("texture dimension must be 2D when copying from an external texture")]
+    #[error("Texture dimension must be 2D when copying from an external texture")]
     InvalidDimensionExternal(TextureId),
-    #[error("buffer offset {0} is not aligned to block size or `COPY_BUFFER_ALIGNMENT`")]
+    #[error("Buffer offset {0} is not aligned to block size or `COPY_BUFFER_ALIGNMENT`")]
     UnalignedBufferOffset(BufferAddress),
-    #[error("copy size {0} does not respect `COPY_BUFFER_ALIGNMENT`")]
+    #[error("Copy size {0} does not respect `COPY_BUFFER_ALIGNMENT`")]
     UnalignedCopySize(BufferAddress),
-    #[error("copy width is not a multiple of block width")]
+    #[error("Copy width is not a multiple of block width")]
     UnalignedCopyWidth,
-    #[error("copy height is not a multiple of block height")]
+    #[error("Copy height is not a multiple of block height")]
     UnalignedCopyHeight,
-    #[error("copy origin's x component is not a multiple of block width")]
+    #[error("Copy origin's x component is not a multiple of block width")]
     UnalignedCopyOriginX,
-    #[error("copy origin's y component is not a multiple of block height")]
+    #[error("Copy origin's y component is not a multiple of block height")]
     UnalignedCopyOriginY,
-    #[error("bytes per row does not respect `COPY_BYTES_PER_ROW_ALIGNMENT`")]
+    #[error("Bytes per row does not respect `COPY_BYTES_PER_ROW_ALIGNMENT`")]
     UnalignedBytesPerRow,
-    #[error("number of bytes per row needs to be specified since more than one row is copied")]
+    #[error("Number of bytes per row needs to be specified since more than one row is copied")]
     UnspecifiedBytesPerRow,
-    #[error("number of rows per image needs to be specified since more than one image is copied")]
+    #[error("Number of rows per image needs to be specified since more than one image is copied")]
     UnspecifiedRowsPerImage,
-    #[error("number of bytes per row is less than the number of bytes in a complete row")]
+    #[error("Number of bytes per row is less than the number of bytes in a complete row")]
     InvalidBytesPerRow,
-    #[error("image is 1D and the copy height and depth are not both set to 1")]
+    #[error("Image is 1D and the copy height and depth are not both set to 1")]
     InvalidCopySize,
-    #[error("number of rows per image is invalid")]
+    #[error("Number of rows per image is invalid")]
     InvalidRowsPerImage,
-    #[error("copy source aspects must refer to all aspects of the source texture format")]
+    #[error("Copy source aspects must refer to all aspects of the source texture format")]
     CopySrcMissingAspects,
     #[error(
-        "copy destination aspects must refer to all aspects of the destination texture format"
+        "Copy destination aspects must refer to all aspects of the destination texture format"
     )]
     CopyDstMissingAspects,
-    #[error("copy aspect must refer to a single aspect of texture format")]
+    #[error("Copy aspect must refer to a single aspect of texture format")]
     CopyAspectNotOne,
-    #[error("copying from textures with format {format:?} and aspect {aspect:?} is forbidden")]
+    #[error("Copying from textures with format {format:?} and aspect {aspect:?} is forbidden")]
     CopyFromForbiddenTextureFormat {
         format: wgt::TextureFormat,
         aspect: wgt::TextureAspect,
     },
-    #[error("copying to textures with format {format:?} and aspect {aspect:?} is forbidden")]
+    #[error("Copying to textures with format {format:?} and aspect {aspect:?} is forbidden")]
     CopyToForbiddenTextureFormat {
         format: wgt::TextureFormat,
         aspect: wgt::TextureAspect,
     },
     #[error(
-        "copying to textures with format {0:?} is forbidden when copying from external texture"
+        "Copying to textures with format {0:?} is forbidden when copying from external texture"
     )]
     ExternalCopyToForbiddenTextureFormat(wgt::TextureFormat),
-    #[error("the entire texture must be copied when copying from depth texture")]
+    #[error("The entire texture must be copied when copying from depth texture")]
     InvalidDepthTextureExtent,
     #[error(
-        "source format ({src_format:?}) and destination format ({dst_format:?}) are not copy-compatible"
+        "Source format ({src_format:?}) and destination format ({dst_format:?}) are not copy-compatible"
     )]
     MismatchedTextureFormats {
         src_format: wgt::TextureFormat,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -344,9 +344,9 @@ pub struct Device<A: HalApi> {
 
 #[derive(Clone, Debug, Error)]
 pub enum CreateDeviceError {
-    #[error("not enough memory left")]
+    #[error("Not enough memory left")]
     OutOfMemory,
-    #[error("failed to create internal buffer for initializing textures")]
+    #[error("Failed to create internal buffer for initializing textures")]
     FailedToCreateZeroBuffer(#[from] DeviceError),
 }
 
@@ -3334,16 +3334,16 @@ impl<A: HalApi> crate::hub::Resource for Device<A> {
 }
 
 #[derive(Clone, Debug, Error)]
-#[error("device is invalid")]
+#[error("Device is invalid")]
 pub struct InvalidDevice;
 
 #[derive(Clone, Debug, Error)]
 pub enum DeviceError {
-    #[error("parent device is invalid")]
+    #[error("Parent device is invalid")]
     Invalid,
-    #[error("parent device is lost")]
+    #[error("Parent device is lost")]
     Lost,
-    #[error("not enough memory left")]
+    #[error("Not enough memory left")]
     OutOfMemory,
 }
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -284,7 +284,7 @@ impl<A: hal::Api> StagingBuffer<A> {
 }
 
 #[derive(Clone, Debug, Error)]
-#[error("queue is invalid")]
+#[error("Queue is invalid")]
 pub struct InvalidQueue;
 
 #[derive(Clone, Debug, Error)]
@@ -301,17 +301,17 @@ pub enum QueueWriteError {
 pub enum QueueSubmitError {
     #[error(transparent)]
     Queue(#[from] DeviceError),
-    #[error("buffer {0:?} is destroyed")]
+    #[error("Buffer {0:?} is destroyed")]
     DestroyedBuffer(id::BufferId),
-    #[error("texture {0:?} is destroyed")]
+    #[error("Texture {0:?} is destroyed")]
     DestroyedTexture(id::TextureId),
     #[error(transparent)]
     Unmap(#[from] BufferAccessError),
     #[error("Buffer {0:?} is still mapped")]
     BufferStillMapped(id::BufferId),
-    #[error("surface output was dropped before the command buffer got submitted")]
+    #[error("Surface output was dropped before the command buffer got submitted")]
     SurfaceOutputDropped,
-    #[error("surface was unconfigured before the command buffer got submitted")]
+    #[error("Surface was unconfigured before the command buffer got submitted")]
     SurfaceUnconfigured,
     #[error("GPU got stuck :(")]
     StuckGpu,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -366,38 +366,38 @@ impl<A: hal::Api> crate::hub::Resource for Adapter<A> {
 
 #[derive(Clone, Debug, Error)]
 pub enum IsSurfaceSupportedError {
-    #[error("invalid adapter")]
+    #[error("Invalid adapter")]
     InvalidAdapter,
-    #[error("invalid surface")]
+    #[error("Invalid surface")]
     InvalidSurface,
 }
 
 #[derive(Clone, Debug, Error)]
 pub enum GetSurfaceSupportError {
-    #[error("invalid adapter")]
+    #[error("Invalid adapter")]
     InvalidAdapter,
-    #[error("invalid surface")]
+    #[error("Invalid surface")]
     InvalidSurface,
-    #[error("surface is not supported by the adapter")]
+    #[error("Surface is not supported by the adapter")]
     Unsupported,
 }
 
 #[derive(Clone, Debug, Error)]
 /// Error when requesting a device from the adaptor
 pub enum RequestDeviceError {
-    #[error("parent adapter is invalid")]
+    #[error("Parent adapter is invalid")]
     InvalidAdapter,
-    #[error("connection to device was lost during initialization")]
+    #[error("Connection to device was lost during initialization")]
     DeviceLost,
-    #[error("device initialization failed due to implementation specific errors")]
+    #[error("Device initialization failed due to implementation specific errors")]
     Internal,
     #[error(transparent)]
     LimitsExceeded(#[from] FailedLimit),
-    #[error("device has no queue supporting graphics")]
+    #[error("Device has no queue supporting graphics")]
     NoGraphicsQueue,
-    #[error("not enough memory left")]
+    #[error("Not enough memory left")]
     OutOfMemory,
-    #[error("unsupported features were requested: {0:?}")]
+    #[error("Unsupported features were requested: {0:?}")]
     UnsupportedFeature(wgt::Features),
 }
 
@@ -422,14 +422,14 @@ impl<I: Clone> AdapterInputs<'_, I> {
 }
 
 #[derive(Clone, Debug, Error)]
-#[error("adapter is invalid")]
+#[error("Adapter is invalid")]
 pub struct InvalidAdapter;
 
 #[derive(Clone, Debug, Error)]
 pub enum RequestAdapterError {
-    #[error("no suitable adapter found")]
+    #[error("No suitable adapter found")]
     NotFound,
-    #[error("surface {0:?} is invalid")]
+    #[error("Surface {0:?} is invalid")]
     InvalidSurface(SurfaceId),
 }
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -133,7 +133,7 @@ pub enum CreateShaderModuleError {
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
     #[error(
-        "shader global {bind:?} uses a group index {group} that exceeds the max_bind_groups limit of {limit}."
+        "Shader global {bind:?} uses a group index {group} that exceeds the max_bind_groups limit of {limit}."
     )]
     InvalidGroupIndex {
         bind: naga::ResourceBinding,
@@ -170,9 +170,9 @@ pub type ImplicitBindGroupCount = u8;
 
 #[derive(Clone, Debug, Error)]
 pub enum ImplicitLayoutError {
-    #[error("missing IDs for deriving {0} bind groups")]
+    #[error("Missing IDs for deriving {0} bind groups")]
     MissingIds(ImplicitBindGroupCount),
-    #[error("unable to reflect the shader {0:?} interface")]
+    #[error("Unable to reflect the shader {0:?} interface")]
     ReflectionError(wgt::ShaderStages),
     #[error(transparent)]
     BindGroup(#[from] CreateBindGroupLayoutError),
@@ -196,11 +196,11 @@ pub struct ComputePipelineDescriptor<'a> {
 pub enum CreateComputePipelineError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("pipeline layout is invalid")]
+    #[error("Pipeline layout is invalid")]
     InvalidLayout,
-    #[error("unable to derive an implicit layout")]
+    #[error("Unable to derive an implicit layout")]
     Implicit(#[from] ImplicitLayoutError),
-    #[error("error matching shader requirements against the pipeline")]
+    #[error("Error matching shader requirements against the pipeline")]
     Stage(#[from] validation::StageError),
     #[error("Internal error: {0}")]
     Internal(String),
@@ -289,34 +289,34 @@ pub struct RenderPipelineDescriptor<'a> {
 
 #[derive(Clone, Debug, Error)]
 pub enum ColorStateError {
-    #[error("format {0:?} is not renderable")]
+    #[error("Format {0:?} is not renderable")]
     FormatNotRenderable(wgt::TextureFormat),
-    #[error("format {0:?} is not blendable")]
+    #[error("Format {0:?} is not blendable")]
     FormatNotBlendable(wgt::TextureFormat),
-    #[error("format {0:?} does not have a color aspect")]
+    #[error("Format {0:?} does not have a color aspect")]
     FormatNotColor(wgt::TextureFormat),
-    #[error("format {0:?} can't be multisampled")]
+    #[error("Format {0:?} can't be multisampled")]
     FormatNotMultisampled(wgt::TextureFormat),
-    #[error("output format {pipeline} is incompatible with the shader {shader}")]
+    #[error("Output format {pipeline} is incompatible with the shader {shader}")]
     IncompatibleFormat {
         pipeline: validation::NumericType,
         shader: validation::NumericType,
     },
-    #[error("blend factors for {0:?} must be `One`")]
+    #[error("Blend factors for {0:?} must be `One`")]
     InvalidMinMaxBlendFactors(wgt::BlendComponent),
-    #[error("invalid write mask {0:?}")]
+    #[error("Invalid write mask {0:?}")]
     InvalidWriteMask(wgt::ColorWrites),
 }
 
 #[derive(Clone, Debug, Error)]
 pub enum DepthStencilStateError {
-    #[error("format {0:?} is not renderable")]
+    #[error("Format {0:?} is not renderable")]
     FormatNotRenderable(wgt::TextureFormat),
-    #[error("format {0:?} does not have a depth aspect, but depth test/write is enabled")]
+    #[error("Format {0:?} does not have a depth aspect, but depth test/write is enabled")]
     FormatNotDepth(wgt::TextureFormat),
-    #[error("format {0:?} does not have a stencil aspect, but stencil test/write is enabled")]
+    #[error("Format {0:?} does not have a stencil aspect, but stencil test/write is enabled")]
     FormatNotStencil(wgt::TextureFormat),
-    #[error("format {0:?} can't be multisampled")]
+    #[error("Format {0:?} can't be multisampled")]
     FormatNotMultisampled(wgt::TextureFormat),
 }
 
@@ -326,33 +326,33 @@ pub enum CreateRenderPipelineError {
     ColorAttachment(#[from] ColorAttachmentError),
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("pipeline layout is invalid")]
+    #[error("Pipeline layout is invalid")]
     InvalidLayout,
-    #[error("unable to derive an implicit layout")]
+    #[error("Unable to derive an implicit layout")]
     Implicit(#[from] ImplicitLayoutError),
-    #[error("color state [{0}] is invalid")]
+    #[error("Color state [{0}] is invalid")]
     ColorState(u8, #[source] ColorStateError),
-    #[error("depth/stencil state is invalid")]
+    #[error("Depth/stencil state is invalid")]
     DepthStencilState(#[from] DepthStencilStateError),
-    #[error("invalid sample count {0}")]
+    #[error("Invalid sample count {0}")]
     InvalidSampleCount(u32),
-    #[error("the number of vertex buffers {given} exceeds the limit {limit}")]
+    #[error("The number of vertex buffers {given} exceeds the limit {limit}")]
     TooManyVertexBuffers { given: u32, limit: u32 },
-    #[error("the total number of vertex attributes {given} exceeds the limit {limit}")]
+    #[error("The total number of vertex attributes {given} exceeds the limit {limit}")]
     TooManyVertexAttributes { given: u32, limit: u32 },
-    #[error("vertex buffer {index} stride {given} exceeds the limit {limit}")]
+    #[error("Vertex buffer {index} stride {given} exceeds the limit {limit}")]
     VertexStrideTooLarge { index: u32, given: u32, limit: u32 },
-    #[error("vertex buffer {index} stride {stride} does not respect `VERTEX_STRIDE_ALIGNMENT`")]
+    #[error("Vertex buffer {index} stride {stride} does not respect `VERTEX_STRIDE_ALIGNMENT`")]
     UnalignedVertexStride {
         index: u32,
         stride: wgt::BufferAddress,
     },
-    #[error("vertex attribute at location {location} has invalid offset {offset}")]
+    #[error("Vertex attribute at location {location} has invalid offset {offset}")]
     InvalidVertexAttributeOffset {
         location: wgt::ShaderLocation,
         offset: wgt::BufferAddress,
     },
-    #[error("strip index format was not set to None but to {strip_index_format:?} while using the non-strip topology {topology:?}")]
+    #[error("Strip index format was not set to None but to {strip_index_format:?} while using the non-strip topology {topology:?}")]
     StripIndexFormatForNonStripTopology {
         strip_index_format: Option<wgt::IndexFormat>,
         topology: wgt::PrimitiveTopology,
@@ -363,7 +363,7 @@ pub enum CreateRenderPipelineError {
     MissingFeatures(#[from] MissingFeatures),
     #[error(transparent)]
     MissingDownlevelFlags(#[from] MissingDownlevelFlags),
-    #[error("error matching {stage:?} shader requirements against the pipeline")]
+    #[error("Error matching {stage:?} shader requirements against the pipeline")]
     Stage {
         stage: wgt::ShaderStages,
         #[source]

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -46,15 +46,15 @@ impl Presentation {
 
 #[derive(Clone, Debug, Error)]
 pub enum SurfaceError {
-    #[error("surface is invalid")]
+    #[error("Surface is invalid")]
     Invalid,
-    #[error("surface is not configured for presentation")]
+    #[error("Surface is not configured for presentation")]
     NotConfigured,
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("surface image is already acquired")]
+    #[error("Surface image is already acquired")]
     AlreadyAcquired,
-    #[error("acquired frame is still referenced")]
+    #[error("Acquired frame is still referenced")]
     StillReferenced,
 }
 
@@ -62,7 +62,7 @@ pub enum SurfaceError {
 pub enum ConfigureSurfaceError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("invalid surface")]
+    #[error("Invalid surface")]
     InvalidSurface,
     #[error("The view format {0:?} is not compatible with texture format {1:?}, only changing srgb-ness is allowed.")]
     InvalidViewFormat(wgt::TextureFormat, wgt::TextureFormat),
@@ -72,24 +72,24 @@ pub enum ConfigureSurfaceError {
     PreviousOutputExists,
     #[error("Both `Surface` width and height must be non-zero. Wait to recreate the `Surface` until the window has non-zero area.")]
     ZeroArea,
-    #[error("surface does not support the adapter's queue family")]
+    #[error("Surface does not support the adapter's queue family")]
     UnsupportedQueueFamily,
-    #[error("requested format {requested:?} is not in list of supported formats: {available:?}")]
+    #[error("Requested format {requested:?} is not in list of supported formats: {available:?}")]
     UnsupportedFormat {
         requested: wgt::TextureFormat,
         available: Vec<wgt::TextureFormat>,
     },
-    #[error("requested present mode {requested:?} is not in the list of supported present modes: {available:?}")]
+    #[error("Requested present mode {requested:?} is not in the list of supported present modes: {available:?}")]
     UnsupportedPresentMode {
         requested: wgt::PresentMode,
         available: Vec<wgt::PresentMode>,
     },
-    #[error("requested alpha mode {requested:?} is not in the list of supported alpha modes: {available:?}")]
+    #[error("Requested alpha mode {requested:?} is not in the list of supported alpha modes: {available:?}")]
     UnsupportedAlphaMode {
         requested: wgt::CompositeAlphaMode,
         available: Vec<wgt::CompositeAlphaMode>,
     },
-    #[error("requested usage is not supported")]
+    #[error("Requested usage is not supported")]
     UnsupportedUsage,
 }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -576,6 +576,22 @@ impl HalTextureViewDescriptor {
     }
 }
 
+#[derive(Debug, Copy, Clone, Error)]
+pub enum TextureViewNotRenderableReason {
+    #[error("the texture this view references doesn't include the RENDER_ATTACHMENT usage. Provided usages: {0:?}")]
+    Usage(wgt::TextureUsages),
+    #[error("the dimension of this texture view is not 2D. View dimension: {0:?}")]
+    Dimension(wgt::TextureViewDimension),
+    #[error("this texture view has more than one mipmap level. View mipmap levels: {0:?}")]
+    MipLevelCount(u32),
+    #[error("this texture view has more than one array layer. View array layers: {0:?}")]
+    ArrayLayerCount(u32),
+    #[error(
+        "the aspects of this texture view are a subset of the aspects in the original texture. Aspects: {0:?}"
+    )]
+    Aspects(hal::FormatAspects),
+}
+
 #[derive(Debug)]
 pub struct TextureView<A: hal::Api> {
     pub(crate) raw: A::TextureView,
@@ -586,8 +602,8 @@ pub struct TextureView<A: hal::Api> {
     //TODO: store device_id for quick access?
     pub(crate) desc: HalTextureViewDescriptor,
     pub(crate) format_features: wgt::TextureFormatFeatures,
-    /// This is `None` only if the texture view is not renderable
-    pub(crate) render_extent: Option<wgt::Extent3d>,
+    /// This is `Err` only if the texture view is not renderable
+    pub(crate) render_extent: Result<wgt::Extent3d, TextureViewNotRenderableReason>,
     pub(crate) samples: u32,
     pub(crate) selector: TextureSelector,
     pub(crate) life_guard: LifeGuard,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -170,46 +170,46 @@ pub struct BufferMapOperation {
 pub enum BufferAccessError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("buffer map failed")]
+    #[error("Buffer map failed")]
     Failed,
-    #[error("buffer is invalid")]
+    #[error("Buffer is invalid")]
     Invalid,
-    #[error("buffer is destroyed")]
+    #[error("Buffer is destroyed")]
     Destroyed,
-    #[error("buffer is already mapped")]
+    #[error("Buffer is already mapped")]
     AlreadyMapped,
-    #[error("buffer map is pending")]
+    #[error("Buffer map is pending")]
     MapAlreadyPending,
     #[error(transparent)]
     MissingBufferUsage(#[from] MissingBufferUsageError),
-    #[error("buffer is not mapped")]
+    #[error("Buffer is not mapped")]
     NotMapped,
     #[error(
-        "buffer map range must start aligned to `MAP_ALIGNMENT` and end to `COPY_BUFFER_ALIGNMENT`"
+        "Buffer map range must start aligned to `MAP_ALIGNMENT` and end to `COPY_BUFFER_ALIGNMENT`"
     )]
     UnalignedRange,
-    #[error("buffer offset invalid: offset {offset} must be multiple of 8")]
+    #[error("Buffer offset invalid: offset {offset} must be multiple of 8")]
     UnalignedOffset { offset: wgt::BufferAddress },
-    #[error("buffer range size invalid: range_size {range_size} must be multiple of 4")]
+    #[error("Buffer range size invalid: range_size {range_size} must be multiple of 4")]
     UnalignedRangeSize { range_size: wgt::BufferAddress },
-    #[error("buffer access out of bounds: index {index} would underrun the buffer (limit: {min})")]
+    #[error("Buffer access out of bounds: index {index} would underrun the buffer (limit: {min})")]
     OutOfBoundsUnderrun {
         index: wgt::BufferAddress,
         min: wgt::BufferAddress,
     },
     #[error(
-        "buffer access out of bounds: last index {index} would overrun the buffer (limit: {max})"
+        "Buffer access out of bounds: last index {index} would overrun the buffer (limit: {max})"
     )]
     OutOfBoundsOverrun {
         index: wgt::BufferAddress,
         max: wgt::BufferAddress,
     },
-    #[error("buffer map range start {start} is greater than end {end}")]
+    #[error("Buffer map range start {start} is greater than end {end}")]
     NegativeRange {
         start: wgt::BufferAddress,
         end: wgt::BufferAddress,
     },
-    #[error("buffer map aborted")]
+    #[error("Buffer map aborted")]
     MapAborted,
 }
 
@@ -238,9 +238,9 @@ pub struct Buffer<A: hal::Api> {
 pub enum CreateBufferError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("failed to map buffer while creating: {0}")]
+    #[error("Failed to map buffer while creating: {0}")]
     AccessError(#[from] BufferAccessError),
-    #[error("buffers that are mapped at creation have to be aligned to `COPY_BUFFER_ALIGNMENT`")]
+    #[error("Buffers that are mapped at creation have to be aligned to `COPY_BUFFER_ALIGNMENT`")]
     UnalignedSize,
     #[error("Invalid usage flags {0:?}")]
     InvalidUsage(wgt::BufferUsages),
@@ -578,16 +578,16 @@ impl HalTextureViewDescriptor {
 
 #[derive(Debug, Copy, Clone, Error)]
 pub enum TextureViewNotRenderableReason {
-    #[error("the texture this view references doesn't include the RENDER_ATTACHMENT usage. Provided usages: {0:?}")]
+    #[error("The texture this view references doesn't include the RENDER_ATTACHMENT usage. Provided usages: {0:?}")]
     Usage(wgt::TextureUsages),
-    #[error("the dimension of this texture view is not 2D. View dimension: {0:?}")]
+    #[error("The dimension of this texture view is not 2D. View dimension: {0:?}")]
     Dimension(wgt::TextureViewDimension),
-    #[error("this texture view has more than one mipmap level. View mipmap levels: {0:?}")]
+    #[error("This texture view has more than one mipmap level. View mipmap levels: {0:?}")]
     MipLevelCount(u32),
-    #[error("this texture view has more than one array layer. View array layers: {0:?}")]
+    #[error("This texture view has more than one array layer. View array layers: {0:?}")]
     ArrayLayerCount(u32),
     #[error(
-        "the aspects of this texture view are a subset of the aspects in the original texture. Aspects: {0:?}"
+        "The aspects of this texture view are a subset of the aspects in the original texture. Aspects: {0:?}"
     )]
     Aspects(hal::FormatAspects),
 }
@@ -611,9 +611,9 @@ pub struct TextureView<A: hal::Api> {
 
 #[derive(Clone, Debug, Error)]
 pub enum CreateTextureViewError {
-    #[error("parent texture is invalid or destroyed")]
+    #[error("Parent texture is invalid or destroyed")]
     InvalidTexture,
-    #[error("not enough memory left")]
+    #[error("Not enough memory left")]
     OutOfMemory,
     #[error("Invalid texture view dimension `{view:?}` with texture of dimension `{texture:?}`")]
     InvalidTextureViewDimension {
@@ -628,9 +628,9 @@ pub enum CreateTextureViewError {
     InvalidCubemapArrayTextureDepth { depth: u32 },
     #[error("Source texture width and height must be equal for a texture view of dimension `Cube`/`CubeArray`")]
     InvalidCubeTextureViewSize,
-    #[error("mip level count is 0")]
+    #[error("Mip level count is 0")]
     ZeroMipLevelCount,
-    #[error("array layer count is 0")]
+    #[error("Array layer count is 0")]
     ZeroArrayLayerCount,
     #[error(
         "TextureView mip level count + base mip level {requested} must be <= Texture mip level count {total}"
@@ -728,11 +728,11 @@ pub struct Sampler<A: hal::Api> {
 pub enum CreateSamplerError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("invalid lod clamp lod_min_clamp:{} lod_max_clamp:{}, must satisfy lod_min_clamp >= 0 and lod_max_clamp >= lod_min_clamp ", .0.start, .0.end)]
+    #[error("Invalid lod clamp lod_min_clamp:{} lod_max_clamp:{}, must satisfy lod_min_clamp >= 0 and lod_max_clamp >= lod_min_clamp ", .0.start, .0.end)]
     InvalidLodClamp(Range<f32>),
-    #[error("invalid anisotropic clamp {0}, must be one of 1, 2, 4, 8 or 16")]
+    #[error("Invalid anisotropic clamp {0}, must be one of 1, 2, 4, 8 or 16")]
     InvalidClamp(u8),
-    #[error("cannot create any more samplers")]
+    #[error("Cannot create any more samplers")]
     TooManyObjects,
     /// AddressMode::ClampToBorder requires feature ADDRESS_MODE_CLAMP_TO_BORDER.
     #[error(transparent)]
@@ -779,8 +779,8 @@ impl<A: hal::Api> Resource for QuerySet<A> {
 
 #[derive(Clone, Debug, Error)]
 pub enum DestroyError {
-    #[error("resource is invalid")]
+    #[error("Resource is invalid")]
     Invalid,
-    #[error("resource is already destroyed")]
+    #[error("Resource is already destroyed")]
     AlreadyDestroyed,
 }

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -128,7 +128,7 @@ pub struct Interface {
 }
 
 #[derive(Clone, Debug, Error)]
-#[error("buffer usage is {actual:?} which does not contain required usage {expected:?}")]
+#[error("Buffer usage is {actual:?} which does not contain required usage {expected:?}")]
 pub struct MissingBufferUsageError {
     pub(crate) actual: wgt::BufferUsages,
     pub(crate) expected: wgt::BufferUsages,
@@ -148,7 +148,7 @@ pub fn check_buffer_usage(
 }
 
 #[derive(Clone, Debug, Error)]
-#[error("texture usage is {actual:?} which does not contain required usage {expected:?}")]
+#[error("Texture usage is {actual:?} which does not contain required usage {expected:?}")]
 pub struct MissingTextureUsageError {
     pub(crate) actual: wgt::TextureUsages,
     pub(crate) expected: wgt::TextureUsages,
@@ -169,74 +169,74 @@ pub fn check_texture_usage(
 
 #[derive(Clone, Debug, Error)]
 pub enum BindingError {
-    #[error("binding is missing from the pipeline layout")]
+    #[error("Binding is missing from the pipeline layout")]
     Missing,
-    #[error("visibility flags don't include the shader stage")]
+    #[error("Visibility flags don't include the shader stage")]
     Invisible,
     #[error("The shader requires the load/store access flags {required:?} but only {allowed:?} is allowed")]
     WrongUsage {
         required: GlobalUse,
         allowed: GlobalUse,
     },
-    #[error("type on the shader side does not match the pipeline binding")]
+    #[error("Type on the shader side does not match the pipeline binding")]
     WrongType,
-    #[error("storage class {binding:?} doesn't match the shader {shader:?}")]
+    #[error("Storage class {binding:?} doesn't match the shader {shader:?}")]
     WrongAddressSpace {
         binding: naga::AddressSpace,
         shader: naga::AddressSpace,
     },
-    #[error("buffer structure size {0}, added to one element of an unbound array, if it's the last field, ended up greater than the given `min_binding_size`")]
+    #[error("Buffer structure size {0}, added to one element of an unbound array, if it's the last field, ended up greater than the given `min_binding_size`")]
     WrongBufferSize(wgt::BufferSize),
-    #[error("view dimension {dim:?} (is array: {is_array}) doesn't match the binding {binding:?}")]
+    #[error("View dimension {dim:?} (is array: {is_array}) doesn't match the binding {binding:?}")]
     WrongTextureViewDimension {
         dim: naga::ImageDimension,
         is_array: bool,
         binding: BindingType,
     },
-    #[error("texture class {binding:?} doesn't match the shader {shader:?}")]
+    #[error("Texture class {binding:?} doesn't match the shader {shader:?}")]
     WrongTextureClass {
         binding: naga::ImageClass,
         shader: naga::ImageClass,
     },
-    #[error("comparison flag doesn't match the shader")]
+    #[error("Comparison flag doesn't match the shader")]
     WrongSamplerComparison,
-    #[error("derived bind group layout type is not consistent between stages")]
+    #[error("Derived bind group layout type is not consistent between stages")]
     InconsistentlyDerivedType,
-    #[error("texture format {0:?} is not supported for storage use")]
+    #[error("Texture format {0:?} is not supported for storage use")]
     BadStorageFormat(wgt::TextureFormat),
     #[error(
-        "storage texture usage {0:?} doesn't have a matching supported `StorageTextureAccess`"
+        "Storage texture usage {0:?} doesn't have a matching supported `StorageTextureAccess`"
     )]
     UnsupportedTextureStorageAccess(GlobalUse),
 }
 
 #[derive(Clone, Debug, Error)]
 pub enum FilteringError {
-    #[error("integer textures can't be sampled with a filtering sampler")]
+    #[error("Integer textures can't be sampled with a filtering sampler")]
     Integer,
-    #[error("non-filterable float textures can't be sampled with a filtering sampler")]
+    #[error("Non-filterable float textures can't be sampled with a filtering sampler")]
     Float,
 }
 
 #[derive(Clone, Debug, Error)]
 pub enum InputError {
-    #[error("input is not provided by the earlier stage in the pipeline")]
+    #[error("Input is not provided by the earlier stage in the pipeline")]
     Missing,
-    #[error("input type is not compatible with the provided {0}")]
+    #[error("Input type is not compatible with the provided {0}")]
     WrongType(NumericType),
-    #[error("input interpolation doesn't match provided {0:?}")]
+    #[error("Input interpolation doesn't match provided {0:?}")]
     InterpolationMismatch(Option<naga::Interpolation>),
-    #[error("input sampling doesn't match provided {0:?}")]
+    #[error("Input sampling doesn't match provided {0:?}")]
     SamplingMismatch(Option<naga::Sampling>),
 }
 
 /// Errors produced when validating a programmable stage of a pipeline.
 #[derive(Clone, Debug, Error)]
 pub enum StageError {
-    #[error("shader module is invalid")]
+    #[error("Shader module is invalid")]
     InvalidModule,
     #[error(
-        "shader entry point's workgroup size {current:?} ({current_total} total invocations) must be less or equal to the per-dimension limit {limit:?} and the total invocation limit {total}"
+        "Shader entry point's workgroup size {current:?} ({current_total} total invocations) must be less or equal to the per-dimension limit {limit:?} and the total invocation limit {total}"
     )]
     InvalidWorkgroupSize {
         current: [u32; 3],
@@ -244,27 +244,27 @@ pub enum StageError {
         limit: [u32; 3],
         total: u32,
     },
-    #[error("shader uses {used} inter-stage components above the limit of {limit}")]
+    #[error("Shader uses {used} inter-stage components above the limit of {limit}")]
     TooManyVaryings { used: u32, limit: u32 },
-    #[error("unable to find entry point '{0}'")]
+    #[error("Unable to find entry point '{0}'")]
     MissingEntryPoint(String),
-    #[error("shader global {0:?} is not available in the layout pipeline layout")]
+    #[error("Shader global {0:?} is not available in the layout pipeline layout")]
     Binding(naga::ResourceBinding, #[source] BindingError),
-    #[error("unable to filter the texture ({texture:?}) by the sampler ({sampler:?})")]
+    #[error("Unable to filter the texture ({texture:?}) by the sampler ({sampler:?})")]
     Filtering {
         texture: naga::ResourceBinding,
         sampler: naga::ResourceBinding,
         #[source]
         error: FilteringError,
     },
-    #[error("location[{location}] {var} is not provided by the previous stage outputs")]
+    #[error("Location[{location}] {var} is not provided by the previous stage outputs")]
     Input {
         location: wgt::ShaderLocation,
         var: InterfaceVar,
         #[source]
         error: InputError,
     },
-    #[error("location[{location}] is provided by the previous stage output but is not consumed as input by this stage.")]
+    #[error("Location[{location}] is provided by the previous stage output but is not consumed as input by this stage.")]
     InputNotConsumed { location: wgt::ShaderLocation },
 }
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -113,15 +113,15 @@ pub type DropGuard = Box<dyn std::any::Any + Send + Sync>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
 pub enum DeviceError {
-    #[error("out of memory")]
+    #[error("Out of memory")]
     OutOfMemory,
-    #[error("device is lost")]
+    #[error("Device is lost")]
     Lost,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
 pub enum ShaderError {
-    #[error("compilation failed: {0:?}")]
+    #[error("Compilation failed: {0:?}")]
     Compilation(String),
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -129,9 +129,9 @@ pub enum ShaderError {
 
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
 pub enum PipelineError {
-    #[error("linkage failed for stage {0:?}: {1}")]
+    #[error("Linkage failed for stage {0:?}: {1}")]
     Linkage(wgt::ShaderStages, String),
-    #[error("entry point for stage {0:?} is invalid")]
+    #[error("Entry point for stage {0:?} is invalid")]
     EntryPoint(naga::ShaderStage),
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -139,13 +139,13 @@ pub enum PipelineError {
 
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
 pub enum SurfaceError {
-    #[error("surface is lost")]
+    #[error("Surface is lost")]
     Lost,
-    #[error("surface is outdated, needs to be re-created")]
+    #[error("Surface is outdated, needs to be re-created")]
     Outdated,
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("other reason: {0}")]
+    #[error("Other reason: {0}")]
     Other(&'static str),
 }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

Reworks how various renderpass related errors work to be significantly more informative.

- Closes #3541 
- Closes #3536 
- Makes all error messages uppercase


All commits standalone, I encorage rebase-merging