### PR TITLE
fix: macOS - added portability bit and extension when creating vulkan instance

### DIFF
--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -215,6 +215,7 @@ impl super::Instance {
         if cfg!(target_os = "macos") {
             // VK_EXT_metal_surface
             extensions.push(ext::MetalSurface::name());
+            extensions.push(CStr::from_bytes_with_nul(b"VK_KHR_portability_enumeration\0").unwrap());
         }
 
         if flags.contains(crate::InstanceFlags::DEBUG) {
@@ -648,8 +649,11 @@ impl crate::Instance<super::Api> for super::Instance {
                 })
                 .collect::<Vec<_>>();
 
+            const VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR: u32 = 0x00000001;
             let create_info = vk::InstanceCreateInfo::builder()
-                .flags(vk::InstanceCreateFlags::empty())
+                .flags(vk::InstanceCreateFlags::from_raw(
+                    VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR,
+                ))
                 .application_info(&app_info)
                 .enabled_layer_names(&str_pointers[..layers.len()])
                 .enabled_extension_names(&str_pointers[layers.len()..]);

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -215,7 +215,8 @@ impl super::Instance {
         if cfg!(target_os = "macos") {
             // VK_EXT_metal_surface
             extensions.push(ext::MetalSurface::name());
-            extensions.push(CStr::from_bytes_with_nul(b"VK_KHR_portability_enumeration\0").unwrap());
+            extensions
+                .push(CStr::from_bytes_with_nul(b"VK_KHR_portability_enumeration\0").unwrap());
         }
 
         if flags.contains(crate::InstanceFlags::DEBUG) {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
`wgpu` can't select the vulkan backend on macos. This should at least get us a bit further down the path. Here's the relevant discussion on the [wgpu users matrix channel](https://app.element.io/#/room/#wgpu-users:matrix.org/$Zd3HHMSCFmNu79FM0XH6D07JP4Cjgiq67jwp3WaU1V4)

**Testing**
Run an example (on macos) with `RUST_LOG=trace WGPU_BACKEND=vk VK_LOADER_DEBUG=error cargo run --bin skybox --features=vulkan-portability`
