### PR TITLE
Pass correct surface for existing canvases

### DIFF
--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -63,19 +63,6 @@ impl<T> From<Identified<T>> for ObjectId {
     }
 }
 
-#[allow(unused_variables)]
-impl<T> From<(Identified<T>, Sendable<T>)> for ObjectId {
-    fn from((id, _data): (Identified<T>, Sendable<T>)) -> Self {
-        Self::new(
-            // TODO: the ID isn't used, so we hardcode it to 1 for now until we rework this
-            // API.
-            core::num::NonZeroU64::new(1).unwrap(),
-            #[cfg(feature = "expose-ids")]
-            id.0,
-        )
-    }
-}
-
 #[derive(Clone, Debug)]
 pub(crate) struct Sendable<T>(T);
 unsafe impl<T> Send for Sendable<T> {}

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -1004,7 +1004,7 @@ pub struct ObjectId {
 }
 
 impl ObjectId {
-    const UNUSED: Self = ObjectId {
+    pub(crate) const UNUSED: Self = ObjectId {
         id: None,
         #[cfg(feature = "expose-ids")]
         global_id: None,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1616,9 +1616,9 @@ impl Instance {
             #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
             data: Box::new(surface),
             #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
-            id: ObjectId::from(surface),
+            id: ObjectId::UNUSED,
             #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
-            data: Box::new(()),
+            data: Box::new(surface.1),
             config: Mutex::new(None),
         })
     }
@@ -1652,9 +1652,9 @@ impl Instance {
             #[cfg(any(not(target_arch = "wasm32"), feature = "webgl"))]
             data: Box::new(surface),
             #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
-            id: ObjectId::from(surface),
+            id: ObjectId::UNUSED,
             #[cfg(all(target_arch = "wasm32", not(feature = "webgl")))]
-            data: Box::new(()),
+            data: Box::new(surface.1),
             config: Mutex::new(None),
         })
     }


### PR DESCRIPTION
**Checklist**

- [ ] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #3710

**Description**
We were passing the `(id, data)` tuple instead of `data` which was expected. This was hard to spot because we use `Any` for surface types, so it eventually results in a `downcast_ref` much later. We should try to improve type safety here after we figure out how `Arc` will be integrated with the WebGPU backend.

**Testing**
Tested by modifying hello-triangle to create the surface from a canvas instead of a handle.