### PR TITLE
Reset the queue state between each command buffer on queue submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ By @teoxoy in [#3534](https://github.com/gfx-rs/wgpu/pull/3534)
 - [gles] fix: Set FORCE_POINT_SIZE if it is vertex shader with mesh consist of point list. By @REASY in [3440](https://github.com/gfx-rs/wgpu/pull/3440)
 - [gles] fix: enable `WEBGL_debug_renderer_info` before querying unmasked vendor/renderer to avoid crashing on emscripten in [#3519](https://github.com/gfx-rs/wgpu/pull/3519)
 - Remove unwraps inside `surface.configure`. By @cwfitzgerald in [#3585](https://github.com/gfx-rs/wgpu/pull/3585)
+- Reset the state of `SAMPLE_ALPHA_TO_COVERAGE` on queue submit. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
 
 #### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,8 @@ By @teoxoy in [#3534](https://github.com/gfx-rs/wgpu/pull/3534)
 - [gles] fix: Set FORCE_POINT_SIZE if it is vertex shader with mesh consist of point list. By @REASY in [3440](https://github.com/gfx-rs/wgpu/pull/3440)
 - [gles] fix: enable `WEBGL_debug_renderer_info` before querying unmasked vendor/renderer to avoid crashing on emscripten in [#3519](https://github.com/gfx-rs/wgpu/pull/3519)
 - Remove unwraps inside `surface.configure`. By @cwfitzgerald in [#3585](https://github.com/gfx-rs/wgpu/pull/3585)
-- Reset the state of `SAMPLE_ALPHA_TO_COVERAGE` on queue submit. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
+- Reset all queue state between command buffers in a submit. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
+- Reset the state of `SAMPLE_ALPHA_TO_COVERAGE` on queue reset. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
 
 #### General
 

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1523,8 +1523,12 @@ impl crate::Queue<super::Api> for super::Queue {
     ) -> Result<(), crate::DeviceError> {
         let shared = Arc::clone(&self.shared);
         let gl = &shared.context.lock();
-        unsafe { self.reset_state(gl) };
         for cmd_buf in command_buffers.iter() {
+            // The command encoder assumes a default state when encoding the command buffer.
+            // Always reset the state between command_buffers to reflect this assumption. Do
+            // this at the beginning of the loop in case something outside of wgpu modified
+            // this state prior to commit.
+            unsafe { self.reset_state(gl) };
             #[cfg(not(target_arch = "wasm32"))]
             if let Some(ref label) = cmd_buf.label {
                 unsafe { gl.push_debug_group(glow::DEBUG_SOURCE_APPLICATION, DEBUG_ID, label) };

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -70,6 +70,7 @@ impl super::Queue {
         unsafe { gl.disable(glow::BLEND) };
         unsafe { gl.disable(glow::CULL_FACE) };
         unsafe { gl.disable(glow::POLYGON_OFFSET_FILL) };
+        unsafe { gl.disable(glow::SAMPLE_ALPHA_TO_COVERAGE) };
         if self.features.contains(wgt::Features::DEPTH_CLIP_CONTROL) {
             unsafe { gl.disable(glow::DEPTH_CLAMP) };
         }


### PR DESCRIPTION
This is a port of https://github.com/gfx-rs/wgpu/pull/3589 to `master`
----
The move of reset_state from outside to inside the loop matches the previous behavior here: https://github.com/gfx-rs/gfx/blob/master/src/backend/gl/src/queue.rs#L1142

Given the command encoder assumes a default state this seems to be the only safe behavior to avoiding leaking state between buffers.

Additionally reset the state of SAMPLE_ALPHA_TO_COVERAGE as part of a queue reset.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
