### PR TITLE
Fix unsetting vertex attributes in gles backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ By @cwfitzgerald in [#3671](https://github.com/gfx-rs/wgpu/pull/3671).
 - Reset the state of `SAMPLE_ALPHA_TO_COVERAGE` on queue reset. By @jleibs [#3589](https://github.com/gfx-rs/wgpu/pull/3589)
 - Fix `Vertex buffer is not big enough for the draw call.` for ANGLE/Web when rendering with instance attributes on a single instance. By @wumpf in [#3597](https://github.com/gfx-rs/wgpu/pull/3597)
 - Fix `copy_external_image_to_texture`, `copy_texture_to_texture` and `copy_buffer_to_texture` not taking the specified index into account if the target texture is a cube map, 2D texture array or cube map array. By @daxpedda [#3641](https://github.com/gfx-rs/wgpu/pull/3641)
+- Fix disabling of vertex attributes with non-consecutive locations [#3706](https://github.com/gfx-rs/wgpu/pull/3706)
 
 #### Metal
 

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -620,7 +620,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         self.state.dirty_vbuf_mask = 0;
         self.state.active_first_instance = 0;
         self.state.color_targets.clear();
-        for vat in self.state.vertex_attributes {
+        for vat in &self.state.vertex_attributes {
             self.cmd_buffer
                 .commands
                 .push(C::UnsetVertexAttribute(vat.location));
@@ -761,7 +761,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 });
             }
         } else {
-            for vat in self.state.vertex_attributes {
+            for vat in &self.state.vertex_attributes {
                 self.cmd_buffer
                     .commands
                     .push(C::UnsetVertexAttribute(vat.location));

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -620,10 +620,10 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         self.state.dirty_vbuf_mask = 0;
         self.state.active_first_instance = 0;
         self.state.color_targets.clear();
-        for index in 0..self.state.vertex_attributes.len() {
+        for vat in self.state.vertex_attributes {
             self.cmd_buffer
                 .commands
-                .push(C::UnsetVertexAttribute(index as u32));
+                .push(C::UnsetVertexAttribute(vat.location));
         }
         self.state.vertex_attributes.clear();
         self.state.primitive = super::PrimitiveState::default();
@@ -761,10 +761,10 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                 });
             }
         } else {
-            for index in 0..self.state.vertex_attributes.len() {
+            for vat in self.state.vertex_attributes {
                 self.cmd_buffer
                     .commands
-                    .push(C::UnsetVertexAttribute(index as u32));
+                    .push(C::UnsetVertexAttribute(vat.location));
             }
             self.state.vertex_attributes.clear();
 

--- a/wgpu/tests/regression/issue_3457.rs
+++ b/wgpu/tests/regression/issue_3457.rs
@@ -12,6 +12,9 @@ use wgpu::*;
 /// submit, delete the second vertex buffer and `poll(Wait)`. Because we maintained the device,
 /// the actual underlying buffer for the second vertex buffer is deleted, causing a draw call
 /// that is invalid if the second attribute is still enabled.
+/// 
+/// We use non-consecutive vertex attribute locations (0 and 5) in order to also test
+/// that we unset the correct locations (see PR #3706).
 #[wasm_bindgen_test]
 #[test]
 fn pass_reset_vertex_buffer() {
@@ -60,7 +63,7 @@ fn pass_reset_vertex_buffer() {
                         VertexBufferLayout {
                             array_stride: 4,
                             step_mode: VertexStepMode::Vertex,
-                            attributes: &vertex_attr_array![1 => Float32],
+                            attributes: &vertex_attr_array![5 => Float32],
                         },
                     ],
                 },

--- a/wgpu/tests/regression/issue_3457.rs
+++ b/wgpu/tests/regression/issue_3457.rs
@@ -12,7 +12,7 @@ use wgpu::*;
 /// submit, delete the second vertex buffer and `poll(Wait)`. Because we maintained the device,
 /// the actual underlying buffer for the second vertex buffer is deleted, causing a draw call
 /// that is invalid if the second attribute is still enabled.
-/// 
+///
 /// We use non-consecutive vertex attribute locations (0 and 5) in order to also test
 /// that we unset the correct locations (see PR #3706).
 #[wasm_bindgen_test]

--- a/wgpu/tests/regression/issue_3457.wgsl
+++ b/wgpu/tests/regression/issue_3457.wgsl
@@ -1,6 +1,6 @@
 struct DoubleVertexIn {
     @location(0) position: vec4<f32>,
-    @location(1) value: f32,
+    @location(5) value: f32,
 }
 
 struct DoubleVertexOut {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/bevyengine/bevy/issues/5732 (and all linked issues)

**Description**
Currently, the code responsible for un-setting vertex attributes uses the attribute's index in the state's array.
Instead we need to use the location of the vertex attribute.
This was causing issues with apps running in wasm on the webgl backend, such as bevy apps.

**Testing**
I tweaked [the test from issue #3457](https://github.com/gfx-rs/wgpu/blob/trunk/wgpu/tests/regression/issue_3457.rs) to use non-consecutive vertex attribute locations. This covers the code path that unsets attribs at the end of a render pass, but does not cover the code path that unsets them upon switching to a new pipeline.
Unfortunately I didn't manage to test that one (unsetting upon pipeline switching), because the webgl context fails silently in that case.
