### PR TITLE
Implement base instance in shaders on GL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Bottom level categories:
 
 ## Unreleased
 
+### New Features
+
+#### OpenGL
+- `@builtin(instance_index)` now properly reflects the range provided in the draw call instead of always counting from 0. By @cwfitzgerald in [#4722](https://github.com/gfx-rs/wgpu/pull/4722).
+
 ### Changes
 
 #### General

--- a/naga/src/back/glsl/keywords.rs
+++ b/naga/src/back/glsl/keywords.rs
@@ -480,4 +480,5 @@ pub const RESERVED_KEYWORDS: &[&str] = &[
     // Naga utilities:
     super::MODF_FUNCTION,
     super::FREXP_FUNCTION,
+    super::BASE_INSTANCE_BINDING,
 ];

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -76,6 +76,7 @@ const CLAMPED_LOD_SUFFIX: &str = "_clamped_lod";
 pub(crate) const MODF_FUNCTION: &str = "naga_modf";
 pub(crate) const FREXP_FUNCTION: &str = "naga_frexp";
 
+// Must match code in glsl_built_in
 pub const BASE_INSTANCE_BINDING: &str = "naga_vs_base_instance";
 
 /// Mapping between resources and bindings.
@@ -572,8 +573,8 @@ impl<'a, W: Write> Writer<'a, W> {
             &[],
             &[],
             &[
-                "gl_", // all GL built-in variables
-                "_group", // all normal bindings
+                "gl_",                     // all GL built-in variables
+                "_group",                  // all normal bindings
                 "_push_constant_binding_", // all push constant bindings
             ],
             &mut names,
@@ -4341,7 +4342,8 @@ const fn glsl_built_in(
         Bi::BaseVertex => "uint(gl_BaseVertex)",
         Bi::ClipDistance => "gl_ClipDistance",
         Bi::CullDistance => "gl_CullDistance",
-        Bi::InstanceIndex => "(uint(gl_InstanceID) + _naga_vs_base_instance)",
+        // Must match BASE_INSTANCE_BINDING
+        Bi::InstanceIndex => "(uint(gl_InstanceID) + naga_vs_base_instance)",
         Bi::PointSize => "gl_PointSize",
         Bi::VertexIndex => "uint(gl_VertexID)",
         // fragment

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -652,6 +652,11 @@ impl<'a, W: Write> Writer<'a, W> {
             writeln!(self.out)?;
         }
 
+        if self.entry_point.stage == ShaderStage::Vertex {
+            writeln!(self.out, "uniform uint _naga_vs_base_instance;")?;
+            writeln!(self.out)?;
+        }
+
         // Enable early depth tests if needed
         if let Some(depth_test) = self.entry_point.early_depth_test {
             // If early depth test is supported for this version of GLSL
@@ -4330,7 +4335,7 @@ const fn glsl_built_in(
         Bi::BaseVertex => "uint(gl_BaseVertex)",
         Bi::ClipDistance => "gl_ClipDistance",
         Bi::CullDistance => "gl_CullDistance",
-        Bi::InstanceIndex => "uint(gl_InstanceID)",
+        Bi::InstanceIndex => "(uint(gl_InstanceID) + _naga_vs_base_instance)",
         Bi::PointSize => "gl_PointSize",
         Bi::VertexIndex => "uint(gl_VertexID)",
         // fragment

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -76,6 +76,8 @@ const CLAMPED_LOD_SUFFIX: &str = "_clamped_lod";
 pub(crate) const MODF_FUNCTION: &str = "naga_modf";
 pub(crate) const FREXP_FUNCTION: &str = "naga_frexp";
 
+pub const BASE_INSTANCE_BINDING: &str = "naga_vs_base_instance";
+
 /// Mapping between resources and bindings.
 pub type BindingMap = std::collections::BTreeMap<crate::ResourceBinding, u8>;
 
@@ -569,7 +571,11 @@ impl<'a, W: Write> Writer<'a, W> {
             keywords::RESERVED_KEYWORDS,
             &[],
             &[],
-            &["gl_"],
+            &[
+                "gl_", // all GL built-in variables
+                "_group", // all normal bindings
+                "_push_constant_binding_", // all push constant bindings
+            ],
             &mut names,
         );
 
@@ -653,7 +659,7 @@ impl<'a, W: Write> Writer<'a, W> {
         }
 
         if self.entry_point.stage == ShaderStage::Vertex {
-            writeln!(self.out, "uniform uint _naga_vs_base_instance;")?;
+            writeln!(self.out, "uniform uint {BASE_INSTANCE_BINDING};")?;
             writeln!(self.out)?;
         }
 

--- a/naga/tests/in/push-constants.wgsl
+++ b/naga/tests/in/push-constants.wgsl
@@ -10,9 +10,10 @@ struct FragmentIn {
 @vertex
 fn vert_main(
   @location(0) pos : vec2<f32>,
+  @builtin(instance_index) ii: u32,
   @builtin(vertex_index) vi: u32,
 ) -> @builtin(position) vec4<f32> {
-    return vec4<f32>(f32(vi) * pc.multiplier * pos, 0.0, 1.0);
+    return vec4<f32>(f32(ii) * f32(vi) * pc.multiplier * pos, 0.0, 1.0);
 }
 
 @fragment

--- a/naga/tests/out/glsl/access.foo_vert.Vertex.glsl
+++ b/naga/tests/out/glsl/access.foo_vert.Vertex.glsl
@@ -3,7 +3,7 @@
 precision highp float;
 precision highp int;
 
-uniform uint _naga_vs_base_instance;
+uniform uint naga_vs_base_instance;
 
 struct GlobalConst {
     uint a;

--- a/naga/tests/out/glsl/access.foo_vert.Vertex.glsl
+++ b/naga/tests/out/glsl/access.foo_vert.Vertex.glsl
@@ -3,6 +3,8 @@
 precision highp float;
 precision highp int;
 
+uniform uint _naga_vs_base_instance;
+
 struct GlobalConst {
     uint a;
     uvec3 b;

--- a/naga/tests/out/glsl/force_point_size_vertex_shader_webgl.vs_main.Vertex.glsl
+++ b/naga/tests/out/glsl/force_point_size_vertex_shader_webgl.vs_main.Vertex.glsl
@@ -3,7 +3,7 @@
 precision highp float;
 precision highp int;
 
-uniform uint _naga_vs_base_instance;
+uniform uint naga_vs_base_instance;
 
 
 void main() {

--- a/naga/tests/out/glsl/force_point_size_vertex_shader_webgl.vs_main.Vertex.glsl
+++ b/naga/tests/out/glsl/force_point_size_vertex_shader_webgl.vs_main.Vertex.glsl
@@ -3,6 +3,8 @@
 precision highp float;
 precision highp int;
 
+uniform uint _naga_vs_base_instance;
+
 
 void main() {
     uint in_vertex_index = uint(gl_VertexID);

--- a/naga/tests/out/glsl/image.queries.Vertex.glsl
+++ b/naga/tests/out/glsl/image.queries.Vertex.glsl
@@ -4,7 +4,7 @@
 precision highp float;
 precision highp int;
 
-uniform uint _naga_vs_base_instance;
+uniform uint naga_vs_base_instance;
 
 uniform highp sampler2D _group_0_binding_0_vs;
 

--- a/naga/tests/out/glsl/image.queries.Vertex.glsl
+++ b/naga/tests/out/glsl/image.queries.Vertex.glsl
@@ -4,6 +4,8 @@
 precision highp float;
 precision highp int;
 
+uniform uint _naga_vs_base_instance;
+
 uniform highp sampler2D _group_0_binding_0_vs;
 
 uniform highp sampler2D _group_0_binding_1_vs;

--- a/naga/tests/out/glsl/interpolate.vert_main.Vertex.glsl
+++ b/naga/tests/out/glsl/interpolate.vert_main.Vertex.glsl
@@ -1,4 +1,6 @@
 #version 400 core
+uniform uint _naga_vs_base_instance;
+
 struct FragmentInput {
     vec4 position;
     uint _flat;

--- a/naga/tests/out/glsl/interpolate.vert_main.Vertex.glsl
+++ b/naga/tests/out/glsl/interpolate.vert_main.Vertex.glsl
@@ -1,5 +1,5 @@
 #version 400 core
-uniform uint _naga_vs_base_instance;
+uniform uint naga_vs_base_instance;
 
 struct FragmentInput {
     vec4 position;

--- a/naga/tests/out/glsl/invariant.vs.Vertex.glsl
+++ b/naga/tests/out/glsl/invariant.vs.Vertex.glsl
@@ -3,7 +3,7 @@
 precision highp float;
 precision highp int;
 
-uniform uint _naga_vs_base_instance;
+uniform uint naga_vs_base_instance;
 
 invariant gl_Position;
 

--- a/naga/tests/out/glsl/invariant.vs.Vertex.glsl
+++ b/naga/tests/out/glsl/invariant.vs.Vertex.glsl
@@ -3,6 +3,8 @@
 precision highp float;
 precision highp int;
 
+uniform uint _naga_vs_base_instance;
+
 invariant gl_Position;
 
 void main() {

--- a/naga/tests/out/glsl/padding.vertex.Vertex.glsl
+++ b/naga/tests/out/glsl/padding.vertex.Vertex.glsl
@@ -3,7 +3,7 @@
 precision highp float;
 precision highp int;
 
-uniform uint _naga_vs_base_instance;
+uniform uint naga_vs_base_instance;
 
 struct S {
     vec3 a;

--- a/naga/tests/out/glsl/padding.vertex.Vertex.glsl
+++ b/naga/tests/out/glsl/padding.vertex.Vertex.glsl
@@ -3,6 +3,8 @@
 precision highp float;
 precision highp int;
 
+uniform uint _naga_vs_base_instance;
+
 struct S {
     vec3 a;
 };

--- a/naga/tests/out/glsl/push-constants.vert_main.Vertex.glsl
+++ b/naga/tests/out/glsl/push-constants.vert_main.Vertex.glsl
@@ -3,6 +3,8 @@
 precision highp float;
 precision highp int;
 
+uniform uint _naga_vs_base_instance;
+
 struct PushConstants {
     float multiplier;
 };
@@ -15,9 +17,10 @@ layout(location = 0) in vec2 _p2vs_location0;
 
 void main() {
     vec2 pos = _p2vs_location0;
+    uint ii = (uint(gl_InstanceID) + _naga_vs_base_instance);
     uint vi = uint(gl_VertexID);
-    float _e5 = _push_constant_binding_vs.multiplier;
-    gl_Position = vec4(((float(vi) * _e5) * pos), 0.0, 1.0);
+    float _e8 = _push_constant_binding_vs.multiplier;
+    gl_Position = vec4((((float(ii) * float(vi)) * _e8) * pos), 0.0, 1.0);
     return;
 }
 

--- a/naga/tests/out/glsl/push-constants.vert_main.Vertex.glsl
+++ b/naga/tests/out/glsl/push-constants.vert_main.Vertex.glsl
@@ -3,7 +3,7 @@
 precision highp float;
 precision highp int;
 
-uniform uint _naga_vs_base_instance;
+uniform uint naga_vs_base_instance;
 
 struct PushConstants {
     float multiplier;

--- a/naga/tests/out/glsl/push-constants.vert_main.Vertex.glsl
+++ b/naga/tests/out/glsl/push-constants.vert_main.Vertex.glsl
@@ -17,7 +17,7 @@ layout(location = 0) in vec2 _p2vs_location0;
 
 void main() {
     vec2 pos = _p2vs_location0;
-    uint ii = (uint(gl_InstanceID) + _naga_vs_base_instance);
+    uint ii = (uint(gl_InstanceID) + naga_vs_base_instance);
     uint vi = uint(gl_VertexID);
     float _e8 = _push_constant_binding_vs.multiplier;
     gl_Position = vec4((((float(ii) * float(vi)) * _e8) * pos), 0.0, 1.0);

--- a/naga/tests/out/glsl/quad-vert.main.Vertex.glsl
+++ b/naga/tests/out/glsl/quad-vert.main.Vertex.glsl
@@ -3,7 +3,7 @@
 precision highp float;
 precision highp int;
 
-uniform uint _naga_vs_base_instance;
+uniform uint naga_vs_base_instance;
 
 struct gen_gl_PerVertex {
     vec4 gen_gl_Position;

--- a/naga/tests/out/glsl/quad-vert.main.Vertex.glsl
+++ b/naga/tests/out/glsl/quad-vert.main.Vertex.glsl
@@ -3,6 +3,8 @@
 precision highp float;
 precision highp int;
 
+uniform uint _naga_vs_base_instance;
+
 struct gen_gl_PerVertex {
     vec4 gen_gl_Position;
     float gen_gl_PointSize;

--- a/naga/tests/out/glsl/quad.vert_main.Vertex.glsl
+++ b/naga/tests/out/glsl/quad.vert_main.Vertex.glsl
@@ -3,7 +3,7 @@
 precision highp float;
 precision highp int;
 
-uniform uint _naga_vs_base_instance;
+uniform uint naga_vs_base_instance;
 
 struct VertexOutput {
     vec2 uv;

--- a/naga/tests/out/glsl/quad.vert_main.Vertex.glsl
+++ b/naga/tests/out/glsl/quad.vert_main.Vertex.glsl
@@ -3,6 +3,8 @@
 precision highp float;
 precision highp int;
 
+uniform uint _naga_vs_base_instance;
+
 struct VertexOutput {
     vec2 uv;
     vec4 position;

--- a/naga/tests/out/glsl/shadow.vs_main.Vertex.glsl
+++ b/naga/tests/out/glsl/shadow.vs_main.Vertex.glsl
@@ -3,6 +3,8 @@
 precision highp float;
 precision highp int;
 
+uniform uint _naga_vs_base_instance;
+
 struct Globals {
     mat4x4 view_proj;
     uvec4 num_lights;

--- a/naga/tests/out/glsl/shadow.vs_main.Vertex.glsl
+++ b/naga/tests/out/glsl/shadow.vs_main.Vertex.glsl
@@ -3,7 +3,7 @@
 precision highp float;
 precision highp int;
 
-uniform uint _naga_vs_base_instance;
+uniform uint naga_vs_base_instance;
 
 struct Globals {
     mat4x4 view_proj;

--- a/naga/tests/out/glsl/skybox.vs_main.Vertex.glsl
+++ b/naga/tests/out/glsl/skybox.vs_main.Vertex.glsl
@@ -3,6 +3,8 @@
 precision highp float;
 precision highp int;
 
+uniform uint _naga_vs_base_instance;
+
 struct VertexOutput {
     vec4 position;
     vec3 uv;

--- a/naga/tests/out/glsl/skybox.vs_main.Vertex.glsl
+++ b/naga/tests/out/glsl/skybox.vs_main.Vertex.glsl
@@ -3,7 +3,7 @@
 precision highp float;
 precision highp int;
 
-uniform uint _naga_vs_base_instance;
+uniform uint naga_vs_base_instance;
 
 struct VertexOutput {
     vec4 position;

--- a/naga/tests/out/hlsl/push-constants.hlsl
+++ b/naga/tests/out/hlsl/push-constants.hlsl
@@ -19,10 +19,10 @@ struct FragmentInput_main {
     float4 color : LOC0;
 };
 
-float4 vert_main(float2 pos : LOC0, uint vi : SV_VertexID) : SV_Position
+float4 vert_main(float2 pos : LOC0, uint ii : SV_InstanceID, uint vi : SV_VertexID) : SV_Position
 {
-    float _expr5 = pc.multiplier;
-    return float4(((float((_NagaConstants.base_vertex + vi)) * _expr5) * pos), 0.0, 1.0);
+    float _expr8 = pc.multiplier;
+    return float4((((float((_NagaConstants.base_instance + ii)) * float((_NagaConstants.base_vertex + vi))) * _expr8) * pos), 0.0, 1.0);
 }
 
 float4 main(FragmentInput_main fragmentinput_main) : SV_Target0

--- a/tests/tests/vertex_indices/mod.rs
+++ b/tests/tests/vertex_indices/mod.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU64;
 
 use wgpu::util::DeviceExt;
 
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
 fn pulling_common(
     ctx: TestingContext,

--- a/tests/tests/vertex_indices/mod.rs
+++ b/tests/tests/vertex_indices/mod.rs
@@ -186,9 +186,7 @@ static DRAW_INSTANCED_OFFSET: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::VERTEX_WRITABLE_STORAGE)
-            // https://github.com/gfx-rs/wgpu/issues/4276
-            .expect_fail(FailureCase::backend(wgpu::Backends::GL)),
+            .features(wgpu::Features::VERTEX_WRITABLE_STORAGE),
     )
     .run_sync(|ctx| {
         pulling_common(ctx, &[0, 1, 2, 3, 4, 5], |cmb| {

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -205,6 +205,7 @@ impl super::CommandEncoder {
         }
     }
 
+    #[allow(clippy::clone_on_copy)] // False positive when cloning glow::UniformLocation
     fn set_pipeline_inner(&mut self, inner: &super::PipelineInner) {
         self.cmd_buffer.commands.push(C::SetProgram(inner.program));
 
@@ -1011,6 +1012,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         instance_count: u32,
     ) {
         self.prepare_draw(base_instance);
+        #[allow(clippy::clone_on_copy)] // False positive when cloning glow::UniformLocation
         self.cmd_buffer.commands.push(C::Draw {
             topology: self.state.topology,
             start_vertex,
@@ -1034,6 +1036,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
             wgt::IndexFormat::Uint32 => (4, glow::UNSIGNED_INT),
         };
         let index_offset = self.state.index_offset + index_size * start_index as wgt::BufferAddress;
+        #[allow(clippy::clone_on_copy)] // False positive when cloning glow::UniformLocation
         self.cmd_buffer.commands.push(C::DrawIndexed {
             topology: self.state.topology,
             index_type,

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -469,7 +469,7 @@ impl super::Device {
 
         let base_instance_location = if has_stages.contains(wgt::ShaderStages::VERTEX) {
             // If this returns none (the uniform isn't active), that's fine, we just won't set it.
-            unsafe { gl.get_uniform_location(program, "_naga_vs_base_instance") }
+            unsafe { gl.get_uniform_location(program, naga::back::glsl::BASE_INSTANCE_BINDING) }
         } else {
             None
         };

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -467,9 +467,17 @@ impl super::Device {
             }
         }
 
+        let base_instance_location = if has_stages.contains(wgt::ShaderStages::VERTEX) {
+            // If this returns none (the uniform isn't active), that's fine, we just won't set it.
+            unsafe { gl.get_uniform_location(program, "_naga_vs_base_instance") }
+        } else {
+            None
+        };
+
         Ok(Arc::new(super::PipelineInner {
             program,
             sampler_map,
+            base_instance_location,
             push_constant_descs: uniforms,
         }))
     }

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -914,6 +914,19 @@ impl fmt::Debug for CommandBuffer {
     }
 }
 
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for CommandBuffer {}
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for CommandBuffer {}
+
 //TODO: we would have something like `Arc<typed_arena::Arena>`
 // here and in the command buffers. So that everything grows
 // inside the encoder and stays there until `reset_all`.
@@ -931,6 +944,19 @@ impl fmt::Debug for CommandEncoder {
             .finish()
     }
 }
+
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Sync for CommandEncoder {}
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "fragile-send-sync-non-atomic-wasm",
+    not(target_feature = "atomics")
+))]
+unsafe impl Send for CommandEncoder {}
 
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
 fn gl_debug_message_callback(source: u32, gltype: u32, id: u32, severity: u32, message: &str) {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -513,6 +513,7 @@ type SamplerBindMap = [Option<u8>; MAX_TEXTURE_SLOTS];
 struct PipelineInner {
     program: glow::Program,
     sampler_map: SamplerBindMap,
+    base_instance_location: Option<glow::UniformLocation>,
     push_constant_descs: ArrayVec<PushConstantDesc, MAX_PUSH_CONSTANT_COMMANDS>,
 }
 
@@ -712,7 +713,9 @@ enum Command {
         topology: u32,
         start_vertex: u32,
         vertex_count: u32,
+        base_instance: u32,
         instance_count: u32,
+        base_instance_location: Option<glow::UniformLocation>,
     },
     DrawIndexed {
         topology: u32,
@@ -720,7 +723,9 @@ enum Command {
         index_count: u32,
         index_offset: wgt::BufferAddress,
         base_vertex: i32,
+        base_instance: u32,
         instance_count: u32,
+        base_instance_location: Option<glow::UniformLocation>,
     },
     DrawIndirect {
         topology: u32,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -159,7 +159,7 @@ impl super::Queue {
                 vertex_count,
                 instance_count,
                 base_instance,
-                base_instance_location,
+                ref base_instance_location,
             } => {
                 // Don't use `gl.draw_arrays` for `instance_count == 1`.
                 // Angle has a bug where it doesn't consider the instance divisor when `DYNAMIC_DRAW` is used in `draw_arrays`.
@@ -183,7 +183,7 @@ impl super::Queue {
                 base_vertex,
                 base_instance,
                 instance_count,
-                base_instance_location,
+                ref base_instance_location,
             } => {
                 unsafe { gl.uniform_1_u32(base_instance_location.as_ref(), base_instance) };
 

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -158,11 +158,15 @@ impl super::Queue {
                 start_vertex,
                 vertex_count,
                 instance_count,
+                base_instance,
+                base_instance_location,
             } => {
                 // Don't use `gl.draw_arrays` for `instance_count == 1`.
                 // Angle has a bug where it doesn't consider the instance divisor when `DYNAMIC_DRAW` is used in `draw_arrays`.
                 // See https://github.com/gfx-rs/wgpu/issues/3578
                 unsafe {
+                    gl.uniform_1_u32(base_instance_location.as_ref(), base_instance);
+
                     gl.draw_arrays_instanced(
                         topology,
                         start_vertex as i32,
@@ -177,8 +181,12 @@ impl super::Queue {
                 index_count,
                 index_offset,
                 base_vertex,
+                base_instance,
                 instance_count,
+                base_instance_location,
             } => {
+                unsafe { gl.uniform_1_u32(base_instance_location.as_ref(), base_instance) };
+
                 match base_vertex {
                     // Don't use `gl.draw_elements`/`gl.draw_elements_base_vertex` for `instance_count == 1`.
                     // Angle has a bug where it doesn't consider the instance divisor when `DYNAMIC_DRAW` is used in `gl.draw_elements`/`gl.draw_elements_base_vertex`.


### PR DESCRIPTION
**Connections**

Closes #4276

**Description**

This adds the necessary logic so that `@builtin(instance_index)` works correctly wrt the base instance in _direct_ draw calls.

We currently don't even issue draw calls using the BaseInstance draw function of gl (we rebind the instance rate buffers), so indirect will be fun to pull off at a future time.

**Testing**

Covered by testing

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
