### PR TITLE
Bring back xtask alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+[alias]
+xtask = "run --manifest-path xtask/Cargo.toml --"
+
+[build]
+rustflags = [
+"--cfg=web_sys_unstable_apis"
+]


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

This reverts the accidental deletion from #4107 and closes #4158 

**Description**
Makes `cargo xtask` alias available again

**Testing**

```bash
 cargo xtask run-wasm --bin cube --features webgl
 ```
