### PR TITLE
Skip `test_multithreaded_compute` on MoltenVK.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,7 @@ jobs:
           done
 
       - uses: actions/upload-artifact@v3
+        if: always() # We want artifacts even if the tests fail.
         with:
           name: comparison-images
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ By @Valaphee in [#3402](https://github.com/gfx-rs/wgpu/pull/3402)
 
 - Ensure that MTLCommandEncoder calls endEncoding before it is deallocated. By @bradwerth in [#4023](https://github.com/gfx-rs/wgpu/pull/4023)
 
+- Skip `test_multithreaded_compute` on MoltenVK. By @jimblandy in [#4096](https://github.com/gfx-rs/wgpu/pull/4096).
+
 ### Documentation
 
 - Add an overview of `RenderPass` and how render state works. By @kpreid in [#4055](https://github.com/gfx-rs/wgpu/pull/4055)

--- a/examples/boids/src/main.rs
+++ b/examples/boids/src/main.rs
@@ -345,7 +345,7 @@ fn boids() {
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
             // Lots of validation errors, maybe related to https://github.com/gfx-rs/wgpu/issues/3160
-            .molten_vk_failure(false),
+            .expect_fail(wgpu_test::FailureCase::molten_vk()),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.005)],
     });
 }

--- a/examples/boids/src/main.rs
+++ b/examples/boids/src/main.rs
@@ -345,7 +345,7 @@ fn boids() {
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
             // Lots of validation errors, maybe related to https://github.com/gfx-rs/wgpu/issues/3160
-            .molten_vk_failure(),
+            .molten_vk_failure(false),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.005)],
     });
 }

