### PR TITLE
Speed up Naga's `cargo xtask validate wgsl` from 12s to 0.8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ Wgpu now exposes backend feature for the Direct3D 12 (`dx12`) and Metal (`metal`
 
 - Naga constant evaluation can now process binary operators whose operands are both vectors. By @jimblandy in [#4861](https://github.com/gfx-rs/wgpu/pull/4861).
 
+- Add `--bulk-validate` option to Naga CLI. By @jimblandy in [#4871](https://github.com/gfx-rs/wgpu/pull/4871).
+
 ### Changes
 
 - Arcanization of wgpu core resources: By @gents83 in [#3626](https://github.com/gfx-rs/wgpu/pull/3626) and thanks also to @jimblandy, @nical, @Wumpf, @Elabajaba & @cwfitzgerald

--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -236,27 +236,16 @@ impl std::error::Error for CliError {}
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
-    // Initialize default parameters
-    //TODO: read the parameters from RON?
-    let mut params = Parameters::default();
-
     // Parse commandline arguments
     let args: Args = argh::from_env();
     if args.version {
         println!("{}", env!("CARGO_PKG_VERSION"));
         return Ok(());
     }
-    let (input_path, input) = if let Some(path) = args.files.first() {
-        let path = Path::new(path);
-        (path, fs::read(path)?)
-    } else if let Some(path) = &args.stdin_file_path {
-        let mut input = vec![];
-        std::io::stdin().lock().read_to_end(&mut input)?;
-        (Path::new(path), input)
-    } else {
-        return Err(CliError("Input file path is not specified").into());
-    };
-    let output_paths = args.files.get(1..).unwrap_or(&[]);
+
+    // Initialize default parameters
+    //TODO: read the parameters from RON?
+    let mut params = Parameters::default();
 
     // Update parameters from commandline arguments
     if let Some(bits) = args.validate {
@@ -286,10 +275,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     params.entry_point = args.entry_point;
-    if let Some(version) = args.profile {
+    if let Some(ref version) = args.profile {
         params.glsl.version = version.0;
     }
-    if let Some(model) = args.shader_model {
+    if let Some(ref model) = args.shader_model {
         params.hlsl.shader_model = model.0;
     }
     params.keep_coordinate_space = args.keep_coordinate_space;
@@ -302,67 +291,21 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         !params.keep_coordinate_space,
     );
 
-    let (mut module, input_text) = match Path::new(&input_path)
-        .extension()
-        .ok_or(CliError("Input filename has no extension"))?
-        .to_str()
-        .ok_or(CliError("Input filename not valid unicode"))?
-    {
-        "bin" => (bincode::deserialize(&input)?, None),
-        "spv" => naga::front::spv::parse_u8_slice(&input, &params.spv_in).map(|m| (m, None))?,
-        "wgsl" => {
-            let input = String::from_utf8(input)?;
-            let result = naga::front::wgsl::parse_str(&input);
-            match result {
-                Ok(v) => (v, Some(input)),
-                Err(ref e) => {
-                    e.emit_to_stderr_with_path(&input, input_path);
-                    return Err(CliError("Could not parse WGSL").into());
-                }
-            }
-        }
-        ext @ ("vert" | "frag" | "comp" | "glsl") => {
-            let input = String::from_utf8(input)?;
-            let mut parser = naga::front::glsl::Frontend::default();
-
-            (
-                parser
-                    .parse(
-                        &naga::front::glsl::Options {
-                            stage: match ext {
-                                "vert" => naga::ShaderStage::Vertex,
-                                "frag" => naga::ShaderStage::Fragment,
-                                "comp" => naga::ShaderStage::Compute,
-                                "glsl" => {
-                                    let internal_name = input_path.to_string_lossy();
-                                    match Path::new(&internal_name[..internal_name.len()-5])
-                                        .extension()
-                                        .ok_or(CliError("Input filename ending with .glsl has no internal extension"))?
-                                        .to_str()
-                                        .ok_or(CliError("Input filename not valid unicode"))?
-                                    {
-                                        "vert" => naga::ShaderStage::Vertex,
-                                        "frag" => naga::ShaderStage::Fragment,
-                                        "comp" => naga::ShaderStage::Compute,
-                                        _ => unreachable!(),
-                                    }
-                                },
-                                _ => unreachable!(),
-                            },
-                            defines: Default::default(),
-                        },
-                        &input,
-                    )
-                    .unwrap_or_else(|errors| {
-                        let filename = input_path.file_name().and_then(std::ffi::OsStr::to_str);
-                        emit_glsl_parser_error(errors, filename.unwrap_or("glsl"), &input);
-                        std::process::exit(1);
-                    }),
-                Some(input),
-            )
-        }
-        _ => return Err(CliError("Unknown input file extension").into()),
+    let (input_path, input) = if let Some(path) = args.files.first() {
+        let path = Path::new(path);
+        (path, fs::read(path)?)
+    } else if let Some(path) = &args.stdin_file_path {
+        let mut input = vec![];
+        std::io::stdin().lock().read_to_end(&mut input)?;
+        (Path::new(path), input)
+    } else {
+        return Err(CliError("Input file path is not specified").into());
     };
+
+    let Parsed {
+        mut module,
+        input_text,
+    } = parse_input(input_path, input, &params)?;
 
     // Include debugging information if requested.
     if args.generate_debug_symbols {
@@ -383,6 +326,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             );
         }
     }
+
+    let output_paths = args.files.get(1..).unwrap_or(&[]);
 
     // Decide which capabilities our output formats can support.
     let validation_caps =
@@ -467,6 +412,84 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+struct Parsed {
+    module: naga::Module,
+    input_text: Option<String>,
+}
+
+fn parse_input(
+    input_path: &Path,
+    input: Vec<u8>,
+    params: &Parameters,
+) -> Result<Parsed, Box<dyn std::error::Error>> {
+    let (module, input_text) = match Path::new(&input_path)
+        .extension()
+        .ok_or(CliError("Input filename has no extension"))?
+        .to_str()
+        .ok_or(CliError("Input filename not valid unicode"))?
+    {
+        "bin" => (bincode::deserialize(&input)?, None),
+        "spv" => naga::front::spv::parse_u8_slice(&input, &params.spv_in).map(|m| (m, None))?,
+        "wgsl" => {
+            let input = String::from_utf8(input)?;
+            let result = naga::front::wgsl::parse_str(&input);
+            match result {
+                Ok(v) => (v, Some(input)),
+                Err(ref e) => {
+                    let message = format!(
+                        "Could not parse WGSL:\n{}",
+                        e.emit_to_string_with_path(&input, input_path)
+                    );
+                    return Err(message.into());
+                }
+            }
+        }
+        ext @ ("vert" | "frag" | "comp" | "glsl") => {
+            let input = String::from_utf8(input)?;
+            let mut parser = naga::front::glsl::Frontend::default();
+
+            (
+                parser
+                    .parse(
+                        &naga::front::glsl::Options {
+                            stage: match ext {
+                                "vert" => naga::ShaderStage::Vertex,
+                                "frag" => naga::ShaderStage::Fragment,
+                                "comp" => naga::ShaderStage::Compute,
+                                "glsl" => {
+                                    let internal_name = input_path.to_string_lossy();
+                                    match Path::new(&internal_name[..internal_name.len()-5])
+                                        .extension()
+                                        .ok_or(CliError("Input filename ending with .glsl has no internal extension"))?
+                                        .to_str()
+                                        .ok_or(CliError("Input filename not valid unicode"))?
+                                    {
+                                        "vert" => naga::ShaderStage::Vertex,
+                                        "frag" => naga::ShaderStage::Fragment,
+                                        "comp" => naga::ShaderStage::Compute,
+                                        _ => unreachable!(),
+                                    }
+                                },
+                                _ => unreachable!(),
+                            },
+                            defines: Default::default(),
+                        },
+                        &input,
+                    )
+                    .unwrap_or_else(|errors| {
+                        let filename = input_path.file_name().and_then(std::ffi::OsStr::to_str);
+                        emit_glsl_parser_error(errors, filename.unwrap_or("glsl"), &input);
+                        std::process::exit(1);
+                    }),
+                Some(input),
+            )
+        }
+        _ => return Err(CliError("Unknown input file extension").into()),
+    };
+
+    Ok(Parsed { module, input_text })
 }
 
 fn write_output(


### PR DESCRIPTION
Implement a `--bulk-validate` option in the Naga CLI, and use it in Naga's `cargo xtask validate wgsl` to validate all WGSL files in a single execution. This reduces real time from 12s to 0.8s.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`.
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
