### PR TITLE
Add details to `RequestDeviceError`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ By @Valaphee in [#3402](https://github.com/gfx-rs/wgpu/pull/3402)
 - Omit texture store bound checks since they are no-ops if out of bounds on all APIs. By @teoxoy in [#3975](https://github.com/gfx-rs/wgpu/pull/3975)
 - Validate `DownlevelFlags::READ_ONLY_DEPTH_STENCIL`. By @teoxoy in [#4031](https://github.com/gfx-rs/wgpu/pull/4031)
 - Add validation in accordance with WebGPU `setViewport` valid usage for `x`, `y` and `this.[[attachment_size]]`. By @James2022-rgb in [#4058](https://github.com/gfx-rs/wgpu/pull/4058)
-- `wgpu::CreateSurfaceError` now gives details of the failure, but no longer implements `PartialEq`. By @kpreid in [#4066](https://github.com/gfx-rs/wgpu/pull/4066)
+- `wgpu::CreateSurfaceError` and `wgpu::RequestDeviceError` now give details of the failure, but no longer implement `PartialEq` and cannot be constructed. By @kpreid in [#4066](https://github.com/gfx-rs/wgpu/pull/4066) and [#4145](https://github.com/gfx-rs/wgpu/pull/4145)
 - Make `WGPU_POWER_PREF=none` a valid value. By @fornwall in [4076](https://github.com/gfx-rs/wgpu/pull/4076)
 
 #### Vulkan

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -449,7 +449,7 @@ pub fn initialize_test(parameters: TestParameters, test_function: impl FnOnce(Te
     }
 }
 
-fn initialize_adapter() -> (Adapter, Option<SurfaceGuard>) {
+pub fn initialize_adapter() -> (Adapter, Option<SurfaceGuard>) {
     let instance = initialize_instance();
     let surface_guard: Option<SurfaceGuard>;
     let compatible_surface;

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -622,8 +622,7 @@ impl crate::Context for Context {
             ()
         ));
         if let Some(err) = error {
-            log::error!("Error in Adapter::request_device: {}", err);
-            return ready(Err(crate::RequestDeviceError));
+            return ready(Err(err.into()));
         }
         let error_sink = Arc::new(Mutex::new(ErrorSinkRaw::new()));
         let device = Device {

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -812,7 +812,9 @@ fn future_request_device(
 
             (device_id, device_data, queue_id, queue_data)
         })
-        .map_err(|_| crate::RequestDeviceError)
+        .map_err(|error_value| crate::RequestDeviceError {
+            inner: crate::RequestDeviceErrorKind::Web(error_value),
+        })
 }
 
 fn future_pop_error_scope(result: JsFutureResult) -> Option<crate::Error> {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Basically just like #4066 — giving the same treatment to `RequestDeviceError` as `InstanceError` and `CreateSurfaceError` got.

**Description**
This will allow developers, particularly those in communication with users with hardware they don't own, to diagnose “why won't this work on my machine” better, without needing to obtain logs in addition to the error value.

Note that this is a semver-breaking change because `RequestDeviceError` no longer implements `PartialEq`, and cannot be constructed outside the crate. (Just like #4066.)

**Testing**
Added a test case and ran it in CI.