### PR TITLE
[gl] add support for line and point polygon modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Previously, `DeviceExt::create_texture_with_data` only allowed data to be provid
 
 #### OpenGL
 - `@builtin(instance_index)` now properly reflects the range provided in the draw call instead of always counting from 0. By @cwfitzgerald in [#4722](https://github.com/gfx-rs/wgpu/pull/4722).
+- Desktop GL now supports `POLYGON_MODE_LINE` and `POLYGON_MODE_POINT`. By @valaphee in #????
+
 #### Naga
 
 - Naga's WGSL front and back ends now have experimental support for 64-bit floating-point literals: `1.0lf` denotes an `f64` value. There has been experimental support for an `f64` type for a while, but until now there was no syntax for writing literals with that type. As before, Naga module validation rejects `f64` values unless `naga::valid::Capabilities::FLOAT64` is requested. By @jimblandy in [#4747](https://github.com/gfx-rs/wgpu/pull/4747).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Previously, `DeviceExt::create_texture_with_data` only allowed data to be provid
 
 #### OpenGL
 - `@builtin(instance_index)` now properly reflects the range provided in the draw call instead of always counting from 0. By @cwfitzgerald in [#4722](https://github.com/gfx-rs/wgpu/pull/4722).
-- Desktop GL now supports `POLYGON_MODE_LINE` and `POLYGON_MODE_POINT`. By @valaphee in #????
+- Desktop GL now supports `POLYGON_MODE_LINE` and `POLYGON_MODE_POINT`. By @valaphee in [#4836](https://github.com/gfx-rs/wgpu/pull/4836)
 
 #### Naga
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -219,10 +219,7 @@ impl super::Adapter {
         log::debug!("Version: {}", version);
 
         let full_ver = Self::parse_full_version(&version).ok();
-        let es_ver = full_ver
-            .is_none()
-            .then_some(())
-            .and_then(|_| Self::parse_version(&version).ok());
+        let es_ver = full_ver.map_or_else(|| Self::parse_version(&version).ok(), |_| None);
         let web_gl = cfg!(target_arch = "wasm32");
 
         if let Some(full_ver) = full_ver {
@@ -555,6 +552,10 @@ impl super::Adapter {
                 || extensions.contains("GL_EXT_color_buffer_float")
                 || extensions.contains("OES_texture_float_linear"),
         );
+
+        if full_ver.is_some() {
+            features |= wgt::Features::POLYGON_MODE_LINE | wgt::Features::POLYGON_MODE_POINT;
+        }
 
         // We *might* be able to emulate bgra8unorm-storage but currently don't attempt to.
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -553,7 +553,7 @@ impl super::Adapter {
                 || extensions.contains("OES_texture_float_linear"),
         );
 
-        if full_ver.is_some() {
+        if es_ver.is_none() {
             features |= wgt::Features::POLYGON_MODE_LINE | wgt::Features::POLYGON_MODE_POINT;
         }
 

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -285,18 +285,6 @@ pub fn map_primitive_topology(topology: wgt::PrimitiveTopology) -> u32 {
 }
 
 pub(super) fn map_primitive_state(state: &wgt::PrimitiveState) -> super::PrimitiveState {
-    match state.polygon_mode {
-        wgt::PolygonMode::Fill => {}
-        wgt::PolygonMode::Line => panic!(
-            "{:?} is not enabled for this backend",
-            wgt::Features::POLYGON_MODE_LINE
-        ),
-        wgt::PolygonMode::Point => panic!(
-            "{:?} is not enabled for this backend",
-            wgt::Features::POLYGON_MODE_POINT
-        ),
-    }
-
     super::PrimitiveState {
         //Note: we are flipping the front face, so that
         // the Y-flip in the generated GLSL keeps the same visibility.
@@ -311,6 +299,11 @@ pub(super) fn map_primitive_state(state: &wgt::PrimitiveState) -> super::Primiti
             None => 0,
         },
         unclipped_depth: state.unclipped_depth,
+        polygon_mode: match state.polygon_mode {
+            wgt::PolygonMode::Fill => glow::FILL,
+            wgt::PolygonMode::Line => glow::LINE,
+            wgt::PolygonMode::Point => glow::POINT,
+        },
     }
 }
 

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -736,6 +736,7 @@ struct PrimitiveState {
     front_face: u32,
     cull_face: u32,
     unclipped_depth: bool,
+    polygon_mode: u32,
 }
 
 type InvalidatedAttachments = ArrayVec<u32, { crate::MAX_COLOR_ATTACHMENTS + 2 }>;

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1330,7 +1330,10 @@ impl super::Queue {
                         unsafe { gl.disable(glow::DEPTH_CLAMP) };
                     }
                 }
-                unsafe { gl.polygon_mode(glow::FRONT_AND_BACK, state.polygon_mode) };
+                // POLYGON_MODE_LINE also implies POLYGON_MODE_POINT
+                if self.features.contains(wgt::Features::POLYGON_MODE_LINE) {
+                    unsafe { gl.polygon_mode(glow::FRONT_AND_BACK, state.polygon_mode) };
+                }
             }
             C::SetBlendConstant(c) => {
                 unsafe { gl.blend_color(c[0], c[1], c[2], c[3]) };

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1,6 +1,5 @@
 use super::{conv::is_layered_target, Command as C, PrivateCapabilities};
 use arrayvec::ArrayVec;
-use bitflags::Flags;
 use glow::HasContext;
 use std::{
     mem, slice,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1,5 +1,6 @@
 use super::{conv::is_layered_target, Command as C, PrivateCapabilities};
 use arrayvec::ArrayVec;
+use bitflags::Flags;
 use glow::HasContext;
 use std::{
     mem, slice,
@@ -1330,6 +1331,7 @@ impl super::Queue {
                         unsafe { gl.disable(glow::DEPTH_CLAMP) };
                     }
                 }
+                unsafe { gl.polygon_mode(glow::FRONT_AND_BACK, state.polygon_mode) };
             }
             C::SetBlendConstant(c) => {
                 unsafe { gl.blend_color(c[0], c[1], c[2], c[3]) };


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/3762

**Description**
Since Desktop GL is now supported, polygon modes can now be implemented for the GL backend.

Also made the full ver/es ver parsing more readable. (is_none then_some and_then -> map_or_else). 

There is no explicit feature check in the map_primitive_state but this is fine as it seems to be already checked before and polygon_mode is always called as glow ignores it if its fill on web.

**Testing**
Tested by running cube, also with different culling options, to see if the behavior is identical to Vulkan, and running the WebGL demos.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
