### PR TITLE
More complete implementation of "lose the device".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ Bottom level categories:
 - Hal
 -->
 
+## Unreleased ##
+
+### Changes ###
+
+#### General ####
+* `LoseDeviceClosure` callback mechanism provided so user agents can resolve `GPUDevice.lost` Promises at the appropriate time by @bradwerth in [#4299](https://github.com/gfx-rs/wgpu/pull/4299)
+
 ## v0.18.0 (2023-10-25)
 
 ### Desktop OpenGL 3.3+ Support on Windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,6 +3844,7 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
  "wgpu",
+ "wgpu-core",
  "wgpu-macros",
  "wgpu-types",
 ]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -40,6 +40,7 @@ png.workspace = true
 pollster.workspace = true
 serde_json.workspace = true
 serde.workspace = true
+wgc.workspace = true
 wgpu.workspace = true
 wgpu-macros.workspace = true
 wgt = { workspace = true, features = ["replay"] }

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -1,7 +1,5 @@
 use wgpu_test::{fail, gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
 
-use wgc::device::{DeviceLostReason, LoseDeviceClosure};
-
 #[gpu_test]
 static CROSS_DEVICE_BIND_GROUP_USAGE: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default().expect_fail(FailureCase::always()))
@@ -467,14 +465,14 @@ static DEVICE_DESTROY_THEN_LOST: GpuTestConfiguration = GpuTestConfiguration::ne
         // and can only run them under certain configs, as is done in
         // request_device_error_on_native, above.
 
-        // Set a LoseDeviceClosure on the device.
-        let closure = LoseDeviceClosure::from_rust(Box::new(move |reason, _m| {
+        // Set a LoseDeviceCallback on the device.
+        let callback = Box::new(move |reason, _m| {
             assert!(
-                matches!(reason, DeviceLostReason::Destroyed),
+                matches!(reason, wgt::DeviceLostReason::Destroyed),
                 "Device lost info reason should match DeviceLostReason::Destroyed."
             );
-        }));
-        ctx.device.set_lose_device_closure(closure);
+        });
+        ctx.device.set_lose_device_callback(callback);
 
         // Destroy the device.
         ctx.device.destroy();

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -3,7 +3,9 @@ use crate::device::trace;
 use crate::{
     binding_model::{self, BindGroupLayout},
     command, conv,
-    device::{life::WaitIdleError, map_buffer, queue, Device, DeviceError, HostMap},
+    device::{
+        life::WaitIdleError, map_buffer, queue, Device, DeviceError, HostMap, LoseDeviceClosure,
+    },
     global::Global,
     hal_api::HalApi,
     hub::Token,
@@ -2633,6 +2635,21 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
     }
 
+    pub fn device_set_lose_device_closure<A: HalApi>(
+        &self,
+        device_id: DeviceId,
+        lose_device_closure: LoseDeviceClosure,
+    ) {
+        let hub = A::hub(self);
+        let mut token = Token::root();
+
+        let (mut device_guard, mut token) = hub.devices.write(&mut token);
+        if let Ok(device) = device_guard.get_mut(device_id) {
+            let mut life_tracker = device.lock_life(&mut token);
+            life_tracker.lose_device_closure = Some(lose_device_closure);
+        }
+    }
+
     pub fn device_destroy<A: HalApi>(&self, device_id: DeviceId) {
         log::trace!("Device::destroy {device_id:?}");
 
@@ -2644,36 +2661,26 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             // Follow the steps at
             // https://gpuweb.github.io/gpuweb/#dom-gpudevice-destroy.
 
-            // It's legal to call destroy multiple times, but if the device
-            // is already invalid, there's nothing more to do. There's also
-            // no need to return an error.
-            if !device.valid {
-                return;
-            }
-
             // The last part of destroy is to lose the device. The spec says
             // delay that until all "currently-enqueued operations on any
-            // queue on this device are completed."
-
-            // TODO: implement this delay.
-
-            // Finish by losing the device.
-
-            // TODO: associate this "destroyed" reason more tightly with
-            // the GPUDeviceLostReason defined in webgpu.idl.
-            device.lose(Some("destroyed"));
+            // queue on this device are completed." This is accomplished by
+            // setting valid to false, and then relying upon maintain to
+            // check for empty queues and a LoseDeviceClosure. At that time,
+            // the LoseDeviceClosure will be called with "destroyed" as the
+            // reason.
+            device.valid = false;
         }
     }
 
