### PR TITLE
In `Context::handle_error_fatal`, print cause chain.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ By @teoxoy in [#3534](https://github.com/gfx-rs/wgpu/pull/3534)
 
 - `copyTextureToTexture` src/dst aspects must both refer to all aspects of src/dst format. By @teoxoy in [#3431](https://github.com/gfx-rs/wgpu/pull/3431)
 - Validate before extracting texture selectors. By @teoxoy in [#3487](https://github.com/gfx-rs/wgpu/pull/3487)
+- Fix fatal errors (those which panic even if an error handler is set) not including all of the details. By @kpreid in [#3563](https://github.com/gfx-rs/wgpu/pull/3563)
 
 #### Vulkan
 

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -302,9 +302,9 @@ impl Context {
     fn handle_error_fatal(
         &self,
         cause: impl Error + Send + Sync + 'static,
-        string: &'static str,
+        operation: &'static str,
     ) -> ! {
-        panic!("Error in {string}: {cause}");
+        panic!("Error in {operation}: {f}", f = self.format_error(&cause));
     }
 
     fn format_error(&self, err: &(impl Error + 'static)) -> String {

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -299,6 +299,7 @@ impl Context {
         self.handle_error(sink_mutex, cause, "", None, string)
     }
 
+    #[track_caller]
     fn handle_error_fatal(
         &self,
         cause: impl Error + Send + Sync + 'static,


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #3551.

**Description**
In `Context::handle_error_fatal`, print cause chain using the same formatting as for non-fatal errors.

Also add `#[track_caller]` so that the panic location is specific to the error.

**Testing**
Manually tested using an application with a deliberately introduced error. Example result:

```
thread 'main' panicked at 'Error in RenderBundleEncoder::finish: Validation Error

Caused by:
    In a set_pipeline command
      note: render pipeline = `BloomPipelines::downsample_pipeline`
    Render pipeline targets are incompatible with render pass
    Incompatible color attachment: the renderpass expected [] but was given [Some(Rgba16Float)]
', /Users/kpreid/Projects/rust/wgpu/wgpu/src/backend/direct.rs:2105:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Previously, the message would have ended at "In a set_pipeline command".