### PR TITLE
Web: handle None for depth_ops and stencil_ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,10 @@ By @cwfitzgerald in [#3610](https://github.com/gfx-rs/wgpu/pull/3610).
 
 ### Bug Fixes
 
+#### WebGPU
+
+- Fix handling of `None` values for `depth_ops` and `stencil_ops` in `RenderPassDescriptor::depth_stencil_attachment`. By @niklaskorz in [#3660](https://github.com/gfx-rs/wgpu/pull/3660)
+
 #### Metal
 - Fix incorrect mipmap being sampled when using `MinLod <= 0.0` and `MaxLod >= 32.0` or when the fragment shader samples different Lods in the same quad. By @cwfitzgerald in [#3610](https://github.com/gfx-rs/wgpu/pull/3610).
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -2079,45 +2079,31 @@ impl crate::context::Context for Context {
         }
 
         if let Some(dsa) = &desc.depth_stencil_attachment {
-            let mut depth_clear_value = 0.0;
-            let mut stencil_clear_value = 0;
-            let depth_ops = dsa.depth_ops.map(|ref ops| {
-                let load_op = match ops.load {
-                    crate::LoadOp::Clear(v) => {
-                        depth_clear_value = v;
-                        web_sys::GpuLoadOp::Clear
-                    }
-                    crate::LoadOp::Load => web_sys::GpuLoadOp::Load,
-                };
-                (load_op, map_store_op(ops.store))
-            });
-            let stencil_ops = dsa.stencil_ops.map(|ref ops| {
-                let load_op = match ops.load {
-                    crate::LoadOp::Clear(v) => {
-                        stencil_clear_value = v;
-                        web_sys::GpuLoadOp::Clear
-                    }
-                    crate::LoadOp::Load => web_sys::GpuLoadOp::Load,
-                };
-                (load_op, map_store_op(ops.store))
-            });
             let mut mapped_depth_stencil_attachment =
                 web_sys::GpuRenderPassDepthStencilAttachment::new(
                     &<<Context as crate::Context>::TextureViewId>::from(dsa.view.id).0,
                 );
-            if let Some((depth_load_op, depth_store_op)) = depth_ops {
-                if depth_load_op == web_sys::GpuLoadOp::Clear {
-                    mapped_depth_stencil_attachment.depth_clear_value(depth_clear_value);
-                }
-                mapped_depth_stencil_attachment.depth_load_op(depth_load_op);
-                mapped_depth_stencil_attachment.depth_store_op(depth_store_op);
+            if let Some(ref ops) = dsa.depth_ops {
+                let load_op = match ops.load {
+                    crate::LoadOp::Clear(v) => {
+                        mapped_depth_stencil_attachment.depth_clear_value(v);
+                        web_sys::GpuLoadOp::Clear
+                    }
+                    crate::LoadOp::Load => web_sys::GpuLoadOp::Load,
+                };
+                mapped_depth_stencil_attachment.depth_load_op(load_op);
+                mapped_depth_stencil_attachment.depth_store_op(map_store_op(ops.store));
             }
-            if let Some((stencil_load_op, stencil_store_op)) = stencil_ops {
-                if stencil_load_op == web_sys::GpuLoadOp::Clear {
-                    mapped_depth_stencil_attachment.stencil_clear_value(stencil_clear_value);
-                }
-                mapped_depth_stencil_attachment.stencil_load_op(stencil_load_op);
-                mapped_depth_stencil_attachment.stencil_store_op(stencil_store_op);
+            if let Some(ref ops) = dsa.stencil_ops {
+                let load_op = match ops.load {
+                    crate::LoadOp::Clear(v) => {
+                        mapped_depth_stencil_attachment.stencil_clear_value(v);
+                        web_sys::GpuLoadOp::Clear
+                    }
+                    crate::LoadOp::Load => web_sys::GpuLoadOp::Load,
+                };
+                mapped_depth_stencil_attachment.stencil_load_op(load_op);
+                mapped_depth_stencil_attachment.stencil_store_op(map_store_op(ops.store));
             }
             mapped_desc.depth_stencil_attachment(&mapped_depth_stencil_attachment);
         }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

There's no corresponding issue yet (should I create one?).

More or less depends on #3657 (at least to see the result), here's a branch merging both fixes for testing: https://github.com/niklaskorz/wgpu/tree/dynamic-dispatch-depth-fix

**Description**
_Describe what problem this is solving, and how it's solved._

When using a `DepthStencilState` with a texture that only includes depth but not stencil data (e.g., `TextureFormat::Depth32Float` instead of `TextureFormat::Depth24PlusStencil8`), and then specifying `stencil_ops: None` in the `RenderPassDepthStencilAttachment`, Chrome Beta 113 reports the following:

```
stencilLoadOp is (LoadOp::Load) and stencilStoreOp is (StoreOp::Store) when stencilReadOnly (0) or the attachment ([TextureView of Texture "depth_texture"]) has no stencil aspect.
 - While validating depthStencilAttachment.
 - While encoding [CommandEncoder "encoder"].BeginRenderPass([RenderPassDescriptor "rpass"]).
```

This is fixed by not defining any stencil parameters on the `web_sys::GpuRenderPassDepthStencilAttachment` when `stencil_ops` is None.

**Testing**
_Explain how this change is tested._

Tested on my project https://github.com/niklaskorz/linon using Chrome Beta 113 (see branch `dynamic-dispatch-workaround`, deployed on https://niklaskorz.github.io/linon/).

