### PR TITLE
Add WGL context creation and OpenGL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ Bottom level categories:
 
 - Update Naga to 9eb3a1dc (2023-10-12), which includes support for WGSL constant expressions. By @jimblandy in [#4233](https://github.com/gfx-rs/wgpu/pull/4233)
 
+#### Support desktop OpenGL via WGL on Windows
+
+Added creating of full OpenGL contexts to the GLES backend using WGL to support older devices.
+
+By @Zoxc in [#4248](https://github.com/gfx-rs/wgpu/pull/4248)
+
 #### Pass timestamp queries
 
 Addition of `TimestampWrites` to compute and render passes to allow profiling.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
  "glutin_egl_sys",
  "glutin_gles2_sys",
  "glutin_glx_sys",
- "glutin_wgl_sys",
+ "glutin_wgl_sys 0.1.5",
  "libloading 0.7.4",
  "log",
  "objc",
@@ -1282,6 +1282,15 @@ name = "glutin_wgl_sys"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5951a1569dbab865c6f2a863efafff193a93caf05538d193e9e3816d21696"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef89398e90033fc6bc65e9bd42fd29bbbfd483bda5b56dc5562f455550618165"
 dependencies = [
  "gl_generator",
 ]
@@ -3353,6 +3362,7 @@ dependencies = [
  "env_logger",
  "glow",
  "glutin",
+ "glutin_wgl_sys 0.4.0",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,6 +3375,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
+ "once_cell",
  "parking_lot",
  "profiling",
  "range-alloc",

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ We have a [wiki](https://github.com/gfx-rs/wgpu/wiki) that serves as a knowledge
 | Metal       |                                |                    | :white_check_mark:        |                           |
 | DX12        | :white_check_mark: (W10+ only) |                    |                           |                           |
 | DX11        | :hammer_and_wrench:            |                    |                           |                           |
-| GLES3       |                                | :ok:               | :ok: (angle; macOS only)  | :ok: (WebGL2 Only)        |
-| OpenGL 3.3+ | :ok:                           |                    |                           |                           |
+| OpenGL      |  :ok: (Desktop GL 3.3+)        | :ok: (GL ES 3.0+)  | :ok: (angle; GL ES 3.0+)  | :ok: (WebGL2)             |
 | WebGPU      |                                |                    |                           | :white_check_mark:        |
 
 :white_check_mark: = First Class Support — :ok: = Best Effort Support — :hammer_and_wrench: = Unsupported, but support in progress

--- a/README.md
+++ b/README.md
@@ -70,14 +70,15 @@ We have a [wiki](https://github.com/gfx-rs/wgpu/wiki) that serves as a knowledge
 
 ## Supported Platforms
 
-| API       | Windows                        | Linux & Android    | macOS & iOS               | Web (wasm)                |
-| --------- | ------------------------------ | ------------------ | ------------------------- | ------------------------- |
-| Vulkan    | :white_check_mark:             | :white_check_mark: | :ok: (vulkan-portability) |                           |
-| Metal     |                                |                    | :white_check_mark:        |                           |
-| DX12      | :white_check_mark: (W10+ only) |                    |                           |                           |
-| DX11      | :hammer_and_wrench:            |                    |                           |                           |
-| GLES3     | :ok: (angle)                   | :ok:               | :ok: (angle; macOS only)  | :ok: (WebGL2 Only)        |
-| WebGPU    |                                |                    |                           | :white_check_mark:        |
+| API         | Windows                        | Linux & Android    | macOS & iOS               | Web (wasm)                |
+| ----------- | ------------------------------ | ------------------ | ------------------------- | ------------------------- |
+| Vulkan      | :white_check_mark:             | :white_check_mark: | :ok: (vulkan-portability) |                           |
+| Metal       |                                |                    | :white_check_mark:        |                           |
+| DX12        | :white_check_mark: (W10+ only) |                    |                           |                           |
+| DX11        | :hammer_and_wrench:            |                    |                           |                           |
+| GLES3       |                                | :ok:               | :ok: (angle; macOS only)  | :ok: (WebGL2 Only)        |
+| OpenGL 3.3+ | :ok:                           |                    |                           |                           |
+| WebGPU      |                                |                    |                           | :white_check_mark:        |
 
 :white_check_mark: = First Class Support — :ok: = Best Effort Support — :hammer_and_wrench: = Unsupported, but support in progress
 
@@ -148,6 +149,7 @@ We have multiple methods of testing, each of which tests different qualities abo
 | DX11/Windows 10  | :construction:     | —                  | using WARP                            |
 | Metal/MacOS      | :heavy_check_mark: | —                  | using hardware runner                 |
 | Vulkan/Linux     | :heavy_check_mark: | -                  | using swiftshader                     |
+| GL/Windows       |                    | —                  |                                       |
 | GLES/Linux       | :heavy_check_mark: | —                  | using llvmpipe                        |
 | WebGL/Chrome     | :heavy_check_mark: | —                  | using swiftshader                     |
 

--- a/tests/tests/multi-instance.rs
+++ b/tests/tests/multi-instance.rs
@@ -1,0 +1,33 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+async fn get() -> wgpu::Adapter {
+    let adapter = {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all),
+            ..Default::default()
+        });
+        instance
+            .request_adapter(&wgpu::RequestAdapterOptions::default())
+            .await
+            .unwrap()
+    };
+
+    log::info!("Selected adapter: {:?}", adapter.get_info());
+
+    adapter
+}
+
+#[test]
+fn multi_instance() {
+    {
+        env_logger::init();
+
+        // Sequential instances.
+        for _ in 0..3 {
+            pollster::block_on(get());
+        }
+
+        // Concurrent instances
+        let _instances: Vec<_> = (0..3).map(|_| pollster::block_on(get())).collect();
+    }
+}

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -36,7 +36,7 @@ targets = [
 default = ["link"]
 metal = ["naga/msl-out", "block"]
 vulkan = ["naga/spv-out", "ash", "gpu-alloc", "gpu-descriptor", "libloading", "smallvec"]
-gles = ["naga/glsl-out", "glow", "khronos-egl", "libloading"]
+gles = ["naga/glsl-out", "glow", "glutin_wgl_sys", "khronos-egl", "libloading"]
 dx11 = ["naga/hlsl-out", "d3d12", "libloading", "winapi/d3d11", "winapi/std", "winapi/d3d11_1", "winapi/d3d11_2", "winapi/d3d11sdklayers", "winapi/dxgi1_6"]
 dx12 = ["naga/hlsl-out", "d3d12", "bit-set", "libloading", "range-alloc", "winapi/std", "winapi/winbase", "winapi/d3d12", "winapi/d3d12shader", "winapi/d3d12sdklayers", "winapi/dxgi1_6"]
 # TODO: This is a separate feature until Mozilla okays windows-rs, see https://github.com/gfx-rs/wgpu/issues/3207 for the tracking issue.
@@ -95,6 +95,8 @@ bit-set = { version = "0.5", optional = true }
 range-alloc = { version = "0.1", optional = true }
 gpu-allocator = { version = "0.23", default_features = false, features = ["d3d12", "public-winapi"], optional = true }
 hassle-rs = { version = "0.10", optional = true }
+# backend: Gles
+glutin_wgl_sys = { version = "0.4", optional = true }
 
 winapi = { version = "0.3", features = ["profileapi", "libloaderapi", "windef", "winuser", "dcomp"] }
 d3d12 = { version = "0.7", features = ["libloading"], optional = true }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -59,6 +59,7 @@ parking_lot = ">=0.11,<0.13"
 profiling = { version = "1", default-features = false }
 raw-window-handle = "0.5"
 thiserror = "1"
+once_cell = "1.18.0"
 
 # backends common
 arrayvec = "0.7"

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -10,7 +10,7 @@
 
 extern crate wgpu_hal as hal;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(windows, target_arch = "wasm32")))]
 fn main() {
     env_logger::init();
     println!("Initializing external GL context");
@@ -116,10 +116,10 @@ fn main() {
     fill_screen(&exposed, 640, 400);
 }
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(any(windows, all(target_arch = "wasm32", not(target_os = "emscripten"))))]
 fn main() {}
 
