### PR TITLE
Fix Issue with Caching on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,17 @@ jobs:
         with:
           tool: cargo-nextest,cargo-llvm-cov
 
+        # Cache step must go before warp and mesa install on windows as they write into the
+        # target directory, and rust-cache will overwrite the entirety of the target directory.
+      - name: caching
+        uses: Swatinem/rust-cache@v2
+        if: matrix.os[0] != 'self-hosted'
+        with:
+          key: test-${{ matrix.os }}-${{ env.CACHE_SUFFIX }}
+          workspaces: |
+            . -> target
+            xtask -> xtask/target
+
       - name: (windows) install warp
         if: matrix.os == 'windows-2022'
         shell: bash
@@ -349,15 +360,6 @@ jobs:
           echo """
           [profile.dev]
           debug = 1" >> .cargo/config.toml
-
-      - name: caching
-        uses: Swatinem/rust-cache@v2
-        if: matrix.os[0] != 'self-hosted'
-        with:
-          key: test-${{ matrix.os }}-${{ env.CACHE_SUFFIX }}
-          workspaces: |
-            . -> target
-            xtask -> xtask/target
 
       - name: run wgpu-info
         shell: bash

--- a/examples/hello-compute/src/tests.rs
+++ b/examples/hello-compute/src/tests.rs
@@ -57,7 +57,9 @@ static MULTITHREADED_COMPUTE: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
-            .skip(FailureCase::adapter("V3D")),
+            .skip(FailureCase::adapter("V3D"))
+            // Segfaults on linux CI only https://github.com/gfx-rs/wgpu/issues/4285
+            .skip(FailureCase::backend_adapter(wgpu::Backends::GL, "llvmpipe")),
     )
     .run_sync(|ctx| {
         use std::{sync::mpsc, sync::Arc, thread, time::Duration};


### PR DESCRIPTION
The cache step was overwriting our copied dlls, causing cache failures.