### PR TITLE
Revert "Ignore the exception values generated by the winit resize event"

### DIFF
--- a/examples/common/src/framework.rs
+++ b/examples/common/src/framework.rs
@@ -309,22 +309,11 @@ fn start<E: Example>(
                     },
                 ..
             } => {
-                // Once winit is fixed, the detection conditions here can be removed.
-                // https://github.com/rust-windowing/winit/issues/2876
-                let max_dimension = adapter.limits().max_texture_dimension_2d;
-                if size.width > max_dimension || size.height > max_dimension {
-                    log::warn!(
-                        "The resizing size {:?} exceeds the limit of {}.",
-                        size,
-                        max_dimension
-                    );
-                } else {
-                    log::info!("Resizing to {:?}", size);
-                    config.width = size.width.max(1);
-                    config.height = size.height.max(1);
-                    example.resize(&config, &device, &queue);
-                    surface.configure(&device, &config);
-                }
+                log::info!("Resizing to {:?}", size);
+                config.width = size.width.max(1);
+                config.height = size.height.max(1);
+                example.resize(&config, &device, &queue);
+                surface.configure(&device, &config);
             }
             event::Event::WindowEvent { event, .. } => match event {
                 WindowEvent::KeyboardInput {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
https://github.com/gfx-rs/wgpu/pull/3916

**Description**
[winit 0.28.7](https://github.com/rust-windowing/winit/issues/2876#issuecomment-1738125351) has already fixed this resizing issue.

**Testing**
Tested examples on macOS Sonoma.
