### PR TITLE
Omit texture store bound checks since they are no-ops if out of bounds on all APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Bottom level categories:
 
 ## Unreleased
 
+### Changes
+
+- Omit texture store bound checks since they are no-ops if out of bounds on all APIs. By @teoxoy in [#3975](https://github.com/gfx-rs/wgpu/pull/3975)
+
 ### Bug Fixes
 
 #### Vulkan

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -222,7 +222,7 @@ impl super::Device {
             index: BoundsCheckPolicy::Unchecked,
             buffer: BoundsCheckPolicy::Unchecked,
             image_load: image_check,
-            image_store: image_check,
+            image_store: BoundsCheckPolicy::Unchecked,
             binding_array: BoundsCheckPolicy::Unchecked,
         };
 

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -100,7 +100,7 @@ impl super::Device {
                 index: bounds_check_policy,
                 buffer: bounds_check_policy,
                 image_load: bounds_check_policy,
-                image_store: bounds_check_policy,
+                image_store: naga::proc::BoundsCheckPolicy::Unchecked,
                 // TODO: support bounds checks on binding arrays
                 binding_array: naga::proc::BoundsCheckPolicy::Unchecked,
             },

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1212,12 +1212,6 @@ impl super::Adapter {
             None
         };
 
-        let image_checks = if self.private_caps.robust_image_access {
-            naga::proc::BoundsCheckPolicy::Unchecked
-        } else {
-            naga::proc::BoundsCheckPolicy::Restrict
-        };
-
         let naga_options = {
             use naga::back::spv;
 
@@ -1279,8 +1273,12 @@ impl super::Adapter {
                     } else {
                         naga::proc::BoundsCheckPolicy::Restrict
                     },
-                    image_load: image_checks,
-                    image_store: image_checks,
+                    image_load: if self.private_caps.robust_image_access {
+                        naga::proc::BoundsCheckPolicy::Unchecked
+                    } else {
+                        naga::proc::BoundsCheckPolicy::Restrict
+                    },
+                    image_store: naga::proc::BoundsCheckPolicy::Unchecked,
                     // TODO: support bounds checks on binding arrays
                     binding_array: naga::proc::BoundsCheckPolicy::Unchecked,
                 },


### PR DESCRIPTION
resolves https://github.com/gfx-rs/wgpu/issues/3894