### PR TITLE
Fix missing 4X MSAA support on some OpenGL backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Bottom level categories:
 
 ### Bug Fixes
 
+- Fix missing 4X MSAA support on some OpenGL backends. By @emilk in [#3780](https://github.com/gfx-rs/wgpu/pull/3780)
+
 #### General
 
 - Fix crash on dropping `wgpu::CommandBuffer`. By @wumpf in [#3726](https://github.com/gfx-rs/wgpu/pull/3726).

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -713,10 +713,12 @@ impl crate::Adapter<super::Api> for super::Adapter {
                     | Tfc::MULTISAMPLE_X16
             } else if max_samples >= 8 {
                 Tfc::MULTISAMPLE_X2 | Tfc::MULTISAMPLE_X4 | Tfc::MULTISAMPLE_X8
-            } else if max_samples >= 4 {
-                Tfc::MULTISAMPLE_X2 | Tfc::MULTISAMPLE_X4
             } else {
-                Tfc::MULTISAMPLE_X2
+                // The lowest supported level in GLE3.0/WebGL2 is 4X
+                // (see GL_MAX_SAMPLES in https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml).
+                // On some platforms, like iOS Safari, `get_parameter_i32(MAX_SAMPLES)` returns 0,
+                // so we always fall back to supporting 4x here.
+                Tfc::MULTISAMPLE_X2 | Tfc::MULTISAMPLE_X4
             }
         };
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
* https://github.com/rerun-io/rerun/issues/2032

**Description**
A regression was introduced in wgpu 0.15 by [#3140](https://github.com/gfx-rs/wgpu/pull/3140/files#diff-d432c3513f13990ea461061053eaaa60715fa35de2fe3047c5d578c0b8befcd9), where some GL backends would report a minimum supported MSAA of 2x. However, GLES3.0 (and therefore WebGL2) guarantees at least 4x.

This problem manifests itself on some versions of iOS Safari, where `get_parameter_i32(glow::MAX_SAMPLES)` returns `0` (for unknown reasons - maybe anti-fingerprinting?), even though 4x MSAA is supported.


**Testing**
Tested on iOS Safari. Before the fix I got:

```
[Error] panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
    Color state [0] is invalid
    Format Rgba8UnormSrgb can't be multisampled

', wgpu/src/backend/direct.rs:3019:5
```

After the fix, everything works (with 4x MSAA).