### PR TITLE
Fix panic on surface creation

### DIFF
--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -746,11 +746,13 @@ impl crate::Surface<Api> for Surface {
         unsafe { swap_chain.SetMaximumFrameLatency(config.swap_chain_size) };
         let waitable = unsafe { swap_chain.GetFrameLatencyWaitableObject() };
 
-        let mut resources = vec![d3d12::Resource::null(); config.swap_chain_size as usize];
-        for (i, res) in resources.iter_mut().enumerate() {
+        let mut resources = Vec::with_capacity(config.swap_chain_size as usize);
+        for i in 0..config.swap_chain_size {
+            let mut resource = d3d12::Resource::null();
             unsafe {
-                swap_chain.GetBuffer(i as _, &d3d12_ty::ID3D12Resource::uuidof(), res.mut_void())
+                swap_chain.GetBuffer(i, &d3d12_ty::ID3D12Resource::uuidof(), resource.mut_void())
             };
+            resources.push(resource);
         }
 
         self.swap_chain = Some(SwapChain {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Closes #3938

**Description**

ComPtr now panics if you clone while null. This is likely the wrong behavior and should be fixed in d3d12. In the mean time, avoid the situation.

**Testing**

Manually.
