### PR TITLE
[vk] check that adapters are Vulkan compliant

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -986,6 +986,15 @@ impl super::Instance {
             );
         };
 
+        if let Some(driver) = phd_capabilities.driver {
+            if driver.conformance_version.major == 0 {
+                log::warn!(
+                    "Adapter is not Vulkan compliant, hiding adapter: {}",
+                    info.name
+                );
+                return None;
+            }
+        }
         if phd_capabilities.device_api_version == vk::API_VERSION_1_0
             && !phd_capabilities.supports_extension(vk::KhrStorageBufferStorageClassFn::name())
         {


### PR DESCRIPTION
Resolves https://github.com/gfx-rs/wgpu/issues/4715.

This PR is meant to cut down on the number of reports we get due to Vulkan implementations not conforming to the spec.

The only driver/hardware combinations I could find that are not compliant are:

- [Mesa's Amd/RADV on GFX6 & GFX7 GPUs](https://gitlab.freedesktop.org/mesa/mesa/-/blob/bafc27583cf7c2d136fa05764e5e2145fedbc9cc/src/amd/vulkan/radv_physical_device.c#L86-90)
- [Mesa's Intel/HASVK on Gen7 iGPUs (Bay Trail/Haswell/Ivy Bridge)](https://gitlab.freedesktop.org/mesa/mesa/-/blob/bafc27583cf7c2d136fa05764e5e2145fedbc9cc/src/intel/vulkan_hasvk/anv_device.c#L1004-1024)
- [Mesa's Nouveau/NVK](https://gitlab.freedesktop.org/mesa/mesa/-/blob/bafc27583cf7c2d136fa05764e5e2145fedbc9cc/src/nouveau/vulkan/nvk_physical_device.c#L566-571)
- [Mesa's Dozen/DZN](https://gitlab.freedesktop.org/mesa/mesa/-/blob/bafc27583cf7c2d136fa05764e5e2145fedbc9cc/src/microsoft/vulkan/dzn_device.c#L979-984)

Related bugs:

- https://github.com/gfx-rs/wgpu/issues/2027
- https://github.com/gfx-rs/wgpu/issues/2480
- https://github.com/gfx-rs/wgpu/issues/3422
- https://github.com/gfx-rs/wgpu/issues/4670

We can provide an instance flag for people to experiment with uncompliant implementations but it's not part of this PR.