### PR TITLE
vk: Enable FifoRelaxed PresentMode

### DIFF
--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -451,8 +451,7 @@ pub fn map_vk_present_mode(mode: vk::PresentModeKHR) -> Option<wgt::PresentMode>
     } else if mode == vk::PresentModeKHR::FIFO {
         Some(wgt::PresentMode::Fifo)
     } else if mode == vk::PresentModeKHR::FIFO_RELAXED {
-        //Some(wgt::PresentMode::Relaxed)
-        None
+        Some(wgt::PresentMode::FifoRelaxed)
     } else {
         log::warn!("Unrecognized present mode {:?}", mode);
         None


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`. (no errors related to my changes)
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Description**
Solves the FifoRelaxed PresentMode not being available for use even if supported by the surface.

**Testing**
Changing PresentMode to FifoRelaxed in the hello-triangle sample should reproduce the bug.
