### PR TITLE
Conditionally lift API logging from trace to info level

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -29,6 +29,8 @@ targets = [
 
 [features]
 default = ["link"]
+# Log all API entry points at info instead of trace level.
+api_log_info = []
 
 # Backends, passed through to wgpu-hal
 metal = ["hal/metal"]

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -76,7 +76,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         size: Option<BufferAddress>,
     ) -> Result<(), ClearError> {
         profiling::scope!("CommandEncoder::clear_buffer");
-        log::trace!("CommandEncoder::clear_buffer {dst:?}");
+        log::info!("CommandEncoder::clear_buffer {dst:?}");
 
         let hub = A::hub(self);
 
@@ -161,7 +161,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         subresource_range: &ImageSubresourceRange,
     ) -> Result<(), ClearError> {
         profiling::scope!("CommandEncoder::clear_texture");
-        log::trace!("CommandEncoder::clear_texture {dst:?}");
+        log::info!("CommandEncoder::clear_texture {dst:?}");
 
         let hub = A::hub(self);
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -3,6 +3,7 @@ use std::{ops::Range, sync::Arc};
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;
 use crate::{
+    api_log,
     command::CommandBuffer,
     get_lowest_common_denom,
     global::Global,
@@ -76,7 +77,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         size: Option<BufferAddress>,
     ) -> Result<(), ClearError> {
         profiling::scope!("CommandEncoder::clear_buffer");
-        log::info!("CommandEncoder::clear_buffer {dst:?}");
+        api_log!("CommandEncoder::clear_buffer {dst:?}");
 
         let hub = A::hub(self);
 
@@ -161,7 +162,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         subresource_range: &ImageSubresourceRange,
     ) -> Result<(), ClearError> {
         profiling::scope!("CommandEncoder::clear_texture");
-        log::info!("CommandEncoder::clear_texture {dst:?}");
+        api_log!("CommandEncoder::clear_texture {dst:?}");
 
         let hub = A::hub(self);
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -435,7 +435,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         label: &str,
     ) -> Result<(), CommandEncoderError> {
         profiling::scope!("CommandEncoder::push_debug_group");
-        log::trace!("CommandEncoder::push_debug_group {label}");
+        log::info!("CommandEncoder::push_debug_group {label}");
 
         let hub = A::hub(self);
 
@@ -466,7 +466,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         label: &str,
     ) -> Result<(), CommandEncoderError> {
         profiling::scope!("CommandEncoder::insert_debug_marker");
-        log::trace!("CommandEncoder::insert_debug_marker {label}");
+        log::info!("CommandEncoder::insert_debug_marker {label}");
 
         let hub = A::hub(self);
 
@@ -497,7 +497,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
     ) -> Result<(), CommandEncoderError> {
         profiling::scope!("CommandEncoder::pop_debug_marker");
-        log::trace!("CommandEncoder::pop_debug_group");
+        log::info!("CommandEncoder::pop_debug_group");
 
         let hub = A::hub(self);
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -26,7 +26,9 @@ use crate::id::CommandBufferId;
 use crate::init_tracker::BufferInitTrackerAction;
 use crate::resource::{Resource, ResourceInfo, ResourceType};
 use crate::track::{Tracker, UsageScope};
-use crate::{global::Global, hal_api::HalApi, id, identity::GlobalIdentityHandlerFactory, Label};
+use crate::{
+    api_log, global::Global, hal_api::HalApi, id, identity::GlobalIdentityHandlerFactory, Label,
+};
 
 use hal::CommandEncoder as _;
 use parking_lot::Mutex;
@@ -435,7 +437,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         label: &str,
     ) -> Result<(), CommandEncoderError> {
         profiling::scope!("CommandEncoder::push_debug_group");
-        log::info!("CommandEncoder::push_debug_group {label}");
+        api_log!("CommandEncoder::push_debug_group {label}");
 
         let hub = A::hub(self);
 
@@ -466,7 +468,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         label: &str,
     ) -> Result<(), CommandEncoderError> {
         profiling::scope!("CommandEncoder::insert_debug_marker");
-        log::info!("CommandEncoder::insert_debug_marker {label}");
+        api_log!("CommandEncoder::insert_debug_marker {label}");
 
         let hub = A::hub(self);
 
@@ -497,7 +499,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         encoder_id: id::CommandEncoderId,
     ) -> Result<(), CommandEncoderError> {
         profiling::scope!("CommandEncoder::pop_debug_marker");
-        log::info!("CommandEncoder::pop_debug_group");
+        api_log!("CommandEncoder::pop_debug_group");
 
         let hub = A::hub(self);
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1410,7 +1410,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         num_dynamic_offsets,
                         bind_group_id,
                     } => {
-                        log::trace!("RenderPass::set_bind_group {index} {bind_group_id:?}");
+                        log::info!("RenderPass::set_bind_group {index} {bind_group_id:?}");
 
                         let scope = PassErrorScope::SetBindGroup(bind_group_id);
                         let max_bind_groups = device.limits.max_bind_groups;
@@ -1493,7 +1493,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
                     }
                     RenderCommand::SetPipeline(pipeline_id) => {
-                        log::trace!("RenderPass::set_pipeline {pipeline_id:?}");
+                        log::info!("RenderPass::set_pipeline {pipeline_id:?}");
 
                         let scope = PassErrorScope::SetPipelineRender(pipeline_id);
                         state.pipeline = Some(pipeline_id);
@@ -1621,7 +1621,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         offset,
                         size,
                     } => {
-                        log::trace!("RenderPass::set_index_buffer {buffer_id:?}");
+                        log::info!("RenderPass::set_index_buffer {buffer_id:?}");
 
                         let scope = PassErrorScope::SetIndexBuffer(buffer_id);
                         let buffer = info
@@ -1674,7 +1674,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         offset,
                         size,
                     } => {
-                        log::trace!("RenderPass::set_vertex_buffer {slot} {buffer_id:?}");
+                        log::info!("RenderPass::set_vertex_buffer {slot} {buffer_id:?}");
 
                         let scope = PassErrorScope::SetVertexBuffer(buffer_id);
                         let buffer = info
@@ -1737,7 +1737,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         state.vertex.update_limits();
                     }
                     RenderCommand::SetBlendConstant(ref color) => {
-                        log::trace!("RenderPass::set_blend_constant");
+                        log::info!("RenderPass::set_blend_constant");
 
                         state.blend_constant = OptionalState::Set;
                         let array = [
@@ -1751,7 +1751,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
                     }
                     RenderCommand::SetStencilReference(value) => {
-                        log::trace!("RenderPass::set_stencil_reference {value}");
+                        log::info!("RenderPass::set_stencil_reference {value}");
 
                         state.stencil_reference = value;
                         if state
@@ -1768,7 +1768,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         depth_min,
                         depth_max,
                     } => {
-                        log::trace!("RenderPass::set_viewport {rect:?}");
+                        log::info!("RenderPass::set_viewport {rect:?}");
 
                         let scope = PassErrorScope::SetViewport;
                         if rect.x < 0.0
@@ -1806,7 +1806,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         size_bytes,
                         values_offset,
                     } => {
-                        log::trace!("RenderPass::set_push_constants");
+                        log::info!("RenderPass::set_push_constants");
 
                         let scope = PassErrorScope::SetPushConstant;
                         let values_offset = values_offset
@@ -1841,7 +1841,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
                     }
                     RenderCommand::SetScissor(ref rect) => {
-                        log::trace!("RenderPass::set_scissor_rect {rect:?}");
+                        log::info!("RenderPass::set_scissor_rect {rect:?}");
 
                         let scope = PassErrorScope::SetScissorRect;
                         if rect.x + rect.w > info.extent.width
@@ -1866,7 +1866,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         first_vertex,
                         first_instance,
                     } => {
-                        log::trace!(
+                        log::info!(
                             "RenderPass::draw {vertex_count} {instance_count} {first_vertex} {first_instance}"
                         );
 
@@ -1910,7 +1910,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         base_vertex,
                         first_instance,
                     } => {
-                        log::trace!("RenderPass::draw_indexed {index_count} {instance_count} {first_index} {base_vertex} {first_instance}");
+                        log::info!("RenderPass::draw_indexed {index_count} {instance_count} {first_index} {base_vertex} {first_instance}");
 
                         let indexed = true;
                         let scope = PassErrorScope::Draw {
@@ -1958,7 +1958,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         count,
                         indexed,
                     } => {
-                        log::trace!("RenderPass::draw_indirect (indexed:{indexed}) {buffer_id:?} {offset} {count:?}");
+                        log::info!("RenderPass::draw_indirect (indexed:{indexed}) {buffer_id:?} {offset} {count:?}");
 
                         let scope = PassErrorScope::Draw {
                             indexed,
@@ -2032,7 +2032,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         max_count,
                         indexed,
                     } => {
-                        log::trace!("RenderPass::multi_draw_indirect_count (indexed:{indexed}) {buffer_id:?} {offset} {count_buffer_id:?} {count_buffer_offset:?} {max_count:?}");
+                        log::info!("RenderPass::multi_draw_indirect_count (indexed:{indexed}) {buffer_id:?} {offset} {count_buffer_id:?} {count_buffer_offset:?} {max_count:?}");
 
                         let scope = PassErrorScope::Draw {
                             indexed,
@@ -2148,7 +2148,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             )
                             .unwrap();
 
-                            log::trace!("RenderPass::push_debug_group {label:?}");
+                            log::info!("RenderPass::push_debug_group {label:?}");
                             unsafe {
                                 raw.begin_debug_marker(label);
                             }
@@ -2156,7 +2156,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         string_offset += len;
                     }
                     RenderCommand::PopDebugGroup => {
-                        log::trace!("RenderPass::pop_debug_group");
+                        log::info!("RenderPass::pop_debug_group");
 
                         let scope = PassErrorScope::PopDebugGroup;
                         if state.debug_scope_depth == 0 {
@@ -2176,7 +2176,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                                 &base.string_data[string_offset..string_offset + len],
                             )
                             .unwrap();
-                            log::trace!("RenderPass::insert_debug_marker {label:?}");
+                            log::info!("RenderPass::insert_debug_marker {label:?}");
                             unsafe {
                                 raw.insert_debug_marker(label);
                             }
@@ -2187,7 +2187,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         query_set_id,
                         query_index,
                     } => {
-                        log::trace!("RenderPass::write_timestamps {query_set_id:?} {query_index}");
+                        log::info!("RenderPass::write_timestamps {query_set_id:?} {query_index}");
                         let scope = PassErrorScope::WriteTimestamp;
 
                         device
@@ -2210,7 +2210,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .map_pass_err(scope)?;
                     }
                     RenderCommand::BeginOcclusionQuery { query_index } => {
-                        log::trace!("RenderPass::begin_occlusion_query {query_index}");
+                        log::info!("RenderPass::begin_occlusion_query {query_index}");
                         let scope = PassErrorScope::BeginOcclusionQuery;
 
                         let query_set_id = occlusion_query_set_id
@@ -2234,7 +2234,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .map_pass_err(scope)?;
                     }
                     RenderCommand::EndOcclusionQuery => {
-                        log::trace!("RenderPass::end_occlusion_query");
+                        log::info!("RenderPass::end_occlusion_query");
                         let scope = PassErrorScope::EndOcclusionQuery;
 
                         end_occlusion_query(raw, &*query_set_guard, &mut active_query)
@@ -2244,7 +2244,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         query_set_id,
                         query_index,
                     } => {
-                        log::trace!("RenderPass::begin_pipeline_statistics_query {query_set_id:?} {query_index}");
+                        log::info!("RenderPass::begin_pipeline_statistics_query {query_set_id:?} {query_index}");
                         let scope = PassErrorScope::BeginPipelineStatisticsQuery;
 
                         let query_set = tracker
@@ -2264,14 +2264,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .map_pass_err(scope)?;
                     }
                     RenderCommand::EndPipelineStatisticsQuery => {
-                        log::trace!("RenderPass::end_pipeline_statistics_query");
+                        log::info!("RenderPass::end_pipeline_statistics_query");
                         let scope = PassErrorScope::EndPipelineStatisticsQuery;
 
                         end_pipeline_statistics_query(raw, &*query_set_guard, &mut active_query)
                             .map_pass_err(scope)?;
                     }
                     RenderCommand::ExecuteBundle(bundle_id) => {
-                        log::trace!("RenderPass::execute_bundle {bundle_id:?}");
+                        log::info!("RenderPass::execute_bundle {bundle_id:?}");
                         let scope = PassErrorScope::ExecuteBundle;
                         let bundle: &command::RenderBundle<A> = tracker
                             .bundles

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1,5 +1,6 @@
 use crate::resource::Resource;
 use crate::{
+    api_log,
     binding_model::BindError,
     command::{
         self,
@@ -1410,7 +1411,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         num_dynamic_offsets,
                         bind_group_id,
                     } => {
-                        log::info!("RenderPass::set_bind_group {index} {bind_group_id:?}");
+                        api_log!("RenderPass::set_bind_group {index} {bind_group_id:?}");
 
                         let scope = PassErrorScope::SetBindGroup(bind_group_id);
                         let max_bind_groups = device.limits.max_bind_groups;
@@ -1493,7 +1494,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
                     }
                     RenderCommand::SetPipeline(pipeline_id) => {
-                        log::info!("RenderPass::set_pipeline {pipeline_id:?}");
+                        api_log!("RenderPass::set_pipeline {pipeline_id:?}");
 
                         let scope = PassErrorScope::SetPipelineRender(pipeline_id);
                         state.pipeline = Some(pipeline_id);
@@ -1621,7 +1622,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         offset,
                         size,
                     } => {
-                        log::info!("RenderPass::set_index_buffer {buffer_id:?}");
+                        api_log!("RenderPass::set_index_buffer {buffer_id:?}");
 
                         let scope = PassErrorScope::SetIndexBuffer(buffer_id);
                         let buffer = info
@@ -1674,7 +1675,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         offset,
                         size,
                     } => {
-                        log::info!("RenderPass::set_vertex_buffer {slot} {buffer_id:?}");
+                        api_log!("RenderPass::set_vertex_buffer {slot} {buffer_id:?}");
 
                         let scope = PassErrorScope::SetVertexBuffer(buffer_id);
                         let buffer = info
@@ -1737,7 +1738,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         state.vertex.update_limits();
                     }
                     RenderCommand::SetBlendConstant(ref color) => {
-                        log::info!("RenderPass::set_blend_constant");
+                        api_log!("RenderPass::set_blend_constant");
 
                         state.blend_constant = OptionalState::Set;
                         let array = [
@@ -1751,7 +1752,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
                     }
                     RenderCommand::SetStencilReference(value) => {
-                        log::info!("RenderPass::set_stencil_reference {value}");
+                        api_log!("RenderPass::set_stencil_reference {value}");
 
                         state.stencil_reference = value;
                         if state
@@ -1768,7 +1769,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         depth_min,
                         depth_max,
                     } => {
-                        log::info!("RenderPass::set_viewport {rect:?}");
+                        api_log!("RenderPass::set_viewport {rect:?}");
 
                         let scope = PassErrorScope::SetViewport;
                         if rect.x < 0.0
@@ -1806,7 +1807,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         size_bytes,
                         values_offset,
                     } => {
-                        log::info!("RenderPass::set_push_constants");
+                        api_log!("RenderPass::set_push_constants");
 
                         let scope = PassErrorScope::SetPushConstant;
                         let values_offset = values_offset
@@ -1841,7 +1842,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
                     }
                     RenderCommand::SetScissor(ref rect) => {
-                        log::info!("RenderPass::set_scissor_rect {rect:?}");
+                        api_log!("RenderPass::set_scissor_rect {rect:?}");
 
                         let scope = PassErrorScope::SetScissorRect;
                         if rect.x + rect.w > info.extent.width
@@ -1866,7 +1867,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         first_vertex,
                         first_instance,
                     } => {
-                        log::info!(
+                        api_log!(
                             "RenderPass::draw {vertex_count} {instance_count} {first_vertex} {first_instance}"
                         );
 
@@ -1910,7 +1911,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         base_vertex,
                         first_instance,
                     } => {
-                        log::info!("RenderPass::draw_indexed {index_count} {instance_count} {first_index} {base_vertex} {first_instance}");
+                        api_log!("RenderPass::draw_indexed {index_count} {instance_count} {first_index} {base_vertex} {first_instance}");
 
                         let indexed = true;
                         let scope = PassErrorScope::Draw {
@@ -1958,7 +1959,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         count,
                         indexed,
                     } => {
-                        log::info!("RenderPass::draw_indirect (indexed:{indexed}) {buffer_id:?} {offset} {count:?}");
+                        api_log!("RenderPass::draw_indirect (indexed:{indexed}) {buffer_id:?} {offset} {count:?}");
 
                         let scope = PassErrorScope::Draw {
                             indexed,
@@ -2032,7 +2033,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         max_count,
                         indexed,
                     } => {
-                        log::info!("RenderPass::multi_draw_indirect_count (indexed:{indexed}) {buffer_id:?} {offset} {count_buffer_id:?} {count_buffer_offset:?} {max_count:?}");
+                        api_log!("RenderPass::multi_draw_indirect_count (indexed:{indexed}) {buffer_id:?} {offset} {count_buffer_id:?} {count_buffer_offset:?} {max_count:?}");
 
                         let scope = PassErrorScope::Draw {
                             indexed,
@@ -2148,7 +2149,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             )
                             .unwrap();
 
-                            log::info!("RenderPass::push_debug_group {label:?}");
+                            api_log!("RenderPass::push_debug_group {label:?}");
                             unsafe {
                                 raw.begin_debug_marker(label);
                             }
@@ -2156,7 +2157,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         string_offset += len;
                     }
                     RenderCommand::PopDebugGroup => {
-                        log::info!("RenderPass::pop_debug_group");
+                        api_log!("RenderPass::pop_debug_group");
 
                         let scope = PassErrorScope::PopDebugGroup;
                         if state.debug_scope_depth == 0 {
@@ -2176,7 +2177,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                                 &base.string_data[string_offset..string_offset + len],
                             )
                             .unwrap();
-                            log::info!("RenderPass::insert_debug_marker {label:?}");
+                            api_log!("RenderPass::insert_debug_marker {label:?}");
                             unsafe {
                                 raw.insert_debug_marker(label);
                             }
@@ -2187,7 +2188,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         query_set_id,
                         query_index,
                     } => {
-                        log::info!("RenderPass::write_timestamps {query_set_id:?} {query_index}");
+                        api_log!("RenderPass::write_timestamps {query_set_id:?} {query_index}");
                         let scope = PassErrorScope::WriteTimestamp;
 
                         device
@@ -2210,7 +2211,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .map_pass_err(scope)?;
                     }
                     RenderCommand::BeginOcclusionQuery { query_index } => {
-                        log::info!("RenderPass::begin_occlusion_query {query_index}");
+                        api_log!("RenderPass::begin_occlusion_query {query_index}");
                         let scope = PassErrorScope::BeginOcclusionQuery;
 
                         let query_set_id = occlusion_query_set_id
@@ -2234,7 +2235,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .map_pass_err(scope)?;
                     }
                     RenderCommand::EndOcclusionQuery => {
-                        log::info!("RenderPass::end_occlusion_query");
+                        api_log!("RenderPass::end_occlusion_query");
                         let scope = PassErrorScope::EndOcclusionQuery;
 
                         end_occlusion_query(raw, &*query_set_guard, &mut active_query)
@@ -2244,7 +2245,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         query_set_id,
                         query_index,
                     } => {
-                        log::info!("RenderPass::begin_pipeline_statistics_query {query_set_id:?} {query_index}");
+                        api_log!("RenderPass::begin_pipeline_statistics_query {query_set_id:?} {query_index}");
                         let scope = PassErrorScope::BeginPipelineStatisticsQuery;
 
                         let query_set = tracker
@@ -2264,14 +2265,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             .map_pass_err(scope)?;
                     }
                     RenderCommand::EndPipelineStatisticsQuery => {
-                        log::info!("RenderPass::end_pipeline_statistics_query");
+                        api_log!("RenderPass::end_pipeline_statistics_query");
                         let scope = PassErrorScope::EndPipelineStatisticsQuery;
 
                         end_pipeline_statistics_query(raw, &*query_set_guard, &mut active_query)
                             .map_pass_err(scope)?;
                     }
                     RenderCommand::ExecuteBundle(bundle_id) => {
-                        log::info!("RenderPass::execute_bundle {bundle_id:?}");
+                        api_log!("RenderPass::execute_bundle {bundle_id:?}");
                         let scope = PassErrorScope::ExecuteBundle;
                         let bundle: &command::RenderBundle<A> = tracker
                             .bundles

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;
 use crate::{
+    api_log,
     command::{clear_texture, CommandBuffer, CommandEncoderError},
     conv,
     device::{Device, MissingDownlevelFlags},
@@ -567,7 +568,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         size: BufferAddress,
     ) -> Result<(), CopyError> {
         profiling::scope!("CommandEncoder::copy_buffer_to_buffer");
-        log::info!(
+        api_log!(
             "CommandEncoder::copy_buffer_to_buffer {source:?} -> {destination:?} {size:?}bytes"
         );
 
@@ -730,7 +731,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
         profiling::scope!("CommandEncoder::copy_buffer_to_texture");
-        log::info!(
+        api_log!(
             "CommandEncoder::copy_buffer_to_texture {:?} -> {:?} {copy_size:?}",
             source.buffer,
             destination.texture
@@ -893,7 +894,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
         profiling::scope!("CommandEncoder::copy_texture_to_buffer");
-        log::info!(
+        api_log!(
             "CommandEncoder::copy_texture_to_buffer {:?} -> {:?} {copy_size:?}",
             source.texture,
             destination.buffer
@@ -1068,7 +1069,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
         profiling::scope!("CommandEncoder::copy_texture_to_texture");
-        log::info!(
+        api_log!(
             "CommandEncoder::copy_texture_to_texture {:?} -> {:?} {copy_size:?}",
             source.texture,
             destination.texture

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -567,6 +567,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         size: BufferAddress,
     ) -> Result<(), CopyError> {
         profiling::scope!("CommandEncoder::copy_buffer_to_buffer");
+        log::info!(
+            "CommandEncoder::copy_buffer_to_buffer {source:?} -> {destination:?} {size:?}bytes"
+        );
 
         if source == destination {
             return Err(TransferError::SameSourceDestinationBuffer.into());
@@ -727,6 +730,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
         profiling::scope!("CommandEncoder::copy_buffer_to_texture");
+        log::info!(
+            "CommandEncoder::copy_buffer_to_texture {:?} -> {:?} {copy_size:?}",
+            source.buffer,
+            destination.texture
+        );
 
         let hub = A::hub(self);
 
@@ -885,6 +893,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
         profiling::scope!("CommandEncoder::copy_texture_to_buffer");
+        log::info!(
+            "CommandEncoder::copy_texture_to_buffer {:?} -> {:?} {copy_size:?}",
+            source.texture,
+            destination.buffer
+        );
 
         let hub = A::hub(self);
 
@@ -1055,6 +1068,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         copy_size: &Extent3d,
     ) -> Result<(), CopyError> {
         profiling::scope!("CommandEncoder::copy_texture_to_texture");
+        log::info!(
+            "CommandEncoder::copy_texture_to_texture {:?} -> {:?} {copy_size:?}",
+            source.texture,
+            destination.texture
+        );
 
         let hub = A::hub(self);
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -185,7 +185,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(buffer);
-            log::trace!("Device::create_buffer({desc:?}) -> {id:?}");
+            log::info!("Device::create_buffer({desc:?}) -> {id:?}");
 
             let buffer_use = if !desc.mapped_at_creation {
                 hal::BufferUses::empty()
@@ -481,7 +481,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_id: id::BufferId,
     ) -> Result<(), resource::DestroyError> {
         profiling::scope!("Buffer::destroy");
-        log::trace!("Buffer::destroy {buffer_id:?}");
+        log::info!("Buffer::destroy {buffer_id:?}");
 
         let hub = A::hub(self);
 
@@ -494,7 +494,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn buffer_drop<A: HalApi>(&self, buffer_id: id::BufferId, wait: bool) {
         profiling::scope!("Buffer::drop");
-        log::trace!("Buffer::drop {buffer_id:?}");
+        log::info!("Buffer::drop {buffer_id:?}");
 
         let hub = A::hub(self);
 
@@ -563,7 +563,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(texture);
-            log::trace!("Device::create_texture({desc:?}) -> {id:?}");
+            log::info!("Device::create_texture({desc:?}) -> {id:?}");
 
             device.trackers.lock().textures.insert_single(
                 id,
@@ -637,7 +637,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 RwLock::new(TextureInitTracker::new(desc.mip_level_count, 0));
 
             let (id, resource) = fid.assign(texture);
-            log::trace!("Device::create_texture -> {id:?}");
+            log::info!("Device::create_texture -> {id:?}");
 
             device.trackers.lock().textures.insert_single(
                 id,
@@ -691,7 +691,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let buffer = device.create_buffer_from_hal(hal_buffer, desc);
 
             let (id, buffer) = fid.assign(buffer);
-            log::trace!("Device::create_buffer -> {id:?}");
+            log::info!("Device::create_buffer -> {id:?}");
 
             device
                 .trackers
@@ -717,7 +717,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         texture_id: id::TextureId,
     ) -> Result<(), resource::DestroyError> {
         profiling::scope!("Texture::destroy");
-        log::trace!("Texture::destroy {texture_id:?}");
+        log::info!("Texture::destroy {texture_id:?}");
 
         let hub = A::hub(self);
 
@@ -758,7 +758,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn texture_drop<A: HalApi>(&self, texture_id: id::TextureId, wait: bool) {
         profiling::scope!("Texture::drop");
-        log::trace!("Texture::drop {texture_id:?}");
+        log::info!("Texture::drop {texture_id:?}");
 
         let hub = A::hub(self);
 
@@ -830,7 +830,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(view);
-            log::trace!("Texture::create_view({texture_id:?}) -> {id:?}");
+            log::info!("Texture::create_view({texture_id:?}) -> {id:?}");
             device.trackers.lock().views.insert_single(id, resource);
             return (id, None);
         };
@@ -850,7 +850,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         wait: bool,
     ) -> Result<(), resource::TextureViewDestroyError> {
         profiling::scope!("TextureView::drop");
-        log::trace!("TextureView::drop {texture_view_id:?}");
+        log::info!("TextureView::drop {texture_view_id:?}");
 
         let hub = A::hub(self);
 
@@ -907,7 +907,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(sampler);
-            log::trace!("Device::create_sampler -> {id:?}");
+            log::info!("Device::create_sampler -> {id:?}");
             device.trackers.lock().samplers.insert_single(id, resource);
 
             return (id, None);
@@ -923,7 +923,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn sampler_drop<A: HalApi>(&self, sampler_id: id::SamplerId) {
         profiling::scope!("Sampler::drop");
-        log::trace!("Sampler::drop {sampler_id:?}");
+        log::info!("Sampler::drop {sampler_id:?}");
 
         let hub = A::hub(self);
 
@@ -994,7 +994,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, _layout) = fid.assign(layout);
-            log::trace!("Device::create_bind_group_layout -> {id:?}");
+            log::info!("Device::create_bind_group_layout -> {id:?}");
             return (id, None);
         };
 
@@ -1009,7 +1009,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn bind_group_layout_drop<A: HalApi>(&self, bind_group_layout_id: id::BindGroupLayoutId) {
         profiling::scope!("BindGroupLayout::drop");
-        log::trace!("BindGroupLayout::drop {bind_group_layout_id:?}");
+        log::info!("BindGroupLayout::drop {bind_group_layout_id:?}");
 
         let hub = A::hub(self);
 
@@ -1059,7 +1059,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, _) = fid.assign(layout);
-            log::trace!("Device::create_pipeline_layout -> {id:?}");
+            log::info!("Device::create_pipeline_layout -> {id:?}");
             return (id, None);
         };
 
@@ -1073,7 +1073,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn pipeline_layout_drop<A: HalApi>(&self, pipeline_layout_id: id::PipelineLayoutId) {
         profiling::scope!("PipelineLayout::drop");
-        log::trace!("PipelineLayout::drop {pipeline_layout_id:?}");
+        log::info!("PipelineLayout::drop {pipeline_layout_id:?}");
 
         let hub = A::hub(self);
         if let Some(layout) = hub.pipeline_layouts.unregister(pipeline_layout_id) {
@@ -1126,7 +1126,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(bind_group);
-            log::trace!("Device::create_bind_group -> {id:?}");
+            log::info!("Device::create_bind_group -> {id:?}");
 
             device
                 .trackers
@@ -1146,7 +1146,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn bind_group_drop<A: HalApi>(&self, bind_group_id: id::BindGroupId) {
         profiling::scope!("BindGroup::drop");
-        log::trace!("BindGroup::drop {bind_group_id:?}");
+        log::info!("BindGroup::drop {bind_group_id:?}");
 
         let hub = A::hub(self);
 
@@ -1213,7 +1213,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, _) = fid.assign(shader);
-            log::trace!("Device::create_shader_module -> {id:?}");
+            log::info!("Device::create_shader_module -> {id:?}");
             return (id, None);
         };
 
@@ -1270,7 +1270,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(e) => break e,
             };
             let (id, _) = fid.assign(shader);
-            log::trace!("Device::create_shader_module_spirv -> {id:?}");
+            log::info!("Device::create_shader_module_spirv -> {id:?}");
             return (id, None);
         };
 
@@ -1286,7 +1286,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn shader_module_drop<A: HalApi>(&self, shader_module_id: id::ShaderModuleId) {
         profiling::scope!("ShaderModule::drop");
-        log::trace!("ShaderModule::drop {shader_module_id:?}");
+        log::info!("ShaderModule::drop {shader_module_id:?}");
 
         let hub = A::hub(self);
         hub.shader_modules.unregister(shader_module_id);
@@ -1336,7 +1336,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             );
 
             let (id, _) = fid.assign(command_buffer);
-            log::trace!("Device::create_command_encoder -> {id:?}");
+            log::info!("Device::create_command_encoder -> {id:?}");
             return (id, None);
         };
 
@@ -1350,7 +1350,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn command_encoder_drop<A: HalApi>(&self, command_encoder_id: id::CommandEncoderId) {
         profiling::scope!("CommandEncoder::drop");
-        log::trace!("CommandEncoder::drop {command_encoder_id:?}");
+        log::info!("CommandEncoder::drop {command_encoder_id:?}");
 
         let hub = A::hub(self);
 
@@ -1363,7 +1363,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn command_buffer_drop<A: HalApi>(&self, command_buffer_id: id::CommandBufferId) {
         profiling::scope!("CommandBuffer::drop");
-        log::trace!("CommandBuffer::drop {command_buffer_id:?}");
+        log::info!("CommandBuffer::drop {command_buffer_id:?}");
         self.command_encoder_drop::<A>(command_buffer_id)
     }
 
@@ -1376,7 +1376,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         Option<command::CreateRenderBundleError>,
     ) {
         profiling::scope!("Device::create_render_bundle_encoder");
-        log::trace!("Device::device_create_render_bundle_encoder");
+        log::info!("Device::device_create_render_bundle_encoder");
         let (encoder, error) = match command::RenderBundleEncoder::new(desc, device_id, None) {
             Ok(encoder) => (encoder, None),
             Err(e) => (command::RenderBundleEncoder::dummy(device_id), Some(e)),
@@ -1425,7 +1425,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(render_bundle);
-            log::trace!("RenderBundleEncoder::finish -> {id:?}");
+            log::info!("RenderBundleEncoder::finish -> {id:?}");
             device.trackers.lock().bundles.insert_single(id, resource);
             return (id, None);
         };
@@ -1440,7 +1440,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn render_bundle_drop<A: HalApi>(&self, render_bundle_id: id::RenderBundleId) {
         profiling::scope!("RenderBundle::drop");
-        log::trace!("RenderBundle::drop {render_bundle_id:?}");
+        log::info!("RenderBundle::drop {render_bundle_id:?}");
 
         let hub = A::hub(self);
 
@@ -1487,7 +1487,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(query_set);
-            log::trace!("Device::create_query_set -> {id:?}");
+            log::info!("Device::create_query_set -> {id:?}");
             device
                 .trackers
                 .lock()
@@ -1503,7 +1503,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn query_set_drop<A: HalApi>(&self, query_set_id: id::QuerySetId) {
         profiling::scope!("QuerySet::drop");
-        log::trace!("QuerySet::drop {query_set_id:?}");
+        log::info!("QuerySet::drop {query_set_id:?}");
 
         let hub = A::hub(self);
 
@@ -1568,7 +1568,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 };
 
             let (id, resource) = fid.assign(pipeline);
-            log::trace!("Device::create_render_pipeline -> {id:?}");
+            log::info!("Device::create_render_pipeline -> {id:?}");
 
             device
                 .trackers
@@ -1644,7 +1644,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn render_pipeline_drop<A: HalApi>(&self, render_pipeline_id: id::RenderPipelineId) {
         profiling::scope!("RenderPipeline::drop");
-        log::trace!("RenderPipeline::drop {render_pipeline_id:?}");
+        log::info!("RenderPipeline::drop {render_pipeline_id:?}");
 
         let hub = A::hub(self);
 
@@ -1703,7 +1703,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(pipeline);
-            log::trace!("Device::create_compute_pipeline -> {id:?}");
+            log::info!("Device::create_compute_pipeline -> {id:?}");
 
             device
                 .trackers
@@ -1779,7 +1779,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn compute_pipeline_drop<A: HalApi>(&self, compute_pipeline_id: id::ComputePipelineId) {
         profiling::scope!("ComputePipeline::drop");
-        log::trace!("ComputePipeline::drop {compute_pipeline_id:?}");
+        log::info!("ComputePipeline::drop {compute_pipeline_id:?}");
 
         let hub = A::hub(self);
 
@@ -2090,7 +2090,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         device_id: DeviceId,
         maintain: wgt::Maintain<queue::WrappedSubmissionIndex>,
     ) -> Result<bool, WaitIdleError> {
-        log::trace!("Device::poll");
+        log::info!("Device::poll");
 
         let (closures, queue_empty) = {
             if let wgt::Maintain::WaitForSubmissionIndex(submission_index) = maintain {
@@ -2160,7 +2160,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     /// Return `all_queue_empty` indicating whether there are more queue
     /// submissions still in flight.
     pub fn poll_all_devices(&self, force_wait: bool) -> Result<bool, WaitIdleError> {
-        log::trace!("poll_all_devices");
+        log::info!("poll_all_devices");
         let mut closures = UserClosures::default();
         let mut all_queue_empty = true;
 
@@ -2200,7 +2200,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_start_capture<A: HalApi>(&self, id: DeviceId) {
-        log::trace!("Device::start_capture");
+        log::info!("Device::start_capture");
 
         let hub = A::hub(self);
 
@@ -2213,7 +2213,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_stop_capture<A: HalApi>(&self, id: DeviceId) {
-        log::trace!("Device::stop_capture");
+        log::info!("Device::stop_capture");
 
         let hub = A::hub(self);
 
@@ -2227,7 +2227,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn device_drop<A: HalApi>(&self, device_id: DeviceId) {
         profiling::scope!("Device::drop");
-        log::trace!("Device::drop {device_id:?}");
+        log::info!("Device::drop {device_id:?}");
 
         let hub = A::hub(self);
         if let Some(device) = hub.devices.unregister(device_id) {
@@ -2260,7 +2260,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_destroy<A: HalApi>(&self, device_id: DeviceId) {
-        log::trace!("Device::destroy {device_id:?}");
+        log::info!("Device::destroy {device_id:?}");
 
         let hub = A::hub(self);
 
@@ -2286,7 +2286,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_mark_lost<A: HalApi>(&self, device_id: DeviceId, message: &str) {
-        log::trace!("Device::mark_lost {device_id:?}");
+        log::info!("Device::mark_lost {device_id:?}");
 
         let hub = A::hub(self);
 
@@ -2297,7 +2297,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn queue_drop<A: HalApi>(&self, queue_id: QueueId) {
         profiling::scope!("Queue::drop");
-        log::trace!("Queue::drop {queue_id:?}");
+        log::info!("Queue::drop {queue_id:?}");
 
         let hub = A::hub(self);
         if let Some(queue) = hub.queues.unregister(queue_id) {
@@ -2311,7 +2311,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         range: Range<BufferAddress>,
         op: BufferMapOperation,
     ) -> BufferAccessResult {
-        log::trace!("Buffer::map_async {buffer_id:?}");
+        log::info!("Buffer::map_async {buffer_id:?}");
 
         // User callbacks must not be called while holding buffer_map_async_inner's locks, so we
         // defer the error callback if it needs to be called immediately (typically when running
@@ -2430,7 +2430,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         size: Option<BufferAddress>,
     ) -> Result<(*mut u8, u64), BufferAccessError> {
         profiling::scope!("Buffer::get_mapped_range");
-        log::trace!("Buffer::get_mapped_range {buffer_id:?}");
+        log::info!("Buffer::get_mapped_range {buffer_id:?}");
 
         let hub = A::hub(self);
 
@@ -2492,7 +2492,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
     pub fn buffer_unmap<A: HalApi>(&self, buffer_id: id::BufferId) -> BufferAccessResult {
         profiling::scope!("unmap", "Buffer");
-        log::trace!("Buffer::unmap {buffer_id:?}");
+        log::info!("Buffer::unmap {buffer_id:?}");
 
         let closure;
         {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "trace")]
 use crate::device::trace;
 use crate::{
-    binding_model, command, conv,
+    api_log, binding_model, command, conv,
     device::{
         life::WaitIdleError, map_buffer, queue, DeviceError, DeviceLostClosure, HostMap,
         IMPLICIT_FAILURE,
@@ -185,7 +185,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(buffer);
-            log::info!("Device::create_buffer({desc:?}) -> {id:?}");
+            api_log!("Device::create_buffer({desc:?}) -> {id:?}");
 
             let buffer_use = if !desc.mapped_at_creation {
                 hal::BufferUses::empty()
@@ -481,7 +481,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         buffer_id: id::BufferId,
     ) -> Result<(), resource::DestroyError> {
         profiling::scope!("Buffer::destroy");
-        log::info!("Buffer::destroy {buffer_id:?}");
+        api_log!("Buffer::destroy {buffer_id:?}");
 
         let hub = A::hub(self);
 
@@ -494,7 +494,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn buffer_drop<A: HalApi>(&self, buffer_id: id::BufferId, wait: bool) {
         profiling::scope!("Buffer::drop");
-        log::info!("Buffer::drop {buffer_id:?}");
+        api_log!("Buffer::drop {buffer_id:?}");
 
         let hub = A::hub(self);
 
@@ -563,7 +563,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(texture);
-            log::info!("Device::create_texture({desc:?}) -> {id:?}");
+            api_log!("Device::create_texture({desc:?}) -> {id:?}");
 
             device.trackers.lock().textures.insert_single(
                 id,
@@ -637,7 +637,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 RwLock::new(TextureInitTracker::new(desc.mip_level_count, 0));
 
             let (id, resource) = fid.assign(texture);
-            log::info!("Device::create_texture -> {id:?}");
+            api_log!("Device::create_texture -> {id:?}");
 
             device.trackers.lock().textures.insert_single(
                 id,
@@ -691,7 +691,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let buffer = device.create_buffer_from_hal(hal_buffer, desc);
 
             let (id, buffer) = fid.assign(buffer);
-            log::info!("Device::create_buffer -> {id:?}");
+            api_log!("Device::create_buffer -> {id:?}");
 
             device
                 .trackers
@@ -717,7 +717,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         texture_id: id::TextureId,
     ) -> Result<(), resource::DestroyError> {
         profiling::scope!("Texture::destroy");
-        log::info!("Texture::destroy {texture_id:?}");
+        api_log!("Texture::destroy {texture_id:?}");
 
         let hub = A::hub(self);
 
@@ -758,7 +758,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn texture_drop<A: HalApi>(&self, texture_id: id::TextureId, wait: bool) {
         profiling::scope!("Texture::drop");
-        log::info!("Texture::drop {texture_id:?}");
+        api_log!("Texture::drop {texture_id:?}");
 
         let hub = A::hub(self);
 
@@ -830,7 +830,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(view);
-            log::info!("Texture::create_view({texture_id:?}) -> {id:?}");
+            api_log!("Texture::create_view({texture_id:?}) -> {id:?}");
             device.trackers.lock().views.insert_single(id, resource);
             return (id, None);
         };
@@ -850,7 +850,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         wait: bool,
     ) -> Result<(), resource::TextureViewDestroyError> {
         profiling::scope!("TextureView::drop");
-        log::info!("TextureView::drop {texture_view_id:?}");
+        api_log!("TextureView::drop {texture_view_id:?}");
 
         let hub = A::hub(self);
 
@@ -907,7 +907,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(sampler);
-            log::info!("Device::create_sampler -> {id:?}");
+            api_log!("Device::create_sampler -> {id:?}");
             device.trackers.lock().samplers.insert_single(id, resource);
 
             return (id, None);
@@ -923,7 +923,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn sampler_drop<A: HalApi>(&self, sampler_id: id::SamplerId) {
         profiling::scope!("Sampler::drop");
-        log::info!("Sampler::drop {sampler_id:?}");
+        api_log!("Sampler::drop {sampler_id:?}");
 
         let hub = A::hub(self);
 
@@ -983,7 +983,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 let bgl_guard = hub.bind_group_layouts.read();
                 device.deduplicate_bind_group_layout(&entry_map, &*bgl_guard)
             } {
-                log::info!("Reusing BindGroupLayout {layout:?} -> {:?}", id);
+                api_log!("Reusing BindGroupLayout {layout:?} -> {:?}", id);
                 let id = fid.assign_existing(&layout);
                 return (id, None);
             }
@@ -994,7 +994,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, _layout) = fid.assign(layout);
-            log::info!("Device::create_bind_group_layout -> {id:?}");
+            api_log!("Device::create_bind_group_layout -> {id:?}");
             return (id, None);
         };
 
@@ -1009,7 +1009,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn bind_group_layout_drop<A: HalApi>(&self, bind_group_layout_id: id::BindGroupLayoutId) {
         profiling::scope!("BindGroupLayout::drop");
-        log::info!("BindGroupLayout::drop {bind_group_layout_id:?}");
+        api_log!("BindGroupLayout::drop {bind_group_layout_id:?}");
 
         let hub = A::hub(self);
 
@@ -1059,7 +1059,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, _) = fid.assign(layout);
-            log::info!("Device::create_pipeline_layout -> {id:?}");
+            api_log!("Device::create_pipeline_layout -> {id:?}");
             return (id, None);
         };
 
@@ -1073,7 +1073,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn pipeline_layout_drop<A: HalApi>(&self, pipeline_layout_id: id::PipelineLayoutId) {
         profiling::scope!("PipelineLayout::drop");
-        log::info!("PipelineLayout::drop {pipeline_layout_id:?}");
+        api_log!("PipelineLayout::drop {pipeline_layout_id:?}");
 
         let hub = A::hub(self);
         if let Some(layout) = hub.pipeline_layouts.unregister(pipeline_layout_id) {
@@ -1126,7 +1126,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(bind_group);
-            log::info!("Device::create_bind_group -> {id:?}");
+            api_log!("Device::create_bind_group -> {id:?}");
 
             device
                 .trackers
@@ -1146,7 +1146,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn bind_group_drop<A: HalApi>(&self, bind_group_id: id::BindGroupId) {
         profiling::scope!("BindGroup::drop");
-        log::info!("BindGroup::drop {bind_group_id:?}");
+        api_log!("BindGroup::drop {bind_group_id:?}");
 
         let hub = A::hub(self);
 
@@ -1213,7 +1213,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, _) = fid.assign(shader);
-            log::info!("Device::create_shader_module -> {id:?}");
+            api_log!("Device::create_shader_module -> {id:?}");
             return (id, None);
         };
 
@@ -1270,7 +1270,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 Err(e) => break e,
             };
             let (id, _) = fid.assign(shader);
-            log::info!("Device::create_shader_module_spirv -> {id:?}");
+            api_log!("Device::create_shader_module_spirv -> {id:?}");
             return (id, None);
         };
 
@@ -1286,7 +1286,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn shader_module_drop<A: HalApi>(&self, shader_module_id: id::ShaderModuleId) {
         profiling::scope!("ShaderModule::drop");
-        log::info!("ShaderModule::drop {shader_module_id:?}");
+        api_log!("ShaderModule::drop {shader_module_id:?}");
 
         let hub = A::hub(self);
         hub.shader_modules.unregister(shader_module_id);
@@ -1336,7 +1336,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             );
 
             let (id, _) = fid.assign(command_buffer);
-            log::info!("Device::create_command_encoder -> {id:?}");
+            api_log!("Device::create_command_encoder -> {id:?}");
             return (id, None);
         };
 
@@ -1350,7 +1350,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn command_encoder_drop<A: HalApi>(&self, command_encoder_id: id::CommandEncoderId) {
         profiling::scope!("CommandEncoder::drop");
-        log::info!("CommandEncoder::drop {command_encoder_id:?}");
+        api_log!("CommandEncoder::drop {command_encoder_id:?}");
 
         let hub = A::hub(self);
 
@@ -1363,7 +1363,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn command_buffer_drop<A: HalApi>(&self, command_buffer_id: id::CommandBufferId) {
         profiling::scope!("CommandBuffer::drop");
-        log::info!("CommandBuffer::drop {command_buffer_id:?}");
+        api_log!("CommandBuffer::drop {command_buffer_id:?}");
         self.command_encoder_drop::<A>(command_buffer_id)
     }
 
@@ -1376,7 +1376,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         Option<command::CreateRenderBundleError>,
     ) {
         profiling::scope!("Device::create_render_bundle_encoder");
-        log::info!("Device::device_create_render_bundle_encoder");
+        api_log!("Device::device_create_render_bundle_encoder");
         let (encoder, error) = match command::RenderBundleEncoder::new(desc, device_id, None) {
             Ok(encoder) => (encoder, None),
             Err(e) => (command::RenderBundleEncoder::dummy(device_id), Some(e)),
@@ -1425,7 +1425,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(render_bundle);
-            log::info!("RenderBundleEncoder::finish -> {id:?}");
+            api_log!("RenderBundleEncoder::finish -> {id:?}");
             device.trackers.lock().bundles.insert_single(id, resource);
             return (id, None);
         };
@@ -1440,7 +1440,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn render_bundle_drop<A: HalApi>(&self, render_bundle_id: id::RenderBundleId) {
         profiling::scope!("RenderBundle::drop");
-        log::info!("RenderBundle::drop {render_bundle_id:?}");
+        api_log!("RenderBundle::drop {render_bundle_id:?}");
 
         let hub = A::hub(self);
 
@@ -1487,7 +1487,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(query_set);
-            log::info!("Device::create_query_set -> {id:?}");
+            api_log!("Device::create_query_set -> {id:?}");
             device
                 .trackers
                 .lock()
@@ -1503,7 +1503,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn query_set_drop<A: HalApi>(&self, query_set_id: id::QuerySetId) {
         profiling::scope!("QuerySet::drop");
-        log::info!("QuerySet::drop {query_set_id:?}");
+        api_log!("QuerySet::drop {query_set_id:?}");
 
         let hub = A::hub(self);
 
@@ -1568,7 +1568,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 };
 
             let (id, resource) = fid.assign(pipeline);
-            log::info!("Device::create_render_pipeline -> {id:?}");
+            api_log!("Device::create_render_pipeline -> {id:?}");
 
             device
                 .trackers
@@ -1644,7 +1644,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn render_pipeline_drop<A: HalApi>(&self, render_pipeline_id: id::RenderPipelineId) {
         profiling::scope!("RenderPipeline::drop");
-        log::info!("RenderPipeline::drop {render_pipeline_id:?}");
+        api_log!("RenderPipeline::drop {render_pipeline_id:?}");
 
         let hub = A::hub(self);
 
@@ -1703,7 +1703,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(pipeline);
-            log::info!("Device::create_compute_pipeline -> {id:?}");
+            api_log!("Device::create_compute_pipeline -> {id:?}");
 
             device
                 .trackers
@@ -1779,7 +1779,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn compute_pipeline_drop<A: HalApi>(&self, compute_pipeline_id: id::ComputePipelineId) {
         profiling::scope!("ComputePipeline::drop");
-        log::info!("ComputePipeline::drop {compute_pipeline_id:?}");
+        api_log!("ComputePipeline::drop {compute_pipeline_id:?}");
 
         let hub = A::hub(self);
 
@@ -1856,7 +1856,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     unreachable!("Fallback system failed to choose present mode. This is a bug. Mode: {:?}, Options: {:?}", config.present_mode, &caps.present_modes);
                 };
 
-                log::info!(
+                api_log!(
                     "Automatically choosing presentation mode by rule {:?}. Chose {new_mode:?}",
                     config.present_mode
                 );
@@ -1900,7 +1900,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     );
                 };
 
-                log::info!(
+                api_log!(
                     "Automatically choosing alpha mode by rule {:?}. Chose {new_alpha_mode:?}",
                     config.composite_alpha_mode
                 );
@@ -2090,7 +2090,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         device_id: DeviceId,
         maintain: wgt::Maintain<queue::WrappedSubmissionIndex>,
     ) -> Result<bool, WaitIdleError> {
-        log::info!("Device::poll");
+        api_log!("Device::poll");
 
         let (closures, queue_empty) = {
             if let wgt::Maintain::WaitForSubmissionIndex(submission_index) = maintain {
@@ -2160,7 +2160,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     /// Return `all_queue_empty` indicating whether there are more queue
     /// submissions still in flight.
     pub fn poll_all_devices(&self, force_wait: bool) -> Result<bool, WaitIdleError> {
-        log::info!("poll_all_devices");
+        api_log!("poll_all_devices");
         let mut closures = UserClosures::default();
         let mut all_queue_empty = true;
 
@@ -2200,7 +2200,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_start_capture<A: HalApi>(&self, id: DeviceId) {
-        log::info!("Device::start_capture");
+        api_log!("Device::start_capture");
 
         let hub = A::hub(self);
 
@@ -2213,7 +2213,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_stop_capture<A: HalApi>(&self, id: DeviceId) {
-        log::info!("Device::stop_capture");
+        api_log!("Device::stop_capture");
 
         let hub = A::hub(self);
 
@@ -2227,7 +2227,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn device_drop<A: HalApi>(&self, device_id: DeviceId) {
         profiling::scope!("Device::drop");
-        log::info!("Device::drop {device_id:?}");
+        api_log!("Device::drop {device_id:?}");
 
         let hub = A::hub(self);
         if let Some(device) = hub.devices.unregister(device_id) {
@@ -2260,7 +2260,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_destroy<A: HalApi>(&self, device_id: DeviceId) {
-        log::info!("Device::destroy {device_id:?}");
+        api_log!("Device::destroy {device_id:?}");
 
         let hub = A::hub(self);
 
@@ -2286,7 +2286,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
 
     pub fn device_mark_lost<A: HalApi>(&self, device_id: DeviceId, message: &str) {
-        log::info!("Device::mark_lost {device_id:?}");
+        api_log!("Device::mark_lost {device_id:?}");
 
         let hub = A::hub(self);
 
@@ -2297,7 +2297,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn queue_drop<A: HalApi>(&self, queue_id: QueueId) {
         profiling::scope!("Queue::drop");
-        log::info!("Queue::drop {queue_id:?}");
+        api_log!("Queue::drop {queue_id:?}");
 
         let hub = A::hub(self);
         if let Some(queue) = hub.queues.unregister(queue_id) {
@@ -2311,7 +2311,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         range: Range<BufferAddress>,
         op: BufferMapOperation,
     ) -> BufferAccessResult {
-        log::info!("Buffer::map_async {buffer_id:?}");
+        api_log!("Buffer::map_async {buffer_id:?}");
 
         // User callbacks must not be called while holding buffer_map_async_inner's locks, so we
         // defer the error callback if it needs to be called immediately (typically when running
@@ -2430,7 +2430,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         size: Option<BufferAddress>,
     ) -> Result<(*mut u8, u64), BufferAccessError> {
         profiling::scope!("Buffer::get_mapped_range");
-        log::info!("Buffer::get_mapped_range {buffer_id:?}");
+        api_log!("Buffer::get_mapped_range {buffer_id:?}");
 
         let hub = A::hub(self);
 
@@ -2492,7 +2492,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     }
     pub fn buffer_unmap<A: HalApi>(&self, buffer_id: id::BufferId) -> BufferAccessResult {
         profiling::scope!("unmap", "Buffer");
-        log::info!("Buffer::unmap {buffer_id:?}");
+        api_log!("Buffer::unmap {buffer_id:?}");
 
         let closure;
         {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -385,6 +385,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         data: &[u8],
     ) -> Result<(), QueueWriteError> {
         profiling::scope!("Queue::write_buffer");
+        log::info!("Queue::write_buffer {buffer_id:?} {}bytes", data.len());
 
         let hub = A::hub(self);
 
@@ -649,6 +650,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         size: &wgt::Extent3d,
     ) -> Result<(), QueueWriteError> {
         profiling::scope!("Queue::write_texture");
+        log::info!("Queue::write_texture {:?} {size:?}", destination.texture);
 
         let hub = A::hub(self);
 
@@ -1115,7 +1117,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         command_buffer_ids: &[id::CommandBufferId],
     ) -> Result<WrappedSubmissionIndex, QueueSubmitError> {
         profiling::scope!("Queue::submit");
-        log::trace!("Queue::submit {queue_id:?}");
+        log::info!("Queue::submit {queue_id:?}");
 
         let (submit_index, callbacks) = {
             let hub = A::hub(self);
@@ -1524,7 +1526,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         queue_id: QueueId,
         closure: SubmittedWorkDoneClosure,
     ) -> Result<(), InvalidQueue> {
-        log::trace!("Queue::on_submitted_work_done {queue_id:?}");
+        log::info!("Queue::on_submitted_work_done {queue_id:?}");
 
         //TODO: flush pending writes
         let hub = A::hub(self);

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "trace")]
 use crate::device::trace::Action;
 use crate::{
+    api_log,
     command::{
         extract_texture_selector, validate_linear_texture_data, validate_texture_copy_range,
         ClearError, CommandBuffer, CopySide, ImageCopyTexture, TransferError,
@@ -385,7 +386,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         data: &[u8],
     ) -> Result<(), QueueWriteError> {
         profiling::scope!("Queue::write_buffer");
-        log::info!("Queue::write_buffer {buffer_id:?} {}bytes", data.len());
+        api_log!("Queue::write_buffer {buffer_id:?} {}bytes", data.len());
 
         let hub = A::hub(self);
 
@@ -650,7 +651,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         size: &wgt::Extent3d,
     ) -> Result<(), QueueWriteError> {
         profiling::scope!("Queue::write_texture");
-        log::info!("Queue::write_texture {:?} {size:?}", destination.texture);
+        api_log!("Queue::write_texture {:?} {size:?}", destination.texture);
 
         let hub = A::hub(self);
 
@@ -1117,7 +1118,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         command_buffer_ids: &[id::CommandBufferId],
     ) -> Result<WrappedSubmissionIndex, QueueSubmitError> {
         profiling::scope!("Queue::submit");
-        log::info!("Queue::submit {queue_id:?}");
+        api_log!("Queue::submit {queue_id:?}");
 
         let (submit_index, callbacks) = {
             let hub = A::hub(self);
@@ -1526,7 +1527,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         queue_id: QueueId,
         closure: SubmittedWorkDoneClosure,
     ) -> Result<(), InvalidQueue> {
-        log::info!("Queue::on_submitted_work_done {queue_id:?}");
+        api_log!("Queue::on_submitted_work_done {queue_id:?}");
 
         //TODO: flush pending writes
         let hub = A::hub(self);

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     any_surface::AnySurface,
+    api_log,
     device::{queue::Queue, resource::Device, DeviceDescriptor},
     global::Global,
     hal_api::HalApi,
@@ -306,7 +307,7 @@ impl<A: HalApi> Adapter<A> {
         instance_flags: wgt::InstanceFlags,
         trace_path: Option<&std::path::Path>,
     ) -> Result<(Device<A>, Queue<A>), RequestDeviceError> {
-        log::info!("Adapter::create_device");
+        api_log!("Adapter::create_device");
 
         let caps = &self.raw.capabilities;
         if let Ok(device) = Device::new(
@@ -762,7 +763,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
     pub fn surface_drop(&self, id: SurfaceId) {
         profiling::scope!("Surface::drop");
 
-        log::info!("Surface::drop {id:?}");
+        api_log!("Surface::drop {id:?}");
 
         fn unconfigure<G: GlobalIdentityHandlerFactory, A: HalApi>(
             global: &Global<G>,
@@ -828,7 +829,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn enumerate_adapters(&self, inputs: AdapterInputs<Input<G, AdapterId>>) -> Vec<AdapterId> {
         profiling::scope!("Instance::enumerate_adapters");
-        log::info!("Instance::enumerate_adapters");
+        api_log!("Instance::enumerate_adapters");
 
         let mut adapters = Vec::new();
 
@@ -884,8 +885,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         desc: &RequestAdapterOptions,
         inputs: AdapterInputs<Input<G, AdapterId>>,
     ) -> Result<AdapterId, RequestAdapterError> {
-        profiling::scope!("Instance::pick_adapter");
-        log::info!("Instance::pick_adapter");
+        profiling::scope!("Instance::request_adapter");
+        api_log!("Instance::request_adapter");
 
         fn gather<A: HalApi, I: Copy>(
             _: A,
@@ -1159,7 +1160,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn adapter_drop<A: HalApi>(&self, adapter_id: AdapterId) {
         profiling::scope!("Adapter::drop");
-        log::info!("Adapter::drop {adapter_id:?}");
+        api_log!("Adapter::drop {adapter_id:?}");
 
         let hub = A::hub(self);
         let mut adapters_locked = hub.adapters.write();
@@ -1185,7 +1186,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         queue_id_in: Input<G, QueueId>,
     ) -> (DeviceId, QueueId, Option<RequestDeviceError>) {
         profiling::scope!("Adapter::request_device");
-        log::info!("Adapter::request_device");
+        api_log!("Adapter::request_device");
 
         let hub = A::hub(self);
         let device_fid = hub.devices.prepare::<G>(device_id_in);

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -828,7 +828,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn enumerate_adapters(&self, inputs: AdapterInputs<Input<G, AdapterId>>) -> Vec<AdapterId> {
         profiling::scope!("Instance::enumerate_adapters");
-        log::trace!("Instance::enumerate_adapters");
+        log::info!("Instance::enumerate_adapters");
 
         let mut adapters = Vec::new();
 
@@ -885,7 +885,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         inputs: AdapterInputs<Input<G, AdapterId>>,
     ) -> Result<AdapterId, RequestAdapterError> {
         profiling::scope!("Instance::pick_adapter");
-        log::trace!("Instance::pick_adapter");
+        log::info!("Instance::pick_adapter");
 
         fn gather<A: HalApi, I: Copy>(
             _: A,
@@ -1159,7 +1159,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
     pub fn adapter_drop<A: HalApi>(&self, adapter_id: AdapterId) {
         profiling::scope!("Adapter::drop");
-        log::trace!("Adapter::drop {adapter_id:?}");
+        log::info!("Adapter::drop {adapter_id:?}");
 
         let hub = A::hub(self);
         let mut adapters_locked = hub.adapters.write();
@@ -1185,7 +1185,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         queue_id_in: Input<G, QueueId>,
     ) -> (DeviceId, QueueId, Option<RequestDeviceError>) {
         profiling::scope!("Adapter::request_device");
-        log::trace!("Adapter::request_device");
+        log::info!("Adapter::request_device");
 
         let hub = A::hub(self);
         let device_fid = hub.devices.prepare::<G>(device_id_in);

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -279,6 +279,16 @@ macro_rules! gfx_select {
     };
 }
 
+#[cfg(feature = "api_log_info")]
+macro_rules! api_log {
+    ($($arg:tt)+) => (log::info!($($arg)+))
+}
+#[cfg(not(feature = "api_log_info"))]
+macro_rules! api_log {
+    ($($arg:tt)+) => (log::trace!($($arg)+))
+}
+pub(crate) use api_log;
+
 /// Fast hash map used internally.
 type FastHashMap<K, V> =
     std::collections::HashMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -45,6 +45,8 @@ fragile-send-sync-non-atomic-wasm = [
     "wgc/fragile-send-sync-non-atomic-wasm",
     "wgt/fragile-send-sync-non-atomic-wasm",
 ]
+# Log all API entry points at info instead of trace level.
+api_log_info = ["wgc/api_log_info"]
 
 # wgpu-core is always available as an optional dependency, "wgc".
 # Whenever wgpu-core is selected, we want raw window handle support.


### PR DESCRIPTION
Most of this logging used to be info level until I demoted it to trace. Unfortunately this gets in my way because:
 - Most of the logging I currently need is these API entry points, there is is a fair amount of more verbose logging in wgpu at higher levels than trace
 - Firefox disable all trace and debug logging for optimized builds, which means I miss the this API logging where I need most.

This patch lifts the API logging back to info level.
It also adds a few missing logs that I found along the way.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
