### PR TITLE
Suppress validation error caused by OBS layer

### DIFF
--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -96,6 +96,10 @@ pub struct DebugUtilsMessengerUserData {
 
     /// Validation layer specification version, from `vk::LayerProperties`.
     validation_layer_spec_version: u32,
+
+    /// If the OBS layer is present. OBS never increments the version of their layer,
+    /// so there's no reason to have the version.
+    has_obs_layer: bool,
 }
 
 pub struct InstanceShared {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Closes https://github.com/gfx-rs/wgpu/issues/3855
Caused by https://github.com/obsproject/obs-studio/issues/9353

**Description**

OBS messed up their modification of surface-derived image textures

**Testing**

Manually
