### PR TITLE
Update naga to 0.11.0@git:b9c5cb5a7841a8728137a58840fbbdbb9b310267

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,7 +1557,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.11.0"
-source = "git+https://github.com/gfx-rs/naga?rev=f59668ccfaf7bdb3a7e43d84363a21c77357b2fe#f59668ccfaf7bdb3a7e43d84363a21c77357b2fe"
+source = "git+https://github.com/gfx-rs/naga?rev=b9c5cb5a7841a8728137a58840fbbdbb9b310267#b9c5cb5a7841a8728137a58840fbbdbb9b310267"
 dependencies = [
  "bit-set",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ version = "0.15"
 
 [workspace.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f59668ccfaf7bdb3a7e43d84363a21c77357b2fe"
+rev = "b9c5cb5a7841a8728137a58840fbbdbb9b310267"
 version = "0.11.0"
 
 [workspace.dependencies]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -67,7 +67,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f59668ccfaf7bdb3a7e43d84363a21c77357b2fe"
+rev = "b9c5cb5a7841a8728137a58840fbbdbb9b310267"
 version = "0.11.0"
 features = ["clone", "span", "validate"]
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -119,14 +119,14 @@ android_system_properties = "0.1.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f59668ccfaf7bdb3a7e43d84363a21c77357b2fe"
+rev = "b9c5cb5a7841a8728137a58840fbbdbb9b310267"
 version = "0.11.0"
 features = ["clone"]
 
 # DEV dependencies
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "f59668ccfaf7bdb3a7e43d84363a21c77357b2fe"
+rev = "b9c5cb5a7841a8728137a58840fbbdbb9b310267"
 version = "0.11.0"
 features = ["wgsl-in"]
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo nextest run`

**Description**

Routine naga update.
