### PR TITLE
Skip Integrated WARP

### DIFF
--- a/wgpu-hal/src/auxil/dxgi/conv.rs
+++ b/wgpu-hal/src/auxil/dxgi/conv.rs
@@ -1,4 +1,12 @@
+use std::{ffi::OsString, os::windows::ffi::OsStringExt};
 use winapi::shared::dxgiformat;
+
+// Helper to convert DXGI adapter name to a normal string
+pub fn map_adapter_name(name: [u16; 128]) -> String {
+    let len = name.iter().take_while(|&&c| c != 0).count();
+    let name = OsString::from_wide(&name[..len]);
+    name.to_string_lossy().into_owned()
+}
 
 pub fn map_texture_format_failable(format: wgt::TextureFormat) -> Option<dxgiformat::DXGI_FORMAT> {
     use wgt::TextureFormat as Tf;

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -78,7 +78,7 @@ pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter
             break;
         }
 
-        if !filter_adapter(&adapter4) {
+        if !filter_adapter(&adapter1) {
             continue;
         }
 

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -14,7 +14,7 @@ pub enum DxgiFactoryType {
     Factory6,
 }
 
-fn filter_adapter(adapter: &dxgi::IDXGIAdapter1) -> bool {
+fn should_keep_adapter(adapter: &dxgi::IDXGIAdapter1) -> bool {
     let mut desc = unsafe { std::mem::zeroed() };
     unsafe { adapter.GetDesc1(&mut desc) };
 
@@ -58,7 +58,7 @@ pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter
                 break;
             }
 
-            if !filter_adapter(&adapter4) {
+            if !should_keep_adapter(&adapter4) {
                 continue;
             }
 
@@ -78,7 +78,7 @@ pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter
             break;
         }
 
-        if !filter_adapter(&adapter1) {
+        if !should_keep_adapter(&adapter1) {
             continue;
         }
 

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -63,7 +63,7 @@ pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter
         // that ignore software adapters will actually run on headless/gpu-less machines.
         //
         // We don't want that and discorage that kind of filtering anyway, so we skip the integrated WARP.
-        if desc.VendorId == 5140 && desc.Flags != dxgi::DXGI_ADAPTER_FLAG_SOFTWARE {
+        if desc.VendorId == 5140 && (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) == 0 {
             let adapter_name = super::conv::map_adapter_name(desc.Description);
             if adapter_name.contains("Microsoft Basic Render Driver") {
                 continue;

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -55,7 +55,7 @@ pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter
             break;
         }
 
-        let mut desc = dxgi::DXGI_ADAPTER_DESC1::default();
+        let mut desc = unsafe { std::mem::zeroed() };
         unsafe { adapter1.GetDesc1(&mut desc) };
 
         // If run completely headless, windows will show two different WARP adapters, one

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -63,8 +63,11 @@ pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter
         // that ignore software adapters will actually run on headless/gpu-less machines.
         //
         // We don't want that and discorage that kind of filtering anyway, so we skip the integrated WARP.
+        dbg!(desc.VendorId);
+        dbg!(desc.Flags);
         if desc.VendorId == 5140 && (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) == 0 {
             let adapter_name = super::conv::map_adapter_name(desc.Description);
+            dbg!(&adapter_name);
             if adapter_name.contains("Microsoft Basic Render Driver") {
                 continue;
             }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -102,12 +102,7 @@ impl super::Adapter {
             adapter.unwrap_adapter2().GetDesc2(&mut desc);
         }
 
-        let device_name = {
-            use std::{ffi::OsString, os::windows::ffi::OsStringExt};
-            let len = desc.Description.iter().take_while(|&&c| c != 0).count();
-            let name = OsString::from_wide(&desc.Description[..len]);
-            name.to_string_lossy().into_owned()
-        };
+        let device_name = auxil::dxgi::conv::map_adapter_name(desc.Description);
 
         let mut features_architecture: d3d12_ty::D3D12_FEATURE_DATA_ARCHITECTURE =
             unsafe { mem::zeroed() };


### PR DESCRIPTION
This is a problem that #3873 brings to light very clearly. As described in the code comment, windows will add a second instance of warp that lies about being an integrated card so that programs still run even if they filter CPU devices.

This is rather annoying behavior, so we now filter out those adapters.
