### PR TITLE
Print errors in a more readable format in the player.

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -158,7 +158,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
         let (cmd_buf, error) = self
             .command_encoder_finish::<A>(encoder, &wgt::CommandBufferDescriptor { label: None });
         if let Some(e) = error {
-            panic!("{:?}", e);
+            panic!("{e}");
         }
         cmd_buf
     }
@@ -186,7 +186,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                 self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_buffer::<A>(device, &desc, id);
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
             }
             Action::FreeBuffer(id) => {
@@ -199,7 +199,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                 self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_texture::<A>(device, &desc, id);
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
             }
             Action::FreeTexture(id) => {
@@ -216,7 +216,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                 self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.texture_create_view::<A>(parent_id, &desc, id);
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
             }
             Action::DestroyTextureView(id) => {
@@ -226,7 +226,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                 self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_sampler::<A>(device, &desc, id);
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
             }
             Action::DestroySampler(id) => {
@@ -242,7 +242,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
             Action::CreateBindGroupLayout(id, desc) => {
                 let (_, error) = self.device_create_bind_group_layout::<A>(device, &desc, id);
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
             }
             Action::DestroyBindGroupLayout(id) => {
@@ -252,7 +252,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                 self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_pipeline_layout::<A>(device, &desc, id);
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
             }
             Action::DestroyPipelineLayout(id) => {
@@ -262,7 +262,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                 self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_bind_group::<A>(device, &desc, id);
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
             }
             Action::DestroyBindGroup(id) => {
@@ -272,7 +272,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                 log::info!("Creating shader from {}", data);
                 let code = fs::read_to_string(dir.join(&data)).unwrap();
                 let source = if data.ends_with(".wgsl") {
-                    wgc::pipeline::ShaderModuleSource::Wgsl(Cow::Owned(code))
+                    wgc::pipeline::ShaderModuleSource::Wgsl(Cow::Owned(code.clone()))
                 } else if data.ends_with(".ron") {
                     let module = ron::de::from_str(&code).unwrap();
                     wgc::pipeline::ShaderModuleSource::Naga(module)
@@ -281,7 +281,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                 };
                 let (_, error) = self.device_create_shader_module::<A>(device, &desc, source, id);
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    println!("shader compilation error:\n---{code}\n---\n{e}");
                 }
             }
             Action::DestroyShaderModule(id) => {
@@ -303,7 +303,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                 let (_, error) =
                     self.device_create_compute_pipeline::<A>(device, &desc, id, implicit_ids);
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
             }
             Action::DestroyComputePipeline(id) => {
@@ -325,7 +325,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                 let (_, error) =
                     self.device_create_render_pipeline::<A>(device, &desc, id, implicit_ids);
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
             }
             Action::DestroyRenderPipeline(id) => {
@@ -340,7 +340,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                     id,
                 );
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
             }
             Action::DestroyRenderBundle(id) => {
@@ -350,7 +350,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                 self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_query_set::<A>(device, &desc, id);
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
             }
             Action::DestroyQuerySet(id) => {
@@ -393,7 +393,7 @@ impl GlobalPlay for wgc::global::Global<IdentityPassThroughFactory> {
                     comb_manager.alloc(device.backend()),
                 );
                 if let Some(e) = error {
-                    panic!("{:?}", e);
+                    panic!("{e}");
                 }
                 let cmdbuf = self.encode_commands::<A>(encoder, commands);
                 self.queue_submit::<A>(device, &[cmdbuf]).unwrap();


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.


**Description**

Use the `Display` impl to print errors instead of `Debug`.

For example when investigating an error with the player, shader validation errors go from

```
[2023-09-14T14:13:35Z ERROR naga::valid::compose] Vector component[1] type Scalar { kind: Sint, width: 4 }
thread 'main' panicked at 'Validation(ShaderError { source: "\n  struct Uniforms {\n    viewProjection: mat4x4f,\n    viewPosition: vec3f,\n    lightPosition: vec3f,\n    shininess: f32,\n  };\n\n  @group(0) @binding(0) var<uniform> uni: Uniforms;\n\n  struct Inst {\n    mat: mat4x4f,\n  };\n\n  @group(0) @binding(1) var<storage, read> perInst: array<Inst>;\n\n  struct VSInput {\n      @location(0) position: vec4f,\n      @location(1) normal: vec3f,\n      @location(2) color: vec4f,\n  };\n\n  struct VSOutput {\n    @builtin(position) position: vec4f,\n    @location(0) normal: vec3f,\n    @location(1) color: vec4f,\n    @location(2) surfaceToLight: vec3f,\n    @location(3) surfaceToView: vec3f,\n  };\n\n  @vertex\n  fn myVSMain(v: VSInput, @builtin(instance_index) instanceIndex: u32) -> VSOutput {\n    var vsOut: VSOutput;\n    let world = perInst[instanceIndex].mat;\n    vsOut.position = uni.viewProjection * world * v.position;\n    vsOut.normal = (world * vec4f(v.normal, 0)).xyz;\n    vsOut.color = v.color;\n\n    let surfaceWorldPosition = (world * v.position).xyz;\n    vsOut.surfaceToLight = uni.lightPosition - surfaceWorldPosition;\n    vsOut.surfaceToView = uni.viewPosition - surfaceWorldPosition;\n\n    return vsOut;\n  }\n\n  @fragment\n  fn myFSMain(v: VSOutput) -> @location(0) vec4f {\n    var normal = normalize(v.normal);\n\n    let surfaceToLightDirection = normalize(v.surfaceToLight);\n    let surfaceToViewDirection = normalize(v.surfaceToView);\n    let halfVector = normalize(surfaceToLightDirection + surfaceToViewDirection);\n\n    let light = dot(normal, surfaceToLightDirection) * 0.5 + 0.5;\n \n    var specular = 0.0;\n    if (light > 0.0) {\n      specular = pow(dot(normal, halfVector), uni.shininess);\n    }\n\n    return vec4f(v.color.rgb * light + specular, v.color.a);\n  }\n  ", label: None, inner: WithSpan { inner: EntryPoint { stage: Vertex, name: "myVSMain", source: Function(Expression { handle: [18], source: Compose(ComponentType { index: 1 }) }) }, spans: [(Span { start: 876, end: 894 }, "naga::Expression [18]")] } })', /home/nical/dev/rust/wgpu/player/src/lib.rs:284:21
``` 

to

```
shader compilation error:
---
  struct Uniforms {
    viewProjection: mat4x4f,
    viewPosition: vec3f,
    lightPosition: vec3f,
    shininess: f32,
  };

  @group(0) @binding(0) var<uniform> uni: Uniforms;

  struct Inst {
    mat: mat4x4f,
  };

  @group(0) @binding(1) var<storage, read> perInst: array<Inst>;

  struct VSInput {
      @location(0) position: vec4f,
      @location(1) normal: vec3f,
      @location(2) color: vec4f,
  };

  struct VSOutput {
    @builtin(position) position: vec4f,
    @location(0) normal: vec3f,
    @location(1) color: vec4f,
    @location(2) surfaceToLight: vec3f,
    @location(3) surfaceToView: vec3f,
  };

  @vertex
  fn myVSMain(v: VSInput, @builtin(instance_index) instanceIndex: u32) -> VSOutput {
    var vsOut: VSOutput;
    let world = perInst[instanceIndex].mat;
    vsOut.position = uni.viewProjection * world * v.position;
    vsOut.normal = (world * vec4f(v.normal, 0)).xyz;
    vsOut.color = v.color;

    let surfaceWorldPosition = (world * v.position).xyz;
    vsOut.surfaceToLight = uni.lightPosition - surfaceWorldPosition;
    vsOut.surfaceToView = uni.viewPosition - surfaceWorldPosition;

    return vsOut;
  }

  @fragment
  fn myFSMain(v: VSOutput) -> @location(0) vec4f {
    var normal = normalize(v.normal);

    let surfaceToLightDirection = normalize(v.surfaceToLight);
    let surfaceToViewDirection = normalize(v.surfaceToView);
    let halfVector = normalize(surfaceToLightDirection + surfaceToViewDirection);

    let light = dot(normal, surfaceToLightDirection) * 0.5 + 0.5;
 
    var specular = 0.0;
    if (light > 0.0) {
      specular = pow(dot(normal, halfVector), uni.shininess);
    }

    return vec4f(v.color.rgb * light + specular, v.color.a);
  }
  
---

Shader validation error: 
   ┌─ :36:29
   │
36 │     vsOut.normal = (world * vec4f(v.normal, 0)).xyz;
   │                             ^^^^^^^^^^^^^^^^^^ naga::Expression [18]
```
