### PR TITLE
[vulkan] Don't bother to free command buffers before destroying the pool.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Bottom level categories:
 
 - Omit texture store bound checks since they are no-ops if out of bounds on all APIs. By @teoxoy in [#3975](https://github.com/gfx-rs/wgpu/pull/3975)
 
+#### Vulkan
+
+- Don't bother calling `vkFreeCommandBuffers` when `vkDestroyCommandPool` will take care of that for us. By @jimblandy in [#4059](https://github.com/gfx-rs/wgpu/pull/4059)
+
 ### Bug Fixes
 
 #### General

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1192,16 +1192,10 @@ impl crate::Device<super::Api> for super::Device {
     }
     unsafe fn destroy_command_encoder(&self, cmd_encoder: super::CommandEncoder) {
         unsafe {
-            if !cmd_encoder.free.is_empty() {
-                self.shared
-                    .raw
-                    .free_command_buffers(cmd_encoder.raw, &cmd_encoder.free)
-            }
-            if !cmd_encoder.discarded.is_empty() {
-                self.shared
-                    .raw
-                    .free_command_buffers(cmd_encoder.raw, &cmd_encoder.discarded)
-            }
+            // `vkDestroyCommandPool` also frees any command buffers allocated
+            // from that pool, so there's no need to explicitly call
+            // `vkFreeCommandBuffers` on `cmd_encoder`'s `free` and `discarded`
+            // fields.
             self.shared.raw.destroy_command_pool(cmd_encoder.raw, None);
         }
     }


### PR DESCRIPTION
Calling `vkDestroyCommandPool` automatically frees all command buffers allocated from that pool, so there is no need for `Device::destroy_command_encoder` to explicitly call `vkFreeCommandBuffers` on the `CommandEncoder`'s `free` and `discarded` lists.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
