### PR TITLE
Re-export Naga

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ By @wumpf in [#4147](https://github.com/gfx-rs/wgpu/pull/4147)
 ### Added/New Features
 
 - Add `gles_minor_version` field to `wgpu::InstanceDescriptor`. By @PJB3005 in [#3998](https://github.com/gfx-rs/wgpu/pull/3998)
+- Re-export Naga. By @exrook in [#4172](https://github.com/gfx-rs/wgpu/pull/4172)
 
 ### Changes
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -54,6 +54,8 @@ pub use wgt::{
 ))]
 #[doc(hidden)]
 pub use ::hal;
+#[cfg(feature = "naga")]
+pub use ::naga;
 #[cfg(any(
     not(target_arch = "wasm32"),
     feature = "webgl",


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #3559

**Description**
Allow users to use the same version of Naga wgpu is using.

Allows the `wgpu::ShaderSource::Naga` and `wgpu::ShaderSource::Glsl` apis to be used without the user having to manually match their own `naga` dependency version to that of `wgpu`.

**Testing**
n/a
