### PR TITLE
add feature RG11B10UFLOAT_RENDERABLE on webgpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ By @cwfitzgerald in [#3671](https://github.com/gfx-rs/wgpu/pull/3671).
 - Implement the new checks for readonly stencils. By @JCapucho in [#3443](https://github.com/gfx-rs/wgpu/pull/3443)
 - Reimplement `adapter|device_features`. By @jinleili in [#3428](https://github.com/gfx-rs/wgpu/pull/3428)
 - Implement `command_encoder_resolve_query_set`. By @JolifantoBambla in [#3489](https://github.com/gfx-rs/wgpu/pull/3489)
+- Add support for `Features::RG11B10UFLOAT_RENDERABLE`. By @mockersf in [#3689](https://github.com/gfx-rs/wgpu/pull/3689)
 
 #### Vulkan
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -296,7 +296,16 @@ bitflags::bitflags! {
         // ? const FLOAT32_BLENDABLE = 1 << 20; (https://github.com/gpuweb/gpuweb/issues/3556)
         // ? const 32BIT_FORMAT_MULTISAMPLE = 1 << 21; (https://github.com/gpuweb/gpuweb/issues/3844)
         // ? const 32BIT_FORMAT_RESOLVE = 1 << 22; (https://github.com/gpuweb/gpuweb/issues/3844)
-        // TODO const RG11B10UFLOAT_RENDERABLE = 1 << 23;
+
+        /// Allows for usage of textures of format [`TextureFormat::Rg11b10Float`] as a render target
+        ///
+        /// Supported platforms:
+        /// - Vulkan
+        /// - DX12
+        /// - Metal
+        ///
+        /// This is a web and native feature.
+        const RG11B10UFLOAT_RENDERABLE = 1 << 23;
 
         /// Allows for explicit creation of textures of format [`TextureFormat::Depth32FloatStencil8`]
         ///

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -621,7 +621,7 @@ fn map_map_mode(mode: crate::MapMode) -> u32 {
     }
 }
 
-const FEATURES_MAPPING: [(wgt::Features, web_sys::GpuFeatureName); 8] = [
+const FEATURES_MAPPING: [(wgt::Features, web_sys::GpuFeatureName); 9] = [
     //TODO: update the name
     (
         wgt::Features::DEPTH_CLIP_CONTROL,
@@ -654,6 +654,10 @@ const FEATURES_MAPPING: [(wgt::Features, web_sys::GpuFeatureName); 8] = [
     (
         wgt::Features::SHADER_F16,
         web_sys::GpuFeatureName::ShaderF16,
+    ),
+    (
+        wgt::Features::RG11B10UFLOAT_RENDERABLE,
+        web_sys::GpuFeatureName::Rg11b10ufloatRenderable,
     ),
 ];
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

**Description**

Add feature `RG11B10UFLOAT_RENDERABLE` on webgpu. I don't think this needs anything else added as, at least for Bevy, it was already working for metal/dx/vulkan

**Testing**

Rendered bloom examples from Bevy on webgpu and metal that use this texture format
webgpu:
<img width="1637" alt="Screenshot 2023-04-14 at 12 13 34" src="https://user-images.githubusercontent.com/8672791/232020835-3e9eb9a6-2abf-49d1-962c-6fd89d506665.png">

metal:
<img width="1280" alt="Screenshot 2023-04-14 at 12 31 11" src="https://user-images.githubusercontent.com/8672791/232020998-246a6922-70f6-4dde-a3d9-e2c8f872610d.png">

