### PR TITLE
wgpu-hal(vk): Add WGPU_ALLOW_NONCOMPLIANT_ADAPTER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Bottom level categories:
 
 ## Unreleased
 
+### `WGPU_ALLOW_NONCOMPLIANT_ADAPTER` environment variable
+
+This adds a way to allow a Vulkan driver which is non-compliant per VK_KHR_driver_properties to be enumerated. This is intended for testing new Vulkan drivers which are not Vulkan compliant yet.
+
 ### New Features
 
 #### General

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ All testing and example infrastructure shares the same set of environment variab
 - `WGPU_POWER_PREF` with the power preference to choose when a specific adapter name isn't specified (`high`, `low` or `none`)
 - `WGPU_DX12_COMPILER` with the DX12 shader compiler you wish to use (`dxc` or `fxc`, note that `dxc` requires `dxil.dll` and `dxcompiler.dll` to be in the working directory otherwise it will fall back to `fxc`)
 - `WGPU_GLES_MINOR_VERSION` with the minor OpenGL ES 3 version number to request (`0`, `1`, `2` or `automatic`).
+- `WGPU_ALLOW_NONCOMPLIANT_ADAPTER` with a boolean whether non-compliant drivers are enumerated (`0` for false, `1` for true).
 
 When running the CTS, use the variables `DENO_WEBGPU_ADAPTER_NAME`, `DENO_WEBGPU_BACKEND`, `DENO_WEBGPU_POWER_PREFERENCE`.
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -995,6 +995,12 @@ impl super::Instance {
             if driver.conformance_version.major == 0 {
                 if driver.driver_id == ash::vk::DriverId::MOLTENVK {
                     log::debug!("Adapter is not Vulkan compliant, but is MoltenVK, continuing");
+                } else if self
+                    .shared
+                    .flags
+                    .contains(wgt::InstanceFlags::ALLOW_NONCOMPLIANT_ADAPTER)
+                {
+                    log::warn!("Adapter is not Vulkan compliant: {}", info.name);
                 } else {
                     log::warn!(
                         "Adapter is not Vulkan compliant, hiding adapter: {}",

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -858,6 +858,11 @@ bitflags::bitflags! {
         const VALIDATION = 1 << 1;
         /// Don't pass labels to wgpu-hal.
         const DISCARD_HAL_LABELS = 1 << 2;
+        /// Whether non-compliant adapters should be enumerated.
+        ///
+        /// This mainly applies to a Vulkan driver's compliance version. If the major compliance version
+        /// is `0`, then the driver is ignored. This flag allows that driver to be enabled for testing.
+        const ALLOW_NONCOMPLIANT_ADAPTER = 1 << 3;
     }
 }
 
@@ -909,6 +914,9 @@ impl InstanceFlags {
         }
         if let Some(bit) = env("WGPU_DEBUG") {
             self.set(Self::DEBUG, bit);
+        }
+        if let Some(bit) = env("WGPU_ALLOW_NONCOMPLIANT_ADAPTER") {
+            self.set(Self::ALLOW_NONCOMPLIANT_ADAPTER, bit);
         }
 
         self


### PR DESCRIPTION
**Connections**
#4718

**Description**
This allows a noncompliant adapter per VK_KHR_driver_properties to be used if the WGPU_ALLOW_NONCOMPLIANT_ADAPTER environment variable is added.

**Testing**
This can only really be locally tested as there aren't exactly non-compliant drivers being shipped.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
