### PR TITLE
List Dx12 adapters before vulkan ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ By @wumpf in [#4147](https://github.com/gfx-rs/wgpu/pull/4147)
 
 - DX12 doesn't support `Features::POLYGON_MODE_POINT``. By @teoxoy in [#4032](https://github.com/gfx-rs/wgpu/pull/4032).
 - Set `Features::VERTEX_WRITABLE_STORAGE` based on the right feature level. By @teoxoy in [#4033](https://github.com/gfx-rs/wgpu/pull/4033).
+- Expose DX12 adapters before vulkan ones when enumerating adapters by @nical in [#4156](https://github.com/gfx-rs/wgpu/pull/4156)
 
 #### Metal
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -826,15 +826,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .transpose()?;
         let mut device_types = Vec::new();
 
-        #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
-        let (id_vulkan, adapters_vk) = gather(
-            hal::api::Vulkan,
-            self.instance.vulkan.as_ref(),
-            &inputs,
-            compatible_surface,
-            desc.force_fallback_adapter,
-            &mut device_types,
-        );
         #[cfg(all(feature = "metal", any(target_os = "macos", target_os = "ios")))]
         let (id_metal, adapters_metal) = gather(
             hal::api::Metal,
@@ -848,6 +839,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let (id_dx12, adapters_dx12) = gather(
             hal::api::Dx12,
             self.instance.dx12.as_ref(),
+            &inputs,
+            compatible_surface,
+            desc.force_fallback_adapter,
+            &mut device_types,
+        );
+        #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
+        let (id_vulkan, adapters_vk) = gather(
+            hal::api::Vulkan,
+            self.instance.vulkan.as_ref(),
             &inputs,
             compatible_surface,
             desc.force_fallback_adapter,


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.


**Description**

I'm not sure whether it's possible to see vulkan adapters on Mac (maybe with moltenvk). In any case, on Windows and Mac it makes more sense to present Dx12 and Metal first, so that programs that pick the first adapter (for example the CTS), get the most sensible default.

Dx11 being more of a fallback option should still be after vulkan on windows.
