### PR TITLE
Implement depth-clip-control using depthClamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Bottom level categories:
 #### Vulkan
 
 - Work around [Vulkan-ValidationLayers#5671](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5671) by ignoring reports of violations of [VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912). By @jimblandy in [#3809](https://github.com/gfx-rs/wgpu/pull/3809).
+- Implement depth-clip-control using depthClamp instead of VK_EXT_depth_clip_enable. By @AlbinBernhardssonARM [#3892](https://github.com/gfx-rs/wgpu/pull/3892).
 
 ### Added/New Features
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -24,7 +24,6 @@ pub struct PhysicalDeviceFeatures {
     timeline_semaphore: Option<vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR>,
     image_robustness: Option<vk::PhysicalDeviceImageRobustnessFeaturesEXT>,
     robustness2: Option<vk::PhysicalDeviceRobustness2FeaturesEXT>,
-    depth_clip_enable: Option<vk::PhysicalDeviceDepthClipEnableFeaturesEXT>,
     multiview: Option<vk::PhysicalDeviceMultiviewFeaturesKHR>,
     astc_hdr: Option<vk::PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT>,
     shader_float16: Option<(
@@ -59,9 +58,6 @@ impl PhysicalDeviceFeatures {
             info = info.push_next(feature);
         }
         if let Some(ref mut feature) = self.robustness2 {
-            info = info.push_next(feature);
-        }
-        if let Some(ref mut feature) = self.depth_clip_enable {
             info = info.push_next(feature);
         }
         if let Some(ref mut feature) = self.astc_hdr {
@@ -179,6 +175,7 @@ impl PhysicalDeviceFeatures {
                 .shader_int16(requested_features.contains(wgt::Features::SHADER_I16))
                 //.shader_resource_residency(requested_features.contains(wgt::Features::SHADER_RESOURCE_RESIDENCY))
                 .geometry_shader(requested_features.contains(wgt::Features::SHADER_PRIMITIVE_INDEX))
+                .depth_clamp(requested_features.contains(wgt::Features::DEPTH_CLIP_CONTROL))
                 .build(),
             descriptor_indexing: if requested_features.intersects(indexing_features()) {
                 Some(
@@ -242,17 +239,6 @@ impl PhysicalDeviceFeatures {
                     vk::PhysicalDeviceRobustness2FeaturesEXT::builder()
                         .robust_buffer_access2(private_caps.robust_buffer_access)
                         .robust_image_access2(private_caps.robust_image_access)
-                        .build(),
-                )
-            } else {
-                None
-            },
-            depth_clip_enable: if enabled_extensions.contains(&vk::ExtDepthClipEnableFn::name()) {
-                Some(
-                    vk::PhysicalDeviceDepthClipEnableFeaturesEXT::builder()
-                        .depth_clip_enable(
-                            requested_features.contains(wgt::Features::DEPTH_CLIP_CONTROL),
-                        )
                         .build(),
                 )
             } else {
@@ -472,9 +458,7 @@ impl PhysicalDeviceFeatures {
             }
         }
 
-        if let Some(ref feature) = self.depth_clip_enable {
-            features.set(F::DEPTH_CLIP_CONTROL, feature.depth_clip_enable != 0);
-        }
+        features.set(F::DEPTH_CLIP_CONTROL, self.core.depth_clamp != 0);
 
         if let Some(ref multiview) = self.multiview {
             features.set(F::MULTIVIEW, multiview.multiview != 0);
@@ -699,11 +683,6 @@ impl PhysicalDeviceCapabilities {
             extensions.push(vk::ExtConservativeRasterizationFn::name());
         }
 
-        // Require `VK_EXT_depth_clip_enable` if the associated feature was requested
-        if requested_features.contains(wgt::Features::DEPTH_CLIP_CONTROL) {
-            extensions.push(vk::ExtDepthClipEnableFn::name());
-        }
-
         // Require `VK_KHR_portability_subset` on macOS/iOS
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         extensions.push(vk::KhrPortabilitySubsetFn::name());
@@ -896,12 +875,6 @@ impl super::InstanceShared {
                 let next = features
                     .robustness2
                     .insert(vk::PhysicalDeviceRobustness2FeaturesEXT::default());
-                builder = builder.push_next(next);
-            }
-            if capabilities.supports_extension(vk::ExtDepthClipEnableFn::name()) {
-                let next = features
-                    .depth_clip_enable
-                    .insert(vk::PhysicalDeviceDepthClipEnableFeaturesEXT::default());
                 builder = builder.push_next(next);
             }
             if capabilities.supports_extension(vk::ExtTextureCompressionAstcHdrFn::name()) {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1611,7 +1611,8 @@ impl crate::Device<super::Api> for super::Device {
         let mut vk_rasterization = vk::PipelineRasterizationStateCreateInfo::builder()
             .polygon_mode(conv::map_polygon_mode(desc.primitive.polygon_mode))
             .front_face(conv::map_front_face(desc.primitive.front_face))
-            .line_width(1.0);
+            .line_width(1.0)
+            .depth_clamp_enable(desc.primitive.unclipped_depth);
         if let Some(face) = desc.primitive.cull_mode {
             vk_rasterization = vk_rasterization.cull_mode(conv::map_cull_face(face))
         }
@@ -1621,13 +1622,6 @@ impl crate::Device<super::Api> for super::Device {
                 .build();
         if desc.primitive.conservative {
             vk_rasterization = vk_rasterization.push_next(&mut vk_rasterization_conservative_state);
-        }
-        let mut vk_depth_clip_state =
-            vk::PipelineRasterizationDepthClipStateCreateInfoEXT::builder()
-                .depth_clip_enable(false)
-                .build();
-        if desc.primitive.unclipped_depth {
-            vk_rasterization = vk_rasterization.push_next(&mut vk_depth_clip_state);
         }
 
         let mut vk_depth_stencil = vk::PipelineDepthStencilStateCreateInfo::builder();


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
In Vulkan, use depthClamp instead of VK_EXT_depth_clip_enable to implement depth-clip-control (unclipped_depth). depthClamp implicitly disables clipping in addition to enabling clamping ([27.4. Primitive Clipping](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vertexpostproc-clipping) in Vulkan spec). Enabling clamping is fine as clamping depth should always be done according to WebGPU spec ([23.3.6. Fragment Processing](https://www.w3.org/TR/webgpu/#fragment-processing)).

depthClamp is more widely supported than VK_EXT_depth_clip_enable (85.94% vs. 38.42% according to [vulkan.gpuinfo.org](http://vulkan.gpuinfo.org/)) so this enables depth-clip-control on more devices.

**Testing**
Ran shadow example.
Ran DepthClamping unit test in https://github.com/Chainsawkitten/HymnToBeauty/ (requires https://github.com/gfx-rs/wgpu-native/pull/270).
