### PR TITLE
remove winit from hello-compute example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ Bottom level categories:
 
 - When reading GLSL, fix the argument types of the double-precision floating-point overloads of the `dot`, `reflect`, `distance`, and `ldexp` builtin functions. Correct the WGSL generated for constructing 64-bit floating-point matrices. Add tests for all the above. By @jimblandy in [#4684](https://github.com/gfx-rs/wgpu/pull/4684).
 
+### Examples
+
+- remove winit dependency from hello-compute example by @psvri in [#4699](https://github.com/gfx-rs/wgpu/pull/4699)
+
+
 ## v0.18.1 (2023-11-15)
 
 (naga version 0.14.1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4222,7 +4222,6 @@ dependencies = [
  "wasm-bindgen-test",
  "wgpu",
  "wgpu-test",
- "winit 0.29.3",
 ]
 
 [[package]]

--- a/examples/hello-compute/Cargo.toml
+++ b/examples/hello-compute/Cargo.toml
@@ -17,7 +17,6 @@ env_logger.workspace = true
 flume.workspace = true
 pollster.workspace = true
 wgpu.workspace = true
-winit.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook.workspace = true


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo clippy`.
- [x] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [x] Add change to CHANGELOG.md.

**Connections**
NA

**Description**
winit is not a required dependency to run hello compute example.

**Testing**
verified by checking that both the below command gave the right output
- cargo run --bin hello-compute 1 2 3 4
- cargo xtask --features=run-wasm run-wasm --bin hello-compute