### PR TITLE
Work around cbindgen issue

### DIFF
--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1572,8 +1572,8 @@ pub struct AccelerationStructureTriangleTransform<'a, A: Api> {
     pub offset: u32,
 }
 
-pub type AccelerationStructureBuildFlags = wgt::AccelerationStructureFlags;
-pub type AccelerationStructureGeometryFlags = wgt::AccelerationStructureGeometryFlags;
+pub use wgt::AccelerationStructureFlags as AccelerationStructureBuildFlags;
+pub use wgt::AccelerationStructureGeometryFlags;
 
 bitflags::bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
**Description**

cbindgen spins out of control (never terminates) if wgpu_hal reexports a wgpu_types type using pub type in stead of pub use while keeping the same name.

This PR just uses the other syntax to work around the issue.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
