### PR TITLE
Fix max_vertex_buffers validation

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1715,7 +1715,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
 
                         let max_vertex_buffers = device.limits.max_vertex_buffers;
-                        if slot > max_vertex_buffers {
+                        if slot >= max_vertex_buffers {
                             return Err(RenderCommandError::VertexBufferIndexOutOfRange {
                                 index: slot,
                                 max: max_vertex_buffers,


### PR DESCRIPTION
We incorrectly check the max_vertex_buffers limit, leading to a panic when pushing into an `ArrayVec`.

No rush to land this, it can wait for #3626.

**Testing**

caught by the CTS. see: https://treeherder.mozilla.org/logviewer?job_id=436598471&repo=try&lineNumber=1736

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
