### PR TITLE
Avoid a division by zero and improve the validation of vertex attributes

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1209,6 +1209,10 @@ impl<A: HalApi> State<A> {
         };
         for (idx, (vbs, step)) in self.vertex.iter().zip(&pipeline.steps).enumerate() {
             if let Some(ref vbs) = *vbs {
+                if step.stride == 0 {
+                    // TODO: nevermind, this needs to be fixed differently.
+                    continue;
+                }
                 let limit = ((vbs.range.end - vbs.range.start) / step.stride) as u32;
                 match step.mode {
                     wgt::VertexStepMode::Vertex => {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -344,8 +344,8 @@ pub enum CreateRenderPipelineError {
     InvalidSampleCount(u32),
     #[error("The number of vertex buffers {given} exceeds the limit {limit}")]
     TooManyVertexBuffers { given: u32, limit: u32 },
-    #[error("The total number of vertex attributes {given} exceeds the limit {limit}")]
-    TooManyVertexAttributes { given: u32, limit: u32 },
+    #[error("The a vertex attribute location {given} exceeds the limit {limit}")]
+    InvalidVertexAttributeLocation { given: u32, limit: u32 },
     #[error("Vertex buffer {index} stride {given} exceeds the limit {limit}")]
     VertexStrideTooLarge { index: u32, given: u32, limit: u32 },
     #[error("Vertex buffer {index} stride {stride} does not respect `VERTEX_STRIDE_ALIGNMENT`")]

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -344,7 +344,7 @@ pub enum CreateRenderPipelineError {
     InvalidSampleCount(u32),
     #[error("The number of vertex buffers {given} exceeds the limit {limit}")]
     TooManyVertexBuffers { given: u32, limit: u32 },
-    #[error("The a vertex attribute location {given} exceeds the limit {limit}")]
+    #[error("A vertex attribute location {given} exceeds the limit {limit}")]
     InvalidVertexAttributeLocation { given: u32, limit: u32 },
     #[error("Vertex buffer {index} stride {given} exceeds the limit {limit}")]
     VertexStrideTooLarge { index: u32, given: u32, limit: u32 },


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**

Found a CTS run in firefox: https://treeherder.mozilla.org/logviewer?job_id=433879486&repo=try&lineNumber=1796

**Description**

The array stride can be zero which causes an invalid division in `bundle::State::vertex_limits`. That validation is implemented differently from the spec which makes it difficult to compare. I think that it isn't quite correct.
 
In the process of investigating that I found some differences between the vertex attribute validation as we implement it and the spec so I fixed these as well.

**Testing**

Covered by the CTS.