### PR TITLE
fix(wgpu-core)!: use `u32` indices for bind group layouts everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Bottom level categories:
 #### General
 
 - Fix crash on dropping `wgpu::CommandBuffer`. By @wumpf in [#3726](https://github.com/gfx-rs/wgpu/pull/3726).
-
+- Use `u32`s internally for bind group indices, rather than `u8`. By @ErichDonGubler in [#3743](https://github.com/gfx-rs/wgpu/pull/3743).
 
 ## v0.16.0 (2023-04-19)
 

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -697,7 +697,7 @@ pub enum BindError {
         s1 = if *.actual >= 2 { "s" } else { "" },
     )]
     MismatchedDynamicOffsetCount {
-        group: u8,
+        group: u32,
         actual: usize,
         expected: usize,
     },
@@ -706,7 +706,7 @@ pub enum BindError {
     )]
     UnalignedDynamicBinding {
         idx: usize,
-        group: u8,
+        group: u32,
         binding: u32,
         offset: u32,
         alignment: u32,
@@ -718,7 +718,7 @@ pub enum BindError {
     )]
     DynamicBindingOutOfBounds {
         idx: usize,
-        group: u8,
+        group: u32,
         binding: u32,
         offset: u32,
         buffer_size: wgt::BufferAddress,
@@ -780,7 +780,7 @@ pub struct BindGroup<A: HalApi> {
 impl<A: HalApi> BindGroup<A> {
     pub(crate) fn validate_dynamic_bindings(
         &self,
-        bind_group_index: u8,
+        bind_group_index: u32,
         offsets: &[wgt::DynamicOffset],
         limits: &wgt::Limits,
     ) -> Result<(), BindError> {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -302,7 +302,7 @@ impl RenderBundleEncoder {
                         .map_pass_err(scope)?;
 
                     let max_bind_groups = device.limits.max_bind_groups;
-                    if (index as u32) >= max_bind_groups {
+                    if index >= max_bind_groups {
                         return Err(RenderCommandError::BindGroupIndexOutOfRange {
                             index,
                             max: max_bind_groups,
@@ -784,7 +784,7 @@ impl<A: HalApi> RenderBundle<A> {
                     unsafe {
                         raw.set_bind_group(
                             &pipeline_layout_guard[pipeline_layout_id.unwrap()].raw,
-                            index as u32,
+                            index,
                             &bind_group.raw,
                             &offsets[..num_dynamic_offsets as usize],
                         )
@@ -1222,7 +1222,7 @@ impl<A: HalApi> State<A> {
 
     fn set_bind_group(
         &mut self,
-        slot: u8,
+        slot: u32,
         bind_group_id: id::BindGroupId,
         layout_id: id::Valid<id::BindGroupLayoutId>,
         dynamic_offsets: Range<usize>,
@@ -1365,7 +1365,7 @@ impl<A: HalApi> State<A> {
                         contents.is_dirty = false;
                         let offsets = &contents.dynamic_offsets;
                         return Some(RenderCommand::SetBindGroup {
-                            index: i as u8,
+                            index: i.try_into().unwrap(),
                             bind_group_id: contents.bind_group_id,
                             num_dynamic_offsets: (offsets.end - offsets.start) as u8,
                         });
@@ -1469,7 +1469,7 @@ pub mod bundle_ffi {
         }
 
         bundle.base.commands.push(RenderCommand::SetBindGroup {
-            index: index.try_into().unwrap(),
+            index,
             num_dynamic_offsets: offset_length.try_into().unwrap(),
             bind_group_id,
         });

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -38,7 +38,7 @@ use std::{fmt, mem, str};
 )]
 pub enum ComputeCommand {
     SetBindGroup {
-        index: u8,
+        index: u32,
         num_dynamic_offsets: u8,
         bind_group_id: id::BindGroupId,
     },
@@ -163,7 +163,7 @@ pub enum ComputePassErrorInner {
     #[error("Bind group {0:?} is invalid")]
     InvalidBindGroup(id::BindGroupId),
     #[error("Bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
-    BindGroupIndexOutOfRange { index: u8, max: u32 },
+    BindGroupIndexOutOfRange { index: u32, max: u32 },
     #[error("Compute pipeline {0:?} is invalid")]
     InvalidPipeline(id::ComputePipelineId),
     #[error("QuerySet {0:?} is invalid")]
@@ -407,7 +407,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     let scope = PassErrorScope::SetBindGroup(bind_group_id);
 
                     let max_bind_groups = cmd_buf.limits.max_bind_groups;
-                    if (index as u32) >= max_bind_groups {
+                    if index >= max_bind_groups {
                         return Err(ComputePassErrorInner::BindGroupIndexOutOfRange {
                             index,
                             max: max_bind_groups,
@@ -464,7 +464,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             unsafe {
                                 raw.set_bind_group(
                                     pipeline_layout,
-                                    index as u32 + i as u32,
+                                    index + i as u32,
                                     raw_bg,
                                     &e.dynamic_offsets,
                                 );
@@ -816,7 +816,7 @@ pub mod compute_ffi {
         }
 
         pass.base.commands.push(ComputeCommand::SetBindGroup {
-            index: index.try_into().unwrap(),
+            index,
             num_dynamic_offsets: offset_length.try_into().unwrap(),
             bind_group_id,
         });

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -66,7 +66,7 @@ pub enum RenderCommandError {
     #[error("Render bundle {0:?} is invalid")]
     InvalidRenderBundle(id::RenderBundleId),
     #[error("Bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
-    BindGroupIndexOutOfRange { index: u8, max: u32 },
+    BindGroupIndexOutOfRange { index: u32, max: u32 },
     #[error("Dynamic buffer offset {0} does not respect device's requested `{1}` limit {2}")]
     UnalignedBufferOffset(u64, &'static str, u32),
     #[error("Number of buffer offsets ({actual}) does not match the number of dynamic bindings ({expected})")]
@@ -148,7 +148,7 @@ pub struct Rect<T> {
 )]
 pub enum RenderCommand {
     SetBindGroup {
-        index: u8,
+        index: u32,
         num_dynamic_offsets: u8,
         bind_group_id: id::BindGroupId,
     },

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1305,7 +1305,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     } => {
                         let scope = PassErrorScope::SetBindGroup(bind_group_id);
                         let max_bind_groups = device.limits.max_bind_groups;
-                        if (index as u32) >= max_bind_groups {
+                        if index >= max_bind_groups {
                             return Err(RenderCommandError::BindGroupIndexOutOfRange {
                                 index,
                                 max: max_bind_groups,
@@ -1372,7 +1372,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                                 unsafe {
                                     raw.set_bind_group(
                                         pipeline_layout,
-                                        index as u32 + i as u32,
+                                        index + i as u32,
                                         raw_bg,
                                         &e.dynamic_offsets,
                                     );
@@ -2225,7 +2225,7 @@ pub mod render_ffi {
         }
 
         pass.base.commands.push(RenderCommand::SetBindGroup {
-            index: index.try_into().unwrap(),
+            index,
             num_dynamic_offsets: offset_length.try_into().unwrap(),
             bind_group_id,
         });


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] ~Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.~
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

See `Description`.

**Description**
_Describe what problem this is solving, and how it's solved._

See discussions in [Mozilla's Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1813705#c8) and [`wgpu`'s Matrix chat](https://matrix.to/#/!FZyQrssSlHEZqrYcOb:matrix.org/$0wv-PJgyTTZ7LHtEhzFmAouNYa4VMY0MzVzW0n5J394?via=matrix.org&via=mozilla.org&via=kde.org).

**Testing**
_Explain how this change is tested._

`cargo nextest run -- --workspace` WFM!
