### PR TITLE
chore(dx12): resolve warnings and errors when `dx11` is not specified

### DIFF
--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -38,7 +38,7 @@ metal = ["naga/msl-out", "block"]
 vulkan = ["naga/spv-out", "ash", "gpu-alloc", "gpu-descriptor", "libloading", "smallvec"]
 gles = ["naga/glsl-out", "glow", "khronos-egl", "libloading"]
 dx11 = ["naga/hlsl-out", "d3d12", "libloading", "winapi/d3d11", "winapi/std", "winapi/d3d11_1", "winapi/d3d11_2", "winapi/d3d11sdklayers", "winapi/dxgi1_6"]
-dx12 = ["naga/hlsl-out", "d3d12", "bit-set", "range-alloc", "winapi/std", "winapi/winbase", "winapi/d3d12", "winapi/d3d12shader", "winapi/d3d12sdklayers", "winapi/dxgi1_6"]
+dx12 = ["naga/hlsl-out", "d3d12", "bit-set", "libloading", "range-alloc", "winapi/std", "winapi/winbase", "winapi/d3d12", "winapi/d3d12shader", "winapi/d3d12sdklayers", "winapi/dxgi1_6"]
 # TODO: This is a separate feature until Mozilla okays windows-rs, see https://github.com/gfx-rs/wgpu/issues/3207 for the tracking issue.
 windows_rs = ["gpu-allocator"]
 dxc_shader_compiler = ["hassle-rs"]

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -7,6 +7,7 @@ use super::result::HResult as _;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DxgiFactoryType {
+    #[cfg(feature = "dx11")]
     Factory1,
     Factory2,
     Factory4,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] ~Run `cargo clippy --target wasm32-unknown-unknown` if applicable.~
- [x] ~Add change to CHANGELOG.md. See simple instructions inside file.~

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

Discovered to be a problem while attempting to test #3936 with `cargo check -p
wgpu-hal --features dx12` and `cargo clippy -p wgpu-hal --features dx12`.

**Description**
_Describe what problem this is solving, and how it's solved._

Make `cargo build --package wgpu-hal --features dx12` actually compile with no
warnings and errors, please!

**Testing**
_Explain how this change is tested._

It compiles, so it works!
