### PR TITLE
Reset the queue state between each command buffer on queue submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Bug Fixes
+
+#### GLES
+- Reset the state of `SAMPLE_ALPHA_TO_COVERAGE` on queue submit. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
+
+
 ## wgpu-0.15.2 (2023-03-08)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@ Bottom level categories:
 ### Bug Fixes
 
 #### GLES
-- Reset the state of `SAMPLE_ALPHA_TO_COVERAGE` on queue submit. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
+- Reset all queue state between command buffers in a submit. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
+- Reset the state of `SAMPLE_ALPHA_TO_COVERAGE` on queue reset. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
 
 
 ## wgpu-0.15.2 (2023-03-08)

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1478,8 +1478,12 @@ impl crate::Queue<super::Api> for super::Queue {
     ) -> Result<(), crate::DeviceError> {
         let shared = Arc::clone(&self.shared);
         let gl = &shared.context.lock();
-        unsafe { self.reset_state(gl) };
         for cmd_buf in command_buffers.iter() {
+            // The command encoder assumes a default state when encoding the command buffer.
+            // Always reset the state between command_buffers to reflect this assumption. Do
+            // this at the beginning of the loop in case something outside of wgpu modified
+            // this state prior to commit.
+            unsafe { self.reset_state(gl) };
             #[cfg(not(target_arch = "wasm32"))]
             if let Some(ref label) = cmd_buf.label {
                 unsafe { gl.push_debug_group(glow::DEBUG_SOURCE_APPLICATION, DEBUG_ID, label) };

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -70,6 +70,7 @@ impl super::Queue {
         unsafe { gl.disable(glow::BLEND) };
         unsafe { gl.disable(glow::CULL_FACE) };
         unsafe { gl.disable(glow::POLYGON_OFFSET_FILL) };
+        unsafe { gl.disable(glow::SAMPLE_ALPHA_TO_COVERAGE) };
         if self.features.contains(wgt::Features::DEPTH_CLIP_CONTROL) {
             unsafe { gl.disable(glow::DEPTH_CLAMP) };
         }


### PR DESCRIPTION
Additionally reset the state of `SAMPLE_ALPHA_TO_COVERAGE` as part of a queue reset.

The move of `reset_state` from outside to inside the loop matches the previous behavior here: https://github.com/gfx-rs/gfx/blob/master/src/backend/gl/src/queue.rs#L1142

Given the command encoder assumes a default state this seems to be the only safe behavior to avoiding leaking state between buffers.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
This is necessary to avoid leaking of alpha-to-coverage between command buffers.

**Testing**
Confirmed alpha-to-coverage set on one pipeline was no longer leaked to the next in our application.