### PR TITLE
Further OpenGL 3.1 support

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -611,6 +611,10 @@ impl super::Adapter {
             super::PrivateCapabilities::DEBUG_FNS,
             supported((3, 2), (4, 3)) && !web_gl,
         );
+        private_caps.set(
+            super::PrivateCapabilities::INVALIDATE_FRAMEBUFFER,
+            supported((3, 0), (4, 3)),
+        );
 
         let max_texture_size = unsafe { gl.get_parameter_i32(glow::MAX_TEXTURE_SIZE) } as u32;
         let max_texture_3d_size = unsafe { gl.get_parameter_i32(glow::MAX_3D_TEXTURE_SIZE) } as u32;

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -474,6 +474,9 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             panic!("Multiple render attachments with external framebuffers are not supported.");
         }
 
+        // `COLOR_ATTACHMENT0` to `COLOR_ATTACHMENT31` gives 32 possible color attachments.
+        assert!(desc.color_attachments.len() <= 32);
+
         match desc
             .color_attachments
             .first()

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -167,6 +167,8 @@ bitflags::bitflags! {
         const TEXTURE_STORAGE = 1 << 12;
         /// Supports `push_debug_group`, `pop_debug_group` and `debug_message_insert`.
         const DEBUG_FNS = 1 << 13;
+        /// Supports framebuffer invalidation.
+        const INVALIDATE_FRAMEBUFFER = 1 << 14;
     }
 }
 

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -969,7 +969,13 @@ impl super::Queue {
                 unsafe { gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, Some(self.draw_fbo)) };
             }
             C::InvalidateAttachments(ref list) => {
-                unsafe { gl.invalidate_framebuffer(glow::DRAW_FRAMEBUFFER, list) };
+                if self
+                    .shared
+                    .private_caps
+                    .contains(PrivateCapabilities::INVALIDATE_FRAMEBUFFER)
+                {
+                    unsafe { gl.invalidate_framebuffer(glow::DRAW_FRAMEBUFFER, list) };
+                }
             }
             C::SetDrawColorBuffers(count) => {
                 self.draw_buffer_count = count;
@@ -990,16 +996,14 @@ impl super::Queue {
                     && is_srgb
                 {
                     unsafe { self.perform_shader_clear(gl, draw_buffer, *color) };
-                } else if draw_buffer < 32 {
-                    // Prefer `clear_color` as `clear_buffer_f32_slice` crashes on Sandy Bridge
+                } else {
+                    // Prefer `clear` as `clear_buffer` functions have issues on Sandy Bridge
                     // on Windows.
                     unsafe {
                         gl.draw_buffers(&[glow::COLOR_ATTACHMENT0 + draw_buffer]);
                         gl.clear_color(color[0], color[1], color[2], color[3]);
                         gl.clear(glow::COLOR_BUFFER_BIT);
                     }
-                } else {
-                    unsafe { gl.clear_buffer_f32_slice(glow::COLOR, draw_buffer, color) };
                 }
             }
             C::ClearColorU(draw_buffer, ref color) => {
@@ -1009,20 +1013,29 @@ impl super::Queue {
                 unsafe { gl.clear_buffer_i32_slice(glow::COLOR, draw_buffer, color) };
             }
             C::ClearDepth(depth) => {
-                unsafe { gl.clear_buffer_f32_slice(glow::DEPTH, 0, &[depth]) };
+                // Prefer `clear` as `clear_buffer` functions have issues on Sandy Bridge
+                // on Windows.
+                unsafe {
+                    gl.clear_depth_f32(depth);
+                    gl.clear(glow::DEPTH_BUFFER_BIT);
+                }
             }
             C::ClearStencil(value) => {
-                unsafe { gl.clear_buffer_i32_slice(glow::STENCIL, 0, &[value as i32]) };
+                // Prefer `clear` as `clear_buffer` functions have issues on Sandy Bridge
+                // on Windows.
+                unsafe {
+                    gl.clear_stencil(value as i32);
+                    gl.clear(glow::STENCIL_BUFFER_BIT);
+                }
             }
             C::ClearDepthAndStencil(depth, stencil_value) => {
+                // Prefer `clear` as `clear_buffer` functions have issues on Sandy Bridge
+                // on Windows.
                 unsafe {
-                    gl.clear_buffer_depth_stencil(
-                        glow::DEPTH_STENCIL,
-                        0,
-                        depth,
-                        stencil_value as i32,
-                    )
-                };
+                    gl.clear_depth_f32(depth);
+                    gl.clear_stencil(stencil_value as i32);
+                    gl.clear(glow::DEPTH_BUFFER_BIT | glow::STENCIL_BUFFER_BIT);
+                }
             }
             C::BufferBarrier(raw, usage) => {
                 let mut flags = 0;


### PR DESCRIPTION
This improves OpenGL 3.1 support by avoiding texture storage and framebuffer invalidation. It also avoids more use of `clear_buffer` functions.