### PR TITLE
Gate usage of `metal::ComputePassDescriptor` on timestamp query support

### DIFF
--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1104,6 +1104,8 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         let raw = self.raw_cmd_buf.as_ref().unwrap();
 
         objc::rc::autoreleasepool(|| {
+            // TimeStamp Queries and ComputePassDescriptor were both introduced in Metal 2.3 (macOS 11, iOS 14)
+            // and we currently only need ComputePassDescriptor for timestamp queries
             let encoder = if self.shared.private_caps.timestamp_query_support.is_empty() {
                 raw.new_compute_command_encoder()
             } else {


### PR DESCRIPTION
Should fix the "Class with name MTLComputePassDescriptor could not be found" error reported in https://github.com/gfx-rs/wgpu/issues/4632 (introduced by https://github.com/gfx-rs/wgpu/pull/3636).

@mcclure could you give this PR a go and post your logs in https://github.com/gfx-rs/wgpu/issues/4632 again?