### PR TITLE
Update naga to 0.11.0@git:f59668ccfaf7bdb3a7e43d84363a21c77357b2fe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.11.0"
-source = "git+https://github.com/gfx-rs/naga?rev=00be08e9f82a7bc2a4b8f8f3645d0191d9a89ec2#00be08e9f82a7bc2a4b8f8f3645d0191d9a89ec2"
+source = "git+https://github.com/gfx-rs/naga?rev=f59668ccfaf7bdb3a7e43d84363a21c77357b2fe#f59668ccfaf7bdb3a7e43d84363a21c77357b2fe"
 dependencies = [
  "bit-set",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ version = "0.15"
 
 [workspace.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "00be08e9f82a7bc2a4b8f8f3645d0191d9a89ec2"
+rev = "f59668ccfaf7bdb3a7e43d84363a21c77357b2fe"
 version = "0.11.0"
 
 [workspace.dependencies]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -67,7 +67,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "00be08e9f82a7bc2a4b8f8f3645d0191d9a89ec2"
+rev = "f59668ccfaf7bdb3a7e43d84363a21c77357b2fe"
 version = "0.11.0"
 features = ["clone", "span", "validate"]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -119,14 +119,14 @@ android_system_properties = "0.1.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "00be08e9f82a7bc2a4b8f8f3645d0191d9a89ec2"
+rev = "f59668ccfaf7bdb3a7e43d84363a21c77357b2fe"
 version = "0.11.0"
 features = ["clone"]
 
 # DEV dependencies
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "00be08e9f82a7bc2a4b8f8f3645d0191d9a89ec2"
+rev = "f59668ccfaf7bdb3a7e43d84363a21c77357b2fe"
 version = "0.11.0"
 features = ["wgsl-in"]
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.

**Description**

I'm back. Let's update naga.
