### PR TITLE
Fix limits interface on web.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,0 @@
-[alias]
-xtask = "run --manifest-path xtask/Cargo.toml --"
-
-[build]
-rustflags = [
-"--cfg=web_sys_unstable_apis"
-]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,10 @@ By @Valaphee in [#3402](https://github.com/gfx-rs/wgpu/pull/3402)
 
 - Ensure that MTLCommandEncoder calls endEncoding before it is deallocated. By @bradwerth in [#4023](https://github.com/gfx-rs/wgpu/pull/4023)
 
+#### WebGPU
+
+- Ensure that limit requests and reporting is done correctly. By @OptimisticPeach in [#4107](https://github.com/gfx-rs/wgpu/pull/4107)
+
 ### Documentation
 
 - Add an overview of `RenderPass` and how render state works. By @kpreid in [#4055](https://github.com/gfx-rs/wgpu/pull/4055)

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -734,7 +734,10 @@ fn map_js_sys_limits(limits: &wgt::Limits) -> js_sys::Object {
                 ::js_sys::Reflect::set(
                     &$on,
                     &::wasm_bindgen::JsValue::from(stringify!($js_ident)),
-                    // TODO: Numbers may be bigger than u32!
+                    // Numbers may be u64, however using `from` on a u64 yields
+                    // errors on the wasm side, since it uses an unsupported api.
+                    // Wasm sends us things that need to fit into u64s by sending
+                    // us f64s instead. So we just send them f64s back.
                     &::wasm_bindgen::JsValue::from($from.$rs_ident as f64)
                 )
                     .expect("Setting Object properties should never fail.");

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1015,7 +1015,6 @@ impl crate::context::Context for Context {
         }
 
         let mut mapped_desc = web_sys::GpuDeviceDescriptor::new();
-        log::info!("descriptor given: {:#?}", desc.limits);
 
         // TODO: Migrate to a web_sys api.
         // See https://github.com/rustwasm/wasm-bindgen/issues/3587
@@ -1071,7 +1070,12 @@ impl crate::context::Context for Context {
             object
         };
 
-        js_sys::Reflect::set(&mapped_desc, &JsValue::from("requiredLimits"), &limits_object).expect("Setting Object properties should never fail.");
+        js_sys::Reflect::set(
+            &mapped_desc,
+            &JsValue::from("requiredLimits"),
+            &limits_object,
+        )
+        .expect("Setting Object properties should never fail.");
 
         let required_features = FEATURES_MAPPING
             .iter()
@@ -1158,12 +1162,11 @@ impl crate::context::Context for Context {
             max_compute_workgroup_size_y: limits.max_compute_workgroup_size_y(),
             max_compute_workgroup_size_z: limits.max_compute_workgroup_size_z(),
             max_compute_workgroups_per_dimension: limits.max_compute_workgroups_per_dimension(),
-            ..wgt::Limits::default()
-            // The following are not part of WebGPU
             /*
               max_push_constant_size: limits.max_push_constant_size(),
               max_non_sampler_bindings: limits.max_non_sampler_bindings(),
             */
+            ..wgt::Limits::default() // The following are not part of WebGPU
         }
     }
 
@@ -1361,12 +1364,11 @@ impl crate::context::Context for Context {
             max_compute_workgroup_size_y: limits.max_compute_workgroup_size_y(),
             max_compute_workgroup_size_z: limits.max_compute_workgroup_size_z(),
             max_compute_workgroups_per_dimension: limits.max_compute_workgroups_per_dimension(),
-            ..wgt::Limits::default()
-            // The following are not part of WebGPU
             /*
               max_push_constant_size: limits.max_push_constant_size(),
               max_non_sampler_bindings: limits.max_non_sampler_bindings(),
             */
+            ..wgt::Limits::default() // The following are not part of WebGPU
         }
     }
 

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -687,6 +687,44 @@ fn map_wgt_features(supported_features: web_sys::GpuSupportedFeatures) -> wgt::F
     features
 }
 
+fn map_wgt_limits(limits: web_sys::GpuSupportedLimits) -> wgt::Limits {
+    wgt::Limits {
+        max_texture_dimension_1d: limits.max_texture_dimension_1d(),
+        max_texture_dimension_2d: limits.max_texture_dimension_2d(),
+        max_texture_dimension_3d: limits.max_texture_dimension_3d(),
+        max_texture_array_layers: limits.max_texture_array_layers(),
+        max_bind_groups: limits.max_bind_groups(),
+        max_bindings_per_bind_group: limits.max_bindings_per_bind_group(),
+        max_dynamic_uniform_buffers_per_pipeline_layout: limits
+            .max_dynamic_uniform_buffers_per_pipeline_layout(),
+        max_dynamic_storage_buffers_per_pipeline_layout: limits
+            .max_dynamic_storage_buffers_per_pipeline_layout(),
+        max_sampled_textures_per_shader_stage: limits.max_sampled_textures_per_shader_stage(),
+        max_samplers_per_shader_stage: limits.max_samplers_per_shader_stage(),
+        max_storage_buffers_per_shader_stage: limits.max_storage_buffers_per_shader_stage(),
+        max_storage_textures_per_shader_stage: limits.max_storage_textures_per_shader_stage(),
+        max_uniform_buffers_per_shader_stage: limits.max_uniform_buffers_per_shader_stage(),
+        max_uniform_buffer_binding_size: limits.max_uniform_buffer_binding_size() as u32,
+        max_storage_buffer_binding_size: limits.max_storage_buffer_binding_size() as u32,
+        max_vertex_buffers: limits.max_vertex_buffers(),
+        max_buffer_size: limits.max_buffer_size() as u64,
+        max_vertex_attributes: limits.max_vertex_attributes(),
+        max_vertex_buffer_array_stride: limits.max_vertex_buffer_array_stride(),
+        min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment(),
+        min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment(),
+        max_inter_stage_shader_components: limits.max_inter_stage_shader_components(),
+        max_compute_workgroup_storage_size: limits.max_compute_workgroup_storage_size(),
+        max_compute_invocations_per_workgroup: limits.max_compute_invocations_per_workgroup(),
+        max_compute_workgroup_size_x: limits.max_compute_workgroup_size_x(),
+        max_compute_workgroup_size_y: limits.max_compute_workgroup_size_y(),
+        max_compute_workgroup_size_z: limits.max_compute_workgroup_size_z(),
+        max_compute_workgroups_per_dimension: limits.max_compute_workgroups_per_dimension(),
+        // The following are not part of WebGPU
+        max_push_constant_size: wgt::Limits::default().max_push_constant_size,
+        max_non_sampler_bindings: wgt::Limits::default().max_non_sampler_bindings,
+    }
+}
+
 type JsFutureResult = Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>;
 
 fn future_request_adapter(
@@ -1028,7 +1066,7 @@ impl crate::context::Context for Context {
                             &$on,
                             &::wasm_bindgen::JsValue::from(stringify!($js_ident)),
                             // TODO: Numbers may be bigger than u32!
-                            &::wasm_bindgen::JsValue::from($from.$rs_ident as u32)
+                            &::wasm_bindgen::JsValue::from($from.$rs_ident as f64)
                         )
                             .expect("Setting Object properties should never fail.");
                     )*
@@ -1130,44 +1168,7 @@ impl crate::context::Context for Context {
         _adapter: &Self::AdapterId,
         adapter_data: &Self::AdapterData,
     ) -> wgt::Limits {
-        let limits = adapter_data.0.limits();
-        wgt::Limits {
-            max_texture_dimension_1d: limits.max_texture_dimension_1d(),
-            max_texture_dimension_2d: limits.max_texture_dimension_2d(),
-            max_texture_dimension_3d: limits.max_texture_dimension_3d(),
-            max_texture_array_layers: limits.max_texture_array_layers(),
-            max_bind_groups: limits.max_bind_groups(),
-            max_bindings_per_bind_group: limits.max_bindings_per_bind_group(),
-            max_dynamic_uniform_buffers_per_pipeline_layout: limits
-                .max_dynamic_uniform_buffers_per_pipeline_layout(),
-            max_dynamic_storage_buffers_per_pipeline_layout: limits
-                .max_dynamic_storage_buffers_per_pipeline_layout(),
-            max_sampled_textures_per_shader_stage: limits.max_sampled_textures_per_shader_stage(),
-            max_samplers_per_shader_stage: limits.max_samplers_per_shader_stage(),
-            max_storage_buffers_per_shader_stage: limits.max_storage_buffers_per_shader_stage(),
-            max_storage_textures_per_shader_stage: limits.max_storage_textures_per_shader_stage(),
-            max_uniform_buffers_per_shader_stage: limits.max_uniform_buffers_per_shader_stage(),
-            max_uniform_buffer_binding_size: limits.max_uniform_buffer_binding_size() as u32,
-            max_storage_buffer_binding_size: limits.max_storage_buffer_binding_size() as u32,
-            max_vertex_buffers: limits.max_vertex_buffers(),
-            max_buffer_size: limits.max_buffer_size() as u64,
-            max_vertex_attributes: limits.max_vertex_attributes(),
-            max_vertex_buffer_array_stride: limits.max_vertex_buffer_array_stride(),
-            min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment(),
-            min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment(),
-            max_inter_stage_shader_components: limits.max_inter_stage_shader_components(),
-            max_compute_workgroup_storage_size: limits.max_compute_workgroup_storage_size(),
-            max_compute_invocations_per_workgroup: limits.max_compute_invocations_per_workgroup(),
-            max_compute_workgroup_size_x: limits.max_compute_workgroup_size_x(),
-            max_compute_workgroup_size_y: limits.max_compute_workgroup_size_y(),
-            max_compute_workgroup_size_z: limits.max_compute_workgroup_size_z(),
-            max_compute_workgroups_per_dimension: limits.max_compute_workgroups_per_dimension(),
-            /*
-              max_push_constant_size: limits.max_push_constant_size(),
-              max_non_sampler_bindings: limits.max_non_sampler_bindings(),
-            */
-            ..wgt::Limits::default() // The following are not part of WebGPU
-        }
+        map_wgt_limits(adapter_data.0.limits())
     }
 
     fn adapter_downlevel_capabilities(
@@ -1332,44 +1333,7 @@ impl crate::context::Context for Context {
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
     ) -> wgt::Limits {
-        let limits = device_data.0.limits();
-        wgt::Limits {
-            max_texture_dimension_1d: limits.max_texture_dimension_1d(),
-            max_texture_dimension_2d: limits.max_texture_dimension_2d(),
-            max_texture_dimension_3d: limits.max_texture_dimension_3d(),
-            max_texture_array_layers: limits.max_texture_array_layers(),
-            max_bind_groups: limits.max_bind_groups(),
-            max_bindings_per_bind_group: limits.max_bindings_per_bind_group(),
-            max_dynamic_uniform_buffers_per_pipeline_layout: limits
-                .max_dynamic_uniform_buffers_per_pipeline_layout(),
-            max_dynamic_storage_buffers_per_pipeline_layout: limits
-                .max_dynamic_storage_buffers_per_pipeline_layout(),
-            max_sampled_textures_per_shader_stage: limits.max_sampled_textures_per_shader_stage(),
-            max_samplers_per_shader_stage: limits.max_samplers_per_shader_stage(),
-            max_storage_buffers_per_shader_stage: limits.max_storage_buffers_per_shader_stage(),
-            max_storage_textures_per_shader_stage: limits.max_storage_textures_per_shader_stage(),
-            max_uniform_buffers_per_shader_stage: limits.max_uniform_buffers_per_shader_stage(),
-            max_uniform_buffer_binding_size: limits.max_uniform_buffer_binding_size() as u32,
-            max_storage_buffer_binding_size: limits.max_storage_buffer_binding_size() as u32,
-            max_vertex_buffers: limits.max_vertex_buffers(),
-            max_buffer_size: limits.max_buffer_size() as u64,
-            max_vertex_attributes: limits.max_vertex_attributes(),
-            max_vertex_buffer_array_stride: limits.max_vertex_buffer_array_stride(),
-            min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment(),
-            min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment(),
-            max_inter_stage_shader_components: limits.max_inter_stage_shader_components(),
-            max_compute_workgroup_storage_size: limits.max_compute_workgroup_storage_size(),
-            max_compute_invocations_per_workgroup: limits.max_compute_invocations_per_workgroup(),
-            max_compute_workgroup_size_x: limits.max_compute_workgroup_size_x(),
-            max_compute_workgroup_size_y: limits.max_compute_workgroup_size_y(),
-            max_compute_workgroup_size_z: limits.max_compute_workgroup_size_z(),
-            max_compute_workgroups_per_dimension: limits.max_compute_workgroups_per_dimension(),
-            /*
-              max_push_constant_size: limits.max_push_constant_size(),
-              max_non_sampler_bindings: limits.max_non_sampler_bindings(),
-            */
-            ..wgt::Limits::default() // The following are not part of WebGPU
-        }
+        map_wgt_limits(device_data.0.limits())
     }
 
     fn device_downlevel_properties(

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -725,6 +725,58 @@ fn map_wgt_limits(limits: web_sys::GpuSupportedLimits) -> wgt::Limits {
     }
 }
 
+fn map_js_sys_limits(limits: &wgt::Limits) -> js_sys::Object {
+    let object = js_sys::Object::new();
+
+    macro_rules! set_properties {
+        (($from:expr) => ($on:expr) : $(($js_ident:ident, $rs_ident:ident)),* $(,)?) => {
+            $(
+                ::js_sys::Reflect::set(
+                    &$on,
+                    &::wasm_bindgen::JsValue::from(stringify!($js_ident)),
+                    // TODO: Numbers may be bigger than u32!
+                    &::wasm_bindgen::JsValue::from($from.$rs_ident as f64)
+                )
+                    .expect("Setting Object properties should never fail.");
+            )*
+        }
+    }
+
+    set_properties![
+        (limits) => (object):
+        (maxTextureDimension1D, max_texture_dimension_1d),
+        (maxTextureDimension2D, max_texture_dimension_2d),
+        (maxTextureDimension3D, max_texture_dimension_3d),
+        (maxTextureArrayLayers, max_texture_array_layers),
+        (maxBindGroups, max_bind_groups),
+        (maxBindingsPerBindGroup, max_bindings_per_bind_group),
+        (maxDynamicUniformBuffersPerPipelineLayout, max_dynamic_uniform_buffers_per_pipeline_layout),
+        (maxDynamicStorageBuffersPerPipelineLayout, max_dynamic_storage_buffers_per_pipeline_layout),
+        (maxSampledTexturesPerShaderStage, max_sampled_textures_per_shader_stage),
+        (maxSamplersPerShaderStage, max_samplers_per_shader_stage),
+        (maxStorageBuffersPerShaderStage, max_storage_buffers_per_shader_stage),
+        (maxStorageTexturesPerShaderStage, max_storage_textures_per_shader_stage),
+        (maxUniformBuffersPerShaderStage, max_uniform_buffers_per_shader_stage),
+        (maxUniformBufferBindingSize, max_uniform_buffer_binding_size),
+        (maxStorageBufferBindingSize, max_storage_buffer_binding_size),
+        (minUniformBufferOffsetAlignment, min_uniform_buffer_offset_alignment),
+        (minStorageBufferOffsetAlignment, min_storage_buffer_offset_alignment),
+        (maxVertexBuffers, max_vertex_buffers),
+        (maxBufferSize, max_buffer_size),
+        (maxVertexAttributes, max_vertex_attributes),
+        (maxVertexBufferArrayStride, max_vertex_buffer_array_stride),
+        (maxInterStageShaderComponents, max_inter_stage_shader_components),
+        (maxComputeWorkgroupStorageSize, max_compute_workgroup_storage_size),
+        (maxComputeInvocationsPerWorkgroup, max_compute_invocations_per_workgroup),
+        (maxComputeWorkgroupSizeX, max_compute_workgroup_size_x),
+        (maxComputeWorkgroupSizeY, max_compute_workgroup_size_y),
+        (maxComputeWorkgroupSizeZ, max_compute_workgroup_size_z),
+        (maxComputeWorkgroupsPerDimension, max_compute_workgroups_per_dimension),
+    ];
+
+    object
+}
+
 type JsFutureResult = Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>;
 
 fn future_request_adapter(
@@ -1056,57 +1108,7 @@ impl crate::context::Context for Context {
 
         // TODO: Migrate to a web_sys api.
         // See https://github.com/rustwasm/wasm-bindgen/issues/3587
-        let limits_object = {
-            let object = js_sys::Object::new();
-
-            macro_rules! set_properties {
-                (($from:expr) => ($on:expr) : $(($js_ident:ident, $rs_ident:ident)),* $(,)?) => {
-                    $(
-                        ::js_sys::Reflect::set(
-                            &$on,
-                            &::wasm_bindgen::JsValue::from(stringify!($js_ident)),
-                            // TODO: Numbers may be bigger than u32!
-                            &::wasm_bindgen::JsValue::from($from.$rs_ident as f64)
-                        )
-                            .expect("Setting Object properties should never fail.");
-                    )*
-                }
-            }
-
-            set_properties![
-                (desc.limits) => (object):
-                (maxTextureDimension1D, max_texture_dimension_1d),
-                (maxTextureDimension2D, max_texture_dimension_2d),
-                (maxTextureDimension3D, max_texture_dimension_3d),
-                (maxTextureArrayLayers, max_texture_array_layers),
-                (maxBindGroups, max_bind_groups),
-                (maxBindingsPerBindGroup, max_bindings_per_bind_group),
-                (maxDynamicUniformBuffersPerPipelineLayout, max_dynamic_uniform_buffers_per_pipeline_layout),
-                (maxDynamicStorageBuffersPerPipelineLayout, max_dynamic_storage_buffers_per_pipeline_layout),
-                (maxSampledTexturesPerShaderStage, max_sampled_textures_per_shader_stage),
-                (maxSamplersPerShaderStage, max_samplers_per_shader_stage),
-                (maxStorageBuffersPerShaderStage, max_storage_buffers_per_shader_stage),
-                (maxStorageTexturesPerShaderStage, max_storage_textures_per_shader_stage),
-                (maxUniformBuffersPerShaderStage, max_uniform_buffers_per_shader_stage),
-                (maxUniformBufferBindingSize, max_uniform_buffer_binding_size),
-                (maxStorageBufferBindingSize, max_storage_buffer_binding_size),
-                (minUniformBufferOffsetAlignment, min_uniform_buffer_offset_alignment),
-                (minStorageBufferOffsetAlignment, min_storage_buffer_offset_alignment),
-                (maxVertexBuffers, max_vertex_buffers),
-                (maxBufferSize, max_buffer_size),
-                (maxVertexAttributes, max_vertex_attributes),
-                (maxVertexBufferArrayStride, max_vertex_buffer_array_stride),
-                (maxInterStageShaderComponents, max_inter_stage_shader_components),
-                (maxComputeWorkgroupStorageSize, max_compute_workgroup_storage_size),
-                (maxComputeInvocationsPerWorkgroup, max_compute_invocations_per_workgroup),
-                (maxComputeWorkgroupSizeX, max_compute_workgroup_size_x),
-                (maxComputeWorkgroupSizeY, max_compute_workgroup_size_y),
-                (maxComputeWorkgroupSizeZ, max_compute_workgroup_size_z),
-                (maxComputeWorkgroupsPerDimension, max_compute_workgroups_per_dimension),
-            ];
-
-            object
-        };
+        let limits_object = map_js_sys_limits(&desc.limits);
 
         js_sys::Reflect::set(
             &mapped_desc,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes the limits request and reporting api for webgpu backend. Notice that since `web_sys` doesn't have an impl of `requiredLimits` for requesting limits, we tack on our own impl as needed (See https://github.com/rustwasm/wasm-bindgen/issues/3587 for more details).

**Description**
Fills in the api for requesting device limits on the web, fills in the api for reporting device limits, and fixes the api for reporting adapter limits. 

**Testing**
In a minimal wasm app, I run the following:
```rs
let adapter = {
    let instance = wgpu::Instance::default();
    instance
        .request_adapter(&wgpu::RequestAdapterOptions::default())
        .await
        .unwrap()
};
let limits = adapter.limits();
let (device, _queue) = adapter.request_device(
    &wgpu::DeviceDescriptor {
        label: None,
        features: Default::default(),
        limits: limits.clone(),
    },
    None,
)
    .await
    .unwrap();
let device_limits = device.limits();
assert_eq!(device_limits, limits);
```
And see no errors.
