### PR TITLE
docs: note feature req. for `Depth32FloatStencil8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Bottom level categories:
 
 ## Unreleased
 
+### Documentation
+
+- Document feature requirements for `DEPTH32FLOAT_STENCIL8` by @ErichDonGubler in [#3734](https://github.com/gfx-rs/wgpu/pull/3734).
+
 ## v0.16.0 (2023-04-19)
 
 ### Major changes

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -523,7 +523,7 @@ pub enum CreateTextureError {
     InvalidSampleCount(u32, wgt::TextureFormat),
     #[error("Multisampled textures must have RENDER_ATTACHMENT usage")]
     MultisampledNotRenderAttachment,
-    #[error("Texture format {0:?} can't be used due to missing features.")]
+    #[error("Texture format {0:?} can't be used due to missing features")]
     MissingFeatures(wgt::TextureFormat, #[source] MissingFeatures),
     #[error(transparent)]
     MissingDownlevelFlags(#[from] MissingDownlevelFlags),

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2025,6 +2025,8 @@ pub enum TextureFormat {
     /// Special depth format with 32 bit floating point depth.
     Depth32Float,
     /// Special depth/stencil format with 32 bit floating point depth and 8 bits integer stencil.
+    ///
+    /// [`Features::DEPTH32FLOAT_STENCIL8`] must be enabled to use this texture format.
     Depth32FloatStencil8,
 
     // Compressed textures usable with `TEXTURE_COMPRESSION_BC` feature.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -270,7 +270,7 @@ bitflags::bitflags! {
 
         /// Allows shaders to acquire the FP16 ability
         ///
-        /// Note: this is not supported in naga yet，only through spir-v passthrough right now.
+        /// Note: this is not supported in `naga` yet，only through `spirv-passthrough` right now.
         ///
         /// Supported Platforms:
         /// - Vulkan
@@ -728,7 +728,7 @@ bitflags::bitflags! {
         ///
         /// This is a native only feature.
         const SHADER_F64 = 1 << 59;
-        /// Allows shaders to use i16. Not currently supported in naga, only available through `spirv-passthrough`.
+        /// Allows shaders to use i16. Not currently supported in `naga`, only available through `spirv-passthrough`.
         ///
         /// Supported platforms:
         /// - Vulkan


### PR DESCRIPTION
**Checklist**

- [x] ~Run `cargo clippy`.~
- [x] ~`Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.~
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

🤷🏻‍♂️

**Description**
_Describe what problem this is solving, and how it's solved._

Feature requirements for `Depth32FloatStencil8` weren't noted before, but they're an important detail for using that texture format.

**Testing**
_Explain how this change is tested._

If this is correct information, and we compile, then we should be good to go!
