### PR TITLE
[naga] Introduce `Scalar` type to IR.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ For naga changelogs at or before v0.14.0. See [naga's changelog](naga/CHANGELOG.
 - Log vulkan validation layer messages during instance creation and destruction: By @exrook in [#4586](https://github.com/gfx-rs/wgpu/pull/4586)
 - `TextureFormat::block_size` is deprecated, use `TextureFormat::block_copy_size` instead: By @wumpf in [#4647](https://github.com/gfx-rs/wgpu/pull/4647)
 
+#### Naga
+
+- Introduce a new `Scalar` struct type for use in Naga's IR, and update all frontend, middle, and backend code appropriately. By @jimblandy in [#4673](https://github.com/gfx-rs/wgpu/pull/4673).
+
 ### Bug Fixes
 
 #### WGL

--- a/naga/src/back/glsl/features.rs
+++ b/naga/src/back/glsl/features.rs
@@ -1,7 +1,7 @@
 use super::{BackendResult, Error, Version, Writer};
 use crate::{
-    AddressSpace, Binding, Bytes, Expression, Handle, ImageClass, ImageDimension, Interpolation,
-    Sampling, ScalarKind, ShaderStage, StorageFormat, Type, TypeInner,
+    AddressSpace, Binding, Expression, Handle, ImageClass, ImageDimension, Interpolation, Sampling,
+    Scalar, ScalarKind, ShaderStage, StorageFormat, Type, TypeInner,
 };
 use std::fmt::Write;
 
@@ -275,10 +275,10 @@ impl<'a, W> Writer<'a, W> {
 
         for (ty_handle, ty) in self.module.types.iter() {
             match ty.inner {
-                TypeInner::Scalar { kind, width } => self.scalar_required_features(kind, width),
-                TypeInner::Vector { kind, width, .. } => self.scalar_required_features(kind, width),
+                TypeInner::Scalar(scalar) => self.scalar_required_features(scalar),
+                TypeInner::Vector { scalar, .. } => self.scalar_required_features(scalar),
                 TypeInner::Matrix { width, .. } => {
-                    self.scalar_required_features(ScalarKind::Float, width)
+                    self.scalar_required_features(Scalar::float(width))
                 }
                 TypeInner::Array { base, size, .. } => {
                     if let TypeInner::Array { .. } = self.module.types[base].inner {
@@ -463,8 +463,8 @@ impl<'a, W> Writer<'a, W> {
     }
 
     /// Helper method that checks the [`Features`] needed by a scalar
-    fn scalar_required_features(&mut self, kind: ScalarKind, width: Bytes) {
-        if kind == ScalarKind::Float && width == 8 {
+    fn scalar_required_features(&mut self, scalar: Scalar) {
+        if scalar.kind == ScalarKind::Float && scalar.width == 8 {
             self.features.request(Features::DOUBLE_TYPE);
         }
     }

--- a/naga/src/back/hlsl/conv.rs
+++ b/naga/src/back/hlsl/conv.rs
@@ -13,21 +13,23 @@ impl crate::ScalarKind {
             Self::Bool => unreachable!(),
         }
     }
+}
 
+impl crate::Scalar {
     /// Helper function that returns scalar related strings
     ///
     /// <https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-scalar>
-    pub(super) const fn to_hlsl_str(self, width: crate::Bytes) -> Result<&'static str, Error> {
-        match self {
-            Self::Sint => Ok("int"),
-            Self::Uint => Ok("uint"),
-            Self::Float => match width {
+    pub(super) const fn to_hlsl_str(self) -> Result<&'static str, Error> {
+        match self.kind {
+            crate::ScalarKind::Sint => Ok("int"),
+            crate::ScalarKind::Uint => Ok("uint"),
+            crate::ScalarKind::Float => match self.width {
                 2 => Ok("half"),
                 4 => Ok("float"),
                 8 => Ok("double"),
-                _ => Err(Error::UnsupportedScalar(self, width)),
+                _ => Err(Error::UnsupportedScalar(self)),
             },
-            Self::Bool => Ok("bool"),
+            crate::ScalarKind::Bool => Ok("bool"),
         }
     }
 }
@@ -71,10 +73,10 @@ impl crate::TypeInner {
         names: &'a crate::FastHashMap<crate::proc::NameKey, String>,
     ) -> Result<Cow<'a, str>, Error> {
         Ok(match gctx.types[base].inner {
-            crate::TypeInner::Scalar { kind, width } => Cow::Borrowed(kind.to_hlsl_str(width)?),
-            crate::TypeInner::Vector { size, kind, width } => Cow::Owned(format!(
+            crate::TypeInner::Scalar(scalar) => Cow::Borrowed(scalar.to_hlsl_str()?),
+            crate::TypeInner::Vector { size, scalar } => Cow::Owned(format!(
                 "{}{}",
-                kind.to_hlsl_str(width)?,
+                scalar.to_hlsl_str()?,
                 crate::back::vector_size_str(size)
             )),
             crate::TypeInner::Matrix {
@@ -83,7 +85,7 @@ impl crate::TypeInner {
                 width,
             } => Cow::Owned(format!(
                 "{}{}x{}",
-                crate::ScalarKind::Float.to_hlsl_str(width)?,
+                crate::Scalar::float(width).to_hlsl_str()?,
                 crate::back::vector_size_str(columns),
                 crate::back::vector_size_str(rows),
             )),

--- a/naga/src/back/hlsl/help.rs
+++ b/naga/src/back/hlsl/help.rs
@@ -133,7 +133,7 @@ impl<'a, W: Write> super::Writer<'a, W> {
             }
             crate::ImageClass::Sampled { kind, multi } => {
                 let multi_str = if multi { "MS" } else { "" };
-                let scalar_kind_str = kind.to_hlsl_str(4)?;
+                let scalar_kind_str = crate::Scalar { kind, width: 4 }.to_hlsl_str()?;
                 write!(self.out, "{multi_str}<{scalar_kind_str}4>")?
             }
             crate::ImageClass::Storage { format, .. } => {
@@ -658,8 +658,7 @@ impl<'a, W: Write> super::Writer<'a, W> {
         let vec_ty = match module.types[member.ty].inner {
             crate::TypeInner::Matrix { rows, width, .. } => crate::TypeInner::Vector {
                 size: rows,
-                kind: crate::ScalarKind::Float,
-                width,
+                scalar: crate::Scalar::float(width),
             },
             _ => unreachable!(),
         };
@@ -737,10 +736,9 @@ impl<'a, W: Write> super::Writer<'a, W> {
             _ => unreachable!(),
         };
         let scalar_ty = match module.types[member.ty].inner {
-            crate::TypeInner::Matrix { width, .. } => crate::TypeInner::Scalar {
-                kind: crate::ScalarKind::Float,
-                width,
-            },
+            crate::TypeInner::Matrix { width, .. } => {
+                crate::TypeInner::Scalar(crate::Scalar::float(width))
+            }
             _ => unreachable!(),
         };
         self.write_value_type(module, &scalar_ty)?;

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -241,8 +241,8 @@ pub struct ReflectionInfo {
 pub enum Error {
     #[error(transparent)]
     IoError(#[from] FmtError),
-    #[error("A scalar with an unsupported width was requested: {0:?} {1:?}")]
-    UnsupportedScalar(crate::ScalarKind, crate::Bytes),
+    #[error("A scalar with an unsupported width was requested: {0:?}")]
+    UnsupportedScalar(crate::Scalar),
     #[error("{0}")]
     Unimplemented(String), // TODO: Error used only during development
     #[error("{0}")]

--- a/naga/src/back/hlsl/storage.rs
+++ b/naga/src/back/hlsl/storage.rs
@@ -157,25 +157,21 @@ impl<W: fmt::Write> super::Writer<'_, W> {
         func_ctx: &FunctionCtx,
     ) -> BackendResult {
         match *result_ty.inner_with(&module.types) {
-            crate::TypeInner::Scalar { kind, width: _ } => {
+            crate::TypeInner::Scalar(scalar) => {
                 // working around the borrow checker in `self.write_expr`
                 let chain = mem::take(&mut self.temp_access_chain);
                 let var_name = &self.names[&NameKey::GlobalVariable(var_handle)];
-                let cast = kind.to_hlsl_cast();
+                let cast = scalar.kind.to_hlsl_cast();
                 write!(self.out, "{cast}({var_name}.Load(")?;
                 self.write_storage_address(module, &chain, func_ctx)?;
                 write!(self.out, "))")?;
                 self.temp_access_chain = chain;
             }
-            crate::TypeInner::Vector {
-                size,
-                kind,
-                width: _,
-            } => {
+            crate::TypeInner::Vector { size, scalar } => {
                 // working around the borrow checker in `self.write_expr`
                 let chain = mem::take(&mut self.temp_access_chain);
                 let var_name = &self.names[&NameKey::GlobalVariable(var_handle)];
-                let cast = kind.to_hlsl_cast();
+                let cast = scalar.kind.to_hlsl_cast();
                 write!(self.out, "{}({}.Load{}(", cast, var_name, size as u8)?;
                 self.write_storage_address(module, &chain, func_ctx)?;
                 write!(self.out, "))")?;
@@ -189,7 +185,7 @@ impl<W: fmt::Write> super::Writer<'_, W> {
                 write!(
                     self.out,
                     "{}{}x{}(",
-                    crate::ScalarKind::Float.to_hlsl_str(width)?,
+                    crate::Scalar::float(width).to_hlsl_str()?,
                     columns as u8,
                     rows as u8,
                 )?;
@@ -199,8 +195,7 @@ impl<W: fmt::Write> super::Writer<'_, W> {
                 let iter = (0..columns as u32).map(|i| {
                     let ty_inner = crate::TypeInner::Vector {
                         size: rows,
-                        kind: crate::ScalarKind::Float,
-                        width,
+                        scalar: crate::Scalar::float(width),
                     };
                     (TypeResolution::Value(ty_inner), i * row_stride)
                 });
@@ -296,7 +291,7 @@ impl<W: fmt::Write> super::Writer<'_, W> {
             }
         };
         match *ty_resolution.inner_with(&module.types) {
-            crate::TypeInner::Scalar { .. } => {
+            crate::TypeInner::Scalar(_) => {
                 // working around the borrow checker in `self.write_expr`
                 let chain = mem::take(&mut self.temp_access_chain);
                 let var_name = &self.names[&NameKey::GlobalVariable(var_handle)];
@@ -330,7 +325,7 @@ impl<W: fmt::Write> super::Writer<'_, W> {
                     self.out,
                     "{}{}{}x{} {}{} = ",
                     level.next(),
-                    crate::ScalarKind::Float.to_hlsl_str(width)?,
+                    crate::Scalar::float(width).to_hlsl_str()?,
                     columns as u8,
                     rows as u8,
                     STORE_TEMP_NAME,
@@ -348,8 +343,7 @@ impl<W: fmt::Write> super::Writer<'_, W> {
                         .push(SubAccess::Offset(i * row_stride));
                     let ty_inner = crate::TypeInner::Vector {
                         size: rows,
-                        kind: crate::ScalarKind::Float,
-                        width,
+                        scalar: crate::Scalar::float(width),
                     };
                     let sv = StoreValue::TempIndex {
                         depth,
@@ -470,8 +464,8 @@ impl<W: fmt::Write> super::Writer<'_, W> {
                 crate::TypeInner::Pointer { base, .. } => match module.types[base].inner {
                     crate::TypeInner::Struct { ref members, .. } => Parent::Struct(members),
                     crate::TypeInner::Array { stride, .. } => Parent::Array { stride },
-                    crate::TypeInner::Vector { width, .. } => Parent::Array {
-                        stride: width as u32,
+                    crate::TypeInner::Vector { scalar, .. } => Parent::Array {
+                        stride: scalar.width as u32,
                     },
                     crate::TypeInner::Matrix { rows, width, .. } => Parent::Array {
                         // The stride between matrices is the count of rows as this is how
@@ -480,8 +474,8 @@ impl<W: fmt::Write> super::Writer<'_, W> {
                     },
                     _ => unreachable!(),
                 },
-                crate::TypeInner::ValuePointer { width, .. } => Parent::Array {
-                    stride: width as u32,
+                crate::TypeInner::ValuePointer { scalar, .. } => Parent::Array {
+                    stride: scalar.width as u32,
                 },
                 _ => unreachable!(),
             };

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -276,8 +276,7 @@ enum LocalType {
         /// If `None`, this represents a scalar type. If `Some`, this represents
         /// a vector type of the given size.
         vector_size: Option<crate::VectorSize>,
-        kind: crate::ScalarKind,
-        width: crate::Bytes,
+        scalar: crate::Scalar,
         pointer_space: Option<spirv::StorageClass>,
     },
     /// A matrix of floating-point values.
@@ -355,18 +354,14 @@ struct LookupFunctionType {
 
 fn make_local(inner: &crate::TypeInner) -> Option<LocalType> {
     Some(match *inner {
-        crate::TypeInner::Scalar { kind, width } | crate::TypeInner::Atomic { kind, width } => {
-            LocalType::Value {
-                vector_size: None,
-                kind,
-                width,
-                pointer_space: None,
-            }
-        }
-        crate::TypeInner::Vector { size, kind, width } => LocalType::Value {
+        crate::TypeInner::Scalar(scalar) | crate::TypeInner::Atomic(scalar) => LocalType::Value {
+            vector_size: None,
+            scalar,
+            pointer_space: None,
+        },
+        crate::TypeInner::Vector { size, scalar } => LocalType::Value {
             vector_size: Some(size),
-            kind,
-            width,
+            scalar,
             pointer_space: None,
         },
         crate::TypeInner::Matrix {
@@ -384,13 +379,11 @@ fn make_local(inner: &crate::TypeInner) -> Option<LocalType> {
         },
         crate::TypeInner::ValuePointer {
             size,
-            kind,
-            width,
+            scalar,
             space,
         } => LocalType::Value {
             vector_size: size,
-            kind,
-            width,
+            scalar,
             pointer_space: Some(helpers::map_storage_class(space)),
         },
         crate::TypeInner::Image {

--- a/naga/src/back/spv/ray.rs
+++ b/naga/src/back/spv/ray.rs
@@ -21,12 +21,10 @@ impl<'w> BlockContext<'w> {
                 //Note: composite extract indices and types must match `generate_ray_desc_type`
                 let desc_id = self.cached[descriptor];
                 let acc_struct_id = self.get_handle_id(acceleration_structure);
-                let width = 4;
 
                 let flag_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
                     vector_size: None,
-                    kind: crate::ScalarKind::Uint,
-                    width,
+                    scalar: crate::Scalar::U32,
                     pointer_space: None,
                 }));
                 let ray_flags_id = self.gen_id();
@@ -46,8 +44,7 @@ impl<'w> BlockContext<'w> {
 
                 let scalar_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
                     vector_size: None,
-                    kind: crate::ScalarKind::Float,
-                    width,
+                    scalar: crate::Scalar::F32,
                     pointer_space: None,
                 }));
                 let tmin_id = self.gen_id();
@@ -67,8 +64,7 @@ impl<'w> BlockContext<'w> {
 
                 let vector_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
                     vector_size: Some(crate::VectorSize::Tri),
-                    kind: crate::ScalarKind::Float,
-                    width,
+                    scalar: crate::Scalar::F32,
                     pointer_space: None,
                 }));
                 let ray_origin_id = self.gen_id();
@@ -115,7 +111,6 @@ impl<'w> BlockContext<'w> {
         query: Handle<crate::Expression>,
         block: &mut Block,
     ) -> spirv::Word {
-        let width = 4;
         let query_id = self.cached[query];
         let intersection_id = self.writer.get_constant_scalar(crate::Literal::U32(
             spirv::RayQueryIntersection::RayQueryCommittedIntersectionKHR as _,
@@ -123,8 +118,7 @@ impl<'w> BlockContext<'w> {
 
         let flag_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
             vector_size: None,
-            kind: crate::ScalarKind::Uint,
-            width,
+            scalar: crate::Scalar::U32,
             pointer_space: None,
         }));
         let kind_id = self.gen_id();
@@ -178,8 +172,7 @@ impl<'w> BlockContext<'w> {
 
         let scalar_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
             vector_size: None,
-            kind: crate::ScalarKind::Float,
-            width,
+            scalar: crate::Scalar::F32,
             pointer_space: None,
         }));
         let t_id = self.gen_id();
@@ -193,8 +186,7 @@ impl<'w> BlockContext<'w> {
 
         let barycentrics_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
             vector_size: Some(crate::VectorSize::Bi),
-            kind: crate::ScalarKind::Float,
-            width,
+            scalar: crate::Scalar::F32,
             pointer_space: None,
         }));
         let barycentrics_id = self.gen_id();
@@ -208,8 +200,7 @@ impl<'w> BlockContext<'w> {
 
         let bool_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
             vector_size: None,
-            kind: crate::ScalarKind::Bool,
-            width: crate::BOOL_WIDTH,
+            scalar: crate::Scalar::BOOL,
             pointer_space: None,
         }));
         let front_face_id = self.gen_id();
@@ -224,7 +215,7 @@ impl<'w> BlockContext<'w> {
         let transform_type_id = self.get_type_id(LookupType::Local(LocalType::Matrix {
             columns: crate::VectorSize::Quad,
             rows: crate::VectorSize::Tri,
-            width,
+            width: 4,
         }));
         let object_to_world_id = self.gen_id();
         block.body.push(Instruction::ray_query_get_intersection(

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -426,11 +426,11 @@ impl<W: Write> Writer<W> {
     /// Adds no trailing or leading whitespace
     fn write_value_type(&mut self, module: &Module, inner: &TypeInner) -> BackendResult {
         match *inner {
-            TypeInner::Vector { size, kind, width } => write!(
+            TypeInner::Vector { size, scalar } => write!(
                 self.out,
                 "vec{}<{}>",
                 back::vector_size_str(size),
-                scalar_kind_str(kind, width),
+                scalar_kind_str(scalar),
             )?,
             TypeInner::Sampler { comparison: false } => {
                 write!(self.out, "sampler")?;
@@ -452,7 +452,7 @@ impl<W: Write> Writer<W> {
                     Ic::Sampled { kind, multi } => (
                         "",
                         if multi { "multisampled_" } else { "" },
-                        scalar_kind_str(kind, 4),
+                        scalar_kind_str(crate::Scalar { kind, width: 4 }),
                         "",
                     ),
                     Ic::Depth { multi } => {
@@ -481,11 +481,11 @@ impl<W: Write> Writer<W> {
                     write!(self.out, "<{format_str}{storage_str}>")?;
                 }
             }
-            TypeInner::Scalar { kind, width } => {
-                write!(self.out, "{}", scalar_kind_str(kind, width))?;
+            TypeInner::Scalar(scalar) => {
+                write!(self.out, "{}", scalar_kind_str(scalar))?;
             }
-            TypeInner::Atomic { kind, width } => {
-                write!(self.out, "atomic<{}>", scalar_kind_str(kind, width))?;
+            TypeInner::Atomic(scalar) => {
+                write!(self.out, "atomic<{}>", scalar_kind_str(scalar))?;
             }
             TypeInner::Array {
                 base,
@@ -552,13 +552,12 @@ impl<W: Write> Writer<W> {
             }
             TypeInner::ValuePointer {
                 size: None,
-                kind,
-                width,
+                scalar,
                 space,
             } => {
                 let (address, maybe_access) = address_space_str(space);
                 if let Some(space) = address {
-                    write!(self.out, "ptr<{}, {}", space, scalar_kind_str(kind, width))?;
+                    write!(self.out, "ptr<{}, {}", space, scalar_kind_str(scalar))?;
                     if let Some(access) = maybe_access {
                         write!(self.out, ", {access}")?;
                     }
@@ -571,8 +570,7 @@ impl<W: Write> Writer<W> {
             }
             TypeInner::ValuePointer {
                 size: Some(size),
-                kind,
-                width,
+                scalar,
                 space,
             } => {
                 let (address, maybe_access) = address_space_str(space);
@@ -582,7 +580,7 @@ impl<W: Write> Writer<W> {
                         "ptr<{}, vec{}<{}>",
                         space,
                         back::vector_size_str(size),
-                        scalar_kind_str(kind, width)
+                        scalar_kind_str(scalar)
                     )?;
                     if let Some(access) = maybe_access {
                         write!(self.out, ", {access}")?;
@@ -1414,7 +1412,11 @@ impl<W: Write> Writer<W> {
                         width,
                         ..
                     } => {
-                        let scalar_kind_str = scalar_kind_str(kind, convert.unwrap_or(width));
+                        let scalar = crate::Scalar {
+                            kind,
+                            width: convert.unwrap_or(width),
+                        };
+                        let scalar_kind_str = scalar_kind_str(scalar);
                         write!(
                             self.out,
                             "mat{}x{}<{}>",
@@ -1423,17 +1425,28 @@ impl<W: Write> Writer<W> {
                             scalar_kind_str
                         )?;
                     }
-                    TypeInner::Vector { size, width, .. } => {
+                    TypeInner::Vector {
+                        size,
+                        scalar: crate::Scalar { width, .. },
+                    } => {
+                        let scalar = crate::Scalar {
+                            kind,
+                            width: convert.unwrap_or(width),
+                        };
                         let vector_size_str = back::vector_size_str(size);
-                        let scalar_kind_str = scalar_kind_str(kind, convert.unwrap_or(width));
+                        let scalar_kind_str = scalar_kind_str(scalar);
                         if convert.is_some() {
                             write!(self.out, "vec{vector_size_str}<{scalar_kind_str}>")?;
                         } else {
                             write!(self.out, "bitcast<vec{vector_size_str}<{scalar_kind_str}>>")?;
                         }
                     }
-                    TypeInner::Scalar { width, .. } => {
-                        let scalar_kind_str = scalar_kind_str(kind, convert.unwrap_or(width));
+                    TypeInner::Scalar(crate::Scalar { width, .. }) => {
+                        let scalar = crate::Scalar {
+                            kind,
+                            width: convert.unwrap_or(width),
+                        };
+                        let scalar_kind_str = scalar_kind_str(scalar);
                         if convert.is_some() {
                             write!(self.out, "{scalar_kind_str}")?
                         } else {
@@ -1783,15 +1796,31 @@ const fn image_dimension_str(dim: crate::ImageDimension) -> &'static str {
     }
 }
 
-const fn scalar_kind_str(kind: crate::ScalarKind, width: u8) -> &'static str {
+const fn scalar_kind_str(scalar: crate::Scalar) -> &'static str {
+    use crate::Scalar;
     use crate::ScalarKind as Sk;
 
-    match (kind, width) {
-        (Sk::Float, 8) => "f64",
-        (Sk::Float, 4) => "f32",
-        (Sk::Sint, 4) => "i32",
-        (Sk::Uint, 4) => "u32",
-        (Sk::Bool, 1) => "bool",
+    match scalar {
+        Scalar {
+            kind: Sk::Float,
+            width: 8,
+        } => "f64",
+        Scalar {
+            kind: Sk::Float,
+            width: 4,
+        } => "f32",
+        Scalar {
+            kind: Sk::Sint,
+            width: 4,
+        } => "i32",
+        Scalar {
+            kind: Sk::Uint,
+            width: 4,
+        } => "u32",
+        Scalar {
+            kind: Sk::Bool,
+            width: 1,
+        } => "bool",
         _ => unreachable!(),
     }
 }

--- a/naga/src/compact/types.rs
+++ b/naga/src/compact/types.rs
@@ -54,10 +54,10 @@ impl ModuleMap {
         use crate::TypeInner as Ti;
         match ty.inner {
             // Types that do not contain handles.
-            Ti::Scalar { .. }
+            Ti::Scalar(_)
             | Ti::Vector { .. }
             | Ti::Matrix { .. }
-            | Ti::Atomic { .. }
+            | Ti::Atomic(_)
             | Ti::ValuePointer { .. }
             | Ti::Image { .. }
             | Ti::Sampler { .. }

--- a/naga/src/front/glsl/builtins.rs
+++ b/naga/src/front/glsl/builtins.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{
     BinaryOperator, DerivativeAxis as Axis, DerivativeControl as Ctrl, Expression, Handle,
     ImageClass, ImageDimension as Dim, ImageQuery, MathFunction, Module, RelationalFunction,
-    SampleLevel, ScalarKind as Sk, Span, Type, TypeInner, UnaryOperator, VectorSize,
+    SampleLevel, Scalar, ScalarKind as Sk, Span, Type, TypeInner, UnaryOperator, VectorSize,
 };
 
 impl crate::ScalarKind {
@@ -54,18 +54,17 @@ impl Module {
 }
 
 const fn make_coords_arg(number_of_components: usize, kind: Sk) -> TypeInner {
-    let width = 4;
+    let scalar = Scalar { kind, width: 4 };
 
     match number_of_components {
-        1 => TypeInner::Scalar { kind, width },
+        1 => TypeInner::Scalar(scalar),
         _ => TypeInner::Vector {
             size: match number_of_components {
                 2 => VectorSize::Bi,
                 3 => VectorSize::Tri,
                 _ => VectorSize::Quad,
             },
-            kind,
-            width,
+            scalar,
         },
     }
 }
@@ -98,7 +97,6 @@ pub fn inject_builtin(
         inject_double_builtin(declaration, module, name)
     }
 
-    let width = 4;
     match name {
         "texture"
         | "textureGrad"
@@ -235,18 +233,12 @@ pub fn inject_builtin(
                     let mut args = vec![image, vector];
 
                     if num_coords == 5 {
-                        args.push(TypeInner::Scalar {
-                            kind: Sk::Float,
-                            width,
-                        });
+                        args.push(TypeInner::Scalar(Scalar::F32));
                     }
 
                     match level_type {
                         TextureLevelType::Lod => {
-                            args.push(TypeInner::Scalar {
-                                kind: Sk::Float,
-                                width,
-                            });
+                            args.push(TypeInner::Scalar(Scalar::F32));
                         }
                         TextureLevelType::Grad => {
                             args.push(make_coords_arg(num_coords_from_dim, Sk::Float));
@@ -260,10 +252,7 @@ pub fn inject_builtin(
                     }
 
                     if bias {
-                        args.push(TypeInner::Scalar {
-                            kind: Sk::Float,
-                            width,
-                        });
+                        args.push(TypeInner::Scalar(Scalar::F32));
                     }
 
                     declaration
@@ -290,10 +279,7 @@ pub fn inject_builtin(
                 let mut args = vec![image];
 
                 if !multi {
-                    args.push(TypeInner::Scalar {
-                        kind: Sk::Sint,
-                        width,
-                    })
+                    args.push(TypeInner::Scalar(Scalar::I32))
                 }
 
                 declaration
@@ -323,14 +309,7 @@ pub fn inject_builtin(
                 let dim_value = image_dims_to_coords_size(dim);
                 let coordinates = make_coords_arg(dim_value + arrayed as usize, Sk::Sint);
 
-                let mut args = vec![
-                    image,
-                    coordinates,
-                    TypeInner::Scalar {
-                        kind: Sk::Sint,
-                        width,
-                    },
-                ];
+                let mut args = vec![image, coordinates, TypeInner::Scalar(Scalar::I32)];
 
                 if offset {
                     args.push(make_coords_arg(dim_value, Sk::Sint));
@@ -441,8 +420,7 @@ pub fn inject_builtin(
                     coordinates,
                     TypeInner::Vector {
                         size: VectorSize::Quad,
-                        kind,
-                        width,
+                        scalar: Scalar { kind, width: 4 },
                     },
                 ];
 
@@ -464,7 +442,6 @@ fn inject_standard_builtins(
     module: &mut Module,
     name: &str,
 ) {
-    let width = 4;
     match name {
         "sampler1D" | "sampler1DArray" | "sampler2D" | "sampler2DArray" | "sampler2DMS"
         | "sampler2DMSArray" | "sampler3D" | "samplerCube" | "samplerCubeArray" => {
@@ -544,12 +521,12 @@ fn inject_standard_builtins(
                     0b10 => Some(VectorSize::Tri),
                     _ => Some(VectorSize::Quad),
                 };
-                let kind = Sk::Float;
+                let scalar = Scalar::F32;
 
                 declaration.overloads.push(module.add_builtin(
                     vec![match size {
-                        Some(size) => TypeInner::Vector { size, kind, width },
-                        None => TypeInner::Scalar { kind, width },
+                        Some(size) => TypeInner::Vector { size, scalar },
+                        None => TypeInner::Scalar(scalar),
                     }],
                     match name {
                         "sin" => MacroCall::MathFunction(MathFunction::Sin),
@@ -595,15 +572,15 @@ fn inject_standard_builtins(
                     0b10 => Some(VectorSize::Tri),
                     _ => Some(VectorSize::Quad),
                 };
-                let kind = match name {
-                    "intBitsToFloat" => Sk::Sint,
-                    _ => Sk::Uint,
+                let scalar = match name {
+                    "intBitsToFloat" => Scalar::I32,
+                    _ => Scalar::U32,
                 };
 
                 declaration.overloads.push(module.add_builtin(
                     vec![match size {
-                        Some(size) => TypeInner::Vector { size, kind, width },
-                        None => TypeInner::Scalar { kind, width },
+                        Some(size) => TypeInner::Vector { size, scalar },
+                        None => TypeInner::Scalar(scalar),
                     }],
                     MacroCall::BitCast(Sk::Float),
                 ))
@@ -619,10 +596,10 @@ fn inject_standard_builtins(
                     0b10 => Some(VectorSize::Tri),
                     _ => Some(VectorSize::Quad),
                 };
-                let kind = Sk::Float;
+                let scalar = Scalar::F32;
                 let ty = || match size {
-                    Some(size) => TypeInner::Vector { size, kind, width },
-                    None => TypeInner::Scalar { kind, width },
+                    Some(size) => TypeInner::Vector { size, scalar },
+                    None => TypeInner::Scalar(scalar),
                 };
 
                 declaration.overloads.push(
@@ -642,14 +619,14 @@ fn inject_standard_builtins(
                     0b10 => Some(VectorSize::Tri),
                     _ => Some(VectorSize::Quad),
                 };
-                let kind = match bits >> 2 {
-                    0b0 => Sk::Float,
-                    _ => Sk::Sint,
+                let scalar = match bits >> 2 {
+                    0b0 => Scalar::F32,
+                    _ => Scalar::I32,
                 };
 
                 let args = vec![match size {
-                    Some(size) => TypeInner::Vector { size, kind, width },
-                    None => TypeInner::Scalar { kind, width },
+                    Some(size) => TypeInner::Vector { size, scalar },
+                    None => TypeInner::Scalar(scalar),
                 }];
 
                 declaration.overloads.push(module.add_builtin(
@@ -684,9 +661,9 @@ fn inject_standard_builtins(
             // bit 0 - int/uint
             // bit 1 through 2 - dims
             for bits in 0..0b1000 {
-                let kind = match bits & 0b1 {
-                    0b0 => Sk::Sint,
-                    _ => Sk::Uint,
+                let scalar = match bits & 0b1 {
+                    0b0 => Scalar::I32,
+                    _ => Scalar::U32,
                 };
                 let size = match bits >> 1 {
                     0b00 => None,
@@ -696,39 +673,27 @@ fn inject_standard_builtins(
                 };
 
                 let ty = || match size {
-                    Some(size) => TypeInner::Vector { size, kind, width },
-                    None => TypeInner::Scalar { kind, width },
+                    Some(size) => TypeInner::Vector { size, scalar },
+                    None => TypeInner::Scalar(scalar),
                 };
 
                 let mut args = vec![ty()];
 
                 match fun {
                     MathFunction::ExtractBits => {
-                        args.push(TypeInner::Scalar {
-                            kind: Sk::Sint,
-                            width: 4,
-                        });
-                        args.push(TypeInner::Scalar {
-                            kind: Sk::Sint,
-                            width: 4,
-                        });
+                        args.push(TypeInner::Scalar(Scalar::I32));
+                        args.push(TypeInner::Scalar(Scalar::I32));
                     }
                     MathFunction::InsertBits => {
                         args.push(ty());
-                        args.push(TypeInner::Scalar {
-                            kind: Sk::Sint,
-                            width: 4,
-                        });
-                        args.push(TypeInner::Scalar {
-                            kind: Sk::Sint,
-                            width: 4,
-                        });
+                        args.push(TypeInner::Scalar(Scalar::I32));
+                        args.push(TypeInner::Scalar(Scalar::I32));
                     }
                     _ => {}
                 }
 
                 // we need to cast the return type of findLsb / findMsb
-                let mc = if kind == Sk::Uint {
+                let mc = if scalar.kind == Sk::Uint {
                     match mc {
                         MacroCall::MathFunction(MathFunction::FindLsb) => MacroCall::FindLsbUint,
                         MacroCall::MathFunction(MathFunction::FindMsb) => MacroCall::FindMsbUint,
@@ -754,15 +719,13 @@ fn inject_standard_builtins(
             let ty = match fun {
                 MathFunction::Pack4x8snorm | MathFunction::Pack4x8unorm => TypeInner::Vector {
                     size: crate::VectorSize::Quad,
-                    kind: Sk::Float,
-                    width: 4,
+                    scalar: Scalar::F32,
                 },
                 MathFunction::Pack2x16unorm
                 | MathFunction::Pack2x16snorm
                 | MathFunction::Pack2x16float => TypeInner::Vector {
                     size: crate::VectorSize::Bi,
-                    kind: Sk::Float,
-                    width: 4,
+                    scalar: Scalar::F32,
                 },
                 _ => unreachable!(),
             };
@@ -784,10 +747,7 @@ fn inject_standard_builtins(
                 _ => unreachable!(),
             };
 
-            let args = vec![TypeInner::Scalar {
-                kind: Sk::Uint,
-                width: 4,
-            }];
+            let args = vec![TypeInner::Scalar(Scalar::U32)];
 
             declaration
                 .overloads
@@ -808,10 +768,10 @@ fn inject_standard_builtins(
                     0b10 => Some(VectorSize::Tri),
                     _ => Some(VectorSize::Quad),
                 };
-                let kind = Sk::Float;
+                let scalar = Scalar::F32;
                 let ty = || match size {
-                    Some(size) => TypeInner::Vector { size, kind, width },
-                    None => TypeInner::Scalar { kind, width },
+                    Some(size) => TypeInner::Vector { size, scalar },
+                    None => TypeInner::Scalar(scalar),
                 };
 
                 let mut args = vec![ty()];
@@ -837,8 +797,7 @@ fn inject_standard_builtins(
 
                 let args = vec![TypeInner::Vector {
                     size,
-                    kind: Sk::Bool,
-                    width: crate::BOOL_WIDTH,
+                    scalar: Scalar::BOOL,
                 }];
 
                 let fun = match name {
@@ -853,19 +812,19 @@ fn inject_standard_builtins(
         }
         "lessThan" | "greaterThan" | "lessThanEqual" | "greaterThanEqual" => {
             for bits in 0..0b1001 {
-                let (size, kind) = match bits {
-                    0b0000 => (VectorSize::Bi, Sk::Float),
-                    0b0001 => (VectorSize::Tri, Sk::Float),
-                    0b0010 => (VectorSize::Quad, Sk::Float),
-                    0b0011 => (VectorSize::Bi, Sk::Sint),
-                    0b0100 => (VectorSize::Tri, Sk::Sint),
-                    0b0101 => (VectorSize::Quad, Sk::Sint),
-                    0b0110 => (VectorSize::Bi, Sk::Uint),
-                    0b0111 => (VectorSize::Tri, Sk::Uint),
-                    _ => (VectorSize::Quad, Sk::Uint),
+                let (size, scalar) = match bits {
+                    0b0000 => (VectorSize::Bi, Scalar::F32),
+                    0b0001 => (VectorSize::Tri, Scalar::F32),
+                    0b0010 => (VectorSize::Quad, Scalar::F32),
+                    0b0011 => (VectorSize::Bi, Scalar::I32),
+                    0b0100 => (VectorSize::Tri, Scalar::I32),
+                    0b0101 => (VectorSize::Quad, Scalar::I32),
+                    0b0110 => (VectorSize::Bi, Scalar::U32),
+                    0b0111 => (VectorSize::Tri, Scalar::U32),
+                    _ => (VectorSize::Quad, Scalar::U32),
                 };
 
-                let ty = || TypeInner::Vector { size, kind, width };
+                let ty = || TypeInner::Vector { size, scalar };
                 let args = vec![ty(), ty()];
 
                 let fun = MacroCall::Binary(match name {
@@ -881,28 +840,22 @@ fn inject_standard_builtins(
         }
         "equal" | "notEqual" => {
             for bits in 0..0b1100 {
-                let (size, kind) = match bits {
-                    0b0000 => (VectorSize::Bi, Sk::Float),
-                    0b0001 => (VectorSize::Tri, Sk::Float),
-                    0b0010 => (VectorSize::Quad, Sk::Float),
-                    0b0011 => (VectorSize::Bi, Sk::Sint),
-                    0b0100 => (VectorSize::Tri, Sk::Sint),
-                    0b0101 => (VectorSize::Quad, Sk::Sint),
-                    0b0110 => (VectorSize::Bi, Sk::Uint),
-                    0b0111 => (VectorSize::Tri, Sk::Uint),
-                    0b1000 => (VectorSize::Quad, Sk::Uint),
-                    0b1001 => (VectorSize::Bi, Sk::Bool),
-                    0b1010 => (VectorSize::Tri, Sk::Bool),
-                    _ => (VectorSize::Quad, Sk::Bool),
+                let (size, scalar) = match bits {
+                    0b0000 => (VectorSize::Bi, Scalar::F32),
+                    0b0001 => (VectorSize::Tri, Scalar::F32),
+                    0b0010 => (VectorSize::Quad, Scalar::F32),
+                    0b0011 => (VectorSize::Bi, Scalar::I32),
+                    0b0100 => (VectorSize::Tri, Scalar::I32),
+                    0b0101 => (VectorSize::Quad, Scalar::I32),
+                    0b0110 => (VectorSize::Bi, Scalar::U32),
+                    0b0111 => (VectorSize::Tri, Scalar::U32),
+                    0b1000 => (VectorSize::Quad, Scalar::U32),
+                    0b1001 => (VectorSize::Bi, Scalar::BOOL),
+                    0b1010 => (VectorSize::Tri, Scalar::BOOL),
+                    _ => (VectorSize::Quad, Scalar::BOOL),
                 };
 
-                let width = if let Sk::Bool = kind {
-                    crate::BOOL_WIDTH
-                } else {
-                    width
-                };
-
-                let ty = || TypeInner::Vector { size, kind, width };
+                let ty = || TypeInner::Vector { size, scalar };
                 let args = vec![ty(), ty()];
 
                 let fun = MacroCall::Binary(match name {
@@ -919,10 +872,10 @@ fn inject_standard_builtins(
             // bit 0 through 1 - scalar kind
             // bit 2 through 4 - dims
             for bits in 0..0b11100 {
-                let kind = match bits & 0b11 {
-                    0b00 => Sk::Float,
-                    0b01 => Sk::Sint,
-                    0b10 => Sk::Uint,
+                let scalar = match bits & 0b11 {
+                    0b00 => Scalar::F32,
+                    0b01 => Scalar::I32,
+                    0b10 => Scalar::U32,
                     _ => continue,
                 };
                 let (size, second_size) = match bits >> 2 {
@@ -937,12 +890,12 @@ fn inject_standard_builtins(
 
                 let args = vec![
                     match size {
-                        Some(size) => TypeInner::Vector { size, kind, width },
-                        None => TypeInner::Scalar { kind, width },
+                        Some(size) => TypeInner::Vector { size, scalar },
+                        None => TypeInner::Scalar(scalar),
                     },
                     match second_size {
-                        Some(size) => TypeInner::Vector { size, kind, width },
-                        None => TypeInner::Scalar { kind, width },
+                        Some(size) => TypeInner::Vector { size, scalar },
+                        None => TypeInner::Scalar(scalar),
                     },
                 ];
 
@@ -969,25 +922,25 @@ fn inject_standard_builtins(
                     0b10 => Some(VectorSize::Quad),
                     _ => None,
                 };
-                let (kind, splatted, boolean) = match bits >> 2 {
-                    0b000 => (Sk::Sint, false, true),
-                    0b001 => (Sk::Uint, false, true),
-                    0b010 => (Sk::Float, false, true),
-                    0b011 => (Sk::Float, false, false),
-                    _ => (Sk::Float, true, false),
+                let (scalar, splatted, boolean) = match bits >> 2 {
+                    0b000 => (Scalar::I32, false, true),
+                    0b001 => (Scalar::U32, false, true),
+                    0b010 => (Scalar::F32, false, true),
+                    0b011 => (Scalar::F32, false, false),
+                    _ => (Scalar::F32, true, false),
                 };
 
-                let ty = |kind, width| match size {
-                    Some(size) => TypeInner::Vector { size, kind, width },
-                    None => TypeInner::Scalar { kind, width },
+                let ty = |scalar| match size {
+                    Some(size) => TypeInner::Vector { size, scalar },
+                    None => TypeInner::Scalar(scalar),
                 };
                 let args = vec![
-                    ty(kind, width),
-                    ty(kind, width),
+                    ty(scalar),
+                    ty(scalar),
                     match (boolean, splatted) {
-                        (true, _) => ty(Sk::Bool, crate::BOOL_WIDTH),
-                        (_, false) => TypeInner::Scalar { kind, width },
-                        _ => ty(kind, width),
+                        (true, _) => ty(Scalar::BOOL),
+                        (_, false) => TypeInner::Scalar(scalar),
+                        _ => ty(scalar),
                     },
                 ];
 
@@ -1009,10 +962,10 @@ fn inject_standard_builtins(
             // 0b11010 is the last element since splatted single elements
             // were already added
             for bits in 0..0b11011 {
-                let kind = match bits & 0b11 {
-                    0b00 => Sk::Float,
-                    0b01 => Sk::Sint,
-                    0b10 => Sk::Uint,
+                let scalar = match bits & 0b11 {
+                    0b00 => Scalar::F32,
+                    0b01 => Scalar::I32,
+                    0b10 => Scalar::U32,
                     _ => continue,
                 };
                 let size = match (bits >> 2) & 0b11 {
@@ -1024,11 +977,11 @@ fn inject_standard_builtins(
                 let splatted = bits & 0b10000 == 0b10000;
 
                 let base_ty = || match size {
-                    Some(size) => TypeInner::Vector { size, kind, width },
-                    None => TypeInner::Scalar { kind, width },
+                    Some(size) => TypeInner::Vector { size, scalar },
+                    None => TypeInner::Scalar(scalar),
                 };
                 let limit_ty = || match splatted {
-                    true => TypeInner::Scalar { kind, width },
+                    true => TypeInner::Scalar(scalar),
                     false => base_ty(),
                 };
 
@@ -1049,7 +1002,6 @@ fn inject_standard_builtins(
 
 /// Injects the builtins into declaration that need doubles
 fn inject_double_builtin(declaration: &mut FunctionDeclaration, module: &mut Module, name: &str) {
-    let width = 8;
     match name {
         "abs" | "sign" => {
             // bits layout
@@ -1061,11 +1013,11 @@ fn inject_double_builtin(declaration: &mut FunctionDeclaration, module: &mut Mod
                     0b10 => Some(VectorSize::Tri),
                     _ => Some(VectorSize::Quad),
                 };
-                let kind = Sk::Float;
+                let scalar = Scalar::F64;
 
                 let args = vec![match size {
-                    Some(size) => TypeInner::Vector { size, kind, width },
-                    None => TypeInner::Scalar { kind, width },
+                    Some(size) => TypeInner::Vector { size, scalar },
+                    None => TypeInner::Scalar(scalar),
                 }];
 
                 declaration.overloads.push(module.add_builtin(
@@ -1091,16 +1043,16 @@ fn inject_double_builtin(declaration: &mut FunctionDeclaration, module: &mut Mod
                     0b101 => (Some(VectorSize::Tri), Some(VectorSize::Tri)),
                     _ => (Some(VectorSize::Quad), Some(VectorSize::Quad)),
                 };
-                let kind = Sk::Float;
+                let scalar = Scalar::F64;
 
                 let args = vec![
                     match size {
-                        Some(size) => TypeInner::Vector { size, kind, width },
-                        None => TypeInner::Scalar { kind, width },
+                        Some(size) => TypeInner::Vector { size, scalar },
+                        None => TypeInner::Scalar(scalar),
                     },
                     match second_size {
-                        Some(size) => TypeInner::Vector { size, kind, width },
-                        None => TypeInner::Scalar { kind, width },
+                        Some(size) => TypeInner::Vector { size, scalar },
+                        None => TypeInner::Scalar(scalar),
                     },
                 ];
 
@@ -1127,24 +1079,24 @@ fn inject_double_builtin(declaration: &mut FunctionDeclaration, module: &mut Mod
                     0b10 => Some(VectorSize::Tri),
                     _ => None,
                 };
-                let kind = Sk::Float;
+                let scalar = Scalar::F64;
                 let (splatted, boolean) = match bits >> 2 {
                     0b00 => (false, false),
                     0b01 => (false, true),
                     _ => (true, false),
                 };
 
-                let ty = |kind, width| match size {
-                    Some(size) => TypeInner::Vector { size, kind, width },
-                    None => TypeInner::Scalar { kind, width },
+                let ty = |scalar| match size {
+                    Some(size) => TypeInner::Vector { size, scalar },
+                    None => TypeInner::Scalar(scalar),
                 };
                 let args = vec![
-                    ty(kind, width),
-                    ty(kind, width),
+                    ty(scalar),
+                    ty(scalar),
                     match (boolean, splatted) {
-                        (true, _) => ty(Sk::Bool, crate::BOOL_WIDTH),
-                        (_, false) => TypeInner::Scalar { kind, width },
-                        _ => ty(kind, width),
+                        (true, _) => ty(Scalar::BOOL),
+                        (_, false) => TypeInner::Scalar(scalar),
+                        _ => ty(scalar),
                     },
                 ];
 
@@ -1165,7 +1117,7 @@ fn inject_double_builtin(declaration: &mut FunctionDeclaration, module: &mut Mod
             // 0b110 is the last element since splatted with single elements
             // is equal to normal single elements
             for bits in 0..0b111 {
-                let kind = Sk::Float;
+                let scalar = Scalar::F64;
                 let size = match bits & 0b11 {
                     0b00 => Some(VectorSize::Bi),
                     0b01 => Some(VectorSize::Tri),
@@ -1175,11 +1127,11 @@ fn inject_double_builtin(declaration: &mut FunctionDeclaration, module: &mut Mod
                 let splatted = bits & 0b100 == 0b100;
 
                 let base_ty = || match size {
-                    Some(size) => TypeInner::Vector { size, kind, width },
-                    None => TypeInner::Scalar { kind, width },
+                    Some(size) => TypeInner::Vector { size, scalar },
+                    None => TypeInner::Scalar(scalar),
                 };
                 let limit_ty = || match splatted {
-                    true => TypeInner::Scalar { kind, width },
+                    true => TypeInner::Scalar(scalar),
                     false => base_ty(),
                 };
 
@@ -1192,14 +1144,15 @@ fn inject_double_builtin(declaration: &mut FunctionDeclaration, module: &mut Mod
         }
         "lessThan" | "greaterThan" | "lessThanEqual" | "greaterThanEqual" | "equal"
         | "notEqual" => {
+            let scalar = Scalar::F64;
             for bits in 0..0b11 {
-                let (size, kind) = match bits {
-                    0b00 => (VectorSize::Bi, Sk::Float),
-                    0b01 => (VectorSize::Tri, Sk::Float),
-                    _ => (VectorSize::Quad, Sk::Float),
+                let size = match bits {
+                    0b00 => VectorSize::Bi,
+                    0b01 => VectorSize::Tri,
+                    _ => VectorSize::Quad,
                 };
 
-                let ty = || TypeInner::Vector { size, kind, width };
+                let ty = || TypeInner::Vector { size, scalar };
                 let args = vec![ty(), ty()];
 
                 let fun = MacroCall::Binary(match name {
@@ -1227,6 +1180,10 @@ fn inject_common_builtin(
     name: &str,
     float_width: crate::Bytes,
 ) {
+    let float_scalar = Scalar {
+        kind: Sk::Float,
+        width: float_width,
+    };
     match name {
         "ceil" | "round" | "roundEven" | "floor" | "fract" | "trunc" | "sqrt" | "inversesqrt"
         | "normalize" | "length" | "isinf" | "isnan" => {
@@ -1243,13 +1200,9 @@ fn inject_common_builtin(
                 let args = vec![match size {
                     Some(size) => TypeInner::Vector {
                         size,
-                        kind: Sk::Float,
-                        width: float_width,
+                        scalar: float_scalar,
                     },
-                    None => TypeInner::Scalar {
-                        kind: Sk::Float,
-                        width: float_width,
-                    },
+                    None => TypeInner::Scalar(float_scalar),
                 }];
 
                 let fun = match name {
@@ -1280,16 +1233,9 @@ fn inject_common_builtin(
                     0b10 => Some(VectorSize::Tri),
                     _ => Some(VectorSize::Quad),
                 };
-                let ty = |kind| match size {
-                    Some(size) => TypeInner::Vector {
-                        size,
-                        kind,
-                        width: float_width,
-                    },
-                    None => TypeInner::Scalar {
-                        kind,
-                        width: float_width,
-                    },
+                let ty = |scalar| match size {
+                    Some(size) => TypeInner::Vector { size, scalar },
+                    None => TypeInner::Scalar(scalar),
                 };
 
                 let fun = match name {
@@ -1300,15 +1246,18 @@ fn inject_common_builtin(
                     _ => unreachable!(),
                 };
 
-                let second_kind = if fun == MacroCall::MathFunction(MathFunction::Ldexp) {
-                    Sk::Sint
+                let second_scalar = if fun == MacroCall::MathFunction(MathFunction::Ldexp) {
+                    Scalar {
+                        kind: Sk::Sint,
+                        width: float_width,
+                    }
                 } else {
-                    Sk::Float
+                    float_scalar
                 };
 
                 declaration
                     .overloads
-                    .push(module.add_builtin(vec![ty(Sk::Float), ty(second_kind)], fun))
+                    .push(module.add_builtin(vec![ty(Scalar::F32), ty(second_scalar)], fun))
             }
         }
         "transpose" => {
@@ -1389,13 +1338,9 @@ fn inject_common_builtin(
                     args.push(match maybe_size {
                         Some(size) => TypeInner::Vector {
                             size,
-                            kind: Sk::Float,
-                            width: float_width,
+                            scalar: float_scalar,
                         },
-                        None => TypeInner::Scalar {
-                            kind: Sk::Float,
-                            width: float_width,
-                        },
+                        None => TypeInner::Scalar(float_scalar),
                     })
                 }
 
@@ -1414,13 +1359,11 @@ fn inject_common_builtin(
             let args = vec![
                 TypeInner::Vector {
                     size: VectorSize::Tri,
-                    kind: Sk::Float,
-                    width: float_width,
+                    scalar: float_scalar,
                 },
                 TypeInner::Vector {
                     size: VectorSize::Tri,
-                    kind: Sk::Float,
-                    width: float_width,
+                    scalar: float_scalar,
                 },
             ];
 
@@ -1447,13 +1390,11 @@ fn inject_common_builtin(
                 let args = vec![
                     TypeInner::Vector {
                         size: size1,
-                        kind: Sk::Float,
-                        width: float_width,
+                        scalar: float_scalar,
                     },
                     TypeInner::Vector {
                         size: size2,
-                        kind: Sk::Float,
-                        width: float_width,
+                        scalar: float_scalar,
                     },
                 ];
 
@@ -1476,13 +1417,9 @@ fn inject_common_builtin(
                 let ty = || match size {
                     Some(size) => TypeInner::Vector {
                         size,
-                        kind: Sk::Float,
-                        width: float_width,
+                        scalar: float_scalar,
                     },
-                    None => TypeInner::Scalar {
-                        kind: Sk::Float,
-                        width: float_width,
-                    },
+                    None => TypeInner::Scalar(float_scalar),
                 };
                 let args = vec![ty(), ty(), ty()];
 
@@ -1509,22 +1446,11 @@ fn inject_common_builtin(
                 let ty = || match size {
                     Some(size) => TypeInner::Vector {
                         size,
-                        kind: Sk::Float,
-                        width: float_width,
+                        scalar: float_scalar,
                     },
-                    None => TypeInner::Scalar {
-                        kind: Sk::Float,
-                        width: float_width,
-                    },
+                    None => TypeInner::Scalar(float_scalar),
                 };
-                let args = vec![
-                    ty(),
-                    ty(),
-                    TypeInner::Scalar {
-                        kind: Sk::Float,
-                        width: 4,
-                    },
-                ];
+                let args = vec![ty(), ty(), TypeInner::Scalar(Scalar::F32)];
                 declaration
                     .overloads
                     .push(module.add_builtin(args, MacroCall::MathFunction(MathFunction::Refract)))
@@ -1549,19 +1475,12 @@ fn inject_common_builtin(
                 let base_ty = || match size {
                     Some(size) => TypeInner::Vector {
                         size,
-                        kind: Sk::Float,
-                        width: float_width,
+                        scalar: float_scalar,
                     },
-                    None => TypeInner::Scalar {
-                        kind: Sk::Float,
-                        width: float_width,
-                    },
+                    None => TypeInner::Scalar(float_scalar),
                 };
                 let ty = || match splatted {
-                    true => TypeInner::Scalar {
-                        kind: Sk::Float,
-                        width: float_width,
-                    },
+                    true => TypeInner::Scalar(float_scalar),
                     false => base_ty(),
                 };
                 declaration.overloads.push(module.add_builtin(
@@ -1810,8 +1729,7 @@ impl MacroCall {
                             name: None,
                             inner: TypeInner::Vector {
                                 size,
-                                kind: crate::ScalarKind::Uint,
-                                width: 4,
+                                scalar: Scalar::U32,
                             },
                         },
                         Span::default(),
@@ -2100,7 +2018,7 @@ fn texture_call(
         let mut array_index = comps.array_index;
 
         if let Some(ref mut array_index_expr) = array_index {
-            ctx.conversion(array_index_expr, meta, Sk::Sint, 4)?;
+            ctx.conversion(array_index_expr, meta, Scalar::I32)?;
         }
 
         Ok(ctx.add_expression(

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -9,8 +9,8 @@ use super::{
 };
 use crate::{
     front::Typifier, proc::Emitter, AddressSpace, Arena, BinaryOperator, Block, Expression,
-    FastHashMap, FunctionArgument, Handle, Literal, LocalVariable, RelationalFunction, ScalarKind,
-    Span, Statement, Type, TypeInner, VectorSize,
+    FastHashMap, FunctionArgument, Handle, Literal, LocalVariable, RelationalFunction, Scalar,
+    ScalarKind, Span, Statement, Type, TypeInner, VectorSize,
 };
 use std::ops::Index;
 
@@ -602,7 +602,7 @@ impl<'a> Context<'a> {
 
                 match op {
                     BinaryOperator::ShiftLeft | BinaryOperator::ShiftRight => {
-                        self.implicit_conversion(&mut right, right_meta, ScalarKind::Uint, 4)?
+                        self.implicit_conversion(&mut right, right_meta, Scalar::U32)?
                     }
                     _ => self
                         .binary_implicit_conversion(&mut left, left_meta, &mut right, right_meta)?,
@@ -824,9 +824,9 @@ impl<'a> Context<'a> {
                         _ => self.add_expression(Expression::Binary { left, op, right }, meta)?,
                     },
                     (
-                        &TypeInner::Scalar {
+                        &TypeInner::Scalar(Scalar {
                             width: left_width, ..
-                        },
+                        }),
                         &TypeInner::Matrix {
                             rows,
                             columns,
@@ -911,9 +911,9 @@ impl<'a> Context<'a> {
                             columns,
                             width: left_width,
                         },
-                        &TypeInner::Scalar {
+                        &TypeInner::Scalar(Scalar {
                             width: right_width, ..
-                        },
+                        }),
                     ) => {
                         // Check that the two arguments have the same width
                         if left_width != right_width {
@@ -1100,37 +1100,24 @@ impl<'a> Context<'a> {
 
                 // We need to do some custom implicit conversions since the two target expressions
                 // are in different bodies
-                if let (
-                    Some((accept_power, accept_width, accept_kind)),
-                    Some((reject_power, reject_width, reject_kind)),
-                ) = (
+                if let (Some((accept_power, accept_scalar)), Some((reject_power, reject_scalar))) = (
                     // Get the components of both branches and calculate the type power
                     self.expr_scalar_components(accept, accept_meta)?
-                        .and_then(|(kind, width)| Some((type_power(kind, width)?, width, kind))),
+                        .and_then(|scalar| Some((type_power(scalar)?, scalar))),
                     self.expr_scalar_components(reject, reject_meta)?
-                        .and_then(|(kind, width)| Some((type_power(kind, width)?, width, kind))),
+                        .and_then(|scalar| Some((type_power(scalar)?, scalar))),
                 ) {
                     match accept_power.cmp(&reject_power) {
                         std::cmp::Ordering::Less => {
                             accept_body = self.with_body(accept_body, |ctx| {
-                                ctx.conversion(
-                                    &mut accept,
-                                    accept_meta,
-                                    reject_kind,
-                                    reject_width,
-                                )?;
+                                ctx.conversion(&mut accept, accept_meta, reject_scalar)?;
                                 Ok(())
                             })?;
                         }
                         std::cmp::Ordering::Equal => {}
                         std::cmp::Ordering::Greater => {
                             reject_body = self.with_body(reject_body, |ctx| {
-                                ctx.conversion(
-                                    &mut reject,
-                                    reject_meta,
-                                    accept_kind,
-                                    accept_width,
-                                )?;
+                                ctx.conversion(&mut reject, reject_meta, accept_scalar)?;
                                 Ok(())
                             })?;
                         }
@@ -1201,8 +1188,8 @@ impl<'a> Context<'a> {
                     ref ty => ty,
                 };
 
-                if let Some((kind, width)) = scalar_components(ty) {
-                    self.implicit_conversion(&mut value, value_meta, kind, width)?;
+                if let Some(scalar) = scalar_components(ty) {
+                    self.implicit_conversion(&mut value, value_meta, scalar)?;
                 }
 
                 self.lower_store(pointer, value, meta)?;
@@ -1218,13 +1205,13 @@ impl<'a> Context<'a> {
                 };
 
                 let res = match *self.resolve_type(left, meta)? {
-                    TypeInner::Scalar { kind, width } => {
-                        let ty = TypeInner::Scalar { kind, width };
-                        Literal::one(kind, width).map(|i| (ty, i, None, None))
+                    TypeInner::Scalar(scalar) => {
+                        let ty = TypeInner::Scalar(scalar);
+                        Literal::one(scalar).map(|i| (ty, i, None, None))
                     }
-                    TypeInner::Vector { size, kind, width } => {
-                        let ty = TypeInner::Vector { size, kind, width };
-                        Literal::one(kind, width).map(|i| (ty, i, Some(size), None))
+                    TypeInner::Vector { size, scalar } => {
+                        let ty = TypeInner::Vector { size, scalar };
+                        Literal::one(scalar).map(|i| (ty, i, Some(size), None))
                     }
                     TypeInner::Matrix {
                         columns,
@@ -1236,8 +1223,11 @@ impl<'a> Context<'a> {
                             rows,
                             width,
                         };
-                        Literal::one(ScalarKind::Float, width)
-                            .map(|i| (ty, i, Some(rows), Some(columns)))
+                        Literal::one(Scalar {
+                            kind: ScalarKind::Float,
+                            width,
+                        })
+                        .map(|i| (ty, i, Some(rows), Some(columns)))
                     }
                     _ => None,
                 };
@@ -1323,19 +1313,14 @@ impl<'a> Context<'a> {
                                     Expression::Literal(Literal::U32(size.get())),
                                     meta,
                                 )?;
-                                self.forced_conversion(
-                                    &mut array_length,
-                                    meta,
-                                    ScalarKind::Sint,
-                                    4,
-                                )?;
+                                self.forced_conversion(&mut array_length, meta, Scalar::I32)?;
                                 array_length
                             }
                             // let the error be handled in type checking if it's not a dynamic array
                             _ => {
                                 let mut array_length = self
                                     .add_expression(Expression::ArrayLength(lowered_array), meta)?;
-                                self.conversion(&mut array_length, meta, ScalarKind::Sint, 4)?;
+                                self.conversion(&mut array_length, meta, Scalar::I32)?;
                                 array_length
                             }
                         }
@@ -1376,7 +1361,7 @@ impl<'a> Context<'a> {
         &mut self,
         expr: Handle<Expression>,
         meta: Span,
-    ) -> Result<Option<(ScalarKind, crate::Bytes)>> {
+    ) -> Result<Option<Scalar>> {
         let ty = self.resolve_type(expr, meta)?;
         Ok(scalar_components(ty))
     }
@@ -1384,21 +1369,20 @@ impl<'a> Context<'a> {
     pub fn expr_power(&mut self, expr: Handle<Expression>, meta: Span) -> Result<Option<u32>> {
         Ok(self
             .expr_scalar_components(expr, meta)?
-            .and_then(|(kind, width)| type_power(kind, width)))
+            .and_then(type_power))
     }
 
     pub fn conversion(
         &mut self,
         expr: &mut Handle<Expression>,
         meta: Span,
-        kind: ScalarKind,
-        width: crate::Bytes,
+        scalar: Scalar,
     ) -> Result<()> {
         *expr = self.add_expression(
             Expression::As {
                 expr: *expr,
-                kind,
-                convert: Some(width),
+                kind: scalar.kind,
+                convert: Some(scalar.width),
             },
             meta,
         )?;
@@ -1410,14 +1394,13 @@ impl<'a> Context<'a> {
         &mut self,
         expr: &mut Handle<Expression>,
         meta: Span,
-        kind: ScalarKind,
-        width: crate::Bytes,
+        scalar: Scalar,
     ) -> Result<()> {
         if let (Some(tgt_power), Some(expr_power)) =
-            (type_power(kind, width), self.expr_power(*expr, meta)?)
+            (type_power(scalar), self.expr_power(*expr, meta)?)
         {
             if tgt_power > expr_power {
-                self.conversion(expr, meta, kind, width)?;
+                self.conversion(expr, meta, scalar)?;
             }
         }
 
@@ -1428,12 +1411,11 @@ impl<'a> Context<'a> {
         &mut self,
         expr: &mut Handle<Expression>,
         meta: Span,
-        kind: ScalarKind,
-        width: crate::Bytes,
+        scalar: Scalar,
     ) -> Result<()> {
-        if let Some((expr_scalar_kind, expr_width)) = self.expr_scalar_components(*expr, meta)? {
-            if expr_scalar_kind != kind || expr_width != width {
-                self.conversion(expr, meta, kind, width)?;
+        if let Some(expr_scalar) = self.expr_scalar_components(*expr, meta)? {
+            if expr_scalar != scalar {
+                self.conversion(expr, meta, scalar)?;
             }
         }
 
@@ -1450,21 +1432,17 @@ impl<'a> Context<'a> {
         let left_components = self.expr_scalar_components(*left, left_meta)?;
         let right_components = self.expr_scalar_components(*right, right_meta)?;
 
-        if let (
-            Some((left_power, left_width, left_kind)),
-            Some((right_power, right_width, right_kind)),
-        ) = (
-            left_components.and_then(|(kind, width)| Some((type_power(kind, width)?, width, kind))),
-            right_components
-                .and_then(|(kind, width)| Some((type_power(kind, width)?, width, kind))),
+        if let (Some((left_power, left_scalar)), Some((right_power, right_scalar))) = (
+            left_components.and_then(|scalar| Some((type_power(scalar)?, scalar))),
+            right_components.and_then(|scalar| Some((type_power(scalar)?, scalar))),
         ) {
             match left_power.cmp(&right_power) {
                 std::cmp::Ordering::Less => {
-                    self.conversion(left, left_meta, right_kind, right_width)?;
+                    self.conversion(left, left_meta, right_scalar)?;
                 }
                 std::cmp::Ordering::Equal => {}
                 std::cmp::Ordering::Greater => {
-                    self.conversion(right, right_meta, left_kind, left_width)?;
+                    self.conversion(right, right_meta, left_scalar)?;
                 }
             }
         }

--- a/naga/src/front/glsl/functions.rs
+++ b/naga/src/front/glsl/functions.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     front::glsl::types::type_power, proc::ensure_block_returns, AddressSpace, Block, EntryPoint,
-    Expression, Function, FunctionArgument, FunctionResult, Handle, Literal, LocalVariable,
+    Expression, Function, FunctionArgument, FunctionResult, Handle, Literal, LocalVariable, Scalar,
     ScalarKind, Span, Statement, StructMember, Type, TypeInner,
 };
 use std::iter;
@@ -20,7 +20,7 @@ struct ProxyWrite {
     /// A pointer to read the value of the store
     value: Handle<Expression>,
     /// An optional conversion to be applied
-    convert: Option<(ScalarKind, crate::Bytes)>,
+    convert: Option<Scalar>,
 }
 
 impl Frontend {
@@ -68,10 +68,14 @@ impl Frontend {
         let expr_is_bool = expr_type.scalar_kind() == Some(ScalarKind::Bool);
 
         // Special case: if casting from a bool, we need to use Select and not As.
-        match ctx.module.types[ty].inner.scalar_kind() {
-            Some(result_scalar_kind) if expr_is_bool && result_scalar_kind != ScalarKind::Bool => {
-                let l0 = Literal::zero(result_scalar_kind, 4).unwrap();
-                let l1 = Literal::one(result_scalar_kind, 4).unwrap();
+        match ctx.module.types[ty].inner.scalar() {
+            Some(result_scalar) if expr_is_bool && result_scalar.kind != ScalarKind::Bool => {
+                let result_scalar = Scalar {
+                    width: 4,
+                    ..result_scalar
+                };
+                let l0 = Literal::zero(result_scalar).unwrap();
+                let l1 = Literal::one(result_scalar).unwrap();
                 let mut reject = ctx.add_expression(Expression::Literal(l0), expr_meta)?;
                 let mut accept = ctx.add_expression(Expression::Literal(l1), expr_meta)?;
 
@@ -93,24 +97,16 @@ impl Frontend {
         }
 
         Ok(match ctx.module.types[ty].inner {
-            TypeInner::Vector { size, kind, width } if vector_size.is_none() => {
-                ctx.forced_conversion(&mut value, expr_meta, kind, width)?;
+            TypeInner::Vector { size, scalar } if vector_size.is_none() => {
+                ctx.forced_conversion(&mut value, expr_meta, scalar)?;
 
                 if let TypeInner::Scalar { .. } = *ctx.resolve_type(value, expr_meta)? {
                     ctx.add_expression(Expression::Splat { size, value }, meta)?
                 } else {
-                    self.vector_constructor(
-                        ctx,
-                        ty,
-                        size,
-                        kind,
-                        width,
-                        &[(value, expr_meta)],
-                        meta,
-                    )?
+                    self.vector_constructor(ctx, ty, size, scalar, &[(value, expr_meta)], meta)?
                 }
             }
-            TypeInner::Scalar { kind, width } => {
+            TypeInner::Scalar(scalar) => {
                 let mut expr = value;
                 if let TypeInner::Vector { .. } | TypeInner::Matrix { .. } =
                     *ctx.resolve_type(value, expr_meta)?
@@ -136,23 +132,23 @@ impl Frontend {
 
                 ctx.add_expression(
                     Expression::As {
-                        kind,
+                        kind: scalar.kind,
                         expr,
-                        convert: Some(width),
+                        convert: Some(scalar.width),
                     },
                     meta,
                 )?
             }
-            TypeInner::Vector { size, kind, width } => {
+            TypeInner::Vector { size, scalar } => {
                 if vector_size.map_or(true, |s| s != size) {
                     value = ctx.vector_resize(size, value, expr_meta)?;
                 }
 
                 ctx.add_expression(
                     Expression::As {
-                        kind,
+                        kind: scalar.kind,
                         expr: value,
-                        convert: Some(width),
+                        convert: Some(scalar.width),
                     },
                     meta,
                 )?
@@ -166,8 +162,8 @@ impl Frontend {
                 let scalar_components = members
                     .get(0)
                     .and_then(|member| scalar_components(&ctx.module.types[member.ty].inner));
-                if let Some((kind, width)) = scalar_components {
-                    ctx.implicit_conversion(&mut value, expr_meta, kind, width)?;
+                if let Some(scalar) = scalar_components {
+                    ctx.implicit_conversion(&mut value, expr_meta, scalar)?;
                 }
 
                 ctx.add_expression(
@@ -181,8 +177,8 @@ impl Frontend {
 
             TypeInner::Array { base, .. } => {
                 let scalar_components = scalar_components(&ctx.module.types[base].inner);
-                if let Some((kind, width)) = scalar_components {
-                    ctx.implicit_conversion(&mut value, expr_meta, kind, width)?;
+                if let Some(scalar) = scalar_components {
+                    ctx.implicit_conversion(&mut value, expr_meta, scalar)?;
                 }
 
                 ctx.add_expression(
@@ -220,9 +216,13 @@ impl Frontend {
         // `Expression::As` doesn't support matrix width
         // casts so we need to do some extra work for casts
 
-        ctx.forced_conversion(&mut value, expr_meta, ScalarKind::Float, width)?;
+        let element_scalar = Scalar {
+            kind: ScalarKind::Float,
+            width,
+        };
+        ctx.forced_conversion(&mut value, expr_meta, element_scalar)?;
         match *ctx.resolve_type(value, expr_meta)? {
-            TypeInner::Scalar { .. } => {
+            TypeInner::Scalar(_) => {
                 // If a matrix is constructed with a single scalar value, then that
                 // value is used to initialize all the values along the diagonal of
                 // the matrix; the rest are given zeros.
@@ -231,14 +231,13 @@ impl Frontend {
                         name: None,
                         inner: TypeInner::Vector {
                             size: rows,
-                            kind: ScalarKind::Float,
-                            width,
+                            scalar: element_scalar,
                         },
                     },
                     meta,
                 );
 
-                let zero_literal = Literal::zero(ScalarKind::Float, width).unwrap();
+                let zero_literal = Literal::zero(element_scalar).unwrap();
                 let zero = ctx.add_expression(Expression::Literal(zero_literal), meta)?;
 
                 for i in 0..columns as u32 {
@@ -268,8 +267,8 @@ impl Frontend {
                 // (column i, row j) in the argument will be initialized from there. All
                 // other components will be initialized to the identity matrix.
 
-                let zero_literal = Literal::zero(ScalarKind::Float, width).unwrap();
-                let one_literal = Literal::one(ScalarKind::Float, width).unwrap();
+                let zero_literal = Literal::zero(element_scalar).unwrap();
+                let one_literal = Literal::one(element_scalar).unwrap();
 
                 let zero = ctx.add_expression(Expression::Literal(zero_literal), meta)?;
                 let one = ctx.add_expression(Expression::Literal(one_literal), meta)?;
@@ -279,8 +278,7 @@ impl Frontend {
                         name: None,
                         inner: TypeInner::Vector {
                             size: rows,
-                            kind: ScalarKind::Float,
-                            width,
+                            scalar: element_scalar,
                         },
                     },
                     meta,
@@ -360,15 +358,14 @@ impl Frontend {
         ctx: &mut Context,
         ty: Handle<Type>,
         size: crate::VectorSize,
-        kind: ScalarKind,
-        width: crate::Bytes,
+        scalar: Scalar,
         args: &[(Handle<Expression>, Span)],
         meta: Span,
     ) -> Result<Handle<Expression>> {
         let mut components = Vec::with_capacity(size as usize);
 
         for (mut arg, expr_meta) in args.iter().copied() {
-            ctx.forced_conversion(&mut arg, expr_meta, kind, width)?;
+            ctx.forced_conversion(&mut arg, expr_meta, scalar)?;
 
             if components.len() >= size as usize {
                 break;
@@ -429,8 +426,12 @@ impl Frontend {
             } => {
                 let mut flattened = Vec::with_capacity(columns as usize * rows as usize);
 
+                let element_scalar = Scalar {
+                    kind: ScalarKind::Float,
+                    width,
+                };
                 for (mut arg, meta) in args.iter().copied() {
-                    ctx.forced_conversion(&mut arg, meta, ScalarKind::Float, width)?;
+                    ctx.forced_conversion(&mut arg, meta, element_scalar)?;
 
                     match *ctx.resolve_type(arg, meta)? {
                         TypeInner::Vector { size, .. } => {
@@ -453,8 +454,7 @@ impl Frontend {
                         name: None,
                         inner: TypeInner::Vector {
                             size: rows,
-                            kind: ScalarKind::Float,
-                            width,
+                            scalar: element_scalar,
                         },
                     },
                     meta,
@@ -471,14 +471,14 @@ impl Frontend {
                 }
                 None
             }
-            TypeInner::Vector { size, kind, width } => {
-                return self.vector_constructor(ctx, ty, size, kind, width, &args, meta)
+            TypeInner::Vector { size, scalar } => {
+                return self.vector_constructor(ctx, ty, size, scalar, &args, meta)
             }
             TypeInner::Array { base, .. } => {
                 for (mut arg, meta) in args.iter().copied() {
                     let scalar_components = scalar_components(&ctx.module.types[base].inner);
-                    if let Some((kind, width)) = scalar_components {
-                        ctx.implicit_conversion(&mut arg, meta, kind, width)?;
+                    if let Some(scalar) = scalar_components {
+                        ctx.implicit_conversion(&mut arg, meta, scalar)?;
                     }
 
                     components.push(arg)
@@ -503,8 +503,8 @@ impl Frontend {
             for ((mut arg, meta), scalar_components) in
                 args.iter().copied().zip(struct_member_data.iter().copied())
             {
-                if let Some((kind, width)) = scalar_components {
-                    ctx.implicit_conversion(&mut arg, meta, kind, width)?;
+                if let Some(scalar) = scalar_components {
+                    ctx.implicit_conversion(&mut arg, meta, scalar)?;
                 }
 
                 components.push(arg)
@@ -813,8 +813,8 @@ impl Frontend {
             let scalar_comps = scalar_components(&ctx.module.types[*parameter].inner);
 
             // Apply implicit conversions as needed
-            if let Some((kind, width)) = scalar_comps {
-                ctx.implicit_conversion(&mut handle, meta, kind, width)?;
+            if let Some(scalar) = scalar_comps {
+                ctx.implicit_conversion(&mut handle, meta, scalar)?;
             }
 
             arguments.push(handle)
@@ -850,8 +850,8 @@ impl Frontend {
                         meta,
                     )?;
 
-                    if let Some((kind, width)) = proxy_write.convert {
-                        ctx.conversion(&mut value, meta, kind, width)?;
+                    if let Some(scalar) = proxy_write.convert {
+                        ctx.conversion(&mut value, meta, scalar)?;
                     }
 
                     ctx.emit_restart();
@@ -893,10 +893,10 @@ impl Frontend {
             // If the argument is to be passed as a pointer but the type of the
             // expression returns a vector it must mean that it was for example
             // swizzled and it must be spilled into a local before calling
-            TypeInner::Vector { size, kind, width } => Some(ctx.module.types.insert(
+            TypeInner::Vector { size, scalar } => Some(ctx.module.types.insert(
                 Type {
                     name: None,
-                    inner: TypeInner::Vector { size, kind, width },
+                    inner: TypeInner::Vector { size, scalar },
                 },
                 Span::default(),
             )),
@@ -906,13 +906,12 @@ impl Frontend {
             TypeInner::Pointer { base, space } if space != AddressSpace::Function => Some(base),
             TypeInner::ValuePointer {
                 size,
-                kind,
-                width,
+                scalar,
                 space,
             } if space != AddressSpace::Function => {
                 let inner = match size {
-                    Some(size) => TypeInner::Vector { size, kind, width },
-                    None => TypeInner::Scalar { kind, width },
+                    Some(size) => TypeInner::Vector { size, scalar },
+                    None => TypeInner::Scalar(scalar),
                 };
 
                 Some(
@@ -1512,31 +1511,22 @@ fn conversion(target: &TypeInner, source: &TypeInner) -> Option<Conversion> {
     use ScalarKind::*;
 
     // Gather the `ScalarKind` and scalar width from both the target and the source
-    let (target_kind, target_width, source_kind, source_width) = match (target, source) {
+    let (target_scalar, source_scalar) = match (target, source) {
         // Conversions between scalars are allowed
-        (
-            &TypeInner::Scalar {
-                kind: tgt_kind,
-                width: tgt_width,
-            },
-            &TypeInner::Scalar {
-                kind: src_kind,
-                width: src_width,
-            },
-        ) => (tgt_kind, tgt_width, src_kind, src_width),
+        (&TypeInner::Scalar(tgt_scalar), &TypeInner::Scalar(src_scalar)) => {
+            (tgt_scalar, src_scalar)
+        }
         // Conversions between vectors of the same size are allowed
         (
             &TypeInner::Vector {
-                kind: tgt_kind,
                 size: tgt_size,
-                width: tgt_width,
+                scalar: tgt_scalar,
             },
             &TypeInner::Vector {
-                kind: src_kind,
                 size: src_size,
-                width: src_width,
+                scalar: src_scalar,
             },
-        ) if tgt_size == src_size => (tgt_kind, tgt_width, src_kind, src_width),
+        ) if tgt_size == src_size => (tgt_scalar, src_scalar),
         // Conversions between matrices of the same size are allowed
         (
             &TypeInner::Matrix {
@@ -1549,29 +1539,63 @@ fn conversion(target: &TypeInner, source: &TypeInner) -> Option<Conversion> {
                 columns: src_cols,
                 width: src_width,
             },
-        ) if tgt_cols == src_cols && tgt_rows == src_rows => (Float, tgt_width, Float, src_width),
+        ) if tgt_cols == src_cols && tgt_rows == src_rows => (
+            Scalar {
+                kind: Float,
+                width: tgt_width,
+            },
+            Scalar {
+                kind: Float,
+                width: src_width,
+            },
+        ),
         _ => return None,
     };
 
     // Check if source can be converted into target, if this is the case then the type
     // power of target must be higher than that of source
-    let target_power = type_power(target_kind, target_width);
-    let source_power = type_power(source_kind, source_width);
+    let target_power = type_power(target_scalar);
+    let source_power = type_power(source_scalar);
     if target_power < source_power {
         return None;
     }
 
-    Some(
-        match ((target_kind, target_width), (source_kind, source_width)) {
-            // A conversion from a float to a double is special
-            ((Float, 8), (Float, 4)) => Conversion::FloatToDouble,
-            // A conversion from an integer to a float is special
-            ((Float, 4), (Sint | Uint, _)) => Conversion::IntToFloat,
-            // A conversion from an integer to a double is special
-            ((Float, 8), (Sint | Uint, _)) => Conversion::IntToDouble,
-            _ => Conversion::Other,
-        },
-    )
+    Some(match (target_scalar, source_scalar) {
+        // A conversion from a float to a double is special
+        (
+            Scalar {
+                kind: Float,
+                width: 8,
+            },
+            Scalar {
+                kind: Float,
+                width: 4,
+            },
+        ) => Conversion::FloatToDouble,
+        // A conversion from an integer to a float is special
+        (
+            Scalar {
+                kind: Float,
+                width: 4,
+            },
+            Scalar {
+                kind: Sint | Uint,
+                width: _,
+            },
+        ) => Conversion::IntToFloat,
+        // A conversion from an integer to a double is special
+        (
+            Scalar {
+                kind: Float,
+                width: 8,
+            },
+            Scalar {
+                kind: Sint | Uint,
+                width: _,
+            },
+        ) => Conversion::IntToDouble,
+        _ => Conversion::Other,
+    })
 }
 
 /// Helper method returning all the non standard builtin variations needed
@@ -1581,10 +1605,10 @@ fn builtin_required_variations<'a>(args: impl Iterator<Item = &'a TypeInner>) ->
 
     for ty in args {
         match *ty {
-            TypeInner::ValuePointer { kind, width, .. }
-            | TypeInner::Scalar { kind, width }
-            | TypeInner::Vector { kind, width, .. } => {
-                if kind == ScalarKind::Float && width == 8 {
+            TypeInner::ValuePointer { scalar, .. }
+            | TypeInner::Scalar(scalar)
+            | TypeInner::Vector { scalar, .. } => {
+                if scalar.kind == ScalarKind::Float && scalar.width == 8 {
                     variations |= BuiltinVariations::DOUBLE
                 }
             }

--- a/naga/src/front/glsl/offset.rs
+++ b/naga/src/front/glsl/offset.rs
@@ -16,7 +16,7 @@ use super::{
     error::{Error, ErrorKind},
     Span,
 };
-use crate::{proc::Alignment, Handle, Type, TypeInner, UniqueArena};
+use crate::{proc::Alignment, Handle, Scalar, Type, TypeInner, UniqueArena};
 
 /// Struct with information needed for defining a struct member.
 ///
@@ -53,12 +53,15 @@ pub fn calculate_offset(
     let (align, span) = match types[ty].inner {
         // 1. If the member is a scalar consuming N basic machine units,
         // the base alignment is N.
-        TypeInner::Scalar { width, .. } => (Alignment::from_width(width), width as u32),
+        TypeInner::Scalar(Scalar { width, .. }) => (Alignment::from_width(width), width as u32),
         // 2. If the member is a two- or four-component vector with components
         // consuming N basic machine units, the base alignment is 2N or 4N, respectively.
         // 3. If the member is a three-component vector with components consuming N
         // basic machine units, the base alignment is 4N.
-        TypeInner::Vector { size, width, .. } => (
+        TypeInner::Vector {
+            size,
+            scalar: Scalar { width, .. },
+        } => (
             Alignment::from(size) * Alignment::from_width(width),
             size as u32 * width as u32,
         ),

--- a/naga/src/front/glsl/parser/declarations.rs
+++ b/naga/src/front/glsl/parser/declarations.rs
@@ -13,8 +13,8 @@ use crate::{
         Error, ErrorKind, Frontend, Span,
     },
     proc::Alignment,
-    AddressSpace, Expression, FunctionResult, Handle, ScalarKind, Statement, StructMember, Type,
-    TypeInner,
+    AddressSpace, Expression, FunctionResult, Handle, Scalar, ScalarKind, Statement, StructMember,
+    Type, TypeInner,
 };
 
 use super::{DeclarationContext, ParsingContext, Result};
@@ -34,10 +34,10 @@ fn element_or_member_type(
 ) -> Handle<Type> {
     match types[ty].inner {
         // The child type of a vector is a scalar of the same kind and width
-        TypeInner::Vector { kind, width, .. } => types.insert(
+        TypeInner::Vector { scalar, .. } => types.insert(
             Type {
                 name: None,
-                inner: TypeInner::Scalar { kind, width },
+                inner: TypeInner::Scalar(scalar),
             },
             Default::default(),
         ),
@@ -48,8 +48,10 @@ fn element_or_member_type(
                 name: None,
                 inner: TypeInner::Vector {
                     size: rows,
-                    kind: ScalarKind::Float,
-                    width,
+                    scalar: Scalar {
+                        kind: ScalarKind::Float,
+                        width,
+                    },
                 },
             },
             Default::default(),
@@ -156,8 +158,8 @@ impl<'source> ParsingContext<'source> {
             let (mut init, init_meta) = ctx.lower_expect(stmt, frontend, expr, ExprPos::Rhs)?;
 
             let scalar_components = scalar_components(&ctx.module.types[ty].inner);
-            if let Some((kind, width)) = scalar_components {
-                ctx.implicit_conversion(&mut init, init_meta, kind, width)?;
+            if let Some(scalar) = scalar_components {
+                ctx.implicit_conversion(&mut init, init_meta, scalar)?;
             }
 
             Ok((init, init_meta))
@@ -233,9 +235,8 @@ impl<'source> ParsingContext<'source> {
                     let (mut expr, init_meta) = self.parse_initializer(frontend, ty, ctx.ctx)?;
 
                     let scalar_components = scalar_components(&ctx.ctx.module.types[ty].inner);
-                    if let Some((kind, width)) = scalar_components {
-                        ctx.ctx
-                            .implicit_conversion(&mut expr, init_meta, kind, width)?;
+                    if let Some(scalar) = scalar_components {
+                        ctx.ctx.implicit_conversion(&mut expr, init_meta, scalar)?;
                     }
 
                     ctx.ctx.is_const = prev_const;
@@ -509,10 +510,10 @@ impl<'source> ParsingContext<'source> {
                     let (ty, meta) = self.parse_type_non_void(frontend, ctx)?;
 
                     match ctx.module.types[ty].inner {
-                        TypeInner::Scalar {
+                        TypeInner::Scalar(Scalar {
                             kind: ScalarKind::Float | ScalarKind::Sint,
                             ..
-                        } => {}
+                        }) => {}
                         _ => frontend.errors.push(Error {
                             kind: ErrorKind::SemanticError(
                                 "Precision statement can only work on floats and ints".into(),

--- a/naga/src/front/glsl/parser_tests.rs
+++ b/naga/src/front/glsl/parser_tests.rs
@@ -509,7 +509,7 @@ fn functions() {
 
 #[test]
 fn constants() {
-    use crate::{Constant, Expression, ScalarKind, Type, TypeInner};
+    use crate::{Constant, Expression, Type, TypeInner};
 
     let mut frontend = Frontend::default();
 
@@ -536,10 +536,7 @@ fn constants() {
         ty,
         &Type {
             name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Float,
-                width: 4
-            }
+            inner: TypeInner::Scalar(crate::Scalar::F32)
         }
     );
 

--- a/naga/src/front/glsl/types.rs
+++ b/naga/src/front/glsl/types.rs
@@ -1,6 +1,6 @@
 use super::{context::Context, Error, ErrorKind, Result, Span};
 use crate::{
-    proc::ResolveContext, Bytes, Expression, Handle, ImageClass, ImageDimension, ScalarKind, Type,
+    proc::ResolveContext, Expression, Handle, ImageClass, ImageDimension, Scalar, ScalarKind, Type,
     TypeInner, VectorSize,
 };
 
@@ -8,38 +8,23 @@ pub fn parse_type(type_name: &str) -> Option<Type> {
     match type_name {
         "bool" => Some(Type {
             name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Bool,
-                width: crate::BOOL_WIDTH,
-            },
+            inner: TypeInner::Scalar(Scalar::BOOL),
         }),
         "float" => Some(Type {
             name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Float,
-                width: 4,
-            },
+            inner: TypeInner::Scalar(Scalar::F32),
         }),
         "double" => Some(Type {
             name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Float,
-                width: 8,
-            },
+            inner: TypeInner::Scalar(Scalar::F64),
         }),
         "int" => Some(Type {
             name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Sint,
-                width: 4,
-            },
+            inner: TypeInner::Scalar(Scalar::I32),
         }),
         "uint" => Some(Type {
             name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Uint,
-                width: 4,
-            },
+            inner: TypeInner::Scalar(Scalar::U32),
         }),
         "sampler" | "samplerShadow" => Some(Type {
             name: None,
@@ -48,13 +33,13 @@ pub fn parse_type(type_name: &str) -> Option<Type> {
             },
         }),
         word => {
-            fn kind_width_parse(ty: &str) -> Option<(ScalarKind, u8)> {
+            fn kind_width_parse(ty: &str) -> Option<Scalar> {
                 Some(match ty {
-                    "" => (ScalarKind::Float, 4),
-                    "b" => (ScalarKind::Bool, crate::BOOL_WIDTH),
-                    "i" => (ScalarKind::Sint, 4),
-                    "u" => (ScalarKind::Uint, 4),
-                    "d" => (ScalarKind::Float, 8),
+                    "" => Scalar::F32,
+                    "b" => Scalar::BOOL,
+                    "i" => Scalar::I32,
+                    "u" => Scalar::U32,
+                    "d" => Scalar::F64,
                     _ => return None,
                 })
             }
@@ -73,12 +58,12 @@ pub fn parse_type(type_name: &str) -> Option<Type> {
 
                 let kind = iter.next()?;
                 let size = iter.next()?;
-                let (kind, width) = kind_width_parse(kind)?;
+                let scalar = kind_width_parse(kind)?;
                 let size = size_parse(size)?;
 
                 Some(Type {
                     name: None,
-                    inner: TypeInner::Vector { size, kind, width },
+                    inner: TypeInner::Vector { size, scalar },
                 })
             };
 
@@ -87,7 +72,7 @@ pub fn parse_type(type_name: &str) -> Option<Type> {
 
                 let kind = iter.next()?;
                 let size = iter.next()?;
-                let (_, width) = kind_width_parse(kind)?;
+                let Scalar { width, .. } = kind_width_parse(kind)?;
 
                 let (columns, rows) = if let Some(size) = size_parse(size) {
                     (size, size)
@@ -204,21 +189,24 @@ pub fn parse_type(type_name: &str) -> Option<Type> {
     }
 }
 
-pub const fn scalar_components(ty: &TypeInner) -> Option<(ScalarKind, Bytes)> {
+pub const fn scalar_components(ty: &TypeInner) -> Option<Scalar> {
     match *ty {
-        TypeInner::Scalar { kind, width } => Some((kind, width)),
-        TypeInner::Vector { kind, width, .. } => Some((kind, width)),
-        TypeInner::Matrix { width, .. } => Some((ScalarKind::Float, width)),
-        TypeInner::ValuePointer { kind, width, .. } => Some((kind, width)),
+        TypeInner::Scalar(scalar)
+        | TypeInner::Vector { scalar, .. }
+        | TypeInner::ValuePointer { scalar, .. } => Some(scalar),
+        TypeInner::Matrix { width, .. } => Some(Scalar {
+            kind: ScalarKind::Float,
+            width,
+        }),
         _ => None,
     }
 }
 
-pub const fn type_power(kind: ScalarKind, width: Bytes) -> Option<u32> {
-    Some(match kind {
+pub const fn type_power(scalar: Scalar) -> Option<u32> {
+    Some(match scalar.kind {
         ScalarKind::Sint => 0,
         ScalarKind::Uint => 1,
-        ScalarKind::Float if width == 4 => 2,
+        ScalarKind::Float if scalar.width == 4 => 2,
         ScalarKind::Float => 3,
         ScalarKind::Bool => return None,
     })

--- a/naga/src/front/glsl/variables.rs
+++ b/naga/src/front/glsl/variables.rs
@@ -6,8 +6,8 @@ use super::{
 };
 use crate::{
     AddressSpace, Binding, BuiltIn, Constant, Expression, GlobalVariable, Handle, Interpolation,
-    LocalVariable, ResourceBinding, ScalarKind, ShaderStage, SwizzleComponent, Type, TypeInner,
-    VectorSize,
+    LocalVariable, ResourceBinding, Scalar, ScalarKind, ShaderStage, SwizzleComponent, Type,
+    TypeInner, VectorSize,
 };
 
 pub struct VarDeclaration<'a, 'key> {
@@ -109,8 +109,7 @@ impl Frontend {
             "gl_Position" => BuiltInData {
                 inner: TypeInner::Vector {
                     size: VectorSize::Quad,
-                    kind: ScalarKind::Float,
-                    width: 4,
+                    scalar: Scalar::F32,
                 },
                 builtin: BuiltIn::Position { invariant: false },
                 mutable: true,
@@ -119,8 +118,7 @@ impl Frontend {
             "gl_FragCoord" => BuiltInData {
                 inner: TypeInner::Vector {
                     size: VectorSize::Quad,
-                    kind: ScalarKind::Float,
-                    width: 4,
+                    scalar: Scalar::F32,
                 },
                 builtin: BuiltIn::Position { invariant: false },
                 mutable: false,
@@ -129,8 +127,7 @@ impl Frontend {
             "gl_PointCoord" => BuiltInData {
                 inner: TypeInner::Vector {
                     size: VectorSize::Bi,
-                    kind: ScalarKind::Float,
-                    width: 4,
+                    scalar: Scalar::F32,
                 },
                 builtin: BuiltIn::PointCoord,
                 mutable: false,
@@ -143,8 +140,7 @@ impl Frontend {
             | "gl_LocalInvocationID" => BuiltInData {
                 inner: TypeInner::Vector {
                     size: VectorSize::Tri,
-                    kind: ScalarKind::Uint,
-                    width: 4,
+                    scalar: Scalar::U32,
                 },
                 builtin: match name {
                     "gl_GlobalInvocationID" => BuiltIn::GlobalInvocationId,
@@ -158,19 +154,13 @@ impl Frontend {
                 storage: StorageQualifier::Input,
             },
             "gl_FrontFacing" => BuiltInData {
-                inner: TypeInner::Scalar {
-                    kind: ScalarKind::Bool,
-                    width: crate::BOOL_WIDTH,
-                },
+                inner: TypeInner::Scalar(Scalar::BOOL),
                 builtin: BuiltIn::FrontFacing,
                 mutable: false,
                 storage: StorageQualifier::Input,
             },
             "gl_PointSize" | "gl_FragDepth" => BuiltInData {
-                inner: TypeInner::Scalar {
-                    kind: ScalarKind::Float,
-                    width: 4,
-                },
+                inner: TypeInner::Scalar(Scalar::F32),
                 builtin: match name {
                     "gl_PointSize" => BuiltIn::PointSize,
                     "gl_FragDepth" => BuiltIn::FragDepth,
@@ -183,10 +173,7 @@ impl Frontend {
                 let base = ctx.module.types.insert(
                     Type {
                         name: None,
-                        inner: TypeInner::Scalar {
-                            kind: ScalarKind::Float,
-                            width: 4,
-                        },
+                        inner: TypeInner::Scalar(Scalar::F32),
                     },
                     meta,
                 );
@@ -219,10 +206,7 @@ impl Frontend {
                 };
 
                 BuiltInData {
-                    inner: TypeInner::Scalar {
-                        kind: ScalarKind::Uint,
-                        width: 4,
-                    },
+                    inner: TypeInner::Scalar(Scalar::U32),
                     builtin,
                     mutable: false,
                     storage: StorageQualifier::Input,

--- a/naga/src/front/spv/image.rs
+++ b/naga/src/front/spv/image.rs
@@ -1,4 +1,7 @@
-use crate::arena::{Handle, UniqueArena};
+use crate::{
+    arena::{Handle, UniqueArena},
+    Scalar,
+};
 
 use super::{Error, LookupExpression, LookupHelper as _};
 
@@ -61,8 +64,11 @@ fn extract_image_coordinates(
     ctx: &mut super::BlockContext,
 ) -> (Handle<crate::Expression>, Option<Handle<crate::Expression>>) {
     let (given_size, kind) = match ctx.type_arena[coordinate_ty].inner {
-        crate::TypeInner::Scalar { kind, .. } => (None, kind),
-        crate::TypeInner::Vector { size, kind, .. } => (Some(size), kind),
+        crate::TypeInner::Scalar(Scalar { kind, .. }) => (None, kind),
+        crate::TypeInner::Vector {
+            size,
+            scalar: Scalar { kind, .. },
+        } => (Some(size), kind),
         ref other => unreachable!("Unexpected texture coordinate {:?}", other),
     };
 
@@ -73,8 +79,7 @@ fn extract_image_coordinates(
                 name: None,
                 inner: crate::TypeInner::Vector {
                     size,
-                    kind,
-                    width: 4,
+                    scalar: Scalar { kind, width: 4 },
                 },
             })
             .expect("Required coordinate type should have been set up by `parse_type_image`!")

--- a/naga/src/front/type_gen.rs
+++ b/naga/src/front/type_gen.rs
@@ -25,24 +25,17 @@ impl crate::Module {
             return handle;
         }
 
-        let width = 4;
         let ty_flag = self.types.insert(
             crate::Type {
                 name: None,
-                inner: crate::TypeInner::Scalar {
-                    width,
-                    kind: crate::ScalarKind::Uint,
-                },
+                inner: crate::TypeInner::Scalar(crate::Scalar::U32),
             },
             Span::UNDEFINED,
         );
         let ty_scalar = self.types.insert(
             crate::Type {
                 name: None,
-                inner: crate::TypeInner::Scalar {
-                    width,
-                    kind: crate::ScalarKind::Float,
-                },
+                inner: crate::TypeInner::Scalar(crate::Scalar::F32),
             },
             Span::UNDEFINED,
         );
@@ -51,8 +44,7 @@ impl crate::Module {
                 name: None,
                 inner: crate::TypeInner::Vector {
                     size: crate::VectorSize::Tri,
-                    kind: crate::ScalarKind::Float,
-                    width,
+                    scalar: crate::Scalar::F32,
                 },
             },
             Span::UNDEFINED,
@@ -127,24 +119,17 @@ impl crate::Module {
             return handle;
         }
 
-        let width = 4;
         let ty_flag = self.types.insert(
             crate::Type {
                 name: None,
-                inner: crate::TypeInner::Scalar {
-                    width,
-                    kind: crate::ScalarKind::Uint,
-                },
+                inner: crate::TypeInner::Scalar(crate::Scalar::U32),
             },
             Span::UNDEFINED,
         );
         let ty_scalar = self.types.insert(
             crate::Type {
                 name: None,
-                inner: crate::TypeInner::Scalar {
-                    width,
-                    kind: crate::ScalarKind::Float,
-                },
+                inner: crate::TypeInner::Scalar(crate::Scalar::F32),
             },
             Span::UNDEFINED,
         );
@@ -152,9 +137,8 @@ impl crate::Module {
             crate::Type {
                 name: None,
                 inner: crate::TypeInner::Vector {
-                    width,
                     size: crate::VectorSize::Bi,
-                    kind: crate::ScalarKind::Float,
+                    scalar: crate::Scalar::F32,
                 },
             },
             Span::UNDEFINED,
@@ -162,10 +146,7 @@ impl crate::Module {
         let ty_bool = self.types.insert(
             crate::Type {
                 name: None,
-                inner: crate::TypeInner::Scalar {
-                    width: crate::BOOL_WIDTH,
-                    kind: crate::ScalarKind::Bool,
-                },
+                inner: crate::TypeInner::Scalar(crate::Scalar::BOOL),
             },
             Span::UNDEFINED,
         );
@@ -175,7 +156,7 @@ impl crate::Module {
                 inner: crate::TypeInner::Matrix {
                     columns: crate::VectorSize::Quad,
                     rows: crate::VectorSize::Tri,
-                    width,
+                    width: 4,
                 },
             },
             Span::UNDEFINED,
@@ -277,28 +258,26 @@ impl crate::Module {
         }
 
         let ty = match special_type {
-            crate::PredeclaredType::AtomicCompareExchangeWeakResult { kind, width } => {
+            crate::PredeclaredType::AtomicCompareExchangeWeakResult(scalar) => {
                 let bool_ty = self.types.insert(
                     crate::Type {
                         name: None,
-                        inner: crate::TypeInner::Scalar {
-                            kind: crate::ScalarKind::Bool,
-                            width: crate::BOOL_WIDTH,
-                        },
+                        inner: crate::TypeInner::Scalar(crate::Scalar::BOOL),
                     },
                     Span::UNDEFINED,
                 );
                 let scalar_ty = self.types.insert(
                     crate::Type {
                         name: None,
-                        inner: crate::TypeInner::Scalar { kind, width },
+                        inner: crate::TypeInner::Scalar(scalar),
                     },
                     Span::UNDEFINED,
                 );
 
                 crate::Type {
                     name: Some(format!(
-                        "__atomic_compare_exchange_result<{kind:?},{width}>"
+                        "__atomic_compare_exchange_result<{:?},{}>",
+                        scalar.kind, scalar.width,
                     )),
                     inner: crate::TypeInner::Struct {
                         members: vec![
@@ -323,10 +302,7 @@ impl crate::Module {
                 let float_ty = self.types.insert(
                     crate::Type {
                         name: None,
-                        inner: crate::TypeInner::Scalar {
-                            kind: crate::ScalarKind::Float,
-                            width,
-                        },
+                        inner: crate::TypeInner::Scalar(crate::Scalar::float(width)),
                     },
                     Span::UNDEFINED,
                 );
@@ -337,8 +313,7 @@ impl crate::Module {
                             name: None,
                             inner: crate::TypeInner::Vector {
                                 size,
-                                kind: crate::ScalarKind::Float,
-                                width,
+                                scalar: crate::Scalar::float(width),
                             },
                         },
                         Span::UNDEFINED,
@@ -379,10 +354,7 @@ impl crate::Module {
                 let float_ty = self.types.insert(
                     crate::Type {
                         name: None,
-                        inner: crate::TypeInner::Scalar {
-                            kind: crate::ScalarKind::Float,
-                            width,
-                        },
+                        inner: crate::TypeInner::Scalar(crate::Scalar::float(width)),
                     },
                     Span::UNDEFINED,
                 );
@@ -390,10 +362,10 @@ impl crate::Module {
                 let int_ty = self.types.insert(
                     crate::Type {
                         name: None,
-                        inner: crate::TypeInner::Scalar {
+                        inner: crate::TypeInner::Scalar(crate::Scalar {
                             kind: crate::ScalarKind::Sint,
                             width,
-                        },
+                        }),
                     },
                     Span::UNDEFINED,
                 );
@@ -404,8 +376,7 @@ impl crate::Module {
                             name: None,
                             inner: crate::TypeInner::Vector {
                                 size,
-                                kind: crate::ScalarKind::Float,
-                                width,
+                                scalar: crate::Scalar::float(width),
                             },
                         },
                         Span::UNDEFINED,
@@ -415,8 +386,10 @@ impl crate::Module {
                             name: None,
                             inner: crate::TypeInner::Vector {
                                 size,
-                                kind: crate::ScalarKind::Sint,
-                                width,
+                                scalar: crate::Scalar {
+                                    kind: crate::ScalarKind::Sint,
+                                    width,
+                                },
                             },
                         },
                         Span::UNDEFINED,

--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -185,11 +185,11 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     ty_inner: &crate::TypeInner::Scalar { .. },
                     ..
                 },
-                Constructor::Type((_, &crate::TypeInner::Scalar { kind, width })),
+                Constructor::Type((_, &crate::TypeInner::Scalar(scalar))),
             ) => crate::Expression::As {
                 expr: component,
-                kind,
-                convert: Some(width),
+                kind: scalar.kind,
+                convert: Some(scalar.width),
             },
 
             // Vector conversion (vector -> vector)
@@ -203,14 +203,13 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     _,
                     &crate::TypeInner::Vector {
                         size: dst_size,
-                        kind: dst_kind,
-                        width: dst_width,
+                        scalar: dst_scalar,
                     },
                 )),
             ) if dst_size == src_size => crate::Expression::As {
                 expr: component,
-                kind: dst_kind,
-                convert: Some(dst_width),
+                kind: dst_scalar.kind,
+                convert: Some(dst_scalar.width),
             },
 
             // Vector conversion (vector -> vector) - partial
@@ -294,23 +293,17 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             (
                 Components::One {
                     component,
-                    ty_inner:
-                        &crate::TypeInner::Scalar {
-                            kind: src_kind,
-                            width: src_width,
-                            ..
-                        },
+                    ty_inner: &crate::TypeInner::Scalar(src_scalar),
                     ..
                 },
                 Constructor::Type((
                     _,
                     &crate::TypeInner::Vector {
                         size,
-                        kind: dst_kind,
-                        width: dst_width,
+                        scalar: dst_scalar,
                     },
                 )),
-            ) if dst_kind == src_kind || dst_width == src_width => crate::Expression::Splat {
+            ) if dst_scalar == src_scalar => crate::Expression::Splat {
                 size,
                 value: component,
             },
@@ -320,8 +313,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 Components::Many {
                     components,
                     first_component_ty_inner:
-                        &crate::TypeInner::Scalar { kind, width }
-                        | &crate::TypeInner::Vector { kind, width, .. },
+                        &crate::TypeInner::Scalar(scalar) | &crate::TypeInner::Vector { scalar, .. },
                     ..
                 },
                 Constructor::PartialVector { size },
@@ -333,9 +325,9 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         &crate::TypeInner::Scalar { .. } | &crate::TypeInner::Vector { .. },
                     ..
                 },
-                Constructor::Type((_, &crate::TypeInner::Vector { size, width, kind })),
+                Constructor::Type((_, &crate::TypeInner::Vector { size, scalar })),
             ) => {
-                let inner = crate::TypeInner::Vector { size, kind, width };
+                let inner = crate::TypeInner::Vector { size, scalar };
                 let ty = ctx.ensure_type_exists(inner);
                 crate::Expression::Compose { ty, components }
             }
@@ -344,7 +336,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             (
                 Components::Many {
                     components,
-                    first_component_ty_inner: &crate::TypeInner::Scalar { width, .. },
+                    first_component_ty_inner: &crate::TypeInner::Scalar(crate::Scalar { width, .. }),
                     ..
                 },
                 Constructor::PartialMatrix { columns, rows },
@@ -365,8 +357,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 )),
             ) => {
                 let vec_ty = ctx.ensure_type_exists(crate::TypeInner::Vector {
-                    width,
-                    kind: crate::ScalarKind::Float,
+                    scalar: crate::Scalar::float(width),
                     size: rows,
                 });
 
@@ -395,7 +386,11 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             (
                 Components::Many {
                     components,
-                    first_component_ty_inner: &crate::TypeInner::Vector { width, .. },
+                    first_component_ty_inner:
+                        &crate::TypeInner::Vector {
+                            scalar: crate::Scalar { width, .. },
+                            ..
+                        },
                     ..
                 },
                 Constructor::PartialMatrix { columns, rows },

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -307,10 +307,7 @@ impl Parser {
             "vec2f" => {
                 return Ok(Some(ast::ConstructorType::Vector {
                     size: crate::VectorSize::Bi,
-                    scalar: Scalar {
-                        kind: crate::ScalarKind::Float,
-                        width: 4,
-                    },
+                    scalar: Scalar::F32,
                 }))
             }
             "vec3" => ast::ConstructorType::PartialVector {
@@ -319,28 +316,19 @@ impl Parser {
             "vec3i" => {
                 return Ok(Some(ast::ConstructorType::Vector {
                     size: crate::VectorSize::Tri,
-                    scalar: Scalar {
-                        kind: crate::ScalarKind::Sint,
-                        width: 4,
-                    },
+                    scalar: Scalar::I32,
                 }))
             }
             "vec3u" => {
                 return Ok(Some(ast::ConstructorType::Vector {
                     size: crate::VectorSize::Tri,
-                    scalar: Scalar {
-                        kind: crate::ScalarKind::Uint,
-                        width: 4,
-                    },
+                    scalar: Scalar::U32,
                 }))
             }
             "vec3f" => {
                 return Ok(Some(ast::ConstructorType::Vector {
                     size: crate::VectorSize::Tri,
-                    scalar: Scalar {
-                        kind: crate::ScalarKind::Float,
-                        width: 4,
-                    },
+                    scalar: Scalar::F32,
                 }))
             }
             "vec4" => ast::ConstructorType::PartialVector {
@@ -349,28 +337,19 @@ impl Parser {
             "vec4i" => {
                 return Ok(Some(ast::ConstructorType::Vector {
                     size: crate::VectorSize::Quad,
-                    scalar: Scalar {
-                        kind: crate::ScalarKind::Sint,
-                        width: 4,
-                    },
+                    scalar: Scalar::I32,
                 }))
             }
             "vec4u" => {
                 return Ok(Some(ast::ConstructorType::Vector {
                     size: crate::VectorSize::Quad,
-                    scalar: Scalar {
-                        kind: crate::ScalarKind::Uint,
-                        width: 4,
-                    },
+                    scalar: Scalar::U32,
                 }))
             }
             "vec4f" => {
                 return Ok(Some(ast::ConstructorType::Vector {
                     size: crate::VectorSize::Quad,
-                    scalar: Scalar {
-                        kind: crate::ScalarKind::Float,
-                        width: 4,
-                    },
+                    scalar: Scalar::F32,
                 }))
             }
             "mat2x2" => ast::ConstructorType::PartialMatrix {
@@ -1109,10 +1088,7 @@ impl Parser {
             },
             "vec2f" => ast::Type::Vector {
                 size: crate::VectorSize::Bi,
-                scalar: Scalar {
-                    kind: crate::ScalarKind::Float,
-                    width: 4,
-                },
+                scalar: Scalar::F32,
             },
             "vec3" => {
                 let scalar = lexer.next_scalar_generic()?;
@@ -1137,10 +1113,7 @@ impl Parser {
             },
             "vec3f" => ast::Type::Vector {
                 size: crate::VectorSize::Tri,
-                scalar: Scalar {
-                    kind: crate::ScalarKind::Float,
-                    width: 4,
-                },
+                scalar: Scalar::F32,
             },
             "vec4" => {
                 let scalar = lexer.next_scalar_generic()?;
@@ -1165,10 +1138,7 @@ impl Parser {
             },
             "vec4f" => ast::Type::Vector {
                 size: crate::VectorSize::Quad,
-                scalar: Scalar {
-                    kind: crate::ScalarKind::Float,
-                    width: 4,
-                },
+                scalar: Scalar::F32,
             },
             "mat2x2" => {
                 self.matrix_scalar_type(lexer, crate::VectorSize::Bi, crate::VectorSize::Bi)?

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -472,6 +472,19 @@ pub enum ScalarKind {
     Bool,
 }
 
+/// Characteristics of a scalar type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct Scalar {
+    /// How the value's bits are to be interpreted.
+    pub kind: ScalarKind,
+
+    /// This size of the value in bytes.
+    pub width: Bytes,
+}
+
 /// Size of an array.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
@@ -677,13 +690,9 @@ pub struct Type {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum TypeInner {
     /// Number of integral or floating-point kind.
-    Scalar { kind: ScalarKind, width: Bytes },
+    Scalar(Scalar),
     /// Vector of numbers.
-    Vector {
-        size: VectorSize,
-        kind: ScalarKind,
-        width: Bytes,
-    },
+    Vector { size: VectorSize, scalar: Scalar },
     /// Matrix of floats.
     Matrix {
         columns: VectorSize,
@@ -691,7 +700,7 @@ pub enum TypeInner {
         width: Bytes,
     },
     /// Atomic scalar.
-    Atomic { kind: ScalarKind, width: Bytes },
+    Atomic(Scalar),
     /// Pointer to another type.
     ///
     /// Pointers to scalars and vectors should be treated as equivalent to
@@ -737,8 +746,7 @@ pub enum TypeInner {
     /// [`TypeResolution::Value`]: proc::TypeResolution::Value
     ValuePointer {
         size: Option<VectorSize>,
-        kind: ScalarKind,
-        width: Bytes,
+        scalar: Scalar,
         space: AddressSpace,
     },
 
@@ -1966,10 +1974,7 @@ pub struct EntryPoint {
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum PredeclaredType {
-    AtomicCompareExchangeWeakResult {
-        kind: ScalarKind,
-        width: Bytes,
-    },
+    AtomicCompareExchangeWeakResult(Scalar),
     ModfResult {
         size: Option<VectorSize>,
         width: Bytes,

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -404,7 +404,7 @@ impl<'a> ConstantEvaluator<'a> {
                 let expr = self.check_and_get(expr)?;
 
                 match convert {
-                    Some(width) => self.cast(expr, kind, width, span),
+                    Some(width) => self.cast(expr, crate::Scalar { kind, width }, span),
                     None => Err(ConstantEvaluatorError::NotImplemented(
                         "bitcast built-in function".into(),
                     )),
@@ -462,12 +462,11 @@ impl<'a> ConstantEvaluator<'a> {
     ) -> Result<Handle<Expression>, ConstantEvaluatorError> {
         match self.expressions[value] {
             Expression::Literal(literal) => {
-                let kind = literal.scalar_kind();
-                let width = literal.width();
+                let scalar = literal.scalar();
                 let ty = self.types.insert(
                     Type {
                         name: None,
-                        inner: TypeInner::Vector { size, kind, width },
+                        inner: TypeInner::Vector { size, scalar },
                     },
                     span,
                 );
@@ -479,7 +478,7 @@ impl<'a> ConstantEvaluator<'a> {
             }
             Expression::ZeroValue(ty) => {
                 let inner = match self.types[ty].inner {
-                    TypeInner::Scalar { kind, width } => TypeInner::Vector { size, kind, width },
+                    TypeInner::Scalar(scalar) => TypeInner::Vector { size, scalar },
                     _ => return Err(ConstantEvaluatorError::SplatScalarOnly),
                 };
                 let res_ty = self.types.insert(Type { name: None, inner }, span);
@@ -498,14 +497,10 @@ impl<'a> ConstantEvaluator<'a> {
         pattern: [crate::SwizzleComponent; 4],
     ) -> Result<Handle<Expression>, ConstantEvaluatorError> {
         let mut get_dst_ty = |ty| match self.types[ty].inner {
-            crate::TypeInner::Vector {
-                size: _,
-                kind,
-                width,
-            } => Ok(self.types.insert(
+            crate::TypeInner::Vector { size: _, scalar } => Ok(self.types.insert(
                 Type {
                     name: None,
-                    inner: crate::TypeInner::Vector { size, kind, width },
+                    inner: crate::TypeInner::Vector { size, scalar },
                 },
                 span,
             )),
@@ -611,7 +606,10 @@ impl<'a> ConstantEvaluator<'a> {
                 && matches!(
                     self.types[ty0].inner,
                     crate::TypeInner::Vector {
-                        kind: crate::ScalarKind::Float,
+                        scalar: crate::Scalar {
+                            kind: crate::ScalarKind::Float,
+                            ..
+                        },
                         ..
                     }
                 ) =>
@@ -709,7 +707,10 @@ impl<'a> ConstantEvaluator<'a> {
                 && matches!(
                     self.types[ty0].inner,
                     crate::TypeInner::Vector {
-                        kind: crate::ScalarKind::Float,
+                        scalar: crate::Scalar {
+                            kind: crate::ScalarKind::Float,
+                            ..
+                        },
                         ..
                     }
                 ) =>
@@ -831,10 +832,10 @@ impl<'a> ConstantEvaluator<'a> {
             Expression::ZeroValue(ty)
                 if matches!(
                     self.types[ty].inner,
-                    crate::TypeInner::Scalar {
+                    crate::TypeInner::Scalar(crate::Scalar {
                         kind: crate::ScalarKind::Uint,
                         ..
-                    }
+                    })
                 ) =>
             {
                 Ok(0)
@@ -873,18 +874,17 @@ impl<'a> ConstantEvaluator<'a> {
         span: Span,
     ) -> Result<Handle<Expression>, ConstantEvaluatorError> {
         match self.types[ty].inner {
-            TypeInner::Scalar { kind, width } => {
+            TypeInner::Scalar(scalar) => {
                 let expr = Expression::Literal(
-                    Literal::zero(kind, width)
-                        .ok_or(ConstantEvaluatorError::TypeNotConstructible)?,
+                    Literal::zero(scalar).ok_or(ConstantEvaluatorError::TypeNotConstructible)?,
                 );
                 self.register_evaluated_expr(expr, span)
             }
-            TypeInner::Vector { size, kind, width } => {
+            TypeInner::Vector { size, scalar } => {
                 let scalar_ty = self.types.insert(
                     Type {
                         name: None,
-                        inner: TypeInner::Scalar { kind, width },
+                        inner: TypeInner::Scalar(scalar),
                     },
                     span,
                 );
@@ -905,8 +905,10 @@ impl<'a> ConstantEvaluator<'a> {
                         name: None,
                         inner: TypeInner::Vector {
                             size: rows,
-                            kind: ScalarKind::Float,
-                            width,
+                            scalar: crate::Scalar {
+                                kind: ScalarKind::Float,
+                                width,
+                            },
                         },
                     },
                     span,
@@ -943,43 +945,57 @@ impl<'a> ConstantEvaluator<'a> {
         }
     }
 
-    /// Convert the scalar components of `expr` to `kind` and `target_width`.
+    /// Convert the scalar components of `expr` to `target`.
     ///
     /// Treat `span` as the location of the resulting expression.
     pub fn cast(
         &mut self,
         expr: Handle<Expression>,
-        kind: ScalarKind,
-        target_width: crate::Bytes,
+        target: crate::Scalar,
         span: Span,
     ) -> Result<Handle<Expression>, ConstantEvaluatorError> {
+        use crate::Scalar as Sc;
+        use crate::ScalarKind as Sk;
+
         let expr = self.eval_zero_value_and_splat(expr, span)?;
 
         let expr = match self.expressions[expr] {
             Expression::Literal(literal) => {
-                let literal = match (kind, target_width) {
-                    (ScalarKind::Sint, 4) => Literal::I32(match literal {
+                let literal = match target {
+                    Sc {
+                        kind: Sk::Sint,
+                        width: 4,
+                    } => Literal::I32(match literal {
                         Literal::I32(v) => v,
                         Literal::U32(v) => v as i32,
                         Literal::F32(v) => v as i32,
                         Literal::Bool(v) => v as i32,
                         Literal::F64(_) => return Err(ConstantEvaluatorError::InvalidCastArg),
                     }),
-                    (ScalarKind::Uint, 4) => Literal::U32(match literal {
+                    Sc {
+                        kind: Sk::Uint,
+                        width: 4,
+                    } => Literal::U32(match literal {
                         Literal::I32(v) => v as u32,
                         Literal::U32(v) => v,
                         Literal::F32(v) => v as u32,
                         Literal::Bool(v) => v as u32,
                         Literal::F64(_) => return Err(ConstantEvaluatorError::InvalidCastArg),
                     }),
-                    (ScalarKind::Float, 4) => Literal::F32(match literal {
+                    Sc {
+                        kind: Sk::Float,
+                        width: 4,
+                    } => Literal::F32(match literal {
                         Literal::I32(v) => v as f32,
                         Literal::U32(v) => v as f32,
                         Literal::F32(v) => v,
                         Literal::Bool(v) => v as u32 as f32,
                         Literal::F64(_) => return Err(ConstantEvaluatorError::InvalidCastArg),
                     }),
-                    (ScalarKind::Bool, crate::BOOL_WIDTH) => Literal::Bool(match literal {
+                    Sc {
+                        kind: Sk::Bool,
+                        width: crate::BOOL_WIDTH,
+                    } => Literal::Bool(match literal {
                         Literal::I32(v) => v != 0,
                         Literal::U32(v) => v != 0,
                         Literal::F32(v) => v != 0.0,
@@ -997,20 +1013,19 @@ impl<'a> ConstantEvaluator<'a> {
                 let ty_inner = match self.types[ty].inner {
                     TypeInner::Vector { size, .. } => TypeInner::Vector {
                         size,
-                        kind,
-                        width: target_width,
+                        scalar: target,
                     },
                     TypeInner::Matrix { columns, rows, .. } => TypeInner::Matrix {
                         columns,
                         rows,
-                        width: target_width,
+                        width: target.width,
                     },
                     _ => return Err(ConstantEvaluatorError::InvalidCastArg),
                 };
 
                 let mut components = src_components.clone();
                 for component in &mut components {
-                    *component = self.cast(*component, kind, target_width, span)?;
+                    *component = self.cast(*component, target, span)?;
                 }
 
                 let ty = self.types.insert(
@@ -1305,10 +1320,7 @@ mod tests {
         let scalar_ty = types.insert(
             Type {
                 name: None,
-                inner: TypeInner::Scalar {
-                    kind: ScalarKind::Sint,
-                    width: 4,
-                },
+                inner: TypeInner::Scalar(crate::Scalar::I32),
             },
             Default::default(),
         );
@@ -1318,8 +1330,10 @@ mod tests {
                 name: None,
                 inner: TypeInner::Vector {
                     size: VectorSize::Bi,
-                    kind: ScalarKind::Sint,
-                    width: 4,
+                    scalar: crate::Scalar {
+                        kind: ScalarKind::Sint,
+                        width: 4,
+                    },
                 },
             },
             Default::default(),
@@ -1441,10 +1455,7 @@ mod tests {
         let scalar_ty = types.insert(
             Type {
                 name: None,
-                inner: TypeInner::Scalar {
-                    kind: ScalarKind::Sint,
-                    width: 4,
-                },
+                inner: TypeInner::Scalar(crate::Scalar::I32),
             },
             Default::default(),
         );
@@ -1509,8 +1520,10 @@ mod tests {
                 name: None,
                 inner: TypeInner::Vector {
                     size: VectorSize::Tri,
-                    kind: ScalarKind::Float,
-                    width: 4,
+                    scalar: crate::Scalar {
+                        kind: ScalarKind::Float,
+                        width: 4,
+                    },
                 },
             },
             Default::default(),
@@ -1649,10 +1662,7 @@ mod tests {
         let i32_ty = types.insert(
             Type {
                 name: None,
-                inner: TypeInner::Scalar {
-                    kind: ScalarKind::Sint,
-                    width: 4,
-                },
+                inner: TypeInner::Scalar(crate::Scalar::I32),
             },
             Default::default(),
         );
@@ -1662,8 +1672,10 @@ mod tests {
                 name: None,
                 inner: TypeInner::Vector {
                     size: VectorSize::Bi,
-                    kind: ScalarKind::Sint,
-                    width: 4,
+                    scalar: crate::Scalar {
+                        kind: ScalarKind::Sint,
+                        width: 4,
+                    },
                 },
             },
             Default::default(),
@@ -1733,10 +1745,7 @@ mod tests {
         let i32_ty = types.insert(
             Type {
                 name: None,
-                inner: TypeInner::Scalar {
-                    kind: ScalarKind::Sint,
-                    width: 4,
-                },
+                inner: TypeInner::Scalar(crate::Scalar::I32),
             },
             Default::default(),
         );
@@ -1746,8 +1755,10 @@ mod tests {
                 name: None,
                 inner: TypeInner::Vector {
                     size: VectorSize::Bi,
-                    kind: ScalarKind::Sint,
-                    width: 4,
+                    scalar: crate::Scalar {
+                        kind: ScalarKind::Sint,
+                        width: 4,
+                    },
                 },
             },
             Default::default(),

--- a/naga/src/proc/layouter.rs
+++ b/naga/src/proc/layouter.rs
@@ -171,17 +171,16 @@ impl Layouter {
         for (ty_handle, ty) in gctx.types.iter().skip(self.layouts.len()) {
             let size = ty.inner.size(gctx);
             let layout = match ty.inner {
-                Ti::Scalar { width, .. } | Ti::Atomic { width, .. } => {
-                    let alignment = Alignment::new(width as u32)
+                Ti::Scalar(scalar) | Ti::Atomic(scalar) => {
+                    let alignment = Alignment::new(scalar.width as u32)
                         .ok_or(LayoutErrorInner::NonPowerOfTwoWidth.with(ty_handle))?;
                     TypeLayout { size, alignment }
                 }
                 Ti::Vector {
                     size: vec_size,
-                    width,
-                    ..
+                    scalar,
                 } => {
-                    let alignment = Alignment::new(width as u32)
+                    let alignment = Alignment::new(scalar.width as u32)
                         .ok_or(LayoutErrorInner::NonPowerOfTwoWidth.with(ty_handle))?;
                     TypeLayout {
                         size,

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -77,6 +77,52 @@ impl super::ScalarKind {
     }
 }
 
+impl super::Scalar {
+    pub const I32: Self = Self {
+        kind: crate::ScalarKind::Sint,
+        width: 4,
+    };
+    pub const U32: Self = Self {
+        kind: crate::ScalarKind::Uint,
+        width: 4,
+    };
+    pub const F32: Self = Self {
+        kind: crate::ScalarKind::Float,
+        width: 4,
+    };
+    pub const F64: Self = Self {
+        kind: crate::ScalarKind::Float,
+        width: 8,
+    };
+    pub const BOOL: Self = Self {
+        kind: crate::ScalarKind::Bool,
+        width: crate::BOOL_WIDTH,
+    };
+
+    /// Construct a float `Scalar` with the given width.
+    ///
+    /// This is especially common when dealing with
+    /// `TypeInner::Matrix`, where the scalar kind is implicit.
+    pub const fn float(width: crate::Bytes) -> Self {
+        Self {
+            kind: crate::ScalarKind::Float,
+            width,
+        }
+    }
+
+    pub const fn to_inner_scalar(self) -> crate::TypeInner {
+        crate::TypeInner::Scalar(self)
+    }
+
+    pub const fn to_inner_vector(self, size: crate::VectorSize) -> crate::TypeInner {
+        crate::TypeInner::Vector { size, scalar: self }
+    }
+
+    pub const fn to_inner_atomic(self) -> crate::TypeInner {
+        crate::TypeInner::Atomic(self)
+    }
+}
+
 impl PartialEq for crate::Literal {
     fn eq(&self, other: &Self) -> bool {
         match (*self, *other) {
@@ -118,8 +164,8 @@ impl std::hash::Hash for crate::Literal {
 }
 
 impl crate::Literal {
-    pub const fn new(value: u8, kind: crate::ScalarKind, width: crate::Bytes) -> Option<Self> {
-        match (value, kind, width) {
+    pub const fn new(value: u8, scalar: crate::Scalar) -> Option<Self> {
+        match (value, scalar.kind, scalar.width) {
             (value, crate::ScalarKind::Float, 8) => Some(Self::F64(value as _)),
             (value, crate::ScalarKind::Float, 4) => Some(Self::F32(value as _)),
             (value, crate::ScalarKind::Uint, 4) => Some(Self::U32(value as _)),
@@ -130,12 +176,12 @@ impl crate::Literal {
         }
     }
 
-    pub const fn zero(kind: crate::ScalarKind, width: crate::Bytes) -> Option<Self> {
-        Self::new(0, kind, width)
+    pub const fn zero(scalar: crate::Scalar) -> Option<Self> {
+        Self::new(0, scalar)
     }
 
-    pub const fn one(kind: crate::ScalarKind, width: crate::Bytes) -> Option<Self> {
-        Self::new(1, kind, width)
+    pub const fn one(scalar: crate::Scalar) -> Option<Self> {
+        Self::new(1, scalar)
     }
 
     pub const fn width(&self) -> crate::Bytes {
@@ -145,44 +191,41 @@ impl crate::Literal {
             Self::Bool(_) => 1,
         }
     }
-    pub const fn scalar_kind(&self) -> crate::ScalarKind {
+    pub const fn scalar(&self) -> crate::Scalar {
         match *self {
-            Self::F64(_) | Self::F32(_) => crate::ScalarKind::Float,
-            Self::U32(_) => crate::ScalarKind::Uint,
-            Self::I32(_) => crate::ScalarKind::Sint,
-            Self::Bool(_) => crate::ScalarKind::Bool,
+            crate::Literal::F64(_) => crate::Scalar::F64,
+            crate::Literal::F32(_) => crate::Scalar::F32,
+            crate::Literal::U32(_) => crate::Scalar::U32,
+            crate::Literal::I32(_) => crate::Scalar::I32,
+            crate::Literal::Bool(_) => crate::Scalar::BOOL,
         }
     }
+    pub const fn scalar_kind(&self) -> crate::ScalarKind {
+        self.scalar().kind
+    }
     pub const fn ty_inner(&self) -> crate::TypeInner {
-        crate::TypeInner::Scalar {
-            kind: self.scalar_kind(),
-            width: self.width(),
-        }
+        crate::TypeInner::Scalar(self.scalar())
     }
 }
 
 pub const POINTER_SPAN: u32 = 4;
 
 impl super::TypeInner {
-    pub const fn scalar_kind(&self) -> Option<super::ScalarKind> {
+    pub const fn scalar(&self) -> Option<super::Scalar> {
+        use crate::TypeInner as Ti;
         match *self {
-            super::TypeInner::Scalar { kind, .. } | super::TypeInner::Vector { kind, .. } => {
-                Some(kind)
-            }
-            super::TypeInner::Matrix { .. } => Some(super::ScalarKind::Float),
+            Ti::Scalar(scalar) | Ti::Vector { scalar, .. } => Some(scalar),
+            Ti::Matrix { width, .. } => Some(super::Scalar::float(width)),
             _ => None,
         }
     }
 
-    pub const fn scalar_width(&self) -> Option<u8> {
-        // Multiply by 8 to get the bit width
-        match *self {
-            super::TypeInner::Scalar { width, .. } | super::TypeInner::Vector { width, .. } => {
-                Some(width * 8)
-            }
-            super::TypeInner::Matrix { width, .. } => Some(width * 8),
-            _ => None,
-        }
+    pub fn scalar_kind(&self) -> Option<super::ScalarKind> {
+        self.scalar().map(|scalar| scalar.kind)
+    }
+
+    pub fn scalar_width(&self) -> Option<u8> {
+        self.scalar().map(|scalar| scalar.width * 8)
     }
 
     pub const fn pointer_space(&self) -> Option<crate::AddressSpace> {
@@ -206,12 +249,8 @@ impl super::TypeInner {
     /// Get the size of this type.
     pub fn size(&self, _gctx: GlobalCtx) -> u32 {
         match *self {
-            Self::Scalar { kind: _, width } | Self::Atomic { kind: _, width } => width as u32,
-            Self::Vector {
-                size,
-                kind: _,
-                width,
-            } => size as u32 * width as u32,
+            Self::Scalar(scalar) | Self::Atomic(scalar) => scalar.width as u32,
+            Self::Vector { size, scalar } => size as u32 * scalar.width as u32,
             // matrices are treated as arrays of aligned columns
             Self::Matrix {
                 columns,
@@ -255,16 +294,14 @@ impl super::TypeInner {
         use crate::TypeInner as Ti;
         match *self {
             Ti::Pointer { base, space } => match types[base].inner {
-                Ti::Scalar { kind, width } => Some(Ti::ValuePointer {
+                Ti::Scalar(scalar) => Some(Ti::ValuePointer {
                     size: None,
-                    kind,
-                    width,
+                    scalar,
                     space,
                 }),
-                Ti::Vector { size, kind, width } => Some(Ti::ValuePointer {
+                Ti::Vector { size, scalar } => Some(Ti::ValuePointer {
                     size: Some(size),
-                    kind,
-                    width,
+                    scalar,
                     space,
                 }),
                 _ => None,
@@ -318,13 +355,10 @@ impl super::TypeInner {
 
     pub fn component_type(&self, index: usize) -> Option<TypeResolution> {
         Some(match *self {
-            Self::Vector { kind, width, .. } => {
-                TypeResolution::Value(crate::TypeInner::Scalar { kind, width })
-            }
+            Self::Vector { scalar, .. } => TypeResolution::Value(crate::TypeInner::Scalar(scalar)),
             Self::Matrix { rows, width, .. } => TypeResolution::Value(crate::TypeInner::Vector {
                 size: rows,
-                kind: crate::ScalarKind::Float,
-                width,
+                scalar: crate::Scalar::float(width),
             }),
             Self::Array {
                 base,
@@ -628,7 +662,7 @@ impl GlobalCtx<'_> {
             match arena[handle] {
                 crate::Expression::Literal(literal) => Some(literal),
                 crate::Expression::ZeroValue(ty) => match gctx.types[ty].inner {
-                    crate::TypeInner::Scalar { kind, width } => crate::Literal::zero(kind, width),
+                    crate::TypeInner::Scalar(scalar) => crate::Literal::zero(scalar),
                     _ => None,
                 },
                 _ => None,

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -159,10 +159,10 @@ impl ExpressionInfo {
             ref_count: 0,
             assignable_global: None,
             // this doesn't matter at this point, will be overwritten
-            ty: TypeResolution::Value(crate::TypeInner::Scalar {
+            ty: TypeResolution::Value(crate::TypeInner::Scalar(crate::Scalar {
                 kind: crate::ScalarKind::Bool,
                 width: 0,
-            }),
+            })),
         }
     }
 }
@@ -1070,8 +1070,7 @@ fn uniform_control_flow() {
             name: None,
             inner: crate::TypeInner::Vector {
                 size: crate::VectorSize::Bi,
-                kind: crate::ScalarKind::Float,
-                width: 4,
+                scalar: crate::Scalar::F32,
             },
         },
         Default::default(),

--- a/naga/src/valid/compose.rs
+++ b/naga/src/valid/compose.rs
@@ -24,19 +24,15 @@ pub fn validate_compose(
 
     match gctx.types[self_ty_handle].inner {
         // vectors are composed from scalars or other vectors
-        Ti::Vector { size, kind, width } => {
+        Ti::Vector { size, scalar } => {
             let mut total = 0;
             for (index, comp_res) in component_resolutions.enumerate() {
                 total += match *comp_res.inner_with(gctx.types) {
-                    Ti::Scalar {
-                        kind: comp_kind,
-                        width: comp_width,
-                    } if comp_kind == kind && comp_width == width => 1,
+                    Ti::Scalar(comp_scalar) if comp_scalar == scalar => 1,
                     Ti::Vector {
                         size: comp_size,
-                        kind: comp_kind,
-                        width: comp_width,
-                    } if comp_kind == kind && comp_width == width => comp_size as u32,
+                        scalar: comp_scalar,
+                    } if comp_scalar == scalar => comp_size as u32,
                     ref other => {
                         log::error!("Vector component[{}] type {:?}", index, other);
                         return Err(ComposeError::ComponentType {
@@ -60,8 +56,7 @@ pub fn validate_compose(
         } => {
             let inner = Ti::Vector {
                 size: rows,
-                kind: crate::ScalarKind::Float,
-                width,
+                scalar: crate::Scalar::float(width),
             };
             if columns as usize != component_resolutions.len() {
                 return Err(ComposeError::ComponentCount {

--- a/naga/src/valid/handles.rs
+++ b/naga/src/valid/handles.rs
@@ -678,10 +678,7 @@ fn constant_deps() {
     let i32_handle = types.insert(
         Type {
             name: None,
-            inner: TypeInner::Scalar {
-                kind: crate::ScalarKind::Sint,
-                width: 4,
-            },
+            inner: TypeInner::Scalar(crate::Scalar::I32),
         },
         nowhere,
     );

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -142,9 +142,7 @@ impl VaryingContext<'_> {
         ty: Handle<crate::Type>,
         binding: &crate::Binding,
     ) -> Result<(), VaryingError> {
-        use crate::{
-            BuiltIn as Bi, ScalarKind as Sk, ShaderStage as St, TypeInner as Ti, VectorSize as Vs,
-        };
+        use crate::{BuiltIn as Bi, ShaderStage as St, TypeInner as Ti, VectorSize as Vs};
 
         let ty_inner = &self.types[ty].inner;
         match *binding {
@@ -174,44 +172,30 @@ impl VaryingContext<'_> {
                     return Err(VaryingError::UnsupportedCapability(required));
                 }
 
-                let width = 4;
                 let (visible, type_good) = match built_in {
                     Bi::BaseInstance | Bi::BaseVertex | Bi::InstanceIndex | Bi::VertexIndex => (
                         self.stage == St::Vertex && !self.output,
-                        *ty_inner
-                            == Ti::Scalar {
-                                kind: Sk::Uint,
-                                width,
-                            },
+                        *ty_inner == Ti::Scalar(crate::Scalar::U32),
                     ),
                     Bi::ClipDistance | Bi::CullDistance => (
                         self.stage == St::Vertex && self.output,
                         match *ty_inner {
                             Ti::Array { base, .. } => {
-                                self.types[base].inner
-                                    == Ti::Scalar {
-                                        kind: Sk::Float,
-                                        width,
-                                    }
+                                self.types[base].inner == Ti::Scalar(crate::Scalar::F32)
                             }
                             _ => false,
                         },
                     ),
                     Bi::PointSize => (
                         self.stage == St::Vertex && self.output,
-                        *ty_inner
-                            == Ti::Scalar {
-                                kind: Sk::Float,
-                                width,
-                            },
+                        *ty_inner == Ti::Scalar(crate::Scalar::F32),
                     ),
                     Bi::PointCoord => (
                         self.stage == St::Fragment && !self.output,
                         *ty_inner
                             == Ti::Vector {
                                 size: Vs::Bi,
-                                kind: Sk::Float,
-                                width,
+                                scalar: crate::Scalar::F32,
                             },
                     ),
                     Bi::Position { .. } => (
@@ -223,8 +207,7 @@ impl VaryingContext<'_> {
                         *ty_inner
                             == Ti::Vector {
                                 size: Vs::Quad,
-                                kind: Sk::Float,
-                                width,
+                                scalar: crate::Scalar::F32,
                             },
                     ),
                     Bi::ViewIndex => (
@@ -232,59 +215,31 @@ impl VaryingContext<'_> {
                             St::Vertex | St::Fragment => !self.output,
                             St::Compute => false,
                         },
-                        *ty_inner
-                            == Ti::Scalar {
-                                kind: Sk::Sint,
-                                width,
-                            },
+                        *ty_inner == Ti::Scalar(crate::Scalar::I32),
                     ),
                     Bi::FragDepth => (
                         self.stage == St::Fragment && self.output,
-                        *ty_inner
-                            == Ti::Scalar {
-                                kind: Sk::Float,
-                                width,
-                            },
+                        *ty_inner == Ti::Scalar(crate::Scalar::F32),
                     ),
                     Bi::FrontFacing => (
                         self.stage == St::Fragment && !self.output,
-                        *ty_inner
-                            == Ti::Scalar {
-                                kind: Sk::Bool,
-                                width: crate::BOOL_WIDTH,
-                            },
+                        *ty_inner == Ti::Scalar(crate::Scalar::BOOL),
                     ),
                     Bi::PrimitiveIndex => (
                         self.stage == St::Fragment && !self.output,
-                        *ty_inner
-                            == Ti::Scalar {
-                                kind: Sk::Uint,
-                                width,
-                            },
+                        *ty_inner == Ti::Scalar(crate::Scalar::U32),
                     ),
                     Bi::SampleIndex => (
                         self.stage == St::Fragment && !self.output,
-                        *ty_inner
-                            == Ti::Scalar {
-                                kind: Sk::Uint,
-                                width,
-                            },
+                        *ty_inner == Ti::Scalar(crate::Scalar::U32),
                     ),
                     Bi::SampleMask => (
                         self.stage == St::Fragment,
-                        *ty_inner
-                            == Ti::Scalar {
-                                kind: Sk::Uint,
-                                width,
-                            },
+                        *ty_inner == Ti::Scalar(crate::Scalar::U32),
                     ),
                     Bi::LocalInvocationIndex => (
                         self.stage == St::Compute && !self.output,
-                        *ty_inner
-                            == Ti::Scalar {
-                                kind: Sk::Uint,
-                                width,
-                            },
+                        *ty_inner == Ti::Scalar(crate::Scalar::U32),
                     ),
                     Bi::GlobalInvocationId
                     | Bi::LocalInvocationId
@@ -295,8 +250,7 @@ impl VaryingContext<'_> {
                         *ty_inner
                             == Ti::Vector {
                                 size: Vs::Tri,
-                                kind: Sk::Uint,
-                                width,
+                                scalar: crate::Scalar::U32,
                             },
                     ),
                 };

--- a/naga/tests/out/analysis/access.info.ron
+++ b/naga/tests/out/analysis/access.info.ron
@@ -55,10 +55,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -79,10 +79,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -168,8 +168,10 @@
                     assignable_global: Some(3),
                     ty: Value(ValuePointer(
                         size: Some(Bi),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -182,8 +184,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -228,8 +232,10 @@
                     assignable_global: Some(3),
                     ty: Value(ValuePointer(
                         size: Some(Bi),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -242,8 +248,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -279,8 +287,10 @@
                     assignable_global: Some(3),
                     ty: Value(ValuePointer(
                         size: Some(Bi),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -293,8 +303,10 @@
                     assignable_global: Some(3),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -305,10 +317,10 @@
                     ),
                     ref_count: 0,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -343,163 +355,10 @@
                     assignable_global: Some(3),
                     ty: Value(ValuePointer(
                         size: Some(Bi),
-                        kind: Float,
-                        width: 4,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Handle(3),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(3),
-                    ty: Value(ValuePointer(
-                        size: None,
-                        kind: Float,
-                        width: 4,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 0,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(3),
-                    ty: Value(Pointer(
-                        base: 16,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(3),
-                    ty: Value(Pointer(
-                        base: 15,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Handle(3),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(3),
-                    ty: Value(ValuePointer(
-                        size: Some(Bi),
-                        kind: Float,
-                        width: 4,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(3),
-                    ty: Value(ValuePointer(
-                        size: None,
-                        kind: Float,
-                        width: 4,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 0,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(3),
-                    ty: Value(Pointer(
-                        base: 16,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(3),
-                    ty: Value(Pointer(
-                        base: 15,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Handle(3),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(3),
-                    ty: Value(ValuePointer(
-                        size: Some(Bi),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -521,8 +380,10 @@
                     assignable_global: Some(3),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -533,9 +394,21 @@
                     ),
                     ref_count: 0,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(3),
+                    ty: Value(Pointer(
+                        base: 16,
+                        space: Uniform,
                     )),
                 ),
                 (
@@ -544,11 +417,162 @@
                         requirements: (""),
                     ),
                     ref_count: 1,
+                    assignable_global: Some(3),
+                    ty: Value(Pointer(
+                        base: 15,
+                        space: Uniform,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Handle(3),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(3),
+                    ty: Value(ValuePointer(
+                        size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Uniform,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(3),
+                    ty: Value(ValuePointer(
+                        size: None,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Uniform,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 0,
+                    assignable_global: None,
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(3),
+                    ty: Value(Pointer(
+                        base: 16,
+                        space: Uniform,
                     )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(3),
+                    ty: Value(Pointer(
+                        base: 15,
+                        space: Uniform,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(3),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(3),
+                    ty: Value(ValuePointer(
+                        size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Uniform,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(3),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(3),
+                    ty: Value(ValuePointer(
+                        size: None,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Uniform,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 0,
+                    assignable_global: None,
+                    ty: Value(Scalar((
+                        kind: Float,
+                        width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
+                        kind: Float,
+                        width: 4,
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -559,8 +583,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -570,35 +596,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Vector(
-                        size: Bi,
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -609,8 +610,37 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Vector(
+                        size: Bi,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -650,10 +680,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -692,10 +722,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -706,8 +736,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -717,35 +749,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Vector(
-                        size: Bi,
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -756,8 +763,37 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Vector(
+                        size: Bi,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -790,8 +826,10 @@
                     assignable_global: None,
                     ty: Value(ValuePointer(
                         size: Some(Bi),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Function,
                     )),
                 ),
@@ -802,70 +840,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Vector(
-                        size: Bi,
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(50),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Pointer(
-                        base: 15,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Handle(3),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(50),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(ValuePointer(
-                        size: Some(Bi),
-                        kind: Float,
-                        width: 4,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -876,121 +854,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(50),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Pointer(
-                        base: 15,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(50),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(ValuePointer(
-                        size: Some(Bi),
-                        kind: Float,
-                        width: 4,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(50),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(ValuePointer(
-                        size: None,
-                        kind: Float,
-                        width: 4,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(50),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Pointer(
-                        base: 15,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(50),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(ValuePointer(
-                        size: Some(Bi),
-                        kind: Float,
-                        width: 4,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Handle(3),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(50),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(ValuePointer(
-                        size: None,
-                        kind: Float,
-                        width: 4,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -1023,8 +890,65 @@
                     assignable_global: None,
                     ty: Value(ValuePointer(
                         size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Vector(
+                        size: Bi,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(50),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 15,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(50),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(ValuePointer(
+                        size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Function,
                     )),
                 ),
@@ -1037,8 +961,10 @@
                     assignable_global: None,
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Function,
                     )),
                 ),
@@ -1049,10 +975,75 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(50),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 15,
+                        space: Function,
                     )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(50),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(ValuePointer(
+                        size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(3),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(50),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(ValuePointer(
+                        size: None,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
+                        kind: Float,
+                        width: 4,
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1084,8 +1075,75 @@
                     assignable_global: None,
                     ty: Value(ValuePointer(
                         size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(50),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(ValuePointer(
+                        size: None,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(50),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 15,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(3),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(50),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(ValuePointer(
+                        size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Function,
                     )),
                 ),
@@ -1107,8 +1165,10 @@
                     assignable_global: None,
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Function,
                     )),
                 ),
@@ -1119,10 +1179,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
             ],
             sampling: [],
@@ -1152,10 +1212,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1176,10 +1236,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1322,8 +1382,10 @@
                     assignable_global: Some(5),
                     ty: Value(ValuePointer(
                         size: Some(Bi),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -1336,8 +1398,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -1394,8 +1458,10 @@
                     assignable_global: Some(5),
                     ty: Value(ValuePointer(
                         size: Some(Bi),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -1408,8 +1474,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -1457,8 +1525,10 @@
                     assignable_global: Some(5),
                     ty: Value(ValuePointer(
                         size: Some(Bi),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -1471,8 +1541,10 @@
                     assignable_global: Some(5),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -1483,10 +1555,10 @@
                     ),
                     ref_count: 0,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1533,8 +1605,10 @@
                     assignable_global: Some(5),
                     ty: Value(ValuePointer(
                         size: Some(Bi),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -1556,8 +1630,10 @@
                     assignable_global: Some(5),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -1568,95 +1644,10 @@
                     ),
                     ref_count: 0,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(5),
-                    ty: Value(Pointer(
-                        base: 20,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(5),
-                    ty: Value(Pointer(
-                        base: 19,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(5),
-                    ty: Value(Pointer(
-                        base: 18,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Handle(3),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(5),
-                    ty: Value(ValuePointer(
-                        size: Some(Bi),
-                        kind: Float,
-                        width: 4,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(5),
-                    ty: Value(ValuePointer(
-                        size: None,
-                        kind: Float,
-                        width: 4,
-                        space: Uniform,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 0,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1712,8 +1703,99 @@
                     assignable_global: Some(5),
                     ty: Value(ValuePointer(
                         size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Uniform,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(5),
+                    ty: Value(ValuePointer(
+                        size: None,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Uniform,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 0,
+                    assignable_global: None,
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(5),
+                    ty: Value(Pointer(
+                        base: 20,
+                        space: Uniform,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(5),
+                    ty: Value(Pointer(
+                        base: 19,
+                        space: Uniform,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(5),
+                    ty: Value(Pointer(
+                        base: 18,
+                        space: Uniform,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(3),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(5),
+                    ty: Value(ValuePointer(
+                        size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -1735,8 +1817,10 @@
                     assignable_global: Some(5),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -1747,10 +1831,10 @@
                     ),
                     ref_count: 0,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1789,10 +1873,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1864,10 +1948,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1878,8 +1962,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -1889,35 +1975,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Vector(
-                        size: Bi,
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1928,8 +1989,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -1939,10 +2002,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1953,8 +2016,37 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Vector(
+                        size: Bi,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -1999,8 +2091,10 @@
                     assignable_global: None,
                     ty: Value(ValuePointer(
                         size: Some(Bi),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Function,
                     )),
                 ),
@@ -2011,82 +2105,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Vector(
-                        size: Bi,
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(54),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Pointer(
-                        base: 19,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(54),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Pointer(
-                        base: 18,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Handle(3),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(54),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(ValuePointer(
-                        size: Some(Bi),
-                        kind: Float,
-                        width: 4,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -2097,145 +2119,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(54),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Pointer(
-                        base: 19,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(54),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Pointer(
-                        base: 18,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(54),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(ValuePointer(
-                        size: Some(Bi),
-                        kind: Float,
-                        width: 4,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(54),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(ValuePointer(
-                        size: None,
-                        kind: Float,
-                        width: 4,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(54),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Pointer(
-                        base: 19,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(54),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Pointer(
-                        base: 18,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(54),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(ValuePointer(
-                        size: Some(Bi),
-                        kind: Float,
-                        width: 4,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(2),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Handle(3),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: Some(54),
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(ValuePointer(
-                        size: None,
-                        kind: Float,
-                        width: 4,
-                        space: Function,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -2280,8 +2167,77 @@
                     assignable_global: None,
                     ty: Value(ValuePointer(
                         size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Vector(
+                        size: Bi,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(54),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 19,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(54),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 18,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(54),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(ValuePointer(
+                        size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Function,
                     )),
                 ),
@@ -2294,8 +2250,10 @@
                     assignable_global: None,
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Function,
                     )),
                 ),
@@ -2306,10 +2264,87 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(54),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 19,
+                        space: Function,
                     )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(54),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 18,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(54),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(ValuePointer(
+                        size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(3),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(54),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(ValuePointer(
+                        size: None,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
+                        kind: Float,
+                        width: 4,
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -2353,8 +2388,87 @@
                     assignable_global: None,
                     ty: Value(ValuePointer(
                         size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(54),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(ValuePointer(
+                        size: None,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(54),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 19,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(54),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 18,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(3),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(54),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(ValuePointer(
+                        size: Some(Bi),
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Function,
                     )),
                 ),
@@ -2376,8 +2490,10 @@
                     assignable_global: None,
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Function,
                     )),
                 ),
@@ -2388,10 +2504,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
             ],
             sampling: [],
@@ -2517,10 +2633,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
             ],
             sampling: [],
@@ -2559,10 +2675,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -2573,8 +2689,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Quad,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -2584,10 +2702,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -2598,8 +2716,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Quad,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -2650,10 +2770,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -2683,10 +2803,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -2769,10 +2889,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -2811,8 +2931,10 @@
                     assignable_global: Some(2),
                     ty: Value(ValuePointer(
                         size: Some(Tri),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Storage(
                             access: ("LOAD | STORE"),
                         ),
@@ -2827,8 +2949,10 @@
                     assignable_global: Some(2),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Storage(
                             access: ("LOAD | STORE"),
                         ),
@@ -2841,10 +2965,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -2909,10 +3033,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -2921,10 +3045,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -2933,10 +3057,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3070,10 +3194,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3082,10 +3206,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3094,10 +3218,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3106,10 +3230,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3139,10 +3263,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3172,10 +3296,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3225,8 +3349,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Quad,
-                        kind: Sint,
-                        width: 4,
+                        scalar: (
+                            kind: Sint,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -3238,8 +3364,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Quad,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -3251,8 +3379,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Tri,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -3262,10 +3392,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3334,8 +3464,10 @@
                     assignable_global: Some(2),
                     ty: Value(ValuePointer(
                         size: Some(Tri),
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Storage(
                             access: ("LOAD | STORE"),
                         ),
@@ -3350,8 +3482,10 @@
                     assignable_global: Some(2),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Storage(
                             access: ("LOAD | STORE"),
                         ),
@@ -3364,10 +3498,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3404,10 +3538,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3418,8 +3552,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Tri,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -3429,35 +3565,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Vector(
-                        size: Tri,
-                        kind: Float,
-                        width: 4,
-                    )),
-                ),
-                (
-                    uniformity: (
-                        non_uniform_result: None,
-                        requirements: (""),
-                    ),
-                    ref_count: 1,
-                    assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Float,
-                        width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3468,8 +3579,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Tri,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -3479,10 +3592,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3493,8 +3606,37 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Tri,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Vector(
+                        size: Tri,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -3541,10 +3683,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3555,8 +3697,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Uint,
-                        width: 4,
+                        scalar: (
+                            kind: Uint,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -3566,10 +3710,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3580,8 +3724,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Uint,
-                        width: 4,
+                        scalar: (
+                            kind: Uint,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -3656,10 +3802,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3691,10 +3837,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3705,8 +3851,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Quad,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
             ],
@@ -3737,10 +3885,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3761,10 +3909,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3775,8 +3923,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Quad,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -3786,10 +3936,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -3800,8 +3950,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Quad,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -3831,27 +3983,27 @@
         ),
     ],
     const_expression_types: [
-        Value(Scalar(
+        Value(Scalar((
             kind: Uint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Uint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Uint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Uint,
             width: 4,
-        )),
+        ))),
         Handle(2),
-        Value(Scalar(
+        Value(Scalar((
             kind: Sint,
             width: 4,
-        )),
+        ))),
         Handle(4),
     ],
 )

--- a/naga/tests/out/analysis/collatz.info.ron
+++ b/naga/tests/out/analysis/collatz.info.ron
@@ -47,10 +47,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -80,10 +80,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -92,10 +92,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Bool,
                         width: 1,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -113,10 +113,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -134,10 +134,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -146,10 +146,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Bool,
                         width: 1,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -167,10 +167,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -188,10 +188,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -218,10 +218,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -248,10 +248,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -334,10 +334,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -388,10 +388,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (

--- a/naga/tests/out/analysis/shadow.info.ron
+++ b/naga/tests/out/analysis/shadow.info.ron
@@ -119,10 +119,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -131,10 +131,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Bool,
                         width: 1,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -143,10 +143,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -155,10 +155,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -194,10 +194,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -226,8 +226,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Bi,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -246,10 +248,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -258,10 +260,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -270,10 +272,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -282,10 +284,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -303,10 +305,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -315,10 +317,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -345,10 +347,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -357,10 +359,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -378,10 +380,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -390,10 +392,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Sint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -402,10 +404,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
             ],
             sampling: [],
@@ -695,8 +697,10 @@
                     assignable_global: Some(3),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Uint,
-                        width: 4,
+                        scalar: (
+                            kind: Uint,
+                            width: 4,
+                        ),
                         space: Uniform,
                     )),
                 ),
@@ -707,10 +711,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -719,10 +723,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Uint,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -731,10 +735,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Bool,
                         width: 1,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -832,8 +836,10 @@
                     assignable_global: None,
                     ty: Value(Vector(
                         size: Quad,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                     )),
                 ),
                 (
@@ -923,8 +929,10 @@
                     assignable_global: Some(4),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Storage(
                             access: ("LOAD"),
                         ),
@@ -937,10 +945,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1002,8 +1010,10 @@
                     assignable_global: Some(4),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Storage(
                             access: ("LOAD"),
                         ),
@@ -1016,10 +1026,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1081,8 +1091,10 @@
                     assignable_global: Some(4),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Storage(
                             access: ("LOAD"),
                         ),
@@ -1095,10 +1107,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1118,8 +1130,10 @@
                     assignable_global: Some(5),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Private,
                     )),
                 ),
@@ -1130,10 +1144,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1144,8 +1158,10 @@
                     assignable_global: Some(5),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Private,
                     )),
                 ),
@@ -1156,10 +1172,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1170,8 +1186,10 @@
                     assignable_global: Some(5),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Private,
                     )),
                 ),
@@ -1182,10 +1200,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1221,10 +1239,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1304,8 +1322,10 @@
                     assignable_global: Some(4),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Storage(
                             access: ("LOAD"),
                         ),
@@ -1318,10 +1338,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1383,8 +1403,10 @@
                     assignable_global: Some(4),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Storage(
                             access: ("LOAD"),
                         ),
@@ -1397,10 +1419,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1462,8 +1484,10 @@
                     assignable_global: Some(4),
                     ty: Value(ValuePointer(
                         size: None,
-                        kind: Float,
-                        width: 4,
+                        scalar: (
+                            kind: Float,
+                            width: 4,
+                        ),
                         space: Storage(
                             access: ("LOAD"),
                         ),
@@ -1476,10 +1500,10 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
+                    ty: Value(Scalar((
                         kind: Float,
                         width: 4,
-                    )),
+                    ))),
                 ),
                 (
                     uniformity: (
@@ -1643,81 +1667,81 @@
         ),
     ],
     const_expression_types: [
-        Value(Scalar(
+        Value(Scalar((
             kind: Float,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Float,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Float,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Float,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Float,
             width: 4,
-        )),
+        ))),
         Handle(1),
         Handle(1),
         Handle(1),
         Handle(2),
-        Value(Scalar(
+        Value(Scalar((
             kind: Uint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Uint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Uint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Sint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Sint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Sint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Sint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Sint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Sint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Sint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Sint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Sint,
             width: 4,
-        )),
-        Value(Scalar(
+        ))),
+        Value(Scalar((
             kind: Sint,
             width: 4,
-        )),
+        ))),
     ],
 )

--- a/naga/tests/out/ir/access.compact.ron
+++ b/naga/tests/out/ir/access.compact.ron
@@ -2,25 +2,27 @@
     types: [
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Uint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
             inner: Vector(
                 size: Tri,
-                kind: Uint,
-                width: 4,
+                scalar: (
+                    kind: Uint,
+                    width: 4,
+                ),
             ),
         ),
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Sint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: Some("GlobalConst"),
@@ -88,10 +90,10 @@
         ),
         (
             name: None,
-            inner: Atomic(
+            inner: Atomic((
                 kind: Sint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
@@ -105,8 +107,10 @@
             name: None,
             inner: Vector(
                 size: Bi,
-                kind: Uint,
-                width: 4,
+                scalar: (
+                    kind: Uint,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -195,8 +199,10 @@
             name: None,
             inner: Vector(
                 size: Bi,
-                kind: Sint,
-                width: 4,
+                scalar: (
+                    kind: Sint,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -231,10 +237,10 @@
         ),
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Float,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
@@ -263,8 +269,10 @@
             name: None,
             inner: Vector(
                 size: Quad,
-                kind: Float,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (

--- a/naga/tests/out/ir/access.ron
+++ b/naga/tests/out/ir/access.ron
@@ -2,25 +2,27 @@
     types: [
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Uint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
             inner: Vector(
                 size: Tri,
-                kind: Uint,
-                width: 4,
+                scalar: (
+                    kind: Uint,
+                    width: 4,
+                ),
             ),
         ),
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Sint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: Some("GlobalConst"),
@@ -88,10 +90,10 @@
         ),
         (
             name: None,
-            inner: Atomic(
+            inner: Atomic((
                 kind: Sint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
@@ -105,8 +107,10 @@
             name: None,
             inner: Vector(
                 size: Bi,
-                kind: Uint,
-                width: 4,
+                scalar: (
+                    kind: Uint,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -195,16 +199,20 @@
             name: None,
             inner: Vector(
                 size: Bi,
-                kind: Sint,
-                width: 4,
+                scalar: (
+                    kind: Sint,
+                    width: 4,
+                ),
             ),
         ),
         (
             name: None,
             inner: Vector(
                 size: Bi,
-                kind: Float,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -239,10 +247,10 @@
         ),
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Float,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
@@ -271,8 +279,10 @@
             name: None,
             inner: Vector(
                 size: Quad,
-                kind: Float,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -296,16 +306,20 @@
             name: None,
             inner: Vector(
                 size: Quad,
-                kind: Sint,
-                width: 4,
+                scalar: (
+                    kind: Sint,
+                    width: 4,
+                ),
             ),
         ),
         (
             name: None,
             inner: Vector(
                 size: Tri,
-                kind: Float,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (

--- a/naga/tests/out/ir/collatz.compact.ron
+++ b/naga/tests/out/ir/collatz.compact.ron
@@ -2,10 +2,10 @@
     types: [
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Uint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
@@ -33,8 +33,10 @@
             name: None,
             inner: Vector(
                 size: Tri,
-                kind: Uint,
-                width: 4,
+                scalar: (
+                    kind: Uint,
+                    width: 4,
+                ),
             ),
         ),
     ],

--- a/naga/tests/out/ir/collatz.ron
+++ b/naga/tests/out/ir/collatz.ron
@@ -2,10 +2,10 @@
     types: [
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Uint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
@@ -33,8 +33,10 @@
             name: None,
             inner: Vector(
                 size: Tri,
-                kind: Uint,
-                width: 4,
+                scalar: (
+                    kind: Uint,
+                    width: 4,
+                ),
             ),
         ),
     ],

--- a/naga/tests/out/ir/shadow.compact.ron
+++ b/naga/tests/out/ir/shadow.compact.ron
@@ -2,40 +2,46 @@
     types: [
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Float,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
             inner: Vector(
                 size: Tri,
-                kind: Float,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Uint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
             inner: Vector(
                 size: Quad,
-                kind: Float,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
             name: None,
             inner: Vector(
                 size: Bi,
-                kind: Float,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -50,17 +56,19 @@
         ),
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Sint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
             inner: Vector(
                 size: Quad,
-                kind: Uint,
-                width: 4,
+                scalar: (
+                    kind: Uint,
+                    width: 4,
+                ),
             ),
         ),
         (

--- a/naga/tests/out/ir/shadow.ron
+++ b/naga/tests/out/ir/shadow.ron
@@ -2,47 +2,53 @@
     types: [
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Float,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
             inner: Vector(
                 size: Tri,
-                kind: Float,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Uint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
             inner: Vector(
                 size: Quad,
-                kind: Float,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Bool,
                 width: 1,
-            ),
+            )),
         ),
         (
             name: None,
             inner: Vector(
                 size: Bi,
-                kind: Float,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -63,10 +69,10 @@
         ),
         (
             name: None,
-            inner: Scalar(
+            inner: Scalar((
                 kind: Sint,
                 width: 4,
-            ),
+            )),
         ),
         (
             name: None,
@@ -86,8 +92,10 @@
             name: None,
             inner: Vector(
                 size: Quad,
-                kind: Uint,
-                width: 4,
+                scalar: (
+                    kind: Uint,
+                    width: 4,
+                ),
             ),
         ),
         (

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1463,33 +1463,27 @@ impl super::Queue {
                     //
                     // --- Float 1-4 Component ---
                     //
-                    naga::TypeInner::Scalar {
-                        kind: naga::ScalarKind::Float,
-                        width: 4,
-                    } => {
+                    naga::TypeInner::Scalar(naga::Scalar::F32) => {
                         let data = unsafe { get_data::<f32, 1>(data_bytes, offset)[0] };
                         unsafe { gl.uniform_1_f32(location, data) };
                     }
                     naga::TypeInner::Vector {
-                        kind: naga::ScalarKind::Float,
                         size: naga::VectorSize::Bi,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         let data = unsafe { get_data::<f32, 2>(data_bytes, offset) };
                         unsafe { gl.uniform_2_f32_slice(location, data) };
                     }
                     naga::TypeInner::Vector {
-                        kind: naga::ScalarKind::Float,
                         size: naga::VectorSize::Tri,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         let data = unsafe { get_data::<f32, 3>(data_bytes, offset) };
                         unsafe { gl.uniform_3_f32_slice(location, data) };
                     }
                     naga::TypeInner::Vector {
-                        kind: naga::ScalarKind::Float,
                         size: naga::VectorSize::Quad,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         let data = unsafe { get_data::<f32, 4>(data_bytes, offset) };
                         unsafe { gl.uniform_4_f32_slice(location, data) };
@@ -1498,33 +1492,27 @@ impl super::Queue {
                     //
                     // --- Int 1-4 Component ---
                     //
-                    naga::TypeInner::Scalar {
-                        kind: naga::ScalarKind::Sint,
-                        width: 4,
-                    } => {
+                    naga::TypeInner::Scalar(naga::Scalar::I32) => {
                         let data = unsafe { get_data::<i32, 1>(data_bytes, offset)[0] };
                         unsafe { gl.uniform_1_i32(location, data) };
                     }
                     naga::TypeInner::Vector {
-                        kind: naga::ScalarKind::Sint,
                         size: naga::VectorSize::Bi,
-                        width: 4,
+                        scalar: naga::Scalar::I32,
                     } => {
                         let data = unsafe { get_data::<i32, 2>(data_bytes, offset) };
                         unsafe { gl.uniform_2_i32_slice(location, data) };
                     }
                     naga::TypeInner::Vector {
-                        kind: naga::ScalarKind::Sint,
                         size: naga::VectorSize::Tri,
-                        width: 4,
+                        scalar: naga::Scalar::I32,
                     } => {
                         let data = unsafe { get_data::<i32, 3>(data_bytes, offset) };
                         unsafe { gl.uniform_3_i32_slice(location, data) };
                     }
                     naga::TypeInner::Vector {
-                        kind: naga::ScalarKind::Sint,
                         size: naga::VectorSize::Quad,
-                        width: 4,
+                        scalar: naga::Scalar::I32,
                     } => {
                         let data = unsafe { get_data::<i32, 4>(data_bytes, offset) };
                         unsafe { gl.uniform_4_i32_slice(location, data) };
@@ -1533,33 +1521,27 @@ impl super::Queue {
                     //
                     // --- Uint 1-4 Component ---
                     //
-                    naga::TypeInner::Scalar {
-                        kind: naga::ScalarKind::Uint,
-                        width: 4,
-                    } => {
+                    naga::TypeInner::Scalar(naga::Scalar::U32) => {
                         let data = unsafe { get_data::<u32, 1>(data_bytes, offset)[0] };
                         unsafe { gl.uniform_1_u32(location, data) };
                     }
                     naga::TypeInner::Vector {
-                        kind: naga::ScalarKind::Uint,
                         size: naga::VectorSize::Bi,
-                        width: 4,
+                        scalar: naga::Scalar::U32,
                     } => {
                         let data = unsafe { get_data::<u32, 2>(data_bytes, offset) };
                         unsafe { gl.uniform_2_u32_slice(location, data) };
                     }
                     naga::TypeInner::Vector {
-                        kind: naga::ScalarKind::Uint,
                         size: naga::VectorSize::Tri,
-                        width: 4,
+                        scalar: naga::Scalar::U32,
                     } => {
                         let data = unsafe { get_data::<u32, 3>(data_bytes, offset) };
                         unsafe { gl.uniform_3_u32_slice(location, data) };
                     }
                     naga::TypeInner::Vector {
-                        kind: naga::ScalarKind::Uint,
                         size: naga::VectorSize::Quad,
-                        width: 4,
+                        scalar: naga::Scalar::U32,
                     } => {
                         let data = unsafe { get_data::<u32, 4>(data_bytes, offset) };
                         unsafe { gl.uniform_4_u32_slice(location, data) };


### PR DESCRIPTION
Introduce a new struct type, `Scalar`, combining a `ScalarKind` and a `Bytes` width, and use this whenever such pairs of values are passed around.

In particular, use `Scalar` in `TypeInner` variants `Scalar`, `Vector`, `Atomic`, and `ValuePointer`.

Introduce associated `Scalar` constants `I32`, `U32`, `F32`, `BOOL` and `F64`, for common cases.

Introduce a helper function `Scalar::float` for constructing `Float` scalars of a given width, for dealing with `TypeInner::Matrix`, which only supplies the scalar width of its elements, not a kind.

Introduce helper functions on `Literal` and `TypeInner`, to produce the `Scalar` describing elements' values.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
