### PR TITLE
Expose shader validation

### DIFF
--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -68,7 +68,7 @@ pub mod resource;
 pub mod storage;
 mod track;
 // This is public for users who pre-compile shaders while still wanting to
-// preserve all run-time checks that `wgpu-hal` does.
+// preserve all run-time checks that `wgpu-core` does.
 // See <https://github.com/gfx-rs/wgpu/issues/3103>, after which this can be
 // made private again.
 pub mod validation;

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -67,7 +67,11 @@ pub mod registry;
 pub mod resource;
 pub mod storage;
 mod track;
-mod validation;
+// This is public for users who pre-compile shaders while still wanting to
+// preserve all run-time checks that `wgpu-hal` does.
+// See <https://github.com/gfx-rs/wgpu/issues/3103>, after which this can be
+// made private again.
+pub mod validation;
 
 pub use hal::{api, MAX_BIND_GROUPS, MAX_COLOR_ATTACHMENTS, MAX_VERTEX_BUFFERS};
 


### PR DESCRIPTION
I was trying to pre-compile shaders while still running the exact same validation that `wgpu` does.
Would it be acceptable to expose this module for that purpose?