### PR TITLE
Add more lints

### DIFF
--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -101,7 +101,7 @@ impl Context {
         &self,
         adapter: &wgc::id::AdapterId,
         hal_device: hal::OpenDevice<A>,
-        desc: &crate::DeviceDescriptor,
+        desc: &crate::DeviceDescriptor<'_>,
         trace_dir: Option<&std::path::Path>,
     ) -> Result<(Device, Queue), crate::RequestDeviceError> {
         let global = &self.0;
@@ -134,7 +134,7 @@ impl Context {
         &self,
         hal_texture: A::Texture,
         device: &Device,
-        desc: &TextureDescriptor,
+        desc: &TextureDescriptor<'_>,
     ) -> Texture {
         let descriptor = desc.map_label_and_view_formats(|l| l.map(Borrowed), |v| v.to_vec());
         let global = &self.0;
@@ -159,7 +159,7 @@ impl Context {
         &self,
         hal_buffer: A::Buffer,
         device: &Device,
-        desc: &BufferDescriptor,
+        desc: &BufferDescriptor<'_>,
     ) -> (wgc::id::BufferId, Buffer) {
         let global = &self.0;
         let (id, error) = unsafe {
@@ -308,7 +308,7 @@ impl Context {
         sink_mutex: &Mutex<ErrorSinkRaw>,
         cause: impl Error + WasmNotSendSync + 'static,
         label_key: &'static str,
-        label: Label,
+        label: Label<'_>,
         string: &'static str,
     ) {
         let error = wgc::error::ContextError {
@@ -375,14 +375,14 @@ impl Context {
     }
 }
 
-fn map_buffer_copy_view(view: crate::ImageCopyBuffer) -> wgc::command::ImageCopyBuffer {
+fn map_buffer_copy_view(view: crate::ImageCopyBuffer<'_>) -> wgc::command::ImageCopyBuffer {
     wgc::command::ImageCopyBuffer {
         buffer: view.buffer.id.into(),
         layout: view.layout,
     }
 }
 
-fn map_texture_copy_view(view: crate::ImageCopyTexture) -> wgc::command::ImageCopyTexture {
+fn map_texture_copy_view(view: crate::ImageCopyTexture<'_>) -> wgc::command::ImageCopyTexture {
     wgc::command::ImageCopyTexture {
         texture: view.texture.id.into(),
         mip_level: view.mip_level,
@@ -396,7 +396,7 @@ fn map_texture_copy_view(view: crate::ImageCopyTexture) -> wgc::command::ImageCo
     allow(unused)
 )]
 fn map_texture_tagged_copy_view(
-    view: crate::ImageCopyTextureTagged,
+    view: crate::ImageCopyTextureTagged<'_>,
 ) -> wgc::command::ImageCopyTextureTagged {
     wgc::command::ImageCopyTextureTagged {
         texture: view.texture.id.into(),
@@ -610,7 +610,7 @@ impl crate::Context for Context {
 
     fn instance_request_adapter(
         &self,
-        options: &crate::RequestAdapterOptions,
+        options: &crate::RequestAdapterOptions<'_, '_>,
     ) -> Self::RequestAdapterFuture {
         let id = self.0.request_adapter(
             &wgc::instance::RequestAdapterOptions {
@@ -627,7 +627,7 @@ impl crate::Context for Context {
         &self,
         adapter: &Self::AdapterId,
         _adapter_data: &Self::AdapterData,
-        desc: &crate::DeviceDescriptor,
+        desc: &crate::DeviceDescriptor<'_>,
         trace_dir: Option<&std::path::Path>,
     ) -> Self::RequestDeviceFuture {
         let global = &self.0;
@@ -890,7 +890,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: ShaderModuleDescriptor,
+        desc: ShaderModuleDescriptor<'_>,
         shader_bound_checks: wgt::ShaderBoundChecks,
     ) -> (Self::ShaderModuleId, Self::ShaderModuleData) {
         let global = &self.0;
@@ -952,7 +952,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &ShaderModuleDescriptorSpirV,
+        desc: &ShaderModuleDescriptorSpirV<'_>,
     ) -> (Self::ShaderModuleId, Self::ShaderModuleData) {
         let global = &self.0;
         let descriptor = wgc::pipeline::ShaderModuleDescriptor {
@@ -980,7 +980,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &BindGroupLayoutDescriptor,
+        desc: &BindGroupLayoutDescriptor<'_>,
     ) -> (Self::BindGroupLayoutId, Self::BindGroupLayoutData) {
         let global = &self.0;
         let descriptor = wgc::binding_model::BindGroupLayoutDescriptor {
@@ -1005,7 +1005,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &BindGroupDescriptor,
+        desc: &BindGroupDescriptor<'_>,
     ) -> (Self::BindGroupId, Self::BindGroupData) {
         use wgc::binding_model as bm;
 
@@ -1120,7 +1120,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &PipelineLayoutDescriptor,
+        desc: &PipelineLayoutDescriptor<'_>,
     ) -> (Self::PipelineLayoutId, Self::PipelineLayoutData) {
         // Limit is always less or equal to hal::MAX_BIND_GROUPS, so this is always right
         // Guards following ArrayVec
@@ -1163,7 +1163,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &RenderPipelineDescriptor,
+        desc: &RenderPipelineDescriptor<'_>,
     ) -> (Self::RenderPipelineId, Self::RenderPipelineData) {
         use wgc::pipeline as pipe;
 
@@ -1234,7 +1234,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &ComputePipelineDescriptor,
+        desc: &ComputePipelineDescriptor<'_>,
     ) -> (Self::ComputePipelineId, Self::ComputePipelineData) {
         use wgc::pipeline as pipe;
 
@@ -1312,7 +1312,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &TextureDescriptor,
+        desc: &TextureDescriptor<'_>,
     ) -> (Self::TextureId, Self::TextureData) {
         let wgt_desc = desc.map_label_and_view_formats(|l| l.map(Borrowed), |v| v.to_vec());
         let global = &self.0;
@@ -1342,7 +1342,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &SamplerDescriptor,
+        desc: &SamplerDescriptor<'_>,
     ) -> (Self::SamplerId, Self::SamplerData) {
         let descriptor = wgc::resource::SamplerDescriptor {
             label: desc.label.map(Borrowed),
@@ -1382,7 +1382,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &wgt::QuerySetDescriptor<Label>,
+        desc: &wgt::QuerySetDescriptor<Label<'_>>,
     ) -> (Self::QuerySetId, Self::QuerySetData) {
         let global = &self.0;
         let (id, error) = wgc::gfx_select!(device => global.device_create_query_set(
@@ -1399,7 +1399,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &CommandEncoderDescriptor,
+        desc: &CommandEncoderDescriptor<'_>,
     ) -> (Self::CommandEncoderId, Self::CommandEncoderData) {
         let global = &self.0;
         let (id, error) = wgc::gfx_select!(device => global.device_create_command_encoder(
@@ -1428,7 +1428,7 @@ impl crate::Context for Context {
         &self,
         device: &Self::DeviceId,
         _device_data: &Self::DeviceData,
-        desc: &RenderBundleEncoderDescriptor,
+        desc: &RenderBundleEncoderDescriptor<'_>,
     ) -> (Self::RenderBundleEncoderId, Self::RenderBundleEncoderData) {
         let descriptor = wgc::command::RenderBundleEncoderDescriptor {
             label: desc.label.map(Borrowed),
@@ -1590,7 +1590,7 @@ impl crate::Context for Context {
         &self,
         texture: &Self::TextureId,
         texture_data: &Self::TextureData,
-        desc: &TextureViewDescriptor,
+        desc: &TextureViewDescriptor<'_>,
     ) -> (Self::TextureViewId, Self::TextureViewData) {
         let descriptor = wgc::resource::TextureViewDescriptor {
             label: desc.label.map(Borrowed),
@@ -1812,8 +1812,8 @@ impl crate::Context for Context {
         &self,
         encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        source: crate::ImageCopyBuffer,
-        destination: crate::ImageCopyTexture,
+        source: crate::ImageCopyBuffer<'_>,
+        destination: crate::ImageCopyTexture<'_>,
         copy_size: wgt::Extent3d,
     ) {
         let global = &self.0;
@@ -1835,8 +1835,8 @@ impl crate::Context for Context {
         &self,
         encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        source: crate::ImageCopyTexture,
-        destination: crate::ImageCopyBuffer,
+        source: crate::ImageCopyTexture<'_>,
+        destination: crate::ImageCopyBuffer<'_>,
         copy_size: wgt::Extent3d,
     ) {
         let global = &self.0;
@@ -1858,8 +1858,8 @@ impl crate::Context for Context {
         &self,
         encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        source: crate::ImageCopyTexture,
-        destination: crate::ImageCopyTexture,
+        source: crate::ImageCopyTexture<'_>,
+        destination: crate::ImageCopyTexture<'_>,
         copy_size: wgt::Extent3d,
     ) {
         let global = &self.0;
@@ -1881,7 +1881,7 @@ impl crate::Context for Context {
         &self,
         encoder: &Self::CommandEncoderId,
         _encoder_data: &Self::CommandEncoderData,
-        desc: &ComputePassDescriptor,
+        desc: &ComputePassDescriptor<'_>,
     ) -> (Self::ComputePassId, Self::ComputePassData) {
         let timestamp_writes =
             desc.timestamp_writes
@@ -2176,7 +2176,7 @@ impl crate::Context for Context {
         &self,
         _encoder: Self::RenderBundleEncoderId,
         encoder_data: Self::RenderBundleEncoderData,
-        desc: &crate::RenderBundleDescriptor,
+        desc: &crate::RenderBundleDescriptor<'_>,
     ) -> (Self::RenderBundleId, Self::RenderBundleData) {
         let global = &self.0;
         let (id, error) = wgc::gfx_select!(encoder_data.parent() => global.render_bundle_encoder_finish(
@@ -2283,7 +2283,7 @@ impl crate::Context for Context {
         &self,
         queue: &Self::QueueId,
         queue_data: &Self::QueueData,
-        texture: crate::ImageCopyTexture,
+        texture: crate::ImageCopyTexture<'_>,
         data: &[u8],
         data_layout: wgt::ImageDataLayout,
         size: wgt::Extent3d,
@@ -2309,7 +2309,7 @@ impl crate::Context for Context {
         queue: &Self::QueueId,
         queue_data: &Self::QueueData,
         source: &wgt::ImageCopyExternalImage,
-        dest: crate::ImageCopyTextureTagged,
+        dest: crate::ImageCopyTextureTagged<'_>,
         size: wgt::Extent3d,
     ) {
         let global = &self.0;

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -139,7 +139,7 @@ pub(crate) struct MakeSendFuture<F, M> {
 impl<F: Future, M: Fn(F::Output) -> T, T> Future for MakeSendFuture<F, M> {
     type Output = T;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         // This is safe because we have no Drop implementation to violate the Pin requirements and
         // do not provide any means of moving the inner future.
         unsafe {
@@ -565,7 +565,7 @@ fn map_texture_view_dimension(
     }
 }
 
-fn map_buffer_copy_view(view: crate::ImageCopyBuffer) -> web_sys::GpuImageCopyBuffer {
+fn map_buffer_copy_view(view: crate::ImageCopyBuffer<'_>) -> web_sys::GpuImageCopyBuffer {
     let buffer: &<Context as crate::Context>::BufferData = downcast_ref(view.buffer.data.as_ref());
     let mut mapped = web_sys::GpuImageCopyBuffer::new(&buffer.0);
     if let Some(bytes_per_row) = view.layout.bytes_per_row {
@@ -578,7 +578,7 @@ fn map_buffer_copy_view(view: crate::ImageCopyBuffer) -> web_sys::GpuImageCopyBu
     mapped
 }
 
-fn map_texture_copy_view(view: crate::ImageCopyTexture) -> web_sys::GpuImageCopyTexture {
+fn map_texture_copy_view(view: crate::ImageCopyTexture<'_>) -> web_sys::GpuImageCopyTexture {
     let texture: &<Context as crate::Context>::TextureData =
         downcast_ref(view.texture.data.as_ref());
     let mut mapped = web_sys::GpuImageCopyTexture::new(&texture.0);
@@ -588,7 +588,7 @@ fn map_texture_copy_view(view: crate::ImageCopyTexture) -> web_sys::GpuImageCopy
 }
 
 fn map_tagged_texture_copy_view(
-    view: crate::ImageCopyTextureTagged,
+    view: crate::ImageCopyTextureTagged<'_>,
 ) -> web_sys::GpuImageCopyTextureTagged {
     let texture: &<Context as crate::Context>::TextureData =
         downcast_ref(view.texture.data.as_ref());
@@ -1138,7 +1138,7 @@ impl crate::context::Context for Context {
         &self,
         _adapter: &Self::AdapterId,
         adapter_data: &Self::AdapterData,
-        desc: &crate::DeviceDescriptor,
+        desc: &crate::DeviceDescriptor<'_>,
         trace_dir: Option<&std::path::Path>,
     ) -> Self::RequestDeviceFuture {
         if trace_dir.is_some() {
@@ -1401,7 +1401,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: crate::ShaderModuleDescriptor,
+        desc: crate::ShaderModuleDescriptor<'_>,
         _shader_bound_checks: wgt::ShaderBoundChecks,
     ) -> (Self::ShaderModuleId, Self::ShaderModuleData) {
         let mut descriptor = match desc.source {
@@ -1487,7 +1487,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         _device_data: &Self::DeviceData,
-        _desc: &crate::ShaderModuleDescriptorSpirV,
+        _desc: &crate::ShaderModuleDescriptorSpirV<'_>,
     ) -> (Self::ShaderModuleId, Self::ShaderModuleData) {
         unreachable!("SPIRV_SHADER_PASSTHROUGH is not enabled for this backend")
     }
@@ -1496,7 +1496,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &crate::BindGroupLayoutDescriptor,
+        desc: &crate::BindGroupLayoutDescriptor<'_>,
     ) -> (Self::BindGroupLayoutId, Self::BindGroupLayoutData) {
         let mapped_bindings = desc
             .entries
@@ -1595,7 +1595,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &crate::BindGroupDescriptor,
+        desc: &crate::BindGroupDescriptor<'_>,
     ) -> (Self::BindGroupId, Self::BindGroupData) {
         let mapped_entries = desc
             .entries
@@ -1654,7 +1654,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &crate::PipelineLayoutDescriptor,
+        desc: &crate::PipelineLayoutDescriptor<'_>,
     ) -> (Self::PipelineLayoutId, Self::PipelineLayoutData) {
         let temp_layouts = desc
             .bind_group_layouts
@@ -1676,7 +1676,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &crate::RenderPipelineDescriptor,
+        desc: &crate::RenderPipelineDescriptor<'_>,
     ) -> (Self::RenderPipelineId, Self::RenderPipelineData) {
         let module: &<Context as crate::Context>::ShaderModuleData =
             downcast_ref(desc.vertex.module.data.as_ref());
@@ -1776,7 +1776,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &crate::ComputePipelineDescriptor,
+        desc: &crate::ComputePipelineDescriptor<'_>,
     ) -> (Self::ComputePipelineId, Self::ComputePipelineData) {
         let shader_module: &<Context as crate::Context>::ShaderModuleData =
             downcast_ref(desc.module.data.as_ref());
@@ -1804,7 +1804,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &crate::BufferDescriptor,
+        desc: &crate::BufferDescriptor<'_>,
     ) -> (Self::BufferId, Self::BufferData) {
         let mut mapped_desc =
             web_sys::GpuBufferDescriptor::new(desc.size as f64, desc.usage.bits());
@@ -1819,7 +1819,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &crate::TextureDescriptor,
+        desc: &crate::TextureDescriptor<'_>,
     ) -> (Self::TextureId, Self::TextureData) {
         let mut mapped_desc = web_sys::GpuTextureDescriptor::new(
             map_texture_format(desc.format),
@@ -1845,7 +1845,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &crate::SamplerDescriptor,
+        desc: &crate::SamplerDescriptor<'_>,
     ) -> (Self::SamplerId, Self::SamplerData) {
         let mut mapped_desc = web_sys::GpuSamplerDescriptor::new();
         mapped_desc.address_mode_u(map_address_mode(desc.address_mode_u));
@@ -1871,7 +1871,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &wgt::QuerySetDescriptor<crate::Label>,
+        desc: &wgt::QuerySetDescriptor<crate::Label<'_>>,
     ) -> (Self::QuerySetId, Self::QuerySetData) {
         let ty = match desc.ty {
             wgt::QueryType::Occlusion => web_sys::GpuQueryType::Occlusion,
@@ -1889,7 +1889,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &crate::CommandEncoderDescriptor,
+        desc: &crate::CommandEncoderDescriptor<'_>,
     ) -> (Self::CommandEncoderId, Self::CommandEncoderData) {
         let mut mapped_desc = web_sys::GpuCommandEncoderDescriptor::new();
         if let Some(label) = desc.label {
@@ -1906,7 +1906,7 @@ impl crate::context::Context for Context {
         &self,
         _device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &crate::RenderBundleEncoderDescriptor,
+        desc: &crate::RenderBundleEncoderDescriptor<'_>,
     ) -> (Self::RenderBundleEncoderId, Self::RenderBundleEncoderData) {
         let mapped_color_formats = desc
             .color_formats
@@ -2061,7 +2061,7 @@ impl crate::context::Context for Context {
         &self,
         _texture: &Self::TextureId,
         texture_data: &Self::TextureData,
-        desc: &crate::TextureViewDescriptor,
+        desc: &crate::TextureViewDescriptor<'_>,
     ) -> (Self::TextureViewId, Self::TextureViewData) {
         let mut mapped = web_sys::GpuTextureViewDescriptor::new();
         if let Some(dim) = desc.dimension {
@@ -2242,8 +2242,8 @@ impl crate::context::Context for Context {
         &self,
         _encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        source: crate::ImageCopyBuffer,
-        destination: crate::ImageCopyTexture,
+        source: crate::ImageCopyBuffer<'_>,
+        destination: crate::ImageCopyTexture<'_>,
         copy_size: wgt::Extent3d,
     ) {
         encoder_data
@@ -2259,8 +2259,8 @@ impl crate::context::Context for Context {
         &self,
         _encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        source: crate::ImageCopyTexture,
-        destination: crate::ImageCopyBuffer,
+        source: crate::ImageCopyTexture<'_>,
+        destination: crate::ImageCopyBuffer<'_>,
         copy_size: wgt::Extent3d,
     ) {
         encoder_data
@@ -2276,8 +2276,8 @@ impl crate::context::Context for Context {
         &self,
         _encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        source: crate::ImageCopyTexture,
-        destination: crate::ImageCopyTexture,
+        source: crate::ImageCopyTexture<'_>,
+        destination: crate::ImageCopyTexture<'_>,
         copy_size: wgt::Extent3d,
     ) {
         encoder_data
@@ -2293,7 +2293,7 @@ impl crate::context::Context for Context {
         &self,
         _encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        desc: &crate::ComputePassDescriptor,
+        desc: &crate::ComputePassDescriptor<'_>,
     ) -> (Self::ComputePassId, Self::ComputePassData) {
         let mut mapped_desc = web_sys::GpuComputePassDescriptor::new();
         if let Some(label) = desc.label {
@@ -2524,7 +2524,7 @@ impl crate::context::Context for Context {
         &self,
         _encoder: Self::RenderBundleEncoderId,
         encoder_data: Self::RenderBundleEncoderData,
-        desc: &crate::RenderBundleDescriptor,
+        desc: &crate::RenderBundleDescriptor<'_>,
     ) -> (Self::RenderBundleId, Self::RenderBundleData) {
         create_identified(match desc.label {
             Some(label) => {
@@ -2641,7 +2641,7 @@ impl crate::context::Context for Context {
         &self,
         _queue: &Self::QueueId,
         queue_data: &Self::QueueData,
-        texture: crate::ImageCopyTexture,
+        texture: crate::ImageCopyTexture<'_>,
         data: &[u8],
         data_layout: wgt::ImageDataLayout,
         size: wgt::Extent3d,
@@ -2678,7 +2678,7 @@ impl crate::context::Context for Context {
         _queue: &Self::QueueId,
         queue_data: &Self::QueueData,
         source: &wgt::ImageCopyExternalImage,
-        dest: crate::ImageCopyTextureTagged,
+        dest: crate::ImageCopyTextureTagged<'_>,
         size: wgt::Extent3d,
     ) {
         queue_data

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -109,7 +109,7 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         &self,
         adapter: &Self::AdapterId,
         adapter_data: &Self::AdapterData,
-        desc: &DeviceDescriptor,
+        desc: &DeviceDescriptor<'_>,
         trace_dir: Option<&std::path::Path>,
     ) -> Self::RequestDeviceFuture;
     fn instance_poll_all_devices(&self, force_wait: bool) -> bool;
@@ -193,80 +193,80 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: ShaderModuleDescriptor,
+        desc: ShaderModuleDescriptor<'_>,
         shader_bound_checks: wgt::ShaderBoundChecks,
     ) -> (Self::ShaderModuleId, Self::ShaderModuleData);
     unsafe fn device_create_shader_module_spirv(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &ShaderModuleDescriptorSpirV,
+        desc: &ShaderModuleDescriptorSpirV<'_>,
     ) -> (Self::ShaderModuleId, Self::ShaderModuleData);
     fn device_create_bind_group_layout(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &BindGroupLayoutDescriptor,
+        desc: &BindGroupLayoutDescriptor<'_>,
     ) -> (Self::BindGroupLayoutId, Self::BindGroupLayoutData);
     fn device_create_bind_group(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &BindGroupDescriptor,
+        desc: &BindGroupDescriptor<'_>,
     ) -> (Self::BindGroupId, Self::BindGroupData);
     fn device_create_pipeline_layout(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &PipelineLayoutDescriptor,
+        desc: &PipelineLayoutDescriptor<'_>,
     ) -> (Self::PipelineLayoutId, Self::PipelineLayoutData);
     fn device_create_render_pipeline(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &RenderPipelineDescriptor,
+        desc: &RenderPipelineDescriptor<'_>,
     ) -> (Self::RenderPipelineId, Self::RenderPipelineData);
     fn device_create_compute_pipeline(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &ComputePipelineDescriptor,
+        desc: &ComputePipelineDescriptor<'_>,
     ) -> (Self::ComputePipelineId, Self::ComputePipelineData);
     fn device_create_buffer(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &BufferDescriptor,
+        desc: &BufferDescriptor<'_>,
     ) -> (Self::BufferId, Self::BufferData);
     fn device_create_texture(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &TextureDescriptor,
+        desc: &TextureDescriptor<'_>,
     ) -> (Self::TextureId, Self::TextureData);
     fn device_create_sampler(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &SamplerDescriptor,
+        desc: &SamplerDescriptor<'_>,
     ) -> (Self::SamplerId, Self::SamplerData);
     fn device_create_query_set(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &QuerySetDescriptor,
+        desc: &QuerySetDescriptor<'_>,
     ) -> (Self::QuerySetId, Self::QuerySetData);
     fn device_create_command_encoder(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &CommandEncoderDescriptor,
+        desc: &CommandEncoderDescriptor<'_>,
     ) -> (Self::CommandEncoderId, Self::CommandEncoderData);
     fn device_create_render_bundle_encoder(
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        desc: &RenderBundleEncoderDescriptor,
+        desc: &RenderBundleEncoderDescriptor<'_>,
     ) -> (Self::RenderBundleEncoderId, Self::RenderBundleEncoderData);
     fn device_drop(&self, device: &Self::DeviceId, device_data: &Self::DeviceData);
     fn device_set_device_lost_callback(
@@ -335,7 +335,7 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         &self,
         texture: &Self::TextureId,
         texture_data: &Self::TextureData,
-        desc: &TextureViewDescriptor,
+        desc: &TextureViewDescriptor<'_>,
     ) -> (Self::TextureViewId, Self::TextureViewData);
 
     fn surface_drop(&self, surface: &Self::SurfaceId, surface_data: &Self::SurfaceData);
@@ -427,24 +427,24 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         &self,
         encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        source: ImageCopyBuffer,
-        destination: ImageCopyTexture,
+        source: ImageCopyBuffer<'_>,
+        destination: ImageCopyTexture<'_>,
         copy_size: Extent3d,
     );
     fn command_encoder_copy_texture_to_buffer(
         &self,
         encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        source: ImageCopyTexture,
-        destination: ImageCopyBuffer,
+        source: ImageCopyTexture<'_>,
+        destination: ImageCopyBuffer<'_>,
         copy_size: Extent3d,
     );
     fn command_encoder_copy_texture_to_texture(
         &self,
         encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        source: ImageCopyTexture,
-        destination: ImageCopyTexture,
+        source: ImageCopyTexture<'_>,
+        destination: ImageCopyTexture<'_>,
         copy_size: Extent3d,
     );
 
@@ -452,7 +452,7 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         &self,
         encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        desc: &ComputePassDescriptor,
+        desc: &ComputePassDescriptor<'_>,
     ) -> (Self::ComputePassId, Self::ComputePassData);
     fn command_encoder_end_compute_pass(
         &self,
@@ -540,7 +540,7 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         &self,
         encoder: Self::RenderBundleEncoderId,
         encoder_data: Self::RenderBundleEncoderData,
-        desc: &RenderBundleDescriptor,
+        desc: &RenderBundleDescriptor<'_>,
     ) -> (Self::RenderBundleId, Self::RenderBundleData);
     fn queue_write_buffer(
         &self,
@@ -579,7 +579,7 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         &self,
         queue: &Self::QueueId,
         queue_data: &Self::QueueData,
-        texture: ImageCopyTexture,
+        texture: ImageCopyTexture<'_>,
         data: &[u8],
         data_layout: ImageDataLayout,
         size: Extent3d,
@@ -590,7 +590,7 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         queue: &Self::QueueId,
         queue_data: &Self::QueueData,
         source: &wgt::ImageCopyExternalImage,
-        dest: crate::ImageCopyTextureTagged,
+        dest: crate::ImageCopyTextureTagged<'_>,
         size: wgt::Extent3d,
     );
     fn queue_submit<I: Iterator<Item = (Self::CommandBufferId, Self::CommandBufferData)>>(
@@ -1243,7 +1243,7 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         &self,
         adapter: &ObjectId,
         adapter_data: &crate::Data,
-        desc: &DeviceDescriptor,
+        desc: &DeviceDescriptor<'_>,
         trace_dir: Option<&std::path::Path>,
     ) -> Pin<AdapterRequestDeviceFuture>;
 
@@ -1314,80 +1314,80 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: ShaderModuleDescriptor,
+        desc: ShaderModuleDescriptor<'_>,
         shader_bound_checks: wgt::ShaderBoundChecks,
     ) -> (ObjectId, Box<crate::Data>);
     unsafe fn device_create_shader_module_spirv(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &ShaderModuleDescriptorSpirV,
+        desc: &ShaderModuleDescriptorSpirV<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_create_bind_group_layout(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &BindGroupLayoutDescriptor,
+        desc: &BindGroupLayoutDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_create_bind_group(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &BindGroupDescriptor,
+        desc: &BindGroupDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_create_pipeline_layout(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &PipelineLayoutDescriptor,
+        desc: &PipelineLayoutDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_create_render_pipeline(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &RenderPipelineDescriptor,
+        desc: &RenderPipelineDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_create_compute_pipeline(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &ComputePipelineDescriptor,
+        desc: &ComputePipelineDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_create_buffer(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &BufferDescriptor,
+        desc: &BufferDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_create_texture(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &TextureDescriptor,
+        desc: &TextureDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_create_sampler(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &SamplerDescriptor,
+        desc: &SamplerDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_create_query_set(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &QuerySetDescriptor,
+        desc: &QuerySetDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_create_command_encoder(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &CommandEncoderDescriptor,
+        desc: &CommandEncoderDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_create_render_bundle_encoder(
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &RenderBundleEncoderDescriptor,
+        desc: &RenderBundleEncoderDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn device_drop(&self, device: &ObjectId, device_data: &crate::Data);
     fn device_set_device_lost_callback(
@@ -1446,7 +1446,7 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         &self,
         texture: &ObjectId,
         texture_data: &crate::Data,
-        desc: &TextureViewDescriptor,
+        desc: &TextureViewDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
 
     fn surface_drop(&self, surface: &ObjectId, surface_data: &crate::Data);
@@ -1502,24 +1502,24 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        source: ImageCopyBuffer,
-        destination: ImageCopyTexture,
+        source: ImageCopyBuffer<'_>,
+        destination: ImageCopyTexture<'_>,
         copy_size: Extent3d,
     );
     fn command_encoder_copy_texture_to_buffer(
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        source: ImageCopyTexture,
-        destination: ImageCopyBuffer,
+        source: ImageCopyTexture<'_>,
+        destination: ImageCopyBuffer<'_>,
         copy_size: Extent3d,
     );
     fn command_encoder_copy_texture_to_texture(
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        source: ImageCopyTexture,
-        destination: ImageCopyTexture,
+        source: ImageCopyTexture<'_>,
+        destination: ImageCopyTexture<'_>,
         copy_size: Extent3d,
     );
 
@@ -1527,7 +1527,7 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        desc: &ComputePassDescriptor,
+        desc: &ComputePassDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn command_encoder_end_compute_pass(
         &self,
@@ -1611,7 +1611,7 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         &self,
         encoder: ObjectId,
         encoder_data: Box<crate::Data>,
-        desc: &RenderBundleDescriptor,
+        desc: &RenderBundleDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn queue_write_buffer(
         &self,
@@ -1650,7 +1650,7 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         &self,
         queue: &ObjectId,
         queue_data: &crate::Data,
-        texture: ImageCopyTexture,
+        texture: ImageCopyTexture<'_>,
         data: &[u8],
         data_layout: ImageDataLayout,
         size: Extent3d,
@@ -1661,7 +1661,7 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         queue: &ObjectId,
         queue_data: &crate::Data,
         source: &wgt::ImageCopyExternalImage,
-        dest: crate::ImageCopyTextureTagged,
+        dest: crate::ImageCopyTextureTagged<'_>,
         size: wgt::Extent3d,
     );
     fn queue_submit<'a>(
@@ -2114,7 +2114,7 @@ where
         &self,
         adapter: &ObjectId,
         adapter_data: &crate::Data,
-        desc: &DeviceDescriptor,
+        desc: &DeviceDescriptor<'_>,
         trace_dir: Option<&std::path::Path>,
     ) -> Pin<AdapterRequestDeviceFuture> {
         let adapter = <T::AdapterId>::from(*adapter);
@@ -2286,7 +2286,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: ShaderModuleDescriptor,
+        desc: ShaderModuleDescriptor<'_>,
         shader_bound_checks: wgt::ShaderBoundChecks,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
@@ -2305,7 +2305,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &ShaderModuleDescriptorSpirV,
+        desc: &ShaderModuleDescriptorSpirV<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2318,7 +2318,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &BindGroupLayoutDescriptor,
+        desc: &BindGroupLayoutDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2331,7 +2331,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &BindGroupDescriptor,
+        desc: &BindGroupDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2344,7 +2344,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &PipelineLayoutDescriptor,
+        desc: &PipelineLayoutDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2357,7 +2357,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &RenderPipelineDescriptor,
+        desc: &RenderPipelineDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2370,7 +2370,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &ComputePipelineDescriptor,
+        desc: &ComputePipelineDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2383,7 +2383,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &BufferDescriptor,
+        desc: &BufferDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2395,7 +2395,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &TextureDescriptor,
+        desc: &TextureDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2407,7 +2407,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &SamplerDescriptor,
+        desc: &SamplerDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2419,7 +2419,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &QuerySetDescriptor,
+        desc: &QuerySetDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2431,7 +2431,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &CommandEncoderDescriptor,
+        desc: &CommandEncoderDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2444,7 +2444,7 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        desc: &RenderBundleEncoderDescriptor,
+        desc: &RenderBundleEncoderDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
@@ -2574,7 +2574,7 @@ where
         &self,
         texture: &ObjectId,
         texture_data: &crate::Data,
-        desc: &TextureViewDescriptor,
+        desc: &TextureViewDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let texture = <T::TextureId>::from(*texture);
         let texture_data = downcast_ref(texture_data);
@@ -2756,8 +2756,8 @@ where
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        source: ImageCopyBuffer,
-        destination: ImageCopyTexture,
+        source: ImageCopyBuffer<'_>,
+        destination: ImageCopyTexture<'_>,
         copy_size: Extent3d,
     ) {
         let encoder = <T::CommandEncoderId>::from(*encoder);
@@ -2776,8 +2776,8 @@ where
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        source: ImageCopyTexture,
-        destination: ImageCopyBuffer,
+        source: ImageCopyTexture<'_>,
+        destination: ImageCopyBuffer<'_>,
         copy_size: Extent3d,
     ) {
         let encoder = <T::CommandEncoderId>::from(*encoder);
@@ -2796,8 +2796,8 @@ where
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        source: ImageCopyTexture,
-        destination: ImageCopyTexture,
+        source: ImageCopyTexture<'_>,
+        destination: ImageCopyTexture<'_>,
         copy_size: Extent3d,
     ) {
         let encoder = <T::CommandEncoderId>::from(*encoder);
@@ -2816,7 +2816,7 @@ where
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        desc: &ComputePassDescriptor,
+        desc: &ComputePassDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let encoder = <T::CommandEncoderId>::from(*encoder);
         let encoder_data = downcast_ref(encoder_data);
@@ -2999,7 +2999,7 @@ where
         &self,
         encoder: ObjectId,
         encoder_data: Box<crate::Data>,
-        desc: &RenderBundleDescriptor,
+        desc: &RenderBundleDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let encoder_data = *encoder_data.downcast().unwrap();
         let (render_bundle, data) =
@@ -3086,7 +3086,7 @@ where
         &self,
         queue: &ObjectId,
         queue_data: &crate::Data,
-        texture: ImageCopyTexture,
+        texture: ImageCopyTexture<'_>,
         data: &[u8],
         data_layout: ImageDataLayout,
         size: Extent3d,
@@ -3102,7 +3102,7 @@ where
         queue: &ObjectId,
         queue_data: &crate::Data,
         source: &wgt::ImageCopyExternalImage,
-        dest: crate::ImageCopyTextureTagged,
+        dest: crate::ImageCopyTextureTagged<'_>,
         size: wgt::Extent3d,
     ) {
         let queue = <T::QueueId>::from(*queue);

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/gfx-rs/wgpu/trunk/logo.png")]
-#![warn(missing_docs, unsafe_op_in_unsafe_fn)]
+#![warn(missing_docs, rust_2018_idioms, unsafe_op_in_unsafe_fn)]
 
 mod backend;
 mod context;
@@ -294,7 +294,7 @@ pub struct BufferSlice<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(BufferSlice: Send, Sync);
+static_assertions::assert_impl_all!(BufferSlice<'_>: Send, Sync);
 
 /// Handle to a texture on the GPU.
 ///
@@ -430,7 +430,7 @@ impl<'window> fmt::Debug for Surface<'window> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(Surface: Send, Sync);
+static_assertions::assert_impl_all!(Surface<'_>: Send, Sync);
 
 impl Drop for Surface<'_> {
     fn drop(&mut self) {
@@ -579,7 +579,7 @@ pub enum ShaderSource<'a> {
     #[doc(hidden)]
     Dummy(PhantomData<&'a ()>),
 }
-static_assertions::assert_impl_all!(ShaderSource: Send, Sync);
+static_assertions::assert_impl_all!(ShaderSource<'_>: Send, Sync);
 
 /// Descriptor for use with [`Device::create_shader_module`].
 ///
@@ -592,7 +592,7 @@ pub struct ShaderModuleDescriptor<'a> {
     /// Source code for the shader.
     pub source: ShaderSource<'a>,
 }
-static_assertions::assert_impl_all!(ShaderModuleDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(ShaderModuleDescriptor<'_>: Send, Sync);
 
 /// Descriptor for a shader module given by SPIR-V binary, for use with
 /// [`Device::create_shader_module_spirv`].
@@ -606,7 +606,7 @@ pub struct ShaderModuleDescriptorSpirV<'a> {
     /// Binary SPIR-V data, in 4-byte words.
     pub source: Cow<'a, [u32]>,
 }
-static_assertions::assert_impl_all!(ShaderModuleDescriptorSpirV: Send, Sync);
+static_assertions::assert_impl_all!(ShaderModuleDescriptorSpirV<'_>: Send, Sync);
 
 /// Handle to a pipeline layout.
 ///
@@ -990,7 +990,7 @@ pub enum BindingResource<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(BindingResource: Send, Sync);
+static_assertions::assert_impl_all!(BindingResource<'_>: Send, Sync);
 
 /// Describes the segment of a buffer to bind.
 ///
@@ -1028,7 +1028,7 @@ pub struct BufferBinding<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(BufferBinding: Send, Sync);
+static_assertions::assert_impl_all!(BufferBinding<'_>: Send, Sync);
 
 /// Operation to perform to the output attachment at the start of a render pass.
 ///
@@ -1131,7 +1131,7 @@ pub struct RenderPassTimestampWrites<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(RenderPassTimestampWrites: Send, Sync);
+static_assertions::assert_impl_all!(RenderPassTimestampWrites<'_>: Send, Sync);
 
 /// Describes a color attachment to a [`RenderPass`].
 ///
@@ -1157,7 +1157,7 @@ pub struct RenderPassColorAttachment<'tex> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(RenderPassColorAttachment: Send, Sync);
+static_assertions::assert_impl_all!(RenderPassColorAttachment<'_>: Send, Sync);
 
 /// Describes a depth/stencil attachment to a [`RenderPass`].
 ///
@@ -1181,7 +1181,7 @@ pub struct RenderPassDepthStencilAttachment<'tex> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(RenderPassDepthStencilAttachment: Send, Sync);
+static_assertions::assert_impl_all!(RenderPassDepthStencilAttachment<'_>: Send, Sync);
 
 // The underlying types are also exported so that documentation shows up for them
 
@@ -1202,7 +1202,7 @@ pub type RequestAdapterOptions<'a, 'b> = RequestAdapterOptionsBase<&'a Surface<'
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(RequestAdapterOptions: Send, Sync);
+static_assertions::assert_impl_all!(RequestAdapterOptions<'_, '_>: Send, Sync);
 /// Describes a [`Device`].
 ///
 /// For use with [`Adapter::request_device`].
@@ -1210,7 +1210,7 @@ static_assertions::assert_impl_all!(RequestAdapterOptions: Send, Sync);
 /// Corresponds to [WebGPU `GPUDeviceDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpudevicedescriptor).
 pub type DeviceDescriptor<'a> = wgt::DeviceDescriptor<Label<'a>>;
-static_assertions::assert_impl_all!(DeviceDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(DeviceDescriptor<'_>: Send, Sync);
 /// Describes a [`Buffer`].
 ///
 /// For use with [`Device::create_buffer`].
@@ -1218,7 +1218,7 @@ static_assertions::assert_impl_all!(DeviceDescriptor: Send, Sync);
 /// Corresponds to [WebGPU `GPUBufferDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpubufferdescriptor).
 pub type BufferDescriptor<'a> = wgt::BufferDescriptor<Label<'a>>;
-static_assertions::assert_impl_all!(BufferDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(BufferDescriptor<'_>: Send, Sync);
 /// Describes a [`CommandEncoder`].
 ///
 /// For use with [`Device::create_command_encoder`].
@@ -1226,7 +1226,7 @@ static_assertions::assert_impl_all!(BufferDescriptor: Send, Sync);
 /// Corresponds to [WebGPU `GPUCommandEncoderDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpucommandencoderdescriptor).
 pub type CommandEncoderDescriptor<'a> = wgt::CommandEncoderDescriptor<Label<'a>>;
-static_assertions::assert_impl_all!(CommandEncoderDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(CommandEncoderDescriptor<'_>: Send, Sync);
 /// Describes a [`RenderBundle`].
 ///
 /// For use with [`RenderBundleEncoder::finish`].
@@ -1234,7 +1234,7 @@ static_assertions::assert_impl_all!(CommandEncoderDescriptor: Send, Sync);
 /// Corresponds to [WebGPU `GPURenderBundleDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpurenderbundledescriptor).
 pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
-static_assertions::assert_impl_all!(RenderBundleDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(RenderBundleDescriptor<'_>: Send, Sync);
 /// Describes a [`Texture`].
 ///
 /// For use with [`Device::create_texture`].
@@ -1242,7 +1242,7 @@ static_assertions::assert_impl_all!(RenderBundleDescriptor: Send, Sync);
 /// Corresponds to [WebGPU `GPUTextureDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gputexturedescriptor).
 pub type TextureDescriptor<'a> = wgt::TextureDescriptor<Label<'a>, &'a [TextureFormat]>;
-static_assertions::assert_impl_all!(TextureDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(TextureDescriptor<'_>: Send, Sync);
 /// Describes a [`QuerySet`].
 ///
 /// For use with [`Device::create_query_set`].
@@ -1250,7 +1250,7 @@ static_assertions::assert_impl_all!(TextureDescriptor: Send, Sync);
 /// Corresponds to [WebGPU `GPUQuerySetDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuquerysetdescriptor).
 pub type QuerySetDescriptor<'a> = wgt::QuerySetDescriptor<Label<'a>>;
-static_assertions::assert_impl_all!(QuerySetDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(QuerySetDescriptor<'_>: Send, Sync);
 pub use wgt::Maintain as MaintainBase;
 /// Passed to [`Device::poll`] to control how and if it should block.
 pub type Maintain = wgt::Maintain<SubmissionIndex>;
@@ -1294,7 +1294,7 @@ pub struct TextureViewDescriptor<'a> {
     /// If `None`, considered to include the rest of the array layers, but at least 1 in total.
     pub array_layer_count: Option<u32>,
 }
-static_assertions::assert_impl_all!(TextureViewDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(TextureViewDescriptor<'_>: Send, Sync);
 
 /// Describes a [`PipelineLayout`].
 ///
@@ -1323,7 +1323,7 @@ pub struct PipelineLayoutDescriptor<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(PipelineLayoutDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(PipelineLayoutDescriptor<'_>: Send, Sync);
 
 /// Describes a [`Sampler`].
 ///
@@ -1358,7 +1358,7 @@ pub struct SamplerDescriptor<'a> {
     /// Border color to use when address_mode is [`AddressMode::ClampToBorder`]
     pub border_color: Option<SamplerBorderColor>,
 }
-static_assertions::assert_impl_all!(SamplerDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(SamplerDescriptor<'_>: Send, Sync);
 
 impl Default for SamplerDescriptor<'_> {
     fn default() -> Self {
@@ -1399,7 +1399,7 @@ pub struct BindGroupEntry<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(BindGroupEntry: Send, Sync);
+static_assertions::assert_impl_all!(BindGroupEntry<'_>: Send, Sync);
 
 /// Describes a group of bindings and the resources to be bound.
 ///
@@ -1423,7 +1423,7 @@ pub struct BindGroupDescriptor<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(BindGroupDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(BindGroupDescriptor<'_>: Send, Sync);
 
 /// Describes the attachments of a render pass.
 ///
@@ -1456,7 +1456,7 @@ pub struct RenderPassDescriptor<'tex, 'desc> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(RenderPassDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(RenderPassDescriptor<'_, '_>: Send, Sync);
 
 /// Describes how the vertex buffer is interpreted.
 ///
@@ -1473,7 +1473,7 @@ pub struct VertexBufferLayout<'a> {
     /// The list of attributes which comprise a single vertex.
     pub attributes: &'a [VertexAttribute],
 }
-static_assertions::assert_impl_all!(VertexBufferLayout: Send, Sync);
+static_assertions::assert_impl_all!(VertexBufferLayout<'_>: Send, Sync);
 
 /// Describes the vertex processing in a render pipeline.
 ///
@@ -1498,7 +1498,7 @@ pub struct VertexState<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(VertexState: Send, Sync);
+static_assertions::assert_impl_all!(VertexState<'_>: Send, Sync);
 
 /// Describes the fragment processing in a render pipeline.
 ///
@@ -1523,7 +1523,7 @@ pub struct FragmentState<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(FragmentState: Send, Sync);
+static_assertions::assert_impl_all!(FragmentState<'_>: Send, Sync);
 
 /// Describes a render (graphics) pipeline.
 ///
@@ -1558,7 +1558,7 @@ pub struct RenderPipelineDescriptor<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(RenderPipelineDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(RenderPipelineDescriptor<'_>: Send, Sync);
 
 /// Describes the timestamp writes of a compute pass.
 ///
@@ -1583,7 +1583,7 @@ pub struct ComputePassTimestampWrites<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(ComputePassTimestampWrites: Send, Sync);
+static_assertions::assert_impl_all!(ComputePassTimestampWrites<'_>: Send, Sync);
 
 /// Describes the attachments of a compute pass.
 ///
@@ -1607,7 +1607,7 @@ pub struct ComputePassDescriptor<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(ComputePassDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(ComputePassDescriptor<'_>: Send, Sync);
 
 /// Describes a compute pipeline.
 ///
@@ -1634,7 +1634,7 @@ pub struct ComputePipelineDescriptor<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(ComputePipelineDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(ComputePipelineDescriptor<'_>: Send, Sync);
 
 pub use wgt::ImageCopyBuffer as ImageCopyBufferBase;
 /// View of a buffer which can be used to copy to/from a texture.
@@ -1649,7 +1649,7 @@ pub type ImageCopyBuffer<'a> = ImageCopyBufferBase<&'a Buffer>;
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(ImageCopyBuffer: Send, Sync);
+static_assertions::assert_impl_all!(ImageCopyBuffer<'_>: Send, Sync);
 
 pub use wgt::ImageCopyTexture as ImageCopyTextureBase;
 /// View of a texture which can be used to copy to/from a buffer/texture.
@@ -1664,7 +1664,7 @@ pub type ImageCopyTexture<'a> = ImageCopyTextureBase<&'a Texture>;
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(ImageCopyTexture: Send, Sync);
+static_assertions::assert_impl_all!(ImageCopyTexture<'_>: Send, Sync);
 
 pub use wgt::ImageCopyTextureTagged as ImageCopyTextureTaggedBase;
 /// View of a texture which can be used to copy to a texture, including
@@ -1680,7 +1680,7 @@ pub type ImageCopyTextureTagged<'a> = ImageCopyTextureTaggedBase<&'a Texture>;
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(ImageCopyTexture: Send, Sync);
+static_assertions::assert_impl_all!(ImageCopyTexture<'_>: Send, Sync);
 
 /// Describes a [`BindGroupLayout`].
 ///
@@ -1696,7 +1696,7 @@ pub struct BindGroupLayoutDescriptor<'a> {
     /// Array of entries in this BindGroupLayout
     pub entries: &'a [BindGroupLayoutEntry],
 }
-static_assertions::assert_impl_all!(BindGroupLayoutDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(BindGroupLayoutDescriptor<'_>: Send, Sync);
 
 /// Describes a [`RenderBundleEncoder`].
 ///
@@ -1720,7 +1720,7 @@ pub struct RenderBundleEncoderDescriptor<'a> {
     /// If this render bundle will rendering to multiple array layers in the attachments at the same time.
     pub multiview: Option<NonZeroU32>,
 }
-static_assertions::assert_impl_all!(RenderBundleEncoderDescriptor: Send, Sync);
+static_assertions::assert_impl_all!(RenderBundleEncoderDescriptor<'_>: Send, Sync);
 
 /// Surface texture that can be rendered to.
 /// Result of a successful call to [`Surface::get_current_texture`].
@@ -1897,7 +1897,7 @@ impl Instance {
     /// If no adapters are found that suffice all the "hard" options, `None` is returned.
     pub fn request_adapter(
         &self,
-        options: &RequestAdapterOptions,
+        options: &RequestAdapterOptions<'_, '_>,
     ) -> impl Future<Output = Option<Adapter>> + WasmNotSend {
         let context = Arc::clone(&self.context);
         let adapter = self.context.instance_request_adapter(options);
@@ -2248,7 +2248,7 @@ impl Adapter {
     /// - Adapter does not support all features wgpu requires to safely operate.
     pub fn request_device(
         &self,
-        desc: &DeviceDescriptor,
+        desc: &DeviceDescriptor<'_>,
         trace_path: Option<&std::path::Path>,
     ) -> impl Future<Output = Result<(Device, Queue), RequestDeviceError>> + WasmNotSend {
         let context = Arc::clone(&self.context);
@@ -2298,7 +2298,7 @@ impl Adapter {
     pub unsafe fn create_device_from_hal<A: wgc::hal_api::HalApi>(
         &self,
         hal_device: hal::OpenDevice<A>,
-        desc: &DeviceDescriptor,
+        desc: &DeviceDescriptor<'_>,
         trace_path: Option<&std::path::Path>,
     ) -> Result<(Device, Queue), RequestDeviceError> {
         let context = Arc::clone(&self.context);
@@ -2363,7 +2363,7 @@ impl Adapter {
     }
 
     /// Returns whether this adapter may present to the passed surface.
-    pub fn is_surface_supported(&self, surface: &Surface) -> bool {
+    pub fn is_surface_supported(&self, surface: &Surface<'_>) -> bool {
         DynContext::adapter_is_surface_supported(
             &*self.context,
             &self.id,
@@ -2467,7 +2467,7 @@ impl Device {
     }
 
     /// Creates a shader module from either SPIR-V or WGSL source code.
-    pub fn create_shader_module(&self, desc: ShaderModuleDescriptor) -> ShaderModule {
+    pub fn create_shader_module(&self, desc: ShaderModuleDescriptor<'_>) -> ShaderModule {
         let (id, data) = DynContext::device_create_shader_module(
             &*self.context,
             &self.id,
@@ -2494,7 +2494,7 @@ impl Device {
     /// This has no effect on web.
     pub unsafe fn create_shader_module_unchecked(
         &self,
-        desc: ShaderModuleDescriptor,
+        desc: ShaderModuleDescriptor<'_>,
     ) -> ShaderModule {
         let (id, data) = DynContext::device_create_shader_module(
             &*self.context,
@@ -2520,7 +2520,7 @@ impl Device {
     /// See also [`include_spirv_raw!`] and [`util::make_spirv_raw`].
     pub unsafe fn create_shader_module_spirv(
         &self,
-        desc: &ShaderModuleDescriptorSpirV,
+        desc: &ShaderModuleDescriptorSpirV<'_>,
     ) -> ShaderModule {
         let (id, data) = unsafe {
             DynContext::device_create_shader_module_spirv(
@@ -2538,7 +2538,7 @@ impl Device {
     }
 
     /// Creates an empty [`CommandEncoder`].
-    pub fn create_command_encoder(&self, desc: &CommandEncoderDescriptor) -> CommandEncoder {
+    pub fn create_command_encoder(&self, desc: &CommandEncoderDescriptor<'_>) -> CommandEncoder {
         let (id, data) = DynContext::device_create_command_encoder(
             &*self.context,
             &self.id,
@@ -2555,8 +2555,8 @@ impl Device {
     /// Creates an empty [`RenderBundleEncoder`].
     pub fn create_render_bundle_encoder(
         &self,
-        desc: &RenderBundleEncoderDescriptor,
-    ) -> RenderBundleEncoder {
+        desc: &RenderBundleEncoderDescriptor<'_>,
+    ) -> RenderBundleEncoder<'_> {
         let (id, data) = DynContext::device_create_render_bundle_encoder(
             &*self.context,
             &self.id,
@@ -2573,7 +2573,7 @@ impl Device {
     }
 
     /// Creates a new [`BindGroup`].
-    pub fn create_bind_group(&self, desc: &BindGroupDescriptor) -> BindGroup {
+    pub fn create_bind_group(&self, desc: &BindGroupDescriptor<'_>) -> BindGroup {
         let (id, data) = DynContext::device_create_bind_group(
             &*self.context,
             &self.id,
@@ -2588,7 +2588,10 @@ impl Device {
     }
 
     /// Creates a [`BindGroupLayout`].
-    pub fn create_bind_group_layout(&self, desc: &BindGroupLayoutDescriptor) -> BindGroupLayout {
+    pub fn create_bind_group_layout(
+        &self,
+        desc: &BindGroupLayoutDescriptor<'_>,
+    ) -> BindGroupLayout {
         let (id, data) = DynContext::device_create_bind_group_layout(
             &*self.context,
             &self.id,
@@ -2603,7 +2606,7 @@ impl Device {
     }
 
     /// Creates a [`PipelineLayout`].
-    pub fn create_pipeline_layout(&self, desc: &PipelineLayoutDescriptor) -> PipelineLayout {
+    pub fn create_pipeline_layout(&self, desc: &PipelineLayoutDescriptor<'_>) -> PipelineLayout {
         let (id, data) = DynContext::device_create_pipeline_layout(
             &*self.context,
             &self.id,
@@ -2618,7 +2621,7 @@ impl Device {
     }
 
     /// Creates a [`RenderPipeline`].
-    pub fn create_render_pipeline(&self, desc: &RenderPipelineDescriptor) -> RenderPipeline {
+    pub fn create_render_pipeline(&self, desc: &RenderPipelineDescriptor<'_>) -> RenderPipeline {
         let (id, data) = DynContext::device_create_render_pipeline(
             &*self.context,
             &self.id,
@@ -2633,7 +2636,7 @@ impl Device {
     }
 
     /// Creates a [`ComputePipeline`].
-    pub fn create_compute_pipeline(&self, desc: &ComputePipelineDescriptor) -> ComputePipeline {
+    pub fn create_compute_pipeline(&self, desc: &ComputePipelineDescriptor<'_>) -> ComputePipeline {
         let (id, data) = DynContext::device_create_compute_pipeline(
             &*self.context,
             &self.id,
@@ -2648,7 +2651,7 @@ impl Device {
     }
 
     /// Creates a [`Buffer`].
-    pub fn create_buffer(&self, desc: &BufferDescriptor) -> Buffer {
+    pub fn create_buffer(&self, desc: &BufferDescriptor<'_>) -> Buffer {
         let mut map_context = MapContext::new(desc.size);
         if desc.mapped_at_creation {
             map_context.initial_range = 0..desc.size;
@@ -2670,7 +2673,7 @@ impl Device {
     /// Creates a new [`Texture`].
     ///
     /// `desc` specifies the general format of the texture.
-    pub fn create_texture(&self, desc: &TextureDescriptor) -> Texture {
+    pub fn create_texture(&self, desc: &TextureDescriptor<'_>) -> Texture {
         let (id, data) =
             DynContext::device_create_texture(&*self.context, &self.id, self.data.as_ref(), desc);
         Texture {
@@ -2701,7 +2704,7 @@ impl Device {
     pub unsafe fn create_texture_from_hal<A: wgc::hal_api::HalApi>(
         &self,
         hal_texture: A::Texture,
-        desc: &TextureDescriptor,
+        desc: &TextureDescriptor<'_>,
     ) -> Texture {
         let texture = unsafe {
             self.context
@@ -2742,7 +2745,7 @@ impl Device {
     pub unsafe fn create_buffer_from_hal<A: wgc::hal_api::HalApi>(
         &self,
         hal_buffer: A::Buffer,
-        desc: &BufferDescriptor,
+        desc: &BufferDescriptor<'_>,
     ) -> Buffer {
         let mut map_context = MapContext::new(desc.size);
         if desc.mapped_at_creation {
@@ -2774,7 +2777,7 @@ impl Device {
     /// Creates a new [`Sampler`].
     ///
     /// `desc` specifies the behavior of the sampler.
-    pub fn create_sampler(&self, desc: &SamplerDescriptor) -> Sampler {
+    pub fn create_sampler(&self, desc: &SamplerDescriptor<'_>) -> Sampler {
         let (id, data) =
             DynContext::device_create_sampler(&*self.context, &self.id, self.data.as_ref(), desc);
         Sampler {
@@ -2785,7 +2788,7 @@ impl Device {
     }
 
     /// Creates a new [`QuerySet`].
-    pub fn create_query_set(&self, desc: &QuerySetDescriptor) -> QuerySet {
+    pub fn create_query_set(&self, desc: &QuerySetDescriptor<'_>) -> QuerySet {
         let (id, data) =
             DynContext::device_create_query_set(&*self.context, &self.id, self.data.as_ref(), desc);
         QuerySet {
@@ -3180,12 +3183,12 @@ impl Drop for BufferViewMut<'_> {
 
 impl Buffer {
     /// Return the binding view of the entire buffer.
-    pub fn as_entire_binding(&self) -> BindingResource {
+    pub fn as_entire_binding(&self) -> BindingResource<'_> {
         BindingResource::Buffer(self.as_entire_buffer_binding())
     }
 
     /// Return the binding view of the entire buffer.
-    pub fn as_entire_buffer_binding(&self) -> BufferBinding {
+    pub fn as_entire_buffer_binding(&self) -> BufferBinding<'_> {
         BufferBinding {
             buffer: self,
             offset: 0,
@@ -3195,7 +3198,7 @@ impl Buffer {
 
     /// Use only a portion of this Buffer for a given operation. Choosing a range with no end
     /// will use the rest of the buffer. Using a totally unbounded range will use the entire buffer.
-    pub fn slice<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferSlice {
+    pub fn slice<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferSlice<'_> {
         let (offset, size) = range_to_offset_size(bounds);
         BufferSlice {
             buffer: self,
@@ -3354,7 +3357,7 @@ impl Texture {
     }
 
     /// Creates a view of this texture.
-    pub fn create_view(&self, desc: &TextureViewDescriptor) -> TextureView {
+    pub fn create_view(&self, desc: &TextureViewDescriptor<'_>) -> TextureView {
         let (id, data) =
             DynContext::texture_create_view(&*self.context, &self.id, self.data.as_ref(), desc);
         TextureView {
@@ -3370,7 +3373,7 @@ impl Texture {
     }
 
     /// Make an `ImageCopyTexture` representing the whole texture.
-    pub fn as_image_copy(&self) -> ImageCopyTexture {
+    pub fn as_image_copy(&self) -> ImageCopyTexture<'_> {
         ImageCopyTexture {
             texture: self,
             mip_level: 0,
@@ -3498,7 +3501,7 @@ impl CommandEncoder {
     /// Begins recording of a compute pass.
     ///
     /// This function returns a [`ComputePass`] object which records a single compute pass.
-    pub fn begin_compute_pass(&mut self, desc: &ComputePassDescriptor) -> ComputePass {
+    pub fn begin_compute_pass(&mut self, desc: &ComputePassDescriptor<'_>) -> ComputePass<'_> {
         let id = self.id.as_ref().unwrap();
         let (id, data) = DynContext::command_encoder_begin_compute_pass(
             &*self.context,
@@ -3545,8 +3548,8 @@ impl CommandEncoder {
     /// Copy data from a buffer to a texture.
     pub fn copy_buffer_to_texture(
         &mut self,
-        source: ImageCopyBuffer,
-        destination: ImageCopyTexture,
+        source: ImageCopyBuffer<'_>,
+        destination: ImageCopyTexture<'_>,
         copy_size: Extent3d,
     ) {
         DynContext::command_encoder_copy_buffer_to_texture(
@@ -3562,8 +3565,8 @@ impl CommandEncoder {
     /// Copy data from a texture to a buffer.
     pub fn copy_texture_to_buffer(
         &mut self,
-        source: ImageCopyTexture,
-        destination: ImageCopyBuffer,
+        source: ImageCopyTexture<'_>,
+        destination: ImageCopyBuffer<'_>,
         copy_size: Extent3d,
     ) {
         DynContext::command_encoder_copy_texture_to_buffer(
@@ -3585,8 +3588,8 @@ impl CommandEncoder {
     /// - Copy would overrun either texture
     pub fn copy_texture_to_texture(
         &mut self,
-        source: ImageCopyTexture,
-        destination: ImageCopyTexture,
+        source: ImageCopyTexture<'_>,
+        destination: ImageCopyTexture<'_>,
         copy_size: Extent3d,
     ) {
         DynContext::command_encoder_copy_texture_to_texture(
@@ -4495,7 +4498,7 @@ impl<'a> Drop for ComputePass<'a> {
 
 impl<'a> RenderBundleEncoder<'a> {
     /// Finishes recording and returns a [`RenderBundle`] that can be executed in other render passes.
-    pub fn finish(self, desc: &RenderBundleDescriptor) -> RenderBundle {
+    pub fn finish(self, desc: &RenderBundleDescriptor<'_>) -> RenderBundle {
         let (id, data) =
             DynContext::render_bundle_encoder_finish(&*self.context, self.id, self.data, desc);
         RenderBundle {
@@ -4738,7 +4741,7 @@ pub struct QueueWriteBufferView<'a> {
         not(target_feature = "atomics")
     )
 ))]
-static_assertions::assert_impl_all!(QueueWriteBufferView: Send, Sync);
+static_assertions::assert_impl_all!(QueueWriteBufferView<'_>: Send, Sync);
 
 impl Deref for QueueWriteBufferView<'_> {
     type Target = [u8];
@@ -4855,7 +4858,7 @@ impl Queue {
     /// This method fails if `size` overruns the size of `texture`, or if `data` is too short.
     pub fn write_texture(
         &self,
-        texture: ImageCopyTexture,
+        texture: ImageCopyTexture<'_>,
         data: &[u8],
         data_layout: ImageDataLayout,
         size: Extent3d,
@@ -4876,7 +4879,7 @@ impl Queue {
     pub fn copy_external_image_to_texture(
         &self,
         source: &wgt::ImageCopyExternalImage,
-        dest: ImageCopyTextureTagged,
+        dest: ImageCopyTextureTagged<'_>,
         size: Extent3d,
     ) {
         DynContext::queue_copy_external_image_to_texture(
@@ -5141,7 +5144,7 @@ impl<T> Copy for Id<T> {}
 
 #[cfg(feature = "expose-ids")]
 impl<T> fmt::Debug for Id<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Id").field(&self.0).finish()
     }
 }
@@ -5366,7 +5369,7 @@ impl Surface<'_> {
     /// The returned value is guaranteed to be unique among all `Surface`s created from the same
     /// `Instance`.
     #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
-    pub fn global_id(&self) -> Id<Surface> {
+    pub fn global_id(&self) -> Id<Surface<'_>> {
         Id(self.id.global_id(), std::marker::PhantomData)
     }
 }

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -98,7 +98,7 @@ impl StagingBelt {
         offset: BufferAddress,
         size: BufferSize,
         device: &Device,
-    ) -> BufferViewMut {
+    ) -> BufferViewMut<'_> {
         let mut chunk = if let Some(index) = self
             .active_chunks
             .iter()

--- a/wgpu/src/util/device.rs
+++ b/wgpu/src/util/device.rs
@@ -13,7 +13,7 @@ pub struct BufferInitDescriptor<'a> {
 /// Utility methods not meant to be in the main API.
 pub trait DeviceExt {
     /// Creates a [Buffer](crate::Buffer) with data to initialize it.
-    fn create_buffer_init(&self, desc: &BufferInitDescriptor) -> crate::Buffer;
+    fn create_buffer_init(&self, desc: &BufferInitDescriptor<'_>) -> crate::Buffer;
 
     /// Upload an entire texture and its mipmaps from a source buffer.
     ///
@@ -30,7 +30,7 @@ pub trait DeviceExt {
     fn create_texture_with_data(
         &self,
         queue: &crate::Queue,
-        desc: &crate::TextureDescriptor,
+        desc: &crate::TextureDescriptor<'_>,
         data: &[u8],
     ) -> crate::Texture;
 }
@@ -77,7 +77,7 @@ impl DeviceExt for crate::Device {
     fn create_texture_with_data(
         &self,
         queue: &crate::Queue,
-        desc: &crate::TextureDescriptor,
+        desc: &crate::TextureDescriptor<'_>,
         data: &[u8],
     ) -> crate::Texture {
         // Implicitly add the COPY_DST usage

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -40,7 +40,7 @@ pub fn power_preference_from_env() -> Option<PowerPreference> {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn initialize_adapter_from_env(
     instance: &Instance,
-    compatible_surface: Option<&Surface>,
+    compatible_surface: Option<&Surface<'_>>,
 ) -> Option<Adapter> {
     let desired_adapter_name = std::env::var("WGPU_ADAPTER_NAME")
         .as_deref()
@@ -72,7 +72,7 @@ pub fn initialize_adapter_from_env(
 #[cfg(target_arch = "wasm32")]
 pub fn initialize_adapter_from_env(
     _instance: &Instance,
-    _compatible_surface: Option<&Surface>,
+    _compatible_surface: Option<&Surface<'_>>,
 ) -> Option<Adapter> {
     None
 }

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -34,7 +34,7 @@ pub use wgt::math::*;
 /// - Input is empty
 /// - SPIR-V magic number is missing from beginning of stream
 #[cfg(feature = "spirv")]
-pub fn make_spirv(data: &[u8]) -> super::ShaderSource {
+pub fn make_spirv(data: &[u8]) -> super::ShaderSource<'_> {
     super::ShaderSource::SpirV(make_spirv_raw(data))
 }
 
@@ -42,7 +42,7 @@ pub fn make_spirv(data: &[u8]) -> super::ShaderSource {
 /// Returns raw slice instead of ShaderSource.
 ///
 /// [`Device::create_shader_module_spirv`]: crate::Device::create_shader_module_spirv
-pub fn make_spirv_raw(data: &[u8]) -> Cow<[u32]> {
+pub fn make_spirv_raw(data: &[u8]) -> Cow<'_, [u32]> {
     const MAGIC_NUMBER: u32 = 0x0723_0203;
     assert_eq!(
         data.len() % size_of::<u32>(),
@@ -94,7 +94,7 @@ impl DownloadBuffer {
     pub fn read_buffer(
         device: &super::Device,
         queue: &super::Queue,
-        buffer: &super::BufferSlice,
+        buffer: &super::BufferSlice<'_>,
         callback: impl FnOnce(Result<Self, super::BufferAsyncError>) + Send + 'static,
     ) {
         let size = match buffer.size {


### PR DESCRIPTION
In #4597 I stumbled on a couple of `Surface`s where I forgot to apply `'static`, which reminded me of `elided-lifetimes-in-paths`. I used it to make sure I didn't miss any others.

I'm not sure if this is desired at all, but thought I would make a PR so maintainers can take a look.
I could also add the whole [`rust-2018-idioms`](https://doc.rust-lang.org/1.73.0/rustc/lints/groups.html) group if that's desirable, it's pretty simply with `cargo fix`.

Requires #4597, but I'm happy to rebase it to `trunk` if it helps.