### PR TITLE
hello_compute: check for missing command-line args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,7 @@ Passing an owned value `window` to `Surface` will return a `Surface<'static>`. S
 ### Examples
 
 - remove winit dependency from hello-compute example by @psvri in [#4699](https://github.com/gfx-rs/wgpu/pull/4699)
+- hello-compute example fix failure with "wgpu error: Validation Error" if arguments are missing by @vilcans in [#4939](https://github.com/gfx-rs/wgpu/pull/4939)
 
 ## v0.18.1 (2023-11-15)
 

--- a/examples/src/hello_compute/mod.rs
+++ b/examples/src/hello_compute/mod.rs
@@ -6,7 +6,7 @@ const OVERFLOW: u32 = 0xffffffff;
 
 #[cfg_attr(test, allow(dead_code))]
 async fn run() {
-    let numbers = if std::env::args().len() <= 1 {
+    let numbers = if std::env::args().len() <= 2 {
         let default = vec![1, 2, 3, 4];
         println!("No numbers were provided, defaulting to {default:?}");
         default


### PR DESCRIPTION
**Connections**
N/A

**Description**

Fixes off-by-one error when checking for missing arguments. Before this, running the example gave this discouraging  error message:

```
$ cargo run --bin wgpu-examples hello_compute
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/wgpu-examples hello_compute`
[2023-12-27T22:14:26Z ERROR wgpu::backend::direct] Handling wgpu errors as fatal by default
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_bind_group
    Buffer binding size 0 is less than minimum 4
      note: buffer = `Storage Buffer`

', wgpu/src/backend/direct.rs:3139:5
```

As this was the first example I tried to run, it almost scared me away, thinking it was a driver issue.

Instead, without arguments the example should use defaults.

**Testing**

Tested from the command-line, now it uses defaults as it should:

```
$ cargo run --bin wgpu-examples hello_compute
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/wgpu-examples hello_compute`
No numbers were provided, defaulting to [1, 2, 3, 4]
Steps: [0, 1, 7, 2]
```

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
  - (they fail but that can't be related)
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
