### PR TITLE
Fix locking order in render_pipeline_get_bind_group_layout

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1915,42 +1915,50 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     ) {
         let hub = A::hub(self);
         let mut token = Token::root();
-        let (pipeline_layout_guard, mut token) = hub.pipeline_layouts.read(&mut token);
 
         let error = loop {
-            let (bgl_guard, mut token) = hub.bind_group_layouts.read(&mut token);
-            let (_, mut token) = hub.bind_groups.read(&mut token);
-            let (pipeline_guard, _) = hub.render_pipelines.read(&mut token);
+            let device_id;
+            let id;
 
-            let pipeline = match pipeline_guard.get(pipeline_id) {
-                Ok(pipeline) => pipeline,
-                Err(_) => break binding_model::GetBindGroupLayoutError::InvalidPipeline,
-            };
-            let id = match pipeline_layout_guard[pipeline.layout_id.value]
-                .bind_group_layout_ids
-                .get(index as usize)
             {
-                Some(id) => id,
-                None => break binding_model::GetBindGroupLayoutError::InvalidGroupIndex(index),
-            };
+                let (pipeline_layout_guard, mut token) = hub.pipeline_layouts.read(&mut token);
 
-            let layout = &bgl_guard[*id];
-            layout.multi_ref_count.inc();
+                let (bgl_guard, mut token) = hub.bind_group_layouts.read(&mut token);
+                let (_, mut token) = hub.bind_groups.read(&mut token);
+                let (pipeline_guard, _) = hub.render_pipelines.read(&mut token);
 
-            if G::ids_are_generated_in_wgpu() {
-                return (id.0, None);
+                let pipeline = match pipeline_guard.get(pipeline_id) {
+                    Ok(pipeline) => pipeline,
+                    Err(_) => break binding_model::GetBindGroupLayoutError::InvalidPipeline,
+                };
+                id = match pipeline_layout_guard[pipeline.layout_id.value]
+                    .bind_group_layout_ids
+                    .get(index as usize)
+                {
+                    Some(id) => *id,
+                    None => break binding_model::GetBindGroupLayoutError::InvalidGroupIndex(index),
+                };
+
+                let layout = &bgl_guard[id];
+                layout.multi_ref_count.inc();
+
+                if G::ids_are_generated_in_wgpu() {
+                    return (id.0, None);
+                }
+
+                device_id = layout.device_id.clone();
             }
 
             // The ID is provided externally, so we must create a new bind group layout
             // with the given ID as a duplicate of the existing one.
             let new_layout = BindGroupLayout {
-                device_id: layout.device_id.clone(),
-                inner: crate::binding_model::BglOrDuplicate::<A>::Duplicate(*id),
+                device_id,
+                inner: crate::binding_model::BglOrDuplicate::<A>::Duplicate(id),
                 multi_ref_count: crate::MultiRefCount::new(),
             };
 
             let fid = hub.bind_group_layouts.prepare(id_in);
-            let id = fid.assign(new_layout, &mut Token::root());
+            let id = fid.assign(new_layout, &mut token);
 
             return (id.0, None);
         };


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.

**Connections**

Blocks https://bugzilla.mozilla.org/show_bug.cgi?id=1856371


**Description**

The code path for when IDs are provided externally was creating a new root token while the previous one still existed. The right thing to do is to ensure the other guards are closed before assigning the newly created bind group which this patch does by scoping the them.

Also add the equivalent code for `compute_pipeline_get_bind_group_layout`.

**Testing**

This is covered by the CTS in Firefox.