### PR TITLE
Extra limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ By @fornwall in [#3904](https://github.com/gfx-rs/wgpu/pull/3904) and [#3905](ht
 #### Misc Breaking Changes
 
 - Change `AdapterInfo::{device,vendor}` to be `u32` instead of `usize`. By @ameknite in [#3760](https://github.com/gfx-rs/wgpu/pull/3760)
+- Optionally specify extra limits at the instance level by @nical in [#4053](https://github.com/gfx-rs/wgpu/pull/4053)
 
 ### Changes
 

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -406,6 +406,7 @@ pub async fn op_webgpu_request_adapter(
             wgpu_types::InstanceDescriptor {
                 backends,
                 dx12_shader_compiler: wgpu_types::Dx12Compiler::Fxc,
+                extra_limits: None,
             },
         )));
         state.borrow::<Instance>()

--- a/examples/capture/src/main.rs
+++ b/examples/capture/src/main.rs
@@ -40,6 +40,7 @@ async fn create_red_image_with_dimensions(
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends,
         dx12_shader_compiler: wgpu::Dx12Compiler::default(),
+        extra_limits: None,
     });
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions::default())

--- a/examples/common/src/framework.rs
+++ b/examples/common/src/framework.rs
@@ -159,6 +159,7 @@ async fn setup<E: Example>(title: &str) -> Setup {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends,
         dx12_shader_compiler,
+        extra_limits: None,
     });
     let (size, surface) = unsafe {
         let size = window.inner_size();

--- a/examples/timestamp-queries/src/main.rs
+++ b/examples/timestamp-queries/src/main.rs
@@ -179,6 +179,7 @@ async fn run() {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends,
         dx12_shader_compiler: wgpu::Dx12Compiler::default(),
+        extra_limits: None,
     });
 
     // `request_adapter` instantiates the general connection to the GPU

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -185,6 +185,7 @@ impl Corpus {
             wgt::InstanceDescriptor {
                 backends: corpus.backends,
                 dx12_shader_compiler: wgt::Dx12Compiler::Fxc,
+                extra_limits: None,
             },
         );
         for &backend in BACKENDS {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -351,6 +351,7 @@ fn initialize_adapter() -> (Adapter, SurfaceGuard) {
     let instance = Instance::new(wgpu::InstanceDescriptor {
         backends,
         dx12_shader_compiler,
+        extra_limits: None,
     });
     let surface_guard;
     let compatible_surface;

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -36,3 +36,76 @@ fn device_mismatch() {
         ctx.device.poll(wgpu::Maintain::Poll);
     });
 }
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn extra_limits() {
+    let max_buffer_size = 8192;
+
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        extra_limits: Some(Box::new(wgpu::Limits {
+            max_buffer_size,
+            ..Default::default()
+        })),
+        ..Default::default()
+    });
+
+    for adapter in instance.enumerate_adapters(wgpu::Backends::all()) {
+        assert!(
+            adapter.limits().max_buffer_size <= max_buffer_size,
+            "adapter.max_buffer_size {:?} should be <= {max_buffer_size}",
+            adapter.limits().max_buffer_size
+        );
+    }
+
+    let adapter = pollster::block_on(wgpu::util::initialize_adapter_from_env_or_default(
+        &instance, None,
+    ))
+    .expect("No suitable GPU adapters found on the system!");
+
+    assert!(adapter.limits().max_buffer_size <= max_buffer_size);
+
+    let should_fail = pollster::block_on(adapter.request_device(
+        &wgpu::DeviceDescriptor {
+            label: None,
+            features: wgpu::Features::default(),
+            limits: wgpu::Limits {
+                max_buffer_size: max_buffer_size + 1,
+                ..Default::default()
+            },
+        },
+        None,
+    ));
+
+    assert!(should_fail.is_err());
+
+    let (device, _) = pollster::block_on(adapter.request_device(
+        &wgpu::DeviceDescriptor {
+            label: None,
+            features: wgpu::Features::default(),
+            limits: wgpu::Limits {
+                max_buffer_size,
+                ..Default::default()
+            },
+        },
+        None,
+    ))
+    .unwrap();
+
+    device.push_error_scope(wgpu::ErrorFilter::Validation);
+
+    let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 9000,
+            usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::MAP_WRITE,
+            mapped_at_creation: false,
+        });
+    }))
+    .is_err();
+
+    let validation_failed = pollster::block_on(device.pop_error_scope()).is_some();
+
+    assert!(!panicked);
+    assert!(validation_failed);
+}

--- a/tests/tests/instance.rs
+++ b/tests/tests/instance.rs
@@ -6,6 +6,7 @@ fn initialize() {
     let _ = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all),
         dx12_shader_compiler: wgpu::util::dx12_shader_compiler_from_env().unwrap_or_default(),
+        extra_limits: None,
     });
 }
 
