### PR TITLE
Fix Panic in Surface Configure (#4635) (0.18 backport)

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2296,12 +2296,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         log::info!("configuring surface with {:?}", config);
 
         let error = 'outer: loop {
-            let hub = A::hub(self);
-            let mut token = Token::root();
-
             // User callbacks must not be called while we are holding locks.
             let user_callbacks;
             {
+                let hub = A::hub(self);
+                let mut token = Token::root();
+
                 let (mut surface_guard, mut token) = self.surfaces.write(&mut token);
                 let (adapter_guard, mut token) = hub.adapters.read(&mut token);
                 let (device_guard, mut token) = hub.devices.read(&mut token);


### PR DESCRIPTION
Am I doing this right
#4635 has a "PR: Needs back-porting" tag
This is #4635 grafted (hg graft, not git cherry-pick, may not work the same way, I don't know, github marks the commit as "unverified" which makes sense because it's not really by @cwfitzgerald) onto the 0.18 branch

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Testing**
I tested it with the code that was crashing in #4630 and it did not crash