### PR TITLE
Update outdated notice of GL being unsupported

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -135,7 +135,8 @@ bitflags::bitflags! {
     pub struct Backends: u32 {
         /// Supported on Windows, Linux/Android, and macOS/iOS via Vulkan Portability (with the Vulkan feature enabled)
         const VULKAN = 1 << Backend::Vulkan as u32;
-        /// Currently unsupported
+        /// Supported on Linux/Android, the web through webassembly via WebGL, and Windows and
+        /// macOS/iOS via ANGLE
         const GL = 1 << Backend::Gl as u32;
         /// Supported on macOS/iOS
         const METAL = 1 << Backend::Metal as u32;


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] (not applicable) Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] (not performed since change does not surface in API changes) Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

No issue relations.

- https://discord.com/channels/676678179678715904/677286494033018924/1092116603652554854 (on the `Game Development in Rust` Discord)
- probably some time ago on Matrix but I forgot where

**Description**
_Describe what problem this is solving, and how it's solved._

This PR removes the outdated notice regarding GL support on the `Backends::GL` constant, as it confused @TornaxO7 so much into thinking that GL was really unsupported.

**Testing**
_Explain how this change is tested._

Not at all, as it is a pure doc change.