### PR TITLE
Use Display instead of Debug to log errors.

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -526,7 +526,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             if wait {
                 match device.wait_for_submit(last_submit_index) {
                     Ok(()) => (),
-                    Err(e) => log::error!("Failed to wait for buffer {:?}: {:?}", buffer_id, e),
+                    Err(e) => log::error!("Failed to wait for buffer {:?}: {}", buffer_id, e),
                 }
             }
         }
@@ -574,7 +574,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             return (id, None);
         };
 
-        log::error!("Device::create_texture error {error:?}");
+        log::error!("Device::create_texture error: {error}");
 
         let id = fid.assign_error(desc.label.borrow_or_default());
         (id, Some(error))
@@ -648,7 +648,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             return (id, None);
         };
 
-        log::error!("Device::create_texture error {error:?}");
+        log::error!("Device::create_texture error: {error}");
 
         let id = fid.assign_error(desc.label.borrow_or_default());
         (id, Some(error))
@@ -702,7 +702,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             return (id, None);
         };
 
-        log::error!("Device::create_buffer error {error:?}");
+        log::error!("Device::create_buffer error: {error}");
 
         let id = fid.assign_error(desc.label.borrow_or_default());
         (id, Some(error))
@@ -790,7 +790,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             if wait {
                 match device.wait_for_submit(last_submit_index) {
                     Ok(()) => (),
-                    Err(e) => log::error!("Failed to wait for texture {:?}: {:?}", texture_id, e),
+                    Err(e) => log::error!("Failed to wait for texture {texture_id:?}: {e}"),
                 }
             }
         }
@@ -835,7 +835,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             return (id, None);
         };
 
-        log::error!("Texture::create_view({texture_id:?}) error {error:?}");
+        log::error!("Texture::create_view({texture_id:?}) error: {error}");
         let id = fid.assign_error(desc.label.borrow_or_default());
         (id, Some(error))
     }
@@ -865,11 +865,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             if wait {
                 match view.device.wait_for_submit(last_submit_index) {
                     Ok(()) => (),
-                    Err(e) => log::error!(
-                        "Failed to wait for texture view {:?}: {:?}",
-                        texture_view_id,
-                        e
-                    ),
+                    Err(e) => {
+                        log::error!("Failed to wait for texture view {texture_view_id:?}: {e}")
+                    }
                 }
             }
         }
@@ -1217,7 +1215,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             return (id, None);
         };
 
-        log::error!("Device::create_shader_module error: {error:?}");
+        log::error!("Device::create_shader_module error: {error}");
 
         let id = fid.assign_error(desc.label.borrow_or_default());
         (id, Some(error))
@@ -1274,7 +1272,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             return (id, None);
         };
 
-        log::error!("Device::create_shader_module_spirv error: {error:?}");
+        log::error!("Device::create_shader_module_spirv error: {error}");
 
         let id = fid.assign_error(desc.label.borrow_or_default());
         (id, Some(error))
@@ -1598,7 +1596,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             }
         }
 
-        log::error!("Device::create_render_pipeline error {error:?}");
+        log::error!("Device::create_render_pipeline error: {error}");
 
         (id, Some(error))
     }
@@ -2321,7 +2319,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             if let Some(callback) = operation.callback.take() {
                 callback.call(Err(err.clone()));
             }
-            log::error!("Buffer::map_async error {err:?}");
+            log::error!("Buffer::map_async error: {err}");
             return Err(err);
         }
 

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -930,7 +930,7 @@ impl<A: HalApi> LifetimeTracker<A> {
                             Ok(())
                         }
                         Err(e) => {
-                            log::error!("Mapping failed {:?}", e);
+                            log::error!("Mapping failed: {e}");
                             Err(e)
                         }
                     }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -268,7 +268,7 @@ impl<A: HalApi> Device<A> {
                     Some(trace)
                 }
                 Err(e) => {
-                    log::error!("Unable to start a trace in '{:?}': {:?}", path, e);
+                    log::error!("Unable to start a trace in '{path:?}': {e}");
                     None
                 }
             })),
@@ -3358,7 +3358,7 @@ impl<A: HalApi> Device<A> {
                 .unwrap()
                 .wait(fence, current_index, CLEANUP_WAIT_MS)
         } {
-            log::error!("failed to wait for the device: {:?}", error);
+            log::error!("failed to wait for the device: {error}");
         }
         let mut life_tracker = self.lock_life();
         let _ = life_tracker.triage_submissions(


### PR DESCRIPTION
**Description**

[Oops](https://treeherder.mozilla.org/logviewer?job_id=438807814&repo=try&lineNumber=3663).

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
