### PR TITLE
Backport #3440 into v0.15 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Bug Fixes
+
+#### GLES
+
+- [gles] fix: Set FORCE_POINT_SIZE if it is vertex shader with mesh consist of point list. By @REASY in [3440](https://github.com/gfx-rs/wgpu/pull/3440)
+
 ## wgpu-0.15.2 (2023-03-08)
 
 ### Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ version = "0.15"
 
 [workspace.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f0edae8"
-version = "0.11"
+rev = "9742f1616c3e3dd2cc9a5880616fc886c391bb9f"
+version = "0.11.0"
 
 [workspace.dependencies]
 arrayvec = "0.7"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -73,7 +73,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f0edae8"
+rev = "9742f1616c3e3dd2cc9a5880616fc886c391bb9f"
 version = "0.11"
 features = ["clone", "span", "validate"]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -120,14 +120,14 @@ android_system_properties = "0.1.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f0edae8"
+rev = "9742f1616c3e3dd2cc9a5880616fc886c391bb9f"
 version = "0.11"
 features = ["clone"]
 
 # DEV dependencies
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f0edae8"
+rev = "9742f1616c3e3dd2cc9a5880616fc886c391bb9f"
 version = "0.11"
 features = ["wgsl-in"]
 

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -151,7 +151,7 @@ impl<A: hal::Api> Example<A> {
                 .join("halmark")
                 .join("shader.wgsl");
             let source = std::fs::read_to_string(shader_file).unwrap();
-            let module = naga::front::wgsl::Parser::new().parse(&source).unwrap();
+            let module = naga::front::wgsl::Frontend::new().parse(&source).unwrap();
             let info = naga::valid::Validator::new(
                 naga::valid::ValidationFlags::all(),
                 naga::valid::Capabilities::empty(),

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -343,6 +343,7 @@ impl super::Device {
         Ok(program)
     }
 
+    #[allow(clippy::too_many_arguments)]
     unsafe fn create_program<'a>(
         gl: &glow::Context,
         shaders: ArrayVec<ShaderStage<'a>, 3>,

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -204,8 +204,10 @@ impl super::Device {
         naga_stage: naga::ShaderStage,
         stage: &crate::ProgrammableStage<super::Api>,
         context: CompilationContext,
+        primitive_topology: Option<wgt::PrimitiveTopology>,
     ) -> Result<glow::Shader, crate::PipelineError> {
         use naga::back::glsl;
+
         let pipeline_options = glsl::PipelineOptions {
             shader_stage: naga_stage,
             entry_point: stage.entry_point.to_string(),
@@ -237,12 +239,31 @@ impl super::Device {
             binding_array: BoundsCheckPolicy::Unchecked,
         };
 
+        let update_naga_options = primitive_topology == Some(wgt::PrimitiveTopology::PointList)
+            && naga_stage == naga::ShaderStage::Vertex;
+        // Update naga options if mesh consist of point list and it is vertex shader
+        let naga_options = if update_naga_options {
+            let mut wrt_flags = context.layout.naga_options.writer_flags;
+            wrt_flags.set(glsl::WriterFlags::FORCE_POINT_SIZE, true);
+            glsl::Options {
+                version: context.layout.naga_options.version,
+                writer_flags: wrt_flags,
+                binding_map: context.layout.naga_options.binding_map.clone(),
+                zero_initialize_workgroup_memory: context
+                    .layout
+                    .naga_options
+                    .zero_initialize_workgroup_memory,
+            }
+        } else {
+            context.layout.naga_options.clone()
+        };
+
         let mut output = String::new();
         let mut writer = glsl::Writer::new(
             &mut output,
             &shader.module,
             &shader.info,
-            &context.layout.naga_options,
+            &naga_options,
             &pipeline_options,
             policies,
         )
@@ -274,6 +295,7 @@ impl super::Device {
         layout: &super::PipelineLayout,
         #[cfg_attr(target_arch = "wasm32", allow(unused))] label: Option<&str>,
         multiview: Option<std::num::NonZeroU32>,
+        primitive_topology: Option<wgt::PrimitiveTopology>,
     ) -> Result<Arc<super::PipelineInner>, crate::PipelineError> {
         let mut program_stages = ArrayVec::new();
         let mut group_to_binding_to_slot = Vec::with_capacity(layout.group_infos.len());
@@ -312,6 +334,7 @@ impl super::Device {
                     multiview,
                     glsl_version,
                     self.shared.private_caps,
+                    primitive_topology,
                 )
             })
             .to_owned()?;
@@ -328,6 +351,7 @@ impl super::Device {
         multiview: Option<std::num::NonZeroU32>,
         glsl_version: u16,
         private_caps: super::PrivateCapabilities,
+        primitive_topology: Option<wgt::PrimitiveTopology>,
     ) -> Result<Arc<super::PipelineInner>, crate::PipelineError> {
         let program = unsafe { gl.create_program() }.unwrap();
         #[cfg(not(target_arch = "wasm32"))]
@@ -352,7 +376,7 @@ impl super::Device {
                 multiview,
             };
 
-            let shader = Self::create_shader(gl, naga_stage, stage, context)?;
+            let shader = Self::create_shader(gl, naga_stage, stage, context, primitive_topology)?;
             shaders_to_delete.push(shader);
         }
 
@@ -1128,8 +1152,16 @@ impl crate::Device<super::Api> for super::Device {
         if let Some(ref fs) = desc.fragment_stage {
             shaders.push((naga::ShaderStage::Fragment, fs));
         }
-        let inner =
-            unsafe { self.create_pipeline(gl, shaders, desc.layout, desc.label, desc.multiview) }?;
+        let inner = unsafe {
+            self.create_pipeline(
+                gl,
+                shaders,
+                desc.layout,
+                desc.label,
+                desc.multiview,
+                Some(desc.primitive.topology),
+            )
+        }?;
 
         let (vertex_buffers, vertex_attributes) = {
             let mut buffers = Vec::new();
@@ -1210,7 +1242,8 @@ impl crate::Device<super::Api> for super::Device {
         let gl = &self.shared.context.lock();
         let mut shaders = ArrayVec::new();
         shaders.push((naga::ShaderStage::Compute, &desc.stage));
-        let inner = unsafe { self.create_pipeline(gl, shaders, desc.layout, desc.label, None) }?;
+        let inner =
+            unsafe { self.create_pipeline(gl, shaders, desc.layout, desc.label, None, None) }?;
 
         Ok(super::ComputePipeline { inner })
     }

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -869,7 +869,7 @@ impl crate::Context for Context {
                     strict_capabilities: true,
                     block_ctx_dump_prefix: None,
                 };
-                let parser = naga::front::spv::Parser::new(spv.iter().cloned(), &options);
+                let parser = naga::front::spv::Frontend::new(spv.iter().cloned(), &options);
                 let module = parser.parse().unwrap();
                 wgc::pipeline::ShaderModuleSource::Naga(Owned(module))
             }
@@ -884,7 +884,7 @@ impl crate::Context for Context {
                     stage,
                     defines: defines.clone(),
                 };
-                let mut parser = naga::front::glsl::Parser::default();
+                let mut parser = naga::front::glsl::Frontend::default();
                 let module = parser.parse(&options, shader).unwrap();
 
                 wgc::pipeline::ShaderModuleSource::Naga(Owned(module))

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1154,7 +1154,7 @@ impl crate::context::Context for Context {
                     strict_capabilities: true,
                     block_ctx_dump_prefix: None,
                 };
-                let spv_parser = front::spv::Parser::new(spv.iter().cloned(), &options);
+                let spv_parser = front::spv::Frontend::new(spv.iter().cloned(), &options);
                 let spv_module = spv_parser.parse().unwrap();
 
                 let mut validator = valid::Validator::new(
@@ -1181,7 +1181,7 @@ impl crate::context::Context for Context {
                     stage,
                     defines: defines.clone(),
                 };
-                let mut parser = front::glsl::Parser::default();
+                let mut parser = front::glsl::Frontend::default();
                 let glsl_module = parser.parse(&options, shader).unwrap();
 
                 let mut validator = valid::Validator::new(


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/gfx-rs/wgpu/pull/3440

**Description**
Backporting https://github.com/gfx-rs/wgpu/pull/3440 into v.0.15 branch

