### PR TITLE
[naga] Make the `example_wgsl` test build without `wgsl-in` feature.

### DIFF
--- a/naga/tests/example_wgsl.rs
+++ b/naga/tests/example_wgsl.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "wgsl-in")]
+
 use naga::{front::wgsl, valid::Validator};
 use std::{fs, path::PathBuf};
 


### PR DESCRIPTION
- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`.
- [X] Run `cargo xtask test` to run tests.
- (not appropriate) Add change to `CHANGELOG.md`. See simple instructions inside file.
