### PR TITLE
wgpu-hal: vulkan: ensure entries to PhysicalDeviceCapabilities use effective api version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ By @teoxoy in [#4185](https://github.com/gfx-rs/wgpu/pull/4185)
 - Rename `wgpu_hal::vulkan::Instance::required_extensions` to `desired_extensions`. By @jimblandy in [#4115](https://github.com/gfx-rs/wgpu/pull/4115)
 
 - Don't bother calling `vkFreeCommandBuffers` when `vkDestroyCommandPool` will take care of that for us. By @jimblandy in [#4059](https://github.com/gfx-rs/wgpu/pull/4059)
+- Ensure entries to PhysicalDeviceCapabilities use effective api version. By @i509VCB in [#4249](https://github.com/gfx-rs/wgpu/pull/4249)
 
 #### DX12
 


### PR DESCRIPTION
This was the cause of an error while testing wgpu-hal on agxv. Specifically I was getting an error about running out of memory while creating the "zero init buffer". This was occuring because PhysicalDeviceCapabilities was reading the instance api version and not the device version. But furthermore this is wrong because the actual api version that can be used is the lower of the instance's api version and device's api version.

agxv does not implement maintenance3 yet, so what was being returned for a max memory allocation size was 0, because ash initialized the value to 0. Then when the gpu allocator is created with a maximum allocation size of 0, all gpu memory allocations fail.

**Checklist**

- [x] Run `cargo clippy`.

Although when running clippy this error shows up. Definitely not a fault of my changes:
```
error: incorrect implementation of `partial_cmp` on an `Ord` type
   --> wgpu-core/src/id.rs:155:1
    |
155 | /  impl<T> PartialOrd for Id<T> {
156 | |      fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
    | | _____________________________________________________________-
157 | ||         self.0.partial_cmp(&other.0)
158 | ||     }
    | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
159 | |  }
    | |__^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incorrect_partial_ord_impl_on_ord_type
    = note: `#[deny(clippy::incorrect_partial_ord_impl_on_ord_type)]` on by default
    ```

- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
