### PR TITLE
Keep the value in its storage after destroy

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1110,9 +1110,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         // it, so make sure to set_size on it.
                         used_surface_textures.set_size(texture_guard.len());
 
+                        // TODO: ideally we would use `get_and_mark_destroyed` but the code here
+                        // wants to consume the command buffer.
                         #[allow(unused_mut)]
-                        let mut cmdbuf = match command_buffer_guard.take_and_mark_destroyed(cmb_id)
-                        {
+                        let mut cmdbuf = match command_buffer_guard.replace_with_error(cmb_id) {
                             Ok(cmdbuf) => cmdbuf,
                             Err(_) => continue,
                         };

--- a/wgpu-core/src/identity.rs
+++ b/wgpu-core/src/identity.rs
@@ -66,7 +66,6 @@ impl IdentityManager {
 
     /// Free `id`. It will never be returned from `alloc` again.
     pub fn free<I: id::TypedId + Debug>(&mut self, id: I) {
-        println!("free id");
         let (index, epoch, _backend) = id.unzip();
         let pe = &mut self.epochs[index as usize];
         assert_eq!(*pe, epoch);

--- a/wgpu-core/src/identity.rs
+++ b/wgpu-core/src/identity.rs
@@ -53,7 +53,6 @@ impl IdentityManager {
     /// The backend is incorporated into the id, so that ids allocated with
     /// different `backend` values are always distinct.
     pub fn alloc<I: id::TypedId>(&mut self, backend: Backend) -> I {
-        println!("alloc id");
         match self.free.pop() {
             Some(index) => I::zip(index, self.epochs[index as usize], backend),
             None => {

--- a/wgpu-core/src/identity.rs
+++ b/wgpu-core/src/identity.rs
@@ -53,6 +53,7 @@ impl IdentityManager {
     /// The backend is incorporated into the id, so that ids allocated with
     /// different `backend` values are always distinct.
     pub fn alloc<I: id::TypedId>(&mut self, backend: Backend) -> I {
+        println!("alloc id");
         match self.free.pop() {
             Some(index) => I::zip(index, self.epochs[index as usize], backend),
             None => {
@@ -66,6 +67,7 @@ impl IdentityManager {
 
     /// Free `id`. It will never be returned from `alloc` again.
     pub fn free<I: id::TypedId + Debug>(&mut self, id: I) {
+        println!("free id");
         let (index, epoch, _backend) = id.unzip();
         let pe = &mut self.epochs[index as usize];
         assert_eq!(*pe, epoch);


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.

**Connections**

Fixes #4668

**Description**

in #4657 the destroy implementation was made to remove the value from the storage and leave an error variant in its place. Unfortunately this causes some issues with the buffer tracking code which expects the ID to be unregistered after the value has been fully destroyed, even if the latter does not need to be in storage anymore. To work around that, this commit adds a `Destroyed` variant in storage which keeps the value so that the previous tracking behavior is preserved while still making sure that most accesses to the destroyed resource lead to validation errors.

... Except for submitted command buffers that need to be consumed right away. These are replaced with `Element::Error` like before this commit.

It's a fair bit unsavory to have the two ways to do the same thing in principle, but a better solution will take more time to bake and would conflict unnecessarily with the arcanization work.

**Testing**

An existing test was altered to cover the regression.