### PR TITLE
CI: Remove obsolete wasm-pack workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,6 @@ jobs:
       - name: execute tests
         run: |
           cd wgpu
-          wasm-pack --version
           wasm-pack test --headless --chrome --features webgl
 
   gpu-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,18 +172,15 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v3
 
-      # TODO: replace with this once there is a release containing this PR:
-      # https://github.com/rustwasm/wasm-pack/pull/1185
-      # - name: Install wasm-pack
-      #   uses: taiki-e/install-action@v2
-      #   with:
-      #     tool: wasm-pack
-      - name: install wasm-pack
-        run: cargo install --git https://github.com/rustwasm/wasm-pack --rev e1010233b0ce304f42cda59962254bf30ae97c3e wasm-pack
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
 
       - name: execute tests
         run: |
           cd wgpu
+          wasm-pack --version
           wasm-pack test --headless --chrome --features webgl
 
   gpu-test:


### PR DESCRIPTION

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
This is a follow-up of #3238 

**Description**
Workspace inheritance is supported by wasm-pack v0.11, so the workaround added in #3238 - which installs a branch version - isn't necessary anymore. Now the released wasm-pack binary can be installed directly.

**Testing**
The test job would fail if wasm-pack wouldn't be correctly installed.
