### PR TITLE
Add trace level logging to most API entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ By @wumpf in [#4147](https://github.com/gfx-rs/wgpu/pull/4147)
 - Make `WGPU_POWER_PREF=none` a valid value. By @fornwall in [4076](https://github.com/gfx-rs/wgpu/pull/4076)
 - Support dual source blending in OpenGL ES, Metal, Vulkan & DX12. By @freqmod in [4022](https://github.com/gfx-rs/wgpu/pull/4022)
 - Add stub support for device destroy and device validity. By @bradwerth in [4163](https://github.com/gfx-rs/wgpu/pull/4163)
+- Add trace-level logging for most entry points in wgpu-core By @nical in [4183](https://github.com/gfx-rs/wgpu/pull/4183)
 
 #### Vulkan
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -79,7 +79,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(), ClearError> {
-        profiling::scope!("CommandEncoder::fill_buffer");
+        profiling::scope!("CommandEncoder::clear_buffer");
+        log::trace!("CommandEncoder::clear_buffer {dst:?}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -158,6 +159,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         subresource_range: &ImageSubresourceRange,
     ) -> Result<(), ClearError> {
         profiling::scope!("CommandEncoder::clear_texture");
+        log::trace!("CommandEncoder::clear_texture {dst:?}");
 
         let hub = A::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -391,6 +391,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         label: &str,
     ) -> Result<(), CommandEncoderError> {
         profiling::scope!("CommandEncoder::push_debug_group");
+        log::trace!("CommandEncoder::push_debug_group {label}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -416,6 +417,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         label: &str,
     ) -> Result<(), CommandEncoderError> {
         profiling::scope!("CommandEncoder::insert_debug_marker");
+        log::trace!("CommandEncoder::insert_debug_marker {label}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -440,6 +442,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
     ) -> Result<(), CommandEncoderError> {
         profiling::scope!("CommandEncoder::pop_debug_marker");
+        log::trace!("CommandEncoder::pop_debug_group");
 
         let hub = A::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2393,6 +2393,7 @@ pub mod render_ffi {
         pass: &mut RenderPass,
         pipeline_id: id::RenderPipelineId,
     ) {
+        log::trace!("RenderPass::set_pipeline {pipeline_id:?}");
         if pass.current_pipeline.set_and_check_redundant(pipeline_id) {
             return;
         }
@@ -2410,6 +2411,7 @@ pub mod render_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
+        log::trace!("RenderPass::set_vertex_buffer {buffer_id:?}");
         pass.base.commands.push(RenderCommand::SetVertexBuffer {
             slot,
             buffer_id,
@@ -2426,11 +2428,13 @@ pub mod render_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
+        log::trace!("RenderPass::set_index_buffer {buffer:?}");
         pass.set_index_buffer(buffer, index_format, offset, size);
     }
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_pass_set_blend_constant(pass: &mut RenderPass, color: &Color) {
+        log::trace!("RenderPass::set_blend_constant");
         pass.base
             .commands
             .push(RenderCommand::SetBlendConstant(*color));
@@ -2438,6 +2442,7 @@ pub mod render_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_pass_set_stencil_reference(pass: &mut RenderPass, value: u32) {
+        log::trace!("RenderPass::set_stencil_reference {value}");
         pass.base
             .commands
             .push(RenderCommand::SetStencilReference(value));
@@ -2453,6 +2458,7 @@ pub mod render_ffi {
         depth_min: f32,
         depth_max: f32,
     ) {
+        log::trace!("RenderPass::set_viewport {x} {y} {w} {h}");
         pass.base.commands.push(RenderCommand::SetViewport {
             rect: Rect { x, y, w, h },
             depth_min,
@@ -2468,6 +2474,7 @@ pub mod render_ffi {
         w: u32,
         h: u32,
     ) {
+        log::trace!("RenderPass::set_scissor_rect {x} {y} {w} {h}");
         pass.base
             .commands
             .push(RenderCommand::SetScissor(Rect { x, y, w, h }));
@@ -2485,6 +2492,7 @@ pub mod render_ffi {
         size_bytes: u32,
         data: *const u8,
     ) {
+        log::trace!("RenderPass::set_push_constants");
         assert_eq!(
             offset & (wgt::PUSH_CONSTANT_ALIGNMENT - 1),
             0,
@@ -2522,6 +2530,10 @@ pub mod render_ffi {
         first_vertex: u32,
         first_instance: u32,
     ) {
+        log::trace!(
+            "RenderPass::draw {vertex_count} {instance_count} {first_vertex} {first_instance}"
+        );
+
         pass.base.commands.push(RenderCommand::Draw {
             vertex_count,
             instance_count,
@@ -2539,6 +2551,7 @@ pub mod render_ffi {
         base_vertex: i32,
         first_instance: u32,
     ) {
+        log::trace!("RenderPass::draw_indexed {index_count} {instance_count} {first_index} {base_vertex} {first_instance}");
         pass.base.commands.push(RenderCommand::DrawIndexed {
             index_count,
             instance_count,
@@ -2554,6 +2567,7 @@ pub mod render_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
+        log::trace!("RenderPass::draw_indirect {buffer_id:?} {offset}");
         pass.base.commands.push(RenderCommand::MultiDrawIndirect {
             buffer_id,
             offset,
@@ -2568,6 +2582,7 @@ pub mod render_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
+        log::trace!("RenderPass::draw_indexed_indirect {buffer_id:?} {offset}");
         pass.base.commands.push(RenderCommand::MultiDrawIndirect {
             buffer_id,
             offset,
@@ -2583,6 +2598,7 @@ pub mod render_ffi {
         offset: BufferAddress,
         count: u32,
     ) {
+        log::trace!("RenderPass::multi_draw_indirect {buffer_id:?} {offset} {count}");
         pass.base.commands.push(RenderCommand::MultiDrawIndirect {
             buffer_id,
             offset,
@@ -2598,6 +2614,7 @@ pub mod render_ffi {
         offset: BufferAddress,
         count: u32,
     ) {
+        log::trace!("RenderPass::multi_draw_indexed_indirect {buffer_id:?} {offset} {count}");
         pass.base.commands.push(RenderCommand::MultiDrawIndirect {
             buffer_id,
             offset,
@@ -2615,6 +2632,7 @@ pub mod render_ffi {
         count_buffer_offset: BufferAddress,
         max_count: u32,
     ) {
+        log::trace!("RenderPass::multi_draw_indirect_count {buffer_id:?} {offset} {count_buffer_id:?} {count_buffer_offset} {max_count}");
         pass.base
             .commands
             .push(RenderCommand::MultiDrawIndirectCount {
@@ -2636,6 +2654,7 @@ pub mod render_ffi {
         count_buffer_offset: BufferAddress,
         max_count: u32,
     ) {
+        log::trace!("RenderPass::multi_draw_indexed_indirect_count {buffer_id:?} {offset} {count_buffer_id:?} {count_buffer_offset} {max_count}");
         pass.base
             .commands
             .push(RenderCommand::MultiDrawIndirectCount {
@@ -2658,7 +2677,10 @@ pub mod render_ffi {
         label: RawString,
         color: u32,
     ) {
-        let bytes = unsafe { ffi::CStr::from_ptr(label) }.to_bytes();
+        let cstr = unsafe { ffi::CStr::from_ptr(label) };
+        log::trace!("RenderPass::push_debug_group {cstr:?}");
+
+        let bytes = cstr.to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 
         pass.base.commands.push(RenderCommand::PushDebugGroup {
@@ -2669,6 +2691,7 @@ pub mod render_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_pass_pop_debug_group(pass: &mut RenderPass) {
+        log::trace!("RenderPass::pop_debug_group");
         pass.base.commands.push(RenderCommand::PopDebugGroup);
     }
 
@@ -2682,7 +2705,10 @@ pub mod render_ffi {
         label: RawString,
         color: u32,
     ) {
-        let bytes = unsafe { ffi::CStr::from_ptr(label) }.to_bytes();
+        let cstr = unsafe { ffi::CStr::from_ptr(label) };
+        log::trace!("RenderPass::insert_debug_marker {cstr:?}");
+
+        let bytes = cstr.to_bytes();
         pass.base.string_data.extend_from_slice(bytes);
 
         pass.base.commands.push(RenderCommand::InsertDebugMarker {
@@ -2697,6 +2723,7 @@ pub mod render_ffi {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) {
+        log::trace!("RenderPass::write_timestamps {query_set_id:?} {query_index}");
         pass.base.commands.push(RenderCommand::WriteTimestamp {
             query_set_id,
             query_index,
@@ -2708,6 +2735,7 @@ pub mod render_ffi {
         pass: &mut RenderPass,
         query_index: u32,
     ) {
+        log::trace!("RenderPass::begin_occlusion_query {query_index}");
         pass.base
             .commands
             .push(RenderCommand::BeginOcclusionQuery { query_index });
@@ -2715,6 +2743,7 @@ pub mod render_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_pass_end_occlusion_query(pass: &mut RenderPass) {
+        log::trace!("RenderPass::end_occlusion_query");
         pass.base.commands.push(RenderCommand::EndOcclusionQuery);
     }
 
@@ -2724,6 +2753,7 @@ pub mod render_ffi {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) {
+        log::trace!("RenderPass::begin_pipeline_statistics_query {query_set_id:?} {query_index}");
         pass.base
             .commands
             .push(RenderCommand::BeginPipelineStatisticsQuery {
@@ -2734,6 +2764,7 @@ pub mod render_ffi {
 
     #[no_mangle]
     pub extern "C" fn wgpu_render_pass_end_pipeline_statistics_query(pass: &mut RenderPass) {
+        log::trace!("RenderPass::end_pipeline_statistics_query");
         pass.base
             .commands
             .push(RenderCommand::EndPipelineStatisticsQuery);
@@ -2749,6 +2780,7 @@ pub mod render_ffi {
         render_bundle_ids: *const id::RenderBundleId,
         render_bundle_ids_length: usize,
     ) {
+        log::trace!("RenderPass::execute_bundles");
         for &bundle_id in
             unsafe { slice::from_raw_parts(render_bundle_ids, render_bundle_ids_length) }
         {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -262,7 +262,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let id = fid.assign(buffer, &mut token);
-            log::info!("Created buffer {:?} with {:?}", id, desc);
+            log::trace!("Device::create_buffer -> {:?}", id);
 
             device
                 .trackers
@@ -482,7 +482,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             //TODO: lock pending writes separately, keep the device read-only
             let (mut device_guard, mut token) = hub.devices.write(&mut token);
 
-            log::info!("Buffer {:?} is destroyed", buffer_id);
+            log::trace!("Buffer::destroy {buffer_id:?}");
             let (mut buffer_guard, _) = hub.buffers.write(&mut token);
             let buffer = buffer_guard
                 .get_mut(buffer_id)
@@ -533,7 +533,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn buffer_drop<A: HalApi>(&self, buffer_id: id::BufferId, wait: bool) {
         profiling::scope!("Buffer::drop");
-        log::debug!("buffer {:?} is dropped", buffer_id);
+        log::trace!("Buffer::drop {buffer_id:?}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -616,7 +616,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let ref_count = texture.life_guard.add_ref();
 
             let id = fid.assign(texture, &mut token);
-            log::info!("Created texture {:?} with {:?}", id, desc);
+            log::trace!("Device::create_texture -> {id:?}");
 
             device.trackers.lock().textures.insert_single(
                 id.0,
@@ -643,7 +643,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &resource::TextureDescriptor,
         id_in: Input<G, id::TextureId>,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
-        profiling::scope!("Device::create_texture");
+        profiling::scope!("Device::create_texture_from_hal");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -696,7 +696,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let ref_count = texture.life_guard.add_ref();
 
             let id = fid.assign(texture, &mut token);
-            log::info!("Created texture {:?} with {:?}", id, desc);
+            log::trace!("Device::create_texture -> {id:?}");
 
             device.trackers.lock().textures.insert_single(
                 id.0,
@@ -756,7 +756,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let ref_count = buffer.life_guard.add_ref();
 
             let id = fid.assign(buffer, &mut token);
-            log::info!("Created buffer {:?} with {:?}", id, desc);
+            log::trace!("Device::create_buffer -> {id:?}");
 
             device
                 .trackers
@@ -780,6 +780,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         texture_id: id::TextureId,
     ) -> Result<(), resource::DestroyError> {
         profiling::scope!("Texture::destroy");
+        log::trace!("Texture::destroy {texture_id:?}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -787,7 +788,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         //TODO: lock pending writes separately, keep the device read-only
         let (mut device_guard, mut token) = hub.devices.write(&mut token);
 
-        log::info!("Buffer {:?} is destroyed", texture_id);
         let (mut texture_guard, _) = hub.textures.write(&mut token);
         let texture = texture_guard
             .get_mut(texture_id)
@@ -837,7 +837,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn texture_drop<A: HalApi>(&self, texture_id: id::TextureId, wait: bool) {
         profiling::scope!("Texture::drop");
-        log::debug!("texture {:?} is dropped", texture_id);
+        log::trace!("Texture::drop {texture_id:?}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -921,8 +921,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let id = fid.assign(view, &mut token);
 
             device.trackers.lock().views.insert_single(id, ref_count);
+
+            log::trace!("Texture::create_view {:?} -> {:?}", texture_id, id.0);
+
             return (id.0, None);
         };
+
+        log::error!("Texture::create_view {:?} error {:?}", texture_id, error);
 
         let id = fid.assign_error(desc.label.borrow_or_default(), &mut token);
         (id, Some(error))
@@ -938,7 +943,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         wait: bool,
     ) -> Result<(), resource::TextureViewDestroyError> {
         profiling::scope!("TextureView::drop");
-        log::debug!("texture view {:?} is dropped", texture_view_id);
+        log::trace!("TextureView::drop {:?}", texture_view_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1019,6 +1024,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             device.trackers.lock().samplers.insert_single(id, ref_count);
 
+            log::trace!("Device::create_sampler -> {:?}", id.0);
+
             return (id.0, None);
         };
 
@@ -1032,7 +1039,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn sampler_drop<A: HalApi>(&self, sampler_id: id::SamplerId) {
         profiling::scope!("Sampler::drop");
-        log::debug!("sampler {:?} is dropped", sampler_id);
+        log::trace!("Sampler::drop {sampler_id:?}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1121,6 +1128,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     //    the branch and instead rely on the indirection to use the
                     //    proper bind group layout id.
                     if G::ids_are_generated_in_wgpu() {
+                        log::trace!("Device::create_bind_group_layout (duplicate of {id:?})");
                         return (id, None);
                     }
 
@@ -1141,6 +1149,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let id = fid.assign(layout, &mut token);
 
+            if let Some(dupe) = compatible_layout {
+                log::trace!(
+                    "Device::create_bind_group_layout (duplicate of {dupe:?}) -> {:?}",
+                    id.0
+                );
+            } else {
+                log::trace!("Device::create_bind_group_layout -> {:?}", id.0);
+            }
+
             return (id.0, None);
         };
 
@@ -1154,7 +1171,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn bind_group_layout_drop<A: HalApi>(&self, bind_group_layout_id: id::BindGroupLayoutId) {
         profiling::scope!("BindGroupLayout::drop");
-        log::debug!("bind group layout {:?} is dropped", bind_group_layout_id);
+        log::trace!("BindGroupLayout::drop {:?}", bind_group_layout_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1219,6 +1236,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let id = fid.assign(layout, &mut token);
+
+            log::trace!("Device::create_pipeline_layout -> {:?}", id.0);
+
             return (id.0, None);
         };
 
@@ -1232,7 +1252,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn pipeline_layout_drop<A: HalApi>(&self, pipeline_layout_id: id::PipelineLayoutId) {
         profiling::scope!("PipelineLayout::drop");
-        log::debug!("pipeline layout {:?} is dropped", pipeline_layout_id);
+        log::trace!("PipelineLayout::drop {:?}", pipeline_layout_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1318,7 +1338,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let ref_count = bind_group.life_guard.add_ref();
 
             let id = fid.assign(bind_group, &mut token);
-            log::debug!("Bind group {:?}", id,);
+
+            log::trace!("Device::create_bind_group -> {:?}", id.0);
 
             device
                 .trackers
@@ -1338,7 +1359,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn bind_group_drop<A: HalApi>(&self, bind_group_id: id::BindGroupId) {
         profiling::scope!("BindGroup::drop");
-        log::debug!("bind group {:?} is dropped", bind_group_id);
+        log::trace!("BindGroup::drop {:?}", bind_group_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1422,6 +1443,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(e) => break e,
             };
             let id = fid.assign(shader, &mut token);
+
+            log::trace!("Device::create_shader_module -> {:?}", id.0);
+
             return (id.0, None);
         };
 
@@ -1493,7 +1517,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn shader_module_drop<A: HalApi>(&self, shader_module_id: id::ShaderModuleId) {
         profiling::scope!("ShaderModule::drop");
-        log::debug!("shader module {:?} is dropped", shader_module_id);
+        log::trace!("ShaderModule::drop {:?}", shader_module_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1559,6 +1583,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             );
 
             let id = fid.assign(command_buffer, &mut token);
+
+            log::trace!("Device::create_command_encoder -> {:?}", id.0);
+
             return (id.0, None);
         };
 
@@ -1572,7 +1599,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn command_encoder_drop<A: HalApi>(&self, command_encoder_id: id::CommandEncoderId) {
         profiling::scope!("CommandEncoder::drop");
-        log::debug!("command encoder {:?} is dropped", command_encoder_id);
+        log::trace!("CommandEncoder::drop {:?}", command_encoder_id);
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1590,7 +1617,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn command_buffer_drop<A: HalApi>(&self, command_buffer_id: id::CommandBufferId) {
         profiling::scope!("CommandBuffer::drop");
-        log::debug!("command buffer {:?} is dropped", command_buffer_id);
+        log::trace!("CommandBuffer::drop {:?}", command_buffer_id);
         self.command_encoder_drop::<A>(command_buffer_id)
     }
 
@@ -1603,6 +1630,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         Option<command::CreateRenderBundleError>,
     ) {
         profiling::scope!("Device::create_render_bundle_encoder");
+        log::trace!("Device::device_create_render_bundle_encoder");
         let (encoder, error) = match command::RenderBundleEncoder::new(desc, device_id, None) {
             Ok(encoder) => (encoder, None),
             Err(e) => (command::RenderBundleEncoder::dummy(device_id), Some(e)),
@@ -1656,6 +1684,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let id = fid.assign(render_bundle, &mut token);
 
             device.trackers.lock().bundles.insert_single(id, ref_count);
+
+            log::trace!("RenderBundleEncoder::finish -> {:?}", id.0);
+
             return (id.0, None);
         };
 
@@ -1669,7 +1700,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn render_bundle_drop<A: HalApi>(&self, render_bundle_id: id::RenderBundleId) {
         profiling::scope!("RenderBundle::drop");
-        log::debug!("render bundle {:?} is dropped", render_bundle_id);
+        log::trace!("RenderBundle::drop {:?}", render_bundle_id);
         let hub = A::hub(self);
         let mut token = Token::root();
 
@@ -1744,12 +1775,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         };
 
         let id = fid.assign_error("", &mut token);
+
+        log::trace!("Device::create_query_set -> {:?}", id);
+
         (id, Some(error))
     }
 
     pub fn query_set_drop<A: HalApi>(&self, query_set_id: id::QuerySetId) {
         profiling::scope!("QuerySet::drop");
-        log::debug!("query set {:?} is dropped", query_set_id);
+        log::trace!("QuerySet::drop {query_set_id:?}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1835,7 +1869,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let ref_count = pipeline.life_guard.add_ref();
 
             let id = fid.assign(pipeline, &mut token);
-            log::info!("Created render pipeline {:?} with {:?}", id, desc);
+            log::trace!("Device::create_render_pipeline -> {id:?}");
 
             device
                 .trackers
@@ -1899,7 +1933,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn render_pipeline_drop<A: HalApi>(&self, render_pipeline_id: id::RenderPipelineId) {
         profiling::scope!("RenderPipeline::drop");
-        log::debug!("render pipeline {:?} is dropped", render_pipeline_id);
+        log::trace!("RenderPipeline::drop {:?}", render_pipeline_id);
         let hub = A::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -1980,7 +2014,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let ref_count = pipeline.life_guard.add_ref();
 
             let id = fid.assign(pipeline, &mut token);
-            log::info!("Created compute pipeline {:?} with {:?}", id, desc);
+            log::trace!("Device::create_compute_pipeline -> {id:?}");
 
             device
                 .trackers
@@ -2043,7 +2077,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn compute_pipeline_drop<A: HalApi>(&self, compute_pipeline_id: id::ComputePipelineId) {
         profiling::scope!("ComputePipeline::drop");
-        log::debug!("compute pipeline {:?} is dropped", compute_pipeline_id);
+        log::trace!("ComputePipeline::drop {:?}", compute_pipeline_id);
         let hub = A::hub(self);
         let mut token = Token::root();
         let (device_guard, mut token) = hub.devices.read(&mut token);
@@ -2355,6 +2389,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         device_id: DeviceId,
         maintain: wgt::Maintain<queue::WrappedSubmissionIndex>,
     ) -> Result<bool, WaitIdleError> {
+        log::trace!("Device::poll");
+
         let (closures, queue_empty) = {
             if let wgt::Maintain::WaitForSubmissionIndex(submission_index) = maintain {
                 if submission_index.queue_id != device_id {
@@ -2470,6 +2506,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_start_capture<A: HalApi>(&self, id: DeviceId) {
+        log::trace!("Device::start_capture");
+
         let hub = A::hub(self);
         let mut token = Token::root();
         let (device_guard, _) = hub.devices.read(&mut token);
@@ -2482,6 +2520,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_stop_capture<A: HalApi>(&self, id: DeviceId) {
+        log::trace!("Device::stop_capture");
+
         let hub = A::hub(self);
         let mut token = Token::root();
         let (device_guard, _) = hub.devices.read(&mut token);
@@ -2495,7 +2535,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn device_drop<A: HalApi>(&self, device_id: DeviceId) {
         profiling::scope!("Device::drop");
-        log::debug!("device {:?} is dropped", device_id);
+        log::trace!("Device::drop {device_id:?}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -2511,6 +2551,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_destroy<A: HalApi>(&self, device_id: DeviceId) {
+        log::trace!("Device::destroy {device_id:?}");
+
         let hub = A::hub(self);
         let mut token = Token::root();
 
@@ -2541,6 +2583,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_lose<A: HalApi>(&self, device_id: DeviceId, reason: Option<&str>) {
+        log::trace!("Device::lose {device_id:?}");
+
         let hub = A::hub(self);
         let mut token = Token::root();
 
@@ -2587,6 +2631,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         range: Range<BufferAddress>,
         op: BufferMapOperation,
     ) -> BufferAccessResult {
+        log::trace!("Buffer::map_async {buffer_id:?}");
+
         // User callbacks must not be called while holding buffer_map_async_inner's locks, so we
         // defer the error callback if it needs to be called immediately (typically when running
         // into errors).
@@ -2705,6 +2751,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         size: Option<BufferAddress>,
     ) -> Result<(*mut u8, u64), BufferAccessError> {
         profiling::scope!("Buffer::get_mapped_range");
+        log::trace!("Buffer::get_mapped_range {buffer_id:?}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -2865,6 +2912,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn buffer_unmap<A: HalApi>(&self, buffer_id: id::BufferId) -> BufferAccessResult {
         profiling::scope!("unmap", "Buffer");
+        log::trace!("Buffer::unmap {buffer_id:?}");
 
         let closure;
         {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1051,6 +1051,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         command_buffer_ids: &[id::CommandBufferId],
     ) -> Result<WrappedSubmissionIndex, QueueSubmitError> {
         profiling::scope!("Queue::submit");
+        log::trace!("Queue::submit {queue_id:?}");
 
         let (submit_index, callbacks) = {
             let hub = A::hub(self);
@@ -1434,6 +1435,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         queue_id: id::QueueId,
         closure: SubmittedWorkDoneClosure,
     ) -> Result<(), InvalidQueue> {
+        log::trace!("Queue::on_submitted_work_done {queue_id:?}");
+
         //TODO: flush pending writes
         let hub = A::hub(self);
         let mut token = Token::root();

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -302,6 +302,8 @@ impl<A: HalApi> Adapter<A> {
         desc: &DeviceDescriptor,
         trace_path: Option<&std::path::Path>,
     ) -> Result<Device<A>, RequestDeviceError> {
+        log::trace!("Adapter::create_device");
+
         let caps = &self.raw.capabilities;
         Device::new(
             open,
@@ -656,6 +658,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn surface_drop(&self, id: SurfaceId) {
         profiling::scope!("Surface::drop");
+        log::trace!("Surface::drop {id:?}");
+
         let mut token = Token::root();
         let (surface, _) = self.surfaces.unregister(id, &mut token);
         let mut surface = surface.unwrap();
@@ -722,6 +726,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn enumerate_adapters(&self, inputs: AdapterInputs<Input<G, AdapterId>>) -> Vec<AdapterId> {
         profiling::scope!("Instance::enumerate_adapters");
+        log::trace!("Instance::enumerate_adapters");
 
         let mut adapters = Vec::new();
 
@@ -779,6 +784,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         inputs: AdapterInputs<Input<G, AdapterId>>,
     ) -> Result<AdapterId, RequestAdapterError> {
         profiling::scope!("Instance::pick_adapter");
+        log::trace!("Instance::pick_adapter");
 
         fn gather<A: HalApi, I: Clone>(
             _: A,
@@ -1060,6 +1066,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn adapter_drop<A: HalApi>(&self, adapter_id: AdapterId) {
         profiling::scope!("Adapter::drop");
+        log::trace!("Adapter::drop {adapter_id:?}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
@@ -1085,6 +1092,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         id_in: Input<G, DeviceId>,
     ) -> (DeviceId, Option<RequestDeviceError>) {
         profiling::scope!("Adapter::request_device");
+        log::trace!("Adapter::request_device");
 
         let hub = A::hub(self);
         let mut token = Token::root();


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**

This PR adds trace-level logs to all or most of the entry points in wgpu-core. A fair amount of debug level logs were converted to trace in the process.
