### PR TITLE
Fold `Error` source chain `Display` output into shader errors

### DIFF
--- a/naga/src/error.rs
+++ b/naga/src/error.rs
@@ -16,6 +16,7 @@ impl fmt::Display for ShaderError<crate::front::wgsl::ParseError> {
         write!(f, "\nShader '{label}' parsing {string}")
     }
 }
+
 #[cfg(feature = "glsl-in")]
 impl fmt::Display for ShaderError<crate::front::glsl::ParseErrors> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -24,6 +25,7 @@ impl fmt::Display for ShaderError<crate::front::glsl::ParseErrors> {
         write!(f, "\nShader '{label}' parsing {string}")
     }
 }
+
 #[cfg(feature = "spv-in")]
 impl fmt::Display for ShaderError<crate::front::spv::Error> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -32,6 +34,7 @@ impl fmt::Display for ShaderError<crate::front::spv::Error> {
         write!(f, "\nShader '{label}' parsing {string}")
     }
 }
+
 impl fmt::Display for ShaderError<crate::WithSpan<crate::valid::ValidationError>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use codespan_reporting::{
@@ -63,6 +66,7 @@ impl fmt::Display for ShaderError<crate::WithSpan<crate::valid::ValidationError>
         )
     }
 }
+
 impl<E> Error for ShaderError<E>
 where
     ShaderError<E>: fmt::Display,


### PR DESCRIPTION
Related: https://github.com/gfx-rs/wgpu/issues/4494

---

**Checklist**

- [x] Run `cargo clippy`.
- [x] ~Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.~
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