-    pub fn device_lose<A: HalApi>(&self, device_id: DeviceId, reason: Option<&str>) {
+    pub fn device_lose<A: HalApi>(&self, device_id: DeviceId, message: &str) {
         log::trace!("Device::lose {device_id:?}");
 
         let hub = A::hub(self);
         let mut token = Token::root();
 
-        let (mut device_guard, _) = hub.devices.write(&mut token);
+        let (mut device_guard, mut token) = hub.devices.write(&mut token);
         if let Ok(device) = device_guard.get_mut(device_id) {
-            device.lose(reason);
+            device.lose(&mut token, message);
         }
     }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -332,7 +332,7 @@ impl<A: HalApi> Device<A> {
         let closures = UserClosures {
             mappings: mapping_closures,
             submissions: submission_closures,
-            lose_device_invocations: lose_device_invocations,
+            lose_device_invocations,
         };
         Ok((closures, life_tracker.queue_empty()))
     }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -8,8 +8,8 @@ use crate::{
     command, conv,
     device::life::WaitIdleError,
     device::{
-        AttachmentData, CommandAllocator, DeviceLostReason, LoseDeviceInvocation,
-        MissingDownlevelFlags, MissingFeatures, RenderPassContext, CLEANUP_WAIT_MS,
+        AttachmentData, CommandAllocator, LoseDeviceInvocation, MissingDownlevelFlags,
+        MissingFeatures, RenderPassContext, CLEANUP_WAIT_MS,
     },
     hal_api::HalApi,
     hal_label,
@@ -34,7 +34,7 @@ use hal::{CommandEncoder as _, Device as _};
 use parking_lot::{Mutex, MutexGuard};
 use smallvec::SmallVec;
 use thiserror::Error;
-use wgt::{TextureFormat, TextureSampleType, TextureViewDimension};
+use wgt::{DeviceLostReason, TextureFormat, TextureSampleType, TextureViewDimension};
 
 use std::{borrow::Cow, iter, num::NonZeroU32};
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -6692,3 +6692,15 @@ mod send_sync {
     )))]
     impl<T> WasmNotSync for T {}
 }
+
+/// Reason for "lose the device".
+///
+/// Corresponds to [WebGPU `GPUDeviceLostReason`](https://gpuweb.github.io/gpuweb/#enumdef-gpudevicelostreason).
+#[repr(u8)]
+#[derive(Debug, Copy, Clone)]
+pub enum DeviceLostReason {
+    /// Triggered by driver
+    Unknown = 0,
+    /// After Device::destroy
+    Destroyed = 1,
+}

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1455,13 +1455,14 @@ impl crate::Context for Context {
 
         wgc::gfx_select!(device => global.device_drop(*device));
     }
