### PR TITLE
Simplify some code around buffer unmapping

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -423,9 +423,18 @@ impl<A: HalApi> Buffer<A> {
         self.raw.get(guard).unwrap()
     }
 
-    pub(crate) fn buffer_unmap_inner(
-        self: &Arc<Self>,
-    ) -> Result<Option<BufferMapPendingClosure>, BufferAccessError> {
+    // Note: This must not be called while holding a lock.
+    pub(crate) fn unmap(self: &Arc<Self>) -> Result<(), BufferAccessError> {
+        if let Some((mut operation, status)) = self.unmap_inner()? {
+            if let Some(callback) = operation.callback.take() {
+                callback.call(status);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn unmap_inner(self: &Arc<Self>) -> Result<Option<BufferMapPendingClosure>, BufferAccessError> {
         use hal::Device;
 
         let device = &self.device;
@@ -533,43 +542,30 @@ impl<A: HalApi> Buffer<A> {
     }
 
     pub(crate) fn destroy(self: &Arc<Self>) -> Result<(), DestroyError> {
-        let map_closure;
-        // Restrict the locks to this scope.
-        {
-            let device = &self.device;
-            let buffer_id = self.info.id();
+        let device = &self.device;
+        let buffer_id = self.info.id();
 
-            map_closure = self.buffer_unmap_inner().unwrap_or(None);
-
-            #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *device.trace.lock() {
-                trace.add(trace::Action::FreeBuffer(buffer_id));
-            }
-            // Note: a future commit will replace this with a read guard
-            // and actually snatch the buffer.
-            let snatch_guard = device.snatchable_lock.read();
-            if self.raw.get(&snatch_guard).is_none() {
-                return Err(resource::DestroyError::AlreadyDestroyed);
-            }
-
-            let temp = queue::TempResource::Buffer(self.clone());
-            let mut pending_writes = device.pending_writes.lock();
-            let pending_writes = pending_writes.as_mut().unwrap();
-            if pending_writes.dst_buffers.contains_key(&buffer_id) {
-                pending_writes.temp_resources.push(temp);
-            } else {
-                let last_submit_index = self.info.submission_index();
-                device
-                    .lock_life()
-                    .schedule_resource_destruction(temp, last_submit_index);
-            }
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *device.trace.lock() {
+            trace.add(trace::Action::FreeBuffer(buffer_id));
+        }
+        // Note: a future commit will replace this with a read guard
+        // and actually snatch the buffer.
+        let snatch_guard = device.snatchable_lock.read();
+        if self.raw.get(&snatch_guard).is_none() {
+            return Err(resource::DestroyError::AlreadyDestroyed);
         }
 
-        // Note: outside the scope where locks are held when calling the callback
-        if let Some((mut operation, status)) = map_closure {
-            if let Some(callback) = operation.callback.take() {
-                callback.call(status);
-            }
+        let temp = queue::TempResource::Buffer(self.clone());
+        let mut pending_writes = device.pending_writes.lock();
+        let pending_writes = pending_writes.as_mut().unwrap();
+        if pending_writes.dst_buffers.contains_key(&buffer_id) {
+            pending_writes.temp_resources.push(temp);
+        } else {
+            let last_submit_index = self.info.submission_index();
+            device
+                .lock_life()
+                .schedule_resource_destruction(temp, last_submit_index);
         }
 
         Ok(())


### PR DESCRIPTION
**Connections**

Another minor refactoring on the way towards #4787.

**Description**

Pre-arcanization we were holding locks a lot longer in wgpu-core, and had to hold off fireing the mapping callback until we'd let go of these locks. In other words we couldn't fire the mapping callback while we had access to the buffer because it was guarded by the hub's buffers lock.

Fast-forward today, arcanization made it so we only briefly take the lock while grabbing an arc to the buffer. There are very few locks that are held now so the code can be simplified.

Now the internal `buffer.unmap()` directly fire the callback in places that don't hold locks. No need to use `buffer_unmap_inner` and hold on to the callback. There is also some unnecessary block nesting that is removed.

This PR also makes it so `buffer_drop` just calls `buffer.unmap()` instead of calling `buffer.destroy()` when the reference count is 1. I don't know why it used to call destroy in that case, I am pretty sure it does not need to and a subsequent PR will make `buffer.destroy` likely to cause contention on the snatch lock so we won't want to call it accidentally in drop.

This also actually fixes a bug! In `buffer_destroy` we were holding the hub's buffer lock when calling `buffer.destroy` which unmapped and involed the callback. Oops!
To address this, the hub buffers lock is contained into a block and `buffer.unmap()` is lifted up closer to the api entry points in `device/global.rs` to avoid accidentally calling something that might call it whil holding a a lock.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable
- [x] Run `cargo xtask test` to run tests.
