### PR TITLE
add dxc error message formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ By @cwfitzgerald in [#3610](https://github.com/gfx-rs/wgpu/pull/3610).
 - Improve attachment related errors. By @cwfitzgerald in [#3549](https://github.com/gfx-rs/wgpu/pull/3549)
 - Make error descriptions all upper case. By @cwfitzgerald in [#3549](https://github.com/gfx-rs/wgpu/pull/3549)
 - Don't include ANSI terminal color escape sequences in shader module validation error messages. By @jimblandy in [#3591](https://github.com/gfx-rs/wgpu/pull/3591)
-- Report error messages from DXC compile. By @Davidster
+- Report error messages from DXC compile. By @Davidster in [#3632](https://github.com/gfx-rs/wgpu/pull/3632)
 
 #### WebGPU
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ By @cwfitzgerald in [#3610](https://github.com/gfx-rs/wgpu/pull/3610).
 - Improve attachment related errors. By @cwfitzgerald in [#3549](https://github.com/gfx-rs/wgpu/pull/3549)
 - Make error descriptions all upper case. By @cwfitzgerald in [#3549](https://github.com/gfx-rs/wgpu/pull/3549)
 - Don't include ANSI terminal color escape sequences in shader module validation error messages. By @jimblandy in [#3591](https://github.com/gfx-rs/wgpu/pull/3591)
+- Report error messages from DXC compile. By @Davidster
 
 #### WebGPU
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
n/a

**Description**
Currently, error messages from dxc are not included in the error messages reported by wgpu. Before this change, error messages would look like this:

```
[2023-04-01T19:51:14Z ERROR wgpu::backend::direct] Handling wgpu errors as fatal by default
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
      note: label = `iced_wgpu::quad pipeline`
    Internal error in VERTEX shader: DXC compile error: DxcOperationResult { inner: ComPtr { ptr: 0x1c754cd23c0 } }

', wgpu\src\backend\direct.rs:3016:5
```

After this change, they look like this:

```
[2023-04-01T19:49:53Z ERROR wgpu::backend::direct] Handling wgpu errors as fatal by default
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
      note: label = `iced_wgpu::quad pipeline`
    Internal error in VERTEX shader: DXC compile error: "error: error reading 'iced_wgpu::quad::shader'\n\0"

', wgpu\src\backend\direct.rs:3016:5
```

**Testing**
The change can be tested by triggering a dxc compile error, which can be triggered by adding a colon in the name of the shader module:

```rust
wgpu::ShaderModuleDescriptor {
    label: Some(":"),
    ..
}
```
