### PR TITLE
reject binding type multisampled when on a float filterable sample type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ By @cwfitzgerald in [#3671](https://github.com/gfx-rs/wgpu/pull/3671).
 - Make error descriptions all upper case. By @cwfitzgerald in [#3549](https://github.com/gfx-rs/wgpu/pull/3549)
 - Don't include ANSI terminal color escape sequences in shader module validation error messages. By @jimblandy in [#3591](https://github.com/gfx-rs/wgpu/pull/3591)
 - Report error messages from DXC compile. By @Davidster in [#3632](https://github.com/gfx-rs/wgpu/pull/3632)
+- Error in native when using a filterable `TextureSampleType::Float` on a multisample `BindingType::Texture`. By @mockersf in [#3686](https://github.com/gfx-rs/wgpu/pull/3686)
 
 #### WebGPU
 

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -29,7 +29,7 @@ pub enum BindGroupLayoutEntryError {
     StorageTextureReadWrite,
     #[error("Arrays of bindings unsupported for this type of binding")]
     ArrayUnsupported,
-    #[error("Binding of TextureSampleType::Float can't be filterable when multisampled")]
+    #[error("Multisampled binding with sample type `TextureSampleType::Float` must have filterable set to false.")]
     SampleTypeFloatFilterableBindingMultisampled,
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -29,6 +29,8 @@ pub enum BindGroupLayoutEntryError {
     StorageTextureReadWrite,
     #[error("Arrays of bindings unsupported for this type of binding")]
     ArrayUnsupported,
+    #[error("Binding of TextureSampleType::Float can't be filterable when multisampled")]
+    SampleTypeFloatFilterableBindingMultisampled,
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
     #[error(transparent)]

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1695,24 +1695,19 @@ impl<A: HalApi> Device<A> {
                     WritableStorage::No,
                 ),
                 Bt::Texture {
-                    multisampled,
-                    sample_type,
+                    multisampled: true,
+                    sample_type: TextureSampleType::Float { filterable: true },
                     ..
                 } => {
-                    if multisampled
-                        && matches!(sample_type, TextureSampleType::Float { filterable: true })
-                    {
-                        return Err(binding_model::CreateBindGroupLayoutError::Entry {
-                            binding: entry.binding,
-                            error: binding_model::BindGroupLayoutEntryError::SampleTypeFloatFilterableBindingMultisampled,
-                        });
-                    } else {
-                        (
-                            Some(wgt::Features::TEXTURE_BINDING_ARRAY),
-                            WritableStorage::No,
-                        )
-                    }
+                    return Err(binding_model::CreateBindGroupLayoutError::Entry {
+                        binding: entry.binding,
+                        error: binding_model::BindGroupLayoutEntryError::SampleTypeFloatFilterableBindingMultisampled,
+                    });
                 }
+                Bt::Texture { .. } => (
+                    Some(wgt::Features::TEXTURE_BINDING_ARRAY),
+                    WritableStorage::No,
+                ),
                 Bt::StorageTexture {
                     access,
                     view_dimension,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**

This binding is failing in webgpu (in Chrome):
```
BindingType::Texture {
  multisampled: true,
  sample_type: TextureSampleType::Float { filterable: true },
  view_dimension: TextureViewDimension::D2,
}
```

with the following error:
```
Sample type TextureSampleType::Float for multisampled texture bindings was TextureSampleType::Float.
 - While validating entries[17]
 - While validating [BindGroupLayoutDescriptor "mesh_view_layout_multisampled"]
 - While calling [Device].CreateBindGroupLayout([BindGroupLayoutDescriptor "mesh_view_layout_multisampled"]).
```

But working in native (metal)

This PR makes it error out in native too with the following error:
```
wgpu error: Validation Error

Caused by:
    In Device::create_bind_group_layout
      note: label = `mesh_view_layout_multisampled`
    Binding 17 entry is invalid
    Binding of TextureSampleType::Float can't be filterable when multisampled
```


**Testing**

Tested with bindings erroring and not erroring in webgpu and in native (metal)