### PR TITLE
Avoid using `WasmAbi` functions on WebGPU backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,10 @@ By @cwfitzgerald in [#3610](https://github.com/gfx-rs/wgpu/pull/3610).
 
 - Fix metal erroring on an `array_stride` of 0. By @teoxoy in [#3538](https://github.com/gfx-rs/wgpu/pull/3538)
 
+#### WebGPU
+
+- Avoid using `WasmAbi` functions for WebGPU backend. By @grovesNL in [#3657](https://github.com/gfx-rs/wgpu/pull/3657)
+
 #### General
 
 - `copyTextureToTexture` src/dst aspects must both refer to all aspects of src/dst format. By @teoxoy in [#3431](https://github.com/gfx-rs/wgpu/pull/3431)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
 resolver = "2"
 members = [
-    # "cts_runner",
-    # "deno_webgpu",
+    "cts_runner",
+    "deno_webgpu",
     "dummy",
     "player",
     "wgpu",
@@ -10,7 +10,7 @@ members = [
     "wgpu-hal",
     "wgpu-info",
     "wgpu-types",
-    # "run-wasm"
+    "run-wasm"
 ]
 exclude = []
 default-members = ["wgpu", "wgpu-hal", "wgpu-info", "wgpu-types"]

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -6,30 +6,27 @@ use std::{
     cell::RefCell,
     fmt,
     future::Future,
+    marker::PhantomData,
     ops::Range,
     pin::Pin,
     rc::Rc,
     task::{self, Poll},
 };
-use wasm_bindgen::{
-    convert::{FromWasmAbi, IntoWasmAbi},
-    prelude::*,
-    JsCast,
-};
+use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{
-    context::{ObjectId, QueueWriteBuffer, Unused},
+    context::{downcast_ref, ObjectId, QueueWriteBuffer, Unused},
     UncapturedErrorHandler,
 };
 
-fn create_identified<T>(value: T) -> Identified<T> {
+fn create_identified<T>(value: T) -> (Identified<T>, Sendable<T>) {
     cfg_if::cfg_if! {
         if #[cfg(feature = "expose-ids")] {
             static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
             let id = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            Identified(value, core::num::NonZeroU64::new(id).unwrap())
+            (Identified(core::num::NonZeroU64::new(id).unwrap(), PhantomData), Sendable(value))
         } else {
-            Identified(value)
+            (Identified(PhantomData), Sendable(value))
         }
     }
 }
@@ -42,31 +39,39 @@ fn create_identified<T>(value: T) -> Identified<T> {
 // type is (for now) harmless.  Eventually wasm32 will support threading, and depending on how this
 // is integrated (or not integrated) with values like those in webgpu, this may become unsound.
 
-impl<T: FromWasmAbi<Abi = u32> + JsCast> From<ObjectId> for Identified<T> {
+#[allow(unused_variables)]
+impl<T> From<ObjectId> for Identified<T> {
     fn from(object_id: ObjectId) -> Self {
-        let id = object_id.id().get() as u32;
-        // SAFETY: wasm_bindgen says an ABI representation may only be cast to a wrapper type if it was created
-        // using into_abi.
-        //
-        // This assumption we sadly have to assume to prevent littering the code with unsafe blocks.
-        let wasm = unsafe { JsValue::from_abi(id) };
-        wgt::strict_assert!(wasm.is_instance_of::<T>());
-        // SAFETY: The ABI of the type must be a u32, and strict asserts ensure the right type is used.
         Self(
-            wasm.unchecked_into(),
             #[cfg(feature = "expose-ids")]
             object_id.global_id(),
+            PhantomData,
         )
     }
 }
 
-impl<T: IntoWasmAbi<Abi = u32>> From<Identified<T>> for ObjectId {
+#[allow(unused_variables)]
+impl<T> From<Identified<T>> for ObjectId {
     fn from(identified: Identified<T>) -> Self {
-        let id = core::num::NonZeroU64::new(identified.0.into_abi() as u64).unwrap();
         Self::new(
-            id,
+            // TODO: the ID isn't used, so we hardcode it to 1 for now until we rework this
+            // API.
+            core::num::NonZeroU64::new(1).unwrap(),
             #[cfg(feature = "expose-ids")]
             identified.1,
+        )
+    }
+}
+
+#[allow(unused_variables)]
+impl<T> From<(Identified<T>, Sendable<T>)> for ObjectId {
+    fn from((id, _data): (Identified<T>, Sendable<T>)) -> Self {
+        Self::new(
+            // TODO: the ID isn't used, so we hardcode it to 1 for now until we rework this
+            // API.
+            core::num::NonZeroU64::new(1).unwrap(),
+            #[cfg(feature = "expose-ids")]
+            id.1,
         )
     }
 }
@@ -77,7 +82,10 @@ unsafe impl<T> Send for Sendable<T> {}
 unsafe impl<T> Sync for Sendable<T> {}
 
 #[derive(Clone, Debug)]
-pub(crate) struct Identified<T>(T, #[cfg(feature = "expose-ids")] std::num::NonZeroU64);
+pub(crate) struct Identified<T>(
+    #[cfg(feature = "expose-ids")] std::num::NonZeroU64,
+    PhantomData<T>,
+);
 unsafe impl<T> Send for Identified<T> {}
 unsafe impl<T> Sync for Identified<T> {}
 
@@ -457,8 +465,8 @@ fn map_texture_view_dimension(
 }
 
 fn map_buffer_copy_view(view: crate::ImageCopyBuffer) -> web_sys::GpuImageCopyBuffer {
-    let buffer = &<<Context as crate::Context>::BufferId>::from(view.buffer.id).0;
-    let mut mapped = web_sys::GpuImageCopyBuffer::new(buffer);
+    let buffer: &<Context as crate::Context>::BufferData = downcast_ref(view.buffer.data.as_ref());
+    let mut mapped = web_sys::GpuImageCopyBuffer::new(&buffer.0);
     if let Some(bytes_per_row) = view.layout.bytes_per_row {
         mapped.bytes_per_row(bytes_per_row);
     }
@@ -470,8 +478,9 @@ fn map_buffer_copy_view(view: crate::ImageCopyBuffer) -> web_sys::GpuImageCopyBu
 }
 
 fn map_texture_copy_view(view: crate::ImageCopyTexture) -> web_sys::GpuImageCopyTexture {
-    let texture = &<<Context as crate::Context>::TextureId>::from(view.texture.id).0;
-    let mut mapped = web_sys::GpuImageCopyTexture::new(texture);
+    let texture: &<Context as crate::Context>::TextureData =
+        downcast_ref(view.texture.data.as_ref());
+    let mut mapped = web_sys::GpuImageCopyTexture::new(&texture.0);
     mapped.mip_level(view.mip_level);
     mapped.origin(&map_origin_3d(view.origin));
     mapped
@@ -480,8 +489,9 @@ fn map_texture_copy_view(view: crate::ImageCopyTexture) -> web_sys::GpuImageCopy
 fn map_tagged_texture_copy_view(
     view: crate::ImageCopyTextureTagged,
 ) -> web_sys::GpuImageCopyTextureTagged {
-    let texture = &<<Context as crate::Context>::TextureId>::from(view.texture.id).0;
-    let mut mapped = web_sys::GpuImageCopyTextureTagged::new(texture);
+    let texture: &<Context as crate::Context>::TextureData =
+        downcast_ref(view.texture.data.as_ref());
+    let mut mapped = web_sys::GpuImageCopyTextureTagged::new(&texture.0);
     mapped.mip_level(view.mip_level);
     mapped.origin(&map_origin_3d(view.origin));
     mapped.aspect(map_texture_aspect(view.aspect));
@@ -598,9 +608,14 @@ fn map_wgt_features(supported_features: web_sys::GpuSupportedFeatures) -> wgt::F
 
 type JsFutureResult = Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>;
 
-fn future_request_adapter(result: JsFutureResult) -> Option<(Identified<web_sys::GpuAdapter>, ())> {
+fn future_request_adapter(
+    result: JsFutureResult,
+) -> Option<(
+    Identified<web_sys::GpuAdapter>,
+    Sendable<web_sys::GpuAdapter>,
+)> {
     match result.and_then(wasm_bindgen::JsCast::dyn_into) {
-        Ok(adapter) => Some((create_identified(adapter), ())),
+        Ok(adapter) => Some(create_identified(adapter)),
         Err(_) => None,
     }
 }
@@ -610,23 +625,18 @@ fn future_request_device(
 ) -> Result<
     (
         Identified<web_sys::GpuDevice>,
-        (),
+        Sendable<web_sys::GpuDevice>,
         Identified<web_sys::GpuQueue>,
-        (),
+        Sendable<web_sys::GpuQueue>,
     ),
     crate::RequestDeviceError,
 > {
     result
         .map(|js_value| {
-            let device_id = web_sys::GpuDevice::from(js_value);
-            let queue_id = device_id.queue();
+            let (device_id, device_data) = create_identified(web_sys::GpuDevice::from(js_value));
+            let (queue_id, queue_data) = create_identified(device_data.0.queue());
 
-            (
-                create_identified(device_id),
-                (),
-                create_identified(queue_id),
-                (),
-            )
+            (device_id, device_data, queue_id, queue_data)
         })
         .map_err(|_| crate::RequestDeviceError)
 }
@@ -687,14 +697,26 @@ impl Context {
     pub fn instance_create_surface_from_canvas(
         &self,
         canvas: &web_sys::HtmlCanvasElement,
-    ) -> Result<<Self as crate::Context>::SurfaceId, crate::CreateSurfaceError> {
+    ) -> Result<
+        (
+            <Self as crate::Context>::SurfaceId,
+            <Self as crate::Context>::SurfaceData,
+        ),
+        crate::CreateSurfaceError,
+    > {
         self.create_surface_from_context(canvas.get_context("webgpu"))
     }
 
     pub fn instance_create_surface_from_offscreen_canvas(
         &self,
         canvas: &web_sys::OffscreenCanvas,
-    ) -> Result<<Self as crate::Context>::SurfaceId, crate::CreateSurfaceError> {
+    ) -> Result<
+        (
+            <Self as crate::Context>::SurfaceId,
+            <Self as crate::Context>::SurfaceData,
+        ),
+        crate::CreateSurfaceError,
+    > {
         self.create_surface_from_context(canvas.get_context("webgpu"))
     }
 
@@ -705,7 +727,13 @@ impl Context {
     fn create_surface_from_context(
         &self,
         context_result: Result<Option<js_sys::Object>, wasm_bindgen::JsValue>,
-    ) -> Result<<Self as crate::Context>::SurfaceId, crate::CreateSurfaceError> {
+    ) -> Result<
+        (
+            <Self as crate::Context>::SurfaceId,
+            <Self as crate::Context>::SurfaceData,
+        ),
+        crate::CreateSurfaceError,
+    > {
         let context: js_sys::Object = match context_result {
             Ok(Some(context)) => context,
             Ok(None) => {
@@ -752,47 +780,47 @@ extern "C" {
 
 impl crate::context::Context for Context {
     type AdapterId = Identified<web_sys::GpuAdapter>;
-    type AdapterData = ();
+    type AdapterData = Sendable<web_sys::GpuAdapter>;
     type DeviceId = Identified<web_sys::GpuDevice>;
-    type DeviceData = ();
+    type DeviceData = Sendable<web_sys::GpuDevice>;
     type QueueId = Identified<web_sys::GpuQueue>;
-    type QueueData = ();
+    type QueueData = Sendable<web_sys::GpuQueue>;
     type ShaderModuleId = Identified<web_sys::GpuShaderModule>;
-    type ShaderModuleData = ();
+    type ShaderModuleData = Sendable<web_sys::GpuShaderModule>;
     type BindGroupLayoutId = Identified<web_sys::GpuBindGroupLayout>;
-    type BindGroupLayoutData = ();
+    type BindGroupLayoutData = Sendable<web_sys::GpuBindGroupLayout>;
     type BindGroupId = Identified<web_sys::GpuBindGroup>;
-    type BindGroupData = ();
+    type BindGroupData = Sendable<web_sys::GpuBindGroup>;
     type TextureViewId = Identified<web_sys::GpuTextureView>;
-    type TextureViewData = ();
+    type TextureViewData = Sendable<web_sys::GpuTextureView>;
     type SamplerId = Identified<web_sys::GpuSampler>;
-    type SamplerData = ();
+    type SamplerData = Sendable<web_sys::GpuSampler>;
     type BufferId = Identified<web_sys::GpuBuffer>;
-    type BufferData = ();
+    type BufferData = Sendable<web_sys::GpuBuffer>;
     type TextureId = Identified<web_sys::GpuTexture>;
-    type TextureData = ();
+    type TextureData = Sendable<web_sys::GpuTexture>;
     type QuerySetId = Identified<web_sys::GpuQuerySet>;
-    type QuerySetData = ();
+    type QuerySetData = Sendable<web_sys::GpuQuerySet>;
     type PipelineLayoutId = Identified<web_sys::GpuPipelineLayout>;
-    type PipelineLayoutData = ();
+    type PipelineLayoutData = Sendable<web_sys::GpuPipelineLayout>;
     type RenderPipelineId = Identified<web_sys::GpuRenderPipeline>;
-    type RenderPipelineData = ();
+    type RenderPipelineData = Sendable<web_sys::GpuRenderPipeline>;
     type ComputePipelineId = Identified<web_sys::GpuComputePipeline>;
-    type ComputePipelineData = ();
+    type ComputePipelineData = Sendable<web_sys::GpuComputePipeline>;
     type CommandEncoderId = Identified<web_sys::GpuCommandEncoder>;
-    type CommandEncoderData = ();
+    type CommandEncoderData = Sendable<web_sys::GpuCommandEncoder>;
     type ComputePassId = Identified<web_sys::GpuComputePassEncoder>;
-    type ComputePassData = ();
+    type ComputePassData = Sendable<web_sys::GpuComputePassEncoder>;
     type RenderPassId = Identified<web_sys::GpuRenderPassEncoder>;
-    type RenderPassData = ();
+    type RenderPassData = Sendable<web_sys::GpuRenderPassEncoder>;
     type CommandBufferId = Identified<web_sys::GpuCommandBuffer>;
-    type CommandBufferData = ();
+    type CommandBufferData = Sendable<web_sys::GpuCommandBuffer>;
     type RenderBundleEncoderId = Identified<web_sys::GpuRenderBundleEncoder>;
-    type RenderBundleEncoderData = ();
+    type RenderBundleEncoderData = Sendable<web_sys::GpuRenderBundleEncoder>;
     type RenderBundleId = Identified<web_sys::GpuRenderBundle>;
-    type RenderBundleData = ();
+    type RenderBundleData = Sendable<web_sys::GpuRenderBundle>;
     type SurfaceId = Identified<web_sys::GpuCanvasContext>;
-    type SurfaceData = ();
+    type SurfaceData = Sendable<web_sys::GpuCanvasContext>;
 
     type SurfaceOutputDetail = SurfaceOutputDetail;
     type SubmissionIndex = Unused;
@@ -855,10 +883,7 @@ impl crate::context::Context for Context {
             .expect("expected to find single canvas")
             .into();
         let canvas_element: web_sys::HtmlCanvasElement = canvas_node.into();
-        Ok((
-            self.instance_create_surface_from_canvas(&canvas_element)?,
-            (),
-        ))
+        Ok(self.instance_create_surface_from_canvas(&canvas_element)?)
     }
 
     fn instance_request_adapter(
@@ -885,8 +910,8 @@ impl crate::context::Context for Context {
 
     fn adapter_request_device(
         &self,
-        adapter: &Self::AdapterId,
-        _adapter_data: &Self::AdapterData,
+        _adapter: &Self::AdapterId,
+        adapter_data: &Self::AdapterData,
         desc: &crate::DeviceDescriptor,
         trace_dir: Option<&std::path::Path>,
     ) -> Self::RequestDeviceFuture {
@@ -914,7 +939,7 @@ impl crate::context::Context for Context {
             mapped_desc.label(label);
         }
 
-        let device_promise = adapter.0.request_device_with_descriptor(&mapped_desc);
+        let device_promise = adapter_data.0.request_device_with_descriptor(&mapped_desc);
 
         MakeSendFuture::new(
             wasm_bindgen_futures::JsFuture::from(device_promise),
@@ -939,18 +964,18 @@ impl crate::context::Context for Context {
 
     fn adapter_features(
         &self,
-        adapter: &Self::AdapterId,
-        _adapter_data: &Self::AdapterData,
+        _adapter: &Self::AdapterId,
+        adapter_data: &Self::AdapterData,
     ) -> wgt::Features {
-        map_wgt_features(adapter.0.features())
+        map_wgt_features(adapter_data.0.features())
     }
 
     fn adapter_limits(
         &self,
-        adapter: &Self::AdapterId,
-        _adapter_data: &Self::AdapterData,
+        _adapter: &Self::AdapterId,
+        adapter_data: &Self::AdapterData,
     ) -> wgt::Limits {
-        let limits = adapter.0.limits();
+        let limits = adapter_data.0.limits();
         wgt::Limits {
             max_texture_dimension_1d: limits.max_texture_dimension_1d(),
             max_texture_dimension_2d: limits.max_texture_dimension_2d(),
@@ -1022,9 +1047,9 @@ impl crate::context::Context for Context {
     fn surface_get_capabilities(
         &self,
         _surface: &Self::SurfaceId,
-        _adapter_data: &Self::AdapterData,
-        _adapter: &Self::AdapterId,
         _surface_data: &Self::SurfaceData,
+        _adapter: &Self::AdapterId,
+        _adapter_data: &Self::AdapterData,
     ) -> wgt::SurfaceCapabilities {
         wgt::SurfaceCapabilities {
             // https://gpuweb.github.io/gpuweb/#supported-context-formats
@@ -1041,10 +1066,10 @@ impl crate::context::Context for Context {
 
     fn surface_configure(
         &self,
-        surface: &Self::SurfaceId,
-        _surface_data: &Self::SurfaceData,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _surface: &Self::SurfaceId,
+        surface_data: &Self::SurfaceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         config: &crate::SurfaceConfiguration,
     ) {
         if let wgt::PresentMode::Mailbox | wgt::PresentMode::Immediate = config.present_mode {
@@ -1060,7 +1085,7 @@ impl crate::context::Context for Context {
             _ => web_sys::GpuCanvasAlphaMode::Opaque,
         };
         let mut mapped =
-            web_sys::GpuCanvasConfiguration::new(&device.0, map_texture_format(config.format));
+            web_sys::GpuCanvasConfiguration::new(&device_data.0, map_texture_format(config.format));
         mapped.usage(config.usage.bits());
         mapped.alpha_mode(alpha_mode);
         let mapped_view_formats = config
@@ -1069,22 +1094,23 @@ impl crate::context::Context for Context {
             .map(|format| JsValue::from(map_texture_format(*format)))
             .collect::<js_sys::Array>();
         mapped.view_formats(&mapped_view_formats);
-        surface.0.configure(&mapped);
+        surface_data.0.configure(&mapped);
     }
 
     fn surface_get_current_texture(
         &self,
-        surface: &Self::SurfaceId,
-        _surface_data: &Self::SurfaceData,
+        _surface: &Self::SurfaceId,
+        surface_data: &Self::SurfaceData,
     ) -> (
         Option<Self::TextureId>,
         Option<Self::TextureData>,
         wgt::SurfaceStatus,
         Self::SurfaceOutputDetail,
     ) {
+        let (surface_id, surface_data) = create_identified(surface_data.0.get_current_texture());
         (
-            Some(create_identified(surface.0.get_current_texture())),
-            Some(()),
+            Some(surface_id),
+            Some(surface_data),
             wgt::SurfaceStatus::Good,
             (),
         )
@@ -1104,10 +1130,10 @@ impl crate::context::Context for Context {
 
     fn device_features(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
     ) -> wgt::Features {
-        map_wgt_features(device.0.features())
+        map_wgt_features(device_data.0.features())
     }
 
     fn device_limits(
@@ -1139,8 +1165,8 @@ impl crate::context::Context for Context {
     )]
     fn device_create_shader_module(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: crate::ShaderModuleDescriptor,
         _shader_bound_checks: wgt::ShaderBoundChecks,
     ) -> (Self::ShaderModuleId, Self::ShaderModuleData) {
@@ -1220,10 +1246,7 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             descriptor.label(label);
         }
-        (
-            create_identified(device.0.create_shader_module(&descriptor)),
-            (),
-        )
+        create_identified(device_data.0.create_shader_module(&descriptor))
     }
 
     unsafe fn device_create_shader_module_spirv(
@@ -1237,8 +1260,8 @@ impl crate::context::Context for Context {
 
     fn device_create_bind_group_layout(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: &crate::BindGroupLayoutDescriptor,
     ) -> (Self::BindGroupLayoutId, Self::BindGroupLayoutData) {
         let mapped_bindings = desc
@@ -1331,16 +1354,13 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        (
-            create_identified(device.0.create_bind_group_layout(&mapped_desc)),
-            (),
-        )
+        create_identified(device_data.0.create_bind_group_layout(&mapped_desc))
     }
 
     fn device_create_bind_group(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: &crate::BindGroupDescriptor,
     ) -> (Self::BindGroupId, Self::BindGroupData) {
         let mapped_entries = desc
@@ -1353,8 +1373,9 @@ impl crate::context::Context for Context {
                         offset,
                         size,
                     }) => {
-                        let buffer = &<<Context as crate::Context>::BufferId>::from(buffer.id).0;
-                        let mut mapped_buffer_binding = web_sys::GpuBufferBinding::new(buffer);
+                        let buffer: &<Context as crate::Context>::BufferData =
+                            downcast_ref(buffer.data.as_ref());
+                        let mut mapped_buffer_binding = web_sys::GpuBufferBinding::new(&buffer.0);
                         mapped_buffer_binding.offset(offset as f64);
                         if let Some(s) = size {
                             mapped_buffer_binding.size(s.get() as f64);
@@ -1365,13 +1386,17 @@ impl crate::context::Context for Context {
                         panic!("Web backend does not support arrays of buffers")
                     }
                     crate::BindingResource::Sampler(sampler) => {
-                        JsValue::from(Self::SamplerId::from(sampler.id).0)
+                        let sampler: &<Context as crate::Context>::SamplerData =
+                            downcast_ref(sampler.data.as_ref());
+                        JsValue::from(&sampler.0)
                     }
                     crate::BindingResource::SamplerArray(..) => {
                         panic!("Web backend does not support arrays of samplers")
                     }
                     crate::BindingResource::TextureView(texture_view) => {
-                        JsValue::from(Self::TextureViewId::from(texture_view.id).0)
+                        let texture_view: &<Context as crate::Context>::TextureViewData =
+                            downcast_ref(texture_view.data.as_ref());
+                        JsValue::from(&texture_view.0)
                     }
                     crate::BindingResource::TextureViewArray(..) => {
                         panic!("Web backend does not support BINDING_INDEXING extension")
@@ -1382,46 +1407,47 @@ impl crate::context::Context for Context {
             })
             .collect::<js_sys::Array>();
 
-        let bgl = &<<Context as crate::Context>::BindGroupLayoutId>::from(desc.layout.id).0;
-        let mut mapped_desc = web_sys::GpuBindGroupDescriptor::new(&mapped_entries, bgl);
+        let bgl: &<Context as crate::Context>::BindGroupLayoutData =
+            downcast_ref(desc.layout.data.as_ref());
+        let mut mapped_desc = web_sys::GpuBindGroupDescriptor::new(&mapped_entries, &bgl.0);
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        (
-            create_identified(device.0.create_bind_group(&mapped_desc)),
-            (),
-        )
+        create_identified(device_data.0.create_bind_group(&mapped_desc))
     }
 
     fn device_create_pipeline_layout(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: &crate::PipelineLayoutDescriptor,
     ) -> (Self::PipelineLayoutId, Self::PipelineLayoutData) {
         let temp_layouts = desc
             .bind_group_layouts
             .iter()
-            .map(|bgl| Self::BindGroupLayoutId::from(bgl.id).0)
+            .map(|bgl| {
+                let bgl: &<Context as crate::Context>::BindGroupLayoutData =
+                    downcast_ref(bgl.data.as_ref());
+                &bgl.0
+            })
             .collect::<js_sys::Array>();
         let mut mapped_desc = web_sys::GpuPipelineLayoutDescriptor::new(&temp_layouts);
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        (
-            create_identified(device.0.create_pipeline_layout(&mapped_desc)),
-            (),
-        )
+        create_identified(device_data.0.create_pipeline_layout(&mapped_desc))
     }
 
     fn device_create_render_pipeline(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: &crate::RenderPipelineDescriptor,
     ) -> (Self::RenderPipelineId, Self::RenderPipelineData) {
-        let module = &<<Context as crate::Context>::ShaderModuleId>::from(desc.vertex.module.id).0;
-        let mut mapped_vertex_state = web_sys::GpuVertexState::new(desc.vertex.entry_point, module);
+        let module: &<Context as crate::Context>::ShaderModuleData =
+            downcast_ref(desc.vertex.module.data.as_ref());
+        let mut mapped_vertex_state =
+            web_sys::GpuVertexState::new(desc.vertex.entry_point, &module.0);
 
         let buffers = desc
             .vertex
@@ -1454,7 +1480,11 @@ impl crate::context::Context for Context {
         let auto_layout = wasm_bindgen::JsValue::from(web_sys::GpuAutoLayoutMode::Auto);
         let mut mapped_desc = web_sys::GpuRenderPipelineDescriptor::new(
             &match desc.layout {
-                Some(layout) => JsValue::from(Self::PipelineLayoutId::from(layout.id).0),
+                Some(layout) => {
+                    let layout: &<Context as crate::Context>::PipelineLayoutData =
+                        downcast_ref(layout.data.as_ref());
+                    JsValue::from(&layout.0)
+                }
                 None => auto_layout,
             },
             &mapped_vertex_state,
@@ -1489,9 +1519,10 @@ impl crate::context::Context for Context {
                     None => wasm_bindgen::JsValue::null(),
                 })
                 .collect::<js_sys::Array>();
-            let module = &<<Context as crate::Context>::ShaderModuleId>::from(frag.module.id).0;
+            let module: &<Context as crate::Context>::ShaderModuleData =
+                downcast_ref(frag.module.data.as_ref());
             let mapped_fragment_desc =
-                web_sys::GpuFragmentState::new(frag.entry_point, module, &targets);
+                web_sys::GpuFragmentState::new(frag.entry_point, &module.0, &targets);
             mapped_desc.fragment(&mapped_fragment_desc);
         }
 
@@ -1504,27 +1535,26 @@ impl crate::context::Context for Context {
         let mapped_primitive = map_primitive_state(&desc.primitive);
         mapped_desc.primitive(&mapped_primitive);
 
-        (
-            create_identified(device.0.create_render_pipeline(&mapped_desc)),
-            (),
-        )
+        create_identified(device_data.0.create_render_pipeline(&mapped_desc))
     }
 
     fn device_create_compute_pipeline(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: &crate::ComputePipelineDescriptor,
     ) -> (Self::ComputePipelineId, Self::ComputePipelineData) {
-        let shader_module = &<<Context as crate::Context>::ShaderModuleId>::from(desc.module.id).0;
+        let shader_module: &<Context as crate::Context>::ShaderModuleData =
+            downcast_ref(desc.module.data.as_ref());
         let mapped_compute_stage =
-            web_sys::GpuProgrammableStage::new(desc.entry_point, shader_module);
+            web_sys::GpuProgrammableStage::new(desc.entry_point, &shader_module.0);
         let auto_layout = wasm_bindgen::JsValue::from(web_sys::GpuAutoLayoutMode::Auto);
         let mut mapped_desc = web_sys::GpuComputePipelineDescriptor::new(
             &match desc.layout {
                 Some(layout) => {
-                    let layout = Self::PipelineLayoutId::from(layout.id);
-                    JsValue::from(layout.0)
+                    let layout: &<Context as crate::Context>::PipelineLayoutData =
+                        downcast_ref(layout.data.as_ref());
+                    JsValue::from(&layout.0)
                 }
                 None => auto_layout,
             },
@@ -1533,16 +1563,13 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        (
-            create_identified(device.0.create_compute_pipeline(&mapped_desc)),
-            (),
-        )
+        create_identified(device_data.0.create_compute_pipeline(&mapped_desc))
     }
 
     fn device_create_buffer(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: &crate::BufferDescriptor,
     ) -> (Self::BufferId, Self::BufferData) {
         let mut mapped_desc =
@@ -1551,13 +1578,13 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        (create_identified(device.0.create_buffer(&mapped_desc)), ())
+        create_identified(device_data.0.create_buffer(&mapped_desc))
     }
 
     fn device_create_texture(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: &crate::TextureDescriptor,
     ) -> (Self::TextureId, Self::TextureData) {
         let mut mapped_desc = web_sys::GpuTextureDescriptor::new(
@@ -1577,13 +1604,13 @@ impl crate::context::Context for Context {
             .map(|format| JsValue::from(map_texture_format(*format)))
             .collect::<js_sys::Array>();
         mapped_desc.view_formats(&mapped_view_formats);
-        (create_identified(device.0.create_texture(&mapped_desc)), ())
+        create_identified(device_data.0.create_texture(&mapped_desc))
     }
 
     fn device_create_sampler(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: &crate::SamplerDescriptor,
     ) -> (Self::SamplerId, Self::SamplerData) {
         let mut mapped_desc = web_sys::GpuSamplerDescriptor::new();
@@ -1603,16 +1630,13 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        (
-            create_identified(device.0.create_sampler_with_descriptor(&mapped_desc)),
-            (),
-        )
+        create_identified(device_data.0.create_sampler_with_descriptor(&mapped_desc))
     }
 
     fn device_create_query_set(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: &wgt::QuerySetDescriptor<crate::Label>,
     ) -> (Self::QuerySetId, Self::QuerySetData) {
         let ty = match desc.ty {
@@ -1624,36 +1648,30 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        (
-            create_identified(device.0.create_query_set(&mapped_desc)),
-            (),
-        )
+        create_identified(device_data.0.create_query_set(&mapped_desc))
     }
 
     fn device_create_command_encoder(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: &crate::CommandEncoderDescriptor,
     ) -> (Self::CommandEncoderId, Self::CommandEncoderData) {
         let mut mapped_desc = web_sys::GpuCommandEncoderDescriptor::new();
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        (
-            create_identified(
-                device
-                    .0
-                    .create_command_encoder_with_descriptor(&mapped_desc),
-            ),
-            (),
+        create_identified(
+            device_data
+                .0
+                .create_command_encoder_with_descriptor(&mapped_desc),
         )
     }
 
     fn device_create_render_bundle_encoder(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         desc: &crate::RenderBundleEncoderDescriptor,
     ) -> (Self::RenderBundleEncoderId, Self::RenderBundleEncoderData) {
         let mapped_color_formats = desc
@@ -1672,10 +1690,7 @@ impl crate::context::Context for Context {
             mapped_desc.depth_stencil_format(map_texture_format(ds.format));
         }
         mapped_desc.sample_count(desc.sample_count);
-        (
-            create_identified(device.0.create_render_bundle_encoder(&mapped_desc)),
-            (),
-        )
+        create_identified(device_data.0.create_render_bundle_encoder(&mapped_desc))
     }
 
     fn device_drop(&self, _device: &Self::DeviceId, _device_data: &Self::DeviceData) {
@@ -1694,15 +1709,15 @@ impl crate::context::Context for Context {
 
     fn device_on_uncaptured_error(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         handler: Box<dyn UncapturedErrorHandler>,
     ) {
         let f = Closure::wrap(Box::new(move |event: web_sys::GpuUncapturedErrorEvent| {
             let error = crate::Error::from_js(event.error().value_of());
             handler(error);
         }) as Box<dyn FnMut(_)>);
-        device
+        device_data
             .0
             .set_onuncapturederror(Some(f.as_ref().unchecked_ref()));
         // TODO: This will leak the memory associated with the error handler by default.
@@ -1711,11 +1726,11 @@ impl crate::context::Context for Context {
 
     fn device_push_error_scope(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
         filter: crate::ErrorFilter,
     ) {
-        device.0.push_error_scope(match filter {
+        device_data.0.push_error_scope(match filter {
             crate::ErrorFilter::OutOfMemory => web_sys::GpuErrorFilter::OutOfMemory,
             crate::ErrorFilter::Validation => web_sys::GpuErrorFilter::Validation,
         });
@@ -1723,10 +1738,10 @@ impl crate::context::Context for Context {
 
     fn device_pop_error_scope(
         &self,
-        device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        _device: &Self::DeviceId,
+        device_data: &Self::DeviceData,
     ) -> Self::PopErrorScopeFuture {
-        let error_promise = device.0.pop_error_scope();
+        let error_promise = device_data.0.pop_error_scope();
         MakeSendFuture::new(
             wasm_bindgen_futures::JsFuture::from(error_promise),
             future_pop_error_scope,
@@ -1735,13 +1750,13 @@ impl crate::context::Context for Context {
 
     fn buffer_map_async(
         &self,
-        buffer: &Self::BufferId,
-        _buffer_data: &Self::BufferData,
+        _buffer: &Self::BufferId,
+        buffer_data: &Self::BufferData,
         mode: crate::MapMode,
         range: Range<wgt::BufferAddress>,
         callback: Box<dyn FnOnce(Result<(), crate::BufferAsyncError>) + Send + 'static>,
     ) {
-        let map_promise = buffer.0.map_async_with_f64_and_f64(
+        let map_promise = buffer_data.0.map_async_with_f64_and_f64(
             map_map_mode(mode),
             range.start as f64,
             (range.end - range.start) as f64,
@@ -1752,11 +1767,11 @@ impl crate::context::Context for Context {
 
     fn buffer_get_mapped_range(
         &self,
-        buffer: &Self::BufferId,
-        _buffer_data: &Self::BufferData,
+        _buffer: &Self::BufferId,
+        buffer_data: &Self::BufferData,
         sub_range: Range<wgt::BufferAddress>,
     ) -> Box<dyn crate::context::BufferMappedRange> {
-        let array_buffer = buffer.0.get_mapped_range_with_f64_and_f64(
+        let array_buffer = buffer_data.0.get_mapped_range_with_f64_and_f64(
             sub_range.start as f64,
             (sub_range.end - sub_range.start) as f64,
         );
@@ -1768,14 +1783,14 @@ impl crate::context::Context for Context {
         })
     }
 
-    fn buffer_unmap(&self, buffer: &Self::BufferId, _buffer_data: &Self::BufferData) {
-        buffer.0.unmap();
+    fn buffer_unmap(&self, _buffer: &Self::BufferId, buffer_data: &Self::BufferData) {
+        buffer_data.0.unmap();
     }
 
     fn texture_create_view(
         &self,
-        texture: &Self::TextureId,
-        _texture_data: &Self::TextureData,
+        _texture: &Self::TextureId,
+        texture_data: &Self::TextureData,
         desc: &crate::TextureViewDescriptor,
     ) -> (Self::TextureViewId, Self::TextureViewData) {
         let mut mapped = web_sys::GpuTextureViewDescriptor::new();
@@ -1797,10 +1812,7 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped.label(label);
         }
-        (
-            create_identified(texture.0.create_view_with_descriptor(&mapped)),
-            (),
-        )
+        create_identified(texture_data.0.create_view_with_descriptor(&mapped))
     }
 
     fn surface_drop(&self, _surface: &Self::SurfaceId, _surface_data: &Self::SurfaceData) {
@@ -1811,16 +1823,16 @@ impl crate::context::Context for Context {
         // Dropped automatically
     }
 
-    fn buffer_destroy(&self, buffer: &Self::BufferId, _buffer_data: &Self::BufferData) {
-        buffer.0.destroy();
+    fn buffer_destroy(&self, _buffer: &Self::BufferId, buffer_data: &Self::BufferData) {
+        buffer_data.0.destroy();
     }
 
     fn buffer_drop(&self, _buffer: &Self::BufferId, _buffer_data: &Self::BufferData) {
         // Dropped automatically
     }
 
-    fn texture_destroy(&self, texture: &Self::TextureId, _texture_data: &Self::TextureData) {
-        texture.0.destroy();
+    fn texture_destroy(&self, _texture: &Self::TextureId, texture_data: &Self::TextureData) {
+        texture_data.0.destroy();
     }
 
     fn texture_drop(&self, _texture: &Self::TextureId, _texture_data: &Self::TextureData) {
@@ -1917,107 +1929,110 @@ impl crate::context::Context for Context {
 
     fn compute_pipeline_get_bind_group_layout(
         &self,
-        pipeline: &Self::ComputePipelineId,
-        _pipeline_data: &Self::ComputePipelineData,
+        _pipeline: &Self::ComputePipelineId,
+        pipeline_data: &Self::ComputePipelineData,
         index: u32,
     ) -> (Self::BindGroupLayoutId, Self::BindGroupLayoutData) {
-        (
-            create_identified(pipeline.0.get_bind_group_layout(index)),
-            (),
-        )
+        create_identified(pipeline_data.0.get_bind_group_layout(index))
     }
 
     fn render_pipeline_get_bind_group_layout(
         &self,
-        pipeline: &Self::RenderPipelineId,
-        _pipeline_data: &Self::ComputePipelineData,
+        _pipeline: &Self::RenderPipelineId,
+        pipeline_data: &Self::RenderPipelineData,
         index: u32,
     ) -> (Self::BindGroupLayoutId, Self::BindGroupLayoutData) {
-        (
-            create_identified(pipeline.0.get_bind_group_layout(index)),
-            (),
-        )
+        create_identified(pipeline_data.0.get_bind_group_layout(index))
     }
 
     fn command_encoder_copy_buffer_to_buffer(
         &self,
-        encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
-        source: &Self::BufferId,
-        _source_data: &Self::BufferData,
+        _encoder: &Self::CommandEncoderId,
+        encoder_data: &Self::CommandEncoderData,
+        _source: &Self::BufferId,
+        source_data: &Self::BufferData,
         source_offset: wgt::BufferAddress,
-        destination: &Self::BufferId,
-        _destination_data: &Self::BufferData,
+        _destination: &Self::BufferId,
+        destination_data: &Self::BufferData,
         destination_offset: wgt::BufferAddress,
         copy_size: wgt::BufferAddress,
     ) {
-        encoder.0.copy_buffer_to_buffer_with_f64_and_f64_and_f64(
-            &source.0,
-            source_offset as f64,
-            &destination.0,
-            destination_offset as f64,
-            copy_size as f64,
-        )
+        encoder_data
+            .0
+            .copy_buffer_to_buffer_with_f64_and_f64_and_f64(
+                &source_data.0,
+                source_offset as f64,
+                &destination_data.0,
+                destination_offset as f64,
+                copy_size as f64,
+            )
     }
 
     fn command_encoder_copy_buffer_to_texture(
         &self,
-        encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
+        _encoder: &Self::CommandEncoderId,
+        encoder_data: &Self::CommandEncoderData,
         source: crate::ImageCopyBuffer,
         destination: crate::ImageCopyTexture,
         copy_size: wgt::Extent3d,
     ) {
-        encoder.0.copy_buffer_to_texture_with_gpu_extent_3d_dict(
-            &map_buffer_copy_view(source),
-            &map_texture_copy_view(destination),
-            &map_extent_3d(copy_size),
-        )
+        encoder_data
+            .0
+            .copy_buffer_to_texture_with_gpu_extent_3d_dict(
+                &map_buffer_copy_view(source),
+                &map_texture_copy_view(destination),
+                &map_extent_3d(copy_size),
+            )
     }
 
     fn command_encoder_copy_texture_to_buffer(
         &self,
-        encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
+        _encoder: &Self::CommandEncoderId,
+        encoder_data: &Self::CommandEncoderData,
         source: crate::ImageCopyTexture,
         destination: crate::ImageCopyBuffer,
         copy_size: wgt::Extent3d,
     ) {
-        encoder.0.copy_texture_to_buffer_with_gpu_extent_3d_dict(
-            &map_texture_copy_view(source),
-            &map_buffer_copy_view(destination),
-            &map_extent_3d(copy_size),
-        )
+        encoder_data
+            .0
+            .copy_texture_to_buffer_with_gpu_extent_3d_dict(
+                &map_texture_copy_view(source),
+                &map_buffer_copy_view(destination),
+                &map_extent_3d(copy_size),
+            )
     }
 
     fn command_encoder_copy_texture_to_texture(
         &self,
-        encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
+        _encoder: &Self::CommandEncoderId,
+        encoder_data: &Self::CommandEncoderData,
         source: crate::ImageCopyTexture,
         destination: crate::ImageCopyTexture,
         copy_size: wgt::Extent3d,
     ) {
-        encoder.0.copy_texture_to_texture_with_gpu_extent_3d_dict(
-            &map_texture_copy_view(source),
-            &map_texture_copy_view(destination),
-            &map_extent_3d(copy_size),
-        )
+        encoder_data
+            .0
+            .copy_texture_to_texture_with_gpu_extent_3d_dict(
+                &map_texture_copy_view(source),
+                &map_texture_copy_view(destination),
+                &map_extent_3d(copy_size),
+            )
     }
 
     fn command_encoder_begin_compute_pass(
         &self,
-        encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
+        _encoder: &Self::CommandEncoderId,
+        encoder_data: &Self::CommandEncoderData,
         desc: &crate::ComputePassDescriptor,
     ) -> (Self::ComputePassId, Self::ComputePassData) {
         let mut mapped_desc = web_sys::GpuComputePassDescriptor::new();
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        (
-            create_identified(encoder.0.begin_compute_pass_with_descriptor(&mapped_desc)),
-            (),
+        create_identified(
+            encoder_data
+                .0
+                .begin_compute_pass_with_descriptor(&mapped_desc),
         )
     }
 
@@ -2025,16 +2040,16 @@ impl crate::context::Context for Context {
         &self,
         _encoder: &Self::CommandEncoderId,
         _encoder_data: &Self::CommandEncoderData,
-        pass: &mut Self::ComputePassId,
-        _pass_data: &mut Self::ComputePassData,
+        _pass: &mut Self::ComputePassId,
+        pass_data: &mut Self::ComputePassData,
     ) {
-        pass.0.end();
+        pass_data.0.end();
     }
 
     fn command_encoder_begin_render_pass(
         &self,
-        encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
+        _encoder: &Self::CommandEncoderId,
+        encoder_data: &Self::CommandEncoderData,
         desc: &crate::RenderPassDescriptor<'_, '_>,
     ) -> (Self::RenderPassId, Self::RenderPassData) {
         let mapped_color_attachments = desc
@@ -2051,18 +2066,21 @@ impl crate::context::Context for Context {
                         crate::LoadOp::Load => web_sys::GpuLoadOp::Load,
                     };
 
+                    let view: &<Context as crate::Context>::TextureViewData =
+                        downcast_ref(ca.view.data.as_ref());
+
                     let mut mapped_color_attachment = web_sys::GpuRenderPassColorAttachment::new(
                         load_value,
                         map_store_op(ca.ops.store),
-                        &<<Context as crate::Context>::TextureViewId>::from(ca.view.id).0,
+                        &view.0,
                     );
                     if let Some(cv) = clear_value {
                         mapped_color_attachment.clear_value(&cv);
                     }
                     if let Some(rt) = ca.resolve_target {
-                        let texture_view =
-                            &<<Context as crate::Context>::TextureViewId>::from(rt.id).0;
-                        mapped_color_attachment.resolve_target(texture_view);
+                        let resolve_target_view: &<Context as crate::Context>::TextureViewData =
+                            downcast_ref(rt.data.as_ref());
+                        mapped_color_attachment.resolve_target(&resolve_target_view.0);
                     }
                     mapped_color_attachment.store_op(map_store_op(ca.ops.store));
 
@@ -2107,10 +2125,10 @@ impl crate::context::Context for Context {
                 }
                 None => (web_sys::GpuLoadOp::Load, web_sys::GpuStoreOp::Store),
             };
+            let dsa_view: &<Context as crate::Context>::TextureViewData =
+                downcast_ref(dsa.view.data.as_ref());
             let mut mapped_depth_stencil_attachment =
-                web_sys::GpuRenderPassDepthStencilAttachment::new(
-                    &<<Context as crate::Context>::TextureViewId>::from(dsa.view.id).0,
-                );
+                web_sys::GpuRenderPassDepthStencilAttachment::new(&dsa_view.0);
             mapped_depth_stencil_attachment.depth_clear_value(depth_clear_value);
             mapped_depth_stencil_attachment.depth_load_op(depth_load_op);
             mapped_depth_stencil_attachment.depth_store_op(depth_store_op);
@@ -2120,38 +2138,32 @@ impl crate::context::Context for Context {
             mapped_desc.depth_stencil_attachment(&mapped_depth_stencil_attachment);
         }
 
-        (
-            create_identified(encoder.0.begin_render_pass(&mapped_desc)),
-            (),
-        )
+        create_identified(encoder_data.0.begin_render_pass(&mapped_desc))
     }
 
     fn command_encoder_end_render_pass(
         &self,
         _encoder: &Self::CommandEncoderId,
         _encoder_data: &Self::CommandEncoderData,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
     ) {
-        pass.0.end();
+        pass_data.0.end();
     }
 
     fn command_encoder_finish(
         &self,
-        encoder: Self::CommandEncoderId,
-        _encoder_data: &mut Self::CommandEncoderData,
+        _encoder: Self::CommandEncoderId,
+        encoder_data: &mut Self::CommandEncoderData,
     ) -> (Self::CommandBufferId, Self::CommandBufferData) {
-        let label = encoder.0.label();
-        (
-            create_identified(if label.is_empty() {
-                encoder.0.finish()
-            } else {
-                let mut mapped_desc = web_sys::GpuCommandBufferDescriptor::new();
-                mapped_desc.label(&label);
-                encoder.0.finish_with_descriptor(&mapped_desc)
-            }),
-            (),
-        )
+        let label = encoder_data.0.label();
+        create_identified(if label.is_empty() {
+            encoder_data.0.finish()
+        } else {
+            let mut mapped_desc = web_sys::GpuCommandBufferDescriptor::new();
+            mapped_desc.label(&label);
+            encoder_data.0.finish_with_descriptor(&mapped_desc)
+        })
     }
 
     fn command_encoder_clear_texture(
@@ -2166,20 +2178,22 @@ impl crate::context::Context for Context {
 
     fn command_encoder_clear_buffer(
         &self,
-        encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
+        _encoder: &Self::CommandEncoderId,
+        encoder_data: &Self::CommandEncoderData,
         buffer: &crate::Buffer,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
-        let buffer_id = &<<Context as crate::Context>::BufferId>::from(buffer.id).0;
+        let buffer: &<Context as crate::Context>::BufferData = downcast_ref(buffer.data.as_ref());
         match size {
-            Some(size) => {
-                encoder
-                    .0
-                    .clear_buffer_with_f64_and_f64(buffer_id, offset as f64, size.get() as f64)
-            }
-            None => encoder.0.clear_buffer_with_f64(buffer_id, offset as f64),
+            Some(size) => encoder_data.0.clear_buffer_with_f64_and_f64(
+                &buffer.0,
+                offset as f64,
+                size.get() as f64,
+            ),
+            None => encoder_data
+                .0
+                .clear_buffer_with_f64(&buffer.0, offset as f64),
         }
     }
 
@@ -2214,77 +2228,76 @@ impl crate::context::Context for Context {
 
     fn command_encoder_write_timestamp(
         &self,
-        encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
-        query_set: &Self::QuerySetId,
-        _query_set_data: &Self::QuerySetData,
+        _encoder: &Self::CommandEncoderId,
+        encoder_data: &Self::CommandEncoderData,
+        _query_set: &Self::QuerySetId,
+        query_set_data: &Self::QuerySetData,
         query_index: u32,
     ) {
-        encoder.0.write_timestamp(&query_set.0, query_index);
+        encoder_data
+            .0
+            .write_timestamp(&query_set_data.0, query_index);
     }
 
     fn command_encoder_resolve_query_set(
         &self,
-        encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
-        query_set: &Self::QuerySetId,
-        _query_set_data: &Self::QuerySetData,
+        _encoder: &Self::CommandEncoderId,
+        encoder_data: &Self::CommandEncoderData,
+        _query_set: &Self::QuerySetId,
+        query_set_data: &Self::QuerySetData,
         first_query: u32,
         query_count: u32,
-        destination: &Self::BufferId,
-        _destination_data: &Self::BufferData,
+        _destination: &Self::BufferId,
+        destination_data: &Self::BufferData,
         destination_offset: wgt::BufferAddress,
     ) {
-        encoder.0.resolve_query_set_with_u32(
-            &query_set.0,
+        encoder_data.0.resolve_query_set_with_u32(
+            &query_set_data.0,
             first_query,
             query_count,
-            &destination.0,
+            &destination_data.0,
             destination_offset as u32,
         );
     }
 
     fn render_bundle_encoder_finish(
         &self,
-        encoder: Self::RenderBundleEncoderId,
-        _encoder_data: Self::CommandEncoderData,
+        _encoder: Self::RenderBundleEncoderId,
+        encoder_data: Self::RenderBundleEncoderData,
         desc: &crate::RenderBundleDescriptor,
     ) -> (Self::RenderBundleId, Self::RenderBundleData) {
-        (
-            create_identified(match desc.label {
-                Some(label) => {
-                    let mut mapped_desc = web_sys::GpuRenderBundleDescriptor::new();
-                    mapped_desc.label(label);
-                    encoder.0.finish_with_descriptor(&mapped_desc)
-                }
-                None => encoder.0.finish(),
-            }),
-            (),
-        )
+        create_identified(match desc.label {
+            Some(label) => {
+                let mut mapped_desc = web_sys::GpuRenderBundleDescriptor::new();
+                mapped_desc.label(label);
+                encoder_data.0.finish_with_descriptor(&mapped_desc)
+            }
+            None => encoder_data.0.finish(),
+        })
     }
 
     fn queue_write_buffer(
         &self,
-        queue: &Self::QueueId,
-        _queue_data: &Self::QueueData,
-        buffer: &Self::BufferId,
-        _buffer_data: &Self::BufferData,
+        _queue: &Self::QueueId,
+        queue_data: &Self::QueueData,
+        _buffer: &Self::BufferId,
+        buffer_data: &Self::BufferData,
         offset: wgt::BufferAddress,
         data: &[u8],
     ) {
         /* Skip the copy once gecko allows BufferSource instead of ArrayBuffer
-        queue.0.write_buffer_with_f64_and_u8_array_and_f64_and_f64(
-            &buffer.0,
+        queue_data.0.write_buffer_with_f64_and_u8_array_and_f64_and_f64(
+            &buffer_data.0,
             offset as f64,
             data,
             0f64,
             data.len() as f64,
         );
         */
-        queue
+        queue_data
             .0
             .write_buffer_with_f64_and_buffer_source_and_f64_and_f64(
-                &buffer.0,
+                &buffer_data.0,
                 offset as f64,
                 &js_sys::Uint8Array::from(data).buffer(),
                 0f64,
@@ -2296,12 +2309,12 @@ impl crate::context::Context for Context {
         &self,
         _queue: &Self::QueueId,
         _queue_data: &Self::QueueData,
-        buffer: &Self::BufferId,
-        _buffer_data: &Self::BufferData,
+        _buffer: &Self::BufferId,
+        buffer_data: &Self::BufferData,
         offset: wgt::BufferAddress,
         size: wgt::BufferSize,
     ) -> Option<()> {
-        let usage = wgt::BufferUsages::from_bits_truncate(buffer.0.usage());
+        let usage = wgt::BufferUsages::from_bits_truncate(buffer_data.0.usage());
         // TODO: actually send this down the error scope
         if !usage.contains(wgt::BufferUsages::COPY_DST) {
             log::error!("Destination buffer is missing the `COPY_DST` usage flag");
@@ -2322,8 +2335,8 @@ impl crate::context::Context for Context {
             );
             return None;
         }
-        if write_size + offset > buffer.0.size() as u64 {
-            log::error!("copy of {}..{} would end up overrunning the bounds of the destination buffer of size {}", offset, offset + write_size, buffer.0.size());
+        if write_size + offset > buffer_data.0.size() as u64 {
+            log::error!("copy of {}..{} would end up overrunning the bounds of the destination buffer of size {}", offset, offset + write_size, buffer_data.0.size());
             return None;
         }
         Some(())
@@ -2366,8 +2379,8 @@ impl crate::context::Context for Context {
 
     fn queue_write_texture(
         &self,
-        queue: &Self::QueueId,
-        _queue_data: &Self::QueueData,
+        _queue: &Self::QueueId,
+        queue_data: &Self::QueueData,
         texture: crate::ImageCopyTexture,
         data: &[u8],
         data_layout: wgt::ImageDataLayout,
@@ -2383,14 +2396,14 @@ impl crate::context::Context for Context {
         mapped_data_layout.offset(data_layout.offset as f64);
 
         /* Skip the copy once gecko allows BufferSource instead of ArrayBuffer
-        queue.0.write_texture_with_u8_array_and_gpu_extent_3d_dict(
+        queue_data.0.write_texture_with_u8_array_and_gpu_extent_3d_dict(
             &map_texture_copy_view(texture),
             data,
             &mapped_data_layout,
             &map_extent_3d(size),
         );
         */
-        queue
+        queue_data
             .0
             .write_texture_with_buffer_source_and_gpu_extent_3d_dict(
                 &map_texture_copy_view(texture),
@@ -2402,13 +2415,13 @@ impl crate::context::Context for Context {
 
     fn queue_copy_external_image_to_texture(
         &self,
-        queue: &Self::QueueId,
-        _queue_data: &Self::QueueData,
+        _queue: &Self::QueueId,
+        queue_data: &Self::QueueData,
         source: &wgt::ImageCopyExternalImage,
         dest: crate::ImageCopyTextureTagged,
         size: wgt::Extent3d,
     ) {
-        queue
+        queue_data
             .0
             .copy_external_image_to_texture_with_gpu_extent_3d_dict(
                 &map_external_texture_copy_view(source),
@@ -2417,15 +2430,17 @@ impl crate::context::Context for Context {
             );
     }
 
-    fn queue_submit<I: Iterator<Item = Self::CommandBufferId>>(
+    fn queue_submit<I: Iterator<Item = (Self::CommandBufferId, Self::CommandBufferData)>>(
         &self,
-        queue: &Self::QueueId,
-        _queue_data: &Self::QueueData,
+        _queue: &Self::QueueId,
+        queue_data: &Self::QueueData,
         command_buffers: I,
     ) -> (Self::SubmissionIndex, Self::SubmissionIndexData) {
-        let temp_command_buffers = command_buffers.map(|i| i.0).collect::<js_sys::Array>();
+        let temp_command_buffers = command_buffers
+            .map(|(_, data)| data.0)
+            .collect::<js_sys::Array>();
 
-        queue.0.submit(&temp_command_buffers);
+        queue_data.0.submit(&temp_command_buffers);
 
         (Unused, ())
     }
@@ -2452,27 +2467,28 @@ impl crate::context::Context for Context {
 
     fn compute_pass_set_pipeline(
         &self,
-        pass: &mut Self::ComputePassId,
-        _pass_data: &mut Self::ComputePassData,
-        pipeline: &Self::ComputePipelineId,
-        _pipeline_data: &Self::ComputePipelineData,
+        _pass: &mut Self::ComputePassId,
+        pass_data: &mut Self::ComputePassData,
+        _pipeline: &Self::ComputePipelineId,
+        pipeline_data: &Self::ComputePipelineData,
     ) {
-        pass.0.set_pipeline(&pipeline.0)
+        pass_data.0.set_pipeline(&pipeline_data.0)
     }
 
     fn compute_pass_set_bind_group(
         &self,
-        pass: &mut Self::ComputePassId,
-        _pass_data: &mut Self::ComputePassData,
+        _pass: &mut Self::ComputePassId,
+        pass_data: &mut Self::ComputePassData,
         index: u32,
-        bind_group: &Self::BindGroupId,
-        _bind_group_data: &Self::BindGroupData,
+        _bind_group: &Self::BindGroupId,
+        bind_group_data: &Self::BindGroupData,
         offsets: &[wgt::DynamicOffset],
     ) {
-        pass.0
+        pass_data
+            .0
             .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
                 index,
-                &bind_group.0,
+                &bind_group_data.0,
                 offsets,
                 0f64,
                 offsets.len() as u32,
@@ -2550,52 +2566,54 @@ impl crate::context::Context for Context {
 
     fn compute_pass_dispatch_workgroups(
         &self,
-        pass: &mut Self::ComputePassId,
-        _pass_data: &mut Self::ComputePassData,
+        _pass: &mut Self::ComputePassId,
+        pass_data: &mut Self::ComputePassData,
         x: u32,
         y: u32,
         z: u32,
     ) {
-        pass.0
+        pass_data
+            .0
             .dispatch_workgroups_with_workgroup_count_y_and_workgroup_count_z(x, y, z);
     }
 
     fn compute_pass_dispatch_workgroups_indirect(
         &self,
-        pass: &mut Self::ComputePassId,
-        _pass_data: &mut Self::ComputePassData,
-        indirect_buffer: &Self::BufferId,
-        _indirect_buffer_data: &Self::BufferData,
+        _pass: &mut Self::ComputePassId,
+        pass_data: &mut Self::ComputePassData,
+        _indirect_buffer: &Self::BufferId,
+        indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        pass.0
-            .dispatch_workgroups_indirect_with_f64(&indirect_buffer.0, indirect_offset as f64);
+        pass_data
+            .0
+            .dispatch_workgroups_indirect_with_f64(&indirect_buffer_data.0, indirect_offset as f64);
     }
 
     fn render_bundle_encoder_set_pipeline(
         &self,
-        encoder: &mut Self::RenderBundleEncoderId,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        pipeline: &Self::RenderPipelineId,
-        _pipeline_data: &Self::RenderPipelineData,
+        _encoder: &mut Self::RenderBundleEncoderId,
+        encoder_data: &mut Self::RenderBundleEncoderData,
+        _pipeline: &Self::RenderPipelineId,
+        pipeline_data: &Self::RenderPipelineData,
     ) {
-        encoder.0.set_pipeline(&pipeline.0);
+        encoder_data.0.set_pipeline(&pipeline_data.0);
     }
 
     fn render_bundle_encoder_set_bind_group(
         &self,
-        encoder: &mut Self::RenderBundleEncoderId,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
+        _encoder: &mut Self::RenderBundleEncoderId,
+        encoder_data: &mut Self::RenderBundleEncoderData,
         index: u32,
-        bind_group: &Self::BindGroupId,
-        _bind_group_data: &Self::BindGroupData,
+        _bind_group: &Self::BindGroupId,
+        bind_group_data: &Self::BindGroupData,
         offsets: &[wgt::DynamicOffset],
     ) {
-        encoder
+        encoder_data
             .0
             .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
                 index,
-                &bind_group.0,
+                &bind_group_data.0,
                 offsets,
                 0f64,
                 offsets.len() as u32,
@@ -2604,26 +2622,26 @@ impl crate::context::Context for Context {
 
     fn render_bundle_encoder_set_index_buffer(
         &self,
-        encoder: &mut Self::RenderBundleEncoderId,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        buffer: &Self::BufferId,
-        _buffer_data: &Self::BufferData,
+        _encoder: &mut Self::RenderBundleEncoderId,
+        encoder_data: &mut Self::RenderBundleEncoderData,
+        _buffer: &Self::BufferId,
+        buffer_data: &Self::BufferData,
         index_format: wgt::IndexFormat,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
         match size {
             Some(s) => {
-                encoder.0.set_index_buffer_with_f64_and_f64(
-                    &buffer.0,
+                encoder_data.0.set_index_buffer_with_f64_and_f64(
+                    &buffer_data.0,
                     map_index_format(index_format),
                     offset as f64,
                     s.get() as f64,
                 );
             }
             None => {
-                encoder.0.set_index_buffer_with_f64(
-                    &buffer.0,
+                encoder_data.0.set_index_buffer_with_f64(
+                    &buffer_data.0,
                     map_index_format(index_format),
                     offset as f64,
                 );
@@ -2633,27 +2651,27 @@ impl crate::context::Context for Context {
 
     fn render_bundle_encoder_set_vertex_buffer(
         &self,
-        encoder: &mut Self::RenderBundleEncoderId,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
+        _encoder: &mut Self::RenderBundleEncoderId,
+        encoder_data: &mut Self::RenderBundleEncoderData,
         slot: u32,
-        buffer: &Self::BufferId,
-        _buffer_data: &Self::BufferData,
+        _buffer: &Self::BufferId,
+        buffer_data: &Self::BufferData,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
         match size {
             Some(s) => {
-                encoder.0.set_vertex_buffer_with_f64_and_f64(
+                encoder_data.0.set_vertex_buffer_with_f64_and_f64(
                     slot,
-                    &buffer.0,
+                    &buffer_data.0,
                     offset as f64,
                     s.get() as f64,
                 );
             }
             None => {
-                encoder
+                encoder_data
                     .0
-                    .set_vertex_buffer_with_f64(slot, &buffer.0, offset as f64);
+                    .set_vertex_buffer_with_f64(slot, &buffer_data.0, offset as f64);
             }
         };
     }
@@ -2671,12 +2689,12 @@ impl crate::context::Context for Context {
 
     fn render_bundle_encoder_draw(
         &self,
-        encoder: &mut Self::RenderBundleEncoderId,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
+        _encoder: &mut Self::RenderBundleEncoderId,
+        encoder_data: &mut Self::RenderBundleEncoderData,
         vertices: Range<u32>,
         instances: Range<u32>,
     ) {
-        encoder
+        encoder_data
             .0
             .draw_with_instance_count_and_first_vertex_and_first_instance(
                 vertices.end - vertices.start,
@@ -2688,13 +2706,13 @@ impl crate::context::Context for Context {
 
     fn render_bundle_encoder_draw_indexed(
         &self,
-        encoder: &mut Self::RenderBundleEncoderId,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
+        _encoder: &mut Self::RenderBundleEncoderId,
+        encoder_data: &mut Self::RenderBundleEncoderData,
         indices: Range<u32>,
         base_vertex: i32,
         instances: Range<u32>,
     ) {
-        encoder
+        encoder_data
             .0
             .draw_indexed_with_instance_count_and_first_index_and_base_vertex_and_first_instance(
                 indices.end - indices.start,
@@ -2707,28 +2725,28 @@ impl crate::context::Context for Context {
 
     fn render_bundle_encoder_draw_indirect(
         &self,
-        encoder: &mut Self::RenderBundleEncoderId,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        indirect_buffer: &Self::BufferId,
-        _indirect_buffer_data: &Self::BufferData,
+        _encoder: &mut Self::RenderBundleEncoderId,
+        encoder_data: &mut Self::RenderBundleEncoderData,
+        _indirect_buffer: &Self::BufferId,
+        indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        encoder
+        encoder_data
             .0
-            .draw_indirect_with_f64(&indirect_buffer.0, indirect_offset as f64);
+            .draw_indirect_with_f64(&indirect_buffer_data.0, indirect_offset as f64);
     }
 
     fn render_bundle_encoder_draw_indexed_indirect(
         &self,
-        encoder: &mut Self::RenderBundleEncoderId,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        indirect_buffer: &Self::BufferId,
-        _indirect_buffer_data: &Self::BufferData,
+        _encoder: &mut Self::RenderBundleEncoderId,
+        encoder_data: &mut Self::RenderBundleEncoderData,
+        _indirect_buffer: &Self::BufferId,
+        indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        encoder
+        encoder_data
             .0
-            .draw_indexed_indirect_with_f64(&indirect_buffer.0, indirect_offset as f64);
+            .draw_indexed_indirect_with_f64(&indirect_buffer_data.0, indirect_offset as f64);
     }
 
     fn render_bundle_encoder_multi_draw_indirect(
@@ -2789,27 +2807,28 @@ impl crate::context::Context for Context {
 
     fn render_pass_set_pipeline(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
-        pipeline: &Self::RenderPipelineId,
-        _pipeline_data: &Self::RenderPipelineData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
+        _pipeline: &Self::RenderPipelineId,
+        pipeline_data: &Self::RenderPipelineData,
     ) {
-        pass.0.set_pipeline(&pipeline.0);
+        pass_data.0.set_pipeline(&pipeline_data.0);
     }
 
     fn render_pass_set_bind_group(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
         index: u32,
-        bind_group: &Self::BindGroupId,
-        _bind_group_data: &Self::BindGroupData,
+        _bind_group: &Self::BindGroupId,
+        bind_group_data: &Self::BindGroupData,
         offsets: &[wgt::DynamicOffset],
     ) {
-        pass.0
+        pass_data
+            .0
             .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
                 index,
-                &bind_group.0,
+                &bind_group_data.0,
                 offsets,
                 0f64,
                 offsets.len() as u32,
@@ -2818,26 +2837,26 @@ impl crate::context::Context for Context {
 
     fn render_pass_set_index_buffer(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
-        buffer: &Self::BufferId,
-        _buffer_data: &Self::BufferData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
+        _buffer: &Self::BufferId,
+        buffer_data: &Self::BufferData,
         index_format: wgt::IndexFormat,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
         match size {
             Some(s) => {
-                pass.0.set_index_buffer_with_f64_and_f64(
-                    &buffer.0,
+                pass_data.0.set_index_buffer_with_f64_and_f64(
+                    &buffer_data.0,
                     map_index_format(index_format),
                     offset as f64,
                     s.get() as f64,
                 );
             }
             None => {
-                pass.0.set_index_buffer_with_f64(
-                    &buffer.0,
+                pass_data.0.set_index_buffer_with_f64(
+                    &buffer_data.0,
                     map_index_format(index_format),
                     offset as f64,
                 );
@@ -2847,26 +2866,27 @@ impl crate::context::Context for Context {
 
     fn render_pass_set_vertex_buffer(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
         slot: u32,
-        buffer: &Self::BufferId,
-        _buffer_data: &Self::BufferData,
+        _buffer: &Self::BufferId,
+        buffer_data: &Self::BufferData,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
         match size {
             Some(s) => {
-                pass.0.set_vertex_buffer_with_f64_and_f64(
+                pass_data.0.set_vertex_buffer_with_f64_and_f64(
                     slot,
-                    &buffer.0,
+                    &buffer_data.0,
                     offset as f64,
                     s.get() as f64,
                 );
             }
             None => {
-                pass.0
-                    .set_vertex_buffer_with_f64(slot, &buffer.0, offset as f64);
+                pass_data
+                    .0
+                    .set_vertex_buffer_with_f64(slot, &buffer_data.0, offset as f64);
             }
         };
     }
@@ -2884,12 +2904,13 @@ impl crate::context::Context for Context {
 
     fn render_pass_draw(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
         vertices: Range<u32>,
         instances: Range<u32>,
     ) {
-        pass.0
+        pass_data
+            .0
             .draw_with_instance_count_and_first_vertex_and_first_instance(
                 vertices.end - vertices.start,
                 instances.end - instances.start,
@@ -2900,13 +2921,14 @@ impl crate::context::Context for Context {
 
     fn render_pass_draw_indexed(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
         indices: Range<u32>,
         base_vertex: i32,
         instances: Range<u32>,
     ) {
-        pass.0
+        pass_data
+            .0
             .draw_indexed_with_instance_count_and_first_index_and_base_vertex_and_first_instance(
                 indices.end - indices.start,
                 instances.end - instances.start,
@@ -2918,26 +2940,28 @@ impl crate::context::Context for Context {
 
     fn render_pass_draw_indirect(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
-        indirect_buffer: &Self::BufferId,
-        _indirect_buffer_data: &Self::BufferData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
+        _indirect_buffer: &Self::BufferId,
+        indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        pass.0
-            .draw_indirect_with_f64(&indirect_buffer.0, indirect_offset as f64);
+        pass_data
+            .0
+            .draw_indirect_with_f64(&indirect_buffer_data.0, indirect_offset as f64);
     }
 
     fn render_pass_draw_indexed_indirect(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
-        indirect_buffer: &Self::BufferId,
-        _indirect_buffer_data: &Self::BufferData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
+        _indirect_buffer: &Self::BufferId,
+        indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        pass.0
-            .draw_indexed_indirect_with_f64(&indirect_buffer.0, indirect_offset as f64);
+        pass_data
+            .0
+            .draw_indexed_indirect_with_f64(&indirect_buffer_data.0, indirect_offset as f64);
     }
 
     fn render_pass_multi_draw_indirect(
@@ -2998,30 +3022,31 @@ impl crate::context::Context for Context {
 
     fn render_pass_set_blend_constant(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
         color: wgt::Color,
     ) {
-        pass.0
+        pass_data
+            .0
             .set_blend_constant_with_gpu_color_dict(&map_color(color));
     }
 
     fn render_pass_set_scissor_rect(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
         x: u32,
         y: u32,
         width: u32,
         height: u32,
     ) {
-        pass.0.set_scissor_rect(x, y, width, height);
+        pass_data.0.set_scissor_rect(x, y, width, height);
     }
 
     fn render_pass_set_viewport(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
         x: f32,
         y: f32,
         width: f32,
@@ -3029,17 +3054,18 @@ impl crate::context::Context for Context {
         min_depth: f32,
         max_depth: f32,
     ) {
-        pass.0
+        pass_data
+            .0
             .set_viewport(x, y, width, height, min_depth, max_depth);
     }
 
     fn render_pass_set_stencil_reference(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
         reference: u32,
     ) {
-        pass.0.set_stencil_reference(reference);
+        pass_data.0.set_stencil_reference(reference);
     }
 
     fn render_pass_insert_debug_marker(
@@ -3103,14 +3129,16 @@ impl crate::context::Context for Context {
 
     fn render_pass_execute_bundles<'a>(
         &self,
-        pass: &mut Self::RenderPassId,
-        _pass_data: &mut Self::RenderPassData,
-        render_bundles: Box<dyn Iterator<Item = Self::RenderBundleId> + 'a>,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
+        render_bundles: Box<
+            dyn Iterator<Item = (Self::RenderBundleId, &'a Self::RenderBundleData)> + 'a,
+        >,
     ) {
         let mapped = render_bundles
-            .map(|bundle| bundle.0)
+            .map(|(_, bundle_data)| &bundle_data.0)
             .collect::<js_sys::Array>();
-        pass.0.execute_bundles(&mapped);
+        pass_data.0.execute_bundles(&mapped);
     }
 }
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -883,7 +883,7 @@ impl crate::context::Context for Context {
             .expect("expected to find single canvas")
             .into();
         let canvas_element: web_sys::HtmlCanvasElement = canvas_node.into();
-        Ok(self.instance_create_surface_from_canvas(&canvas_element)?)
+        self.instance_create_surface_from_canvas(&canvas_element)
     }
 
     fn instance_request_adapter(

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -570,7 +570,7 @@ pub trait Context: Debug + Send + Sized + Sync {
         dest: crate::ImageCopyTextureTagged,
         size: wgt::Extent3d,
     );
-    fn queue_submit<I: Iterator<Item = Self::CommandBufferId>>(
+    fn queue_submit<I: Iterator<Item = (Self::CommandBufferId, Self::CommandBufferData)>>(
         &self,
         queue: &Self::QueueId,
         queue_data: &Self::QueueData,
@@ -987,7 +987,9 @@ pub trait Context: Debug + Send + Sized + Sync {
         &self,
         pass: &mut Self::RenderPassId,
         pass_data: &mut Self::RenderPassData,
-        render_bundles: Box<dyn Iterator<Item = Self::RenderBundleId> + 'a>,
+        render_bundles: Box<
+            dyn Iterator<Item = (Self::RenderBundleId, &'a Self::RenderBundleData)> + 'a,
+        >,
     );
 }
 
@@ -1025,6 +1027,7 @@ impl ObjectId {
         }
     }
 
+    #[allow(dead_code)]
     pub fn id(&self) -> NonZeroU64 {
         self.id.unwrap()
     }
@@ -1038,7 +1041,7 @@ impl ObjectId {
 
 static_assertions::assert_impl_all!(ObjectId: Send, Sync);
 
-fn downcast_ref<T: Debug + Send + Sync + 'static>(data: &crate::Data) -> &T {
+pub(crate) fn downcast_ref<T: Debug + Send + Sync + 'static>(data: &crate::Data) -> &T {
     strict_assert!(data.is::<T>());
     // Copied from std.
     unsafe { &*(data as *const dyn Any as *const T) }
@@ -1501,7 +1504,7 @@ pub(crate) trait DynContext: Debug + Send + Sync {
         &self,
         queue: &ObjectId,
         queue_data: &crate::Data,
-        command_buffers: Box<dyn Iterator<Item = ObjectId> + 'a>,
+        command_buffers: Box<dyn Iterator<Item = (ObjectId, Box<crate::Data>)> + 'a>,
     ) -> (ObjectId, Arc<crate::Data>);
     fn queue_get_timestamp_period(&self, queue: &ObjectId, queue_data: &crate::Data) -> f32;
     fn queue_on_submitted_work_done(
@@ -1902,7 +1905,7 @@ pub(crate) trait DynContext: Debug + Send + Sync {
         &self,
         pass: &mut ObjectId,
         pass_data: &mut crate::Data,
-        render_bundles: Box<dyn Iterator<Item = &'a ObjectId> + 'a>,
+        render_bundles: Box<dyn Iterator<Item = (&'a ObjectId, &'a crate::Data)> + 'a>,
     );
 }
 
@@ -2902,11 +2905,14 @@ where
         &self,
         queue: &ObjectId,
         queue_data: &crate::Data,
-        command_buffers: Box<dyn Iterator<Item = ObjectId> + 'a>,
+        command_buffers: Box<dyn Iterator<Item = (ObjectId, Box<crate::Data>)> + 'a>,
     ) -> (ObjectId, Arc<crate::Data>) {
         let queue = <T::QueueId>::from(*queue);
         let queue_data = downcast_ref(queue_data);
-        let command_buffers = command_buffers.into_iter().map(<T::CommandBufferId>::from);
+        let command_buffers = command_buffers.into_iter().map(|(id, data)| {
+            let command_buffer_data: <T as Context>::CommandBufferData = *data.downcast().unwrap();
+            (<T::CommandBufferId>::from(id), command_buffer_data)
+        });
         let (submission_index, data) =
             Context::queue_submit(self, &queue, queue_data, command_buffers);
         (submission_index.into(), Arc::new(data) as _)
@@ -3843,15 +3849,14 @@ where
         &self,
         pass: &mut ObjectId,
         pass_data: &mut crate::Data,
-        render_bundles: Box<dyn Iterator<Item = &'a ObjectId> + 'a>,
+        render_bundles: Box<dyn Iterator<Item = (&'a ObjectId, &'a crate::Data)> + 'a>,
     ) {
         let mut pass = <T::RenderPassId>::from(*pass);
         let pass_data = downcast_mut::<T::RenderPassData>(pass_data);
-        let render_bundles = Box::new(
-            render_bundles
-                .into_iter()
-                .map(|id| <T::RenderBundleId>::from(*id)),
-        );
+        let render_bundles = Box::new(render_bundles.into_iter().map(|(id, data)| {
+            let render_bundle_data: &<T as Context>::RenderBundleData = downcast_ref(data);
+            (<T::RenderBundleId>::from(*id), render_bundle_data)
+        }));
         Context::render_pass_execute_bundles(self, &mut pass, pass_data, render_bundles)
     }
 }


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #3430

**Description**
`IntoWasmAbi` and `FromWasmAbi` can be problematic for our use case because `IntoWasmAbi` takes ownership of our type. We could workaround this in different ways, but the most straightforward path right now seems to be to avoid using these entirely and instead not tracking IDs for the WebGPU backend.

We could look at doing this in a few different ways once we internally make some changes to better support multi-threading (e.g., many types will be `Arc` internally so we could consider some other approaches).

**Testing**
Tested the WebGPU examples that are known to work (hello-triangle, boids, msaa-line, etc.) in Canary.
