### PR TITLE
Validate shader location clashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ By @cwfitzgerald in [#3610](https://github.com/gfx-rs/wgpu/pull/3610).
 - `copyTextureToTexture` src/dst aspects must both refer to all aspects of src/dst format. By @teoxoy in [#3431](https://github.com/gfx-rs/wgpu/pull/3431)
 - Validate before extracting texture selectors. By @teoxoy in [#3487](https://github.com/gfx-rs/wgpu/pull/3487)
 - Fix fatal errors (those which panic even if an error handler is set) not including all of the details. By @kpreid in [#3563](https://github.com/gfx-rs/wgpu/pull/3563)
+- Validate shader location clashes. By @emilk in [#3613](https://github.com/gfx-rs/wgpu/pull/3613)
 
 #### Vulkan
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -2806,10 +2806,16 @@ impl<A: HalApi> Device<A> {
                     self.require_features(wgt::Features::VERTEX_ATTRIBUTE_64BIT)?;
                 }
 
-                io.insert(
+                let previous = io.insert(
                     attribute.shader_location,
                     validation::InterfaceVar::vertex_attribute(attribute.format),
                 );
+
+                if previous.is_some() {
+                    return Err(pipeline::CreateRenderPipelineError::ShaderLocationClash(
+                        attribute.shader_location,
+                    ));
+                }
             }
             total_attributes += vb_state.attributes.len();
         }

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -352,6 +352,8 @@ pub enum CreateRenderPipelineError {
         location: wgt::ShaderLocation,
         offset: wgt::BufferAddress,
     },
+    #[error("Two or more attributes were assigned to the same shader lcoation {0}")]
+    ShaderLocationClash(u32),
     #[error("Strip index format was not set to None but to {strip_index_format:?} while using the non-strip topology {topology:?}")]
     StripIndexFormatForNonStripTopology {
         strip_index_format: Option<wgt::IndexFormat>,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Validate that no two attributes are assigned to the same shader location.

> "Each attrib in the union of all [GPUVertexAttribute](https://www.w3.org/TR/webgpu/#dictdef-gpuvertexattribute) across descriptor.[buffers](https://www.w3.org/TR/webgpu/#dom-gpuvertexstate-buffers) has a distinct attrib.[shaderLocation](https://www.w3.org/TR/webgpu/#dom-gpuvertexattribute-shaderlocation) value." (https://www.w3.org/TR/webgpu/#abstract-opdef-validating-gpuvertexstate)

(Thanks to @Wumpf for finding that quote, and for guiding me to making this PR)

**Testing**
`cargo nextest run --no-fail-fast` works the same as on `master`, which means one failure:

```
        FAIL [   0.064s]                  wgpu::wgpu-tests zero_init_texture_after_discard::discarding_depth_target_resets_texture_init_state_check_visible_on_copy_in_same_encoder

--- STDOUT:                               wgpu::wgpu-tests zero_init_texture_after_discard::discarding_depth_target_resets_texture_init_state_check_visible_on_copy_in_same_encoder ---

running 1 test

--- STDERR:                               wgpu::wgpu-tests zero_init_texture_after_discard::discarding_depth_target_resets_texture_init_state_check_visible_on_copy_in_same_encoder ---
-[AGXG13XFamilyCommandBuffer renderCommandEncoderWithDescriptor:]:380: failed assertion `A command encoder is already encoding to this command buffer'
```