### PR TITLE
Fix typo in documentation of QueueWriteBufferView

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4649,7 +4649,7 @@ impl<'a> RenderBundleEncoder<'a> {
     }
 }
 
-/// A read-only view into a staging buffer.
+/// A write-only view into a staging buffer.
 ///
 /// Reading into this buffer won't yield the contents of the buffer from the
 /// GPU and is likely to be slow. Because of this, although [`AsMut`] is


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
Fixes #4587

**Description**
Change "read-only" to "write-only" in documentation of "QueueWriteBufferView".

**Testing**
View the generated docs.
