### PR TITLE
Use DeviceError::Lost to represent device loss.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,8 @@ By @teoxoy in [#4185](https://github.com/gfx-rs/wgpu/pull/4185)
 - Add `Rgb10a2Uint` format. By @teoxoy in [4199](https://github.com/gfx-rs/wgpu/pull/4199)
 - Validate that resources are used on the right device. By @nical in [4207](https://github.com/gfx-rs/wgpu/pull/4207)
 - Expose instance flags. By @nical in [4230](https://github.com/gfx-rs/wgpu/pull/4230)
-- Add support for the bgra8unorm-storage feature. By @jinleili and @nical in [https://github.com/gfx-rs/wgpu/pull/4228](4228)
+- Add support for the bgra8unorm-storage feature. By @jinleili and @nical in [#4228](https://github.com/gfx-rs/wgpu/pull/4228)
+- Calls to lost devices now return `DeviceError::Lost` instead of `DeviceError::Invalid`. By @bradwerth in [#4238]([https://github.com/gfx-rs/wgpu/pull/4238])
 
 #### Vulkan
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1360,7 +1360,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let device = &device_guard[device_id];
             if !device.is_valid() {
-                return Err(DeviceError::Invalid).map_pass_err(init_scope);
+                return Err(DeviceError::Lost).map_pass_err(init_scope);
             }
             cmd_buf.encoder.open_pass(base.label);
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -159,7 +159,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             if desc.usage.is_empty() {
@@ -380,7 +380,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .get(device_id)
             .map_err(|_| DeviceError::Invalid)?;
         if !device.valid {
-            return Err(DeviceError::Invalid.into());
+            return Err(DeviceError::Lost.into());
         }
         let buffer = buffer_guard
             .get_mut(buffer_id)
@@ -440,7 +440,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .get(device_id)
             .map_err(|_| DeviceError::Invalid)?;
         if !device.valid {
-            return Err(DeviceError::Invalid.into());
+            return Err(DeviceError::Lost.into());
         }
         let buffer = buffer_guard
             .get_mut(buffer_id)
@@ -606,7 +606,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
             #[cfg(feature = "trace")]
             if let Some(ref trace) = device.trace {
@@ -664,7 +664,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             // NB: Any change done through the raw texture handle will not be
@@ -743,7 +743,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             // NB: Any change done through the raw buffer handle will not be
@@ -1012,7 +1012,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             #[cfg(feature = "trace")]
@@ -1096,7 +1096,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             #[cfg(feature = "trace")]
@@ -1231,7 +1231,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             #[cfg(feature = "trace")]
@@ -1317,7 +1317,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             #[cfg(feature = "trace")]
@@ -1428,7 +1428,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             #[cfg(feature = "trace")]
@@ -1500,7 +1500,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             #[cfg(feature = "trace")]
@@ -1574,7 +1574,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid,
             };
             if !device.valid {
-                break DeviceError::Invalid;
+                break DeviceError::Lost;
             }
 
             let dev_stored = Stored {
@@ -1764,7 +1764,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             #[cfg(feature = "trace")]
@@ -1860,7 +1860,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             let adapter = &adapter_guard[device.adapter_id.value];
@@ -2024,7 +2024,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(_) => break DeviceError::Invalid.into(),
             };
             if !device.valid {
-                break DeviceError::Invalid.into();
+                break DeviceError::Lost.into();
             }
 
             #[cfg(feature = "trace")]
@@ -2280,7 +2280,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     Err(_) => break DeviceError::Invalid.into(),
                 };
                 if !device.valid {
-                    break DeviceError::Invalid.into();
+                    break DeviceError::Lost.into();
                 }
 
                 #[cfg(feature = "trace")]
@@ -2734,7 +2734,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let device = &device_guard[buffer.device_id.value];
             if !device.valid {
-                return Err((op, DeviceError::Invalid.into()));
+                return Err((op, DeviceError::Lost.into()));
             }
 
             if let Err(e) = check_buffer_usage(buffer.usage, pub_usage) {
@@ -2980,7 +2980,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 .map_err(|_| BufferAccessError::Invalid)?;
             let device = &mut device_guard[buffer.device_id.value];
             if !device.valid {
-                return Err(DeviceError::Invalid.into());
+                return Err(DeviceError::Lost.into());
             }
 
             closure = self.buffer_unmap_inner(buffer_id, buffer, device)

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -307,7 +307,7 @@ pub enum DeviceError {
 impl From<hal::DeviceError> for DeviceError {
     fn from(error: hal::DeviceError) -> Self {
         match error {
-            hal::DeviceError::Lost => DeviceError::Invalid,
+            hal::DeviceError::Lost => DeviceError::Lost,
             hal::DeviceError::OutOfMemory => DeviceError::OutOfMemory,
             hal::DeviceError::ResourceCreationFailed => DeviceError::ResourceCreationFailed,
         }

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -139,7 +139,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             Some(ref present) => {
                 let device = &device_guard[present.device_id.value];
                 if !device.is_valid() {
-                    return Err(DeviceError::Invalid.into());
+                    return Err(DeviceError::Lost.into());
                 }
                 (device, present.config.clone())
             }
@@ -294,7 +294,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let device = &mut device_guard[present.device_id.value];
         if !device.is_valid() {
-            return Err(DeviceError::Invalid.into());
+            return Err(DeviceError::Lost.into());
         }
 
         #[cfg(feature = "trace")]
@@ -383,7 +383,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let device = &mut device_guard[present.device_id.value];
         if !device.is_valid() {
-            return Err(DeviceError::Invalid.into());
+            return Err(DeviceError::Lost.into());
         }
 
         #[cfg(feature = "trace")]


### PR DESCRIPTION
The device.valid boolean, regardless of its name, represents a state that is only activated through "lose the device". This patch changes error reporting of an invalid/lost device to use DeviceError::Lost. The value DeviceError::Invalid is used when a device id is not found.

**Checklist**

- [X] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
None

**Description**
This separates the meaning of DeviceError::Invalid (unknown device id) from DeviceError::Lost (device known and lost).

**Testing**
There is no real testing of this. The test `device_destroy_then_more` is making calls that result in a `DeviceError::Lost` value, but the test infrastructure checks for *any* failure, not a specific error type.
