### PR TITLE
Allow clippy::pattern_type_mismatch

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3073,7 +3073,7 @@ impl<A: HalApi> Device<A> {
         if validated_stages.contains(wgt::ShaderStages::FRAGMENT) {
             for (i, output) in io.iter() {
                 match color_targets.get(*i as usize) {
-                    Some(&Some(ref state)) => {
+                    Some(Some(state)) => {
                         validation::check_texture_format(state.format, &output.ty).map_err(
                             |pipeline| {
                                 pipeline::CreateRenderPipelineError::ColorState(

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -34,17 +34,15 @@
     // For some reason `rustc` can warn about these in const generics even
     // though they are required.
     unused_braces,
-    // Clashes with clippy::pattern_type_mismatch
-    clippy::needless_borrowed_reference,
+    // It gets in the way a lot and does not prevent bugs in practice.
+    clippy::pattern_type_mismatch,
 )]
 #![warn(
     trivial_casts,
     trivial_numeric_casts,
     unsafe_op_in_unsafe_fn,
     unused_extern_crates,
-    unused_qualifications,
-    // We don't match on a reference, unless required.
-    clippy::pattern_type_mismatch,
+    unused_qualifications
 )]
 
 pub mod any_surface;

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -134,7 +134,7 @@ where
     pub(crate) fn label_for_invalid_id(&self, id: I) -> &str {
         let (index, _, _) = id.unzip();
         match self.map.get(index as usize) {
-            Some(&Element::Error(_, ref label)) => label,
+            Some(Element::Error(_, label)) => label,
             _ => "",
         }
     }

--- a/wgpu-core/src/track/range.rs
+++ b/wgpu-core/src/track/range.rs
@@ -77,8 +77,8 @@ impl<I: Copy + Ord, T: Copy + PartialEq> RangedStates<I, T> {
     ) -> impl Iterator<Item = (Range<I>, &T)> + 'a {
         self.ranges
             .iter()
-            .filter(move |&&(ref inner, ..)| inner.end > range.start && inner.start < range.end)
-            .map(move |&(ref inner, ref v)| {
+            .filter(move |&(inner, ..)| inner.end > range.start && inner.start < range.end)
+            .map(move |(inner, v)| {
                 let new_range = inner.start.max(range.start)..inner.end.min(range.end);
 
                 (new_range, v)

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -42,7 +42,7 @@ impl<Id: TypedId, T: Resource<Id>> StatelessBindGroupSate<Id, T> {
         let resources = self.resources.lock();
         resources
             .iter()
-            .map(|&(_, ref resource)| resource.clone())
+            .map(|(_, resource)| resource.clone())
             .collect::<Vec<_>>()
             .into_iter()
     }


### PR DESCRIPTION
**Description**

I hate this lint with passion. 

Its [documentation](https://rust-lang.github.io/rust-clippy/master/index.html#/pattern_type_mismatch) itself admits that it does not fix anything serious:

> It isn’t bad in general. But in some contexts it can be desirable because it increases ownership hints in the code, and will guard against some changes in ownership.

In order to work around it we even have to disable another clippy lint (`needless_borrowed_reference`) which it clashes with.

In all of my years of rust I have never run into an issue that could have been prevented by this lint. Rust's type system does not leave much room for ambiguity between owned and borrowed data.
There is a language keyword, `ref`, which you typically don't see much if at all in rust code, because it was made obsolete by the syntax that the lint aims to prevent, but we have to sprinkle it in places to pass clippy.

Rust's syntax is pretty clear when it comes to pattern matching:

```rust
let something = &mut Some(thing);
match something {
    Some(thing) => {
        // thing is &mut because we matched an &mut Option<Thing>
    }
    None => {}
}

let something_moved = Some(thing);
match something_moved {
    Some(thing) => {
        // thing is by value because we matched an Option<Thing> (by value).
    }
    None => {}
}
```

It could be argued that some code could benefit from being a bit explicit with `ref` keyword (I don't think so but there's always going to be someone who does), like there are cases where spelling out types makes some code easier to understand even if type inference makes it optional.
But enforcing the explicit `ref` for references in all matched patterns makes as much sense as disallowing inferred types entirely.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
