### PR TITLE
[vk] Don't request portability enumeration without the extension.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ By @Valaphee in [#3402](https://github.com/gfx-rs/wgpu/pull/3402)
 #### Vulkan
 - Fix enabling `wgpu::Features::PARTIALLY_BOUND_BINDING_ARRAY` not being actually enabled in vulkan backend. By @39ali in[#3772](https://github.com/gfx-rs/wgpu/pull/3772).
 
+- Don't pass `vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR` unless the `VK_KHR_portability_enumeration` extension is available. By @jimblandy in[#4038](https://github.com/gfx-rs/wgpu/pull/4038).
+
 #### DX12
 
 - DX12 doesn't support `Features::POLYGON_MODE_POINT``. By @teoxoy in [#4032](https://github.com/gfx-rs/wgpu/pull/4032).

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -667,11 +667,8 @@ impl crate::Instance<super::Api> for super::Instance {
                 })
                 .collect::<Vec<_>>();
 
-            const VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR: u32 = 0x00000001;
             let create_info = vk::InstanceCreateInfo::builder()
-                .flags(vk::InstanceCreateFlags::from_raw(
-                    VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR,
-                ))
+                .flags(vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR)
                 .application_info(&app_info)
                 .enabled_layer_names(&str_pointers[..layers.len()])
                 .enabled_extension_names(&str_pointers[layers.len()..]);

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -589,6 +589,11 @@ impl crate::Instance<super::Api> for super::Instance {
 
         let extensions = Self::required_extensions(&entry, driver_api_version, desc.flags)?;
 
+        let portability_enumeration_extension =
+            CStr::from_bytes_with_nul(b"VK_KHR_portability_enumeration\0").unwrap();
+        let has_portability_enumeration_extension =
+            extensions.contains(&portability_enumeration_extension);
+
         let instance_layers = entry.enumerate_instance_layer_properties().map_err(|e| {
             log::info!("enumerate_instance_layer_properties: {:?}", e);
             crate::InstanceError
@@ -657,6 +662,15 @@ impl crate::Instance<super::Api> for super::Instance {
         #[cfg(not(target_os = "android"))]
         let android_sdk_version = 0;
 
+        let mut flags = vk::InstanceCreateFlags::empty();
+
+        // Avoid VUID-VkInstanceCreateInfo-flags-06559: Only ask the instance to
+        // enumerate incomplete Vulkan implementations (which we need on Mac) if
+        // we managed to find the extension that provides the flag.
+        if has_portability_enumeration_extension {
+            flags |= vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR;
+        }
+
         let vk_instance = {
             let str_pointers = layers
                 .iter()
@@ -668,7 +682,7 @@ impl crate::Instance<super::Api> for super::Instance {
                 .collect::<Vec<_>>();
 
             let create_info = vk::InstanceCreateInfo::builder()
-                .flags(vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR)
+                .flags(flags)
                 .application_info(&app_info)
                 .enabled_layer_names(&str_pointers[..layers.len()])
                 .enabled_extension_names(&str_pointers[layers.len()..]);


### PR DESCRIPTION
VUID-VkInstanceCreateInfo-flags-06559 forbids us from passing `vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR` unless we actually found and requested the "VK_KHR_portability_enumeration" layer.

Fixes #4004.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Testing**
This is covered by `wgpu-test::wgpu-tests encoder::drop_encoder`.
