### PR TITLE
Put raw texture access behind snatch guards

### DIFF
--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -254,7 +254,7 @@ pub(crate) fn clear_texture<A: HalApi>(
 ) -> Result<(), ClearError> {
     let snatch_guard = dst_texture.device.snatchable_lock.read();
     let dst_raw = dst_texture
-        .as_raw(&snatch_guard)
+        .raw(&snatch_guard)
         .ok_or_else(|| ClearError::InvalidTexture(dst_texture.as_info().id()))?;
 
     // Issue the right barrier.

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -230,7 +230,7 @@ impl<A: HalApi> CommandBuffer<A> {
         let texture_barriers = transitions
             .into_iter()
             .enumerate()
-            .map(|(i, p)| p.into_hal(textures[i].unwrap().as_raw().unwrap()));
+            .map(|(i, p)| p.into_hal(textures[i].unwrap().raw().unwrap()));
 
         unsafe {
             raw.transition_buffers(buffer_barriers);

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -226,11 +226,11 @@ impl<A: HalApi> CommandBuffer<A> {
         profiling::scope!("drain_barriers");
 
         let buffer_barriers = base.buffers.drain_transitions(snatch_guard);
-        let (transitions, textures) = base.textures.drain_transitions();
+        let (transitions, textures) = base.textures.drain_transitions(snatch_guard);
         let texture_barriers = transitions
             .into_iter()
             .enumerate()
-            .map(|(i, p)| p.into_hal(textures[i].as_ref().unwrap()));
+            .map(|(i, p)| p.into_hal(textures[i].unwrap().as_raw().unwrap()));
 
         unsafe {
             raw.transition_buffers(buffer_barriers);

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -812,7 +812,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .set_single(&dst_texture, dst_range, hal::TextureUses::COPY_DST)
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
         let dst_raw = dst_texture
-            .as_raw(&snatch_guard)
+            .raw(&snatch_guard)
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
         if !dst_texture.desc.usage.contains(TextureUsages::COPY_DST) {
             return Err(
@@ -949,7 +949,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .set_single(&src_texture, src_range, hal::TextureUses::COPY_SRC)
             .ok_or(TransferError::InvalidTexture(source.texture))?;
         let src_raw = src_texture
-            .as_raw(&snatch_guard)
+            .raw(&snatch_guard)
             .ok_or(TransferError::InvalidTexture(source.texture))?;
         if !src_texture.desc.usage.contains(TextureUsages::COPY_SRC) {
             return Err(TransferError::MissingCopySrcUsageFlag.into());
@@ -1163,7 +1163,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .set_single(&src_texture, src_range, hal::TextureUses::COPY_SRC)
             .ok_or(TransferError::InvalidTexture(source.texture))?;
         let src_raw = src_texture
-            .as_raw(&snatch_guard)
+            .raw(&snatch_guard)
             .ok_or(TransferError::InvalidTexture(source.texture))?;
         if !src_texture.desc.usage.contains(TextureUsages::COPY_SRC) {
             return Err(TransferError::MissingCopySrcUsageFlag.into());
@@ -1181,7 +1181,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .set_single(&dst_texture, dst_range, hal::TextureUses::COPY_DST)
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
         let dst_raw = dst_texture
-            .as_raw(&snatch_guard)
+            .raw(&snatch_guard)
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
         if !dst_texture.desc.usage.contains(TextureUsages::COPY_DST) {
             return Err(

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -813,7 +813,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .use_at(device.active_submission_index.load(Ordering::Relaxed) + 1);
 
         let dst_raw = dst
-            .as_raw(&snatch_guard)
+            .raw(&snatch_guard)
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
 
         let bytes_per_row = data_layout
@@ -1075,7 +1075,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let snatch_guard = device.snatchable_lock.read();
         let dst_raw = dst
-            .as_raw(&snatch_guard)
+            .raw(&snatch_guard)
             .ok_or(TransferError::InvalidTexture(destination.texture))?;
 
         let regions = hal::TextureCopy {
@@ -1397,7 +1397,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             let texture_barriers = transitions
                                 .into_iter()
                                 .enumerate()
-                                .map(|(i, p)| p.into_hal(textures[i].unwrap().as_raw().unwrap()));
+                                .map(|(i, p)| p.into_hal(textures[i].unwrap().raw().unwrap()));
                             let present = unsafe {
                                 baked.encoder.transition_textures(texture_barriers);
                                 baked.encoder.end_encoding().unwrap()
@@ -1450,7 +1450,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     let texture_barriers = transitions
                         .into_iter()
                         .enumerate()
-                        .map(|(i, p)| p.into_hal(textures[i].unwrap().as_raw().unwrap()));
+                        .map(|(i, p)| p.into_hal(textures[i].unwrap().raw().unwrap()));
                     unsafe {
                         pending_writes
                             .command_encoder

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -908,7 +908,7 @@ impl<A: HalApi> Device<A> {
         let snatch_guard = texture.device.snatchable_lock.read();
 
         let texture_raw = texture
-            .as_raw(&snatch_guard)
+            .raw(&snatch_guard)
             .ok_or(resource::CreateTextureViewError::InvalidTexture)?;
 
         // resolve TextureViewDescriptor defaults

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -27,6 +27,7 @@ use crate::{
     identity::{GlobalIdentityHandlerFactory, Input},
     init_tracker::TextureInitTracker,
     resource::{self, ResourceInfo},
+    snatch::Snatchable,
     track,
 };
 
@@ -215,11 +216,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 let mut presentation = surface.presentation.lock();
                 let present = presentation.as_mut().unwrap();
                 let texture = resource::Texture {
-                    inner: RwLock::new(Some(resource::TextureInner::Surface {
+                    inner: Snatchable::new(resource::TextureInner::Surface {
                         raw: Some(ast.texture),
                         parent_id: surface_id,
                         has_work: AtomicBool::new(false),
-                    })),
+                    }),
                     device: device.clone(),
                     desc: texture_desc,
                     hal_usage,
@@ -325,8 +326,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let texture = hub.textures.unregister(texture_id);
             if let Some(texture) = texture {
+                let mut exclusive_snatch_guard = device.snatchable_lock.write();
                 let suf = A::get_surface(&surface);
-                let mut inner = texture.inner_mut();
+                let mut inner = texture.inner_mut(&mut exclusive_snatch_guard);
                 let inner = inner.as_mut().unwrap();
 
                 match *inner {
@@ -420,13 +422,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             let texture = hub.textures.unregister(texture_id);
             if let Some(texture) = texture {
                 let suf = A::get_surface(&surface);
-                match *texture.inner_mut().as_mut().take().as_mut().unwrap() {
-                    &mut resource::TextureInner::Surface {
-                        ref mut raw,
-                        ref parent_id,
+                let exclusive_snatch_guard = device.snatchable_lock.write();
+                match texture.inner.snatch(exclusive_snatch_guard).unwrap() {
+                    resource::TextureInner::Surface {
+                        mut raw,
+                        parent_id,
                         has_work: _,
                     } => {
-                        if surface_id == *parent_id {
+                        if surface_id == parent_id {
                             unsafe { suf.unwrap().raw.discard_texture(raw.take().unwrap()) };
                         } else {
                             log::warn!("Surface texture is outdated");

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -14,14 +14,14 @@ use crate::{
     identity::{GlobalIdentityHandlerFactory, IdentityManager},
     init_tracker::{BufferInitTracker, TextureInitTracker},
     resource, resource_log,
-    snatch::{SnatchGuard, Snatchable},
+    snatch::{ExclusiveSnatchGuard, SnatchGuard, Snatchable},
     track::TextureSelector,
     validation::MissingBufferUsageError,
     Label, SubmissionIndex,
 };
 
 use hal::CommandEncoder;
-use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use parking_lot::{Mutex, RwLock};
 use smallvec::SmallVec;
 use thiserror::Error;
 use wgt::WasmNotSendSync;
@@ -709,7 +709,7 @@ pub type TextureDescriptor<'a> = wgt::TextureDescriptor<Label<'a>, Vec<wgt::Text
 #[derive(Debug)]
 pub(crate) enum TextureInner<A: HalApi> {
     Native {
-        raw: Option<A::Texture>,
+        raw: A::Texture,
     },
     Surface {
         raw: Option<A::SurfaceTexture>,
@@ -720,11 +720,9 @@ pub(crate) enum TextureInner<A: HalApi> {
 
 impl<A: HalApi> TextureInner<A> {
     pub fn as_raw(&self) -> Option<&A::Texture> {
-        match *self {
-            Self::Native { raw: Some(ref tex) } => Some(tex),
-            Self::Surface {
-                raw: Some(ref tex), ..
-            } => Some(tex.borrow()),
+        match self {
+            Self::Native { raw } => Some(raw),
+            Self::Surface { raw: Some(tex), .. } => Some(tex.borrow()),
             _ => None,
         }
     }
@@ -748,7 +746,7 @@ pub enum TextureClearMode<A: HalApi> {
 
 #[derive(Debug)]
 pub struct Texture<A: HalApi> {
-    pub(crate) inner: RwLock<Option<TextureInner<A>>>,
+    pub(crate) inner: Snatchable<TextureInner<A>>,
     pub(crate) device: Arc<Device<A>>,
     pub(crate) desc: wgt::TextureDescriptor<(), Vec<wgt::TextureFormat>>,
     pub(crate) hal_usage: hal::TextureUses,
@@ -789,11 +787,8 @@ impl<A: HalApi> Drop for Texture<A> {
             }
             _ => {}
         };
-        if self.inner.read().is_none() {
-            return;
-        }
-        let inner = self.inner.write().take().unwrap();
-        if let TextureInner::Native { raw: Some(raw) } = inner {
+
+        if let Some(TextureInner::Native { raw }) = self.inner.take() {
             unsafe {
                 self.device.raw().destroy_texture(raw);
             }
@@ -802,11 +797,15 @@ impl<A: HalApi> Drop for Texture<A> {
 }
 
 impl<A: HalApi> Texture<A> {
-    pub(crate) fn inner<'a>(&'a self) -> RwLockReadGuard<'a, Option<TextureInner<A>>> {
-        self.inner.read()
+    pub(crate) fn as_raw<'a>(&'a self, snatch_guard: &'a SnatchGuard) -> Option<&'a A::Texture> {
+        self.inner.get(snatch_guard)?.as_raw()
     }
-    pub(crate) fn inner_mut<'a>(&'a self) -> RwLockWriteGuard<'a, Option<TextureInner<A>>> {
-        self.inner.write()
+
+    pub(crate) fn inner_mut<'a>(
+        &'a self,
+        guard: &mut ExclusiveSnatchGuard,
+    ) -> Option<&'a mut TextureInner<A>> {
+        self.inner.get_mut(guard)
     }
     pub(crate) fn get_clear_view<'a>(
         clear_mode: &'a TextureClearMode<A>,
@@ -850,9 +849,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         profiling::scope!("Texture::as_hal");
 
         let hub = A::hub(self);
-        let texture = { hub.textures.try_get(id).ok().flatten() };
-        let inner = texture.as_ref().unwrap().inner();
-        let hal_texture = inner.as_ref().unwrap().as_raw();
+        let texture_opt = { hub.textures.try_get(id).ok().flatten() };
+        let texture = texture_opt.as_ref().unwrap();
+        let snatch_guard = texture.device.snatchable_lock.read();
+        let hal_texture = texture.as_raw(&snatch_guard);
 
         hal_texture_callback(hal_texture);
     }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -719,7 +719,7 @@ pub(crate) enum TextureInner<A: HalApi> {
 }
 
 impl<A: HalApi> TextureInner<A> {
-    pub fn as_raw(&self) -> Option<&A::Texture> {
+    pub fn raw(&self) -> Option<&A::Texture> {
         match self {
             Self::Native { raw } => Some(raw),
             Self::Surface { raw: Some(tex), .. } => Some(tex.borrow()),
@@ -797,8 +797,8 @@ impl<A: HalApi> Drop for Texture<A> {
 }
 
 impl<A: HalApi> Texture<A> {
-    pub(crate) fn as_raw<'a>(&'a self, snatch_guard: &'a SnatchGuard) -> Option<&'a A::Texture> {
-        self.inner.get(snatch_guard)?.as_raw()
+    pub(crate) fn raw<'a>(&'a self, snatch_guard: &'a SnatchGuard) -> Option<&'a A::Texture> {
+        self.inner.get(snatch_guard)?.raw()
     }
 
     pub(crate) fn inner_mut<'a>(
@@ -852,7 +852,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let texture_opt = { hub.textures.try_get(id).ok().flatten() };
         let texture = texture_opt.as_ref().unwrap();
         let snatch_guard = texture.device.snatchable_lock.read();
-        let hal_texture = texture.as_raw(&snatch_guard);
+        let hal_texture = texture.raw(&snatch_guard);
 
         hal_texture_callback(hal_texture);
     }

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -30,6 +30,11 @@ impl<T> Snatchable<T> {
         unsafe { (*self.value.get()).as_ref() }
     }
 
+    /// Get write access to the value. Requires a the snatchable lock's write guard.
+    pub fn get_mut(&self, _guard: &mut ExclusiveSnatchGuard) -> Option<&mut T> {
+        unsafe { (*self.value.get()).as_mut() }
+    }
+
     /// Take the value. Requires a the snatchable lock's write guard.
     pub fn snatch(&self, _guard: ExclusiveSnatchGuard) -> Option<T> {
         unsafe { (*self.value.get()).take() }

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -151,12 +151,7 @@ impl PendingTransition<hal::BufferUses> {
 
 impl PendingTransition<hal::TextureUses> {
     /// Produce the hal barrier corresponding to the transition.
-    pub fn into_hal<'a, A: HalApi>(
-        self,
-        tex: &'a resource::TextureInner<A>,
-    ) -> hal::TextureBarrier<'a, A> {
-        let texture = tex.as_raw().expect("Texture is destroyed");
-
+    pub fn into_hal<'a, A: HalApi>(self, texture: &'a A::Texture) -> hal::TextureBarrier<'a, A> {
         // These showing up in a barrier is always a bug
         strict_assert_ne!(self.usage.start, hal::TextureUses::UNKNOWN);
         strict_assert_ne!(self.usage.end, hal::TextureUses::UNKNOWN);


### PR DESCRIPTION
**Connections**

Another step towards #4787

**Description**

Require that the snatch_guard be held to raw textures.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
