### PR TITLE
Remove expected failure on AMD/DX12 from msaa example

### DIFF
--- a/examples/msaa-line/src/main.rs
+++ b/examples/msaa-line/src/main.rs
@@ -329,13 +329,7 @@ static TEST: wgpu_example::framework::ExampleTestParams =
         width: 1024,
         height: 768,
         optional_features: wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
-        base_test_parameters: wgpu_test::TestParameters::default()
-            // AMD seems to render nothing on DX12 https://github.com/gfx-rs/wgpu/issues/3838
-            .expect_fail(FailureCase {
-                backends: Some(wgpu::Backends::DX12),
-                vendor: Some(0x1002),
-                ..FailureCase::default()
-            }),
+        base_test_parameters: wgpu_test::TestParameters::default(),
         // There's a lot of natural variance so we check the weighted median too to differentiate
         // real failures from variance.
         comparisons: &[

--- a/examples/msaa-line/src/main.rs
+++ b/examples/msaa-line/src/main.rs
@@ -12,8 +12,6 @@ use std::{borrow::Cow, iter};
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
-#[cfg(test)]
-use wgpu_test::FailureCase;
 use winit::{
     event::{ElementState, KeyEvent, WindowEvent},
     keyboard::{Key, NamedKey},


### PR DESCRIPTION
Follow-up to https://github.com/gfx-rs/wgpu/issues/3838.

We think this was a driver issue, if you (a future reader) observe this failure, let us know in the original issue above.