### PR TITLE
[gles] Fix `tex_sub_image_*` calls not always adjusting to target texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,7 @@ By @cwfitzgerald in [#3610](https://github.com/gfx-rs/wgpu/pull/3610).
 - Reset all queue state between command buffers in a submit. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
 - Reset the state of `SAMPLE_ALPHA_TO_COVERAGE` on queue reset. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
 - Fix `Vertex buffer is not big enough for the draw call.` for ANGLE/Web when rendering with instance attributes on a single instance. By @wumpf in [#3597](https://github.com/gfx-rs/wgpu/pull/3597)
-- Fix `copy_external_image_to_texture` and `copy_texture_to_texture` not taking 2D texture arrays and cube maps into account. By @daxpedda [#3641](https://github.com/gfx-rs/wgpu/pull/3641)
+- Fix `copy_external_image_to_texture`, `copy_texture_to_texture` and `copy_buffer_to_texture` not taking the specified index into account if the target texture is a cube map, 2D texture array or cube map array. By @daxpedda [#3641](https://github.com/gfx-rs/wgpu/pull/3641)
 
 #### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ By @cwfitzgerald in [#3610](https://github.com/gfx-rs/wgpu/pull/3610).
 - Reset all queue state between command buffers in a submit. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
 - Reset the state of `SAMPLE_ALPHA_TO_COVERAGE` on queue reset. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
 - Fix `Vertex buffer is not big enough for the draw call.` for ANGLE/Web when rendering with instance attributes on a single instance. By @wumpf in [#3597](https://github.com/gfx-rs/wgpu/pull/3597)
+- Fix `copy_external_image_to_texture` and `copy_texture_to_texture` not taking 2D texture arrays and cube maps into account. By @daxpedda [#3641](https://github.com/gfx-rs/wgpu/pull/3641)
 
 #### General
 

--- a/wgpu/tests/external_texture.rs
+++ b/wgpu/tests/external_texture.rs
@@ -244,7 +244,7 @@ async fn image_bitmap_import() {
                         dest_layers = 2;
                     }
                     TestCase::SecondSliceCopy => {
-                        correct = false; // TODO: what?
+                        correct = true;
                         dest_origin.z = 1;
                         dest_data_layer = 1;
                         dest_layers = 2;

--- a/wgpu/tests/external_texture.rs
+++ b/wgpu/tests/external_texture.rs
@@ -162,8 +162,6 @@ async fn image_bitmap_import() {
 
                 // If the test is suppoed to be valid call to copyExternal.
                 let mut valid = true;
-                // If the result is incorrect
-                let mut correct = true;
                 match case {
                     TestCase::Normal => {}
                     TestCase::FlipY => {
@@ -244,7 +242,6 @@ async fn image_bitmap_import() {
                         dest_layers = 2;
                     }
                     TestCase::SecondSliceCopy => {
-                        correct = true;
                         dest_origin.z = 1;
                         dest_data_layer = 1;
                         dest_layers = 2;
@@ -336,7 +333,7 @@ async fn image_bitmap_import() {
                 let gpu_image_cropped =
                     image::imageops::crop_imm(&gpu_image, 0, 0, 3, 3).to_image();
 
-                if valid && correct {
+                if valid {
                     assert_eq!(
                         raw_image, gpu_image_cropped,
                         "Failed on test case {case:?} {source:?}"


### PR DESCRIPTION
**Connections**
Fixes #3197.

**Description**
In GLES different arguments have to be passed into `tex_sub_image_*` calls depending on the target texture. Specifically cube maps, 2D texture arrays and cube map arrays. This was done correctly in some calls, specifically `write_texture`, but not in others.

This fixes it.

**Testing**
There was a test actually testing `copy_external_image_to_texture` for texture array, which was expected to fail, it succeeds now.

---

**Details**

The following functions now take the array index into account (only listing changes):
- `copy_external_image_to_texture` when targeting cube maps, 2D texture arrays and cube map arrays.
- `copy_texture_to_texture` when targeting 2D texture arrays and cube map arrays.
- `copy_buffer_to_texture` when targeting uncompressed cube map arrays.
- `copy_buffer_to_texture` when targeting compressed 2D texture arrays and cube map arrays.

Basically the change is to make sure that all calls to `tex_sub_image_*` take into account the following:
- If the target texture is a 2D texture array or cube map array, pass the array layer in the `offset_z` parameter.
- If the target texture is a cube map, pass the array layer in the `target` parameter.