### PR TITLE
Implement mipmap views on the OpenGL backend

### DIFF
--- a/examples/mipmap/src/main.rs
+++ b/examples/mipmap/src/main.rs
@@ -514,8 +514,7 @@ static TEST: wgpu_example::framework::ExampleTestParams =
         width: 1024,
         height: 768,
         optional_features: wgpu::Features::default(),
-        base_test_parameters: wgpu_test::TestParameters::default()
-            .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::GL)),
+        base_test_parameters: wgpu_test::TestParameters::default(),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
         _phantom: std::marker::PhantomData::<Example>,
     };
@@ -529,8 +528,7 @@ static TEST_QUERY: wgpu_example::framework::ExampleTestParams =
         width: 1024,
         height: 768,
         optional_features: QUERY_FEATURES,
-        base_test_parameters: wgpu_test::TestParameters::default()
-            .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::GL)),
+        base_test_parameters: wgpu_test::TestParameters::default(),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.025)],
         _phantom: std::marker::PhantomData::<Example>,
     };

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -698,6 +698,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                     raw,
                     target,
                     aspects,
+                    ref mip_levels,
                 } => {
                     dirty_textures |= 1 << slot;
                     self.state.texture_slots[slot as usize].tex_target = target;
@@ -706,6 +707,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                         texture: raw,
                         target,
                         aspects,
+                        mip_levels: mip_levels.clone(),
                     });
                 }
                 super::RawBinding::Image(ref binding) => {

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1112,8 +1112,8 @@ impl crate::Device<super::Api> for super::Device {
                 }
                 wgt::BindingType::Texture { .. } => {
                     let view = desc.textures[entry.resource_index as usize].view;
-                    if view.mip_levels.start != 0 || view.array_layers.start != 0 {
-                        log::error!("Unable to create a sampled texture binding for non-zero mipmap level or array layer.\n{}",
+                    if view.array_layers.start != 0 {
+                        log::error!("Unable to create a sampled texture binding for non-zero array layer.\n{}",
                             "This is an implementation problem of wgpu-hal/gles backend.")
                     }
                     let (raw, target) = view.inner.as_native();
@@ -1121,6 +1121,7 @@ impl crate::Device<super::Api> for super::Device {
                         raw,
                         target,
                         aspects: view.aspects,
+                        mip_levels: view.mip_levels.clone(),
                     }
                 }
                 wgt::BindingType::StorageTexture {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -424,7 +424,8 @@ enum RawBinding {
         raw: glow::Texture,
         target: BindTarget,
         aspects: crate::FormatAspects,
-        //TODO: mip levels, array layers
+        mip_levels: Range<u32>,
+        //TODO: array layers
     },
     Image(ImageBinding),
     Sampler(glow::Sampler),
@@ -869,6 +870,7 @@ enum Command {
         texture: glow::Texture,
         target: BindTarget,
         aspects: crate::FormatAspects,
+        mip_levels: Range<u32>,
     },
     BindImage {
         slot: u32,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -127,6 +127,7 @@ impl super::Queue {
                     };
                 } else {
                     unsafe {
+                        assert_eq!(view.mip_levels.len(), 1);
                         gl.framebuffer_texture_2d(
                             fbo_target,
                             attachment,
@@ -1333,9 +1334,21 @@ impl super::Queue {
                 texture,
                 target,
                 aspects,
+                ref mip_levels,
             } => {
                 unsafe { gl.active_texture(glow::TEXTURE0 + slot) };
                 unsafe { gl.bind_texture(target, Some(texture)) };
+
+                unsafe {
+                    gl.tex_parameter_i32(target, glow::TEXTURE_BASE_LEVEL, mip_levels.start as i32)
+                };
+                unsafe {
+                    gl.tex_parameter_i32(
+                        target,
+                        glow::TEXTURE_MAX_LEVEL,
+                        (mip_levels.end - 1) as i32,
+                    )
+                };
 
                 let version = gl.version();
                 let is_min_es_3_1 = version.is_embedded && (version.major, version.minor) >= (3, 1);


### PR DESCRIPTION
This makes the `mipmap` example work on AMD HD 5870 / llvmpipe on Windows.