### PR TITLE
Fix documentation comments for `multi_draw_*_indirect_count`

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3293,7 +3293,7 @@ impl<'a> RenderPass<'a> {
     /// Dispatches multiple draw calls from the active vertex buffer(s) based on the contents of the `indirect_buffer`.
     /// The count buffer is read to determine how many draws to issue.
     ///
-    /// The indirect buffer must be long enough to account for `max_count` draws, however only `count` will
+    /// The indirect buffer must be long enough to account for `max_count` draws, however only `count`
     /// draws will be read. If `count` is greater than `max_count`, `max_count` will be used.
     ///
     /// The active vertex buffers can be set with [`RenderPass::set_vertex_buffer`].
@@ -3335,7 +3335,7 @@ impl<'a> RenderPass<'a> {
     /// Dispatches multiple draw calls from the active index buffer and the active vertex buffers,
     /// based on the contents of the `indirect_buffer`. The count buffer is read to determine how many draws to issue.
     ///
-    /// The indirect buffer must be long enough to account for `max_count` draws, however only `count` will
+    /// The indirect buffer must be long enough to account for `max_count` draws, however only `count`
     /// draws will be read. If `count` is greater than `max_count`, `max_count` will be used.
     ///
     /// The active index buffer can be set with [`RenderPass::set_index_buffer`], while the active


### PR DESCRIPTION
Fixes typo in the documentation in two methods `multi_draw_indirect_count` and `multi_draw_indexed_indirect_count` for `RenderPass` struct.

> The indirect buffer must be long enough to account for max_count draws, however only count **will** draws **will** be read. If count is greater than max_count, max_count will be used.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- ~[ ] Add change to CHANGELOG.md. See simple instructions inside file.~
