### PR TITLE
[gles] enable/disable blending per attachment only when available (on ES 3.2 or higher)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,10 @@ By @teoxoy in [#4185](https://github.com/gfx-rs/wgpu/pull/4185)
 - Ensure that limit requests and reporting is done correctly. By @OptimisticPeach in [#4107](https://github.com/gfx-rs/wgpu/pull/4107)
 - Validate usage of polygon mode. By @teoxoy in [#4196](https://github.com/gfx-rs/wgpu/pull/4196)
 
+#### GLES
+
+- enable/disable blending per attachment only when available (on ES 3.2 or higher). By @teoxoy in [#4234](https://github.com/gfx-rs/wgpu/pull/4234)
+
 #### Testing
 
 - Skip `test_multithreaded_compute` on MoltenVK. By @jimblandy in [#4096](https://github.com/gfx-rs/wgpu/pull/4096).

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -457,10 +457,6 @@ impl super::Adapter {
             !cfg!(target_arch = "wasm32"),
         );
         private_caps.set(
-            super::PrivateCapabilities::CAN_DISABLE_DRAW_BUFFER,
-            !cfg!(target_arch = "wasm32"),
-        );
-        private_caps.set(
             super::PrivateCapabilities::GET_BUFFER_SUB_DATA,
             cfg!(target_arch = "wasm32"),
         );

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -146,8 +146,6 @@ bitflags::bitflags! {
         /// Indicates that buffers used as `GL_ELEMENT_ARRAY_BUFFER` may be created / initialized / used
         /// as other targets, if not present they must not be mixed with other targets.
         const INDEX_BUFFER_ROLE_CHANGE = 1 << 5;
-        /// Indicates that the device supports disabling draw buffers
-        const CAN_DISABLE_DRAW_BUFFER = 1 << 6;
         /// Supports `glGetBufferSubData`
         const GET_BUFFER_SUB_DATA = 1 << 7;
         /// Supports `f16` color buffers

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -55,10 +55,6 @@ impl super::Queue {
                 .collect::<ArrayVec<_, { crate::MAX_COLOR_ATTACHMENTS }>>();
             unsafe { gl.draw_buffers(&indices) };
         }
-        #[cfg(not(target_arch = "wasm32"))]
-        for draw_buffer in 0..self.draw_buffer_count as u32 {
-            unsafe { gl.disable_draw_buffer(glow::BLEND, draw_buffer) };
-        }
     }
 
     unsafe fn reset_state(&mut self, gl: &glow::Context) {
@@ -970,16 +966,6 @@ impl super::Queue {
                     .map(|i| glow::COLOR_ATTACHMENT0 + i)
                     .collect::<ArrayVec<_, { crate::MAX_COLOR_ATTACHMENTS }>>();
                 unsafe { gl.draw_buffers(&indices) };
-
-                if self
-                    .shared
-                    .private_caps
-                    .contains(super::PrivateCapabilities::CAN_DISABLE_DRAW_BUFFER)
-                {
-                    for draw_buffer in 0..count as u32 {
-                        unsafe { gl.disable_draw_buffer(glow::BLEND, draw_buffer) };
-                    }
-                }
             }
             C::ClearColorF {
                 draw_buffer,
@@ -1249,7 +1235,7 @@ impl super::Queue {
                         )
                     };
                     if let Some(ref blend) = *blend {
-                        unsafe { gl.enable_draw_buffer(index, glow::BLEND) };
+                        unsafe { gl.enable_draw_buffer(glow::BLEND, index) };
                         if blend.color != blend.alpha {
                             unsafe {
                                 gl.blend_equation_separate_draw_buffer(
@@ -1273,12 +1259,8 @@ impl super::Queue {
                                 gl.blend_func_draw_buffer(index, blend.color.src, blend.color.dst)
                             };
                         }
-                    } else if self
-                        .shared
-                        .private_caps
-                        .contains(super::PrivateCapabilities::CAN_DISABLE_DRAW_BUFFER)
-                    {
-                        unsafe { gl.disable_draw_buffer(index, glow::BLEND) };
+                    } else {
+                        unsafe { gl.disable_draw_buffer(glow::BLEND, index) };
                     }
                 } else {
                     unsafe {


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
fixes https://github.com/gfx-rs/wgpu/issues/2987

**Description**
- enable/disable blending per attachment only when available (on ES 3.2 or higher)
- remove `PrivateCapabilities::CAN_DISABLE_DRAW_BUFFER` as it's equivalent to `DownlevelFlags::INDEPENDENT_BLEND`
- fix order of args given to `enable_draw_buffer` & `disable_draw_buffer` (https://github.com/grovesNL/glow/pull/10)

**Testing**
CI & @Zoxc could you try this patch? (I don't have a device with ES 3.1 or lower)
