### PR TITLE
Remove backend_bits from initialize_adapter_from_env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Bottom level categories:
 #### Misc Breaking Changes
 
 - Change `AdapterInfo::{device,vendor}` to be `u32` instead of `usize`. By @ameknite in [#3760](https://github.com/gfx-rs/wgpu/pull/3760)
+- Remove the `backend_bits` parameter in `initialize_adapter_from_env` and `initialize_adapter_from_env_or_default` - use [InstanceDescriptor::backends](https://docs.rs/wgpu/latest/wgpu/struct.InstanceDescriptor.html#structfield.backends) instead. By @fornwall in [#3904](https://github.com/gfx-rs/wgpu/pull/3904)
 
 #### DX12
 

--- a/examples/common/src/framework.rs
+++ b/examples/common/src/framework.rs
@@ -180,10 +180,9 @@ async fn setup<E: Example>(title: &str) -> Setup {
 
         (size, surface)
     };
-    let adapter =
-        wgpu::util::initialize_adapter_from_env_or_default(&instance, backends, Some(&surface))
-            .await
-            .expect("No suitable GPU adapters found on the system!");
+    let adapter = wgpu::util::initialize_adapter_from_env_or_default(&instance, Some(&surface))
+        .await
+        .expect("No suitable GPU adapters found on the system!");
 
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -392,7 +392,6 @@ fn initialize_adapter() -> (Adapter, SurfaceGuard) {
     let compatible_surface: Option<&Surface> = compatible_surface.as_ref();
     let adapter = pollster::block_on(wgpu::util::initialize_adapter_from_env_or_default(
         &instance,
-        backends,
         compatible_surface,
     ))
     .expect("could not find suitable adapter on the system");

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -37,13 +37,13 @@ pub fn power_preference_from_env() -> Option<PowerPreference> {
 
 /// Initialize the adapter obeying the WGPU_ADAPTER_NAME environment variable.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn initialize_adapter_from_env(instance: &Instance, backend_bits: Backends) -> Option<Adapter> {
+pub fn initialize_adapter_from_env(instance: &Instance) -> Option<Adapter> {
     let desired_adapter_name = std::env::var("WGPU_ADAPTER_NAME")
         .as_deref()
         .map(str::to_lowercase)
         .ok()?;
 
-    let adapters = instance.enumerate_adapters(backend_bits);
+    let adapters = instance.enumerate_adapters(Backends::all());
 
     let mut chosen_adapter = None;
     for adapter in adapters {
@@ -60,20 +60,16 @@ pub fn initialize_adapter_from_env(instance: &Instance, backend_bits: Backends) 
 
 /// Initialize the adapter obeying the WGPU_ADAPTER_NAME environment variable.
 #[cfg(target_arch = "wasm32")]
-pub fn initialize_adapter_from_env(
-    _instance: &Instance,
-    _backend_bits: Backends,
-) -> Option<Adapter> {
+pub fn initialize_adapter_from_env(_instance: &Instance) -> Option<Adapter> {
     None
 }
 
 /// Initialize the adapter obeying the WGPU_ADAPTER_NAME environment variable and if it doesn't exist fall back on a default adapter.
 pub async fn initialize_adapter_from_env_or_default(
     instance: &Instance,
-    backend_bits: wgt::Backends,
     compatible_surface: Option<&Surface>,
 ) -> Option<Adapter> {
-    match initialize_adapter_from_env(instance, backend_bits) {
+    match initialize_adapter_from_env(instance) {
         Some(a) => Some(a),
         None => {
             instance


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
[#3792, initialize_adapter_from_env_or_default ignores backend_bits if WGPU_ADAPTER_NAME is not set](https://github.com/gfx-rs/wgpu/issues/3792)

**Description**
As described in #3792, the `initialize_adapter_from_env_or_default` function currently ignores `backend_bits` if `WGPU_ADAPTER_NAME` is not set.

Instead of going towards the path of making these utility functions more complex (or adding e.g. `backend_bits` to `RequestAdapterOptions`), let's perhaps remove `backend_bits` from these functions completely, in favour of using `InstanceDescriptor::backends`? So instead of

```rust
let instance = wgpu::Instance::default();
let backends = wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all);
let adapter = wgpu::util::initialize_adapter_from_env_or_default(&instance, backends, None)
```

the recommended way would be:

```rust
let backends = wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all);
let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends, ..Default::default() });
let adapter = wgpu::util::initialize_adapter_from_env_or_default(&instance, None)
```

What do you think?

**Testing**
By existing tests, or a utility program such as listed above.