### PR TITLE
Vulkan portability in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
           # Mac
           - name: Mac aarch64
             os: [self-hosted, macOS]
-            backends: metal
+            backends: vulkan metal
 
           # Linux
           - name: Linux x86_64
@@ -275,7 +275,7 @@ jobs:
         run: |
           set -e
 
-          cargo llvm-cov --no-cfg-coverage run --bin wgpu-info --no-report
+          cargo llvm-cov --no-cfg-coverage run --bin wgpu-info --no-report --features vulkan-portability
 
       - name: run tests
         shell: bash
@@ -284,7 +284,7 @@ jobs:
 
           for backend in ${{ matrix.backends }}; do
             echo "======= NATIVE TESTS $backend ======";
-            WGPU_BACKEND=$backend cargo llvm-cov --no-cfg-coverage nextest --no-fail-fast --no-report
+            WGPU_BACKEND=$backend cargo llvm-cov --no-cfg-coverage nextest --no-fail-fast --no-report --features vulkan-portability
           done
 
       - uses: actions/upload-artifact@v3

--- a/examples/boids/src/main.rs
+++ b/examples/boids/src/main.rs
@@ -340,6 +340,7 @@ fn boids() {
         base_test_parameters: wgpu_test::TestParameters::default()
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
+            // Lots of validation errors, maybe related to https://github.com/gfx-rs/wgpu/issues/3160
             .molten_vk_failure(),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.005)],
     });

--- a/examples/boids/src/main.rs
+++ b/examples/boids/src/main.rs
@@ -339,7 +339,8 @@ fn boids() {
         optional_features: wgpu::Features::default(),
         base_test_parameters: wgpu_test::TestParameters::default()
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
-            .limits(wgpu::Limits::downlevel_defaults()),
+            .limits(wgpu::Limits::downlevel_defaults())
+            .molten_vk_failure(),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.005)],
     });
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -184,6 +184,18 @@ impl TestParameters {
         });
         self
     }
+
+    /// Mark the test as failing on vulkan on mac only
+    pub fn molten_vk_failure(self) -> Self {
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        {
+            self.specific_failure(Some(wgpu::Backends::VULKAN), None, None, false)
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        {
+            self
+        }
+    }
 }
 
 pub fn initialize_test(parameters: TestParameters, test_function: impl FnOnce(TestingContext)) {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

Followup to fixes letting vulkan-portability run #3962 
