### PR TITLE
Support dual source blending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ By @Valaphee in [#3402](https://github.com/gfx-rs/wgpu/pull/3402)
 - Add validation in accordance with WebGPU `setViewport` valid usage for `x`, `y` and `this.[[attachment_size]]`. By @James2022-rgb in [#4058](https://github.com/gfx-rs/wgpu/pull/4058)
 - `wgpu::CreateSurfaceError` and `wgpu::RequestDeviceError` now give details of the failure, but no longer implement `PartialEq` and cannot be constructed. By @kpreid in [#4066](https://github.com/gfx-rs/wgpu/pull/4066) and [#4145](https://github.com/gfx-rs/wgpu/pull/4145)
 - Make `WGPU_POWER_PREF=none` a valid value. By @fornwall in [4076](https://github.com/gfx-rs/wgpu/pull/4076)
+- Support dual source blending in OpenGL ES, Metal, Vulkan & DX12. By @freqmod in [4022](https://github.com/gfx-rs/wgpu/pull/4022)
 
 #### Vulkan
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -384,6 +384,15 @@ pub enum CreateRenderPipelineError {
     },
     #[error("In the provided shader, the type given for group {group} binding {binding} has a size of {size}. As the device does not support `DownlevelFlags::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED`, the type must have a size that is a multiple of 16 bytes.")]
     UnalignedShader { group: u32, binding: u32, size: u64 },
+    #[error("Using the blend factor {factor:?} for render target {target} is not possible. Only the first render target may be used when dual-source blending.")]
+    BlendFactorOnUnsupportedTarget {
+        factor: wgt::BlendFactor,
+        target: u32,
+    },
+    #[error("Pipeline expects the shader entry point to make use of dual-source blending.")]
+    PipelineExpectsShaderToUseDualSourceBlending,
+    #[error("Shader entry point expects the pipeline to make use of dual-source blending.")]
+    ShaderExpectsPipelineToUseDualSourceBlending,
 }
 
 bitflags::bitflags! {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -393,6 +393,8 @@ pub enum CreateRenderPipelineError {
     PipelineExpectsShaderToUseDualSourceBlending,
     #[error("Shader entry point expects the pipeline to make use of dual-source blending.")]
     ShaderExpectsPipelineToUseDualSourceBlending,
+    #[error("Shader entry point expects the pipeline to make use of dual-source blending, but pipeline contains no fragment stage.")]
+    ShaderExpectsPipelineToUseDualSourceBlendingNoFragmentStage,
 }
 
 bitflags::bitflags! {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -393,8 +393,6 @@ pub enum CreateRenderPipelineError {
     PipelineExpectsShaderToUseDualSourceBlending,
     #[error("Shader entry point expects the pipeline to make use of dual-source blending.")]
     ShaderExpectsPipelineToUseDualSourceBlending,
-    #[error("Shader entry point expects the pipeline to make use of dual-source blending, but pipeline contains no fragment stage.")]
-    ShaderExpectsPipelineToUseDualSourceBlendingNoFragmentStage,
 }
 
 bitflags::bitflags! {

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1184,4 +1184,19 @@ impl Interface {
             .values()
             .any(|point| point.dual_source_blending)
     }
+    pub fn is_fragment_entry_dual_source<'a>(
+        &self,
+        fragment: &crate::pipeline::FragmentState<'a>,
+    ) -> Result<bool, StageError> {
+        if let Some(entry_point) = self.entry_points.get(&(
+            naga::ShaderStage::Fragment,
+            String::from(fragment.stage.entry_point.as_ref()),
+        )) {
+            Ok(entry_point.dual_source_blending)
+        } else {
+            Err(StageError::MissingEntryPoint(String::from(
+                fragment.stage.entry_point.as_ref(),
+            )))
+        }
+    }
 }

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -116,6 +116,7 @@ struct EntryPoint {
     spec_constants: Vec<SpecializationConstant>,
     sampling_pairs: FastHashSet<(naga::Handle<Resource>, naga::Handle<Resource>)>,
     workgroup_size: [u32; 3],
+    dual_source_blending: bool,
 }
 
 #[derive(Debug)]
@@ -903,7 +904,7 @@ impl Interface {
                 ep.sampling_pairs
                     .insert((resource_mapping[&key.image], resource_mapping[&key.sampler]));
             }
-
+            ep.dual_source_blending = info.dual_source_blending;
             ep.workgroup_size = entry_point.workgroup_size;
 
             entry_points.insert((entry_point.stage, entry_point.name.clone()), ep);
@@ -1176,5 +1177,11 @@ impl Interface {
             })
             .collect();
         Ok(outputs)
+    }
+
+    pub fn has_dual_source_blending_entry_point(&self) -> bool {
+        self.entry_points
+            .values()
+            .any(|point| point.dual_source_blending)
     }
 }

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1179,24 +1179,14 @@ impl Interface {
         Ok(outputs)
     }
 
-    pub fn has_dual_source_blending_entry_point(&self) -> bool {
-        self.entry_points
-            .values()
-            .any(|point| point.dual_source_blending)
-    }
-    pub fn is_fragment_entry_dual_source<'a>(
+    pub fn fragment_uses_dual_source_blending(
         &self,
-        fragment: &crate::pipeline::FragmentState<'a>,
+        entry_point_name: &str,
     ) -> Result<bool, StageError> {
-        if let Some(entry_point) = self.entry_points.get(&(
-            naga::ShaderStage::Fragment,
-            String::from(fragment.stage.entry_point.as_ref()),
-        )) {
-            Ok(entry_point.dual_source_blending)
-        } else {
-            Err(StageError::MissingEntryPoint(String::from(
-                fragment.stage.entry_point.as_ref(),
-            )))
-        }
+        let pair = (naga::ShaderStage::Fragment, entry_point_name.to_string());
+        self.entry_points
+            .get(&pair)
+            .ok_or(StageError::MissingEntryPoint(pair.1))
+            .map(|ep| ep.dual_source_blending)
     }
 }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -251,7 +251,7 @@ impl super::Adapter {
             | wgt::Features::PUSH_CONSTANTS
             | wgt::Features::SHADER_PRIMITIVE_INDEX
             | wgt::Features::RG11B10UFLOAT_RENDERABLE
-            | wgt::Features::BLEND_FUNC_EXTENDED;
+            | wgt::Features::DUAL_SOURCE_BLENDING;
 
         //TODO: in order to expose this, we need to run a compute shader
         // that extract the necessary statistics out of the D3D12 result.

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -250,7 +250,9 @@ impl super::Adapter {
             | wgt::Features::TEXTURE_FORMAT_16BIT_NORM
             | wgt::Features::PUSH_CONSTANTS
             | wgt::Features::SHADER_PRIMITIVE_INDEX
-            | wgt::Features::RG11B10UFLOAT_RENDERABLE;
+            | wgt::Features::RG11B10UFLOAT_RENDERABLE
+            | wgt::Features::BLEND_FUNC_EXTENDED;
+
         //TODO: in order to expose this, we need to run a compute shader
         // that extract the necessary statistics out of the D3D12 result.
         // Alternatively, we could allocate a buffer for the query set,

--- a/wgpu-hal/src/dx12/conv.rs
+++ b/wgpu-hal/src/dx12/conv.rs
@@ -246,12 +246,12 @@ fn map_blend_factor(factor: wgt::BlendFactor, is_alpha: bool) -> d3d12_ty::D3D12
         Bf::Constant => d3d12_ty::D3D12_BLEND_BLEND_FACTOR,
         Bf::OneMinusConstant => d3d12_ty::D3D12_BLEND_INV_BLEND_FACTOR,
         Bf::SrcAlphaSaturated => d3d12_ty::D3D12_BLEND_SRC_ALPHA_SAT,
-        //Bf::Src1Color if is_alpha => d3d12_ty::D3D12_BLEND_SRC1_ALPHA,
-        //Bf::Src1Color => d3d12_ty::D3D12_BLEND_SRC1_COLOR,
-        //Bf::OneMinusSrc1Color if is_alpha => d3d12_ty::D3D12_BLEND_INV_SRC1_ALPHA,
-        //Bf::OneMinusSrc1Color => d3d12_ty::D3D12_BLEND_INV_SRC1_COLOR,
-        //Bf::Src1Alpha => d3d12_ty::D3D12_BLEND_SRC1_ALPHA,
-        //Bf::OneMinusSrc1Alpha => d3d12_ty::D3D12_BLEND_INV_SRC1_ALPHA,
+        Bf::Src1 if is_alpha => d3d12_ty::D3D12_BLEND_SRC1_ALPHA,
+        Bf::Src1 => d3d12_ty::D3D12_BLEND_SRC1_COLOR,
+        Bf::OneMinusSrc1 if is_alpha => d3d12_ty::D3D12_BLEND_INV_SRC1_ALPHA,
+        Bf::OneMinusSrc1 => d3d12_ty::D3D12_BLEND_INV_SRC1_COLOR,
+        Bf::Src1Alpha => d3d12_ty::D3D12_BLEND_SRC1_ALPHA,
+        Bf::OneMinusSrc1Alpha => d3d12_ty::D3D12_BLEND_INV_SRC1_ALPHA,
     }
 }
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -364,6 +364,10 @@ impl super::Adapter {
             extensions.contains("OVR_multiview2"),
         );
         features.set(
+            wgt::Features::DUAL_SOURCE_BLENDING,
+            extensions.contains("GL_EXT_blend_func_extended"),
+        );
+        features.set(
             wgt::Features::SHADER_PRIMITIVE_INDEX,
             ver >= (3, 2) || extensions.contains("OES_geometry_shader"),
         );

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -376,6 +376,10 @@ fn map_blend_factor(factor: wgt::BlendFactor) -> u32 {
         Bf::Constant => glow::CONSTANT_COLOR,
         Bf::OneMinusConstant => glow::ONE_MINUS_CONSTANT_COLOR,
         Bf::SrcAlphaSaturated => glow::SRC_ALPHA_SATURATE,
+        Bf::Src1 => glow::SRC1_COLOR,
+        Bf::OneMinusSrc1 => glow::ONE_MINUS_SRC1_COLOR,
+        Bf::Src1Alpha => glow::SRC1_ALPHA,
+        Bf::OneMinusSrc1Alpha => glow::ONE_MINUS_SRC1_ALPHA,
     }
 }
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -796,7 +796,6 @@ impl super::PrivateCapabilities {
                 None
             },
             timestamp_query_support,
