### PR TITLE
Roll libloading back to 0.7 to avoid windows-rs dep.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ futures-intrusive = "0.4"
 rustc-hash = "1.1.0"
 glam = "0.21.3"
 image = { version = "0.24", default-features = false, features = ["png"] }
-libloading = "0.8"
+libloading = "0.7.4"
 libc = "0.2"
 log = "0.4"
 nanorand = { version = "0.7", default-features = false }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.

**Connections**

Dependabot updated libloading to 0.8 in https://github.com/gfx-rs/wgpu/commit/7f179ff1fa0ab28fc9828ca7d5f55fbc857e0137

**Description**

Libloading switched from winapi to windows-rs in 0.8, making wgpu unconditionally depend on windows-rs. Unfortunately mozilla is still not ready to take that dependency. This commit rolls back to the previous libloading version so that the windows-rs dep remains optional.
