### PR TITLE
Remove id32 Feature

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -56,8 +56,6 @@ replay = ["serde", "wgt/replay", "arrayvec/serde", "naga/deserialize"]
 ## Enable serializable compute/render passes, and bundle encoders.
 serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
 
-id32 = []
-
 ## Enable `ShaderModuleSource::Wgsl`
 wgsl = ["naga/wgsl-in"]
 

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -8,17 +8,8 @@ use std::{
 };
 use wgt::{Backend, WasmNotSendSync};
 
-#[cfg(feature = "id32")]
-type IdType = u32;
-#[cfg(not(feature = "id32"))]
 type IdType = u64;
-#[cfg(feature = "id32")]
-type NonZeroId = std::num::NonZeroU32;
-#[cfg(not(feature = "id32"))]
 type NonZeroId = std::num::NonZeroU64;
-#[cfg(feature = "id32")]
-type ZippedIndex = u16;
-#[cfg(not(feature = "id32"))]
 type ZippedIndex = Index;
 
 const INDEX_BITS: usize = std::mem::size_of::<ZippedIndex>() * 8;

--- a/wgpu/src/backend/direct.rs
+++ b/wgpu/src/backend/direct.rs
@@ -3064,9 +3064,7 @@ where
     T: 'static + WasmNotSendSync,
 {
     fn from(id: ObjectId) -> Self {
-        // If the id32 feature is enabled in wgpu-core, this will make sure that the id fits in a NonZeroU32.
-        #[allow(clippy::useless_conversion)]
-        let id = id.id().try_into().expect("Id exceeded 32-bits");
+        let id = id.id();
         // SAFETY: The id was created via the impl below
         unsafe { Self::from_raw(id) }
     }
@@ -3077,9 +3075,7 @@ where
     T: 'static + WasmNotSendSync,
 {
     fn from(id: wgc::id::Id<T>) -> Self {
-        // If the id32 feature is enabled in wgpu-core, the conversion is not useless
-        #[allow(clippy::useless_conversion)]
-        let id = id.into_raw().into();
+        let id = id.into_raw();
         Self::from_global_id(id)
     }
 }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -5170,6 +5170,14 @@ impl Surface<'_> {
 #[repr(transparent)]
 pub struct Id<T>(NonZeroU64, PhantomData<*mut T>);
 
+impl<T> Id<T> {
+    /// For testing use only. We provide no guarentees about the actual value of the ids.
+    #[doc(hidden)]
+    pub fn inner(&self) -> u64 {
+        self.0.get()
+    }
+}
+
 // SAFETY: `Id` is a bare `NonZeroU64`, the type parameter is a marker purely to avoid confusing Ids
 // returned for different types , so `Id` can safely implement Send and Sync.
 unsafe impl<T> Send for Id<T> {}


### PR DESCRIPTION
**Description**

Removes the id32 feature as it is completely unused and caused surprising behavior in tests.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
