### PR TITLE
Backport #3801 to v0.16 (Implement Send and Sync for `Id` again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ Bottom level categories:
 
 ## Unreleased
 
+## v0.16.3 (2023-07-17)
+
+### Changes
+
+#### General
+
+- Make the `Id` type that is exposed when using the `expose-ids` feature implement `Send` and `Sync` again. This was unintentionally changed by the v0.16.0 release and is now fixed.
+
 ## v0.16.2 (2023-07-09)
 
 ### Changes

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4251,6 +4251,15 @@ impl Surface {
 #[repr(transparent)]
 pub struct Id<T>(core::num::NonZeroU64, std::marker::PhantomData<*mut T>);
 
+// SAFETY: `Id` is a bare `NonZeroU64`, the type parameter is a marker purely to avoid confusing Ids
+// returned for different types , so `Id` can safely implement Send and Sync.
+#[cfg(feature = "expose-ids")]
+unsafe impl<T> Send for Id<T> {}
+
+// SAFETY: See the implementation for `Send`.
+#[cfg(feature = "expose-ids")]
+unsafe impl<T> Sync for Id<T> {}
+
 #[cfg(feature = "expose-ids")]
 impl<T> Clone for Id<T> {
     fn clone(&self) -> Self {


### PR DESCRIPTION
**Checklist**

- [ ] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

Backports #3801 for v0.16 and adds a changelog entry for v0.16.3.