### PR TITLE
Self Hosted Mac Runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,10 +192,16 @@ jobs:
             os: windows-2022
             backends: dx12
 
+          # Mac
+          - name: Mac aarch64
+            os: [self-hosted, macOS]
+            backends: metal
+
           # Linux
           - name: Linux x86_64
             os: ubuntu-22.04
             backends: vulkan gl
+
 
     name: Test ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -245,6 +251,7 @@ jobs:
 
       - name: caching
         uses: Swatinem/rust-cache@v2
+        if: matrix.os[0] != 'self-hosted'
         with:
           key: test-${{ matrix.os }}-${{ env.CACHE_SUFFIX }}
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.

**Connections**

Depends on #3828 

**Description**

This adds a self-hosted mac runner job to the CI. This runner is hosted by me and is not required, so if there are outages, CI will not be held up.

**Testing**

It is.
