### PR TITLE
WIP: refactor(hal): migrate from `cstr_from_bytes_until_nul` to `CStr::from_bytes_until_nul`

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,6 +5,6 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "1.65"
+channel = "1.69"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Not mergeable until:

-   [ ] MSRV is Rust 1.69.
-   [ ] We figure out what to do with `type c_char = i8`.

**Checklist**

-   [ ] Run `cargo clippy`.
-   [x] ~Run `cargo clippy --target wasm32-unknown-unknown` if applicable.~
-   [x] ~Add change to CHANGELOG.md. See simple instructions inside file.~

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

N/A

**Description**
_Describe what problem this is solving, and how it's solved._

See removed code commentary about API we're migrating to.

**Testing**
_Explain how this change is tested._

If CI passes, then I have enough confidence to ship this.
