### PR TITLE
Run cargo check to pick up bitflags 2.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ name = "metal"
 version = "0.25.0"
 source = "git+https://github.com/gfx-rs/metal-rs.git?rev=a6a0446#a6a04463db388e8fd3e99095ab4fbb87cbe9d69c"
 dependencies = [
- "bitflags 2.3.1",
+ "bitflags 2.3.2",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",


### PR DESCRIPTION
It annoyingly gets added in all pull requests as soon as anyone builds or has rustanalyzer running.

