### PR TITLE
[metal] set the image stride to zero when updating a single layer of a 3D texture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
 
           for backend in ${{ matrix.backends }}; do
             echo "======= NATIVE TESTS $backend ======";
-            WGPU_BACKEND=$backend cargo llvm-cov --no-cfg-coverage nextest --no-fail-fast --no-report --features vulkan-portability
+            WGPU_BACKEND=$backend METAL_DEVICE_WRAPPER_TYPE=1 cargo llvm-cov --no-cfg-coverage nextest --no-fail-fast --no-report --features vulkan-portability
           done
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,10 @@ jobs:
 
           for backend in ${{ matrix.backends }}; do
             echo "======= NATIVE TESTS $backend ======";
-            WGPU_BACKEND=$backend METAL_DEVICE_WRAPPER_TYPE=1 cargo llvm-cov --no-cfg-coverage nextest --no-fail-fast --no-report --features vulkan-portability
+            if ["$backend" == "metal"]; then
+              echo "METAL_DEVICE_WRAPPER_TYPE=1" >> "$GITHUB_ENV"
+            fi
+            WGPU_BACKEND=$backend cargo llvm-cov --no-cfg-coverage nextest --no-fail-fast --no-report --features vulkan-portability
           done
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Follow up to https://github.com/gfx-rs/wgpu/pull/3063.

**Description**
See https://github.com/gfx-rs/wgpu/pull/3063#issuecomment-1662472629.

**Testing**
Test has been modified.