### PR TITLE
[naga wgsl-in] Include base when printing pointer and array types.

### DIFF
--- a/naga/src/front/wgsl/to_wgsl.rs
+++ b/naga/src/front/wgsl/to_wgsl.rs
@@ -57,16 +57,14 @@ impl crate::TypeInner {
                 format!("atomic<{}>", scalar.to_wgsl())
             }
             Ti::Pointer { base, .. } => {
-                let base = &gctx.types[base];
-                let name = base.name.as_deref().unwrap_or("unknown");
+                let name = base.to_wgsl(gctx);
                 format!("ptr<{name}>")
             }
             Ti::ValuePointer { scalar, .. } => {
                 format!("ptr<{}>", scalar.to_wgsl())
             }
             Ti::Array { base, size, .. } => {
-                let member_type = &gctx.types[base];
-                let base = member_type.name.as_deref().unwrap_or("unknown");
+                let base = base.to_wgsl(gctx);
                 match size {
                     crate::ArraySize::Constant(size) => format!("array<{base}, {size}>"),
                     crate::ArraySize::Dynamic => format!("array<{base}>"),


### PR DESCRIPTION
When formatting `TypeInner::Pointer` and `TypeInner::Array` as WGSL source code, bother to actually generate text for the target/element type. This avoids producing ridiculous messages like:

> the type of `foo` is expected to be `array<unknown, 2>`, but got `array<unknown, 2>`

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
- [X] Run `cargo xtask test` to run tests. 
- (not appropriate) Add change to `CHANGELOG.md`. See simple instructions inside file.
