### PR TITLE
fix(limits): properly calculate `max_bindings_per_bind_group`

### DIFF
--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -2,6 +2,8 @@ use std::num::NonZeroU64;
 
 use winapi::um::{d3d11, d3dcommon};
 
+use crate::auxil::{max_bindings_per_bind_group, MaxBindingsPerBindGroupInput};
+
 impl crate::Adapter<super::Api> for super::Adapter {
     unsafe fn open(
         &self,
@@ -203,6 +205,21 @@ impl super::Adapter {
         let max_compute_workgroups_per_dimension =
             d3d11::D3D11_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION;
 
+        let max_sampled_textures_per_shader_stage = max_sampled_textures;
+        let max_samplers_per_shader_stage = max_samplers;
+        let max_storage_buffers_per_shader_stage = max_uavs;
+        let max_storage_textures_per_shader_stage = max_uavs;
+        let max_uniform_buffers_per_shader_stage = max_constant_buffers;
+
+        let max_bindings_per_bind_group =
+            max_bindings_per_bind_group(MaxBindingsPerBindGroupInput {
+                max_sampled_textures_per_shader_stage,
+                max_samplers_per_shader_stage,
+                max_storage_buffers_per_shader_stage,
+                max_storage_textures_per_shader_stage,
+                max_uniform_buffers_per_shader_stage,
+            });
+
         let limits = wgt::Limits {
             max_texture_dimension_1d: max_texture_dimension_2d,
             max_texture_dimension_2d,
@@ -212,11 +229,11 @@ impl super::Adapter {
             max_bindings_per_bind_group: 65535,
             max_dynamic_uniform_buffers_per_pipeline_layout: max_constant_buffers,
             max_dynamic_storage_buffers_per_pipeline_layout: 0,
-            max_sampled_textures_per_shader_stage: max_sampled_textures,
-            max_samplers_per_shader_stage: max_samplers,
-            max_storage_buffers_per_shader_stage: max_uavs,
-            max_storage_textures_per_shader_stage: max_uavs,
-            max_uniform_buffers_per_shader_stage: max_constant_buffers,
+            max_sampled_textures_per_shader_stage,
+            max_samplers_per_shader_stage,
+            max_storage_buffers_per_shader_stage,
+            max_storage_textures_per_shader_stage,
+            max_uniform_buffers_per_shader_stage,
             max_uniform_buffer_binding_size: 1 << 16,
             max_storage_buffer_binding_size: u32::MAX,
             max_vertex_buffers,

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -182,6 +182,8 @@ impl super::Adapter {
     pub(super) unsafe fn expose(
         context: super::AdapterContext,
     ) -> Option<crate::ExposedAdapter<super::Api>> {
+        use crate::auxil::{max_bindings_per_bind_group, MaxBindingsPerBindGroupInput};
+
         let gl = context.lock();
         let extensions = gl.supported_extensions();
 
@@ -499,6 +501,18 @@ impl super::Adapter {
             0
         };
 
+        let max_sampled_textures_per_shader_stage = super::MAX_TEXTURE_SLOTS as u32;
+        let max_samplers_per_shader_stage = super::MAX_SAMPLERS as u32;
+
+        let max_bindings_per_bind_group =
+            max_bindings_per_bind_group(MaxBindingsPerBindGroupInput {
+                max_sampled_textures_per_shader_stage,
+                max_samplers_per_shader_stage,
+                max_storage_buffers_per_shader_stage,
+                max_storage_textures_per_shader_stage,
+                max_uniform_buffers_per_shader_stage,
+            });
+
         let limits = wgt::Limits {
             max_texture_dimension_1d: max_texture_size,
             max_texture_dimension_2d: max_texture_size,
@@ -507,11 +521,11 @@ impl super::Adapter {
                 gl.get_parameter_i32(glow::MAX_ARRAY_TEXTURE_LAYERS)
             } as u32,
             max_bind_groups: crate::MAX_BIND_GROUPS as u32,
-            max_bindings_per_bind_group: 65535,
+            max_bindings_per_bind_group,
             max_dynamic_uniform_buffers_per_pipeline_layout: max_uniform_buffers_per_shader_stage,
             max_dynamic_storage_buffers_per_pipeline_layout: max_storage_buffers_per_shader_stage,
-            max_sampled_textures_per_shader_stage: super::MAX_TEXTURE_SLOTS as u32,
-            max_samplers_per_shader_stage: super::MAX_SAMPLERS as u32,
+            max_sampled_textures_per_shader_stage,
+            max_samplers_per_shader_stage,
             max_storage_buffers_per_shader_stage,
             max_storage_textures_per_shader_stage,
             max_uniform_buffers_per_shader_stage,

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1,3 +1,4 @@
+use crate::auxil::{max_bindings_per_bind_group, MaxBindingsPerBindGroupInput};
 use metal::{MTLFeatureSet, MTLGPUFamily, MTLLanguageVersion, MTLReadWriteTextureTier};
 use objc::{class, msg_send, sel, sel_impl};
 use parking_lot::Mutex;
@@ -829,6 +830,21 @@ impl super::PrivateCapabilities {
             .flags
             .set(wgt::DownlevelFlags::ANISOTROPIC_FILTERING, true);
 
+        let max_sampled_textures_per_shader_stage = self.max_textures_per_stage;
+        let max_samplers_per_shader_stage = self.max_samplers_per_stage;
+        let max_storage_buffers_per_shader_stage = self.max_buffers_per_stage;
+        let max_storage_textures_per_shader_stage = self.max_textures_per_stage;
+        let max_uniform_buffers_per_shader_stage = self.max_buffers_per_stage;
+
+        let max_bindings_per_bind_group =
+            max_bindings_per_bind_group(MaxBindingsPerBindGroupInput {
+                max_sampled_textures_per_shader_stage,
+                max_samplers_per_shader_stage,
+                max_storage_buffers_per_shader_stage,
+                max_storage_textures_per_shader_stage,
+                max_uniform_buffers_per_shader_stage,
+            });
+
         let base = wgt::Limits::default();
         crate::Capabilities {
             limits: wgt::Limits {
@@ -837,16 +853,16 @@ impl super::PrivateCapabilities {
                 max_texture_dimension_3d: self.max_texture_3d_size as u32,
                 max_texture_array_layers: self.max_texture_layers as u32,
                 max_bind_groups: 8,
-                max_bindings_per_bind_group: 65535,
+                max_bindings_per_bind_group,
                 max_dynamic_uniform_buffers_per_pipeline_layout: base
                     .max_dynamic_uniform_buffers_per_pipeline_layout,
                 max_dynamic_storage_buffers_per_pipeline_layout: base
                     .max_dynamic_storage_buffers_per_pipeline_layout,
-                max_sampled_textures_per_shader_stage: self.max_textures_per_stage,
-                max_samplers_per_shader_stage: self.max_samplers_per_stage,
-                max_storage_buffers_per_shader_stage: self.max_buffers_per_stage,
-                max_storage_textures_per_shader_stage: self.max_textures_per_stage,
-                max_uniform_buffers_per_shader_stage: self.max_buffers_per_stage,
+                max_sampled_textures_per_shader_stage,
+                max_samplers_per_shader_stage,
+                max_storage_buffers_per_shader_stage,
+                max_storage_textures_per_shader_stage,
+                max_uniform_buffers_per_shader_stage,
                 max_uniform_buffer_binding_size: self.max_buffer_size.min(!0u32 as u64) as u32,
                 max_storage_buffer_binding_size: self.max_buffer_size.min(!0u32 as u64) as u32,
                 max_vertex_buffers: self.max_vertex_buffers,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1,3 +1,5 @@
+use crate::auxil::{max_bindings_per_bind_group, MaxBindingsPerBindGroupInput};
+
 use super::conv;
 
 use ash::{extensions::khr, vk};
@@ -713,6 +715,21 @@ impl PhysicalDeviceCapabilities {
                 u64::MAX
             };
 
+        let max_sampled_textures_per_shader_stage = limits.max_per_stage_descriptor_sampled_images;
+        let max_samplers_per_shader_stage = limits.max_per_stage_descriptor_samplers;
+        let max_storage_buffers_per_shader_stage = limits.max_per_stage_descriptor_storage_buffers;
+        let max_storage_textures_per_shader_stage = limits.max_per_stage_descriptor_storage_images;
+        let max_uniform_buffers_per_shader_stage = limits.max_per_stage_descriptor_uniform_buffers;
+
+        let max_bindings_per_bind_group =
+            max_bindings_per_bind_group(MaxBindingsPerBindGroupInput {
+                max_sampled_textures_per_shader_stage,
+                max_samplers_per_shader_stage,
+                max_storage_buffers_per_shader_stage,
+                max_storage_textures_per_shader_stage,
+                max_uniform_buffers_per_shader_stage,
+            });
+
         wgt::Limits {
             max_texture_dimension_1d: limits.max_image_dimension1_d,
             max_texture_dimension_2d: limits.max_image_dimension2_d,
@@ -721,16 +738,16 @@ impl PhysicalDeviceCapabilities {
             max_bind_groups: limits
                 .max_bound_descriptor_sets
                 .min(crate::MAX_BIND_GROUPS as u32),
-            max_bindings_per_bind_group: wgt::Limits::default().max_bindings_per_bind_group,
+            max_bindings_per_bind_group,
             max_dynamic_uniform_buffers_per_pipeline_layout: limits
                 .max_descriptor_set_uniform_buffers_dynamic,
             max_dynamic_storage_buffers_per_pipeline_layout: limits
                 .max_descriptor_set_storage_buffers_dynamic,
-            max_sampled_textures_per_shader_stage: limits.max_per_stage_descriptor_sampled_images,
-            max_samplers_per_shader_stage: limits.max_per_stage_descriptor_samplers,
-            max_storage_buffers_per_shader_stage: limits.max_per_stage_descriptor_storage_buffers,
-            max_storage_textures_per_shader_stage: limits.max_per_stage_descriptor_storage_images,
-            max_uniform_buffers_per_shader_stage: limits.max_per_stage_descriptor_uniform_buffers,
+            max_sampled_textures_per_shader_stage,
+            max_samplers_per_shader_stage,
+            max_storage_buffers_per_shader_stage,
+            max_storage_textures_per_shader_stage,
+            max_uniform_buffers_per_shader_stage,
             max_uniform_buffer_binding_size: limits
                 .max_uniform_buffer_range
                 .min(crate::auxil::MAX_I32_BINDING_SIZE),


### PR DESCRIPTION
Depends on #3942.

---

**Checklist**

-   [x] Run `cargo clippy`.
-   [x] ~Run `cargo clippy --target wasm32-unknown-unknown` if applicable.~
-   [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

Currently tracked in the Mozilla bug tracker at [bug 1844230](https://bugzilla.mozilla.org/show_bug.cgi?id=1844230).

**Description**
_Describe what problem this is solving, and how it's solved._

`AdapterInfo::max_bindings_per_bind_group` is incorrectly calculated, according to the [WebGPU spec.]:

> **_max shader stages per pipeline_** is `2`, because a `GPURenderPipeline` supports both a vertex and fragment shader.

[WebGPU spec.]: https://gpuweb.github.io/gpuweb/#max-shader-stages-per-pipeline

**Testing**
_Explain how this change is tested._

Tested by experimentally consuming this fix in Firefox, and demonstrating that the `webgpu:api,operation,adapter,requestDevice:limit,worse_than_default:limit="maxBindingsPerBindGroup"` case works correctly (TODO: link).
