### PR TITLE
metal: support (simulated) visionOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Bottom level categories:
 #### Metal
 
 - Fix renderpasses being used inside of renderpasses. By @cwfitzgerald in [#3828](https://github.com/gfx-rs/wgpu/pull/3828)
-- Add visionOS support. By @jinleili in [#3883](https://github.com/gfx-rs/wgpu/pull/3883)
+- Support (simulated) visionOS. By @jinleili in [#3883](https://github.com/gfx-rs/wgpu/pull/3883)
 
 #### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Bottom level categories:
 #### Metal
 
 - Fix renderpasses being used inside of renderpasses. By @cwfitzgerald in [#3828](https://github.com/gfx-rs/wgpu/pull/3828)
+- Add visionOS support. By @jinleili in [#3883](https://github.com/gfx-rs/wgpu/pull/3883)
 
 #### General
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Apple announced the new **visionOS** at WWDC 2023. Now, visionOS 1.0 can be run on Xcode 15 Beta 2 through the simulator. This pull request addresses a bug that occurs when running wgpu on visionOS.

The MSL version was determined based on the iOS and macOS versions. The following error occurs when running the `boids` example: 
```log
Using Apple xrOS simulator GPU (Metal)
[2023-06-22T07:41:49Z ERROR wgpu::backend::direct] Handling wgpu errors as fatal by default
thread '<unnamed>' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_compute_pipeline
      note: label = `Compute pipeline`
    Internal error: MSL: UnsupportedAddressSpace(Storage { access: StorageAccess(LOAD) })

', /Users/lijinlei/Rust/forks/wgpu/wgpu/src/backend/direct.rs:3023:5
```

In addition,  the `family_check` field was also set based on the iOS and macOS versions, which causes feature detection to fail on visionOS. The following error occurs when running the `shadow` example: 
```log
-[MTLDebugRenderCommandEncoder validateCommonDrawErrors:]:5780: failed assertion `Draw Errors Validation

Vertex Function(vs_bake): the offset into the buffer u_entity that is bound at buffer index 1 must be a multiple of 256 but was set to 128.
'
```


**Testing**
Tested via https://github.com/jinleili/wgpu-in-app

https://github.com/gfx-rs/wgpu/assets/1001342/d6926b17-8707-4cdf-815b-659d6f2e3049

