### PR TITLE
validation: More detailed on incompatible BGL

### DIFF
--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -59,24 +59,33 @@ mod compat {
 
             if let Some(expected_bgl) = self.expected.as_ref() {
                 if let Some(assigned_bgl) = self.assigned.as_ref() {
-
                     for (id, e_entry) in &expected_bgl.entries {
                         if let Some(a_entry) = assigned_bgl.entries.get(id) {
-
                             if a_entry.binding != e_entry.binding {
-                                    diff.push(format!("Entry {id} binding expected {}, got {}", e_entry.binding, a_entry.binding));
-                                }
-                                if a_entry.count != e_entry.count {
-                                    diff.push(format!("Entry {id} count expected {:?}, got {:?}", e_entry.count, a_entry.count));
-                                }
-                                if a_entry.ty != e_entry.ty {
-                                    diff.push(format!("Entry {id} type expected {:?}, got {:?}", e_entry.ty, a_entry.ty));
-                                }
-                                if a_entry.visibility != e_entry.visibility {
-                                    diff.push(format!("Entry {id} visibility expected {:?}, got {:?}", e_entry.visibility, a_entry.visibility));
-                                }
-
-                            } else {
+                                diff.push(format!(
+                                    "Entry {id} binding expected {}, got {}",
+                                    e_entry.binding, a_entry.binding
+                                ));
+                            }
+                            if a_entry.count != e_entry.count {
+                                diff.push(format!(
+                                    "Entry {id} count expected {:?}, got {:?}",
+                                    e_entry.count, a_entry.count
+                                ));
+                            }
+                            if a_entry.ty != e_entry.ty {
+                                diff.push(format!(
+                                    "Entry {id} type expected {:?}, got {:?}",
+                                    e_entry.ty, a_entry.ty
+                                ));
+                            }
+                            if a_entry.visibility != e_entry.visibility {
+                                diff.push(format!(
+                                    "Entry {id} visibility expected {:?}, got {:?}",
+                                    e_entry.visibility, a_entry.visibility
+                                ));
+                            }
+                        } else {
                             diff.push(format!("Entry {id} not found in assigned bindgroup layout"))
                         }
                     }
@@ -86,15 +95,17 @@ mod compat {
                             diff.push(format!("Entry {id} not found in expected bindgroup layout"))
                         }
                     });
-
                 } else {
-                    diff.push("Assigned bindgroup layout is implicit, expected explicit".to_owned());
+                    diff.push(
+                        "Assigned bindgroup layout is implicit, expected explicit".to_owned(),
+                    );
                 }
             } else if let Some(_assigned_bgl) = self.assigned.as_ref() {
-                diff.push("Assigned bindgroup layout is not implicit, expected implicit".to_owned());
+                diff.push(
+                    "Assigned bindgroup layout is not implicit, expected implicit".to_owned(),
+                );
             }
 
-            
             diff
         }
     }
@@ -169,8 +180,8 @@ mod compat {
         pub fn bgl_diff(&self) -> Vec<String> {
             for e in &self.entries {
                 if !e.is_valid() {
-                    return e.bgl_diff()
-                }                   
+                    return e.bgl_diff();
+                }
             }
             vec![String::from("No differences detected?")]
         }

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -54,11 +54,21 @@ mod compat {
             self.expected.is_none() || !self.is_valid()
         }
 
