### PR TITLE
Enable vulkan presentation on Intel Mesa >= v21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ By @Valaphee in [#3402](https://github.com/gfx-rs/wgpu/pull/3402)
 
 - Enhancement of [#4038], using ash's definition instead of hard-coded c_str. By @hybcloud in[#4044](https://github.com/gfx-rs/wgpu/pull/4044).
 
+- Enable vulkan presentation on (Linux) Intel Mesa >= v21.2. By @flukejones in[#4110](https://github.com/gfx-rs/wgpu/pull/4110)
+
 #### DX12
 
 - DX12 doesn't support `Features::POLYGON_MODE_POINT``. By @teoxoy in [#4032](https://github.com/gfx-rs/wgpu/pull/4032).


### PR DESCRIPTION
Due to an issue with Mesa versions less than 21.2 presentation on Vulkan was forced to Nvidia only. This in itself brought new issues around the Nvidia driver specfic format modifers.

As of Mesa 21.2 the Intel vulkan issue is fixed. This commit enables presentation on versions 21.2 and above for Intel.

References:
- https://github.com/NVIDIA/egl-wayland/issues/72

Closes [#4101](https://github.com/gfx-rs/wgpu/issues/4101)