### PR TITLE
Change examples page menu on smaller screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,7 @@ Passing an owned value `window` to `Surface` will return a `Surface<'static>`. S
 ### Examples
 
 - remove winit dependency from hello-compute example by @psvri in [#4699](https://github.com/gfx-rs/wgpu/pull/4699)
+- Made the examples page not crash on Chrome on Android, and responsive to screen sizes by @Dinnerbone in [#4958](https://github.com/gfx-rs/wgpu/pull/4958)
 
 ## v0.18.1 (2023-11-15)
 

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -189,6 +189,7 @@ fn print_examples() {
 
             let item = document.create_element("div").unwrap();
             item.append_child(&link).unwrap();
+            item.set_class_name("example-item");
             ul.append_child(&item).unwrap();
         }
     }

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -1,6 +1,7 @@
 <html>
 
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
     <style type="text/css">
         :focus {
@@ -42,6 +43,10 @@
             display: flex;
             flex-direction: row;
             justify-content: space-evenly;
+
+            @media only screen and (max-width: 1000px) {
+                flex-direction: column;
+            }
         }
 
         .backend-list {
@@ -57,6 +62,21 @@
             flex-wrap: wrap;
             align-content: center;
             height: 100px;
+
+            @media only screen and (max-width: 1000px) {
+                flex-direction: row;
+                height: initial;
+            }
+        }
+
+        .example-item {
+            @media only screen and (max-width: 1000px) {
+                width: 33vw;
+            }
+
+            @media only screen and (max-width: 500px) {
+                width: 50vw;
+            }
         }
 
         .example-link {

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -23,10 +23,21 @@
             flex-direction: column;
         }
 
-        .banner {
+        #banner {
             background: #dee;
             padding: 0.5em 0;
             border-bottom: 1px solid #abb;
+
+            @media only screen and (max-width: 1000px) {
+                max-height: 0;
+                transition: max-height 0.15s ease;
+                overflow: hidden;
+                padding: 0;
+            }
+        }
+
+        #banner.visible {
+            max-height: 100%;
         }
 
         .banner-prefix {
@@ -95,12 +106,36 @@
             /* This forces CSS to ignore the width/height of the canvas, this is needed for WebGL */
             contain: size;
         }
+
+
+        #menu-button {
+            display: none;
+
+            @media only screen and (max-width: 1000px) {
+                display: block;
+                width: 30px;
+                height: 33px;
+                margin: 0 auto;
+            }
+        }
+
+        #menu-button span {
+            display: block;
+            width: 100%;
+            height: 3px;
+            margin: 6px auto;
+            background-color: #333;
+            transition: all 0.3s ease-in-out;
+        }
+
     </style>
 </head>
 
 <body>
     <div class="root">
-        <div class="banner">
+        <div id="menu-button"><span></span><span></span><span></span></div>
+
+        <div id="banner">
             <div class="banner-prefix">
                 <p>
                     <a href="../index.html">
@@ -136,6 +171,18 @@
                 `${window.location.href}?backend=webgl2&example=hello_triangle`
             );
         }
+
+        const menuButton = document.getElementById("menu-button");
+        const banner = document.getElementById("banner");
+        menuButton.onclick = () => {
+            if (menuButton.classList.contains("active")) {
+                menuButton.classList.remove("active");
+                banner.classList.remove("visible");
+            } else {
+                menuButton.classList.add("active");
+                banner.classList.add("visible");
+            }
+        };
     </script>
 </body>
 


### PR DESCRIPTION
**Connections**
Crash discovered whilst trying to debug https://bugs.chromium.org/p/chromium/issues/detail?id=1510149

**Description**
This fixes the crash on chrome android because we didn't set initial scaling/sizing info, so the browse zoomed way out and made the canvas size hit the 4k limit on Chrome.

It also makes it kinda actually usable on mobile. :D

## 720p desktop (unchanged)
![Screen Shot 2024-01-02 at 19 04 36](https://github.com/gfx-rs/wgpu/assets/317625/ec514206-df74-4004-a1f1-b46612ce6546)

## iPad (default)
![Screen Shot 2024-01-02 at 19 06 53](https://github.com/gfx-rs/wgpu/assets/317625/114ac6b9-c816-47a7-818b-7d6a644758a4)

## iPad (expanded)
![Screen Shot 2024-01-02 at 19 07 17](https://github.com/gfx-rs/wgpu/assets/317625/b54cbd3d-483c-4d4c-a8b4-1639ca94306a)

## Galaxy Note 20 (expanded)
![Screen Shot 2024-01-02 at 19 07 30](https://github.com/gfx-rs/wgpu/assets/317625/7fe7f53d-6fc8-4601-aef8-24a5dd2ee558)


**Testing**
Manually.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
