### PR TITLE
Introduce semaphores and wait on submit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 exclude = []
 default-members = [
     "d3d12",
-    "examples/",
+    # "examples/",
     "naga-cli",
     "naga",
     "naga/fuzz",

--- a/examples/src/hello_triangle/mod.rs
+++ b/examples/src/hello_triangle/mod.rs
@@ -72,6 +72,10 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         multiview: None,
     });
 
+    let image_available = device.create_semaphore(&wgpu::SemaphoreDescriptor {
+        label: Some("Image Available"),
+    });
+
     let mut config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         format: swapchain_format,
@@ -108,7 +112,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                     }
                     WindowEvent::RedrawRequested => {
                         let frame = surface
-                            .get_current_texture()
+                            .get_current_texture(&image_available)
                             .expect("Failed to acquire next swap chain texture");
                         let view = frame
                             .texture

--- a/examples/src/hello_windows/mod.rs
+++ b/examples/src/hello_windows/mod.rs
@@ -16,6 +16,7 @@ struct ViewportDesc {
 struct Viewport {
     desc: ViewportDesc,
     config: wgpu::SurfaceConfiguration,
+    image_available: wgpu::Semaphore,
 }
 
 impl ViewportDesc {
@@ -44,7 +45,15 @@ impl ViewportDesc {
 
         self.surface.configure(device, &config);
 
-        Viewport { desc: self, config }
+        let image_available = device.create_semaphore(&wgpu::SemaphoreDescriptor {
+            label: Some("Image Available"),
+        });
+
+        Viewport {
+            desc: self,
+            config,
+            image_available,
+        }
     }
 }
 
@@ -57,7 +66,7 @@ impl Viewport {
     fn get_current_texture(&mut self) -> wgpu::SurfaceTexture {
         self.desc
             .surface
-            .get_current_texture()
+            .get_current_texture(&self.image_available)
             .expect("Failed to acquire next swap chain texture")
     }
 }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -450,6 +450,8 @@ pub enum DeviceError {
     ResourceCreationFailed,
     #[error("QueueId is invalid")]
     InvalidQueueId,
+    #[error("SempahoreId is invalid")]
+    InvalidSemaphoreId,
     #[error("Attempt to use a resource with a different device from the one that created it")]
     WrongDevice,
 }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -22,7 +22,7 @@ use crate::{
     registry::Registry,
     resource::ResourceInfo,
     resource::{
-        self, Buffer, QuerySet, Resource, ResourceType, Sampler, Texture, TextureView,
+        self, Buffer, QuerySet, Resource, ResourceType, Sampler, Semaphore, Texture, TextureView,
         TextureViewNotRenderableReason,
     },
     resource_log,
@@ -472,6 +472,19 @@ impl<A: HalApi> Device<A> {
             }
         }
         self.lock_life().suspected_resources.extend(temp_suspected);
+    }
+
+    pub(crate) fn create_semaphore(
+        self: &Arc<Self>,
+        desc: &resource::SemaphoreDescriptor<'_>,
+    ) -> Result<Semaphore<A>, resource::CreateSemaphoreError> {
+        let semaphore = unsafe { self.raw().create_semaphore() }.map_err(DeviceError::from)?;
+
+        Ok(Semaphore {
+            raw: semaphore,
+            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            device: self.clone(),
+        })
     }
 
     pub(crate) fn create_buffer(

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -61,6 +61,7 @@ pub enum Action<'a> {
     GetSurfaceTexture {
         id: id::TextureId,
         parent_id: id::SurfaceId,
+        image_available: id::SemaphoreId,
     },
     Present(id::SurfaceId),
     DiscardSurfaceTexture(id::SurfaceId),
@@ -122,7 +123,11 @@ pub enum Action<'a> {
         layout: wgt::ImageDataLayout,
         size: wgt::Extent3d,
     },
-    Submit(crate::SubmissionIndex, Vec<Command>),
+    Submit {
+        index: crate::SubmissionIndex,
+        commands: Vec<Command>,
+        wait_semaphore: Option<id::SemaphoreId>,
+    },
 }
 
 #[derive(Debug)]

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -120,7 +120,7 @@ use crate::{
     instance::{Adapter, HalSurface, Surface},
     pipeline::{ComputePipeline, RenderPipeline, ShaderModule},
     registry::{Registry, RegistryReport},
-    resource::{Buffer, QuerySet, Sampler, StagingBuffer, Texture, TextureView},
+    resource::{Buffer, QuerySet, Sampler, Semaphore, StagingBuffer, Texture, TextureView},
     storage::{Element, Storage},
 };
 use std::fmt::Debug;
