### PR TITLE
Update CI to install wasm-pack from binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,14 +172,10 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v3
 
-      # TODO: replace with this once there is a release containing this PR:
-      # https://github.com/rustwasm/wasm-pack/pull/1185
-      # - name: Install wasm-pack
-      #   uses: taiki-e/install-action@v2
-      #   with:
-      #     tool: wasm-pack
-      - name: install wasm-pack
-        run: cargo install --git https://github.com/rustwasm/wasm-pack --rev e1010233b0ce304f42cda59962254bf30ae97c3e wasm-pack
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
 
       - name: execute tests
         run: |


### PR DESCRIPTION
Fixes CI failure due to a library used by wasm-pack not being compatible with our MSRV

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.
    Seemed unnecessary since I doubt anyone looking at our changelog cares about changes to our CI. Just lmk if I should add something though.

**Connections**
Fixes this CI failure https://github.com/gfx-rs/wgpu/actions/runs/4889931906/jobs/8758745206?pr=3750#step:3:221

**Description**
Updates the wasm-test CI job to install wasm-pack from a precompiled binary using [taiki-e/install-action](https://github.com/taiki-e/install-action).
Now that wasm-pack has [released a version with support for workspace](https://github.com/rustwasm/wasm-pack/releases/tag/v0.11.0) inheritance we don't need to build it ourselves. 

This has the benefit of avoiding a CI failure that started today due to our MSRV no longer being compatible with wasm-pack's [time](https://github.com/time-rs/time/blob/main/CHANGELOG.md#0321-2023-05-05) dependency. This failure is what prompted this PR.

**Testing**
Probably easiest to just run the CI on Github.
If you want to run it locally, I used https://github.com/nektos/act with this command to mimic a github action runner using a minimal image that still contained the Rust stuff needed to get past the wasm-pack install.
```shell
act -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:rust-latest -j wasm-test
```
