### PR TITLE
Argument Buffers on Metal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,7 +1603,6 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.13.0"
-source = "git+https://github.com/gfx-rs/naga?rev=cc87b8f9eb30bb55d0735b89d3df3e099e1a6e7c#cc87b8f9eb30bb55d0735b89d3df3e099e1a6e7c"
 dependencies = [
  "bit-set",
  "bitflags 2.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = [
     "wgpu-hal",
     "wgpu-info",
     "wgpu-types",
-    "tests"
+    "tests",
 ]
 
 [workspace.package]
@@ -81,7 +81,11 @@ noise = "0.8"
 obj = "0.10"
 # parking_lot 0.12 switches from `winapi` to `windows`; permit either
 parking_lot = ">=0.11,<0.13"
-pico-args = { version = "0.5.0", features = ["eq-separator", "short-space-opt", "combined-flags"] }
+pico-args = { version = "0.5.0", features = [
+    "eq-separator",
+    "short-space-opt",
+    "combined-flags",
+] }
 png = "0.17.10"
 pollster = "0.3"
 profiling = { version = "1", default-features = false }
@@ -96,9 +100,9 @@ thiserror = "1"
 wgpu = { version = "0.17.0", path = "./wgpu" }
 wgpu-core = { version = "0.17.0", path = "./wgpu-core" }
 wgpu-example = { version = "0.17.0", path = "./examples/common" }
-wgpu-test = { version = "0.17", path = "./tests"}
+wgpu-test = { version = "0.17", path = "./tests" }
 wgpu-types = { version = "0.17.0", path = "./wgpu-types" }
-winit = { version = "0.28.6", features = [ "android-native-activity" ] }
+winit = { version = "0.28.6", features = ["android-native-activity"] }
 
 # Metal dependencies
 block = "0.1"
@@ -114,7 +118,11 @@ android_system_properties = "0.1.1"
 
 # DX dependencies
 bit-set = "0.5"
-gpu-allocator = { version = "0.21", default_features = false, features = ["d3d12", "windows", "public-winapi"] }
+gpu-allocator = { version = "0.21", default_features = false, features = [
+    "d3d12",
+    "windows",
+    "public-winapi",
+] }
 d3d12 = "0.7.0"
 range-alloc = "0.1"
 winapi = "0.3"
@@ -145,7 +153,7 @@ tokio = "1.32.0"
 termcolor = "1.2.0"
 
 [patch."https://github.com/gfx-rs/naga"]
-#naga = { path = "../naga" }
+naga = { path = "../naga" }
 
 [patch."https://github.com/zakarumych/gpu-descriptor"]
 #gpu-descriptor = { path = "../gpu-descriptor/gpu-descriptor" }
@@ -154,7 +162,7 @@ termcolor = "1.2.0"
 #gpu-alloc = { path = "../gpu-alloc/gpu-alloc" }
 
 [patch.crates-io]
-#naga = { path = "../naga" }
+naga = { path = "../naga" }
 #glow = { path = "../glow" }
 #d3d12 = { path = "../d3d12-rs" }
 #metal = { path = "../metal-rs" }


### PR DESCRIPTION
# Overview
This PR attempts to close #3334 

## Progress
When used in concert with [this naga PR](https://github.com/gfx-rs/naga/pull/2547), significantly simplifies wgpu's Metal backend by, in large part, replacing the existing resource binding model with argument buffers.

In many ways, a large part of the work done by the existing Metal backend is attempting to resolve the impedance mismatch between WebGPU (and, by extension, Vulkan's) descriptor set based binding model and Metal's pre-argument buffer binding model. This required very careful tracking and populating of a function argument table and passing knowledge of those bindings down to naga at shader generation time.

This PR instead tries to simplify that work by instead generating a Metal shader that uses argument buffers and employs a "reflection" style architecture that allows the generated shader to provide a simple 1:1 mapping between the members of a given bind group and the resources used in the shader.

## Further work
While I believe the bulk of the work has been done, I have sadly run out of available time to fully test and resolve all the edge cases required to finish this issue.

In particular, there are, unfortunately, *at least* two wrinkles that prevent the wholesale adoption of argument buffers:

- Writable textures on devices below tier 1
- Buffers with dynamic offsets

These two use cases would require passing the resource by argument into the entry point, as per the existing binding model. It should be reasonably straightforward to check for the presence of these two cases, and any others that arise, and handle them accordingly.

I have also not yet integrated the new binding model with compute shaders as I had hoped to resolve the issues with fragment/vertex shaders first.