### PR TITLE
fix: vulkan only uses robust_*_access2 if the driver supports it

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -234,11 +234,11 @@ impl PhysicalDeviceFeatures {
             robustness2: if enabled_extensions.contains(&vk::ExtRobustness2Fn::name()) {
                 // Note: enabling `robust_buffer_access2` isn't requires, strictly speaking
                 // since we can enable `robust_buffer_access` all the time. But it improves
-                // program portability, so we opt into it anyway.
+                // program portability, so we opt into it if they are supported.
                 Some(
                     vk::PhysicalDeviceRobustness2FeaturesEXT::builder()
-                        .robust_buffer_access2(private_caps.robust_buffer_access)
-                        .robust_image_access2(private_caps.robust_image_access)
+                        .robust_buffer_access2(private_caps.robust_buffer_access2)
+                        .robust_image_access2(private_caps.robust_image_access2)
                         .build(),
                 )
             } else {
@@ -1063,6 +1063,16 @@ impl super::Instance {
                     .image_robustness
                     .map_or(false, |ext| ext.robust_image_access != 0),
             },
+            robust_buffer_access2: phd_features
+                .robustness2
+                .as_ref()
+                .map(|r| r.robust_buffer_access2 == 1)
+                .unwrap_or_default(),
+            robust_image_access2: phd_features
+                .robustness2
+                .as_ref()
+                .map(|r| r.robust_image_access2 == 1)
+                .unwrap_or_default(),
             zero_initialize_workgroup_memory: phd_features
                 .zero_initialize_workgroup_memory
                 .map_or(false, |ext| {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -189,6 +189,8 @@ struct PrivateCapabilities {
     non_coherent_map_mask: wgt::BufferAddress,
     robust_buffer_access: bool,
     robust_image_access: bool,
+    robust_buffer_access2: bool,
+    robust_image_access2: bool,
     zero_initialize_workgroup_memory: bool,
 }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
This finishes up the work started in #3958 and allows the vulkan backend to be selected on macOS.

**Description**
Added `robust_[buffer|image]_access2 parameters to `PrivateCapabilities` to specify if those caps are supported by the driver, then bubbled those up to `PhysicalDeviceFeatures`.

**Testing**
On macOS, run `WGPU_BACKEND=vk VK_LOADER_DEBUG=error cargo run --bin skybox --features=vulkan-portability` and it should succeed.
