### PR TITLE
[v0.15] WebGl workaround for drawing single instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Bottom level categories:
 -->
 
 ## Unreleased
+### Bug Fixes
+#### GLES
+- Fix `Vertex buffer is not big enough for the draw call.` for ANGLE/Web when rendering with instance attributes on a single instance. By @wumpf in [#3596](https://github.com/gfx-rs/wgpu/pull/3596)
 
 ## wgpu-0.15.2 (2023-03-08)
 

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -164,18 +164,17 @@ impl super::Queue {
                 vertex_count,
                 instance_count,
             } => {
-                if instance_count == 1 {
-                    unsafe { gl.draw_arrays(topology, start_vertex as i32, vertex_count as i32) };
-                } else {
-                    unsafe {
-                        gl.draw_arrays_instanced(
-                            topology,
-                            start_vertex as i32,
-                            vertex_count as i32,
-                            instance_count as i32,
-                        )
-                    };
-                }
+                // Don't use `gl.draw_arrays` for `instance_count == 1`.
+                // Angle has a bug where it doesn't consider the instance divisor when `DYNAMIC_DRAW` is used in `draw_arrays`.
+                // See https://github.com/gfx-rs/wgpu/issues/3578
+                unsafe {
+                    gl.draw_arrays_instanced(
+                        topology,
+                        start_vertex as i32,
+                        vertex_count as i32,
+                        instance_count as i32,
+                    )
+                };
             }
             C::DrawIndexed {
                 topology,
@@ -184,44 +183,32 @@ impl super::Queue {
                 index_offset,
                 base_vertex,
                 instance_count,
-            } => match (base_vertex, instance_count) {
-                (0, 1) => unsafe {
-                    gl.draw_elements(
-                        topology,
-                        index_count as i32,
-                        index_type,
-                        index_offset as i32,
-                    )
-                },
-                (0, _) => unsafe {
-                    gl.draw_elements_instanced(
-                        topology,
-                        index_count as i32,
-                        index_type,
-                        index_offset as i32,
-                        instance_count as i32,
-                    )
-                },
-                (_, 1) => unsafe {
-                    gl.draw_elements_base_vertex(
-                        topology,
-                        index_count as i32,
-                        index_type,
-                        index_offset as i32,
-                        base_vertex,
-                    )
-                },
-                (_, _) => unsafe {
-                    gl.draw_elements_instanced_base_vertex(
-                        topology,
-                        index_count as _,
-                        index_type,
-                        index_offset as i32,
-                        instance_count as i32,
-                        base_vertex,
-                    )
-                },
-            },
+            } => {
+                match base_vertex {
+                    // Don't use `gl.draw_elements`/`gl.draw_elements_base_vertex` for `instance_count == 1`.
+                    // Angle has a bug where it doesn't consider the instance divisor when `DYNAMIC_DRAW` is used in `gl.draw_elements`/`gl.draw_elements_base_vertex`.
+                    // See https://github.com/gfx-rs/wgpu/issues/3578
+                    0 => unsafe {
+                        gl.draw_elements_instanced(
+                            topology,
+                            index_count as i32,
+                            index_type,
+                            index_offset as i32,
+                            instance_count as i32,
+                        )
+                    },
+                    _ => unsafe {
+                        gl.draw_elements_instanced_base_vertex(
+                            topology,
+                            index_count as _,
+                            index_type,
+                            index_offset as i32,
+                            instance_count as i32,
+                            base_vertex,
+                        )
+                    },
+                }
+            }
             C::DrawIndirect {
                 topology,
                 indirect_buf,


### PR DESCRIPTION
**Checklist**
- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/gfx-rs/wgpu/issues/3578

**Description**
Whenever there is any instance attribute, we need to need use an instanced draw call on ANGLE. Otherwise, the following error will be (potentially spuriously) generated and may render incorrectly:
```
[.WebGL-0000554C38753500] GL_INVALID_OPERATION: Error: 0x00000502, in ..\..\third_party\angle\src\libANGLE\renderer\d3d\VertexDataManager.cpp, reserveSpaceForAttrib:520. Internal error: 0x00000502: Vertex buffer is not big enough for the draw call.
```

**Testing**
Tested on https://github.com/rerun-io/rerun