### PR TITLE
[naga] Preserve spans when compacting Arenas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Bottom level categories:
 
 - When evaluating const-expressions and generating SPIR-V, properly handle `Compose` expressions whose operands are `Splat` expressions. Such expressions are created and marked as constant by the constant evaluator. By @jimblandy in [#4695](https://github.com/gfx-rs/wgpu/pull/4695).
 
+- Preserve the source spans for constants and expressions correctly across module compaction. By @jimblandy in [#4696](https://github.com/gfx-rs/wgpu/pull/4696).
+
 ### Examples
 
 - remove winit dependency from hello-compute example by @psvri in [#4699](https://github.com/gfx-rs/wgpu/pull/4699)

--- a/naga/src/arena.rs
+++ b/naga/src/arena.rs
@@ -430,11 +430,26 @@ impl<T> Arena<T> {
         P: FnMut(Handle<T>, &mut T) -> bool,
     {
         let mut index = 0;
+        let mut retained = 0;
         self.data.retain_mut(|elt| {
+            let handle = Handle::new(Index::new(index as u32 + 1).unwrap());
+            let keep = predicate(handle, elt);
+
+            // Since `predicate` needs mutable access to each element,
+            // we can't feasibly call it twice, so we have to compact
+            // spans by hand in parallel as part of this iteration.
+            #[cfg(feature = "span")]
+            if keep {
+                self.span_info[retained] = self.span_info[index];
+                retained += 1;
+            }
+
             index += 1;
-            let handle = Handle::new(Index::new(index).unwrap());
-            predicate(handle, elt)
-        })
+            keep
+        });
+
+        #[cfg(feature = "span")]
+        self.span_info.truncate(retained);
     }
 }
 


### PR DESCRIPTION
When compacting a module, properly adjust spans along with `Arena` contents.

**Checklist**

- [X] Run `cargo clippy`.
- [X] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md. See simple instructions inside file.