-            dual_source_blending: version.at_least((11, 0), (14, 0), os_is_mac),
         }
     }
 
@@ -836,7 +835,7 @@ impl super::PrivateCapabilities {
         );
         features.set(
             F::DUAL_SOURCE_BLENDING,
-            self.msl_version >= MTLLanguageVersion::V1_2,
+            self.msl_version >= MTLLanguageVersion::V1_2 && self.dual_source_blending,
         );
         features.set(F::TEXTURE_COMPRESSION_ASTC, self.format_astc);
         features.set(F::TEXTURE_COMPRESSION_ASTC_HDR, self.format_astc_hdr);

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -796,6 +796,7 @@ impl super::PrivateCapabilities {
                 None
             },
             timestamp_query_support,
+            blend_func_extended: version.at_least((11, 0), (14, 0), os_is_mac),
         }
     }
 
@@ -832,6 +833,10 @@ impl super::PrivateCapabilities {
             F::TIMESTAMP_QUERY_INSIDE_PASSES,
             self.timestamp_query_support
                 .contains(TimestampQuerySupport::INSIDE_WGPU_PASSES),
+        );
+        features.set(
+            F::DUAL_SOURCE_BLENDING,
+            self.msl_version >= MTLLanguageVersion::V1_2,
         );
         features.set(F::TEXTURE_COMPRESSION_ASTC, self.format_astc);
         features.set(F::TEXTURE_COMPRESSION_ASTC_HDR, self.format_astc_hdr);

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -796,7 +796,7 @@ impl super::PrivateCapabilities {
                 None
             },
             timestamp_query_support,
