### PR TITLE
Buffer snatching

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -16,8 +16,8 @@ use crate::{
     identity::{GlobalIdentityHandlerFactory, Input},
     init_tracker::{has_copy_partial_init_tracker_coverage, TextureInitRange},
     resource::{
-        Buffer, BufferAccessError, BufferMapState, Resource, ResourceInfo, ResourceType,
-        StagingBuffer, Texture, TextureInner,
+        Buffer, BufferAccessError, BufferMapState, DestroyedBuffer, Resource, ResourceInfo,
+        ResourceType, StagingBuffer, Texture, TextureInner,
     },
     resource_log, track, FastHashMap, SubmissionIndex,
 };
@@ -163,6 +163,7 @@ pub struct WrappedSubmissionIndex {
 pub enum TempResource<A: HalApi> {
     Buffer(Arc<Buffer<A>>),
     StagingBuffer(Arc<StagingBuffer<A>>),
+    DestroyedBuffer(Arc<DestroyedBuffer<A>>),
     Texture(Arc<Texture<A>>),
 }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -413,7 +413,7 @@ pub struct Buffer<A: HalApi> {
 impl<A: HalApi> Drop for Buffer<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw Buffer {:?}", self.info.label());
+            resource_log!("Deallocate raw Buffer (dropped) {:?}", self.info.label());
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_buffer(raw);
@@ -553,14 +553,25 @@ impl<A: HalApi> Buffer<A> {
         if let Some(ref mut trace) = *device.trace.lock() {
             trace.add(trace::Action::FreeBuffer(buffer_id));
         }
-        // Note: a future commit will replace this with a read guard
-        // and actually snatch the buffer.
-        let snatch_guard = device.snatchable_lock.read();
-        if self.raw.get(&snatch_guard).is_none() {
-            return Err(resource::DestroyError::AlreadyDestroyed);
-        }
 
-        let temp = queue::TempResource::Buffer(self.clone());
+        let temp = {
+            let snatch_guard = device.snatchable_lock.write();
+            let raw = match self.raw.snatch(snatch_guard) {
+                Some(raw) => raw,
+                None => {
+                    return Err(resource::DestroyError::AlreadyDestroyed);
+                }
+            };
+
+            queue::TempResource::DestroyedBuffer(Arc::new(DestroyedBuffer {
+                raw: Some(raw),
+                device: Arc::clone(&self.device),
+                submission_index: self.info.submission_index(),
+                id: self.info.id.unwrap(),
+                label: self.info.label.clone(),
+            }))
+        };
+
         let mut pending_writes = device.pending_writes.lock();
         let pending_writes = pending_writes.as_mut().unwrap();
         if pending_writes.dst_buffers.contains_key(&buffer_id) {
@@ -604,6 +615,38 @@ impl<A: HalApi> Resource<BufferId> for Buffer<A> {
 
     fn as_info_mut(&mut self) -> &mut ResourceInfo<BufferId> {
         &mut self.info
+    }
+}
+
+/// A buffer that has been marked as destroyed and is staged for actual deletion soon.
+#[derive(Debug)]
+pub struct DestroyedBuffer<A: HalApi> {
+    raw: Option<A::Buffer>,
+    device: Arc<Device<A>>,
+    label: String,
+    pub(crate) id: BufferId,
+    pub(crate) submission_index: u64,
+}
+
+impl<A: HalApi> DestroyedBuffer<A> {
+    pub fn label(&self) -> &dyn Debug {
+        if !self.label.is_empty() {
+            return &self.label;
+        }
+
+        &self.id
+    }
+}
+
+impl<A: HalApi> Drop for DestroyedBuffer<A> {
+    fn drop(&mut self) {
+        if let Some(raw) = self.raw.take() {
+            resource_log!("Deallocate raw Buffer (destroyed) {:?}", self.label());
+            unsafe {
+                use hal::Device;
+                self.device.raw().destroy_buffer(raw);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
**Connections**

Fixes the buffer part of #4787
Rebased on top of #4895 and #4894

**Description**

Move (snatch) the raw buffer out of the wgpu-core buffer when destroying the latter, putting it into a `DestroyedBuffer<A>` structure which lifecycle is tracked independently. The idea is that the `Buffer<A>` can be held alive by other resource like bind groups in an a destroyed state, which we go ahead ad deallocated the snatched buffer as soon as it is safe to do so.

For garage collected environments such as the web it means we can rely on `destroy()` for releasing resources in a reasonable time.

I think it might even actually work.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
