### PR TITLE
Expose and validate the bgra8unorm-storage feature

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -558,6 +558,14 @@ impl<A: HalApi> Device<A> {
             return Err(CreateTextureError::InvalidUsage(desc.usage));
         }
 
+        // Check for for the bgra8unorml-storage feature.
+        if desc.format == wgt::TextureFormat::Bgra8Unorm
+            && desc.usage.contains(wgt::TextureUsages::STORAGE_BINDING)
+            && !self.features.contains(wgt::Features::BGRA8UNORM_STORAGE)
+        {
+            return Err(CreateTextureError::InvalidUsage(desc.usage));
+        }
+
         conv::check_texture_dimension_size(
             desc.dimension,
             desc.size,

--- a/wgpu-hal/src/dx11/adapter.rs
+++ b/wgpu-hal/src/dx11/adapter.rs
@@ -152,6 +152,9 @@ impl super::Adapter {
             features |= wgt::Features::VERTEX_WRITABLE_STORAGE;
         }
 
+        // bgra8unorm-storage is never supported on dx11 according to:
+        // https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/format-support-for-direct3d-11-0-feature-level-hardware#dxgi_format_b8g8r8a8_unormfcs-87
+
         //
         // Fill out limits and alignments
         //

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -825,7 +825,8 @@ impl super::PrivateCapabilities {
             | F::TEXTURE_FORMAT_16BIT_NORM
             | F::SHADER_F16
             | F::DEPTH32FLOAT_STENCIL8
-            | F::MULTI_DRAW_INDIRECT;
+            | F::MULTI_DRAW_INDIRECT
+            | F::BGRA8UNORM_STORAGE;
 
         features.set(
             F::TIMESTAMP_QUERY,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -488,6 +488,14 @@ impl PhysicalDeviceFeatures {
             );
         }
 
+        let bgra8u = vk::Format::B8G8R8A8_UNORM;
+        let storage_flag = vk::FormatFeatureFlags::STORAGE_IMAGE;
+        features.set(
+            F::BGRA8UNORM_STORAGE,
+            supports_format(instance, phd, bgra8u, vk::ImageTiling::OPTIMAL, storage_flag)
+            && supports_format(instance, phd, bgra8u, vk::ImageTiling::LINEAR, storage_flag)
+        );
+
         let supports_depth_format = |format| {
             supports_format(
                 instance,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -309,13 +309,15 @@ bitflags::bitflags! {
         //
         // ? const FORMATS_TIER_1 = 1 << 14; (https://github.com/gpuweb/gpuweb/issues/3837)
         // ? const RW_STORAGE_TEXTURE_TIER_1 = 1 << 15; (https://github.com/gpuweb/gpuweb/issues/3838)
-        // TODO const BGRA8UNORM_STORAGE = 1 << 16;
         // ? const NORM16_FILTERABLE = 1 << 17; (https://github.com/gpuweb/gpuweb/issues/3839)
         // ? const NORM16_RESOLVE = 1 << 18; (https://github.com/gpuweb/gpuweb/issues/3839)
         // TODO const FLOAT32_FILTERABLE = 1 << 19;
         // ? const FLOAT32_BLENDABLE = 1 << 20; (https://github.com/gpuweb/gpuweb/issues/3556)
         // ? const 32BIT_FORMAT_MULTISAMPLE = 1 << 21; (https://github.com/gpuweb/gpuweb/issues/3844)
         // ? const 32BIT_FORMAT_RESOLVE = 1 << 22; (https://github.com/gpuweb/gpuweb/issues/3844)
+
+        /// Allows [`TextureUsages::STORAGE_BINDING`] on textures with [`TextureFormat::Bgra8unorm`].
+        const BGRA8UNORM_STORAGE = 1 << 16;
 
         /// Allows for usage of textures of format [`TextureFormat::Rg11b10Float`] as a render target
         ///


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1829895

**Description**

This adds initial support for the `bgra8unorm-storage` feature by only proposing it where supported out of the box. I've seen some discussions about emulating it on some configurations so I'll probably look into that next.


I haven't looked into whether it can work with the GL backend.

**Testing**

I only checked that the feature is supported via wgpu-info on a linux and a windows laptop. I suspect that the CTS has coverage for this but I have not checked.