@@ -13,6 +14,7 @@ fn request_adapter_inner(power: wgt::PowerPreference) {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all),
         dx12_shader_compiler: wgpu::util::dx12_shader_compiler_from_env().unwrap_or_default(),
+        extra_limits: None,
     });
 
     let _adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -26,13 +26,15 @@ pub struct GlobalReport {
 pub struct Global<G: GlobalIdentityHandlerFactory> {
     pub instance: Instance,
     pub surfaces: Registry<Surface, id::SurfaceId, G>,
+    pub extra_limits: Option<Box<wgt::Limits>>,
     pub(crate) hubs: Hubs<G>,
 }
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
-    pub fn new(name: &str, factory: G, instance_desc: wgt::InstanceDescriptor) -> Self {
+    pub fn new(name: &str, factory: G, mut instance_desc: wgt::InstanceDescriptor) -> Self {
         profiling::scope!("Global::new");
         Self {
+            extra_limits: instance_desc.extra_limits.take(),
             instance: Instance::new(name, instance_desc),
             surfaces: Registry::without_backend(&factory, "Surface"),
             hubs: Hubs::new(&factory),
@@ -52,6 +54,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             instance: A::create_instance_from_hal(name, hal_instance),
             surfaces: Registry::without_backend(&factory, "Surface"),
             hubs: Hubs::new(&factory),
+            extra_limits: None,
         }
     }
 
@@ -71,6 +74,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             instance,
             surfaces: Registry::without_backend(&factory, "Surface"),
             hubs: Hubs::new(&factory),
+            extra_limits: None,
         }
     }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1194,6 +1194,61 @@ impl Limits {
         compare!(max_compute_workgroups_per_dimension, Less);
         compare!(max_buffer_size, Less);
     }
+
+    /// Combine limits so to make a more restrictive set of limits.
+    pub fn restrict(&self, restrictions: &Self) -> Self {
+        macro_rules! combine_limits {
+            (
+                keep lowest: {
+                    $($name_lo:ident),+
+                }
+                keep highest: {
+                    $($name_hi:ident),+
+                }
+            ) => (
+                Self {
+                    $($name_lo: self.$name_lo.min(restrictions.$name_lo),)+
+                    $($name_hi: self.$name_hi.max(restrictions.$name_hi),)+
+                }
+            );
+        }
+
+        combine_limits! {
+            keep lowest: {
+                max_texture_dimension_1d,
+                max_texture_dimension_2d,
+                max_texture_dimension_3d,
+                max_texture_array_layers,
+                max_bindings_per_bind_group,
+                max_bind_groups,
+                max_dynamic_uniform_buffers_per_pipeline_layout,
+                max_dynamic_storage_buffers_per_pipeline_layout,
+                max_sampled_textures_per_shader_stage,
+                max_samplers_per_shader_stage,
+                max_storage_buffers_per_shader_stage,
+                max_storage_textures_per_shader_stage,
+                max_uniform_buffers_per_shader_stage,
+                max_uniform_buffer_binding_size,
+                max_storage_buffer_binding_size,
+                max_vertex_buffers,
+                max_vertex_attributes,
+                max_vertex_buffer_array_stride,
+                max_push_constant_size,
+                max_inter_stage_shader_components,
+                max_compute_workgroup_storage_size,
+                max_compute_invocations_per_workgroup,
+                max_compute_workgroup_size_x,
+                max_compute_workgroup_size_y,
+                max_compute_workgroup_size_z,
+                max_compute_workgroups_per_dimension,
+                max_buffer_size
+            }
+            keep highest: {
+                min_uniform_buffer_offset_alignment,
+                min_storage_buffer_offset_alignment
+            }
+        }
+    }
 }
 
 /// Represents the sets of additional limits on an adapter,
@@ -6405,6 +6460,8 @@ pub struct InstanceDescriptor {
     pub backends: Backends,
     /// Which DX12 shader compiler to use.
     pub dx12_shader_compiler: Dx12Compiler,
+    /// Optionally impose extra limits on all adapters.
+    pub extra_limits: Option<Box<Limits>>,
 }
 
 impl Default for InstanceDescriptor {
@@ -6412,6 +6469,7 @@ impl Default for InstanceDescriptor {
         Self {
             backends: Backends::all(),
             dx12_shader_compiler: Dx12Compiler::default(),
+            extra_limits: None,
         }
     }
 }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**


**Description**

In gecko we want to be able to impose limits on the devices we expose to web content that are potentially more conservative than what the device may advertise.

This PR adds allows optionally specifying extra limits at the instance level. If so, enumerated adapters will pretend to be at least as limited as the provided extra limits.

For example if the extra limits have `max_texture_size` set to `4096` and the device exposes adapters with max texture sizes of `8192`, then the user will see `4096` when looking in the limits of enumerated adapters, and more importantly, the `4096` limit will be enforced during validation.

To specify some limits and leave others untouched, the rule of thumb is to use the maximum value for limits that start with `max` and zero for limits that start with  `min`.

**Testing**

Yep.