### PR TITLE
Add rust toolchain file to specify the rust version used on CI.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,10 @@
+# If you see this, run "rustup self update" to get rustup 1.23 or newer.
+
+# NOTE: above comment is for older `rustup` (before TOML support was added),
+# which will treat the first line as the toolchain name, and therefore show it
+# to the user in the error, instead of "error: invalid channel name '[toolchain]'".
+
+[toolchain]
+channel = "1.64"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.

~- [ ] Add change to CHANGELOG.md. See simple instructions inside file.~ Not interesting enough

**Description**
This caused me quite some annoyance when fixing clippy issues - my local clippy used a newer version than CI. With this in place it runs the same version automatically

**Testing**
Run clippy etc.