### PR TITLE
Add `BGRA8UNORM_STORAGE` extension

### DIFF
--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -268,6 +268,9 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     if features.contains(wgpu_types::Features::RG11B10UFLOAT_RENDERABLE) {
         return_features.push("rg11b10ufloat-renderable");
     }
+    if features.contains(wgpu_types::Features::BGRA8UNORM_STORAGE) {
+        return_features.push("bgra8unorm-storage");
+    }
 
     // extended from spec
 
@@ -490,6 +493,10 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
         features.set(
             wgpu_types::Features::RG11B10UFLOAT_RENDERABLE,
             required_features.0.contains("rg11b10ufloat-renderable"),
+        );
+        features.set(
+            wgpu_types::Features::BGRA8UNORM_STORAGE,
+            required_features.0.contains("bgra8unorm-storage"),
         );
 
         // extended from spec

--- a/deno_webgpu/webgpu.idl
+++ b/deno_webgpu/webgpu.idl
@@ -102,6 +102,7 @@ enum GPUFeatureName {
     // shader
     "shader-f16",
     "rg11b10ufloat-renderable",
+    "bgra8unorm-storage",
 
     // extended from spec
 

--- a/player/tests/data/buffer-copy.ron
+++ b/player/tests/data/buffer-copy.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x1_0000,
+    features: 0x2_0000,
     expectations: [
         (
             name: "basic",

--- a/player/tests/data/clear-buffer-texture.ron
+++ b/player/tests/data/clear-buffer-texture.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0000_0004_0001_0000,
+    features: 0x0000_0004_0002_0000,
     expectations: [
         (
             name: "Quad",

--- a/player/tests/data/zero-init-buffer.ron
+++ b/player/tests/data/zero-init-buffer.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x1_0000,
+    features: 0x2_0000,
     expectations: [
         // Ensuring that mapping zero-inits buffers.
         (

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1017,6 +1017,17 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         adapter_guard
             .get(adapter_id)
             .map(|adapter| adapter.raw.features)
+            .map(|mut features| {
+                // SHADER_F16 is not supported in naga yet (https://github.com/gfx-rs/naga/issues/1884)
+                if features.contains(wgt::Features::SHADER_F16) {
+                    features.remove(wgt::Features::SHADER_F16);
+                }
+                // BGRA8UNORM_STORAGE is not supported in naga yet (https://github.com/gfx-rs/naga/issues/2195)
+                if features.contains(wgt::Features::BGRA8UNORM_STORAGE) {
+                    features.remove(wgt::Features::BGRA8UNORM_STORAGE);
+                }
+                features
+            })
             .map_err(|_| InvalidAdapter)
     }
 

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -4,7 +4,9 @@ use crate::{
 };
 use std::{mem, ptr, sync::Arc, thread};
 use winapi::{
-    shared::{dxgi, dxgi1_2, minwindef::DWORD, windef, winerror},
+    shared::{
+        dxgi, dxgi1_2, dxgiformat::DXGI_FORMAT_B8G8R8A8_UNORM, minwindef::DWORD, windef, winerror,
+    },
     um::{d3d12 as d3d12_ty, d3d12sdklayers, winuser},
 };
 
@@ -272,6 +274,25 @@ impl super::Adapter {
                 | wgt::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING
                 | wgt::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
             shader_model_support.HighestShaderModel >= d3d12_ty::D3D_SHADER_MODEL_5_1,
+        );
+
+        let bgra8unorm_storage_supported = {
+            let mut bgra8unorm_info: d3d12_ty::D3D12_FEATURE_DATA_FORMAT_SUPPORT =
+                unsafe { mem::zeroed() };
+            bgra8unorm_info.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+            let hr = unsafe {
+                device.CheckFeatureSupport(
+                    d3d12_ty::D3D12_FEATURE_FORMAT_SUPPORT,
+                    &mut bgra8unorm_info as *mut _ as *mut _,
+                    mem::size_of::<d3d12_ty::D3D12_FEATURE_DATA_FORMAT_SUPPORT>() as _,
+                )
+            };
+            hr == 0
+                && (bgra8unorm_info.Support2 & d3d12_ty::D3D12_FORMAT_SUPPORT2_UAV_TYPED_STORE != 0)
+        };
+        features.set(
+            wgt::Features::BGRA8UNORM_STORAGE,
+            bgra8unorm_storage_supported,
         );
 
         // TODO: Determine if IPresentationManager is supported

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -821,7 +821,8 @@ impl super::PrivateCapabilities {
             | F::TEXTURE_FORMAT_16BIT_NORM
             | F::SHADER_F16
             | F::DEPTH32FLOAT_STENCIL8
-            | F::MULTI_DRAW_INDIRECT;
+            | F::MULTI_DRAW_INDIRECT
+            | F::BGRA8UNORM_STORAGE;
 
         features.set(
             F::TIMESTAMP_QUERY,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -521,6 +521,14 @@ impl PhysicalDeviceFeatures {
         );
         features.set(F::RG11B10UFLOAT_RENDERABLE, rg11b10ufloat_renderable);
 
+        let bgra8unorm_storage = supports_format(
+            instance,
+            phd,
+            vk::Format::B8G8R8A8_UNORM,
+            vk::ImageTiling::OPTIMAL,
+            vk::FormatFeatureFlags::STORAGE_IMAGE,
+        );
+        features.set(F::BGRA8UNORM_STORAGE, bgra8unorm_storage);
         (features, dl_flags)
     }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -309,7 +309,19 @@ bitflags::bitflags! {
         //
         // ? const FORMATS_TIER_1 = 1 << 14; (https://github.com/gpuweb/gpuweb/issues/3837)
         // ? const RW_STORAGE_TEXTURE_TIER_1 = 1 << 15; (https://github.com/gpuweb/gpuweb/issues/3838)
-        // TODO const BGRA8UNORM_STORAGE = 1 << 16;
+
+        /// Allows the [`wgpu::TextureUsages::STORAGE_BINDING`] usage on textures with format [`TextureFormat::Bgra8unorm`]
+        ///
+        /// Note: this is not supported in naga yet.
+        ///
+        /// Supported Platforms:
+        /// - Vulkan
+        /// - DX12
+        /// - Metal
+        ///
+        /// This is a web and native feature.
+        const BGRA8UNORM_STORAGE = 1 << 16;
+
         // ? const NORM16_FILTERABLE = 1 << 17; (https://github.com/gpuweb/gpuweb/issues/3839)
         // ? const NORM16_RESOLVE = 1 << 18; (https://github.com/gpuweb/gpuweb/issues/3839)
         // TODO const FLOAT32_FILTERABLE = 1 << 19;
@@ -2857,6 +2869,11 @@ impl TextureFormat {
         } else {
             basic
         };
+        let bgra8unorm = if device_features.contains(Features::BGRA8UNORM_STORAGE) {
+            attachment | TextureUsages::STORAGE_BINDING
+        } else {
+            attachment
+        };
 
         #[rustfmt::skip] // lets make a nice table
         let (
@@ -2885,7 +2902,7 @@ impl TextureFormat {
             Self::Rgba8Snorm =>           (        noaa,    storage),
             Self::Rgba8Uint =>            (        msaa,  all_flags),
             Self::Rgba8Sint =>            (        msaa,  all_flags),
-            Self::Bgra8Unorm =>           (msaa_resolve, attachment),
+            Self::Bgra8Unorm =>           (msaa_resolve, bgra8unorm),
             Self::Bgra8UnormSrgb =>       (msaa_resolve, attachment),
             Self::Rgb10a2Unorm =>         (msaa_resolve, attachment),
             Self::Rg11b10Float =>         (        msaa,   rg11b10f),

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -635,7 +635,7 @@ fn map_map_mode(mode: crate::MapMode) -> u32 {
     }
 }
 
-const FEATURES_MAPPING: [(wgt::Features, web_sys::GpuFeatureName); 9] = [
+const FEATURES_MAPPING: [(wgt::Features, web_sys::GpuFeatureName); 10] = [
     //TODO: update the name
     (
         wgt::Features::DEPTH_CLIP_CONTROL,
@@ -672,6 +672,10 @@ const FEATURES_MAPPING: [(wgt::Features, web_sys::GpuFeatureName); 9] = [
     (
         wgt::Features::RG11B10UFLOAT_RENDERABLE,
         web_sys::GpuFeatureName::Rg11b10ufloatRenderable,
+    ),
+    (
+        wgt::Features::BGRA8UNORM_STORAGE,
+        web_sys::GpuFeatureName::Bgra8unormStorage,
     ),
 ];
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
resolves https://github.com/gfx-rs/wgpu/issues/3359

**Testing**
Tested locally on metal, vulkan(--features=vulkan-portability) and dx12 backends:
```rust
fn required_features() -> wgpu::Features {
    // wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
    // OR
    wgpu::Features::BGRA8UNORM_STORAGE
}

// ...

let a_texture = device.create_texture(&wgpu::TextureDescriptor {
    format: wgpu::TextureFormat::Bgra8Unorm,
    usage: wgpu::TextureUsages::STORAGE_BINDING,
    ...,
});

let test_tv = a_texture.create_view(&wgpu::TextureViewDescriptor {
    format: Some(wgpu::TextureFormat::Bgra8Unorm),
    ..Default::default()
});
```
