### PR TITLE
Change `AdapterInfo::{device,vendor}` fields to `u32`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Changes
+
+#### Misc Breaking Changes
+
+- Change `AdapterInfo::{device,vendor}` to be `u32` instead of `usize`. By @ameknite in [#3760](https://github.com/gfx-rs/wgpu/pull/3760)
+
 ### Documentation
 
 #### General

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -115,8 +115,8 @@ impl super::Adapter {
         let info = wgt::AdapterInfo {
             backend: wgt::Backend::Dx12,
             name: device_name,
-            vendor: desc.VendorId as usize,
-            device: desc.DeviceId as usize,
+            vendor: desc.VendorId,
+            device: desc.DeviceId,
             device_type: if (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0 {
                 workarounds.avoid_cpu_descriptor_overwrites = true;
                 wgt::DeviceType::Cpu

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -170,7 +170,7 @@ impl super::Adapter {
 
         wgt::AdapterInfo {
             name: renderer_orig,
-            vendor: vendor_id as usize,
+            vendor: vendor_id,
             device: 0,
             device_type: inferred_device_type,
             driver: String::new(),

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -961,8 +961,8 @@ impl super::Instance {
                     .unwrap_or("?")
                     .to_owned()
             },
-            vendor: phd_capabilities.properties.vendor_id as usize,
-            device: phd_capabilities.properties.device_id as usize,
+            vendor: phd_capabilities.properties.vendor_id,
+            device: phd_capabilities.properties.device_id,
             device_type: match phd_capabilities.properties.device_type {
                 ash::vk::PhysicalDeviceType::OTHER => wgt::DeviceType::Other,
                 ash::vk::PhysicalDeviceType::INTEGRATED_GPU => wgt::DeviceType::IntegratedGpu,

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -691,12 +691,12 @@ impl crate::Instance<super::Api> for super::Instance {
         // Detect if it's an Intel + NVidia configuration with Optimus
         let has_nvidia_dgpu = exposed_adapters.iter().any(|exposed| {
             exposed.info.device_type == wgt::DeviceType::DiscreteGpu
-                && exposed.info.vendor == db::nvidia::VENDOR as usize
+                && exposed.info.vendor == db::nvidia::VENDOR
         });
         if cfg!(target_os = "linux") && has_nvidia_dgpu && self.shared.has_nv_optimus {
             for exposed in exposed_adapters.iter_mut() {
                 if exposed.info.device_type == wgt::DeviceType::IntegratedGpu
-                    && exposed.info.vendor == db::intel::VENDOR as usize
+                    && exposed.info.vendor == db::intel::VENDOR
                 {
                     // See https://gitlab.freedesktop.org/mesa/mesa/-/issues/4688
                     log::warn!(

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1307,9 +1307,9 @@ pub struct AdapterInfo {
     ///
     /// If the vendor has no PCI id, then this value will be the backend's vendor id equivalent. On Vulkan,
     /// Mesa would have a vendor id equivalent to it's `VkVendorId` value.
-    pub vendor: usize,
+    pub vendor: u32,
     /// PCI id of the adapter
-    pub device: usize,
+    pub device: u32,
     /// Type of device
     pub device_type: DeviceType,
     /// Driver name

--- a/wgpu/tests/common/mod.rs
+++ b/wgpu/tests/common/mod.rs
@@ -53,7 +53,7 @@ fn lowest_downlevel_properties() -> DownlevelCapabilities {
 
 pub struct FailureCase {
     backends: Option<wgpu::Backends>,
-    vendor: Option<usize>,
+    vendor: Option<u32>,
     adapter: Option<String>,
     skip: bool,
 }
@@ -170,7 +170,7 @@ impl TestParameters {
     pub fn specific_failure(
         mut self,
         backends: Option<Backends>,
-        vendor: Option<usize>,
+        vendor: Option<u32>,
         device: Option<&'static str>,
         skip: bool,
     ) -> Self {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fix #3759