### PR TITLE
Mark some methods `unsafe`

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -57,11 +57,13 @@ fn main() {
     let mut command_buffer_id_manager = wgc::identity::IdentityManager::default();
 
     #[cfg(feature = "winit")]
-    let surface = global.instance_create_surface(
-        window.display_handle().unwrap().into(),
-        window.window_handle().unwrap().into(),
-        wgc::id::TypedId::zip(0, 1, wgt::Backend::Empty),
-    );
+    let surface = unsafe {
+        global.instance_create_surface(
+            window.display_handle().unwrap().into(),
+            window.window_handle().unwrap().into(),
+            wgc::id::TypedId::zip(0, 1, wgt::Backend::Empty),
+        )
+    };
 
     let device = match actions.pop() {
         Some(trace::Action::Init { desc, backend }) => {

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -459,8 +459,13 @@ pub enum RequestAdapterError {
 }
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
+    /// # Safety
+    ///
+    /// - `display_handle` must be a valid object to create a surface upon.
+    /// - `window_handle` must remain valid as long as the returned
+    ///   [`SurfaceId`] is being used.
     #[cfg(feature = "raw-window-handle")]
-    pub fn instance_create_surface(
+    pub unsafe fn instance_create_surface(
         &self,
         display_handle: raw_window_handle::RawDisplayHandle,
         window_handle: raw_window_handle::RawWindowHandle,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -588,14 +588,15 @@ impl crate::Context for Context {
         ))
     }
 
-    fn instance_create_surface(
+    unsafe fn instance_create_surface(
         &self,
         display_handle: raw_window_handle::RawDisplayHandle,
         window_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<(Self::SurfaceId, Self::SurfaceData), crate::CreateSurfaceError> {
-        let id = self
-            .0
-            .instance_create_surface(display_handle, window_handle, ());
+        let id = unsafe {
+            self.0
+                .instance_create_surface(display_handle, window_handle, ())
+        };
 
         Ok((
             id,

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1085,7 +1085,7 @@ impl crate::context::Context for Context {
         Context(gpu)
     }
 
-    fn instance_create_surface(
+    unsafe fn instance_create_surface(
         &self,
         _display_handle: raw_window_handle::RawDisplayHandle,
         window_handle: raw_window_handle::RawWindowHandle,

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -96,7 +96,7 @@ pub trait Context: Debug + WasmNotSend + WasmNotSync + Sized {
     type PopErrorScopeFuture: Future<Output = Option<Error>> + WasmNotSend + 'static;
 
     fn init(instance_desc: wgt::InstanceDescriptor) -> Self;
-    fn instance_create_surface(
+    unsafe fn instance_create_surface(
         &self,
         display_handle: raw_window_handle::RawDisplayHandle,
         window_handle: raw_window_handle::RawWindowHandle,
@@ -1204,7 +1204,7 @@ pub type SubmittedWorkDoneCallback = Box<dyn FnOnce() + 'static>;
 pub(crate) trait DynContext: Debug + WasmNotSend + WasmNotSync {
     fn as_any(&self) -> &dyn Any;
 
-    fn instance_create_surface(
+    unsafe fn instance_create_surface(
         &self,
         display_handle: raw_window_handle::RawDisplayHandle,
         window_handle: raw_window_handle::RawWindowHandle,
@@ -2058,13 +2058,13 @@ where
         self
     }
 
-    fn instance_create_surface(
+    unsafe fn instance_create_surface(
         &self,
         display_handle: raw_window_handle::RawDisplayHandle,
         window_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<(ObjectId, Box<crate::Data>), crate::CreateSurfaceError> {
         let (surface, data) =
-            Context::instance_create_surface(self, display_handle, window_handle)?;
+            unsafe { Context::instance_create_surface(self, display_handle, window_handle) }?;
         Ok((surface.into(), Box::new(data) as _))
     }
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1954,11 +1954,13 @@ impl Instance {
                 inner: CreateSurfaceErrorKind::RawHandle(e),
             })?
             .as_raw();
-        let (id, data) = DynContext::instance_create_surface(
-            &*self.context,
-            raw_display_handle,
-            raw_window_handle,
-        )?;
+        let (id, data) = unsafe {
+            DynContext::instance_create_surface(
+                &*self.context,
+                raw_display_handle,
+                raw_window_handle,
+            )
+        }?;
         Ok(Surface {
             context: Arc::clone(&self.context),
             id,


### PR DESCRIPTION
As far as I could tell `wgpu_core::global::Global::instance_create_surface()` was the only public method that should have been `unsafe`, but I followed up the chain and marked non-public methods in `wgpu` `unsafe` as well that should be.