### PR TITLE
vk: Only support bgra8unorm_storage if STORAGE_READ_WITHOUT_FORMAT is supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ For naga changelogs at or before v0.14.0. See [naga's changelog](naga/CHANGELOG.
 
 - Fix issue where local variables were sometimes using variable names from previous functions.
 
+#### Vulkan
+- Only expose support for BGRA8UNORM_STORAGE if STORAGE_READ_WITHOUT_FORMAT is supported: By @sethdusek in [#4655](https://github.com/gfx-rs/wgpu/pull/4655)
 ## v0.18.0 (2023-10-25)
 
 ### Desktop OpenGL 3.3+ Support on Windows

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1776,5 +1776,6 @@ fn supports_bgra8unorm_storage(
 
         features2.contains(vk::FormatFeatureFlags::STORAGE_IMAGE)
             && features3.contains(vk::FormatFeatureFlags2::STORAGE_WRITE_WITHOUT_FORMAT)
+            && features3.contains(vk::FormatFeatureFlags2::STORAGE_READ_WITHOUT_FORMAT)
     }
 }


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
On Intel 6th generation GPUs, a simple compute shader that reads from a bgra8unorm texture and writes to a bgra8unorm texture does not work. Upon further inspection, writes to the texture were working but reading wasn't. After running it through renderdoc with validation layers I get the following error: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdDispatch-OpTypeImage-07028

It seems my Intel GPU supports  VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT but does not support VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT. 

This PR only enables BGRA8UNORM_STORAGE if both of these are present.

However I do not understand why wgpu requires both WRITE_WITHOUT_FORMAT and READ_WITHOUT_FORMAT in the first place. I've tried specifying the format of the texture when creating the TextureView that gets passed to the compute shader but to no avail, as I get the same validation errors (and an empty screen since nothing is being read). It seems wgpu is ignoring these view formats somehow and thus requires both of these WITHOUT_FORMAT extensions?


**Testing**
I've tested this patch on an Intel HD Graphics 520. Now it does not support BGRA8UNORM_STORAGE, as it should, instead of spitting out validation errors later. It works as expected on any normal GPU that supports both these features.

> thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: RequestDeviceError { inner: Core(UnsupportedFeature(Features(BGRA8UNORM_STORAGE))) }', src/wgpu_renderer.rs:167:14

