### PR TITLE
Add a basic test for mismatched devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ name = "metal"
 version = "0.25.0"
 source = "git+https://github.com/gfx-rs/metal-rs.git?rev=a6a0446#a6a04463db388e8fd3e99095ab4fbb87cbe9d69c"
 dependencies = [
- "bitflags 2.3.1",
+ "bitflags 2.3.2",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -9,3 +9,29 @@ fn device_initialization() {
         // intentionally empty
     })
 }
+
+#[test]
+fn device_mismatch() {
+    initialize_test(TestParameters::default().failure(), |ctx| {
+        // Create a bind group uisng a lyaout from another device. This should be a validation
+        // error but currently crashes.
+        let (device2, _) =
+            pollster::block_on(ctx.adapter.request_device(&Default::default(), None)).unwrap();
+
+        {
+            let bind_group_layout =
+                device2.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: None,
+                    entries: &[],
+                });
+
+            let _bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &bind_group_layout,
+                entries: &[],
+            });
+        }
+
+        ctx.device.poll(wgpu::Maintain::Poll);
+    });
+}

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -11,6 +11,7 @@ fn device_initialization() {
 }
 
 #[test]
+#[ignore]
 fn device_mismatch() {
     initialize_test(TestParameters::default().failure(), |ctx| {
         // Create a bind group uisng a lyaout from another device. This should be a validation


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.

**Connections**

[Bugzilla bug 1843021](https://bugzilla.mozilla.org/show_bug.cgi?id=1843021)

**Description**

wgpu IDs don't currently associate resources with specific devices. This causes crashes in Firefox in when running the portion of the CTS that checks that validation catches mismatch device usage.

**Testing**

This PR just adds a very simple crashing test as a demonstration. No fix yet.