### PR TITLE
`expose-ids`: pass the correct field for global ID

### DIFF
--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -58,7 +58,7 @@ impl<T> From<Identified<T>> for ObjectId {
             // API.
             core::num::NonZeroU64::new(1).unwrap(),
             #[cfg(feature = "expose-ids")]
-            identified.1,
+            identified.0,
         )
     }
 }
@@ -71,7 +71,7 @@ impl<T> From<(Identified<T>, Sendable<T>)> for ObjectId {
             // API.
             core::num::NonZeroU64::new(1).unwrap(),
             #[cfg(feature = "expose-ids")]
-            id.1,
+            id.0,
         )
     }
 }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

introduced in https://github.com/gfx-rs/wgpu/pull/3657

**Description**

Compiling with feature `expose-ids` is failing:
```
   Compiling wgpu v0.15.0 (/wgpu/wgpu)
error[E0308]: mismatched types
    --> /wgpu/wgpu/src/backend/web.rs:61:13
     |
56   |         Self::new(
     |         --------- arguments to this function are incorrect
...
61   |             identified.1,
     |             ^^^^^^^^^^^^ expected struct `NonZeroU64`, found struct `PhantomData`
     |
     = note: expected struct `NonZeroU64`
                found struct `PhantomData<T>`
note: associated function defined here
    --> /wgpu/wgpu/src/context.rs:1013:12
     |
1013 |     pub fn new(id: NonZeroU64, #[cfg(feature = "expose-ids")] global_id: NonZeroU64) -> Self {
     |            ^^^                 ----------------------------------------------------

error[E0308]: mismatched types
    --> /wgpu/wgpu/src/backend/web.rs:74:13
     |
69   |         Self::new(
     |         --------- arguments to this function are incorrect
...
74   |             id.1,
     |             ^^^^ expected struct `NonZeroU64`, found struct `PhantomData`
     |
     = note: expected struct `NonZeroU64`
                found struct `PhantomData<T>`
note: associated function defined here
    --> /wgpu/wgpu/src/context.rs:1013:12
     |
1013 |     pub fn new(id: NonZeroU64, #[cfg(feature = "expose-ids")] global_id: NonZeroU64) -> Self {
     |            ^^^                 ----------------------------------------------------
```

The global ID is on field 0 of `Identified`, not 1

**Testing**
_Explain how this change is tested._
