### PR TITLE
Expose TextureUsages in SurfaceCapabilities

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -151,10 +151,7 @@ pub fn map_texture_usage_from_hal(uses: hal::TextureUses) -> wgt::TextureUsages 
     );
     u.set(
         wgt::TextureUsages::RENDER_ATTACHMENT,
-        uses.contains(hal::TextureUses::COLOR_TARGET)
-            | uses.contains(
-                hal::TextureUses::DEPTH_STENCIL_READ | hal::TextureUses::DEPTH_STENCIL_WRITE,
-            ),
+        uses.contains(hal::TextureUses::COLOR_TARGET),
     );
     u
 }

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -131,9 +131,7 @@ pub fn map_texture_usage(
     u
 }
 
-pub fn map_texture_usage_from_hal(
-    uses: hal::TextureUses,
-) -> wgt::TextureUsages{
+pub fn map_texture_usage_from_hal(uses: hal::TextureUses) -> wgt::TextureUsages {
     let mut u = wgt::TextureUsages::empty();
     u.set(
         wgt::TextureUsages::COPY_SRC,
@@ -149,21 +147,17 @@ pub fn map_texture_usage_from_hal(
     );
     u.set(
         wgt::TextureUsages::STORAGE_BINDING,
-        uses.contains(
-            hal::TextureUses::STORAGE_READ | hal::TextureUses::STORAGE_READ_WRITE,
-        ),
+        uses.contains(hal::TextureUses::STORAGE_READ | hal::TextureUses::STORAGE_READ_WRITE),
     );
     u.set(
         wgt::TextureUsages::RENDER_ATTACHMENT,
         uses.contains(hal::TextureUses::COLOR_TARGET)
             | uses.contains(
-                hal::TextureUses::DEPTH_STENCIL_READ
-                    | hal::TextureUses::DEPTH_STENCIL_WRITE,
+                hal::TextureUses::DEPTH_STENCIL_READ | hal::TextureUses::DEPTH_STENCIL_WRITE,
             ),
     );
     u
 }
-
 
 pub fn check_texture_dimension_size(
     dimension: wgt::TextureDimension,

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -131,6 +131,40 @@ pub fn map_texture_usage(
     u
 }
 
+pub fn map_texture_usage_from_hal(
+    uses: hal::TextureUses,
+) -> wgt::TextureUsages{
+    let mut u = wgt::TextureUsages::empty();
+    u.set(
+        wgt::TextureUsages::COPY_SRC,
+        uses.contains(hal::TextureUses::COPY_SRC),
+    );
+    u.set(
+        wgt::TextureUsages::COPY_DST,
+        uses.contains(hal::TextureUses::COPY_DST),
+    );
+    u.set(
+        wgt::TextureUsages::TEXTURE_BINDING,
+        uses.contains(hal::TextureUses::RESOURCE),
+    );
+    u.set(
+        wgt::TextureUsages::STORAGE_BINDING,
+        uses.contains(
+            hal::TextureUses::STORAGE_READ | hal::TextureUses::STORAGE_READ_WRITE,
+        ),
+    );
+    u.set(
+        wgt::TextureUsages::RENDER_ATTACHMENT,
+        uses.contains(hal::TextureUses::COLOR_TARGET)
+            | uses.contains(
+                hal::TextureUses::DEPTH_STENCIL_READ
+                    | hal::TextureUses::DEPTH_STENCIL_WRITE,
+            ),
+    );
+    u
+}
+
+
 pub fn check_texture_dimension_size(
     dimension: wgt::TextureDimension,
     wgt::Extent3d {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -58,10 +58,39 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             hal_caps.formats.sort_by_key(|f| !f.is_srgb());
 
+            let mut usages = wgt::TextureUsages::empty();
+            usages.set(
+                wgt::TextureUsages::COPY_SRC,
+                hal_caps.usage.contains(hal::TextureUses::COPY_SRC),
+            );
+            usages.set(
+                wgt::TextureUsages::COPY_DST,
+                hal_caps.usage.contains(hal::TextureUses::COPY_DST),
+            );
+            usages.set(
+                wgt::TextureUsages::TEXTURE_BINDING,
+                hal_caps.usage.contains(hal::TextureUses::RESOURCE),
+            );
+            usages.set(
+                wgt::TextureUsages::STORAGE_BINDING,
+                hal_caps.usage.contains(
+                    hal::TextureUses::STORAGE_READ | hal::TextureUses::STORAGE_READ_WRITE,
+                ),
+            );
+            usages.set(
+                wgt::TextureUsages::RENDER_ATTACHMENT,
+                hal_caps.usage.contains(hal::TextureUses::COLOR_TARGET)
+                    | hal_caps.usage.contains(
+                        hal::TextureUses::DEPTH_STENCIL_READ
+                            | hal::TextureUses::DEPTH_STENCIL_WRITE,
+                    ),
+            );
+
             Ok(wgt::SurfaceCapabilities {
                 formats: hal_caps.formats,
                 present_modes: hal_caps.present_modes,
                 alpha_modes: hal_caps.composite_alpha_modes,
+                usages,
             })
         })
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -58,33 +58,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             hal_caps.formats.sort_by_key(|f| !f.is_srgb());
 
-            let mut usages = wgt::TextureUsages::empty();
-            usages.set(
-                wgt::TextureUsages::COPY_SRC,
-                hal_caps.usage.contains(hal::TextureUses::COPY_SRC),
-            );
-            usages.set(
-                wgt::TextureUsages::COPY_DST,
-                hal_caps.usage.contains(hal::TextureUses::COPY_DST),
-            );
-            usages.set(
-                wgt::TextureUsages::TEXTURE_BINDING,
-                hal_caps.usage.contains(hal::TextureUses::RESOURCE),
-            );
-            usages.set(
-                wgt::TextureUsages::STORAGE_BINDING,
-                hal_caps.usage.contains(
-                    hal::TextureUses::STORAGE_READ | hal::TextureUses::STORAGE_READ_WRITE,
-                ),
-            );
-            usages.set(
-                wgt::TextureUsages::RENDER_ATTACHMENT,
-                hal_caps.usage.contains(hal::TextureUses::COLOR_TARGET)
-                    | hal_caps.usage.contains(
-                        hal::TextureUses::DEPTH_STENCIL_READ
-                            | hal::TextureUses::DEPTH_STENCIL_WRITE,
-                    ),
-            );
+            let usages = conv::map_texture_usage_from_hal(hal_caps.usage);
 
             Ok(wgt::SurfaceCapabilities {
                 formats: hal_caps.formats,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4584,6 +4584,10 @@ pub struct SurfaceCapabilities {
     ///
     /// Will return at least one element, CompositeAlphaMode::Opaque or CompositeAlphaMode::Inherit.
     pub alpha_modes: Vec<CompositeAlphaMode>,
+    /// List of supported texture usages for the surface to use with the given adapter.
+    ///
+    /// What happens if the surface is incompatible with the adapter?
+    pub usages: TextureUsages,
 }
 
 impl Default for SurfaceCapabilities {
@@ -4592,6 +4596,7 @@ impl Default for SurfaceCapabilities {
             formats: Vec::new(),
             present_modes: Vec::new(),
             alpha_modes: vec![CompositeAlphaMode::Opaque],
+            usages: TextureUsages::empty(),
         }
     }
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4584,9 +4584,9 @@ pub struct SurfaceCapabilities {
     ///
     /// Will return at least one element, CompositeAlphaMode::Opaque or CompositeAlphaMode::Inherit.
     pub alpha_modes: Vec<CompositeAlphaMode>,
-    /// List of supported texture usages for the surface to use with the given adapter.
+    /// Bitflag of supported texture usages for the surface to use with the given adapter.
     ///
-    /// What happens if the surface is incompatible with the adapter?
+    /// The usage TextureUsages::RENDER_ATTACHMENT is guaranteed.
     pub usages: TextureUsages,
 }
 
@@ -4596,7 +4596,7 @@ impl Default for SurfaceCapabilities {
             formats: Vec::new(),
             present_modes: Vec::new(),
             alpha_modes: vec![CompositeAlphaMode::Opaque],
-            usages: TextureUsages::empty(),
+            usages: TextureUsages::RENDER_ATTACHMENT,
         }
     }
 }

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1113,7 +1113,6 @@ impl crate::context::Context for Context {
         _adapter: &Self::AdapterId,
         _adapter_data: &Self::AdapterData,
     ) -> wgt::SurfaceCapabilities {
-        
         wgt::SurfaceCapabilities {
             // https://gpuweb.github.io/gpuweb/#supported-context-formats
             formats: vec![
@@ -1124,8 +1123,8 @@ impl crate::context::Context for Context {
             // Doesn't really have meaning on the web.
             present_modes: vec![wgt::PresentMode::Fifo],
             alpha_modes: vec![wgt::CompositeAlphaMode::Opaque],
-            
-            // Something has to go here
+            // Statically set to RENDER_ATTACHMENT for now. See https://github.com/gfx-rs/wgpu/pull/3874
+            usages: TextureUsages::RENDER_ATTACHMENT,
         }
     }
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1161,7 +1161,7 @@ impl crate::context::Context for Context {
             present_modes: vec![wgt::PresentMode::Fifo],
             alpha_modes: vec![wgt::CompositeAlphaMode::Opaque],
             // Statically set to RENDER_ATTACHMENT for now. See https://github.com/gfx-rs/wgpu/pull/3874
-            usages: TextureUsages::RENDER_ATTACHMENT,
+            usages: wgt::TextureUsages::RENDER_ATTACHMENT,
         }
     }
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1160,7 +1160,7 @@ impl crate::context::Context for Context {
             // Doesn't really have meaning on the web.
             present_modes: vec![wgt::PresentMode::Fifo],
             alpha_modes: vec![wgt::CompositeAlphaMode::Opaque],
-            // Statically set to RENDER_ATTACHMENT for now. See https://github.com/gfx-rs/wgpu/pull/3874
+            // Statically set to RENDER_ATTACHMENT for now. See https://gpuweb.github.io/gpuweb/#dom-gpucanvasconfiguration-usage
             usages: wgt::TextureUsages::RENDER_ATTACHMENT,
         }
     }

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1113,6 +1113,7 @@ impl crate::context::Context for Context {
         _adapter: &Self::AdapterId,
         _adapter_data: &Self::AdapterData,
     ) -> wgt::SurfaceCapabilities {
+        
         wgt::SurfaceCapabilities {
             // https://gpuweb.github.io/gpuweb/#supported-context-formats
             formats: vec![
@@ -1123,6 +1124,8 @@ impl crate::context::Context for Context {
             // Doesn't really have meaning on the web.
             present_modes: vec![wgt::PresentMode::Fifo],
             alpha_modes: vec![wgt::CompositeAlphaMode::Opaque],
+            
+            // Something has to go here
         }
     }
 


### PR DESCRIPTION
**Checklist**

- [ ] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Closes https://github.com/gfx-rs/wgpu/issues/3869.

**Description**
As mentioned in the issue, on native the texture usages of the surface are already known on `hal::SurfaceCapabilites`. This is in the form of hal::TextureUses rather than the frontfacing TextureUsages however. I couldn't find a function mapping in this direction, but tried to construct the correct logic based on the inverse mapping of `map_texture_usage` in wgpu-core/src/conv.rs.

This is very much a draft though, as I have no idea how to access the TextureUs[es|ages] from the wasm side.

**Testing**
None yet.
