### PR TITLE
Fix crash on command buffer drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ Bottom level categories:
 
 ## Unreleased
 
+### Bug Fixes
+
+#### General
+
+- Fix crash on dropping `wgpu::CommandBuffer`. By @wumpf in [#3726](https://github.com/gfx-rs/wgpu/pull/3726).
+
+
 ## v0.16.0 (2023-04-19)
 
 ### Major changes

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -574,8 +574,9 @@ static_assertions::assert_impl_all!(CommandBuffer: Send, Sync);
 impl Drop for CommandBuffer {
     fn drop(&mut self) {
         if !thread::panicking() {
-            if let Some(ref id) = self.id {
-                self.context.command_buffer_drop(id, &self.data.take());
+            if let Some(id) = self.id.take() {
+                self.context
+                    .command_buffer_drop(&id, self.data.take().unwrap().as_ref());
             }
         }
     }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Fixes #3724

**Description**

Oversight in: #3657
Passed the wrong object was passed for `data` to `command_buffer_drop`, causing type conversion assertion to fail at runtime 😱 

**Testing**

Add minimal repro
```rust
let encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
drop(encoder.finish());
```
to hello triangle. Before: `thread 'main' panicked at 'assertion failed: data.is::<T>()', wgpu/src/context.rs:1045:5`
