### PR TITLE
Change AdapterInfo::vendor to string and add AdapterInfo::vendor_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ By @cwfitzgerald in [#3671](https://github.com/gfx-rs/wgpu/pull/3671).
 - Change type of `mip_level_count` and `array_layer_count` (members of `TextureViewDescriptor` and `ImageSubresourceRange`) from `Option<NonZeroU32>` to `Option<u32>`. By @teoxoy in [#3445](https://github.com/gfx-rs/wgpu/pull/3445)
 - All `fxhash` dependencies have been replaced with `rustc-hash`. By @james7132 in [#3502](https://github.com/gfx-rs/wgpu/pull/3502)
 - Change type of `bytes_per_row` and `rows_per_image` (members of `ImageDataLayout`) from `Option<NonZeroU32>` to `Option<u32>`. By @teoxoy in [#3529](https://github.com/gfx-rs/wgpu/pull/3529)
+- Rename `vendor` to `vendor_id` since webgpu standard defines `vendor` a string. By @i509VCB in [#3704](https://github.com/gfx-rs/wgpu/pull/3704)
 
 ### Changes
 
@@ -144,6 +145,7 @@ By @cwfitzgerald in [#3671](https://github.com/gfx-rs/wgpu/pull/3671).
 - Don't include ANSI terminal color escape sequences in shader module validation error messages. By @jimblandy in [#3591](https://github.com/gfx-rs/wgpu/pull/3591)
 - Report error messages from DXC compile. By @Davidster in [#3632](https://github.com/gfx-rs/wgpu/pull/3632)
 - Error in native when using a filterable `TextureSampleType::Float` on a multisample `BindingType::Texture`. By @mockersf in [#3686](https://github.com/gfx-rs/wgpu/pull/3686)
+- Add `vendor` string to `AdapterInfo`. Note this is not fully implemented in each backend yet. By @i509VCB in [#3704](https://github.com/gfx-rs/wgpu/pull/3704)
 
 #### WebGPU
 

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -610,7 +610,7 @@ pub async fn op_webgpu_request_adapter_info(
     let info = gfx_select!(adapter => instance.adapter_get_info(adapter))?;
 
     Ok(GPUAdapterInfo {
-        vendor: info.vendor.to_string(),
+        vendor: info.vendor_id.to_string(),
         architecture: String::new(), // TODO(#2170)
         device: info.device.to_string(),
         description: info.name,

--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -248,7 +248,8 @@ impl super::Adapter {
 
         let device_info = wgt::AdapterInfo {
             name: String::new(),
-            vendor: 0,
+            vendor: String::new(),
+            vendor_id: 0,
             device: 0,
             device_type: match d3d11_features2.UnifiedMemoryArchitecture {
                 0 => wgt::DeviceType::DiscreteGpu,

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -115,7 +115,8 @@ impl super::Adapter {
         let info = wgt::AdapterInfo {
             backend: wgt::Backend::Dx12,
             name: device_name,
-            vendor: desc.VendorId as usize,
+            vendor: String::new(),
+            vendor_id: desc.VendorId as usize,
             device: desc.DeviceId as usize,
             device_type: if (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0 {
                 workarounds.avoid_cpu_descriptor_overwrites = true;

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -170,7 +170,8 @@ impl super::Adapter {
 
         wgt::AdapterInfo {
             name: renderer_orig,
-            vendor: vendor_id as usize,
+            vendor: vendor_orig,
+            vendor_id: vendor_id as usize,
             device: 0,
             device_type: inferred_device_type,
             driver: String::new(),

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -109,11 +109,13 @@ impl crate::Instance<Api> for Instance {
             .into_iter()
             .map(|dev| {
                 let name = dev.name().into();
+                let vendor = dev.vendor().into();
                 let shared = AdapterShared::new(dev);
                 crate::ExposedAdapter {
                     info: wgt::AdapterInfo {
                         name,
-                        vendor: 0,
+                        vendor,
+                        vendor_id: 0,
                         device: 0,
                         device_type: shared.private_caps.device_type(),
                         driver: String::new(),

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -951,7 +951,8 @@ impl super::Instance {
                     .unwrap_or("?")
                     .to_owned()
             },
-            vendor: phd_capabilities.properties.vendor_id as usize,
+            vendor: String::new(),
+            vendor_id: phd_capabilities.properties.vendor_id as usize,
             device: phd_capabilities.properties.device_id as usize,
             device_type: match phd_capabilities.properties.device_type {
                 ash::vk::PhysicalDeviceType::OTHER => wgt::DeviceType::Other,

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -691,12 +691,12 @@ impl crate::Instance<super::Api> for super::Instance {
         // Detect if it's an Intel + NVidia configuration with Optimus
         let has_nvidia_dgpu = exposed_adapters.iter().any(|exposed| {
             exposed.info.device_type == wgt::DeviceType::DiscreteGpu
-                && exposed.info.vendor == db::nvidia::VENDOR as usize
+                && exposed.info.vendor_id == db::nvidia::VENDOR as usize
         });
         if cfg!(target_os = "linux") && has_nvidia_dgpu && self.shared.has_nv_optimus {
             for exposed in exposed_adapters.iter_mut() {
                 if exposed.info.device_type == wgt::DeviceType::IntegratedGpu
-                    && exposed.info.vendor == db::intel::VENDOR as usize
+                    && exposed.info.vendor_id == db::intel::VENDOR as usize
                 {
                     // See https://gitlab.freedesktop.org/mesa/mesa/-/issues/4688
                     log::warn!(

--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -143,7 +143,8 @@ mod inner {
         println!("Adapter {idx}:");
         println!("\t   Backend: {:?}", info.backend);
         println!("\t      Name: {:?}", info.name);
-        println!("\t  VendorID: {:?}", info.vendor);
+        println!("\t  Vendor: {:?}", info.vendor);
+        println!("\t  VendorID: {:?}", info.vendor_id);
         println!("\t  DeviceID: {:?}", info.device);
         println!("\t      Type: {:?}", info.device_type);
         println!("\t    Driver: {:?}", info.driver);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1303,11 +1303,17 @@ pub enum DeviceType {
 pub struct AdapterInfo {
     /// Adapter name
     pub name: String,
-    /// Vendor PCI id of the adapter
+    /// The name of the adapter vendor.
+    ///
+    /// This may be empty if not available.
+    pub vendor: String,
+    /// Vendor PCI id of the adapter.
+    ///
+    /// This value is not available on web.
     ///
     /// If the vendor has no PCI id, then this value will be the backend's vendor id equivalent. On Vulkan,
     /// Mesa would have a vendor id equivalent to it's `VkVendorId` value.
-    pub vendor: usize,
+    pub vendor_id: usize,
     /// PCI id of the adapter
     pub device: usize,
     /// Type of device

--- a/wgpu/examples/hello-compute/main.rs
+++ b/wgpu/examples/hello-compute/main.rs
@@ -56,7 +56,7 @@ async fn execute_gpu(numbers: &[u32]) -> Option<Vec<u32>> {
 
     let info = adapter.get_info();
     // skip this on LavaPipe temporarily
-    if info.vendor == 0x10005 {
+    if info.vendor_id == 0x10005 {
         return None;
     }
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1084,7 +1084,8 @@ impl crate::context::Context for Context {
         // TODO: web-sys has no way of getting information on adapters
         wgt::AdapterInfo {
             name: String::new(),
-            vendor: 0,
+            vendor: String::new(),
+            vendor_id: 0,
             device: 0,
             device_type: wgt::DeviceType::Other,
             driver: String::new(),

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -255,7 +255,7 @@ pub fn initialize_test(parameters: TestParameters, test_function: impl FnOnce(Te
         let expect_failure_backend = failure
             .backends
             .map(|f| f.contains(wgpu::Backends::from(adapter_info.backend)));
-        let expect_failure_vendor = failure.vendor.map(|v| v == adapter_info.vendor);
+        let expect_failure_vendor = failure.vendor.map(|v| v == adapter_info.vendor_id);
         let expect_failure_adapter = failure
             .adapter
             .as_deref()


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

**Description**
Start to make AdapterInfo match more closely to GPUAdapterInfo. The old `vendor` field was renamed to `vendor_id`. 

Note that looking up the vendor name is not implemented in all backends yet (Web, DX12 and Vulkan).
