### PR TITLE
refactor(d3d12): use `mut_self` instead of round-tripping w/ `mut_void`

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -1097,7 +1097,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         // `src_pending` and `dst_pending` try to hold `trackers.textures` mutably.
         let mut barriers: ArrayVec<_, 2> = src_pending
             .map(|pending| pending.into_hal(src_texture))
-            .into_iter()
             .collect();
 
         let dst_pending = cmd_buf

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -804,8 +804,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         };
 
         unsafe {
-            encoder
-                .transition_textures(transition.map(|pending| pending.into_hal(dst)).into_iter());
+            encoder.transition_textures(transition.map(|pending| pending.into_hal(dst)));
             encoder.transition_buffers(iter::once(barrier));
             encoder.copy_buffer_to_texture(&staging_buffer.raw, dst_raw, regions);
         }

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -44,7 +44,7 @@ pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter
 
         profiling::scope!("IDXGIFactory1::EnumAdapters1");
         let mut adapter1 = d3d12::WeakPtr::<dxgi::IDXGIAdapter1>::null();
-        let hr = unsafe { factory.EnumAdapters1(cur_index, adapter1.mut_void() as *mut *mut _) };
+        let hr = unsafe { factory.EnumAdapters1(cur_index, adapter1.mut_self()) };
 
         if hr == winerror::DXGI_ERROR_NOT_FOUND {
             break;


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] ~Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.~ Not necessary.
- [x] ~Add change to CHANGELOG.md. See simple instructions inside file.~ Not necessary.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

N/A

**Description**
_Describe what problem this is solving, and how it's solved._

N/A

**Testing**
_Explain how this change is tested._

Still compiles, so it should be good!