### PR TITLE
Fix incorrect aspect in barriers when using emulated Stencil8 textures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ Bottom level categories:
 
 - Fix Multiview to disable validation of TextureViewDimension and ArrayLayerCount. By @MalekiRe in [#3779](https://github.com/gfx-rs/wgpu/pull/3779#issue-1713269437).
 
+#### Vulkan
+- Fix incorrect aspect in barriers when using emulated Stencil8 textures. By @cwfitzgerald in [#3833](https://github.com/gfx-rs/wgpu/pull/3833).
+
 ### Examples
 
 #### General

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -157,7 +157,11 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         vk_barriers.clear();
 
         for bar in barriers {
-            let range = conv::map_subresource_range(&bar.range, bar.texture.format);
+            let range = conv::map_subresource_range_combined_aspect(
+                &bar.range,
+                bar.texture.format,
+                &self.device.private_caps,
+            );
             let (src_stage, src_access) = conv::map_texture_usage_to_barrier(bar.usage.start);
             let src_layout = conv::derive_image_layout(bar.usage.start, bar.texture.format);
             src_stages |= src_stage;

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -598,6 +598,20 @@ pub fn map_subresource_range(
     }
 }
 
+// Special subresource range mapping for dealing with barriers
+// so that we account for the "hidden" depth aspect in emulated Stencil8.
+pub(super) fn map_subresource_range_combined_aspect(
+    range: &wgt::ImageSubresourceRange,
+    format: wgt::TextureFormat,
+    private_caps: &super::PrivateCapabilities,
+) -> vk::ImageSubresourceRange {
+    let mut range = map_subresource_range(range, format);
+    if !private_caps.texture_s8 && format == wgt::TextureFormat::Stencil8 {
+        range.aspect_mask |= vk::ImageAspectFlags::DEPTH;
+    }
+    range
+}
+
 pub fn map_subresource_layers(
     base: &crate::TextureCopyBase,
 ) -> (vk::ImageSubresourceLayers, vk::Offset3D) {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Found in #3830 

**Description**

We didn't account for Stencil8 "adding" an aspect that the texture format alone didn't show us.

**Testing**

Manually testing on a Intel 630/Windows
