### PR TITLE
[naga wgsl-in] Support abstract operands to binary operators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,10 @@ This feature allowed you to call `global_id` on any wgpu opaque handle to get a 
 
 #### Naga
 
-- Naga'sn WGSL front and back ends now have experimental support for 64-bit floating-point literals: `1.0lf` denotes an `f64` value. There has been experimental support for an `f64` type for a while, but until now there was no syntax for writing literals with that type. As before, Naga module validation rejects `f64` values unless `naga::valid::Capabilities::FLOAT64` is requested. By @jimblandy in [#4747](https://github.com/gfx-rs/wgpu/pull/4747).
+- Naga's WGSL front end now allows binary operators to produce values with abstract types, rather than concretizing thir operands. By @jimblandy in [#4850](https://github.com/gfx-rs/wgpu/pull/4850).
+
+- Naga's WGSL front and back ends now have experimental support for 64-bit floating-point literals: `1.0lf` denotes an `f64` value. There has been experimental support for an `f64` type for a while, but until now there was no syntax for writing literals with that type. As before, Naga module validation rejects `f64` values unless `naga::valid::Capabilities::FLOAT64` is requested. By @jimblandy in [#4747](https://github.com/gfx-rs/wgpu/pull/4747).
+
 - Naga constant evaluation can now process binary operators whose operands are both vectors. By @jimblandy in [#4861](https://github.com/gfx-rs/wgpu/pull/4861).
 
 ### Changes

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -257,6 +257,12 @@ pub enum Error<'a> {
         source_span: Span,
         source_type: String,
     },
