### PR TITLE
Fix link to GPUVertexBufferLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Bottom level categories:
 ### Documentation
 
 - Better documentation for draw, draw_indexed, set_viewport and set_scissor_rect. By @genusistimelord in [#3860](https://github.com/gfx-rs/wgpu/pull/3860)
+- Fix link to `GPUVertexBufferLayout`. By @fornwall in [#3906](https://github.com/gfx-rs/wgpu/pull/3906)
 
 #### General
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1351,7 +1351,7 @@ static_assertions::assert_impl_all!(RenderPassDescriptor: Send, Sync);
 /// For use in [`VertexState`].
 ///
 /// Corresponds to [WebGPU `GPUVertexBufferLayout`](
-/// https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpassdescriptor).
+/// https://gpuweb.github.io/gpuweb/#dictdef-gpuvertexbufferlayout).
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct VertexBufferLayout<'a> {
     /// The stride, in bytes, between elements of this buffer.


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #3342.

**Description**
The link to `GPUVertexBufferLayout` in the documentation is wrong.

**Testing**
Browse the generated docs.
