### PR TITLE
[naga wgsl-in] Drop spanless labels from front-end error messages.

### DIFF
--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -34,9 +34,9 @@ impl ParseError {
             .with_labels(
                 self.labels
                     .iter()
-                    .map(|label| {
-                        Label::primary((), label.0.to_range().unwrap())
-                            .with_message(label.1.to_string())
+                    .filter_map(|label| label.0.to_range().map(|range| (label, range)))
+                    .map(|(label, range)| {
+                        Label::primary((), range).with_message(label.1.to_string())
                     })
                     .collect(),
             )

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -1986,6 +1986,25 @@ fn function_param_redefinition_as_local() {
 }
 
 #[test]
+fn constructor_type_error_span() {
+    check(
+        "
+        fn unfortunate() {
+            var i: i32;
+            var a: array<f32, 1> = array<f32, 1>(i);
+        }
+    ",
+        r###"error: automatic conversions cannot convert `i32` to `f32`
+  ┌─ wgsl:4:36
+  │
+4 │             var a: array<f32, 1> = array<f32, 1>(i);
+  │                                    ^^^^^^^^^^^^^^^^ a value of type f32 is required here
+
+"###,
+    )
+}
+
+#[test]
 fn binding_array_local() {
     check_validation! {
         "fn f() { var x: binding_array<sampler, 4>; }":


### PR DESCRIPTION
When a label in a WGSL front end error has an undefined span, omit the label from the error message. This is not great, but because of the way Naga IR represents local variable references it is hard to get the right span, and omitting the label better than panicking in `unwrap`, since the error message has a general message anyway.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`.
- [X] Run `cargo xtask test` to run tests.
- (not appropriate) Add change to `CHANGELOG.md`. See simple instructions inside file.
