### PR TITLE
remove old comment about swapchain for the web

### DIFF
--- a/wgpu/examples/hello-triangle/main.rs
+++ b/wgpu/examples/hello-triangle/main.rs
@@ -145,7 +145,6 @@ fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     {
         env_logger::init();
-        // Temporarily avoid srgb formats for the swapchain on the web
         pollster::block_on(run(event_loop, window));
     }
     #[cfg(target_arch = "wasm32")]

--- a/wgpu/examples/hello-windows/main.rs
+++ b/wgpu/examples/hello-windows/main.rs
@@ -196,7 +196,6 @@ fn main() {
         }
 
         env_logger::init();
-        // Temporarily avoid srgb formats for the swapchain on the web
         pollster::block_on(run(event_loop, viewports));
     }
     #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
**Checklist**

- [ ] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Those comments were made irrelevant in https://github.com/gfx-rs/wgpu/commit/81bcc726510aaac9261002a1bd9f621263199c0a

**Description**

Remove old comments

**Testing**
_Explain how this change is tested._
