### PR TITLE
Ensure that DeviceLostCallbackC is always called exactly once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Wgpu now exposes backend feature for the Direct3D 12 (`dx12`) and Metal (`metal`
 - No longer validate surfaces against their allowed extent range on configure. This caused warnings that were almost impossible to avoid. As before, the resulting behavior depends on the compositor. By @wumpf in [#4796](https://github.com/gfx-rs/wgpu/pull/4796)
 - Added support for the float32-filterable feature. By @almarklein in [#4759](https://github.com/gfx-rs/wgpu/pull/4759)
 - wgpu and wgpu-core features are now documented on docs.rs. By @wumpf in [#4886](https://github.com/gfx-rs/wgpu/pull/4886)
+- DeviceLostCallbackC is guaranteed to be invoked exactly once. By @bradwerth in [#4862](https://github.com/gfx-rs/wgpu/pull/4862)
 
 #### OpenGL
 - `@builtin(instance_index)` now properly reflects the range provided in the draw call instead of always counting from 0. By @cwfitzgerald in [#4722](https://github.com/gfx-rs/wgpu/pull/4722).
@@ -757,7 +758,7 @@ By @cwfitzgerald in [#3671](https://github.com/gfx-rs/wgpu/pull/3671).
 
 - Implemented basic ray-tracing api for acceleration structures, and ray-queries @daniel-keitel (started by @expenses) in [#3507](https://github.com/gfx-rs/wgpu/pull/3507)
 
-#### Hal 
+#### Hal
 
 - Added basic ray-tracing api for acceleration structures, and ray-queries @daniel-keitel (started by @expenses) in [#3507](https://github.com/gfx-rs/wgpu/pull/3507)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Wgpu now exposes backend feature for the Direct3D 12 (`dx12`) and Metal (`metal`
 - No longer validate surfaces against their allowed extent range on configure. This caused warnings that were almost impossible to avoid. As before, the resulting behavior depends on the compositor. By @wumpf in [#4796](https://github.com/gfx-rs/wgpu/pull/4796)
 - Added support for the float32-filterable feature. By @almarklein in [#4759](https://github.com/gfx-rs/wgpu/pull/4759)
 - wgpu and wgpu-core features are now documented on docs.rs. By @wumpf in [#4886](https://github.com/gfx-rs/wgpu/pull/4886)
-- DeviceLostCallbackC is guaranteed to be invoked exactly once. By @bradwerth in [#4862](https://github.com/gfx-rs/wgpu/pull/4862)
+- DeviceLostClosure is guaranteed to be invoked exactly once. By @bradwerth in [#4862](https://github.com/gfx-rs/wgpu/pull/4862)
 
 #### OpenGL
 - `@builtin(instance_index)` now properly reflects the range provided in the draw call instead of always counting from 0. By @cwfitzgerald in [#4722](https://github.com/gfx-rs/wgpu/pull/4722).

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -245,7 +245,11 @@ impl Drop for DeviceLostClosureC {
                 // Invoke the closure with reason Destroyed so embedder can recover
                 // the memory.
                 let message = std::ffi::CString::new("Dropped").unwrap();
-                (self.callback)(self.user_data, DeviceLostReason::Destroyed as u8, message.as_ptr())
+                (self.callback)(
+                    self.user_data,
+                    DeviceLostReason::Destroyed as u8,
+                    message.as_ptr(),
+                )
             }
         }
     }

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -1210,7 +1210,7 @@ pub type SubmittedWorkDoneCallback = Box<dyn FnOnce() + 'static>;
         not(target_feature = "atomics")
     )
 ))]
-pub type DeviceLostCallback = Box<dyn FnOnce(DeviceLostReason, String) + Send + 'static>;
+pub type DeviceLostCallback = Box<dyn Fn(DeviceLostReason, String) + Send + 'static>;
 #[cfg(not(any(
     not(target_arch = "wasm32"),
     all(
@@ -1218,7 +1218,7 @@ pub type DeviceLostCallback = Box<dyn FnOnce(DeviceLostReason, String) + Send + 
         not(target_feature = "atomics")
     )
 )))]
-pub type DeviceLostCallback = Box<dyn FnOnce(DeviceLostReason, String) + 'static>;
+pub type DeviceLostCallback = Box<dyn Fn(DeviceLostReason, String) + 'static>;
 
 /// An object safe variant of [`Context`] implemented by all types that implement [`Context`].
 pub(crate) trait DynContext: Debug + WasmNotSendSync {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2923,7 +2923,7 @@ impl Device {
     /// Set a DeviceLostCallback on this device.
     pub fn set_device_lost_callback(
         &self,
-        callback: impl FnOnce(DeviceLostReason, String) + Send + 'static,
+        callback: impl Fn(DeviceLostReason, String) + Send + 'static,
     ) {
         DynContext::device_set_device_lost_callback(
             &*self.context,


### PR DESCRIPTION
**Connections**
N/A

**Description**
The `DeviceLostClosure` callback should guarantee that the closure is eventually called exactly once. The changes here ensure that the callback is called when the `DeviceLostClosureC` or `DeviceLostClosureRust` is dropped, only if it hasn't already been called.

**Testing**
The Rust embedding is checked in a new test DEVICE_DROP_THEN_LOST. 

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [X] Run `cargo xtask test` to run tests.
- [X] Add change to `CHANGELOG.md`. See simple instructions inside file.
