### PR TITLE
Backport #3798 to 0.16 (DX12 increase `max_storage_buffers/textures_per_shader_stage`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Changes
+
+#### DX12
+
+- Increase the `max_storage_buffers_per_shader_stage` and `max_storage_textures_per_shader_stage` limits based on what the hardware supports. by @Elabajaba in [#3798]https://github.com/gfx-rs/wgpu/pull/3798
+
 ## v0.16.1 (2023-05-24)
 
 ### Bug Fixes

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -844,7 +844,7 @@ pub struct Limits {
     pub max_samplers_per_shader_stage: u32,
     /// Amount of storage buffers visible in a single shader stage. Defaults to 8. Higher is "better".
     pub max_storage_buffers_per_shader_stage: u32,
-    /// Amount of storage textures visible in a single shader stage. Defaults to 8. Higher is "better".
+    /// Amount of storage textures visible in a single shader stage. Defaults to 4. Higher is "better".
     pub max_storage_textures_per_shader_stage: u32,
     /// Amount of uniform buffers visible in a single shader stage. Defaults to 12. Higher is "better".
     pub max_uniform_buffers_per_shader_stage: u32,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/bevyengine/bevy/issues/8888

**Description**
Backports https://github.com/gfx-rs/wgpu/pull/3798 to 0.16 to fix Bevy's SSAO when using DX12.

**Testing**
Bevy's SSAO works when I use this branch.
