### PR TITLE
feat: correct bounds policy checking on MSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ By @teoxoy in [#3534](https://github.com/gfx-rs/wgpu/pull/3534)
 #### Metal
 - `create_texture` returns an error if `new_texture` returns NULL. By @jinleili in [#3554](https://github.com/gfx-rs/wgpu/pull/3554)
 - Fix definition of `NSOperatingSystemVersion` to avoid potential crashes. By @grovesNL in [#3557](https://github.com/gfx-rs/wgpu/pull/3557)
+- Fix shader bounds checking being ignored. By @FL33TW00D in [#3603](https://github.com/gfx-rs/wgpu/pull/3603)
 
 ## wgpu-0.15.0 (2023-01-25)
 

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -75,11 +75,27 @@ impl super::Device {
             },
         };
 
+        let mut temp_options;
+        let options = if !stage.module.runtime_checks {
+            temp_options = layout.naga_options.clone();
+            if !stage.module.runtime_checks {
+                temp_options.bounds_check_policies = naga::proc::BoundsCheckPolicies {
+                    index: naga::proc::BoundsCheckPolicy::Unchecked,
+                    buffer: naga::proc::BoundsCheckPolicy::Unchecked,
+                    image: naga::proc::BoundsCheckPolicy::Unchecked,
+                    binding_array: naga::proc::BoundsCheckPolicy::Unchecked,
+                };
+            }
+            &temp_options
+        } else {
+            &layout.naga_options
+        };
+
         let module = &stage.module.naga.module;
         let (source, info) = naga::back::msl::write_string(
             module,
             &stage.module.naga.info,
-            &layout.naga_options,
+            options,
             &pipeline_options,
         )
         .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("MSL: {:?}", e)))?;
@@ -777,11 +793,14 @@ impl crate::Device<super::Api> for super::Device {
 
     unsafe fn create_shader_module(
         &self,
-        _desc: &crate::ShaderModuleDescriptor,
+        desc: &crate::ShaderModuleDescriptor,
         shader: crate::ShaderInput,
     ) -> Result<super::ShaderModule, crate::ShaderError> {
         match shader {
-            crate::ShaderInput::Naga(naga) => Ok(super::ShaderModule { naga }),
+            crate::ShaderInput::Naga(naga) => Ok(super::ShaderModule {
+                naga,
+                runtime_checks: desc.runtime_checks,
+            }),
             crate::ShaderInput::SpirV(_) => {
                 panic!("SPIRV_SHADER_PASSTHROUGH is not enabled for this backend")
             }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -78,14 +78,12 @@ impl super::Device {
         let mut temp_options;
         let options = if !stage.module.runtime_checks {
             temp_options = layout.naga_options.clone();
-            if !stage.module.runtime_checks {
-                temp_options.bounds_check_policies = naga::proc::BoundsCheckPolicies {
-                    index: naga::proc::BoundsCheckPolicy::Unchecked,
-                    buffer: naga::proc::BoundsCheckPolicy::Unchecked,
-                    image: naga::proc::BoundsCheckPolicy::Unchecked,
-                    binding_array: naga::proc::BoundsCheckPolicy::Unchecked,
-                };
-            }
+            temp_options.bounds_check_policies = naga::proc::BoundsCheckPolicies {
+                index: naga::proc::BoundsCheckPolicy::Unchecked,
+                buffer: naga::proc::BoundsCheckPolicy::Unchecked,
+                image: naga::proc::BoundsCheckPolicy::Unchecked,
+                binding_array: naga::proc::BoundsCheckPolicy::Unchecked,
+            };
             &temp_options
         } else {
             &layout.naga_options

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -622,6 +622,7 @@ unsafe impl Sync for BindGroup {}
 #[derive(Debug)]
 pub struct ShaderModule {
     naga: crate::NagaShader,
+    runtime_checks: bool,
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/3483

**Description**
Previously on metal, using `create_shader_module_unchecked` would not set the bounds check policy to unchecked.

**Testing**
Check the produced metal shader.
