### PR TITLE
Make examples in main workspace visible to run-wasm xtask

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,6 +2,7 @@ use std::process::ExitCode;
 
 use anyhow::Context;
 use cli::{Args, Subcommand};
+use pico_args::Arguments;
 
 mod cli;
 
@@ -26,7 +27,15 @@ fn main() -> ExitCode {
 fn run(args: Args) -> anyhow::Result<()> {
     let Args { subcommand } = args;
     match subcommand {
-        Subcommand::RunWasm { args } => {
+        Subcommand::RunWasm { mut args } => {
+            // Use top-level Cargo.toml instead of xtask/Cargo.toml by default
+            let manifest_path = args.value_from_str("--manifest-path")
+                .unwrap_or_else(|_| "../Cargo.toml".to_string());
+            let mut arg_vec = args.finish();
+            arg_vec.push("--manifest-path".into());
+            arg_vec.push(manifest_path.into());
+            let args = Arguments::from_vec(arg_vec);
+
             cargo_run_wasm::run_wasm_with_css_and_args(
                 "body { margin: 0px; }",
                 cargo_run_wasm::Args::from_args(args)


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

The run-wasm xtask was introduced with #3844.

**Description**
_Describe what problem this is solving, and how it's solved._

Running examples through run-wasm (as in `cargo xtask run-wasm --bin hello-triangle`) would fail with the error message:
```
error: no bin target named `hello-triangle`.
Available bin targets:
    xtask
```
This is because the xtask package was separate and not part of the wgpu workspace (`xtask` is the only known binary target). This change makes xtask a workspace member so that the examples are visible, causing the above command to succeed as expected.


**Testing**
_Explain how this change is tested._

Running `cargo xtask run-wasm --bin hello-triangle` in the top directory of the repository now correctly builds and serves the example. It can correctly be viewed in Firefox Nightly.

I was also going to add a test in the github CI workflow that simply calls `cargo xtask run-wasm --bin hello-triangle --build-only` but it turns out that `cargo_run_wasm` doesn't report any errors so the test would never fail in the intended cases.

It was also necessary to adjust `.deny.toml` so that the cargo-deny checks pass.