### PR TITLE
Make the command_encoder_clear_buffer's size an Option<BufferAddress>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ By @gents83 in [#3626](https://github.com/gfx-rs/wgpu/pull/3626) and tnx also to
 - Log vulkan validation layer messages during instance creation and destruction: By @exrook in [#4586](https://github.com/gfx-rs/wgpu/pull/4586)
 - `TextureFormat::block_size` is deprecated, use `TextureFormat::block_copy_size` instead: By @wumpf in [#4647](https://github.com/gfx-rs/wgpu/pull/4647)
 - Rename of `DispatchIndirect`, `DrawIndexedIndirect`, and `DrawIndirect` types in the `wgpu::util` module to `DispatchIndirectArgs`, `DrawIndexedIndirectArgs`, and `DrawIndirectArgs`. By @cwfitzgerald in [#4723](https://github.com/gfx-rs/wgpu/pull/4723).
+- Make the size parameter of `encoder.clear_buffer` an `Option<u64>` instead of `Option<NonZero<u64>>`. By @nical in [#4737](https://github.com/gfx-rs/wgpu/pull/4737)
 
 #### Safe `Surface` creation
 

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -475,7 +475,7 @@ pub fn op_webgpu_command_encoder_clear_buffer(
       command_encoder,
       destination_resource.1,
       offset,
-      std::num::NonZeroU64::new(size)
+      Some(size)
     ))
 }
 

--- a/tests/tests/regression/issue_4122.rs
+++ b/tests/tests/regression/issue_4122.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroU64, ops::Range};
+use std::ops::Range;
 
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestingContext};
 
@@ -27,11 +27,7 @@ fn fill_test(ctx: &TestingContext, range: Range<u64>, size: u64) -> bool {
             label: Some("encoder"),
         });
 
-    encoder.clear_buffer(
-        &gpu_buffer,
-        range.start,
-        NonZeroU64::new(range.end - range.start),
-    );
+    encoder.clear_buffer(&gpu_buffer, range.start, Some(range.end - range.start));
     encoder.copy_buffer_to_buffer(&gpu_buffer, 0, &cpu_buffer, 0, size);
 
     ctx.queue.submit(Some(encoder.finish()));

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -154,7 +154,7 @@ pub enum Command {
     ClearBuffer {
         dst: id::BufferId,
         offset: wgt::BufferAddress,
-        size: Option<wgt::BufferSize>,
+        size: Option<wgt::BufferAddress>,
     },
     ClearTexture {
         dst: id::TextureId,

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -2059,7 +2059,7 @@ impl crate::Context for Context {
         encoder_data: &Self::CommandEncoderData,
         buffer: &crate::Buffer,
         offset: wgt::BufferAddress,
-        size: Option<wgt::BufferSize>,
+        size: Option<wgt::BufferAddress>,
     ) {
         let global = &self.0;
         if let Err(cause) = wgc::gfx_select!(encoder => global.command_encoder_clear_buffer(

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -2446,15 +2446,15 @@ impl crate::context::Context for Context {
         encoder_data: &Self::CommandEncoderData,
         buffer: &crate::Buffer,
         offset: wgt::BufferAddress,
-        size: Option<wgt::BufferSize>,
+        size: Option<wgt::BufferAddress>,
     ) {
         let buffer: &<Context as crate::Context>::BufferData = downcast_ref(buffer.data.as_ref());
         match size {
-            Some(size) => encoder_data.0.clear_buffer_with_f64_and_f64(
-                &buffer.0,
-                offset as f64,
-                size.get() as f64,
-            ),
+            Some(size) => {
+                encoder_data
+                    .0
+                    .clear_buffer_with_f64_and_f64(&buffer.0, offset as f64, size as f64)
+            }
             None => encoder_data
                 .0
                 .clear_buffer_with_f64(&buffer.0, offset as f64),

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -494,7 +494,7 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         encoder_data: &Self::CommandEncoderData,
         buffer: &Buffer,
         offset: BufferAddress,
-        size: Option<BufferSize>,
+        size: Option<BufferAddress>,
     );
 
     fn command_encoder_insert_debug_marker(
@@ -1570,7 +1570,7 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         encoder_data: &crate::Data,
         buffer: &Buffer,
         offset: BufferAddress,
-        size: Option<BufferSize>,
+        size: Option<BufferAddress>,
     );
 
     fn command_encoder_insert_debug_marker(
@@ -2914,7 +2914,7 @@ where
         encoder_data: &crate::Data,
         buffer: &Buffer,
         offset: BufferAddress,
-        size: Option<BufferSize>,
+        size: Option<BufferAddress>,
     ) {
         let encoder = <T::CommandEncoderId>::from(*encoder);
         let encoder_data = downcast_ref(encoder_data);

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3643,7 +3643,7 @@ impl CommandEncoder {
         &mut self,
         buffer: &Buffer,
         offset: BufferAddress,
-        size: Option<BufferSize>,
+        size: Option<BufferAddress>,
     ) {
         DynContext::command_encoder_clear_buffer(
             &*self.context,


### PR DESCRIPTION
**Connections**

Gecko side work: https://bugzilla.mozilla.org/show_bug.cgi?id=1865830
CTS test `cts.https.html?q=webgpu:api,operation,command_buffer,clearBuffer:clear:*`

**Description**

The size parameter in WebGPU can be zero so the types have to allow expressing it.
In general I don't think any of the `BufferSize` (which is `NonZero<u32>`) usage in wgpu_core's API is desirable for the same reason (I'd extend that to wgpu's API since it's rather tedious to deal with NonZero there as well).

**Testing**

CTS test `cts.https.html?q=webgpu:api,operation,command_buffer,clearBuffer:clear:*`

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
