### PR TITLE
Bump js-sys and web-sys to 0.3.65 on v0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3553,9 +3553,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3563,9 +3563,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
@@ -3590,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3600,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3613,9 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -3726,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3878,7 +3878,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.1",
  "log",
  "metal",
  "naga",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,11 +149,11 @@ glutin = "0.29.1"
 # wasm32 dependencies
 console_error_panic_hook = "0.1.7"
 console_log = "1"
-js-sys = "0.3.64"
+js-sys = "0.3.65"
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.34"
 wasm-bindgen-test = "0.3"
-web-sys = "0.3.64"
+web-sys = "0.3.65"
 
 # deno dependencies
 deno_console = "0.119.0"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -95,7 +95,7 @@ version = "0.18.0"
 default_features = false
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-web-sys = { version = "0.3.64", features = [
+web-sys = { version = "0.3.65", features = [
     "HtmlCanvasElement",
     "OffscreenCanvas",
 ] }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -150,13 +150,13 @@ core-graphics-types = "0.1"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
 wasm-bindgen = "0.2.87"
-web-sys = { version = "0.3.64", features = [
+web-sys = { version = "0.3.65", features = [
     "Window",
     "HtmlCanvasElement",
     "WebGl2RenderingContext",
     "OffscreenCanvas",
 ] }
-js-sys = "0.3.64"
+js-sys = "0.3.65"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -38,8 +38,8 @@ bitflags = "2"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.64"
-web-sys = { version = "0.3.64", features = [
+js-sys = "0.3.65"
+web-sys = { version = "0.3.65", features = [
     "ImageBitmap",
     "HtmlVideoElement",
     "HtmlCanvasElement",

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -159,7 +159,7 @@ web-sys = { workspace = true, features = [
     "GpuCompilationMessageType",
     "GpuComputePassDescriptor",
     "GpuComputePassEncoder",
-    "GpuComputePassTimestampWrite",
+    "GpuComputePassTimestampWrites",
     "GpuComputePipeline",
     "GpuComputePipelineDescriptor",
     "GpuCullMode",

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -398,12 +398,14 @@ fn map_stencil_state_face(desc: &wgt::StencilFaceState) -> web_sys::GpuStencilFa
 }
 
 fn map_depth_stencil_state(desc: &wgt::DepthStencilState) -> web_sys::GpuDepthStencilState {
-    let mut mapped = web_sys::GpuDepthStencilState::new(map_texture_format(desc.format));
+    let mut mapped = web_sys::GpuDepthStencilState::new(
+        map_compare_function(desc.depth_compare),
+        desc.depth_write_enabled,
+        map_texture_format(desc.format),
+    );
     mapped.depth_bias(desc.bias.constant);
     mapped.depth_bias_clamp(desc.bias.clamp);
     mapped.depth_bias_slope_scale(desc.bias.slope_scale);
-    mapped.depth_compare(map_compare_function(desc.depth_compare));
-    mapped.depth_write_enabled(desc.depth_write_enabled);
     mapped.stencil_back(&map_stencil_state_face(&desc.stencil.back));
     mapped.stencil_front(&map_stencil_state_face(&desc.stencil.front));
     mapped.stencil_read_mask(desc.stencil.read_mask);
@@ -2732,13 +2734,13 @@ impl crate::context::Context for Context {
         offsets: &[wgt::DynamicOffset],
     ) {
         if offsets.is_empty() {
-            pass_data.0.set_bind_group(index, &bind_group_data.0);
+            pass_data.0.set_bind_group(index, Some(&bind_group_data.0));
         } else {
             pass_data
                 .0
                 .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
                     index,
-                    &bind_group_data.0,
+                    Some(&bind_group_data.0),
                     offsets,
                     0f64,
                     offsets.len() as u32,
@@ -2861,13 +2863,15 @@ impl crate::context::Context for Context {
         offsets: &[wgt::DynamicOffset],
     ) {
         if offsets.is_empty() {
-            encoder_data.0.set_bind_group(index, &bind_group_data.0);
+            encoder_data
+                .0
+                .set_bind_group(index, Some(&bind_group_data.0));
         } else {
             encoder_data
                 .0
                 .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
                     index,
-                    &bind_group_data.0,
+                    Some(&bind_group_data.0),
                     offsets,
                     0f64,
                     offsets.len() as u32,
@@ -2918,15 +2922,17 @@ impl crate::context::Context for Context {
             Some(s) => {
                 encoder_data.0.set_vertex_buffer_with_f64_and_f64(
                     slot,
-                    &buffer_data.0,
+                    Some(&buffer_data.0),
                     offset as f64,
                     s.get() as f64,
                 );
             }
             None => {
-                encoder_data
-                    .0
-                    .set_vertex_buffer_with_f64(slot, &buffer_data.0, offset as f64);
+                encoder_data.0.set_vertex_buffer_with_f64(
+                    slot,
+                    Some(&buffer_data.0),
+                    offset as f64,
+                );
             }
         };
     }
@@ -3080,13 +3086,13 @@ impl crate::context::Context for Context {
         offsets: &[wgt::DynamicOffset],
     ) {
         if offsets.is_empty() {
-            pass_data.0.set_bind_group(index, &bind_group_data.0);
+            pass_data.0.set_bind_group(index, Some(&bind_group_data.0));
         } else {
             pass_data
                 .0
                 .set_bind_group_with_u32_array_and_f64_and_dynamic_offsets_data_length(
                     index,
-                    &bind_group_data.0,
+                    Some(&bind_group_data.0),
                     offsets,
                     0f64,
                     offsets.len() as u32,
@@ -3137,7 +3143,7 @@ impl crate::context::Context for Context {
             Some(s) => {
                 pass_data.0.set_vertex_buffer_with_f64_and_f64(
                     slot,
-                    &buffer_data.0,
+                    Some(&buffer_data.0),
                     offset as f64,
                     s.get() as f64,
                 );
@@ -3145,7 +3151,7 @@ impl crate::context::Context for Context {
             None => {
                 pass_data
                     .0
-                    .set_vertex_buffer_with_f64(slot, &buffer_data.0, offset as f64);
+                    .set_vertex_buffer_with_f64(slot, Some(&buffer_data.0), offset as f64);
             }
         };
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1542,7 +1542,7 @@ static_assertions::assert_impl_all!(RenderPipelineDescriptor: Send, Sync);
 /// For use with [`ComputePassDescriptor`].
 /// At least one of `beginning_of_pass_write_index` and `end_of_pass_write_index` must be `Some`.
 ///
-/// Corresponds to [WebGPU `GPUComputePassTimestampWrite`](
+/// Corresponds to [WebGPU `GPUComputePassTimestampWrites`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpucomputepasstimestampwrites).
 #[derive(Clone, Debug)]
 pub struct ComputePassTimestampWrites<'a> {


### PR DESCRIPTION
This is a backport of https://github.com/gfx-rs/wgpu/pull/4777 to `v0.18`.
Fixes https://github.com/gfx-rs/wgpu/issues/4776.