--- a/examples/common/src/framework.rs
+++ b/examples/common/src/framework.rs
@@ -625,7 +625,7 @@ pub fn test<E: Example>(mut params: FrameworkRefTest) {
 
             wgpu_test::image::compare_image_output(
                 env!("CARGO_MANIFEST_DIR").to_string() + "/../../" + params.image_path,
-                ctx.adapter_info.backend,
+                &ctx.adapter_info,
                 params.width,
                 params.height,
                 &bytes,

--- a/examples/hello-compute/src/tests.rs
+++ b/examples/hello-compute/src/tests.rs
@@ -80,14 +80,9 @@ fn test_multithreaded_compute() {
             .features(wgpu::Features::TIMESTAMP_QUERY)
             .adapter_failure_skip("V3D")
             // https://github.com/gfx-rs/wgpu/issues/3944
-            .specific_failure(
-                Some(wgpu::Backends::VULKAN),
-                None,
-                Some("swiftshader"),
-                true,
-            )
+            .backend_adapter_failure(wgpu::Backends::VULKAN, "swiftshader", true)
             // https://github.com/gfx-rs/wgpu/issues/3250
-            .specific_failure(Some(wgpu::Backends::GL), None, Some("llvmpipe"), true),
+            .backend_adapter_failure(wgpu::Backends::GL, "llvmpipe", true),
         |ctx| {
             use std::{sync::mpsc, thread, time::Duration};
 

--- a/examples/hello-compute/src/tests.rs
+++ b/examples/hello-compute/src/tests.rs
@@ -13,7 +13,7 @@ fn test_compute_1() {
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
             .features(wgpu::Features::TIMESTAMP_QUERY)
-            .specific_failure(None, None, Some("V3D"), true),
+            .adapter_failure_skip("V3D"),
         |ctx| {
             let input = &[1, 2, 3, 4];
 
@@ -35,7 +35,7 @@ fn test_compute_2() {
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
             .features(wgpu::Features::TIMESTAMP_QUERY)
-            .specific_failure(None, None, Some("V3D"), true),
+            .adapter_failure_skip("V3D"),
         |ctx| {
             let input = &[5, 23, 10, 9];
 
@@ -57,7 +57,7 @@ fn test_compute_overflow() {
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
             .features(wgpu::Features::TIMESTAMP_QUERY)
-            .specific_failure(None, None, Some("V3D"), true),
+            .adapter_failure_skip("V3D"),
         |ctx| {
             let input = &[77031, 837799, 8400511, 63728127];
             pollster::block_on(assert_execute_gpu(
@@ -78,7 +78,7 @@ fn test_multithreaded_compute() {
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
             .features(wgpu::Features::TIMESTAMP_QUERY)
-            .specific_failure(None, None, Some("V3D"), true)
+            .adapter_failure_skip("V3D")
             // https://github.com/gfx-rs/wgpu/issues/3944
             .specific_failure(
                 Some(wgpu::Backends::VULKAN),

--- a/examples/hello-compute/src/tests.rs
+++ b/examples/hello-compute/src/tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::*;
-use wgpu_test::{initialize_test, TestParameters};
+use wgpu_test::{initialize_test, FailureCase, TestParameters};
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
@@ -13,7 +13,7 @@ fn test_compute_1() {
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
             .features(wgpu::Features::TIMESTAMP_QUERY)
-            .adapter_failure_skip("V3D"),
+            .skip(FailureCase::adapter("V3D")),
         |ctx| {
             let input = &[1, 2, 3, 4];
 
@@ -35,7 +35,7 @@ fn test_compute_2() {
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
             .features(wgpu::Features::TIMESTAMP_QUERY)
-            .adapter_failure_skip("V3D"),
+            .skip(FailureCase::adapter("V3D")),
         |ctx| {
             let input = &[5, 23, 10, 9];
 
@@ -57,7 +57,7 @@ fn test_compute_overflow() {
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
             .features(wgpu::Features::TIMESTAMP_QUERY)
-            .adapter_failure_skip("V3D"),
+            .skip(FailureCase::adapter("V3D")),
         |ctx| {
             let input = &[77031, 837799, 8400511, 63728127];
             pollster::block_on(assert_execute_gpu(
@@ -78,12 +78,15 @@ fn test_multithreaded_compute() {
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
             .features(wgpu::Features::TIMESTAMP_QUERY)
-            .adapter_failure_skip("V3D")
+            .skip(FailureCase::adapter("V3D"))
             // https://github.com/gfx-rs/wgpu/issues/3944
-            .backend_adapter_failure(wgpu::Backends::VULKAN, "swiftshader", true)
+            .skip(FailureCase::backend_adapter(
+                wgpu::Backends::VULKAN,
+                "swiftshader",
+            ))
             // https://github.com/gfx-rs/wgpu/issues/3250
-            .backend_adapter_failure(wgpu::Backends::GL, "llvmpipe", true)
-            .molten_vk_failure(true),
+            .skip(FailureCase::backend_adapter(wgpu::Backends::GL, "llvmpipe"))
+            .skip(FailureCase::molten_vk()),
         |ctx| {
             use std::{sync::mpsc, thread, time::Duration};
 

--- a/examples/hello-compute/src/tests.rs
+++ b/examples/hello-compute/src/tests.rs
@@ -82,7 +82,8 @@ fn test_multithreaded_compute() {
             // https://github.com/gfx-rs/wgpu/issues/3944
             .backend_adapter_failure(wgpu::Backends::VULKAN, "swiftshader", true)
             // https://github.com/gfx-rs/wgpu/issues/3250
-            .backend_adapter_failure(wgpu::Backends::GL, "llvmpipe", true),
+            .backend_adapter_failure(wgpu::Backends::GL, "llvmpipe", true)
+            .molten_vk_failure(true),
         |ctx| {
             use std::{sync::mpsc, thread, time::Duration};
 

--- a/examples/mipmap/src/main.rs
+++ b/examples/mipmap/src/main.rs
@@ -521,7 +521,7 @@ fn mipmap() {
         height: 768,
         optional_features: wgpu::Features::default(),
         base_test_parameters: wgpu_test::TestParameters::default()
-            .backend_failure(wgpu::Backends::GL),
+            .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::GL)),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     });
 }
@@ -535,7 +535,7 @@ fn mipmap_query() {
         height: 768,
         optional_features: QUERY_FEATURES,
         base_test_parameters: wgpu_test::TestParameters::default()
-            .backend_failure(wgpu::Backends::GL),
+            .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::GL)),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     });
 }

--- a/examples/msaa-line/src/main.rs
+++ b/examples/msaa-line/src/main.rs
@@ -329,7 +329,7 @@ fn msaa_line() {
         optional_features: wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
         base_test_parameters: wgpu_test::TestParameters::default()
             // AMD seems to render nothing on DX12 https://github.com/gfx-rs/wgpu/issues/3838
-            .specific_failure(FailureCase {
+            .expect_fail(FailureCase {
                 backends: Some(wgpu::Backends::DX12),
                 vendor: Some(0x1002),
                 ..FailureCase::default()

--- a/examples/msaa-line/src/main.rs
+++ b/examples/msaa-line/src/main.rs
@@ -12,6 +12,9 @@ use std::{borrow::Cow, iter};
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
+#[cfg(test)]
+use wgpu_test::FailureCase;
+
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
 struct Vertex {
@@ -326,7 +329,12 @@ fn msaa_line() {
         optional_features: wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
         base_test_parameters: wgpu_test::TestParameters::default()
             // AMD seems to render nothing on DX12 https://github.com/gfx-rs/wgpu/issues/3838
-            .specific_failure(Some(wgpu::Backends::DX12), Some(0x1002), None, false),
+            .specific_failure(FailureCase {
+                backends: Some(wgpu::Backends::DX12),
+                vendor: Some(0x1002),
+                adapter: None,
+                skip: false,
+            }),
         // There's a lot of natural variance so we check the weighted median too to differentiate
         // real failures from variance.
         comparisons: &[

--- a/examples/msaa-line/src/main.rs
+++ b/examples/msaa-line/src/main.rs
@@ -332,8 +332,7 @@ fn msaa_line() {
             .specific_failure(FailureCase {
                 backends: Some(wgpu::Backends::DX12),
                 vendor: Some(0x1002),
-                adapter: None,
-                skip: false,
+                ..FailureCase::default()
             }),
         // There's a lot of natural variance so we check the weighted median too to differentiate
         // real failures from variance.

--- a/examples/shadow/src/main.rs
+++ b/examples/shadow/src/main.rs
@@ -857,9 +857,9 @@ fn shadow() {
         base_test_parameters: wgpu_test::TestParameters::default()
             .downlevel_flags(wgpu::DownlevelFlags::COMPARISON_SAMPLERS)
             // rpi4 on VK doesn't work: https://gitlab.freedesktop.org/mesa/mesa/-/issues/3916
-            .specific_failure(Some(wgpu::Backends::VULKAN), None, Some("V3D"), false)
+            .backend_adapter_failure(wgpu::Backends::VULKAN, "V3D", false)
             // llvmpipe versions in CI are flaky: https://github.com/gfx-rs/wgpu/issues/2594
-            .specific_failure(Some(wgpu::Backends::VULKAN), None, Some("llvmpipe"), true),
+            .backend_adapter_failure(wgpu::Backends::VULKAN, "llvmpipe", true),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     });
 }

--- a/examples/shadow/src/main.rs
+++ b/examples/shadow/src/main.rs
@@ -857,9 +857,15 @@ fn shadow() {
         base_test_parameters: wgpu_test::TestParameters::default()
             .downlevel_flags(wgpu::DownlevelFlags::COMPARISON_SAMPLERS)
             // rpi4 on VK doesn't work: https://gitlab.freedesktop.org/mesa/mesa/-/issues/3916
-            .backend_adapter_failure(wgpu::Backends::VULKAN, "V3D", false)
+            .expect_fail(wgpu_test::FailureCase::backend_adapter(
+                wgpu::Backends::VULKAN,
+                "V3D",
+            ))
             // llvmpipe versions in CI are flaky: https://github.com/gfx-rs/wgpu/issues/2594
-            .backend_adapter_failure(wgpu::Backends::VULKAN, "llvmpipe", true),
+            .skip(wgpu_test::FailureCase::backend_adapter(
+                wgpu::Backends::VULKAN,
+                "llvmpipe",
+            )),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     });
 }

--- a/examples/skybox/src/main.rs
+++ b/examples/skybox/src/main.rs
@@ -475,10 +475,9 @@ fn skybox() {
         width: 1024,
         height: 768,
         optional_features: wgpu::Features::default(),
-        base_test_parameters: wgpu_test::TestParameters::default().specific_failure(
-            Some(wgpu::Backends::GL),
-            None,
-            Some("ANGLE"),
+        base_test_parameters: wgpu_test::TestParameters::default().backend_adapter_failure(
+            wgpu::Backends::GL,
+            "ANGLE",
             false,
         ),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.015)],

--- a/examples/skybox/src/main.rs
+++ b/examples/skybox/src/main.rs
@@ -475,10 +475,8 @@ fn skybox() {
         width: 1024,
         height: 768,
         optional_features: wgpu::Features::default(),
-        base_test_parameters: wgpu_test::TestParameters::default().backend_adapter_failure(
-            wgpu::Backends::GL,
-            "ANGLE",
-            false,
+        base_test_parameters: wgpu_test::TestParameters::default().expect_fail(
+            wgpu_test::FailureCase::backend_adapter(wgpu::Backends::GL, "ANGLE"),
         ),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.015)],
     });

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -115,7 +115,7 @@ impl TestParameters {
         self
     }
 
-    /// Mark the test as always failing, equivalent to specific_failure(None, None, None)
+    /// Mark the test as always failing, but not to be skipped.
     pub fn failure(mut self) -> Self {
         self.failures.push(FailureCase {
             backends: None,
@@ -126,7 +126,7 @@ impl TestParameters {
         self
     }
 
-    /// Mark the test as always failing and needing to be skipped, equivalent to specific_failure(None, None, None)
+    /// Mark the test as always failing, and needing to be skipped.
     pub fn skip(mut self) -> Self {
         self.failures.push(FailureCase {
             backends: None,
@@ -137,7 +137,7 @@ impl TestParameters {
         self
     }
 
-    /// Mark the test as always failing on a specific backend, equivalent to specific_failure(backend, None, None)
+    /// Mark the test as always failing on `backends`, but not to be skipped.
     pub fn backend_failure(mut self, backends: wgpu::Backends) -> Self {
         self.failures.push(FailureCase {
             backends: Some(backends),
@@ -148,8 +148,10 @@ impl TestParameters {
         self
     }
 
-    /// Mark the test as always failing on WebGL. Because limited ability of wasm to recover from errors, we need to wholesale
-    /// skip the test if it's not supported.
+    /// Mark the test as always failing on WebGL, and needing to be skipped.
+    ///
+    /// Because limited ability of wasm to recover from errors, we
+    /// need to wholesale skip the test if it's not supported.
     pub fn webgl2_failure(mut self) -> Self {
         let _ = &mut self;
         #[cfg(target_arch = "wasm32")]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -247,10 +247,11 @@ impl TestParameters {
     }
 
     /// Mark the test as failing on vulkan on mac only
-    pub fn molten_vk_failure(self) -> Self {
+    pub fn molten_vk_failure(self, skip: bool) -> Self {
         self.specific_failure(FailureCase {
             backends: Some(wgpu::Backends::VULKAN),
             driver: Some("MoltenVK"),
+            skip,
             ..FailureCase::default()
         })
     }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -198,6 +198,17 @@ impl TestParameters {
             self
         }
     }
+
+    /// Mark the test as always failing on `adapter`, and needing to be skipped.
+    pub fn adapter_failure_skip(mut self, adapter: &str) -> Self {
+        self.failures.push(FailureCase {
+            backends: None,
+            vendor: None,
+            adapter: Some(adapter.to_lowercase()),
+            skip: true,
+        });
+        self
+    }
 }
 
 pub fn initialize_test(parameters: TestParameters, test_function: impl FnOnce(TestingContext)) {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -209,6 +209,24 @@ impl TestParameters {
         });
         self
     }
+
+    /// Mark the test as always failing on the given `adapter` and `backends`.
+    ///
+    /// If `skip` is true, skip the test altogether on such devices.
+    pub fn backend_adapter_failure(
+        mut self,
+        backends: wgpu::Backends,
+        adapter: &str,
+        skip: bool,
+    ) -> Self {
+        self.failures.push(FailureCase {
+            backends: Some(backends),
+            vendor: None,
+            adapter: Some(adapter.to_lowercase()),
+            skip,
+        });
+        self
+    }
 }
 
 pub fn initialize_test(parameters: TestParameters, test_function: impl FnOnce(TestingContext)) {

--- a/tests/tests/clear_texture.rs
+++ b/tests/tests/clear_texture.rs
@@ -385,7 +385,7 @@ fn clear_texture_bc() {
     initialize_test(
         TestParameters::default()
             .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_BC)
-            .specific_failure(Some(wgpu::Backends::GL), None, Some("ANGLE"), false) // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
+            .backend_adapter_failure(wgpu::Backends::GL, "ANGLE", false) // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
             .backend_failure(wgpu::Backends::GL), // compressed texture copy to buffer not yet implemented
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_BC);
@@ -402,7 +402,7 @@ fn clear_texture_astc() {
                 max_texture_dimension_2d: wgpu::COPY_BYTES_PER_ROW_ALIGNMENT * 12,
                 ..wgpu::Limits::downlevel_defaults()
             })
-            .specific_failure(Some(wgpu::Backends::GL), None, Some("ANGLE"), false) // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
+            .backend_adapter_failure(wgpu::Backends::GL, "ANGLE", false) // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
             .backend_failure(wgpu::Backends::GL), // compressed texture copy to buffer not yet implemented
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_ASTC);
@@ -415,7 +415,7 @@ fn clear_texture_etc2() {
     initialize_test(
         TestParameters::default()
             .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_ETC2)
-            .specific_failure(Some(wgpu::Backends::GL), None, Some("ANGLE"), false) // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
+            .backend_adapter_failure(wgpu::Backends::GL, "ANGLE", false) // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
             .backend_failure(wgpu::Backends::GL), // compressed texture copy to buffer not yet implemented
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_ETC2);

--- a/tests/tests/clear_texture.rs
+++ b/tests/tests/clear_texture.rs
@@ -1,5 +1,7 @@
 use wasm_bindgen_test::*;
-use wgpu_test::{image::ReadbackBuffers, initialize_test, TestParameters, TestingContext};
+use wgpu_test::{
+    image::ReadbackBuffers, initialize_test, FailureCase, TestParameters, TestingContext,
+};
 
 static TEXTURE_FORMATS_UNCOMPRESSED_GLES_COMPAT: &[wgpu::TextureFormat] = &[
     wgpu::TextureFormat::R8Unorm,
@@ -328,7 +330,7 @@ fn clear_texture_tests(ctx: &TestingContext, formats: &[wgpu::TextureFormat]) {
 fn clear_texture_uncompressed_gles_compat() {
     initialize_test(
         TestParameters::default()
-            .webgl2_failure()
+            .skip(FailureCase::webgl2())
             .features(wgpu::Features::CLEAR_TEXTURE),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_UNCOMPRESSED_GLES_COMPAT);
@@ -341,8 +343,8 @@ fn clear_texture_uncompressed_gles_compat() {
 fn clear_texture_uncompressed() {
     initialize_test(
         TestParameters::default()
-            .webgl2_failure()
-            .backend_failure(wgpu::Backends::GL)
+            .skip(FailureCase::webgl2())
+            .expect_fail(FailureCase::backend(wgpu::Backends::GL))
             .features(wgpu::Features::CLEAR_TEXTURE),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_UNCOMPRESSED);
@@ -355,7 +357,7 @@ fn clear_texture_uncompressed() {
 fn clear_texture_depth() {
     initialize_test(
         TestParameters::default()
-            .webgl2_failure()
+            .skip(FailureCase::webgl2())
             .downlevel_flags(
                 wgpu::DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES
                     | wgpu::DownlevelFlags::COMPUTE_SHADERS,
@@ -385,8 +387,10 @@ fn clear_texture_bc() {
     initialize_test(
         TestParameters::default()
             .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_BC)
-            .backend_adapter_failure(wgpu::Backends::GL, "ANGLE", false) // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
-            .backend_failure(wgpu::Backends::GL), // compressed texture copy to buffer not yet implemented
+            // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
+            .expect_fail(FailureCase::backend_adapter(wgpu::Backends::GL, "ANGLE"))
+            // compressed texture copy to buffer not yet implemented
+            .expect_fail(FailureCase::backend(wgpu::Backends::GL)),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_BC);
         },
@@ -402,8 +406,10 @@ fn clear_texture_astc() {
                 max_texture_dimension_2d: wgpu::COPY_BYTES_PER_ROW_ALIGNMENT * 12,
                 ..wgpu::Limits::downlevel_defaults()
             })
-            .backend_adapter_failure(wgpu::Backends::GL, "ANGLE", false) // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
-            .backend_failure(wgpu::Backends::GL), // compressed texture copy to buffer not yet implemented
+            // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
+            .expect_fail(FailureCase::backend_adapter(wgpu::Backends::GL, "ANGLE"))
+            // compressed texture copy to buffer not yet implemented
+            .expect_fail(FailureCase::backend(wgpu::Backends::GL)),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_ASTC);
         },
@@ -415,8 +421,10 @@ fn clear_texture_etc2() {
     initialize_test(
         TestParameters::default()
             .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::TEXTURE_COMPRESSION_ETC2)
-            .backend_adapter_failure(wgpu::Backends::GL, "ANGLE", false) // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
-            .backend_failure(wgpu::Backends::GL), // compressed texture copy to buffer not yet implemented
+            // https://bugs.chromium.org/p/angleproject/issues/detail?id=7056
+            .expect_fail(FailureCase::backend_adapter(wgpu::Backends::GL, "ANGLE"))
+            // compressed texture copy to buffer not yet implemented
+            .expect_fail(FailureCase::backend(wgpu::Backends::GL)),
         |ctx| {
             clear_texture_tests(&ctx, TEXTURE_FORMATS_ETC2);
         },

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen_test::*;
 
-use wgpu_test::{initialize_test, TestParameters};
+use wgpu_test::{initialize_test, FailureCase, TestParameters};
 
 #[test]
 #[wasm_bindgen_test]
@@ -13,26 +13,30 @@ fn device_initialization() {
 #[test]
 #[ignore]
 fn device_mismatch() {
-    initialize_test(TestParameters::default().failure(), |ctx| {
-        // Create a bind group uisng a lyaout from another device. This should be a validation
-        // error but currently crashes.
-        let (device2, _) =
-            pollster::block_on(ctx.adapter.request_device(&Default::default(), None)).unwrap();
+    initialize_test(
+        // https://github.com/gfx-rs/wgpu/issues/3927
+        TestParameters::default().expect_fail(FailureCase::always()),
+        |ctx| {
+            // Create a bind group uisng a lyaout from another device. This should be a validation
+            // error but currently crashes.
+            let (device2, _) =
+                pollster::block_on(ctx.adapter.request_device(&Default::default(), None)).unwrap();
 
-        {
-            let bind_group_layout =
-                device2.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            {
+                let bind_group_layout =
+                    device2.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                        label: None,
+                        entries: &[],
+                    });
+
+                let _bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
                     label: None,
+                    layout: &bind_group_layout,
                     entries: &[],
                 });
+            }
 
-            let _bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
-                label: None,
-                layout: &bind_group_layout,
-                entries: &[],
-            });
-        }
-
-        ctx.device.poll(wgpu::Maintain::Poll);
-    });
+            ctx.device.poll(wgpu::Maintain::Poll);
+        },
+    );
 }

--- a/tests/tests/encoder.rs
+++ b/tests/tests/encoder.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen_test::*;
 use wgpu::RenderPassDescriptor;
-use wgpu_test::{fail, initialize_test, TestParameters};
+use wgpu_test::{fail, initialize_test, FailureCase, TestParameters};
 
 #[test]
 #[wasm_bindgen_test]
@@ -22,7 +22,8 @@ fn drop_encoder_after_error() {
     // #543: COMMAND_ALLOCATOR_CANNOT_RESET]
     //
     // For now, we mark the test as failing on DX12.
-    let parameters = TestParameters::default().backend_failure(wgpu::Backends::DX12);
+    let parameters =
+        TestParameters::default().expect_fail(FailureCase::backend(wgpu::Backends::DX12));
     initialize_test(parameters, |ctx| {
         let mut encoder = ctx
             .device

--- a/tests/tests/poll.rs
+++ b/tests/tests/poll.rs
@@ -7,7 +7,7 @@ use wgpu::{
 };
 
 use wasm_bindgen_test::*;
-use wgpu_test::{initialize_test, TestParameters, TestingContext};
+use wgpu_test::{initialize_test, FailureCase, TestParameters, TestingContext};
 
 fn generate_dummy_work(ctx: &TestingContext) -> CommandBuffer {
     let buffer = ctx.device.create_buffer(&BufferDescriptor {
@@ -56,60 +56,75 @@ fn generate_dummy_work(ctx: &TestingContext) -> CommandBuffer {
 #[test]
 #[wasm_bindgen_test]
 fn wait() {
-    initialize_test(TestParameters::default().skip(), |ctx| {
-        let cmd_buf = generate_dummy_work(&ctx);
+    initialize_test(
+        TestParameters::default().skip(FailureCase::always()),
+        |ctx| {
+            let cmd_buf = generate_dummy_work(&ctx);
 
-        ctx.queue.submit(Some(cmd_buf));
-        ctx.device.poll(Maintain::Wait);
-    })
+            ctx.queue.submit(Some(cmd_buf));
+            ctx.device.poll(Maintain::Wait);
+        },
+    )
 }
 
 #[test]
 #[wasm_bindgen_test]
 fn double_wait() {
-    initialize_test(TestParameters::default().skip(), |ctx| {
-        let cmd_buf = generate_dummy_work(&ctx);
+    initialize_test(
+        TestParameters::default().skip(FailureCase::always()),
+        |ctx| {
+            let cmd_buf = generate_dummy_work(&ctx);
 
-        ctx.queue.submit(Some(cmd_buf));
-        ctx.device.poll(Maintain::Wait);
-        ctx.device.poll(Maintain::Wait);
-    })
+            ctx.queue.submit(Some(cmd_buf));
+            ctx.device.poll(Maintain::Wait);
+            ctx.device.poll(Maintain::Wait);
+        },
+    )
 }
 
 #[test]
 #[wasm_bindgen_test]
 fn wait_on_submission() {
-    initialize_test(TestParameters::default().skip(), |ctx| {
-        let cmd_buf = generate_dummy_work(&ctx);
+    initialize_test(
+        TestParameters::default().skip(FailureCase::always()),
+        |ctx| {
+            let cmd_buf = generate_dummy_work(&ctx);
 
-        let index = ctx.queue.submit(Some(cmd_buf));
-        ctx.device.poll(Maintain::WaitForSubmissionIndex(index));
-    })
+            let index = ctx.queue.submit(Some(cmd_buf));
+            ctx.device.poll(Maintain::WaitForSubmissionIndex(index));
+        },
+    )
 }
 
 #[test]
 #[wasm_bindgen_test]
 fn double_wait_on_submission() {
-    initialize_test(TestParameters::default().skip(), |ctx| {
-        let cmd_buf = generate_dummy_work(&ctx);
+    initialize_test(
+        TestParameters::default().skip(FailureCase::always()),
+        |ctx| {
+            let cmd_buf = generate_dummy_work(&ctx);
 
-        let index = ctx.queue.submit(Some(cmd_buf));
-        ctx.device
-            .poll(Maintain::WaitForSubmissionIndex(index.clone()));
-        ctx.device.poll(Maintain::WaitForSubmissionIndex(index));
-    })
+            let index = ctx.queue.submit(Some(cmd_buf));
+            ctx.device
+                .poll(Maintain::WaitForSubmissionIndex(index.clone()));
+            ctx.device.poll(Maintain::WaitForSubmissionIndex(index));
+        },
+    )
 }
 
 #[test]
 #[wasm_bindgen_test]
 fn wait_out_of_order() {
-    initialize_test(TestParameters::default().skip(), |ctx| {
-        let cmd_buf1 = generate_dummy_work(&ctx);
-        let cmd_buf2 = generate_dummy_work(&ctx);
+    initialize_test(
+        TestParameters::default().skip(FailureCase::always()),
+        |ctx| {
+            let cmd_buf1 = generate_dummy_work(&ctx);
+            let cmd_buf2 = generate_dummy_work(&ctx);
 
-        let index1 = ctx.queue.submit(Some(cmd_buf1));
-        let index2 = ctx.queue.submit(Some(cmd_buf2));
-        ctx.device.poll(Maintain::WaitForSubmissionIndex(index2));
-        ctx.device.poll(Maintain::WaitForSubmissionIndex(index1));
-    })
+            let index1 = ctx.queue.submit(Some(cmd_buf1));
+            let index2 = ctx.queue.submit(Some(cmd_buf2));
+            ctx.device.poll(Maintain::WaitForSubmissionIndex(index2));
+            ctx.device.poll(Maintain::WaitForSubmissionIndex(index1));
+        },
+    )
 }

--- a/tests/tests/shader/struct_layout.rs
+++ b/tests/tests/shader/struct_layout.rs
@@ -182,7 +182,7 @@ fn uniform_input() {
         TestParameters::default()
             .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
             // Validation errors thrown by the SPIR-V validator https://github.com/gfx-rs/naga/issues/2034
-            .specific_failure(Some(wgpu::Backends::VULKAN), None, None, false)
+            .backend_failure(wgpu::Backends::VULKAN)
             .limits(Limits::downlevel_defaults()),
         |ctx| {
             shader_input_output_test(

--- a/tests/tests/shader/struct_layout.rs
+++ b/tests/tests/shader/struct_layout.rs
@@ -4,7 +4,7 @@ use wasm_bindgen_test::*;
 use wgpu::{Backends, DownlevelFlags, Features, Limits};
 
 use crate::shader::{shader_input_output_test, InputStorageType, ShaderTest, MAX_BUFFER_SIZE};
-use wgpu_test::{initialize_test, TestParameters};
+use wgpu_test::{initialize_test, FailureCase, TestParameters};
 
 fn create_struct_layout_tests(storage_type: InputStorageType) -> Vec<ShaderTest> {
     let input_values: Vec<_> = (0..(MAX_BUFFER_SIZE as u32 / 4)).collect();
@@ -182,7 +182,7 @@ fn uniform_input() {
         TestParameters::default()
             .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
             // Validation errors thrown by the SPIR-V validator https://github.com/gfx-rs/naga/issues/2034
-            .backend_failure(wgpu::Backends::VULKAN)
+            .expect_fail(FailureCase::backend(wgpu::Backends::VULKAN))
             .limits(Limits::downlevel_defaults()),
         |ctx| {
             shader_input_output_test(
@@ -222,7 +222,7 @@ fn push_constant_input() {
                 max_push_constant_size: MAX_BUFFER_SIZE as u32,
                 ..Limits::downlevel_defaults()
             })
-            .backend_failure(Backends::GL),
+            .expect_fail(FailureCase::backend(Backends::GL)),
         |ctx| {
             shader_input_output_test(
                 ctx,

--- a/tests/tests/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/shader/zero_init_workgroup_mem.rs
@@ -8,7 +8,7 @@ use wgpu::{
     ShaderStages,
 };
 
-use wgpu_test::{initialize_test, TestParameters, TestingContext};
+use wgpu_test::{initialize_test, FailureCase, TestParameters, TestingContext};
 
 #[test]
 fn zero_init_workgroup_mem() {
@@ -18,12 +18,12 @@ fn zero_init_workgroup_mem() {
             .limits(Limits::downlevel_defaults())
             // remove both of these once we get to https://github.com/gfx-rs/wgpu/issues/3193 or
             // https://github.com/gfx-rs/wgpu/issues/3160
-            .specific_failure(
-                Some(Backends::DX12),
-                Some(5140),
-                Some("Microsoft Basic Render Driver"),
-                true,
-            )
+            .specific_failure(FailureCase {
+                backends: Some(Backends::DX12),
+                vendor: Some(5140),
+                adapter: Some("Microsoft Basic Render Driver"),
+                skip: true,
+            })
             .backend_adapter_failure(Backends::VULKAN, "swiftshader", true),
         zero_init_workgroup_mem_impl,
     );

--- a/tests/tests/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/shader/zero_init_workgroup_mem.rs
@@ -24,7 +24,7 @@ fn zero_init_workgroup_mem() {
                 Some("Microsoft Basic Render Driver"),
                 true,
             )
-            .specific_failure(Some(Backends::VULKAN), None, Some("swiftshader"), true),
+            .backend_adapter_failure(Backends::VULKAN, "swiftshader", true),
         zero_init_workgroup_mem_impl,
     );
 }

--- a/tests/tests/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/shader/zero_init_workgroup_mem.rs
@@ -18,14 +18,16 @@ fn zero_init_workgroup_mem() {
             .limits(Limits::downlevel_defaults())
             // remove both of these once we get to https://github.com/gfx-rs/wgpu/issues/3193 or
             // https://github.com/gfx-rs/wgpu/issues/3160
-            .specific_failure(FailureCase {
+            .skip(FailureCase {
                 backends: Some(Backends::DX12),
                 vendor: Some(5140),
                 adapter: Some("Microsoft Basic Render Driver"),
-                skip: true,
                 ..FailureCase::default()
             })
-            .backend_adapter_failure(Backends::VULKAN, "swiftshader", true),
+            .skip(FailureCase::backend_adapter(
+                Backends::VULKAN,
+                "swiftshader",
+            )),
         zero_init_workgroup_mem_impl,
     );
 }

--- a/tests/tests/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/shader/zero_init_workgroup_mem.rs
@@ -23,6 +23,7 @@ fn zero_init_workgroup_mem() {
                 vendor: Some(5140),
                 adapter: Some("Microsoft Basic Render Driver"),
                 skip: true,
+                ..FailureCase::default()
             })
             .backend_adapter_failure(Backends::VULKAN, "swiftshader", true),
         zero_init_workgroup_mem_impl,

--- a/tests/tests/shader_view_format/mod.rs
+++ b/tests/tests/shader_view_format/mod.rs
@@ -1,12 +1,19 @@
 use wgpu::{util::DeviceExt, DownlevelFlags, Limits, TextureFormat};
-use wgpu_test::{image::calc_difference, initialize_test, TestParameters, TestingContext};
+use wgpu_test::{
+    image::calc_difference, initialize_test, FailureCase, TestParameters, TestingContext,
+};
 
 #[test]
 fn reinterpret_srgb_ness() {
     let parameters = TestParameters::default()
         .downlevel_flags(DownlevelFlags::VIEW_FORMATS)
         .limits(Limits::downlevel_defaults())
-        .specific_failure(Some(wgpu::Backends::GL), None, None, true);
+        .specific_failure(FailureCase {
+            backends: Some(wgpu::Backends::GL),
+            vendor: None,
+            adapter: None,
+            skip: true,
+        });
     initialize_test(parameters, |ctx| {
         let unorm_data: [[u8; 4]; 4] = [
             [180, 0, 0, 255],

--- a/tests/tests/shader_view_format/mod.rs
+++ b/tests/tests/shader_view_format/mod.rs
@@ -8,9 +8,8 @@ fn reinterpret_srgb_ness() {
     let parameters = TestParameters::default()
         .downlevel_flags(DownlevelFlags::VIEW_FORMATS)
         .limits(Limits::downlevel_defaults())
-        .specific_failure(FailureCase {
+        .skip(FailureCase {
             backends: Some(wgpu::Backends::GL),
-            skip: true,
             ..FailureCase::default()
         });
     initialize_test(parameters, |ctx| {

--- a/tests/tests/shader_view_format/mod.rs
+++ b/tests/tests/shader_view_format/mod.rs
@@ -10,9 +10,8 @@ fn reinterpret_srgb_ness() {
         .limits(Limits::downlevel_defaults())
         .specific_failure(FailureCase {
             backends: Some(wgpu::Backends::GL),
-            vendor: None,
-            adapter: None,
             skip: true,
+            ..FailureCase::default()
         });
     initialize_test(parameters, |ctx| {
         let unorm_data: [[u8; 4]; 4] = [

--- a/tests/tests/vertex_indices/mod.rs
+++ b/tests/tests/vertex_indices/mod.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroU64;
 use wasm_bindgen_test::*;
 use wgpu::util::DeviceExt;
 
-use wgpu_test::{initialize_test, TestParameters, TestingContext};
+use wgpu_test::{initialize_test, FailureCase, TestParameters, TestingContext};
 
 fn pulling_common(
     ctx: TestingContext,
@@ -150,7 +150,7 @@ fn draw_vertex_offset() {
     initialize_test(
         TestParameters::default()
             .test_features_limits()
-            .backend_failure(wgpu::Backends::DX11),
+            .expect_fail(FailureCase::backend(wgpu::Backends::DX11)),
         |ctx| {
             pulling_common(ctx, &[0, 1, 2, 3, 4, 5], |cmb| {
                 cmb.draw(0..3, 0..1);
@@ -176,7 +176,7 @@ fn draw_instanced_offset() {
     initialize_test(
         TestParameters::default()
             .test_features_limits()
-            .backend_failure(wgpu::Backends::DX11),
+            .expect_fail(FailureCase::backend(wgpu::Backends::DX11)),
         |ctx| {
             pulling_common(ctx, &[0, 1, 2, 3, 4, 5], |cmb| {
                 cmb.draw(0..3, 0..1);

--- a/tests/tests/write_texture.rs
+++ b/tests/tests/write_texture.rs
@@ -1,6 +1,6 @@
 //! Tests for texture copy
 
-use wgpu_test::{initialize_test, TestParameters};
+use wgpu_test::{initialize_test, FailureCase, TestParameters};
 
 use wasm_bindgen_test::*;
 
@@ -8,7 +8,8 @@ use wasm_bindgen_test::*;
 #[wasm_bindgen_test]
 fn write_texture_subset_2d() {
     let size = 256;
-    let parameters = TestParameters::default().backend_failure(wgpu::Backends::DX12);
+    let parameters =
+        TestParameters::default().expect_fail(FailureCase::backend(wgpu::Backends::DX12));
     initialize_test(parameters, |ctx| {
         let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,

--- a/tests/tests/zero_init_texture_after_discard.rs
+++ b/tests/tests/zero_init_texture_after_discard.rs
@@ -1,38 +1,46 @@
 use wasm_bindgen_test::*;
 use wgpu::*;
-use wgpu_test::{image::ReadbackBuffers, initialize_test, TestParameters, TestingContext};
+use wgpu_test::{
+    image::ReadbackBuffers, initialize_test, FailureCase, TestParameters, TestingContext,
+};
 
 // Checks if discarding a color target resets its init state, causing a zero read of this texture when copied in after submit of the encoder.
 #[test]
 #[wasm_bindgen_test]
 fn discarding_color_target_resets_texture_init_state_check_visible_on_copy_after_submit() {
-    initialize_test(TestParameters::default().webgl2_failure(), |mut ctx| {
-        let mut case = TestCase::new(&mut ctx, TextureFormat::Rgba8UnormSrgb);
-        case.create_command_encoder();
-        case.discard();
-        case.submit_command_encoder();
+    initialize_test(
+        TestParameters::default().skip(FailureCase::webgl2()),
+        |mut ctx| {
+            let mut case = TestCase::new(&mut ctx, TextureFormat::Rgba8UnormSrgb);
+            case.create_command_encoder();
+            case.discard();
+            case.submit_command_encoder();
 
-        case.create_command_encoder();
-        case.copy_texture_to_buffer();
-        case.submit_command_encoder();
+            case.create_command_encoder();
+            case.copy_texture_to_buffer();
+            case.submit_command_encoder();
 
-        case.assert_buffers_are_zero();
-    });
+            case.assert_buffers_are_zero();
+        },
+    );
 }
 
 // Checks if discarding a color target resets its init state, causing a zero read of this texture when copied in the same encoder to a buffer.
 #[test]
 #[wasm_bindgen_test]
 fn discarding_color_target_resets_texture_init_state_check_visible_on_copy_in_same_encoder() {
-    initialize_test(TestParameters::default().webgl2_failure(), |mut ctx| {
-        let mut case = TestCase::new(&mut ctx, TextureFormat::Rgba8UnormSrgb);
-        case.create_command_encoder();
-        case.discard();
-        case.copy_texture_to_buffer();
-        case.submit_command_encoder();
+    initialize_test(
+        TestParameters::default().skip(FailureCase::webgl2()),
+        |mut ctx| {
+            let mut case = TestCase::new(&mut ctx, TextureFormat::Rgba8UnormSrgb);
+            case.create_command_encoder();
+            case.discard();
+            case.copy_texture_to_buffer();
+            case.submit_command_encoder();
 
-        case.assert_buffers_are_zero();
-    });
+            case.assert_buffers_are_zero();
+        },
+    );
 }
 
 #[test]


### PR DESCRIPTION
Skip `tests::test_multithreaded_compute` in `examples/hello-compute/src/tests.rs` on MoltenVK for timeouts.

All commits should pass CI, but may be fine-grained enough that squashing makes sense. Up to you.

Various cleanups to expected failure code:

- Give test image snapshots distinctive names.

  Include the adapter name and driver name in the filenames generated to store the `-actual.png` and `-difference.png` files holding screenshots of test program output.

  Previously, the filename only incorporated the backend, but since we test the Vulkan backend on both Mac and Windows, one was overwriting the other in the artifacts.

- Upload GitHub workflow artifacts even when the test fails.

  When a test in `.github/workflows/ci.yml`'s `gpu-test` fails, ensure that it uploads the artifacts anyway. These are screenshots and comparison images, so they're valuable in debugging the failure.

- Allow expected test failures to match the driver name.

  Add a new field `FailureCase::driver`, which must match `AdapterInfo::driver` if given.

  Use this in `TestParameters::molten_vk_failure`.

- Implement `Default` for `FailureCase`, and use it where appropriate.

  This makes it easier to add new fields to `FailureCase` in the future, without having to fix every use.

- Make `TestParameters::specific_failure` take a `FailureCase`.

  Make `TestParameters::specific_failure` take a `FailureCase` struct as its sole argument, thus requiring callers to label each parameter with its meaning. This is clearer than using four positional parameters.

- Introduce TestParameters::backend_adapter_failure.

  Introduce a new `TestParameters` builder method, `backend_adapter_failure`, for marking an expected failure on a specific adapter and backend. Use where appropriate.

- Introduce TestParameters::adapter_failure_skip.

  Introduce a new `TestParameters` builder method for skipping a test on a specific adapter. Use where appropriate.

- Update doc comments for some `TestParameters` methods.

  Replace references to `specific_failures` with outdated parameter lists with plain English explaining what each function actually does.

- Use TestParameters::backend_failure method where appropriate.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._
