### PR TITLE
Put QuartzCore behind link feature flag

### DIFF
--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -17,7 +17,7 @@ use objc::{
 use parking_lot::Mutex;
 
 #[cfg(target_os = "macos")]
-#[link(name = "QuartzCore", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "QuartzCore", kind = "framework"))]
 extern "C" {
     #[allow(non_upper_case_globals)]
     static kCAGravityTopLeft: *mut Object;


### PR DESCRIPTION
Allow weak linking of QuartzCore framework on macOS. Follow up to: https://github.com/gfx-rs/wgpu/commit/973cd3ebf8fae01c6c85dea244b8ce8323f6efa2