### PR TITLE
refactor: resolve `clippy::redundant_clone`

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -5470,7 +5470,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 if !caps.formats.contains(&config.format) {
                     break 'outer E::UnsupportedFormat {
                         requested: config.format,
-                        available: caps.formats.clone(),
+                        available: caps.formats,
                     };
                 }
                 if config.format.remove_srgb_suffix() != format.remove_srgb_suffix() {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] ~Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.~
- [x] ~Add change to CHANGELOG.md. See simple instructions inside file.~

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

N/A

**Description**
_Describe what problem this is solving, and how it's solved._

Clippy fires this warning, and it needs to not do that.

**Testing**
_Explain how this change is tested._

By running `cargo clippy --workspace`. 🙂
