### PR TITLE
webgl: Comment why it's okay to overwrite `webgl2_context`.

### DIFF
--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -25,6 +25,7 @@ impl AdapterContext {
 
 #[derive(Debug)]
 pub struct Instance {
+    /// Set when a canvas is provided, and used to implement [`Instance::enumerate_adapters()`].
     webgl2_context: Mutex<Option<web_sys::WebGl2RenderingContext>>,
 }
 
@@ -82,6 +83,8 @@ impl Instance {
             .dyn_into()
             .expect("canvas context is not a WebGl2RenderingContext");
 
+        // It is not inconsistent to overwrite an existing context, because the only thing that
+        // `self.webgl2_context` is used for is producing the response to `enumerate_adapters()`.
         *self.webgl2_context.lock() = Some(webgl2_context.clone());
 
         Ok(Surface {


### PR DESCRIPTION
**Checklist**
- [X] Run `cargo clippy`.
- [X] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] ~~Add change to CHANGELOG.md. See simple instructions inside file.~~ trivial change

**Description**
This looked to me like it would corrupt state, but it doesn't.
These comments will save future readers some worry.

**Testing**
N/A — comments only