@@ -189,6 +189,7 @@ pub struct Hub<A: HalApi> {
     pub render_pipelines: Registry<id::RenderPipelineId, RenderPipeline<A>>,
     pub compute_pipelines: Registry<id::ComputePipelineId, ComputePipeline<A>>,
     pub query_sets: Registry<id::QuerySetId, QuerySet<A>>,
+    pub semaphores: Registry<id::SemaphoreId, Semaphore<A>>,
     pub buffers: Registry<id::BufferId, Buffer<A>>,
     pub staging_buffers: Registry<id::StagingBufferId, StagingBuffer<A>>,
     pub textures: Registry<id::TextureId, Texture<A>>,
@@ -211,6 +212,7 @@ impl<A: HalApi> Hub<A> {
             render_pipelines: Registry::new(A::VARIANT, factory),
             compute_pipelines: Registry::new(A::VARIANT, factory),
             query_sets: Registry::new(A::VARIANT, factory),
+            semaphores: Registry::new(A::VARIANT, factory),
             buffers: Registry::new(A::VARIANT, factory),
             staging_buffers: Registry::new(A::VARIANT, factory),
             textures: Registry::new(A::VARIANT, factory),

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -240,6 +240,7 @@ pub type SurfaceId = Id<crate::instance::Surface>;
 pub type DeviceId = Id<crate::device::Device<Dummy>>;
 pub type QueueId = DeviceId;
 // Resource
+pub type SemaphoreId = Id<crate::resource::Semaphore<Dummy>>;
 pub type BufferId = Id<crate::resource::Buffer<Dummy>>;
 pub type StagingBufferId = Id<crate::resource::StagingBuffer<Dummy>>;
 pub type TextureViewId = Id<crate::resource::TextureView<Dummy>>;

--- a/wgpu-core/src/identity.rs
+++ b/wgpu-core/src/identity.rs
@@ -163,6 +163,7 @@ pub trait GlobalIdentityHandlerFactory:
     + IdentityHandlerFactory<id::RenderPipelineId>
     + IdentityHandlerFactory<id::ComputePipelineId>
     + IdentityHandlerFactory<id::QuerySetId>
+    + IdentityHandlerFactory<id::SemaphoreId>
     + IdentityHandlerFactory<id::BufferId>
     + IdentityHandlerFactory<id::StagingBufferId>
     + IdentityHandlerFactory<id::TextureId>

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -8,8 +8,8 @@ use crate::{
     global::Global,
     hal_api::HalApi,
     id::{
-        AdapterId, BufferId, DeviceId, QuerySetId, SamplerId, StagingBufferId, SurfaceId,
-        TextureId, TextureViewId, TypedId,
+        AdapterId, BufferId, DeviceId, QuerySetId, SamplerId, SemaphoreId, StagingBufferId,
+        SurfaceId, TextureId, TextureViewId, TypedId,
     },
     identity::{GlobalIdentityHandlerFactory, IdentityManager},
     init_tracker::{BufferInitTracker, TextureInitTracker},
@@ -396,7 +396,28 @@ pub(crate) struct BufferPendingMapping<A: HalApi> {
     pub _parent_buffer: Arc<Buffer<A>>,
 }
 
+pub type SemaphoreDescriptor<'a> = wgt::SemaphoreDescriptor<Label<'a>>;
+
 pub type BufferDescriptor<'a> = wgt::BufferDescriptor<Label<'a>>;
+
+#[derive(Debug)]
+pub struct Semaphore<A: HalApi> {
+    pub(crate) raw: A::Semaphore,
+    pub(crate) info: ResourceInfo<SemaphoreId>,
+    pub(crate) device: Arc<Device<A>>,
+}
+
+impl<A: HalApi> Resource<SemaphoreId> for Semaphore<A> {
+    const TYPE: ResourceType = "Semaphore";
+
+    fn as_info(&self) -> &ResourceInfo<SemaphoreId> {
+        &self.info
+    }
+
+    fn as_info_mut(&mut self) -> &mut ResourceInfo<SemaphoreId> {
+        &mut self.info
+    }
+}
 
 #[derive(Debug)]
 pub struct Buffer<A: HalApi> {
@@ -583,6 +604,12 @@ impl<A: HalApi> Buffer<A> {
 
         Ok(())
     }
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum CreateSemaphoreError {
+    #[error(transparent)]
+    Device(#[from] DeviceError),
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -496,6 +496,7 @@ where
 
 /// A full double sided tracker used by CommandBuffers and the Device.
 pub(crate) struct Tracker<A: HalApi> {
+    pub semaphores: StatelessTracker<A, id::SemaphoreId, resource::Semaphore<A>>,
     pub buffers: BufferTracker<A>,
     pub textures: TextureTracker<A>,
     pub views: StatelessTracker<A, id::TextureViewId, resource::TextureView<A>>,
@@ -510,6 +511,7 @@ pub(crate) struct Tracker<A: HalApi> {
 impl<A: HalApi> Tracker<A> {
     pub fn new() -> Self {
         Self {
+            semaphores: StatelessTracker::new(),
             buffers: BufferTracker::new(),
             textures: TextureTracker::new(),
             views: StatelessTracker::new(),

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -21,6 +21,7 @@ impl crate::Api for Api {
     type Queue = Context;
     type CommandEncoder = Encoder;
     type CommandBuffer = Resource;
+    type Semaphore = Resource;
 
     type Buffer = Resource;
     type Texture = Resource;
@@ -70,6 +71,7 @@ impl crate::Surface<Api> for Context {
     unsafe fn acquire_texture(
         &self,
         timeout: Option<std::time::Duration>,
+        image_available: &Resource,
     ) -> Result<Option<crate::AcquiredSurfaceTexture<Api>>, crate::SurfaceError> {
         Ok(None)
     }
@@ -105,6 +107,7 @@ impl crate::Queue<Api> for Context {
         &self,
         command_buffers: &[&Resource],
         signal_fence: Option<(&mut Resource, crate::FenceValue)>,
+        wait_semaphore: Option<&Resource>,
     ) -> DeviceResult<()> {
         Ok(())
     }
@@ -139,6 +142,10 @@ impl crate::Device<Api> for Context {
     }
     unsafe fn flush_mapped_ranges<I>(&self, buffer: &Resource, ranges: I) {}
     unsafe fn invalidate_mapped_ranges<I>(&self, buffer: &Resource, ranges: I) {}
+
+    unsafe fn create_semaphore(&self) -> DeviceResult<Resource> {
+        Ok(Resource)
+    }
 
     unsafe fn create_texture(&self, desc: &crate::TextureDescriptor) -> DeviceResult<Resource> {
         Ok(Resource)

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -692,6 +692,10 @@ impl crate::Device<super::Api> for super::Device {
         //TODO: do we need to do anything?
     }
 
+    unsafe fn create_semaphore(&self) -> Result<super::Semaphore, crate::DeviceError> {
+        Ok(super::Semaphore)
+    }
+
     unsafe fn create_texture(
         &self,
         desc: &crate::TextureDescriptor,

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1355,6 +1355,7 @@ impl crate::Surface<super::Api> for Surface {
     unsafe fn acquire_texture(
         &self,
         _timeout_ms: Option<Duration>, //TODO
+        _image_available: &super::Semaphore,
     ) -> Result<Option<crate::AcquiredSurfaceTexture<super::Api>>, crate::SurfaceError> {
         let swapchain = self.swapchain.read();
         let sc = swapchain.as_ref().unwrap();

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -145,6 +145,7 @@ impl crate::Api for Api {
     type Queue = Queue;
     type CommandEncoder = CommandEncoder;
     type CommandBuffer = CommandBuffer;
+    type Semaphore = Semaphore;
 
     type Buffer = Buffer;
     type Texture = Texture;
@@ -963,6 +964,9 @@ unsafe impl Sync for CommandBuffer {}
     not(target_feature = "atomics")
 ))]
 unsafe impl Send for CommandBuffer {}
+
+#[derive(Debug)]
+pub struct Semaphore;
 
 //TODO: we would have something like `Arc<typed_arena::Arena>`
 // here and in the command buffers. So that everything grows

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1749,6 +1749,7 @@ impl crate::Queue<super::Api> for super::Queue {
         &self,
         command_buffers: &[&super::CommandBuffer],
         signal_fence: Option<(&mut super::Fence, crate::FenceValue)>,
+        _wait_semaphore: Option<&super::Semaphore>,
     ) -> Result<(), crate::DeviceError> {
         let shared = Arc::clone(&self.shared);
         let gl = &shared.context.lock();

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -627,16 +627,11 @@ impl super::Device {
         let images =
             unsafe { functor.get_swapchain_images(raw) }.map_err(crate::DeviceError::from)?;
 
-        let vk_info = vk::FenceCreateInfo::builder().build();
-        let fence = unsafe { self.shared.raw.create_fence(&vk_info, None) }
-            .map_err(crate::DeviceError::from)?;
-
         Ok(super::Swapchain {
             raw,
             raw_flags,
             functor,
             device: Arc::clone(&self.shared),
-            fence,
             images,
             config: config.clone(),
             view_formats: wgt_view_formats,
@@ -971,6 +966,22 @@ impl crate::Device<super::Api> for super::Device {
             }
             .unwrap();
         }
+    }
+
+    unsafe fn create_semaphore(&self) -> Result<super::Semaphore, crate::DeviceError> {
+        let vk_info = vk::SemaphoreCreateInfo::builder().build();
+
+        let raw = unsafe {
+            self.shared
+                .raw
+                .create_semaphore(&vk_info, None)
+                .map_err(crate::DeviceError::from)?
+        };
+
+        Ok(super::Semaphore {
+            device: self.shared.clone(),
+            raw,
+        })
     }
 
     unsafe fn create_texture(

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1653,6 +1653,25 @@ pub struct AdapterInfo {
     pub backend: Backend,
 }
 
+/// Describes a semaphore.
+#[repr(C)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "trace", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct SemaphoreDescriptor<L> {
+    /// Debug label of the semaphore.
+    pub label: L,
+}
+
+impl<L> SemaphoreDescriptor<L> {
+    /// Takes a closure and maps the label of the device descriptor into another.
+    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> SemaphoreDescriptor<K> {
+        SemaphoreDescriptor {
+            label: fun(&self.label),
+        }
+    }
+}
+
 /// Describes a [`Device`](../wgpu/struct.Device.html).
 ///
 /// Corresponds to [WebGPU `GPUDeviceDescriptor`](

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -111,7 +111,7 @@ impl DownloadBuffer {
             device.create_command_encoder(&super::CommandEncoderDescriptor { label: None });
         encoder.copy_buffer_to_buffer(buffer.buffer, buffer.offset, &download, 0, size);
         let command_buffer: super::CommandBuffer = encoder.finish();
-        queue.submit(Some(command_buffer));
+        queue.submit(Some(command_buffer), None);
 
         download
             .clone()


### PR DESCRIPTION
**Connections**
#4689, #4775, #4919

bevyengine/bevy#10792

**Description**
This is a WIP PR to gather feedback. I've yet to port all the examples or other backends than Vulkan to use semaphores and fill out the `SemaphoreDescriptor` fully.

This introduces user-facing semaphores and allows one to be used to synchronize when a surface texture becomes available during submission.

It was suggested in #4775 that the fence blocking might be a driver bug. I don't necessarily think that's the case. The fence used is only required to trigger at some point in the future when the surface texture becomes available. Vulkan on Android for example (I can't recall where I read this) seems to hold onto the surface texture until a new frame is available from a call to submit. In that scenario it's understandable why the fence never signals in user facing code prior to that.

This might imply that wait semaphores are the only "correct" way to perform this synchronization when using [`vkAcquireNextImageKHR`](https://stackoverflow.com/questions/52665787/vkacquirenextimagekhr-semantics-what-does-timing-out-mean). So it might be a good idea to make this a user facing feature which is what this PR does.

**Alternative designs**

It might be possible to keep track of the semaphores internally. I'm just not sure how that can be done right now while not limiting functionality.

**TODO**

* Implement changes to other backends.
* Fix examples to use semaphores.
* Should we support more than one semaphore during submit? One might use more than one acquired image in the pipeline.