### PR TITLE
Manually implement traits on `wgpu::Id`

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4243,8 +4243,41 @@ impl Surface {
 #[cfg(feature = "expose-ids")]
 #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Id<T>(core::num::NonZeroU64, std::marker::PhantomData<*mut T>);
+
+#[cfg(feature = "expose-ids")]
+impl<T> Clone for Id<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl<T> Copy for Id<T> {}
+
+#[cfg(feature = "expose-ids")]
+impl<T> Debug for Id<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_tuple("Id").field(&self.0).finish()
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl<T> PartialEq for Id<T> {
+    fn eq(&self, other: &Id<T>) -> bool {
+        self.0 == other.0
+    }
+}
+
+#[cfg(feature = "expose-ids")]
+impl<T> Eq for Id<T> {}
+
+#[cfg(feature = "expose-ids")]
+impl<T> std::hash::Hash for Id<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
+}
 
 #[cfg(feature = "expose-ids")]
 impl Adapter {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
In #3575, I neglected the fact that `#[derive(Trait)]` for built-in traits puts a `T: Trait` bound on `wgpu::Id`. This is certainly unwanted, so I've replaced the derive macros with the equivalent manual implementations.

**Testing**
Tested on my own code which relies upon these traits being implemented for concrete `T`