+        // Describe how bind group layouts are incompatible, for validation
+        // error message.
         fn bgl_diff(&self) -> Vec<String> {
             let mut diff = Vec::new();
 
             if let Some(expected_bgl) = self.expected.as_ref() {
+                diff.push(format!(
+                    "Should be compatible with bind group layout with label = `{}`",
+                    expected_bgl.label()
+                ));
                 if let Some(assigned_bgl) = self.assigned.as_ref() {
+                    diff.push(format!(
+                        "Assigned bind group layout with label = `{}`",
+                        assigned_bgl.label()
+                    ));
                     for (id, e_entry) in &expected_bgl.entries {
                         if let Some(a_entry) = assigned_bgl.entries.get(id) {
                             if a_entry.binding != e_entry.binding {
@@ -100,10 +110,18 @@ mod compat {
                         "Assigned bindgroup layout is implicit, expected explicit".to_owned(),
                     );
                 }
-            } else if let Some(_assigned_bgl) = self.assigned.as_ref() {
+            } else if let Some(assigned_bgl) = self.assigned.as_ref() {
+                diff.push(format!(
+                    "Assigned bind group layout = `{}`",
+                    assigned_bgl.label()
+                ));
                 diff.push(
                     "Assigned bindgroup layout is not implicit, expected implicit".to_owned(),
                 );
+            }
+
+            if diff.is_empty() {
+                diff.push("But no differences found? (internal error)".to_owned())
             }
 
             diff
@@ -183,7 +201,7 @@ mod compat {
                     return e.bgl_diff();
                 }
             }
-            vec![String::from("No differences detected?")]
+            vec![String::from("No differences detected? (internal error)")]
         }
     }
 }

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -55,7 +55,7 @@ mod compat {
         }
 
         fn bgl_diff(&self) -> Vec<String> {
-            let mut diff = vec![];
+            let mut diff = Vec::new();
 
             if let Some(expected_bgl) = self.expected.as_ref() {
                 if let Some(assigned_bgl) = self.assigned.as_ref() {
@@ -169,11 +169,10 @@ mod compat {
         pub fn bgl_diff(&self) -> Vec<String> {
             for e in &self.entries {
                 if !e.is_valid() {
-                
                     return e.bgl_diff()
                 }                   
             }
-            vec![format!("huh?!")]
+            vec![String::from("No differences detected?")]
         }
     }
 }

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -53,6 +53,50 @@ mod compat {
         fn is_incompatible(&self) -> bool {
             self.expected.is_none() || !self.is_valid()
         }
+
+        fn bgl_diff(&self) -> Vec<String> {
+            let mut diff = vec![];
+
+            if let Some(expected_bgl) = self.expected.as_ref() {
+                if let Some(assigned_bgl) = self.assigned.as_ref() {
+
+                    for (id, e_entry) in &expected_bgl.entries {
+                        if let Some(a_entry) = assigned_bgl.entries.get(id) {
+
+                            if a_entry.binding != e_entry.binding {
+                                    diff.push(format!("Entry {id} binding expected {}, got {}", e_entry.binding, a_entry.binding));
+                                }
+                                if a_entry.count != e_entry.count {
+                                    diff.push(format!("Entry {id} count expected {:?}, got {:?}", e_entry.count, a_entry.count));
+                                }
+                                if a_entry.ty != e_entry.ty {
+                                    diff.push(format!("Entry {id} type expected {:?}, got {:?}", e_entry.ty, a_entry.ty));
+                                }
+                                if a_entry.visibility != e_entry.visibility {
+                                    diff.push(format!("Entry {id} visibility expected {:?}, got {:?}", e_entry.visibility, a_entry.visibility));
+                                }
+
+                            } else {
+                            diff.push(format!("Entry {id} not found in assigned bindgroup layout"))
+                        }
+                    }
+
+                    assigned_bgl.entries.iter().for_each(|(id, _e_entry)| {
+                        if !expected_bgl.entries.contains_key(id) {
+                            diff.push(format!("Entry {id} not found in expected bindgroup layout"))
+                        }
+                    });
+
+                } else {
+                    diff.push("Assigned bindgroup layout is implicit, expected explicit".to_owned());
+                }
+            } else if let Some(_assigned_bgl) = self.assigned.as_ref() {
+                diff.push("Assigned bindgroup layout is not implicit, expected implicit".to_owned());
+            }
+
+            
+            diff
+        }
     }
 
     #[derive(Debug, Default)]
@@ -120,6 +164,16 @@ mod compat {
                     mask | 1u8 << i
                 }
             })
+        }
+
+        pub fn bgl_diff(&self) -> Vec<String> {
+            for e in &self.entries {
+                if !e.is_valid() {
+                
+                    return e.bgl_diff()
+                }                   
+            }
+            vec![format!("huh?!")]
         }
     }
 }
