### PR TITLE
web: use `get_preferred_canvas_format()` to fill `SurfaceCapabilities`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ Bottom level categories:
 
 - Disable suballocation on Intel Iris(R) Xe. By @xiaopengli89 in [#3668](https://github.com/gfx-rs/wgpu/pull/3668)
 
+#### WebGPU
+
+- Use `get_preferred_canvas_format()` to fill `formats` of `SurfaceCapabilities`. By @jinleili in [#3744](https://github.com/gfx-rs/wgpu/pull/3744)
+
 ### Examples
 
 #### General

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1114,14 +1114,20 @@ impl crate::context::Context for Context {
         _adapter_data: &Self::AdapterData,
     ) -> wgt::SurfaceCapabilities {
         let format = self.0.get_preferred_canvas_format();
-        let preferred_format = if map_texture_format(wgt::TextureFormat::Bgra8Unorm) == format {
-            wgt::TextureFormat::Bgra8Unorm
+        let (preferred, second) = if map_texture_format(wgt::TextureFormat::Bgra8Unorm) == format {
+            (
+                wgt::TextureFormat::Bgra8Unorm,
+                wgt::TextureFormat::Rgba8Unorm,
+            )
         } else {
-            wgt::TextureFormat::Rgba8Unorm
+            (
+                wgt::TextureFormat::Rgba8Unorm,
+                wgt::TextureFormat::Bgra8Unorm,
+            )
         };
         wgt::SurfaceCapabilities {
             // https://gpuweb.github.io/gpuweb/#supported-context-formats
-            formats: vec![preferred_format, wgt::TextureFormat::Rgba16Float],
+            formats: vec![preferred, second, wgt::TextureFormat::Rgba16Float],
             // Doesn't really have meaning on the web.
             present_modes: vec![wgt::PresentMode::Fifo],
             alpha_modes: vec![wgt::CompositeAlphaMode::Opaque],

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1118,17 +1118,11 @@ impl crate::context::Context for Context {
             wgt::TextureFormat::Bgra8Unorm,
             wgt::TextureFormat::Rgba16Float,
         ];
-        let mapped_formats: Vec<_> = formats
-            .iter()
-            .map(|format| map_texture_format(*format))
-            .collect();
+        let mut mapped_formats = formats.iter().map(|format| map_texture_format(*format));
         // Preferred canvas format will only be either "rgba8unorm" or "bgra8unorm".
         // https://www.w3.org/TR/webgpu/#dom-gpu-getpreferredcanvasformat
         let preferred_format = self.0.get_preferred_canvas_format();
-        if let Some(index) = mapped_formats
-            .iter()
-            .position(|format| *format == preferred_format)
-        {
+        if let Some(index) = mapped_formats.position(|format| format == preferred_format) {
             formats.swap(0, index);
         }
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1113,13 +1113,15 @@ impl crate::context::Context for Context {
         _adapter: &Self::AdapterId,
         _adapter_data: &Self::AdapterData,
     ) -> wgt::SurfaceCapabilities {
+        let format = self.0.get_preferred_canvas_format();
+        let preferred_format = if map_texture_format(wgt::TextureFormat::Bgra8Unorm) == format {
+            wgt::TextureFormat::Bgra8Unorm
+        } else {
+            wgt::TextureFormat::Rgba8Unorm
+        };
         wgt::SurfaceCapabilities {
             // https://gpuweb.github.io/gpuweb/#supported-context-formats
-            formats: vec![
-                wgt::TextureFormat::Bgra8Unorm,
-                wgt::TextureFormat::Rgba8Unorm,
-                wgt::TextureFormat::Rgba16Float,
-            ],
+            formats: vec![preferred_format, wgt::TextureFormat::Rgba16Float],
             // Doesn't really have meaning on the web.
             present_modes: vec![wgt::PresentMode::Fifo],
             alpha_modes: vec![wgt::CompositeAlphaMode::Opaque],

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1113,7 +1113,6 @@ impl crate::context::Context for Context {
         _adapter: &Self::AdapterId,
         _adapter_data: &Self::AdapterData,
     ) -> wgt::SurfaceCapabilities {
-        let preferred_format = self.0.get_preferred_canvas_format();
         let mut formats = vec![
             wgt::TextureFormat::Rgba8Unorm,
             wgt::TextureFormat::Bgra8Unorm,
@@ -1123,6 +1122,9 @@ impl crate::context::Context for Context {
             .iter()
             .map(|format| map_texture_format(*format))
             .collect();
+        // Preferred canvas format will only be either "rgba8unorm" or "bgra8unorm".
+        // https://www.w3.org/TR/webgpu/#dom-gpu-getpreferredcanvasformat
+        let preferred_format = self.0.get_preferred_canvas_format();
         if let Some(index) = mapped_formats
             .iter()
             .position(|format| *format == preferred_format)


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
On the web, wgpu always prioritizes returning the `Bgra8Unorm` format in the `formats` field of `SurfaceCapabilities`, but this format is not supported on Android devices:
<img width="988" alt="截屏2023-05-03 19 44 17" src="https://user-images.githubusercontent.com/1001342/235906788-5f39c805-8621-4d7e-9d33-83413cf31f0a.png">

**Testing**
Tested on Android Chrome Canary 115.0.5747.0 via https://jinleili.github.io/learn-wgpu-zh/simuverse
<img width="987" alt="截屏2023-05-03 19 58 50" src="https://user-images.githubusercontent.com/1001342/235909639-c267b896-df8a-4a4b-8eba-9c2f43cbb3df.png">
