### PR TITLE
Safe surface creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ Bottom level categories:
 - Log vulkan validation layer messages during instance creation and destruction: By @exrook in [#4586](https://github.com/gfx-rs/wgpu/pull/4586)
 - `TextureFormat::block_size` is deprecated, use `TextureFormat::block_copy_size` instead: By @wumpf in [#4647](https://github.com/gfx-rs/wgpu/pull/4647)
 
+#### Safe `Surface` creation
+
+It is now possible to safely create a `wgpu::Surface` with `Surface::create_surface()` and carries a lifetime to the passed `window`. `Surface::create_surface_from_raw()` can be used to produce a `Surface<'static>`, which remains `unsafe`.
+
 #### Naga
 
 - Introduce a new `Scalar` struct type for use in Naga's IR, and update all frontend, middle, and backend code appropriately. By @jimblandy in [#4673](https://github.com/gfx-rs/wgpu/pull/4673).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,11 @@ Bottom level categories:
 
 #### Safe `Surface` creation
 
-It is now possible to safely create a `wgpu::Surface` with `Surface::create_surface()`. `Surface::create_surface_from_raw()` can be used to produce a `Surface<'static>`, which remains `unsafe`.
+It is now possible to safely create a `wgpu::Surface` with `Surface::create_surface()` by letting `Surface` hold a lifetime to `window`.
+
+Passing an owned value `window` to `Surface` will return a `Surface<'static>`. Shared ownership over `window` can still be achieved with e.g. an `Arc`. Alternatively a reference could be passed, which will return a `Surface<'window>`.
+
+`Surface::create_surface_from_raw()` can be used to continue producing a `Surface<'static>` without any lifetime requirements over `window`, which also remains `unsafe`.
 
 #### Naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Bottom level categories:
 
 #### Safe `Surface` creation
 
-It is now possible to safely create a `wgpu::Surface` with `Surface::create_surface()` and carries a lifetime to the passed `window`. `Surface::create_surface_from_raw()` can be used to produce a `Surface<'static>`, which remains `unsafe`.
+It is now possible to safely create a `wgpu::Surface` with `Surface::create_surface()`. `Surface::create_surface_from_raw()` can be used to produce a `Surface<'static>`, which remains `unsafe`.
 
 #### Naga
 

--- a/examples/common/src/framework.rs
+++ b/examples/common/src/framework.rs
@@ -254,7 +254,7 @@ struct ExampleContext {
 }
 impl ExampleContext {
     /// Initializes the example context.
-    async fn init_async<'a, E: Example>(surface: &mut SurfaceWrapper, window: Arc<Window>) -> Self {
+    async fn init_async<E: Example>(surface: &mut SurfaceWrapper, window: Arc<Window>) -> Self {
         log::info!("Initializing wgpu...");
 
         let backends = wgpu::util::backend_bits_from_env().unwrap_or_default();

--- a/examples/hello-triangle/src/main.rs
+++ b/examples/hello-triangle/src/main.rs
@@ -12,7 +12,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
 
     let instance = wgpu::Instance::default();
 
-    let surface = unsafe { instance.create_surface(&window) }.unwrap();
+    let surface = instance.create_surface(&window).unwrap();
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::default(),
@@ -84,6 +84,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
 
     surface.configure(&device, &config);
 
+    let window = &window;
     event_loop
         .run(move |event, target| {
             // Have the closure take ownership of the resources.

--- a/examples/uniform-values/src/main.rs
+++ b/examples/uniform-values/src/main.rs
@@ -83,9 +83,9 @@ impl Default for AppState {
     }
 }
 
-struct WgpuContext {
-    pub window: Window,
-    pub surface: wgpu::Surface,
+struct WgpuContext<'window> {
+    pub window: &'window Window,
+    pub surface: wgpu::Surface<'window>,
     pub surface_config: wgpu::SurfaceConfiguration,
     pub device: wgpu::Device,
     pub queue: wgpu::Queue,
@@ -94,12 +94,12 @@ struct WgpuContext {
     pub uniform_buffer: wgpu::Buffer,
 }
 
-impl WgpuContext {
-    async fn new(window: Window) -> WgpuContext {
+impl WgpuContext<'_> {
+    async fn new(window: &Window) -> WgpuContext {
         let size = window.inner_size();
 
         let instance = wgpu::Instance::default();
-        let surface = unsafe { instance.create_surface(&window) }.unwrap();
+        let surface = instance.create_surface(window).unwrap();
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
@@ -224,7 +224,7 @@ impl WgpuContext {
 }
 
 async fn run(event_loop: EventLoop<()>, window: Window) {
-    let mut wgpu_context = Some(WgpuContext::new(window).await);
+    let mut wgpu_context = Some(WgpuContext::new(&window).await);
     // (6)
     let mut state = Some(AppState::default());
     let main_window_id = wgpu_context.as_ref().unwrap().window.id();

--- a/examples/uniform-values/src/main.rs
+++ b/examples/uniform-values/src/main.rs
@@ -16,6 +16,7 @@
 //! The usage of the uniform buffer within the shader itself is pretty self-explanatory given
 //! some understanding of WGSL.
 
+use std::sync::Arc;
 // We won't bring StorageBuffer into scope as that might be too easy to confuse
 // with actual GPU-allocated WGPU storage buffers.
 use encase::ShaderType;
@@ -83,9 +84,9 @@ impl Default for AppState {
     }
 }
 
-struct WgpuContext<'window> {
-    pub window: &'window Window,
-    pub surface: wgpu::Surface<'window>,
+struct WgpuContext {
+    pub window: Arc<Window>,
+    pub surface: wgpu::Surface<'static>,
     pub surface_config: wgpu::SurfaceConfiguration,
     pub device: wgpu::Device,
     pub queue: wgpu::Queue,
@@ -94,12 +95,12 @@ struct WgpuContext<'window> {
     pub uniform_buffer: wgpu::Buffer,
 }
 
-impl WgpuContext<'_> {
-    async fn new(window: &Window) -> WgpuContext {
+impl WgpuContext {
+    async fn new(window: Arc<Window>) -> WgpuContext {
         let size = window.inner_size();
 
         let instance = wgpu::Instance::default();
-        let surface = instance.create_surface(window).unwrap();
+        let surface = instance.create_surface(window.clone()).unwrap();
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
@@ -223,8 +224,8 @@ impl WgpuContext<'_> {
     }
 }
 
-async fn run(event_loop: EventLoop<()>, window: Window) {
-    let mut wgpu_context = Some(WgpuContext::new(&window).await);
+async fn run(event_loop: EventLoop<()>, window: Arc<Window>) {
+    let mut wgpu_context = Some(WgpuContext::new(window).await);
     // (6)
     let mut state = Some(AppState::default());
     let main_window_id = wgpu_context.as_ref().unwrap().window.id();
@@ -351,6 +352,7 @@ fn main() {
         .with_inner_size(winit::dpi::LogicalSize::new(900, 900))
         .build(&event_loop)
         .unwrap();
+    let window = Arc::new(window);
     #[cfg(not(target_arch = "wasm32"))]
     {
         env_logger::builder().format_timestamp_nanos().init();

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -1109,7 +1109,7 @@ impl crate::context::Context for Context {
 
     fn instance_request_adapter(
         &self,
-        options: &crate::RequestAdapterOptions<'_>,
+        options: &crate::RequestAdapterOptions<'_, '_>,
     ) -> Self::RequestAdapterFuture {
         //TODO: support this check, return `None` if the flag is not set.
         // It's not trivial, since we need the Future logic to have this check,

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -103,7 +103,7 @@ pub trait Context: Debug + WasmNotSend + WasmNotSync + Sized {
     ) -> Result<(Self::SurfaceId, Self::SurfaceData), crate::CreateSurfaceError>;
     fn instance_request_adapter(
         &self,
-        options: &RequestAdapterOptions<'_>,
+        options: &RequestAdapterOptions<'_, '_>,
     ) -> Self::RequestAdapterFuture;
     fn adapter_request_device(
         &self,
@@ -1239,7 +1239,7 @@ pub(crate) trait DynContext: Debug + WasmNotSend + WasmNotSync {
     #[allow(clippy::type_complexity)]
     fn instance_request_adapter(
         &self,
-        options: &RequestAdapterOptions<'_>,
+        options: &RequestAdapterOptions<'_, '_>,
     ) -> Pin<InstanceRequestAdapterFuture>;
     fn adapter_request_device(
         &self,
@@ -2103,7 +2103,7 @@ where
 
     fn instance_request_adapter(
         &self,
-        options: &RequestAdapterOptions<'_>,
+        options: &RequestAdapterOptions<'_, '_>,
     ) -> Pin<InstanceRequestAdapterFuture> {
         let future: T::RequestAdapterFuture = Context::instance_request_adapter(self, options);
         Box::pin(async move {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1961,13 +1961,13 @@ impl Instance {
     /// - On macOS/Metal: will panic if not called on the main thread.
     /// - On web: will panic if the `raw_window_handle` does not properly refer to a
     ///   canvas element.
-    pub fn create_surface<
-        'window,
-        W: HasWindowHandle + HasDisplayHandle + WasmNotSend + WasmNotSync + 'window,
-    >(
+    pub fn create_surface<'window, W>(
         &self,
         window: W,
-    ) -> Result<Surface<'window>, CreateSurfaceError> {
+    ) -> Result<Surface<'window>, CreateSurfaceError>
+    where
+        W: HasWindowHandle + HasDisplayHandle + WasmNotSend + WasmNotSync + 'window,
+    {
         let mut surface = unsafe { self.create_surface_from_raw(&window) }?;
         surface._surface = Some(Box::new(window));
         Ok(surface)
@@ -1985,10 +1985,13 @@ impl Instance {
     /// - `raw_window_handle` must be a valid object to create a surface upon.
     /// - `raw_window_handle` must remain valid until after the returned [`Surface`] is
     ///   dropped.
-    pub unsafe fn create_surface_from_raw<W: HasWindowHandle + HasDisplayHandle>(
+    pub unsafe fn create_surface_from_raw<W>(
         &self,
         window: &W,
-    ) -> Result<Surface<'static>, CreateSurfaceError> {
+    ) -> Result<Surface<'static>, CreateSurfaceError>
+    where
+        W: HasWindowHandle + HasDisplayHandle,
+    {
         let raw_display_handle = window
             .display_handle()
             .map_err(|e| CreateSurfaceError {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -380,18 +380,9 @@ impl Drop for Sampler {
 pub type SurfaceConfiguration = wgt::SurfaceConfiguration<Vec<TextureFormat>>;
 static_assertions::assert_impl_all!(SurfaceConfiguration: Send, Sync);
 
-/// This is used in [`Instance::create_surface`]. For a passed `window` to
-/// fullfill the requirements, [`HasWindowHandle`], [`HasDisplayHandle`] (and
-/// if not targetting Wasm [`Send`] and [`Sync`]) is required.
-pub trait WgpuSurfaceRequirement:
-    HasWindowHandle + HasDisplayHandle + WasmNotSend + WasmNotSync
-{
-}
+trait WgpuSurfaceRequirement: WasmNotSend + WasmNotSync {}
 
-impl<T: HasWindowHandle + HasDisplayHandle + WasmNotSend + WasmNotSync> WgpuSurfaceRequirement
-    for T
-{
-}
+impl<T: WasmNotSend + WasmNotSync> WgpuSurfaceRequirement for T {}
 
 /// Handle to a presentable surface.
 ///
@@ -1970,7 +1961,10 @@ impl Instance {
     /// - On macOS/Metal: will panic if not called on the main thread.
     /// - On web: will panic if the `raw_window_handle` does not properly refer to a
     ///   canvas element.
-    pub fn create_surface<'window, W: WgpuSurfaceRequirement + 'window>(
+    pub fn create_surface<
+        'window,
+        W: HasWindowHandle + HasDisplayHandle + WasmNotSend + WasmNotSync + 'window,
+    >(
         &self,
         window: W,
     ) -> Result<Surface<'window>, CreateSurfaceError> {

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -80,7 +80,7 @@ pub fn initialize_adapter_from_env(
 /// Initialize the adapter obeying the WGPU_ADAPTER_NAME environment variable and if it doesn't exist fall back on a default adapter.
 pub async fn initialize_adapter_from_env_or_default(
     instance: &Instance,
-    compatible_surface: Option<&Surface>,
+    compatible_surface: Option<&Surface<'_>>,
 ) -> Option<Adapter> {
     match initialize_adapter_from_env(instance, compatible_surface) {
         Some(a) => Some(a),


### PR DESCRIPTION
Now that we use `raw-window-handle` v0.6 (#4202), safe `Surface` creation should be possible. This is done by adding a lifetime to `Surface` that is bound to the passed `window`.

Additionally I added `Surface::create_surface_from_raw()` which still takes a `HasWindowHandle + HasDisplayHandle` but remains `unsafe` and returns a `Surface<'static>`. 

Fixes #1463.