### PR TITLE
Corrects typo in examples FrameCounter

### DIFF
--- a/examples/common/src/framework.rs
+++ b/examples/common/src/framework.rs
@@ -342,11 +342,11 @@ impl FrameCounter {
     fn update(&mut self) {
         self.frame_count += 1;
         let new_instant = web_time::Instant::now();
-        let elasped_secs = (new_instant - self.last_printed_instant).as_secs_f32();
-        if elasped_secs > 1.0 {
-            let elapsed_ms = elasped_secs * 1000.0;
+        let elapsed_secs = (new_instant - self.last_printed_instant).as_secs_f32();
+        if elapsed_secs > 1.0 {
+            let elapsed_ms = elapsed_secs * 1000.0;
             let frame_time = elapsed_ms / self.frame_count as f32;
-            let fps = self.frame_count as f32 / elasped_secs;
+            let fps = self.frame_count as f32 / elapsed_secs;
             log::info!("Frame time {:.2}ms ({:.1} FPS)", frame_time, fps);
 
             self.last_printed_instant = new_instant;


### PR DESCRIPTION
**Connections**
The issue this PR addreses is #4724 .

**Description**
The issue is that a variable in the `update` method from `FrameCounter` in the examples has a typo ([here](https://github.com/gfx-rs/wgpu/blob/fd53ea90e675d94f1d79a1c3c44b2f356cecd9c5/examples/common/src/framework.rs#L345), `elasped_secs`). This PR just renames that variable to `elapsed_secs`.

**Testing**
Because of the nature of the change no new tests were added.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.

**Comments**
I do not think it is necessary to add this to `CHANGELOG.md`.
