### PR TITLE
Support nv12 texture format

### DIFF
--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -124,7 +124,7 @@ pub fn op_webgpu_create_texture_view(
         format: args.format,
         dimension: args.dimension,
         range: args.range,
-        plane: 0,
+        plane: None,
     };
 
     gfx_put!(texture => instance.texture_create_view(

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -124,6 +124,7 @@ pub fn op_webgpu_create_texture_view(
         format: args.format,
         dimension: args.dimension,
         range: args.range,
+        plane: 0,
     };
 
     gfx_put!(texture => instance.texture_create_view(

--- a/examples/src/mipmap/mod.rs
+++ b/examples/src/mipmap/mod.rs
@@ -133,6 +133,7 @@ impl Example {
                     mip_level_count: Some(1),
                     base_array_layer: 0,
                     array_layer_count: None,
+                    ..Default::default()
                 })
             })
             .collect::<Vec<_>>();

--- a/examples/src/shadow/mod.rs
+++ b/examples/src/shadow/mod.rs
@@ -398,6 +398,7 @@ impl crate::framework::Example for Example {
                     mip_level_count: None,
                     base_array_layer: i as u32,
                     array_layer_count: Some(1),
+                    ..Default::default()
                 }))
             })
             .collect::<Vec<_>>();

--- a/tests/tests/bgra8unorm_storage.rs
+++ b/tests/tests/bgra8unorm_storage.rs
@@ -49,6 +49,7 @@ static BGRA8_UNORM_STORAGE: GpuTestConfiguration = GpuTestConfiguration::new()
             base_array_layer: 0,
             mip_level_count: Some(1),
             array_layer_count: Some(1),
+            ..Default::default()
         });
 
         let readback_buffer = device.create_buffer(&wgpu::BufferDescriptor {

--- a/tests/tests/nv12_texture/mod.rs
+++ b/tests/tests/nv12_texture/mod.rs
@@ -1,6 +1,6 @@
 //! Tests for nv12 texture creation and sampling.
 
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
 
 #[gpu_test]
 static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfiguration::new()
@@ -116,4 +116,122 @@ static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfigurati
         rpass.draw(0..4, 0..1);
         drop(rpass);
         ctx.queue.submit(Some(encoder.finish()));
+    });
+
+#[gpu_test]
+static NV12_TEXTURE_CREATION_BAD_VIEW_FORMATS: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::TEXTURE_FORMAT_NV12)
+            .expect_fail(FailureCase::always()),
+    )
+    .run_sync(|ctx| {
+        let size = wgpu::Extent3d {
+            width: 256,
+            height: 256,
+            depth_or_array_layers: 1,
+        };
+        let _ = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size,
+            format: wgpu::TextureFormat::NV12,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING,
+            mip_level_count: 1,
+            sample_count: 1,
+            view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
+        });
+    });
+
+/// For D3D12 backend, textures always have plane 0
+#[gpu_test]
+static NV12_TEXTURE_VIEW_PLANE_ON_NON_PLANAR_FORMAT: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .features(wgpu::Features::TEXTURE_FORMAT_NV12)
+                .expect_fail(FailureCase::backend(
+                    wgpu::Backends::all().remove(wgpu::Backends::DX12),
+                )),
+        )
+        .run_sync(|ctx| {
+            let size = wgpu::Extent3d {
+                width: 256,
+                height: 256,
+                depth_or_array_layers: 1,
+            };
+            let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+                label: None,
+                dimension: wgpu::TextureDimension::D2,
+                size,
+                format: wgpu::TextureFormat::R8Unorm,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING,
+                mip_level_count: 1,
+                sample_count: 1,
+                view_formats: &[],
+            });
+            let _ = tex.create_view(&wgpu::TextureViewDescriptor {
+                plane: Some(0),
+                ..Default::default()
+            });
+        });
+
+#[gpu_test]
+static NV12_TEXTURE_VIEW_PLANE_OUT_OF_BOUNDS: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::TEXTURE_FORMAT_NV12)
+            .expect_fail(FailureCase::always()),
+    )
+    .run_sync(|ctx| {
+        let size = wgpu::Extent3d {
+            width: 256,
+            height: 256,
+            depth_or_array_layers: 1,
+        };
+        let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size,
+            format: wgpu::TextureFormat::NV12,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING,
+            mip_level_count: 1,
+            sample_count: 1,
+            view_formats: &[wgpu::TextureFormat::R8Unorm, wgpu::TextureFormat::Rg8Unorm],
+        });
+        let _ = tex.create_view(&wgpu::TextureViewDescriptor {
+            format: Some(wgpu::TextureFormat::R8Unorm),
+            plane: Some(2),
+            ..Default::default()
+        });
+    });
+
+#[gpu_test]
+static NV12_TEXTURE_BAD_FORMAT_VIEW_PLANE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::TEXTURE_FORMAT_NV12)
+            .expect_fail(FailureCase::always()),
+    )
+    .run_sync(|ctx| {
+        let size = wgpu::Extent3d {
+            width: 256,
+            height: 256,
+            depth_or_array_layers: 1,
+        };
+        let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size,
+            format: wgpu::TextureFormat::NV12,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING,
+            mip_level_count: 1,
+            sample_count: 1,
+            view_formats: &[wgpu::TextureFormat::R8Unorm, wgpu::TextureFormat::Rg8Unorm],
+        });
+        let _ = tex.create_view(&wgpu::TextureViewDescriptor {
+            format: Some(wgpu::TextureFormat::R8gUnorm),
+            plane: Some(0),
+            ..Default::default()
+        });
     });

--- a/tests/tests/nv12_texture/mod.rs
+++ b/tests/tests/nv12_texture/mod.rs
@@ -1,0 +1,119 @@
+//! Tests for nv12 texture creation and sampling.
+
+use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
+
+#[gpu_test]
+static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_FORMAT_NV12))
+    .run_sync(|ctx| {
+        let size = wgpu::Extent3d {
+            width: 256,
+            height: 256,
+            depth_or_array_layers: 1,
+        };
+        let target_format = wgpu::TextureFormat::Bgra8UnormSrgb;
+
+        let shader = ctx
+            .device
+            .create_shader_module(wgpu::include_wgsl!("nv12_texture.wgsl"));
+        let pipeline = ctx
+            .device
+            .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("nv12 pipeline"),
+                layout: None,
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: "vs_main",
+                    buffers: &[],
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: "fs_main",
+                    targets: &[Some(target_format.into())],
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    strip_index_format: Some(wgpu::IndexFormat::Uint32),
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+            });
+
+        let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size,
+            format: wgpu::TextureFormat::NV12,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING,
+            mip_level_count: 1,
+            sample_count: 1,
+            view_formats: &[wgpu::TextureFormat::R8Unorm, wgpu::TextureFormat::Rg8Unorm],
+        });
+        let y_view = tex.create_view(&wgpu::TextureViewDescriptor {
+            format: Some(wgpu::TextureFormat::R8Unorm),
+            plane: 0,
+            ..Default::default()
+        });
+        let uv_view = tex.create_view(&wgpu::TextureViewDescriptor {
+            format: Some(wgpu::TextureFormat::Rg8Unorm),
+            plane: 1,
+            ..Default::default()
+        });
+        let sampler = ctx.device.create_sampler(&wgpu::SamplerDescriptor {
+            min_filter: wgpu::FilterMode::Linear,
+            mag_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &pipeline.get_bind_group_layout(0),
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&y_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::TextureView(&uv_view),
+                },
+            ],
+        });
+
+        let target_tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: target_format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let target_view = target_tex.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: None,
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                ops: wgpu::Operations::default(),
+                resolve_target: None,
+                view: &target_view,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+        rpass.set_pipeline(&pipeline);
+        rpass.set_bind_group(0, &bind_group, &[]);
+        rpass.draw(0..4, 0..1);
+        drop(rpass);
+        ctx.queue.submit(Some(encoder.finish()));
+    });

