### PR TITLE
Add a generic parameter to `wgpu::Id`

### DIFF
--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -998,7 +998,7 @@ pub struct ObjectId {
     id: Option<NonZeroU64>,
     #[cfg(feature = "expose-ids")]
     /// ID that is unique at all times
-    global_id: Option<crate::Id>,
+    global_id: Option<NonZeroU64>,
 }
 
 impl ObjectId {
@@ -1008,7 +1008,7 @@ impl ObjectId {
         global_id: None,
     };
 
-    pub fn new(id: NonZeroU64, #[cfg(feature = "expose-ids")] global_id: crate::Id) -> Self {
+    pub fn new(id: NonZeroU64, #[cfg(feature = "expose-ids")] global_id: NonZeroU64) -> Self {
         Self {
             id: Some(id),
             #[cfg(feature = "expose-ids")]
@@ -1021,7 +1021,7 @@ impl ObjectId {
         Self {
             id: Some(global_id),
             #[cfg(feature = "expose-ids")]
-            global_id: Some(crate::Id(global_id)),
+            global_id: Some(global_id),
         }
     }
 
@@ -1031,7 +1031,7 @@ impl ObjectId {
 
     #[cfg(feature = "expose-ids")]
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> crate::Id {
+    pub fn global_id(&self) -> NonZeroU64 {
         self.global_id.unwrap()
     }
 }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4244,17 +4244,18 @@ impl Surface {
 #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Id(core::num::NonZeroU64);
+pub struct Id<T>(core::num::NonZeroU64, std::marker::PhantomData<*mut T>);
 
 #[cfg(feature = "expose-ids")]
 impl Adapter {
     /// Returns a globally-unique identifier for this `Adapter`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `Adapter`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<Adapter> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4263,10 +4264,11 @@ impl Device {
     /// Returns a globally-unique identifier for this `Device`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `Device`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<Device> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4275,10 +4277,11 @@ impl Queue {
     /// Returns a globally-unique identifier for this `Queue`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `Queue`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<Queue> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4287,10 +4290,11 @@ impl ShaderModule {
     /// Returns a globally-unique identifier for this `ShaderModule`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `ShaderModule`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<ShaderModule> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4299,10 +4303,11 @@ impl BindGroupLayout {
     /// Returns a globally-unique identifier for this `BindGroupLayout`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `BindGroupLayout`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<BindGroupLayout> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4311,10 +4316,11 @@ impl BindGroup {
     /// Returns a globally-unique identifier for this `BindGroup`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `BindGroup`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<BindGroup> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4323,10 +4329,11 @@ impl TextureView {
     /// Returns a globally-unique identifier for this `TextureView`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `TextureView`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<TextureView> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4335,10 +4342,11 @@ impl Sampler {
     /// Returns a globally-unique identifier for this `Sampler`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `Sampler`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<Sampler> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4347,10 +4355,11 @@ impl Buffer {
     /// Returns a globally-unique identifier for this `Buffer`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `Buffer`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<Buffer> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4359,10 +4368,11 @@ impl Texture {
     /// Returns a globally-unique identifier for this `Texture`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `Texture`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<Texture> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4371,10 +4381,11 @@ impl QuerySet {
     /// Returns a globally-unique identifier for this `QuerySet`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `QuerySet`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<QuerySet> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4383,10 +4394,11 @@ impl PipelineLayout {
     /// Returns a globally-unique identifier for this `PipelineLayout`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `PipelineLayout`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<PipelineLayout> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4395,10 +4407,11 @@ impl RenderPipeline {
     /// Returns a globally-unique identifier for this `RenderPipeline`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `RenderPipeline`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<RenderPipeline> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4407,10 +4420,11 @@ impl ComputePipeline {
     /// Returns a globally-unique identifier for this `ComputePipeline`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `ComputePipeline`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<ComputePipeline> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4419,10 +4433,11 @@ impl RenderBundle {
     /// Returns a globally-unique identifier for this `RenderBundle`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `RenderBundle`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<RenderBundle> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 
@@ -4431,10 +4446,11 @@ impl Surface {
     /// Returns a globally-unique identifier for this `Surface`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
-    /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
+    /// The returned value is guaranteed to be unique among all `Surface`s created from the same
+    /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id {
-        self.id.global_id()
+    pub fn global_id(&self) -> Id<Surface> {
+        Id(self.id.global_id(), std::marker::PhantomData)
     }
 }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
The documentation I wrote in `wgpu::*::global_id()` didn't match the behaviour in `wgpu-core`. Specifically, `wgpu::Id`s are only unique among objects of the same type, while the documentation promised them to be unique among all objects spawned from the same `wgpu::Instance`.

This PR changes the documentation of all previous public `global_id` methods, and adds a type parameter to `wgpu::Id` to prevent the caller from trying to compare `Id`s from different resource types.

**Testing**
Not tested, only typechecked
