### PR TITLE
Fix order of arguments to glPolygonOffset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Bottom level categories:
 
 ### Bug Fixes
 
+- Fix order of arguments to glPolygonOffset by @komadori in [#3783](https://github.com/gfx-rs/wgpu/pull/3783).
+
 #### General
 
 - Fix crash on dropping `wgpu::CommandBuffer`. By @wumpf in [#3726](https://github.com/gfx-rs/wgpu/pull/3726).

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1186,7 +1186,7 @@ impl super::Queue {
             C::SetDepthBias(bias) => {
                 if bias.is_enabled() {
                     unsafe { gl.enable(glow::POLYGON_OFFSET_FILL) };
-                    unsafe { gl.polygon_offset(bias.constant as f32, bias.slope_scale) };
+                    unsafe { gl.polygon_offset(bias.slope_scale, bias.constant as f32) };
                 } else {
                     unsafe { gl.disable(glow::POLYGON_OFFSET_FILL) };
                 }


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [X] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
While investigating a Z-fighting issue shown in https://github.com/komadori/bevy_mod_outline/issues/19 which is apparently specific to WebGL, I noticed that wgpu-hal's GL ES back-end appears to be passing the wrong arguments to glPolygonOffset. However, this bug is ultimately largely incidental to that issue.

**Description**
[glPolygonOffset](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glPolygonOffset.xhtml) takes two arguments, `factor` and `units`. The terminology used is slightly different to wgpu, but I believe `factor` ("_specifies a scale factor_") should correspond to `slope_scale` and `units` ("_create a constant depth offset_") to `constant`. However, wgpu passes these arguments in the reverse order and this PR corrects that.

**Testing**
In practice, both the `slope_scale` and `constant` are often set to around 1 so wgpu swapping them would go unnoticed. I don't have a meaningful test case for this and am judging it correct by inspection of the code and OpenGL documentation.