--- a/tests/tests/nv12_texture/mod.rs
+++ b/tests/tests/nv12_texture/mod.rs
@@ -224,3 +224,27 @@ static NV12_TEXTURE_BAD_FORMAT_VIEW_PLANE: GpuTestConfiguration = GpuTestConfigu
             });
         });
     });
+
+#[gpu_test]
+static NV12_TEXTURE_BAD_SIZE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_FORMAT_NV12))
+    .run_sync(|ctx| {
+        let size = wgpu::Extent3d {
+            width: 255,
+            height: 255,
+            depth_or_array_layers: 1,
+        };
+
+        fail(&ctx.device, || {
+            let _ = ctx.device.create_texture(&wgpu::TextureDescriptor {
+                label: None,
+                dimension: wgpu::TextureDimension::D2,
+                size,
+                format: wgpu::TextureFormat::NV12,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING,
+                mip_level_count: 1,
+                sample_count: 1,
+                view_formats: &[wgpu::TextureFormat::R8Unorm, wgpu::TextureFormat::Rg8Unorm],
+            });
+        });
+    });

--- a/tests/tests/nv12_texture/mod.rs
+++ b/tests/tests/nv12_texture/mod.rs
@@ -1,6 +1,6 @@
 //! Tests for nv12 texture creation and sampling.
 
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
+use wgpu_test::{fail, gpu_test, GpuTestConfiguration, TestParameters};
 
 #[gpu_test]
 static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfiguration::new()
@@ -120,42 +120,31 @@ static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfigurati
 
 #[gpu_test]
 static NV12_TEXTURE_CREATION_BAD_VIEW_FORMATS: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .features(wgpu::Features::TEXTURE_FORMAT_NV12)
-            .expect_fail(FailureCase::always()),
-    )
+    .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_FORMAT_NV12))
     .run_sync(|ctx| {
         let size = wgpu::Extent3d {
             width: 256,
             height: 256,
             depth_or_array_layers: 1,
         };
-        let _ = ctx.device.create_texture(&wgpu::TextureDescriptor {
-            label: None,
-            dimension: wgpu::TextureDimension::D2,
-            size,
-            format: wgpu::TextureFormat::NV12,
-            usage: wgpu::TextureUsages::TEXTURE_BINDING,
-            mip_level_count: 1,
-            sample_count: 1,
-            view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
+        fail(&ctx.device, || {
+            let _ = ctx.device.create_texture(&wgpu::TextureDescriptor {
+                label: None,
+                dimension: wgpu::TextureDimension::D2,
+                size,
+                format: wgpu::TextureFormat::NV12,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING,
+                mip_level_count: 1,
+                sample_count: 1,
+                view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
+            });
         });
     });
 
-/// For DX11/DX12 backend, textures always have plane 0
 #[gpu_test]
 static NV12_TEXTURE_VIEW_PLANE_ON_NON_PLANAR_FORMAT: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(
-            TestParameters::default()
-                .features(wgpu::Features::TEXTURE_FORMAT_NV12)
-                .expect_fail(FailureCase::backend({
-                    let mut backends = wgpu::Backends::all();
-                    backends.remove(wgpu::Backends::DX11 | wgpu::Backends::DX12);
-                    backends
-                })),
-        )
+        .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_FORMAT_NV12))
         .run_sync(|ctx| {
             let size = wgpu::Extent3d {
                 width: 256,
@@ -172,19 +161,17 @@ static NV12_TEXTURE_VIEW_PLANE_ON_NON_PLANAR_FORMAT: GpuTestConfiguration =
                 sample_count: 1,
                 view_formats: &[],
             });
-            let _ = tex.create_view(&wgpu::TextureViewDescriptor {
-                plane: Some(0),
-                ..Default::default()
+            fail(&ctx.device, || {
+                let _ = tex.create_view(&wgpu::TextureViewDescriptor {
+                    plane: Some(0),
+                    ..Default::default()
+                });
             });
         });
 
 #[gpu_test]
 static NV12_TEXTURE_VIEW_PLANE_OUT_OF_BOUNDS: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .features(wgpu::Features::TEXTURE_FORMAT_NV12)
-            .expect_fail(FailureCase::always()),
-    )
+    .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_FORMAT_NV12))
     .run_sync(|ctx| {
         let size = wgpu::Extent3d {
             width: 256,
@@ -201,20 +188,18 @@ static NV12_TEXTURE_VIEW_PLANE_OUT_OF_BOUNDS: GpuTestConfiguration = GpuTestConf
             sample_count: 1,
             view_formats: &[wgpu::TextureFormat::R8Unorm, wgpu::TextureFormat::Rg8Unorm],
         });
-        let _ = tex.create_view(&wgpu::TextureViewDescriptor {
-            format: Some(wgpu::TextureFormat::R8Unorm),
-            plane: Some(2),
-            ..Default::default()
+        fail(&ctx.device, || {
+            let _ = tex.create_view(&wgpu::TextureViewDescriptor {
+                format: Some(wgpu::TextureFormat::R8Unorm),
+                plane: Some(2),
+                ..Default::default()
+            });
         });
     });
 
 #[gpu_test]
 static NV12_TEXTURE_BAD_FORMAT_VIEW_PLANE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .features(wgpu::Features::TEXTURE_FORMAT_NV12)
-            .expect_fail(FailureCase::always()),
-    )
+    .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_FORMAT_NV12))
     .run_sync(|ctx| {
         let size = wgpu::Extent3d {
             width: 256,
@@ -231,9 +216,11 @@ static NV12_TEXTURE_BAD_FORMAT_VIEW_PLANE: GpuTestConfiguration = GpuTestConfigu
             sample_count: 1,
             view_formats: &[wgpu::TextureFormat::R8Unorm, wgpu::TextureFormat::Rg8Unorm],
         });
-        let _ = tex.create_view(&wgpu::TextureViewDescriptor {
-            format: Some(wgpu::TextureFormat::Rg8Unorm),
-            plane: Some(0),
-            ..Default::default()
+        fail(&ctx.device, || {
+            let _ = tex.create_view(&wgpu::TextureViewDescriptor {
+                format: Some(wgpu::TextureFormat::Rg8Unorm),
+                plane: Some(0),
+                ..Default::default()
+            });
         });
     });

--- a/tests/tests/nv12_texture/mod.rs
+++ b/tests/tests/nv12_texture/mod.rs
@@ -143,16 +143,18 @@ static NV12_TEXTURE_CREATION_BAD_VIEW_FORMATS: GpuTestConfiguration = GpuTestCon
         });
     });
 
