### PR TITLE
Fix incorrect ConfigureSurfaceError::TooLarge message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@ Passing an owned value `window` to `Surface` will return a `Surface<'static>`. S
 
 - `BufferMappedRange` trait is now `WasmNotSendSync`, i.e. it is `Send`/`Sync` if not on wasm or `fragile-send-sync-non-atomic-wasm` is enabled. By @wumpf in [#4818](https://github.com/gfx-rs/wgpu/pull/4818)
 - Align `wgpu_types::CompositeAlphaMode` serde serialization to spec. By @littledivy in [#4940](https://github.com/gfx-rs/wgpu/pull/4940)
+- Fix error message of `ConfigureSurfaceError::TooLarge`. By @Dinnerbone in [#4960](https://github.com/gfx-rs/wgpu/pull/4960)
 
 #### Vulkan
 

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -77,7 +77,7 @@ pub enum ConfigureSurfaceError {
     PreviousOutputExists,
     #[error("Both `Surface` width and height must be non-zero. Wait to recreate the `Surface` until the window has non-zero area.")]
     ZeroArea,
-    #[error("`Surface` width and height must be within the maximum supported texture size. Requested was ({width}, height), maximum extent is {max_texture_dimension_2d}.")]
+    #[error("`Surface` width and height must be within the maximum supported texture size. Requested was ({width}, {height}), maximum extent is {max_texture_dimension_2d}.")]
     TooLarge {
         width: u32,
         height: u32,


### PR DESCRIPTION
**Connections**
Seen in error message before the fix by #4958

**Description**
Very very small change, a typo in the error message made it not actually show the value that was wrong.

Before:
>`Surface` width and height must be within the maximum supported texture size. Requested was (2572, height), maximum extent is 4096.
After:
>`Surface` width and height must be within the maximum supported texture size. Requested was (2572, 5110), maximum extent is 4096.

**Testing**
Manually. You can open chrome on android on our webgl demos before #4958, or just manually make a large surface.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
