### PR TITLE
Remove surface extent validation (and thus fix the annoying `Requested size ... is outside of the supported range` warning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Previously, `DeviceExt::create_texture_with_data` only allowed data to be provid
 
 #### General
 - Added `DownlevelFlags::VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW` to know if `@builtin(vertex_index)` and `@builtin(instance_index)` will respect the `first_vertex` / `first_instance` in indirect calls. If this is not present, both will always start counting from 0. Currently enabled on all backends except DX12. By @cwfitzgerald in [#4722](https://github.com/gfx-rs/wgpu/pull/4722)
+- No longer validate surfaces against their allowed extent range on configure. This caused warnings that were almost impossible to avoid. As before, the resulting behavior depends on the compositor. By @wumpf in [#????](https://github.com/gfx-rs/wgpu/pull/????)
 
 #### OpenGL
 - `@builtin(instance_index)` now properly reflects the range provided in the draw call instead of always counting from 0. By @cwfitzgerald in [#4722](https://github.com/gfx-rs/wgpu/pull/4722).

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1812,18 +1812,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         ) -> Result<(), E> {
             let width = config.extent.width;
             let height = config.extent.height;
-            if width < caps.extents.start().width
-                || width > caps.extents.end().width
-                || height < caps.extents.start().height
-                || height > caps.extents.end().height
-            {
-                log::warn!(
-                    "Requested size {}x{} is outside of the supported range: {:?}",
-                    width,
-                    height,
-                    caps.extents
-                );
-            }
+
             if !caps.present_modes.contains(&config.present_mode) {
                 let new_mode = 'b: loop {
                     // Automatic present mode checks.

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1809,9 +1809,18 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         fn validate_surface_configuration(
             config: &mut hal::SurfaceConfiguration,
             caps: &hal::SurfaceCapabilities,
+            max_texture_dimension_2d: u32,
         ) -> Result<(), E> {
             let width = config.extent.width;
             let height = config.extent.height;
+
+            if width > max_texture_dimension_2d || height > max_texture_dimension_2d {
+                return Err(E::TooLarge {
+                    width,
+                    height,
+                    max_texture_dimension_2d,
+                });
+            }
 
             if !caps.present_modes.contains(&config.present_mode) {
                 let new_mode = 'b: loop {
@@ -1986,7 +1995,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     view_formats: hal_view_formats,
                 };
 
-                if let Err(error) = validate_surface_configuration(&mut hal_config, &caps) {
+                if let Err(error) = validate_surface_configuration(
+                    &mut hal_config,
+                    &caps,
+                    device.limits.max_texture_dimension_2d,
+                ) {
                     break error;
                 }
 

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -77,6 +77,12 @@ pub enum ConfigureSurfaceError {
     PreviousOutputExists,
     #[error("Both `Surface` width and height must be non-zero. Wait to recreate the `Surface` until the window has non-zero area.")]
     ZeroArea,
+    #[error("`Surface` width and height must be within the maximum supported texture size. Requested was ({width}, height), maximum extent is {max_texture_dimension_2d}.")]
+    TooLarge {
+        width: u32,
+        height: u32,
+        max_texture_dimension_2d: u32,
+    },
     #[error("Surface does not support the adapter's queue family")]
     UnsupportedQueueFamily,
     #[error("Requested format {requested:?} is not in list of supported formats: {available:?}")]

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -625,16 +625,6 @@ impl crate::Adapter<super::Api> for super::Adapter {
             // we currently use a flip effect which supports 2..=16 buffers
             swap_chain_sizes: 2..=16,
             current_extent,
-            // TODO: figure out the exact bounds
-            extents: wgt::Extent3d {
-                width: 16,
-                height: 16,
-                depth_or_array_layers: 1,
-            }..=wgt::Extent3d {
-                width: 4096,
-                height: 4096,
-                depth_or_array_layers: 1,
-            },
             usage: crate::TextureUses::COLOR_TARGET
                 | crate::TextureUses::COPY_SRC
                 | crate::TextureUses::COPY_DST,

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -798,7 +798,6 @@ impl super::Adapter {
                     workarounds,
                     features,
                     shading_language_version,
-                    max_texture_size,
                     next_shader_id: Default::default(),
                     program_cache: Default::default(),
                     es: es_ver.is_some(),
@@ -1144,15 +1143,6 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 composite_alpha_modes: vec![wgt::CompositeAlphaMode::Opaque], //TODO
                 swap_chain_sizes: 2..=2,
                 current_extent: None,
-                extents: wgt::Extent3d {
-                    width: 4,
-                    height: 4,
-                    depth_or_array_layers: 1,
-                }..=wgt::Extent3d {
-                    width: self.shared.max_texture_size,
-                    height: self.shared.max_texture_size,
-                    depth_or_array_layers: 1,
-                },
                 usage: crate::TextureUses::COLOR_TARGET,
             })
         } else {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -249,7 +249,6 @@ struct AdapterShared {
     features: wgt::Features,
     workarounds: Workarounds,
     shading_language_version: naga::back::glsl::Version,
-    max_texture_size: u32,
     next_shader_id: AtomicU32,
     program_cache: Mutex<ProgramCache>,
     es: bool,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -882,11 +882,6 @@ pub struct SurfaceCapabilities {
     /// Current extent of the surface, if known.
     pub current_extent: Option<wgt::Extent3d>,
 
-    /// Range of supported extents.
-    ///
-    /// `current_extent` must be inside this range.
-    pub extents: RangeInclusive<wgt::Extent3d>,
-
     /// Supported texture usage flags.
     ///
     /// Must have at least `TextureUses::COLOR_TARGET`

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -338,15 +338,6 @@ impl crate::Adapter<super::Api> for super::Adapter {
             ],
 
             current_extent,
-            extents: wgt::Extent3d {
-                width: 4,
-                height: 4,
-                depth_or_array_layers: 1,
-            }..=wgt::Extent3d {
-                width: pc.max_texture_size as u32,
-                height: pc.max_texture_size as u32,
-                depth_or_array_layers: 1,
-            },
             usage: crate::TextureUses::COLOR_TARGET | crate::TextureUses::COPY_DST, //TODO: expose more
         })
     }

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1642,18 +1642,6 @@ impl crate::Adapter<super::Api> for super::Adapter {
             None
         };
 
-        let min_extent = wgt::Extent3d {
-            width: caps.min_image_extent.width,
-            height: caps.min_image_extent.height,
-            depth_or_array_layers: 1,
-        };
-
-        let max_extent = wgt::Extent3d {
-            width: caps.max_image_extent.width,
-            height: caps.max_image_extent.height,
-            depth_or_array_layers: caps.max_image_array_layers,
-        };
-
         let raw_present_modes = {
             profiling::scope!("vkGetPhysicalDeviceSurfacePresentModesKHR");
             match unsafe {
@@ -1692,7 +1680,6 @@ impl crate::Adapter<super::Api> for super::Adapter {
             formats,
             swap_chain_sizes: caps.min_image_count..=max_image_count,
             current_extent,
-            extents: min_extent..=max_extent,
             usage: conv::map_vk_image_usage(caps.supported_usage_flags),
             present_modes: raw_present_modes
                 .into_iter()

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -48,6 +48,13 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         return vk::FALSE;
     }
 
+    // Silence Vulkan Validation error "VUID-VkSwapchainCreateInfoKHR-pNext-07781"
+    // - it's another false positive due to the inherent racy-ness of surface resizing
+    const VUID_VKSWAPCHAINCREATEINFOKHR_PNEXT_07781: i32 = 0x4c8929c1;
+    if cd.message_id_number == VUID_VKSWAPCHAINCREATEINFOKHR_PNEXT_07781 {
+        return vk::FALSE;
+    }
+
     // Silence Vulkan Validation error "VUID-VkRenderPassBeginInfo-framebuffer-04627"
     // if the OBS layer is enabled. This is a bug in the OBS layer. As the OBS layer
     // does not have a version number they increment, there is no way to qualify the

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -41,15 +41,9 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         }
     }
 
-    // Silence Vulkan Validation error "VUID-VkSwapchainCreateInfoKHR-imageExtent-01274"
-    // - it's a false positive due to the inherent racy-ness of surface resizing
-    const VUID_VKSWAPCHAINCREATEINFOKHR_IMAGEEXTENT_01274: i32 = 0x7cd0911d;
-    if cd.message_id_number == VUID_VKSWAPCHAINCREATEINFOKHR_IMAGEEXTENT_01274 {
-        return vk::FALSE;
-    }
-
     // Silence Vulkan Validation error "VUID-VkSwapchainCreateInfoKHR-pNext-07781"
-    // - it's another false positive due to the inherent racy-ness of surface resizing
+    // This happens when a surface is configured with a size outside the allowed extent.
+    // It's s false positive due to the inherent racy-ness of surface resizing.
     const VUID_VKSWAPCHAINCREATEINFOKHR_PNEXT_07781: i32 = 0x4c8929c1;
     if cd.message_id_number == VUID_VKSWAPCHAINCREATEINFOKHR_PNEXT_07781 {
         return vk::FALSE;


### PR DESCRIPTION
**Connections**
-

**Description**

Removes surface extent validation since its inherently racy: The user has no way of getting the size that we expect in there. Also our expectation might be outdated already anyways.

Enable `VUID-VkSwapchainCreateInfoKHR-imageExtent-01689` vulkan validation warning - according to spec this is ONLY about zero size surfaces and we correctly validate against this.
Added exception for `VUID-VkSwapchainCreateInfoKHR-pNext-07781` instead which triggers when configuring a surface with the wrong size.

**Testing**

ran hello_triangle, didn't get the validation there to begin with, but it's gone so I hardly gonna see it again in the egui based applications I've been hitting this on Linux and Windows😄 

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
