### PR TITLE
Fix multiview rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Bottom level categories:
 
 - Fix crash on dropping `wgpu::CommandBuffer`. By @wumpf in [#3726](https://github.com/gfx-rs/wgpu/pull/3726).
 - Use `u32`s internally for bind group indices, rather than `u8`. By @ErichDonGubler in [#3743](https://github.com/gfx-rs/wgpu/pull/3743).
+- Fix Multiview to disable validation of TextureViewDimension and ArrayLayerCount. By @MalekiRe in [#3779](https://github.com/gfx-rs/wgpu/pull/3779#issue-1713269437).
 
 ### Examples
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1189,7 +1189,10 @@ impl<A: HalApi> Device<A> {
                 break 'b Err(TextureViewNotRenderableReason::Usage(texture.desc.usage));
             }
 
-            if resolved_dimension != TextureViewDimension::D2 {
+            if !(resolved_dimension == TextureViewDimension::D2
+                || (self.features.contains(wgt::Features::MULTIVIEW)
+                    && resolved_dimension == TextureViewDimension::D2Array))
+            {
                 break 'b Err(TextureViewNotRenderableReason::Dimension(
                     resolved_dimension,
                 ));
@@ -1201,7 +1204,9 @@ impl<A: HalApi> Device<A> {
                 ));
             }
 
-            if resolved_array_layer_count != 1 {
+            if resolved_array_layer_count != 1
+                && !(self.features.contains(wgt::Features::MULTIVIEW))
+            {
                 break 'b Err(TextureViewNotRenderableReason::ArrayLayerCount(
                     resolved_array_layer_count,
                 ));


### PR DESCRIPTION
**Checklist**

- [ x] Run `cargo clippy`.
- [ ] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
fixes https://github.com/gfx-rs/wgpu/issues/3778

**Description**
WGPU Multiview works again by disabling some validation of TextureViewDimension and ResolvedArrayLayerCount

**Testing**
Running WGPU with a multiview enabled and trying it with multiple views.