@@ -272,6 +326,10 @@ impl<A: HalApi> Binder<A> {
 
     pub(super) fn invalid_mask(&self) -> BindGroupMask {
         self.manager.invalid_mask()
+    }
+
+    pub(super) fn bgl_diff(&self) -> Vec<String> {
+        self.manager.bgl_diff()
     }
 
     /// Scan active buffer bindings corresponding to layouts without `min_binding_size` specified.

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -28,9 +28,8 @@ pub enum DrawError {
     #[error("The pipeline layout, associated with the current render pipeline, contains a incompatible bind group layout at index {index}")]
     IncompatibleBindGroup {
         index: u32,
-        diff: Vec<String>
-        //expected: BindGroupLayoutId,
-        //provided: Option<(BindGroupLayoutId, BindGroupId)>,
+        diff: Vec<String>, //expected: BindGroupLayoutId,
+                           //provided: Option<(BindGroupLayoutId, BindGroupId)>,
     },
     #[error("Vertex {last_vertex} extends beyond limit {vertex_limit} imposed by the buffer in slot {slot}. Did you bind the correct `Vertex` step-rate vertex buffer?")]
     VertexBeyondLimit {

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -25,12 +25,8 @@ pub enum DrawError {
     MissingVertexBuffer { index: u32 },
     #[error("Index buffer must be set")]
     MissingIndexBuffer,
-    #[error("The pipeline layout, associated with the current render pipeline, contains a incompatible bind group layout at index {index}")]
-    IncompatibleBindGroup {
-        index: u32,
-        diff: Vec<String>, //expected: BindGroupLayoutId,
-                           //provided: Option<(BindGroupLayoutId, BindGroupId)>,
-    },
+    #[error("Incompatible bind group at index {index} in the current render pipeline")]
+    IncompatibleBindGroup { index: u32, diff: Vec<String> },
     #[error("Vertex {last_vertex} extends beyond limit {vertex_limit} imposed by the buffer in slot {slot}. Did you bind the correct `Vertex` step-rate vertex buffer?")]
     VertexBeyondLimit {
         last_vertex: u32,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -25,9 +25,10 @@ pub enum DrawError {
     MissingVertexBuffer { index: u32 },
     #[error("Index buffer must be set")]
     MissingIndexBuffer,
-    #[error("The pipeline layout, associated with the current render pipeline, contains a bind group layout at index {index} which is incompatible with the bind group layout associated with the bind group at {index}")]
+    #[error("The pipeline layout, associated with the current render pipeline, contains a incompatible bind group layout at index {index}")]
     IncompatibleBindGroup {
         index: u32,
+        diff: Vec<String>
         //expected: BindGroupLayoutId,
         //provided: Option<(BindGroupLayoutId, BindGroupId)>,
     },

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -441,6 +441,7 @@ impl<A: HalApi> State<A> {
             //let (expected, provided) = self.binder.entries[index as usize].info();
             return Err(DrawError::IncompatibleBindGroup {
                 index: bind_mask.trailing_zeros(),
+                diff: self.binder.bgl_diff()
             });
         }
         if self.pipeline.is_none() {
@@ -642,6 +643,11 @@ impl PrettyError for RenderPassErrorInner {
         fmt.error(self);
         if let Self::InvalidAttachment(id) = *self {
             fmt.texture_view_label_with_key(&id, "attachment");
+        };
+        if let Self::Draw(DrawError::IncompatibleBindGroup { diff, .. }) = self {
+            for d in diff {
+                fmt.note(&d);
+            }
         };
     }
 }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -441,7 +441,7 @@ impl<A: HalApi> State<A> {
             //let (expected, provided) = self.binder.entries[index as usize].info();
             return Err(DrawError::IncompatibleBindGroup {
                 index: bind_mask.trailing_zeros(),
-                diff: self.binder.bgl_diff()
+                diff: self.binder.bgl_diff(),
             });
         }
         if self.pipeline.is_none() {


### PR DESCRIPTION
When encountering a incompatible BindGroupLayout on RenderPipelines,
attempt to report the actual difference causing the incompatibility.

**Description**
When encountering a validation error of incompatible layouts on a renderpipeline, the validation error wasn't too helpful.

```
Caused by:
    In a RenderPass
      note: encoder = `<CommandBuffer-(0, 1, Metal)>`
    In a draw command, indexed:true indirect:false
      note: render pipeline = `shadow`
    The pipeline layout, associated with the current render pipeline, contains a bind group layout at index 1 which is incompatible with the bind group layout associated with the bind group at 1
```
I shortened the final error message a little, as it was confusingly wordy, and then added info on the differences:
```
Caused by:
    In a RenderPass
      note: encoder = `<CommandBuffer-(0, 1, Metal)>`
    In a draw command, indexed:true indirect:false
      note: render pipeline = `shadow`
    The pipeline layout, associated with the current render pipeline, contains a incompatible bind group layout at index 1
      note: Entry 1 not found in assigned bindgroup layout
```

At this stage, I'm still asking opinions on how the overall approach, and implementation.

Still things to do:
- [ ] Go through the wording a bit more
- [ ] Show the labels of the BGLs
- [ ] Implement the same for compute pipelines
- [ ] .. and the checklist stuff


**Testing**
Manually munging the examples.


<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
