### PR TITLE
fix example-framework

### DIFF
--- a/examples/common/src/framework.rs
+++ b/examples/common/src/framework.rs
@@ -11,7 +11,8 @@ use wgpu_test::GpuTestConfiguration;
 use winit::{
     event::{self, KeyEvent, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    keyboard::{Key, NamedKey}, window::Window,
+    keyboard::{Key, NamedKey},
+    window::Window,
 };
 
 #[allow(dead_code)]

--- a/examples/common/src/framework.rs
+++ b/examples/common/src/framework.rs
@@ -11,7 +11,7 @@ use wgpu_test::GpuTestConfiguration;
 use winit::{
     event::{self, KeyEvent, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    keyboard::{Key, NamedKey},
+    keyboard::{Key, NamedKey}, window::Window,
 };
 
 #[allow(dead_code)]
@@ -69,6 +69,7 @@ pub trait Example: 'static + Sized {
 }
 
 struct Setup {
+    _window: Window,
     event_loop: EventLoop<()>,
     instance: wgpu::Instance,
     size: winit::dpi::PhysicalSize<u32>,
@@ -240,6 +241,7 @@ async fn setup<E: Example>(title: &str) -> Setup {
         .expect("Unable to find a suitable GPU adapter!");
 
     Setup {
+        _window: window,
         event_loop,
         instance,
         size,
@@ -261,6 +263,7 @@ fn start<E: Example>(
         adapter,
         device,
         queue,
+        ..
     }: Setup,
     #[cfg(target_arch = "wasm32")] Setup {
         event_loop,
@@ -271,6 +274,7 @@ fn start<E: Example>(
         device,
         queue,
         offscreen_canvas_setup,
+        ..
     }: Setup,
 ) {
     let mut config = surface


### PR DESCRIPTION
**Checklist**

- [ ] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Closes https://github.com/gfx-rs/wgpu/issues/4584

**Description**
Adding a missing attribute to the testing framework which should fix the issue.

**Testing**
`cargo run` in the examples