### PR TITLE
Use i32::MAX as the max buffer size for Dx12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ By @fornwall in [#3904](https://github.com/gfx-rs/wgpu/pull/3904) and [#3905](ht
 #### DX12
 
 - Disable suballocation on Intel Iris(R) Xe. By @xiaopengli89 in [#3668](https://github.com/gfx-rs/wgpu/pull/3668)
+- Change the `max_buffer_size` limit from `u64::MAX` to `i32::MAX`. By @nical in [#4020](https://github.com/gfx-rs/wgpu/pull/4020)
 
 #### WebGPU
 

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -355,7 +355,10 @@ impl super::Adapter {
                     max_compute_workgroup_size_z: d3d12_ty::D3D12_CS_THREAD_GROUP_MAX_Z,
                     max_compute_workgroups_per_dimension:
                         d3d12_ty::D3D12_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION,
-                    max_buffer_size: u64::MAX,
+                    // Dx12 does not expose a maximum buffer size in the API.
+                    // This limit is chosen to avoid potential issues with drivers should they internally
+                    // store buffer sizes using 32 bit ints (a situation we have already encountered with vulkan).
+                    max_buffer_size: i32::MAX as u64,
                 },
                 alignments: crate::Alignments {
                     buffer_copy_offset: wgt::BufferSize::new(


### PR DESCRIPTION
This is also the limit used in Dawn.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.


**Description**

Orthogonal but somewhat related to #4019 . We currently expose a max buffer size of u64::MAX in Dx12 which is not realistic. 

I propose using i32::MAX has the advantage of being more bad-driver-proof as some implementation may use signed integers to store sizes. We've already run into this situation with vulkan and were able to diagnose it thanks to the driver in question being open-source but it's trickier to investigate this type of things with closed source windows drivers.

Dawn uses a similar limit for its dx12 backend.