### PR TITLE
Specify the metal dependency in hal instead of the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,6 @@ termcolor = "1.3.0"
 #d3d12 = { path = "../d3d12-rs" }
 #metal = { path = "../metal-rs" }
 #metal = { path = "../metal-rs" }
-metal = { git = "https://github.com/gfx-rs/metal-rs/", rev = "d24f1a4" } # More timer support via https://github.com/gfx-rs/metal-rs/pull/280
 #web-sys = { path = "../wasm-bindgen/crates/web-sys" }
 #js-sys = { path = "../wasm-bindgen/crates/js-sys" }
 #wasm-bindgen = { path = "../wasm-bindgen" }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -103,7 +103,7 @@ d3d12 = { version = "0.7", features = ["libloading"], optional = true }
 # backend: Metal
 block = { version = "0.1", optional = true }
 
-metal = "0.26.0"
+metal = { git = "https://github.com/gfx-rs/metal-rs/", rev = "d24f1a4" }
 objc = "0.2.5"
 core-graphics-types = "0.1"
 


### PR DESCRIPTION
**Connections**

https://bugzilla.mozilla.org/show_bug.cgi?id=1854615

**Description**

Specifying the dependency at the workspace level does not appear to work with cargo vendor which Firefox uses.
