### PR TITLE
Make wgpu-core errors non-exhaustive

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -21,6 +21,7 @@ use std::{borrow::Cow, ops::Range};
 use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum BindGroupLayoutEntryError {
     #[error("Cube dimension is not expected for texture storage")]
     StorageTextureCube,
@@ -35,6 +36,7 @@ pub enum BindGroupLayoutEntryError {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreateBindGroupLayoutError {
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -57,6 +59,7 @@ pub enum CreateBindGroupLayoutError {
 //TODO: refactor this to move out `enum BindingError`.
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreateBindGroupError {
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -467,6 +470,7 @@ impl<A: hal::Api> Resource for BindGroupLayout<A> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreatePipelineLayoutError {
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -507,6 +511,7 @@ impl PrettyError for CreatePipelineLayoutError {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum PushConstantUploadError {
     #[error("Provided push constant with indices {offset}..{end_offset} overruns matching push constant range at index {idx}, with stage(s) {:?} and indices {:?}", range.stages, range.range)]
     TooLarge {
@@ -682,6 +687,7 @@ pub enum BindingResource<'a> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum BindError {
     #[error(
         "Bind group {group} expects {expected} dynamic offset{s0}. However {actual} dynamic offset{s1} were provided.",
@@ -828,6 +834,7 @@ impl<A: HalApi> Resource for BindGroup<A> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum GetBindGroupLayoutError {
     #[error("Pipeline is invalid")]
     InvalidPipeline,

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -695,6 +695,7 @@ impl RenderBundleEncoder {
 
 /// Error type returned from `RenderBundleEncoder::new` if the sample count is invalid.
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreateRenderBundleError {
     #[error(transparent)]
     ColorAttachment(#[from] ColorAttachmentError),
@@ -704,6 +705,7 @@ pub enum CreateRenderBundleError {
 
 /// Error type returned from `RenderBundleEncoder::new` if the sample count is invalid.
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum ExecutionError {
     #[error("Buffer {0:?} is destroyed")]
     DestroyedBuffer(id::BufferId),

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -20,6 +20,7 @@ use wgt::{
 
 /// Error encountered while attempting a clear.
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum ClearError {
     #[error("To use clear_texture the CLEAR_TEXTURE feature needs to be enabled")]
     MissingClearTextureFeature,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -137,6 +137,7 @@ pub struct ComputePassDescriptor<'a> {
 }
 
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum DispatchError {
     #[error("Compute pipeline must be set")]
     MissingPipeline,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 
 /// Error validating a draw call.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum DrawError {
     #[error("Blend constant needs to be set")]
     MissingBlendConstant,
@@ -58,6 +59,7 @@ pub enum DrawError {
 /// Error encountered when encoding a render command.
 /// This is the shared error set between render bundles and passes.
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum RenderCommandError {
     #[error("Bind group {0:?} is invalid")]
     InvalidBindGroup(id::BindGroupId),

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -328,6 +328,7 @@ impl<C: Clone> BasePass<C> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CommandEncoderError {
     #[error("Command encoder is invalid")]
     Invalid,

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -99,6 +99,7 @@ impl From<wgt::QueryType> for SimplifiedQueryType {
 
 /// Error encountered when dealing with queries
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum QueryError {
     #[error(transparent)]
     Encoder(#[from] CommandEncoderError),
@@ -126,6 +127,7 @@ impl crate::error::PrettyError for QueryError {
 
 /// Error encountered while trying to use queries
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum QueryUseError {
     #[error("Query {query_index} is out of bounds for a query set of size {query_set_size}")]
     OutOfBounds {
@@ -150,6 +152,7 @@ pub enum QueryUseError {
 
 /// Error encountered while trying to resolve a query.
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum ResolveError {
     #[error("Queries can only be resolved to buffers that contain the QUERY_RESOLVE usage")]
     MissingBufferUsage,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -465,6 +465,7 @@ impl fmt::Display for AttachmentErrorLocation {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum ColorAttachmentError {
     #[error("Attachment format {0:?} is not a color format")]
     InvalidFormat(wgt::TextureFormat),

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -34,6 +34,7 @@ pub enum CopySide {
 
 /// Error encountered while attempting a data transfer.
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum TransferError {
     #[error("Buffer {0:?} is invalid or destroyed")]
     InvalidBuffer(BufferId),
@@ -170,6 +171,7 @@ impl PrettyError for TransferError {
 }
 /// Error encountered while attempting to do a copy on a command encoder.
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CopyError {
     #[error(transparent)]
     Encoder(#[from] CommandEncoderError),

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -220,6 +220,7 @@ struct ActiveSubmission<A: hal::Api> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum WaitIdleError {
     #[error(transparent)]
     Device(#[from] DeviceError),

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -84,6 +84,7 @@ pub(crate) struct RenderPassContext {
     pub multiview: Option<NonZeroU32>,
 }
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum RenderPassCompatibilityError {
     #[error(
         "Incompatible color attachments at indices {indices:?}: the RenderPass uses textures with formats {expected:?} but the {ty:?} uses attachments with formats {actual:?}",
@@ -343,6 +344,7 @@ pub struct Device<A: HalApi> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreateDeviceError {
     #[error("Not enough memory left")]
     OutOfMemory,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -288,6 +288,7 @@ impl<A: hal::Api> StagingBuffer<A> {
 pub struct InvalidQueue;
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum QueueWriteError {
     #[error(transparent)]
     Queue(#[from] DeviceError),
@@ -298,6 +299,7 @@ pub enum QueueWriteError {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum QueueSubmitError {
     #[error(transparent)]
     Queue(#[from] DeviceError),

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -365,6 +365,7 @@ impl<A: hal::Api> crate::hub::Resource for Adapter<A> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum IsSurfaceSupportedError {
     #[error("Invalid adapter")]
     InvalidAdapter,
@@ -373,6 +374,7 @@ pub enum IsSurfaceSupportedError {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum GetSurfaceSupportError {
     #[error("Invalid adapter")]
     InvalidAdapter,
@@ -384,6 +386,7 @@ pub enum GetSurfaceSupportError {
 
 #[derive(Clone, Debug, Error)]
 /// Error when requesting a device from the adaptor
+#[non_exhaustive]
 pub enum RequestDeviceError {
     #[error("Parent adapter is invalid")]
     InvalidAdapter,
@@ -426,6 +429,7 @@ impl<I: Clone> AdapterInputs<'_, I> {
 pub struct InvalidAdapter;
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum RequestAdapterError {
     #[error("No suitable adapter found")]
     NotFound,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -120,6 +120,7 @@ where
 
 //Note: `Clone` would require `WithSpan: Clone`.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum CreateShaderModuleError {
     #[cfg(feature = "wgsl")]
     #[error(transparent)]
@@ -169,6 +170,7 @@ pub struct ProgrammableStageDescriptor<'a> {
 pub type ImplicitBindGroupCount = u8;
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum ImplicitLayoutError {
     #[error("Missing IDs for deriving {0} bind groups")]
     MissingIds(ImplicitBindGroupCount),
@@ -193,6 +195,7 @@ pub struct ComputePipelineDescriptor<'a> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreateComputePipelineError {
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -288,6 +291,7 @@ pub struct RenderPipelineDescriptor<'a> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum ColorStateError {
     #[error("Format {0:?} is not renderable")]
     FormatNotRenderable(wgt::TextureFormat),
@@ -309,6 +313,7 @@ pub enum ColorStateError {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum DepthStencilStateError {
     #[error("Format {0:?} is not renderable")]
     FormatNotRenderable(wgt::TextureFormat),
@@ -321,6 +326,7 @@ pub enum DepthStencilStateError {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreateRenderPipelineError {
     #[error(transparent)]
     ColorAttachment(#[from] ColorAttachmentError),

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -45,6 +45,7 @@ impl Presentation {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum SurfaceError {
     #[error("Surface is invalid")]
     Invalid,
@@ -59,6 +60,7 @@ pub enum SurfaceError {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum ConfigureSurfaceError {
     #[error(transparent)]
     Device(#[from] DeviceError),

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -167,6 +167,7 @@ pub struct BufferMapOperation {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum BufferAccessError {
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -235,6 +236,7 @@ pub struct Buffer<A: hal::Api> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreateBufferError {
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -459,6 +461,7 @@ pub enum TextureErrorDimension {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum TextureDimensionError {
     #[error("Dimension {0:?} is zero")]
     Zero(TextureErrorDimension),
@@ -487,6 +490,7 @@ pub enum TextureDimensionError {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreateTextureError {
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -610,6 +614,7 @@ pub struct TextureView<A: hal::Api> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreateTextureViewError {
     #[error("Parent texture is invalid or destroyed")]
     InvalidTexture,
@@ -656,6 +661,7 @@ pub enum CreateTextureViewError {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum TextureViewDestroyError {}
 
 impl<A: hal::Api> Resource for TextureView<A> {
@@ -725,6 +731,7 @@ impl std::fmt::Debug for SamplerFilterErrorType {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreateSamplerError {
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -759,6 +766,7 @@ impl<A: hal::Api> Resource for Sampler<A> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum CreateQuerySetError {
     #[error(transparent)]
     Device(#[from] DeviceError),
@@ -789,6 +797,7 @@ impl<A: hal::Api> Resource for QuerySet<A> {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum DestroyError {
     #[error("Resource is invalid")]
     Invalid,

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -168,6 +168,7 @@ pub fn check_texture_usage(
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum BindingError {
     #[error("Binding is missing from the pipeline layout")]
     Missing,
@@ -211,6 +212,7 @@ pub enum BindingError {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum FilteringError {
     #[error("Integer textures can't be sampled with a filtering sampler")]
     Integer,
@@ -219,6 +221,7 @@ pub enum FilteringError {
 }
 
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum InputError {
     #[error("Input is not provided by the earlier stage in the pipeline")]
     Missing,
@@ -232,6 +235,7 @@ pub enum InputError {
 
 /// Errors produced when validating a programmable stage of a pipeline.
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum StageError {
     #[error("Shader module is invalid")]
     InvalidModule,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

This lets us backport changes that change error messages. The error message is otherwise opaque to the user, but would be technically be a breaking change.
