### PR TITLE
Check if `source` is empty when constructing `hal::DebugSource` (0.18 backport)

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1317,18 +1317,19 @@ impl<A: HalApi> Device<A> {
                 .contains(wgt::DownlevelFlags::CUBE_ARRAY_TEXTURES),
         );
 
-        let debug_source = if self.instance_flags.contains(wgt::InstanceFlags::DEBUG) {
-            Some(hal::DebugSource {
-                file_name: Cow::Owned(
-                    desc.label
-                        .as_ref()
-                        .map_or("shader".to_string(), |l| l.to_string()),
-                ),
-                source_code: Cow::Owned(source.clone()),
-            })
-        } else {
-            None
-        };
+        let debug_source =
+            if self.instance_flags.contains(wgt::InstanceFlags::DEBUG) && !source.is_empty() {
+                Some(hal::DebugSource {
+                    file_name: Cow::Owned(
+                        desc.label
+                            .as_ref()
+                            .map_or("shader".to_string(), |l| l.to_string()),
+                    ),
+                    source_code: Cow::Owned(source.clone()),
+                })
+            } else {
+                None
+            };
 
         let info = naga::valid::Validator::new(naga::valid::ValidationFlags::all(), caps)
             .validate(&module)


### PR DESCRIPTION
Is this correct? I mostly based it on what @mcclure did in #4649, though I did `git cherry-pick` rather than `hg graft`.

**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
This is the commit from #4642 cherry-picked onto a branch forked from the v0.18 branch, targeting that branch in gfx-rs/wgpu.

**Testing**
Tested the code example from #4569 with https://github.com/danielhjacobs/wgpu/commit/dfdb2f138993e0995882573a1ff57c60abf10e76 vs with https://github.com/gfx-rs/wgpu/tree/v0.18 (changing `let module = naga::front::wgsl` to `let module = wgpu::naga::front::wgsl` in the code example to fix the issue "note: `naga::Module` and `wgpu::naga::Module` have similar names, but are actually distinct types") and saw the panic was gone with this commit.
