### PR TITLE
Reintroduce buffer snatching Part 1

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -785,6 +785,8 @@ impl<A: HalApi> RenderBundle<A> {
             }
         }
 
+        let snatch_guard = self.device.snatchable_lock.read();
+
         for command in self.base.commands.iter() {
             match *command {
                 RenderCommand::SetBindGroup {
@@ -818,7 +820,7 @@ impl<A: HalApi> RenderBundle<A> {
                     size,
                 } => {
                     let buffers = trackers.buffers.read();
-                    let buffer = buffers.get(buffer_id).unwrap().raw();
+                    let buffer = buffers.get(buffer_id).unwrap().raw(&snatch_guard);
                     let bb = hal::BufferBinding {
                         buffer,
                         offset,
@@ -833,7 +835,7 @@ impl<A: HalApi> RenderBundle<A> {
                     size,
                 } => {
                     let buffers = trackers.buffers.read();
-                    let buffer = buffers.get(buffer_id).unwrap().raw();
+                    let buffer = buffers.get(buffer_id).unwrap().raw(&snatch_guard);
                     let bb = hal::BufferBinding {
                         buffer,
                         offset,
@@ -912,7 +914,7 @@ impl<A: HalApi> RenderBundle<A> {
                     indexed: false,
                 } => {
                     let buffers = trackers.buffers.read();
-                    let buffer = buffers.get(buffer_id).unwrap().raw();
+                    let buffer = buffers.get(buffer_id).unwrap().raw(&snatch_guard);
                     unsafe { raw.draw_indirect(buffer, offset, 1) };
                 }
                 RenderCommand::MultiDrawIndirect {
@@ -922,7 +924,7 @@ impl<A: HalApi> RenderBundle<A> {
                     indexed: true,
                 } => {
                     let buffers = trackers.buffers.read();
-                    let buffer = buffers.get(buffer_id).unwrap().raw();
+                    let buffer = buffers.get(buffer_id).unwrap().raw(&snatch_guard);
                     unsafe { raw.draw_indexed_indirect(buffer, offset, 1) };
                 }
                 RenderCommand::MultiDrawIndirect { .. }

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1,5 +1,5 @@
-use crate::device::resource::SnatchGuard;
 use crate::resource::Resource;
+use crate::snatch::SnatchGuard;
 use crate::{
     binding_model::{
         BindError, BindGroup, LateMinBufferBindingSizeMismatch, PushConstantUploadError,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1,3 +1,4 @@
+use crate::device::resource::SnatchGuard;
 use crate::resource::Resource;
 use crate::{
     binding_model::{
@@ -310,6 +311,7 @@ impl<A: HalApi> State<A> {
         base_trackers: &mut Tracker<A>,
         bind_group_guard: &Storage<BindGroup<A>, id::BindGroupId>,
         indirect_buffer: Option<id::BufferId>,
+        snatch_guard: &SnatchGuard,
     ) -> Result<(), UsageConflict> {
         for id in self.binder.list_active() {
             unsafe { self.scope.merge_bind_group(&bind_group_guard[id].used)? };
@@ -335,7 +337,7 @@ impl<A: HalApi> State<A> {
 
         log::trace!("Encoding dispatch barriers");
 
-        CommandBuffer::drain_barriers(raw_encoder, base_trackers);
+        CommandBuffer::drain_barriers(raw_encoder, base_trackers, snatch_guard);
         Ok(())
     }
 }
@@ -452,6 +454,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         } else {
             None
         };
+
+        let snatch_guard = device.snatchable_lock.read();
 
         tracker.set_size(
             Some(&*buffer_guard),
@@ -673,7 +677,13 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     state.is_ready().map_pass_err(scope)?;
 
                     state
-                        .flush_states(raw, &mut intermediate_trackers, &*bind_group_guard, None)
+                        .flush_states(
+                            raw,
+                            &mut intermediate_trackers,
+                            &*bind_group_guard,
+                            None,
+                            &snatch_guard,
+                        )
                         .map_pass_err(scope)?;
 
                     let groups_size_limit = cmd_buf.limits.max_compute_workgroups_per_dimension;
@@ -727,7 +737,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
                     let buf_raw = indirect_buffer
                         .raw
-                        .as_ref()
+                        .get(&snatch_guard)
                         .ok_or(ComputePassErrorInner::InvalidIndirectBuffer(buffer_id))
                         .map_pass_err(scope)?;
 
@@ -747,6 +757,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             &mut intermediate_trackers,
                             &*bind_group_guard,
                             Some(buffer_id),
+                            &snatch_guard,
                         )
                         .map_pass_err(scope)?;
                     unsafe {
@@ -860,7 +871,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             &mut tracker.textures,
             device,
         );
-        CommandBuffer::insert_barriers_from_tracker(transit, tracker, &intermediate_trackers);
+        CommandBuffer::insert_barriers_from_tracker(
+            transit,
+            tracker,
+            &intermediate_trackers,
+            &snatch_guard,
+        );
         // Close the command buffer, and swap it with the previous.
         encoder.close_and_swap();
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -18,11 +18,11 @@ pub use self::{
 
 use self::memory_init::CommandBufferTextureMemoryActions;
 
-use crate::device::resource::SnatchGuard;
 use crate::device::Device;
 use crate::error::{ErrorFormatter, PrettyError};
 use crate::hub::Hub;
 use crate::id::CommandBufferId;
+use crate::snatch::SnatchGuard;
 
 use crate::init_tracker::BufferInitTrackerAction;
 use crate::resource::{Resource, ResourceInfo, ResourceType};

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -64,6 +64,7 @@ pub mod pipeline;
 pub mod present;
 pub mod registry;
 pub mod resource;
+mod snatch;
 pub mod storage;
 mod track;
 // This is public for users who pre-compile shaders while still wanting to

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2,7 +2,9 @@
 use crate::device::trace;
 use crate::{
     device::{
-        queue, BufferMapPendingClosure, Device, DeviceError, HostMap, MissingDownlevelFlags,
+        queue,
+        resource::{SnatchGuard, Snatchable},
+        BufferMapPendingClosure, Device, DeviceError, HostMap, MissingDownlevelFlags,
         MissingFeatures,
     },
     global::Global,
@@ -395,7 +397,7 @@ pub type BufferDescriptor<'a> = wgt::BufferDescriptor<Label<'a>>;
 
 #[derive(Debug)]
 pub struct Buffer<A: HalApi> {
-    pub(crate) raw: Option<A::Buffer>,
+    pub(crate) raw: Snatchable<A::Buffer>,
     pub(crate) device: Arc<Device<A>>,
     pub(crate) usage: wgt::BufferUsages,
     pub(crate) size: wgt::BufferAddress,
@@ -418,8 +420,8 @@ impl<A: HalApi> Drop for Buffer<A> {
 }
 
 impl<A: HalApi> Buffer<A> {
-    pub(crate) fn raw(&self) -> &A::Buffer {
-        self.raw.as_ref().unwrap()
+    pub(crate) fn raw(&self, guard: &SnatchGuard) -> &A::Buffer {
+        self.raw.get(guard).unwrap()
     }
 
     pub(crate) fn buffer_unmap_inner(
@@ -428,6 +430,7 @@ impl<A: HalApi> Buffer<A> {
         use hal::Device;
 
         let device = &self.device;
+        let snatch_guard = device.snatchable_lock.read();
         let buffer_id = self.info.id();
         log::debug!("Buffer {:?} map state -> Idle", buffer_id);
         match mem::replace(&mut *self.map_state.lock(), resource::BufferMapState::Idle) {
@@ -451,13 +454,17 @@ impl<A: HalApi> Buffer<A> {
                 let _ = ptr;
                 if needs_flush {
                     unsafe {
-                        device
-                            .raw()
-                            .flush_mapped_ranges(stage_buffer.raw(), iter::once(0..self.size));
+                        device.raw().flush_mapped_ranges(
+                            stage_buffer.raw(&snatch_guard),
+                            iter::once(0..self.size),
+                        );
                     }
                 }
 
-                let raw_buf = self.raw.as_ref().ok_or(BufferAccessError::Destroyed)?;
+                let raw_buf = self
+                    .raw
+                    .get(&snatch_guard)
+                    .ok_or(BufferAccessError::Destroyed)?;
 
                 self.info
                     .use_at(device.active_submission_index.load(Ordering::Relaxed) + 1);
@@ -467,7 +474,7 @@ impl<A: HalApi> Buffer<A> {
                     size,
                 });
                 let transition_src = hal::BufferBarrier {
-                    buffer: stage_buffer.raw(),
+                    buffer: stage_buffer.raw(&snatch_guard),
                     usage: hal::BufferUses::MAP_WRITE..hal::BufferUses::COPY_SRC,
                 };
                 let transition_dst = hal::BufferBarrier {
@@ -483,7 +490,7 @@ impl<A: HalApi> Buffer<A> {
                     );
                     if self.size > 0 {
                         encoder.copy_buffer_to_buffer(
-                            stage_buffer.raw(),
+                            stage_buffer.raw(&snatch_guard),
                             raw_buf,
                             region.into_iter(),
                         );
@@ -518,7 +525,7 @@ impl<A: HalApi> Buffer<A> {
                 unsafe {
                     device
                         .raw()
-                        .unmap_buffer(self.raw())
+                        .unmap_buffer(self.raw(&snatch_guard))
                         .map_err(DeviceError::from)?
                 };
             }
@@ -539,7 +546,10 @@ impl<A: HalApi> Buffer<A> {
             if let Some(ref mut trace) = *device.trace.lock() {
                 trace.add(trace::Action::FreeBuffer(buffer_id));
             }
-            if self.raw.is_none() {
+            // Note: a future commit will replace this with a read guard
+            // and actually snatch the buffer.
+            let snatch_guard = device.snatchable_lock.read();
+            if self.raw.get(&snatch_guard).is_none() {
                 return Err(resource::DestroyError::AlreadyDestroyed);
             }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2,9 +2,7 @@
 use crate::device::trace;
 use crate::{
     device::{
-        queue,
-        resource::{SnatchGuard, Snatchable},
-        BufferMapPendingClosure, Device, DeviceError, HostMap, MissingDownlevelFlags,
+        queue, BufferMapPendingClosure, Device, DeviceError, HostMap, MissingDownlevelFlags,
         MissingFeatures,
     },
     global::Global,
@@ -16,6 +14,7 @@ use crate::{
     identity::{GlobalIdentityHandlerFactory, IdentityManager},
     init_tracker::{BufferInitTracker, TextureInitTracker},
     resource, resource_log,
+    snatch::{SnatchGuard, Snatchable},
     track::TextureSelector,
     validation::MissingBufferUsageError,
     Label, SubmissionIndex,

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -1,0 +1,86 @@
+#![allow(unused)]
+
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::cell::UnsafeCell;
+
+/// A guard that provides read access to snatchable data.
+pub struct SnatchGuard<'a>(RwLockReadGuard<'a, ()>);
+/// A guard that allows snatching the snatchable data.
+pub struct ExclusiveSnatchGuard<'a>(RwLockWriteGuard<'a, ()>);
+
+/// A value that is mostly immutable but can be "snatched" if we need to destroy
+/// it early.
+///
+/// In order to safely access the underlying data, the device's global snatchable
+/// lock must be taken. To guarentee it, methods take a read or write guard of that
+/// special lock.
+pub struct Snatchable<T> {
+    value: UnsafeCell<Option<T>>,
+}
+
+impl<T> Snatchable<T> {
+    pub fn new(val: T) -> Self {
+        Snatchable {
+            value: UnsafeCell::new(Some(val)),
+        }
+    }
+
+    /// Get read access to the value. Requires a the snatchable lock's read guard.
+    pub fn get(&self, _guard: &SnatchGuard) -> Option<&T> {
+        unsafe { (*self.value.get()).as_ref() }
+    }
+
+    /// Take the value. Requires a the snatchable lock's write guard.
+    pub fn snatch(&self, _guard: ExclusiveSnatchGuard) -> Option<T> {
+        unsafe { (*self.value.get()).take() }
+    }
+
+    /// Take the value without a guard. This can only be used with exclusive access
+    /// to self, so it does not require locking.
+    ///
+    /// Typically useful in a drop implementation.
+    pub fn take(&mut self) -> Option<T> {
+        self.value.get_mut().take()
+    }
+}
+
+// Can't safely print the contents of a snatchable object without holding
+// the lock.
+impl<T> std::fmt::Debug for Snatchable<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "<snatchable>")
+    }
+}
+
+unsafe impl<T> Sync for Snatchable<T> {}
+
+/// A Device-global lock for all snatchable data.
+pub struct SnatchLock {
+    lock: RwLock<()>,
+}
+
+impl SnatchLock {
+    /// The safety of `Snatchable::get` and `Snatchable::snatch` rely on their using of the
+    /// right SnatchLock (the one associated to the same device). This method is unsafe
+    /// to force force sers to think twice about creating a SnatchLock. The only place this
+    /// method sould be called is when creating the device.
+    pub unsafe fn new() -> Self {
+        SnatchLock {
+            lock: RwLock::new(()),
+        }
+    }
+
+    /// Request read access to snatchable resources.
+    pub fn read(&self) -> SnatchGuard {
+        SnatchGuard(self.lock.read())
+    }
+
+    /// Request write access to snatchable resources.
+    ///
+    /// This should only be called when a resource needs to be snatched. This has
+    /// a high risk of causing lock contention if called concurrently with other
+    /// wgpu work.
+    pub fn write(&self) -> ExclusiveSnatchGuard {
+        ExclusiveSnatchGuard(self.lock.write())
+    }
+}

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -9,10 +9,10 @@ use std::{borrow::Cow, marker::PhantomData, sync::Arc};
 
 use super::{PendingTransition, ResourceTracker};
 use crate::{
-    device::resource::SnatchGuard,
     hal_api::HalApi,
     id::{BufferId, TypedId},
     resource::{Buffer, Resource},
+    snatch::SnatchGuard,
     storage::Storage,
     track::{
         invalid_resource_state, skip_barrier, ResourceMetadata, ResourceMetadataProvider,

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -103,6 +103,7 @@ mod texture;
 
 use crate::{
     binding_model, command, conv,
+    device::resource::SnatchGuard,
     hal_api::HalApi,
     id::{self, TypedId},
     pipeline, resource,
@@ -138,8 +139,9 @@ impl PendingTransition<hal::BufferUses> {
     pub fn into_hal<'a, A: HalApi>(
         self,
         buf: &'a resource::Buffer<A>,
+        snatch_guard: &'a SnatchGuard<'a>,
     ) -> hal::BufferBarrier<'a, A> {
-        let buffer = buf.raw.as_ref().expect("Buffer is destroyed");
+        let buffer = buf.raw.get(snatch_guard).expect("Buffer is destroyed");
         hal::BufferBarrier {
             buffer,
             usage: self.usage,

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -103,10 +103,10 @@ mod texture;
 
 use crate::{
     binding_model, command, conv,
-    device::resource::SnatchGuard,
     hal_api::HalApi,
     id::{self, TypedId},
     pipeline, resource,
+    snatch::SnatchGuard,
     storage::Storage,
 };
 


### PR DESCRIPTION
**Connections**

This is the first step towards addressing #4787.

**Description**

We need `destroy()` methods to be able to deallocate gpu resources while the associated handle is still alive. This is difficult to do safely because most of wegpu's API can be used from any thread.One of the steps towards our goal is to re-introduce "buffer snatching". The idea is that when, say, `buffer.destroy()` is called, we snatch the raw buffer out of `wgpu_core`'s buffer struct, and enqueue it to be deallocated after the latest submission the buffer has been used in is complete.
Snatching the raw handle out requires some form of locking. @cwfitzgerald's proposed solution is to protect all raw buffer and texture reads behind the read guard of a device-global `RwLock`, and only ever thake a write lock during snatching. The hope is that the overhead of taking a single read guard in most places will be small enough and that `destroy` will be called concurrently with other wgpu work rarely enough that it won't cause very bad contention.

This PR implements the very first step of Connor's idea:
 - `Device` holds `snatchable_lock`.
 - a `Snatchable<T>` type is introduced. Its content cannot be accessed without an appropriate lock guard.
 - `Buffer.raw` is now a ``Snatchable<A::Buffer>` and all associated reads need the guard.

The snatching is not actually performed in this PR (yet). It will come in a followup.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
