### PR TITLE
Bump `khronos-egl` to v6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,12 +1466,12 @@ dependencies = [
 
 [[package]]
 name = "khronos-egl"
-version = "4.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.1",
  "pkg-config",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ winapi = "0.3"
 hassle-rs = "0.10.0"
 
 # Gles dependencies
-khronos-egl = "4.1"
+khronos-egl = "6"
 glow = "0.12.3"
 glutin = "0.29.1"
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -80,12 +80,12 @@ gpu-alloc = { version = "0.6", optional = true }
 gpu-descriptor = { version = "0.2", optional = true }
 smallvec = { version = "1", optional = true, features = ["union"] }
 
-khronos-egl = { version = "4.1", features = ["dynamic"], optional = true }
+khronos-egl = { version = "6", features = ["dynamic"], optional = true }
 libloading = { version = ">=0.7, <0.9", optional = true }
 renderdoc-sys = { version = "1.0.0", optional = true }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-khronos-egl = { version = "4.1", features = ["static", "no-pkg-config"] }
+khronos-egl = { version = "6", features = ["static", "no-pkg-config"] }
 #Note: it's unused by emscripten, but we keep it to have single code base in egl.rs
 libloading = { version = ">=0.7, <0.9", optional = true }
 

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -72,7 +72,7 @@ fn main() {
 
     println!("Initializing external GL context");
     let egl = khronos_egl::Instance::new(khronos_egl::Static);
-    let display = egl.get_display(khronos_egl::DEFAULT_DISPLAY).unwrap();
+    let display = unsafe { egl.get_display(khronos_egl::DEFAULT_DISPLAY) }.unwrap();
     egl.initialize(display)
         .expect("unable to initialize display");
 

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -790,24 +790,26 @@ impl crate::Instance<super::Api> for Instance {
             if let (Some(library), Some(egl)) = (wayland_library, egl1_5) {
                 log::info!("Using Wayland platform");
                 let display_attributes = [khronos_egl::ATTRIB_NONE];
-                let display = egl
-                    .get_platform_display(
+                let display = unsafe {
+                    egl.get_platform_display(
                         EGL_PLATFORM_WAYLAND_KHR,
                         khronos_egl::DEFAULT_DISPLAY,
                         &display_attributes,
                     )
-                    .unwrap();
+                }
+                .unwrap();
                 (display, Some(Arc::new(library)), WindowKind::Wayland)
             } else if let (Some(display_owner), Some(egl)) = (x11_display_library, egl1_5) {
                 log::info!("Using X11 platform");
                 let display_attributes = [khronos_egl::ATTRIB_NONE];
-                let display = egl
-                    .get_platform_display(
+                let display = unsafe {
+                    egl.get_platform_display(
                         EGL_PLATFORM_X11_KHR,
                         display_owner.display.as_ptr(),
                         &display_attributes,
                     )
-                    .unwrap();
+                }
+                .unwrap();
                 (display, Some(Arc::new(display_owner)), WindowKind::X11)
             } else if let (Some(display_owner), Some(egl)) = (angle_x11_display_library, egl1_5) {
                 log::info!("Using Angle platform with X11");
@@ -818,28 +820,30 @@ impl crate::Instance<super::Api> for Instance {
                     usize::from(desc.flags.contains(crate::InstanceFlags::VALIDATION)),
                     khronos_egl::ATTRIB_NONE,
                 ];
-                let display = egl
-                    .get_platform_display(
+                let display = unsafe {
+                    egl.get_platform_display(
                         EGL_PLATFORM_ANGLE_ANGLE,
                         display_owner.display.as_ptr(),
                         &display_attributes,
                     )
-                    .unwrap();
+                }
+                .unwrap();
                 (display, Some(Arc::new(display_owner)), WindowKind::AngleX11)
             } else if client_ext_str.contains("EGL_MESA_platform_surfaceless") {
                 log::info!("No windowing system present. Using surfaceless platform");
                 let egl = egl1_5.expect("Failed to get EGL 1.5 for surfaceless");
-                let display = egl
-                    .get_platform_display(
+                let display = unsafe {
+                    egl.get_platform_display(
                         EGL_PLATFORM_SURFACELESS_MESA,
                         std::ptr::null_mut(),
                         &[khronos_egl::ATTRIB_NONE],
                     )
-                    .unwrap();
+                }
+                .unwrap();
                 (display, None, WindowKind::Unknown)
             } else {
                 log::info!("EGL_MESA_platform_surfaceless not available. Using default platform");
-                let display = egl.get_display(khronos_egl::DEFAULT_DISPLAY).unwrap();
+                let display = unsafe { egl.get_display(khronos_egl::DEFAULT_DISPLAY) }.unwrap();
                 (display, None, WindowKind::Unknown)
             };
 
@@ -936,17 +940,19 @@ impl crate::Instance<super::Api> for Instance {
                     use std::ops::DerefMut;
                     let display_attributes = [khronos_egl::ATTRIB_NONE];
 
-                    let display = inner
-                        .egl
-                        .instance
-                        .upcast::<khronos_egl::EGL1_5>()
-                        .unwrap()
-                        .get_platform_display(
-                            EGL_PLATFORM_WAYLAND_KHR,
-                            display_handle.display,
-                            &display_attributes,
-                        )
-                        .unwrap();
+                    let display = unsafe {
+                        inner
+                            .egl
+                            .instance
+                            .upcast::<khronos_egl::EGL1_5>()
+                            .unwrap()
+                            .get_platform_display(
+                                EGL_PLATFORM_WAYLAND_KHR,
+                                display_handle.display,
+                                &display_attributes,
+                            )
+                    }
+                    .unwrap();
 
                     let new_inner = Inner::create(
                         self.flags,
@@ -1276,12 +1282,14 @@ impl crate::Surface<super::Api> for Surface {
                             .into_iter()
                             .map(|v| v as usize)
                             .collect::<Vec<_>>();
-                        egl.create_platform_window_surface(
-                            self.egl.display,
-                            self.config,
-                            native_window_ptr,
-                            &attributes_usize,
-                        )
+                        unsafe {
+                            egl.create_platform_window_surface(
+                                self.egl.display,
+                                self.config,
+                                native_window_ptr,
+                                &attributes_usize,
+                            )
+                        }
                     }
                     _ => unsafe {
                         self.egl.instance.create_window_surface(


### PR DESCRIPTION
Nothing changed except the `libloading` dependency: https://github.com/timothee-haudebourg/khronos-egl/blob/5.0.0/CHANGELOG.md#500.

This is done in the same spirit as https://github.com/gfx-rs/wgpu/pull/3711 because `khronos-egl` v5 also depends on `libloading` v0.8, which in turn depends on `windows-sys`, which `wgpu` doesn't want to commit to yet: https://github.com/gfx-rs/wgpu/issues/3207.

Requires https://github.com/timothee-haudebourg/khronos-egl/pull/23.
Replaces https://github.com/gfx-rs/wgpu/pull/3797.