### PR TITLE
Remove some locks in BindGroup

### DIFF
--- a/tests/tests/mem_leaks.rs
+++ b/tests/tests/mem_leaks.rs
@@ -243,6 +243,10 @@ fn draw_test_with_reports(
 
     ctx.device
         .poll(wgpu::Maintain::WaitForSubmissionIndex(submit_index));
+    // Because of dependency between resources, A resource being destroyed during poll
+    // can cause another resource to be ready for destruction next time poll is called.
+    // Call poll twice to ensure all destroyable resources are destroyed.
+    ctx.device.poll(wgpu::Maintain::Poll);
 
     let global_report = ctx.instance.generate_report();
     let report = global_report.hub_report(ctx.adapter_info.backend);

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -318,10 +318,10 @@ impl RenderBundleEncoder {
                     next_dynamic_offset = offsets_range.end;
                     let offsets = &base.dynamic_offsets[offsets_range.clone()];
 
-                    if bind_group.dynamic_binding_info.read().len() != offsets.len() {
+                    if bind_group.dynamic_binding_info.len() != offsets.len() {
                         return Err(RenderCommandError::InvalidDynamicOffsetCount {
                             actual: offsets.len(),
-                            expected: bind_group.dynamic_binding_info.read().len(),
+                            expected: bind_group.dynamic_binding_info.len(),
                         })
                         .map_pass_err(scope);
                     }
@@ -330,7 +330,7 @@ impl RenderBundleEncoder {
                     for (offset, info) in offsets
                         .iter()
                         .map(|offset| *offset as wgt::BufferAddress)
-                        .zip(bind_group.dynamic_binding_info.read().iter())
+                        .zip(bind_group.dynamic_binding_info.iter())
                     {
                         let (alignment, limit_name) =
                             buffer_binding_type_alignment(&device.limits, info.binding_type);
@@ -342,8 +342,8 @@ impl RenderBundleEncoder {
                         }
                     }
 
-                    buffer_memory_init_actions.extend_from_slice(&bind_group.used_buffer_ranges.read());
-                    texture_memory_init_actions.extend_from_slice(&bind_group.used_texture_ranges.read());
+                    buffer_memory_init_actions.extend_from_slice(&bind_group.used_buffer_ranges);
+                    texture_memory_init_actions.extend_from_slice(&bind_group.used_texture_ranges);
 
                     state.set_bind_group(index, bind_group_guard.get(bind_group_id).as_ref().unwrap(), &bind_group.layout, offsets_range);
                     unsafe {

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -527,20 +527,16 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         .map_pass_err(scope)?;
 
                     buffer_memory_init_actions.extend(
-                        bind_group
-                            .used_buffer_ranges
-                            .read()
-                            .iter()
-                            .filter_map(|action| {
-                                action
-                                    .buffer
-                                    .initialization_status
-                                    .read()
-                                    .check_action(action)
-                            }),
+                        bind_group.used_buffer_ranges.iter().filter_map(|action| {
+                            action
+                                .buffer
+                                .initialization_status
+                                .read()
+                                .check_action(action)
+                        }),
                     );
 
-                    for action in bind_group.used_texture_ranges.read().iter() {
+                    for action in bind_group.used_texture_ranges.iter() {
                         pending_discard_init_fixups
                             .extend(texture_memory_actions.register_init_action(action));
                     }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1462,19 +1462,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         // is held to the bind group itself.
 
                         buffer_memory_init_actions.extend(
-                            bind_group
-                                .used_buffer_ranges
-                                .read()
-                                .iter()
-                                .filter_map(|action| {
-                                    action
-                                        .buffer
-                                        .initialization_status
-                                        .read()
-                                        .check_action(action)
-                                }),
+                            bind_group.used_buffer_ranges.iter().filter_map(|action| {
+                                action
+                                    .buffer
+                                    .initialization_status
+                                    .read()
+                                    .check_action(action)
+                            }),
                         );
-                        for action in bind_group.used_texture_ranges.read().iter() {
+                        for action in bind_group.used_texture_ranges.iter() {
                             info.pending_discard_init_fixups
                                 .extend(texture_memory_actions.register_init_action(action));
                         }

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -524,10 +524,6 @@ impl<A: HalApi> LifetimeTracker<A> {
                     .samplers
                     .insert(v.as_info().id(), v);
             }
-            //Releasing safely unused resources to decrement refcount
-            bind_group.used_buffer_ranges.write().clear();
-            bind_group.used_texture_ranges.write().clear();
-            bind_group.dynamic_binding_info.write().clear();
 
             self.suspected_resources
                 .bind_group_layouts

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2196,9 +2196,9 @@ impl<A: HalApi> Device<A> {
             layout: layout.clone(),
             info: ResourceInfo::new(desc.label.borrow_or_default()),
             used,
-            used_buffer_ranges: RwLock::new(used_buffer_ranges),
-            used_texture_ranges: RwLock::new(used_texture_ranges),
-            dynamic_binding_info: RwLock::new(dynamic_binding_info),
+            used_buffer_ranges,
+            used_texture_ranges,
+            dynamic_binding_info,
             // collect in the order of BGL iteration
             late_buffer_binding_sizes: layout
                 .entries


### PR DESCRIPTION
These are only written to clear the vectors when triaging bind groups for destruction, which is not necessary. We can let the reference counts drop when the bind group is dropped.

**Description**

The three locks aren't necessary. They allow us to clear references to the buffers and textures a tad earlier when triaging dropped bind groups, but we can let that happen automatically when the `BindGroup` struct is actually dropped soon after.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
