### PR TITLE
Better way to handle vk khr portability enumeration extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ By @Valaphee in [#3402](https://github.com/gfx-rs/wgpu/pull/3402)
 
 - Don't pass `vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR` unless the `VK_KHR_portability_enumeration` extension is available. By @jimblandy in[#4038](https://github.com/gfx-rs/wgpu/pull/4038).
 
+- Enhancement of [#4038], using ash's definition instead of hard-coded c_str. By @hybcloud in[#4044](https://github.com/gfx-rs/wgpu/pull/4044).
+
 #### DX12
 
 - DX12 doesn't support `Features::POLYGON_MODE_POINT``. By @teoxoy in [#4032](https://github.com/gfx-rs/wgpu/pull/4032).

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -228,8 +228,7 @@ impl super::Instance {
         if cfg!(target_os = "macos") {
             // VK_EXT_metal_surface
             extensions.push(ext::MetalSurface::name());
-            extensions
-                .push(CStr::from_bytes_with_nul(b"VK_KHR_portability_enumeration\0").unwrap());
+            extensions.push(ash::vk::KhrPortabilityEnumerationFn::name());
         }
 
         if flags.contains(crate::InstanceFlags::DEBUG) {
@@ -589,11 +588,6 @@ impl crate::Instance<super::Api> for super::Instance {
 
         let extensions = Self::required_extensions(&entry, driver_api_version, desc.flags)?;
 
-        let portability_enumeration_extension =
-            CStr::from_bytes_with_nul(b"VK_KHR_portability_enumeration\0").unwrap();
-        let has_portability_enumeration_extension =
-            extensions.contains(&portability_enumeration_extension);
-
         let instance_layers = entry.enumerate_instance_layer_properties().map_err(|e| {
             log::info!("enumerate_instance_layer_properties: {:?}", e);
             crate::InstanceError
@@ -667,7 +661,7 @@ impl crate::Instance<super::Api> for super::Instance {
         // Avoid VUID-VkInstanceCreateInfo-flags-06559: Only ask the instance to
         // enumerate incomplete Vulkan implementations (which we need on Mac) if
         // we managed to find the extension that provides the flag.
-        if has_portability_enumeration_extension {
+        if extensions.contains(&ash::vk::KhrPortabilityEnumerationFn::name()) {
             flags |= vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR;
         }
 


### PR DESCRIPTION
Better way to handle vk khr portability enumeration extension of hard-coded c_str.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
#4038
#3958
https://github.com/ash-rs/ash/blob/f5587619979b791c8d37110393c4a9b4c50e0a34/examples/src/lib.rs#L235

**Description**
The PR enhances the solution of #4038, which solves the bug introduced in #3958 by using ash's KHR definition (semantically, it's the funtion's name, not extension's name, but they share the same name, and ash uses it as extension's name in its own
example code 
(https://github.com/ash-rs/ash/blob/f5587619979b791c8d37110393c4a9b4c50e0a34/examples/src/lib.rs#L235)
(In ash's example code just mentioned, they requires another extension called KhrGetPhysicalDeviceProperties2. The extension is a KHR in vk1.0 but soon get into core in vk 1.1, and I don't have a mac to test if it matters, so I choose to keep it right the same as before)
)

**Testing**
Thanks to #4038,  validation layers on windows stop reporting error about VK_KHR_portability_subset. It's a simple enhancement of #4038, and wgpu example (hello-triangle) has been shown to work fine when backends flag is VULKAN.
