### PR TITLE
[wgpu-hal] fall back from broken `VK_KHR_timeline_semaphore` impls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@ By @cwfitzgerald in [#3671](https://github.com/gfx-rs/wgpu/pull/3671).
 #### Vulkan
 
 - Treat `VK_SUBOPTIMAL_KHR` as `VK_SUCCESS` on Android. By @James2022-rgb in [#3525](https://github.com/gfx-rs/wgpu/pull/3525)
+- Work around some broken `VK_KHR_timeline_semaphore` impls (e.g. Oculus Quest 2), by falling back to a fence pool when `VkCreateSemaphore` returns `ERROR_INITIALIZATION_FAILED`. By @eddyb in [#3693](https://github.com/gfx-rs/wgpu/pull/3693)
 
 #### Metal
 - `create_texture` returns an error if `new_texture` returns NULL. By @jinleili in [#3554](https://github.com/gfx-rs/wgpu/pull/3554)


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] ~~Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.~~
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
~~_Link to the issues addressed by this PR, or dependent PRs in other repositories_~~

**Description**
I encountered this while [testing an wgpu example on the Oculus Quest 2](https://github.com/EmbarkStudios/rust-gpu/pull/1033), but the important part is this:
```
04-14 14:43:26.051 11925 11925 W Thread-1: type=1400 audit(0.0:321): avc: denied { ioctl } for path="/dev/kgsl-3d0" dev="tmpfs" ino=1206 ioctlcmd=0x958 scontext=u:r:untrusted_app:s0:c94,c256,c512,c768 tcontext=u:object_r:gpu_device:s0 tclass=chr_file permissive=0
...
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: QUALCOMM build          : d66bb48e17, I18aabff2be
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Build Date              : 11/28/22
...
04-14 14:43:26.057 11925 11950 D wgpu_hal::vulkan::ada..: Supported extensions: ["VK_KHR_swapchain", "VK_KHR_image_format_list", "VK_KHR_imageless_framebuffer", "VK_KHR_driver_properties", "VK_KHR_timeline_semaphore", "VK_EXT_image_robustness", "VK_EXT_robustness2"]
04-14 14:43:26.059 11925 11950 W wgpu_hal::vulkan: Unrecognized device error ERROR_INITIALIZATION_FAILED
04-15 10:42:47.264 11611 11635 E wgpu::backend::direct: Error in Adapter::request_device: Not enough memory left
```

So my understanding is roughly as follows:
* Oculus Quest 2's latest update includes an AdrenoVK version that *advertises* `VK_KHR_timeline_semaphore`
* calling `VkCreateSemaphore` to use the extension fails due to SELinux(?) rules not having been updated
  * AFAICT [`path="/dev/kgsl-3d0" ... ioctlcmd=0x958` *is* `IOCTL_KGSL_TIMELINE_CREATE`](https://sourcegraph.com/search?q=context:global+KGSL_IOC_TYPE%2C+0x58&patternType=standard&sm=1)
  * searching around seems to confirm other users have ran into the same bug: https://communityforums.atmeta.com/t5/Quest-Development/Issue-with-VK-KHR-timeline-semaphore/td-p/1027690
  * absolutely no idea why that SELinux(?) `audit` message shows out of of order
    * (maybe that's an interaction between `android_logger` and other Android log buffers?)
* *before* this PR: `VkCreateSemaphore` failing w/ `ERROR_INITIALIZATION_FAILED` leads to `wgpu::Adapter::request_device` returning `Err(RequestDeviceError)`
* *after* this PR: that specific error is special-cased and the fallback (fence pool) implementation is used
  * more logging would probably be a good idea, also treating unknown errors as "out of memory" seems wrong?

**Testing**
The same `wgpu`-using demo that failed with the above, works with this change, and as expected it logs:
```
04-15 11:11:13.472 13889 13915 W wgpu_hal::vulkan::dev..: `VkCreateSemaphore` failed with `ERROR_INITIALIZATION_FAILED`, falling back to fence pool
```