### PR TITLE
Allow empty scissor rects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ Bottom level categories:
 
 - Work around [Vulkan-ValidationLayers#5671](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5671) by ignoring reports of violations of [VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912). By @jimblandy in [#3809](https://github.com/gfx-rs/wgpu/pull/3809).
 
+### Added/New Features
+
+- Empty scissor rects are allowed now, matching the specification. by @PJB3005 in [#3863](https://github.com/gfx-rs/wgpu/pull/3863).
+
 ### Documentation
 
 #### General

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1685,9 +1685,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                     RenderCommand::SetScissor(ref rect) => {
                         let scope = PassErrorScope::SetScissorRect;
-                        if rect.w == 0
-                            || rect.h == 0
-                            || rect.x + rect.w > info.extent.width
+                        if rect.x + rect.w > info.extent.width
                             || rect.y + rect.h > info.extent.height
                         {
                             return Err(RenderCommandError::InvalidScissorRect(*rect, info.extent))

--- a/wgpu-hal/src/auxil/dxgi/exception.rs
+++ b/wgpu-hal/src/auxil/dxgi/exception.rs
@@ -87,6 +87,11 @@ unsafe extern "system" fn output_debug_string_handler(
         return excpt::EXCEPTION_CONTINUE_SEARCH;
     }
 
+    if level == log::Level::Warn && message.contains("DRAW_EMPTY_SCISSOR_RECTANGLE") {
+        // This is normal, WebGPU allows passing empty scissor rectangles.
+        return excpt::EXCEPTION_CONTINUE_SEARCH;
+    }
+
     let _ = std::panic::catch_unwind(|| {
         log::log!(level, "{}", message);
     });


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
*none*

**Description**
This used to be disallowed in older versions of the WebGPU spec, but it's allowed now: https://github.com/gpuweb/gpuweb/commit/eb96ea65229d99027f85b280e5ddf73a27541948

That said, I'm not sure about the Metal side of it all. According to the original discussion, Metal doesn't support empty scissor rects. I tested just now however, and at least on Ventura 13.4 it's absolutely allowed. I cross-checked Dawn's source code and there doesn't seem to be any special trickery of using empty viewports there either (as suggested in the spec commit).

I just left the Metal backend untouched and, well, it seems to work.

**Testing**
I modified `hello-triangle` to draw with an empty scissor rectangle, and confirmed it did what I want.