### PR TITLE
Improve wgpu-info code after bitflags 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,8 +3182,8 @@ dependencies = [
 name = "wgpu-info"
 version = "0.16.0"
 dependencies = [
+ "bitflags 2.3.1",
  "env_logger",
- "num-traits 0.2.15",
  "wgpu",
 ]
 

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -11,6 +11,6 @@ license.workspace = true
 publish = false
 
 [dependencies]
+bitflags.workspace = true
 env_logger.workspace = true
-num-traits.workspace = true
 wgpu.workspace = true


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

https://github.com/gfx-rs/wgpu/pull/3606 missed breakages in wgpu-info, this fixxes them up, and cleans up the code quite a bit.

**Testing**

Ran locally and everything is back to normal