### PR TITLE
Publish examples to wgpu.rs on updates to trunk branch instead of gecko

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust WASM target
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
 
       - name: Install wasm-bindgen-cli
         run: cargo install wasm-bindgen-cli --version=0.2.84

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches:
-      - gecko
+      - trunk
 
 env:
   CARGO_INCREMENTAL: false
@@ -21,10 +21,12 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust WASM target
-        run: rustup target add wasm32-unknown-unknown
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version=0.2.83
+        run: cargo install wasm-bindgen-cli --version=0.2.84
 
       - name: Build WebGPU examples
         run: cargo build --package wgpu --release --target wasm32-unknown-unknown --examples

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Remove hardcoded MSRV
+        # Okay to build examples using the latest Rust.
+        # Fixes issues building wasm-bindgen-cli
+        run: rm -f rust-toolchain
+
       - name: Install Rust WASM target
         run: rustup target add wasm32-unknown-unknown
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,16 +20,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Remove hardcoded MSRV
-        # Okay to build examples using the latest Rust.
-        # Fixes issues building wasm-bindgen-cli
-        run: rm -f rust-toolchain
-
       - name: Install Rust WASM target
         run: rustup target add wasm32-unknown-unknown
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version=0.2.84
+        run: cargo +stable install wasm-bindgen-cli --version=0.2.84
 
       - name: Build WebGPU examples
         run: cargo build --package wgpu --release --target wasm32-unknown-unknown --examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ Bottom level categories:
 - Fix crash on dropping `wgpu::CommandBuffer`. By @wumpf in [#3726](https://github.com/gfx-rs/wgpu/pull/3726).
 - Use `u32`s internally for bind group indices, rather than `u8`. By @ErichDonGubler in [#3743](https://github.com/gfx-rs/wgpu/pull/3743).
 
+### Examples
+
+#### General
+
+- Publish examples to wgpu.rs on updates to trunk branch instead of gecko. By @paul-hansen in [#3750](https://github.com/gfx-rs/wgpu/pull/3750)
+
 ## v0.16.0 (2023-04-19)
 
 ### Major changes


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`. 
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #3684

**Description**
Switched the branch the publish action is using to `trunk` to allow the examples to be kept up to date as requested in #3684 

When testing I ran into the error `rustup: command not found` in the `Main Install Rust WASM target` step, I fixed this by using [dtolnay/rust-toolchain](https://github.com/marketplace/actions/rustup-toolchain-install) which is what the [Bevy CI template](https://github.com/bevyengine/bevy_github_ci_template/blob/main/.github/workflows/release.yaml) uses for installing Rust in an action. Lmk if you would prefer I revert that.

**Testing**
I tested this by installing https://github.com/nektos/act and running this command to mimic a github action runner using a minimal image that still contained the Rust stuff needed.
```shell
act -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:rust-latest -j publish
``` 
Note that it fails at uploading to github pages, which is expected since running locally you wouldn't have access to the secrets needed to do so.
