### PR TITLE
remove_abandoned fix

### DIFF
--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -339,11 +339,11 @@ impl<A: HalApi> ResourceTracker<BufferId, Buffer<A>> for BufferTracker<A> {
                         id,
                         existing_ref_count
                     );
+                    return false;
                 }
             }
         }
-
-        false
+        true
     }
 }
 

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -308,7 +308,7 @@ impl<A: HalApi> ResourceTracker<BufferId, Buffer<A>> for BufferTracker<A> {
     /// `triage_suspected` will remove 3), leaving 1) as the sole
     /// remaining reference.
     ///
-    /// Returns true if the resource was removed or if not exiting in metadata.
+    /// Returns true if the resource was removed or if not existing in metadata.
     ///
     /// [`Device::trackers`]: crate::device::Device
     /// [`self.metadata`]: BufferTracker::metadata

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -293,7 +293,7 @@ pub(crate) struct BufferTracker<A: HalApi> {
 }
 
 impl<A: HalApi> ResourceTracker<BufferId, Buffer<A>> for BufferTracker<A> {
-    /// Removes the buffer `id` from this tracker if it is otherwise unused.
+    /// Try to remove the buffer `id` from this tracker if it is otherwise unused.
     ///
     /// A buffer is 'otherwise unused' when the only references to it are:
     ///
@@ -308,8 +308,7 @@ impl<A: HalApi> ResourceTracker<BufferId, Buffer<A>> for BufferTracker<A> {
     /// `triage_suspected` will remove 3), leaving 1) as the sole
     /// remaining reference.
     ///
-    /// Return `true` if this tracker contained the buffer `id`. This
-    /// implies that we removed it.
+    /// Returns true if the resource was removed or if not exiting in metadata.
     ///
     /// [`Device::trackers`]: crate::device::Device
     /// [`self.metadata`]: BufferTracker::metadata

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -122,14 +122,7 @@ impl<A: HalApi, I: TypedId, T: Resource<I>> ResourceMetadata<A, I, T> {
     /// existing tables. See `tracker_assert_in_bounds`.
     #[inline(always)]
     pub(super) unsafe fn get_ref_count_unchecked(&self, index: usize) -> usize {
-        unsafe {
-            Arc::strong_count(
-                self.resources
-                    .get_unchecked(index)
-                    .as_ref()
-                    .unwrap_unchecked(),
-            )
-        }
+        unsafe { Arc::strong_count(self.get_resource_unchecked(index)) }
     }
 
     /// Returns an iterator over the resources owned by `self`.

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -78,10 +78,10 @@ pub(crate) struct StatelessTracker<A: HalApi, Id: TypedId, T: Resource<Id>> {
 impl<A: HalApi, Id: TypedId, T: Resource<Id>> ResourceTracker<Id, T>
     for StatelessTracker<A, Id, T>
 {
-    /// Removes the given resource from the tracker iff we have the last reference to the
+    /// Try to remove the given resource from the tracker iff we have the last reference to the
     /// resource and the epoch matches.
     ///
-    /// Returns true if the resource was removed.
+    /// Returns true if the resource was removed or if not exiting in metadata.
     ///
     /// If the ID is higher than the length of internal vectors,
     /// false will be returned.

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -81,7 +81,7 @@ impl<A: HalApi, Id: TypedId, T: Resource<Id>> ResourceTracker<Id, T>
     /// Try to remove the given resource from the tracker iff we have the last reference to the
     /// resource and the epoch matches.
     ///
-    /// Returns true if the resource was removed or if not exiting in metadata.
+    /// Returns true if the resource was removed or if not existing in metadata.
     ///
     /// If the ID is higher than the length of internal vectors,
     /// false will be returned.

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -113,11 +113,11 @@ impl<A: HalApi, Id: TypedId, T: Resource<Id>> ResourceTracker<Id, T>
                         id,
                         existing_ref_count
                     );
+                    return false;
                 }
             }
         }
-
-        false
+        true
     }
 }
 

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -428,11 +428,11 @@ impl<A: HalApi> ResourceTracker<TextureId, Texture<A>> for TextureTracker<A> {
                         id,
                         existing_ref_count
                     );
+                    return false;
                 }
             }
         }
-
-        false
+        true
     }
 }
 

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -397,7 +397,7 @@ impl<A: HalApi> ResourceTracker<TextureId, Texture<A>> for TextureTracker<A> {
     /// Try to remove the given resource from the tracker iff we have the last reference to the
     /// resource and the epoch matches.
     ///
-    /// Returns true if the resource was removed or if not exiting in metadata.
+    /// Returns true if the resource was removed or if not existing in metadata.
     ///
     /// If the ID is higher than the length of internal vectors,
     /// false will be returned.

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -394,10 +394,10 @@ pub(crate) struct TextureTracker<A: HalApi> {
 }
 
 impl<A: HalApi> ResourceTracker<TextureId, Texture<A>> for TextureTracker<A> {
-    /// Removes the given resource from the tracker iff we have the last reference to the
+    /// Try to remove the given resource from the tracker iff we have the last reference to the
     /// resource and the epoch matches.
     ///
-    /// Returns true if the resource was removed.
+    /// Returns true if the resource was removed or if not exiting in metadata.
     ///
     /// If the ID is higher than the length of internal vectors,
     /// false will be returned.


### PR DESCRIPTION
Whenever a resource is not inside a tracker we can allow the triage resource to remove it.
In the example shadow we saw that surface texture was continously not removed due to this wrong check not allowing the texture to be dropped
@scoopr discovered it - tnx a lot 👍  