### PR TITLE
Add get_mapped_range_as_array_buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ By @fornwall in [#3904](https://github.com/gfx-rs/wgpu/pull/3904) and [#3905](ht
 
 - Empty scissor rects are allowed now, matching the specification. by @PJB3005 in [#3863](https://github.com/gfx-rs/wgpu/pull/3863).
 - Add back components info to `TextureFormat`s. By @teoxoy in [#3843](https://github.com/gfx-rs/wgpu/pull/3843).
+- Add `get_mapped_range_as_array_buffer` for faster buffer read-backs in wasm builds. By @ryankaplan in [#4042] (https://github.com/gfx-rs/wgpu/pull/4042).
 
 ### Documentation
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1890,16 +1890,26 @@ impl crate::context::Context for Context {
         buffer_data: &Self::BufferData,
         sub_range: Range<wgt::BufferAddress>,
     ) -> Box<dyn crate::context::BufferMappedRange> {
-        let array_buffer = buffer_data.0.get_mapped_range_with_f64_and_f64(
-            sub_range.start as f64,
-            (sub_range.end - sub_range.start) as f64,
-        );
+        let array_buffer =
+            self.buffer_get_mapped_range_as_array_buffer(_buffer, buffer_data, sub_range);
         let actual_mapping = js_sys::Uint8Array::new(&array_buffer);
         let temporary_mapping = actual_mapping.to_vec();
         Box::new(BufferMappedRange {
             actual_mapping,
             temporary_mapping,
         })
+    }
+
+    fn buffer_get_mapped_range_as_array_buffer(
+        &self,
+        _buffer: &Self::BufferId,
+        buffer_data: &Self::BufferData,
+        sub_range: Range<wgt::BufferAddress>,
+    ) -> js_sys::ArrayBuffer {
+        buffer_data.0.get_mapped_range_with_f64_and_f64(
+            sub_range.start as f64,
+            (sub_range.end - sub_range.start) as f64,
+        )
     }
 
     fn buffer_unmap(&self, _buffer: &Self::BufferId, buffer_data: &Self::BufferData) {

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -307,6 +307,16 @@ pub trait Context: Debug + WasmNotSend + WasmNotSync + Sized {
         buffer_data: &Self::BufferData,
         sub_range: Range<BufferAddress>,
     ) -> Box<dyn BufferMappedRange>;
+    #[cfg(all(
+        target_arch = "wasm32",
+        not(any(target_os = "emscripten", feature = "webgl"))
+    ))]
+    fn buffer_get_mapped_range_as_array_buffer(
+        &self,
+        buffer: &Self::BufferId,
+        buffer_data: &Self::BufferData,
+        sub_range: Range<BufferAddress>,
+    ) -> js_sys::ArrayBuffer;
     fn buffer_unmap(&self, buffer: &Self::BufferId, buffer_data: &Self::BufferData);
     fn texture_create_view(
         &self,
@@ -1386,6 +1396,16 @@ pub(crate) trait DynContext: Debug + WasmNotSend + WasmNotSync {
         buffer_data: &crate::Data,
         sub_range: Range<BufferAddress>,
     ) -> Box<dyn BufferMappedRange>;
+    #[cfg(all(
+        target_arch = "wasm32",
+        not(any(target_os = "emscripten", feature = "webgl"))
+    ))]
+    fn buffer_get_mapped_range_as_array_buffer(
+        &self,
+        buffer: &ObjectId,
+        buffer_data: &crate::Data,
+        sub_range: Range<BufferAddress>,
+    ) -> js_sys::ArrayBuffer;
     fn buffer_unmap(&self, buffer: &ObjectId, buffer_data: &crate::Data);
     fn texture_create_view(
         &self,
@@ -2469,6 +2489,21 @@ where
         let buffer = <T::BufferId>::from(*buffer);
         let buffer_data = downcast_ref(buffer_data);
         Context::buffer_get_mapped_range(self, &buffer, buffer_data, sub_range)
+    }
+
+    #[cfg(all(
+        target_arch = "wasm32",
+        not(any(target_os = "emscripten", feature = "webgl"))
+    ))]
+    fn buffer_get_mapped_range_as_array_buffer(
+        &self,
+        buffer: &ObjectId,
+        buffer_data: &crate::Data,
+        sub_range: Range<BufferAddress>,
+    ) -> js_sys::ArrayBuffer {
+        let buffer = <T::BufferId>::from(*buffer);
+        let buffer_data = downcast_ref(buffer_data);
+        Context::buffer_get_mapped_range_as_array_buffer(self, &buffer, buffer_data, sub_range)
     }
 
     fn buffer_unmap(&self, buffer: &ObjectId, buffer_data: &crate::Data) {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

This change came out of this discussion: https://matrix.to/#/!XFRnMvAfptAHthwBCx:matrix.org/$DUm42m4q3w5SsU6oDki7aXSyLnA2RkC-zQh7Be2rhKE?via=matrix.org&via=fachschaften.org&via=jepcraft.ddns.net%3A443

There isn't a GitHub issue for this but I'm happy to create one if that would be useful.

**Description**

I'm using wgpu in a wasm build and occasionally want to read texture data in Javascript. Right now when I do that, the data goes from WebGPU -> Uint8Array -> Rust heap -> Uint8Array. That's a lot of copies 😅

This PR adds `Buffer::buffer_get_mapped_range_as_array_buffer` which bypasses the copy into the Rust heap. It passes the Uint8Array that rust gets from JS directly to the caller, who can then pass it back to their own JS code.

**Testing**

This is my first change to wgpu -- please feel free to tell me to check extra things to be sure I didn't break anything.

I didn't see a way to add automated tests for this, but I've been using this new API with code that is very similar to this example and it works great: https://github.com/gfx-rs/wgpu/blob/trunk/examples/capture/src/main.rs#L158

