### PR TITLE
[naga wgsl-in] Experimental 64-bit floating-point literals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ Bottom level categories:
 
 #### OpenGL
 - `@builtin(instance_index)` now properly reflects the range provided in the draw call instead of always counting from 0. By @cwfitzgerald in [#4722](https://github.com/gfx-rs/wgpu/pull/4722).
+#### Naga
+
+- Naga's WGSL front and back ends now have experimental support for 64-bit floating-point literals: `1.0lf` denotes an `f64` value. There has been experimental support for an `f64` type for a while, but until now there was no syntax for writing literals with that type. As before, Naga module validation rejects `f64` values unless `naga::valid::Capabilities::FLOAT64` is requested. By @jimblandy in [#4747](https://github.com/gfx-rs/wgpu/pull/4747).
 
 ### Changes
 

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -1095,9 +1095,7 @@ impl<W: Write> Writer<W> {
                     crate::Literal::U32(value) => write!(self.out, "{}u", value)?,
                     crate::Literal::I32(value) => write!(self.out, "{}", value)?,
                     crate::Literal::Bool(value) => write!(self.out, "{}", value)?,
-                    crate::Literal::F64(_) => {
-                        return Err(Error::Custom("unsupported f64 literal".to_string()));
-                    }
+                    crate::Literal::F64(value) => write!(self.out, "{:?}lf", value)?,
                     crate::Literal::I64(_) => {
                         return Err(Error::Custom("unsupported i64 literal".to_string()));
                     }

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1472,6 +1472,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     ast::Literal::Number(Number::F32(f)) => crate::Literal::F32(f),
                     ast::Literal::Number(Number::I32(i)) => crate::Literal::I32(i),
                     ast::Literal::Number(Number::U32(u)) => crate::Literal::U32(u),
+                    ast::Literal::Number(Number::F64(f)) => crate::Literal::F64(f),
                     ast::Literal::Number(_) => {
                         unreachable!("got abstract numeric type when not expected");
                     }

--- a/naga/src/front/wgsl/parse/lexer.rs
+++ b/naga/src/front/wgsl/parse/lexer.rs
@@ -626,6 +626,22 @@ fn test_numbers() {
 }
 
 #[test]
+fn double_floats() {
+    sub_test(
+        "0x1.2p4lf 0x1p8lf 0.0625lf 625e-4lf 10lf 10l",
+        &[
+            Token::Number(Ok(Number::F64(18.0))),
+            Token::Number(Ok(Number::F64(256.0))),
+            Token::Number(Ok(Number::F64(0.0625))),
+            Token::Number(Ok(Number::F64(0.0625))),
+            Token::Number(Ok(Number::F64(10.0))),
+            Token::Number(Ok(Number::I32(10))),
+            Token::Word("l"),
+        ],
+    )
+}
+
+#[test]
 fn test_tokens() {
     sub_test("id123_OK", &[Token::Word("id123_OK")]);
     sub_test(
@@ -679,7 +695,7 @@ fn test_tokens() {
     // Type suffixes are only allowed on hex float literals
     // if you provided an exponent.
     sub_test(
-        "0x1.2f 0x1.2f 0x1.2h 0x1.2H",
+        "0x1.2f 0x1.2f 0x1.2h 0x1.2H 0x1.2lf",
         &[
             // The 'f' suffixes are taken as a hex digit:
             // the fractional part is 0x2f / 256.
@@ -689,6 +705,8 @@ fn test_tokens() {
             Token::Word("h"),
             Token::Number(Ok(Number::F32(1.125))),
             Token::Word("H"),
+            Token::Number(Ok(Number::F32(1.125))),
+            Token::Word("lf"),
         ],
     )
 }

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -998,6 +998,14 @@ impl<'a> ConstantEvaluator<'a> {
                             return Err(ConstantEvaluatorError::InvalidCastArg)
                         }
                     }),
+                    Sc::F64 => Literal::F64(match literal {
+                        Literal::I32(v) => v as f64,
+                        Literal::U32(v) => v as f64,
+                        Literal::F32(v) => v as f64,
+                        Literal::Bool(v) => v as u32 as f64,
+                        Literal::F64(v) => v,
+                        Literal::I64(_) => return Err(ConstantEvaluatorError::InvalidCastArg),
+                    }),
                     Sc::BOOL => Literal::Bool(match literal {
                         Literal::I32(v) => v != 0,
                         Literal::U32(v) => v != 0,

--- a/naga/tests/in/f64.param.ron
+++ b/naga/tests/in/f64.param.ron
@@ -1,0 +1,12 @@
+(
+	god_mode: true,
+	spv: (
+		version: (1, 0),
+	),
+	glsl: (
+		version: Desktop(420),
+		writer_flags: (""),
+		binding_map: { },
+		zero_initialize_workgroup_memory: true,
+	),
+)

--- a/naga/tests/in/f64.wgsl
+++ b/naga/tests/in/f64.wgsl
@@ -1,0 +1,13 @@
+var<private> v: f64 = 1lf;
+const k: f64 = 2.0lf;
+
+fn f(x: f64) -> f64 {
+   let y: f64 = 3e1lf + 4.0e2lf;
+   var z = y + f64(5);
+   return x + y + k + 5.0lf;
+}
+
+@compute @workgroup_size(1)
+fn main() {
+   f(6.0lf);
+}

--- a/naga/tests/out/glsl/f64.main.Compute.glsl
+++ b/naga/tests/out/glsl/f64.main.Compute.glsl
@@ -8,7 +8,7 @@ const double k = 2.0LF;
 double f(double x) {
     double z = 0.0;
     double y = (30.0LF + 400.0LF);
-    z = (y + double(5));
+    z = (y + 5.0LF);
     return (((x + y) + k) + 5.0LF);
 }
 

--- a/naga/tests/out/glsl/f64.main.Compute.glsl
+++ b/naga/tests/out/glsl/f64.main.Compute.glsl
@@ -1,0 +1,19 @@
+#version 420 core
+#extension GL_ARB_compute_shader : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+const double k = 2.0LF;
+
+
+double f(double x) {
+    double z = 0.0;
+    double y = (30.0LF + 400.0LF);
+    z = (y + double(5));
+    return (((x + y) + k) + 5.0LF);
+}
+
+void main() {
+    double _e1 = f(6.0LF);
+    return;
+}
+

--- a/naga/tests/out/hlsl/f64.hlsl
+++ b/naga/tests/out/hlsl/f64.hlsl
@@ -7,7 +7,7 @@ double f(double x)
     double z = (double)0;
 
     double y = (30.0L + 400.0L);
-    z = (y + double(5));
+    z = (y + 5.0L);
     return (((x + y) + k) + 5.0L);
 }
 

--- a/naga/tests/out/hlsl/f64.hlsl
+++ b/naga/tests/out/hlsl/f64.hlsl
@@ -1,0 +1,19 @@
+static const double k = 2.0L;
+
+static double v = 1.0L;
+
+double f(double x)
+{
+    double z = (double)0;
+
+    double y = (30.0L + 400.0L);
+    z = (y + double(5));
+    return (((x + y) + k) + 5.0L);
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    const double _e1 = f(6.0L);
+    return;
+}

--- a/naga/tests/out/hlsl/f64.ron
+++ b/naga/tests/out/hlsl/f64.ron
@@ -1,0 +1,12 @@
+(
+    vertex:[
+    ],
+    fragment:[
+    ],
+    compute:[
+        (
+            entry_point:"main",
+            target_profile:"cs_5_1",
+        ),
+    ],
+)

--- a/naga/tests/out/spv/f64.spvasm
+++ b/naga/tests/out/spv/f64.spvasm
@@ -1,0 +1,48 @@
+; SPIR-V
+; Version: 1.0
+; Generator: rspirv
+; Bound: 33
+OpCapability Shader
+OpCapability Float64
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %28 "main"
+OpExecutionMode %28 LocalSize 1 1 1
+%2 = OpTypeVoid
+%3 = OpTypeFloat 64
+%4 = OpConstant  %3  1.0
+%5 = OpConstant  %3  2.0
+%7 = OpTypePointer Private %3
+%6 = OpVariable  %7  Private %4
+%11 = OpTypeFunction %3 %3
+%12 = OpConstant  %3  30.0
+%13 = OpConstant  %3  400.0
+%14 = OpTypeInt 32 1
+%15 = OpConstant  %14  5
+%16 = OpConstant  %3  5.0
+%18 = OpTypePointer Function %3
+%19 = OpConstantNull  %3
+%29 = OpTypeFunction %2
+%30 = OpConstant  %3  6.0
+%10 = OpFunction  %3  None %11
+%9 = OpFunctionParameter  %3
+%8 = OpLabel
+%17 = OpVariable  %18  Function %19
+OpBranch %20
+%20 = OpLabel
+%21 = OpFAdd  %3  %12 %13
+%22 = OpConvertSToF  %3  %15
+%23 = OpFAdd  %3  %21 %22
+OpStore %17 %23
+%24 = OpFAdd  %3  %9 %21
+%25 = OpFAdd  %3  %24 %5
+%26 = OpFAdd  %3  %25 %16
+OpReturnValue %26
+OpFunctionEnd
+%28 = OpFunction  %2  None %29
+%27 = OpLabel
+OpBranch %31
+%31 = OpLabel
+%32 = OpFunctionCall  %3  %10 %30
+OpReturn
+OpFunctionEnd

--- a/naga/tests/out/spv/f64.spvasm
+++ b/naga/tests/out/spv/f64.spvasm
@@ -1,13 +1,13 @@
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 33
+; Bound: 30
 OpCapability Shader
 OpCapability Float64
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %28 "main"
-OpExecutionMode %28 LocalSize 1 1 1
+OpEntryPoint GLCompute %25 "main"
+OpExecutionMode %25 LocalSize 1 1 1
 %2 = OpTypeVoid
 %3 = OpTypeFloat 64
 %4 = OpConstant  %3  1.0
@@ -17,32 +17,29 @@ OpExecutionMode %28 LocalSize 1 1 1
 %11 = OpTypeFunction %3 %3
 %12 = OpConstant  %3  30.0
 %13 = OpConstant  %3  400.0
-%14 = OpTypeInt 32 1
-%15 = OpConstant  %14  5
-%16 = OpConstant  %3  5.0
-%18 = OpTypePointer Function %3
-%19 = OpConstantNull  %3
-%29 = OpTypeFunction %2
-%30 = OpConstant  %3  6.0
+%14 = OpConstant  %3  5.0
+%16 = OpTypePointer Function %3
+%17 = OpConstantNull  %3
+%26 = OpTypeFunction %2
+%27 = OpConstant  %3  6.0
 %10 = OpFunction  %3  None %11
 %9 = OpFunctionParameter  %3
 %8 = OpLabel
-%17 = OpVariable  %18  Function %19
-OpBranch %20
-%20 = OpLabel
-%21 = OpFAdd  %3  %12 %13
-%22 = OpConvertSToF  %3  %15
-%23 = OpFAdd  %3  %21 %22
-OpStore %17 %23
-%24 = OpFAdd  %3  %9 %21
-%25 = OpFAdd  %3  %24 %5
-%26 = OpFAdd  %3  %25 %16
-OpReturnValue %26
+%15 = OpVariable  %16  Function %17
+OpBranch %18
+%18 = OpLabel
+%19 = OpFAdd  %3  %12 %13
+%20 = OpFAdd  %3  %19 %14
+OpStore %15 %20
+%21 = OpFAdd  %3  %9 %19
+%22 = OpFAdd  %3  %21 %5
+%23 = OpFAdd  %3  %22 %14
+OpReturnValue %23
 OpFunctionEnd
-%28 = OpFunction  %2  None %29
-%27 = OpLabel
-OpBranch %31
-%31 = OpLabel
-%32 = OpFunctionCall  %3  %10 %30
+%25 = OpFunction  %2  None %26
+%24 = OpLabel
+OpBranch %28
+%28 = OpLabel
+%29 = OpFunctionCall  %3  %10 %27
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/double-math-functions.frag.wgsl
+++ b/naga/tests/out/wgsl/double-math-functions.frag.wgsl
@@ -1,6 +1,6 @@
 fn main_1() {
-    var a: vec4<f64>;
-    var b: vec4<f64>;
+    var a: vec4<f64> = vec4(1.0lf);
+    var b: vec4<f64> = vec4(2.0lf);
     var m: mat4x4<f64>;
     var i: i32 = 5;
     var ceilOut: vec4<f64>;
@@ -29,8 +29,6 @@ fn main_1() {
     var smoothStepVector: vec4<f64>;
     var smoothStepMixed: vec4<f64>;
 
-    a = vec4(f64(1.0));
-    b = vec4(f64(2.0));
     let _e8 = a;
     let _e9 = b;
     let _e10 = a;
@@ -95,8 +93,8 @@ fn main_1() {
     let _e152 = i;
     ldexpOut = ldexp(_e150.x, _e152);
     smoothStepScalar = f64(smoothstep(0.0, 1.0, 0.5));
-    smoothStepVector = smoothstep(vec4(f64(0.0)), vec4(f64(1.0)), vec4(f64(0.5)));
-    smoothStepMixed = smoothstep(vec4(f64(0.0)), vec4(f64(1.0)), vec4(f64(0.5)));
+    smoothStepVector = smoothstep(vec4(0.0lf), vec4(1.0lf), vec4(0.5lf));
+    smoothStepMixed = smoothstep(vec4(0.0lf), vec4(1.0lf), vec4(0.5lf));
     return;
 }
 

--- a/naga/tests/out/wgsl/f64.wgsl
+++ b/naga/tests/out/wgsl/f64.wgsl
@@ -1,0 +1,17 @@
+const k: f64 = 2.0lf;
+
+var<private> v: f64 = 1.0lf;
+
+fn f(x: f64) -> f64 {
+    var z: f64;
+
+    let y = (30.0lf + 400.0lf);
+    z = (y + f64(5));
+    return (((x + y) + k) + 5.0lf);
+}
+
+@compute @workgroup_size(1, 1, 1) 
+fn main() {
+    let _e1 = f(6.0lf);
+    return;
+}

--- a/naga/tests/out/wgsl/f64.wgsl
+++ b/naga/tests/out/wgsl/f64.wgsl
@@ -6,7 +6,7 @@ fn f(x: f64) -> f64 {
     var z: f64;
 
     let y = (30.0lf + 400.0lf);
-    z = (y + f64(5));
+    z = (y + 5.0lf);
     return (((x + y) + k) + 5.0lf);
 }
 

--- a/naga/tests/snapshots.rs
+++ b/naga/tests/snapshots.rs
@@ -779,6 +779,10 @@ fn convert_wgsl() {
             "struct-layout",
             Targets::WGSL | Targets::GLSL | Targets::SPIRV | Targets::HLSL | Targets::METAL,
         ),
+        (
+            "f64",
+            Targets::SPIRV | Targets::GLSL | Targets::HLSL | Targets::WGSL,
+        ),
     ];
 
     for &(name, targets) in inputs.iter() {


### PR DESCRIPTION
In the WGSL front end, support an `l` suffix on floating-point literals to yield 64-bit integer literals.

Unless `Capabilities::FLOAT64` is selected, these literals will always be validated out, so it doesn't affect standards compliance.

This PR is questionable. I guess it's nice to have `f64` support to play with (edit: and the front and back ends already parse and emit an `f64` WGSL type), but it's hardly urgent. Who knows whether the spec will ever actually have `f64` support, and if it does, what the syntax will be?

But the truth is, I have ulterior motives for this patch. It's a little circuitous:

- On the abstract type branch, all constructor built-in functions know how to consume abstract values. Calls to scalar constructor built-in functions (say, `f32(5)`) are handled by generating `As` expressions and letting the constant evaluator convert abstract values to concrete values. So `f32(5)` constant-evaluates the AbstractInt `5` to the `f32` `5.0`.
- It happens that the test case `tests/out/wgsl/double-math-functions.frag.wgsl` contains expressions like `f64(1.0)`. It's translated from GLSL, which does have a `double` type.
- Naga should either accept `f64(1.0)` or reject it.
    - If Naga rejects it, then we cannot translate `tests/in/glsl/double-math-functions.frag` to WGSL. The GLSL snapshots aren't really set up to generate other output languages; I don't really want to change that. Fine, maybe we back this test out, it's hardly essential. But let's assume that we want to accept it.
    - If Naga accepts it, then the only reasonable semantics for this expression should be that applying the `f64` constructor built-in function to an AbstractFloat gives you an `f64`.
- `ConstantEvaluator::cast` doesn't happen to support casting to `f64`. Since it returns an error, the WGSL front end assumes that the expression is not constant-evaluatable, and leaves it in the IR as an`AbstractFloat` literal, which the validator then rejects.
- Expanding `ConstantEvaluator::cast` to support casting to `f64` allows the `out/wgsl` file to validate.
- However, it also means that `Literal::F64` values start making it to the WGSL backend, which errors out because **WGSL has no `f64` literal syntax.** Hence the present PR.

So it seems to me we have two options:

- Give WGSL syntax for 64-bit literals, and have it generate them in `tests/out/wgsl/double-math-functions.frag.wgsl` and then read and validate them.
- Remove `tests/in/glsl/double-math-functions.frag` and forget all this.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
