### PR TITLE
Remove `expose-ids` Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ This adds a way to allow a Vulkan driver which is non-compliant per VK_KHR_drive
 
 Previously, `DeviceExt::create_texture_with_data` only allowed data to be provided in layer major order. There is now a `order` parameter which allows you to specify if the data is in layer major or mip major order.
 
+### `expose-ids` feature now available unconditionally
+
+This feature allowed you to call `global_id` on any wgpu opaque handle to get a unique hashable identity for the given resource. This is now available without the feature flag. By @cwfitzgerald in [#4841](https://github.com/gfx-rs/wgpu/pull/4841)
+
 ### New Features
 
 #### General

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -38,7 +38,6 @@ angle = ["wgc/gles"]
 webgl = ["hal", "wgc/gles"]
 # Enables the Vulkan backend on macOS & iOS
 vulkan-portability = ["wgc/vulkan"]
-expose-ids = []
 # Implement `Send` and `Sync` on Wasm.
 fragile-send-sync-non-atomic-wasm = [
     "hal/fragile-send-sync-non-atomic-wasm",

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -1033,7 +1033,6 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
 pub struct ObjectId {
     /// ID that is unique at any given time
     id: Option<NonZeroU64>,
-    #[cfg(feature = "expose-ids")]
     /// ID that is unique at all times
     global_id: Option<NonZeroU64>,
 }
@@ -1041,14 +1040,12 @@ pub struct ObjectId {
 impl ObjectId {
     pub(crate) const UNUSED: Self = ObjectId {
         id: None,
-        #[cfg(feature = "expose-ids")]
         global_id: None,
     };
 
-    pub fn new(id: NonZeroU64, #[cfg(feature = "expose-ids")] global_id: NonZeroU64) -> Self {
+    pub fn new(id: NonZeroU64, global_id: NonZeroU64) -> Self {
         Self {
             id: Some(id),
-            #[cfg(feature = "expose-ids")]
             global_id: Some(global_id),
         }
     }
@@ -1057,7 +1054,6 @@ impl ObjectId {
     pub fn from_global_id(global_id: NonZeroU64) -> Self {
         Self {
             id: Some(global_id),
-            #[cfg(feature = "expose-ids")]
             global_id: Some(global_id),
         }
     }
@@ -1067,8 +1063,6 @@ impl ObjectId {
         self.id.unwrap()
     }
 
-    #[cfg(feature = "expose-ids")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> NonZeroU64 {
         self.global_id.unwrap()
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
     error, fmt,
     future::Future,
     marker::PhantomData,
-    num::NonZeroU32,
+    num::{NonZeroU32, NonZeroU64},
     ops::{Bound, Deref, DerefMut, Range, RangeBounds},
     sync::Arc,
     thread,
@@ -5124,243 +5124,201 @@ impl Surface<'_> {
 }
 
 /// Opaque globally-unique identifier
-#[cfg(feature = "expose-ids")]
-#[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
 #[repr(transparent)]
-pub struct Id<T>(::core::num::NonZeroU64, std::marker::PhantomData<*mut T>);
+pub struct Id<T>(NonZeroU64, PhantomData<*mut T>);
 
 // SAFETY: `Id` is a bare `NonZeroU64`, the type parameter is a marker purely to avoid confusing Ids
 // returned for different types , so `Id` can safely implement Send and Sync.
-#[cfg(feature = "expose-ids")]
 unsafe impl<T> Send for Id<T> {}
 
 // SAFETY: See the implementation for `Send`.
-#[cfg(feature = "expose-ids")]
 unsafe impl<T> Sync for Id<T> {}
 
-#[cfg(feature = "expose-ids")]
 impl<T> Clone for Id<T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl<T> Copy for Id<T> {}
 
-#[cfg(feature = "expose-ids")]
 impl<T> fmt::Debug for Id<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Id").field(&self.0).finish()
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl<T> PartialEq for Id<T> {
     fn eq(&self, other: &Id<T>) -> bool {
         self.0 == other.0
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl<T> Eq for Id<T> {}
 
-#[cfg(feature = "expose-ids")]
 impl<T> std::hash::Hash for Id<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl Adapter {
     /// Returns a globally-unique identifier for this `Adapter`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl Device {
     /// Returns a globally-unique identifier for this `Device`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl Queue {
     /// Returns a globally-unique identifier for this `Queue`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl ShaderModule {
     /// Returns a globally-unique identifier for this `ShaderModule`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl BindGroupLayout {
     /// Returns a globally-unique identifier for this `BindGroupLayout`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl BindGroup {
     /// Returns a globally-unique identifier for this `BindGroup`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl TextureView {
     /// Returns a globally-unique identifier for this `TextureView`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl Sampler {
     /// Returns a globally-unique identifier for this `Sampler`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl Buffer {
     /// Returns a globally-unique identifier for this `Buffer`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl Texture {
     /// Returns a globally-unique identifier for this `Texture`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl QuerySet {
     /// Returns a globally-unique identifier for this `QuerySet`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl PipelineLayout {
     /// Returns a globally-unique identifier for this `PipelineLayout`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl RenderPipeline {
     /// Returns a globally-unique identifier for this `RenderPipeline`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl ComputePipeline {
     /// Returns a globally-unique identifier for this `ComputePipeline`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl RenderBundle {
     /// Returns a globally-unique identifier for this `RenderBundle`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Self> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 
-#[cfg(feature = "expose-ids")]
 impl Surface<'_> {
     /// Returns a globally-unique identifier for this `Surface`.
     ///
     /// Calling this method multiple times on the same object will always return the same value.
     /// The returned value is guaranteed to be different for all resources created from the same `Instance`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "expose-ids")))]
     pub fn global_id(&self) -> Id<Surface<'_>> {
-        Id(self.id.global_id(), std::marker::PhantomData)
+        Id(self.id.global_id(), PhantomData)
     }
 }
 


### PR DESCRIPTION
**Description**

Per discussion in the meeting today, we shouldn't be hiding the `global_id` behind a feature out of imaginary fear of performance costs.

This converts the feature into being unconditionally available.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
