### PR TITLE
Fix `capture` example panic in the browser

### DIFF
--- a/examples/capture/src/main.rs
+++ b/examples/capture/src/main.rs
@@ -148,13 +148,13 @@ async fn create_png(
     //
     // We pass our submission index so we don't need to wait for any other possible submissions.
     device.poll(wgpu::Maintain::WaitForSubmissionIndex(submission_index));
-    // If a file system is available, write the buffer as a PNG
-    let has_file_system_available = cfg!(not(target_arch = "wasm32"));
-    if !has_file_system_available {
-        return;
-    }
 
     if let Some(Ok(())) = receiver.receive().await {
+        // If a file system is available, write the buffer as a PNG
+        let has_file_system_available = cfg!(not(target_arch = "wasm32"));
+        if !has_file_system_available {
+            return;
+        }
         let padded_buffer = buffer_slice.get_mapped_range();
 
         let mut png_encoder = png::Encoder::new(


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/gfx-rs/wgpu/issues/4041

**Testing**
Tested on macOS and Chrome | Firefox Nightly