-    fn device_set_lose_device_closure(
+    fn device_set_lose_device_callback(
         &self,
         device: &Self::DeviceId,
         _device_data: &Self::DeviceData,
-        lose_device_closure: LoseDeviceClosure,
+        lose_device_callback: crate::context::LoseDeviceCallback,
     ) {
         let global = &self.0;
+        let lose_device_closure = LoseDeviceClosure::from_rust(lose_device_callback);
         wgc::gfx_select!(device => global.device_set_lose_device_closure(*device, lose_device_closure));
     }
     fn device_destroy(&self, device: &Self::DeviceId, _device_data: &Self::DeviceData) {

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -22,6 +22,7 @@ use std::{
     sync::Arc,
 };
 use wgc::command::{bundle_ffi::*, compute_ffi::*, render_ffi::*};
+use wgc::device::LoseDeviceClosure;
 use wgc::id::TypedId;
 use wgt::{WasmNotSend, WasmNotSync};
 
@@ -1454,14 +1455,24 @@ impl crate::Context for Context {
 
         wgc::gfx_select!(device => global.device_drop(*device));
     }
+    fn device_set_lose_device_closure(
+        &self,
+        device: &Self::DeviceId,
+        _device_data: &Self::DeviceData,
+        lose_device_closure: LoseDeviceClosure,
+    ) {
+        let global = &self.0;
+        wgc::gfx_select!(device => global.device_set_lose_device_closure(*device, lose_device_closure));
+    }
     fn device_destroy(&self, device: &Self::DeviceId, _device_data: &Self::DeviceData) {
         let global = &self.0;
         wgc::gfx_select!(device => global.device_destroy(*device));
     }
-    fn device_lose(&self, device: &Self::DeviceId, _device_data: &Self::DeviceData) {
-        // TODO: accept a reason, and pass it to device_lose.
+    fn device_lose(&self, device: &Self::DeviceId, _device_data: &Self::DeviceData, message: &str) {
+        // We do not provide a reason to device_lose, because all reasons other than
+        // destroyed (which this is not) are "unknown".
         let global = &self.0;
-        wgc::gfx_select!(device => global.device_lose(*device, None));
+        wgc::gfx_select!(device => global.device_lose(*device, message));
     }
     fn device_poll(
         &self,

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1941,11 +1941,20 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         _device_data: &Self::DeviceData,
-        message: &str,
+        _message: &str,
     ) {
         // TODO: figure out the GPUDevice implementation of this, including resolving
         // the device.lost promise, which will require a different invocation pattern
         // with a callback.
+    }
+
+    fn device_set_lose_device_callback(
+        &self,
+        _device: &Self::DeviceId,
+        _device_data: &Self::DeviceData,
+        _lose_device_callback: crate::context::LoseDeviceCallback,
+    ) {
+        unimplemented!();
     }
 
     fn device_poll(

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1937,7 +1937,12 @@ impl crate::context::Context for Context {
         device_data.0.destroy();
     }
 
-    fn device_lose(&self, _device: &Self::DeviceId, _device_data: &Self::DeviceData) {
+    fn device_lose(
+        &self,
+        _device: &Self::DeviceId,
+        _device_data: &Self::DeviceData,
+        message: &str,
+    ) {
         // TODO: figure out the GPUDevice implementation of this, including resolving
         // the device.lost promise, which will require a different invocation pattern
         // with a callback.

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -47,6 +47,8 @@ pub use wgt::{
     VERTEX_STRIDE_ALIGNMENT,
 };
 
+pub use wgc::device::LoseDeviceClosure;
+
 #[cfg(any(
     not(target_arch = "wasm32"),
     feature = "webgl",
@@ -2796,6 +2798,16 @@ impl Device {
     /// Destroy this device.
     pub fn destroy(&self) {
         DynContext::device_destroy(&*self.context, &self.id, self.data.as_ref())
+    }
+
+    /// Set a LoseDeviceClosure on this device.
+    pub fn set_lose_device_closure(&self, lose_device_closure: LoseDeviceClosure) {
+        DynContext::device_set_lose_device_closure(
+            &*self.context,
+            &self.id,
+            self.data.as_ref(),
+            lose_device_closure,
+        )
     }
 }
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -32,22 +32,20 @@ pub use wgt::{
     BindingType, BlendComponent, BlendFactor, BlendOperation, BlendState, BufferAddress,
     BufferBindingType, BufferSize, BufferUsages, Color, ColorTargetState, ColorWrites,
     CommandBufferDescriptor, CompareFunction, CompositeAlphaMode, DepthBiasState,
-    DepthStencilState, DeviceType, DownlevelCapabilities, DownlevelFlags, Dx12Compiler,
-    DynamicOffset, Extent3d, Face, Features, FilterMode, FrontFace, Gles3MinorVersion,
-    ImageDataLayout, ImageSubresourceRange, IndexFormat, InstanceDescriptor, InstanceFlags, Limits,
-    MultisampleState, Origin2d, Origin3d, PipelineStatisticsTypes, PolygonMode, PowerPreference,
-    PredefinedColorSpace, PresentMode, PresentationTimestamp, PrimitiveState, PrimitiveTopology,
-    PushConstantRange, QueryType, RenderBundleDepthStencil, SamplerBindingType, SamplerBorderColor,
-    ShaderLocation, ShaderModel, ShaderStages, StencilFaceState, StencilOperation, StencilState,
-    StorageTextureAccess, SurfaceCapabilities, SurfaceStatus, TextureAspect, TextureDimension,
-    TextureFormat, TextureFormatFeatureFlags, TextureFormatFeatures, TextureSampleType,
-    TextureUsages, TextureViewDimension, VertexAttribute, VertexFormat, VertexStepMode,
-    WasmNotSend, WasmNotSync, COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT, MAP_ALIGNMENT,
-    PUSH_CONSTANT_ALIGNMENT, QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE,
-    VERTEX_STRIDE_ALIGNMENT,
+    DepthStencilState, DeviceLostReason, DeviceType, DownlevelCapabilities, DownlevelFlags,
+    Dx12Compiler, DynamicOffset, Extent3d, Face, Features, FilterMode, FrontFace,
+    Gles3MinorVersion, ImageDataLayout, ImageSubresourceRange, IndexFormat, InstanceDescriptor,
+    InstanceFlags, Limits, MultisampleState, Origin2d, Origin3d, PipelineStatisticsTypes,
+    PolygonMode, PowerPreference, PredefinedColorSpace, PresentMode, PresentationTimestamp,
+    PrimitiveState, PrimitiveTopology, PushConstantRange, QueryType, RenderBundleDepthStencil,
+    SamplerBindingType, SamplerBorderColor, ShaderLocation, ShaderModel, ShaderStages,
+    StencilFaceState, StencilOperation, StencilState, StorageTextureAccess, SurfaceCapabilities,
+    SurfaceStatus, TextureAspect, TextureDimension, TextureFormat, TextureFormatFeatureFlags,
+    TextureFormatFeatures, TextureSampleType, TextureUsages, TextureViewDimension, VertexAttribute,
+    VertexFormat, VertexStepMode, WasmNotSend, WasmNotSync, COPY_BUFFER_ALIGNMENT,
+    COPY_BYTES_PER_ROW_ALIGNMENT, MAP_ALIGNMENT, PUSH_CONSTANT_ALIGNMENT,
+    QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
 };
-
-pub use wgc::device::LoseDeviceClosure;
 
 #[cfg(any(
     not(target_arch = "wasm32"),
@@ -2800,13 +2798,16 @@ impl Device {
         DynContext::device_destroy(&*self.context, &self.id, self.data.as_ref())
     }
 
-    /// Set a LoseDeviceClosure on this device.
-    pub fn set_lose_device_closure(&self, lose_device_closure: LoseDeviceClosure) {
-        DynContext::device_set_lose_device_closure(
+    /// Set a LoseDeviceCallback on this device.
+    pub fn set_lose_device_callback(
+        &self,
+        callback: impl FnOnce(DeviceLostReason, String) + Send + 'static,
+    ) {
+        DynContext::device_set_lose_device_callback(
             &*self.context,
             &self.id,
             self.data.as_ref(),
-            lose_device_closure,
+            Box::new(callback),
         )
     }
 }


### PR DESCRIPTION
**Checklist**

- [X] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
N/A

**Description**
This provides a way for wgpu-core to specify a callback on "lose the device". It ensures this callback is called at the appropriate times: either after `device.destroy` has empty queues, or on demand from `device.lose`.

**Testing**
A test has been added to device.rs.
