### PR TITLE
Make power_preference_from_env() respect WGPU_POWER_PREF=none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ By @Valaphee in [#3402](https://github.com/gfx-rs/wgpu/pull/3402)
 - Omit texture store bound checks since they are no-ops if out of bounds on all APIs. By @teoxoy in [#3975](https://github.com/gfx-rs/wgpu/pull/3975)
 - Validate `DownlevelFlags::READ_ONLY_DEPTH_STENCIL`. By @teoxoy in [#4031](https://github.com/gfx-rs/wgpu/pull/4031)
 - Add validation in accordance with WebGPU `setViewport` valid usage for `x`, `y` and `this.[[attachment_size]]`. By @James2022-rgb in [#4058](https://github.com/gfx-rs/wgpu/pull/4058)
+- Make `WGPU_POWER_PREF=none` a valid value. By @fornwall in [4076](https://github.com/gfx-rs/wgpu/pull/4076)
 
 #### Vulkan
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ All testing and example infrastructure shares the same set of environment variab
 
 - `WGPU_ADAPTER_NAME` with a substring of the name of the adapter you want to use (ex. `1080` will match `NVIDIA GeForce 1080ti`).
 - `WGPU_BACKEND` with a comma separated list of the backends you want to use (`vulkan`, `metal`, `dx12`, `dx11`, or `gl`).
-- `WGPU_POWER_PREF` with the power preference to choose when a specific adapter name isn't specified (`high` or `low`)
+- `WGPU_POWER_PREF` with the power preference to choose when a specific adapter name isn't specified (`high`, `low` or `none`)
 - `WGPU_DX12_COMPILER` with the DX12 shader compiler you wish to use (`dxc` or `fxc`, note that `dxc` requires `dxil.dll` and `dxcompiler.dll` to be in the working directory otherwise it will fall back to `fxc`)
 - `WGPU_GLES_MINOR_VERSION` with the minor OpenGL ES 3 version number to request (`0`, `1`, `2` or `automatic`).
 

--- a/wgpu/README.md
+++ b/wgpu/README.md
@@ -35,9 +35,9 @@ The following environment variables can be used to configure how the framework e
 
 - `WGPU_POWER_PREF`
 
-  Options: `low`, `high`
+  Options: `low`, `high`, `none`
 
-  If unset a low power adapter is preferred.
+  If unset power usage is not considered when choosing an adapter.
 
 - `WGPU_ADAPTER_NAME`
 

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -30,6 +30,7 @@ pub fn power_preference_from_env() -> Option<PowerPreference> {
         {
             Ok("low") => PowerPreference::LowPower,
             Ok("high") => PowerPreference::HighPerformance,
+            Ok("none") => PowerPreference::None,
             _ => return None,
         },
     )


### PR DESCRIPTION
Also update wgpu/README.md now that default() is None.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Respecting `WGPU_POWER_PREF=none` makes no difference to wgpu testing and examples, as the fallback is already `default()` (which is `PowerPreference::None`), but makes a difference to other projects which for instance uses the logic "check for WGPU_POWER_PREF in the env, otherwise use high power".

Also updates `wgpu/README.md` to reflect that the default is now `None`.

**Testing**
Manually testing.