-            blend_func_extended: version.at_least((11, 0), (14, 0), os_is_mac),
+            dual_source_blending: version.at_least((11, 0), (14, 0), os_is_mac),
         }
     }
 

--- a/wgpu-hal/src/metal/conv.rs
+++ b/wgpu-hal/src/metal/conv.rs
@@ -152,8 +152,6 @@ pub fn map_blend_factor(factor: wgt::BlendFactor) -> metal::MTLBlendFactor {
         Bf::OneMinusDstAlpha => OneMinusDestinationAlpha,
         Bf::Constant => BlendColor,
         Bf::OneMinusConstant => OneMinusBlendColor,
-        //Bf::ConstantAlpha => BlendAlpha,
-        //Bf::OneMinusConstantAlpha => OneMinusBlendAlpha,
         Bf::SrcAlphaSaturated => SourceAlphaSaturated,
         Bf::Src1 => Source1Color,
         Bf::OneMinusSrc1 => OneMinusSource1Color,

--- a/wgpu-hal/src/metal/conv.rs
+++ b/wgpu-hal/src/metal/conv.rs
@@ -155,10 +155,10 @@ pub fn map_blend_factor(factor: wgt::BlendFactor) -> metal::MTLBlendFactor {
         //Bf::ConstantAlpha => BlendAlpha,
         //Bf::OneMinusConstantAlpha => OneMinusBlendAlpha,
         Bf::SrcAlphaSaturated => SourceAlphaSaturated,
-        //Bf::Src1 => Source1Color,
-        //Bf::OneMinusSrc1 => OneMinusSource1Color,
-        //Bf::Src1Alpha => Source1Alpha,
-        //Bf::OneMinusSrc1Alpha => OneMinusSource1Alpha,
+        Bf::Src1 => Source1Color,
+        Bf::OneMinusSrc1 => OneMinusSource1Color,
+        Bf::Src1Alpha => Source1Alpha,
+        Bf::OneMinusSrc1Alpha => OneMinusSource1Alpha,
     }
 }
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -177,6 +177,7 @@ impl PhysicalDeviceFeatures {
                 //.shader_resource_residency(requested_features.contains(wgt::Features::SHADER_RESOURCE_RESIDENCY))
                 .geometry_shader(requested_features.contains(wgt::Features::SHADER_PRIMITIVE_INDEX))
                 .depth_clamp(requested_features.contains(wgt::Features::DEPTH_CLIP_CONTROL))
+                .dual_src_blend(requested_features.contains(wgt::Features::DUAL_SOURCE_BLENDING))
                 .build(),
             descriptor_indexing: if requested_features.intersects(indexing_features()) {
                 Some(
@@ -460,6 +461,7 @@ impl PhysicalDeviceFeatures {
         }
 
         features.set(F::DEPTH_CLIP_CONTROL, self.core.depth_clamp != 0);
+        features.set(F::DUAL_SOURCE_BLENDING, self.core.dual_src_blend != 0);
 
         if let Some(ref multiview) = self.multiview {
             features.set(F::MULTIVIEW, multiview.multiview != 0);

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -792,6 +792,10 @@ fn map_blend_factor(factor: wgt::BlendFactor) -> vk::BlendFactor {
         Bf::SrcAlphaSaturated => vk::BlendFactor::SRC_ALPHA_SATURATE,
         Bf::Constant => vk::BlendFactor::CONSTANT_COLOR,
         Bf::OneMinusConstant => vk::BlendFactor::ONE_MINUS_CONSTANT_COLOR,
+        Bf::Src1 => vk::BlendFactor::SRC1_COLOR,
+        Bf::OneMinusSrc1 => vk::BlendFactor::ONE_MINUS_SRC1_COLOR,
+        Bf::Src1Alpha => vk::BlendFactor::SRC1_ALPHA,
+        Bf::OneMinusSrc1Alpha => vk::BlendFactor::ONE_MINUS_SRC1_ALPHA,
     }
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -792,8 +792,6 @@ bitflags::bitflags! {
         /// - Vulkan (with dualSrcBlend)
         /// - DX12
         const DUAL_SOURCE_BLENDING = 1 << 63;
-
-        // no more space left
     }
 }
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -421,6 +421,15 @@ fn map_blend_factor(factor: wgt::BlendFactor) -> web_sys::GpuBlendFactor {
         BlendFactor::SrcAlphaSaturated => bf::SrcAlphaSaturated,
         BlendFactor::Constant => bf::Constant,
         BlendFactor::OneMinusConstant => bf::OneMinusConstant,
+        BlendFactor::Src1
+        | BlendFactor::OneMinusSrc1
+        | BlendFactor::Src1Alpha
+        | BlendFactor::OneMinusSrc1Alpha => {
+            panic!(
+                "{:?} is not enabled for this backend",
+                wgt::Features::DUAL_SOURCE_BLENDING
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Support writing shaders with alt blender mode.
See https://github.com/freqmod/helicoid/tree/master/helicoid-wgpu for usage example.

**Checklist**
- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file. TBD: This is a PR to get initial feedback.

**Connections**
Resolves https://github.com/gfx-rs/wgpu/issues/1804.
Depends on https://github.com/gfx-rs/naga/pull/2427.

**Description**
See issue 1804 (linked above)

**Testing**
Tested on linux with OpenGL, and Vulkan, and on Mac using metal. I have made some changes for Direct X but since I don't have a windows build environment I haven't tested that.
Tested in the helicoid-wgpu crate in external repo, I guess a test or example could be made if we deem it useful.

