### PR TITLE
Revert "Make shader write&read storage buffers match non readonly layouts"

### DIFF
--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -409,7 +409,7 @@ impl Resource {
                                 )
                             }
                         };
-                        if !address_space_matches(self.class, class) {
+                        if self.class != class {
                             return Err(BindingError::WrongAddressSpace {
                                 binding: class,
                                 shader: self.class,
@@ -1235,74 +1235,5 @@ impl Interface {
             })
             .collect();
         Ok(outputs)
-    }
-}
-
-fn address_space_matches(shader: naga::AddressSpace, binding: naga::AddressSpace) -> bool {
-    match (shader, binding) {
-        (
-            naga::AddressSpace::Storage {
-                access: access_shader,
-            },
-            naga::AddressSpace::Storage {
-                access: access_pipeline,
-            },
-        ) => {
-            // Allow read- and write-only usages to match read-write layouts:
-            (access_shader & access_pipeline) == access_shader
-        }
-        (a, b) => a == b,
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::address_space_matches;
-
-    #[test]
-    fn address_space_matches_correctly() {
-        assert!(address_space_matches(
-            naga::AddressSpace::Uniform,
-            naga::AddressSpace::Uniform
-        ));
-
-        assert!(!address_space_matches(
-            naga::AddressSpace::Uniform,
-            naga::AddressSpace::Storage {
-                access: naga::StorageAccess::LOAD
-            }
-        ));
-
-        let test_cases = [
-            (naga::StorageAccess::LOAD, naga::StorageAccess::LOAD, true),
-            (naga::StorageAccess::STORE, naga::StorageAccess::LOAD, false),
-            (naga::StorageAccess::LOAD, naga::StorageAccess::STORE, false),
-            (naga::StorageAccess::STORE, naga::StorageAccess::STORE, true),
-            (
-                naga::StorageAccess::LOAD | naga::StorageAccess::STORE,
-                naga::StorageAccess::LOAD | naga::StorageAccess::STORE,
-                true,
-            ),
-            (
-                naga::StorageAccess::STORE,
-                naga::StorageAccess::LOAD | naga::StorageAccess::STORE,
-                true,
-            ),
-            (
-                naga::StorageAccess::LOAD,
-                naga::StorageAccess::LOAD | naga::StorageAccess::STORE,
-                true,
-            ),
-        ];
-
-        for (shader, binding, expect_match) in test_cases {
-            assert_eq!(
-                expect_match,
-                address_space_matches(
-                    naga::AddressSpace::Storage { access: shader },
-                    naga::AddressSpace::Storage { access: binding }
-                )
-            );
-        }
     }
 }


### PR DESCRIPTION
This reverts commit 17143c149c13ea5af36909ef6033e776cecad28c (#3893) as it changed validation in a non-spec compliant way.

Relevant Spec Text:

![image](https://github.com/gfx-rs/wgpu/assets/28601907/8a72b720-3a9f-4504-83e2-02adb4ea9ac9)

Even if we want to relax the validation, this won't work for dx12 as we use UAVs for read-write storage buffers and SRVs for read-only storage buffers.

I think we should remove write-only storage buffers as they are not part of the spec anymore (avoiding https://github.com/gfx-rs/wgpu/issues/2897 altogether). Related: https://github.com/gfx-rs/wgpu/issues/4411

Found while investigating https://github.com/gfx-rs/wgpu/issues/3983.