### PR TITLE
Fix using trunk version on mac

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,12 +100,6 @@ wgpu-test = { version = "0.17", path = "./tests"}
 wgpu-types = { version = "0.17.0", path = "./wgpu-types" }
 winit = { version = "0.28.6", features = [ "android-native-activity" ] }
 
-# Metal dependencies
-block = "0.1"
-metal = "0.26.0"
-objc = "0.2.5"
-core-graphics-types = "0.1"
-
 # Vulkan dependencies
 ash = "0.37.3"
 gpu-alloc = "0.6"
@@ -157,9 +151,6 @@ termcolor = "1.3.0"
 #naga = { path = "../naga" }
 #glow = { path = "../glow" }
 #d3d12 = { path = "../d3d12-rs" }
-#metal = { path = "../metal-rs" }
-#metal = { path = "../metal-rs" }
-metal = { git = "https://github.com/gfx-rs/metal-rs/", rev = "d24f1a4" } # More timer support via https://github.com/gfx-rs/metal-rs/pull/280
 #web-sys = { path = "../wasm-bindgen/crates/web-sys" }
 #js-sys = { path = "../wasm-bindgen/crates/js-sys" }
 #wasm-bindgen = { path = "../wasm-bindgen" }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -103,7 +103,7 @@ d3d12 = { version = "0.7", features = ["libloading"], optional = true }
 # backend: Metal
 block = { version = "0.1", optional = true }
 
-metal = "0.26.0"
+metal = { git = "https://github.com/gfx-rs/metal-rs/", rev = "d24f1a4" } # More timer support via https://github.com/gfx-rs/metal-rs/pull/280
 objc = "0.2.5"
 core-graphics-types = "0.1"
 


### PR DESCRIPTION
Overriding the metal version in the workspace `Cargo.toml` using a patch section does not work for projects building against the trunk version of wgpu:

```toml
wgpu = { git = "https://github.com/gfx-rs/wgpu", branch = "trunk" }
```

So projects having the above dependencies does currently not build on mac, since version `0.26.0` is resolved version of metal.

Instead specify the metal dependencies only once in wgpu-hal.

While another option could be awaiting a new release of metal, perhaps this change is good on its own, to avoid restating metal dependencies in both the workspace `Cargo.toml` and in `wgpu-hal/Cargo.toml`?