### PR TITLE
Remove `flume` dependency of `wgpu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4013,7 +4013,6 @@ version = "0.18.0"
 dependencies = [
  "arrayvec 0.7.4",
  "cfg-if",
- "flume",
  "js-sys",
  "log",
  "naga",

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -103,7 +103,6 @@ optional = true
 [dependencies]
 arrayvec.workspace = true
 cfg-if.workspace = true
-flume.workspace = true
 log.workspace = true
 parking_lot.workspace = true
 profiling.workspace = true

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -36,9 +36,9 @@ pub struct StagingBelt {
     /// into `active_chunks`.
     free_chunks: Vec<Chunk>,
     /// When closed chunks are mapped again, the map callback sends them here.
-    sender: flume::Sender<Chunk>,
+    sender: std::sync::mpsc::Sender<Chunk>,
     /// Free chunks are received here to be put on `self.free_chunks`.
-    receiver: flume::Receiver<Chunk>,
+    receiver: std::sync::mpsc::Receiver<Chunk>,
 }
 
 impl StagingBelt {
@@ -53,7 +53,7 @@ impl StagingBelt {
     ///   (per [`StagingBelt::finish()`]); and
     /// * bigger is better, within these bounds.
     pub fn new(chunk_size: BufferAddress) -> Self {
-        let (sender, receiver) = flume::unbounded();
+        let (sender, receiver) = std::sync::mpsc::channel();
         StagingBelt {
             chunk_size,
             active_chunks: Vec::new(),


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside .