### PR TITLE
[naga]: Let `TypeInner::Matrix` hold a `Scalar`, not just a width.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ Passing an owned value `window` to `Surface` will return a `Surface<'static>`. S
 
 - When reading GLSL, fix the argument types of the double-precision floating-point overloads of the `dot`, `reflect`, `distance`, and `ldexp` builtin functions. Correct the WGSL generated for constructing 64-bit floating-point matrices. Add tests for all the above. By @jimblandy in [#4684](https://github.com/gfx-rs/wgpu/pull/4684).
 
+- Allow Naga's IR types to represent matrices with elements elements of any scalar kind. This makes it possible for Naga IR types to represent WGSL abstract matrices. By @jimblandy in [#4735](https://github.com/gfx-rs/wgpu/pull/4735).
+
 - When evaluating const-expressions and generating SPIR-V, properly handle `Compose` expressions whose operands are `Splat` expressions. Such expressions are created and marked as constant by the constant evaluator. By @jimblandy in [#4695](https://github.com/gfx-rs/wgpu/pull/4695).
 
 - Preserve the source spans for constants and expressions correctly across module compaction. By @jimblandy in [#4696](https://github.com/gfx-rs/wgpu/pull/4696).

--- a/naga/src/back/glsl/features.rs
+++ b/naga/src/back/glsl/features.rs
@@ -275,11 +275,9 @@ impl<'a, W> Writer<'a, W> {
 
         for (ty_handle, ty) in self.module.types.iter() {
             match ty.inner {
-                TypeInner::Scalar(scalar) => self.scalar_required_features(scalar),
-                TypeInner::Vector { scalar, .. } => self.scalar_required_features(scalar),
-                TypeInner::Matrix { width, .. } => {
-                    self.scalar_required_features(Scalar::float(width))
-                }
+                TypeInner::Scalar(scalar)
+                | TypeInner::Vector { scalar, .. }
+                | TypeInner::Matrix { scalar, .. } => self.scalar_required_features(scalar),
                 TypeInner::Array { base, size, .. } => {
                     if let TypeInner::Array { .. } = self.module.types[base].inner {
                         self.features.request(Features::ARRAY_OF_ARRAYS)

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -985,11 +985,11 @@ impl<'a, W: Write> Writer<'a, W> {
             TypeInner::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             } => write!(
                 self.out,
                 "{}mat{}x{}",
-                glsl_scalar(crate::Scalar::float(width))?.prefix,
+                glsl_scalar(scalar)?.prefix,
                 columns as u8,
                 rows as u8
             )?,

--- a/naga/src/back/hlsl/conv.rs
+++ b/naga/src/back/hlsl/conv.rs
@@ -47,10 +47,10 @@ impl crate::TypeInner {
             Self::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             } => {
-                let stride = Alignment::from(rows) * width as u32;
-                let last_row_size = rows as u32 * width as u32;
+                let stride = Alignment::from(rows) * scalar.width as u32;
+                let last_row_size = rows as u32 * scalar.width as u32;
                 ((columns as u32 - 1) * stride) + last_row_size
             }
             Self::Array { base, size, stride } => {
@@ -82,10 +82,10 @@ impl crate::TypeInner {
             crate::TypeInner::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             } => Cow::Owned(format!(
                 "{}{}x{}",
-                crate::Scalar::float(width).to_hlsl_str()?,
+                scalar.to_hlsl_str()?,
                 crate::back::vector_size_str(columns),
                 crate::back::vector_size_str(rows),
             )),

--- a/naga/src/back/hlsl/help.rs
+++ b/naga/src/back/hlsl/help.rs
@@ -656,10 +656,9 @@ impl<'a, W: Write> super::Writer<'a, W> {
             _ => unreachable!(),
         };
         let vec_ty = match module.types[member.ty].inner {
-            crate::TypeInner::Matrix { rows, width, .. } => crate::TypeInner::Vector {
-                size: rows,
-                scalar: crate::Scalar::float(width),
-            },
+            crate::TypeInner::Matrix { rows, scalar, .. } => {
+                crate::TypeInner::Vector { size: rows, scalar }
+            }
             _ => unreachable!(),
         };
         self.write_value_type(module, &vec_ty)?;
@@ -736,9 +735,7 @@ impl<'a, W: Write> super::Writer<'a, W> {
             _ => unreachable!(),
         };
         let scalar_ty = match module.types[member.ty].inner {
-            crate::TypeInner::Matrix { width, .. } => {
-                crate::TypeInner::Scalar(crate::Scalar::float(width))
-            }
+            crate::TypeInner::Matrix { scalar, .. } => crate::TypeInner::Scalar(scalar),
             _ => unreachable!(),
         };
         self.write_value_type(module, &scalar_ty)?;

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -908,12 +908,9 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 TypeInner::Matrix {
                     rows,
                     columns,
-                    width,
+                    scalar,
                 } if member.binding.is_none() && rows == crate::VectorSize::Bi => {
-                    let vec_ty = crate::TypeInner::Vector {
-                        size: rows,
-                        scalar: crate::Scalar::float(width),
-                    };
+                    let vec_ty = crate::TypeInner::Vector { size: rows, scalar };
                     let field_name_key = NameKey::StructMember(handle, index as u32);
 
                     for i in 0..columns as u8 {
@@ -1037,7 +1034,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
             TypeInner::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             } => {
                 // The IR supports only float matrix
                 // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-matrix
@@ -1046,7 +1043,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 write!(
                     self.out,
                     "{}{}x{}",
-                    crate::Scalar::float(width).to_hlsl_str()?,
+                    scalar.to_hlsl_str()?,
                     back::vector_size_str(columns),
                     back::vector_size_str(rows),
                 )?;
@@ -3241,11 +3238,11 @@ pub(super) fn get_inner_matrix_data(
         TypeInner::Matrix {
             columns,
             rows,
-            width,
+            scalar,
         } => Some(MatrixType {
             columns,
             rows,
-            width,
+            width: scalar.width,
         }),
         TypeInner::Array { base, .. } => get_inner_matrix_data(module, base),
         _ => None,
@@ -3276,12 +3273,12 @@ pub(super) fn get_inner_matrix_of_struct_array_member(
             TypeInner::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             } => {
                 mat_data = Some(MatrixType {
                     columns,
                     rows,
-                    width,
+                    width: scalar.width,
                 })
             }
             TypeInner::Array { base, .. } => {
@@ -3333,12 +3330,12 @@ fn get_inner_matrix_of_global_uniform(
             TypeInner::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             } => {
                 mat_data = Some(MatrixType {
                     columns,
                     rows,
-                    width,
+                    width: scalar.width,
                 })
             }
             TypeInner::Array { base, .. } => {

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -1942,11 +1942,11 @@ impl<W: Write> Writer<W> {
                 crate::TypeInner::Matrix {
                     columns,
                     rows,
-                    width,
+                    scalar,
                 } => {
                     let target_scalar = crate::Scalar {
                         kind,
-                        width: convert.unwrap_or(width),
+                        width: convert.unwrap_or(scalar.width),
                     };
                     put_numeric_type(&mut self.out, target_scalar, &[rows, columns])?;
                     write!(self.out, "(")?;
@@ -2555,10 +2555,9 @@ impl<W: Write> Writer<W> {
             TypeResolution::Value(crate::TypeInner::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             }) => {
-                let element = crate::Scalar::float(width);
-                put_numeric_type(&mut self.out, element, &[rows, columns])?;
+                put_numeric_type(&mut self.out, scalar, &[rows, columns])?;
             }
             TypeResolution::Value(ref other) => {
                 log::warn!("Type {:?} isn't a known local", other); //TEMP!

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -494,7 +494,7 @@ impl<'w> BlockContext<'w> {
                         crate::TypeInner::Matrix {
                             columns,
                             rows,
-                            width,
+                            scalar,
                         } => {
                             self.write_matrix_matrix_column_op(
                                 block,
@@ -504,7 +504,7 @@ impl<'w> BlockContext<'w> {
                                 right_id,
                                 columns,
                                 rows,
-                                width,
+                                scalar.width,
                                 spirv::Op::FAdd,
                             );
 
@@ -522,7 +522,7 @@ impl<'w> BlockContext<'w> {
                         crate::TypeInner::Matrix {
                             columns,
                             rows,
-                            width,
+                            scalar,
                         } => {
                             self.write_matrix_matrix_column_op(
                                 block,
@@ -532,7 +532,7 @@ impl<'w> BlockContext<'w> {
                                 right_id,
                                 columns,
                                 rows,
-                                width,
+                                scalar.width,
                                 spirv::Op::FSub,
                             );
 
@@ -1141,9 +1141,7 @@ impl<'w> BlockContext<'w> {
                     match *self.fun_info[expr].ty.inner_with(&self.ir_module.types) {
                         crate::TypeInner::Scalar(scalar) => (scalar, None, false),
                         crate::TypeInner::Vector { scalar, size } => (scalar, Some(size), false),
-                        crate::TypeInner::Matrix { width, .. } => {
-                            (crate::Scalar::float(width), None, true)
-                        }
+                        crate::TypeInner::Matrix { scalar, .. } => (scalar, None, true),
                         ref other => {
                             log::error!("As source {:?}", other);
                             return Err(Error::Validation("Unexpected Expression::As source"));

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -367,11 +367,11 @@ fn make_local(inner: &crate::TypeInner) -> Option<LocalType> {
         crate::TypeInner::Matrix {
             columns,
             rows,
-            width,
+            scalar,
         } => LocalType::Matrix {
             columns,
             rows,
-            width,
+            width: scalar.width,
         },
         crate::TypeInner::Pointer { base, space } => LocalType::Pointer {
             base,

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -1766,10 +1766,10 @@ impl Writer {
         if let crate::TypeInner::Matrix {
             columns: _,
             rows,
-            width,
+            scalar,
         } = *member_array_subty_inner
         {
-            let byte_stride = Alignment::from(rows) * width as u32;
+            let byte_stride = Alignment::from(rows) * scalar.width as u32;
             self.annotations.push(Instruction::member_decorate(
                 struct_id,
                 index as u32,

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -524,14 +524,14 @@ impl<W: Write> Writer<W> {
             TypeInner::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             } => {
                 write!(
                     self.out,
                     "mat{}x{}<{}>",
                     back::vector_size_str(columns),
                     back::vector_size_str(rows),
-                    scalar_kind_str(crate::Scalar::float(width))
+                    scalar_kind_str(scalar)
                 )?;
             }
             TypeInner::Pointer { base, space } => {
@@ -1412,12 +1412,11 @@ impl<W: Write> Writer<W> {
                     TypeInner::Matrix {
                         columns,
                         rows,
-                        width,
-                        ..
+                        scalar,
                     } => {
                         let scalar = crate::Scalar {
                             kind,
-                            width: convert.unwrap_or(width),
+                            width: convert.unwrap_or(scalar.width),
                         };
                         let scalar_kind_str = scalar_kind_str(scalar);
                         write!(

--- a/naga/src/front/glsl/builtins.rs
+++ b/naga/src/front/glsl/builtins.rs
@@ -1276,7 +1276,7 @@ fn inject_common_builtin(
                     vec![TypeInner::Matrix {
                         columns,
                         rows,
-                        width: float_width,
+                        scalar: float_scalar,
                     }],
                     MacroCall::MathFunction(MathFunction::Transpose),
                 ))
@@ -1295,7 +1295,7 @@ fn inject_common_builtin(
                 let args = vec![TypeInner::Matrix {
                     columns,
                     rows,
-                    width: float_width,
+                    scalar: float_scalar,
                 }];
 
                 declaration.overloads.push(module.add_builtin(

--- a/naga/src/front/glsl/offset.rs
+++ b/naga/src/front/glsl/offset.rs
@@ -109,9 +109,9 @@ pub fn calculate_offset(
         TypeInner::Matrix {
             columns,
             rows,
-            width,
+            scalar,
         } => {
-            let mut align = Alignment::from(rows) * Alignment::from_width(width);
+            let mut align = Alignment::from(rows) * Alignment::from_width(scalar.width);
 
             // See comment at the beginning of the function
             if StructLayout::Std430 != layout {

--- a/naga/src/front/glsl/parser/declarations.rs
+++ b/naga/src/front/glsl/parser/declarations.rs
@@ -43,13 +43,10 @@ fn element_or_member_type(
         ),
         // The child type of a matrix is a vector of floats with the same
         // width and the size of the matrix rows.
-        TypeInner::Matrix { rows, width, .. } => types.insert(
+        TypeInner::Matrix { rows, scalar, .. } => types.insert(
             Type {
                 name: None,
-                inner: TypeInner::Vector {
-                    size: rows,
-                    scalar: Scalar::float(width),
-                },
+                inner: TypeInner::Vector { size: rows, scalar },
             },
             Default::default(),
         ),

--- a/naga/src/front/glsl/types.rs
+++ b/naga/src/front/glsl/types.rs
@@ -72,7 +72,7 @@ pub fn parse_type(type_name: &str) -> Option<Type> {
 
                 let kind = iter.next()?;
                 let size = iter.next()?;
-                let Scalar { width, .. } = kind_width_parse(kind)?;
+                let scalar = kind_width_parse(kind)?;
 
                 let (columns, rows) = if let Some(size) = size_parse(size) {
                     (size, size)
@@ -89,7 +89,7 @@ pub fn parse_type(type_name: &str) -> Option<Type> {
                     inner: TypeInner::Matrix {
                         columns,
                         rows,
-                        width,
+                        scalar,
                     },
                 })
             };
@@ -193,8 +193,8 @@ pub const fn scalar_components(ty: &TypeInner) -> Option<Scalar> {
     match *ty {
         TypeInner::Scalar(scalar)
         | TypeInner::Vector { scalar, .. }
-        | TypeInner::ValuePointer { scalar, .. } => Some(scalar),
-        TypeInner::Matrix { width, .. } => Some(Scalar::float(width)),
+        | TypeInner::ValuePointer { scalar, .. }
+        | TypeInner::Matrix { scalar, .. } => Some(scalar),
         _ => None,
     }
 }

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -2831,8 +2831,8 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                     let ty_lookup = self.lookup_type.lookup(result_type_id)?;
                     let scalar = match ctx.type_arena[ty_lookup.handle].inner {
                         crate::TypeInner::Scalar(scalar)
-                        | crate::TypeInner::Vector { scalar, .. } => scalar,
-                        crate::TypeInner::Matrix { width, .. } => crate::Scalar::float(width),
+                        | crate::TypeInner::Vector { scalar, .. }
+                        | crate::TypeInner::Matrix { scalar, .. } => scalar,
                         _ => return Err(Error::InvalidAsType(ty_lookup.handle)),
                     };
 
@@ -4377,7 +4377,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
             crate::TypeInner::Vector { size, scalar } => crate::TypeInner::Matrix {
                 columns: map_vector_size(num_columns)?,
                 rows: size,
-                width: scalar.width,
+                scalar,
             },
             _ => return Err(Error::InvalidInnerType(vector_type_id)),
         };
@@ -4674,17 +4674,17 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
             if let crate::TypeInner::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             } = *inner
             {
                 if let Some(stride) = decor.matrix_stride {
-                    let expected_stride = Alignment::from(rows) * width as u32;
+                    let expected_stride = Alignment::from(rows) * scalar.width as u32;
                     if stride.get() != expected_stride {
                         return Err(Error::UnsupportedMatrixStride {
                             stride: stride.get(),
                             columns: columns as u8,
                             rows: rows as u8,
-                            width,
+                            width: scalar.width,
                         });
                     }
                 }

--- a/naga/src/front/type_gen.rs
+++ b/naga/src/front/type_gen.rs
@@ -156,7 +156,7 @@ impl crate::Module {
                 inner: crate::TypeInner::Matrix {
                     columns: crate::VectorSize::Quad,
                     rows: crate::VectorSize::Tri,
-                    width: 4,
+                    scalar: crate::Scalar::F32,
                 },
             },
             Span::UNDEFINED,

--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -244,13 +244,13 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     &crate::TypeInner::Matrix {
                         columns: dst_columns,
                         rows: dst_rows,
-                        width: dst_width,
+                        scalar: dst_scalar,
                     },
                 )),
             ) if dst_columns == src_columns && dst_rows == src_rows => crate::Expression::As {
                 expr: component,
                 kind: crate::ScalarKind::Float,
-                convert: Some(dst_width),
+                convert: Some(dst_scalar.width),
             },
 
             // Matrix conversion (matrix -> matrix) - partial
@@ -336,7 +336,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             (
                 Components::Many {
                     components,
-                    first_component_ty_inner: &crate::TypeInner::Scalar(crate::Scalar { width, .. }),
+                    first_component_ty_inner: &crate::TypeInner::Scalar(scalar),
                     ..
                 },
                 Constructor::PartialMatrix { columns, rows },
@@ -352,14 +352,12 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     &crate::TypeInner::Matrix {
                         columns,
                         rows,
-                        width,
+                        scalar,
                     },
                 )),
             ) => {
-                let vec_ty = ctx.ensure_type_exists(crate::TypeInner::Vector {
-                    scalar: crate::Scalar::float(width),
-                    size: rows,
-                });
+                let vec_ty =
+                    ctx.ensure_type_exists(crate::TypeInner::Vector { scalar, size: rows });
 
                 let components = components
                     .chunks(rows as usize)
@@ -377,7 +375,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 let ty = ctx.ensure_type_exists(crate::TypeInner::Matrix {
                     columns,
                     rows,
-                    width,
+                    scalar,
                 });
                 crate::Expression::Compose { ty, components }
             }
@@ -386,11 +384,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             (
                 Components::Many {
                     components,
-                    first_component_ty_inner:
-                        &crate::TypeInner::Vector {
-                            scalar: crate::Scalar { width, .. },
-                            ..
-                        },
+                    first_component_ty_inner: &crate::TypeInner::Vector { scalar, .. },
                     ..
                 },
                 Constructor::PartialMatrix { columns, rows },
@@ -406,14 +400,14 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     &crate::TypeInner::Matrix {
                         columns,
                         rows,
-                        width,
+                        scalar,
                     },
                 )),
             ) => {
                 let ty = ctx.ensure_type_exists(crate::TypeInner::Matrix {
                     columns,
                     rows,
-                    width,
+                    scalar,
                 });
                 crate::Expression::Compose { ty, components }
             }
@@ -531,7 +525,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 let ty = ctx.ensure_type_exists(crate::TypeInner::Matrix {
                     columns,
                     rows,
-                    width,
+                    scalar: crate::Scalar::float(width),
                 });
                 Constructor::Type(ty)
             }

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -2529,7 +2529,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             } => crate::TypeInner::Matrix {
                 columns,
                 rows,
-                width,
+                scalar: crate::Scalar::float(width),
             },
             ast::Type::Atomic(scalar) => scalar.to_inner_atomic(),
             ast::Type::Pointer { base, space } => {

--- a/naga/src/front/wgsl/to_wgsl.rs
+++ b/naga/src/front/wgsl/to_wgsl.rs
@@ -44,13 +44,13 @@ impl crate::TypeInner {
             Ti::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             } => {
                 format!(
                     "mat{}x{}<{}>",
                     columns as u32,
                     rows as u32,
-                    crate::Scalar::float(width).to_wgsl(),
+                    scalar.to_wgsl(),
                 )
             }
             Ti::Atomic(scalar) => {
@@ -236,7 +236,7 @@ mod tests {
         let mat = crate::TypeInner::Matrix {
             rows: crate::VectorSize::Quad,
             columns: crate::VectorSize::Bi,
-            width: 8,
+            scalar: crate::Scalar::F64,
         };
         assert_eq!(mat.to_wgsl(&gctx), "mat2x4<f64>");
 

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -693,11 +693,11 @@ pub enum TypeInner {
     Scalar(Scalar),
     /// Vector of numbers.
     Vector { size: VectorSize, scalar: Scalar },
-    /// Matrix of floats.
+    /// Matrix of numbers.
     Matrix {
         columns: VectorSize,
         rows: VectorSize,
-        width: Bytes,
+        scalar: Scalar,
     },
     /// Atomic scalar.
     Atomic(Scalar),

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -914,15 +914,12 @@ impl<'a> ConstantEvaluator<'a> {
             TypeInner::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             } => {
                 let vec_ty = self.types.insert(
                     Type {
                         name: None,
-                        inner: TypeInner::Vector {
-                            size: rows,
-                            scalar: crate::Scalar::float(width),
-                        },
+                        inner: TypeInner::Vector { size: rows, scalar },
                     },
                     span,
                 );
@@ -1026,7 +1023,7 @@ impl<'a> ConstantEvaluator<'a> {
                     TypeInner::Matrix { columns, rows, .. } => TypeInner::Matrix {
                         columns,
                         rows,
-                        width: target.width,
+                        scalar: target,
                     },
                     _ => return Err(ConstantEvaluatorError::InvalidCastArg),
                 };
@@ -1522,7 +1519,7 @@ mod tests {
                 inner: TypeInner::Matrix {
                     columns: VectorSize::Bi,
                     rows: VectorSize::Tri,
-                    width: 4,
+                    scalar: crate::Scalar::F32,
                 },
             },
             Default::default(),

--- a/naga/src/proc/layouter.rs
+++ b/naga/src/proc/layouter.rs
@@ -190,9 +190,9 @@ impl Layouter {
                 Ti::Matrix {
                     columns: _,
                     rows,
-                    width,
+                    scalar,
                 } => {
-                    let alignment = Alignment::new(width as u32)
+                    let alignment = Alignment::new(scalar.width as u32)
                         .ok_or(LayoutErrorInner::NonPowerOfTwoWidth.with(ty_handle))?;
                     TypeLayout {
                         size,

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -226,7 +226,7 @@ impl super::TypeInner {
         use crate::TypeInner as Ti;
         match *self {
             Ti::Scalar(scalar) | Ti::Vector { scalar, .. } => Some(scalar),
-            Ti::Matrix { width, .. } => Some(super::Scalar::float(width)),
+            Ti::Matrix { scalar, .. } => Some(scalar),
             _ => None,
         }
     }
@@ -266,8 +266,8 @@ impl super::TypeInner {
             Self::Matrix {
                 columns,
                 rows,
-                width,
-            } => Alignment::from(rows) * width as u32 * columns as u32,
+                scalar,
+            } => Alignment::from(rows) * scalar.width as u32 * columns as u32,
             Self::Pointer { .. } | Self::ValuePointer { .. } => POINTER_SPAN,
             Self::Array {
                 base: _,
@@ -367,10 +367,9 @@ impl super::TypeInner {
     pub fn component_type(&self, index: usize) -> Option<TypeResolution> {
         Some(match *self {
             Self::Vector { scalar, .. } => TypeResolution::Value(crate::TypeInner::Scalar(scalar)),
-            Self::Matrix { rows, width, .. } => TypeResolution::Value(crate::TypeInner::Vector {
-                size: rows,
-                scalar: crate::Scalar::float(width),
-            }),
+            Self::Matrix { rows, scalar, .. } => {
+                TypeResolution::Value(crate::TypeInner::Vector { size: rows, scalar })
+            }
             Self::Array {
                 base,
                 size: crate::ArraySize::Constant(_),
@@ -773,7 +772,7 @@ fn test_matrix_size() {
         crate::TypeInner::Matrix {
             columns: crate::VectorSize::Tri,
             rows: crate::VectorSize::Tri,
-            width: 4
+            scalar: crate::Scalar::F32,
         }
         .size(module.to_ctx()),
         48,

--- a/naga/src/valid/compose.rs
+++ b/naga/src/valid/compose.rs
@@ -50,12 +50,9 @@ pub fn validate_compose(
         Ti::Matrix {
             columns,
             rows,
-            width,
+            scalar,
         } => {
-            let inner = Ti::Vector {
-                size: rows,
-                scalar: crate::Scalar::float(width),
-            };
+            let inner = Ti::Vector { size: rows, scalar };
             if columns as usize != component_resolutions.len() {
                 return Err(ComposeError::ComponentCount {
                     expected: columns as u32,

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -1501,7 +1501,7 @@ impl super::Validator {
                     crate::TypeInner::Scalar(scalar) | crate::TypeInner::Vector { scalar, .. } => {
                         scalar
                     }
-                    crate::TypeInner::Matrix { width, .. } => crate::Scalar::float(width),
+                    crate::TypeInner::Matrix { scalar, .. } => scalar,
                     _ => return Err(ExpressionError::InvalidCastArgument),
                 };
                 base_scalar.kind = kind;

--- a/naga/tests/out/ir/access.compact.ron
+++ b/naga/tests/out/ir/access.compact.ron
@@ -69,7 +69,10 @@
             inner: Matrix(
                 columns: Quad,
                 rows: Tri,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -77,7 +80,10 @@
             inner: Matrix(
                 columns: Bi,
                 rows: Bi,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -178,7 +184,10 @@
             inner: Matrix(
                 columns: Tri,
                 rows: Bi,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -210,7 +219,10 @@
             inner: Matrix(
                 columns: Quad,
                 rows: Bi,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (

--- a/naga/tests/out/ir/access.ron
+++ b/naga/tests/out/ir/access.ron
@@ -69,7 +69,10 @@
             inner: Matrix(
                 columns: Quad,
                 rows: Tri,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -77,7 +80,10 @@
             inner: Matrix(
                 columns: Bi,
                 rows: Bi,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -178,7 +184,10 @@
             inner: Matrix(
                 columns: Tri,
                 rows: Bi,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (
@@ -220,7 +229,10 @@
             inner: Matrix(
                 columns: Quad,
                 rows: Bi,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (

--- a/naga/tests/out/ir/shadow.compact.ron
+++ b/naga/tests/out/ir/shadow.compact.ron
@@ -90,7 +90,10 @@
             inner: Matrix(
                 columns: Quad,
                 rows: Quad,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (

--- a/naga/tests/out/ir/shadow.ron
+++ b/naga/tests/out/ir/shadow.ron
@@ -138,7 +138,10 @@
             inner: Matrix(
                 columns: Quad,
                 rows: Quad,
-                width: 4,
+                scalar: (
+                    kind: Float,
+                    width: 4,
+                ),
             ),
         ),
         (

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -792,10 +792,10 @@ impl Interface {
             naga::TypeInner::Matrix {
                 columns,
                 rows,
-                width,
+                scalar,
             } => NumericType {
                 dim: NumericDimension::Matrix(columns, rows),
-                scalar: naga::Scalar::float(width),
+                scalar,
             },
             naga::TypeInner::Struct { ref members, .. } => {
                 for member in members {

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1563,7 +1563,7 @@ impl super::Queue {
                     naga::TypeInner::Matrix {
                         columns: naga::VectorSize::Bi,
                         rows: naga::VectorSize::Bi,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         let data = unsafe { get_data::<f32, 4>(data_bytes, offset) };
                         unsafe { gl.uniform_matrix_2_f32_slice(location, false, data) };
@@ -1571,7 +1571,7 @@ impl super::Queue {
                     naga::TypeInner::Matrix {
                         columns: naga::VectorSize::Bi,
                         rows: naga::VectorSize::Tri,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         // repack 2 vec3s into 6 values.
                         let unpacked_data = unsafe { get_data::<f32, 8>(data_bytes, offset) };
@@ -1585,7 +1585,7 @@ impl super::Queue {
                     naga::TypeInner::Matrix {
                         columns: naga::VectorSize::Bi,
                         rows: naga::VectorSize::Quad,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         let data = unsafe { get_data::<f32, 8>(data_bytes, offset) };
                         unsafe { gl.uniform_matrix_2x4_f32_slice(location, false, data) };
@@ -1597,7 +1597,7 @@ impl super::Queue {
                     naga::TypeInner::Matrix {
                         columns: naga::VectorSize::Tri,
                         rows: naga::VectorSize::Bi,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         let data = unsafe { get_data::<f32, 6>(data_bytes, offset) };
                         unsafe { gl.uniform_matrix_3x2_f32_slice(location, false, data) };
@@ -1605,7 +1605,7 @@ impl super::Queue {
                     naga::TypeInner::Matrix {
                         columns: naga::VectorSize::Tri,
                         rows: naga::VectorSize::Tri,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         // repack 3 vec3s into 9 values.
                         let unpacked_data = unsafe { get_data::<f32, 12>(data_bytes, offset) };
@@ -1620,7 +1620,7 @@ impl super::Queue {
                     naga::TypeInner::Matrix {
                         columns: naga::VectorSize::Tri,
                         rows: naga::VectorSize::Quad,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         let data = unsafe { get_data::<f32, 12>(data_bytes, offset) };
                         unsafe { gl.uniform_matrix_3x4_f32_slice(location, false, data) };
@@ -1632,7 +1632,7 @@ impl super::Queue {
                     naga::TypeInner::Matrix {
                         columns: naga::VectorSize::Quad,
                         rows: naga::VectorSize::Bi,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         let data = unsafe { get_data::<f32, 8>(data_bytes, offset) };
                         unsafe { gl.uniform_matrix_4x2_f32_slice(location, false, data) };
@@ -1640,7 +1640,7 @@ impl super::Queue {
                     naga::TypeInner::Matrix {
                         columns: naga::VectorSize::Quad,
                         rows: naga::VectorSize::Tri,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         // repack 4 vec3s into 12 values.
                         let unpacked_data = unsafe { get_data::<f32, 16>(data_bytes, offset) };
@@ -1656,7 +1656,7 @@ impl super::Queue {
                     naga::TypeInner::Matrix {
                         columns: naga::VectorSize::Quad,
                         rows: naga::VectorSize::Quad,
-                        width: 4,
+                        scalar: naga::Scalar::F32,
                     } => {
                         let data = unsafe { get_data::<f32, 16>(data_bytes, offset) };
                         unsafe { gl.uniform_matrix_4_f32_slice(location, false, data) };


### PR DESCRIPTION
Let `naga::TypeInner::Matrix` hold a full `Scalar`, with a kind and byte width, not merely a byte width, to make it possible to represent matrices of AbstractFloats for WGSL.

This is a prerequisite for implementing abstract types in the WGSL front end, because it allows us to describe matrices whose elements are abstract floats.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
