### PR TITLE
add new line in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ We have a [wiki](https://github.com/gfx-rs/wgpu/wiki) that serves as a knowledge
 
 :white_check_mark: = First Class Support  
 :ok: = Downlevel/Best Effort Support  
-:triangular_ruler: = Requires the [ANGLE](#angle) translation layer (GL ES 3.0 only)
+:triangular_ruler: = Requires the [ANGLE](#angle) translation layer (GL ES 3.0 only)  
 :volcano: = Requires the [MoltenVK](https://vulkan.lunarg.com/sdk/home#mac) translation layer  
 :hammer_and_wrench: = Unsupported, though open to contributions  
 


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
None – this is a standalone documentation fix.

**Description**
This PR corrects the Markdown formatting for the support level legend in the README file to ensure that each emoji at [Supported Platforms](https://github.com/gfx-rs/wgpu#supported-platforms) and its corresponding description are displayed on separate lines without extra line breaks. Two spaces have been added at the end of :triangular_ruler: line to create proper line breaks in Markdown rendering.

**Testing**
This change is visual and can be verified by viewing the README.md file to ensure that each support level description is correctly displayed on its own line. No additional code testing is necessary as this is a documentation-only update.
