### PR TITLE
Add request_device_error

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -25,9 +25,9 @@ pub struct HalSurface<A: hal::Api> {
 #[derive(Clone, Debug, Error)]
 #[error("Limit '{name}' value {requested} is better than allowed {allowed}")]
 pub struct FailedLimit {
-    name: &'static str,
-    requested: u64,
-    allowed: u64,
+    pub name: &'static str,
+    pub requested: u64,
+    pub allowed: u64,
 }
 
 fn check_limits(requested: &wgt::Limits, allowed: &wgt::Limits) -> Vec<FailedLimit> {
@@ -1091,6 +1091,18 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let id = fid.assign_error(desc.label.borrow_or_default(), &mut token);
         (id, Some(error))
+    }
+
+    /// Creates a device in the error sate.
+    pub fn adapter_request_device_error<A: HalApi>(
+        &self,
+        label: &crate::Label,
+        id_in: Input<G, DeviceId>,
+    ) {
+        let hub = A::hub(self);
+        let mut token = Token::root();
+        let fid = hub.devices.prepare(id_in);
+        fid.assign_error(label.borrow_or_default(), &mut token);
     }
 
     /// # Safety


### PR DESCRIPTION
Will be used by gecko for some bits of firefox-sepcific validation

**Connections**

Bugzilla bug https://bugzilla.mozilla.org/show_bug.cgi?id=1846661

**Description**

In Firefox we want to be able to impose stricter limits than what the device advertises (in particular for things related to large allocations, like `max_buffer_size`) and be stricter than what would make sense for native wgpu.
This means a bit of validation is done outside of wgpu and we need the entry point for creating a device in the error state.

**Testing**

This is covered by the CTS in firefox.