### PR TITLE
Make shader write&read storage buffers match non readonly layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Bottom level categories:
 
 - Fix order of arguments to glPolygonOffset by @komadori in [#3783](https://github.com/gfx-rs/wgpu/pull/3783).
 - Fix OpenGL/EGL backend not respecting non-sRGB texture formats in `SurfaceConfiguration`. by @liquidev in [#3817](https://github.com/gfx-rs/wgpu/pull/3817)
+- Make write- and read-only marked buffers match non-readonly layouts. by @fornwall in [#3893](https://github.com/gfx-rs/wgpu/pull/3893)
 
 #### Metal
 

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -409,7 +409,7 @@ impl Resource {
                                 )
                             }
                         };
-                        if self.class != class {
+                        if !address_space_matches(self.class, class) {
                             return Err(BindingError::WrongAddressSpace {
                                 binding: class,
                                 shader: self.class,
@@ -1235,5 +1235,74 @@ impl Interface {
             })
             .collect();
         Ok(outputs)
+    }
+}
+
+fn address_space_matches(shader: naga::AddressSpace, binding: naga::AddressSpace) -> bool {
+    match (shader, binding) {
+        (
+            naga::AddressSpace::Storage {
+                access: access_shader,
+            },
+            naga::AddressSpace::Storage {
+                access: access_pipeline,
+            },
+        ) => {
+            // Allow read- and write-only usages to match read-write layouts:
+            (access_shader & access_pipeline) == access_shader
+        }
+        (a, b) => a == b,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::address_space_matches;
+
+    #[test]
+    fn address_space_matches_correctly() {
+        assert!(address_space_matches(
+            naga::AddressSpace::Uniform,
+            naga::AddressSpace::Uniform
+        ));
+
+        assert!(!address_space_matches(
+            naga::AddressSpace::Uniform,
+            naga::AddressSpace::Storage {
+                access: naga::StorageAccess::LOAD
+            }
+        ));
+
+        let test_cases = [
+            (naga::StorageAccess::LOAD, naga::StorageAccess::LOAD, true),
+            (naga::StorageAccess::STORE, naga::StorageAccess::LOAD, false),
+            (naga::StorageAccess::LOAD, naga::StorageAccess::STORE, false),
+            (naga::StorageAccess::STORE, naga::StorageAccess::STORE, true),
+            (
+                naga::StorageAccess::LOAD | naga::StorageAccess::STORE,
+                naga::StorageAccess::LOAD | naga::StorageAccess::STORE,
+                true,
+            ),
+            (
+                naga::StorageAccess::STORE,
+                naga::StorageAccess::LOAD | naga::StorageAccess::STORE,
+                true,
+            ),
+            (
+                naga::StorageAccess::LOAD,
+                naga::StorageAccess::LOAD | naga::StorageAccess::STORE,
+                true,
+            ),
+        ];
+
+        for (shader, binding, expect_match) in test_cases {
+            assert_eq!(
+                expect_match,
+                address_space_matches(
+                    naga::AddressSpace::Storage { access: shader },
+                    naga::AddressSpace::Storage { access: binding }
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
See [#2897, write-only storage buffer cannot match a Pipeline Layout](https://github.com/gfx-rs/wgpu/issues/2897).

**Description**
From the linked issue: When you provide a storage buffer pipeline layout with read-only set to false, if the shader marks the buffer is write, it will complain about a mismatched PLL and shader

**Testing**
Mark a storage storage buffer as `write` in a shader, and use it with a buffer pipeline layout with read-only set to false. There is also a unit test of the `address_space_matches` function. 