### PR TITLE
Add WinUI 3 SwapChainPanel support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ By @teoxoy in [#4185](https://github.com/gfx-rs/wgpu/pull/4185)
 
 - Add `gles_minor_version` field to `wgpu::InstanceDescriptor`. By @PJB3005 in [#3998](https://github.com/gfx-rs/wgpu/pull/3998)
 - Re-export Naga. By @exrook in [#4172](https://github.com/gfx-rs/wgpu/pull/4172)
+- Add WinUI 3 SwapChainPanel support. By @ddrboxman in [#4191](https://github.com/gfx-rs/wgpu/pull/4191)
 
 ### Changes
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -672,7 +672,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
             vulkan: None,
             dx12: self.instance.dx12.as_ref().map(|inst| HalSurface {
-                raw: unsafe { inst.create_surface_from_swap_chain_panel(swap_chain_panel) },
+                raw: unsafe { inst.create_surface_from_swap_chain_panel(swap_chain_panel as _) },
             }),
             dx11: None,
             #[cfg(feature = "gles")]

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -580,7 +580,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
                         None
                     }
                 }
-                SurfaceTarget::Visual(_) | SurfaceTarget::SurfaceHandle(_) => None,
+                SurfaceTarget::Visual(_) | SurfaceTarget::SurfaceHandle(_) | SurfaceTarget::SwapChainPanel(_)=> None,
             }
         };
 

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -580,7 +580,9 @@ impl crate::Adapter<super::Api> for super::Adapter {
                         None
                     }
                 }
