### PR TITLE
Define wgpu_core::Global::create_render_bundle_error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ By @cwfitzgerald in [#3671](https://github.com/gfx-rs/wgpu/pull/3671).
 - Report error messages from DXC compile. By @Davidster in [#3632](https://github.com/gfx-rs/wgpu/pull/3632)
 - Error in native when using a filterable `TextureSampleType::Float` on a multisample `BindingType::Texture`. By @mockersf in [#3686](https://github.com/gfx-rs/wgpu/pull/3686)
 - On Web, the size of the canvas is adjusted when using `Surface::configure()`. If the canvas was given an explicit size (via CSS), this will not affect the visual size of the canvas. By @daxpedda in [#3690](https://github.com/gfx-rs/wgpu/pull/3690)
+- Added `Global::create_render_bundle_error`. By @jimblandy in [#3746](https://github.com/gfx-rs/wgpu/pull/3746)
 
 #### WebGPU
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3704,6 +3704,18 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut token = Token::root();
         let fid = hub.buffers.prepare(id_in);
 
+        fid.assign_error(label.borrow_or_default(), &mut token);
+    }
+
+    pub fn create_render_bundle_error<A: HalApi>(
+        &self,
+        id_in: Input<G, id::RenderBundleId>,
+        label: Label,
+    ) {
+        let hub = A::hub(self);
+        let mut token = Token::root();
+        let fid = hub.render_bundles.prepare(id_in);
+
         let (_, mut token) = hub.devices.read(&mut token);
         fid.assign_error(label.borrow_or_default(), &mut token);
     }
@@ -3716,7 +3728,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut token = Token::root();
         let fid = hub.textures.prepare(id_in);
 
-        let (_, mut token) = hub.devices.read(&mut token);
         fid.assign_error(label.borrow_or_default(), &mut token);
     }
 


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
