### PR TITLE
[naga] Fix type error in test.

### DIFF
--- a/naga/tests/wgsl-errors.rs
+++ b/naga/tests/wgsl-errors.rs
@@ -1909,7 +1909,7 @@ fn function_returns_void() {
     check(
         "
         fn x() {
-	        let a = vec2<f32>(1, 2u);
+	        let a = vec2<f32>(1.0, 2.0);
         }
 
         fn b() {


### PR DESCRIPTION
Change the WGSL code in the `function_returns_void` test in `tests/wgsl-errors.rs` so that the construction expression types correctly. Subsequent iterations of the WGSL front end will be doing some type checking earlier, to support WGSL's automatic conversions, and without this fix, this test will stop checking what it is intended to check.

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
- [X] Run `cargo xtask test` to run tests.
- (not appropriate) Add change to `CHANGELOG.md`. See simple instructions inside file.
