### PR TITLE
add pipeline constants plumbing

### DIFF
--- a/examples/boids/src/main.rs
+++ b/examples/boids/src/main.rs
@@ -132,6 +132,7 @@ impl wgpu_example::framework::Example for Example {
             vertex: wgpu::VertexState {
                 module: &draw_shader,
                 entry_point: "main_vs",
+                constants: &Default::default(),
                 buffers: &[
                     wgpu::VertexBufferLayout {
                         array_stride: 4 * 4,
@@ -148,6 +149,7 @@ impl wgpu_example::framework::Example for Example {
             fragment: Some(wgpu::FragmentState {
                 module: &draw_shader,
                 entry_point: "main_fs",
+                constants: &Default::default(),
                 targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState::default(),
@@ -163,6 +165,7 @@ impl wgpu_example::framework::Example for Example {
             layout: Some(&compute_pipeline_layout),
             module: &compute_shader,
             entry_point: "main",
+            constants: &Default::default(),
         });
 
         // buffer for the three 2d triangle vertices of each instance

--- a/examples/bunnymark/src/main.rs
+++ b/examples/bunnymark/src/main.rs
@@ -203,11 +203,13 @@ impl wgpu_example::framework::Example for Example {
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: config.view_formats[0],
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),

--- a/examples/conservative-raster/src/main.rs
+++ b/examples/conservative-raster/src/main.rs
@@ -97,11 +97,13 @@ impl wgpu_example::framework::Example for Example {
                 vertex: wgpu::VertexState {
                     module: &shader_triangle_and_lines,
                     entry_point: "vs_main",
+                    constants: &Default::default(),
                     buffers: &[],
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &shader_triangle_and_lines,
                     entry_point: "fs_main_red",
+                    constants: &Default::default(),
                     targets: &[Some(RENDER_TARGET_FORMAT.into())],
                 }),
                 primitive: wgpu::PrimitiveState {
@@ -120,11 +122,13 @@ impl wgpu_example::framework::Example for Example {
                 vertex: wgpu::VertexState {
                     module: &shader_triangle_and_lines,
                     entry_point: "vs_main",
+                    constants: &Default::default(),
                     buffers: &[],
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &shader_triangle_and_lines,
                     entry_point: "fs_main_blue",
+                    constants: &Default::default(),
                     targets: &[Some(RENDER_TARGET_FORMAT.into())],
                 }),
                 primitive: wgpu::PrimitiveState::default(),
@@ -144,11 +148,13 @@ impl wgpu_example::framework::Example for Example {
                     vertex: wgpu::VertexState {
                         module: &shader_triangle_and_lines,
                         entry_point: "vs_main",
+                        constants: &Default::default(),
                         buffers: &[],
                     },
                     fragment: Some(wgpu::FragmentState {
                         module: &shader_triangle_and_lines,
                         entry_point: "fs_main_white",
+                        constants: &Default::default(),
                         targets: &[Some(config.view_formats[0].into())],
                     }),
                     primitive: wgpu::PrimitiveState {
@@ -205,11 +211,13 @@ impl wgpu_example::framework::Example for Example {
                     vertex: wgpu::VertexState {
                         module: &shader,
                         entry_point: "vs_main",
+                        constants: &Default::default(),
                         buffers: &[],
                     },
                     fragment: Some(wgpu::FragmentState {
                         module: &shader,
                         entry_point: "fs_main",
+                        constants: &Default::default(),
                         targets: &[Some(config.view_formats[0].into())],
                     }),
                     primitive: wgpu::PrimitiveState::default(),

--- a/examples/cube/src/main.rs
+++ b/examples/cube/src/main.rs
@@ -244,11 +244,13 @@ impl wgpu_example::framework::Example for Example {
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &vertex_buffers,
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {
@@ -270,11 +272,13 @@ impl wgpu_example::framework::Example for Example {
                 vertex: wgpu::VertexState {
                     module: &shader,
                     entry_point: "vs_main",
+                    constants: &Default::default(),
                     buffers: &vertex_buffers,
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &shader,
                     entry_point: "fs_wire",
+                    constants: &Default::default(),
                     targets: &[Some(wgpu::ColorTargetState {
                         format: config.view_formats[0],
                         blend: Some(wgpu::BlendState {

--- a/examples/hello-compute/src/main.rs
+++ b/examples/hello-compute/src/main.rs
@@ -109,6 +109,7 @@ async fn execute_gpu_inner(
         layout: None,
         module: &cs_module,
         entry_point: "main",
+        constants: &Default::default(),
     });
 
     // Instantiates the bind group, once again specifying the binding of buffers.

--- a/examples/hello-synchronization/src/main.rs
+++ b/examples/hello-synchronization/src/main.rs
@@ -103,12 +103,14 @@ async fn execute(
         layout: Some(&pipeline_layout),
         module: &shaders_module,
         entry_point: "patient_main",
+        constants: &Default::default(),
     });
     let hasty_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
         label: None,
         layout: Some(&pipeline_layout),
         module: &shaders_module,
         entry_point: "hasty_main",
+        constants: &Default::default(),
     });
 
     //----------------------------------------------------------

--- a/examples/hello-triangle/src/main.rs
+++ b/examples/hello-triangle/src/main.rs
@@ -60,10 +60,12 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
             module: &shader,
             entry_point: "vs_main",
             buffers: &[],
+            constants: &Default::default(),
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,
             entry_point: "fs_main",
+            constants: &Default::default(),
             targets: &[Some(swapchain_format.into())],
         }),
         primitive: wgpu::PrimitiveState::default(),

--- a/examples/hello-workgroups/src/main.rs
+++ b/examples/hello-workgroups/src/main.rs
@@ -110,6 +110,7 @@ async fn run() {
         layout: Some(&pipeline_layout),
         module: &shader,
         entry_point: "main",
+        constants: &Default::default(),
     });
 
     //----------------------------------------------------------

--- a/examples/mipmap/src/main.rs
+++ b/examples/mipmap/src/main.rs
@@ -93,11 +93,13 @@ impl Example {
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(TEXTURE_FORMAT.into())],
             }),
             primitive: wgpu::PrimitiveState {
@@ -290,11 +292,13 @@ impl wgpu_example::framework::Example for Example {
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {

--- a/examples/msaa-line/src/main.rs
+++ b/examples/msaa-line/src/main.rs
@@ -54,6 +54,7 @@ impl Example {
             vertex: wgpu::VertexState {
                 module: shader,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
@@ -63,6 +64,7 @@ impl Example {
             fragment: Some(wgpu::FragmentState {
                 module: shader,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {

--- a/examples/render-to-texture/src/main.rs
+++ b/examples/render-to-texture/src/main.rs
@@ -59,11 +59,13 @@ async fn run(_path: Option<String>) {
         vertex: wgpu::VertexState {
             module: &shader,
             entry_point: "vs_main",
+            constants: &Default::default(),
             buffers: &[],
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,
             entry_point: "fs_main",
+            constants: &Default::default(),
             targets: &[Some(wgpu::TextureFormat::Rgba8UnormSrgb.into())],
         }),
         primitive: wgpu::PrimitiveState::default(),

--- a/examples/repeated-compute/src/main.rs
+++ b/examples/repeated-compute/src/main.rs
@@ -242,6 +242,7 @@ impl WgpuContext {
             layout: Some(&pipeline_layout),
             module: &shader,
             entry_point: "main",
+            constants: &Default::default(),
         });
 
         WgpuContext {

--- a/examples/shadow/src/main.rs
+++ b/examples/shadow/src/main.rs
@@ -500,6 +500,7 @@ impl wgpu_example::framework::Example for Example {
                 vertex: wgpu::VertexState {
                     module: &shader,
                     entry_point: "vs_bake",
+                    constants: &Default::default(),
                     buffers: &[vb_desc.clone()],
                 },
                 fragment: None,
@@ -632,6 +633,7 @@ impl wgpu_example::framework::Example for Example {
                 vertex: wgpu::VertexState {
                     module: &shader,
                     entry_point: "vs_main",
+                    constants: &Default::default(),
                     buffers: &[vb_desc],
                 },
                 fragment: Some(wgpu::FragmentState {
@@ -641,6 +643,7 @@ impl wgpu_example::framework::Example for Example {
                     } else {
                         "fs_main_without_storage"
                     },
+                    constants: &Default::default(),
                     targets: &[Some(config.view_formats[0].into())],
                 }),
                 primitive: wgpu::PrimitiveState {

--- a/examples/skybox/src/main.rs
+++ b/examples/skybox/src/main.rs
@@ -199,11 +199,13 @@ impl wgpu_example::framework::Example for Example {
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_sky",
+                constants: &Default::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_sky",
+                constants: &Default::default(),
                 targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {
@@ -226,6 +228,7 @@ impl wgpu_example::framework::Example for Example {
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_entity",
+                constants: &Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
@@ -235,6 +238,7 @@ impl wgpu_example::framework::Example for Example {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_entity",
+                constants: &Default::default(),
                 targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {

--- a/examples/srgb-blend/src/main.rs
+++ b/examples/srgb-blend/src/main.rs
@@ -131,11 +131,13 @@ impl<const SRGB: bool> wgpu_example::framework::Example for Example<SRGB> {
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &vertex_buffers,
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: config.view_formats[0],
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),

--- a/examples/stencil-triangles/src/main.rs
+++ b/examples/stencil-triangles/src/main.rs
@@ -74,11 +74,13 @@ impl wgpu_example::framework::Example for Example {
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &vertex_buffers,
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: config.view_formats[0],
                     blend: None,
@@ -112,11 +114,13 @@ impl wgpu_example::framework::Example for Example {
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &vertex_buffers,
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: Default::default(),

--- a/examples/storage-texture/src/main.rs
+++ b/examples/storage-texture/src/main.rs
@@ -100,6 +100,7 @@ async fn run(_path: Option<String>) {
         layout: Some(&pipeline_layout),
         module: &shader,
         entry_point: "main",
+        constants: &Default::default(),
     });
 
     log::info!("Wgpu context set up.");

--- a/examples/texture-arrays/src/main.rs
+++ b/examples/texture-arrays/src/main.rs
@@ -321,6 +321,7 @@ impl wgpu_example::framework::Example for Example {
             vertex: wgpu::VertexState {
                 module: &base_shader_module,
                 entry_point: "vert_main",
+                constants: &Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: vertex_size as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
@@ -330,6 +331,7 @@ impl wgpu_example::framework::Example for Example {
             fragment: Some(wgpu::FragmentState {
                 module: fragment_shader_module,
                 entry_point: fragment_entry_point,
+                constants: &Default::default(),
                 targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {

--- a/examples/timestamp-queries/src/main.rs
+++ b/examples/timestamp-queries/src/main.rs
@@ -288,6 +288,7 @@ fn compute_pass(
         layout: None,
         module,
         entry_point: "main_cs",
+        constants: &Default::default(),
     });
     let bind_group_layout = compute_pipeline.get_bind_group_layout(0);
     let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -342,11 +343,13 @@ fn render_pass(
         vertex: wgpu::VertexState {
             module,
             entry_point: "vs_main",
+            constants: &Default::default(),
             buffers: &[],
         },
         fragment: Some(wgpu::FragmentState {
             module,
             entry_point: "fs_main",
+            constants: &Default::default(),
             targets: &[Some(format.into())],
         }),
         primitive: wgpu::PrimitiveState::default(),

--- a/examples/uniform-values/src/main.rs
+++ b/examples/uniform-values/src/main.rs
@@ -179,11 +179,13 @@ impl WgpuContext {
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(swapchain_format.into())],
             }),
             primitive: wgpu::PrimitiveState::default(),

--- a/examples/water/src/main.rs
+++ b/examples/water/src/main.rs
@@ -512,6 +512,7 @@ impl wgpu_example::framework::Example for Example {
             vertex: wgpu::VertexState {
                 module: &water_module,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 // Layout of our vertices. This should match the structs
                 // which are uploaded to the GPU. This should also be
                 // ensured by tagging on either a `#[repr(C)]` onto a
@@ -527,6 +528,7 @@ impl wgpu_example::framework::Example for Example {
             fragment: Some(wgpu::FragmentState {
                 module: &water_module,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 // Describes how the colour will be interpolated
                 // and assigned to the output attachment.
                 targets: &[Some(wgpu::ColorTargetState {
@@ -581,6 +583,7 @@ impl wgpu_example::framework::Example for Example {
             vertex: wgpu::VertexState {
                 module: &terrain_module,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: terrain_vertex_size as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
@@ -590,6 +593,7 @@ impl wgpu_example::framework::Example for Example {
             fragment: Some(wgpu::FragmentState {
                 module: &terrain_module,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(config.view_formats[0].into())],
             }),
             primitive: wgpu::PrimitiveState {

--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -529,6 +529,7 @@ fn write_output(
                     pipeline_options_owned = spv::PipelineOptions {
                         entry_point: name.clone(),
                         shader_stage: module.entry_points[ep_index].stage,
+                        constants: naga::back::PipelineConstants::default(),
                     };
                     Some(&pipeline_options_owned)
                 }
@@ -569,6 +570,7 @@ fn write_output(
                     _ => unreachable!(),
                 },
                 multiview: None,
+                constants: naga::back::PipelineConstants::default(),
             };
 
             let mut buffer = String::new();
@@ -604,6 +606,7 @@ fn write_output(
                         "Generating hlsl output requires validation to \
                          succeed, and it failed in a previous step",
                     ))?,
+                    &hlsl::PipelineOptions::default(),
                 )
                 .unwrap_pretty();
             fs::write(output_path, buffer)?;

--- a/naga/benches/criterion.rs
+++ b/naga/benches/criterion.rs
@@ -193,6 +193,7 @@ fn backends(c: &mut Criterion) {
                     let pipeline_options = naga::back::spv::PipelineOptions {
                         shader_stage: ep.stage,
                         entry_point: ep.name.clone(),
+                        constants: naga::back::PipelineConstants::default(),
                     };
                     writer
                         .write(module, info, Some(&pipeline_options), &None, &mut data)
@@ -223,10 +224,11 @@ fn backends(c: &mut Criterion) {
     group.bench_function("hlsl", |b| {
         b.iter(|| {
             let options = naga::back::hlsl::Options::default();
+            let pipeline_options = naga::back::hlsl::PipelineOptions::default();
             let mut string = String::new();
             for &(ref module, ref info) in inputs.iter() {
                 let mut writer = naga::back::hlsl::Writer::new(&mut string, &options);
-                let _ = writer.write(module, info); // may fail on unimplemented things
+                let _ = writer.write(module, info, &pipeline_options); // may fail on unimplemented things
                 string.clear();
             }
         });
@@ -248,6 +250,7 @@ fn backends(c: &mut Criterion) {
                         shader_stage: ep.stage,
                         entry_point: ep.name.clone(),
                         multiview: None,
+                        constants: naga::back::PipelineConstants::default(),
                     };
 
                     // might be `Err` if missing features

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -276,7 +276,7 @@ impl Default for Options {
 }
 
 /// A subset of options meant to be changed per pipeline.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct PipelineOptions {
@@ -288,6 +288,8 @@ pub struct PipelineOptions {
     pub entry_point: String,
     /// How many views to render to, if doing multiview rendering.
     pub multiview: Option<std::num::NonZeroU32>,
+    /// Pipeline constants.
+    pub constants: back::PipelineConstants,
 }
 
 #[derive(Debug)]

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -195,6 +195,14 @@ pub struct Options {
     pub zero_initialize_workgroup_memory: bool,
 }
 
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+pub struct PipelineOptions {
+    /// Pipeline constants.
+    pub constants: back::PipelineConstants,
+}
+
 impl Default for Options {
     fn default() -> Self {
         Options {

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -1,7 +1,7 @@
 use super::{
     help::{WrappedArrayLength, WrappedConstructor, WrappedImageQuery, WrappedStructMatrixAccess},
     storage::StoreValue,
-    BackendResult, Error, Options,
+    BackendResult, Error, Options, PipelineOptions,
 };
 use crate::{
     back,
@@ -183,6 +183,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         &mut self,
         module: &Module,
         module_info: &valid::ModuleInfo,
+        _pipeline_options: &PipelineOptions,
     ) -> Result<super::ReflectionInfo, Error> {
         self.reset(module);
 

--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -22,6 +22,15 @@ const BAKE_PREFIX: &str = "_e";
 
 type NeedBakeExpressions = crate::FastHashSet<crate::Handle<crate::Expression>>;
 
+/// Specifies the values of pipeline-overridable constants in the shader module.
+///
+/// If an `@id` attribute was specified on the declaration,
+/// the key must be the pipeline constant ID as a decimal ASCII number; if not,
+/// the key must be the constant's identifier name.
+///
+/// The value may represent any of WGSL's concrete scalar types.
+pub type PipelineConstants = std::collections::HashMap<String, f64>;
+
 #[derive(Clone, Copy)]
 struct Level(usize);
 

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -221,7 +221,7 @@ impl Default for Options {
 }
 
 /// A subset of options that are meant to be changed per pipeline.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct PipelineOptions {
@@ -232,6 +232,8 @@ pub struct PipelineOptions {
     ///
     /// Enable this for vertex shaders with point primitive topologies.
     pub allow_and_force_point_size: bool,
+    /// Pipeline constants.
+    pub constants: crate::back::PipelineConstants,
 }
 
 impl Options {

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -716,7 +716,7 @@ impl<'a> Default for Options<'a> {
 }
 
 // A subset of options meant to be changed per pipeline.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct PipelineOptions {
@@ -726,6 +726,8 @@ pub struct PipelineOptions {
     ///
     /// If no entry point that matches is found while creating a [`Writer`], a error will be thrown.
     pub entry_point: String,
+    /// Pipeline constants.
+    pub constants: crate::back::PipelineConstants,
 }
 
 pub fn write_vec(

--- a/naga/tests/in/interface.param.ron
+++ b/naga/tests/in/interface.param.ron
@@ -27,5 +27,6 @@
 	),
 	msl_pipeline: (
 		allow_and_force_point_size: true,
+		constants: {},
 	),
 )

--- a/naga/tests/snapshots.rs
+++ b/naga/tests/snapshots.rs
@@ -421,6 +421,7 @@ fn write_output_spv(
             let pipeline_options = spv::PipelineOptions {
                 entry_point: ep.name.clone(),
                 shader_stage: ep.stage,
+                constants: naga::back::PipelineConstants::default(),
             };
             write_output_spv_inner(
                 input,
@@ -509,6 +510,7 @@ fn write_output_glsl(
         shader_stage: stage,
         entry_point: ep_name.to_string(),
         multiview,
+        constants: naga::back::PipelineConstants::default(),
     };
 
     let mut buffer = String::new();
@@ -541,7 +543,9 @@ fn write_output_hlsl(
 
     let mut buffer = String::new();
     let mut writer = hlsl::Writer::new(&mut buffer, options);
-    let reflection_info = writer.write(module, info).expect("HLSL write failed");
+    let reflection_info = writer
+        .write(module, info, &hlsl::PipelineOptions::default())
+        .expect("HLSL write failed");
 
     input.write_output_file("hlsl", "hlsl", buffer);
 

--- a/player/tests/data/bind-group.ron
+++ b/player/tests/data/bind-group.ron
@@ -57,6 +57,7 @@
                 stage: (
                     module: Id(0, 1, Empty),
                     entry_point: "main",
+                    constants: {},
                 ),
             ),
         ),

--- a/player/tests/data/pipeline-statistics-query.ron
+++ b/player/tests/data/pipeline-statistics-query.ron
@@ -30,6 +30,7 @@
                 stage: (
                     module: Id(0, 1, Empty),
                     entry_point: "main",
+                    constants: {},
                 ),
             ),
         ),

--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -58,6 +58,7 @@
                     stage: (
                         module: Id(0, 1, Empty),
                         entry_point: "vs_main",
+                        constants: {},
                     ),
                     buffers: [],
                 ),
@@ -65,6 +66,7 @@
                     stage: (
                         module: Id(0, 1, Empty),
                         entry_point: "fs_main",
+                        constants: {},
                     ),
                     targets: [
                         Some((

--- a/player/tests/data/zero-init-buffer.ron
+++ b/player/tests/data/zero-init-buffer.ron
@@ -134,6 +134,7 @@
                 stage: (
                     module: Id(0, 1, Empty),
                     entry_point: "main",
+                    constants: {},
                 ),
             ),
         ),

--- a/player/tests/data/zero-init-texture-binding.ron
+++ b/player/tests/data/zero-init-texture-binding.ron
@@ -135,6 +135,7 @@
                 stage: (
                     module: Id(0, 1, Empty),
                     entry_point: "main",
+                    constants: {},
                 ),
             ),
         ),

--- a/tests/src/image.rs
+++ b/tests/src/image.rs
@@ -367,6 +367,7 @@ fn copy_via_compute(
         layout: Some(&pll),
         module: &sm,
         entry_point: "copy_texture_to_buffer",
+        constants: &Default::default(),
     });
 
     {

--- a/tests/tests/bgra8unorm_storage.rs
+++ b/tests/tests/bgra8unorm_storage.rs
@@ -96,6 +96,7 @@ static BGRA8_UNORM_STORAGE: GpuTestConfiguration = GpuTestConfiguration::new()
             label: None,
             layout: Some(&pl),
             entry_point: "main",
+            constants: &Default::default(),
             module: &module,
         });
 

--- a/tests/tests/bind_group_layout_dedup.rs
+++ b/tests/tests/bind_group_layout_dedup.rs
@@ -70,17 +70,20 @@ static BIND_GROUP_LAYOUT_DEDUPLICATION: GpuTestConfiguration = GpuTestConfigurat
             write_mask: Default::default(),
         })];
 
+        let constants = std::collections::HashMap::default();
         let desc = wgpu::RenderPipelineDescriptor {
             label: None,
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &module,
                 entry_point: "vs_main",
+                constants: &constants,
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &module,
                 entry_point: "fs_main",
+                constants: &constants,
                 targets,
             }),
             primitive: wgpu::PrimitiveState::default(),

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -446,6 +446,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     vertex: wgpu::VertexState {
                         module: &shader_module,
                         entry_point: "",
+                        constants: &Default::default(),
                         buffers: &[],
                     },
                     primitive: wgpu::PrimitiveState::default(),
@@ -464,6 +465,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     layout: None,
                     module: &shader_module,
                     entry_point: "",
+                    constants: &Default::default(),
                 });
         });
 

--- a/tests/tests/mem_leaks.rs
+++ b/tests/tests/mem_leaks.rs
@@ -95,15 +95,17 @@ fn draw_test_with_reports(
             layout: Some(&ppl),
             vertex: wgpu::VertexState {
                 buffers: &[],
-                entry_point: "vs_main",
                 module: &shader,
+                entry_point: "vs_main",
+                constants: &Default::default(),
             },
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
             fragment: Some(wgpu::FragmentState {
-                entry_point: "fs_main",
                 module: &shader,
+                entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: wgpu::TextureFormat::Rgba8Unorm,
                     blend: None,

--- a/tests/tests/occlusion_query/mod.rs
+++ b/tests/tests/occlusion_query/mod.rs
@@ -37,6 +37,7 @@ static OCCLUSION_QUERY: GpuTestConfiguration = GpuTestConfiguration::new()
                 vertex: wgpu::VertexState {
                     module: &shader,
                     entry_point: "vs_main",
+                    constants: &Default::default(),
                     buffers: &[],
                 },
                 fragment: None,

--- a/tests/tests/partially_bounded_arrays/mod.rs
+++ b/tests/tests/partially_bounded_arrays/mod.rs
@@ -69,6 +69,7 @@ static PARTIALLY_BOUNDED_ARRAY: GpuTestConfiguration = GpuTestConfiguration::new
             layout: Some(&pipeline_layout),
             module: &cs_module,
             entry_point: "main",
+            constants: &Default::default(),
         });
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {

--- a/tests/tests/pipeline.rs
+++ b/tests/tests/pipeline.rs
@@ -28,6 +28,7 @@ static PIPELINE_DEFAULT_LAYOUT_BAD_MODULE: GpuTestConfiguration = GpuTestConfigu
                     layout: None,
                     module: &module,
                     entry_point: "doesn't exist",
+                    constants: &Default::default(),
                 });
 
             pipeline.get_bind_group_layout(0);

--- a/tests/tests/push_constants.rs
+++ b/tests/tests/push_constants.rs
@@ -103,6 +103,7 @@ fn partial_update_test(ctx: TestingContext) {
             layout: Some(&pipeline_layout),
             module: &sm,
             entry_point: "main",
+            constants: &Default::default(),
         });
 
     let mut encoder = ctx

--- a/tests/tests/regression/issue_3349.rs
+++ b/tests/tests/regression/issue_3349.rs
@@ -102,11 +102,13 @@ fn multi_stage_data_binding_test(ctx: TestingContext) {
             vertex: wgpu::VertexState {
                 module: &vs_sm,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &fs_sm,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: wgpu::TextureFormat::Rgba8Unorm,
                     blend: None,

--- a/tests/tests/regression/issue_3457.rs
+++ b/tests/tests/regression/issue_3457.rs
@@ -52,6 +52,7 @@ static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration =
                 vertex: VertexState {
                     module: &module,
                     entry_point: "double_buffer_vert",
+                    constants: &Default::default(),
                     buffers: &[
                         VertexBufferLayout {
                             array_stride: 16,
@@ -71,6 +72,7 @@ static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration =
                 fragment: Some(FragmentState {
                     module: &module,
                     entry_point: "double_buffer_frag",
+                    constants: &Default::default(),
                     targets: &[Some(ColorTargetState {
                         format: TextureFormat::Rgba8Unorm,
                         blend: None,
@@ -88,6 +90,7 @@ static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration =
                 vertex: VertexState {
                     module: &module,
                     entry_point: "single_buffer_vert",
+                    constants: &Default::default(),
                     buffers: &[VertexBufferLayout {
                         array_stride: 16,
                         step_mode: VertexStepMode::Vertex,
@@ -100,6 +103,7 @@ static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration =
                 fragment: Some(FragmentState {
                     module: &module,
                     entry_point: "single_buffer_frag",
+                    constants: &Default::default(),
                     targets: &[Some(ColorTargetState {
                         format: TextureFormat::Rgba8Unorm,
                         blend: None,

--- a/tests/tests/scissor_tests/mod.rs
+++ b/tests/tests/scissor_tests/mod.rs
@@ -38,16 +38,18 @@ fn scissor_test_impl(ctx: &TestingContext, scissor_rect: Rect, expected_data: [u
             label: Some("Pipeline"),
             layout: None,
             vertex: wgpu::VertexState {
-                entry_point: "vs_main",
                 module: &shader,
+                entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &[],
             },
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
             fragment: Some(wgpu::FragmentState {
-                entry_point: "fs_main",
                 module: &shader,
+                entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: wgpu::TextureFormat::Rgba8Unorm,
                     blend: None,

--- a/tests/tests/shader/mod.rs
+++ b/tests/tests/shader/mod.rs
@@ -307,6 +307,7 @@ fn shader_input_output_test(
                 layout: Some(&pll),
                 module: &sm,
                 entry_point: "cs_main",
+                constants: &Default::default(),
             });
 
         // -- Initializing data --

--- a/tests/tests/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/shader/zero_init_workgroup_mem.rs
@@ -88,6 +88,7 @@ static ZERO_INIT_WORKGROUP_MEMORY: GpuTestConfiguration = GpuTestConfiguration::
                 layout: Some(&pll),
                 module: &sm,
                 entry_point: "read",
+                constants: &Default::default(),
             });
 
         let pipeline_write = ctx
@@ -97,6 +98,7 @@ static ZERO_INIT_WORKGROUP_MEMORY: GpuTestConfiguration = GpuTestConfiguration::
                 layout: None,
                 module: &sm,
                 entry_point: "write",
+                constants: &Default::default(),
             });
 
         // -- Initializing data --

--- a/tests/tests/shader_primitive_index/mod.rs
+++ b/tests/tests/shader_primitive_index/mod.rs
@@ -118,6 +118,9 @@ fn pulling_common(
             label: None,
             layout: None,
             vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: 8,
                     step_mode: wgpu::VertexStepMode::Vertex,
@@ -127,15 +130,14 @@ fn pulling_common(
                         shader_location: 0,
                     }],
                 }],
-                entry_point: "vs_main",
-                module: &shader,
             },
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
             fragment: Some(wgpu::FragmentState {
-                entry_point: "fs_main",
                 module: &shader,
+                entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: wgpu::TextureFormat::Rgba8Unorm,
                     blend: None,

--- a/tests/tests/shader_view_format/mod.rs
+++ b/tests/tests/shader_view_format/mod.rs
@@ -90,11 +90,13 @@ fn reinterpret(
             vertex: wgpu::VertexState {
                 module: shader,
                 entry_point: "vs_main",
+                constants: &Default::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: shader,
                 entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(src_format.into())],
             }),
             primitive: wgpu::PrimitiveState {

--- a/tests/tests/vertex_indices/mod.rs
+++ b/tests/tests/vertex_indices/mod.rs
@@ -67,16 +67,18 @@ fn pulling_common(
             label: None,
             layout: Some(&ppl),
             vertex: wgpu::VertexState {
-                buffers: &[],
-                entry_point: "vs_main",
                 module: &shader,
+                entry_point: "vs_main",
+                constants: &Default::default(),
+                buffers: &[],
             },
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
             fragment: Some(wgpu::FragmentState {
-                entry_point: "fs_main",
                 module: &shader,
+                entry_point: "fs_main",
+                constants: &Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: wgpu::TextureFormat::Rgba8Unorm,
                     blend: None,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2552,8 +2552,9 @@ impl<A: HalApi> Device<A> {
             label: desc.label.to_hal(self.instance_flags),
             layout: layout.raw(),
             stage: hal::ProgrammableStage {
-                entry_point: desc.stage.entry_point.as_ref(),
                 module: shader_module.raw(),
+                entry_point: desc.stage.entry_point.as_ref(),
+                constants: desc.stage.constants.as_ref(),
             },
         };
 
@@ -2949,6 +2950,7 @@ impl<A: HalApi> Device<A> {
             hal::ProgrammableStage {
                 module: shader_module.raw(),
                 entry_point: stage.entry_point.as_ref(),
+                constants: stage.constants.as_ref(),
             }
         };
 
@@ -3008,6 +3010,7 @@ impl<A: HalApi> Device<A> {
                 Some(hal::ProgrammableStage {
                     module: shader_module.raw(),
                     entry_point: fragment.stage.entry_point.as_ref(),
+                    constants: fragment.stage.constants.as_ref(),
                 })
             }
             None => None,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -194,6 +194,14 @@ pub struct ProgrammableStageDescriptor<'a> {
     /// The name of the entry point in the compiled shader. There must be a function with this name
     /// in the shader.
     pub entry_point: Cow<'a, str>,
+    /// Specifies the values of pipeline-overridable constants in the shader module.
+    ///
+    /// If an `@id` attribute was specified on the declaration,
+    /// the key must be the pipeline constant ID as a decimal ASCII number; if not,
+    /// the key must be the constant's identifier name.
+    ///
+    /// The value may represent any of WGSL's concrete scalar types.
+    pub constants: Cow<'a, naga::back::PipelineConstants>,
 }
 
 /// Number of implicit bind groups derived at pipeline creation.

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -245,17 +245,20 @@ impl<A: hal::Api> Example<A> {
                 .unwrap()
         };
 
+        let constants = naga::back::PipelineConstants::default();
         let pipeline_desc = hal::RenderPipelineDescriptor {
             label: None,
             layout: &pipeline_layout,
             vertex_stage: hal::ProgrammableStage {
                 module: &shader,
                 entry_point: "vs_main",
+                constants: &constants,
             },
             vertex_buffers: &[],
             fragment_stage: Some(hal::ProgrammableStage {
                 module: &shader,
                 entry_point: "fs_main",
+                constants: &constants,
             }),
             primitive: wgt::PrimitiveState {
                 topology: wgt::PrimitiveTopology::TriangleStrip,

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -210,10 +210,13 @@ impl super::Device {
         //TODO: reuse the writer
         let mut source = String::new();
         let mut writer = hlsl::Writer::new(&mut source, &layout.naga_options);
+        let pipeline_options = hlsl::PipelineOptions {
+            constants: stage.constants.to_owned(),
+        };
         let reflection_info = {
             profiling::scope!("naga::back::hlsl::write");
             writer
-                .write(module, &stage.module.naga.info)
+                .write(module, &stage.module.naga.info, &pipeline_options)
                 .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("HLSL: {e:?}")))?
         };
 

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -218,6 +218,7 @@ impl super::Device {
             shader_stage: naga_stage,
             entry_point: stage.entry_point.to_string(),
             multiview: context.multiview,
+            constants: stage.constants.to_owned(),
         };
 
         let shader = &stage.module.naga;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1146,6 +1146,8 @@ pub struct ProgrammableStage<'a, A: Api> {
     /// The name of the entry point in the compiled shader. There must be a function with this name
     ///  in the shader.
     pub entry_point: &'a str,
+    /// Pipeline constants
+    pub constants: &'a naga::back::PipelineConstants,
 }
 
 // Rust gets confused about the impl requirements for `A`
@@ -1154,6 +1156,7 @@ impl<A: Api> Clone for ProgrammableStage<'_, A> {
         Self {
             module: self.module,
             entry_point: self.entry_point,
+            constants: self.constants,
         }
     }
 }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -112,6 +112,7 @@ impl super::Device {
                 metal::MTLPrimitiveTopologyClass::Point => true,
                 _ => false,
             },
+            constants: stage.constants.to_owned(),
         };
 
         let (source, info) = naga::back::msl::write_string(

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -722,6 +722,7 @@ impl super::Device {
                 let pipeline_options = naga::back::spv::PipelineOptions {
                     entry_point: stage.entry_point.to_string(),
                     shader_stage: naga_stage,
+                    constants: stage.constants.to_owned(),
                 };
                 let needs_temp_options = !runtime_checks
                     || !binding_map.is_empty()

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -1194,6 +1194,7 @@ impl crate::Context for Context {
                 stage: pipe::ProgrammableStageDescriptor {
                     module: desc.vertex.module.id.into(),
                     entry_point: Borrowed(desc.vertex.entry_point),
+                    constants: Borrowed(desc.vertex.constants),
                 },
                 buffers: Borrowed(&vertex_buffers),
             },
@@ -1204,6 +1205,7 @@ impl crate::Context for Context {
                 stage: pipe::ProgrammableStageDescriptor {
                     module: frag.module.id.into(),
                     entry_point: Borrowed(frag.entry_point),
+                    constants: Borrowed(frag.constants),
                 },
                 targets: Borrowed(frag.targets),
             }),
@@ -1253,6 +1255,7 @@ impl crate::Context for Context {
             stage: pipe::ProgrammableStageDescriptor {
                 module: desc.module.id.into(),
                 entry_point: Borrowed(desc.entry_point),
+                constants: Borrowed(desc.constants),
             },
         };
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -15,6 +15,7 @@ mod macros;
 use std::{
     any::Any,
     borrow::Cow,
+    collections::HashMap,
     error, fmt,
     future::Future,
     marker::PhantomData,
@@ -1496,6 +1497,14 @@ pub struct VertexState<'a> {
     /// The name of the entry point in the compiled shader. There must be a function with this name
     /// in the shader.
     pub entry_point: &'a str,
+    /// Specifies the values of pipeline-overridable constants in the shader module.
+    ///
+    /// If an `@id` attribute was specified on the declaration,
+    /// the key must be the pipeline constant ID as a decimal ASCII number; if not,
+    /// the key must be the constant's identifier name.
+    ///
+    /// The value may represent any of WGSL's concrete scalar types.
+    pub constants: &'a HashMap<String, f64>,
     /// The format of any vertex buffers used with this pipeline.
     pub buffers: &'a [VertexBufferLayout<'a>],
 }
@@ -1521,6 +1530,14 @@ pub struct FragmentState<'a> {
     /// The name of the entry point in the compiled shader. There must be a function with this name
     /// in the shader.
     pub entry_point: &'a str,
+    /// Specifies the values of pipeline-overridable constants in the shader module.
+    ///
+    /// If an `@id` attribute was specified on the declaration,
+    /// the key must be the pipeline constant ID as a decimal ASCII number; if not,
+    /// the key must be the constant's identifier name.
+    ///
+    /// The value may represent any of WGSL's concrete scalar types.
+    pub constants: &'a HashMap<String, f64>,
     /// The color state of the render targets.
     pub targets: &'a [Option<ColorTargetState>],
 }
@@ -1634,6 +1651,14 @@ pub struct ComputePipelineDescriptor<'a> {
     /// The name of the entry point in the compiled shader. There must be a function with this name
     /// and no return value in the shader.
     pub entry_point: &'a str,
+    /// Specifies the values of pipeline-overridable constants in the shader module.
+    ///
+    /// If an `@id` attribute was specified on the declaration,
+    /// the key must be the pipeline constant ID as a decimal ASCII number; if not,
+    /// the key must be the constant's identifier name.
+    ///
+    /// The value may represent any of WGSL's concrete scalar types.
+    pub constants: &'a HashMap<String, f64>,
 }
 #[cfg(any(
     not(target_arch = "wasm32"),


### PR DESCRIPTION
Adds pipeline constants plumbing to the `pipeline-constants` feature branch.

Tracking meta issue: https://github.com/gfx-rs/wgpu/issues/4484.

Take 3 (https://github.com/gfx-rs/wgpu/pull/4677, https://github.com/gfx-rs/wgpu/pull/4683).