### PR TITLE
Make it possible to filter labels out ahead of wgpu-hal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ By @teoxoy in [#4185](https://github.com/gfx-rs/wgpu/pull/4185)
 - Add support for the bgra8unorm-storage feature. By @jinleili and @nical in [#4228](https://github.com/gfx-rs/wgpu/pull/4228)
 - Calls to lost devices now return `DeviceError::Lost` instead of `DeviceError::Invalid`. By @bradwerth in [#4238]([https://github.com/gfx-rs/wgpu/pull/4238])
 - Let the `"strict_asserts"` feature enable check that wgpu-core's lock-ordering tokens are unique per thread. By @jimblandy in [#4258]([https://github.com/gfx-rs/wgpu/pull/4258])
+- Allow filtering labels out before they are passed to GPU drivers by @nical in [https://github.com/gfx-rs/wgpu/pull/4246](4246)
 
 #### Vulkan
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -776,11 +776,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 }
                 ComputeCommand::PushDebugGroup { color: _, len } => {
                     state.debug_scope_depth += 1;
+                    let label =
+                        str::from_utf8(&base.string_data[string_offset..string_offset + len])
+                            .unwrap();
+                    string_offset += len;
                     if !discard_hal_labels {
-                        let label =
-                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
-                                .unwrap();
-                        string_offset += len;
                         unsafe {
                             raw.begin_debug_marker(label);
                         }
@@ -801,11 +801,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                 }
                 ComputeCommand::InsertDebugMarker { color: _, len } => {
+                    let label =
+                        str::from_utf8(&base.string_data[string_offset..string_offset + len])
+                            .unwrap();
+                    string_offset += len;
                     if !discard_hal_labels {
-                        let label =
-                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
-                                .unwrap();
-                        string_offset += len;
                         unsafe { raw.insert_debug_marker(label) }
                     }
                 }

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -14,6 +14,7 @@ use crate::{
     error::{ErrorFormatter, PrettyError},
     global::Global,
     hal_api::HalApi,
+    hal_label,
     hub::Token,
     id,
     id::DeviceId,
@@ -476,8 +477,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             Some(&*query_set_guard),
         );
 
+        let discard_hal_labels = self
+            .instance
+            .flags
+            .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS);
         let hal_desc = hal::ComputePassDescriptor {
-            label: base.label,
+            label: hal_label(base.label, self.instance.flags),
             timestamp_writes,
         };
 
@@ -771,12 +776,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 }
                 ComputeCommand::PushDebugGroup { color: _, len } => {
                     state.debug_scope_depth += 1;
-                    let label =
-                        str::from_utf8(&base.string_data[string_offset..string_offset + len])
-                            .unwrap();
-                    string_offset += len;
-                    unsafe {
-                        raw.begin_debug_marker(label);
+                    if !discard_hal_labels {
+                        let label =
+                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
+                                .unwrap();
+                        string_offset += len;
+                        unsafe {
+                            raw.begin_debug_marker(label);
+                        }
                     }
                 }
                 ComputeCommand::PopDebugGroup => {
@@ -787,16 +794,20 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .map_pass_err(scope);
                     }
                     state.debug_scope_depth -= 1;
-                    unsafe {
-                        raw.end_debug_marker();
+                    if !discard_hal_labels {
+                        unsafe {
+                            raw.end_debug_marker();
+                        }
                     }
                 }
                 ComputeCommand::InsertDebugMarker { color: _, len } => {
-                    let label =
-                        str::from_utf8(&base.string_data[string_offset..string_offset + len])
-                            .unwrap();
-                    string_offset += len;
-                    unsafe { raw.insert_debug_marker(label) }
+                    if !discard_hal_labels {
+                        let label =
+                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
+                                .unwrap();
+                        string_offset += len;
+                        unsafe { raw.insert_debug_marker(label) }
+                    }
                 }
                 ComputeCommand::WriteTimestamp {
                     query_set_id,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -776,15 +776,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 }
                 ComputeCommand::PushDebugGroup { color: _, len } => {
                     state.debug_scope_depth += 1;
-                    let label =
-                        str::from_utf8(&base.string_data[string_offset..string_offset + len])
-                            .unwrap();
-                    string_offset += len;
                     if !discard_hal_labels {
+                        let label =
+                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
+                                .unwrap();
                         unsafe {
                             raw.begin_debug_marker(label);
                         }
                     }
+                    string_offset += len;
                 }
                 ComputeCommand::PopDebugGroup => {
                     let scope = PassErrorScope::PopDebugGroup;
@@ -801,13 +801,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                 }
                 ComputeCommand::InsertDebugMarker { color: _, len } => {
-                    let label =
-                        str::from_utf8(&base.string_data[string_offset..string_offset + len])
-                            .unwrap();
-                    string_offset += len;
                     if !discard_hal_labels {
+                        let label =
+                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
+                                .unwrap();
                         unsafe { raw.insert_debug_marker(label) }
                     }
+                    string_offset += len;
                 }
                 ComputeCommand::WriteTimestamp {
                     query_set_id,

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -405,8 +405,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         let cmd_buf_raw = cmd_buf.encoder.open();
-        unsafe {
-            cmd_buf_raw.begin_debug_marker(label);
+        if !self
+            .instance
+            .flags
+            .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS)
+        {
+            unsafe {
+                cmd_buf_raw.begin_debug_marker(label);
+            }
         }
         Ok(())
     }
@@ -430,9 +436,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             list.push(TraceCommand::InsertDebugMarker(label.to_string()));
         }
 
-        let cmd_buf_raw = cmd_buf.encoder.open();
-        unsafe {
-            cmd_buf_raw.insert_debug_marker(label);
+        if !self
+            .instance
+            .flags
+            .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS)
+        {
+            let cmd_buf_raw = cmd_buf.encoder.open();
+            unsafe {
+                cmd_buf_raw.insert_debug_marker(label);
+            }
         }
         Ok(())
     }
@@ -456,8 +468,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         let cmd_buf_raw = cmd_buf.encoder.open();
-        unsafe {
-            cmd_buf_raw.end_debug_marker();
+        if !self
+            .instance
+            .flags
+            .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS)
+        {
+            unsafe {
+                cmd_buf_raw.end_debug_marker();
+            }
         }
         Ok(())
     }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -127,14 +127,14 @@ impl<A: HalApi> CommandBuffer<A> {
         _downlevel: wgt::DownlevelCapabilities,
         features: wgt::Features,
         #[cfg(feature = "trace")] enable_tracing: bool,
-        label: &Label,
+        label: Option<String>,
     ) -> Self {
         CommandBuffer {
             encoder: CommandEncoder {
                 raw: encoder,
                 is_open: false,
                 list: Vec::new(),
-                label: crate::LabelHelpers::borrow_option(label).map(|s| s.to_string()),
+                label,
             },
             status: CommandEncoderStatus::Recording,
             device_id,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2163,17 +2163,18 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                     RenderCommand::PushDebugGroup { color: _, len } => {
                         state.debug_scope_depth += 1;
-                        let label =
-                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
-                                .unwrap();
-
-                        log::trace!("RenderPass::push_debug_group {label:?}");
-                        string_offset += len;
                         if !discard_hal_labels {
+                            let label = str::from_utf8(
+                                &base.string_data[string_offset..string_offset + len],
+                            )
+                            .unwrap();
+
+                            log::trace!("RenderPass::push_debug_group {label:?}");
                             unsafe {
                                 raw.begin_debug_marker(label);
                             }
                         }
+                        string_offset += len;
                     }
                     RenderCommand::PopDebugGroup => {
                         log::trace!("RenderPass::pop_debug_group");
@@ -2191,16 +2192,17 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
                     }
                     RenderCommand::InsertDebugMarker { color: _, len } => {
-                        let label =
-                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
-                                .unwrap();
-                        log::trace!("RenderPass::insert_debug_marker {label:?}");
-                        string_offset += len;
                         if !discard_hal_labels {
+                            let label = str::from_utf8(
+                                &base.string_data[string_offset..string_offset + len],
+                            )
+                            .unwrap();
+                            log::trace!("RenderPass::insert_debug_marker {label:?}");
                             unsafe {
                                 raw.insert_debug_marker(label);
                             }
                         }
+                        string_offset += len;
                     }
                     RenderCommand::WriteTimestamp {
                         query_set_id,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2163,14 +2163,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                     RenderCommand::PushDebugGroup { color: _, len } => {
                         state.debug_scope_depth += 1;
-                        if !discard_hal_labels {
-                            let label = str::from_utf8(
-                                &base.string_data[string_offset..string_offset + len],
-                            )
-                            .unwrap();
+                        let label =
+                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
+                                .unwrap();
 
-                            log::trace!("RenderPass::push_debug_group {label:?}");
-                            string_offset += len;
+                        log::trace!("RenderPass::push_debug_group {label:?}");
+                        string_offset += len;
+                        if !discard_hal_labels {
                             unsafe {
                                 raw.begin_debug_marker(label);
                             }
@@ -2192,13 +2191,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
                     }
                     RenderCommand::InsertDebugMarker { color: _, len } => {
+                        let label =
+                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
+                                .unwrap();
+                        log::trace!("RenderPass::insert_debug_marker {label:?}");
+                        string_offset += len;
                         if !discard_hal_labels {
-                            let label = str::from_utf8(
-                                &base.string_data[string_offset..string_offset + len],
-                            )
-                            .unwrap();
-                            log::trace!("RenderPass::insert_debug_marker {label:?}");
-                            string_offset += len;
                             unsafe {
                                 raw.insert_debug_marker(label);
                             }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -16,6 +16,7 @@ use crate::{
     error::{ErrorFormatter, PrettyError},
     global::Global,
     hal_api::HalApi,
+    hal_label,
     hub::Token,
     id,
     identity::GlobalIdentityHandlerFactory,
@@ -1183,7 +1184,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
         };
 
         let hal_desc = hal::RenderPassDescriptor {
-            label,
+            label: hal_label(label, device.instance_flags),
             extent,
             sample_count,
             color_attachments: &colors,
@@ -1323,6 +1324,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             "CommandEncoder::run_render_pass {}",
             base.label.unwrap_or("")
         );
+
+        let discard_hal_labels = self
+            .instance
+            .flags
+            .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS);
+        let label = hal_label(base.label, self.instance.flags);
+
         let init_scope = PassErrorScope::Pass(encoder_id);
 
         let hub = A::hub(self);
@@ -1362,7 +1370,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             if !device.is_valid() {
                 return Err(DeviceError::Lost).map_pass_err(init_scope);
             }
-            cmd_buf.encoder.open_pass(base.label);
+            cmd_buf.encoder.open_pass(label);
 
             let (bundle_guard, mut token) = hub.render_bundles.read(&mut token);
             let (pipeline_layout_guard, mut token) = hub.pipeline_layouts.read(&mut token);
@@ -1381,7 +1389,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let mut info = RenderPassInfo::start(
                 device,
-                base.label,
+                label,
                 color_attachments,
                 depth_stencil_attachment,
                 timestamp_writes,
@@ -2155,14 +2163,17 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                     RenderCommand::PushDebugGroup { color: _, len } => {
                         state.debug_scope_depth += 1;
-                        let label =
-                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
-                                .unwrap();
+                        if !discard_hal_labels {
+                            let label = str::from_utf8(
+                                &base.string_data[string_offset..string_offset + len],
+                            )
+                            .unwrap();
 
-                        log::trace!("RenderPass::push_debug_group {label:?}");
-                        string_offset += len;
-                        unsafe {
-                            raw.begin_debug_marker(label);
+                            log::trace!("RenderPass::push_debug_group {label:?}");
+                            string_offset += len;
+                            unsafe {
+                                raw.begin_debug_marker(label);
+                            }
                         }
                     }
                     RenderCommand::PopDebugGroup => {
@@ -2174,18 +2185,23 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                                 .map_pass_err(scope);
                         }
                         state.debug_scope_depth -= 1;
-                        unsafe {
-                            raw.end_debug_marker();
+                        if !discard_hal_labels {
+                            unsafe {
+                                raw.end_debug_marker();
+                            }
                         }
                     }
                     RenderCommand::InsertDebugMarker { color: _, len } => {
-                        let label =
-                            str::from_utf8(&base.string_data[string_offset..string_offset + len])
-                                .unwrap();
-                        log::trace!("RenderPass::insert_debug_marker {label:?}");
-                        string_offset += len;
-                        unsafe {
-                            raw.insert_debug_marker(label);
+                        if !discard_hal_labels {
+                            let label = str::from_utf8(
+                                &base.string_data[string_offset..string_offset + len],
+                            )
+                            .unwrap();
+                            log::trace!("RenderPass::insert_debug_marker {label:?}");
+                            string_offset += len;
+                            unsafe {
+                                raw.insert_debug_marker(label);
+                            }
                         }
                     }
                     RenderCommand::WriteTimestamp {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1150,11 +1150,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         multi_ref_count: crate::MultiRefCount::new(),
                     }
                 } else {
-                    match device.create_bind_group_layout(
-                        device_id,
-                        desc.label.borrow_option(),
-                        entry_map,
-                    ) {
+                    match device.create_bind_group_layout(device_id, &desc.label, entry_map) {
                         Ok(layout) => layout,
                         Err(e) => break e,
                     }
@@ -1597,7 +1593,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 device.features,
                 #[cfg(feature = "trace")]
                 device.trace.is_some(),
-                &desc.label,
+                desc.label
+                    .to_hal(device.instance_flags)
+                    .map(|s| s.to_string()),
             );
 
             let id = fid.assign(command_buffer, &mut token);

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -12,6 +12,7 @@ use crate::{
         RenderPassContext, CLEANUP_WAIT_MS,
     },
     hal_api::HalApi,
+    hal_label,
     hub::{Hub, Token},
     id,
     identity::GlobalIdentityHandlerFactory,
@@ -101,6 +102,7 @@ pub struct Device<A: HalApi> {
     pub(crate) limits: wgt::Limits,
     pub(crate) features: wgt::Features,
     pub(crate) downlevel: wgt::DownlevelCapabilities,
+    pub(crate) instance_flags: wgt::InstanceFlags,
     // TODO: move this behind another mutex. This would allow several methods to
     // switch to borrow Device immutably, such as `write_buffer`, `write_texture`,
     // and `buffer_unmap`.
@@ -147,6 +149,7 @@ impl<A: HalApi> Device<A> {
         downlevel: wgt::DownlevelCapabilities,
         desc: &DeviceDescriptor,
         trace_path: Option<&std::path::Path>,
+        instance_flags: wgt::InstanceFlags,
     ) -> Result<Self, CreateDeviceError> {
         #[cfg(not(feature = "trace"))]
         if let Some(_) = trace_path {
@@ -167,7 +170,7 @@ impl<A: HalApi> Device<A> {
         let zero_buffer = unsafe {
             open.device
                 .create_buffer(&hal::BufferDescriptor {
-                    label: Some("(wgpu internal) zero init buffer"),
+                    label: hal_label(Some("(wgpu internal) zero init buffer"), instance_flags),
                     size: ZERO_BUFFER_SIZE,
                     usage: hal::BufferUses::COPY_SRC | hal::BufferUses::COPY_DST,
                     memory_flags: hal::MemoryFlags::empty(),
@@ -227,6 +230,7 @@ impl<A: HalApi> Device<A> {
             limits: desc.limits.clone(),
             features: desc.features,
             downlevel,
+            instance_flags,
             pending_writes,
         })
     }
@@ -466,7 +470,7 @@ impl<A: HalApi> Device<A> {
         memory_flags.set(hal::MemoryFlags::TRANSIENT, transient);
 
         let hal_desc = hal::BufferDescriptor {
-            label: desc.label.borrow_option(),
+            label: desc.label.to_hal(self.instance_flags),
             size: aligned_size,
             usage,
             memory_flags,
@@ -722,7 +726,7 @@ impl<A: HalApi> Device<A> {
             };
 
         let hal_desc = hal::TextureDescriptor {
-            label: desc.label.borrow_option(),
+            label: desc.label.to_hal(self.instance_flags),
             size: desc.size,
             mip_level_count: desc.mip_level_count,
             sample_count: desc.sample_count,
@@ -753,11 +757,16 @@ impl<A: HalApi> Device<A> {
                 wgt::TextureDimension::D3 => unreachable!(),
             };
 
+            let clear_label = hal_label(
+                Some("(wgpu internal) clear texture view"),
+                self.instance_flags,
+            );
+
             let mut clear_views = SmallVec::new();
             for mip_level in 0..desc.mip_level_count {
                 for array_layer in 0..desc.size.depth_or_array_layers {
                     let desc = hal::TextureViewDescriptor {
-                        label: Some("(wgpu internal) clear texture view"),
+                        label: clear_label,
                         format: desc.format,
                         dimension,
                         usage,
@@ -1059,7 +1068,7 @@ impl<A: HalApi> Device<A> {
         };
 
         let hal_desc = hal::TextureViewDescriptor {
-            label: desc.label.borrow_option(),
+            label: desc.label.to_hal(self.instance_flags),
             format,
             dimension: resolved_dimension,
             usage,
@@ -1177,7 +1186,7 @@ impl<A: HalApi> Device<A> {
         //TODO: check for wgt::DownlevelFlags::COMPARISON_SAMPLERS
 
         let hal_desc = hal::SamplerDescriptor {
-            label: desc.label.borrow_option(),
+            label: desc.label.to_hal(self.instance_flags),
             address_modes: desc.address_modes,
             mag_filter: desc.mag_filter,
             min_filter: desc.min_filter,
@@ -1316,7 +1325,7 @@ impl<A: HalApi> Device<A> {
         let hal_shader = hal::ShaderInput::Naga(hal::NagaShader { module, info });
 
         let hal_desc = hal::ShaderModuleDescriptor {
-            label: desc.label.borrow_option(),
+            label: desc.label.to_hal(self.instance_flags),
             runtime_checks: desc.shader_bound_checks.runtime_checks(),
         };
         let raw = match unsafe { self.raw.create_shader_module(&hal_desc, hal_shader) } {
@@ -1355,7 +1364,7 @@ impl<A: HalApi> Device<A> {
     ) -> Result<pipeline::ShaderModule<A>, pipeline::CreateShaderModuleError> {
         self.require_features(wgt::Features::SPIRV_SHADER_PASSTHROUGH)?;
         let hal_desc = hal::ShaderModuleDescriptor {
-            label: desc.label.borrow_option(),
+            label: desc.label.to_hal(self.instance_flags),
             runtime_checks: desc.shader_bound_checks.runtime_checks(),
         };
         let hal_shader = hal::ShaderInput::SpirV(source);
@@ -1464,7 +1473,7 @@ impl<A: HalApi> Device<A> {
     pub(super) fn create_bind_group_layout(
         &self,
         self_id: id::DeviceId,
-        label: Option<&str>,
+        label: &crate::Label,
         entry_map: binding_model::BindEntryMap,
     ) -> Result<binding_model::BindGroupLayout<A>, binding_model::CreateBindGroupLayoutError> {
         #[derive(PartialEq)]
@@ -1629,7 +1638,7 @@ impl<A: HalApi> Device<A> {
         let mut hal_bindings = entry_map.values().cloned().collect::<Vec<_>>();
         hal_bindings.sort_by_key(|b| b.binding);
         let hal_desc = hal::BindGroupLayoutDescriptor {
-            label,
+            label: label.to_hal(self.instance_flags),
             flags: bgl_flags,
             entries: &hal_bindings,
         };
@@ -1664,7 +1673,7 @@ impl<A: HalApi> Device<A> {
                 count_validator,
                 entries: entry_map,
                 #[cfg(debug_assertions)]
-                label: label.unwrap_or("").to_string(),
+                label: label.borrow_or_default().to_string(),
             }),
         })
     }
@@ -2087,7 +2096,7 @@ impl<A: HalApi> Device<A> {
         let layout_inner = layout.assume_deduplicated();
 
         let hal_desc = hal::BindGroupDescriptor {
-            label: desc.label.borrow_option(),
+            label: desc.label.to_hal(self.instance_flags),
             layout: &layout_inner.raw,
             entries: &hal_entries,
             buffers: &hal_buffers,
@@ -2371,7 +2380,7 @@ impl<A: HalApi> Device<A> {
             })
             .collect::<Vec<_>>();
         let hal_desc = hal::PipelineLayoutDescriptor {
-            label: desc.label.borrow_option(),
+            label: desc.label.to_hal(self.instance_flags),
             flags: hal::PipelineLayoutFlags::BASE_VERTEX_INSTANCE,
             bind_group_layouts: &bgl_vec,
             push_constant_ranges: desc.push_constant_ranges.as_ref(),
@@ -2437,7 +2446,7 @@ impl<A: HalApi> Device<A> {
                     *bgl_id = dedup_id;
                 }
                 None => {
-                    let bgl = self.create_bind_group_layout(self_id, None, map)?;
+                    let bgl = self.create_bind_group_layout(self_id, &None, map)?;
                     bgl_guard.force_replace(*bgl_id, bgl);
                 }
             };
@@ -2542,7 +2551,7 @@ impl<A: HalApi> Device<A> {
             Device::make_late_sized_buffer_groups(&shader_binding_sizes, layout, &*bgl_guard);
 
         let pipeline_desc = hal::ComputePipelineDescriptor {
-            label: desc.label.borrow_option(),
+            label: desc.label.to_hal(self.instance_flags),
             layout: &layout.raw,
             stage: hal::ProgrammableStage {
                 entry_point: desc.stage.entry_point.as_ref(),
@@ -3072,7 +3081,7 @@ impl<A: HalApi> Device<A> {
             Device::make_late_sized_buffer_groups(&shader_binding_sizes, layout, &*bgl_guard);
 
         let pipeline_desc = hal::RenderPipelineDescriptor {
-            label: desc.label.borrow_option(),
+            label: desc.label.to_hal(self.instance_flags),
             layout: &layout.raw,
             vertex_buffers: &vertex_buffers,
             vertex_stage,
@@ -3231,7 +3240,7 @@ impl<A: HalApi> Device<A> {
             });
         }
 
-        let hal_desc = desc.map_label(crate::LabelHelpers::borrow_option);
+        let hal_desc = desc.map_label(|label| label.to_hal(self.instance_flags));
         Ok(resource::QuerySet {
             raw: unsafe { self.raw.create_query_set(&hal_desc).unwrap() },
             device_id: Stored {

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -87,15 +87,31 @@ pub type Label<'a> = Option<Cow<'a, str>>;
 
 trait LabelHelpers<'a> {
     fn borrow_option(&'a self) -> Option<&'a str>;
+    fn to_hal(&'a self, flags: wgt::InstanceFlags) -> Option<&'a str>;
     fn borrow_or_default(&'a self) -> &'a str;
 }
 impl<'a> LabelHelpers<'a> for Label<'a> {
     fn borrow_option(&'a self) -> Option<&'a str> {
         self.as_ref().map(|cow| cow.as_ref())
     }
+    fn to_hal(&'a self, flags: wgt::InstanceFlags) -> Option<&'a str> {
+        if flags.contains(wgt::InstanceFlags::DISCARD_HAL_LABELS) {
+            return None;
+        }
+
+        self.as_ref().map(|cow| cow.as_ref())
+    }
     fn borrow_or_default(&'a self) -> &'a str {
         self.borrow_option().unwrap_or_default()
     }
+}
+
+pub fn hal_label(opt: Option<&str>, flags: wgt::InstanceFlags) -> Option<&str> {
+    if flags.contains(wgt::InstanceFlags::DISCARD_HAL_LABELS) {
+        return None;
+    }
+
+    opt
 }
 
 /// Reference count object that is 1:1 with each reference.

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -18,6 +18,7 @@ use crate::{
     device::{DeviceError, MissingDownlevelFlags, WaitIdleError},
     global::Global,
     hal_api::HalApi,
+    hal_label,
     hub::Token,
     id::{DeviceId, SurfaceId, TextureId, Valid},
     identity::{GlobalIdentityHandlerFactory, Input},
@@ -166,7 +167,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         } {
             Ok(Some(ast)) => {
                 let clear_view_desc = hal::TextureViewDescriptor {
-                    label: Some("(wgpu internal) clear surface texture view"),
+                    label: hal_label(
+                        Some("(wgpu internal) clear surface texture view"),
+                        self.instance.flags,
+                    ),
                     format: config.format,
                     dimension: wgt::TextureViewDimension::D2,
                     usage: hal::TextureUses::COLOR_TARGET,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -841,6 +841,8 @@ bitflags::bitflags! {
         const DEBUG = 1 << 0;
         /// Enable validation, if possible.
         const VALIDATION = 1 << 1;
+        /// Don't pass labels to wgpu-hal.
+        const DISCARD_HAL_LABELS = 1 << 2;
     }
 }
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.


**Description**

This is intended as a hardening feature. If we don't trust the author of labels (for example web content) and don't trust drivers to handle long or non-ascii strings, an instance flags can be set to filter out hal labels. When the flag is set, wgpu-core can still hold on to labels but they are not passed down to GPU drivers.

Most people should not enable this flag. Labels are pretty useful for debugging with renderdoc and similar tools.
