### PR TITLE
metal: if `new_texture` returns NULL, `create_texture` returns an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,9 @@ By @teoxoy in [#3436](https://github.com/gfx-rs/wgpu/pull/3436)
 
 - Treat `VK_SUBOPTIMAL_KHR` as `VK_SUCCESS` on Android. By @James2022-rgb in [#3525](https://github.com/gfx-rs/wgpu/pull/3525)
 
+#### Metal
+- `create_texture` returns an error if `new_texture` returns NULL. By @jinleili in [#3554](https://github.com/gfx-rs/wgpu/pull/3554)
+
 ## wgpu-0.15.0 (2023-01-25)
 
 ### Major Changes

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -288,6 +288,8 @@ impl crate::Device<super::Api> for super::Device {
         &self,
         desc: &crate::TextureDescriptor,
     ) -> DeviceResult<super::Texture> {
+        use foreign_types::ForeignTypeRef;
+
         let mtl_format = self.shared.private_caps.map_format(desc.format);
 
         objc::rc::autoreleasepool(|| {
@@ -321,6 +323,9 @@ impl crate::Device<super::Api> for super::Device {
             descriptor.set_storage_mode(metal::MTLStorageMode::Private);
 
             let raw = self.shared.device.lock().new_texture(&descriptor);
+            if raw.as_ptr().is_null() {
+                return Err(crate::DeviceError::OutOfMemory);
+            }
             if let Some(label) = desc.label {
                 raw.set_label(label);
             }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
fixes https://github.com/gfx-rs/wgpu/issues/3153

**Testing**
Tested on M1 Mac and Intel Mac
