### PR TITLE
Bind group layout dedup

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -36,7 +36,11 @@ impl<I: Clone + Debug + wgc::id::TypedId> wgc::identity::IdentityHandlerFactory<
         IdentityPassThrough(PhantomData)
     }
 }
-impl wgc::identity::GlobalIdentityHandlerFactory for IdentityPassThroughFactory {}
+impl wgc::identity::GlobalIdentityHandlerFactory for IdentityPassThroughFactory {
+    fn ids_are_generated_in_wgpu() -> bool {
+        false
+    }
+}
 
 pub trait GlobalPlay {
     fn encode_commands<A: wgc::hal_api::HalApi>(

--- a/tests/tests/bind_group_layout_dedup.rs
+++ b/tests/tests/bind_group_layout_dedup.rs
@@ -1,0 +1,144 @@
+use wgpu_test::{initialize_test, TestParameters};
+
+#[test]
+fn bind_group_layout_deduplication() {
+    initialize_test(TestParameters::default(), |ctx| {
+        let entries_1 = &[];
+
+        let entries_2 = &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::VERTEX,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        }];
+
+        let bgl_1a = ctx
+            .device
+            .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: None,
+                entries: entries_1,
+            });
+
+        let _bgl_2 = ctx
+            .device
+            .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: None,
+                entries: entries_2,
+            });
+
+        let bgl_1b = ctx
+            .device
+            .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: None,
+                entries: entries_1,
+            });
+
+        let bg_1a = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &bgl_1a,
+            entries: &[],
+        });
+
+        let bg_1b = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &bgl_1b,
+            entries: &[],
+        });
+
+        let pipeline_layout = ctx
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: None,
+                bind_group_layouts: &[&bgl_1b],
+                push_constant_ranges: &[],
+            });
+
+        let module = ctx
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: None,
+                source: wgpu::ShaderSource::Wgsl(SHADER_SRC.into()),
+            });
+
+        let targets = &[Some(wgpu::ColorTargetState {
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            blend: None,
+            write_mask: Default::default(),
+        })];
+
+        let desc = wgpu::RenderPipelineDescriptor {
+            label: None,
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &module,
+                entry_point: "vs_main",
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &module,
+                entry_point: "fs_main",
+                targets,
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multiview: None,
+            multisample: wgpu::MultisampleState::default(),
+        };
+
+        let pipeline = ctx.device.create_render_pipeline(&desc);
+
+        let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size: wgpu::Extent3d {
+                width: 32,
+                height: 32,
+                depth_or_array_layers: 1,
+            },
+            sample_count: 1,
+            mip_level_count: 1,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+
+        let texture_view = texture.create_view(&Default::default());
+
+        let mut encoder = ctx.device.create_command_encoder(&Default::default());
+
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: None,
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &texture_view,
+                    resolve_target: None,
+                    ops: Default::default(),
+                })],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+            });
+
+            pass.set_bind_group(0, &bg_1b, &[]);
+
+            pass.set_pipeline(&pipeline);
+
+            pass.draw(0..6, 0..1);
+
+            pass.set_bind_group(0, &bg_1a, &[]);
+
+            pass.draw(0..6, 0..1);
+        }
+
+        ctx.queue.submit(Some(encoder.finish()));
+    })
+}
+
+const SHADER_SRC: &str = "
+@vertex fn vs_main() -> @builtin(position) vec4<f32> { return vec4<f32>(1.0); }
+@fragment fn fs_main() -> @location(0) vec4<f32> { return vec4<f32>(1.0); }
+";

--- a/tests/tests/root.rs
+++ b/tests/tests/root.rs
@@ -5,6 +5,7 @@ mod regression {
     mod issue_4024;
 }
 
