### PR TITLE
Allow to use NVIDIA Nsight Graphics with wgpu applications on Vulkan 

### DIFF
--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -154,7 +154,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     label: Some("(wgpu internal) clear surface texture view"),
                     format: config.format,
                     dimension: wgt::TextureViewDimension::D2,
-                    usage: hal::TextureUses::COLOR_TARGET,
+                    usage: hal::TextureUses::empty(),
                     range: wgt::ImageSubresourceRange::default(),
                 };
                 let mut clear_views = smallvec::SmallVec::new();

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -596,6 +596,9 @@ impl crate::Queue<Api> for Queue {
         texture: SurfaceTexture,
     ) -> Result<(), crate::SurfaceError> {
         let ssc = surface.swapchain.as_ref().unwrap();
+        if ssc.device.raw.handle() != self.device.raw.handle() {
+            return Err(crate::SurfaceError::Outdated);
+        }
 
         let swapchains = [ssc.raw];
         let image_indices = [texture.index];


### PR DESCRIPTION
Add check to avoid new issue with IMAGE_STATE in PostCallRecordCreateImageView
linked to this: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6122

@kvark it would be nice if you could check if it invalidate somehow your imageless framebuffer impl of https://github.com/gfx-rs/wgpu/pull/1701 or if everything is still consistent