### PR TITLE
Fix definition of `NSOperatingSystemVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ By @teoxoy in [#3534](https://github.com/gfx-rs/wgpu/pull/3534)
 
 #### Metal
 - `create_texture` returns an error if `new_texture` returns NULL. By @jinleili in [#3554](https://github.com/gfx-rs/wgpu/pull/3554)
+- Fix definition of `NSOperatingSystemVersion` to avoid potential crashes. By @grovesNL in [#3557](https://github.com/gfx-rs/wgpu/pull/3557)
 
 ## wgpu-0.15.0 (2023-01-25)
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -452,12 +452,16 @@ impl super::PrivateCapabilities {
             major: usize,
             minor: usize,
             patch: usize,
-            is_mac: bool,
         }
 
         impl NSOperatingSystemVersion {
-            fn at_least(&self, mac_version: (usize, usize), ios_version: (usize, usize)) -> bool {
-                if self.is_mac {
+            fn at_least(
+                &self,
+                mac_version: (usize, usize),
+                ios_version: (usize, usize),
+                is_mac: bool,
+            ) -> bool {
+                if is_mac {
                     self.major > mac_version.0
                         || (self.major == mac_version.0 && self.minor >= mac_version.1)
                 } else {
@@ -467,15 +471,14 @@ impl super::PrivateCapabilities {
             }
         }
 
-        let mut version: NSOperatingSystemVersion = unsafe {
+        let version: NSOperatingSystemVersion = unsafe {
             let process_info: *mut objc::runtime::Object =
                 msg_send![class!(NSProcessInfo), processInfo];
             msg_send![process_info, operatingSystemVersion]
         };
 
         let os_is_mac = device.supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v1);
-        version.is_mac = os_is_mac;
-        let family_check = version.at_least((10, 15), (13, 0));
+        let family_check = version.at_least((10, 15), (13, 0), os_is_mac);
 
         let mut sample_count_mask = crate::TextureFormatCapabilities::MULTISAMPLE_X4; // 1 and 4 samples are supported on all devices
         if device.supports_texture_sample_count(2) {
@@ -488,9 +491,9 @@ impl super::PrivateCapabilities {
             sample_count_mask |= crate::TextureFormatCapabilities::MULTISAMPLE_X16;
         }
 
-        let rw_texture_tier = if version.at_least((10, 13), (11, 0)) {
+        let rw_texture_tier = if version.at_least((10, 13), (11, 0), os_is_mac) {
             device.read_write_texture_support()
-        } else if version.at_least((10, 12), OS_NOT_SUPPORT) {
+        } else if version.at_least((10, 12), OS_NOT_SUPPORT, os_is_mac) {
             if Self::supports_any(device, &[MTLFeatureSet::macOS_ReadWriteTextureTier2]) {
                 MTLReadWriteTextureTier::Tier2
             } else {
@@ -502,25 +505,25 @@ impl super::PrivateCapabilities {
 
         Self {
             family_check,
-            msl_version: if version.at_least((12, 0), (15, 0)) {
+            msl_version: if version.at_least((12, 0), (15, 0), os_is_mac) {
                 MTLLanguageVersion::V2_4
-            } else if version.at_least((11, 0), (14, 0)) {
+            } else if version.at_least((11, 0), (14, 0), os_is_mac) {
                 MTLLanguageVersion::V2_3
-            } else if version.at_least((10, 15), (13, 0)) {
+            } else if version.at_least((10, 15), (13, 0), os_is_mac) {
                 MTLLanguageVersion::V2_2
-            } else if version.at_least((10, 14), (12, 0)) {
+            } else if version.at_least((10, 14), (12, 0), os_is_mac) {
                 MTLLanguageVersion::V2_1
-            } else if version.at_least((10, 13), (11, 0)) {
+            } else if version.at_least((10, 13), (11, 0), os_is_mac) {
                 MTLLanguageVersion::V2_0
-            } else if version.at_least((10, 12), (10, 0)) {
+            } else if version.at_least((10, 12), (10, 0), os_is_mac) {
                 MTLLanguageVersion::V1_2
-            } else if version.at_least((10, 11), (9, 0)) {
+            } else if version.at_least((10, 11), (9, 0), os_is_mac) {
                 MTLLanguageVersion::V1_1
             } else {
                 MTLLanguageVersion::V1_0
             },
             // macOS 10.11 doesn't support read-write resources
-            fragment_rw_storage: version.at_least((10, 12), (8, 0)),
+            fragment_rw_storage: version.at_least((10, 12), (8, 0), os_is_mac),
             read_write_texture_tier: rw_texture_tier,
             msaa_desktop: os_is_mac,
             msaa_apple3: if family_check {
@@ -537,7 +540,7 @@ impl super::PrivateCapabilities {
                 MUTABLE_COMPARISON_SAMPLER_SUPPORT,
             ),
             sampler_clamp_to_border: Self::supports_any(device, SAMPLER_CLAMP_TO_BORDER_SUPPORT),
-            sampler_lod_average: { version.at_least((11, 0), (9, 0)) },
+            sampler_lod_average: { version.at_least((11, 0), (9, 0), os_is_mac) },
             base_instance: Self::supports_any(device, BASE_INSTANCE_SUPPORT),
             base_vertex_instance_drawing: Self::supports_any(device, BASE_VERTEX_INSTANCE_SUPPORT),
             dual_source_blending: Self::supports_any(device, DUAL_SOURCE_BLEND_SUPPORT),
@@ -626,7 +629,7 @@ impl super::PrivateCapabilities {
             },
             max_samplers_per_stage: 16,
             buffer_alignment: if os_is_mac { 256 } else { 64 },
-            max_buffer_size: if version.at_least((10, 14), (12, 0)) {
+            max_buffer_size: if version.at_least((10, 14), (12, 0), os_is_mac) {
                 // maxBufferLength available on macOS 10.14+ and iOS 12.0+
                 let buffer_size: metal::NSInteger =
                     unsafe { msg_send![device.as_ref(), maxBufferLength] };
@@ -710,10 +713,10 @@ impl super::PrivateCapabilities {
             supports_binary_archives: family_check
                 && (device.supports_family(MTLGPUFamily::Apple3)
                     || device.supports_family(MTLGPUFamily::Mac1)),
-            supports_capture_manager: version.at_least((10, 13), (11, 0)),
-            can_set_maximum_drawables_count: version.at_least((10, 14), (11, 2)),
-            can_set_display_sync: version.at_least((10, 13), OS_NOT_SUPPORT),
-            can_set_next_drawable_timeout: version.at_least((10, 13), (11, 0)),
+            supports_capture_manager: version.at_least((10, 13), (11, 0), os_is_mac),
+            can_set_maximum_drawables_count: version.at_least((10, 14), (11, 2), os_is_mac),
+            can_set_display_sync: version.at_least((10, 13), OS_NOT_SUPPORT, os_is_mac),
+            can_set_next_drawable_timeout: version.at_least((10, 13), (11, 0), os_is_mac),
             supports_arrays_of_textures: Self::supports_any(
                 device,
                 &[
@@ -726,14 +729,14 @@ impl super::PrivateCapabilities {
                 && (device.supports_family(MTLGPUFamily::Apple6)
                     || device.supports_family(MTLGPUFamily::Mac1)
                     || device.supports_family(MTLGPUFamily::MacCatalyst1)),
-            supports_mutability: version.at_least((10, 13), (11, 0)),
+            supports_mutability: version.at_least((10, 13), (11, 0), os_is_mac),
             //Depth clipping is supported on all macOS GPU families and iOS family 4 and later
             supports_depth_clip_control: os_is_mac
                 || device.supports_feature_set(MTLFeatureSet::iOS_GPUFamily4_v1),
-            supports_preserve_invariance: version.at_least((11, 0), (13, 0)),
+            supports_preserve_invariance: version.at_least((11, 0), (13, 0), os_is_mac),
             // Metal 2.2 on mac, 2.3 on iOS.
-            supports_shader_primitive_index: version.at_least((10, 15), (14, 0)),
-            has_unified_memory: if version.at_least((10, 15), (13, 0)) {
+            supports_shader_primitive_index: version.at_least((10, 15), (14, 0), os_is_mac),
+            has_unified_memory: if version.at_least((10, 15), (13, 0), os_is_mac) {
                 Some(device.has_unified_memory())
             } else {
                 None


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #3556

**Description**
The `NSOperatingSystemVersion` struct is [defined by Apple](https://developer.apple.com/documentation/foundation/nsoperatingsystemversion) and doesn't contain an `is_mac` flag, so the existing cast in `msg_send![process_info, operatingSystemVersion]` is invalid.

**Testing**
Untested
