### PR TITLE
[naga]: Make snapshot tests include paths in errors.

### DIFF
--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -316,8 +316,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             match result {
                 Ok(v) => (v, Some(input)),
                 Err(ref e) => {
-                    let path = input_path.to_string_lossy();
-                    e.emit_to_stderr_with_path(&input, &path);
+                    e.emit_to_stderr_with_path(&input, input_path);
                     return Err(CliError("Could not parse WGSL").into());
                 }
             }

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -55,7 +55,11 @@ impl ParseError {
     }
 
     /// Emits a summary of the error to standard error stream.
-    pub fn emit_to_stderr_with_path(&self, source: &str, path: &str) {
+    pub fn emit_to_stderr_with_path<P>(&self, source: &str, path: P)
+    where
+        P: AsRef<std::path::Path>,
+    {
+        let path = path.as_ref().display().to_string();
         let files = SimpleFile::new(path, source);
         let config = codespan_reporting::term::Config::default();
         let writer = StandardStream::stderr(ColorChoice::Auto);
@@ -69,7 +73,11 @@ impl ParseError {
     }
 
     /// Emits a summary of the error to a string.
-    pub fn emit_to_string_with_path(&self, source: &str, path: &str) -> String {
+    pub fn emit_to_string_with_path<P>(&self, source: &str, path: P) -> String
+    where
+        P: AsRef<std::path::Path>,
+    {
+        let path = path.as_ref().display().to_string();
         let files = SimpleFile::new(path, source);
         let config = codespan_reporting::term::Config::default();
         let mut writer = NoColor::new(Vec::new());

--- a/naga/tests/snapshots.rs
+++ b/naga/tests/snapshots.rs
@@ -783,7 +783,10 @@ fn convert_wgsl() {
         let source = input.read_source();
         match naga::front::wgsl::parse_str(&source) {
             Ok(mut module) => check_targets(&input, &mut module, targets, None),
-            Err(e) => panic!("{}", e.emit_to_string(&source)),
+            Err(e) => panic!(
+                "{}",
+                e.emit_to_string_with_path(&source, input.input_path())
+            ),
         }
     }
 
@@ -798,7 +801,10 @@ fn convert_wgsl() {
             let source = input.read_source();
             match naga::front::wgsl::parse_str(&source) {
                 Ok(mut module) => check_targets(&input, &mut module, targets, Some(&source)),
-                Err(e) => panic!("{}", e.emit_to_string(&source)),
+                Err(e) => panic!(
+                    "{}",
+                    e.emit_to_string_with_path(&source, input.input_path())
+                ),
             }
         }
     }


### PR DESCRIPTION
Following Rust convention, let `naga::front::wgsl::ParseError`'s methods `emit_to_stderr_with_path` and `emit_to_string_with_path` accept any `AsRef<Path>` argument as the path.

Pass input paths in snapshot tests, so that failures processing shaders name the input file being processed.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
- [X] Run `cargo xtask test` to run tests.
- (not appropriate) Add change to `CHANGELOG.md`. See simple instructions inside file.
