### PR TITLE
Adjust log levels per #3626

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -241,7 +241,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let id = fid.assign(buffer, &mut token);
-            log::info!("Created buffer {:?} with {:?}", id, desc);
+            log::info!("Created Buffer {:?} with {:?}", id, desc);
 
             device
                 .trackers
@@ -461,7 +461,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             //TODO: lock pending writes separately, keep the device read-only
             let (mut device_guard, mut token) = hub.devices.write(&mut token);
 
-            log::info!("Buffer {:?} is destroyed", buffer_id);
+            log::debug!("Buffer {:?} is destroyed", buffer_id);
             let (mut buffer_guard, _) = hub.buffers.write(&mut token);
             let buffer = buffer_guard
                 .get_mut(buffer_id)
@@ -512,7 +512,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn buffer_drop<A: HalApi>(&self, buffer_id: id::BufferId, wait: bool) {
         profiling::scope!("Buffer::drop");
-        log::debug!("buffer {:?} is dropped", buffer_id);
+        log::debug!("buffer {:?} is asked to be dropped", buffer_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -700,7 +700,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         //TODO: lock pending writes separately, keep the device read-only
         let (mut device_guard, mut token) = hub.devices.write(&mut token);
 
-        log::info!("Buffer {:?} is destroyed", texture_id);
+        log::debug!("Texture {:?} is destroyed", texture_id);
         let (mut texture_guard, _) = hub.textures.write(&mut token);
         let texture = texture_guard
             .get_mut(texture_id)
@@ -750,7 +750,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn texture_drop<A: HalApi>(&self, texture_id: id::TextureId, wait: bool) {
         profiling::scope!("Texture::drop");
-        log::debug!("texture {:?} is dropped", texture_id);
+        log::debug!("texture {:?} is asked to be dropped", texture_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -832,6 +832,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
             let ref_count = view.life_guard.add_ref();
             let id = fid.assign(view, &mut token);
+            log::info!("Created TextureView {:?}", id);
 
             device.trackers.lock().views.insert_single(id, ref_count);
             return (id.0, None);
@@ -851,7 +852,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         wait: bool,
     ) -> Result<(), resource::TextureViewDestroyError> {
         profiling::scope!("TextureView::drop");
-        log::debug!("texture view {:?} is dropped", texture_view_id);
+        log::debug!("texture view {:?} is asked to be dropped", texture_view_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -925,6 +926,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
             let ref_count = sampler.life_guard.add_ref();
             let id = fid.assign(sampler, &mut token);
+            log::info!("Created Sampler {:?}", id);
 
             device.trackers.lock().samplers.insert_single(id, ref_count);
 
@@ -941,7 +943,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn sampler_drop<A: HalApi>(&self, sampler_id: id::SamplerId) {
         profiling::scope!("Sampler::drop");
-        log::debug!("sampler {:?} is dropped", sampler_id);
+        log::debug!("sampler {:?} is asked to be dropped", sampler_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1034,6 +1036,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let id = fid.assign(layout, &mut token);
+            log::info!("Created BindGroupLayout {:?}", id);
             return (id.0, None);
         };
 
@@ -1047,7 +1050,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn bind_group_layout_drop<A: HalApi>(&self, bind_group_layout_id: id::BindGroupLayoutId) {
         profiling::scope!("BindGroupLayout::drop");
-        log::debug!("bind group layout {:?} is dropped", bind_group_layout_id);
+        log::debug!(
+            "bind group layout {:?} is asked to be dropped",
+            bind_group_layout_id
+        );
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1108,6 +1114,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let id = fid.assign(layout, &mut token);
+            log::info!("Created PipelineLayout {:?}", id);
             return (id.0, None);
         };
 
@@ -1121,7 +1128,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn pipeline_layout_drop<A: HalApi>(&self, pipeline_layout_id: id::PipelineLayoutId) {
         profiling::scope!("PipelineLayout::drop");
-        log::debug!("pipeline layout {:?} is dropped", pipeline_layout_id);
+        log::debug!(
+            "pipeline layout {:?} is asked to be dropped",
+            pipeline_layout_id
+        );
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1191,7 +1201,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let ref_count = bind_group.life_guard.add_ref();
 
             let id = fid.assign(bind_group, &mut token);
-            log::debug!("Bind group {:?}", id,);
+            log::debug!("Created BindGroup {:?}", id,);
 
             device
                 .trackers
@@ -1211,7 +1221,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn bind_group_drop<A: HalApi>(&self, bind_group_id: id::BindGroupId) {
         profiling::scope!("BindGroup::drop");
-        log::debug!("bind group {:?} is dropped", bind_group_id);
+        log::debug!("bind group {:?} is asked to be dropped", bind_group_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1291,6 +1301,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(e) => break e,
             };
             let id = fid.assign(shader, &mut token);
+            log::info!("Created ShaderModule {:?} with {:?}", id, desc);
             return (id.0, None);
         };
 
@@ -1345,6 +1356,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     Err(e) => break e,
                 };
             let id = fid.assign(shader, &mut token);
+            log::info!("Created ShaderModule {:?} with {:?}", id, desc);
             return (id.0, None);
         };
 
@@ -1358,7 +1370,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn shader_module_drop<A: HalApi>(&self, shader_module_id: id::ShaderModuleId) {
         profiling::scope!("ShaderModule::drop");
-        log::debug!("shader module {:?} is dropped", shader_module_id);
+        log::debug!(
+            "shader module {:?} is asked to be dropped",
+            shader_module_id
+        );
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1420,6 +1435,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             );
 
             let id = fid.assign(command_buffer, &mut token);
+            log::info!("Created CommandBuffer {:?} with {:?}", id, desc);
             return (id.0, None);
         };
 
@@ -1433,7 +1449,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn command_encoder_drop<A: HalApi>(&self, command_encoder_id: id::CommandEncoderId) {
         profiling::scope!("CommandEncoder::drop");
-        log::debug!("command encoder {:?} is dropped", command_encoder_id);
+        log::debug!(
+            "command encoder {:?} is asked to be dropped",
+            command_encoder_id
+        );
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1451,7 +1470,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn command_buffer_drop<A: HalApi>(&self, command_buffer_id: id::CommandBufferId) {
         profiling::scope!("CommandBuffer::drop");
-        log::debug!("command buffer {:?} is dropped", command_buffer_id);
+        log::debug!(
+            "command buffer {:?} is asked to be dropped",
+            command_buffer_id
+        );
         self.command_encoder_drop::<A>(command_buffer_id)
     }
 
@@ -1508,9 +1530,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(e) => break e,
             };
 
-            log::debug!("Render bundle");
             let ref_count = render_bundle.life_guard.add_ref();
             let id = fid.assign(render_bundle, &mut token);
+            log::info!("Created RenderBundle {:?}", id);
 
             device.trackers.lock().bundles.insert_single(id, ref_count);
             return (id.0, None);
@@ -1526,7 +1548,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn render_bundle_drop<A: HalApi>(&self, render_bundle_id: id::RenderBundleId) {
         profiling::scope!("RenderBundle::drop");
-        log::debug!("render bundle {:?} is dropped", render_bundle_id);
+        log::debug!(
+            "render bundle {:?} is asked to be dropped",
+            render_bundle_id
+        );
         let hub = A::hub(self);
         let mut token = Token::root();
 
@@ -1586,6 +1611,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let ref_count = query_set.life_guard.add_ref();
             let id = fid.assign(query_set, &mut token);
+            log::info!("Created QuerySet {:?}", id);
 
             device
                 .trackers
@@ -1602,7 +1628,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn query_set_drop<A: HalApi>(&self, query_set_id: id::QuerySetId) {
         profiling::scope!("QuerySet::drop");
-        log::debug!("query set {:?} is dropped", query_set_id);
+        log::debug!("query set {:?} is asked to be dropped", query_set_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1684,7 +1710,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let ref_count = pipeline.life_guard.add_ref();
 
             let id = fid.assign(pipeline, &mut token);
-            log::info!("Created render pipeline {:?} with {:?}", id, desc);
+            log::info!("Created RenderPipeline {:?} with {:?}", id, desc);
 
             device
                 .trackers
@@ -1748,7 +1774,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn render_pipeline_drop<A: HalApi>(&self, render_pipeline_id: id::RenderPipelineId) {
         profiling::scope!("RenderPipeline::drop");
-        log::debug!("render pipeline {:?} is dropped", render_pipeline_id);
+        log::debug!(
+            "render pipeline {:?} is asked to be dropped",
+            render_pipeline_id
+        );
         let hub = A::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -1825,7 +1854,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let ref_count = pipeline.life_guard.add_ref();
 
             let id = fid.assign(pipeline, &mut token);
-            log::info!("Created compute pipeline {:?} with {:?}", id, desc);
+            log::info!("Created ComputePipeline {:?} with {:?}", id, desc);
 
             device
                 .trackers
@@ -1888,7 +1917,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn compute_pipeline_drop<A: HalApi>(&self, compute_pipeline_id: id::ComputePipelineId) {
         profiling::scope!("ComputePipeline::drop");
-        log::debug!("compute pipeline {:?} is dropped", compute_pipeline_id);
+        log::debug!(
+            "compute pipeline {:?} is asked to be dropped",
+            compute_pipeline_id
+        );
         let hub = A::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -2318,7 +2350,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn device_drop<A: HalApi>(&self, device_id: DeviceId) {
         profiling::scope!("Device::drop");
-        log::debug!("device {:?} is dropped", device_id);
+        log::debug!("device {:?} is asked to be dropped", device_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -407,7 +407,7 @@ impl<A: hal::Api> LifetimeTracker<A> {
 
         let mut work_done_closures = SmallVec::new();
         for a in self.active.drain(..done_count) {
-            log::trace!("Active submission {} is done", a.index);
+            log::info!("Active submission {} is done", a.index);
             self.free_resources.extend(a.last_resources);
             self.ready_to_map.extend(a.mapped);
             for encoder in a.encoders {
@@ -516,7 +516,7 @@ impl<A: HalApi> LifetimeTracker<A> {
 
             while let Some(id) = self.suspected_resources.render_bundles.pop() {
                 if trackers.bundles.remove_abandoned(id) {
-                    log::debug!("Bundle {:?} will be destroyed", id);
+                    log::info!("Bundle {:?} will be destroyed", id);
                     #[cfg(feature = "trace")]
                     if let Some(t) = trace {
                         t.lock().add(trace::Action::DestroyRenderBundle(id.0));
@@ -535,7 +535,7 @@ impl<A: HalApi> LifetimeTracker<A> {
 
             while let Some(id) = self.suspected_resources.bind_groups.pop() {
                 if trackers.bind_groups.remove_abandoned(id) {
-                    log::debug!("Bind group {:?} will be destroyed", id);
+                    log::info!("Bind group {:?} will be destroyed", id);
                     #[cfg(feature = "trace")]
                     if let Some(t) = trace {
                         t.lock().add(trace::Action::DestroyBindGroup(id.0));
@@ -567,7 +567,7 @@ impl<A: HalApi> LifetimeTracker<A> {
             let mut list = mem::take(&mut self.suspected_resources.texture_views);
             for id in list.drain(..) {
                 if trackers.views.remove_abandoned(id) {
-                    log::debug!("Texture view {:?} will be destroyed", id);
+                    log::info!("Texture view {:?} will be destroyed", id);
                     #[cfg(feature = "trace")]
                     if let Some(t) = trace {
                         t.lock().add(trace::Action::DestroyTextureView(id.0));
@@ -594,7 +594,7 @@ impl<A: HalApi> LifetimeTracker<A> {
 
             for id in self.suspected_resources.textures.drain(..) {
                 if trackers.textures.remove_abandoned(id) {
-                    log::debug!("Texture {:?} will be destroyed", id);
+                    log::info!("Texture {:?} will be destroyed", id);
                     #[cfg(feature = "trace")]
                     if let Some(t) = trace {
                         t.lock().add(trace::Action::DestroyTexture(id.0));
@@ -631,7 +631,7 @@ impl<A: HalApi> LifetimeTracker<A> {
 
             for id in self.suspected_resources.samplers.drain(..) {
                 if trackers.samplers.remove_abandoned(id) {
-                    log::debug!("Sampler {:?} will be destroyed", id);
+                    log::info!("Sampler {:?} will be destroyed", id);
                     #[cfg(feature = "trace")]
                     if let Some(t) = trace {
                         t.lock().add(trace::Action::DestroySampler(id.0));
@@ -656,7 +656,7 @@ impl<A: HalApi> LifetimeTracker<A> {
 
             for id in self.suspected_resources.buffers.drain(..) {
                 if trackers.buffers.remove_abandoned(id) {
-                    log::debug!("Buffer {:?} will be destroyed", id);
+                    log::info!("Buffer {:?} will be destroyed", id);
                     #[cfg(feature = "trace")]
                     if let Some(t) = trace {
                         t.lock().add(trace::Action::DestroyBuffer(id.0));
@@ -684,7 +684,7 @@ impl<A: HalApi> LifetimeTracker<A> {
 
             for id in self.suspected_resources.compute_pipelines.drain(..) {
                 if trackers.compute_pipelines.remove_abandoned(id) {
-                    log::debug!("Compute pipeline {:?} will be destroyed", id);
+                    log::info!("Compute pipeline {:?} will be destroyed", id);
                     #[cfg(feature = "trace")]
                     if let Some(t) = trace {
                         t.lock().add(trace::Action::DestroyComputePipeline(id.0));
@@ -709,7 +709,7 @@ impl<A: HalApi> LifetimeTracker<A> {
 
             for id in self.suspected_resources.render_pipelines.drain(..) {
                 if trackers.render_pipelines.remove_abandoned(id) {
-                    log::debug!("Render pipeline {:?} will be destroyed", id);
+                    log::info!("Render pipeline {:?} will be destroyed", id);
                     #[cfg(feature = "trace")]
                     if let Some(t) = trace {
                         t.lock().add(trace::Action::DestroyRenderPipeline(id.0));
@@ -781,7 +781,7 @@ impl<A: HalApi> LifetimeTracker<A> {
 
             for id in self.suspected_resources.query_sets.drain(..) {
                 if trackers.query_sets.remove_abandoned(id) {
-                    log::debug!("Query set {:?} will be destroyed", id);
+                    log::info!("Query set {:?} will be destroyed", id);
                     // #[cfg(feature = "trace")]
                     // trace.map(|t| t.lock().add(trace::Action::DestroyComputePipeline(id.0)));
                     if let Some(res) = hub.query_sets.unregister_locked(id.0, &mut *guard) {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -408,6 +408,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let fid = hub.staging_buffers.prepare(id_in);
         let id = fid.assign(staging_buffer, device_token);
+        log::info!("Created StagingBuffer {:?}", id);
 
         Ok((id.0, staging_buffer_ptr))
     }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2520,7 +2520,7 @@ impl<A: HalApi> Device<A> {
                 .iter()
                 .any(|ct| ct.write_mask != first.write_mask || ct.blend != first.blend)
         } {
-            log::info!("Color targets: {:?}", color_targets);
+            log::debug!("Color targets: {:?}", color_targets);
             self.require_downlevel_flags(wgt::DownlevelFlags::INDEPENDENT_BLEND)?;
         }
 

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -121,7 +121,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 impl<G: GlobalIdentityHandlerFactory> Drop for Global<G> {
     fn drop(&mut self) {
         profiling::scope!("Global::drop");
-        log::info!("Dropping Global");
+        log::info!("Destroying Global");
         let mut surface_guard = self.surfaces.data.write();
 
         // destroy hubs before the instance gets dropped

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -930,7 +930,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let mut token = Token::root();
         let fid = A::hub(self).adapters.prepare(input);
 
-        match A::VARIANT {
+        let id = match A::VARIANT {
             #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
             Backend::Vulkan => fid.assign(Adapter::new(hal_adapter), &mut token).0,
             #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
@@ -942,7 +942,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             #[cfg(feature = "gles")]
             Backend::Gl => fid.assign(Adapter::new(hal_adapter), &mut token).0,
             _ => unreachable!(),
-        }
+        };
+        log::info!("Created Adapter {:?}", id);
+        id
     }
 
     pub fn adapter_get_info<A: HalApi>(
@@ -1066,6 +1068,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(e) => break e,
             };
             let id = fid.assign(device, &mut token);
+            log::info!("Created Device {:?}", id);
             return (id.0, None);
         };
 
@@ -1103,6 +1106,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     Err(e) => break e,
                 };
             let id = fid.assign(device, &mut token);
+            log::info!("Created Device {:?}", id);
             return (id.0, None);
         };
 

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -114,7 +114,7 @@ impl<A: hal::Api> Example<A> {
         };
         let surface_caps =
             unsafe { adapter.surface_capabilities(&surface) }.ok_or(hal::InstanceError)?;
-        log::info!("Surface caps: {:#?}", surface_caps);
+        log::debug!("Surface caps: {:#?}", surface_caps);
 
         let hal::OpenDevice { device, mut queue } = unsafe {
             adapter
@@ -723,7 +723,7 @@ impl<A: hal::Api> Example<A> {
         };
 
         if do_fence {
-            log::info!("Context switch from {}", self.context_index);
+            log::debug!("Context switch from {}", self.context_index);
             let old_fence_value = ctx.fence_value;
             if self.contexts.len() == 1 {
                 let hal_desc = hal::CommandEncoderDescriptor {

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -65,7 +65,7 @@ pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter
                     continue;
                 }
                 Err(err) => {
-                    log::info!("Failed casting Adapter1 to Adapter3: {}", err);
+                    log::warn!("Failed casting Adapter1 to Adapter3: {}", err);
                 }
             }
         }
@@ -79,7 +79,7 @@ pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter
                     continue;
                 }
                 Err(err) => {
-                    log::info!("Failed casting Adapter1 to Adapter2: {}", err);
+                    log::warn!("Failed casting Adapter1 to Adapter2: {}", err);
                 }
             }
         }
@@ -141,7 +141,7 @@ pub fn create_factory(
         }
         // If we don't print it to info as all win7 will hit this case.
         Err(err) => {
-            log::info!("IDXGIFactory1 creation function not found: {:?}", err);
+            log::warn!("IDXGIFactory1 creation function not found: {:?}", err);
             None
         }
     };
@@ -163,7 +163,7 @@ pub fn create_factory(
             }
             // If we don't print it to info.
             Err(err) => {
-                log::info!("Failed to cast IDXGIFactory4 to IDXGIFactory6: {:?}", err);
+                log::warn!("Failed to cast IDXGIFactory4 to IDXGIFactory6: {:?}", err);
                 return Ok((lib_dxgi, d3d12::DxgiFactory::Factory4(factory4)));
             }
         }
@@ -201,7 +201,7 @@ pub fn create_factory(
         }
         // If we don't print it to info.
         Err(err) => {
-            log::info!("Failed to cast IDXGIFactory1 to IDXGIFactory2: {:?}", err);
+            log::warn!("Failed to cast IDXGIFactory1 to IDXGIFactory2: {:?}", err);
         }
     }
 

--- a/wgpu-hal/src/dx11/library.rs
+++ b/wgpu-hal/src/dx11/library.rs
@@ -121,7 +121,7 @@ impl D3D11Lib {
                     return Some((super::D3D11Device::Device2(device2), feature_level));
                 }
                 Err(hr) => {
-                    log::info!("Failed to cast device to ID3D11Device2: {}", hr)
+                    log::warn!("Failed to cast device to ID3D11Device2: {}", hr)
                 }
             }
         }
@@ -134,7 +134,7 @@ impl D3D11Lib {
                     return Some((super::D3D11Device::Device1(device1), feature_level));
                 }
                 Err(hr) => {
-                    log::info!("Failed to cast device to ID3D11Device1: {}", hr)
+                    log::warn!("Failed to cast device to ID3D11Device1: {}", hr)
                 }
             }
         }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -183,7 +183,7 @@ impl super::Device {
         }
 
         let value = cur_value + 1;
-        log::info!("Waiting for idle with value {}", value);
+        log::debug!("Waiting for idle with value {}", value);
         self.present_queue.signal(self.idler.fence, value);
         let hr = self
             .idler

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -49,7 +49,7 @@ impl crate::Instance<super::Api> for super::Instance {
                 }
             },
             Err(err) => {
-                log::info!("IDXGIFactory1 creation function not found: {:?}", err);
+                log::warn!("IDXGIFactory1 creation function not found: {:?}", err);
                 None
             }
         };

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -208,9 +208,9 @@ impl super::Adapter {
             (vendor, renderer)
         };
         let version = unsafe { gl.get_parameter_string(glow::VERSION) };
-        log::info!("Vendor: {}", vendor);
-        log::info!("Renderer: {}", renderer);
-        log::info!("Version: {}", version);
+        log::debug!("Vendor: {}", vendor);
+        log::debug!("Renderer: {}", renderer);
+        log::debug!("Version: {}", version);
 
         log::debug!("Extensions: {:#?}", extensions);
 
@@ -229,7 +229,7 @@ impl super::Adapter {
 
         let shading_language_version = {
             let sl_version = unsafe { gl.get_parameter_string(glow::SHADING_LANGUAGE_VERSION) };
-            log::info!("SL version: {}", &sl_version);
+            log::debug!("SL version: {}", &sl_version);
             let (sl_major, sl_minor) = Self::parse_version(&sl_version).ok()?;
             let value = sl_major as u16 * 100 + sl_minor as u16 * 10;
             naga::back::glsl::Version::Embedded {

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -170,7 +170,7 @@ impl super::Device {
         unsafe { gl.shader_source(raw, shader) };
         unsafe { gl.compile_shader(raw) };
 
-        log::info!("\tCompiled shader {:?}", raw);
+        log::debug!("\tCompiled shader {:?}", raw);
 
         let compiled_ok = unsafe { gl.get_shader_compile_status(raw) };
         let msg = unsafe { gl.get_shader_info_log(raw) };
@@ -347,7 +347,7 @@ impl super::Device {
         // Create empty fragment shader if only vertex shader is present
         if has_stages == wgt::ShaderStages::VERTEX {
             let shader_src = format!("#version {glsl_version} es \n void main(void) {{}}",);
-            log::info!("Only vertex shader is present. Creating an empty fragment shader",);
+            log::warn!("Only vertex shader is present. Creating an empty fragment shader",);
             let shader = unsafe {
                 Self::compile_shader(
                     gl,
@@ -368,7 +368,7 @@ impl super::Device {
             unsafe { gl.delete_shader(shader) };
         }
 
-        log::info!("\tLinked program {:?}", program);
+        log::debug!("\tLinked program {:?}", program);
 
         let linked_ok = unsafe { gl.get_program_link_status(program) };
         let msg = unsafe { gl.get_program_info_log(program) };

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -113,7 +113,7 @@ unsafe extern "system" fn egl_debug_proc(
 }
 
 fn open_x_display() -> Option<(ptr::NonNull<raw::c_void>, libloading::Library)> {
-    log::info!("Loading X11 library to get the current display");
+    log::debug!("Loading X11 library to get the current display");
     unsafe {
         let library = libloading::Library::new("libX11.so").ok()?;
         let func: libloading::Symbol<XOpenDisplayFun> = library.get(b"XOpenDisplay").unwrap();
@@ -136,7 +136,7 @@ fn test_wayland_display() -> Option<libloading::Library> {
     /* We try to connect and disconnect here to simply ensure there
      * is an active wayland display available.
      */
-    log::info!("Loading Wayland library to get the current display");
+    log::debug!("Loading Wayland library to get the current display");
     let library = unsafe {
         let client_library = find_library(&["libwayland-client.so.0", "libwayland-client.so"])?;
         let wl_display_connect: libloading::Symbol<WlDisplayConnectFun> =
@@ -191,7 +191,7 @@ fn choose_config(
     let mut attributes = Vec::with_capacity(9);
     for tier_max in (0..tiers.len()).rev() {
         let name = tiers[tier_max].0;
-        log::info!("\tTrying {}", name);
+        log::debug!("\tTrying {}", name);
 
         attributes.clear();
         for &(_, tier_attr) in tiers[..=tier_max].iter() {
@@ -448,17 +448,17 @@ impl Inner {
             .query_string(Some(display), khronos_egl::EXTENSIONS)
             .unwrap()
             .to_string_lossy();
-        log::info!("Display vendor {:?}, version {:?}", vendor, version,);
+        log::debug!("Display vendor {:?}, version {:?}", vendor, version,);
         log::debug!(
             "Display extensions: {:#?}",
             display_extensions.split_whitespace().collect::<Vec<_>>()
         );
 
         let srgb_kind = if version >= (1, 5) {
-            log::info!("\tEGL surface: +srgb");
+            log::debug!("\tEGL surface: +srgb");
             SrgbFrameBufferKind::Core
         } else if display_extensions.contains("EGL_KHR_gl_colorspace") {
-            log::info!("\tEGL surface: +srgb khr");
+            log::debug!("\tEGL surface: +srgb khr");
             SrgbFrameBufferKind::Khr
         } else {
             log::warn!("\tEGL surface: -srgb");
@@ -495,14 +495,14 @@ impl Inner {
         ];
         if flags.contains(crate::InstanceFlags::DEBUG) {
             if version >= (1, 5) {
-                log::info!("\tEGL context: +debug");
+                log::debug!("\tEGL context: +debug");
                 context_attributes.push(khronos_egl::CONTEXT_OPENGL_DEBUG);
                 context_attributes.push(khronos_egl::TRUE as _);
             } else if supports_khr_context {
-                log::info!("\tEGL context: +debug KHR");
+                log::debug!("\tEGL context: +debug KHR");
                 khr_context_flags |= EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR;
             } else {
-                log::info!("\tEGL context: -debug");
+                log::debug!("\tEGL context: -debug");
             }
         }
         if needs_robustness {
@@ -510,11 +510,11 @@ impl Inner {
             // (regardless of whether the extension is supported!).
             // In fact, Angle does precisely that awful behavior, so we don't try it there.
             if version >= (1, 5) && !display_extensions.contains("EGL_ANGLE_") {
-                log::info!("\tEGL context: +robust access");
+                log::debug!("\tEGL context: +robust access");
                 context_attributes.push(khronos_egl::CONTEXT_OPENGL_ROBUST_ACCESS);
                 context_attributes.push(khronos_egl::TRUE as _);
             } else if display_extensions.contains("EGL_EXT_create_context_robustness") {
-                log::info!("\tEGL context: +robust access EXT");
+                log::debug!("\tEGL context: +robust access EXT");
                 context_attributes.push(EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT);
                 context_attributes.push(khronos_egl::TRUE as _);
             } else {
@@ -544,7 +544,7 @@ impl Inner {
             || display_extensions.contains("EGL_KHR_surfaceless_context")
             || cfg!(target_os = "emscripten")
         {
-            log::info!("\tEGL context: +surfaceless");
+            log::debug!("\tEGL context: +surfaceless");
             None
         } else {
             let attributes = [
@@ -660,7 +660,7 @@ impl crate::Instance<super::Api> for Instance {
         let egl = match egl_result {
             Ok(egl) => Arc::new(egl),
             Err(e) => {
-                log::info!("Unable to open libEGL: {:?}", e);
+                log::warn!("Unable to open libEGL: {:?}", e);
                 return Err(crate::InstanceError);
             }
         };
@@ -736,7 +736,7 @@ impl crate::Instance<super::Api> for Instance {
                 .unwrap();
             (display, Some(Arc::new(library)), WindowKind::AngleX11)
         } else if client_ext_str.contains("EGL_MESA_platform_surfaceless") {
-            log::info!("No windowing system present. Using surfaceless platform");
+            log::warn!("No windowing system present. Using surfaceless platform");
             let egl = egl1_5.expect("Failed to get EGL 1.5 for surfaceless");
             let display = egl
                 .get_platform_display(
@@ -747,7 +747,7 @@ impl crate::Instance<super::Api> for Instance {
                 .unwrap();
             (display, None, WindowKind::Unknown)
         } else {
-            log::info!("EGL_MESA_platform_surfaceless not available. Using default platform");
+            log::warn!("EGL_MESA_platform_surfaceless not available. Using default platform");
             let display = egl.get_display(khronos_egl::DEFAULT_DISPLAY).unwrap();
             (display, None, WindowKind::Unknown)
         };
@@ -755,7 +755,7 @@ impl crate::Instance<super::Api> for Instance {
         if desc.flags.contains(crate::InstanceFlags::VALIDATION)
             && client_ext_str.contains("EGL_KHR_debug")
         {
-            log::info!("Enabling EGL debug output");
+            log::debug!("Enabling EGL debug output");
             let function: EglDebugMessageControlFun = {
                 let addr = egl.get_proc_address("eglDebugMessageControlKHR").unwrap();
                 unsafe { std::mem::transmute(addr) }
@@ -903,13 +903,13 @@ impl crate::Instance<super::Api> for Instance {
         };
 
         if self.flags.contains(crate::InstanceFlags::DEBUG) && gl.supports_debug() {
-            log::info!("Max label length: {}", unsafe {
+            log::debug!("Max label length: {}", unsafe {
                 gl.get_parameter_i32(glow::MAX_LABEL_LENGTH)
             });
         }
 
         if self.flags.contains(crate::InstanceFlags::VALIDATION) && gl.supports_debug() {
-            log::info!("Enabling GLES debug output");
+            log::debug!("Enabling GLES debug output");
             unsafe { gl.enable(glow::DEBUG_OUTPUT) };
             unsafe { gl.debug_message_callback(gl_debug_message_callback) };
         }

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -175,7 +175,7 @@ impl crate::Surface<super::Api> for super::Surface {
         device: &super::Device,
         config: &crate::SurfaceConfiguration,
     ) -> Result<(), crate::SurfaceError> {
-        log::info!("build swapchain {:?}", config);
+        log::debug!("build swapchain {:?}", config);
 
         let caps = &device.shared.private_caps;
         self.swapchain_format = Some(config.format);

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -165,7 +165,7 @@ impl super::Instance {
         let instance_extensions = entry
             .enumerate_instance_extension_properties(None)
             .map_err(|e| {
-                log::info!("enumerate_instance_extension_properties: {:?}", e);
+                log::debug!("enumerate_instance_extension_properties: {:?}", e);
                 crate::InstanceError
             })?;
 
@@ -222,7 +222,7 @@ impl super::Instance {
             }) {
                 true
             } else {
-                log::info!("Unable to find extension: {}", ext.to_string_lossy());
+                log::warn!("Unable to find extension: {}", ext.to_string_lossy());
                 false
             }
         });
@@ -247,10 +247,10 @@ impl super::Instance {
         has_nv_optimus: bool,
         drop_guard: Option<crate::DropGuard>,
     ) -> Result<Self, crate::InstanceError> {
-        log::info!("Instance version: 0x{:x}", driver_api_version);
+        log::debug!("Instance version: 0x{:x}", driver_api_version);
 
         let debug_utils = if extensions.contains(&ext::DebugUtils::name()) {
-            log::info!("Enabling debug utils");
+            log::debug!("Enabling debug utils");
             let extension = ext::DebugUtils::new(&entry, &raw_instance);
             // having ERROR unconditionally because Vk doesn't like empty flags
             let mut severity = vk::DebugUtilsMessageSeverityFlagsEXT::ERROR;
@@ -284,7 +284,7 @@ impl super::Instance {
 
         let get_physical_device_properties =
             if extensions.contains(&khr::GetPhysicalDeviceProperties2::name()) {
-                log::info!("Enabling device properties2");
+                log::debug!("Enabling device properties2");
                 Some(khr::GetPhysicalDeviceProperties2::new(
                     &entry,
                     &raw_instance,
@@ -499,7 +499,7 @@ impl crate::Instance<super::Api> for super::Instance {
         let entry = match unsafe { ash::Entry::load() } {
             Ok(entry) => entry,
             Err(err) => {
-                log::info!("Missing Vulkan entry points: {:?}", err);
+                log::warn!("Missing Vulkan entry points: {:?}", err);
                 return Err(crate::InstanceError);
             }
         };
@@ -539,7 +539,7 @@ impl crate::Instance<super::Api> for super::Instance {
         let extensions = Self::required_extensions(&entry, driver_api_version, desc.flags)?;
 
         let instance_layers = entry.enumerate_instance_layer_properties().map_err(|e| {
-            log::info!("enumerate_instance_layer_properties: {:?}", e);
+            log::debug!("enumerate_instance_layer_properties: {:?}", e);
             crate::InstanceError
         })?;
 


### PR DESCRIPTION
#3626 makes a bunch of minor changes to `log::foo!` macros. I thought it might make it easier to review to pull them out, but it's kind of marginal.

In any case: this PR depends on #3796.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.
