### PR TITLE
Fix depth stencil attachment downcast for WebGPU

### DIFF
--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -2098,7 +2098,7 @@ impl crate::context::Context for Context {
 
         if let Some(dsa) = &desc.depth_stencil_attachment {
             let depth_stencil_attachment: &<Context as crate::Context>::TextureViewData =
-                downcast_ref(&dsa.view.data);
+                downcast_ref(dsa.view.data.as_ref());
             let mut mapped_depth_stencil_attachment =
                 web_sys::GpuRenderPassDepthStencilAttachment::new(&depth_stencil_attachment.0);
             if let Some(ref ops) = dsa.depth_ops {


### PR DESCRIPTION
**Checklist**

- [ ] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #3663 (maybe?)

**Description**
Untested but I believe we should be using `as_ref()` here instead

**Testing**
Untested