### PR TITLE
Bump web-sys to 0.3.65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4047,9 +4047,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.38"
 wasm-bindgen-test = "0.3"
 web-time = "0.2.3"
-web-sys = "0.3.64"
+web-sys = "0.3.65"
 
 # deno dependencies
 deno_console = "0.119.0"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -99,7 +99,7 @@ version = "0.18.0"
 default_features = false
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-web-sys = { version = "0.3.64", features = [
+web-sys = { version = "0.3.65", features = [
     "HtmlCanvasElement",
     "OffscreenCanvas",
 ] }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -152,7 +152,7 @@ core-graphics-types = "0.1"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
 wasm-bindgen = "0.2.87"
-web-sys = { version = "0.3.64", features = [
+web-sys = { version = "0.3.65", features = [
     "Window",
     "HtmlCanvasElement",
     "WebGl2RenderingContext",

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "1", features = ["serde_derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.65"
-web-sys = { version = "0.3.64", features = [
+web-sys = { version = "0.3.65", features = [
     "ImageBitmap",
     "HtmlVideoElement",
     "HtmlCanvasElement",

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -167,7 +167,7 @@ web-sys = { workspace = true, features = [
     "GpuCompilationMessageType",
     "GpuComputePassDescriptor",
     "GpuComputePassEncoder",
-    "GpuComputePassTimestampWrite",
+    "GpuComputePassTimestampWrites",
     "GpuComputePipeline",
     "GpuComputePipelineDescriptor",
     "GpuCullMode",

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -398,12 +398,14 @@ fn map_stencil_state_face(desc: &wgt::StencilFaceState) -> web_sys::GpuStencilFa
 }
 
 fn map_depth_stencil_state(desc: &wgt::DepthStencilState) -> web_sys::GpuDepthStencilState {
-    let mut mapped = web_sys::GpuDepthStencilState::new(map_texture_format(desc.format));
+    let mut mapped = web_sys::GpuDepthStencilState::new(
+        map_compare_function(desc.depth_compare),
+        desc.depth_write_enabled,
+        map_texture_format(desc.format),
+    );
     mapped.depth_bias(desc.bias.constant);
     mapped.depth_bias_clamp(desc.bias.clamp);
     mapped.depth_bias_slope_scale(desc.bias.slope_scale);
-    mapped.depth_compare(map_compare_function(desc.depth_compare));
-    mapped.depth_write_enabled(desc.depth_write_enabled);
     mapped.stencil_back(&map_stencil_state_face(&desc.stencil.back));
     mapped.stencil_front(&map_stencil_state_face(&desc.stencil.front));
     mapped.stencil_read_mask(desc.stencil.read_mask);
@@ -2750,13 +2752,13 @@ impl crate::context::Context for Context {
         offsets: &[wgt::DynamicOffset],
     ) {
         if offsets.is_empty() {
-            pass_data.0.set_bind_group(index, &bind_group_data.0);
+            pass_data.0.set_bind_group(index, Some(&bind_group_data.0));
         } else {
             pass_data
                 .0
                 .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
                     index,
-                    &bind_group_data.0,
+                    Some(&bind_group_data.0),
                     offsets,
                     0f64,
                     offsets.len() as u32,
@@ -2879,13 +2881,15 @@ impl crate::context::Context for Context {
         offsets: &[wgt::DynamicOffset],
     ) {
         if offsets.is_empty() {
-            encoder_data.0.set_bind_group(index, &bind_group_data.0);
+            encoder_data
+                .0
+                .set_bind_group(index, Some(&bind_group_data.0));
         } else {
             encoder_data
                 .0
                 .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
                     index,
-                    &bind_group_data.0,
+                    Some(&bind_group_data.0),
                     offsets,
                     0f64,
                     offsets.len() as u32,
@@ -2936,15 +2940,17 @@ impl crate::context::Context for Context {
             Some(s) => {
                 encoder_data.0.set_vertex_buffer_with_f64_and_f64(
                     slot,
-                    &buffer_data.0,
+                    Some(&buffer_data.0),
                     offset as f64,
                     s.get() as f64,
                 );
             }
             None => {
-                encoder_data
-                    .0
-                    .set_vertex_buffer_with_f64(slot, &buffer_data.0, offset as f64);
+                encoder_data.0.set_vertex_buffer_with_f64(
+                    slot,
+                    Some(&buffer_data.0),
+                    offset as f64,
+                );
             }
         };
     }
@@ -3098,13 +3104,13 @@ impl crate::context::Context for Context {
         offsets: &[wgt::DynamicOffset],
     ) {
         if offsets.is_empty() {
-            pass_data.0.set_bind_group(index, &bind_group_data.0);
+            pass_data.0.set_bind_group(index, Some(&bind_group_data.0));
         } else {
             pass_data
                 .0
                 .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
                     index,
-                    &bind_group_data.0,
+                    Some(&bind_group_data.0),
                     offsets,
                     0f64,
                     offsets.len() as u32,
@@ -3155,7 +3161,7 @@ impl crate::context::Context for Context {
             Some(s) => {
                 pass_data.0.set_vertex_buffer_with_f64_and_f64(
                     slot,
-                    &buffer_data.0,
+                    Some(&buffer_data.0),
                     offset as f64,
                     s.get() as f64,
                 );
@@ -3163,7 +3169,7 @@ impl crate::context::Context for Context {
             None => {
                 pass_data
                     .0
-                    .set_vertex_buffer_with_f64(slot, &buffer_data.0, offset as f64);
+                    .set_vertex_buffer_with_f64(slot, Some(&buffer_data.0), offset as f64);
             }
         };
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1573,7 +1573,7 @@ static_assertions::assert_impl_all!(RenderPipelineDescriptor<'_>: Send, Sync);
 /// For use with [`ComputePassDescriptor`].
 /// At least one of `beginning_of_pass_write_index` and `end_of_pass_write_index` must be `Some`.
 ///
-/// Corresponds to [WebGPU `GPUComputePassTimestampWrite`](
+/// Corresponds to [WebGPU `GPUComputePassTimestampWrites`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpucomputepasstimestampwrites).
 #[derive(Clone, Debug)]
 pub struct ComputePassTimestampWrites<'a> {


### PR DESCRIPTION
**Connections**
Cc: https://github.com/gfx-rs/wgpu/issues/4776

**Description**
Bump web-sys to 0.3.65.

**Testing**
I relied on CI for this: https://github.com/torokati44/wgpu/actions/runs/6993021092/job/19025254784

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