+mod bind_group_layout_dedup;
 mod buffer;
 mod buffer_copy;
 mod buffer_usages;

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1,5 +1,5 @@
 use crate::{
-    binding_model::BindError,
+    binding_model::{BindError, BindGroupLayouts},
     command::{
         self,
         bind::Binder,
@@ -421,7 +421,11 @@ struct State {
 }
 
 impl State {
-    fn is_ready(&self, indexed: bool) -> Result<(), DrawError> {
+    fn is_ready<A: hal::Api>(
+        &self,
+        indexed: bool,
+        bind_group_layouts: &BindGroupLayouts<A>,
+    ) -> Result<(), DrawError> {
         // Determine how many vertex buffers have already been bound
         let vertex_buffer_count = self.vertex.inputs.iter().take_while(|v| v.bound).count() as u32;
         // Compare with the needed quantity
@@ -431,7 +435,7 @@ impl State {
             });
         }
 
-        let bind_mask = self.binder.invalid_mask();
+        let bind_mask = self.binder.invalid_mask(bind_group_layouts);
         if bind_mask != 0 {
             //let (expected, provided) = self.binder.entries[index as usize].info();
             return Err(DrawError::IncompatibleBindGroup {
@@ -1349,6 +1353,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let (bind_group_guard, mut token) = hub.bind_groups.read(&mut token);
             let (render_pipeline_guard, mut token) = hub.render_pipelines.read(&mut token);
             let (query_set_guard, mut token) = hub.query_sets.read(&mut token);
+            let (bind_group_layout_guard, mut token) = hub.bind_group_layouts.read(&mut token);
             let (buffer_guard, mut token) = hub.buffers.read(&mut token);
             let (texture_guard, mut token) = hub.textures.read(&mut token);
             let (view_guard, _) = hub.texture_views.read(&mut token);
@@ -1819,7 +1824,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             indirect: false,
                             pipeline: state.pipeline,
                         };
-                        state.is_ready(indexed).map_pass_err(scope)?;
+                        state
+                            .is_ready::<A>(indexed, &bind_group_layout_guard)
+                            .map_pass_err(scope)?;
 
                         let last_vertex = first_vertex + vertex_count;
                         let vertex_limit = state.vertex.vertex_limit;
@@ -1859,7 +1866,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             indirect: false,
                             pipeline: state.pipeline,
                         };
-                        state.is_ready(indexed).map_pass_err(scope)?;
+                        state
+                            .is_ready::<A>(indexed, &*bind_group_layout_guard)
+                            .map_pass_err(scope)?;
 
                         //TODO: validate that base_vertex + max_index() is
                         // within the provided range
@@ -1904,7 +1913,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             indirect: true,
                             pipeline: state.pipeline,
                         };
-                        state.is_ready(indexed).map_pass_err(scope)?;
+                        state
+                            .is_ready::<A>(indexed, &*bind_group_layout_guard)
+                            .map_pass_err(scope)?;
 
                         let stride = match indexed {
                             false => mem::size_of::<wgt::DrawIndirectArgs>(),
@@ -1976,7 +1987,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             indirect: true,
                             pipeline: state.pipeline,
                         };
-                        state.is_ready(indexed).map_pass_err(scope)?;
+                        state
+                            .is_ready::<A>(indexed, &*bind_group_layout_guard)
+                            .map_pass_err(scope)?;
 
                         let stride = match indexed {
                             false => mem::size_of::<wgt::DrawIndirectArgs>(),

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1078,19 +1078,30 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 }
             }
 
-            // If there is an equivalent BGL, just bump the refcount and return it.
-            // This is only applicable for identity filters that are generating new IDs,
-            // so their inputs are `PhantomData` of size 0.
-            if mem::size_of::<Input<G, id::BindGroupLayoutId>>() == 0 {
+            let mut compatible_layout = None;
+            {
                 let (bgl_guard, _) = hub.bind_group_layouts.read(&mut token);
                 if let Some(id) =
                     Device::deduplicate_bind_group_layout(device_id, &entry_map, &*bgl_guard)
                 {
-                    return (id, None);
+                    // If there is an equivalent BGL, just bump the refcount and return it.
+                    // This is only applicable to identity filters that generate their IDs,
+                    // which use PhantomData as their identity.
+                    // In practice this means:
+                    //  - wgpu users take this branch and return the existing
+                    //    id without using the indirection layer in BindGroupLayout.
+                    //  - Other users like gecko or the replay tool use don't take
+                    //    the branch and instead rely on the indirection to use the
+                    //    proper bind group layout id.
+                    if std::mem::size_of::<Input<G, id::BindGroupLayoutId>>() == 0 {
+                        return (id, None);
+                    }
+
+                    compatible_layout = Some(id::Valid(id));
                 }
             }
 
-            let layout = match device.create_bind_group_layout(
+            let mut layout = match device.create_bind_group_layout(
                 device_id,
                 desc.label.borrow_option(),
                 entry_map,
@@ -1099,7 +1110,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(e) => break e,
             };
 
+            layout.compatible_layout = compatible_layout;
+
             let id = fid.assign(layout, &mut token);
+
             return (id.0, None);
         };
 
@@ -1244,16 +1258,28 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     .add(trace::Action::CreateBindGroup(fid.id(), desc.clone()));
             }
 
-            let bind_group_layout = match bind_group_layout_guard.get(desc.layout) {
+            let mut bind_group_layout = match bind_group_layout_guard.get(desc.layout) {
                 Ok(layout) => layout,
-                Err(_) => break binding_model::CreateBindGroupError::InvalidLayout,
+                Err(..) => break binding_model::CreateBindGroupError::InvalidLayout,
             };
-            let bind_group =
-                match device.create_bind_group(device_id, bind_group_layout, desc, hub, &mut token)
-                {
-                    Ok(bind_group) => bind_group,
-                    Err(e) => break e,
-                };
+
+            let mut layout_id = id::Valid(desc.layout);
+            if let Some(id) = bind_group_layout.compatible_layout {
+                layout_id = id;
+                bind_group_layout = &bind_group_layout_guard[id];
+            }
+
+            let bind_group = match device.create_bind_group(
+                device_id,
+                bind_group_layout,
+                layout_id,
+                desc,
+                hub,
+                &mut token,
+            ) {
+                Ok(bind_group) => bind_group,
+                Err(e) => break e,
+            };
             let ref_count = bind_group.life_guard.add_ref();
 
             let id = fid.assign(bind_group, &mut token);

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1085,15 +1085,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     Device::deduplicate_bind_group_layout(device_id, &entry_map, &*bgl_guard)
                 {
                     // If there is an equivalent BGL, just bump the refcount and return it.
-                    // This is only applicable to identity filters that generate their IDs,
-                    // which use PhantomData as their identity.
-                    // In practice this means:
+                    // This is only applicable if ids are generated in wgpu. In practice:
                     //  - wgpu users take this branch and return the existing
                     //    id without using the indirection layer in BindGroupLayout.
                     //  - Other users like gecko or the replay tool use don't take
                     //    the branch and instead rely on the indirection to use the
                     //    proper bind group layout id.
-                    if std::mem::size_of::<Input<G, id::BindGroupLayoutId>>() == 0 {
+                    if G::ids_are_generated_in_wgpu() {
                         return (id, None);
                     }
 

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -243,6 +243,7 @@ impl<A: HalApi> Access<PipelineLayout<A>> for RenderBundle<A> {}
 impl<A: HalApi> Access<BindGroupLayout<A>> for Root {}
 impl<A: HalApi> Access<BindGroupLayout<A>> for Device<A> {}
 impl<A: HalApi> Access<BindGroupLayout<A>> for PipelineLayout<A> {}
+impl<A: HalApi> Access<BindGroupLayout<A>> for QuerySet<A> {}
 impl<A: HalApi> Access<BindGroup<A>> for Root {}
 impl<A: HalApi> Access<BindGroup<A>> for Device<A> {}
 impl<A: HalApi> Access<BindGroup<A>> for BindGroupLayout<A> {}

--- a/wgpu-core/src/identity.rs
+++ b/wgpu-core/src/identity.rs
@@ -162,9 +162,14 @@ pub trait GlobalIdentityHandlerFactory:
     + IdentityHandlerFactory<id::SamplerId>
     + IdentityHandlerFactory<id::SurfaceId>
 {
+    fn ids_are_generated_in_wgpu() -> bool;
 }
 
-impl GlobalIdentityHandlerFactory for IdentityManagerFactory {}
+impl GlobalIdentityHandlerFactory for IdentityManagerFactory {
+    fn ids_are_generated_in_wgpu() -> bool {
+        true
+    }
+}
 
 pub type Input<G, I> = <<G as IdentityHandlerFactory<I>>::Filter as IdentityHandler<I>>::Input;
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**

Currently wgpu-core implement bind group layout deduplication only when it creates its own resource IDs. In other words it works for wgpu but not in Firefox.

This PR bridges the gap by allowing an optional indirection in bind group layouts: each BGL may store an ID referring to its "deduplicated" BGL. The indirection ID is never set in wgpu (when the IDs are generated by wgpu core), so in this configuration the behavior is unchanged (the indirection ID is always `None`).

When referring to a BGL the rest of the code must make sure to follow the indirection. The exception is command buffer processing which is considered hot code and where we first validate against the provided BGL ID and only follow the indirection if the initial check failed.


The main pain point with this approach is the various places where wgpu-core manually updates reference counts: we have to be careful about following the indirection to track the right BGL. I suspect that arcanization makes this better but I haven't tried to rebase this on top of it yet.

On the plus side, the plumbing to enable the validation to follow the indirection will make it very easy to decorate validation errors with labels in a followup PR.

This is the main thing preventing bevy apps from running in Firefox.

**Alternatives**

Deduplication could be re-implemented in Firefox's DOM glue, however it has a few disadvantages:
 - The deduplication logic would be duplicated.
 - More importantly, Firefox's WebGPU DOM/IPC glue is currently very simple. It is mostly a bunch of proxies for the various objects created and manipulated by wgpu-core. If BGL deduplication was implemented there, these proxies would have to reimplement much of the lifetime tracking logic that is present in wgpu-core: bind groups and pipeline layouts must keep their layouts alive, pipelines must keep their pipeline layouts alive, etc. We would prefer to preserve the simplicity of these proxies.

**Can we do better in the long run?**

I hope so. In a potential future where wgpu-core generates its own IDs even when run in Firefox, everything could be simpler and most of what's in this PR would be unnecessary. We have been discussing this with @jimblandy our plans aren't very well formed and it is rather far down the priority list but I'll try to summarize that in another issue.

**Testing**

I added a test which actually only covers wgpu's default configuration and not the new code. It's a bit tedious to test that (Need to write the test against wgpu-core, add an identity factory, etc), however that code path is covered by the WebGPU CTS so regressions will be caught in Firefox's CI (with a delay unfortunately).