### PR TITLE
Fix x11 hang when resizing on vulkan

### DIFF
--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -159,6 +159,8 @@ impl super::Swapchain {
         profiling::scope!("Swapchain::release_resources");
         {
             profiling::scope!("vkDeviceWaitIdle");
+            // We need to also wait until all presentation work is done. Because there is no way to portably wait until
+            // the presentation work is done, we are forced to wait until the device is idle.
             let _ = unsafe { device.device_wait_idle() };
         };
         unsafe { device.destroy_fence(self.fence, None) };

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -157,6 +157,10 @@ impl super::Swapchain {
     /// - The device must have been made idle before calling this function.
     unsafe fn release_resources(self, device: &ash::Device) -> Self {
         profiling::scope!("Swapchain::release_resources");
+        {
+            profiling::scope!("vkDeviceWaitIdle");
+            let _ = unsafe { device.device_wait_idle() };
+        };
         unsafe { device.destroy_fence(self.fence, None) };
         self
     }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/4180

**Description**
From @cwfitzgerald : The problem is that we actually don't have access to wait until presentation is finished. I suspect what is happening is that without the device.wait_idle() call whatever presentation things are happening are still in progress and calling device.wait_idle() is the only way to actually do that

**Testing**
Reproduced the steps in https://github.com/gfx-rs/wgpu/issues/4180, and everything resizes smoothly again