### PR TITLE
Handle user callbacks in surface_configure

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2256,15 +2256,19 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             Ok(())
         }
 
-        log::info!("configuring surface with {:?}", config);
-        let hub = A::hub(self);
-        let mut token = Token::root();
+        // User callbacks must not be called while we are holding locks.
+        let mut user_callbacks = None;
 
-        let (mut surface_guard, mut token) = self.surfaces.write(&mut token);
-        let (adapter_guard, mut token) = hub.adapters.read(&mut token);
-        let (device_guard, mut token) = hub.devices.read(&mut token);
+        log::info!("configuring surface with {:?}", config);
 
         let error = 'outer: loop {
+            let hub = A::hub(self);
+            let mut token = Token::root();
+
+            let (mut surface_guard, mut token) = self.surfaces.write(&mut token);
+            let (adapter_guard, mut token) = hub.adapters.read(&mut token);
+            let (device_guard, mut token) = hub.devices.read(&mut token);
+
             let device = match device_guard.get(device_id) {
                 Ok(device) => device,
                 Err(_) => break DeviceError::Invalid.into(),
@@ -2340,8 +2344,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             }
 
             // Wait for all work to finish before configuring the surface.
-            if let Err(e) = device.maintain(hub, wgt::Maintain::Wait, &mut token) {
-                break e.into();
+            match device.maintain(hub, wgt::Maintain::Wait, &mut token) {
+                Ok((closures, _)) => {
+                    user_callbacks = Some(closures);
+                }
+                Err(e) => {
+                    break e.into();
+                }
             }
 
             // All textures must be destroyed before the surface can be re-configured.
@@ -2388,6 +2397,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             return None;
         };
+
+        if let Some(callbacks) = user_callbacks {
+            callbacks.fire();
+        }
 
         Some(error)
     }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Fixes #4214.

**Description**

We have assertions in place to check that we never forget to fire a map callback (otherwise that can cause memory leaks for some users of the API). `surface_configure` was not handling the user callbacks returned by maintain and this PR adds that.

**Testing**

:cricket: 