### PR TITLE
[naga] Improve algorithm for Module compaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,11 @@ For naga changelogs at or before v0.14.0. See [naga's changelog](naga/CHANGELOG.
 
 - Create a hidden window per `wgpu::Instance` instead of sharing a global one.
 
-#### Naga MSL-OUT
+#### Naga
+
+- Improve algorithm used by module compaction. By @jimblandy in [#4662](https://github.com/gfx-rs/wgpu/pull/4662).
+
+##### MSL-OUT
 
 - Fix issue where local variables were sometimes using variable names from previous functions.
 

--- a/naga/src/compact/handle_set_map.rs
+++ b/naga/src/compact/handle_set_map.rs
@@ -26,13 +26,23 @@ impl<T> HandleSet<T> {
     }
 
     /// Add `handle` to the set.
-    ///
-    /// Return `true` if the handle was not already in the set. In
-    /// other words, return true if it was newly inserted.
-    pub fn insert(&mut self, handle: Handle<T>) -> bool {
+    pub fn insert(&mut self, handle: Handle<T>) {
         // Note that, oddly, `Handle::index` does not return a 1-based
         // `Index`, but rather a zero-based `usize`.
-        self.members.insert(handle.index())
+        self.members.insert(handle.index());
+    }
+
+    /// Add handles from `iter` to the set.
+    pub fn insert_iter(&mut self, iter: impl IntoIterator<Item = Handle<T>>) {
+        for handle in iter {
+            self.insert(handle);
+        }
+    }
+
+    pub fn contains(&self, handle: Handle<T>) -> bool {
+        // Note that, oddly, `Handle::index` does not return a 1-based
+        // `Index`, but rather a zero-based `usize`.
+        self.members.contains(handle.index())
     }
 }
 
@@ -148,6 +158,8 @@ impl<T: 'static> HandleMap<T> {
                 // Build a zero-based end-exclusive range, given one-based handle indices.
                 compacted = first1.get() - 1..last1.get();
             } else {
+                // The range contains only a single live handle, which
+                // we identified with the first `find_map` call.
                 compacted = first1.get() - 1..first1.get();
             }
         } else {

--- a/naga/src/compact/types.rs
+++ b/naga/src/compact/types.rs
@@ -7,16 +7,25 @@ pub struct TypeTracer<'a> {
 }
 
 impl<'a> TypeTracer<'a> {
-    pub fn trace_type(&mut self, ty: Handle<crate::Type>) {
-        let mut work_list = vec![ty];
-        while let Some(ty) = work_list.pop() {
-            // If we've already seen this type, no need to traverse further.
-            if !self.types_used.insert(ty) {
+    /// Propagate usage through `self.types`, starting with `self.types_used`.
+    ///
+    /// Treat `self.types_used` as the initial set of "known
+    /// live" types, and follow through to identify all
+    /// transitively used types.
+    pub fn trace_types(&mut self) {
+        // We don't need recursion or a work list. Because an
+        // expression may only refer to other expressions that precede
+        // it in the arena, it suffices to make a single pass over the
+        // arena from back to front, marking the referents of used
+        // expressions as used themselves.
+        for (handle, ty) in self.types.iter().rev() {
+            // If this type isn't used, it doesn't matter what it uses.
+            if !self.types_used.contains(handle) {
                 continue;
             }
 
             use crate::TypeInner as Ti;
-            match self.types[ty].inner {
+            match ty.inner {
                 // Types that do not contain handles.
                 Ti::Scalar { .. }
                 | Ti::Vector { .. }
@@ -29,19 +38,19 @@ impl<'a> TypeTracer<'a> {
                 | Ti::RayQuery => {}
 
                 // Types that do contain handles.
-                Ti::Pointer { base, space: _ } => work_list.push(base),
-                Ti::Array {
+                Ti::Pointer { base, space: _ }
+                | Ti::Array {
                     base,
                     size: _,
                     stride: _,
-                } => work_list.push(base),
+                }
+                | Ti::BindingArray { base, size: _ } => self.types_used.insert(base),
                 Ti::Struct {
                     ref members,
                     span: _,
                 } => {
-                    work_list.extend(members.iter().map(|m| m.ty));
+                    self.types_used.insert_iter(members.iter().map(|m| m.ty));
                 }
-                Ti::BindingArray { base, size: _ } => work_list.push(base),
             }
         }
     }


### PR DESCRIPTION
Identify reachable function expressions, constant expressions, and types using a single pass over each arena, taking advantage of the fact that expressions and types may only refer to other entries that precede them within their arena. Only walking the statement tree still requires a worklist/recursion.

In addition to presumably being faster, this change slightly reduces the number of non-comment lines of code in `src/compact`.

Closes https://github.com/gfx-rs/wgpu/issues/4509.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
