### PR TITLE
[naga] Make compaction preserve named types, even if unused.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ Passing an owned value `window` to `Surface` will return a `Surface<'static>`. S
 
 #### Naga
 
+- Make module compaction preserve the module's named types, even if they are unused. By @jimblandy in [#4734](https://github.com/gfx-rs/wgpu/pull/4734).
+
 - Improve algorithm used by module compaction. By @jimblandy in [#4662](https://github.com/gfx-rs/wgpu/pull/4662).
 
 - When reading GLSL, fix the argument types of the double-precision floating-point overloads of the `dot`, `reflect`, `distance`, and `ldexp` builtin functions. Correct the WGSL generated for constructing 64-bit floating-point matrices. Add tests for all the above. By @jimblandy in [#4684](https://github.com/gfx-rs/wgpu/pull/4684).

--- a/naga/src/compact/mod.rs
+++ b/naga/src/compact/mod.rs
@@ -100,6 +100,14 @@ pub fn compact(module: &mut crate::Module) {
         }
     }
 
+    // Treat all named types as used.
+    for (handle, ty) in module.types.iter() {
+        log::trace!("tracing type {:?}, name {:?}", handle, ty.name);
+        if ty.name.is_some() {
+            module_tracer.types_used.insert(handle);
+        }
+    }
+
     // Propagate usage through types.
     module_tracer.as_type().trace_types();
 

--- a/naga/tests/out/spv/runtime-array-in-unused-struct.spvasm
+++ b/naga/tests/out/spv/runtime-array-in-unused-struct.spvasm
@@ -1,9 +1,24 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 3
+; Bound: 10
 OpCapability Shader
 OpCapability Linkage
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
+OpMemberDecorate %5 0 Offset 0
+OpMemberDecorate %5 1 Offset 16
+OpDecorate %6 ArrayStride 32
+OpMemberDecorate %7 0 Offset 0
+OpDecorate %7 Block
+OpDecorate %8 ArrayStride 4
+OpMemberDecorate %9 0 Offset 0
+OpDecorate %9 Block
 %2 = OpTypeVoid
+%3 = OpTypeFloat 32
+%4 = OpTypeVector %3 4
+%5 = OpTypeStruct %3 %4
+%6 = OpTypeRuntimeArray %5
+%7 = OpTypeStruct %6
+%8 = OpTypeRuntimeArray %3
+%9 = OpTypeStruct %8


### PR DESCRIPTION
Have `compact::compact` preserve entries in the `Module::types` arena if they have names.

Future abstract type support will require the WGSL front end to compact the module before validation. Without this change, that will drop `alias` declarations, making it harder to test type validation.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
