### PR TITLE
Don't drop command buffers when submitting in wgpu_core

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1111,12 +1111,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         used_surface_textures.set_size(texture_guard.len());
 
                         #[allow(unused_mut)]
-                        let mut cmdbuf = match hub
-                            .command_buffers
-                            .unregister_locked(cmb_id, &mut *command_buffer_guard)
+                        let mut cmdbuf = match command_buffer_guard.take_and_mark_destroyed(cmb_id)
                         {
-                            Some(cmdbuf) => cmdbuf,
-                            None => continue,
+                            Ok(cmdbuf) => cmdbuf,
+                            Err(_) => continue,
                         };
 
                         if cmdbuf.device_id.value.0 != queue_id {

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -2344,6 +2344,11 @@ impl crate::Context for Context {
             Ok(index) => index,
             Err(err) => self.handle_error_fatal(err, "Queue::submit"),
         };
+
+        for cmdbuf in &temp_command_buffers {
+            wgc::gfx_select!(*queue => global.command_buffer_drop(*cmdbuf));
+        }
+
         (Unused, index)
     }
 


### PR DESCRIPTION
Since wgpu's submit API consumes command buffers, they are dropped when submitting via wgpu but not when when using wgpu_core.

**Checklist**

- [x] Run `cargo clippy`.

**Connections**

Addresses #4659, unblocks https://phabricator.services.mozilla.com/D192839

**Description**

With WebGPU it is possible for a submitted command buffer to appear inother API entry point. This should cause validation errors but currently it panics because submit unregisters the command buffers. This PR makes it so command buffers are not dropped at the wgpu core level when submitting (they are dropped at the wgpu level to avoid changing the API).

**Testing**

This is covered by the CTS in firefox and for the wgpu behavior, it is exercised by a number of the existing tests.