### PR TITLE
Don't implement `Send` or `Sync` on Wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
           set -e
 
           # build for WebGPU
+          cargo clippy --target ${{ matrix.target }} --tests --features glsl,spirv,fragile-send-sync-non-atomic-wasm
           cargo clippy --target ${{ matrix.target }} --tests --features glsl,spirv
           cargo doc --target ${{ matrix.target }} --no-deps --features glsl,spirv
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Bottom level categories:
 - Document feature requirements for `DEPTH32FLOAT_STENCIL8` by @ErichDonGubler in [#3734](https://github.com/gfx-rs/wgpu/pull/3734).
 - Flesh out docs. for `AdapterInfo::{device,vendor}` by @ErichDonGubler in [#3763](https://github.com/gfx-rs/wgpu/pull/3763).
 - Spell out which sizes are in bytes. By @jimblandy in [#3773](https://github.com/gfx-rs/wgpu/pull/3773).
+- On Web, types don't implement `Send` or `Sync` anymore. By @daxpedda in [#3691](https://github.com/gfx-rs/wgpu/pull/3691)
 
 ### Bug Fixes
 

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -48,6 +48,8 @@ serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
 id32 = []
 # Enable `ShaderModuleSource::Wgsl`
 wgsl = ["naga/wgsl-in"]
+# Implement `Send` and `Sync` on Wasm.
+fragile-send-sync-non-atomic-wasm = ["hal/fragile-send-sync-non-atomic-wasm", "wgt/fragile-send-sync-non-atomic-wasm"]
 
 [dependencies]
 arrayvec = "0.7"

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -746,7 +746,9 @@ pub struct RenderBundle<A: HalApi> {
     pub(crate) life_guard: LifeGuard,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 unsafe impl<A: HalApi> Send for RenderBundle<A> {}
+#[cfg(not(target_arch = "wasm32"))]
 unsafe impl<A: HalApi> Sync for RenderBundle<A> {}
 
 impl<A: HalApi> RenderBundle<A> {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -746,9 +746,21 @@ pub struct RenderBundle<A: HalApi> {
     pub(crate) life_guard: LifeGuard,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 unsafe impl<A: HalApi> Send for RenderBundle<A> {}
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 unsafe impl<A: HalApi> Sync for RenderBundle<A> {}
 
 impl<A: HalApi> RenderBundle<A> {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -37,6 +37,7 @@ pub struct SubmittedWorkDoneClosureC {
     pub user_data: *mut u8,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 unsafe impl Send for SubmittedWorkDoneClosureC {}
 
 pub struct SubmittedWorkDoneClosure {
@@ -45,17 +46,18 @@ pub struct SubmittedWorkDoneClosure {
     inner: SubmittedWorkDoneClosureInner,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+type SubmittedWorkDoneCallback = Box<dyn FnOnce() + Send + 'static>;
+#[cfg(target_arch = "wasm32")]
+type SubmittedWorkDoneCallback = Box<dyn FnOnce() + 'static>;
+
 enum SubmittedWorkDoneClosureInner {
-    Rust {
-        callback: Box<dyn FnOnce() + Send + 'static>,
-    },
-    C {
-        inner: SubmittedWorkDoneClosureC,
-    },
+    Rust { callback: SubmittedWorkDoneCallback },
+    C { inner: SubmittedWorkDoneClosureC },
 }
 
 impl SubmittedWorkDoneClosure {
-    pub fn from_rust(callback: Box<dyn FnOnce() + Send + 'static>) -> Self {
+    pub fn from_rust(callback: SubmittedWorkDoneCallback) -> Self {
         Self {
             inner: SubmittedWorkDoneClosureInner::Rust { callback },
         }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -37,7 +37,13 @@ pub struct SubmittedWorkDoneClosureC {
     pub user_data: *mut u8,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 unsafe impl Send for SubmittedWorkDoneClosureC {}
 
 pub struct SubmittedWorkDoneClosure {
@@ -46,9 +52,21 @@ pub struct SubmittedWorkDoneClosure {
     inner: SubmittedWorkDoneClosureInner,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 type SubmittedWorkDoneCallback = Box<dyn FnOnce() + Send + 'static>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+)))]
 type SubmittedWorkDoneCallback = Box<dyn FnOnce() + 'static>;
 
 enum SubmittedWorkDoneClosureInner {

--- a/wgpu-core/src/error.rs
+++ b/wgpu-core/src/error.rs
@@ -162,7 +162,10 @@ pub fn format_pretty_any(
 #[derive(Debug)]
 pub struct ContextError {
     pub string: &'static str,
+    #[cfg(not(target_arch = "wasm32"))]
     pub cause: Box<dyn Error + Send + Sync + 'static>,
+    #[cfg(target_arch = "wasm32")]
+    pub cause: Box<dyn Error + 'static>,
     pub label_key: &'static str,
     pub label: String,
 }

--- a/wgpu-core/src/error.rs
+++ b/wgpu-core/src/error.rs
@@ -162,9 +162,21 @@ pub fn format_pretty_any(
 #[derive(Debug)]
 pub struct ContextError {
     pub string: &'static str,
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        all(
+            feature = "fragile-send-sync-non-atomic-wasm",
+            not(target_feature = "atomics")
+        )
+    ))]
     pub cause: Box<dyn Error + Send + Sync + 'static>,
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(not(any(
+        not(target_arch = "wasm32"),
+        all(
+            feature = "fragile-send-sync-non-atomic-wasm",
+            not(target_feature = "atomics")
+        )
+    )))]
     pub cause: Box<dyn Error + 'static>,
     pub label_key: &'static str,
     pub label: String,

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -155,7 +155,16 @@ impl<G: GlobalIdentityHandlerFactory> Drop for Global<G> {
     }
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(
+    test,
+    any(
+        not(target_arch = "wasm32"),
+        all(
+            feature = "fragile-send-sync-non-atomic-wasm",
+            not(target_feature = "atomics")
+        )
+    )
+))]
 fn _test_send_sync(global: &Global<crate::identity::IdentityManagerFactory>) {
     fn test_internal<T: Send + Sync>(_: T) {}
     test_internal(global)

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -155,7 +155,7 @@ impl<G: GlobalIdentityHandlerFactory> Drop for Global<G> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 fn _test_send_sync(global: &Global<crate::identity::IdentityManagerFactory>) {
     fn test_internal<T: Send + Sync>(_: T) {}
     test_internal(global)

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -79,9 +79,21 @@ pub(crate) enum BufferMapState<A: hal::Api> {
     Idle,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 unsafe impl<A: hal::Api> Send for BufferMapState<A> {}
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 unsafe impl<A: hal::Api> Sync for BufferMapState<A> {}
 
 #[repr(C)]
@@ -90,7 +102,13 @@ pub struct BufferMapCallbackC {
     pub user_data: *mut u8,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 unsafe impl Send for BufferMapCallbackC {}
 
 pub struct BufferMapCallback {
@@ -99,9 +117,21 @@ pub struct BufferMapCallback {
     inner: Option<BufferMapCallbackInner>,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 type BufferMapCallbackCallback = Box<dyn FnOnce(BufferAccessResult) + Send + 'static>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+)))]
 type BufferMapCallbackCallback = Box<dyn FnOnce(BufferAccessResult) + 'static>;
 
 enum BufferMapCallbackInner {

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -43,6 +43,7 @@ dx12 = ["naga/hlsl-out", "d3d12", "bit-set", "range-alloc", "winapi/std", "winap
 windows_rs = ["gpu-allocator"]
 dxc_shader_compiler = ["hassle-rs"]
 renderdoc = ["libloading", "renderdoc-sys"]
+fragile-send-sync-non-atomic-wasm = ["wgt/fragile-send-sync-non-atomic-wasm"]
 
 [[example]]
 name = "halmark"

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -936,12 +936,6 @@ impl super::AdapterShared {
     }
 }
 
-// SAFE: Wasm doesn't have threads
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for super::Adapter {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for super::Adapter {}
-
 #[cfg(test)]
 mod tests {
     use super::super::Adapter;

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -936,6 +936,19 @@ impl super::AdapterShared {
     }
 }
 
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for super::Adapter {}
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for super::Adapter {}
+
 #[cfg(test)]
 mod tests {
     use super::super::Adapter;

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1320,9 +1320,3 @@ impl crate::Device<super::Api> for super::Device {
         }
     }
 }
-
-// SAFE: Wasm doesn't have threads
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for super::Device {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for super::Device {}

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1320,3 +1320,16 @@ impl crate::Device<super::Api> for super::Device {
         }
     }
 }
+
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for super::Device {}
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for super::Device {}

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -246,12 +246,6 @@ pub struct Buffer {
     data: Option<Arc<std::sync::Mutex<Vec<u8>>>>,
 }
 
-// Safe: Wasm doesn't have threads
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for Buffer {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for Buffer {}
-
 #[derive(Clone, Debug)]
 pub enum TextureInner {
     Renderbuffer {
@@ -267,12 +261,6 @@ pub enum TextureInner {
         inner: web_sys::WebGlFramebuffer,
     },
 }
-
-// SAFE: Wasm doesn't have threads
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for TextureInner {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for TextureInner {}
 
 impl TextureInner {
     fn as_native(&self) -> (glow::Texture, BindTarget) {
@@ -462,12 +450,6 @@ struct UniformDesc {
     utype: u32,
 }
 
-// Safe: Wasm doesn't have threads
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for UniformDesc {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for UniformDesc {}
-
 /// For each texture in the pipeline layout, store the index of the only
 /// sampler (in this layout) that the texture is used with.
 type SamplerBindMap = [Option<u8>; MAX_TEXTURE_SLOTS];
@@ -530,21 +512,9 @@ pub struct RenderPipeline {
     alpha_to_coverage_enabled: bool,
 }
 
-// SAFE: Wasm doesn't have threads
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for RenderPipeline {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for RenderPipeline {}
-
 pub struct ComputePipeline {
     inner: Arc<PipelineInner>,
 }
-
-// SAFE: Wasm doesn't have threads
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for ComputePipeline {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for ComputePipeline {}
 
 #[derive(Debug)]
 pub struct QuerySet {
@@ -558,7 +528,9 @@ pub struct Fence {
     pending: Vec<(crate::FenceValue, glow::Fence)>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 unsafe impl Send for Fence {}
+#[cfg(not(target_arch = "wasm32"))]
 unsafe impl Sync for Fence {}
 
 impl Fence {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -246,6 +246,19 @@ pub struct Buffer {
     data: Option<Arc<std::sync::Mutex<Vec<u8>>>>,
 }
 
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for Buffer {}
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for Buffer {}
+
 #[derive(Clone, Debug)]
 pub enum TextureInner {
     Renderbuffer {
@@ -261,6 +274,19 @@ pub enum TextureInner {
         inner: web_sys::WebGlFramebuffer,
     },
 }
+
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for TextureInner {}
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for TextureInner {}
 
 impl TextureInner {
     fn as_native(&self) -> (glow::Texture, BindTarget) {
@@ -450,6 +476,19 @@ struct UniformDesc {
     utype: u32,
 }
 
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for UniformDesc {}
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for UniformDesc {}
+
 /// For each texture in the pipeline layout, store the index of the only
 /// sampler (in this layout) that the texture is used with.
 type SamplerBindMap = [Option<u8>; MAX_TEXTURE_SLOTS];
@@ -512,9 +551,35 @@ pub struct RenderPipeline {
     alpha_to_coverage_enabled: bool,
 }
 
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for RenderPipeline {}
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for RenderPipeline {}
+
 pub struct ComputePipeline {
     inner: Arc<PipelineInner>,
 }
+
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for ComputePipeline {}
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for ComputePipeline {}
 
 #[derive(Debug)]
 pub struct QuerySet {
@@ -528,9 +593,21 @@ pub struct Fence {
     pending: Vec<(crate::FenceValue, glow::Fence)>,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 unsafe impl Send for Fence {}
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 unsafe impl Sync for Fence {}
 
 impl Fence {

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1524,3 +1524,16 @@ impl crate::Queue<super::Api> for super::Queue {
         1.0
     }
 }
+
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for super::Queue {}
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for super::Queue {}

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1524,9 +1524,3 @@ impl crate::Queue<super::Api> for super::Queue {
         1.0
     }
 }
-
-// SAFE: Wasm doesn't have threads
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for super::Queue {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for super::Queue {}

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -106,6 +106,17 @@ impl Instance {
     }
 }
 
+#[cfg(all(
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for Instance {}
+#[cfg(all(
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for Instance {}
+
 impl crate::Instance<super::Api> for Instance {
     unsafe fn init(_desc: &crate::InstanceDescriptor) -> Result<Self, crate::InstanceError> {
         Ok(Instance {
@@ -166,6 +177,17 @@ pub struct Surface {
     pub(super) presentable: bool,
     srgb_present_program: Option<glow::Program>,
 }
+
+#[cfg(all(
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for Surface {}
+#[cfg(all(
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for Surface {}
 
 #[derive(Clone, Debug)]
 enum Canvas {

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -106,10 +106,6 @@ impl Instance {
     }
 }
 
-// SAFE: Wasm doesn't have threads
-unsafe impl Sync for Instance {}
-unsafe impl Send for Instance {}
-
 impl crate::Instance<super::Api> for Instance {
     unsafe fn init(_desc: &crate::InstanceDescriptor) -> Result<Self, crate::InstanceError> {
         Ok(Instance {
@@ -176,10 +172,6 @@ enum Canvas {
     Canvas(web_sys::HtmlCanvasElement),
     Offscreen(web_sys::OffscreenCanvas),
 }
-
-// SAFE: Because web doesn't have threads ( yet )
-unsafe impl Sync for Surface {}
-unsafe impl Send for Surface {}
 
 #[derive(Clone, Debug)]
 pub struct Swapchain {

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -95,6 +95,7 @@ use std::{
 
 use bitflags::bitflags;
 use thiserror::Error;
+use wgt::{WasmNotSend, WasmNotSync};
 
 pub const MAX_ANISOTROPY: u8 = 16;
 pub const MAX_BIND_GROUPS: usize = 8;
@@ -161,25 +162,25 @@ pub trait Api: Clone + Sized {
 
     type Queue: Queue<Self>;
     type CommandEncoder: CommandEncoder<Self>;
-    type CommandBuffer: MaybeSend + MaybeSync + fmt::Debug;
+    type CommandBuffer: WasmNotSend + WasmNotSync + fmt::Debug;
 
-    type Buffer: fmt::Debug + MaybeSend + MaybeSync + 'static;
-    type Texture: fmt::Debug + MaybeSend + MaybeSync + 'static;
-    type SurfaceTexture: fmt::Debug + MaybeSend + MaybeSync + Borrow<Self::Texture>;
-    type TextureView: fmt::Debug + MaybeSend + MaybeSync;
-    type Sampler: fmt::Debug + MaybeSend + MaybeSync;
-    type QuerySet: fmt::Debug + MaybeSend + MaybeSync;
-    type Fence: fmt::Debug + MaybeSend + MaybeSync;
+    type Buffer: fmt::Debug + WasmNotSend + WasmNotSync + 'static;
+    type Texture: fmt::Debug + WasmNotSend + WasmNotSync + 'static;
+    type SurfaceTexture: fmt::Debug + WasmNotSend + WasmNotSync + Borrow<Self::Texture>;
+    type TextureView: fmt::Debug + WasmNotSend + WasmNotSync;
+    type Sampler: fmt::Debug + WasmNotSend + WasmNotSync;
+    type QuerySet: fmt::Debug + WasmNotSend + WasmNotSync;
+    type Fence: fmt::Debug + WasmNotSend + WasmNotSync;
 
-    type BindGroupLayout: MaybeSend + MaybeSync;
-    type BindGroup: fmt::Debug + MaybeSend + MaybeSync;
-    type PipelineLayout: MaybeSend + MaybeSync;
-    type ShaderModule: fmt::Debug + MaybeSend + MaybeSync;
-    type RenderPipeline: MaybeSend + MaybeSync;
-    type ComputePipeline: MaybeSend + MaybeSync;
+    type BindGroupLayout: WasmNotSend + WasmNotSync;
+    type BindGroup: fmt::Debug + WasmNotSend + WasmNotSync;
+    type PipelineLayout: WasmNotSend + WasmNotSync;
+    type ShaderModule: fmt::Debug + WasmNotSend + WasmNotSync;
+    type RenderPipeline: WasmNotSend + WasmNotSync;
+    type ComputePipeline: WasmNotSend + WasmNotSync;
 }
 
-pub trait Instance<A: Api>: Sized + MaybeSend + MaybeSync {
+pub trait Instance<A: Api>: Sized + WasmNotSend + WasmNotSync {
     unsafe fn init(desc: &InstanceDescriptor) -> Result<Self, InstanceError>;
     unsafe fn create_surface(
         &self,
@@ -190,7 +191,7 @@ pub trait Instance<A: Api>: Sized + MaybeSend + MaybeSync {
     unsafe fn enumerate_adapters(&self) -> Vec<ExposedAdapter<A>>;
 }
 
-pub trait Surface<A: Api>: MaybeSend + MaybeSync {
+pub trait Surface<A: Api>: WasmNotSend + WasmNotSync {
     unsafe fn configure(
         &mut self,
         device: &A::Device,
@@ -216,7 +217,7 @@ pub trait Surface<A: Api>: MaybeSend + MaybeSync {
     unsafe fn discard_texture(&mut self, texture: A::SurfaceTexture);
 }
 
-pub trait Adapter<A: Api>: MaybeSend + MaybeSync {
+pub trait Adapter<A: Api>: WasmNotSend + WasmNotSync {
     unsafe fn open(
         &self,
         features: wgt::Features,
@@ -240,7 +241,7 @@ pub trait Adapter<A: Api>: MaybeSend + MaybeSync {
     unsafe fn get_presentation_timestamp(&self) -> wgt::PresentationTimestamp;
 }
 
-pub trait Device<A: Api>: MaybeSend + MaybeSync {
+pub trait Device<A: Api>: WasmNotSend + WasmNotSync {
     /// Exit connection to this logical device.
     unsafe fn exit(self, queue: A::Queue);
     /// Creates a new buffer.
@@ -336,7 +337,7 @@ pub trait Device<A: Api>: MaybeSend + MaybeSync {
     unsafe fn stop_capture(&self);
 }
 
-pub trait Queue<A: Api>: MaybeSend + MaybeSync {
+pub trait Queue<A: Api>: WasmNotSend + WasmNotSync {
     /// Submits the command buffers for execution on GPU.
     ///
     /// Valid usage:
@@ -360,7 +361,7 @@ pub trait Queue<A: Api>: MaybeSend + MaybeSync {
 /// Serves as a parent for all the encoded command buffers.
 /// Works in bursts of action: one or more command buffers are recorded,
 /// then submitted to a queue, and then it needs to be `reset_all()`.
-pub trait CommandEncoder<A: Api>: MaybeSend + MaybeSync + fmt::Debug {
+pub trait CommandEncoder<A: Api>: WasmNotSend + WasmNotSync + fmt::Debug {
     /// Begin encoding a new command buffer.
     unsafe fn begin_encoding(&mut self, label: Label) -> Result<(), DeviceError>;
     /// Discard currently recorded list, if any.
@@ -1307,28 +1308,6 @@ impl ValidationCanary {
     pub fn get_and_reset(&self) -> bool {
         self.inner.swap(false, std::sync::atomic::Ordering::SeqCst)
     }
-}
-
-use send_sync::*;
-
-mod send_sync {
-    #[cfg(not(target_arch = "wasm32"))]
-    pub trait MaybeSend: Send {}
-    #[cfg(not(target_arch = "wasm32"))]
-    impl<T: Send> MaybeSend for T {}
-    #[cfg(target_arch = "wasm32")]
-    pub trait MaybeSend {}
-    #[cfg(target_arch = "wasm32")]
-    impl<T> MaybeSend for T {}
-
-    #[cfg(not(target_arch = "wasm32"))]
-    pub trait MaybeSync: Sync {}
-    #[cfg(not(target_arch = "wasm32"))]
-    impl<T: Sync> MaybeSync for T {}
-    #[cfg(target_arch = "wasm32")]
-    pub trait MaybeSync {}
-    #[cfg(target_arch = "wasm32")]
-    impl<T> MaybeSync for T {}
 }
 
 #[test]

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -25,6 +25,7 @@ targets = [
 trace = ["serde"]
 replay = ["serde"]
 strict_asserts = []
+fragile-send-sync-non-atomic-wasm = []
 
 [dependencies]
 bitflags = "2"

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -6312,3 +6312,26 @@ impl Default for InstanceDescriptor {
         }
     }
 }
+
+pub use send_sync::*;
+
+#[doc(hidden)]
+mod send_sync {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub trait WasmNotSend: Send {}
+    #[cfg(not(target_arch = "wasm32"))]
+    impl<T: Send> WasmNotSend for T {}
+    #[cfg(target_arch = "wasm32")]
+    pub trait WasmNotSend {}
+    #[cfg(target_arch = "wasm32")]
+    impl<T> WasmNotSend for T {}
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub trait WasmNotSync: Sync {}
+    #[cfg(not(target_arch = "wasm32"))]
+    impl<T: Sync> WasmNotSync for T {}
+    #[cfg(target_arch = "wasm32")]
+    pub trait WasmNotSync {}
+    #[cfg(target_arch = "wasm32")]
+    impl<T> WasmNotSync for T {}
+}

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -5917,6 +5917,19 @@ impl std::ops::Deref for ExternalImageSource {
     }
 }
 
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for ExternalImageSource {}
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for ExternalImageSource {}
+
 /// Color spaces supported on the web.
 ///
 /// Corresponds to [HTML Canvas `PredefinedColorSpace`](
@@ -6317,21 +6330,69 @@ pub use send_sync::*;
 
 #[doc(hidden)]
 mod send_sync {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        all(
+            feature = "fragile-send-sync-non-atomic-wasm",
+            not(target_feature = "atomics")
+        )
+    ))]
     pub trait WasmNotSend: Send {}
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        all(
+            feature = "fragile-send-sync-non-atomic-wasm",
+            not(target_feature = "atomics")
+        )
+    ))]
     impl<T: Send> WasmNotSend for T {}
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(not(any(
+        not(target_arch = "wasm32"),
+        all(
+            feature = "fragile-send-sync-non-atomic-wasm",
+            not(target_feature = "atomics")
+        )
+    )))]
     pub trait WasmNotSend {}
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(not(any(
+        not(target_arch = "wasm32"),
+        all(
+            feature = "fragile-send-sync-non-atomic-wasm",
+            not(target_feature = "atomics")
+        )
+    )))]
     impl<T> WasmNotSend for T {}
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        all(
+            feature = "fragile-send-sync-non-atomic-wasm",
+            not(target_feature = "atomics")
+        )
+    ))]
     pub trait WasmNotSync: Sync {}
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        all(
+            feature = "fragile-send-sync-non-atomic-wasm",
+            not(target_feature = "atomics")
+        )
+    ))]
     impl<T: Sync> WasmNotSync for T {}
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(not(any(
+        not(target_arch = "wasm32"),
+        all(
+            feature = "fragile-send-sync-non-atomic-wasm",
+            not(target_feature = "atomics")
+        )
+    )))]
     pub trait WasmNotSync {}
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(not(any(
+        not(target_arch = "wasm32"),
+        all(
+            feature = "fragile-send-sync-non-atomic-wasm",
+            not(target_feature = "atomics")
+        )
+    )))]
     impl<T> WasmNotSync for T {}
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -5917,11 +5917,6 @@ impl std::ops::Deref for ExternalImageSource {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for ExternalImageSource {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for ExternalImageSource {}
-
 /// Color spaces supported on the web.
 ///
 /// Corresponds to [HTML Canvas `PredefinedColorSpace`](

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -38,6 +38,8 @@ angle = ["wgc/angle"]
 webgl = ["hal", "wgc"]
 vulkan-portability = ["wgc/vulkan"]
 expose-ids = []
+# Implement `Send` and `Sync` on Wasm.
+fragile-send-sync-non-atomic-wasm = ["hal/fragile-send-sync-non-atomic-wasm", "wgc/fragile-send-sync-non-atomic-wasm", "wgt/fragile-send-sync-non-atomic-wasm"]
 
 # wgpu-core is always available as an optional dependency, "wgc".
 # Whenever wgpu-core is selected, we want the GLES backend and raw

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -2,8 +2,8 @@ use crate::{
     context::{ObjectId, Unused},
     AdapterInfo, BindGroupDescriptor, BindGroupLayoutDescriptor, BindingResource, BufferBinding,
     CommandEncoderDescriptor, ComputePassDescriptor, ComputePipelineDescriptor,
-    DownlevelCapabilities, Features, Label, Limits, LoadOp, MapMode, MaybeSend, MaybeSync,
-    Operations, PipelineLayoutDescriptor, RenderBundleEncoderDescriptor, RenderPipelineDescriptor,
+    DownlevelCapabilities, Features, Label, Limits, LoadOp, MapMode, Operations,
+    PipelineLayoutDescriptor, RenderBundleEncoderDescriptor, RenderPipelineDescriptor,
     SamplerDescriptor, ShaderModuleDescriptor, ShaderModuleDescriptorSpirV, ShaderSource,
     SurfaceStatus, TextureDescriptor, TextureViewDescriptor, UncapturedErrorHandler,
 };
@@ -23,6 +23,7 @@ use std::{
 };
 use wgc::command::{bundle_ffi::*, compute_ffi::*, render_ffi::*};
 use wgc::id::TypedId;
+use wgt::{WasmNotSend, WasmNotSync};
 
 const LABEL: &str = "label";
 
@@ -263,7 +264,7 @@ impl Context {
     fn handle_error(
         &self,
         sink_mutex: &Mutex<ErrorSinkRaw>,
-        cause: impl Error + MaybeSend + MaybeSync + 'static,
+        cause: impl Error + WasmNotSend + WasmNotSync + 'static,
         label_key: &'static str,
         label: Label,
         string: &'static str,
@@ -297,7 +298,7 @@ impl Context {
     fn handle_error_nolabel(
         &self,
         sink_mutex: &Mutex<ErrorSinkRaw>,
-        cause: impl Error + MaybeSend + MaybeSync + 'static,
+        cause: impl Error + WasmNotSend + WasmNotSync + 'static,
         string: &'static str,
     ) {
         self.handle_error(sink_mutex, cause, "", None, string)
@@ -306,7 +307,7 @@ impl Context {
     #[track_caller]
     fn handle_error_fatal(
         &self,
-        cause: impl Error + MaybeSend + MaybeSync + 'static,
+        cause: impl Error + WasmNotSend + WasmNotSync + 'static,
         operation: &'static str,
     ) -> ! {
         panic!("Error in {operation}: {f}", f = self.format_error(&cause));

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -3052,9 +3052,21 @@ pub struct BufferMappedRange {
     size: usize,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 unsafe impl Send for BufferMappedRange {}
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 unsafe impl Sync for BufferMappedRange {}
 
 impl crate::context::BufferMappedRange for BufferMappedRange {

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -19,14 +19,14 @@ use crate::{
     UncapturedErrorHandler,
 };
 
-fn create_identified<T>(value: T) -> (Identified<T>, T) {
+fn create_identified<T>(value: T) -> (Identified<T>, Sendable<T>) {
     cfg_if::cfg_if! {
         if #[cfg(feature = "expose-ids")] {
             static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
             let id = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            (Identified(core::num::NonZeroU64::new(id).unwrap(), PhantomData), value)
+            (Identified(core::num::NonZeroU64::new(id).unwrap(), PhantomData), Sendable(value))
         } else {
-            (Identified(PhantomData), value)
+            (Identified(PhantomData), Sendable(value))
         }
     }
 }
@@ -64,12 +64,45 @@ impl<T> From<Identified<T>> for ObjectId {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) struct Sendable<T>(T);
+#[cfg(all(
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl<T> Send for Sendable<T> {}
+#[cfg(all(
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl<T> Sync for Sendable<T> {}
+
+#[derive(Clone, Debug)]
 pub(crate) struct Identified<T>(
     #[cfg(feature = "expose-ids")] std::num::NonZeroU64,
     PhantomData<T>,
 );
+#[cfg(all(
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl<T> Send for Identified<T> {}
+#[cfg(all(
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl<T> Sync for Identified<T> {}
 
 pub(crate) struct Context(web_sys::Gpu);
+#[cfg(all(
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for Context {}
+#[cfg(all(
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for Context {}
 
 impl fmt::Debug for Context {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -98,12 +131,12 @@ impl crate::Error {
 // This is safe on wasm32 *for now*, but similarly to the unsafe Send impls for the handle type
 // wrappers, the full story for threading on wasm32 is still unfolding.
 
-pub(crate) struct MapFuture<F, M> {
+pub(crate) struct MakeSendFuture<F, M> {
     future: F,
     map: M,
 }
 
-impl<F: Future, M: Fn(F::Output) -> T, T> Future for MapFuture<F, M> {
+impl<F: Future, M: Fn(F::Output) -> T, T> Future for MakeSendFuture<F, M> {
     type Output = T;
 
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
@@ -119,11 +152,17 @@ impl<F: Future, M: Fn(F::Output) -> T, T> Future for MapFuture<F, M> {
     }
 }
 
-impl<F, M> MapFuture<F, M> {
+impl<F, M> MakeSendFuture<F, M> {
     fn new(future: F, map: M) -> Self {
         Self { future, map }
     }
 }
+
+#[cfg(all(
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl<F, M> Send for MakeSendFuture<F, M> {}
 
 fn map_texture_format(texture_format: wgt::TextureFormat) -> web_sys::GpuTextureFormat {
     use web_sys::GpuTextureFormat as tf;
@@ -504,7 +543,7 @@ fn map_texture_view_dimension(
 
 fn map_buffer_copy_view(view: crate::ImageCopyBuffer) -> web_sys::GpuImageCopyBuffer {
     let buffer: &<Context as crate::Context>::BufferData = downcast_ref(view.buffer.data.as_ref());
-    let mut mapped = web_sys::GpuImageCopyBuffer::new(buffer);
+    let mut mapped = web_sys::GpuImageCopyBuffer::new(&buffer.0);
     if let Some(bytes_per_row) = view.layout.bytes_per_row {
         mapped.bytes_per_row(bytes_per_row);
     }
@@ -518,7 +557,7 @@ fn map_buffer_copy_view(view: crate::ImageCopyBuffer) -> web_sys::GpuImageCopyBu
 fn map_texture_copy_view(view: crate::ImageCopyTexture) -> web_sys::GpuImageCopyTexture {
     let texture: &<Context as crate::Context>::TextureData =
         downcast_ref(view.texture.data.as_ref());
-    let mut mapped = web_sys::GpuImageCopyTexture::new(texture);
+    let mut mapped = web_sys::GpuImageCopyTexture::new(&texture.0);
     mapped.mip_level(view.mip_level);
     mapped.origin(&map_origin_3d(view.origin));
     mapped
@@ -529,7 +568,7 @@ fn map_tagged_texture_copy_view(
 ) -> web_sys::GpuImageCopyTextureTagged {
     let texture: &<Context as crate::Context>::TextureData =
         downcast_ref(view.texture.data.as_ref());
-    let mut mapped = web_sys::GpuImageCopyTextureTagged::new(texture);
+    let mut mapped = web_sys::GpuImageCopyTextureTagged::new(&texture.0);
     mapped.mip_level(view.mip_level);
     mapped.origin(&map_origin_3d(view.origin));
     mapped.aspect(map_texture_aspect(view.aspect));
@@ -652,7 +691,10 @@ type JsFutureResult = Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>;
 
 fn future_request_adapter(
     result: JsFutureResult,
-) -> Option<(Identified<web_sys::GpuAdapter>, web_sys::GpuAdapter)> {
+) -> Option<(
+    Identified<web_sys::GpuAdapter>,
+    Sendable<web_sys::GpuAdapter>,
+)> {
     match result.and_then(wasm_bindgen::JsCast::dyn_into) {
         Ok(adapter) => Some(create_identified(adapter)),
         Err(_) => None,
@@ -664,16 +706,16 @@ fn future_request_device(
 ) -> Result<
     (
         Identified<web_sys::GpuDevice>,
-        web_sys::GpuDevice,
+        Sendable<web_sys::GpuDevice>,
         Identified<web_sys::GpuQueue>,
-        web_sys::GpuQueue,
+        Sendable<web_sys::GpuQueue>,
     ),
     crate::RequestDeviceError,
 > {
     result
         .map(|js_value| {
             let (device_id, device_data) = create_identified(web_sys::GpuDevice::from(js_value));
-            let (queue_id, queue_data) = create_identified(device_data.queue());
+            let (queue_id, queue_data) = create_identified(device_data.0.queue());
 
             (device_id, device_data, queue_id, queue_data)
         })
@@ -828,57 +870,57 @@ pub enum Canvas {
 
 impl crate::context::Context for Context {
     type AdapterId = Identified<web_sys::GpuAdapter>;
-    type AdapterData = web_sys::GpuAdapter;
+    type AdapterData = Sendable<web_sys::GpuAdapter>;
     type DeviceId = Identified<web_sys::GpuDevice>;
-    type DeviceData = web_sys::GpuDevice;
+    type DeviceData = Sendable<web_sys::GpuDevice>;
     type QueueId = Identified<web_sys::GpuQueue>;
-    type QueueData = web_sys::GpuQueue;
+    type QueueData = Sendable<web_sys::GpuQueue>;
     type ShaderModuleId = Identified<web_sys::GpuShaderModule>;
-    type ShaderModuleData = web_sys::GpuShaderModule;
+    type ShaderModuleData = Sendable<web_sys::GpuShaderModule>;
     type BindGroupLayoutId = Identified<web_sys::GpuBindGroupLayout>;
-    type BindGroupLayoutData = web_sys::GpuBindGroupLayout;
+    type BindGroupLayoutData = Sendable<web_sys::GpuBindGroupLayout>;
     type BindGroupId = Identified<web_sys::GpuBindGroup>;
-    type BindGroupData = web_sys::GpuBindGroup;
+    type BindGroupData = Sendable<web_sys::GpuBindGroup>;
     type TextureViewId = Identified<web_sys::GpuTextureView>;
-    type TextureViewData = web_sys::GpuTextureView;
+    type TextureViewData = Sendable<web_sys::GpuTextureView>;
     type SamplerId = Identified<web_sys::GpuSampler>;
-    type SamplerData = web_sys::GpuSampler;
+    type SamplerData = Sendable<web_sys::GpuSampler>;
     type BufferId = Identified<web_sys::GpuBuffer>;
-    type BufferData = web_sys::GpuBuffer;
+    type BufferData = Sendable<web_sys::GpuBuffer>;
     type TextureId = Identified<web_sys::GpuTexture>;
-    type TextureData = web_sys::GpuTexture;
+    type TextureData = Sendable<web_sys::GpuTexture>;
     type QuerySetId = Identified<web_sys::GpuQuerySet>;
-    type QuerySetData = web_sys::GpuQuerySet;
+    type QuerySetData = Sendable<web_sys::GpuQuerySet>;
     type PipelineLayoutId = Identified<web_sys::GpuPipelineLayout>;
-    type PipelineLayoutData = web_sys::GpuPipelineLayout;
+    type PipelineLayoutData = Sendable<web_sys::GpuPipelineLayout>;
     type RenderPipelineId = Identified<web_sys::GpuRenderPipeline>;
-    type RenderPipelineData = web_sys::GpuRenderPipeline;
+    type RenderPipelineData = Sendable<web_sys::GpuRenderPipeline>;
     type ComputePipelineId = Identified<web_sys::GpuComputePipeline>;
-    type ComputePipelineData = web_sys::GpuComputePipeline;
+    type ComputePipelineData = Sendable<web_sys::GpuComputePipeline>;
     type CommandEncoderId = Identified<web_sys::GpuCommandEncoder>;
-    type CommandEncoderData = web_sys::GpuCommandEncoder;
+    type CommandEncoderData = Sendable<web_sys::GpuCommandEncoder>;
     type ComputePassId = Identified<web_sys::GpuComputePassEncoder>;
-    type ComputePassData = web_sys::GpuComputePassEncoder;
+    type ComputePassData = Sendable<web_sys::GpuComputePassEncoder>;
     type RenderPassId = Identified<web_sys::GpuRenderPassEncoder>;
-    type RenderPassData = web_sys::GpuRenderPassEncoder;
+    type RenderPassData = Sendable<web_sys::GpuRenderPassEncoder>;
     type CommandBufferId = Identified<web_sys::GpuCommandBuffer>;
-    type CommandBufferData = web_sys::GpuCommandBuffer;
+    type CommandBufferData = Sendable<web_sys::GpuCommandBuffer>;
     type RenderBundleEncoderId = Identified<web_sys::GpuRenderBundleEncoder>;
-    type RenderBundleEncoderData = web_sys::GpuRenderBundleEncoder;
+    type RenderBundleEncoderData = Sendable<web_sys::GpuRenderBundleEncoder>;
     type RenderBundleId = Identified<web_sys::GpuRenderBundle>;
-    type RenderBundleData = web_sys::GpuRenderBundle;
+    type RenderBundleData = Sendable<web_sys::GpuRenderBundle>;
     type SurfaceId = Identified<(Canvas, web_sys::GpuCanvasContext)>;
-    type SurfaceData = (Canvas, web_sys::GpuCanvasContext);
+    type SurfaceData = Sendable<(Canvas, web_sys::GpuCanvasContext)>;
 
     type SurfaceOutputDetail = SurfaceOutputDetail;
     type SubmissionIndex = Unused;
     type SubmissionIndexData = ();
 
-    type RequestAdapterFuture = MapFuture<
+    type RequestAdapterFuture = MakeSendFuture<
         wasm_bindgen_futures::JsFuture,
         fn(JsFutureResult) -> Option<(Self::AdapterId, Self::AdapterData)>,
     >;
-    type RequestDeviceFuture = MapFuture<
+    type RequestDeviceFuture = MakeSendFuture<
         wasm_bindgen_futures::JsFuture,
         fn(
             JsFutureResult,
@@ -893,7 +935,7 @@ impl crate::context::Context for Context {
         >,
     >;
     type PopErrorScopeFuture =
-        MapFuture<wasm_bindgen_futures::JsFuture, fn(JsFutureResult) -> Option<crate::Error>>;
+        MakeSendFuture<wasm_bindgen_futures::JsFuture, fn(JsFutureResult) -> Option<crate::Error>>;
 
     fn init(_instance_desc: wgt::InstanceDescriptor) -> Self {
         let global: Global = js_sys::global().unchecked_into();
@@ -950,7 +992,7 @@ impl crate::context::Context for Context {
         mapped_options.power_preference(mapped_power_preference);
         let adapter_promise = self.0.request_adapter_with_options(&mapped_options);
 
-        MapFuture::new(
+        MakeSendFuture::new(
             wasm_bindgen_futures::JsFuture::from(adapter_promise),
             future_request_adapter,
         )
@@ -987,9 +1029,9 @@ impl crate::context::Context for Context {
             mapped_desc.label(label);
         }
 
-        let device_promise = adapter_data.request_device_with_descriptor(&mapped_desc);
+        let device_promise = adapter_data.0.request_device_with_descriptor(&mapped_desc);
 
-        MapFuture::new(
+        MakeSendFuture::new(
             wasm_bindgen_futures::JsFuture::from(device_promise),
             future_request_device,
         )
@@ -1015,7 +1057,7 @@ impl crate::context::Context for Context {
         _adapter: &Self::AdapterId,
         adapter_data: &Self::AdapterData,
     ) -> wgt::Features {
-        map_wgt_features(adapter_data.features())
+        map_wgt_features(adapter_data.0.features())
     }
 
     fn adapter_limits(
@@ -1023,7 +1065,7 @@ impl crate::context::Context for Context {
         _adapter: &Self::AdapterId,
         adapter_data: &Self::AdapterData,
     ) -> wgt::Limits {
-        let limits = adapter_data.limits();
+        let limits = adapter_data.0.limits();
         wgt::Limits {
             max_texture_dimension_1d: limits.max_texture_dimension_1d(),
             max_texture_dimension_2d: limits.max_texture_dimension_2d(),
@@ -1129,7 +1171,7 @@ impl crate::context::Context for Context {
         device_data: &Self::DeviceData,
         config: &crate::SurfaceConfiguration,
     ) {
-        match surface_data.0 {
+        match surface_data.0 .0 {
             Canvas::Canvas(ref canvas) => {
                 canvas.set_width(config.width);
                 canvas.set_height(config.height);
@@ -1153,7 +1195,7 @@ impl crate::context::Context for Context {
             _ => web_sys::GpuCanvasAlphaMode::Opaque,
         };
         let mut mapped =
-            web_sys::GpuCanvasConfiguration::new(device_data, map_texture_format(config.format));
+            web_sys::GpuCanvasConfiguration::new(&device_data.0, map_texture_format(config.format));
         mapped.usage(config.usage.bits());
         mapped.alpha_mode(alpha_mode);
         let mapped_view_formats = config
@@ -1162,7 +1204,7 @@ impl crate::context::Context for Context {
             .map(|format| JsValue::from(map_texture_format(*format)))
             .collect::<js_sys::Array>();
         mapped.view_formats(&mapped_view_formats);
-        surface_data.1.configure(&mapped);
+        surface_data.0 .1.configure(&mapped);
     }
 
     fn surface_get_current_texture(
@@ -1175,7 +1217,7 @@ impl crate::context::Context for Context {
         wgt::SurfaceStatus,
         Self::SurfaceOutputDetail,
     ) {
-        let (surface_id, surface_data) = create_identified(surface_data.1.get_current_texture());
+        let (surface_id, surface_data) = create_identified(surface_data.0 .1.get_current_texture());
         (
             Some(surface_id),
             Some(surface_data),
@@ -1201,7 +1243,7 @@ impl crate::context::Context for Context {
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
     ) -> wgt::Features {
-        map_wgt_features(device_data.features())
+        map_wgt_features(device_data.0.features())
     }
 
     fn device_limits(
@@ -1314,7 +1356,7 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             descriptor.label(label);
         }
-        create_identified(device_data.create_shader_module(&descriptor))
+        create_identified(device_data.0.create_shader_module(&descriptor))
     }
 
     unsafe fn device_create_shader_module_spirv(
@@ -1422,7 +1464,7 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        create_identified(device_data.create_bind_group_layout(&mapped_desc))
+        create_identified(device_data.0.create_bind_group_layout(&mapped_desc))
     }
 
     fn device_create_bind_group(
@@ -1443,7 +1485,7 @@ impl crate::context::Context for Context {
                     }) => {
                         let buffer: &<Context as crate::Context>::BufferData =
                             downcast_ref(buffer.data.as_ref());
-                        let mut mapped_buffer_binding = web_sys::GpuBufferBinding::new(buffer);
+                        let mut mapped_buffer_binding = web_sys::GpuBufferBinding::new(&buffer.0);
                         mapped_buffer_binding.offset(offset as f64);
                         if let Some(s) = size {
                             mapped_buffer_binding.size(s.get() as f64);
@@ -1456,7 +1498,7 @@ impl crate::context::Context for Context {
                     crate::BindingResource::Sampler(sampler) => {
                         let sampler: &<Context as crate::Context>::SamplerData =
                             downcast_ref(sampler.data.as_ref());
-                        JsValue::from(sampler)
+                        JsValue::from(&sampler.0)
                     }
                     crate::BindingResource::SamplerArray(..) => {
                         panic!("Web backend does not support arrays of samplers")
@@ -1464,7 +1506,7 @@ impl crate::context::Context for Context {
                     crate::BindingResource::TextureView(texture_view) => {
                         let texture_view: &<Context as crate::Context>::TextureViewData =
                             downcast_ref(texture_view.data.as_ref());
-                        JsValue::from(texture_view)
+                        JsValue::from(&texture_view.0)
                     }
                     crate::BindingResource::TextureViewArray(..) => {
                         panic!("Web backend does not support BINDING_INDEXING extension")
@@ -1477,11 +1519,11 @@ impl crate::context::Context for Context {
 
         let bgl: &<Context as crate::Context>::BindGroupLayoutData =
             downcast_ref(desc.layout.data.as_ref());
-        let mut mapped_desc = web_sys::GpuBindGroupDescriptor::new(&mapped_entries, bgl);
+        let mut mapped_desc = web_sys::GpuBindGroupDescriptor::new(&mapped_entries, &bgl.0);
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        create_identified(device_data.create_bind_group(&mapped_desc))
+        create_identified(device_data.0.create_bind_group(&mapped_desc))
     }
 
     fn device_create_pipeline_layout(
@@ -1496,14 +1538,14 @@ impl crate::context::Context for Context {
             .map(|bgl| {
                 let bgl: &<Context as crate::Context>::BindGroupLayoutData =
                     downcast_ref(bgl.data.as_ref());
-                bgl
+                &bgl.0
             })
             .collect::<js_sys::Array>();
         let mut mapped_desc = web_sys::GpuPipelineLayoutDescriptor::new(&temp_layouts);
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        create_identified(device_data.create_pipeline_layout(&mapped_desc))
+        create_identified(device_data.0.create_pipeline_layout(&mapped_desc))
     }
 
     fn device_create_render_pipeline(
@@ -1514,7 +1556,8 @@ impl crate::context::Context for Context {
     ) -> (Self::RenderPipelineId, Self::RenderPipelineData) {
         let module: &<Context as crate::Context>::ShaderModuleData =
             downcast_ref(desc.vertex.module.data.as_ref());
-        let mut mapped_vertex_state = web_sys::GpuVertexState::new(desc.vertex.entry_point, module);
+        let mut mapped_vertex_state =
+            web_sys::GpuVertexState::new(desc.vertex.entry_point, &module.0);
 
         let buffers = desc
             .vertex
@@ -1550,7 +1593,7 @@ impl crate::context::Context for Context {
                 Some(layout) => {
                     let layout: &<Context as crate::Context>::PipelineLayoutData =
                         downcast_ref(layout.data.as_ref());
-                    JsValue::from(layout)
+                    JsValue::from(&layout.0)
                 }
                 None => auto_layout,
             },
@@ -1589,7 +1632,7 @@ impl crate::context::Context for Context {
             let module: &<Context as crate::Context>::ShaderModuleData =
                 downcast_ref(frag.module.data.as_ref());
             let mapped_fragment_desc =
-                web_sys::GpuFragmentState::new(frag.entry_point, module, &targets);
+                web_sys::GpuFragmentState::new(frag.entry_point, &module.0, &targets);
             mapped_desc.fragment(&mapped_fragment_desc);
         }
 
@@ -1602,7 +1645,7 @@ impl crate::context::Context for Context {
         let mapped_primitive = map_primitive_state(&desc.primitive);
         mapped_desc.primitive(&mapped_primitive);
 
-        create_identified(device_data.create_render_pipeline(&mapped_desc))
+        create_identified(device_data.0.create_render_pipeline(&mapped_desc))
     }
 
     fn device_create_compute_pipeline(
@@ -1614,14 +1657,14 @@ impl crate::context::Context for Context {
         let shader_module: &<Context as crate::Context>::ShaderModuleData =
             downcast_ref(desc.module.data.as_ref());
         let mapped_compute_stage =
-            web_sys::GpuProgrammableStage::new(desc.entry_point, shader_module);
+            web_sys::GpuProgrammableStage::new(desc.entry_point, &shader_module.0);
         let auto_layout = wasm_bindgen::JsValue::from(web_sys::GpuAutoLayoutMode::Auto);
         let mut mapped_desc = web_sys::GpuComputePipelineDescriptor::new(
             &match desc.layout {
                 Some(layout) => {
                     let layout: &<Context as crate::Context>::PipelineLayoutData =
                         downcast_ref(layout.data.as_ref());
-                    JsValue::from(layout)
+                    JsValue::from(&layout.0)
                 }
                 None => auto_layout,
             },
@@ -1630,7 +1673,7 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        create_identified(device_data.create_compute_pipeline(&mapped_desc))
+        create_identified(device_data.0.create_compute_pipeline(&mapped_desc))
     }
 
     fn device_create_buffer(
@@ -1645,7 +1688,7 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        create_identified(device_data.create_buffer(&mapped_desc))
+        create_identified(device_data.0.create_buffer(&mapped_desc))
     }
 
     fn device_create_texture(
@@ -1671,7 +1714,7 @@ impl crate::context::Context for Context {
             .map(|format| JsValue::from(map_texture_format(*format)))
             .collect::<js_sys::Array>();
         mapped_desc.view_formats(&mapped_view_formats);
-        create_identified(device_data.create_texture(&mapped_desc))
+        create_identified(device_data.0.create_texture(&mapped_desc))
     }
 
     fn device_create_sampler(
@@ -1697,7 +1740,7 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        create_identified(device_data.create_sampler_with_descriptor(&mapped_desc))
+        create_identified(device_data.0.create_sampler_with_descriptor(&mapped_desc))
     }
 
     fn device_create_query_set(
@@ -1715,7 +1758,7 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        create_identified(device_data.create_query_set(&mapped_desc))
+        create_identified(device_data.0.create_query_set(&mapped_desc))
     }
 
     fn device_create_command_encoder(
@@ -1728,7 +1771,11 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        create_identified(device_data.create_command_encoder_with_descriptor(&mapped_desc))
+        create_identified(
+            device_data
+                .0
+                .create_command_encoder_with_descriptor(&mapped_desc),
+        )
     }
 
     fn device_create_render_bundle_encoder(
@@ -1755,7 +1802,7 @@ impl crate::context::Context for Context {
             mapped_desc.stencil_read_only(ds.stencil_read_only);
         }
         mapped_desc.sample_count(desc.sample_count);
-        create_identified(device_data.create_render_bundle_encoder(&mapped_desc))
+        create_identified(device_data.0.create_render_bundle_encoder(&mapped_desc))
     }
 
     fn device_drop(&self, _device: &Self::DeviceId, _device_data: &Self::DeviceData) {
@@ -1782,7 +1829,9 @@ impl crate::context::Context for Context {
             let error = crate::Error::from_js(event.error().value_of());
             handler(error);
         }) as Box<dyn FnMut(_)>);
-        device_data.set_onuncapturederror(Some(f.as_ref().unchecked_ref()));
+        device_data
+            .0
+            .set_onuncapturederror(Some(f.as_ref().unchecked_ref()));
         // TODO: This will leak the memory associated with the error handler by default.
         f.forget();
     }
@@ -1793,7 +1842,7 @@ impl crate::context::Context for Context {
         device_data: &Self::DeviceData,
         filter: crate::ErrorFilter,
     ) {
-        device_data.push_error_scope(match filter {
+        device_data.0.push_error_scope(match filter {
             crate::ErrorFilter::OutOfMemory => web_sys::GpuErrorFilter::OutOfMemory,
             crate::ErrorFilter::Validation => web_sys::GpuErrorFilter::Validation,
         });
@@ -1804,8 +1853,8 @@ impl crate::context::Context for Context {
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
     ) -> Self::PopErrorScopeFuture {
-        let error_promise = device_data.pop_error_scope();
-        MapFuture::new(
+        let error_promise = device_data.0.pop_error_scope();
+        MakeSendFuture::new(
             wasm_bindgen_futures::JsFuture::from(error_promise),
             future_pop_error_scope,
         )
@@ -1819,7 +1868,7 @@ impl crate::context::Context for Context {
         range: Range<wgt::BufferAddress>,
         callback: crate::context::BufferMapCallback,
     ) {
-        let map_promise = buffer_data.map_async_with_f64_and_f64(
+        let map_promise = buffer_data.0.map_async_with_f64_and_f64(
             map_map_mode(mode),
             range.start as f64,
             (range.end - range.start) as f64,
@@ -1834,7 +1883,7 @@ impl crate::context::Context for Context {
         buffer_data: &Self::BufferData,
         sub_range: Range<wgt::BufferAddress>,
     ) -> Box<dyn crate::context::BufferMappedRange> {
-        let array_buffer = buffer_data.get_mapped_range_with_f64_and_f64(
+        let array_buffer = buffer_data.0.get_mapped_range_with_f64_and_f64(
             sub_range.start as f64,
             (sub_range.end - sub_range.start) as f64,
         );
@@ -1847,7 +1896,7 @@ impl crate::context::Context for Context {
     }
 
     fn buffer_unmap(&self, _buffer: &Self::BufferId, buffer_data: &Self::BufferData) {
-        buffer_data.unmap();
+        buffer_data.0.unmap();
     }
 
     fn texture_create_view(
@@ -1875,7 +1924,7 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped.label(label);
         }
-        create_identified(texture_data.create_view_with_descriptor(&mapped))
+        create_identified(texture_data.0.create_view_with_descriptor(&mapped))
     }
 
     fn surface_drop(&self, _surface: &Self::SurfaceId, _surface_data: &Self::SurfaceData) {
@@ -1887,7 +1936,7 @@ impl crate::context::Context for Context {
     }
 
     fn buffer_destroy(&self, _buffer: &Self::BufferId, buffer_data: &Self::BufferData) {
-        buffer_data.destroy();
+        buffer_data.0.destroy();
     }
 
     fn buffer_drop(&self, _buffer: &Self::BufferId, _buffer_data: &Self::BufferData) {
@@ -1895,7 +1944,7 @@ impl crate::context::Context for Context {
     }
 
     fn texture_destroy(&self, _texture: &Self::TextureId, texture_data: &Self::TextureData) {
-        texture_data.destroy();
+        texture_data.0.destroy();
     }
 
     fn texture_drop(&self, _texture: &Self::TextureId, _texture_data: &Self::TextureData) {
@@ -1996,7 +2045,7 @@ impl crate::context::Context for Context {
         pipeline_data: &Self::ComputePipelineData,
         index: u32,
     ) -> (Self::BindGroupLayoutId, Self::BindGroupLayoutData) {
-        create_identified(pipeline_data.get_bind_group_layout(index))
+        create_identified(pipeline_data.0.get_bind_group_layout(index))
     }
 
     fn render_pipeline_get_bind_group_layout(
@@ -2005,7 +2054,7 @@ impl crate::context::Context for Context {
         pipeline_data: &Self::RenderPipelineData,
         index: u32,
     ) -> (Self::BindGroupLayoutId, Self::BindGroupLayoutData) {
-        create_identified(pipeline_data.get_bind_group_layout(index))
+        create_identified(pipeline_data.0.get_bind_group_layout(index))
     }
 
     fn command_encoder_copy_buffer_to_buffer(
@@ -2020,13 +2069,15 @@ impl crate::context::Context for Context {
         destination_offset: wgt::BufferAddress,
         copy_size: wgt::BufferAddress,
     ) {
-        encoder_data.copy_buffer_to_buffer_with_f64_and_f64_and_f64(
-            source_data,
-            source_offset as f64,
-            destination_data,
-            destination_offset as f64,
-            copy_size as f64,
-        )
+        encoder_data
+            .0
+            .copy_buffer_to_buffer_with_f64_and_f64_and_f64(
+                &source_data.0,
+                source_offset as f64,
+                &destination_data.0,
+                destination_offset as f64,
+                copy_size as f64,
+            )
     }
 
     fn command_encoder_copy_buffer_to_texture(
@@ -2037,11 +2088,13 @@ impl crate::context::Context for Context {
         destination: crate::ImageCopyTexture,
         copy_size: wgt::Extent3d,
     ) {
-        encoder_data.copy_buffer_to_texture_with_gpu_extent_3d_dict(
-            &map_buffer_copy_view(source),
-            &map_texture_copy_view(destination),
-            &map_extent_3d(copy_size),
-        )
+        encoder_data
+            .0
+            .copy_buffer_to_texture_with_gpu_extent_3d_dict(
+                &map_buffer_copy_view(source),
+                &map_texture_copy_view(destination),
+                &map_extent_3d(copy_size),
+            )
     }
 
     fn command_encoder_copy_texture_to_buffer(
@@ -2052,11 +2105,13 @@ impl crate::context::Context for Context {
         destination: crate::ImageCopyBuffer,
         copy_size: wgt::Extent3d,
     ) {
-        encoder_data.copy_texture_to_buffer_with_gpu_extent_3d_dict(
-            &map_texture_copy_view(source),
-            &map_buffer_copy_view(destination),
-            &map_extent_3d(copy_size),
-        )
+        encoder_data
+            .0
+            .copy_texture_to_buffer_with_gpu_extent_3d_dict(
+                &map_texture_copy_view(source),
+                &map_buffer_copy_view(destination),
+                &map_extent_3d(copy_size),
+            )
     }
 
     fn command_encoder_copy_texture_to_texture(
@@ -2067,11 +2122,13 @@ impl crate::context::Context for Context {
         destination: crate::ImageCopyTexture,
         copy_size: wgt::Extent3d,
     ) {
-        encoder_data.copy_texture_to_texture_with_gpu_extent_3d_dict(
-            &map_texture_copy_view(source),
-            &map_texture_copy_view(destination),
-            &map_extent_3d(copy_size),
-        )
+        encoder_data
+            .0
+            .copy_texture_to_texture_with_gpu_extent_3d_dict(
+                &map_texture_copy_view(source),
+                &map_texture_copy_view(destination),
+                &map_extent_3d(copy_size),
+            )
     }
 
     fn command_encoder_begin_compute_pass(
@@ -2084,7 +2141,11 @@ impl crate::context::Context for Context {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
-        create_identified(encoder_data.begin_compute_pass_with_descriptor(&mapped_desc))
+        create_identified(
+            encoder_data
+                .0
+                .begin_compute_pass_with_descriptor(&mapped_desc),
+        )
     }
 
     fn command_encoder_end_compute_pass(
@@ -2094,7 +2155,7 @@ impl crate::context::Context for Context {
         _pass: &mut Self::ComputePassId,
         pass_data: &mut Self::ComputePassData,
     ) {
-        pass_data.end();
+        pass_data.0.end();
     }
 
     fn command_encoder_begin_render_pass(
@@ -2123,7 +2184,7 @@ impl crate::context::Context for Context {
                     let mut mapped_color_attachment = web_sys::GpuRenderPassColorAttachment::new(
                         load_value,
                         map_store_op(ca.ops.store),
-                        view,
+                        &view.0,
                     );
                     if let Some(cv) = clear_value {
                         mapped_color_attachment.clear_value(&cv);
@@ -2131,7 +2192,7 @@ impl crate::context::Context for Context {
                     if let Some(rt) = ca.resolve_target {
                         let resolve_target_view: &<Context as crate::Context>::TextureViewData =
                             downcast_ref(rt.data.as_ref());
-                        mapped_color_attachment.resolve_target(resolve_target_view);
+                        mapped_color_attachment.resolve_target(&resolve_target_view.0);
                     }
                     mapped_color_attachment.store_op(map_store_op(ca.ops.store));
 
@@ -2151,7 +2212,7 @@ impl crate::context::Context for Context {
             let depth_stencil_attachment: &<Context as crate::Context>::TextureViewData =
                 downcast_ref(dsa.view.data.as_ref());
             let mut mapped_depth_stencil_attachment =
-                web_sys::GpuRenderPassDepthStencilAttachment::new(depth_stencil_attachment);
+                web_sys::GpuRenderPassDepthStencilAttachment::new(&depth_stencil_attachment.0);
             if let Some(ref ops) = dsa.depth_ops {
                 let load_op = match ops.load {
                     crate::LoadOp::Clear(v) => {
@@ -2179,7 +2240,7 @@ impl crate::context::Context for Context {
             mapped_desc.depth_stencil_attachment(&mapped_depth_stencil_attachment);
         }
 
-        create_identified(encoder_data.begin_render_pass(&mapped_desc))
+        create_identified(encoder_data.0.begin_render_pass(&mapped_desc))
     }
 
     fn command_encoder_end_render_pass(
@@ -2189,7 +2250,7 @@ impl crate::context::Context for Context {
         _pass: &mut Self::RenderPassId,
         pass_data: &mut Self::RenderPassData,
     ) {
-        pass_data.end();
+        pass_data.0.end();
     }
 
     fn command_encoder_finish(
@@ -2197,13 +2258,13 @@ impl crate::context::Context for Context {
         _encoder: Self::CommandEncoderId,
         encoder_data: &mut Self::CommandEncoderData,
     ) -> (Self::CommandBufferId, Self::CommandBufferData) {
-        let label = encoder_data.label();
+        let label = encoder_data.0.label();
         create_identified(if label.is_empty() {
-            encoder_data.finish()
+            encoder_data.0.finish()
         } else {
             let mut mapped_desc = web_sys::GpuCommandBufferDescriptor::new();
             mapped_desc.label(&label);
-            encoder_data.finish_with_descriptor(&mapped_desc)
+            encoder_data.0.finish_with_descriptor(&mapped_desc)
         })
     }
 
@@ -2227,10 +2288,14 @@ impl crate::context::Context for Context {
     ) {
         let buffer: &<Context as crate::Context>::BufferData = downcast_ref(buffer.data.as_ref());
         match size {
-            Some(size) => {
-                encoder_data.clear_buffer_with_f64_and_f64(buffer, offset as f64, size.get() as f64)
-            }
-            None => encoder_data.clear_buffer_with_f64(buffer, offset as f64),
+            Some(size) => encoder_data.0.clear_buffer_with_f64_and_f64(
+                &buffer.0,
+                offset as f64,
+                size.get() as f64,
+            ),
+            None => encoder_data
+                .0
+                .clear_buffer_with_f64(&buffer.0, offset as f64),
         }
     }
 
@@ -2271,7 +2336,9 @@ impl crate::context::Context for Context {
         query_set_data: &Self::QuerySetData,
         query_index: u32,
     ) {
-        encoder_data.write_timestamp(query_set_data, query_index);
+        encoder_data
+            .0
+            .write_timestamp(&query_set_data.0, query_index);
     }
 
     fn command_encoder_resolve_query_set(
@@ -2286,11 +2353,11 @@ impl crate::context::Context for Context {
         destination_data: &Self::BufferData,
         destination_offset: wgt::BufferAddress,
     ) {
-        encoder_data.resolve_query_set_with_u32(
-            query_set_data,
+        encoder_data.0.resolve_query_set_with_u32(
+            &query_set_data.0,
             first_query,
             query_count,
-            destination_data,
+            &destination_data.0,
             destination_offset as u32,
         );
     }
@@ -2305,9 +2372,9 @@ impl crate::context::Context for Context {
             Some(label) => {
                 let mut mapped_desc = web_sys::GpuRenderBundleDescriptor::new();
                 mapped_desc.label(label);
-                encoder_data.finish_with_descriptor(&mapped_desc)
+                encoder_data.0.finish_with_descriptor(&mapped_desc)
             }
-            None => encoder_data.finish(),
+            None => encoder_data.0.finish(),
         })
     }
 
@@ -2321,21 +2388,23 @@ impl crate::context::Context for Context {
         data: &[u8],
     ) {
         /* Skip the copy once gecko allows BufferSource instead of ArrayBuffer
-        queue_data.write_buffer_with_f64_and_u8_array_and_f64_and_f64(
-            buffer_data,
+        queue_data.0.write_buffer_with_f64_and_u8_array_and_f64_and_f64(
+            &buffer_data.0,
             offset as f64,
             data,
             0f64,
             data.len() as f64,
         );
         */
-        queue_data.write_buffer_with_f64_and_buffer_source_and_f64_and_f64(
-            buffer_data,
-            offset as f64,
-            &js_sys::Uint8Array::from(data).buffer(),
-            0f64,
-            data.len() as f64,
-        );
+        queue_data
+            .0
+            .write_buffer_with_f64_and_buffer_source_and_f64_and_f64(
+                &buffer_data.0,
+                offset as f64,
+                &js_sys::Uint8Array::from(data).buffer(),
+                0f64,
+                data.len() as f64,
+            );
     }
 
     fn queue_validate_write_buffer(
@@ -2347,7 +2416,7 @@ impl crate::context::Context for Context {
         offset: wgt::BufferAddress,
         size: wgt::BufferSize,
     ) -> Option<()> {
-        let usage = wgt::BufferUsages::from_bits_truncate(buffer_data.usage());
+        let usage = wgt::BufferUsages::from_bits_truncate(buffer_data.0.usage());
         // TODO: actually send this down the error scope
         if !usage.contains(wgt::BufferUsages::COPY_DST) {
             log::error!("Destination buffer is missing the `COPY_DST` usage flag");
@@ -2368,8 +2437,8 @@ impl crate::context::Context for Context {
             );
             return None;
         }
-        if write_size + offset > buffer_data.size() as u64 {
-            log::error!("copy of {}..{} would end up overrunning the bounds of the destination buffer of size {}", offset, offset + write_size, buffer_data.size());
+        if write_size + offset > buffer_data.0.size() as u64 {
+            log::error!("copy of {}..{} would end up overrunning the bounds of the destination buffer of size {}", offset, offset + write_size, buffer_data.0.size());
             return None;
         }
         Some(())
@@ -2429,19 +2498,21 @@ impl crate::context::Context for Context {
         mapped_data_layout.offset(data_layout.offset as f64);
 
         /* Skip the copy once gecko allows BufferSource instead of ArrayBuffer
-        queue_data.write_texture_with_u8_array_and_gpu_extent_3d_dict(
+        queue_data.0.write_texture_with_u8_array_and_gpu_extent_3d_dict(
             &map_texture_copy_view(texture),
             data,
             &mapped_data_layout,
             &map_extent_3d(size),
         );
         */
-        queue_data.write_texture_with_buffer_source_and_gpu_extent_3d_dict(
-            &map_texture_copy_view(texture),
-            &js_sys::Uint8Array::from(data).buffer(),
-            &mapped_data_layout,
-            &map_extent_3d(size),
-        );
+        queue_data
+            .0
+            .write_texture_with_buffer_source_and_gpu_extent_3d_dict(
+                &map_texture_copy_view(texture),
+                &js_sys::Uint8Array::from(data).buffer(),
+                &mapped_data_layout,
+                &map_extent_3d(size),
+            );
     }
 
     fn queue_copy_external_image_to_texture(
@@ -2452,11 +2523,13 @@ impl crate::context::Context for Context {
         dest: crate::ImageCopyTextureTagged,
         size: wgt::Extent3d,
     ) {
-        queue_data.copy_external_image_to_texture_with_gpu_extent_3d_dict(
-            &map_external_texture_copy_view(source),
-            &map_tagged_texture_copy_view(dest),
-            &map_extent_3d(size),
-        );
+        queue_data
+            .0
+            .copy_external_image_to_texture_with_gpu_extent_3d_dict(
+                &map_external_texture_copy_view(source),
+                &map_tagged_texture_copy_view(dest),
+                &map_extent_3d(size),
+            );
     }
 
     fn queue_submit<I: Iterator<Item = (Self::CommandBufferId, Self::CommandBufferData)>>(
@@ -2466,10 +2539,10 @@ impl crate::context::Context for Context {
         command_buffers: I,
     ) -> (Self::SubmissionIndex, Self::SubmissionIndexData) {
         let temp_command_buffers = command_buffers
-            .map(|(_, data)| data)
+            .map(|(_, data)| data.0)
             .collect::<js_sys::Array>();
 
-        queue_data.submit(&temp_command_buffers);
+        queue_data.0.submit(&temp_command_buffers);
 
         (Unused, ())
     }
@@ -2501,7 +2574,7 @@ impl crate::context::Context for Context {
         _pipeline: &Self::ComputePipelineId,
         pipeline_data: &Self::ComputePipelineData,
     ) {
-        pass_data.set_pipeline(pipeline_data)
+        pass_data.0.set_pipeline(&pipeline_data.0)
     }
 
     fn compute_pass_set_bind_group(
@@ -2513,13 +2586,15 @@ impl crate::context::Context for Context {
         bind_group_data: &Self::BindGroupData,
         offsets: &[wgt::DynamicOffset],
     ) {
-        pass_data.set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
-            index,
-            bind_group_data,
-            offsets,
-            0f64,
-            offsets.len() as u32,
-        );
+        pass_data
+            .0
+            .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
+                index,
+                &bind_group_data.0,
+                offsets,
+                0f64,
+                offsets.len() as u32,
+            );
     }
 
     fn compute_pass_set_push_constants(
@@ -2599,7 +2674,9 @@ impl crate::context::Context for Context {
         y: u32,
         z: u32,
     ) {
-        pass_data.dispatch_workgroups_with_workgroup_count_y_and_workgroup_count_z(x, y, z);
+        pass_data
+            .0
+            .dispatch_workgroups_with_workgroup_count_y_and_workgroup_count_z(x, y, z);
     }
 
     fn compute_pass_dispatch_workgroups_indirect(
@@ -2611,7 +2688,8 @@ impl crate::context::Context for Context {
         indirect_offset: wgt::BufferAddress,
     ) {
         pass_data
-            .dispatch_workgroups_indirect_with_f64(indirect_buffer_data, indirect_offset as f64);
+            .0
+            .dispatch_workgroups_indirect_with_f64(&indirect_buffer_data.0, indirect_offset as f64);
     }
 
     fn render_bundle_encoder_set_pipeline(
@@ -2621,7 +2699,7 @@ impl crate::context::Context for Context {
         _pipeline: &Self::RenderPipelineId,
         pipeline_data: &Self::RenderPipelineData,
     ) {
-        encoder_data.set_pipeline(pipeline_data);
+        encoder_data.0.set_pipeline(&pipeline_data.0);
     }
 
     fn render_bundle_encoder_set_bind_group(
@@ -2633,13 +2711,15 @@ impl crate::context::Context for Context {
         bind_group_data: &Self::BindGroupData,
         offsets: &[wgt::DynamicOffset],
     ) {
-        encoder_data.set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
-            index,
-            bind_group_data,
-            offsets,
-            0f64,
-            offsets.len() as u32,
-        );
+        encoder_data
+            .0
+            .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
+                index,
+                &bind_group_data.0,
+                offsets,
+                0f64,
+                offsets.len() as u32,
+            );
     }
 
     fn render_bundle_encoder_set_index_buffer(
@@ -2654,16 +2734,16 @@ impl crate::context::Context for Context {
     ) {
         match size {
             Some(s) => {
-                encoder_data.set_index_buffer_with_f64_and_f64(
-                    buffer_data,
+                encoder_data.0.set_index_buffer_with_f64_and_f64(
+                    &buffer_data.0,
                     map_index_format(index_format),
                     offset as f64,
                     s.get() as f64,
                 );
             }
             None => {
-                encoder_data.set_index_buffer_with_f64(
-                    buffer_data,
+                encoder_data.0.set_index_buffer_with_f64(
+                    &buffer_data.0,
                     map_index_format(index_format),
                     offset as f64,
                 );
@@ -2683,15 +2763,17 @@ impl crate::context::Context for Context {
     ) {
         match size {
             Some(s) => {
-                encoder_data.set_vertex_buffer_with_f64_and_f64(
+                encoder_data.0.set_vertex_buffer_with_f64_and_f64(
                     slot,
-                    buffer_data,
+                    &buffer_data.0,
                     offset as f64,
                     s.get() as f64,
                 );
             }
             None => {
-                encoder_data.set_vertex_buffer_with_f64(slot, buffer_data, offset as f64);
+                encoder_data
+                    .0
+                    .set_vertex_buffer_with_f64(slot, &buffer_data.0, offset as f64);
             }
         };
     }
@@ -2714,12 +2796,14 @@ impl crate::context::Context for Context {
         vertices: Range<u32>,
         instances: Range<u32>,
     ) {
-        encoder_data.draw_with_instance_count_and_first_vertex_and_first_instance(
-            vertices.end - vertices.start,
-            instances.end - instances.start,
-            vertices.start,
-            instances.start,
-        );
+        encoder_data
+            .0
+            .draw_with_instance_count_and_first_vertex_and_first_instance(
+                vertices.end - vertices.start,
+                instances.end - instances.start,
+                vertices.start,
+                instances.start,
+            );
     }
 
     fn render_bundle_encoder_draw_indexed(
@@ -2731,6 +2815,7 @@ impl crate::context::Context for Context {
         instances: Range<u32>,
     ) {
         encoder_data
+            .0
             .draw_indexed_with_instance_count_and_first_index_and_base_vertex_and_first_instance(
                 indices.end - indices.start,
                 instances.end - instances.start,
@@ -2748,7 +2833,9 @@ impl crate::context::Context for Context {
         indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        encoder_data.draw_indirect_with_f64(indirect_buffer_data, indirect_offset as f64);
+        encoder_data
+            .0
+            .draw_indirect_with_f64(&indirect_buffer_data.0, indirect_offset as f64);
     }
 
     fn render_bundle_encoder_draw_indexed_indirect(
@@ -2759,7 +2846,9 @@ impl crate::context::Context for Context {
         indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        encoder_data.draw_indexed_indirect_with_f64(indirect_buffer_data, indirect_offset as f64);
+        encoder_data
+            .0
+            .draw_indexed_indirect_with_f64(&indirect_buffer_data.0, indirect_offset as f64);
     }
 
     fn render_bundle_encoder_multi_draw_indirect(
@@ -2825,7 +2914,7 @@ impl crate::context::Context for Context {
         _pipeline: &Self::RenderPipelineId,
         pipeline_data: &Self::RenderPipelineData,
     ) {
-        pass_data.set_pipeline(pipeline_data);
+        pass_data.0.set_pipeline(&pipeline_data.0);
     }
 
     fn render_pass_set_bind_group(
@@ -2837,13 +2926,15 @@ impl crate::context::Context for Context {
         bind_group_data: &Self::BindGroupData,
         offsets: &[wgt::DynamicOffset],
     ) {
-        pass_data.set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
-            index,
-            bind_group_data,
-            offsets,
-            0f64,
-            offsets.len() as u32,
-        );
+        pass_data
+            .0
+            .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
+                index,
+                &bind_group_data.0,
+                offsets,
+                0f64,
+                offsets.len() as u32,
+            );
     }
 
     fn render_pass_set_index_buffer(
@@ -2858,16 +2949,16 @@ impl crate::context::Context for Context {
     ) {
         match size {
             Some(s) => {
-                pass_data.set_index_buffer_with_f64_and_f64(
-                    buffer_data,
+                pass_data.0.set_index_buffer_with_f64_and_f64(
+                    &buffer_data.0,
                     map_index_format(index_format),
                     offset as f64,
                     s.get() as f64,
                 );
             }
             None => {
-                pass_data.set_index_buffer_with_f64(
-                    buffer_data,
+                pass_data.0.set_index_buffer_with_f64(
+                    &buffer_data.0,
                     map_index_format(index_format),
                     offset as f64,
                 );
@@ -2887,15 +2978,17 @@ impl crate::context::Context for Context {
     ) {
         match size {
             Some(s) => {
-                pass_data.set_vertex_buffer_with_f64_and_f64(
+                pass_data.0.set_vertex_buffer_with_f64_and_f64(
                     slot,
-                    buffer_data,
+                    &buffer_data.0,
                     offset as f64,
                     s.get() as f64,
                 );
             }
             None => {
-                pass_data.set_vertex_buffer_with_f64(slot, buffer_data, offset as f64);
+                pass_data
+                    .0
+                    .set_vertex_buffer_with_f64(slot, &buffer_data.0, offset as f64);
             }
         };
     }
@@ -2918,12 +3011,14 @@ impl crate::context::Context for Context {
         vertices: Range<u32>,
         instances: Range<u32>,
     ) {
-        pass_data.draw_with_instance_count_and_first_vertex_and_first_instance(
-            vertices.end - vertices.start,
-            instances.end - instances.start,
-            vertices.start,
-            instances.start,
-        );
+        pass_data
+            .0
+            .draw_with_instance_count_and_first_vertex_and_first_instance(
+                vertices.end - vertices.start,
+                instances.end - instances.start,
+                vertices.start,
+                instances.start,
+            );
     }
 
     fn render_pass_draw_indexed(
@@ -2935,6 +3030,7 @@ impl crate::context::Context for Context {
         instances: Range<u32>,
     ) {
         pass_data
+            .0
             .draw_indexed_with_instance_count_and_first_index_and_base_vertex_and_first_instance(
                 indices.end - indices.start,
                 instances.end - instances.start,
@@ -2952,7 +3048,9 @@ impl crate::context::Context for Context {
         indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        pass_data.draw_indirect_with_f64(indirect_buffer_data, indirect_offset as f64);
+        pass_data
+            .0
+            .draw_indirect_with_f64(&indirect_buffer_data.0, indirect_offset as f64);
     }
 
     fn render_pass_draw_indexed_indirect(
@@ -2963,7 +3061,9 @@ impl crate::context::Context for Context {
         indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        pass_data.draw_indexed_indirect_with_f64(indirect_buffer_data, indirect_offset as f64);
+        pass_data
+            .0
+            .draw_indexed_indirect_with_f64(&indirect_buffer_data.0, indirect_offset as f64);
     }
 
     fn render_pass_multi_draw_indirect(
@@ -3028,7 +3128,9 @@ impl crate::context::Context for Context {
         pass_data: &mut Self::RenderPassData,
         color: wgt::Color,
     ) {
-        pass_data.set_blend_constant_with_gpu_color_dict(&map_color(color));
+        pass_data
+            .0
+            .set_blend_constant_with_gpu_color_dict(&map_color(color));
     }
 
     fn render_pass_set_scissor_rect(
@@ -3040,7 +3142,7 @@ impl crate::context::Context for Context {
         width: u32,
         height: u32,
     ) {
-        pass_data.set_scissor_rect(x, y, width, height);
+        pass_data.0.set_scissor_rect(x, y, width, height);
     }
 
     fn render_pass_set_viewport(
@@ -3054,7 +3156,9 @@ impl crate::context::Context for Context {
         min_depth: f32,
         max_depth: f32,
     ) {
-        pass_data.set_viewport(x, y, width, height, min_depth, max_depth);
+        pass_data
+            .0
+            .set_viewport(x, y, width, height, min_depth, max_depth);
     }
 
     fn render_pass_set_stencil_reference(
@@ -3063,7 +3167,7 @@ impl crate::context::Context for Context {
         pass_data: &mut Self::RenderPassData,
         reference: u32,
     ) {
-        pass_data.set_stencil_reference(reference);
+        pass_data.0.set_stencil_reference(reference);
     }
 
     fn render_pass_insert_debug_marker(
@@ -3134,9 +3238,9 @@ impl crate::context::Context for Context {
         >,
     ) {
         let mapped = render_bundles
-            .map(|(_, bundle_data)| bundle_data)
+            .map(|(_, bundle_data)| &bundle_data.0)
             .collect::<js_sys::Array>();
-        pass_data.execute_bundles(&mapped);
+        pass_data.0.execute_bundles(&mapped);
     }
 }
 

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -8,10 +8,10 @@ use wgt::{
 };
 
 use crate::{
-    BindGroupDescriptor, BindGroupLayoutDescriptor, Buffer, BufferAsyncError, BufferDescriptor,
-    CommandEncoderDescriptor, ComputePassDescriptor, ComputePipelineDescriptor, DeviceDescriptor,
-    Error, ErrorFilter, ImageCopyBuffer, ImageCopyTexture, Maintain, MapMode,
-    PipelineLayoutDescriptor, QuerySetDescriptor, RenderBundleDescriptor,
+    AnySendSync, BindGroupDescriptor, BindGroupLayoutDescriptor, Buffer, BufferAsyncError,
+    BufferDescriptor, CommandEncoderDescriptor, ComputePassDescriptor, ComputePipelineDescriptor,
+    DeviceDescriptor, Error, ErrorFilter, ImageCopyBuffer, ImageCopyTexture, Maintain, MapMode,
+    MaybeSend, MaybeSync, PipelineLayoutDescriptor, QuerySetDescriptor, RenderBundleDescriptor,
     RenderBundleEncoderDescriptor, RenderPassDescriptor, RenderPipelineDescriptor,
     RequestAdapterOptions, RequestDeviceError, SamplerDescriptor, ShaderModuleDescriptor,
     ShaderModuleDescriptorSpirV, Texture, TextureDescriptor, TextureViewDescriptor,
@@ -27,59 +27,59 @@ impl<T: Into<ObjectId> + From<ObjectId> + Debug + 'static> ContextId for T {}
 /// Meta trait for an data associated with an id tracked by a context.
 ///
 /// There is no need to manually implement this trait since there is a blanket implementation for this trait.
-pub trait ContextData: Debug + Send + Sync + 'static {}
-impl<T: Debug + Send + Sync + 'static> ContextData for T {}
+pub trait ContextData: Debug + MaybeSend + MaybeSync + 'static {}
+impl<T: Debug + MaybeSend + MaybeSync + 'static> ContextData for T {}
 
-pub trait Context: Debug + Send + Sized + Sync {
-    type AdapterId: ContextId + Send + Sync;
+pub trait Context: Debug + MaybeSend + MaybeSync + Sized {
+    type AdapterId: ContextId + MaybeSend + MaybeSync;
     type AdapterData: ContextData;
-    type DeviceId: ContextId + Send + Sync;
+    type DeviceId: ContextId + MaybeSend + MaybeSync;
     type DeviceData: ContextData;
-    type QueueId: ContextId + Send + Sync;
+    type QueueId: ContextId + MaybeSend + MaybeSync;
     type QueueData: ContextData;
-    type ShaderModuleId: ContextId + Send + Sync;
+    type ShaderModuleId: ContextId + MaybeSend + MaybeSync;
     type ShaderModuleData: ContextData;
-    type BindGroupLayoutId: ContextId + Send + Sync;
+    type BindGroupLayoutId: ContextId + MaybeSend + MaybeSync;
     type BindGroupLayoutData: ContextData;
-    type BindGroupId: ContextId + Send + Sync;
+    type BindGroupId: ContextId + MaybeSend + MaybeSync;
     type BindGroupData: ContextData;
-    type TextureViewId: ContextId + Send + Sync;
+    type TextureViewId: ContextId + MaybeSend + MaybeSync;
     type TextureViewData: ContextData;
-    type SamplerId: ContextId + Send + Sync;
+    type SamplerId: ContextId + MaybeSend + MaybeSync;
     type SamplerData: ContextData;
-    type BufferId: ContextId + Send + Sync;
+    type BufferId: ContextId + MaybeSend + MaybeSync;
     type BufferData: ContextData;
-    type TextureId: ContextId + Send + Sync;
+    type TextureId: ContextId + MaybeSend + MaybeSync;
     type TextureData: ContextData;
-    type QuerySetId: ContextId + Send + Sync;
+    type QuerySetId: ContextId + MaybeSend + MaybeSync;
     type QuerySetData: ContextData;
-    type PipelineLayoutId: ContextId + Send + Sync;
+    type PipelineLayoutId: ContextId + MaybeSend + MaybeSync;
     type PipelineLayoutData: ContextData;
-    type RenderPipelineId: ContextId + Send + Sync;
+    type RenderPipelineId: ContextId + MaybeSend + MaybeSync;
     type RenderPipelineData: ContextData;
-    type ComputePipelineId: ContextId + Send + Sync;
+    type ComputePipelineId: ContextId + MaybeSend + MaybeSync;
     type ComputePipelineData: ContextData;
-    type CommandEncoderId: ContextId + Send + Sync;
+    type CommandEncoderId: ContextId + MaybeSend + MaybeSync;
     type CommandEncoderData: ContextData;
     type ComputePassId: ContextId;
     type ComputePassData: ContextData;
     type RenderPassId: ContextId;
     type RenderPassData: ContextData;
-    type CommandBufferId: ContextId + Send + Sync;
+    type CommandBufferId: ContextId + MaybeSend + MaybeSync;
     type CommandBufferData: ContextData;
     type RenderBundleEncoderId: ContextId;
     type RenderBundleEncoderData: ContextData;
-    type RenderBundleId: ContextId + Send + Sync;
+    type RenderBundleId: ContextId + MaybeSend + MaybeSync;
     type RenderBundleData: ContextData;
-    type SurfaceId: ContextId + Send + Sync;
+    type SurfaceId: ContextId + MaybeSend + MaybeSync;
     type SurfaceData: ContextData;
 
-    type SurfaceOutputDetail: Send + Sync + 'static;
-    type SubmissionIndex: ContextId + Clone + Copy + Send + Sync;
+    type SurfaceOutputDetail: MaybeSend + MaybeSync + 'static;
+    type SubmissionIndex: ContextId + Clone + Copy + MaybeSend + MaybeSync;
     type SubmissionIndexData: ContextData + Copy;
 
     type RequestAdapterFuture: Future<Output = Option<(Self::AdapterId, Self::AdapterData)>>
-        + Send
+        + MaybeSend
         + 'static;
     type RequestDeviceFuture: Future<
             Output = Result<
@@ -91,9 +91,9 @@ pub trait Context: Debug + Send + Sized + Sync {
                 ),
                 RequestDeviceError,
             >,
-        > + Send
+        > + MaybeSend
         + 'static;
-    type PopErrorScopeFuture: Future<Output = Option<Error>> + Send + 'static;
+    type PopErrorScopeFuture: Future<Output = Option<Error>> + MaybeSend + 'static;
 
     fn init(instance_desc: wgt::InstanceDescriptor) -> Self;
     fn instance_create_surface(
@@ -299,7 +299,7 @@ pub trait Context: Debug + Send + Sized + Sync {
         buffer_data: &Self::BufferData,
         mode: MapMode,
         range: Range<BufferAddress>,
-        callback: Box<dyn FnOnce(Result<(), BufferAsyncError>) + Send + 'static>,
+        callback: BufferMapCallback,
     );
     fn buffer_get_mapped_range(
         &self,
@@ -585,7 +585,7 @@ pub trait Context: Debug + Send + Sized + Sync {
         &self,
         queue: &Self::QueueId,
         queue_data: &Self::QueueData,
-        callback: Box<dyn FnOnce() + Send + 'static>,
+        callback: SubmittedWorkDoneCallback,
     );
 
     fn device_start_capture(&self, device: &Self::DeviceId, device_data: &Self::DeviceData);
@@ -1039,15 +1039,16 @@ impl ObjectId {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(ObjectId: Send, Sync);
 
-pub(crate) fn downcast_ref<T: Debug + Send + Sync + 'static>(data: &crate::Data) -> &T {
+pub(crate) fn downcast_ref<T: Debug + MaybeSend + MaybeSync + 'static>(data: &crate::Data) -> &T {
     strict_assert!(data.is::<T>());
     // Copied from std.
     unsafe { &*(data as *const dyn Any as *const T) }
 }
 
-fn downcast_mut<T: Debug + Send + Sync + 'static>(data: &mut crate::Data) -> &mut T {
+fn downcast_mut<T: Debug + MaybeSend + MaybeSync + 'static>(data: &mut crate::Data) -> &mut T {
     strict_assert!(data.is::<T>());
     // Copied from std.
     unsafe { &mut *(data as *mut dyn Any as *mut T) }
@@ -1079,8 +1080,37 @@ pub(crate) struct DeviceRequest {
     pub queue_data: Box<crate::Data>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub type BufferMapCallback = Box<dyn FnOnce(Result<(), BufferAsyncError>) + Send + 'static>;
+#[cfg(target_arch = "wasm32")]
+pub type BufferMapCallback = Box<dyn FnOnce(Result<(), BufferAsyncError>) + 'static>;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) type AdapterRequestDeviceFuture =
+    Box<dyn Future<Output = Result<DeviceRequest, RequestDeviceError>> + Send>;
+#[cfg(target_arch = "wasm32")]
+pub(crate) type AdapterRequestDeviceFuture =
+    Box<dyn Future<Output = Result<DeviceRequest, RequestDeviceError>>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type InstanceRequestAdapterFuture =
+    Box<dyn Future<Output = Option<(ObjectId, Box<crate::Data>)>> + Send>;
+#[cfg(target_arch = "wasm32")]
+pub type InstanceRequestAdapterFuture =
+    Box<dyn Future<Output = Option<(ObjectId, Box<crate::Data>)>>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type DevicePopErrorFuture = Box<dyn Future<Output = Option<Error>> + Send>;
+#[cfg(target_arch = "wasm32")]
+pub type DevicePopErrorFuture = Box<dyn Future<Output = Option<Error>>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type SubmittedWorkDoneCallback = Box<dyn FnOnce() + Send + 'static>;
+#[cfg(target_arch = "wasm32")]
+pub type SubmittedWorkDoneCallback = Box<dyn FnOnce() + 'static>;
+
 /// An object safe variant of [`Context`] implemented by all types that implement [`Context`].
-pub(crate) trait DynContext: Debug + Send + Sync {
+pub(crate) trait DynContext: Debug + MaybeSend + MaybeSync {
     fn as_any(&self) -> &dyn Any;
 
     fn instance_create_surface(
@@ -1092,14 +1122,14 @@ pub(crate) trait DynContext: Debug + Send + Sync {
     fn instance_request_adapter(
         &self,
         options: &RequestAdapterOptions<'_>,
-    ) -> Pin<Box<dyn Future<Output = Option<(ObjectId, Box<crate::Data>)>> + Send>>;
+    ) -> Pin<InstanceRequestAdapterFuture>;
     fn adapter_request_device(
         &self,
         adapter: &ObjectId,
         adapter_data: &crate::Data,
         desc: &DeviceDescriptor,
         trace_dir: Option<&std::path::Path>,
-    ) -> Pin<Box<dyn Future<Output = Result<DeviceRequest, RequestDeviceError>> + Send>>;
+    ) -> Pin<AdapterRequestDeviceFuture>;
 
     fn instance_poll_all_devices(&self, force_wait: bool) -> bool;
     fn adapter_is_surface_supported(
@@ -1152,10 +1182,10 @@ pub(crate) trait DynContext: Debug + Send + Sync {
         Option<ObjectId>,
         Option<Box<crate::Data>>,
         SurfaceStatus,
-        Box<dyn Any + Send + Sync>,
+        Box<dyn AnySendSync>,
     );
-    fn surface_present(&self, texture: &ObjectId, detail: &(dyn Any + Send + Sync));
-    fn surface_texture_discard(&self, texture: &ObjectId, detail: &(dyn Any + Send + Sync));
+    fn surface_present(&self, texture: &ObjectId, detail: &dyn AnySendSync);
+    fn surface_texture_discard(&self, texture: &ObjectId, detail: &dyn AnySendSync);
 
     fn device_features(&self, device: &ObjectId, device_data: &crate::Data) -> Features;
     fn device_limits(&self, device: &ObjectId, device_data: &crate::Data) -> Limits;
@@ -1262,14 +1292,14 @@ pub(crate) trait DynContext: Debug + Send + Sync {
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-    ) -> Pin<Box<dyn Future<Output = Option<Error>> + Send + 'static>>;
+    ) -> Pin<DevicePopErrorFuture>;
     fn buffer_map_async(
         &self,
         buffer: &ObjectId,
         buffer_data: &crate::Data,
         mode: MapMode,
         range: Range<BufferAddress>,
-        callback: Box<dyn FnOnce(Result<(), BufferAsyncError>) + Send + 'static>,
+        callback: BufferMapCallback,
     );
     fn buffer_get_mapped_range(
         &self,
@@ -1511,7 +1541,7 @@ pub(crate) trait DynContext: Debug + Send + Sync {
         &self,
         queue: &ObjectId,
         queue_data: &crate::Data,
-        callback: Box<dyn FnOnce() + Send + 'static>,
+        callback: SubmittedWorkDoneCallback,
     );
 
     fn device_start_capture(&self, device: &ObjectId, data: &crate::Data);
@@ -1931,7 +1961,7 @@ where
     fn instance_request_adapter(
         &self,
         options: &RequestAdapterOptions<'_>,
-    ) -> Pin<Box<dyn Future<Output = Option<(ObjectId, Box<crate::Data>)>> + Send>> {
+    ) -> Pin<InstanceRequestAdapterFuture> {
         let future: T::RequestAdapterFuture = Context::instance_request_adapter(self, options);
         Box::pin(async move {
             let result: Option<(T::AdapterId, T::AdapterData)> = future.await;
@@ -1945,7 +1975,7 @@ where
         adapter_data: &crate::Data,
         desc: &DeviceDescriptor,
         trace_dir: Option<&std::path::Path>,
-    ) -> Pin<Box<dyn Future<Output = Result<DeviceRequest, RequestDeviceError>> + Send>> {
+    ) -> Pin<AdapterRequestDeviceFuture> {
         let adapter = <T::AdapterId>::from(*adapter);
         let adapter_data = downcast_ref(adapter_data);
         let future = Context::adapter_request_device(self, &adapter, adapter_data, desc, trace_dir);
@@ -2064,13 +2094,13 @@ where
         Option<ObjectId>,
         Option<Box<crate::Data>>,
         SurfaceStatus,
-        Box<dyn Any + Send + Sync>,
+        Box<dyn AnySendSync>,
     ) {
         let surface = <T::SurfaceId>::from(*surface);
         let surface_data = downcast_ref(surface_data);
         let (texture, texture_data, status, detail) =
             Context::surface_get_current_texture(self, &surface, surface_data);
-        let detail = Box::new(detail) as Box<dyn Any + Send + Sync>;
+        let detail = Box::new(detail) as Box<dyn AnySendSync>;
         (
             texture.map(Into::into),
             texture_data.map(|b| Box::new(b) as _),
@@ -2079,12 +2109,12 @@ where
         )
     }
 
-    fn surface_present(&self, texture: &ObjectId, detail: &(dyn Any + Send + Sync)) {
+    fn surface_present(&self, texture: &ObjectId, detail: &dyn AnySendSync) {
         let texture = <T::TextureId>::from(*texture);
         Context::surface_present(self, &texture, detail.downcast_ref().unwrap())
     }
 
-    fn surface_texture_discard(&self, texture: &ObjectId, detail: &(dyn Any + Send + Sync)) {
+    fn surface_texture_discard(&self, texture: &ObjectId, detail: &dyn AnySendSync) {
         let texture = <T::TextureId>::from(*texture);
         Context::surface_texture_discard(self, &texture, detail.downcast_ref().unwrap())
     }
@@ -2325,7 +2355,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-    ) -> Pin<Box<dyn Future<Output = Option<Error>> + Send + 'static>> {
+    ) -> Pin<DevicePopErrorFuture> {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
         Box::pin(Context::device_pop_error_scope(self, &device, device_data))
@@ -2337,7 +2367,7 @@ where
         buffer_data: &crate::Data,
         mode: MapMode,
         range: Range<BufferAddress>,
-        callback: Box<dyn FnOnce(Result<(), BufferAsyncError>) + Send + 'static>,
+        callback: BufferMapCallback,
     ) {
         let buffer = <T::BufferId>::from(*buffer);
         let buffer_data = downcast_ref(buffer_data);
@@ -2928,7 +2958,7 @@ where
         &self,
         queue: &ObjectId,
         queue_data: &crate::Data,
-        callback: Box<dyn FnOnce() + Send + 'static>,
+        callback: SubmittedWorkDoneCallback,
     ) {
         let queue = <T::QueueId>::from(*queue);
         let queue_data = downcast_ref(queue_data);
@@ -3861,7 +3891,7 @@ where
     }
 }
 
-pub trait QueueWriteBuffer: Send + Sync {
+pub trait QueueWriteBuffer: MaybeSend + MaybeSync {
     fn slice(&self) -> &[u8];
 
     fn slice_mut(&mut self) -> &mut [u8];

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -4,14 +4,14 @@ use wgt::{
     strict_assert, strict_assert_eq, AdapterInfo, BufferAddress, BufferSize, Color,
     DownlevelCapabilities, DynamicOffset, Extent3d, Features, ImageDataLayout,
     ImageSubresourceRange, IndexFormat, Limits, ShaderStages, SurfaceStatus, TextureFormat,
-    TextureFormatFeatures,
+    TextureFormatFeatures, WasmNotSend, WasmNotSync,
 };
 
 use crate::{
-    AnySendSync, BindGroupDescriptor, BindGroupLayoutDescriptor, Buffer, BufferAsyncError,
+    AnyWasmNotSendSync, BindGroupDescriptor, BindGroupLayoutDescriptor, Buffer, BufferAsyncError,
     BufferDescriptor, CommandEncoderDescriptor, ComputePassDescriptor, ComputePipelineDescriptor,
     DeviceDescriptor, Error, ErrorFilter, ImageCopyBuffer, ImageCopyTexture, Maintain, MapMode,
-    MaybeSend, MaybeSync, PipelineLayoutDescriptor, QuerySetDescriptor, RenderBundleDescriptor,
+    PipelineLayoutDescriptor, QuerySetDescriptor, RenderBundleDescriptor,
     RenderBundleEncoderDescriptor, RenderPassDescriptor, RenderPipelineDescriptor,
     RequestAdapterOptions, RequestDeviceError, SamplerDescriptor, ShaderModuleDescriptor,
     ShaderModuleDescriptorSpirV, Texture, TextureDescriptor, TextureViewDescriptor,
@@ -27,59 +27,59 @@ impl<T: Into<ObjectId> + From<ObjectId> + Debug + 'static> ContextId for T {}
 /// Meta trait for an data associated with an id tracked by a context.
 ///
 /// There is no need to manually implement this trait since there is a blanket implementation for this trait.
-pub trait ContextData: Debug + MaybeSend + MaybeSync + 'static {}
-impl<T: Debug + MaybeSend + MaybeSync + 'static> ContextData for T {}
+pub trait ContextData: Debug + WasmNotSend + WasmNotSync + 'static {}
+impl<T: Debug + WasmNotSend + WasmNotSync + 'static> ContextData for T {}
 
-pub trait Context: Debug + MaybeSend + MaybeSync + Sized {
-    type AdapterId: ContextId + MaybeSend + MaybeSync;
+pub trait Context: Debug + WasmNotSend + WasmNotSync + Sized {
+    type AdapterId: ContextId + WasmNotSend + WasmNotSync;
     type AdapterData: ContextData;
-    type DeviceId: ContextId + MaybeSend + MaybeSync;
+    type DeviceId: ContextId + WasmNotSend + WasmNotSync;
     type DeviceData: ContextData;
-    type QueueId: ContextId + MaybeSend + MaybeSync;
+    type QueueId: ContextId + WasmNotSend + WasmNotSync;
     type QueueData: ContextData;
-    type ShaderModuleId: ContextId + MaybeSend + MaybeSync;
+    type ShaderModuleId: ContextId + WasmNotSend + WasmNotSync;
     type ShaderModuleData: ContextData;
-    type BindGroupLayoutId: ContextId + MaybeSend + MaybeSync;
+    type BindGroupLayoutId: ContextId + WasmNotSend + WasmNotSync;
     type BindGroupLayoutData: ContextData;
-    type BindGroupId: ContextId + MaybeSend + MaybeSync;
+    type BindGroupId: ContextId + WasmNotSend + WasmNotSync;
     type BindGroupData: ContextData;
-    type TextureViewId: ContextId + MaybeSend + MaybeSync;
+    type TextureViewId: ContextId + WasmNotSend + WasmNotSync;
     type TextureViewData: ContextData;
-    type SamplerId: ContextId + MaybeSend + MaybeSync;
+    type SamplerId: ContextId + WasmNotSend + WasmNotSync;
     type SamplerData: ContextData;
-    type BufferId: ContextId + MaybeSend + MaybeSync;
+    type BufferId: ContextId + WasmNotSend + WasmNotSync;
     type BufferData: ContextData;
-    type TextureId: ContextId + MaybeSend + MaybeSync;
+    type TextureId: ContextId + WasmNotSend + WasmNotSync;
     type TextureData: ContextData;
-    type QuerySetId: ContextId + MaybeSend + MaybeSync;
+    type QuerySetId: ContextId + WasmNotSend + WasmNotSync;
     type QuerySetData: ContextData;
-    type PipelineLayoutId: ContextId + MaybeSend + MaybeSync;
+    type PipelineLayoutId: ContextId + WasmNotSend + WasmNotSync;
     type PipelineLayoutData: ContextData;
-    type RenderPipelineId: ContextId + MaybeSend + MaybeSync;
+    type RenderPipelineId: ContextId + WasmNotSend + WasmNotSync;
     type RenderPipelineData: ContextData;
-    type ComputePipelineId: ContextId + MaybeSend + MaybeSync;
+    type ComputePipelineId: ContextId + WasmNotSend + WasmNotSync;
     type ComputePipelineData: ContextData;
-    type CommandEncoderId: ContextId + MaybeSend + MaybeSync;
+    type CommandEncoderId: ContextId + WasmNotSend + WasmNotSync;
     type CommandEncoderData: ContextData;
     type ComputePassId: ContextId;
     type ComputePassData: ContextData;
     type RenderPassId: ContextId;
     type RenderPassData: ContextData;
-    type CommandBufferId: ContextId + MaybeSend + MaybeSync;
+    type CommandBufferId: ContextId + WasmNotSend + WasmNotSync;
     type CommandBufferData: ContextData;
     type RenderBundleEncoderId: ContextId;
     type RenderBundleEncoderData: ContextData;
-    type RenderBundleId: ContextId + MaybeSend + MaybeSync;
+    type RenderBundleId: ContextId + WasmNotSend + WasmNotSync;
     type RenderBundleData: ContextData;
-    type SurfaceId: ContextId + MaybeSend + MaybeSync;
+    type SurfaceId: ContextId + WasmNotSend + WasmNotSync;
     type SurfaceData: ContextData;
 
-    type SurfaceOutputDetail: MaybeSend + MaybeSync + 'static;
-    type SubmissionIndex: ContextId + Clone + Copy + MaybeSend + MaybeSync;
+    type SurfaceOutputDetail: WasmNotSend + WasmNotSync + 'static;
+    type SubmissionIndex: ContextId + Clone + Copy + WasmNotSend + WasmNotSync;
     type SubmissionIndexData: ContextData + Copy;
 
     type RequestAdapterFuture: Future<Output = Option<(Self::AdapterId, Self::AdapterData)>>
-        + MaybeSend
+        + WasmNotSend
         + 'static;
     type RequestDeviceFuture: Future<
             Output = Result<
@@ -91,9 +91,9 @@ pub trait Context: Debug + MaybeSend + MaybeSync + Sized {
                 ),
                 RequestDeviceError,
             >,
-        > + MaybeSend
+        > + WasmNotSend
         + 'static;
-    type PopErrorScopeFuture: Future<Output = Option<Error>> + MaybeSend + 'static;
+    type PopErrorScopeFuture: Future<Output = Option<Error>> + WasmNotSend + 'static;
 
     fn init(instance_desc: wgt::InstanceDescriptor) -> Self;
     fn instance_create_surface(
@@ -1042,13 +1042,15 @@ impl ObjectId {
 #[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(ObjectId: Send, Sync);
 
-pub(crate) fn downcast_ref<T: Debug + MaybeSend + MaybeSync + 'static>(data: &crate::Data) -> &T {
+pub(crate) fn downcast_ref<T: Debug + WasmNotSend + WasmNotSync + 'static>(
+    data: &crate::Data,
+) -> &T {
     strict_assert!(data.is::<T>());
     // Copied from std.
     unsafe { &*(data as *const dyn Any as *const T) }
 }
 
-fn downcast_mut<T: Debug + MaybeSend + MaybeSync + 'static>(data: &mut crate::Data) -> &mut T {
+fn downcast_mut<T: Debug + WasmNotSend + WasmNotSync + 'static>(data: &mut crate::Data) -> &mut T {
     strict_assert!(data.is::<T>());
     // Copied from std.
     unsafe { &mut *(data as *mut dyn Any as *mut T) }
@@ -1110,7 +1112,7 @@ pub type SubmittedWorkDoneCallback = Box<dyn FnOnce() + Send + 'static>;
 pub type SubmittedWorkDoneCallback = Box<dyn FnOnce() + 'static>;
 
 /// An object safe variant of [`Context`] implemented by all types that implement [`Context`].
-pub(crate) trait DynContext: Debug + MaybeSend + MaybeSync {
+pub(crate) trait DynContext: Debug + WasmNotSend + WasmNotSync {
     fn as_any(&self) -> &dyn Any;
 
     fn instance_create_surface(
@@ -1182,10 +1184,10 @@ pub(crate) trait DynContext: Debug + MaybeSend + MaybeSync {
         Option<ObjectId>,
         Option<Box<crate::Data>>,
         SurfaceStatus,
-        Box<dyn AnySendSync>,
+        Box<dyn AnyWasmNotSendSync>,
     );
-    fn surface_present(&self, texture: &ObjectId, detail: &dyn AnySendSync);
-    fn surface_texture_discard(&self, texture: &ObjectId, detail: &dyn AnySendSync);
+    fn surface_present(&self, texture: &ObjectId, detail: &dyn AnyWasmNotSendSync);
+    fn surface_texture_discard(&self, texture: &ObjectId, detail: &dyn AnyWasmNotSendSync);
 
     fn device_features(&self, device: &ObjectId, device_data: &crate::Data) -> Features;
     fn device_limits(&self, device: &ObjectId, device_data: &crate::Data) -> Limits;
@@ -2094,13 +2096,13 @@ where
         Option<ObjectId>,
         Option<Box<crate::Data>>,
         SurfaceStatus,
-        Box<dyn AnySendSync>,
+        Box<dyn AnyWasmNotSendSync>,
     ) {
         let surface = <T::SurfaceId>::from(*surface);
         let surface_data = downcast_ref(surface_data);
         let (texture, texture_data, status, detail) =
             Context::surface_get_current_texture(self, &surface, surface_data);
-        let detail = Box::new(detail) as Box<dyn AnySendSync>;
+        let detail = Box::new(detail) as Box<dyn AnyWasmNotSendSync>;
         (
             texture.map(Into::into),
             texture_data.map(|b| Box::new(b) as _),
@@ -2109,12 +2111,12 @@ where
         )
     }
 
-    fn surface_present(&self, texture: &ObjectId, detail: &dyn AnySendSync) {
+    fn surface_present(&self, texture: &ObjectId, detail: &dyn AnyWasmNotSendSync) {
         let texture = <T::TextureId>::from(*texture);
         Context::surface_present(self, &texture, detail.downcast_ref().unwrap())
     }
 
-    fn surface_texture_discard(&self, texture: &ObjectId, detail: &dyn AnySendSync) {
+    fn surface_texture_discard(&self, texture: &ObjectId, detail: &dyn AnyWasmNotSendSync) {
         let texture = <T::TextureId>::from(*texture);
         Context::surface_texture_discard(self, &texture, detail.downcast_ref().unwrap())
     }
@@ -3891,7 +3893,7 @@ where
     }
 }
 
-pub trait QueueWriteBuffer: MaybeSend + MaybeSync {
+pub trait QueueWriteBuffer: WasmNotSend + WasmNotSync {
     fn slice(&self) -> &[u8];
 
     fn slice_mut(&mut self) -> &mut [u8];

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -1039,7 +1039,13 @@ impl ObjectId {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(ObjectId: Send, Sync);
 
 pub(crate) fn downcast_ref<T: Debug + WasmNotSend + WasmNotSync + 'static>(
@@ -1082,33 +1088,93 @@ pub(crate) struct DeviceRequest {
     pub queue_data: Box<crate::Data>,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 pub type BufferMapCallback = Box<dyn FnOnce(Result<(), BufferAsyncError>) + Send + 'static>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+)))]
 pub type BufferMapCallback = Box<dyn FnOnce(Result<(), BufferAsyncError>) + 'static>;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 pub(crate) type AdapterRequestDeviceFuture =
     Box<dyn Future<Output = Result<DeviceRequest, RequestDeviceError>> + Send>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+)))]
 pub(crate) type AdapterRequestDeviceFuture =
     Box<dyn Future<Output = Result<DeviceRequest, RequestDeviceError>>>;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 pub type InstanceRequestAdapterFuture =
     Box<dyn Future<Output = Option<(ObjectId, Box<crate::Data>)>> + Send>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+)))]
 pub type InstanceRequestAdapterFuture =
     Box<dyn Future<Output = Option<(ObjectId, Box<crate::Data>)>>>;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 pub type DevicePopErrorFuture = Box<dyn Future<Output = Option<Error>> + Send>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+)))]
 pub type DevicePopErrorFuture = Box<dyn Future<Output = Option<Error>>>;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 pub type SubmittedWorkDoneCallback = Box<dyn FnOnce() + Send + 'static>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+)))]
 pub type SubmittedWorkDoneCallback = Box<dyn FnOnce() + 'static>;
 
 /// An object safe variant of [`Context`] implemented by all types that implement [`Context`].

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -79,9 +79,21 @@ pub enum ErrorFilter {
 static_assertions::assert_impl_all!(ErrorFilter: Send, Sync);
 
 type C = dyn DynContext;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 type Data = dyn Any + Send + Sync;
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+)))]
 type Data = dyn Any;
 
 /// Context for all other wgpu objects. Instance of wgpu.
@@ -96,7 +108,13 @@ type Data = dyn Any;
 pub struct Instance {
     context: Arc<C>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(Instance: Send, Sync);
 
 /// Handle to a physical graphics and/or compute device.
@@ -113,7 +131,13 @@ pub struct Adapter {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(Adapter: Send, Sync);
 
 impl Drop for Adapter {
@@ -138,7 +162,13 @@ pub struct Device {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(Device: Send, Sync);
 
 /// Identifier for a particular call to [`Queue::submit`]. Can be used
@@ -149,7 +179,13 @@ static_assertions::assert_impl_all!(Device: Send, Sync);
 /// There is no analogue in the WebGPU specification.
 #[derive(Debug, Clone)]
 pub struct SubmissionIndex(ObjectId, Arc<crate::Data>);
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(SubmissionIndex: Send, Sync);
 
 /// The main purpose of this struct is to resolve mapped ranges (convert sizes
@@ -226,7 +262,13 @@ pub struct Buffer {
     usage: BufferUsages,
     // Todo: missing map_state https://www.w3.org/TR/webgpu/#dom-gpubuffer-mapstate
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(Buffer: Send, Sync);
 
 /// Slice into a [`Buffer`].
@@ -243,7 +285,13 @@ pub struct BufferSlice<'a> {
     offset: BufferAddress,
     size: Option<BufferSize>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(BufferSlice: Send, Sync);
 
 /// Handle to a texture on the GPU.
@@ -259,7 +307,13 @@ pub struct Texture {
     owned: bool,
     descriptor: TextureDescriptor<'static>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(Texture: Send, Sync);
 
 /// Handle to a texture view.
@@ -274,7 +328,13 @@ pub struct TextureView {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(TextureView: Send, Sync);
 
 /// Handle to a sampler.
@@ -292,7 +352,13 @@ pub struct Sampler {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(Sampler: Send, Sync);
 
 impl Drop for Sampler {
@@ -333,7 +399,13 @@ pub struct Surface {
     // been created is is additionally wrapped in an option.
     config: Mutex<Option<SurfaceConfiguration>>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(Surface: Send, Sync);
 
 impl Drop for Surface {
@@ -361,7 +433,13 @@ pub struct BindGroupLayout {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(BindGroupLayout: Send, Sync);
 
 impl Drop for BindGroupLayout {
@@ -387,7 +465,13 @@ pub struct BindGroup {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(BindGroup: Send, Sync);
 
 impl Drop for BindGroup {
@@ -412,7 +496,13 @@ pub struct ShaderModule {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(ShaderModule: Send, Sync);
 
 impl Drop for ShaderModule {
@@ -505,7 +595,13 @@ pub struct PipelineLayout {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(PipelineLayout: Send, Sync);
 
 impl Drop for PipelineLayout {
@@ -529,7 +625,13 @@ pub struct RenderPipeline {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(RenderPipeline: Send, Sync);
 
 impl Drop for RenderPipeline {
@@ -564,7 +666,13 @@ pub struct ComputePipeline {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(ComputePipeline: Send, Sync);
 
 impl Drop for ComputePipeline {
@@ -602,7 +710,13 @@ pub struct CommandBuffer {
     id: Option<ObjectId>,
     data: Option<Box<Data>>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(CommandBuffer: Send, Sync);
 
 impl Drop for CommandBuffer {
@@ -631,7 +745,13 @@ pub struct CommandEncoder {
     id: Option<ObjectId>,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(CommandEncoder: Send, Sync);
 
 impl Drop for CommandEncoder {
@@ -708,7 +828,13 @@ pub struct RenderBundle {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(RenderBundle: Send, Sync);
 
 impl Drop for RenderBundle {
@@ -730,7 +856,13 @@ pub struct QuerySet {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(QuerySet: Send, Sync);
 
 impl Drop for QuerySet {
@@ -754,7 +886,13 @@ pub struct Queue {
     id: ObjectId,
     data: Box<Data>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(Queue: Send, Sync);
 
 /// Resource that can be bound to a pipeline.
@@ -800,7 +938,13 @@ pub enum BindingResource<'a> {
     /// [`BindGroupLayoutEntry::count`] set to Some.
     TextureViewArray(&'a [&'a TextureView]),
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(BindingResource: Send, Sync);
 
 /// Describes the segment of a buffer to bind.
@@ -832,7 +976,13 @@ pub struct BufferBinding<'a> {
     /// Size of the binding in bytes, or `None` for using the rest of the buffer.
     pub size: Option<BufferSize>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(BufferBinding: Send, Sync);
 
 /// Operation to perform to the output attachment at the start of a render pass.
@@ -894,7 +1044,13 @@ pub struct RenderPassColorAttachment<'tex> {
     /// What operations will be performed on this color attachment.
     pub ops: Operations<Color>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(RenderPassColorAttachment: Send, Sync);
 
 /// Describes a depth/stencil attachment to a [`RenderPass`].
@@ -912,7 +1068,13 @@ pub struct RenderPassDepthStencilAttachment<'tex> {
     /// What operations will be performed on the stencil part of the attachment.
     pub stencil_ops: Option<Operations<u32>>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(RenderPassDepthStencilAttachment: Send, Sync);
 
 // The underlying types are also exported so that documentation shows up for them
@@ -927,7 +1089,13 @@ pub use wgt::RequestAdapterOptions as RequestAdapterOptionsBase;
 /// Corresponds to [WebGPU `GPURequestAdapterOptions`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpurequestadapteroptions).
 pub type RequestAdapterOptions<'a> = RequestAdapterOptionsBase<&'a Surface>;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(RequestAdapterOptions: Send, Sync);
 /// Describes a [`Device`].
 ///
@@ -980,7 +1148,13 @@ static_assertions::assert_impl_all!(QuerySetDescriptor: Send, Sync);
 pub use wgt::Maintain as MaintainBase;
 /// Passed to [`Device::poll`] to control how and if it should block.
 pub type Maintain = wgt::Maintain<SubmissionIndex>;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(Maintain: Send, Sync);
 
 /// Describes a [`TextureView`].
@@ -1036,7 +1210,13 @@ pub struct PipelineLayoutDescriptor<'a> {
     /// If this array is non-empty, the [`Features::PUSH_CONSTANTS`] must be enabled.
     pub push_constant_ranges: &'a [PushConstantRange],
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(PipelineLayoutDescriptor: Send, Sync);
 
 /// Describes a [`Sampler`].
@@ -1106,7 +1286,13 @@ pub struct BindGroupEntry<'a> {
     /// Resource to attach to the binding
     pub resource: BindingResource<'a>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(BindGroupEntry: Send, Sync);
 
 /// Describes a group of bindings and the resources to be bound.
@@ -1124,7 +1310,13 @@ pub struct BindGroupDescriptor<'a> {
     /// The resources to bind to this bind group.
     pub entries: &'a [BindGroupEntry<'a>],
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(BindGroupDescriptor: Send, Sync);
 
 /// Describes the attachments of a render pass.
@@ -1145,7 +1337,13 @@ pub struct RenderPassDescriptor<'tex, 'desc> {
     /// The depth and stencil attachment of the render pass, if any.
     pub depth_stencil_attachment: Option<RenderPassDepthStencilAttachment<'tex>>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(RenderPassDescriptor: Send, Sync);
 
 /// Describes how the vertex buffer is interpreted.
@@ -1181,7 +1379,13 @@ pub struct VertexState<'a> {
     /// The format of any vertex buffers used with this pipeline.
     pub buffers: &'a [VertexBufferLayout<'a>],
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(VertexState: Send, Sync);
 
 /// Describes the fragment processing in a render pipeline.
@@ -1200,7 +1404,13 @@ pub struct FragmentState<'a> {
     /// The color state of the render targets.
     pub targets: &'a [Option<ColorTargetState>],
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(FragmentState: Send, Sync);
 
 /// Describes a render (graphics) pipeline.
@@ -1229,7 +1439,13 @@ pub struct RenderPipelineDescriptor<'a> {
     /// layers the attachments will have.
     pub multiview: Option<NonZeroU32>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(RenderPipelineDescriptor: Send, Sync);
 
 /// Describes the attachments of a compute pass.
@@ -1263,7 +1479,13 @@ pub struct ComputePipelineDescriptor<'a> {
     /// and no return value in the shader.
     pub entry_point: &'a str,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(ComputePipelineDescriptor: Send, Sync);
 
 pub use wgt::ImageCopyBuffer as ImageCopyBufferBase;
@@ -1272,7 +1494,13 @@ pub use wgt::ImageCopyBuffer as ImageCopyBufferBase;
 /// Corresponds to [WebGPU `GPUImageCopyBuffer`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopybuffer).
 pub type ImageCopyBuffer<'a> = ImageCopyBufferBase<&'a Buffer>;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(ImageCopyBuffer: Send, Sync);
 
 pub use wgt::ImageCopyTexture as ImageCopyTextureBase;
@@ -1281,7 +1509,13 @@ pub use wgt::ImageCopyTexture as ImageCopyTextureBase;
 /// Corresponds to [WebGPU `GPUImageCopyTexture`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopytexture).
 pub type ImageCopyTexture<'a> = ImageCopyTextureBase<&'a Texture>;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(ImageCopyTexture: Send, Sync);
 
 pub use wgt::ImageCopyTextureTagged as ImageCopyTextureTaggedBase;
@@ -1291,7 +1525,13 @@ pub use wgt::ImageCopyTextureTagged as ImageCopyTextureTaggedBase;
 /// Corresponds to [WebGPU `GPUImageCopyTextureTagged`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopytexturetagged).
 pub type ImageCopyTextureTagged<'a> = ImageCopyTextureTaggedBase<&'a Texture>;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(ImageCopyTexture: Send, Sync);
 
 /// Describes a [`BindGroupLayout`].
@@ -1350,7 +1590,13 @@ pub struct SurfaceTexture {
     presented: bool,
     detail: Box<dyn AnyWasmNotSendSync>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(SurfaceTexture: Send, Sync);
 
 /// Result of an unsuccessful call to [`Surface::get_current_texture`].
@@ -4011,7 +4257,13 @@ pub struct QueueWriteBufferView<'a> {
     offset: BufferAddress,
     inner: Box<dyn context::QueueWriteBuffer>,
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(QueueWriteBufferView: Send, Sync);
 
 impl Deref for QueueWriteBufferView<'_> {
@@ -4651,25 +4903,55 @@ pub enum Error {
     /// Out of memory error
     OutOfMemory {
         /// Lower level source of the error.
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(any(
+            not(target_arch = "wasm32"),
+            all(
+                feature = "fragile-send-sync-non-atomic-wasm",
+                not(target_feature = "atomics")
+            )
+        ))]
         source: Box<dyn error::Error + Send + 'static>,
         /// Lower level source of the error.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(not(any(
+            not(target_arch = "wasm32"),
+            all(
+                feature = "fragile-send-sync-non-atomic-wasm",
+                not(target_feature = "atomics")
+            )
+        )))]
         source: Box<dyn error::Error + 'static>,
     },
     /// Validation error, signifying a bug in code or data
     Validation {
         /// Lower level source of the error.
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(any(
+            not(target_arch = "wasm32"),
+            all(
+                feature = "fragile-send-sync-non-atomic-wasm",
+                not(target_feature = "atomics")
+            )
+        ))]
         source: Box<dyn error::Error + Send + 'static>,
         /// Lower level source of the error.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(not(any(
+            not(target_arch = "wasm32"),
+            all(
+                feature = "fragile-send-sync-non-atomic-wasm",
+                not(target_feature = "atomics")
+            )
+        )))]
         source: Box<dyn error::Error + 'static>,
         /// Description of the validation error.
         description: String,
     },
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        feature = "fragile-send-sync-non-atomic-wasm",
+        not(target_feature = "atomics")
+    )
+))]
 static_assertions::assert_impl_all!(Error: Send);
 
 impl error::Error for Error {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -66,8 +66,6 @@ pub use ::wgc as core;
 // specific, but these need to depend on web-sys.
 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 pub use wgt::{ExternalImageSource, ImageCopyExternalImage};
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-static_assertions::assert_impl_all!(ExternalImageSource: Send, Sync);
 
 /// Filter for error scopes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
@@ -80,7 +78,10 @@ pub enum ErrorFilter {
 static_assertions::assert_impl_all!(ErrorFilter: Send, Sync);
 
 type C = dyn DynContext;
+#[cfg(not(target_arch = "wasm32"))]
 type Data = dyn Any + Send + Sync;
+#[cfg(target_arch = "wasm32")]
+type Data = dyn Any;
 
 /// Context for all other wgpu objects. Instance of wgpu.
 ///
@@ -94,6 +95,7 @@ type Data = dyn Any + Send + Sync;
 pub struct Instance {
     context: Arc<C>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(Instance: Send, Sync);
 
 /// Handle to a physical graphics and/or compute device.
@@ -110,6 +112,7 @@ pub struct Adapter {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(Adapter: Send, Sync);
 
 impl Drop for Adapter {
@@ -134,6 +137,7 @@ pub struct Device {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(Device: Send, Sync);
 
 /// Identifier for a particular call to [`Queue::submit`]. Can be used
@@ -144,6 +148,7 @@ static_assertions::assert_impl_all!(Device: Send, Sync);
 /// There is no analogue in the WebGPU specification.
 #[derive(Debug, Clone)]
 pub struct SubmissionIndex(ObjectId, Arc<crate::Data>);
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(SubmissionIndex: Send, Sync);
 
 /// The main purpose of this struct is to resolve mapped ranges (convert sizes
@@ -220,6 +225,7 @@ pub struct Buffer {
     usage: BufferUsages,
     // Todo: missing map_state https://www.w3.org/TR/webgpu/#dom-gpubuffer-mapstate
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(Buffer: Send, Sync);
 
 /// Slice into a [`Buffer`].
@@ -236,6 +242,7 @@ pub struct BufferSlice<'a> {
     offset: BufferAddress,
     size: Option<BufferSize>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(BufferSlice: Send, Sync);
 
 /// Handle to a texture on the GPU.
@@ -251,6 +258,7 @@ pub struct Texture {
     owned: bool,
     descriptor: TextureDescriptor<'static>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(Texture: Send, Sync);
 
 /// Handle to a texture view.
@@ -265,6 +273,7 @@ pub struct TextureView {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(TextureView: Send, Sync);
 
 /// Handle to a sampler.
@@ -282,6 +291,7 @@ pub struct Sampler {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(Sampler: Send, Sync);
 
 impl Drop for Sampler {
@@ -322,6 +332,7 @@ pub struct Surface {
     // been created is is additionally wrapped in an option.
     config: Mutex<Option<SurfaceConfiguration>>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(Surface: Send, Sync);
 
 impl Drop for Surface {
@@ -349,6 +360,7 @@ pub struct BindGroupLayout {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(BindGroupLayout: Send, Sync);
 
 impl Drop for BindGroupLayout {
@@ -374,6 +386,7 @@ pub struct BindGroup {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(BindGroup: Send, Sync);
 
 impl Drop for BindGroup {
@@ -398,6 +411,7 @@ pub struct ShaderModule {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(ShaderModule: Send, Sync);
 
 impl Drop for ShaderModule {
@@ -490,6 +504,7 @@ pub struct PipelineLayout {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(PipelineLayout: Send, Sync);
 
 impl Drop for PipelineLayout {
@@ -513,6 +528,7 @@ pub struct RenderPipeline {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(RenderPipeline: Send, Sync);
 
 impl Drop for RenderPipeline {
@@ -547,6 +563,7 @@ pub struct ComputePipeline {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(ComputePipeline: Send, Sync);
 
 impl Drop for ComputePipeline {
@@ -584,6 +601,7 @@ pub struct CommandBuffer {
     id: Option<ObjectId>,
     data: Option<Box<Data>>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(CommandBuffer: Send, Sync);
 
 impl Drop for CommandBuffer {
@@ -612,6 +630,7 @@ pub struct CommandEncoder {
     id: Option<ObjectId>,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(CommandEncoder: Send, Sync);
 
 impl Drop for CommandEncoder {
@@ -688,6 +707,7 @@ pub struct RenderBundle {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(RenderBundle: Send, Sync);
 
 impl Drop for RenderBundle {
@@ -709,6 +729,7 @@ pub struct QuerySet {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(QuerySet: Send, Sync);
 
 impl Drop for QuerySet {
@@ -732,6 +753,7 @@ pub struct Queue {
     id: ObjectId,
     data: Box<Data>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(Queue: Send, Sync);
 
 /// Resource that can be bound to a pipeline.
@@ -777,6 +799,7 @@ pub enum BindingResource<'a> {
     /// [`BindGroupLayoutEntry::count`] set to Some.
     TextureViewArray(&'a [&'a TextureView]),
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(BindingResource: Send, Sync);
 
 /// Describes the segment of a buffer to bind.
@@ -808,6 +831,7 @@ pub struct BufferBinding<'a> {
     /// Size of the binding in bytes, or `None` for using the rest of the buffer.
     pub size: Option<BufferSize>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(BufferBinding: Send, Sync);
 
 /// Operation to perform to the output attachment at the start of a render pass.
@@ -869,6 +893,7 @@ pub struct RenderPassColorAttachment<'tex> {
     /// What operations will be performed on this color attachment.
     pub ops: Operations<Color>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(RenderPassColorAttachment: Send, Sync);
 
 /// Describes a depth/stencil attachment to a [`RenderPass`].
@@ -886,6 +911,7 @@ pub struct RenderPassDepthStencilAttachment<'tex> {
     /// What operations will be performed on the stencil part of the attachment.
     pub stencil_ops: Option<Operations<u32>>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(RenderPassDepthStencilAttachment: Send, Sync);
 
 // The underlying types are also exported so that documentation shows up for them
@@ -900,6 +926,7 @@ pub use wgt::RequestAdapterOptions as RequestAdapterOptionsBase;
 /// Corresponds to [WebGPU `GPURequestAdapterOptions`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpurequestadapteroptions).
 pub type RequestAdapterOptions<'a> = RequestAdapterOptionsBase<&'a Surface>;
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(RequestAdapterOptions: Send, Sync);
 /// Describes a [`Device`].
 ///
@@ -952,6 +979,7 @@ static_assertions::assert_impl_all!(QuerySetDescriptor: Send, Sync);
 pub use wgt::Maintain as MaintainBase;
 /// Passed to [`Device::poll`] to control how and if it should block.
 pub type Maintain = wgt::Maintain<SubmissionIndex>;
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(Maintain: Send, Sync);
 
 /// Describes a [`TextureView`].
@@ -1007,6 +1035,7 @@ pub struct PipelineLayoutDescriptor<'a> {
     /// If this array is non-empty, the [`Features::PUSH_CONSTANTS`] must be enabled.
     pub push_constant_ranges: &'a [PushConstantRange],
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(PipelineLayoutDescriptor: Send, Sync);
 
 /// Describes a [`Sampler`].
@@ -1076,6 +1105,7 @@ pub struct BindGroupEntry<'a> {
     /// Resource to attach to the binding
     pub resource: BindingResource<'a>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(BindGroupEntry: Send, Sync);
 
 /// Describes a group of bindings and the resources to be bound.
@@ -1093,6 +1123,7 @@ pub struct BindGroupDescriptor<'a> {
     /// The resources to bind to this bind group.
     pub entries: &'a [BindGroupEntry<'a>],
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(BindGroupDescriptor: Send, Sync);
 
 /// Describes the attachments of a render pass.
@@ -1113,6 +1144,7 @@ pub struct RenderPassDescriptor<'tex, 'desc> {
     /// The depth and stencil attachment of the render pass, if any.
     pub depth_stencil_attachment: Option<RenderPassDepthStencilAttachment<'tex>>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(RenderPassDescriptor: Send, Sync);
 
 /// Describes how the vertex buffer is interpreted.
@@ -1148,6 +1180,7 @@ pub struct VertexState<'a> {
     /// The format of any vertex buffers used with this pipeline.
     pub buffers: &'a [VertexBufferLayout<'a>],
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(VertexState: Send, Sync);
 
 /// Describes the fragment processing in a render pipeline.
@@ -1166,6 +1199,7 @@ pub struct FragmentState<'a> {
     /// The color state of the render targets.
     pub targets: &'a [Option<ColorTargetState>],
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(FragmentState: Send, Sync);
 
 /// Describes a render (graphics) pipeline.
@@ -1194,6 +1228,7 @@ pub struct RenderPipelineDescriptor<'a> {
     /// layers the attachments will have.
     pub multiview: Option<NonZeroU32>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(RenderPipelineDescriptor: Send, Sync);
 
 /// Describes the attachments of a compute pass.
@@ -1227,6 +1262,7 @@ pub struct ComputePipelineDescriptor<'a> {
     /// and no return value in the shader.
     pub entry_point: &'a str,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(ComputePipelineDescriptor: Send, Sync);
 
 pub use wgt::ImageCopyBuffer as ImageCopyBufferBase;
@@ -1235,6 +1271,7 @@ pub use wgt::ImageCopyBuffer as ImageCopyBufferBase;
 /// Corresponds to [WebGPU `GPUImageCopyBuffer`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopybuffer).
 pub type ImageCopyBuffer<'a> = ImageCopyBufferBase<&'a Buffer>;
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(ImageCopyBuffer: Send, Sync);
 
 pub use wgt::ImageCopyTexture as ImageCopyTextureBase;
@@ -1243,6 +1280,7 @@ pub use wgt::ImageCopyTexture as ImageCopyTextureBase;
 /// Corresponds to [WebGPU `GPUImageCopyTexture`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopytexture).
 pub type ImageCopyTexture<'a> = ImageCopyTextureBase<&'a Texture>;
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(ImageCopyTexture: Send, Sync);
 
 pub use wgt::ImageCopyTextureTagged as ImageCopyTextureTaggedBase;
@@ -1252,6 +1290,7 @@ pub use wgt::ImageCopyTextureTagged as ImageCopyTextureTaggedBase;
 /// Corresponds to [WebGPU `GPUImageCopyTextureTagged`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopytexturetagged).
 pub type ImageCopyTextureTagged<'a> = ImageCopyTextureTaggedBase<&'a Texture>;
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(ImageCopyTexture: Send, Sync);
 
 /// Describes a [`BindGroupLayout`].
@@ -1308,8 +1347,9 @@ pub struct SurfaceTexture {
     /// but should be recreated for maximum performance.
     pub suboptimal: bool,
     presented: bool,
-    detail: Box<dyn Any + Send + Sync>,
+    detail: Box<dyn AnySendSync>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(SurfaceTexture: Send, Sync);
 
 /// Result of an unsuccessful call to [`Surface::get_current_texture`].
@@ -1463,7 +1503,7 @@ impl Instance {
     pub fn request_adapter(
         &self,
         options: &RequestAdapterOptions,
-    ) -> impl Future<Output = Option<Adapter>> + Send {
+    ) -> impl Future<Output = Option<Adapter>> + MaybeSend {
         let context = Arc::clone(&self.context);
         let adapter = self.context.instance_request_adapter(options);
         async move {
@@ -1743,7 +1783,7 @@ impl Adapter {
         &self,
         desc: &DeviceDescriptor,
         trace_path: Option<&std::path::Path>,
-    ) -> impl Future<Output = Result<(Device, Queue), RequestDeviceError>> + Send {
+    ) -> impl Future<Output = Result<(Device, Queue), RequestDeviceError>> + MaybeSend {
         let context = Arc::clone(&self.context);
         let device = DynContext::adapter_request_device(
             &*self.context,
@@ -2257,7 +2297,7 @@ impl Device {
     }
 
     /// Pop an error scope.
-    pub fn pop_error_scope(&self) -> impl Future<Output = Option<Error>> + Send {
+    pub fn pop_error_scope(&self) -> impl Future<Output = Option<Error>> + MaybeSend {
         self.context
             .device_pop_error_scope(&self.id, self.data.as_ref())
     }
@@ -2562,7 +2602,7 @@ impl<'a> BufferSlice<'a> {
     pub fn map_async(
         &self,
         mode: MapMode,
-        callback: impl FnOnce(Result<(), BufferAsyncError>) + Send + 'static,
+        callback: impl FnOnce(Result<(), BufferAsyncError>) + MaybeSend + 'static,
     ) {
         let mut mc = self.buffer.map_context.lock();
         assert_eq!(
@@ -3970,6 +4010,7 @@ pub struct QueueWriteBufferView<'a> {
     offset: BufferAddress,
     inner: Box<dyn context::QueueWriteBuffer>,
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(QueueWriteBufferView: Send, Sync);
 
 impl Deref for QueueWriteBufferView<'_> {
@@ -4609,16 +4650,25 @@ pub enum Error {
     /// Out of memory error
     OutOfMemory {
         /// Lower level source of the error.
+        #[cfg(not(target_arch = "wasm32"))]
         source: Box<dyn error::Error + Send + 'static>,
+        /// Lower level source of the error.
+        #[cfg(target_arch = "wasm32")]
+        source: Box<dyn error::Error + 'static>,
     },
     /// Validation error, signifying a bug in code or data
     Validation {
         /// Lower level source of the error.
+        #[cfg(not(target_arch = "wasm32"))]
         source: Box<dyn error::Error + Send + 'static>,
+        /// Lower level source of the error.
+        #[cfg(target_arch = "wasm32")]
+        source: Box<dyn error::Error + 'static>,
         /// Description of the validation error.
         description: String,
     },
 }
+#[cfg(not(target_arch = "wasm32"))]
 static_assertions::assert_impl_all!(Error: Send);
 
 impl error::Error for Error {
@@ -4635,6 +4685,54 @@ impl Display for Error {
         match self {
             Error::OutOfMemory { .. } => f.write_str("Out of Memory"),
             Error::Validation { description, .. } => f.write_str(description),
+        }
+    }
+}
+
+use send_sync::*;
+
+mod send_sync {
+    use std::any::Any;
+    use std::fmt;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub trait MaybeSend: Send {}
+    #[cfg(not(target_arch = "wasm32"))]
+    impl<T: Send> MaybeSend for T {}
+    #[cfg(target_arch = "wasm32")]
+    pub trait MaybeSend {}
+    #[cfg(target_arch = "wasm32")]
+    impl<T> MaybeSend for T {}
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub trait MaybeSync: Sync {}
+    #[cfg(not(target_arch = "wasm32"))]
+    impl<T: Sync> MaybeSync for T {}
+    #[cfg(target_arch = "wasm32")]
+    pub trait MaybeSync {}
+    #[cfg(target_arch = "wasm32")]
+    impl<T> MaybeSync for T {}
+
+    pub trait AnySendSync: Any + MaybeSend + MaybeSync {
+        fn upcast_any_ref(&self) -> &dyn Any;
+    }
+    impl<T: Any + MaybeSend + MaybeSync> AnySendSync for T {
+        #[inline]
+        fn upcast_any_ref(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    impl dyn AnySendSync + 'static {
+        #[inline]
+        pub fn downcast_ref<T: 'static>(&self) -> Option<&T> {
+            self.upcast_any_ref().downcast_ref::<T>()
+        }
+    }
+
+    impl fmt::Debug for dyn AnySendSync {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Any").finish_non_exhaustive()
         }
     }
 }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #2884.
Addresses #3026.

**Description**
Currently all types unsafely implement `Send` and `Sync` on the Wasm target under the assumption that Wasm doesn't support multi-threading. Which it actually does (on nightly).

This PR removes all these implementations and introduces `MaybeSend` and `MaybeSync` supertraits to continue implementing `Send` and `Sync` on non-Wasm targets.

**Testing**
It's not, maybe in the future we could add some Wasm multithreading examples/tests.