### PR TITLE
Validate that resources belong to the right device.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ By @teoxoy in [#4185](https://github.com/gfx-rs/wgpu/pull/4185)
 - Add stub support for device destroy and device validity. By @bradwerth in [4163](https://github.com/gfx-rs/wgpu/pull/4163)
 - Add trace-level logging for most entry points in wgpu-core By @nical in [4183](https://github.com/gfx-rs/wgpu/pull/4183)
 - Add `Rgb10a2Uint` format. By @teoxoy in [4199](https://github.com/gfx-rs/wgpu/pull/4199)
+- Validate that resources are used on the right device. By @nical in [4207](https://github.com/gfx-rs/wgpu/pull/4207)
 
 #### Vulkan
 

--- a/deno_webgpu/error.rs
+++ b/deno_webgpu/error.rs
@@ -104,9 +104,9 @@ impl From<DeviceError> for WebGpuError {
         match err {
             DeviceError::Lost => WebGpuError::Lost,
             DeviceError::OutOfMemory => WebGpuError::OutOfMemory,
-            DeviceError::ResourceCreationFailed | DeviceError::Invalid => {
-                WebGpuError::Validation(fmt_err(&err))
-            }
+            DeviceError::ResourceCreationFailed
+            | DeviceError::Invalid
+            | DeviceError::WrongDevice => WebGpuError::Validation(fmt_err(&err)),
         }
     }
 }

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -11,7 +11,6 @@ fn device_initialization() {
 }
 
 #[test]
-#[ignore]
 fn device_mismatch() {
     initialize_test(
         // https://github.com/gfx-rs/wgpu/issues/3927

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1326,6 +1326,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(..) => break binding_model::CreateBindGroupError::InvalidLayout,
             };
 
+            if bind_group_layout.device_id.value.0 != device_id {
+                break DeviceError::WrongDevice.into();
+            }
+
             let mut layout_id = id::Valid(desc.layout);
             if let Some(id) = bind_group_layout.as_duplicate() {
                 layout_id = id;

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -300,6 +300,8 @@ pub enum DeviceError {
     OutOfMemory,
     #[error("Creation of a resource failed for a reason other than running out of memory.")]
     ResourceCreationFailed,
+    #[error("Attempt to use a resource with a different device from the one that created it")]
+    WrongDevice,
 }
 
 impl From<hal::DeviceError> for DeviceError {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Fixes #3927

**Description**

A pretty boring and mechanical change set although fairly important  for the browser use case. Each entry point that takes resources as input must check that these resources are associated with the same device.

I'm sure that I have forgotten some, thankfully it looks like the CTS is rather thorough about testing this so we'll see what's missing when this makes its way into firefox.


**Testing**

I enabled the the `device_msimatch` test which I added when filing the issue. It only covers a tiny portion of the cases but the CTS has good coverage of this so adding exhaustive tests here is not as important.