### PR TITLE
Update CODEOWNERS with new wgpu team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
-/cts_runner/    @crowlKats
-/deno_webgpu/   @crowlKats
+* @gfx-rs/wgpu
+
+/cts_runner/    @gfx-rs/deno @gfx-rs/wgpu
+/deno_webgpu/   @gfx-rs/deno @gfx-rs/wgpu


### PR DESCRIPTION
I believe because of the weird precedence rules in code owners, we need to specify gfx-rs/wgpu in the deno rules too, otherwise, we won't get requested if something _only_ touches that part of the code.