### PR TITLE
Avoid allocating memory every time we might log a label

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -467,7 +467,7 @@ pub struct BindGroupLayout<A: HalApi> {
 impl<A: HalApi> Drop for BindGroupLayout<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw BindGroupLayout {}", self.info.label());
+            resource_log!("Destroy raw BindGroupLayout {:?}", self.info.label());
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_bind_group_layout(raw);
@@ -605,7 +605,7 @@ pub struct PipelineLayout<A: HalApi> {
 impl<A: HalApi> Drop for PipelineLayout<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw PipelineLayout {}", self.info.label());
+            resource_log!("Destroy raw PipelineLayout {:?}", self.info.label());
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_pipeline_layout(raw);
@@ -826,7 +826,7 @@ pub struct BindGroup<A: HalApi> {
 impl<A: HalApi> Drop for BindGroup<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw BindGroup {}", self.info.label());
+            resource_log!("Destroy raw BindGroup {:?}", self.info.label());
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_bind_group(raw);

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -139,7 +139,7 @@ impl<A: HalApi> Drop for CommandBuffer<A> {
         if self.data.lock().is_none() {
             return;
         }
-        resource_log!("resource::CommandBuffer::drop {}", self.info.label());
+        resource_log!("resource::CommandBuffer::drop {:?}", self.info.label());
         let mut baked = self.extract_baked_commands();
         unsafe {
             baked.encoder.reset_all(baked.list.into_iter());

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -143,7 +143,7 @@ impl<A: HalApi> std::fmt::Debug for Device<A> {
 
 impl<A: HalApi> Drop for Device<A> {
     fn drop(&mut self) {
-        resource_log!("Destroy raw Device {}", self.info.label());
+        resource_log!("Destroy raw Device {:?}", self.info.label());
         let raw = self.raw.take().unwrap();
         let pending_writes = self.pending_writes.lock().take().unwrap();
         pending_writes.dispose(&raw);

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -54,7 +54,7 @@ pub struct ShaderModule<A: HalApi> {
 impl<A: HalApi> Drop for ShaderModule<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw ShaderModule {}", self.info.label());
+            resource_log!("Destroy raw ShaderModule {:?}", self.info.label());
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *self.device.trace.lock() {
                 trace.add(trace::Action::DestroyShaderModule(self.info.id()));
@@ -250,7 +250,7 @@ pub struct ComputePipeline<A: HalApi> {
 impl<A: HalApi> Drop for ComputePipeline<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw ComputePipeline {}", self.info.label());
+            resource_log!("Destroy raw ComputePipeline {:?}", self.info.label());
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_compute_pipeline(raw);
@@ -491,7 +491,7 @@ pub struct RenderPipeline<A: HalApi> {
 impl<A: HalApi> Drop for RenderPipeline<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw RenderPipeline {}", self.info.label());
+            resource_log!("Destroy raw RenderPipeline {:?}", self.info.label());
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_render_pipeline(raw);

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -94,15 +94,19 @@ impl<Id: TypedId> ResourceInfo<Id> {
         }
     }
 
-    pub(crate) fn label(&self) -> String
+    pub(crate) fn label(&self) -> &dyn Debug
     where
         Id: Debug,
     {
-        if let Some(id) = self.id.as_ref() {
-            format!("[{}] {:?}", self.label, id)
-        } else {
-            format!("[{}]", self.label)
+        if !self.label.is_empty() {
+            return &self.label;
         }
+
+        if let Some(id) = &self.id {
+            return id;
+        }
+
+        &""
     }
 
     pub(crate) fn id(&self) -> Id {
@@ -409,7 +413,7 @@ pub struct Buffer<A: HalApi> {
 impl<A: HalApi> Drop for Buffer<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw Buffer {}", self.info.label());
+            resource_log!("Destroy raw Buffer {:?}", self.info.label());
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_buffer(raw);
@@ -638,7 +642,7 @@ pub struct StagingBuffer<A: HalApi> {
 impl<A: HalApi> Drop for StagingBuffer<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.lock().take() {
-            resource_log!("Destroy raw StagingBuffer {}", self.info.label());
+            resource_log!("Destroy raw StagingBuffer {:?}", self.info.label());
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_buffer(raw);
@@ -720,7 +724,7 @@ pub struct Texture<A: HalApi> {
 
 impl<A: HalApi> Drop for Texture<A> {
     fn drop(&mut self) {
-        resource_log!("Destroy raw Texture {}", self.info.label());
+        resource_log!("Destroy raw Texture {:?}", self.info.label());
         use hal::Device;
         let mut clear_mode = self.clear_mode.write();
         let clear_mode = &mut *clear_mode;
@@ -1052,7 +1056,7 @@ pub struct TextureView<A: HalApi> {
 impl<A: HalApi> Drop for TextureView<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw TextureView {}", self.info.label());
+            resource_log!("Destroy raw TextureView {:?}", self.info.label());
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_texture_view(raw);
@@ -1173,7 +1177,7 @@ pub struct Sampler<A: HalApi> {
 
 impl<A: HalApi> Drop for Sampler<A> {
     fn drop(&mut self) {
-        resource_log!("Destroy raw Sampler {}", self.info.label());
+        resource_log!("Destroy raw Sampler {:?}", self.info.label());
         if let Some(raw) = self.raw.take() {
             unsafe {
                 use hal::Device;
@@ -1270,7 +1274,7 @@ pub struct QuerySet<A: HalApi> {
 
 impl<A: HalApi> Drop for QuerySet<A> {
     fn drop(&mut self) {
-        resource_log!("Destroy raw QuerySet {}", self.info.label());
+        resource_log!("Destroy raw QuerySet {:?}", self.info.label());
         if let Some(raw) = self.raw.take() {
             unsafe {
                 use hal::Device;


### PR DESCRIPTION
**Description**

We allocate a String every time we want to get a label for logging. The string is also allocated when logging is disabled. Either way, the allocation is unnecessary. This commit replaces the String with a dyn Debug reference which does not need any allocation.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
