### PR TITLE
Validate that BufferDescriptor::usage is not zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Bottom level categories:
 - Flesh out docs. for `AdapterInfo::{device,vendor}` by @ErichDonGubler in [#3763](https://github.com/gfx-rs/wgpu/pull/3763).
 - Spell out which sizes are in bytes. By @jimblandy in [#3773](https://github.com/gfx-rs/wgpu/pull/3773).
 - On Web, types don't implement `Send` or `Sync` anymore. By @daxpedda in [#3691](https://github.com/gfx-rs/wgpu/pull/3691)
+- Validate that `descriptor.usage` is not empty in `create_buffer` by @nical in [https://github.com/gfx-rs/wgpu/pull/#3928](3928)
 
 ### Bug Fixes
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -145,6 +145,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Ok(device) => device,
                 Err(_) => break DeviceError::Invalid.into(),
             };
+
+            if desc.usage.is_empty() {
+                // Per spec, `usage` must not be zero.
+                break resource::CreateBufferError::InvalidUsage(desc.usage);
+            }
+
             #[cfg(feature = "trace")]
             if let Some(ref trace) = device.trace {
                 let mut desc = desc.clone();


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Found this while investigating CTS failures in Firefox.

**Description**

WebGPU's spec says that [descriptor.usage must not be 0](https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer). [The vulkan spec as well](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkBufferUsageFlagBits), in fact it's the validation layer that helped me notice. 

**Testing**

It's covered by the CTS run by Firefox, so I got lazy and did not produce a test. Let me know if you want a test here as well.