### PR TITLE
[naga wgsl-in] Use a better span for errors in constructors.

### DIFF
--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -448,7 +448,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 ctx.try_automatic_conversions_slice(
                     &mut components,
                     &Tr::Value(component_ty),
-                    span,
+                    ty_span,
                 )?;
                 expr = crate::Expression::Compose { ty, components };
             }
@@ -497,7 +497,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             // Array constructor, explicit type
             (components, Constructor::Type((ty, &crate::TypeInner::Array { base, .. }))) => {
                 let mut components = components.into_components_vec();
-                ctx.try_automatic_conversions_slice(&mut components, &Tr::Handle(base), span)?;
+                ctx.try_automatic_conversions_slice(&mut components, &Tr::Handle(base), ty_span)?;
                 expr = crate::Expression::Compose { ty, components };
             }
 

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -213,9 +213,8 @@ fn constructor_parameter_type_mismatch() {
   ┌─ wgsl:3:21
   │
 3 │                 _ = mat2x2<f32>(array(0, 1), vec2(2, 3));
-  │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  │                     │           │
-  │                     │           this expression has type array<{AbstractInt}, 2>
+  │                     ^^^^^^^^^^^ ^^^^^^^^^^^ this expression has type array<{AbstractInt}, 2>
+  │                     │            
   │                     a value of type vec2<f32> is required here
 
 "#,


### PR DESCRIPTION
When reporting errors in construction expressions, use the span of the constructor itself (that is, the type name) in preference to the span of the overall expression. This makes errors easier to follow.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`.
- [X] Run `cargo xtask test` to run tests.
- (not appropriate) Add change to `CHANGELOG.md`. See simple instructions inside file.
