### PR TITLE
Downgrade some of wgpu_core's logging level from info to trace and debug

### DIFF
--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -255,7 +255,7 @@ impl<A: HalApi> CommandBuffer<A> {
     }
 
     pub(crate) fn extract_baked_commands(&mut self) -> BakedCommands<A> {
-        log::info!(
+        log::trace!(
             "Extracting BakedCommands from CommandBuffer {:?}",
             self.info.label()
         );

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -369,7 +369,7 @@ impl<A: HalApi> LifetimeTracker<A> {
 
         let mut work_done_closures: SmallVec<_> = self.work_done_closures.drain(..).collect();
         for a in self.active.drain(..done_count) {
-            log::info!("Active submission {} is done", a.index);
+            log::debug!("Active submission {} is done", a.index);
             self.free_resources.extend(a.last_resources);
             self.ready_to_map.extend(a.mapped);
             for encoder in a.encoders {
@@ -979,7 +979,7 @@ impl<A: HalApi> LifetimeTracker<A> {
             };
             if is_removed {
                 *buffer.map_state.lock() = resource::BufferMapState::Idle;
-                log::info!("Buffer ready to map {:?} is not tracked anymore", buffer_id);
+                log::trace!("Buffer ready to map {:?} is not tracked anymore", buffer_id);
                 self.free_resources.insert(buffer_id, buffer.clone());
             } else {
                 let mapping = match std::mem::replace(

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -230,7 +230,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 };
 
                 let (id, resource) = fid.assign(texture);
-                log::info!("Created CURRENT Surface Texture {:?}", id);
+                log::debug!("Created CURRENT Surface Texture {:?}", id);
 
                 {
                     // register it in the device tracker as uninitialized

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -173,13 +173,13 @@ where
     }
 
     pub(crate) fn insert(&mut self, id: I, value: Arc<T>) {
-        log::info!("User is inserting {}{:?}", T::TYPE, id);
+        log::trace!("User is inserting {}{:?}", T::TYPE, id);
         let (index, epoch, _backend) = id.unzip();
         self.insert_impl(index as usize, epoch, Element::Occupied(value, epoch))
     }
 
     pub(crate) fn insert_error(&mut self, id: I, label: &str) {
-        log::info!("User is insering as error {}{:?}", T::TYPE, id);
+        log::trace!("User is insering as error {}{:?}", T::TYPE, id);
         let (index, epoch, _) = id.unzip();
         self.insert_impl(
             index as usize,
@@ -225,13 +225,13 @@ where
     }
 
     pub(crate) fn force_replace(&mut self, id: I, value: T) {
-        log::info!("User is replacing {}{:?}", T::TYPE, id);
+        log::trace!("User is replacing {}{:?}", T::TYPE, id);
         let (index, epoch, _) = id.unzip();
         self.map[index as usize] = Element::Occupied(Arc::new(value), epoch);
     }
 
     pub(crate) fn remove(&mut self, id: I) -> Option<Arc<T>> {
-        log::info!("User is removing {}{:?}", T::TYPE, id);
+        log::trace!("User is removing {}{:?}", T::TYPE, id);
         let (index, epoch, _) = id.unzip();
         match std::mem::replace(&mut self.map[index as usize], Element::Vacant) {
             Element::Occupied(value, storage_epoch) | Element::Destroyed(value, storage_epoch) => {

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -331,10 +331,10 @@ impl<A: HalApi> ResourceTracker<BufferId, Buffer<A>> for BufferTracker<A> {
                 let min_ref_count = 1 + external_count;
                 if existing_ref_count <= min_ref_count {
                     self.metadata.remove(index);
-                    log::info!("Buffer {:?} is not tracked anymore", id,);
+                    log::trace!("Buffer {:?} is not tracked anymore", id,);
                     return true;
                 } else {
-                    log::info!(
+                    log::trace!(
                         "Buffer {:?} is still referenced from {}",
                         id,
                         existing_ref_count

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -101,10 +101,10 @@ impl<A: HalApi, Id: TypedId, T: Resource<Id>> ResourceTracker<Id, T>
                 let min_ref_count = 1 + external_count;
                 if existing_ref_count <= min_ref_count {
                     self.metadata.remove(index);
-                    log::info!("{} {:?} is not tracked anymore", T::TYPE, id,);
+                    log::trace!("{} {:?} is not tracked anymore", T::TYPE, id,);
                     return true;
                 } else {
-                    log::info!(
+                    log::trace!(
                         "{} {:?} is still referenced from {}",
                         T::TYPE,
                         id,

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -420,10 +420,10 @@ impl<A: HalApi> ResourceTracker<TextureId, Texture<A>> for TextureTracker<A> {
                     self.start_set.complex.remove(&index);
                     self.end_set.complex.remove(&index);
                     self.metadata.remove(index);
-                    log::info!("Texture {:?} is not tracked anymore", id,);
+                    log::trace!("Texture {:?} is not tracked anymore", id,);
                     return true;
                 } else {
-                    log::info!(
+                    log::trace!(
                         "Texture {:?} is still referenced from {}",
                         id,
                         existing_ref_count


### PR DESCRIPTION
**Connections**

#3206

**Description**

 - Most of the log that was very specific to some wgpu internals was downgraded to `trace`.
 - A few logs that provided more rare contextual information were downgraded to `debug`.
 - The main remaining per-frame `info` log is relative to the internal resource lifetime management (which currently has bugs that I am investigating so I'll handle them separately in another PR, probably similarly to the api log until the issues are resolved).

I didn't audit the existing `debug` logging.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
