### PR TITLE
Update `naga` to 0.13.0@git:3c7dbc4016b84a35c69b30305b12abaeefc21fd9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,7 +1686,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.13.0"
-source = "git+https://github.com/gfx-rs/naga?rev=6668d0694cc51ee66c71c2ca3a1ab1081956299b#6668d0694cc51ee66c71c2ca3a1ab1081956299b"
+source = "git+https://github.com/gfx-rs/naga?rev=3c7dbc4016b84a35c69b30305b12abaeefc21fd9#3c7dbc4016b84a35c69b30305b12abaeefc21fd9"
 dependencies = [
  "bit-set",
  "bitflags 2.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ version = "0.17"
 
 [workspace.dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "6668d0694cc51ee66c71c2ca3a1ab1081956299b"
+rev = "3c7dbc4016b84a35c69b30305b12abaeefc21fd9"
 version = "0.13.0"
 
 [workspace.dependencies]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -77,7 +77,7 @@ thiserror = "1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "6668d0694cc51ee66c71c2ca3a1ab1081956299b"
+rev = "3c7dbc4016b84a35c69b30305b12abaeefc21fd9"
 version = "0.13.0"
 features = ["clone", "span", "validate"]
 

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -350,6 +350,7 @@ fn map_storage_format_from_naga(format: naga::StorageFormat) -> wgt::TextureForm
         Sf::Rgba8Snorm => Tf::Rgba8Snorm,
         Sf::Rgba8Uint => Tf::Rgba8Uint,
         Sf::Rgba8Sint => Tf::Rgba8Sint,
+        Sf::Bgra8Unorm => Tf::Bgra8Unorm,
 
         Sf::Rgb10a2Uint => Tf::Rgb10a2Uint,
         Sf::Rgb10a2Unorm => Tf::Rgb10a2Unorm,

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -120,14 +120,14 @@ android_system_properties = "0.1.1"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "6668d0694cc51ee66c71c2ca3a1ab1081956299b"
+rev = "3c7dbc4016b84a35c69b30305b12abaeefc21fd9"
 version = "0.13.0"
 features = ["clone"]
 
 # DEV dependencies
 [dev-dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "6668d0694cc51ee66c71c2ca3a1ab1081956299b"
+rev = "3c7dbc4016b84a35c69b30305b12abaeefc21fd9"
 version = "0.13.0"
 features = ["wgsl-in"]
 


### PR DESCRIPTION
Routine naga update. It contains parts of the Bgra8unorm storage work that #3634 depends on.