### PR TITLE
fix Wasm casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,7 +339,7 @@ By @cwfitzgerald in [#3671](https://github.com/gfx-rs/wgpu/pull/3671).
 ### Documentation
 
 #### General
-- Build for WASM on docs.rs. By @daxpedda in [#3462](https://github.com/gfx-rs/wgpu/pull/3428)
+- Build for Wasm on docs.rs. By @daxpedda in [#3462](https://github.com/gfx-rs/wgpu/pull/3428)
 
 
 ## wgpu-0.15.0 (2023-01-25)
@@ -1725,7 +1725,7 @@ DeviceDescriptor {
   - better error messages
   - timestamp and pipeline statistics queries
   - ETC2 and ASTC compressed textures
-  - (beta) targeting WASM with WebGL backend
+  - (beta) targeting Wasm with WebGL backend
   - reduced dependencies
   - Native-only:
     - clamp-to-border addressing

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -585,7 +585,7 @@ impl super::Adapter {
         let downlevel_defaults = wgt::DownlevelLimits {};
 
         // Drop the GL guard so we can move the context into AdapterShared
-        // ( on WASM the gl handle is just a ref so we tell clippy to allow
+        // ( on Wasm the gl handle is just a ref so we tell clippy to allow
         // dropping the ref )
         #[allow(clippy::drop_ref)]
         drop(gl);
@@ -936,7 +936,7 @@ impl super::AdapterShared {
     }
 }
 
-// SAFE: WASM doesn't have threads
+// SAFE: Wasm doesn't have threads
 #[cfg(target_arch = "wasm32")]
 unsafe impl Sync for super::Adapter {}
 #[cfg(target_arch = "wasm32")]

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1321,7 +1321,7 @@ impl crate::Device<super::Api> for super::Device {
     }
 }
 
-// SAFE: WASM doesn't have threads
+// SAFE: Wasm doesn't have threads
 #[cfg(target_arch = "wasm32")]
 unsafe impl Sync for super::Device {}
 #[cfg(target_arch = "wasm32")]

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -246,7 +246,7 @@ pub struct Buffer {
     data: Option<Arc<std::sync::Mutex<Vec<u8>>>>,
 }
 
-// Safe: WASM doesn't have threads
+// Safe: Wasm doesn't have threads
 #[cfg(target_arch = "wasm32")]
 unsafe impl Sync for Buffer {}
 #[cfg(target_arch = "wasm32")]
@@ -268,7 +268,7 @@ pub enum TextureInner {
     },
 }
 
-// SAFE: WASM doesn't have threads
+// SAFE: Wasm doesn't have threads
 #[cfg(target_arch = "wasm32")]
 unsafe impl Send for TextureInner {}
 #[cfg(target_arch = "wasm32")]
@@ -462,7 +462,7 @@ struct UniformDesc {
     utype: u32,
 }
 
-// Safe: WASM doesn't have threads
+// Safe: Wasm doesn't have threads
 #[cfg(target_arch = "wasm32")]
 unsafe impl Sync for UniformDesc {}
 #[cfg(target_arch = "wasm32")]
@@ -530,7 +530,7 @@ pub struct RenderPipeline {
     alpha_to_coverage_enabled: bool,
 }
 
-// SAFE: WASM doesn't have threads
+// SAFE: Wasm doesn't have threads
 #[cfg(target_arch = "wasm32")]
 unsafe impl Send for RenderPipeline {}
 #[cfg(target_arch = "wasm32")]
@@ -540,7 +540,7 @@ pub struct ComputePipeline {
     inner: Arc<PipelineInner>,
 }
 
-// SAFE: WASM doesn't have threads
+// SAFE: Wasm doesn't have threads
 #[cfg(target_arch = "wasm32")]
 unsafe impl Send for ComputePipeline {}
 #[cfg(target_arch = "wasm32")]

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1525,7 +1525,7 @@ impl crate::Queue<super::Api> for super::Queue {
     }
 }
 
-// SAFE: WASM doesn't have threads
+// SAFE: Wasm doesn't have threads
 #[cfg(target_arch = "wasm32")]
 unsafe impl Sync for super::Queue {}
 #[cfg(target_arch = "wasm32")]

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -106,7 +106,7 @@ impl Instance {
     }
 }
 
-// SAFE: WASM doesn't have threads
+// SAFE: Wasm doesn't have threads
 unsafe impl Sync for Instance {}
 unsafe impl Send for Instance {}
 

--- a/wgpu/README.md
+++ b/wgpu/README.md
@@ -2,7 +2,7 @@
 
 wgpu-rs is an idiomatic Rust wrapper over [wgpu-core](https://github.com/gfx-rs/wgpu). It's designed to be suitable for general purpose graphics and computation needs of Rust community.
 
-wgpu-rs can target both the natively supported backends and WASM directly.
+wgpu-rs can target both the natively supported backends and Wasm directly.
 
 See our [gallery](https://wgpu.rs/#showcase) and the [wiki page](https://github.com/gfx-rs/wgpu/wiki/Users) for the list of libraries and applications using `wgpu-rs`.
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.


**Description**
fix Wasm casing
WebAssembly is abbreviated Wasm. Source https://webassembly.org/.

This change replaces the upper casing used in the codebase.

**Testing**
Ran cargo test.