-#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
+#[cfg(any(not(any(windows, target_arch = "wasm32")), target_os = "emscripten"))]
 fn fill_screen(exposed: &hal::ExposedAdapter<hal::api::Gles>, width: u32, height: u32) {
     use hal::{Adapter as _, CommandEncoder as _, Device as _, Queue as _};
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -277,7 +277,11 @@ impl super::Adapter {
             log::info!("SL version: {}", &sl_version);
             if full_ver.is_some() {
                 let (sl_major, sl_minor) = Self::parse_full_version(&sl_version).ok()?;
-                let value = sl_major as u16 * 100 + sl_minor as u16 * 10;
+                let mut value = sl_major as u16 * 100 + sl_minor as u16 * 10;
+                // Naga doesn't think it supports GL 460+, so we cap it at 450
+                if value > 450 {
+                    value = 450;
+                }
                 naga::back::glsl::Version::Desktop(value)
             } else {
                 let (sl_major, sl_minor) = Self::parse_version(&sl_version).ok()?;

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -843,7 +843,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             device: super::Device {
                 shared: Arc::clone(&self.shared),
                 main_vao,
-                #[cfg(all(not(any(target_arch = "wasm32", windows)), feature = "renderdoc"))]
+                #[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
                 render_doc: Default::default(),
             },
             queue: super::Queue {

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -599,9 +599,7 @@ impl super::Adapter {
             max_uniform_buffer_binding_size: unsafe {
                 gl.get_parameter_i32(glow::MAX_UNIFORM_BLOCK_SIZE)
             } as u32,
-            max_storage_buffer_binding_size: if supported((3, 1), (4, 3))
-                || extensions.contains("GL_ARB_shader_storage_buffer_object")
-            {
+            max_storage_buffer_binding_size: if supports_storage {
                 unsafe { gl.get_parameter_i32(glow::MAX_SHADER_STORAGE_BLOCK_SIZE) }
             } else {
                 0

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -269,7 +269,7 @@ impl super::Adapter {
         let supports_storage =
             supported((3, 1), (4, 3)) || extensions.contains("GL_ARB_shader_storage_buffer_object");
         let supports_compute =
-            supported((3, 1), (4, 6)) || extensions.contains("GL_ARB_compute_shader");
+            supported((3, 1), (4, 3)) || extensions.contains("GL_ARB_compute_shader");
         let supports_work_group_params = supports_compute;
 
         let shading_language_version = {
@@ -439,13 +439,13 @@ impl super::Adapter {
         );
         features.set(
             wgt::Features::SHADER_PRIMITIVE_INDEX,
-            supported((3, 2), (4, 6))
+            supported((3, 2), (3, 2))
                 || extensions.contains("OES_geometry_shader")
                 || extensions.contains("GL_ARB_geometry_shader4"),
         );
         features.set(
             wgt::Features::SHADER_EARLY_DEPTH_TEST,
-            supported((3, 1), (4, 6)) || extensions.contains("GL_ARB_shader_image_load_store"),
+            supported((3, 1), (4, 2)) || extensions.contains("GL_ARB_shader_image_load_store"),
         );
         features.set(wgt::Features::SHADER_UNUSED_VERTEX_OUTPUT, true);
         let gles_bcn_exts = [

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1304,7 +1304,7 @@ impl crate::Device<super::Api> for super::Device {
     }
 
     unsafe fn start_capture(&self) -> bool {
-        #[cfg(all(not(any(target_arch = "wasm32", windows)), feature = "renderdoc"))]
+        #[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
         return unsafe {
             self.render_doc
                 .start_frame_capture(self.shared.context.raw_context(), ptr::null_mut())
@@ -1313,7 +1313,7 @@ impl crate::Device<super::Api> for super::Device {
         false
     }
     unsafe fn stop_capture(&self) {
-        #[cfg(all(not(any(target_arch = "wasm32", windows)), feature = "renderdoc"))]
+        #[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
         unsafe {
             self.render_doc
                 .end_frame_capture(ptr::null_mut(), ptr::null_mut())

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -272,10 +272,6 @@ impl super::Device {
                 entry_point: stage.entry_point.to_owned(),
             });
         }
-        let glsl_version = match self.shared.shading_language_version {
-            naga::back::glsl::Version::Embedded { version, .. } => version,
-            naga::back::glsl::Version::Desktop(_) => unreachable!(),
-        };
         let mut guard = self
             .shared
             .program_cache
@@ -295,7 +291,7 @@ impl super::Device {
                     layout,
                     label,
                     multiview,
-                    glsl_version,
+                    self.shared.shading_language_version,
                     self.shared.private_caps,
                 )
             })
@@ -311,9 +307,13 @@ impl super::Device {
         layout: &super::PipelineLayout,
         #[cfg_attr(target_arch = "wasm32", allow(unused))] label: Option<&str>,
         multiview: Option<std::num::NonZeroU32>,
-        glsl_version: u16,
+        glsl_version: naga::back::glsl::Version,
         private_caps: super::PrivateCapabilities,
     ) -> Result<Arc<super::PipelineInner>, crate::PipelineError> {
+        let glsl_version = match glsl_version {
+            naga::back::glsl::Version::Embedded { version, .. } => format!("{version} es"),
+            naga::back::glsl::Version::Desktop(version) => format!("{version}"),
+        };
         let program = unsafe { gl.create_program() }.unwrap();
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(label) = label {
@@ -343,7 +343,7 @@ impl super::Device {
 
         // Create empty fragment shader if only vertex shader is present
         if has_stages == wgt::ShaderStages::VERTEX {
-            let shader_src = format!("#version {glsl_version} es \n void main(void) {{}}",);
+            let shader_src = format!("#version {glsl_version}\n void main(void) {{}}",);
             log::info!("Only vertex shader is present. Creating an empty fragment shader",);
             let shader = unsafe {
                 Self::compile_shader(
@@ -1304,7 +1304,7 @@ impl crate::Device<super::Api> for super::Device {
     }
 
     unsafe fn start_capture(&self) -> bool {
-        #[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
+        #[cfg(all(not(any(target_arch = "wasm32", windows)), feature = "renderdoc"))]
         return unsafe {
             self.render_doc
                 .start_frame_capture(self.shared.context.raw_context(), ptr::null_mut())
@@ -1313,7 +1313,7 @@ impl crate::Device<super::Api> for super::Device {
         false
     }
     unsafe fn stop_capture(&self) {
-        #[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
+        #[cfg(all(not(any(target_arch = "wasm32", windows)), feature = "renderdoc"))]
         unsafe {
             self.render_doc
                 .end_frame_capture(ptr::null_mut(), ptr::null_mut())

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -289,55 +289,6 @@ fn choose_config(
     )))
 }
 
-fn gl_debug_message_callback(source: u32, gltype: u32, id: u32, severity: u32, message: &str) {
-    let source_str = match source {
-        glow::DEBUG_SOURCE_API => "API",
-        glow::DEBUG_SOURCE_WINDOW_SYSTEM => "Window System",
-        glow::DEBUG_SOURCE_SHADER_COMPILER => "ShaderCompiler",
-        glow::DEBUG_SOURCE_THIRD_PARTY => "Third Party",
-        glow::DEBUG_SOURCE_APPLICATION => "Application",
-        glow::DEBUG_SOURCE_OTHER => "Other",
-        _ => unreachable!(),
-    };
-
-    let log_severity = match severity {
-        glow::DEBUG_SEVERITY_HIGH => log::Level::Error,
-        glow::DEBUG_SEVERITY_MEDIUM => log::Level::Warn,
-        glow::DEBUG_SEVERITY_LOW => log::Level::Info,
-        glow::DEBUG_SEVERITY_NOTIFICATION => log::Level::Trace,
-        _ => unreachable!(),
-    };
-
-    let type_str = match gltype {
-        glow::DEBUG_TYPE_DEPRECATED_BEHAVIOR => "Deprecated Behavior",
-        glow::DEBUG_TYPE_ERROR => "Error",
-        glow::DEBUG_TYPE_MARKER => "Marker",
-        glow::DEBUG_TYPE_OTHER => "Other",
-        glow::DEBUG_TYPE_PERFORMANCE => "Performance",
-        glow::DEBUG_TYPE_POP_GROUP => "Pop Group",
-        glow::DEBUG_TYPE_PORTABILITY => "Portability",
-        glow::DEBUG_TYPE_PUSH_GROUP => "Push Group",
-        glow::DEBUG_TYPE_UNDEFINED_BEHAVIOR => "Undefined Behavior",
-        _ => unreachable!(),
-    };
-
-    let _ = std::panic::catch_unwind(|| {
-        log::log!(
-            log_severity,
-            "GLES: [{}/{}] ID {} : {}",
-            source_str,
-            type_str,
-            id,
-            message
-        );
-    });
-
-    if cfg!(debug_assertions) && log_severity == log::Level::Error {
-        // Set canary and continue
-        crate::VALIDATION_CANARY.set();
-    }
-}
-
 #[derive(Clone, Debug)]
 struct EglContext {
     instance: Arc<EglInstance>,
@@ -1014,7 +965,7 @@ impl crate::Instance<super::Api> for Instance {
         if self.flags.contains(wgt::InstanceFlags::VALIDATION) && gl.supports_debug() {
             log::info!("Enabling GLES debug output");
             unsafe { gl.enable(glow::DEBUG_OUTPUT) };
-            unsafe { gl.debug_message_callback(gl_debug_message_callback) };
+            unsafe { gl.debug_message_callback(super::gl_debug_message_callback) };
         }
 
         inner.egl.unmake_current();
@@ -1094,8 +1045,9 @@ impl Surface {
     pub(super) unsafe fn present(
         &mut self,
         _suf_texture: super::Texture,
-        gl: &glow::Context,
+        context: &AdapterContext,
     ) -> Result<(), crate::SurfaceError> {
+        let gl = unsafe { context.get_without_egl_lock() };
         let sc = self.swapchain.as_ref().unwrap();
 
         self.egl

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -57,12 +57,14 @@ To address this, we invalidate the vertex buffers based on:
 */
 
 ///cbindgen:ignore
-#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
+#[cfg(not(any(windows, all(target_arch = "wasm32", not(target_os = "emscripten")))))]
 mod egl;
 #[cfg(target_os = "emscripten")]
 mod emscripten;
 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 mod web;
+#[cfg(windows)]
+mod wgl;
 
 mod adapter;
 mod command;
@@ -72,15 +74,20 @@ mod queue;
 
 use crate::{CopyExtent, TextureDescriptor};
 
-#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
+#[cfg(not(any(windows, all(target_arch = "wasm32", not(target_os = "emscripten")))))]
 pub use self::egl::{AdapterContext, AdapterContextLock};
-#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
+#[cfg(not(any(windows, all(target_arch = "wasm32", not(target_os = "emscripten")))))]
 use self::egl::{Instance, Surface};
 
 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 pub use self::web::AdapterContext;
 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 use self::web::{Instance, Surface};
+
+#[cfg(windows)]
+use self::wgl::AdapterContext;
+#[cfg(windows)]
+use self::wgl::{Instance, Surface};
 
 use arrayvec::ArrayVec;
 
@@ -213,7 +220,7 @@ pub struct Adapter {
 pub struct Device {
     shared: Arc<AdapterShared>,
     main_vao: glow::VertexArray,
-    #[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
+    #[cfg(all(not(any(target_arch = "wasm32", windows)), feature = "renderdoc"))]
     render_doc: crate::auxil::renderdoc::RenderDoc,
 }
 
@@ -902,5 +909,55 @@ impl fmt::Debug for CommandEncoder {
         f.debug_struct("CommandEncoder")
             .field("cmd_buffer", &self.cmd_buffer)
             .finish()
+    }
+}
+
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+fn gl_debug_message_callback(source: u32, gltype: u32, id: u32, severity: u32, message: &str) {
+    let source_str = match source {
+        glow::DEBUG_SOURCE_API => "API",
+        glow::DEBUG_SOURCE_WINDOW_SYSTEM => "Window System",
+        glow::DEBUG_SOURCE_SHADER_COMPILER => "ShaderCompiler",
+        glow::DEBUG_SOURCE_THIRD_PARTY => "Third Party",
+        glow::DEBUG_SOURCE_APPLICATION => "Application",
+        glow::DEBUG_SOURCE_OTHER => "Other",
+        _ => unreachable!(),
+    };
+
+    let log_severity = match severity {
+        glow::DEBUG_SEVERITY_HIGH => log::Level::Error,
+        glow::DEBUG_SEVERITY_MEDIUM => log::Level::Warn,
+        glow::DEBUG_SEVERITY_LOW => log::Level::Info,
+        glow::DEBUG_SEVERITY_NOTIFICATION => log::Level::Trace,
+        _ => unreachable!(),
+    };
+
+    let type_str = match gltype {
+        glow::DEBUG_TYPE_DEPRECATED_BEHAVIOR => "Deprecated Behavior",
+        glow::DEBUG_TYPE_ERROR => "Error",
+        glow::DEBUG_TYPE_MARKER => "Marker",
+        glow::DEBUG_TYPE_OTHER => "Other",
+        glow::DEBUG_TYPE_PERFORMANCE => "Performance",
+        glow::DEBUG_TYPE_POP_GROUP => "Pop Group",
+        glow::DEBUG_TYPE_PORTABILITY => "Portability",
+        glow::DEBUG_TYPE_PUSH_GROUP => "Push Group",
+        glow::DEBUG_TYPE_UNDEFINED_BEHAVIOR => "Undefined Behavior",
+        _ => unreachable!(),
+    };
+
+    let _ = std::panic::catch_unwind(|| {
+        log::log!(
+            log_severity,
+            "GLES: [{}/{}] ID {} : {}",
+            source_str,
+            type_str,
+            id,
+            message
+        );
+    });
+
+    if cfg!(debug_assertions) && log_severity == log::Level::Error {
+        // Set canary and continue
+        crate::VALIDATION_CANARY.set();
     }
 }

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -221,7 +221,7 @@ pub struct Adapter {
 pub struct Device {
     shared: Arc<AdapterShared>,
     main_vao: glow::VertexArray,
-    #[cfg(all(not(any(target_arch = "wasm32", windows)), feature = "renderdoc"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "renderdoc"))]
     render_doc: crate::auxil::renderdoc::RenderDoc,
 }
 

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -211,6 +211,7 @@ struct AdapterShared {
     max_texture_size: u32,
     next_shader_id: AtomicU32,
     program_cache: Mutex<ProgramCache>,
+    es: bool,
 }
 
 pub struct Adapter {

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1443,13 +1443,7 @@ impl crate::Queue<super::Api> for super::Queue {
         surface: &mut super::Surface,
         texture: super::Texture,
     ) -> Result<(), crate::SurfaceError> {
-        #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
-        let gl = unsafe { &self.shared.context.get_without_egl_lock() };
-
-        #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-        let gl = &self.shared.context.glow_context;
-
-        unsafe { surface.present(texture, gl) }
+        unsafe { surface.present(texture, &self.shared.context) }
     }
 
     unsafe fn get_timestamp_period(&self) -> f32 {

--- a/wgpu-hal/src/gles/shaders/clear.frag
+++ b/wgpu-hal/src/gles/shaders/clear.frag
@@ -1,5 +1,3 @@
-#version 300 es
-precision lowp float;
 uniform vec4 color;
 //Hack: Some WebGL implementations don't find "color" otherwise.
 uniform vec4 color_workaround;

--- a/wgpu-hal/src/gles/shaders/clear.vert
+++ b/wgpu-hal/src/gles/shaders/clear.vert
@@ -1,7 +1,5 @@
-#version 300 es
-precision lowp float;
 // A triangle that fills the whole screen
-const vec2[3] TRIANGLE_POS = vec2[](
+vec2[3] TRIANGLE_POS = vec2[](
   vec2( 0.0, -3.0),
   vec2(-3.0,  1.0),
   vec2( 3.0,  1.0)

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -215,8 +215,9 @@ impl Surface {
     pub(super) unsafe fn present(
         &mut self,
         _suf_texture: super::Texture,
-        gl: &glow::Context,
+        context: &AdapterContext,
     ) -> Result<(), crate::SurfaceError> {
+        let gl = &context.glow_context;
         let swapchain = self.swapchain.as_ref().ok_or(crate::SurfaceError::Other(
             "need to configure surface before presenting",
         ))?;

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -52,6 +52,10 @@ impl AdapterContext {
         true
     }
 
+    pub fn raw_context(&self) -> *mut c_void {
+        self.inner.lock().context.context as *mut _
+    }
+
     /// Obtain a lock to the WGL context and get handle to the [`glow::Context`] that can be used to
     /// do rendering.
     #[track_caller]

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -3,6 +3,7 @@ use glutin_wgl_sys::wgl_extra::{
     Wgl, CONTEXT_CORE_PROFILE_BIT_ARB, CONTEXT_DEBUG_BIT_ARB, CONTEXT_FLAGS_ARB,
     CONTEXT_PROFILE_MASK_ARB,
 };
+use once_cell::sync::Lazy;
 use parking_lot::{Mutex, MutexGuard};
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use std::{
@@ -314,12 +315,9 @@ fn get_global_device_context() -> Result<HDC, crate::InstanceError> {
     unsafe impl Sync for SendDc {}
     unsafe impl Send for SendDc {}
 
-    static GLOBAL: Mutex<Option<Result<SendDc, crate::InstanceError>>> = Mutex::new(None);
-    let mut guard = GLOBAL.lock();
-    if guard.is_none() {
-        *guard = Some(create_global_device_context().map(SendDc));
-    }
-    guard.clone().unwrap().map(|dc| dc.0)
+    static GLOBAL: Lazy<Result<SendDc, crate::InstanceError>> =
+        Lazy::new(|| create_global_device_context().map(SendDc));
+    GLOBAL.clone().map(|dc| dc.0)
 }
 
 impl crate::Instance<super::Api> for Instance {

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -1,0 +1,664 @@
+use glow::HasContext;
+use glutin_wgl_sys::wgl_extra::{
+    Wgl, CONTEXT_CORE_PROFILE_BIT_ARB, CONTEXT_DEBUG_BIT_ARB, CONTEXT_FLAGS_ARB,
+    CONTEXT_PROFILE_MASK_ARB,
+};
+use parking_lot::{Mutex, MutexGuard};
+use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
+use std::{
+    collections::HashSet,
+    ffi::{c_void, CStr, CString},
+    io::Error,
+    mem,
+    os::raw::c_int,
+    ptr,
+    sync::Arc,
+    time::Duration,
+};
+use wgt::InstanceFlags;
+use winapi::{
+    shared::{
+        minwindef::{FALSE, HMODULE, UINT},
+        windef::{HDC, HGLRC},
+    },
+    um::{
+        libloaderapi::{GetProcAddress, LoadLibraryA},
+        wingdi::{
+            wglCreateContext, wglDeleteContext, wglGetCurrentContext, wglGetProcAddress,
+            wglMakeCurrent, wglShareLists, ChoosePixelFormat, CreateCompatibleDC, DeleteDC,
+            DescribePixelFormat, GetPixelFormat, SetPixelFormat, SwapBuffers, PFD_DOUBLEBUFFER,
+            PFD_DRAW_TO_WINDOW, PFD_SUPPORT_OPENGL, PFD_TYPE_RGBA, PIXELFORMATDESCRIPTOR,
+        },
+        winuser::GetDC,
+    },
+};
+
+/// The amount of time to wait while trying to obtain a lock to the adapter context
+const CONTEXT_LOCK_TIMEOUT_SECS: u64 = 1;
+
+/// A wrapper around a `[`glow::Context`]` and the required WGL context that uses locking to
+/// guarantee exclusive access when shared with multiple threads.
+pub struct AdapterContext {
+    inner: Arc<Mutex<Inner>>,
+}
+
+unsafe impl Sync for AdapterContext {}
+unsafe impl Send for AdapterContext {}
+
+impl AdapterContext {
+    pub fn is_owned(&self) -> bool {
+        true
+    }
+
+    /// Obtain a lock to the WGL context and get handle to the [`glow::Context`] that can be used to
+    /// do rendering.
+    #[track_caller]
+    pub fn lock(&self) -> AdapterContextLock<'_> {
+        let inner = self
+            .inner
+            // Don't lock forever. If it takes longer than 1 second to get the lock we've got a
+            // deadlock and should panic to show where we got stuck
+            .try_lock_for(Duration::from_secs(CONTEXT_LOCK_TIMEOUT_SECS))
+            .expect("Could not lock adapter context. This is most-likely a deadlock.");
+
+        inner.context.make_current().unwrap();
+
+        AdapterContextLock { inner }
+    }
+}
+
+/// A guard containing a lock to an [`AdapterContext`]
+pub struct AdapterContextLock<'a> {
+    inner: MutexGuard<'a, Inner>,
+}
+
+impl<'a> std::ops::Deref for AdapterContextLock<'a> {
+    type Target = glow::Context;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.gl
+    }
+}
+
+impl<'a> Drop for AdapterContextLock<'a> {
+    fn drop(&mut self) {
+        self.inner.context.unmake_current().unwrap();
+    }
+}
+
+struct WglContext {
+    device: HDC,
+    context: HGLRC,
+}
+
+impl WglContext {
+    fn make_current(&self) -> Result<(), Error> {
+        if unsafe { wglMakeCurrent(self.device, self.context) } == FALSE {
+            Err(Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn unmake_current(&self) -> Result<(), Error> {
+        if unsafe { wglGetCurrentContext().is_null() } {
+            return Ok(());
+        }
+        if unsafe { wglMakeCurrent(ptr::null_mut(), ptr::null_mut()) } == FALSE {
+            Err(Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for WglContext {
+    fn drop(&mut self) {
+        unsafe {
+            if let Err(err) = self.unmake_current() {
+                log::error!("failed to unset the current WGL context {}", err);
+                return;
+            }
+
+            if wglDeleteContext(self.context) == FALSE {
+                log::error!("failed to delete WGL context {}", Error::last_os_error());
+            }
+        };
+    }
+}
+
+unsafe impl Send for WglContext {}
+unsafe impl Sync for WglContext {}
+
+struct Inner {
+    opengl_module: HMODULE,
+    gl: glow::Context,
+    /// Keep this alive as it's referenced by `context.device`.
+    _memory_device: DeviceContext,
+    context: WglContext,
+}
+
+pub struct Instance {
+    srgb_capable: bool,
+    inner: Arc<Mutex<Inner>>,
+}
+
+unsafe impl Send for Instance {}
+unsafe impl Sync for Instance {}
+
+struct DeviceContext {
+    dc: HDC,
+}
+
+impl Drop for DeviceContext {
+    fn drop(&mut self) {
+        unsafe {
+            if DeleteDC(self.dc) == FALSE {
+                log::error!("failed to delete device context {}", Error::last_os_error());
+            }
+        };
+    }
+}
+
+fn load_gl_func(name: &str, module: Option<HMODULE>) -> *const c_void {
+    let addr = CString::new(name.as_bytes()).unwrap();
+    let mut ptr = unsafe { wglGetProcAddress(addr.as_ptr()) };
+    if ptr.is_null() {
+        if let Some(module) = module {
+            ptr = unsafe { GetProcAddress(module, addr.as_ptr()) };
+        }
+    }
+    ptr.cast()
+}
+
+fn extensions(extra: &Wgl, dc: HDC) -> HashSet<String> {
+    if extra.GetExtensionsStringARB.is_loaded() {
+        unsafe { CStr::from_ptr(extra.GetExtensionsStringARB(dc as *const _)) }
+            .to_str()
+            .unwrap_or("")
+    } else {
+        ""
+    }
+    .split(' ')
+    .map(|s| s.to_owned())
+    .collect()
+}
+
+unsafe fn setup_pixel_format(dc: HDC) -> Result<(), crate::InstanceError> {
+    let mut format: PIXELFORMATDESCRIPTOR = unsafe { mem::zeroed() };
+    format.nSize = mem::size_of_val(&format) as u16;
+    format.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+    format.iPixelType = PFD_TYPE_RGBA;
+    format.cColorBits = 32;
+
+    let index = unsafe { ChoosePixelFormat(dc, &format) };
+    if index == 0 {
+        return Err(crate::InstanceError::with_source(
+            String::from("unable to choose pixel format"),
+            Error::last_os_error(),
+        ));
+    }
+    if unsafe { SetPixelFormat(dc, index, &format) } == FALSE {
+        return Err(crate::InstanceError::with_source(
+            String::from("unable to set pixel format"),
+            Error::last_os_error(),
+        ));
+    }
+
+    let index = unsafe { GetPixelFormat(dc) };
+    if index == 0 {
+        return Err(crate::InstanceError::with_source(
+            String::from("unable to get pixel format index"),
+            Error::last_os_error(),
+        ));
+    }
+    if unsafe { DescribePixelFormat(dc, index, mem::size_of_val(&format) as UINT, &mut format) }
+        == 0
+    {
+        return Err(crate::InstanceError::with_source(
+            String::from("unable to read pixel format"),
+            Error::last_os_error(),
+        ));
+    }
+
+    if format.dwFlags & PFD_SUPPORT_OPENGL == 0 || format.iPixelType != PFD_TYPE_RGBA {
+        return Err(crate::InstanceError::new(String::from(
+            "unsuitable pixel format",
+        )));
+    }
+    Ok(())
+}
+
+impl crate::Instance<super::Api> for Instance {
+    unsafe fn init(desc: &crate::InstanceDescriptor) -> Result<Self, crate::InstanceError> {
+        let opengl_module = unsafe { LoadLibraryA("opengl32.dll\0".as_ptr() as *const _) };
+        if opengl_module.is_null() {
+            return Err(crate::InstanceError::with_source(
+                String::from("unable to load the OpenGL library"),
+                Error::last_os_error(),
+            ));
+        }
+
+        // TODO: Try using EnumDisplayDevices to look for multiple GPUs.
+
+        let dc = unsafe { CreateCompatibleDC(ptr::null_mut()) };
+        if dc.is_null() {
+            return Err(crate::InstanceError::with_source(
+                String::from("unable to create memory device"),
+                Error::last_os_error(),
+            ));
+        }
+        let dc = DeviceContext { dc };
+
+        unsafe { setup_pixel_format(dc.dc)? };
+
+        let context = unsafe { wglCreateContext(dc.dc) };
+        if context.is_null() {
+            return Err(crate::InstanceError::with_source(
+                String::from("unable to create initial OpenGL context"),
+                Error::last_os_error(),
+            ));
+        }
+        let context = WglContext {
+            context,
+            device: dc.dc,
+        };
+        context.make_current().map_err(|e| {
+            crate::InstanceError::with_source(
+                String::from("unable to set initial OpenGL context as current"),
+                e,
+            )
+        })?;
+
+        let extra = Wgl::load_with(|name| load_gl_func(name, None));
+        let extentions = extensions(&extra, dc.dc);
+
+        if !extentions.contains("WGL_ARB_create_context_profile")
+            || !extra.CreateContextAttribsARB.is_loaded()
+        {
+            return Err(crate::InstanceError::new(String::from(
+                "WGL_ARB_create_context_profile unsupported",
+            )));
+        }
+
+        let context = unsafe {
+            extra.CreateContextAttribsARB(
+                dc.dc as *const _,
+                ptr::null(),
+                [
+                    CONTEXT_PROFILE_MASK_ARB as c_int,
+                    CONTEXT_CORE_PROFILE_BIT_ARB as c_int,
+                    CONTEXT_FLAGS_ARB as c_int,
+                    if desc.flags.contains(InstanceFlags::DEBUG) {
+                        CONTEXT_DEBUG_BIT_ARB as c_int
+                    } else {
+                        0
+                    },
+                    0, // End of list
+                ]
+                .as_ptr(),
+            )
+        };
+        if context.is_null() {
+            return Err(crate::InstanceError::with_source(
+                String::from("unable to create OpenGL context"),
+                Error::last_os_error(),
+            ));
+        }
+        let context = WglContext {
+            context: context as *mut _,
+            device: dc.dc,
+        };
+
+        context.make_current().map_err(|e| {
+            crate::InstanceError::with_source(
+                String::from("unable to set OpenGL context as current"),
+                e,
+            )
+        })?;
+
+        let gl = unsafe {
+            glow::Context::from_loader_function(|name| load_gl_func(name, Some(opengl_module)))
+        };
+
+        let extra = Wgl::load_with(|name| load_gl_func(name, None));
+        let extentions = extensions(&extra, dc.dc);
+
+        let srgb_capable = extentions.contains("GL_ARB_framebuffer_sRGB")
+            || extentions.contains("WGL_EXT_framebuffer_sRGB");
+
+        if desc.flags.contains(InstanceFlags::VALIDATION) && gl.supports_debug() {
+            log::info!("Enabling GL debug output");
+            unsafe { gl.enable(glow::DEBUG_OUTPUT) };
+            unsafe { gl.debug_message_callback(super::gl_debug_message_callback) };
+        }
+
+        context.unmake_current().map_err(|e| {
+            crate::InstanceError::with_source(
+                String::from("unable to unset the current WGL context"),
+                e,
+            )
+        })?;
+
+        Ok(Instance {
+            inner: Arc::new(Mutex::new(Inner {
+                opengl_module,
+                gl,
+                context,
+                _memory_device: dc,
+            })),
+            srgb_capable,
+        })
+    }
+
+    #[cfg_attr(target_os = "macos", allow(unused, unused_mut, unreachable_code))]
+    unsafe fn create_surface(
+        &self,
+        _display_handle: RawDisplayHandle,
+        window_handle: RawWindowHandle,
+    ) -> Result<Surface, crate::InstanceError> {
+        let window = if let RawWindowHandle::Win32(handle) = window_handle {
+            handle
+        } else {
+            return Err(crate::InstanceError::new(format!(
+                "unsupported window: {window_handle:?}"
+            )));
+        };
+        let dc = unsafe { GetDC(window.hwnd as *mut _) };
+        if dc.is_null() {
+            return Err(crate::InstanceError::with_source(
+                String::from("unable to get the device context from window"),
+                Error::last_os_error(),
+            ));
+        }
+        Ok(Surface {
+            dc,
+            presentable: true,
+            swapchain: None,
+            srgb_capable: self.srgb_capable,
+        })
+    }
+    unsafe fn destroy_surface(&self, _surface: Surface) {}
+
+    unsafe fn enumerate_adapters(&self) -> Vec<crate::ExposedAdapter<super::Api>> {
+        unsafe {
+            super::Adapter::expose(AdapterContext {
+                inner: self.inner.clone(),
+            })
+        }
+        .into_iter()
+        .collect()
+    }
+}
+
+pub struct Swapchain {
+    surface_context: WglContext,
+    surface_gl: glow::Context,
+    framebuffer: glow::Framebuffer,
+    renderbuffer: glow::Renderbuffer,
+    /// Extent because the window lies
+    extent: wgt::Extent3d,
+    format: wgt::TextureFormat,
+    format_desc: super::TextureFormatDesc,
+    #[allow(unused)]
+    sample_type: wgt::TextureSampleType,
+}
+
+pub struct Surface {
+    // FIXME: Find a way to call ReleaseDC on the same thread as GetDC.
+    dc: HDC,
+    pub(super) presentable: bool,
+    swapchain: Option<Swapchain>,
+    srgb_capable: bool,
+}
+
+unsafe impl Send for Surface {}
+unsafe impl Sync for Surface {}
+
+impl Surface {
+    pub(super) unsafe fn present(
+        &mut self,
+        _suf_texture: super::Texture,
+        context: &AdapterContext,
+    ) -> Result<(), crate::SurfaceError> {
+        let sc = self.swapchain.as_ref().unwrap();
+        // Hold the lock for the shared context as we're using resources from there.
+        let _inner = context.inner.lock();
+
+        if let Err(e) = sc.surface_context.make_current() {
+            log::error!("unable to make the surface OpenGL context current: {e}",);
+            return Err(crate::SurfaceError::Other(
+                "unable to make the surface OpenGL context current",
+            ));
+        }
+
+        let gl = &sc.surface_gl;
+
+        // Note the Y-flipping here. GL's presentation is not flipped,
+        // but main rendering is. Therefore, we Y-flip the output positions
+        // in the shader, and also this blit.
+        unsafe {
+            gl.blit_framebuffer(
+                0,
+                sc.extent.height as i32,
+                sc.extent.width as i32,
+                0,
+                0,
+                0,
+                sc.extent.width as i32,
+                sc.extent.height as i32,
+                glow::COLOR_BUFFER_BIT,
+                glow::NEAREST,
+            )
+        };
+
+        if unsafe { SwapBuffers(self.dc) } == FALSE {
+            log::error!("unable to swap buffers: {}", Error::last_os_error());
+        }
+
+        Ok(())
+    }
+
+    pub fn supports_srgb(&self) -> bool {
+        self.srgb_capable
+    }
+}
+
+impl crate::Surface<super::Api> for Surface {
+    unsafe fn configure(
+        &mut self,
+        device: &super::Device,
+        config: &crate::SurfaceConfiguration,
+    ) -> Result<(), crate::SurfaceError> {
+        let format_desc = device.shared.describe_texture_format(config.format);
+        let inner = &device.shared.context.inner.lock();
+
+        if let Err(e) = inner.context.make_current() {
+            log::error!("unable to make the shared OpengL context current: {e}",);
+            return Err(crate::SurfaceError::Other(
+                "unable to make the shared OpengL context current",
+            ));
+        }
+
+        let gl = &inner.gl;
+        let renderbuffer = unsafe { gl.create_renderbuffer() }.map_err(|error| {
+            log::error!("Internal swapchain renderbuffer creation failed: {error}");
+            crate::DeviceError::OutOfMemory
+        })?;
+        unsafe { gl.bind_renderbuffer(glow::RENDERBUFFER, Some(renderbuffer)) };
+        unsafe {
+            gl.renderbuffer_storage(
+                glow::RENDERBUFFER,
+                format_desc.internal,
+                config.extent.width as _,
+                config.extent.height as _,
+            )
+        };
+        let framebuffer = unsafe { gl.create_framebuffer() }.map_err(|error| {
+            log::error!("Internal swapchain framebuffer creation failed: {error}");
+            crate::DeviceError::OutOfMemory
+        })?;
+        unsafe { gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(framebuffer)) };
+        unsafe {
+            gl.framebuffer_renderbuffer(
+                glow::READ_FRAMEBUFFER,
+                glow::COLOR_ATTACHMENT0,
+                glow::RENDERBUFFER,
+                Some(renderbuffer),
+            )
+        };
+        unsafe { gl.bind_renderbuffer(glow::RENDERBUFFER, None) };
+        unsafe { gl.bind_framebuffer(glow::READ_FRAMEBUFFER, None) };
+
+        if self.srgb_capable && config.format.is_srgb() {
+            unsafe { gl.enable(glow::FRAMEBUFFER_SRGB) };
+        }
+
+        // Create the swap chain OpenGL context
+
+        if let Err(e) = unsafe { setup_pixel_format(self.dc) } {
+            log::error!("unable to setup surface pixel format: {e}",);
+            return Err(crate::SurfaceError::Other(
+                "unable to setup surface pixel format",
+            ));
+        }
+
+        let context = unsafe { wglCreateContext(self.dc) };
+        if context.is_null() {
+            log::error!(
+                "unable to create surface OpenGL context: {}",
+                Error::last_os_error()
+            );
+            return Err(crate::SurfaceError::Other(
+                "unable to create surface OpenGL context",
+            ));
+        }
+        let surface_context = WglContext {
+            context,
+            device: self.dc,
+        };
+
+        if unsafe { wglShareLists(inner.context.context, surface_context.context) } == FALSE {
+            log::error!(
+                "unable to share objects between OpenGL contexts: {}",
+                Error::last_os_error()
+            );
+            return Err(crate::SurfaceError::Other(
+                "unable to share objects between OpenGL contexts",
+            ));
+        }
+
+        if let Err(e) = surface_context.make_current() {
+            log::error!("unable to make the surface OpengL context current: {e}",);
+            return Err(crate::SurfaceError::Other(
+                "unable to make the surface OpengL context current",
+            ));
+        }
+
+        let extra = Wgl::load_with(|name| load_gl_func(name, None));
+        let extentions = extensions(&extra, self.dc);
+        if !(extentions.contains("WGL_EXT_swap_control") && extra.SwapIntervalEXT.is_loaded()) {
+            log::error!("WGL_EXT_swap_control is unsupported");
+            return Err(crate::SurfaceError::Other(
+                "WGL_EXT_swap_control is unsupported",
+            ));
+        }
+
+        let vsync = match config.present_mode {
+            wgt::PresentMode::Mailbox => false,
+            wgt::PresentMode::Fifo => true,
+            _ => {
+                log::error!("unsupported present mode: {:?}", config.present_mode);
+                return Err(crate::SurfaceError::Other("unsupported present mode"));
+            }
+        };
+
+        if unsafe { extra.SwapIntervalEXT(if vsync { 1 } else { 0 }) } == FALSE {
+            log::error!("unable to set swap interval: {}", Error::last_os_error());
+            return Err(crate::SurfaceError::Other("unable to set swap interval"));
+        }
+
+        let surface_gl = unsafe {
+            glow::Context::from_loader_function(|name| {
+                load_gl_func(name, Some(inner.opengl_module))
+            })
+        };
+
+        // Check that the surface context OpenGL is new enough to support framebuffers.
+        let version = unsafe { gl.get_parameter_string(glow::VERSION) };
+        let version = super::Adapter::parse_full_version(&version);
+        match version {
+            Ok(version) => {
+                if version < (3, 0) {
+                    log::error!(
+                        "surface context OpenGL version ({}.{}) too old",
+                        version.0,
+                        version.1
+                    );
+                    return Err(crate::SurfaceError::Other(
+                        "surface context OpenGL version too old",
+                    ));
+                }
+            }
+            Err(e) => {
+                log::error!("unable to parse surface context OpenGL version: {e}",);
+                return Err(crate::SurfaceError::Other(
+                    "unable to parse surface context OpenGL version",
+                ));
+            }
+        }
+
+        unsafe { surface_gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, None) };
+        unsafe { surface_gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(framebuffer)) };
+
+        self.swapchain = Some(Swapchain {
+            surface_context,
+            surface_gl,
+            renderbuffer,
+            framebuffer,
+            extent: config.extent,
+            format: config.format,
+            format_desc,
+            sample_type: wgt::TextureSampleType::Float { filterable: false },
+        });
+
+        Ok(())
+    }
+
+    unsafe fn unconfigure(&mut self, device: &super::Device) {
+        let gl = &device.shared.context.lock();
+        if let Some(sc) = self.swapchain.take() {
+            unsafe {
+                gl.delete_renderbuffer(sc.renderbuffer);
+                gl.delete_framebuffer(sc.framebuffer)
+            };
+        }
+    }
+
+    unsafe fn acquire_texture(
+        &mut self,
+        _timeout_ms: Option<Duration>,
+    ) -> Result<Option<crate::AcquiredSurfaceTexture<super::Api>>, crate::SurfaceError> {
+        let sc = self.swapchain.as_ref().unwrap();
+        let texture = super::Texture {
+            inner: super::TextureInner::Renderbuffer {
+                raw: sc.renderbuffer,
+            },
+            drop_guard: None,
+            array_layer_count: 1,
+            mip_level_count: 1,
+            format: sc.format,
+            format_desc: sc.format_desc.clone(),
+            copy_size: crate::CopyExtent {
+                width: sc.extent.width,
+                height: sc.extent.height,
+                depth: 1,
+            },
+        };
+        Ok(Some(crate::AcquiredSurfaceTexture {
+            texture,
+            suboptimal: false,
+        }))
+    }
+    unsafe fn discard_texture(&mut self, _texture: super::Texture) {}
+}

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -571,6 +571,9 @@ impl crate::Surface<super::Api> for Surface {
         device: &super::Device,
         config: &crate::SurfaceConfiguration,
     ) -> Result<(), crate::SurfaceError> {
+        // Remove the old configuration.
+        unsafe { self.unconfigure(device) };
+
         let format_desc = device.shared.describe_texture_format(config.format);
         let inner = &device.shared.context.inner.lock();
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1176,7 +1176,7 @@ impl Limits {
     ///     max_push_constant_size: 0,
     ///     min_uniform_buffer_offset_alignment: 256,
     ///     min_storage_buffer_offset_alignment: 256,
-    ///     max_inter_stage_shader_components: 60,
+    ///     max_inter_stage_shader_components: 31,
     ///     max_compute_workgroup_storage_size: 0, // +
     ///     max_compute_invocations_per_workgroup: 0, // +
     ///     max_compute_workgroup_size_x: 0, // +
@@ -1201,6 +1201,9 @@ impl Limits {
             max_compute_workgroup_size_y: 0,
             max_compute_workgroup_size_z: 0,
             max_compute_workgroups_per_dimension: 0,
+
+            // Value supported by Intel Celeron B830 on Windows (OpenGL 3.1)
+            max_inter_stage_shader_components: 31,
 
             // Most of the values should be the same as the downlevel defaults
             ..Self::downlevel_defaults()

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -61,10 +61,10 @@ features = ["raw-window-handle"]
 workspace = true
 features = ["metal"]
 
-# We want the wgpu-core Direct3D backends on Windows.
+# We want the wgpu-core Direct3D backends and OpenGL (via WGL) on Windows.
 [target.'cfg(windows)'.dependencies.wgc]
 workspace = true
-features = ["dx11", "dx12"]
+features = ["dx11", "dx12", "gles"]
 
 # We want the wgpu-core Vulkan backend on Unix (but not emscripten, macOS, iOS) and Windows.
 [target.'cfg(any(windows, all(unix, not(target_os = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]


### PR DESCRIPTION
This adds WGL context creation and desktop OpenGL support to the `gles` backend. It's used instead of `EGL` on Windows. Only WGL requests desktop OpenGL contexts. The behavior of `EGL` is left unchanged.

To enable construction of an OpenGL context without a surface, a memory device is used. Each surface gets their own OpenGL context which share object with the memory device OpenGL context. Rendering to surfaces happens indirectly via renderbuffers as framebuffers cannot be shared across OpenGL contexts.

Currently a lot of `gles` backend features are not enabled on desktop OpenGL.

I've tested it with an HD 5870 using the examples and [vello](https://github.com/linebender/vello).

`bunnymark` is plain blue. `skybox` crashes in the driver. `mipmap` is too white, Vsync locks to 30 fps instead of 60 fps on a 60 Hz display. These may be issues with the driver or `gles` backend rather than this PR however.
