### PR TITLE
Support Device fence sharing with dx12 on Windows

### DIFF
--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1514,7 +1514,7 @@ impl crate::Device<super::Api> for super::Device {
         let hr = unsafe {
             self.raw.CreateFence(
                 0,
-                d3d12_ty::D3D12_FENCE_FLAG_NONE,
+                d3d12_ty::D3D12_FENCE_FLAG_SHARED,
                 &d3d12_ty::ID3D12Fence::uuidof(),
                 raw.mut_void(),
             )

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -493,6 +493,12 @@ pub struct Fence {
 unsafe impl Send for Fence {}
 unsafe impl Sync for Fence {}
 
+impl Fence {
+    pub fn raw_fence(&self) -> &d3d12::Fence {
+        &self.raw
+    }
+}
+
 #[derive(Debug)]
 pub struct BindGroupLayout {
     /// Sorted list of entries.


### PR DESCRIPTION
**Connections**
Fixes #4872

**Description**
To use Device:::fence outside of wgpu with dx12 for synchronization, the following changes are done.
- Add public api for getting Device:::fence
- Create d3d12::Fence with sharing flag
- Add public api for getting raw fence(d3d12::Fence)

**Checklist**
- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. 
