### PR TITLE
Cleanups for WebGPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,17 @@ SamplerDescriptor {
 
 By @cwfitzgerald in [#3610](https://github.com/gfx-rs/wgpu/pull/3610).
 
+#### TextureFormat Names
+
+Some texture format names have changed to get back in line with the spec.
+
+```diff
+- TextureFormat::Bc6hRgbSfloat
++ TextureFormat::Bc6hRgbFloat
+```
+
+By @cwfitzgerald in [#3671](https://github.com/gfx-rs/wgpu/pull/3671).
+
 #### General
 
 - Change type of `mip_level_count` and `array_layer_count` (members of `TextureViewDescriptor` and `ImageSubresourceRange`) from `Option<NonZeroU32>` to `Option<u32>`. By @teoxoy in [#3445](https://github.com/gfx-rs/wgpu/pull/3445)

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -750,7 +750,7 @@ impl NumericType {
             Tf::Bc5RgUnorm | Tf::Bc5RgSnorm | Tf::EacRg11Unorm | Tf::EacRg11Snorm => {
                 (NumericDimension::Vector(Vs::Bi), Sk::Float)
             }
-            Tf::Bc6hRgbUfloat | Tf::Bc6hRgbSfloat | Tf::Etc2Rgb8Unorm | Tf::Etc2Rgb8UnormSrgb => {
+            Tf::Bc6hRgbUfloat | Tf::Bc6hRgbFloat | Tf::Etc2Rgb8Unorm | Tf::Etc2Rgb8UnormSrgb => {
                 (NumericDimension::Vector(Vs::Tri), Sk::Float)
             }
             Tf::Astc {

--- a/wgpu-hal/src/auxil/dxgi/conv.rs
+++ b/wgpu-hal/src/auxil/dxgi/conv.rs
@@ -64,7 +64,7 @@ pub fn map_texture_format_failable(format: wgt::TextureFormat) -> Option<dxgifor
         Tf::Bc5RgUnorm => DXGI_FORMAT_BC5_UNORM,
         Tf::Bc5RgSnorm => DXGI_FORMAT_BC5_SNORM,
         Tf::Bc6hRgbUfloat => DXGI_FORMAT_BC6H_UF16,
-        Tf::Bc6hRgbSfloat => DXGI_FORMAT_BC6H_SF16,
+        Tf::Bc6hRgbFloat => DXGI_FORMAT_BC6H_SF16,
         Tf::Bc7RgbaUnorm => DXGI_FORMAT_BC7_UNORM,
         Tf::Bc7RgbaUnormSrgb => DXGI_FORMAT_BC7_UNORM_SRGB,
         Tf::Etc2Rgb8Unorm

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -831,7 +831,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             | Tf::Bc4RSnorm
             | Tf::Bc5RgUnorm
             | Tf::Bc5RgSnorm
-            | Tf::Bc6hRgbSfloat
+            | Tf::Bc6hRgbFloat
             | Tf::Bc6hRgbUfloat
             | Tf::Bc7RgbaUnorm
             | Tf::Bc7RgbaUnormSrgb => bcn_features,

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -94,7 +94,7 @@ impl super::AdapterShared {
             Tf::Bc5RgUnorm => (glow::COMPRESSED_RG_RGTC2, glow::RG, 0),
             Tf::Bc5RgSnorm => (glow::COMPRESSED_SIGNED_RG_RGTC2, glow::RG, 0),
             Tf::Bc6hRgbUfloat => (glow::COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT, glow::RGB, 0),
-            Tf::Bc6hRgbSfloat => (glow::COMPRESSED_RGB_BPTC_SIGNED_FLOAT, glow::RGB, 0),
+            Tf::Bc6hRgbFloat => (glow::COMPRESSED_RGB_BPTC_SIGNED_FLOAT, glow::RGB, 0),
             Tf::Bc7RgbaUnorm => (glow::COMPRESSED_RGBA_BPTC_UNORM, glow::RGBA, 0),
             Tf::Bc7RgbaUnormSrgb => (glow::COMPRESSED_SRGB_ALPHA_BPTC_UNORM, glow::RGBA, 0),
             Tf::Etc2Rgb8Unorm => (glow::COMPRESSED_RGB8_ETC2, glow::RGB, 0),

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -221,7 +221,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             | Tf::Bc5RgUnorm
             | Tf::Bc5RgSnorm
             | Tf::Bc6hRgbUfloat
-            | Tf::Bc6hRgbSfloat
+            | Tf::Bc6hRgbFloat
             | Tf::Bc7RgbaUnorm
             | Tf::Bc7RgbaUnormSrgb => {
                 if pc.format_bc {
@@ -939,7 +939,7 @@ impl super::PrivateCapabilities {
             Tf::Bc4RSnorm => BC4_RSnorm,
             Tf::Bc5RgUnorm => BC5_RGUnorm,
             Tf::Bc5RgSnorm => BC5_RGSnorm,
-            Tf::Bc6hRgbSfloat => BC6H_RGBFloat,
+            Tf::Bc6hRgbFloat => BC6H_RGBFloat,
             Tf::Bc6hRgbUfloat => BC6H_RGBUfloat,
             Tf::Bc7RgbaUnorm => BC7_RGBAUnorm,
             Tf::Bc7RgbaUnormSrgb => BC7_RGBAUnorm_sRGB,

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -85,7 +85,7 @@ impl super::PrivateCapabilities {
             Tf::Bc5RgUnorm => F::BC5_UNORM_BLOCK,
             Tf::Bc5RgSnorm => F::BC5_SNORM_BLOCK,
             Tf::Bc6hRgbUfloat => F::BC6H_UFLOAT_BLOCK,
-            Tf::Bc6hRgbSfloat => F::BC6H_SFLOAT_BLOCK,
+            Tf::Bc6hRgbFloat => F::BC6H_SFLOAT_BLOCK,
             Tf::Bc7RgbaUnorm => F::BC7_UNORM_BLOCK,
             Tf::Bc7RgbaUnormSrgb => F::BC7_SRGB_BLOCK,
             Tf::Etc2Rgb8Unorm => F::ETC2_R8G8B8_UNORM_BLOCK,

--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -71,7 +71,7 @@ mod inner {
         wgpu::TextureFormat::Bc5RgUnorm,
         wgpu::TextureFormat::Bc5RgSnorm,
         wgpu::TextureFormat::Bc6hRgbUfloat,
-        wgpu::TextureFormat::Bc6hRgbSfloat,
+        wgpu::TextureFormat::Bc6hRgbFloat,
         wgpu::TextureFormat::Bc7RgbaUnorm,
         wgpu::TextureFormat::Bc7RgbaUnormSrgb,
         wgpu::TextureFormat::Etc2Rgb8Unorm,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2100,7 +2100,7 @@ pub enum TextureFormat {
     /// Also known as BPTC (float).
     ///
     /// [`Features::TEXTURE_COMPRESSION_BC`] must be enabled to use this texture format.
-    Bc6hRgbSfloat,
+    Bc6hRgbFloat,
     /// 4x4 block compressed texture. 16 bytes per block (8 bit/px). Variable sized pallet. 8 bit integer RGBA.
     /// [0, 255] converted to/from float [0, 1] in shader.
     ///
@@ -2258,7 +2258,7 @@ impl<'de> Deserialize<'de> for TextureFormat {
                     "bc5-rg-unorm" => TextureFormat::Bc5RgUnorm,
                     "bc5-rg-snorm" => TextureFormat::Bc5RgSnorm,
                     "bc6h-rgb-ufloat" => TextureFormat::Bc6hRgbUfloat,
-                    "bc6h-rgb-float" => TextureFormat::Bc6hRgbSfloat,
+                    "bc6h-rgb-float" => TextureFormat::Bc6hRgbFloat,
                     "bc7-rgba-unorm" => TextureFormat::Bc7RgbaUnorm,
                     "bc7-rgba-unorm-srgb" => TextureFormat::Bc7RgbaUnormSrgb,
                     "etc2-rgb8unorm" => TextureFormat::Etc2Rgb8Unorm,
@@ -2384,7 +2384,7 @@ impl Serialize for TextureFormat {
             TextureFormat::Bc5RgUnorm => "bc5-rg-unorm",
             TextureFormat::Bc5RgSnorm => "bc5-rg-snorm",
             TextureFormat::Bc6hRgbUfloat => "bc6h-rgb-ufloat",
-            TextureFormat::Bc6hRgbSfloat => "bc6h-rgb-float",
+            TextureFormat::Bc6hRgbFloat => "bc6h-rgb-float",
             TextureFormat::Bc7RgbaUnorm => "bc7-rgba-unorm",
             TextureFormat::Bc7RgbaUnormSrgb => "bc7-rgba-unorm-srgb",
             TextureFormat::Etc2Rgb8Unorm => "etc2-rgb8unorm",
@@ -2574,7 +2574,7 @@ impl TextureFormat {
             | Self::Bc5RgUnorm
             | Self::Bc5RgSnorm
             | Self::Bc6hRgbUfloat
-            | Self::Bc6hRgbSfloat
+            | Self::Bc6hRgbFloat
             | Self::Bc7RgbaUnorm
             | Self::Bc7RgbaUnormSrgb => (4, 4),
 
@@ -2678,7 +2678,7 @@ impl TextureFormat {
             | Self::Bc5RgUnorm
             | Self::Bc5RgSnorm
             | Self::Bc6hRgbUfloat
-            | Self::Bc6hRgbSfloat
+            | Self::Bc6hRgbFloat
             | Self::Bc7RgbaUnorm
             | Self::Bc7RgbaUnormSrgb => Features::TEXTURE_COMPRESSION_BC,
 
@@ -2784,7 +2784,7 @@ impl TextureFormat {
             Self::Bc5RgUnorm =>           (        noaa,      basic),
             Self::Bc5RgSnorm =>           (        noaa,      basic),
             Self::Bc6hRgbUfloat =>        (        noaa,      basic),
-            Self::Bc6hRgbSfloat =>        (        noaa,      basic),
+            Self::Bc6hRgbFloat =>        (        noaa,      basic),
             Self::Bc7RgbaUnorm =>         (        noaa,      basic),
             Self::Bc7RgbaUnormSrgb =>     (        noaa,      basic),
 
@@ -2890,7 +2890,7 @@ impl TextureFormat {
             | Self::Bc5RgUnorm
             | Self::Bc5RgSnorm
             | Self::Bc6hRgbUfloat
-            | Self::Bc6hRgbSfloat
+            | Self::Bc6hRgbFloat
             | Self::Bc7RgbaUnorm
             | Self::Bc7RgbaUnormSrgb => Some(float),
 
@@ -2974,7 +2974,7 @@ impl TextureFormat {
             | Self::Bc5RgUnorm
             | Self::Bc5RgSnorm
             | Self::Bc6hRgbUfloat
-            | Self::Bc6hRgbSfloat
+            | Self::Bc6hRgbFloat
             | Self::Bc7RgbaUnorm
             | Self::Bc7RgbaUnormSrgb => Some(16),
 
@@ -3284,7 +3284,7 @@ fn texture_format_serialize() {
         "\"bc6h-rgb-ufloat\"".to_string()
     );
     assert_eq!(
-        serde_json::to_string(&TextureFormat::Bc6hRgbSfloat).unwrap(),
+        serde_json::to_string(&TextureFormat::Bc6hRgbFloat).unwrap(),
         "\"bc6h-rgb-float\"".to_string()
     );
     assert_eq!(
@@ -3577,7 +3577,7 @@ fn texture_format_deserialize() {
     );
     assert_eq!(
         serde_json::from_str::<TextureFormat>("\"bc6h-rgb-float\"").unwrap(),
-        TextureFormat::Bc6hRgbSfloat
+        TextureFormat::Bc6hRgbFloat
     );
     assert_eq!(
         serde_json::from_str::<TextureFormat>("\"bc7-rgba-unorm\"").unwrap(),
@@ -5160,9 +5160,15 @@ impl<L> CommandBufferDescriptor<L> {
 pub struct RenderBundleDepthStencil {
     /// Format of the attachment.
     pub format: TextureFormat,
-    /// True if the depth aspect is used but not modified.
+    /// If the depth aspect of the depth stencil attachment is going to be written to.
+    ///
+    /// This must match the [`RenderPassDepthStencilAttachment::depth_ops`] of the renderpass this render bundle is executed in.
+    /// If depth_ops is `Some(..)` this must be false. If it is `None` this must be true.
     pub depth_read_only: bool,
-    /// True if the stencil aspect is used but not modified.
+    /// If the stencil aspect of the depth stencil attachment is going to be written to.
+    ///
+    /// This must match the [`RenderPassDepthStencilAttachment::stencil_ops`] of the renderpass this render bundle is executed in.
+    /// If depth_ops is `Some(..)` this must be false. If it is `None` this must be true.
     pub stencil_read_only: bool,
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2784,7 +2784,7 @@ impl TextureFormat {
             Self::Bc5RgUnorm =>           (        noaa,      basic),
             Self::Bc5RgSnorm =>           (        noaa,      basic),
             Self::Bc6hRgbUfloat =>        (        noaa,      basic),
-            Self::Bc6hRgbFloat =>        (        noaa,      basic),
+            Self::Bc6hRgbFloat =>         (        noaa,      basic),
             Self::Bc7RgbaUnorm =>         (        noaa,      basic),
             Self::Bc7RgbaUnormSrgb =>     (        noaa,      basic),
 

--- a/wgpu/examples/boids/main.rs
+++ b/wgpu/examples/boids/main.rs
@@ -151,7 +151,7 @@ impl framework::Example for Example {
             fragment: Some(wgpu::FragmentState {
                 module: &draw_shader,
                 entry_point: "main_fs",
-                targets: &[Some(config.format.into())],
+                targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,

--- a/wgpu/examples/bunnymark/main.rs
+++ b/wgpu/examples/bunnymark/main.rs
@@ -117,7 +117,7 @@ impl framework::Example for Example {
                 module: &shader,
                 entry_point: "fs_main",
                 targets: &[Some(wgpu::ColorTargetState {
-                    format: config.format,
+                    format: config.view_formats[0],
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),
                     write_mask: wgpu::ColorWrites::default(),
                 })],

--- a/wgpu/examples/conservative-raster/main.rs
+++ b/wgpu/examples/conservative-raster/main.rs
@@ -152,7 +152,7 @@ impl framework::Example for Example {
                     fragment: Some(wgpu::FragmentState {
                         module: &shader_triangle_and_lines,
                         entry_point: "fs_main_white",
-                        targets: &[Some(config.format.into())],
+                        targets: &[Some(config.view_formats[0].into())],
                     }),
                     primitive: wgpu::PrimitiveState {
                         polygon_mode: wgpu::PolygonMode::Line,
@@ -213,7 +213,7 @@ impl framework::Example for Example {
                     fragment: Some(wgpu::FragmentState {
                         module: &shader,
                         entry_point: "fs_main",
-                        targets: &[Some(config.format.into())],
+                        targets: &[Some(config.view_formats[0].into())],
                     }),
                     primitive: wgpu::PrimitiveState::default(),
                     depth_stencil: None,

--- a/wgpu/examples/cube/main.rs
+++ b/wgpu/examples/cube/main.rs
@@ -274,7 +274,7 @@ impl framework::Example for Example {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
-                targets: &[Some(config.format.into())],
+                targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {
                 cull_mode: Some(wgpu::Face::Back),
@@ -298,7 +298,7 @@ impl framework::Example for Example {
                     module: &shader,
                     entry_point: "fs_wire",
                     targets: &[Some(wgpu::ColorTargetState {
-                        format: config.format,
+                        format: config.view_formats[0],
                         blend: Some(wgpu::BlendState {
                             color: wgpu::BlendComponent {
                                 operation: wgpu::BlendOperation::Add,

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -550,7 +550,7 @@ pub fn test<E: Example>(mut params: FrameworkRefTest) {
                     height: params.height,
                     present_mode: wgpu::PresentMode::Fifo,
                     alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                    view_formats: vec![wgpu::TextureFormat::Rgba8Unorm],
+                    view_formats: vec![wgpu::TextureFormat::Rgba8UnormSrgb],
                 },
                 &ctx.adapter,
                 &ctx.device,

--- a/wgpu/examples/framework.rs
+++ b/wgpu/examples/framework.rs
@@ -275,6 +275,8 @@ fn start<E: Example>(
     let mut config = surface
         .get_default_config(&adapter, size.width, size.height)
         .expect("Surface isn't supported by the adapter.");
+    let surface_view_format = config.format.add_srgb_suffix();
+    config.view_formats.push(surface_view_format);
     surface.configure(&device, &config);
 
     log::info!("Initializing the example...");
@@ -369,9 +371,10 @@ fn start<E: Example>(
                             .expect("Failed to acquire next surface texture!")
                     }
                 };
-                let view = frame
-                    .texture
-                    .create_view(&wgpu::TextureViewDescriptor::default());
+                let view = frame.texture.create_view(&wgpu::TextureViewDescriptor {
+                    format: Some(surface_view_format),
+                    ..wgpu::TextureViewDescriptor::default()
+                });
 
                 example.render(&view, &device, &queue, &spawner);
 

--- a/wgpu/examples/mipmap/main.rs
+++ b/wgpu/examples/mipmap/main.rs
@@ -291,7 +291,7 @@ impl framework::Example for Example {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
-                targets: &[Some(config.format.into())],
+                targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleStrip,

--- a/wgpu/examples/msaa-line/main.rs
+++ b/wgpu/examples/msaa-line/main.rs
@@ -61,7 +61,7 @@ impl Example {
             fragment: Some(wgpu::FragmentState {
                 module: shader,
                 entry_point: "fs_main",
-                targets: &[Some(config.format.into())],
+                targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::LineList,
@@ -78,7 +78,7 @@ impl Example {
         let mut encoder =
             device.create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
                 label: None,
-                color_formats: &[Some(config.format)],
+                color_formats: &[Some(config.view_formats[0])],
                 depth_stencil: None,
                 sample_count,
                 multiview: None,
@@ -106,7 +106,7 @@ impl Example {
             mip_level_count: 1,
             sample_count,
             dimension: wgpu::TextureDimension::D2,
-            format: config.format,
+            format: config.view_formats[0],
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             label: None,
             view_formats: &[],
@@ -131,7 +131,9 @@ impl framework::Example for Example {
     ) -> Self {
         log::info!("Press left/right arrow keys to change sample_count.");
 
-        let sample_flags = _adapter.get_texture_format_features(config.format).flags;
+        let sample_flags = _adapter
+            .get_texture_format_features(config.view_formats[0])
+            .flags;
 
         let max_sample_count = {
             if sample_flags.contains(wgpu::TextureFormatFeatureFlags::MULTISAMPLE_X16) {

--- a/wgpu/examples/shadow/main.rs
+++ b/wgpu/examples/shadow/main.rs
@@ -210,7 +210,7 @@ impl framework::Example for Example {
     }
 
     fn init(
-        sc_desc: &wgpu::SurfaceConfiguration,
+        config: &wgpu::SurfaceConfiguration,
         adapter: &wgpu::Adapter,
         device: &wgpu::Device,
         _queue: &wgpu::Queue,
@@ -593,7 +593,7 @@ impl framework::Example for Example {
                 push_constant_ranges: &[],
             });
 
-            let mx_total = Self::generate_matrix(sc_desc.width as f32 / sc_desc.height as f32);
+            let mx_total = Self::generate_matrix(config.width as f32 / config.height as f32);
             let forward_uniforms = GlobalUniforms {
                 proj: mx_total.to_cols_array_2d(),
                 num_lights: [lights.len() as u32, 0, 0, 0],
@@ -644,7 +644,7 @@ impl framework::Example for Example {
                     } else {
                         "fs_main_without_storage"
                     },
-                    targets: &[Some(sc_desc.format.into())],
+                    targets: &[Some(config.view_formats[0].into())],
                 }),
                 primitive: wgpu::PrimitiveState {
                     front_face: wgpu::FrontFace::Ccw,
@@ -669,7 +669,7 @@ impl framework::Example for Example {
             }
         };
 
-        let forward_depth = Self::create_depth_texture(sc_desc, device);
+        let forward_depth = Self::create_depth_texture(config, device);
 
         Example {
             entities,

--- a/wgpu/examples/shadow/shader.wgsl
+++ b/wgpu/examples/shadow/shader.wgsl
@@ -35,7 +35,7 @@ fn vs_main(
     let w = u_entity.world;
     let world_pos = u_entity.world * vec4<f32>(position);
     var result: VertexOutput;
-    result.world_normal = mat3x3<f32>(w.x.xyz, w.y.xyz, w.z.xyz) * vec3<f32>(normal.xyz);
+    result.world_normal = mat3x3<f32>(w[0].xyz, w[1].xyz, w[2].xyz) * vec3<f32>(normal.xyz);
     result.world_position = world_pos;
     result.proj_position = u_globals.view_proj * world_pos;
     return result;

--- a/wgpu/examples/skybox/main.rs
+++ b/wgpu/examples/skybox/main.rs
@@ -207,7 +207,7 @@ impl framework::Example for Skybox {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_sky",
-                targets: &[Some(config.format.into())],
+                targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {
                 front_face: wgpu::FrontFace::Cw,
@@ -238,7 +238,7 @@ impl framework::Example for Skybox {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_entity",
-                targets: &[Some(config.format.into())],
+                targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {
                 front_face: wgpu::FrontFace::Cw,

--- a/wgpu/examples/skybox/shader.wgsl
+++ b/wgpu/examples/skybox/shader.wgsl
@@ -30,7 +30,7 @@ fn vs_sky(@builtin(vertex_index) vertex_index: u32) -> SkyOutput {
     );
 
     // transposition = inversion for this orthonormal matrix
-    let inv_model_view = transpose(mat3x3<f32>(r_data.view.x.xyz, r_data.view.y.xyz, r_data.view.z.xyz));
+    let inv_model_view = transpose(mat3x3<f32>(r_data.view[0].xyz, r_data.view[1].xyz, r_data.view[2].xyz));
     let unprojected = r_data.proj_inv * pos;
 
     var result: SkyOutput;

--- a/wgpu/examples/stencil-triangles/main.rs
+++ b/wgpu/examples/stencil-triangles/main.rs
@@ -83,7 +83,7 @@ impl framework::Example for Triangles {
                 module: &shader,
                 entry_point: "fs_main",
                 targets: &[Some(wgpu::ColorTargetState {
-                    format: config.format,
+                    format: config.view_formats[0],
                     blend: None,
                     write_mask: wgpu::ColorWrites::empty(),
                 })],
@@ -120,7 +120,7 @@ impl framework::Example for Triangles {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
-                targets: &[Some(config.format.into())],
+                targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: Default::default(),
             depth_stencil: Some(wgpu::DepthStencilState {

--- a/wgpu/examples/texture-arrays/main.rs
+++ b/wgpu/examples/texture-arrays/main.rs
@@ -333,7 +333,7 @@ impl framework::Example for Example {
             fragment: Some(wgpu::FragmentState {
                 module: fragment_shader_module,
                 entry_point: fragment_entry_point,
-                targets: &[Some(config.format.into())],
+                targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {
                 front_face: wgpu::FrontFace::Ccw,

--- a/wgpu/examples/water/main.rs
+++ b/wgpu/examples/water/main.rs
@@ -193,7 +193,7 @@ impl Example {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: config.format,
+            format: config.view_formats[0],
             usage: wgpu::TextureUsages::TEXTURE_BINDING
                 | wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::RENDER_ATTACHMENT,
@@ -533,7 +533,7 @@ impl framework::Example for Example {
                 // Describes how the colour will be interpolated
                 // and assigned to the output attachment.
                 targets: &[Some(wgpu::ColorTargetState {
-                    format: config.format,
+                    format: config.view_formats[0],
                     blend: Some(wgpu::BlendState {
                         color: wgpu::BlendComponent {
                             src_factor: wgpu::BlendFactor::SrcAlpha,
@@ -593,7 +593,7 @@ impl framework::Example for Example {
             fragment: Some(wgpu::FragmentState {
                 module: &terrain_module,
                 entry_point: "fs_main",
-                targets: &[Some(config.format.into())],
+                targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {
                 front_face: wgpu::FrontFace::Ccw,
@@ -616,7 +616,7 @@ impl framework::Example for Example {
             let mut encoder =
                 device.create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
                     label: None,
-                    color_formats: &[Some(config.format)],
+                    color_formats: &[Some(config.view_formats[0])],
                     depth_stencil: Some(wgpu::RenderBundleDepthStencil {
                         format: wgpu::TextureFormat::Depth32Float,
                         depth_read_only: false,

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -203,7 +203,69 @@ fn map_texture_format(texture_format: wgt::TextureFormat) -> web_sys::GpuTexture
         TextureFormat::Depth32Float => tf::Depth32float,
         // "depth32float-stencil8" feature
         TextureFormat::Depth32FloatStencil8 => tf::Depth32floatStencil8,
-        _ => unimplemented!(),
+
+        TextureFormat::Bc1RgbaUnorm => tf::Bc1RgbaUnorm,
+        TextureFormat::Bc1RgbaUnormSrgb => tf::Bc1RgbaUnormSrgb,
+        TextureFormat::Bc2RgbaUnorm => tf::Bc2RgbaUnorm,
+        TextureFormat::Bc2RgbaUnormSrgb => tf::Bc2RgbaUnormSrgb,
+        TextureFormat::Bc3RgbaUnorm => tf::Bc3RgbaUnorm,
+        TextureFormat::Bc3RgbaUnormSrgb => tf::Bc3RgbaUnormSrgb,
+        TextureFormat::Bc4RUnorm => tf::Bc4RUnorm,
+        TextureFormat::Bc4RSnorm => tf::Bc4RSnorm,
+        TextureFormat::Bc5RgUnorm => tf::Bc5RgUnorm,
+        TextureFormat::Bc5RgSnorm => tf::Bc5RgSnorm,
+        TextureFormat::Bc6hRgbUfloat => tf::Bc6hRgbUfloat,
+        TextureFormat::Bc6hRgbFloat => tf::Bc6hRgbFloat,
+        TextureFormat::Bc7RgbaUnorm => tf::Bc7RgbaUnorm,
+        TextureFormat::Bc7RgbaUnormSrgb => tf::Bc7RgbaUnormSrgb,
+        TextureFormat::Etc2Rgb8Unorm => tf::Etc2Rgb8unorm,
+        TextureFormat::Etc2Rgb8UnormSrgb => tf::Etc2Rgb8unormSrgb,
+        TextureFormat::Etc2Rgb8A1Unorm => tf::Etc2Rgb8a1unorm,
+        TextureFormat::Etc2Rgb8A1UnormSrgb => tf::Etc2Rgb8a1unormSrgb,
+        TextureFormat::Etc2Rgba8Unorm => tf::Etc2Rgba8unorm,
+        TextureFormat::Etc2Rgba8UnormSrgb => tf::Etc2Rgba8unormSrgb,
+        TextureFormat::EacR11Unorm => tf::EacR11unorm,
+        TextureFormat::EacR11Snorm => tf::EacR11snorm,
+        TextureFormat::EacRg11Unorm => tf::EacRg11unorm,
+        TextureFormat::EacRg11Snorm => tf::EacRg11snorm,
+        TextureFormat::Astc { block, channel } => match channel {
+            wgt::AstcChannel::Unorm => match block {
+                wgt::AstcBlock::B4x4 => tf::Astc4x4Unorm,
+                wgt::AstcBlock::B5x4 => tf::Astc5x4Unorm,
+                wgt::AstcBlock::B5x5 => tf::Astc5x5Unorm,
+                wgt::AstcBlock::B6x5 => tf::Astc6x5Unorm,
+                wgt::AstcBlock::B6x6 => tf::Astc6x6Unorm,
+                wgt::AstcBlock::B8x5 => tf::Astc8x5Unorm,
+                wgt::AstcBlock::B8x6 => tf::Astc8x6Unorm,
+                wgt::AstcBlock::B8x8 => tf::Astc8x8Unorm,
+                wgt::AstcBlock::B10x5 => tf::Astc10x5Unorm,
+                wgt::AstcBlock::B10x6 => tf::Astc10x6Unorm,
+                wgt::AstcBlock::B10x8 => tf::Astc10x8Unorm,
+                wgt::AstcBlock::B10x10 => tf::Astc10x10Unorm,
+                wgt::AstcBlock::B12x10 => tf::Astc12x10Unorm,
+                wgt::AstcBlock::B12x12 => tf::Astc12x12Unorm,
+            },
+            wgt::AstcChannel::UnormSrgb => match block {
+                wgt::AstcBlock::B4x4 => tf::Astc4x4UnormSrgb,
+                wgt::AstcBlock::B5x4 => tf::Astc5x4UnormSrgb,
+                wgt::AstcBlock::B5x5 => tf::Astc5x5UnormSrgb,
+                wgt::AstcBlock::B6x5 => tf::Astc6x5UnormSrgb,
+                wgt::AstcBlock::B6x6 => tf::Astc6x6UnormSrgb,
+                wgt::AstcBlock::B8x5 => tf::Astc8x5UnormSrgb,
+                wgt::AstcBlock::B8x6 => tf::Astc8x6UnormSrgb,
+                wgt::AstcBlock::B8x8 => tf::Astc8x8UnormSrgb,
+                wgt::AstcBlock::B10x5 => tf::Astc10x5UnormSrgb,
+                wgt::AstcBlock::B10x6 => tf::Astc10x6UnormSrgb,
+                wgt::AstcBlock::B10x8 => tf::Astc10x8UnormSrgb,
+                wgt::AstcBlock::B10x10 => tf::Astc10x10UnormSrgb,
+                wgt::AstcBlock::B12x10 => tf::Astc12x10UnormSrgb,
+                wgt::AstcBlock::B12x12 => tf::Astc12x12UnormSrgb,
+            },
+            wgt::AstcChannel::Hdr => {
+                unimplemented!("Format {texture_format:?} has no WebGPU equivilant")
+            }
+        },
+        _ => unimplemented!("Format {texture_format:?} has no WebGPU equivilant"),
     }
 }
 
@@ -1688,6 +1750,8 @@ impl crate::context::Context for Context {
         }
         if let Some(ds) = desc.depth_stencil {
             mapped_desc.depth_stencil_format(map_texture_format(ds.format));
+            mapped_desc.depth_read_only(ds.depth_read_only);
+            mapped_desc.stencil_read_only(ds.stencil_read_only);
         }
         mapped_desc.sample_count(desc.sample_count);
         create_identified(device_data.0.create_render_bundle_encoder(&mapped_desc))
@@ -2112,6 +2176,7 @@ impl crate::context::Context for Context {
                 mapped_depth_stencil_attachment.depth_load_op(load_op);
                 mapped_depth_stencil_attachment.depth_store_op(map_store_op(ops.store));
             }
+            mapped_depth_stencil_attachment.depth_read_only(dsa.depth_ops.is_none());
             if let Some(ref ops) = dsa.stencil_ops {
                 let load_op = match ops.load {
                     crate::LoadOp::Clear(v) => {
@@ -2123,6 +2188,7 @@ impl crate::context::Context for Context {
                 mapped_depth_stencil_attachment.stencil_load_op(load_op);
                 mapped_depth_stencil_attachment.stencil_store_op(map_store_op(ops.store));
             }
+            mapped_depth_stencil_attachment.stencil_read_only(dsa.stencil_ops.is_none());
             mapped_desc.depth_stencil_attachment(&mapped_depth_stencil_attachment);
         }
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -936,7 +936,8 @@ static_assertions::assert_impl_all!(Maintain: Send, Sync);
 pub struct TextureViewDescriptor<'a> {
     /// Debug label of the texture view. This will show up in graphics debuggers for easy identification.
     pub label: Label<'a>,
-    /// Format of the texture view. At this time, it must be the same as the underlying format of the texture.
+    /// Format of the texture view. Either must be the same as the texture format or in the list
+    /// of `view_formats` in the texture's descriptor.
     pub format: Option<TextureFormat>,
     /// The dimension of the texture view. For 1D textures, this must be `D1`. For 2D textures it must be one of
     /// `D2`, `D2Array`, `Cube`, and `CubeArray`. For 3D textures it must be `D3`

--- a/wgpu/tests/clear_texture.rs
+++ b/wgpu/tests/clear_texture.rs
@@ -64,7 +64,7 @@ static TEXTURE_FORMATS_BC: &[wgpu::TextureFormat] = &[
     wgpu::TextureFormat::Bc5RgUnorm,
     wgpu::TextureFormat::Bc5RgSnorm,
     wgpu::TextureFormat::Bc6hRgbUfloat,
-    wgpu::TextureFormat::Bc6hRgbSfloat,
+    wgpu::TextureFormat::Bc6hRgbFloat,
     wgpu::TextureFormat::Bc7RgbaUnorm,
     wgpu::TextureFormat::Bc7RgbaUnormSrgb,
 ];


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