+    AutoConversionLeafScalar {
+        dest_span: Span,
+        dest_scalar: String,
+        source_span: Span,
+        source_type: String,
+    },
     ConcretizationFailed {
         expr_span: Span,
         expr_type: String,
@@ -730,6 +736,20 @@ impl<'a> Error<'a> {
                     (
                         dest_span,
                         format!("a value of type {dest_type} is required here").into(),
+                    ),
+                    (
+                        source_span,
+                        format!("this expression has type {source_type}").into(),
+                    )
+                ],
+                notes: vec![],
+            },
+            Error::AutoConversionLeafScalar { dest_span, ref dest_scalar, source_span, ref source_type } => ParseError {
+                message: format!("automatic conversions cannot convert elements of `{source_type}` to `{dest_scalar}`"),
+                labels: vec![
+                    (
+                        dest_span,
+                        format!("a value with elements of type {dest_scalar} is required here").into(),
                     ),
                     (
                         source_span,

--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -299,7 +299,10 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 },
                 Constructor::Type((_, &crate::TypeInner::Vector { size, scalar })),
             ) => {
-                ctx.convert_slice_to_common_scalar(std::slice::from_mut(&mut component), scalar)?;
+                ctx.convert_slice_to_common_leaf_scalar(
+                    std::slice::from_mut(&mut component),
+                    scalar,
+                )?;
                 expr = crate::Expression::Splat {
                     size,
                     value: component,
@@ -319,7 +322,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         .map_err(|index| {
                             Error::InvalidConstructorComponentType(spans[index], index as i32)
                         })?;
-                ctx.convert_slice_to_common_scalar(&mut components, consensus_scalar)?;
+                ctx.convert_slice_to_common_leaf_scalar(&mut components, consensus_scalar)?;
                 let inner = consensus_scalar.to_inner_vector(size);
                 let ty = ctx.ensure_type_exists(inner);
                 expr = crate::Expression::Compose { ty, components };
@@ -351,7 +354,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 let consensus_scalar = consensus_scalar
                     .automatic_conversion_combine(crate::Scalar::ABSTRACT_FLOAT)
                     .unwrap_or(consensus_scalar);
-                ctx.convert_slice_to_common_scalar(&mut components, consensus_scalar)?;
+                ctx.convert_slice_to_common_leaf_scalar(&mut components, consensus_scalar)?;
                 let vec_ty = ctx.ensure_type_exists(consensus_scalar.to_inner_vector(rows));
 
                 let components = components
@@ -425,7 +428,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         .map_err(|index| {
                             Error::InvalidConstructorComponentType(spans[index], index as i32)
                         })?;
-                ctx.convert_slice_to_common_scalar(&mut components, consensus_scalar)?;
+                ctx.convert_slice_to_common_leaf_scalar(&mut components, consensus_scalar)?;
                 let ty = ctx.ensure_type_exists(crate::TypeInner::Matrix {
                     columns,
                     rows,
@@ -473,7 +476,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     // do. And if this array construction is not well-typed,
                     // these conversions will not make it so, and we can let
                     // validation catch the error.
-                    ctx.convert_slice_to_common_scalar(&mut components, consensus_scalar)?;
+                    ctx.convert_slice_to_common_leaf_scalar(&mut components, consensus_scalar)?;
                 } else {
                     // There's no consensus scalar. Emit the `Compose`
                     // expression anyway, and let validation catch the problem.

--- a/naga/src/front/wgsl/lower/conversion.rs
+++ b/naga/src/front/wgsl/lower/conversion.rs
@@ -214,13 +214,17 @@ impl<'source, 'temp, 'out> super::ExpressionContext<'source, 'temp, 'out> {
     /// considers their leaf scalar types. This means it may return `Ok`
     /// even when the Naga validator will reject the resulting
     /// construction expression later.
-    pub fn automatic_conversion_consensus(
+    pub fn automatic_conversion_consensus<'handle, I>(
         &self,
-        components: &[Handle<crate::Expression>],
-    ) -> Result<crate::Scalar, usize> {
+        components: I,
+    ) -> Result<crate::Scalar, usize>
+    where
+        I: IntoIterator<Item = &'handle Handle<crate::Expression>>,
+        I::IntoIter: Clone, // for debugging
+    {
         let types = &self.module.types;
         let mut inners = components
-            .iter()
+            .into_iter()
             .map(|&c| self.typifier()[c].inner_with(types));
         log::debug!(
             "wgsl automatic_conversion_consensus: {:?}",

--- a/naga/src/front/wgsl/lower/conversion.rs
+++ b/naga/src/front/wgsl/lower/conversion.rs
@@ -140,7 +140,7 @@ impl<'source, 'temp, 'out> super::ExpressionContext<'source, 'temp, 'out> {
     /// themselves whether the casts we we generate are justified,
     /// perhaps by calling `TypeInner::automatically_converts_to` or
     /// `Scalar::automatic_conversion_combine`.
-    pub fn convert_slice_to_common_scalar(
+    pub fn convert_slice_to_common_leaf_scalar(
         &mut self,
         exprs: &mut [Handle<crate::Expression>],
         goal: crate::Scalar,

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1602,11 +1602,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 return Ok(Typed::Reference(pointer));
             }
             ast::Expression::Binary { op, left, right } => {
-                // Load both operands.
-                let mut left = self.expression(left, ctx)?;
-                let mut right = self.expression(right, ctx)?;
-                ctx.binary_op_splat(op, &mut left, &mut right)?;
-                Typed::Plain(crate::Expression::Binary { op, left, right })
+                self.binary(op, left, right, span, ctx)?
             }
             ast::Expression::Call {
                 ref function,
@@ -1735,6 +1731,52 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
         };
 
         expr.try_map(|handle| ctx.append_expression(handle, span))
+    }
+
+    fn binary(
+        &mut self,
+        op: crate::BinaryOperator,
+        left: Handle<ast::Expression<'source>>,
+        right: Handle<ast::Expression<'source>>,
+        span: Span,
+        ctx: &mut ExpressionContext<'source, '_, '_>,
+    ) -> Result<Typed<crate::Expression>, Error<'source>> {
+        // Load both operands.
+        let mut left = self.expression_for_abstract(left, ctx)?;
+        let mut right = self.expression_for_abstract(right, ctx)?;
+
+        // Convert `scalar op vector` to `vector op vector` by introducing
+        // `Splat` expressions.
+        ctx.binary_op_splat(op, &mut left, &mut right)?;
+
+        // Apply automatic conversions.
+        match op {
+            // Shift operators require the right operand to be `u32` or
+            // `vecN<u32>`. We can let the validator sort out vector length
+            // issues, but the right operand must be, or convert to, a u32 leaf
+            // scalar.
+            crate::BinaryOperator::ShiftLeft | crate::BinaryOperator::ShiftRight => {
+                right =
+                    ctx.try_automatic_conversion_for_leaf_scalar(right, crate::Scalar::U32, span)?;
+            }
+
+            // All other operators follow the same pattern: reconcile the
+            // scalar leaf types. If there's no reconciliation possible,
+            // leave the expressions as they are: validation will report the
+            // problem.
+            _ => {
+                ctx.grow_types(left)?;
+                ctx.grow_types(right)?;
+                if let Ok(consensus_scalar) =
+                    ctx.automatic_conversion_consensus([left, right].iter())
+                {
+                    ctx.convert_to_leaf_scalar(&mut left, consensus_scalar)?;
+                    ctx.convert_to_leaf_scalar(&mut right, consensus_scalar)?;
+                }
+            }
+        }
+
+        Ok(Typed::Plain(crate::Expression::Binary { op, left, right }))
     }
 
     /// Generate Naga IR for call expressions and statements, and type

--- a/naga/tests/in/abstract-types-operators.wgsl
+++ b/naga/tests/in/abstract-types-operators.wgsl
@@ -1,0 +1,45 @@
+const plus_fafaf: f32 = 1.0 + 2.0;
+const plus_fafai: f32 = 1.0 + 2;
+const plus_faf_f: f32 = 1.0 + 2f;
+const plus_faiaf: f32 = 1 + 2.0;
+const plus_faiai: f32 = 1 + 2;
+const plus_fai_f: f32 = 1 + 2f;
+const plus_f_faf: f32 = 1f + 2.0;
+const plus_f_fai: f32 = 1f + 2;
+const plus_f_f_f: f32 = 1f + 2f;
+
+const plus_iaiai: i32 = 1 + 2;
+const plus_iai_i: i32 = 1 + 2i;
+const plus_i_iai: i32 = 1i + 2;
+const plus_i_i_i: i32 = 1i + 2i;
+
+const plus_uaiai: u32 = 1 + 2;
+const plus_uai_u: u32 = 1 + 2u;
+const plus_u_uai: u32 = 1u + 2;
+const plus_u_u_u: u32 = 1u + 2u;
+
+fn runtime_values() {
+  var f: f32 = 42;
+  var i: i32 = 43;
+  var u: u32 = 44;
+
+  var plus_fafaf: f32 = 1.0 + 2.0;
+  var plus_fafai: f32 = 1.0 + 2;
+  var plus_faf_f: f32 = 1.0 + f;
+  var plus_faiaf: f32 = 1 + 2.0;
+  var plus_faiai: f32 = 1 + 2;
+  var plus_fai_f: f32 = 1 + f;
+  var plus_f_faf: f32 = f + 2.0;
+  var plus_f_fai: f32 = f + 2;
+  var plus_f_f_f: f32 = f + f;
+
+  var plus_iaiai: i32 = 1 + 2;
+  var plus_iai_i: i32 = 1 + i;
+  var plus_i_iai: i32 = i + 2;
+  var plus_i_i_i: i32 = i + i;
+
+  var plus_uaiai: u32 = 1 + 2;
+  var plus_uai_u: u32 = 1 + u;
+  var plus_u_uai: u32 = u + 2;
+  var plus_u_u_u: u32 = u + u;
+}

--- a/naga/tests/out/msl/abstract-types-operators.msl
+++ b/naga/tests/out/msl/abstract-types-operators.msl
@@ -1,0 +1,73 @@
+// language: metal1.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+constant float plus_fafaf_1 = 3.0;
+constant float plus_fafai_1 = 3.0;
+constant float plus_faf_f_1 = 3.0;
+constant float plus_faiaf_1 = 3.0;
+constant float plus_faiai_1 = 3.0;
+constant float plus_fai_f_1 = 3.0;
+constant float plus_f_faf_1 = 3.0;
+constant float plus_f_fai_1 = 3.0;
+constant float plus_f_f_f_1 = 3.0;
+constant int plus_iaiai_1 = 3;
+constant int plus_iai_i_1 = 3;
+constant int plus_i_iai_1 = 3;
+constant int plus_i_i_i_1 = 3;
+constant uint plus_uaiai_1 = 3u;
+constant uint plus_uai_u_1 = 3u;
+constant uint plus_u_uai_1 = 3u;
+constant uint plus_u_u_u_1 = 3u;
+
+void runtime_values(
+) {
+    float f = 42.0;
+    int i = 43;
+    uint u = 44u;
+    float plus_fafaf = 3.0;
+    float plus_fafai = 3.0;
+    float plus_faf_f = {};
+    float plus_faiaf = 3.0;
+    float plus_faiai = 3.0;
+    float plus_fai_f = {};
+    float plus_f_faf = {};
+    float plus_f_fai = {};
+    float plus_f_f_f = {};
+    int plus_iaiai = 3;
+    int plus_iai_i = {};
+    int plus_i_iai = {};
+    int plus_i_i_i = {};
+    uint plus_uaiai = 3u;
+    uint plus_uai_u = {};
+    uint plus_u_uai = {};
+    uint plus_u_u_u = {};
+    float _e8 = f;
+    plus_faf_f = 1.0 + _e8;
+    float _e14 = f;
+    plus_fai_f = 1.0 + _e14;
+    float _e18 = f;
+    plus_f_faf = _e18 + 2.0;
+    float _e22 = f;
+    plus_f_fai = _e22 + 2.0;
+    float _e26 = f;
+    float _e27 = f;
+    plus_f_f_f = _e26 + _e27;
+    int _e31 = i;
+    plus_iai_i = 1 + _e31;
+    int _e35 = i;
+    plus_i_iai = _e35 + 2;
+    int _e39 = i;
+    int _e40 = i;
+    plus_i_i_i = _e39 + _e40;
+    uint _e44 = u;
+    plus_uai_u = 1u + _e44;
+    uint _e48 = u;
+    plus_u_uai = _e48 + 2u;
+    uint _e52 = u;
+    uint _e53 = u;
+    plus_u_u_u = _e52 + _e53;
+    return;
+}

--- a/naga/tests/out/spv/abstract-types-operators.spvasm
+++ b/naga/tests/out/spv/abstract-types-operators.spvasm
@@ -1,0 +1,101 @@
+; SPIR-V
+; Version: 1.1
+; Generator: rspirv
+; Bound: 81
+OpCapability Shader
+OpCapability Linkage
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+%2 = OpTypeVoid
+%3 = OpTypeFloat 32
+%4 = OpTypeInt 32 1
+%5 = OpTypeInt 32 0
+%6 = OpConstant  %3  3.0
+%7 = OpConstant  %4  3
+%8 = OpConstant  %5  3
+%11 = OpTypeFunction %2
+%12 = OpConstant  %3  42.0
+%13 = OpConstant  %4  43
+%14 = OpConstant  %5  44
+%15 = OpConstant  %3  1.0
+%16 = OpConstant  %3  2.0
+%17 = OpConstant  %4  1
+%18 = OpConstant  %4  2
+%19 = OpConstant  %5  1
+%20 = OpConstant  %5  2
+%22 = OpTypePointer Function %3
+%24 = OpTypePointer Function %4
+%26 = OpTypePointer Function %5
+%30 = OpConstantNull  %3
+%34 = OpConstantNull  %3
+%36 = OpConstantNull  %3
+%38 = OpConstantNull  %3
+%40 = OpConstantNull  %3
+%43 = OpConstantNull  %4
+%45 = OpConstantNull  %4
+%47 = OpConstantNull  %4
+%50 = OpConstantNull  %5
+%52 = OpConstantNull  %5
+%54 = OpConstantNull  %5
+%10 = OpFunction  %2  None %11
+%9 = OpLabel
+%53 = OpVariable  %26  Function %54
+%48 = OpVariable  %26  Function %8
+%42 = OpVariable  %24  Function %43
+%37 = OpVariable  %22  Function %38
+%32 = OpVariable  %22  Function %6
+%28 = OpVariable  %22  Function %6
+%23 = OpVariable  %24  Function %13
+%51 = OpVariable  %26  Function %52
+%46 = OpVariable  %24  Function %47
+%41 = OpVariable  %24  Function %7
+%35 = OpVariable  %22  Function %36
+%31 = OpVariable  %22  Function %6
+%27 = OpVariable  %22  Function %6
+%21 = OpVariable  %22  Function %12
+%49 = OpVariable  %26  Function %50
+%44 = OpVariable  %24  Function %45
+%39 = OpVariable  %22  Function %40
+%33 = OpVariable  %22  Function %34
+%29 = OpVariable  %22  Function %30
+%25 = OpVariable  %26  Function %14
+OpBranch %55
+%55 = OpLabel
+%56 = OpLoad  %3  %21
+%57 = OpFAdd  %3  %15 %56
+OpStore %29 %57
+%58 = OpLoad  %3  %21
+%59 = OpFAdd  %3  %15 %58
+OpStore %33 %59
+%60 = OpLoad  %3  %21
+%61 = OpFAdd  %3  %60 %16
+OpStore %35 %61
+%62 = OpLoad  %3  %21
+%63 = OpFAdd  %3  %62 %16
+OpStore %37 %63
+%64 = OpLoad  %3  %21
+%65 = OpLoad  %3  %21
+%66 = OpFAdd  %3  %64 %65
+OpStore %39 %66
+%67 = OpLoad  %4  %23
+%68 = OpIAdd  %4  %17 %67
+OpStore %42 %68
+%69 = OpLoad  %4  %23
+%70 = OpIAdd  %4  %69 %18
+OpStore %44 %70
+%71 = OpLoad  %4  %23
+%72 = OpLoad  %4  %23
+%73 = OpIAdd  %4  %71 %72
+OpStore %46 %73
+%74 = OpLoad  %5  %25
+%75 = OpIAdd  %5  %19 %74
+OpStore %49 %75
+%76 = OpLoad  %5  %25
+%77 = OpIAdd  %5  %76 %20
+OpStore %51 %77
+%78 = OpLoad  %5  %25
+%79 = OpLoad  %5  %25
+%80 = OpIAdd  %5  %78 %79
+OpStore %53 %80
+OpReturn
+OpFunctionEnd

--- a/naga/tests/out/spv/debug-symbol-terrain.spvasm
+++ b/naga/tests/out/spv/debug-symbol-terrain.spvasm
@@ -555,9 +555,9 @@ OpDecorate %582 Location 0
 %79 = OpConstantComposite  %4  %78 %78 %78
 %80 = OpConstantComposite  %4  %74 %74 %74
 %81 = OpConstant  %5  2.0
-%82 = OpConstant  %5  1.7928429
-%83 = OpConstant  %5  0.85373473
-%84 = OpConstantComposite  %4  %82 %82 %82
+%82 = OpConstant  %5  0.85373473
+%83 = OpConstant  %5  1.7928429
+%84 = OpConstantComposite  %4  %83 %83 %83
 %85 = OpConstant  %5  130.0
 %87 = OpTypePointer Function %6
 %88 = OpConstantNull  %6
@@ -659,6 +659,7 @@ OpBranch %60
 %60 = OpLabel
 OpLine %3 10 52
 %61 = OpVectorTimesScalar  %4  %52 %55
+OpLine %3 10 63
 OpLine %3 10 50
 %62 = OpFAdd  %4  %61 %57
 %63 = OpFMul  %4  %62 %52
@@ -755,6 +756,7 @@ OpLine %3 21 28
 %154 = OpVectorShuffle  %6  %153 %153 2 3
 %155 = OpDot  %5  %152 %154
 %156 = OpCompositeConstruct  %4  %145 %150 %155
+OpLine %3 21 28
 %157 = OpFSub  %4  %79 %156
 OpLine %3 21 24
 %158 = OpExtInst  %4  %1 FMax %157 %80
@@ -772,17 +774,21 @@ OpLine %3 23 9
 %164 = OpFMul  %4  %162 %163
 OpLine %3 23 5
 OpStore %94 %164
-OpLine %3 24 13
+OpLine %3 24 18
 %165 = OpVectorShuffle  %4  %73 %73 3 3 3
 %166 = OpFMul  %4  %144 %165
 %167 = OpExtInst  %4  %1 Fract %166
+OpLine %3 24 13
 %168 = OpVectorTimesScalar  %4  %167 %81
+OpLine %3 24 37
 OpLine %3 24 13
 %169 = OpFSub  %4  %168 %57
 OpLine %3 25 13
 %170 = OpExtInst  %4  %1 FAbs %169
+OpLine %3 25 22
 OpLine %3 25 13
 %171 = OpFSub  %4  %170 %79
+OpLine %3 26 24
 OpLine %3 26 14
 %172 = OpFAdd  %4  %169 %79
 %173 = OpExtInst  %4  %1 Floor %172
@@ -790,11 +796,13 @@ OpLine %3 27 14
 %174 = OpFSub  %4  %169 %173
 OpLine %3 1 1
 %175 = OpLoad  %4  %94
-OpLine %3 28 9
+OpLine %3 28 53
 %176 = OpFMul  %4  %174 %174
 %177 = OpFMul  %4  %171 %171
 %178 = OpFAdd  %4  %176 %177
-%179 = OpVectorTimesScalar  %4  %178 %83
+OpLine %3 28 14
+%179 = OpVectorTimesScalar  %4  %178 %82
+OpLine %3 28 9
 %180 = OpFSub  %4  %84 %179
 %181 = OpFMul  %4  %175 %180
 OpLine %3 28 5
@@ -817,9 +825,10 @@ OpLine %3 29 13
 %196 = OpFMul  %6  %193 %195
 %197 = OpFAdd  %6  %192 %196
 %198 = OpCompositeConstruct  %4  %188 %197
-OpLine %3 30 12
+OpLine %3 30 19
 %199 = OpLoad  %4  %94
 %200 = OpDot  %5  %199 %198
+OpLine %3 30 12
 %201 = OpFMul  %5  %85 %200
 OpReturnValue %201
 OpFunctionEnd
@@ -1149,6 +1158,7 @@ OpLine %3 163 14
 %429 = OpCompositeConstruct  %6  %424 %428
 OpLine %3 165 30
 %430 = OpVectorTimesScalar  %6  %429 %81
+OpLine %3 165 30
 %431 = OpFAdd  %6  %419 %430
 OpLine %3 165 20
 %432 = OpCompositeConstruct  %7  %431 %74 %56

--- a/naga/tests/out/wgsl/abstract-types-operators.wgsl
+++ b/naga/tests/out/wgsl/abstract-types-operators.wgsl
@@ -1,0 +1,68 @@
+const plus_fafaf_1: f32 = 3f;
+const plus_fafai_1: f32 = 3f;
+const plus_faf_f_1: f32 = 3f;
+const plus_faiaf_1: f32 = 3f;
+const plus_faiai_1: f32 = 3f;
+const plus_fai_f_1: f32 = 3f;
+const plus_f_faf_1: f32 = 3f;
+const plus_f_fai_1: f32 = 3f;
+const plus_f_f_f_1: f32 = 3f;
+const plus_iaiai_1: i32 = 3i;
+const plus_iai_i_1: i32 = 3i;
+const plus_i_iai_1: i32 = 3i;
+const plus_i_i_i_1: i32 = 3i;
+const plus_uaiai_1: u32 = 3u;
+const plus_uai_u_1: u32 = 3u;
+const plus_u_uai_1: u32 = 3u;
+const plus_u_u_u_1: u32 = 3u;
+
+fn runtime_values() {
+    var f: f32 = 42f;
+    var i: i32 = 43i;
+    var u: u32 = 44u;
+    var plus_fafaf: f32 = 3f;
+    var plus_fafai: f32 = 3f;
+    var plus_faf_f: f32;
+    var plus_faiaf: f32 = 3f;
+    var plus_faiai: f32 = 3f;
+    var plus_fai_f: f32;
+    var plus_f_faf: f32;
+    var plus_f_fai: f32;
+    var plus_f_f_f: f32;
+    var plus_iaiai: i32 = 3i;
+    var plus_iai_i: i32;
+    var plus_i_iai: i32;
+    var plus_i_i_i: i32;
+    var plus_uaiai: u32 = 3u;
+    var plus_uai_u: u32;
+    var plus_u_uai: u32;
+    var plus_u_u_u: u32;
+
+    let _e8 = f;
+    plus_faf_f = (1f + _e8);
+    let _e14 = f;
+    plus_fai_f = (1f + _e14);
+    let _e18 = f;
+    plus_f_faf = (_e18 + 2f);
+    let _e22 = f;
+    plus_f_fai = (_e22 + 2f);
+    let _e26 = f;
+    let _e27 = f;
+    plus_f_f_f = (_e26 + _e27);
+    let _e31 = i;
+    plus_iai_i = (1i + _e31);
+    let _e35 = i;
+    plus_i_iai = (_e35 + 2i);
+    let _e39 = i;
+    let _e40 = i;
+    plus_i_i_i = (_e39 + _e40);
+    let _e44 = u;
+    plus_uai_u = (1u + _e44);
+    let _e48 = u;
+    plus_u_uai = (_e48 + 2u);
+    let _e52 = u;
+    let _e53 = u;
+    plus_u_u_u = (_e52 + _e53);
+    return;
+}
+

--- a/naga/tests/snapshots.rs
+++ b/naga/tests/snapshots.rs
@@ -798,6 +798,10 @@ fn convert_wgsl() {
             "abstract-types-var",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::WGSL,
         ),
+        (
+            "abstract-types-operators",
+            Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::WGSL,
+        ),
     ];
 
     for &(name, targets) in inputs.iter() {


### PR DESCRIPTION
Still some missing bits and some invalid output, but roughly working.

Note that commits are split out, only the last one should be interesting.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`.
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
