### PR TITLE
Add COPY_SRC to Metal's surface usage bits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,10 @@ Passing an owned value `window` to `Surface` will return a `Surface<'static>`. S
 
 - Record the names of WGSL `alias` declarations in Naga IR `Type`s. By @jimblandy in [#4733](https://github.com/gfx-rs/wgpu/pull/4733).
 
+#### Metal
+
+- Allow the `COPY_SRC` usage flag in surface configuration. By @Toqozz in [#4852](https://github.com/gfx-rs/wgpu/pull/4852).
+
 ### Examples
 
 - remove winit dependency from hello-compute example by @psvri in [#4699](https://github.com/gfx-rs/wgpu/pull/4699)

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -339,7 +339,9 @@ impl crate::Adapter<super::Api> for super::Adapter {
             ],
 
             current_extent,
-            usage: crate::TextureUses::COLOR_TARGET | crate::TextureUses::COPY_DST, //TODO: expose more
+            usage: crate::TextureUses::COLOR_TARGET
+                | crate::TextureUses::COPY_SRC
+                | crate::TextureUses::COPY_DST,
         })
     }
 


### PR DESCRIPTION
**Description**
On machines running Metal, we could not configure surfaces with the `COPY_SRC` usage flag.  This flag is used a pretty often on platforms that do support it, and often you'll have macOS users submitting a bug to the root project, which requires them to implement a backbuffer or some other workaround.

See "Discussion".

**Testing**
The simplest way to test is to add a wgpu::TextureUsages::COPY_SRC usage flag to hello_triangle example's surface configuration. Prior to this change (and given you're on macOS), you'll get a panic Error in Surface::configure: requested usage is not supported. This change fixes the panic.

**Discussion**
I can't find anything that says why this shouldn't be/isn't possible.  I've tested the change on an M1 Pro Macbook which works without any issues, and I've even run it with Metal API validation enabled -- no errors.  I found [this](https://github.com/gfx-rs/wgpu/pull/2491) pull request from Feb 2022, which added the `COPY_DST` flag with similar concerns, but no real answers.

From reading the Metal documentation (I'm a novice, to be clear), it seems that the flag that really matters is `isFrameBufferOnly`, which we already set appropriately depending on whether the texture usage is *only* `RENDER_ATTACHMENT`.
> Textures obtained from a [CAMetalDrawable](https://developer.apple.com/documentation/quartzcore/cametaldrawable) object may only be usable as attachments, depending on the value of [framebufferOnly](https://developer.apple.com/documentation/quartzcore/cametallayer/1478168-framebufferonly) passed to their parent [CAMetalLayer](https://developer.apple.com/documentation/quartzcore/cametallayer) object. Textures created directly by the app do not have such restrictions.
> https://developer.apple.com/documentation/metal/mtltexture/1515749-isframebufferonly

> https://developer.apple.com/documentation/metal/onscreen_presentation/reading_pixel_data_from_a_drawable_texture

So everything seems fine.  We could probably allow more flags, but this at least brings things in line with DX12.