### PR TITLE
Fix xtask wasm-bindgen install

### DIFF
--- a/xtask/src/run_wasm.rs
+++ b/xtask/src/run_wasm.rs
@@ -2,16 +2,28 @@ use anyhow::Context;
 
 use pico_args::Arguments;
 
-use crate::util::check_all_programs;
+use crate::util::{check_all_programs, Program};
 
 pub(crate) fn run_wasm(mut args: Arguments) -> Result<(), anyhow::Error> {
     let no_serve = args.contains("--no-serve");
     let release = args.contains("--release");
 
     let programs_needed: &[_] = if no_serve {
-        &["wasm-bindgen"]
+        &[Program {
+            crate_name: "wasm-bindgen-cli",
+            binary_name: "wasm-bindgen",
+        }]
     } else {
-        &["wasm-bindgen", "simple-http-server"]
+        &[
+            Program {
+                crate_name: "wasm-bindgen-cli",
+                binary_name: "wasm-bindgen",
+            },
+            Program {
+                crate_name: "simple-http-server",
+                binary_name: "simple-http-server",
+            },
+        ]
     };
 
     check_all_programs(programs_needed)?;

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -1,21 +1,30 @@
 use std::{io, process::Command};
 
-pub(crate) fn check_all_programs(programs: &[&str]) -> anyhow::Result<()> {
+pub(crate) struct Program {
+    pub binary_name: &'static str,
+    pub crate_name: &'static str,
+}
+
+pub(crate) fn check_all_programs(programs: &[Program]) -> anyhow::Result<()> {
     let mut failed = Vec::new();
-    for &program in programs {
-        let mut cmd = Command::new(program);
+    for Program {
+        binary_name,
+        crate_name,
+    } in programs
+    {
+        let mut cmd = Command::new(binary_name);
         cmd.arg("--help");
         let output = cmd.output();
         match output {
             Ok(_output) => {
-                log::info!("Checking for {program} in PATH: ✅");
+                log::info!("Checking for {binary_name} in PATH: ✅");
             }
             Err(e) if matches!(e.kind(), io::ErrorKind::NotFound) => {
-                log::error!("Checking for {program} in PATH: ❌");
-                failed.push(program);
+                log::error!("Checking for {binary_name} in PATH: ❌");
+                failed.push(*crate_name);
             }
             Err(e) => {
-                log::error!("Checking for {program} in PATH: ❌");
+                log::error!("Checking for {binary_name} in PATH: ❌");
                 panic!("Unknown IO error: {:?}", e);
             }
         }


### PR DESCRIPTION
The xtask assumes that a crates binary name is the same as the crate name, which is not neccessarily true.
This resulted in it reccomending I run the command `cargo install wasm-bindgen` which fails as wasm-bindgen is not a binary but a library.
What it should have reccomended was `cargo install wasm-bindgen-cli`.
This PR fixes that.