### PR TITLE
add RG11B10UFLOAT_RENDERABLE to all adapters

### DIFF
--- a/deno_webgpu/02_idl_types.js
+++ b/deno_webgpu/02_idl_types.js
@@ -114,6 +114,7 @@ webidl.converters["GPUFeatureName"] = webidl.createEnumConverter(
     "texture-compression-bc",
     "texture-compression-etc2",
     "texture-compression-astc",
+    "rg11b10ufloat-renderable",
 
     // extended from spec
 

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -186,6 +186,9 @@ fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {
     if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC) {
         return_features.push("texture-compression-astc");
     }
+    if features.contains(wgpu_types::Features::RG11B10UFLOAT_RENDERABLE) {
+        return_features.push("rg11b10ufloat-renderable");
+    }
 
     // extended from spec
 
@@ -403,6 +406,10 @@ impl From<GpuRequiredFeatures> for wgpu_types::Features {
         features.set(
             wgpu_types::Features::TEXTURE_COMPRESSION_ASTC,
             required_features.0.contains("texture-compression-astc"),
+        );
+        features.set(
+            wgpu_types::Features::RG11B10UFLOAT_RENDERABLE,
+            required_features.0.contains("rg11b10ufloat-renderable"),
         );
 
         // extended from spec

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -223,7 +223,8 @@ impl super::Adapter {
             | wgt::Features::CLEAR_TEXTURE
             | wgt::Features::TEXTURE_FORMAT_16BIT_NORM
             | wgt::Features::PUSH_CONSTANTS
-            | wgt::Features::SHADER_PRIMITIVE_INDEX;
+            | wgt::Features::SHADER_PRIMITIVE_INDEX
+            | wgt::Features::RG11B10UFLOAT_RENDERABLE;
         //TODO: in order to expose this, we need to run a compute shader
         // that extract the necessary statistics out of the D3D12 result.
         // Alternatively, we could allocate a buffer for the query set,

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -765,7 +765,8 @@ impl super::PrivateCapabilities {
             | F::TEXTURE_FORMAT_16BIT_NORM
             | F::SHADER_F16
             | F::DEPTH32FLOAT_STENCIL8
-            | F::MULTI_DRAW_INDIRECT;
+            | F::MULTI_DRAW_INDIRECT
+            | F::RG11B10UFLOAT_RENDERABLE;
 
         features.set(F::TEXTURE_COMPRESSION_ASTC, self.format_astc);
         features.set(F::TEXTURE_COMPRESSION_ASTC_HDR, self.format_astc_hdr);

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -324,7 +324,8 @@ impl PhysicalDeviceFeatures {
             | F::TIMESTAMP_QUERY
             | F::TIMESTAMP_QUERY_INSIDE_PASSES
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | F::CLEAR_TEXTURE;
+            | F::CLEAR_TEXTURE
+            | F::RG11B10UFLOAT_RENDERABLE;
 
         let mut dl_flags = Df::COMPUTE_SHADERS
             | Df::BASE_VERTEX


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Finishing #3689

**Description**

Add the feature on all adapters. I tried searching if it needs to be conditional but couldn't find anything about it.

**Testing**

