### PR TITLE
Fix ASTC feature selection in the webgl backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Bottom level categories:
 - Fix OpenGL/EGL backend not respecting non-sRGB texture formats in `SurfaceConfiguration`. by @liquidev in [#3817](https://github.com/gfx-rs/wgpu/pull/3817)
 - Make write- and read-only marked buffers match non-readonly layouts. by @fornwall in [#3893](https://github.com/gfx-rs/wgpu/pull/3893)
 - Fix leaking X11 connections. by @wez in [#3924](https://github.com/gfx-rs/wgpu/pull/3924)
+- Fix ASTC feature selection in the webgl backend. by @expenses in [#3934](https://github.com/gfx-rs/wgpu/pull/3934)
 
 #### Metal
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,9 +1049,9 @@ checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
 
 [[package]]
 name = "glow"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807edf58b70c0b5b2181dd39fe1839dbdb3ba02645630dc5f753e23da307f762"
+checksum = "ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728"
 dependencies = [
  "js-sys",
  "slotmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ hassle-rs = "0.10.0"
 
 # Gles dependencies
 khronos-egl = "4.1"
-glow = "0.12.2"
+glow = "0.12.3"
 glutin = "0.29.1"
 
 # wasm32 dependencies

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -66,7 +66,7 @@ rustc-hash = "1.1"
 log = "0.4"
 
 # backend: Gles
-glow = { version = "0.12.2", optional = true }
+glow = { version = "0.12.3", optional = true }
 
 [dependencies.wgt]
 package = "wgpu-types"

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -397,8 +397,27 @@ impl super::Adapter {
         if extensions.contains("WEBGL_compressed_texture_astc")
             || extensions.contains("GL_OES_texture_compression_astc")
         {
-            features.insert(wgt::Features::TEXTURE_COMPRESSION_ASTC);
-            features.insert(wgt::Features::TEXTURE_COMPRESSION_ASTC_HDR);
+            #[cfg(target_arch = "wasm32")]
+            {
+                if context
+                    .glow_context
+                    .compressed_texture_astc_supports_ldr_profile()
+                {
+                    features.insert(wgt::Features::TEXTURE_COMPRESSION_ASTC);
+                }
+                if context
+                    .glow_context
+                    .compressed_texture_astc_supports_hdr_profile()
+                {
+                    features.insert(wgt::Features::TEXTURE_COMPRESSION_ASTC_HDR);
+                }
+            }
+
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                features.insert(wgt::Features::TEXTURE_COMPRESSION_ASTC);
+                features.insert(wgt::Features::TEXTURE_COMPRESSION_ASTC_HDR);
+            }
         } else {
             features.set(
                 wgt::Features::TEXTURE_COMPRESSION_ASTC,

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -397,7 +397,7 @@ impl super::Adapter {
         if extensions.contains("WEBGL_compressed_texture_astc")
             || extensions.contains("GL_OES_texture_compression_astc")
         {
-            #[cfg(target_arch = "wasm32")]
+            #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             {
                 if context
                     .glow_context
@@ -413,7 +413,7 @@ impl super::Adapter {
                 }
             }
 
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
             {
                 features.insert(wgt::Features::TEXTURE_COMPRESSION_ASTC);
                 features.insert(wgt::Features::TEXTURE_COMPRESSION_ASTC_HDR);


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

https://github.com/grovesNL/glow/issues/244
https://github.com/grovesNL/glow/pull/245

**Description**

Currently we report both `TEXTURE_COMPRESSION_ASTC` and `TEXTURE_COMPRESSION_ASTC_HDR` if the extension is implemented, even if only SDR or HDR is enabled.

**Testing**

I've been using these changes on my own branch for a while.