### PR TITLE
[naga xtask] Run validation jobs in parallel, using jobserver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ Wgpu now exposes backend feature for the Direct3D 12 (`dx12`) and Metal (`metal`
 
 - Add `--bulk-validate` option to Naga CLI. By @jimblandy in [#4871](https://github.com/gfx-rs/wgpu/pull/4871).
 
+- Naga's `cargo xtask validate` now runs validation jobs in parallel, using the [jobserver](https://crates.io/crates/jobserver) protocol to limit concurrency, and offers a `validate all` subcommand, which runs all available validation types. By @jimblandy in [#4902](https://github.com/gfx-rs/wgpu/pull/4902).
+
 ### Changes
 
 - Arcanization of wgpu core resources: By @gents83 in [#3626](https://github.com/gfx-rs/wgpu/pull/3626) and thanks also to @jimblandy, @nical, @Wumpf, @Elabajaba & @cwfitzgerald

--- a/naga/xtask/Cargo.lock
+++ b/naga/xtask/Cargo.lock
@@ -15,10 +15,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
@@ -42,6 +61,34 @@ dependencies = [
  "anyhow",
  "nanoserde",
 ]
+
+[[package]]
+name = "indicatif"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -74,6 +121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7a94da6c6181c35d043fc61c43ac96d3a5d739e7b8027f77650ba41504d6ab"
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,10 +139,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "which"
@@ -103,6 +168,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
 name = "xtask"
 version = "0.1.0"
 dependencies = [
@@ -110,6 +241,7 @@ dependencies = [
  "env_logger",
  "glob",
  "hlsl-snapshots",
+ "indicatif",
  "log",
  "pico-args",
  "shell-words",

--- a/naga/xtask/Cargo.lock
+++ b/naga/xtask/Cargo.lock
@@ -55,6 +55,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
 name = "hlsl-snapshots"
 version = "0.1.0"
 dependencies = [
@@ -82,6 +88,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -119,6 +134,16 @@ name = "nanoserde-derive"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7a94da6c6181c35d043fc61c43ac96d3a5d739e7b8027f77650ba41504d6ab"
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "number_prefix"
@@ -242,7 +267,9 @@ dependencies = [
  "glob",
  "hlsl-snapshots",
  "indicatif",
+ "jobserver",
  "log",
+ "num_cpus",
  "pico-args",
  "shell-words",
  "which",

--- a/naga/xtask/Cargo.toml
+++ b/naga/xtask/Cargo.toml
@@ -10,7 +10,9 @@ env_logger = { version = "0.10.0", default-features = false }
 glob = "0.3.1"
 hlsl-snapshots = { path = "../hlsl-snapshots"}
 indicatif = "0.17"
+jobserver = "0.1"
 log = "0.4.17"
+num_cpus = "1.16"
 pico-args = "0.5.0"
 shell-words = "1.1.0"
 which = "4.4.0"

--- a/naga/xtask/Cargo.toml
+++ b/naga/xtask/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1"
 env_logger = { version = "0.10.0", default-features = false }
 glob = "0.3.1"
 hlsl-snapshots = { path = "../hlsl-snapshots"}
+indicatif = "0.17"
 log = "0.4.17"
 pico-args = "0.5.0"
 shell-words = "1.1.0"

--- a/naga/xtask/src/cli.rs
+++ b/naga/xtask/src/cli.rs
@@ -127,6 +127,19 @@ impl ValidateSubcommand {
             }
         }
     }
+
+    pub(crate) fn all() -> impl Iterator<Item = Self> {
+        [
+            Self::Spirv,
+            Self::Metal,
+            Self::Glsl,
+            Self::Dot,
+            Self::Wgsl,
+            Self::Hlsl(ValidateHlslCommand::Dxc),
+            Self::Hlsl(ValidateHlslCommand::Fxc),
+        ]
+        .into_iter()
+    }
 }
 
 #[derive(Debug)]

--- a/naga/xtask/src/cli.rs
+++ b/naga/xtask/src/cli.rs
@@ -77,6 +77,8 @@ impl Subcommand {
     }
 }
 
+// If you add a new validation subcommand, be sure to update the code
+// that processes `All`.
 #[derive(Debug)]
 pub(crate) enum ValidateSubcommand {
     Spirv,
@@ -85,6 +87,7 @@ pub(crate) enum ValidateSubcommand {
     Dot,
     Wgsl,
     Hlsl(ValidateHlslCommand),
+    All,
 }
 
 impl ValidateSubcommand {
@@ -114,7 +117,11 @@ impl ValidateSubcommand {
                 ensure_remaining_args_empty(args)?;
                 Ok(Self::Wgsl)
             }
-            "hlsl" => return Ok(Self::Hlsl(ValidateHlslCommand::parse(args)?)),
+            "hlsl" => Ok(Self::Hlsl(ValidateHlslCommand::parse(args)?)),
+            "all" => {
+                ensure_remaining_args_empty(args)?;
+                Ok(Self::All)
+            }
             other => {
                 bail!("unrecognized `validate` subcommand {other:?}; see `--help` for more details")
             }

--- a/naga/xtask/src/glob.rs
+++ b/naga/xtask/src/glob.rs
@@ -1,37 +1,34 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use glob::glob;
 
-use crate::result::{ErrorStatus, LogIfError};
+/// Apply `f` to each file matching `pattern` in `top_dir`.
+///
+/// Pass files as `anyhow::Result` values, to carry errors from
+/// directory iteration and metadata checking.
+pub(crate) fn for_each_file(
+    top_dir: impl AsRef<Path>,
+    pattern: impl AsRef<Path>,
+    mut f: impl FnMut(anyhow::Result<PathBuf>),
+) {
+    fn filter_files(glob: &str, result: glob::GlobResult) -> anyhow::Result<Option<PathBuf>> {
+        let path = result.with_context(|| format!("error while iterating over glob {glob:?}"))?;
+        let metadata = path
+            .metadata()
+            .with_context(|| format!("failed to fetch metadata for {path:?}"))?;
+        Ok(metadata.is_file().then_some(path))
+    }
 
-pub(crate) fn visit_files(
-    path: impl AsRef<Path>,
-    glob_expr: &str,
-    mut f: impl FnMut(&Path) -> anyhow::Result<()>,
-) -> ErrorStatus {
-    let path = path.as_ref();
-    let glob_expr = path.join(glob_expr);
-    let glob_expr = glob_expr.to_str().unwrap();
+    let pattern_in_dir = top_dir.as_ref().join(pattern.as_ref());
+    let pattern_in_dir = pattern_in_dir.to_str().unwrap();
 
-    let mut status = ErrorStatus::NoFailuresFound;
-    glob(glob_expr)
+    glob(pattern_in_dir)
         .context("glob pattern {path:?} is invalid")
         .unwrap()
-        .for_each(|path_res| {
-            if let Some(path) = path_res
-                .with_context(|| format!("error while iterating over glob {path:?}"))
-                .log_if_err_found(&mut status)
-            {
-                if path
-                    .metadata()
-                    .with_context(|| format!("failed to fetch metadata for {path:?}"))
-                    .log_if_err_found(&mut status)
-                    .map_or(false, |m| m.is_file())
-                {
-                    f(&path).log_if_err_found(&mut status);
-                }
+        .for_each(|result| {
+            if let Some(result) = filter_files(pattern_in_dir, result).transpose() {
+                f(result);
             }
         });
-    status
 }

--- a/naga/xtask/src/jobserver.rs
+++ b/naga/xtask/src/jobserver.rs
@@ -1,0 +1,34 @@
+//! Running jobs in parallel, with a controlled degree of concurrency.
+
+use std::sync::OnceLock;
+
+use jobserver::Client;
+
+static JOB_SERVER: OnceLock<Client> = OnceLock::new();
+
+pub fn init() {
+    JOB_SERVER.get_or_init(|| {
+        // Try to connect to a jobserver inherited from our parent.
+        if let Some(client) = unsafe { Client::from_env() } {
+            log::debug!("connected to inherited jobserver client");
+            client
+        } else {
+            // Otherwise, start our own jobserver.
+            log::debug!("no inherited jobserver client; creating a new jobserver");
+            Client::new(num_cpus::get()).expect("failed to create jobserver")
+        }
+    });
+}
+
+/// Wait until it is okay to start a new job, and then spawn a thread running `body`.
+pub fn start_job_thread<F>(body: F) -> anyhow::Result<()>
+where
+    F: FnOnce() + Send + 'static,
+{
+    let acquired = JOB_SERVER.get().unwrap().acquire()?;
+    std::thread::spawn(move || {
+        body();
+        drop(acquired);
+    });
+    Ok(())
+}

--- a/naga/xtask/src/main.rs
+++ b/naga/xtask/src/main.rs
@@ -13,6 +13,7 @@ use crate::{
 mod cli;
 mod fs;
 mod glob;
+mod jobserver;
 mod path;
 mod process;
 mod result;
@@ -24,6 +25,8 @@ fn main() -> ExitCode {
         .parse_default_env()
         .format_indent(Some(0))
         .init();
+
+    jobserver::init();
 
     let args = Args::parse();
 

--- a/naga/xtask/src/main.rs
+++ b/naga/xtask/src/main.rs
@@ -1,19 +1,13 @@
-use std::{
-    io::{BufRead, BufReader},
-    path::Path,
-    process::{ExitCode, Stdio},
-};
+use std::process::ExitCode;
 
-use anyhow::{bail, Context};
+use anyhow::Context;
 use cli::Args;
 
 use crate::{
-    cli::{Subcommand, ValidateHlslCommand, ValidateSubcommand},
-    fs::{open_file, remove_dir_all},
-    glob::visit_files,
+    cli::Subcommand,
+    fs::remove_dir_all,
     path::join_path,
     process::{which, EasyCommand},
-    result::{ErrorStatus, LogIfError},
 };
 
 mod cli;
@@ -22,6 +16,7 @@ mod glob;
 mod path;
 mod process;
 mod result;
+mod validate;
 
 fn main() -> ExitCode {
     env_logger::builder()
@@ -42,8 +37,6 @@ fn main() -> ExitCode {
 }
 
 fn run(args: Args) -> anyhow::Result<()> {
-    let snapshots_base_out = join_path(["tests", "out"]);
-
     let Args { subcommand } = args;
 
     assert!(which("cargo").is_ok());
@@ -75,244 +68,6 @@ fn run(args: Args) -> anyhow::Result<()> {
             }
             EasyCommand::simple("cargo", ["bench"]).success()
         }
-        Subcommand::Validate(cmd) => {
-            let ack_visiting = |path: &Path| log::info!("Validating {}", path.display());
-            let err_status = match cmd {
-                ValidateSubcommand::Spirv => {
-                    let spirv_as = "spirv-as";
-                    which(spirv_as)?;
-
-                    let spirv_val = "spirv-val";
-                    which(spirv_val)?;
-
-                    visit_files(snapshots_base_out, "spv/*.spvasm", |path| {
-                        ack_visiting(path);
-                        let second_line = {
-                            let mut file = BufReader::new(open_file(path)?);
-                            let mut buf = String::new();
-                            file.read_line(&mut buf).with_context(|| {
-                                format!("failed to read first line from {path:?}")
-                            })?;
-                            buf.clear();
-                            file.read_line(&mut buf).with_context(|| {
-                                format!("failed to read second line from {path:?}")
-                            })?;
-                            buf
-                        };
-                        let expected_header_prefix = "; Version: ";
-                        let Some(version) =
-                            second_line.strip_prefix(expected_header_prefix) else {
-                                bail!(
-                                    "no {expected_header_prefix:?} header found in {path:?}"
-                                );
-                            };
-                        let file = open_file(path)?;
-                        let mut spirv_as_cmd = EasyCommand::new(spirv_as, |cmd| {
-                            cmd.stdin(Stdio::from(file))
-                                .stdout(Stdio::piped())
-                                .arg("--target-env")
-                                .arg(format!("spv{version}"))
-                                .args(["-", "-o", "-"])
-                        });
-                        let child = spirv_as_cmd
-                            .spawn()
-                            .with_context(|| format!("failed to spawn {cmd:?}"))?;
-                        EasyCommand::new(spirv_val, |cmd| cmd.stdin(child.stdout.unwrap()))
-                            .success()
-                    })
-                }
-                ValidateSubcommand::Metal => {
-                    let xcrun = "xcrun";
-                    which(xcrun)?;
-                    visit_files(snapshots_base_out, "msl/*.msl", |path| {
-                        ack_visiting(path);
-                        let first_line = {
-                            let mut file = BufReader::new(open_file(path)?);
-                            let mut buf = String::new();
-                            file.read_line(&mut buf)
-                                .with_context(|| format!("failed to read header from {path:?}"))?;
-                            buf
-                        };
-                        let expected_header_prefix = "// language: ";
-                        let Some(language) =
-                            first_line.strip_prefix(expected_header_prefix) else {
-                                bail!(
-                                    "no {expected_header_prefix:?} header found in {path:?}"
-                                );
-                            };
-                        let language = language.strip_suffix('\n').unwrap_or(language);
-
-                        let file = open_file(path)?;
-                        EasyCommand::new(xcrun, |cmd| {
-                            cmd.stdin(Stdio::from(file))
-                                .args(["-sdk", "macosx", "metal", "-mmacosx-version-min=10.11"])
-                                .arg(format!("-std=macos-{language}"))
-                                .args(["-x", "metal", "-", "-o", "/dev/null"])
-                        })
-                        .success()
-                    })
-                }
-                ValidateSubcommand::Glsl => {
-                    let glslang_validator = "glslangValidator";
-                    which(glslang_validator)?;
-                    let mut err_status = ErrorStatus::NoFailuresFound;
-                    for (glob, type_arg) in [
-                        ("glsl/*.Vertex.glsl", "vert"),
-                        ("glsl/*.Fragment.glsl", "frag"),
-                        ("glsl/*.Compute.glsl", "comp"),
-                    ] {
-                        let type_err_status = visit_files(&snapshots_base_out, glob, |path| {
-                            ack_visiting(path);
-                            let file = open_file(path)?;
-                            EasyCommand::new(glslang_validator, |cmd| {
-                                cmd.stdin(Stdio::from(file))
-                                    .args(["--stdin", "-S"])
-                                    .arg(type_arg)
-                            })
-                            .success()
-                        });
-                        err_status = err_status.merge(type_err_status);
-                    }
-                    err_status
-                }
-                ValidateSubcommand::Dot => {
-                    let dot = "dot";
-                    which(dot)?;
-                    visit_files(snapshots_base_out, "dot/*.dot", |path| {
-                        ack_visiting(path);
-                        let file = open_file(path)?;
-                        EasyCommand::new(dot, |cmd| {
-                            cmd.stdin(Stdio::from(file)).stdout(Stdio::null())
-                        })
-                        .success()
-                    })
-                }
-                ValidateSubcommand::Wgsl => {
-                    let mut paths = vec![];
-                    let mut error_status = visit_files(snapshots_base_out, "wgsl/*.wgsl", |path| {
-                        paths.push(path.to_owned());
-                        Ok(())
-                    });
-                    EasyCommand::new("cargo", |cmd| {
-                        cmd.args(["run", "-p", "naga-cli", "--", "--bulk-validate"]).args(paths)
-                    }).success()
-                        .log_if_err_found(&mut error_status);
-                    error_status
-                }
-                ValidateSubcommand::Hlsl(cmd) => {
-                    let visit_hlsl = |consume_config_item: &mut dyn FnMut(
-                        &Path,
-                        hlsl_snapshots::ConfigItem,
-                    )
-                        -> anyhow::Result<()>| {
-                        visit_files(snapshots_base_out, "hlsl/*.hlsl", |path| {
-                            ack_visiting(path);
-                            let hlsl_snapshots::Config {
-                                vertex,
-                                fragment,
-                                compute,
-                            } = hlsl_snapshots::Config::from_path(path.with_extension("ron"))?;
-                            let mut status = ErrorStatus::NoFailuresFound;
-                            [vertex, fragment, compute]
-                                .into_iter()
-                                .flatten()
-                                .for_each(|shader| {
-                                    consume_config_item(path, shader).log_if_err_found(&mut status);
-                                });
-                            match status {
-                                ErrorStatus::NoFailuresFound => Ok(()),
-                                ErrorStatus::OneOrMoreFailuresFound => bail!(
-                                    "one or more shader HLSL shader tests failed for {}",
-                                    path.display()
-                                ),
-                            }
-                        })
-                    };
-                    let validate = |bin, file: &_, config_item, params: &[_]| {
-                        let hlsl_snapshots::ConfigItem {
-                            entry_point,
-                            target_profile,
-                        } = config_item;
-                        EasyCommand::new(bin, |cmd| {
-                            cmd.arg(file)
-                                .arg("-T")
-                                .arg(&target_profile)
-                                .arg("-E")
-                                .arg(&entry_point)
-                                .args(params)
-                                .stdout(Stdio::null())
-                        })
-                        .success()
-                        .with_context(|| {
-                            format!(
-                                "failed to validate entry point {entry_point:?} with profile \
-                                {target_profile:?}"
-                            )
-                        })
-                    };
-                    match cmd {
-                        ValidateHlslCommand::Dxc => {
-                            let bin = "dxc";
-                            which(bin)?;
-                            visit_hlsl(&mut |file, config_item| {
-                                // Reference:
-                                // <https://github.com/microsoft/DirectXShaderCompiler/blob/6ee4074a4b43fa23bf5ad27e4f6cafc6b835e437/tools/clang/docs/UsingDxc.rst>.
-                                validate(
-                                    bin,
-                                    file,
-                                    config_item,
-                                    &[
-                                        "-Wno-parentheses-equality",
-                                        "-Zi",
-                                        "-Qembed_debug",
-                                        "-Od",
-                                        "-HV",
-                                        "2018",
-                                    ],
-                                )
-                            })
-                        }
-                        ValidateHlslCommand::Fxc => {
-                            let bin = "fxc";
-                            which(bin)?;
-                            visit_hlsl(&mut |file, config_item| {
-                                let Some(Ok(shader_model_major_version)) = config_item
-                                    .target_profile
-                                    .split('_')
-                                    .nth(1)
-                                    .map(|segment| segment.parse::<u8>()) else {
-                                        bail!(
-                                            "expected target profile of the form \
-                                            `{{model}}_{{major}}_{{minor}}`, found invalid target \
-                                            profile {:?} in file {}",
-                                            config_item.target_profile,
-                                            file.display()
-                                        )
-                                    };
-                                // NOTE: This isn't implemented by `fxc.exe`; see
-                                // <https://learn.microsoft.com/en-us/windows/win32/direct3dtools/dx-graphics-tools-fxc-syntax#profiles>.
-                                if shader_model_major_version < 6 {
-                                    // Reference:
-                                    // <https://learn.microsoft.com/en-us/windows/win32/direct3dtools/dx-graphics-tools-fxc-syntax>.
-                                    validate(bin, file, config_item, &["-Zi", "-Od"])
-                                } else {
-                                    log::debug!(
-                                        "skipping config. item {config_item:?} because the \
-                                        shader model major version is > 6"
-                                    );
-                                    Ok(())
-                                }
-                            })
-                        }
-                    }
-                }
-            };
-            match err_status {
-                ErrorStatus::NoFailuresFound => Ok(()),
-                ErrorStatus::OneOrMoreFailuresFound => {
-                    bail!("failed to validate one or more files, see above output for more details")
-                }
-            }
-        }
+        Subcommand::Validate(cmd) => validate::validate(cmd),
     }
 }

--- a/naga/xtask/src/process.rs
+++ b/naga/xtask/src/process.rs
@@ -35,13 +35,15 @@ impl EasyCommand {
     pub fn success(&mut self) -> anyhow::Result<()> {
         let Self { inner } = self;
         log::debug!("running {inner:?}");
-        let status = inner
-            .status()
+        let output = inner
+            .output()
             .with_context(|| format!("failed to run {self}"))?;
         ensure!(
-            status.success(),
-            "{self} failed to run; exit code: {:?}",
-            status.code()
+            output.status.success(),
+            "{self} failed to run; exit code: {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
         );
         Ok(())
     }

--- a/naga/xtask/src/validate.rs
+++ b/naga/xtask/src/validate.rs
@@ -54,9 +54,10 @@ pub(crate) fn validate(cmd: ValidateSubcommand) -> anyhow::Result<()> {
 
     progress_bar.finish_and_clear();
 
-    if !all_good {
-        bail!("failed to validate one or more files, see above output for more details")
-    }
+    anyhow::ensure!(
+        all_good,
+        "failed to validate one or more files, see above output for more details"
+    );
 
     if let Err(error) = enqueuing_thread.join().unwrap() {
         bail!("Error enqueuing jobs:\n{:#}", error);

--- a/naga/xtask/src/validate.rs
+++ b/naga/xtask/src/validate.rs
@@ -13,10 +13,6 @@ use crate::{
     process::{which, EasyCommand},
 };
 
-fn ack_visiting(path: &Path) {
-    log::info!("Validating {}", path.display());
-}
-
 pub(crate) fn validate(cmd: ValidateSubcommand) -> anyhow::Result<()> {
     let mut jobs = vec![];
     collect_validation_jobs(&mut jobs, cmd)?;
@@ -140,7 +136,6 @@ fn collect_validation_jobs(jobs: &mut Vec<Job>, cmd: ValidateSubcommand) -> anyh
 }
 
 fn validate_spirv(path: &Path, spirv_as: &str, spirv_val: &str) -> anyhow::Result<()> {
-    ack_visiting(path);
     let second_line = {
         let mut file = BufReader::new(open_file(path)?);
         let mut buf = String::new();
@@ -173,7 +168,6 @@ fn validate_spirv(path: &Path, spirv_as: &str, spirv_val: &str) -> anyhow::Resul
 }
 
 fn validate_metal(path: &Path, xcrun: &str) -> anyhow::Result<()> {
-    ack_visiting(path);
     let first_line = {
         let mut file = BufReader::new(open_file(path)?);
         let mut buf = String::new();
@@ -201,7 +195,6 @@ fn validate_metal(path: &Path, xcrun: &str) -> anyhow::Result<()> {
 }
 
 fn validate_glsl(path: &Path, type_arg: &str, glslang_validator: &str) -> anyhow::Result<()> {
-    ack_visiting(path);
     let file = open_file(path)?;
     EasyCommand::new(glslang_validator, |cmd| {
         cmd.stdin(Stdio::from(file))
@@ -212,7 +205,6 @@ fn validate_glsl(path: &Path, type_arg: &str, glslang_validator: &str) -> anyhow
 }
 
 fn validate_dot(path: &Path, dot: &str) -> anyhow::Result<()> {
-    ack_visiting(path);
     let file = open_file(path)?;
     EasyCommand::new(dot, |cmd| {
         cmd.stdin(Stdio::from(file)).stdout(Stdio::null())
@@ -236,7 +228,6 @@ fn push_job_for_each_hlsl_config_item(
         + Clone
         + 'static,
 ) -> anyhow::Result<()> {
-    ack_visiting(path);
     let hlsl_snapshots::Config {
         vertex,
         fragment,

--- a/naga/xtask/src/validate.rs
+++ b/naga/xtask/src/validate.rs
@@ -46,7 +46,7 @@ pub(crate) fn validate(cmd: ValidateSubcommand) -> anyhow::Result<()> {
         if let Err(error) = result {
             all_good = false;
             progress_bar.suspend(|| {
-                eprintln!("{:#}", error);
+                log::error!("{:#}", error);
             });
         }
         progress_bar.inc(1);

--- a/naga/xtask/src/validate.rs
+++ b/naga/xtask/src/validate.rs
@@ -142,6 +142,27 @@ fn collect_validation_jobs(jobs: &mut Vec<Job>, cmd: ValidateSubcommand) -> anyh
                 })
             });
         }
+        ValidateSubcommand::All => {
+            collect_validation_jobs(jobs, ValidateSubcommand::Wgsl)?;
+            collect_validation_jobs(jobs, ValidateSubcommand::Spirv)?;
+            collect_validation_jobs(jobs, ValidateSubcommand::Glsl)?;
+            collect_validation_jobs(jobs, ValidateSubcommand::Dot)?;
+
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            collect_validation_jobs(jobs, ValidateSubcommand::Metal)?;
+
+            // The FXC compiler is only available on Windows.
+            //
+            // The DXC compiler can be built and run on any platform,
+            // but they don't make Linux releases and it's not clear
+            // what Git commit actually works on Linux, so restrict
+            // that to Windows as well.
+            #[cfg(windows)]
+            {
+                collect_validation_jobs(jobs, ValidateSubcommand::Hlsl(ValidateHlslCommand::Dxc))?;
+                collect_validation_jobs(jobs, ValidateSubcommand::Hlsl(ValidateHlslCommand::Fxc))?;
+            }
+        }
     };
 
     Ok(())

--- a/naga/xtask/src/validate.rs
+++ b/naga/xtask/src/validate.rs
@@ -15,9 +15,12 @@ use crate::{
     result::{ErrorStatus, LogIfError},
 };
 
+fn ack_visiting(path: &Path) {
+    log::info!("Validating {}", path.display());
+}
+
 pub(crate) fn validate(cmd: ValidateSubcommand) -> anyhow::Result<()> {
     let snapshots_base_out = join_path(["tests", "out"]);
-    let ack_visiting = |path: &Path| log::info!("Validating {}", path.display());
     let err_status = match cmd {
         ValidateSubcommand::Spirv => {
             let spirv_as = "spirv-as";
@@ -27,67 +30,14 @@ pub(crate) fn validate(cmd: ValidateSubcommand) -> anyhow::Result<()> {
             which(spirv_val)?;
 
             visit_files(snapshots_base_out, "spv/*.spvasm", |path| {
-                ack_visiting(path);
-                let second_line = {
-                    let mut file = BufReader::new(open_file(path)?);
-                    let mut buf = String::new();
-                    file.read_line(&mut buf)
-                        .with_context(|| format!("failed to read first line from {path:?}"))?;
-                    buf.clear();
-                    file.read_line(&mut buf)
-                        .with_context(|| format!("failed to read second line from {path:?}"))?;
-                    buf
-                };
-                let expected_header_prefix = "; Version: ";
-                let Some(version) =
-                    second_line.strip_prefix(expected_header_prefix) else {
-                        bail!(
-                            "no {expected_header_prefix:?} header found in {path:?}"
-                        );
-                    };
-                let file = open_file(path)?;
-                let mut spirv_as_cmd = EasyCommand::new(spirv_as, |cmd| {
-                    cmd.stdin(Stdio::from(file))
-                        .stdout(Stdio::piped())
-                        .arg("--target-env")
-                        .arg(format!("spv{version}"))
-                        .args(["-", "-o", "-"])
-                });
-                let child = spirv_as_cmd
-                    .spawn()
-                    .with_context(|| format!("failed to spawn {cmd:?}"))?;
-                EasyCommand::new(spirv_val, |cmd| cmd.stdin(child.stdout.unwrap())).success()
+                validate_spirv(path, spirv_as, spirv_val)
             })
         }
         ValidateSubcommand::Metal => {
             let xcrun = "xcrun";
             which(xcrun)?;
             visit_files(snapshots_base_out, "msl/*.msl", |path| {
-                ack_visiting(path);
-                let first_line = {
-                    let mut file = BufReader::new(open_file(path)?);
-                    let mut buf = String::new();
-                    file.read_line(&mut buf)
-                        .with_context(|| format!("failed to read header from {path:?}"))?;
-                    buf
-                };
-                let expected_header_prefix = "// language: ";
-                let Some(language) =
-                    first_line.strip_prefix(expected_header_prefix) else {
-                        bail!(
-                            "no {expected_header_prefix:?} header found in {path:?}"
-                        );
-                    };
-                let language = language.strip_suffix('\n').unwrap_or(language);
-
-                let file = open_file(path)?;
-                EasyCommand::new(xcrun, |cmd| {
-                    cmd.stdin(Stdio::from(file))
-                        .args(["-sdk", "macosx", "metal", "-mmacosx-version-min=10.11"])
-                        .arg(format!("-std=macos-{language}"))
-                        .args(["-x", "metal", "-", "-o", "/dev/null"])
-                })
-                .success()
+                validate_metal(path, xcrun)
             })
         }
         ValidateSubcommand::Glsl => {
@@ -100,14 +50,7 @@ pub(crate) fn validate(cmd: ValidateSubcommand) -> anyhow::Result<()> {
                 ("glsl/*.Compute.glsl", "comp"),
             ] {
                 let type_err_status = visit_files(&snapshots_base_out, glob, |path| {
-                    ack_visiting(path);
-                    let file = open_file(path)?;
-                    EasyCommand::new(glslang_validator, |cmd| {
-                        cmd.stdin(Stdio::from(file))
-                            .args(["--stdin", "-S"])
-                            .arg(type_arg)
-                    })
-                    .success()
+                    validate_glsl(path, type_arg, glslang_validator)
                 });
                 err_status = err_status.merge(type_err_status);
             }
@@ -117,12 +60,7 @@ pub(crate) fn validate(cmd: ValidateSubcommand) -> anyhow::Result<()> {
             let dot = "dot";
             which(dot)?;
             visit_files(snapshots_base_out, "dot/*.dot", |path| {
-                ack_visiting(path);
-                let file = open_file(path)?;
-                EasyCommand::new(dot, |cmd| {
-                    cmd.stdin(Stdio::from(file)).stdout(Stdio::null())
-                })
-                .success()
+                validate_dot(path, dot)
             })
         }
         ValidateSubcommand::Wgsl => {
@@ -131,121 +69,25 @@ pub(crate) fn validate(cmd: ValidateSubcommand) -> anyhow::Result<()> {
                 paths.push(path.to_owned());
                 Ok(())
             });
-            EasyCommand::new("cargo", |cmd| {
-                cmd.args(["run", "-p", "naga-cli", "--", "--bulk-validate"])
-                    .args(paths)
-            })
-            .success()
-            .log_if_err_found(&mut error_status);
+            validate_wgsl(&paths).log_if_err_found(&mut error_status);
             error_status
         }
-        ValidateSubcommand::Hlsl(cmd) => {
-            let visit_hlsl = |consume_config_item: &mut dyn FnMut(
-                &Path,
-                hlsl_snapshots::ConfigItem,
-            )
-                -> anyhow::Result<()>| {
+        ValidateSubcommand::Hlsl(cmd) => match cmd {
+            ValidateHlslCommand::Dxc => {
+                let bin = "dxc";
+                which(bin)?;
                 visit_files(snapshots_base_out, "hlsl/*.hlsl", |path| {
-                    ack_visiting(path);
-                    let hlsl_snapshots::Config {
-                        vertex,
-                        fragment,
-                        compute,
-                    } = hlsl_snapshots::Config::from_path(path.with_extension("ron"))?;
-                    let mut status = ErrorStatus::NoFailuresFound;
-                    [vertex, fragment, compute]
-                        .into_iter()
-                        .flatten()
-                        .for_each(|shader| {
-                            consume_config_item(path, shader).log_if_err_found(&mut status);
-                        });
-                    match status {
-                        ErrorStatus::NoFailuresFound => Ok(()),
-                        ErrorStatus::OneOrMoreFailuresFound => bail!(
-                            "one or more shader HLSL shader tests failed for {}",
-                            path.display()
-                        ),
-                    }
+                    visit_hlsl_shaders(path, bin, validate_hlsl_with_dxc)
                 })
-            };
-            let validate = |bin, file: &_, config_item, params: &[_]| {
-                let hlsl_snapshots::ConfigItem {
-                    entry_point,
-                    target_profile,
-                } = config_item;
-                EasyCommand::new(bin, |cmd| {
-                    cmd.arg(file)
-                        .arg("-T")
-                        .arg(&target_profile)
-                        .arg("-E")
-                        .arg(&entry_point)
-                        .args(params)
-                        .stdout(Stdio::null())
-                })
-                .success()
-                .with_context(|| {
-                    format!(
-                        "failed to validate entry point {entry_point:?} with profile \
-                             {target_profile:?}"
-                    )
-                })
-            };
-            match cmd {
-                ValidateHlslCommand::Dxc => {
-                    let bin = "dxc";
-                    which(bin)?;
-                    visit_hlsl(&mut |file, config_item| {
-                        // Reference:
-                        // <https://github.com/microsoft/DirectXShaderCompiler/blob/6ee4074a4b43fa23bf5ad27e4f6cafc6b835e437/tools/clang/docs/UsingDxc.rst>.
-                        validate(
-                            bin,
-                            file,
-                            config_item,
-                            &[
-                                "-Wno-parentheses-equality",
-                                "-Zi",
-                                "-Qembed_debug",
-                                "-Od",
-                                "-HV",
-                                "2018",
-                            ],
-                        )
-                    })
-                }
-                ValidateHlslCommand::Fxc => {
-                    let bin = "fxc";
-                    which(bin)?;
-                    visit_hlsl(&mut |file, config_item| {
-                        let Some(Ok(shader_model_major_version)) = config_item
-                            .target_profile
-                            .split('_')
-                            .nth(1)
-                            .map(|segment| segment.parse::<u8>()) else {
-                                bail!(
-                                    "expected target profile of the form \
-                                     `{{model}}_{{major}}_{{minor}}`, found invalid target \
-                                     profile {:?} in file {}",
-                                    config_item.target_profile,
-                                    file.display()
-                                )
-                            };
-                        // NOTE: This isn't implemented by `fxc.exe`; see
-                        // <https://learn.microsoft.com/en-us/windows/win32/direct3dtools/dx-graphics-tools-fxc-syntax#profiles>.
-                        if shader_model_major_version < 6 {
-                            // Reference:
-                            // <https://learn.microsoft.com/en-us/windows/win32/direct3dtools/dx-graphics-tools-fxc-syntax>.
-                            validate(bin, file, config_item, &["-Zi", "-Od"])
-                        } else {
-                            log::debug!(
-                                "skipping config. item {config_item:?} because the \
-                                 shader model major version is > 6"
-                            );
-                            Ok(())
-                        }
-                    })
-                }
             }
-        }
+            ValidateHlslCommand::Fxc => {
+                let bin = "fxc";
+                which(bin)?;
+                visit_files(snapshots_base_out, "hlsl/*.hlsl", |path| {
+                    visit_hlsl_shaders(path, bin, validate_hlsl_with_fxc)
+                })
+            }
+        },
     };
     match err_status {
         ErrorStatus::NoFailuresFound => Ok(()),
@@ -253,4 +95,200 @@ pub(crate) fn validate(cmd: ValidateSubcommand) -> anyhow::Result<()> {
             bail!("failed to validate one or more files, see above output for more details")
         }
     }
+}
+
+fn validate_spirv(path: &Path, spirv_as: &str, spirv_val: &str) -> anyhow::Result<()> {
+    ack_visiting(path);
+    let second_line = {
+        let mut file = BufReader::new(open_file(path)?);
+        let mut buf = String::new();
+        file.read_line(&mut buf)
+            .with_context(|| format!("failed to read first line from {path:?}"))?;
+        buf.clear();
+        file.read_line(&mut buf)
+            .with_context(|| format!("failed to read second line from {path:?}"))?;
+        buf
+    };
+    let expected_header_prefix = "; Version: ";
+    let Some(version) =
+        second_line.strip_prefix(expected_header_prefix) else {
+            bail!(
+                "no {expected_header_prefix:?} header found in {path:?}"
+            );
+        };
+    let file = open_file(path)?;
+    let mut spirv_as_cmd = EasyCommand::new(spirv_as, |cmd| {
+        cmd.stdin(Stdio::from(file))
+            .stdout(Stdio::piped())
+            .arg("--target-env")
+            .arg(format!("spv{version}"))
+            .args(["-", "-o", "-"])
+    });
+    let child = spirv_as_cmd
+        .spawn()
+        .with_context(|| format!("failed to spawn {spirv_as_cmd:?}"))?;
+    EasyCommand::new(spirv_val, |cmd| cmd.stdin(child.stdout.unwrap())).success()
+}
+
+fn validate_metal(path: &Path, xcrun: &str) -> anyhow::Result<()> {
+    ack_visiting(path);
+    let first_line = {
+        let mut file = BufReader::new(open_file(path)?);
+        let mut buf = String::new();
+        file.read_line(&mut buf)
+            .with_context(|| format!("failed to read header from {path:?}"))?;
+        buf
+    };
+    let expected_header_prefix = "// language: ";
+    let Some(language) =
+        first_line.strip_prefix(expected_header_prefix) else {
+            bail!(
+                "no {expected_header_prefix:?} header found in {path:?}"
+            );
+        };
+    let language = language.strip_suffix('\n').unwrap_or(language);
+
+    let file = open_file(path)?;
+    EasyCommand::new(xcrun, |cmd| {
+        cmd.stdin(Stdio::from(file))
+            .args(["-sdk", "macosx", "metal", "-mmacosx-version-min=10.11"])
+            .arg(format!("-std=macos-{language}"))
+            .args(["-x", "metal", "-", "-o", "/dev/null"])
+    })
+    .success()
+}
+
+fn validate_glsl(path: &Path, type_arg: &str, glslang_validator: &str) -> anyhow::Result<()> {
+    ack_visiting(path);
+    let file = open_file(path)?;
+    EasyCommand::new(glslang_validator, |cmd| {
+        cmd.stdin(Stdio::from(file))
+            .args(["--stdin", "-S"])
+            .arg(type_arg)
+    })
+    .success()
+}
+
+fn validate_dot(path: &Path, dot: &str) -> anyhow::Result<()> {
+    ack_visiting(path);
+    let file = open_file(path)?;
+    EasyCommand::new(dot, |cmd| {
+        cmd.stdin(Stdio::from(file)).stdout(Stdio::null())
+    })
+    .success()
+}
+
+fn validate_wgsl(paths: &[std::path::PathBuf]) -> anyhow::Result<()> {
+    EasyCommand::new("cargo", |cmd| {
+        cmd.args(["run", "-p", "naga-cli", "--", "--bulk-validate"])
+            .args(paths)
+    })
+    .success()
+}
+
+fn visit_hlsl_shaders(
+    path: &Path,
+    bin: &str,
+    mut consume_config_item: impl FnMut(&Path, hlsl_snapshots::ConfigItem, &str) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    ack_visiting(path);
+    let hlsl_snapshots::Config {
+        vertex,
+        fragment,
+        compute,
+    } = hlsl_snapshots::Config::from_path(path.with_extension("ron"))?;
+    let mut status = ErrorStatus::NoFailuresFound;
+    for shader in [vertex, fragment, compute].into_iter().flatten() {
+        consume_config_item(path, shader, bin).log_if_err_found(&mut status);
+    }
+    match status {
+        ErrorStatus::NoFailuresFound => Ok(()),
+        ErrorStatus::OneOrMoreFailuresFound => bail!(
+            "one or more shader HLSL shader tests failed for {}",
+            path.display()
+        ),
+    }
+}
+
+fn validate_hlsl_with_dxc(
+    file: &Path,
+    config_item: hlsl_snapshots::ConfigItem,
+    dxc: &str,
+) -> anyhow::Result<()> {
+    // Reference:
+    // <https://github.com/microsoft/DirectXShaderCompiler/blob/6ee4074a4b43fa23bf5ad27e4f6cafc6b835e437/tools/clang/docs/UsingDxc.rst>.
+    validate_hlsl(
+        file,
+        dxc,
+        config_item,
+        &[
+            "-Wno-parentheses-equality",
+            "-Zi",
+            "-Qembed_debug",
+            "-Od",
+            "-HV",
+            "2018",
+        ],
+    )
+}
+
+fn validate_hlsl_with_fxc(
+    file: &Path,
+    config_item: hlsl_snapshots::ConfigItem,
+    fxc: &str,
+) -> anyhow::Result<()> {
+    let Some(Ok(shader_model_major_version)) = config_item
+        .target_profile
+        .split('_')
+        .nth(1)
+        .map(|segment| segment.parse::<u8>()) else {
+            bail!(
+                "expected target profile of the form \
+                 `{{model}}_{{major}}_{{minor}}`, found invalid target \
+                 profile {:?} in file {}",
+                config_item.target_profile,
+                file.display()
+            )
+        };
+    // NOTE: This isn't implemented by `fxc.exe`; see
+    // <https://learn.microsoft.com/en-us/windows/win32/direct3dtools/dx-graphics-tools-fxc-syntax#profiles>.
+    if shader_model_major_version < 6 {
+        // Reference:
+        // <https://learn.microsoft.com/en-us/windows/win32/direct3dtools/dx-graphics-tools-fxc-syntax>.
+        validate_hlsl(file, fxc, config_item, &["-Zi", "-Od"])
+    } else {
+        log::debug!(
+            "skipping config. item {config_item:?} because the \
+             shader model major version is > 6"
+        );
+        Ok(())
+    }
+}
+
+fn validate_hlsl(
+    file: &Path,
+    bin: &str,
+    config_item: hlsl_snapshots::ConfigItem,
+    params: &[&str],
+) -> anyhow::Result<()> {
+    let hlsl_snapshots::ConfigItem {
+        entry_point,
+        target_profile,
+    } = config_item;
+    EasyCommand::new(bin, |cmd| {
+        cmd.arg(file)
+            .arg("-T")
+            .arg(&target_profile)
+            .arg("-E")
+            .arg(&entry_point)
+            .args(params)
+            .stdout(Stdio::null())
+    })
+    .success()
+    .with_context(|| {
+        format!(
+            "failed to validate entry point {entry_point:?} with profile \
+                 {target_profile:?}"
+        )
+    })
 }

--- a/naga/xtask/src/validate.rs
+++ b/naga/xtask/src/validate.rs
@@ -1,0 +1,256 @@
+use std::{
+    io::{BufRead, BufReader},
+    path::Path,
+    process::Stdio,
+};
+
+use anyhow::{bail, Context};
+
+use crate::{
+    cli::{ValidateHlslCommand, ValidateSubcommand},
+    fs::open_file,
+    glob::visit_files,
+    path::join_path,
+    process::{which, EasyCommand},
+    result::{ErrorStatus, LogIfError},
+};
+
+pub(crate) fn validate(cmd: ValidateSubcommand) -> anyhow::Result<()> {
+    let snapshots_base_out = join_path(["tests", "out"]);
+    let ack_visiting = |path: &Path| log::info!("Validating {}", path.display());
+    let err_status = match cmd {
+        ValidateSubcommand::Spirv => {
+            let spirv_as = "spirv-as";
+            which(spirv_as)?;
+
+            let spirv_val = "spirv-val";
+            which(spirv_val)?;
+
+            visit_files(snapshots_base_out, "spv/*.spvasm", |path| {
+                ack_visiting(path);
+                let second_line = {
+                    let mut file = BufReader::new(open_file(path)?);
+                    let mut buf = String::new();
+                    file.read_line(&mut buf)
+                        .with_context(|| format!("failed to read first line from {path:?}"))?;
+                    buf.clear();
+                    file.read_line(&mut buf)
+                        .with_context(|| format!("failed to read second line from {path:?}"))?;
+                    buf
+                };
+                let expected_header_prefix = "; Version: ";
+                let Some(version) =
+                    second_line.strip_prefix(expected_header_prefix) else {
+                        bail!(
+                            "no {expected_header_prefix:?} header found in {path:?}"
+                        );
+                    };
+                let file = open_file(path)?;
+                let mut spirv_as_cmd = EasyCommand::new(spirv_as, |cmd| {
+                    cmd.stdin(Stdio::from(file))
+                        .stdout(Stdio::piped())
+                        .arg("--target-env")
+                        .arg(format!("spv{version}"))
+                        .args(["-", "-o", "-"])
+                });
+                let child = spirv_as_cmd
+                    .spawn()
+                    .with_context(|| format!("failed to spawn {cmd:?}"))?;
+                EasyCommand::new(spirv_val, |cmd| cmd.stdin(child.stdout.unwrap())).success()
+            })
+        }
+        ValidateSubcommand::Metal => {
+            let xcrun = "xcrun";
+            which(xcrun)?;
+            visit_files(snapshots_base_out, "msl/*.msl", |path| {
+                ack_visiting(path);
+                let first_line = {
+                    let mut file = BufReader::new(open_file(path)?);
+                    let mut buf = String::new();
+                    file.read_line(&mut buf)
+                        .with_context(|| format!("failed to read header from {path:?}"))?;
+                    buf
+                };
+                let expected_header_prefix = "// language: ";
+                let Some(language) =
+                    first_line.strip_prefix(expected_header_prefix) else {
+                        bail!(
+                            "no {expected_header_prefix:?} header found in {path:?}"
+                        );
+                    };
+                let language = language.strip_suffix('\n').unwrap_or(language);
+
+                let file = open_file(path)?;
+                EasyCommand::new(xcrun, |cmd| {
+                    cmd.stdin(Stdio::from(file))
+                        .args(["-sdk", "macosx", "metal", "-mmacosx-version-min=10.11"])
+                        .arg(format!("-std=macos-{language}"))
+                        .args(["-x", "metal", "-", "-o", "/dev/null"])
+                })
+                .success()
+            })
+        }
+        ValidateSubcommand::Glsl => {
+            let glslang_validator = "glslangValidator";
+            which(glslang_validator)?;
+            let mut err_status = ErrorStatus::NoFailuresFound;
+            for (glob, type_arg) in [
+                ("glsl/*.Vertex.glsl", "vert"),
+                ("glsl/*.Fragment.glsl", "frag"),
+                ("glsl/*.Compute.glsl", "comp"),
+            ] {
+                let type_err_status = visit_files(&snapshots_base_out, glob, |path| {
+                    ack_visiting(path);
+                    let file = open_file(path)?;
+                    EasyCommand::new(glslang_validator, |cmd| {
+                        cmd.stdin(Stdio::from(file))
+                            .args(["--stdin", "-S"])
+                            .arg(type_arg)
+                    })
+                    .success()
+                });
+                err_status = err_status.merge(type_err_status);
+            }
+            err_status
+        }
+        ValidateSubcommand::Dot => {
+            let dot = "dot";
+            which(dot)?;
+            visit_files(snapshots_base_out, "dot/*.dot", |path| {
+                ack_visiting(path);
+                let file = open_file(path)?;
+                EasyCommand::new(dot, |cmd| {
+                    cmd.stdin(Stdio::from(file)).stdout(Stdio::null())
+                })
+                .success()
+            })
+        }
+        ValidateSubcommand::Wgsl => {
+            let mut paths = vec![];
+            let mut error_status = visit_files(snapshots_base_out, "wgsl/*.wgsl", |path| {
+                paths.push(path.to_owned());
+                Ok(())
+            });
+            EasyCommand::new("cargo", |cmd| {
+                cmd.args(["run", "-p", "naga-cli", "--", "--bulk-validate"])
+                    .args(paths)
+            })
+            .success()
+            .log_if_err_found(&mut error_status);
+            error_status
+        }
+        ValidateSubcommand::Hlsl(cmd) => {
+            let visit_hlsl = |consume_config_item: &mut dyn FnMut(
+                &Path,
+                hlsl_snapshots::ConfigItem,
+            )
+                -> anyhow::Result<()>| {
+                visit_files(snapshots_base_out, "hlsl/*.hlsl", |path| {
+                    ack_visiting(path);
+                    let hlsl_snapshots::Config {
+                        vertex,
+                        fragment,
+                        compute,
+                    } = hlsl_snapshots::Config::from_path(path.with_extension("ron"))?;
+                    let mut status = ErrorStatus::NoFailuresFound;
+                    [vertex, fragment, compute]
+                        .into_iter()
+                        .flatten()
+                        .for_each(|shader| {
+                            consume_config_item(path, shader).log_if_err_found(&mut status);
+                        });
+                    match status {
+                        ErrorStatus::NoFailuresFound => Ok(()),
+                        ErrorStatus::OneOrMoreFailuresFound => bail!(
+                            "one or more shader HLSL shader tests failed for {}",
+                            path.display()
+                        ),
+                    }
+                })
+            };
+            let validate = |bin, file: &_, config_item, params: &[_]| {
+                let hlsl_snapshots::ConfigItem {
+                    entry_point,
+                    target_profile,
+                } = config_item;
+                EasyCommand::new(bin, |cmd| {
+                    cmd.arg(file)
+                        .arg("-T")
+                        .arg(&target_profile)
+                        .arg("-E")
+                        .arg(&entry_point)
+                        .args(params)
+                        .stdout(Stdio::null())
+                })
+                .success()
+                .with_context(|| {
+                    format!(
+                        "failed to validate entry point {entry_point:?} with profile \
+                             {target_profile:?}"
+                    )
+                })
+            };
+            match cmd {
+                ValidateHlslCommand::Dxc => {
+                    let bin = "dxc";
+                    which(bin)?;
+                    visit_hlsl(&mut |file, config_item| {
+                        // Reference:
+                        // <https://github.com/microsoft/DirectXShaderCompiler/blob/6ee4074a4b43fa23bf5ad27e4f6cafc6b835e437/tools/clang/docs/UsingDxc.rst>.
+                        validate(
+                            bin,
+                            file,
+                            config_item,
+                            &[
+                                "-Wno-parentheses-equality",
+                                "-Zi",
+                                "-Qembed_debug",
+                                "-Od",
+                                "-HV",
+                                "2018",
+                            ],
+                        )
+                    })
+                }
+                ValidateHlslCommand::Fxc => {
+                    let bin = "fxc";
+                    which(bin)?;
+                    visit_hlsl(&mut |file, config_item| {
+                        let Some(Ok(shader_model_major_version)) = config_item
+                            .target_profile
+                            .split('_')
+                            .nth(1)
+                            .map(|segment| segment.parse::<u8>()) else {
+                                bail!(
+                                    "expected target profile of the form \
+                                     `{{model}}_{{major}}_{{minor}}`, found invalid target \
+                                     profile {:?} in file {}",
+                                    config_item.target_profile,
+                                    file.display()
+                                )
+                            };
+                        // NOTE: This isn't implemented by `fxc.exe`; see
+                        // <https://learn.microsoft.com/en-us/windows/win32/direct3dtools/dx-graphics-tools-fxc-syntax#profiles>.
+                        if shader_model_major_version < 6 {
+                            // Reference:
+                            // <https://learn.microsoft.com/en-us/windows/win32/direct3dtools/dx-graphics-tools-fxc-syntax>.
+                            validate(bin, file, config_item, &["-Zi", "-Od"])
+                        } else {
+                            log::debug!(
+                                "skipping config. item {config_item:?} because the \
+                                 shader model major version is > 6"
+                            );
+                            Ok(())
+                        }
+                    })
+                }
+            }
+        }
+    };
+    match err_status {
+        ErrorStatus::NoFailuresFound => Ok(()),
+        ErrorStatus::OneOrMoreFailuresFound => {
+            bail!("failed to validate one or more files, see above output for more details")
+        }
+    }
+}


### PR DESCRIPTION
Run all snapshot validation tasks in parallel, using the [jobserver](https://crates.io/crates/jobserver) crate to limit concurrency.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