-/// For D3D12 backend, textures always have plane 0
+/// For DX11/DX12 backend, textures always have plane 0
 #[gpu_test]
 static NV12_TEXTURE_VIEW_PLANE_ON_NON_PLANAR_FORMAT: GpuTestConfiguration =
     GpuTestConfiguration::new()
         .parameters(
             TestParameters::default()
                 .features(wgpu::Features::TEXTURE_FORMAT_NV12)
-                .expect_fail(FailureCase::backend(
-                    wgpu::Backends::all().remove(wgpu::Backends::DX12),
-                )),
+                .expect_fail(FailureCase::backend({
+                    let mut backends = wgpu::Backends::all();
+                    backends.remove(wgpu::Backends::DX11 | wgpu::Backends::DX12);
+                    backends
+                })),
         )
         .run_sync(|ctx| {
             let size = wgpu::Extent3d {
@@ -230,7 +232,7 @@ static NV12_TEXTURE_BAD_FORMAT_VIEW_PLANE: GpuTestConfiguration = GpuTestConfigu
             view_formats: &[wgpu::TextureFormat::R8Unorm, wgpu::TextureFormat::Rg8Unorm],
         });
         let _ = tex.create_view(&wgpu::TextureViewDescriptor {
-            format: Some(wgpu::TextureFormat::R8gUnorm),
+            format: Some(wgpu::TextureFormat::Rg8Unorm),
             plane: Some(0),
             ..Default::default()
         });

--- a/tests/tests/nv12_texture/mod.rs
+++ b/tests/tests/nv12_texture/mod.rs
@@ -53,12 +53,12 @@ static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfigurati
         });
         let y_view = tex.create_view(&wgpu::TextureViewDescriptor {
             format: Some(wgpu::TextureFormat::R8Unorm),
-            plane: 0,
+            plane: Some(0),
             ..Default::default()
         });
         let uv_view = tex.create_view(&wgpu::TextureViewDescriptor {
             format: Some(wgpu::TextureFormat::Rg8Unorm),
-            plane: 1,
+            plane: Some(1),
             ..Default::default()
         });
         let sampler = ctx.device.create_sampler(&wgpu::SamplerDescriptor {

--- a/tests/tests/nv12_texture/nv12_texture.wgsl
+++ b/tests/tests/nv12_texture/nv12_texture.wgsl
@@ -1,0 +1,33 @@
+struct VertexOutput {
+    @builtin(position) pos: vec4<f32>,
+    uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
+    var output: VertexOutput;
+    // 0, 0
+    // 2, 0
+    // 0, 2
+    // 2, 2
+    let v_data = vec2<f32>(f32((vertexIndex << 1u) & 2u), f32(vertexIndex & 2u));
+    output.pos = vec4<f32>(v_data - 1.0, 0.0, 1.0);
+    output.uv = v_data / 2.0;
+    return output;
+}
+
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var tex_y: texture_2d<f32>;
+@group(0) @binding(2) var tex_uv: texture_2d<f32>;
+
+@fragment
+fn fs_main(v_ouput: VertexOutput) -> @location(0) vec4<f32> {
+    let luminance = textureSample(tex_y, s, v_ouput.uv).r;
+    let chrominance = textureSample(tex_uv, s, v_ouput.uv).rg;
+    let rgb = mat3x3<f32>(
+        1.000000, 1.000000, 1.000000,
+        0.000000,-0.187324, 1.855600,
+        1.574800,-0.468124, 0.000000,
+    ) * vec3<f32>(luminance, chrominance.r - 0.5, chrominance.g - 0.5);
+    return vec4<f32>(rgb, 1.0);
+}

--- a/tests/tests/nv12_texture/nv12_texture.wgsl
+++ b/tests/tests/nv12_texture/nv12_texture.wgsl
@@ -1,6 +1,6 @@
 struct VertexOutput {
     @builtin(position) pos: vec4<f32>,
-    uv: vec2<f32>,
+    @location(0) uv: vec2<f32>,
 }
 
 @vertex

--- a/tests/tests/root.rs
+++ b/tests/tests/root.rs
@@ -18,6 +18,7 @@ mod external_texture;
 mod instance;
 mod life_cycle;
 mod mem_leaks;
+mod nv12_texture;
 mod occlusion_query;
 mod partially_bounded_arrays;
 mod pipeline;

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -339,7 +339,7 @@ fn clear_texture_via_buffer_copies<A: HalApi>(
 
     if texture_desc.format == wgt::TextureFormat::NV12 {
         // TODO: Currently COPY_DST for NV12 textures is unsupported.
-        return Ok(());
+        return;
     }
 
     // Gather list of zero_buffer copies and issue a single command then to perform them

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -337,6 +337,11 @@ fn clear_texture_via_buffer_copies<A: HalApi>(
         hal::FormatAspects::COLOR
     );
 
+    if texture_desc.format == wgt::TextureFormat::NV12 {
+        // TODO: Currently COPY_DST for NV12 textures is unsupported.
+        return Ok(());
+    }
+
     // Gather list of zero_buffer copies and issue a single command then to perform them
     let mut zero_buffer_copy_regions = Vec::new();
     let buffer_copy_pitch = alignments.buffer_copy_pitch.get() as u32;

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -751,17 +751,7 @@ impl<A: HalApi> Device<A> {
                 continue;
             }
 
-            if !matches!(
-                (desc.format, *format),
-                (
-                    TextureFormat::NV12,
-                    TextureFormat::R8Unorm
-                        | TextureFormat::R8Uint
-                        | TextureFormat::Rg8Unorm
-                        | TextureFormat::Rg8Uint,
-                )
-            ) && desc.format.remove_srgb_suffix() != format.remove_srgb_suffix()
-            {
+            if !check_texture_view_format_compatible(desc.format, *format) {
                 return Err(CreateTextureError::InvalidViewFormat(*format, desc.format));
             }
             hal_view_formats.push(*format);
@@ -3359,5 +3349,17 @@ impl<A: HalApi> Resource<DeviceId> for Device<A> {
 
     fn as_info_mut(&mut self) -> &mut ResourceInfo<DeviceId> {
         &mut self.info
+    }
+}
+
+fn check_texture_view_format_compatible(
+    texture_format: TextureFormat,
+    view_format: TextureFormat,
+) -> bool {
+    use TextureFormat::*;
+
+    match (texture_format, view_format) {
+        (NV12, R8Unorm | R8Uint | Rg8Unorm | Rg8Uint) => true,
+        _ => texture_format.remove_srgb_suffix() == view_format.remove_srgb_suffix(),
     }
 }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -811,11 +811,6 @@ impl<A: HalApi> Device<A> {
             );
 
             let mut clear_views = SmallVec::new();
-            let plane_count = if desc.format == wgt::TextureFormat::NV12 {
-                2
-            } else {
-                1
-            };
             for mip_level in 0..desc.mip_level_count {
                 for array_layer in 0..desc.size.depth_or_array_layers {
                     let desc = hal::TextureViewDescriptor {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -750,15 +750,15 @@ impl<A: HalApi> Device<A> {
             if desc.format == *format {
                 continue;
             }
-            match (desc.format, *format) {
-                (
-                    TextureFormat::NV12,
-                    TextureFormat::R8Unorm
-                    | TextureFormat::R8Uint
-                    | TextureFormat::Rg8Unorm
-                    | TextureFormat::Rg8Uint,
-                ) => continue,
-                _ => {}
+            if let (
+                TextureFormat::NV12,
+                TextureFormat::R8Unorm
+                | TextureFormat::R8Uint
+                | TextureFormat::Rg8Unorm
+                | TextureFormat::Rg8Uint,
+            ) = (desc.format, *format)
+            {
+                continue;
             }
             if desc.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
                 return Err(CreateTextureError::InvalidViewFormat(*format, desc.format));

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -750,17 +750,18 @@ impl<A: HalApi> Device<A> {
             if desc.format == *format {
                 continue;
             }
-            if let (
-                TextureFormat::NV12,
-                TextureFormat::R8Unorm
-                | TextureFormat::R8Uint
-                | TextureFormat::Rg8Unorm
-                | TextureFormat::Rg8Uint,
-            ) = (desc.format, *format)
+
+            if !matches!(
+                (desc.format, *format),
+                (
+                    TextureFormat::NV12,
+                    TextureFormat::R8Unorm
+                        | TextureFormat::R8Uint
+                        | TextureFormat::Rg8Unorm
+                        | TextureFormat::Rg8Uint,
+                )
+            ) && desc.format.remove_srgb_suffix() != format.remove_srgb_suffix()
             {
-                continue;
-            }
-            if desc.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
                 return Err(CreateTextureError::InvalidViewFormat(*format, desc.format));
             }
             hal_view_formats.push(*format);

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -750,6 +750,16 @@ impl<A: HalApi> Device<A> {
             if desc.format == *format {
                 continue;
             }
+            match (desc.format, *format) {
+                (
+                    TextureFormat::NV12,
+                    TextureFormat::R8Unorm
+                    | TextureFormat::R8Uint
+                    | TextureFormat::Rg8Unorm
+                    | TextureFormat::Rg8Uint,
+                ) => continue,
+                _ => {}
+            }
             if desc.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
                 return Err(CreateTextureError::InvalidViewFormat(*format, desc.format));
             }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -811,6 +811,11 @@ impl<A: HalApi> Device<A> {
             );
 
             let mut clear_views = SmallVec::new();
+            let plane_count = if desc.format == wgt::TextureFormat::NV12 {
+                2
+            } else {
+                1
+            };
             for mip_level in 0..desc.mip_level_count {
                 for array_layer in 0..desc.size.depth_or_array_layers {
                     let desc = hal::TextureViewDescriptor {
@@ -825,6 +830,7 @@ impl<A: HalApi> Device<A> {
                             base_array_layer: array_layer,
                             array_layer_count: Some(1),
                         },
+                        plane: None,
                     };
                     clear_views.push(Some(
                         unsafe { self.raw().create_texture_view(&raw_texture, &desc) }
@@ -1115,6 +1121,7 @@ impl<A: HalApi> Device<A> {
             dimension: resolved_dimension,
             usage,
             range: resolved_range,
+            plane: desc.plane,
         };
 
         let raw = unsafe {

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -196,7 +196,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     dimension: wgt::TextureViewDimension::D2,
                     usage: hal::TextureUses::COLOR_TARGET,
                     range: wgt::ImageSubresourceRange::default(),
-                    plane: 0,
+                    plane: None,
                 };
                 let clear_view = unsafe {
                     hal::Device::create_texture_view(

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -196,6 +196,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     dimension: wgt::TextureViewDimension::D2,
                     usage: hal::TextureUses::COLOR_TARGET,
                     range: wgt::ImageSubresourceRange::default(),
+                    plane: 0,
                 };
                 let clear_view = unsafe {
                     hal::Device::create_texture_view(

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -988,6 +988,8 @@ pub struct TextureViewDescriptor<'a> {
     pub dimension: Option<wgt::TextureViewDimension>,
     /// Range within the texture that is accessible via this view.
     pub range: wgt::ImageSubresourceRange,
+    ///  The plane of the texture view.
+    pub plane: u32,
 }
 
 #[derive(Debug)]

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -989,7 +989,7 @@ pub struct TextureViewDescriptor<'a> {
     /// Range within the texture that is accessible via this view.
     pub range: wgt::ImageSubresourceRange,
     ///  The plane of the texture view.
-    pub plane: u32,
+    pub plane: Option<u32>,
 }
 
 #[derive(Debug)]

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1100,6 +1100,16 @@ pub enum CreateTextureViewError {
         texture: wgt::TextureFormat,
         view: wgt::TextureFormat,
     },
+    #[error("Invalid texture view plane `{plane:?}` with view format `{view_format:?}`")]
+    InvalidTextureViewPlane {
+        plane: Option<u32>,
+        view_format: wgt::TextureFormat,
+    },
+    #[error("Invalid texture view plane `{plane:?}` on non-planar texture `{texture_format:?}`")]
+    InvalidTextureViewPlaneOnNonplanarTexture {
+        plane: Option<u32>,
+        texture_format: wgt::TextureFormat,
+    },
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -690,6 +690,7 @@ impl NumericType {
             | Tf::Depth24PlusStencil8 => {
                 panic!("Unexpected depth format")
             }
+            Tf::NV12 => panic!("Unexpected nv12 format"),
             Tf::Rgb9e5Ufloat => (NumericDimension::Vector(Vs::Tri), Scalar::F32),
             Tf::Bc1RgbaUnorm
             | Tf::Bc1RgbaUnormSrgb

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -422,6 +422,7 @@ impl<A: hal::Api> Example<A> {
             dimension: wgt::TextureViewDimension::D2,
             usage: hal::TextureUses::RESOURCE,
             range: wgt::ImageSubresourceRange::default(),
+            plane: 0,
         };
         let texture_view = unsafe { device.create_texture_view(&texture, &view_desc).unwrap() };
 
@@ -658,6 +659,7 @@ impl<A: hal::Api> Example<A> {
             dimension: wgt::TextureViewDimension::D2,
             usage: hal::TextureUses::COLOR_TARGET,
             range: wgt::ImageSubresourceRange::default(),
+            plane: 0,
         };
         let surface_tex_view = unsafe {
             self.device

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -422,7 +422,7 @@ impl<A: hal::Api> Example<A> {
             dimension: wgt::TextureViewDimension::D2,
             usage: hal::TextureUses::RESOURCE,
             range: wgt::ImageSubresourceRange::default(),
-            plane: 0,
+            plane: None,
         };
         let texture_view = unsafe { device.create_texture_view(&texture, &view_desc).unwrap() };
 
@@ -659,7 +659,7 @@ impl<A: hal::Api> Example<A> {
             dimension: wgt::TextureViewDimension::D2,
             usage: hal::TextureUses::COLOR_TARGET,
             range: wgt::ImageSubresourceRange::default(),
-            plane: 0,
+            plane: None,
         };
         let surface_tex_view = unsafe {
             self.device

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -142,7 +142,7 @@ fn fill_screen(exposed: &hal::ExposedAdapter<hal::api::Gles>, width: u32, height
                     dimension: wgt::TextureViewDimension::D2,
                     usage: hal::TextureUses::COLOR_TARGET,
                     range: wgt::ImageSubresourceRange::default(),
-                    plane: 0,
+                    plane: None,
                 },
             )
             .unwrap()

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -142,6 +142,7 @@ fn fill_screen(exposed: &hal::ExposedAdapter<hal::api::Gles>, width: u32, height
                     dimension: wgt::TextureViewDimension::D2,
                     usage: hal::TextureUses::COLOR_TARGET,
                     range: wgt::ImageSubresourceRange::default(),
+                    plane: 0,
                 },
             )
             .unwrap()

--- a/wgpu-hal/src/auxil/dxgi/conv.rs
+++ b/wgpu-hal/src/auxil/dxgi/conv.rs
@@ -62,6 +62,7 @@ pub fn map_texture_format_failable(format: wgt::TextureFormat) -> Option<dxgifor
         Tf::Depth24PlusStencil8 => DXGI_FORMAT_D24_UNORM_S8_UINT,
         Tf::Depth32Float => DXGI_FORMAT_D32_FLOAT,
         Tf::Depth32FloatStencil8 => DXGI_FORMAT_D32_FLOAT_S8X24_UINT,
+        Tf::NV12 => DXGI_FORMAT_NV12,
         Tf::Bc1RgbaUnorm => DXGI_FORMAT_BC1_UNORM,
         Tf::Bc1RgbaUnormSrgb => DXGI_FORMAT_BC1_UNORM_SRGB,
         Tf::Bc2RgbaUnorm => DXGI_FORMAT_BC2_UNORM,

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -249,7 +249,8 @@ impl super::Adapter {
             | wgt::Features::PUSH_CONSTANTS
             | wgt::Features::SHADER_PRIMITIVE_INDEX
             | wgt::Features::RG11B10UFLOAT_RENDERABLE
-            | wgt::Features::DUAL_SOURCE_BLENDING;
+            | wgt::Features::DUAL_SOURCE_BLENDING
+            | wgt::Features::TEXTURE_FORMAT_NV12;
 
         //TODO: in order to expose this, we need to run a compute shader
         // that extract the necessary statistics out of the D3D12 result.

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -467,7 +467,11 @@ impl crate::Device<super::Api> for super::Device {
             aspects: view_desc.aspects,
             target_base: (
                 texture.resource.clone(),
-                texture.calc_subresource(desc.range.base_mip_level, desc.range.base_array_layer, 0),
+                texture.calc_subresource(
+                    desc.range.base_mip_level,
+                    desc.range.base_array_layer,
+                    desc.plane.unwrap_or(0),
+                ),
             ),
             handle_srv: if desc.usage.intersects(crate::TextureUses::RESOURCE) {
                 let raw_desc = unsafe { view_desc.to_srv() };

--- a/wgpu-hal/src/dx12/view.rs
+++ b/wgpu-hal/src/dx12/view.rs
@@ -14,6 +14,7 @@ pub(super) struct ViewDescriptor {
     array_layer_count: u32,
     mip_level_base: u32,
     mip_level_count: u32,
+    plane: u32,
 }
 
 impl crate::TextureViewDescriptor<'_> {
@@ -30,6 +31,7 @@ impl crate::TextureViewDescriptor<'_> {
             mip_level_count: self.range.mip_level_count.unwrap_or(!0),
             array_layer_base: self.range.base_array_layer,
             array_layer_count: self.range.array_layer_count.unwrap_or(!0),
+            plane: self.plane,
         }
     }
 }
@@ -79,7 +81,7 @@ impl ViewDescriptor {
                     *desc.u.Texture2D_mut() = d3d12_ty::D3D12_TEX2D_SRV {
                         MostDetailedMip: self.mip_level_base,
                         MipLevels: self.mip_level_count,
-                        PlaneSlice: 0,
+                        PlaneSlice: self.plane,
                         ResourceMinLODClamp: 0.0,
                     }
                 }
@@ -103,7 +105,7 @@ impl ViewDescriptor {
                         MipLevels: self.mip_level_count,
                         FirstArraySlice: self.array_layer_base,
                         ArraySize: self.array_layer_count,
-                        PlaneSlice: 0,
+                        PlaneSlice: self.plane,
                         ResourceMinLODClamp: 0.0,
                     }
                 }

--- a/wgpu-hal/src/dx12/view.rs
+++ b/wgpu-hal/src/dx12/view.rs
@@ -31,7 +31,7 @@ impl crate::TextureViewDescriptor<'_> {
             mip_level_count: self.range.mip_level_count.unwrap_or(!0),
             array_layer_base: self.range.base_array_layer,
             array_layer_count: self.range.array_layer_count.unwrap_or(!0),
-            plane: self.plane,
+            plane: self.plane.unwrap_or(0),
         }
     }
 }

--- a/wgpu-hal/src/dx12/view.rs
+++ b/wgpu-hal/src/dx12/view.rs
@@ -181,7 +181,7 @@ impl ViewDescriptor {
                 unsafe {
                     *desc.u.Texture2D_mut() = d3d12_ty::D3D12_TEX2D_UAV {
                         MipSlice: self.mip_level_base,
-                        PlaneSlice: 0,
+                        PlaneSlice: self.plane,
                     }
                 }
             }
@@ -192,7 +192,7 @@ impl ViewDescriptor {
                         MipSlice: self.mip_level_base,
                         FirstArraySlice: self.array_layer_base,
                         ArraySize: self.array_layer_count,
-                        PlaneSlice: 0,
+                        PlaneSlice: self.plane,
                     }
                 }
             }
@@ -252,7 +252,7 @@ impl ViewDescriptor {
                 unsafe {
                     *desc.u.Texture2D_mut() = d3d12_ty::D3D12_TEX2D_RTV {
                         MipSlice: self.mip_level_base,
-                        PlaneSlice: 0,
+                        PlaneSlice: self.plane,
                     }
                 }
             }
@@ -274,7 +274,7 @@ impl ViewDescriptor {
                         MipSlice: self.mip_level_base,
                         FirstArraySlice: self.array_layer_base,
                         ArraySize: self.array_layer_count,
-                        PlaneSlice: 0,
+                        PlaneSlice: self.plane,
                     }
                 }
             }

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -1073,6 +1073,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
             | Tf::Depth32FloatStencil8
             | Tf::Depth24Plus
             | Tf::Depth24PlusStencil8 => depth,
+            Tf::NV12 => unreachable!(),
             Tf::Rgb9e5Ufloat => filterable,
             Tf::Bc1RgbaUnorm
             | Tf::Bc1RgbaUnormSrgb

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -87,6 +87,7 @@ impl super::AdapterShared {
                 glow::DEPTH_STENCIL,
                 glow::UNSIGNED_INT_24_8,
             ),
+            Tf::NV12 => unreachable!(),
             Tf::Rgb9e5Ufloat => (glow::RGB9_E5, glow::RGB, glow::UNSIGNED_INT_5_9_9_9_REV),
             Tf::Bc1RgbaUnorm => (glow::COMPRESSED_RGBA_S3TC_DXT1_EXT, glow::RGBA, 0),
             Tf::Bc1RgbaUnormSrgb => (glow::COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT, glow::RGBA, 0),

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -981,7 +981,7 @@ pub struct TextureViewDescriptor<'a> {
     pub dimension: wgt::TextureViewDimension,
     pub usage: TextureUses,
     pub range: wgt::ImageSubresourceRange,
-    pub plane: u32,
+    pub plane: Option<u32>,
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -981,6 +981,7 @@ pub struct TextureViewDescriptor<'a> {
     pub dimension: wgt::TextureViewDimension,
     pub usage: TextureUses,
     pub range: wgt::ImageSubresourceRange,
+    pub plane: u32,
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -232,7 +232,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 }
                 flags
             }
-            Tf::NV12 => unreachable!(),
+            Tf::NV12 => return Tfc::empty(),
             Tf::Rgb9e5Ufloat => {
                 if pc.msaa_apple3 {
                     all_caps

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -232,6 +232,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 }
                 flags
             }
+            Tf::NV12 => unreachable!(),
             Tf::Rgb9e5Ufloat => {
                 if pc.msaa_apple3 {
                     all_caps
@@ -1022,6 +1023,7 @@ impl super::PrivateCapabilities {
                     Depth32Float_Stencil8
                 }
             }
+            Tf::NV12 => unreachable!(),
             Tf::Rgb9e5Ufloat => RGB9E5Float,
             Tf::Bc1RgbaUnorm => BC1_RGBA,
             Tf::Bc1RgbaUnormSrgb => BC1_RGBA_sRGB,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -537,8 +537,17 @@ impl PhysicalDeviceFeatures {
 
         features.set(
             F::TEXTURE_FORMAT_NV12,
-            caps.device_api_version >= vk::API_VERSION_1_1
-                || caps.supports_extension(vk::KhrSamplerYcbcrConversionFn::name()),
+            (caps.device_api_version >= vk::API_VERSION_1_1
+                || caps.supports_extension(vk::KhrSamplerYcbcrConversionFn::name()))
+                && supports_format(
+                    instance,
+                    phd,
+                    vk::Format::G8_B8R8_2PLANE_420_UNORM,
+                    vk::ImageTiling::OPTIMAL,
+                    vk::FormatFeatureFlags::SAMPLED_IMAGE
+                        | vk::FormatFeatureFlags::TRANSFER_SRC
+                        | vk::FormatFeatureFlags::TRANSFER_DST,
+                ),
         );
 
         (features, dl_flags)

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -543,7 +543,6 @@ impl PhysicalDeviceFeatures {
                 vk::Format::G8_B8R8_2PLANE_420_UNORM,
                 vk::ImageTiling::OPTIMAL,
                 vk::FormatFeatureFlags::SAMPLED_IMAGE
-                    | vk::FormatFeatureFlags::STORAGE_IMAGE
                     | vk::FormatFeatureFlags::TRANSFER_SRC
                     | vk::FormatFeatureFlags::TRANSFER_DST,
             ),
@@ -1565,14 +1564,14 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 .framebuffer_stencil_sample_counts
                 .min(limits.sampled_image_stencil_sample_counts)
         } else {
-            match format.sample_type(None).unwrap() {
-                wgt::TextureSampleType::Float { filterable: _ } => limits
+            match format.sample_type(None) {
+                Some(wgt::TextureSampleType::Float { filterable: _ }) => limits
                     .framebuffer_color_sample_counts
                     .min(limits.sampled_image_color_sample_counts),
-                wgt::TextureSampleType::Sint | wgt::TextureSampleType::Uint => {
+                Some(wgt::TextureSampleType::Sint) | Some(wgt::TextureSampleType::Uint) => {
                     limits.sampled_image_integer_sample_counts
                 }
-                _ => unreachable!(),
+                _ => vk::SampleCountFlags::TYPE_1,
             }
         };
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -535,6 +535,20 @@ impl PhysicalDeviceFeatures {
             supports_bgra8unorm_storage(instance, phd, caps.device_api_version),
         );
 
+        features.set(
+            F::TEXTURE_FORMAT_NV12,
+            supports_format(
+                instance,
+                phd,
+                vk::Format::G8_B8R8_2PLANE_420_UNORM,
+                vk::ImageTiling::OPTIMAL,
+                vk::FormatFeatureFlags::SAMPLED_IMAGE
+                    | vk::FormatFeatureFlags::STORAGE_IMAGE
+                    | vk::FormatFeatureFlags::TRANSFER_SRC
+                    | vk::FormatFeatureFlags::TRANSFER_DST,
+            ),
+        );
+
         (features, dl_flags)
     }
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -535,19 +535,10 @@ impl PhysicalDeviceFeatures {
             supports_bgra8unorm_storage(instance, phd, caps.device_api_version),
         );
 
-        // https://github.com/KhronosGroup/MoltenVK/issues/440
-        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         features.set(
             F::TEXTURE_FORMAT_NV12,
-            supports_format(
-                instance,
-                phd,
-                vk::Format::G8_B8R8_2PLANE_420_UNORM,
-                vk::ImageTiling::OPTIMAL,
-                vk::FormatFeatureFlags::SAMPLED_IMAGE
-                    | vk::FormatFeatureFlags::TRANSFER_SRC
-                    | vk::FormatFeatureFlags::TRANSFER_DST,
-            ),
+            caps.device_api_version >= vk::API_VERSION_1_1
+                || caps.supports_extension(vk::KhrSamplerYcbcrConversionFn::name()),
         );
 
         (features, dl_flags)

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -549,7 +549,7 @@ impl PhysicalDeviceFeatures {
                         | vk::FormatFeatureFlags::TRANSFER_SRC
                         | vk::FormatFeatureFlags::TRANSFER_DST,
                 )
-                && !adapter_info.driver.contains("moltenvk"),
+                && !adapter_info.driver.contains("MoltenVK"),
         );
 
         (features, dl_flags)

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -301,6 +301,7 @@ impl PhysicalDeviceFeatures {
 
     fn to_wgpu(
         &self,
+        adapter_info: &wgt::AdapterInfo,
         instance: &ash::Instance,
         phd: vk::PhysicalDevice,
         caps: &PhysicalDeviceCapabilities,
@@ -547,7 +548,8 @@ impl PhysicalDeviceFeatures {
                     vk::FormatFeatureFlags::SAMPLED_IMAGE
                         | vk::FormatFeatureFlags::TRANSFER_SRC
                         | vk::FormatFeatureFlags::TRANSFER_DST,
-                ),
+                )
+                && !adapter_info.driver.contains("moltenvk"),
         );
 
         (features, dl_flags)
@@ -984,7 +986,7 @@ impl super::Instance {
         };
 
         let (available_features, downlevel_flags) =
-            phd_features.to_wgpu(&self.shared.raw, phd, &phd_capabilities);
+            phd_features.to_wgpu(&info, &self.shared.raw, phd, &phd_capabilities);
         let mut workarounds = super::Workarounds::empty();
         {
             // see https://github.com/gfx-rs/gfx/issues/1930

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -535,6 +535,8 @@ impl PhysicalDeviceFeatures {
             supports_bgra8unorm_storage(instance, phd, caps.device_api_version),
         );
 
+        // https://github.com/KhronosGroup/MoltenVK/issues/440
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         features.set(
             F::TEXTURE_FORMAT_NV12,
             supports_format(

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -1,10 +1,5 @@
 use ash::vk;
 
-// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageAspectFlagBits.html
-const VK_IMAGE_ASPECT_PLANE_0_BIT: vk::Flags = 0x00000010;
-const VK_IMAGE_ASPECT_PLANE_1_BIT: vk::Flags = 0x00000020;
-const VK_IMAGE_ASPECT_PLANE_2_BIT: vk::Flags = 0x00000040;
-
 impl super::PrivateCapabilities {
     pub fn map_texture_format(&self, format: wgt::TextureFormat) -> vk::Format {
         use ash::vk::Format as F;
@@ -410,9 +405,9 @@ pub fn map_vertex_format(vertex_format: wgt::VertexFormat) -> vk::Format {
 pub fn map_aspects(aspects: crate::FormatAspects, plane: Option<u32>) -> vk::ImageAspectFlags {
     let mut flags = vk::ImageAspectFlags::empty();
     match plane {
-        Some(0) => flags |= vk::ImageAspectFlags::from_raw(VK_IMAGE_ASPECT_PLANE_0_BIT),
-        Some(1) => flags |= vk::ImageAspectFlags::from_raw(VK_IMAGE_ASPECT_PLANE_1_BIT),
-        Some(2) => flags |= vk::ImageAspectFlags::from_raw(VK_IMAGE_ASPECT_PLANE_2_BIT),
+        Some(0) => flags |= vk::ImageAspectFlags::PLANE_0,
+        Some(1) => flags |= vk::ImageAspectFlags::PLANE_1,
+        Some(2) => flags |= vk::ImageAspectFlags::PLANE_2,
         _ if aspects.contains(crate::FormatAspects::COLOR) => {
             flags |= vk::ImageAspectFlags::COLOR;
         }

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -1,7 +1,6 @@
 use ash::vk;
 
 // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageAspectFlagBits.html
-const VK_IMAGE_ASPECT_NONE: vk::Flags = 0;
 const VK_IMAGE_ASPECT_PLANE_0_BIT: vk::Flags = 0x00000010;
 const VK_IMAGE_ASPECT_PLANE_1_BIT: vk::Flags = 0x00000020;
 const VK_IMAGE_ASPECT_PLANE_2_BIT: vk::Flags = 0x00000040;
@@ -410,8 +409,14 @@ pub fn map_vertex_format(vertex_format: wgt::VertexFormat) -> vk::Format {
 
 pub fn map_aspects(aspects: crate::FormatAspects, plane: Option<u32>) -> vk::ImageAspectFlags {
     let mut flags = vk::ImageAspectFlags::empty();
-    if aspects.contains(crate::FormatAspects::COLOR) {
-        flags |= vk::ImageAspectFlags::COLOR;
+    match plane {
+        Some(0) => flags |= vk::ImageAspectFlags::from_raw(VK_IMAGE_ASPECT_PLANE_0_BIT),
+        Some(1) => flags |= vk::ImageAspectFlags::from_raw(VK_IMAGE_ASPECT_PLANE_1_BIT),
+        Some(2) => flags |= vk::ImageAspectFlags::from_raw(VK_IMAGE_ASPECT_PLANE_2_BIT),
+        _ if aspects.contains(crate::FormatAspects::COLOR) => {
+            flags |= vk::ImageAspectFlags::COLOR;
+        }
+        _ => {}
     }
     if aspects.contains(crate::FormatAspects::DEPTH) {
         flags |= vk::ImageAspectFlags::DEPTH;
@@ -419,12 +424,6 @@ pub fn map_aspects(aspects: crate::FormatAspects, plane: Option<u32>) -> vk::Ima
     if aspects.contains(crate::FormatAspects::STENCIL) {
         flags |= vk::ImageAspectFlags::STENCIL;
     }
-    flags |= vk::ImageAspectFlags::from_raw(match plane {
-        Some(0) => VK_IMAGE_ASPECT_PLANE_0_BIT,
-        Some(1) => VK_IMAGE_ASPECT_PLANE_1_BIT,
-        Some(2) => VK_IMAGE_ASPECT_PLANE_2_BIT,
-        _ => VK_IMAGE_ASPECT_NONE,
-    });
     flags
 }
 

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -74,6 +74,7 @@ impl super::PrivateCapabilities {
                 }
             }
             Tf::Depth16Unorm => F::D16_UNORM,
+            Tf::NV12 => unreachable!(),
             Tf::Rgb9e5Ufloat => F::E5B9G9R9_UFLOAT_PACK32,
             Tf::Bc1RgbaUnorm => F::BC1_RGBA_UNORM_BLOCK,
             Tf::Bc1RgbaUnormSrgb => F::BC1_RGBA_SRGB_BLOCK,

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -408,10 +408,12 @@ pub fn map_aspects(aspects: crate::FormatAspects, plane: Option<u32>) -> vk::Ima
         Some(0) => flags |= vk::ImageAspectFlags::PLANE_0,
         Some(1) => flags |= vk::ImageAspectFlags::PLANE_1,
         Some(2) => flags |= vk::ImageAspectFlags::PLANE_2,
-        _ if aspects.contains(crate::FormatAspects::COLOR) => {
-            flags |= vk::ImageAspectFlags::COLOR;
+        Some(plane) => panic!("Unexpected plane {}", plane),
+        None => {
+            if aspects.contains(crate::FormatAspects::COLOR) {
+                flags |= vk::ImageAspectFlags::COLOR;
+            }
         }
-        _ => {}
     }
     if aspects.contains(crate::FormatAspects::DEPTH) {
         flags |= vk::ImageAspectFlags::DEPTH;

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1062,8 +1062,7 @@ impl crate::Device<super::Api> for super::Device {
         texture: &super::Texture,
         desc: &crate::TextureViewDescriptor,
     ) -> Result<super::TextureView, crate::DeviceError> {
-        let subresource_range =
-            conv::map_subresource_range(&desc.range, desc.format, Some(desc.plane));
+        let subresource_range = conv::map_subresource_range(&desc.range, desc.format, desc.plane);
         let mut vk_info = vk::ImageViewCreateInfo::builder()
             .flags(vk::ImageViewCreateFlags::empty())
             .image(texture.raw)

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1062,7 +1062,8 @@ impl crate::Device<super::Api> for super::Device {
         texture: &super::Texture,
         desc: &crate::TextureViewDescriptor,
     ) -> Result<super::TextureView, crate::DeviceError> {
-        let subresource_range = conv::map_subresource_range(&desc.range, desc.format);
+        let subresource_range =
+            conv::map_subresource_range(&desc.range, desc.format, Some(desc.plane));
         let mut vk_info = vk::ImageViewCreateInfo::builder()
             .flags(vk::ImageViewCreateFlags::empty())
             .image(texture.raw)

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -775,6 +775,7 @@ bitflags::bitflags! {
         ///
         /// Supported platforms:
         /// - DX12
+        /// - Vulkan
         ///
         /// This is a native only feature.
         const TEXTURE_FORMAT_NV12 = 1 << 55;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2393,7 +2393,7 @@ pub enum TextureFormat {
     /// - 1: Dual 8 bit channel chrominance at half width and half height.
     ///
     /// Valid view formats for luminance are [`TextureFormat::R8Unorm`] and [`TextureFormat::R8Uint`].
-    /// 
+    ///
     /// Valid view formats for chrominance are [`TextureFormat::Rg8Unorm`] and [`TextureFormat::Rg8Uint`].
     ///
     /// Width and height must be even.
@@ -2951,8 +2951,9 @@ impl TextureFormat {
             | Self::Depth24Plus
             | Self::Depth24PlusStencil8
             | Self::Depth32Float
-            | Self::Depth32FloatStencil8
-            | Self::NV12 => (1, 1),
+            | Self::Depth32FloatStencil8 => (1, 1),
+
+            Self::NV12 => (2, 2),
 
             Self::Bc1RgbaUnorm
             | Self::Bc1RgbaUnormSrgb

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2386,9 +2386,16 @@ pub enum TextureFormat {
     /// [`Features::DEPTH32FLOAT_STENCIL8`] must be enabled to use this texture format.
     Depth32FloatStencil8,
 
-    /// YUV 4:2:0 video resource format.
-    /// Valid luminance data view formats for this video resource format are [`TextureFormat::R8Unorm`] and [`TextureFormat::R8Uint`].
-    /// Valid chrominance data view formats (width and height are each 1/2 of luminance view) for this video resource format are [`TextureFormat::Rg8Unorm`] and [`TextureFormat::Rg8Uint`].
+    /// YUV 4:2:0 chroma subsampled format.
+    ///
+    /// Contains two planes:
+    /// - 0: Single 8 bit channel luminance.
+    /// - 1: Dual 8 bit channel chrominance at half width and half height.
+    ///
+    /// Valid view formats for luminance are [`TextureFormat::R8Unorm`] and [`TextureFormat::R8Uint`].
+    /// 
+    /// Valid view formats for chrominance are [`TextureFormat::Rg8Unorm`] and [`TextureFormat::Rg8Uint`].
+    ///
     /// Width and height must be even.
     ///
     /// [`Features::TEXTURE_FORMAT_NV12`] must be enabled to use this texture format.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -3101,6 +3101,7 @@ impl TextureFormat {
             TextureUsages::COPY_SRC | TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING;
         let attachment = basic | TextureUsages::RENDER_ATTACHMENT;
         let storage = basic | TextureUsages::STORAGE_BINDING;
+        let binding = TextureUsages::TEXTURE_BINDING;
         let all_flags = TextureUsages::all();
         let rg11b10f = if device_features.contains(Features::RG11B10UFLOAT_RENDERABLE) {
             attachment
@@ -3162,7 +3163,8 @@ impl TextureFormat {
             Self::Depth32Float =>         (        msaa, attachment),
             Self::Depth32FloatStencil8 => (        msaa, attachment),
 
-            Self::NV12 =>                 (        noaa,      basic),
+            // We only support sampling nv12 textures until we implement transfer plane data.
+            Self::NV12 =>                 (        noaa,    binding),
 
             Self::R16Unorm =>             (        msaa,    storage),
             Self::R16Snorm =>             (        msaa,    storage),

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -771,8 +771,12 @@ bitflags::bitflags! {
         /// - OpenGL
         const SHADER_UNUSED_VERTEX_OUTPUT = 1 << 54;
 
-        /// Supported platform:
+        /// Allows for creation of textures of format [`TextureFormat::NV12`]
+        ///
+        /// Supported platforms:
         /// - DX12
+        ///
+        /// This is a native only feature.
         const TEXTURE_FORMAT_NV12 = 1 << 55;
 
         // 55..59 available
@@ -2381,7 +2385,12 @@ pub enum TextureFormat {
     /// [`Features::DEPTH32FLOAT_STENCIL8`] must be enabled to use this texture format.
     Depth32FloatStencil8,
 
+    /// YUV 4:2:0 video resource format.
+    /// Valid luminance data view formats for this video resource format are [`TextureFormat::R8Unorm`] and [`TextureFormat::R8Uint`].
+    /// Valid chrominance data view formats (width and height are each 1/2 of luminance view) for this video resource format are [`TextureFormat::Rg8Unorm`] and [`TextureFormat::Rg8Uint`].
+    /// Width and height must be even.
     ///
+    /// [`Features::TEXTURE_FORMAT_NV12`] must be enabled to use this texture format.
     NV12,
 
     // Compressed textures usable with `TEXTURE_COMPRESSION_BC` feature.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -771,7 +771,11 @@ bitflags::bitflags! {
         /// - OpenGL
         const SHADER_UNUSED_VERTEX_OUTPUT = 1 << 54;
 
-        // 54..59 available
+        /// Supported platform:
+        /// - DX12
+        const TEXTURE_FORMAT_NV12 = 1 << 55;
+
+        // 55..59 available
 
         // Shader:
 
@@ -2377,6 +2381,9 @@ pub enum TextureFormat {
     /// [`Features::DEPTH32FLOAT_STENCIL8`] must be enabled to use this texture format.
     Depth32FloatStencil8,
 
+    ///
+    NV12,
+
     // Compressed textures usable with `TEXTURE_COMPRESSION_BC` feature.
     /// 4x4 block compressed texture. 8 bytes per block (4 bit/px). 4 color + alpha pallet. 5 bit R + 6 bit G + 5 bit B + 1 bit alpha.
     /// [0, 63] ([0, 1] for alpha) converted to/from float [0, 1] in shader.
@@ -2606,6 +2613,7 @@ impl<'de> Deserialize<'de> for TextureFormat {
                     "depth16unorm" => TextureFormat::Depth16Unorm,
                     "depth24plus" => TextureFormat::Depth24Plus,
                     "depth24plus-stencil8" => TextureFormat::Depth24PlusStencil8,
+                    "nv12" => TextureFormat::NV12,
                     "rgb9e5ufloat" => TextureFormat::Rgb9e5Ufloat,
                     "bc1-rgba-unorm" => TextureFormat::Bc1RgbaUnorm,
                     "bc1-rgba-unorm-srgb" => TextureFormat::Bc1RgbaUnormSrgb,
@@ -2733,6 +2741,7 @@ impl Serialize for TextureFormat {
             TextureFormat::Depth32FloatStencil8 => "depth32float-stencil8",
             TextureFormat::Depth24Plus => "depth24plus",
             TextureFormat::Depth24PlusStencil8 => "depth24plus-stencil8",
+            TextureFormat::NV12 => "nv12",
             TextureFormat::Rgb9e5Ufloat => "rgb9e5ufloat",
             TextureFormat::Bc1RgbaUnorm => "bc1-rgba-unorm",
             TextureFormat::Bc1RgbaUnormSrgb => "bc1-rgba-unorm-srgb",
@@ -2925,7 +2934,8 @@ impl TextureFormat {
             | Self::Depth24Plus
             | Self::Depth24PlusStencil8
             | Self::Depth32Float
-            | Self::Depth32FloatStencil8 => (1, 1),
+            | Self::Depth32FloatStencil8
+            | Self::NV12 => (1, 1),
 
             Self::Bc1RgbaUnorm
             | Self::Bc1RgbaUnormSrgb
@@ -3024,6 +3034,8 @@ impl TextureFormat {
             | Self::Depth32Float => Features::empty(),
 
             Self::Depth32FloatStencil8 => Features::DEPTH32FLOAT_STENCIL8,
+
+            Self::NV12 => Features::TEXTURE_FORMAT_NV12,
 
             Self::R16Unorm
             | Self::R16Snorm
@@ -3140,6 +3152,8 @@ impl TextureFormat {
             Self::Depth32Float =>         (        msaa, attachment),
             Self::Depth32FloatStencil8 => (        msaa, attachment),
 
+            Self::NV12 =>                 (        noaa,      basic),
+
             Self::R16Unorm =>             (        msaa,    storage),
             Self::R16Snorm =>             (        msaa,    storage),
             Self::Rg16Unorm =>            (        msaa,    storage),
@@ -3246,6 +3260,8 @@ impl TextureFormat {
                 Some(TextureAspect::DepthOnly) => Some(depth),
                 Some(TextureAspect::StencilOnly) => Some(uint),
             },
+
+            Self::NV12 => None,
 
             Self::R16Unorm
             | Self::R16Snorm
@@ -3363,6 +3379,8 @@ impl TextureFormat {
                 Some(TextureAspect::StencilOnly) => Some(1),
             },
 
+            Self::NV12 => None,
+
             Self::Bc1RgbaUnorm | Self::Bc1RgbaUnormSrgb | Self::Bc4RUnorm | Self::Bc4RSnorm => {
                 Some(8)
             }
@@ -3453,6 +3471,8 @@ impl TextureFormat {
                 TextureAspect::All => 2,
                 TextureAspect::DepthOnly | TextureAspect::StencilOnly => 1,
             },
+
+            Self::NV12 => 3,
 
             Self::Bc4RUnorm | Self::Bc4RSnorm => 1,
             Self::Bc5RgUnorm | Self::Bc5RgSnorm => 2,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1610,6 +1610,7 @@ impl crate::Context for Context {
                 base_array_layer: desc.base_array_layer,
                 array_layer_count: desc.array_layer_count,
             },
+            plane: desc.plane,
         };
         let global = &self.0;
         let (id, error) = wgc::gfx_select!(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1302,7 +1302,7 @@ pub struct TextureViewDescriptor<'a> {
     /// If `None`, considered to include the rest of the array layers, but at least 1 in total.
     pub array_layer_count: Option<u32>,
     /// The index (plane slice number) of the plane to use in the texture.
-    pub plane: u32,
+    pub plane: Option<u32>,
 }
 static_assertions::assert_impl_all!(TextureViewDescriptor<'_>: Send, Sync);
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1301,6 +1301,8 @@ pub struct TextureViewDescriptor<'a> {
     /// If `Some(count)`, `base_array_layer + count` must be less or equal to the underlying array count.
     /// If `None`, considered to include the rest of the array layers, but at least 1 in total.
     pub array_layer_count: Option<u32>,
+    /// The index (plane slice number) of the plane to use in the texture.
+    pub plane: u32,
 }
 static_assertions::assert_impl_all!(TextureViewDescriptor<'_>: Send, Sync);
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
With this pr, we can create/import nv12 textures, which helps with video rendering.
