### PR TITLE
[naga wgsl-in] Preserve type names in `alias` declarations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ Passing an owned value `window` to `Surface` will return a `Surface<'static>`. S
 
 - Preserve the source spans for constants and expressions correctly across module compaction. By @jimblandy in [#4696](https://github.com/gfx-rs/wgpu/pull/4696).
 
+- Record the names of WGSL `alias` declarations in Naga IR `Type`s. By @jimblandy in [#4733](https://github.com/gfx-rs/wgpu/pull/4733).
+
 ### Examples
 
 - remove winit dependency from hello-compute example by @psvri in [#4699](https://github.com/gfx-rs/wgpu/pull/4699)

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -98,10 +98,14 @@ impl<'source> GlobalContext<'source, '_, '_> {
         }
     }
 
-    fn ensure_type_exists(&mut self, inner: crate::TypeInner) -> Handle<crate::Type> {
+    fn ensure_type_exists(
+        &mut self,
+        name: Option<String>,
+        inner: crate::TypeInner,
+    ) -> Handle<crate::Type> {
         self.module
             .types
-            .insert(crate::Type { inner, name: None }, Span::UNDEFINED)
+            .insert(crate::Type { inner, name }, Span::UNDEFINED)
     }
 }
 
@@ -635,7 +639,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
     }
 
     fn ensure_type_exists(&mut self, inner: crate::TypeInner) -> Handle<crate::Type> {
-        self.as_global().ensure_type_exists(inner)
+        self.as_global().ensure_type_exists(None, inner)
     }
 }
 
@@ -936,7 +940,11 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         .insert(s.name.name, LoweredGlobalDecl::Type(handle));
                 }
                 ast::GlobalDeclKind::Type(ref alias) => {
-                    let ty = self.resolve_ast_type(alias.ty, &mut ctx)?;
+                    let ty = self.resolve_named_ast_type(
+                        alias.ty,
+                        Some(alias.name.name.to_string()),
+                        &mut ctx,
+                    )?;
                     ctx.globals
                         .insert(alias.name.name, LoweredGlobalDecl::Type(ty));
                 }
@@ -2513,10 +2521,19 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
         })
     }
 
-    /// Return a Naga `Handle<Type>` representing the front-end type `handle`.
-    fn resolve_ast_type(
+    /// Build the Naga equivalent of a named AST type.
+    ///
+    /// Return a Naga `Handle<Type>` representing the front-end type
+    /// `handle`, which should be named `name`, if given.
+    ///
+    /// If `handle` refers to a type cached in [`SpecialTypes`],
+    /// `name` may be ignored.
+    ///
+    /// [`SpecialTypes`]: crate::SpecialTypes
+    fn resolve_named_ast_type(
         &mut self,
         handle: Handle<ast::Type<'source>>,
+        name: Option<String>,
         ctx: &mut GlobalContext<'source, '_, '_>,
     ) -> Result<Handle<crate::Type>, Error<'source>> {
         let inner = match ctx.types[handle] {
@@ -2577,7 +2594,16 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             }
         };
 
-        Ok(ctx.ensure_type_exists(inner))
+        Ok(ctx.ensure_type_exists(name, inner))
+    }
+
+    /// Return a Naga `Handle<Type>` representing the front-end type `handle`.
+    fn resolve_ast_type(
+        &mut self,
+        handle: Handle<ast::Type<'source>>,
+        ctx: &mut GlobalContext<'source, '_, '_>,
+    ) -> Result<Handle<crate::Type>, Error<'source>> {
+        self.resolve_named_ast_type(handle, None, ctx)
     }
 
     fn binding(


### PR DESCRIPTION
Given a WGSL `alias` declaration, create a Naga `Type` with the alias's name, rather than dropping the type name on the floor.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