-                SurfaceTarget::Visual(_) | SurfaceTarget::SurfaceHandle(_) | SurfaceTarget::SwapChainPanel(_)=> None,
+                SurfaceTarget::Visual(_)
+                | SurfaceTarget::SurfaceHandle(_)
+                | SurfaceTarget::SwapChainPanel(_) => None,
             }
         };
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -127,7 +127,7 @@ impl Instance {
 
     pub unsafe fn create_surface_from_swap_chain_panel(
         &self,
-        swap_chain_panel: *mut ISwapChainPanelNative,
+        swap_chain_panel: *mut types::ISwapChainPanelNative,
     ) -> Surface {
         Surface {
             factory: self.factory.clone(),
@@ -158,7 +158,7 @@ enum SurfaceTarget {
     WndHandle(windef::HWND),
     Visual(d3d12::ComPtr<dcomp::IDCompositionVisual>),
     SurfaceHandle(winnt::HANDLE),
-    SwapChainPanel(d3d12::ComPtr<ISwapChainPanelNative>),
+    SwapChainPanel(d3d12::ComPtr<types::ISwapChainPanelNative>),
 }
 
 pub struct Surface {
@@ -740,7 +740,7 @@ impl crate::Surface<Api> for Surface {
                     }
                     &SurfaceTarget::SwapChainPanel(ref swap_chain_panel) => {
                         if let Err(err) =
-                        unsafe { swap_chain_panel.SetSwapChain(swap_chain1.as_unknown()) }.into_result()
+                        unsafe { swap_chain_panel.SetSwapChain(swap_chain1.as_ptr()) }.into_result()
                         {
                             log::error!("Unable to SetSwapChain: {}", err);
                             return Err(crate::SurfaceError::Other(

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -132,7 +132,9 @@ impl Instance {
         Surface {
             factory: self.factory.clone(),
             factory_media: self.factory_media.clone(),
-            target: SurfaceTarget::SwapChainPanel(unsafe { d3d12::ComPtr::from_raw(swap_chain_panel) }),
+            target: SurfaceTarget::SwapChainPanel(unsafe {
+                d3d12::ComPtr::from_raw(swap_chain_panel)
+            }),
             supports_allow_tearing: self.supports_allow_tearing,
             swap_chain: None,
         }
@@ -740,7 +742,8 @@ impl crate::Surface<Api> for Surface {
                     }
                     &SurfaceTarget::SwapChainPanel(ref swap_chain_panel) => {
                         if let Err(err) =
-                        unsafe { swap_chain_panel.SetSwapChain(swap_chain1.as_ptr()) }.into_result()
+                            unsafe { swap_chain_panel.SetSwapChain(swap_chain1.as_ptr()) }
+                                .into_result()
                         {
                             log::error!("Unable to SetSwapChain: {}", err);
                             return Err(crate::SurfaceError::Other(
@@ -772,7 +775,9 @@ impl crate::Surface<Api> for Surface {
                     )
                 };
             }
-            SurfaceTarget::Visual(_) | SurfaceTarget::SurfaceHandle(_) | SurfaceTarget::SwapChainPanel(_) => {} 
+            SurfaceTarget::Visual(_)
+            | SurfaceTarget::SurfaceHandle(_)
+            | SurfaceTarget::SwapChainPanel(_) => {}
         }
 
         unsafe { swap_chain.SetMaximumFrameLatency(config.swap_chain_size) };

--- a/wgpu-hal/src/dx12/types.rs
+++ b/wgpu-hal/src/dx12/types.rs
@@ -33,7 +33,7 @@ winapi::STRUCT! {
     }
 }
 
-winapi::RIDL!{#[uuid(0x63aad0b8, 0x7c24, 0x40ff, 0x64, 0x0d, 0x94, 0x4c, 0xc3, 0x25)]
+winapi::RIDL!{#[uuid(0x63aad0b8, 0x7c24, 0x40ff, 0x85, 0xa8, 0x64, 0x0d, 0x94, 0x4c, 0xc3, 0x25)]
 interface ISwapChainPanelNative(ISwapChainPanelNativeVtbl): IUnknown(IUnknownVtbl) {
     fn SetSwapChain(swapChain: *mut winapi::shared::dxgi::IDXGISwapChain) -> winapi::um::winnt::HRESULT,
 }}

--- a/wgpu-hal/src/dx12/types.rs
+++ b/wgpu-hal/src/dx12/types.rs
@@ -1,6 +1,16 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+// use here so that the recursive RIDL macro can find the crate
+use winapi::RIDL;
+use winapi::um::unknwnbase::{IUnknown, IUnknownVtbl};
+
+RIDL!{#[uuid(0x63aad0b8, 0x7c24, 0x40ff, 0x85, 0xa8, 0x64, 0x0d, 0x94, 0x4c, 0xc3, 0x25)]
+    interface ISwapChainPanelNative(ISwapChainPanelNativeVtbl): IUnknown(IUnknownVtbl) {
+        fn SetSwapChain(swapChain: *const winapi::shared::dxgi1_2::IDXGISwapChain1,) -> winapi::um::winnt::HRESULT,
+    }}
+    
+
 winapi::ENUM! {
     enum D3D12_VIEW_INSTANCING_TIER {
         D3D12_VIEW_INSTANCING_TIER_NOT_SUPPORTED  = 0,
@@ -33,7 +43,4 @@ winapi::STRUCT! {
     }
 }
 
-winapi::RIDL!{#[uuid(0x63aad0b8, 0x7c24, 0x40ff, 0x85, 0xa8, 0x64, 0x0d, 0x94, 0x4c, 0xc3, 0x25)]
-interface ISwapChainPanelNative(ISwapChainPanelNativeVtbl): IUnknown(IUnknownVtbl) {
-    fn SetSwapChain(swapChain: *mut winapi::shared::dxgi::IDXGISwapChain) -> winapi::um::winnt::HRESULT,
-}}
+

--- a/wgpu-hal/src/dx12/types.rs
+++ b/wgpu-hal/src/dx12/types.rs
@@ -32,3 +32,8 @@ winapi::STRUCT! {
         BarycentricsSupported: winapi::shared::minwindef::BOOL,
     }
 }
+
+winapi::RIDL!{#[uuid(0x63aad0b8, 0x7c24, 0x40ff, 0x64, 0x0d, 0x94, 0x4c, 0xc3, 0x25)]
+interface ISwapChainPanelNative(ISwapChainPanelNativeVtbl): IUnknown(IUnknownVtbl) {
+    fn SetSwapChain(swapChain: *mut winapi::shared::dxgi::IDXGISwapChain) -> winapi::um::winnt::HRESULT,
+}}

--- a/wgpu-hal/src/dx12/types.rs
+++ b/wgpu-hal/src/dx12/types.rs
@@ -2,14 +2,13 @@
 #![allow(non_snake_case)]
 
 // use here so that the recursive RIDL macro can find the crate
-use winapi::RIDL;
 use winapi::um::unknwnbase::{IUnknown, IUnknownVtbl};
+use winapi::RIDL;
 
-RIDL!{#[uuid(0x63aad0b8, 0x7c24, 0x40ff, 0x85, 0xa8, 0x64, 0x0d, 0x94, 0x4c, 0xc3, 0x25)]
-    interface ISwapChainPanelNative(ISwapChainPanelNativeVtbl): IUnknown(IUnknownVtbl) {
-        fn SetSwapChain(swapChain: *const winapi::shared::dxgi1_2::IDXGISwapChain1,) -> winapi::um::winnt::HRESULT,
-    }}
-    
+RIDL! {#[uuid(0x63aad0b8, 0x7c24, 0x40ff, 0x85, 0xa8, 0x64, 0x0d, 0x94, 0x4c, 0xc3, 0x25)]
+interface ISwapChainPanelNative(ISwapChainPanelNativeVtbl): IUnknown(IUnknownVtbl) {
+    fn SetSwapChain(swapChain: *const winapi::shared::dxgi1_2::IDXGISwapChain1,) -> winapi::um::winnt::HRESULT,
+}}
 
 winapi::ENUM! {
     enum D3D12_VIEW_INSTANCING_TIER {
@@ -42,5 +41,3 @@ winapi::STRUCT! {
         BarycentricsSupported: winapi::shared::minwindef::BOOL,
     }
 }
-
-

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -287,6 +287,21 @@ impl Context {
         }
     }
 
+    #[cfg(target_os = "windows")]
+    pub unsafe fn create_surface_from_swap_chain_panel(
+        &self,
+        swap_chain_panel: *mut std::ffi::c_void,
+    ) -> Surface {
+        let id = unsafe {
+            self.0
+                .instance_create_surface_from_swap_chain_panel(swap_chain_panel, ())
+        };
+        Surface {
+            id,
+            configured_device: Mutex::default(),
+        }
+    }
+
     fn handle_error(
         &self,
         sink_mutex: &Mutex<ErrorSinkRaw>,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2039,7 +2039,7 @@ impl Instance {
                 .as_any()
                 .downcast_ref::<crate::backend::Context>()
                 .unwrap()
-                .create_surface_from_visual(visual)
+                .create_surface_from_swap_chain_panel(swap_chain_panel)
         };
         Surface {
             context: Arc::clone(&self.context),

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2027,6 +2027,28 @@ impl Instance {
         }
     }
 
+    /// Creates a surface from `SwapChainPanel`.
+    ///
+    /// # Safety
+    ///
+    /// - visual must be a valid SwapChainPanel to create a surface upon.
+    #[cfg(target_os = "windows")]
+    pub unsafe fn create_surface_from_swap_chain_panel(&self, swap_chain_panel: *mut std::ffi::c_void) -> Surface {
+        let surface = unsafe {
+            self.context
+                .as_any()
+                .downcast_ref::<crate::backend::Context>()
+                .unwrap()
+                .create_surface_from_visual(visual)
+        };
+        Surface {
+            context: Arc::clone(&self.context),
+            id: ObjectId::from(surface.id()),
+            data: Box::new(surface),
+            config: Mutex::new(None),
+        }
+    }
+
     /// Creates a surface from a `web_sys::HtmlCanvasElement`.
     ///
     /// The `canvas` argument must be a valid `<canvas>` element to

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2033,7 +2033,10 @@ impl Instance {
     ///
     /// - visual must be a valid SwapChainPanel to create a surface upon.
     #[cfg(target_os = "windows")]
-    pub unsafe fn create_surface_from_swap_chain_panel(&self, swap_chain_panel: *mut std::ffi::c_void) -> Surface {
+    pub unsafe fn create_surface_from_swap_chain_panel(
+        &self,
+        swap_chain_panel: *mut std::ffi::c_void,
+    ) -> Surface {
         let surface = unsafe {
             self.context
                 .as_any()


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Closes https://github.com/gfx-rs/wgpu/issues/4187

**Description**

Currently WinUI3 requires using a SwapChainPanel to render into a widget with directx.

This allows passing down a SwapChainPanel reference and then sets the swap chain on the panel.

**Testing**

Called from a C# Win UI App and rendered the triangle from the tutorial to the swap chain


![Screenshot 2023-10-08 201300](https://github.com/gfx-rs/wgpu/assets/207897/7533dbdb-94e7-40f9-9c2a-3085d5f91584)
