### PR TITLE
Remove unwraps inside `surface.configure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ By @teoxoy in [#3534](https://github.com/gfx-rs/wgpu/pull/3534)
 
 - [gles] fix: Set FORCE_POINT_SIZE if it is vertex shader with mesh consist of point list. By @REASY in [3440](https://github.com/gfx-rs/wgpu/pull/3440)
 - [gles] fix: enable `WEBGL_debug_renderer_info` before querying unmasked vendor/renderer to avoid crashing on emscripten in [#3519](https://github.com/gfx-rs/wgpu/pull/3519)
+- Remove unwraps inside `surface.configure`. By @cwfitzgerald in [#3585](https://github.com/gfx-rs/wgpu/pull/3585)
 
 #### General
 

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1222,7 +1222,10 @@ impl crate::Surface<super::Api> for Surface {
 
         let format_desc = device.shared.describe_texture_format(config.format);
         let gl = &device.shared.context.lock();
-        let renderbuffer = unsafe { gl.create_renderbuffer() }.unwrap();
+        let renderbuffer = unsafe { gl.create_renderbuffer() }.map_err(|error| {
+            log::error!("Internal swapchain renderbuffer creation failed: {error}");
+            crate::DeviceError::OutOfMemory
+        })?;
         unsafe { gl.bind_renderbuffer(glow::RENDERBUFFER, Some(renderbuffer)) };
         unsafe {
             gl.renderbuffer_storage(
@@ -1232,7 +1235,10 @@ impl crate::Surface<super::Api> for Surface {
                 config.extent.height as _,
             )
         };
-        let framebuffer = unsafe { gl.create_framebuffer() }.unwrap();
+        let framebuffer = unsafe { gl.create_framebuffer() }.map_err(|error| {
+            log::error!("Internal swapchain framebuffer creation failed: {error}");
+            crate::DeviceError::OutOfMemory
+        })?;
         unsafe { gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(framebuffer)) };
         unsafe {
             gl.framebuffer_renderbuffer(

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -285,7 +285,10 @@ impl crate::Surface<super::Api> for Surface {
             unsafe { gl.delete_texture(texture) };
         }
 
-        self.texture = Some(unsafe { gl.create_texture() }.unwrap());
+        self.texture = Some(unsafe { gl.create_texture() }.map_err(|error| {
+            log::error!("Internal swapchain texture creation failed: {error}");
+            crate::DeviceError::OutOfMemory
+        })?);
 
         let desc = device.shared.describe_texture_format(config.format);
         unsafe { gl.bind_texture(glow::TEXTURE_2D, self.texture) };
@@ -313,7 +316,10 @@ impl crate::Surface<super::Api> for Surface {
             )
         };
 
-        let framebuffer = unsafe { gl.create_framebuffer() }.unwrap();
+        let framebuffer = unsafe { gl.create_framebuffer() }.map_err(|error| {
+            log::error!("Internal swapchain framebuffer creation failed: {error}");
+            crate::DeviceError::OutOfMemory
+        })?;
         unsafe { gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(framebuffer)) };
         unsafe {
             gl.framebuffer_texture_2d(


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

None

**Description**

This doesn't solve the top level fatality of surface unwraps, but means that once that it fixed, users can catch surface configure failures.

**Testing**

Not tested
