### PR TITLE
Make GLES optional on Windows & macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ depth_ops: Some(wgpu::Operations {
 
 By @wumpf in [#4147](https://github.com/gfx-rs/wgpu/pull/4147)
 
+#### The GLES backend is now optional on Windows & macOS
+
+The `angle` feature flag has to be set for the GLES backend to be enabled on Windows & macOS.
+
+By @teoxoy in [#4185](https://github.com/gfx-rs/wgpu/pull/4185)
+
 
 ### Added/New Features
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ We have a [wiki](https://github.com/gfx-rs/wgpu/wiki) that serves as a knowledge
 | Metal  |                                |                    | :white_check_mark:        |
 | DX12   | :white_check_mark: (W10+ only) |                    |                           |
 | DX11   | :hammer_and_wrench:            |                    |                           |
-| GLES3  |                                | :ok:               |                           |
-| Angle  | :ok:                           | :ok:               | :ok: (macOS only)         |
+| GLES3  | :ok: (angle)                   | :ok:               | :ok: (angle; macOS only)  |
 
 :white_check_mark: = First Class Support — :ok: = Best Effort Support — :hammer_and_wrench: = Unsupported, but support in progress
 

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -10,10 +10,6 @@ keywords.workspace = true
 license.workspace = true
 publish = false
 
-[features]
-angle = ["wgc/angle"]
-vulkan-portability = ["wgc/vulkan"]
-
 [dependencies]
 env_logger.workspace = true
 log.workspace = true

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -41,7 +41,6 @@ renderdoc = ["hal/renderdoc"]
 # Apply run-time checks, even in release builds. These are in addition
 # to the validation carried out at public APIs in all builds.
 strict_asserts = ["wgt/strict_asserts"]
-angle = ["hal/gles"]
 # Enable API tracing
 trace = ["ron", "serde", "wgt/trace", "arrayvec/serde", "naga/serialize"]
 # Enable API replaying

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -34,30 +34,29 @@ glsl = ["naga/glsl-in"]
 wgsl = ["wgc?/wgsl"]
 trace = ["serde", "wgc/trace"]
 replay = ["serde", "wgc/replay"]
-angle = ["wgc/angle"]
-webgl = ["hal", "wgc"]
+# Enables the GLES backend on Windows & macOS
+angle = ["wgc/gles"]
+webgl = ["hal", "wgc/gles"]
+# Enables the Vulkan backend on macOS & iOS
 vulkan-portability = ["wgc/vulkan"]
 expose-ids = []
 # Implement `Send` and `Sync` on Wasm.
 fragile-send-sync-non-atomic-wasm = ["hal/fragile-send-sync-non-atomic-wasm", "wgc/fragile-send-sync-non-atomic-wasm", "wgt/fragile-send-sync-non-atomic-wasm"]
 
 # wgpu-core is always available as an optional dependency, "wgc".
-# Whenever wgpu-core is selected, we want the GLES backend and raw
-# window handle support.
+# Whenever wgpu-core is selected, we want raw window handle support.
 [dependencies.wgc]
 optional = true
 workspace = true
-features = ["raw-window-handle", "gles"]
+features = ["raw-window-handle"]
 
 # wgpu-core is required whenever not targeting web APIs directly.
-# Whenever wgpu-core is selected, we want the GLES backend and raw
-# window handle support.
+# Whenever wgpu-core is selected, we want raw window handle support.
 [target.'cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))'.dependencies.wgc]
 workspace = true
-features = ["raw-window-handle", "gles"]
+features = ["raw-window-handle"]
 
 # We want the wgpu-core Metal backend on macOS and iOS.
-# (We should consider also enabling "vulkan" for Vulkan Portability.)
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.wgc]
 workspace = true
 features = ["metal"]
@@ -67,10 +66,15 @@ features = ["metal"]
 workspace = true
 features = ["dx11", "dx12"]
 
-# We want the wgpu-core Vulkan backend on Unix (but not Emscripten) and Windows.
+# We want the wgpu-core Vulkan backend on Unix (but not emscripten, macOS, iOS) and Windows.
 [target.'cfg(any(windows, all(unix, not(target_os = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
 workspace = true
 features = ["vulkan"]
+
+# We want the wgpu-core GLES backend on Unix (but not macOS, iOS).
+[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies.wgc]
+workspace = true
+features = ["gles"]
 
 [dependencies.wgt]
 workspace = true


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/gfx-rs/wgpu/issues/4109#issuecomment-1739651614

**Description**
Users of GLES on Windows and macOS should have to opt into using the GLES backend via Angle since they'd have to package it with the app. Otherwise we might pick up a random version of Angle on their system.

