### PR TITLE
[naga] Fix crash when range is invalid

### DIFF
--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -35,7 +35,7 @@ impl ParseError {
                 self.labels
                     .iter()
                     .map(|label| {
-                        Label::primary((), label.0.to_range().unwrap())
+                        Label::primary((), label.0.to_range().unwrap_or_default())
                             .with_message(label.1.to_string())
                     })
                     .collect(),


### PR DESCRIPTION
Often when trying to validate a "wrongly written" wsgl I'm getting a crash.
This allow to output the diagnostic message without crashing