### PR TITLE
[naga] Let constant evaluation of `As` preserve `Splat` expressions.

### DIFF
--- a/naga/tests/out/wgsl/900-implicit-conversions.frag.wgsl
+++ b/naga/tests/out/wgsl/900-implicit-conversions.frag.wgsl
@@ -57,7 +57,7 @@ fn implicit_dims_3(v_6: vec4<f32>) {
 fn main_1() {
     exact_1(1);
     implicit(1.0);
-    implicit_dims_2(vec3<f32>(1.0, 1.0, 1.0));
+    implicit_dims_2(vec3(1.0));
     return;
 }
 


### PR DESCRIPTION
When asked to evaluate an `Expression::As` cast applied to a `Splat` expression, change `ConstantEvaluator::cast` to preserve the `Splat`, rather than expanding it out to a `Compose` expression.

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
- [X] Run `cargo xtask test` to run tests.
- (not appropriate) Add change to `CHANGELOG.md`. See simple instructions inside file.
