### PR TITLE
Make the naga version in trunk as high as the latest published one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.14.0"
+version = "0.14.2"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga"
-version = "0.14.0"
+version = "0.14.2"
 authors = ["gfx-rs developers"]
 edition = "2021"
 description = "Shader translation infrastructure"


### PR DESCRIPTION
**Connections**

Fixes #4889 

**Description**

The naga version in trunk is lower than what's on crates.io, making it tedious to update to it.
