### PR TITLE
[naga] Follow-ups to #4763, Introduce `Scalar` type to IR.

### DIFF
--- a/naga/src/front/glsl/functions.rs
+++ b/naga/src/front/glsl/functions.rs
@@ -1539,16 +1539,9 @@ fn conversion(target: &TypeInner, source: &TypeInner) -> Option<Conversion> {
                 columns: src_cols,
                 width: src_width,
             },
-        ) if tgt_cols == src_cols && tgt_rows == src_rows => (
-            Scalar {
-                kind: Float,
-                width: tgt_width,
-            },
-            Scalar {
-                kind: Float,
-                width: src_width,
-            },
-        ),
+        ) if tgt_cols == src_cols && tgt_rows == src_rows => {
+            (Scalar::float(tgt_width), Scalar::float(src_width))
+        }
         _ => return None,
     };
 
@@ -1562,22 +1555,10 @@ fn conversion(target: &TypeInner, source: &TypeInner) -> Option<Conversion> {
 
     Some(match (target_scalar, source_scalar) {
         // A conversion from a float to a double is special
-        (
-            Scalar {
-                kind: Float,
-                width: 8,
-            },
-            Scalar {
-                kind: Float,
-                width: 4,
-            },
-        ) => Conversion::FloatToDouble,
+        (Scalar::F64, Scalar::F32) => Conversion::FloatToDouble,
         // A conversion from an integer to a float is special
         (
-            Scalar {
-                kind: Float,
-                width: 4,
-            },
+            Scalar::F32,
             Scalar {
                 kind: Sint | Uint,
                 width: _,
@@ -1585,10 +1566,7 @@ fn conversion(target: &TypeInner, source: &TypeInner) -> Option<Conversion> {
         ) => Conversion::IntToFloat,
         // A conversion from an integer to a double is special
         (
-            Scalar {
-                kind: Float,
-                width: 8,
-            },
+            Scalar::F64,
             Scalar {
                 kind: Sint | Uint,
                 width: _,
@@ -1608,7 +1586,7 @@ fn builtin_required_variations<'a>(args: impl Iterator<Item = &'a TypeInner>) ->
             TypeInner::ValuePointer { scalar, .. }
             | TypeInner::Scalar(scalar)
             | TypeInner::Vector { scalar, .. } => {
-                if scalar.kind == ScalarKind::Float && scalar.width == 8 {
+                if scalar == Scalar::F64 {
                     variations |= BuiltinVariations::DOUBLE
                 }
             }

--- a/naga/src/front/glsl/parser/declarations.rs
+++ b/naga/src/front/glsl/parser/declarations.rs
@@ -48,10 +48,7 @@ fn element_or_member_type(
                 name: None,
                 inner: TypeInner::Vector {
                     size: rows,
-                    scalar: Scalar {
-                        kind: ScalarKind::Float,
-                        width,
-                    },
+                    scalar: Scalar::float(width),
                 },
             },
             Default::default(),

--- a/naga/src/front/glsl/types.rs
+++ b/naga/src/front/glsl/types.rs
@@ -194,10 +194,7 @@ pub const fn scalar_components(ty: &TypeInner) -> Option<Scalar> {
         TypeInner::Scalar(scalar)
         | TypeInner::Vector { scalar, .. }
         | TypeInner::ValuePointer { scalar, .. } => Some(scalar),
-        TypeInner::Matrix { width, .. } => Some(Scalar {
-            kind: ScalarKind::Float,
-            width,
-        }),
+        TypeInner::Matrix { width, .. } => Some(Scalar::float(width)),
         _ => None,
     }
 }

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -607,7 +607,7 @@ impl<'a> ConstantEvaluator<'a> {
                     self.types[ty0].inner,
                     crate::TypeInner::Vector {
                         scalar: crate::Scalar {
-                            kind: crate::ScalarKind::Float,
+                            kind: ScalarKind::Float,
                             ..
                         },
                         ..
@@ -708,7 +708,7 @@ impl<'a> ConstantEvaluator<'a> {
                     self.types[ty0].inner,
                     crate::TypeInner::Vector {
                         scalar: crate::Scalar {
-                            kind: crate::ScalarKind::Float,
+                            kind: ScalarKind::Float,
                             ..
                         },
                         ..
@@ -833,7 +833,7 @@ impl<'a> ConstantEvaluator<'a> {
                 if matches!(
                     self.types[ty].inner,
                     crate::TypeInner::Scalar(crate::Scalar {
-                        kind: crate::ScalarKind::Uint,
+                        kind: ScalarKind::Uint,
                         ..
                     })
                 ) =>
@@ -905,10 +905,7 @@ impl<'a> ConstantEvaluator<'a> {
                         name: None,
                         inner: TypeInner::Vector {
                             size: rows,
-                            scalar: crate::Scalar {
-                                kind: ScalarKind::Float,
-                                width,
-                            },
+                            scalar: crate::Scalar::float(width),
                         },
                     },
                     span,
@@ -955,47 +952,34 @@ impl<'a> ConstantEvaluator<'a> {
         span: Span,
     ) -> Result<Handle<Expression>, ConstantEvaluatorError> {
         use crate::Scalar as Sc;
-        use crate::ScalarKind as Sk;
 
         let expr = self.eval_zero_value_and_splat(expr, span)?;
 
         let expr = match self.expressions[expr] {
             Expression::Literal(literal) => {
                 let literal = match target {
-                    Sc {
-                        kind: Sk::Sint,
-                        width: 4,
-                    } => Literal::I32(match literal {
+                    Sc::I32 => Literal::I32(match literal {
                         Literal::I32(v) => v,
                         Literal::U32(v) => v as i32,
                         Literal::F32(v) => v as i32,
                         Literal::Bool(v) => v as i32,
                         Literal::F64(_) => return Err(ConstantEvaluatorError::InvalidCastArg),
                     }),
-                    Sc {
-                        kind: Sk::Uint,
-                        width: 4,
-                    } => Literal::U32(match literal {
+                    Sc::U32 => Literal::U32(match literal {
                         Literal::I32(v) => v as u32,
                         Literal::U32(v) => v,
                         Literal::F32(v) => v as u32,
                         Literal::Bool(v) => v as u32,
                         Literal::F64(_) => return Err(ConstantEvaluatorError::InvalidCastArg),
                     }),
-                    Sc {
-                        kind: Sk::Float,
-                        width: 4,
-                    } => Literal::F32(match literal {
+                    Sc::F32 => Literal::F32(match literal {
                         Literal::I32(v) => v as f32,
                         Literal::U32(v) => v as f32,
                         Literal::F32(v) => v,
                         Literal::Bool(v) => v as u32 as f32,
                         Literal::F64(_) => return Err(ConstantEvaluatorError::InvalidCastArg),
                     }),
-                    Sc {
-                        kind: Sk::Bool,
-                        width: crate::BOOL_WIDTH,
-                    } => Literal::Bool(match literal {
+                    Sc::BOOL => Literal::Bool(match literal {
                         Literal::I32(v) => v != 0,
                         Literal::U32(v) => v != 0,
                         Literal::F32(v) => v != 0.0,
@@ -1330,10 +1314,7 @@ mod tests {
                 name: None,
                 inner: TypeInner::Vector {
                     size: VectorSize::Bi,
-                    scalar: crate::Scalar {
-                        kind: ScalarKind::Sint,
-                        width: 4,
-                    },
+                    scalar: crate::Scalar::I32,
                 },
             },
             Default::default(),
@@ -1520,10 +1501,7 @@ mod tests {
                 name: None,
                 inner: TypeInner::Vector {
                     size: VectorSize::Tri,
-                    scalar: crate::Scalar {
-                        kind: ScalarKind::Float,
-                        width: 4,
-                    },
+                    scalar: crate::Scalar::F32,
                 },
             },
             Default::default(),
@@ -1672,10 +1650,7 @@ mod tests {
                 name: None,
                 inner: TypeInner::Vector {
                     size: VectorSize::Bi,
-                    scalar: crate::Scalar {
-                        kind: ScalarKind::Sint,
-                        width: 4,
-                    },
+                    scalar: crate::Scalar::I32,
                 },
             },
             Default::default(),
@@ -1755,10 +1730,7 @@ mod tests {
                 name: None,
                 inner: TypeInner::Vector {
                     size: VectorSize::Bi,
-                    scalar: crate::Scalar {
-                        kind: ScalarKind::Sint,
-                        width: 4,
-                    },
+                    scalar: crate::Scalar::I32,
                 },
             },
             Default::default(),

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -193,11 +193,11 @@ impl crate::Literal {
     }
     pub const fn scalar(&self) -> crate::Scalar {
         match *self {
-            crate::Literal::F64(_) => crate::Scalar::F64,
-            crate::Literal::F32(_) => crate::Scalar::F32,
-            crate::Literal::U32(_) => crate::Scalar::U32,
-            crate::Literal::I32(_) => crate::Scalar::I32,
-            crate::Literal::Bool(_) => crate::Scalar::BOOL,
+            Self::F64(_) => crate::Scalar::F64,
+            Self::F32(_) => crate::Scalar::F32,
+            Self::U32(_) => crate::Scalar::U32,
+            Self::I32(_) => crate::Scalar::I32,
+            Self::Bool(_) => crate::Scalar::BOOL,
         }
     }
     pub const fn scalar_kind(&self) -> crate::ScalarKind {


### PR DESCRIPTION
Clean up some things that should have been taken care of in the original PR:
- Use `Scalar::float` helper.
- Use `Scalar` associated constants in match patterns.
- Use `Scalar`'s `PartialEq` implementation.
- Clean up identifier paths.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- (not appropriate) Add change to CHANGELOG.md. See simple instructions inside file.
