### PR TITLE
[wgpu] correct doc for resolve query set

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3674,7 +3674,7 @@ impl CommandEncoder {
 
     /// Resolves a query set, writing the results into the supplied destination buffer.
     ///
-    /// Occlusion and timestamp queries are 8 bytes each (see [`wgpu::QUERY_SIZE`]). For pipeline statistics queries,
+    /// Occlusion and timestamp queries are 8 bytes each (see [`crate::QUERY_SIZE`]). For pipeline statistics queries,
     /// see [`PipelineStatisticsTypes`] for more information.
     pub fn resolve_query_set(
         &mut self,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3671,6 +3671,31 @@ impl CommandEncoder {
         let id = self.id.as_ref().unwrap();
         DynContext::command_encoder_pop_debug_group(&*self.context, id, self.data.as_ref());
     }
+
+    /// Resolves a query set, writing the results into the supplied destination buffer.
+    ///
+    /// Occlusion and timestamp queries are 8 bytes each. For pipeline statistics queries,
+    /// see [`PipelineStatisticsTypes`] for more information.
+    pub fn resolve_query_set(
+        &mut self,
+        query_set: &QuerySet,
+        query_range: Range<u32>,
+        destination: &Buffer,
+        destination_offset: BufferAddress,
+    ) {
+        DynContext::command_encoder_resolve_query_set(
+            &*self.context,
+            self.id.as_ref().unwrap(),
+            self.data.as_ref(),
+            &query_set.id,
+            query_set.data.as_ref(),
+            query_range.start,
+            query_range.end - query_range.start,
+            &destination.id,
+            destination.data.as_ref(),
+            destination_offset,
+        )
+    }
 }
 
 /// [`Features::TIMESTAMP_QUERY`] must be enabled on the device in order to call these functions.
@@ -3690,33 +3715,6 @@ impl CommandEncoder {
             &query_set.id,
             query_set.data.as_ref(),
             query_index,
-        )
-    }
-}
-
-/// [`Features::TIMESTAMP_QUERY`] or [`Features::PIPELINE_STATISTICS_QUERY`] must be enabled on the device in order to call these functions.
-impl CommandEncoder {
-    /// Resolve a query set, writing the results into the supplied destination buffer.
-    ///
-    /// Queries may be between 8 and 40 bytes each. See [`PipelineStatisticsTypes`] for more information.
-    pub fn resolve_query_set(
-        &mut self,
-        query_set: &QuerySet,
-        query_range: Range<u32>,
-        destination: &Buffer,
-        destination_offset: BufferAddress,
-    ) {
-        DynContext::command_encoder_resolve_query_set(
-            &*self.context,
-            self.id.as_ref().unwrap(),
-            self.data.as_ref(),
-            &query_set.id,
-            query_set.data.as_ref(),
-            query_range.start,
-            query_range.end - query_range.start,
-            &destination.id,
-            destination.data.as_ref(),
-            destination_offset,
         )
     }
 }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3674,7 +3674,7 @@ impl CommandEncoder {
 
     /// Resolves a query set, writing the results into the supplied destination buffer.
     ///
-    /// Occlusion and timestamp queries are 8 bytes each. For pipeline statistics queries,
+    /// Occlusion and timestamp queries are 8 bytes each (see [`wgpu::QUERY_SIZE`]). For pipeline statistics queries,
     /// see [`PipelineStatisticsTypes`] for more information.
     pub fn resolve_query_set(
         &mut self,


### PR DESCRIPTION
**Connections**
Closes https://github.com/gfx-rs/wgpu/issues/4838

**Description**
Moved `resolve_query_set` to the general command encoder impl, as it technically doesn't require any feature, is not meaningful to the end user, and it's not possible to create a query set with an unsupported type anyway.

And added info about how many bytes to expect.

**Testing**

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
