### PR TITLE
Add test case for #4167, marked as an expected failure.

### DIFF
--- a/tests/tests/pipeline.rs
+++ b/tests/tests/pipeline.rs
@@ -1,0 +1,37 @@
+use wasm_bindgen_test::*;
+use wgpu_test::{fail, initialize_test, FailureCase, TestParameters};
+
+#[test]
+#[wasm_bindgen_test]
+fn pipeline_default_layout_bad_module() {
+    // Create an invalid shader and a compute pipeline that uses it
+    // with a default bindgroup layout, and then ask for that layout.
+    // Validation should fail, but wgpu should not panic.
+    let parameters = TestParameters::default()
+        .skip(FailureCase::webgl2())
+        // https://github.com/gfx-rs/wgpu/issues/4167
+        .expect_fail(FailureCase::always());
+    initialize_test(parameters, |ctx| {
+        ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
+
+        fail(&ctx.device, || {
+            let module = ctx
+                .device
+                .create_shader_module(wgpu::ShaderModuleDescriptor {
+                    label: None,
+                    source: wgpu::ShaderSource::Wgsl("not valid wgsl".into()),
+                });
+
+            let pipeline = ctx
+                .device
+                .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                    label: Some("mandelbrot compute pipeline"),
+                    layout: None,
+                    module: &module,
+                    entry_point: "doesn't exist",
+                });
+
+            pipeline.get_bind_group_layout(0);
+        });
+    });
+}

--- a/tests/tests/root.rs
+++ b/tests/tests/root.rs
@@ -19,6 +19,7 @@ mod external_texture;
 mod instance;
 mod occlusion_query;
 mod partially_bounded_arrays;
+mod pipeline;
 mod poll;
 mod query_set;
 mod queue_transfer;


### PR DESCRIPTION
This adds a test case for #4167, marked as an expected failure with a comment referring to the issue.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- (not appropriate) Add change to CHANGELOG.md. See simple instructions inside file.
