### PR TITLE
Add validation in accordance with WebGPU `setViewport` valid usage fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ By @Valaphee in [#3402](https://github.com/gfx-rs/wgpu/pull/3402)
 
 - Omit texture store bound checks since they are no-ops if out of bounds on all APIs. By @teoxoy in [#3975](https://github.com/gfx-rs/wgpu/pull/3975)
 - Validate `DownlevelFlags::READ_ONLY_DEPTH_STENCIL`. By @teoxoy in [#4031](https://github.com/gfx-rs/wgpu/pull/4031)
+- Add validation in accordance with WebGPU `setViewport` valid usage for `x`, `y` and `this.[[attachment_size]]`. By @James2022-rgb in [#4058](https://github.com/gfx-rs/wgpu/pull/4058)
 
 ### Bug Fixes
 

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -89,8 +89,8 @@ pub enum RenderCommandError {
     MissingTextureUsage(#[from] MissingTextureUsageError),
     #[error(transparent)]
     PushConstants(#[from] PushConstantUploadError),
-    #[error("Viewport width {0} and/or height {1} are less than or equal to 0")]
-    InvalidViewportDimension(f32, f32),
+    #[error("Viewport has invalid rect {0:?}; origin and/or size is less than or equal to 0, and/or is not contained in the render target {1:?}")]
+    InvalidViewportRect(Rect<f32>, wgt::Extent3d),
     #[error("Viewport minDepth {0} and/or maxDepth {1} are not in [0, 1]")]
     InvalidViewportDepth(f32, f32),
     #[error("Scissor {0:?} is not contained in the render target {1:?}")]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1727,9 +1727,16 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         depth_max,
                     } => {
                         let scope = PassErrorScope::SetViewport;
-                        if rect.w <= 0.0 || rect.h <= 0.0 {
-                            return Err(RenderCommandError::InvalidViewportDimension(
-                                rect.w, rect.h,
+                        if rect.x < 0.0
+                            || rect.y < 0.0
+                            || rect.w <= 0.0
+                            || rect.h <= 0.0
+                            || rect.x + rect.w > info.extent.width as f32
+                            || rect.y + rect.h > info.extent.height as f32
+                        {
+                            return Err(RenderCommandError::InvalidViewportRect(
+                                *rect,
+                                info.extent,
                             ))
                             .map_pass_err(scope);
                         }


### PR DESCRIPTION
…r `x`, `y` and `this.[[attachment_size]]`.

`x` and `y` must not be negative, and the rect must be contained in the render target.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
   Done just in case, with --feature gles.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
For `wgpu::RenderPass::set_viewport`, it was possible to use values such that:
- `x` and/or `y` is negative
- the rect is not contained in the render target.

both of which are in violation of the valid usage defined for `setViewport` in the WebGPU spec:
> x ≥ 0
> y ≥ 0
> x + width ≤ this.[[[attachment_size]]].width
> y + height ≤ this.[[[attachment_size]]].height

This PR renames `RenderCommandError::InvalidViewportDimension` to `InvalidViewportRect` and adds render target extent to it, in the same spirit as `InvalidScissorRect` (which has similar valid usage regarding render target extent).

**Testing**
Tested locally.
