### PR TITLE
Backport device limits fix to 0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Bottom level categories:
 #### Vulkan
 
 - Fix x11 hang while resizing on vulkan. @Azorlogh in [#4184](https://github.com/gfx-rs/wgpu/pull/4184).
+- Backport fix to ensure that limit requests and reporting is done correctly. (By @OptimisticPeach in [#4107](https://github.com/gfx-rs/wgpu/pull/4107)), @cshenton in  [#4964](https://github.com/gfx-rs/wgpu/pull/4964)
 
 ## v0.17.1 (2023-09-27)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,8 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.13.0"
-source = "git+https://github.com/gfx-rs/naga?rev=bac2d82a430fbfcf100ee22b7c3bc12f3d593079#bac2d82a430fbfcf100ee22b7c3bc12f3d593079"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ceaaa4eedaece7e4ec08c55c640ba03dbb73fb812a6570a59bcf1930d0f70e"
 dependencies = [
  "bit-set",
  "bitflags 2.3.3",
@@ -1537,6 +1538,25 @@ dependencies = [
  "num-traits 0.2.16",
  "petgraph",
  "pp-rs",
+ "rustc-hash",
+ "spirv",
+ "termcolor",
+ "thiserror",
+ "unicode-xid",
+]
+
+[[package]]
+name = "naga"
+version = "0.13.0"
+source = "git+https://github.com/gfx-rs/naga?rev=bac2d82a430fbfcf100ee22b7c3bc12f3d593079#bac2d82a430fbfcf100ee22b7c3bc12f3d593079"
+dependencies = [
+ "bit-set",
+ "bitflags 2.3.3",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap 1.9.3",
+ "log",
+ "num-traits 0.2.16",
  "rustc-hash",
  "serde",
  "spirv",
@@ -2940,7 +2960,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "log",
- "naga",
+ "naga 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot",
  "profiling",
  "raw-window-handle 0.5.2",
@@ -3021,7 +3041,7 @@ dependencies = [
  "bitflags 2.3.3",
  "codespan-reporting",
  "log",
- "naga",
+ "naga 0.13.0 (git+https://github.com/gfx-rs/naga?rev=bac2d82a430fbfcf100ee22b7c3bc12f3d593079)",
  "parking_lot",
  "profiling",
  "raw-window-handle 0.5.2",
@@ -3095,7 +3115,7 @@ dependencies = [
  "libloading 0.8.0",
  "log",
  "metal",
- "naga",
+ "naga 0.13.0 (git+https://github.com/gfx-rs/naga?rev=bac2d82a430fbfcf100ee22b7c3bc12f3d593079)",
  "objc",
  "parking_lot",
  "profiling",
@@ -3266,7 +3286,7 @@ dependencies = [
  "image",
  "js-sys",
  "log",
- "naga",
+ "naga 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nv-flip",
  "png",
  "pollster",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ path = "./wgpu-hal"
 version = "0.17"
 
 [workspace.dependencies.naga]
-git = "https://github.com/gfx-rs/naga"
-rev = "bac2d82a430fbfcf100ee22b7c3bc12f3d593079"
+# git = "https://github.com/gfx-rs/naga"
+# rev = "bac2d82a430fbfcf100ee22b7c3bc12f3d593079"
 version = "0.13.0"
 
 [workspace.dependencies]

--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -689,6 +689,99 @@ fn map_wgt_features(supported_features: web_sys::GpuSupportedFeatures) -> wgt::F
     features
 }
 
+fn map_wgt_limits(limits: web_sys::GpuSupportedLimits) -> wgt::Limits {
+    wgt::Limits {
+        max_texture_dimension_1d: limits.max_texture_dimension_1d(),
+        max_texture_dimension_2d: limits.max_texture_dimension_2d(),
+        max_texture_dimension_3d: limits.max_texture_dimension_3d(),
+        max_texture_array_layers: limits.max_texture_array_layers(),
+        max_bind_groups: limits.max_bind_groups(),
+        max_bindings_per_bind_group: limits.max_bindings_per_bind_group(),
+        max_dynamic_uniform_buffers_per_pipeline_layout: limits
+            .max_dynamic_uniform_buffers_per_pipeline_layout(),
+        max_dynamic_storage_buffers_per_pipeline_layout: limits
+            .max_dynamic_storage_buffers_per_pipeline_layout(),
+        max_sampled_textures_per_shader_stage: limits.max_sampled_textures_per_shader_stage(),
+        max_samplers_per_shader_stage: limits.max_samplers_per_shader_stage(),
+        max_storage_buffers_per_shader_stage: limits.max_storage_buffers_per_shader_stage(),
+        max_storage_textures_per_shader_stage: limits.max_storage_textures_per_shader_stage(),
+        max_uniform_buffers_per_shader_stage: limits.max_uniform_buffers_per_shader_stage(),
+        max_uniform_buffer_binding_size: limits.max_uniform_buffer_binding_size() as u32,
+        max_storage_buffer_binding_size: limits.max_storage_buffer_binding_size() as u32,
+        max_vertex_buffers: limits.max_vertex_buffers(),
+        max_buffer_size: limits.max_buffer_size() as u64,
+        max_vertex_attributes: limits.max_vertex_attributes(),
+        max_vertex_buffer_array_stride: limits.max_vertex_buffer_array_stride(),
+        min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment(),
+        min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment(),
+        max_inter_stage_shader_components: limits.max_inter_stage_shader_components(),
+        max_compute_workgroup_storage_size: limits.max_compute_workgroup_storage_size(),
+        max_compute_invocations_per_workgroup: limits.max_compute_invocations_per_workgroup(),
+        max_compute_workgroup_size_x: limits.max_compute_workgroup_size_x(),
+        max_compute_workgroup_size_y: limits.max_compute_workgroup_size_y(),
+        max_compute_workgroup_size_z: limits.max_compute_workgroup_size_z(),
+        max_compute_workgroups_per_dimension: limits.max_compute_workgroups_per_dimension(),
+        // The following are not part of WebGPU
+        max_push_constant_size: wgt::Limits::default().max_push_constant_size,
+        // max_non_sampler_bindings: wgt::Limits::default().max_non_sampler_bindings,
+    }
+}
+
+fn map_js_sys_limits(limits: &wgt::Limits) -> js_sys::Object {
+    let object = js_sys::Object::new();
+
+    macro_rules! set_properties {
+        (($from:expr) => ($on:expr) : $(($js_ident:ident, $rs_ident:ident)),* $(,)?) => {
+            $(
+                ::js_sys::Reflect::set(
+                    &$on,
+                    &::wasm_bindgen::JsValue::from(stringify!($js_ident)),
+                    // Numbers may be u64, however using `from` on a u64 yields
+                    // errors on the wasm side, since it uses an unsupported api.
+                    // Wasm sends us things that need to fit into u64s by sending
+                    // us f64s instead. So we just send them f64s back.
+                    &::wasm_bindgen::JsValue::from($from.$rs_ident as f64)
+                )
+                    .expect("Setting Object properties should never fail.");
+            )*
+        }
+    }
+
+    set_properties![
+        (limits) => (object):
+        (maxTextureDimension1D, max_texture_dimension_1d),
+        (maxTextureDimension2D, max_texture_dimension_2d),
+        (maxTextureDimension3D, max_texture_dimension_3d),
+        (maxTextureArrayLayers, max_texture_array_layers),
+        (maxBindGroups, max_bind_groups),
+        (maxBindingsPerBindGroup, max_bindings_per_bind_group),
+        (maxDynamicUniformBuffersPerPipelineLayout, max_dynamic_uniform_buffers_per_pipeline_layout),
+        (maxDynamicStorageBuffersPerPipelineLayout, max_dynamic_storage_buffers_per_pipeline_layout),
+        (maxSampledTexturesPerShaderStage, max_sampled_textures_per_shader_stage),
+        (maxSamplersPerShaderStage, max_samplers_per_shader_stage),
+        (maxStorageBuffersPerShaderStage, max_storage_buffers_per_shader_stage),
+        (maxStorageTexturesPerShaderStage, max_storage_textures_per_shader_stage),
+        (maxUniformBuffersPerShaderStage, max_uniform_buffers_per_shader_stage),
+        (maxUniformBufferBindingSize, max_uniform_buffer_binding_size),
+        (maxStorageBufferBindingSize, max_storage_buffer_binding_size),
+        (minUniformBufferOffsetAlignment, min_uniform_buffer_offset_alignment),
+        (minStorageBufferOffsetAlignment, min_storage_buffer_offset_alignment),
+        (maxVertexBuffers, max_vertex_buffers),
+        (maxBufferSize, max_buffer_size),
+        (maxVertexAttributes, max_vertex_attributes),
+        (maxVertexBufferArrayStride, max_vertex_buffer_array_stride),
+        (maxInterStageShaderComponents, max_inter_stage_shader_components),
+        (maxComputeWorkgroupStorageSize, max_compute_workgroup_storage_size),
+        (maxComputeInvocationsPerWorkgroup, max_compute_invocations_per_workgroup),
+        (maxComputeWorkgroupSizeX, max_compute_workgroup_size_x),
+        (maxComputeWorkgroupSizeY, max_compute_workgroup_size_y),
+        (maxComputeWorkgroupSizeZ, max_compute_workgroup_size_z),
+        (maxComputeWorkgroupsPerDimension, max_compute_workgroups_per_dimension),
+    ];
+
+    object
+}
+
 type JsFutureResult = Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>;
 
 fn future_request_adapter(
@@ -1016,8 +1109,18 @@ impl crate::context::Context for Context {
             //Error: Tracing isn't supported on the Web target
         }
 
-        // TODO: non-guaranteed limits
         let mut mapped_desc = web_sys::GpuDeviceDescriptor::new();
+
+        // TODO: Migrate to a web_sys api.
+        // See https://github.com/rustwasm/wasm-bindgen/issues/3587
+        let limits_object = map_js_sys_limits(&desc.limits);
+
+        js_sys::Reflect::set(
+            &mapped_desc,
+            &JsValue::from("requiredLimits"),
+            &limits_object,
+        )
+        .expect("Setting Object properties should never fail.");
 
         let required_features = FEATURES_MAPPING
             .iter()
@@ -1072,30 +1175,7 @@ impl crate::context::Context for Context {
         _adapter: &Self::AdapterId,
         adapter_data: &Self::AdapterData,
     ) -> wgt::Limits {
-        let limits = adapter_data.0.limits();
-        wgt::Limits {
-            max_texture_dimension_1d: limits.max_texture_dimension_1d(),
-            max_texture_dimension_2d: limits.max_texture_dimension_2d(),
-            max_texture_dimension_3d: limits.max_texture_dimension_3d(),
-            max_texture_array_layers: limits.max_texture_array_layers(),
-            max_bind_groups: limits.max_bind_groups(),
-            max_bindings_per_bind_group: limits.max_bindings_per_bind_group(),
-            max_dynamic_uniform_buffers_per_pipeline_layout: limits
-                .max_dynamic_uniform_buffers_per_pipeline_layout(),
-            max_dynamic_storage_buffers_per_pipeline_layout: limits
-                .max_dynamic_storage_buffers_per_pipeline_layout(),
-            max_sampled_textures_per_shader_stage: limits.max_sampled_textures_per_shader_stage(),
-            max_samplers_per_shader_stage: limits.max_samplers_per_shader_stage(),
-            max_storage_buffers_per_shader_stage: limits.max_storage_buffers_per_shader_stage(),
-            max_storage_textures_per_shader_stage: limits.max_storage_textures_per_shader_stage(),
-            max_uniform_buffers_per_shader_stage: limits.max_uniform_buffers_per_shader_stage(),
-            max_uniform_buffer_binding_size: limits.max_uniform_buffer_binding_size() as u32,
-            max_storage_buffer_binding_size: limits.max_storage_buffer_binding_size() as u32,
-            max_vertex_buffers: limits.max_vertex_buffers(),
-            max_vertex_attributes: limits.max_vertex_attributes(),
-            max_vertex_buffer_array_stride: limits.max_vertex_buffer_array_stride(),
-            ..wgt::Limits::default()
-        }
+        map_wgt_limits(adapter_data.0.limits())
     }
 
     fn adapter_downlevel_capabilities(
@@ -1258,10 +1338,9 @@ impl crate::context::Context for Context {
     fn device_limits(
         &self,
         _device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
+        device_data: &Self::DeviceData,
     ) -> wgt::Limits {
-        // TODO
-        wgt::Limits::default()
+        map_wgt_limits(device_data.0.limits())
     }
 
     fn device_downlevel_properties(


### PR DESCRIPTION
**Description**
[This commit](https://github.com/gfx-rs/wgpu/commit/41efabbd886d09163b7e340caee6bca84eae968d) in 0.18 and later fixed an issue where limits passed to `request_device` would be dropped due to an upstream issue with `wasm_bindgen` and `web_sys`.

This PR backports that fix to 0.17 so that dependent packages can enjoy correct device initialisation behaviour on the web.

**Testing**

This has been tested alongside a modified copy of `bevy 0.12.0` (updated to depend on `wgpu 0.17.2`), to confirm that the device limits are now respected. For example device request properly fails on too large a `maxBufferSize` and no longer errors when buffers less than the requested `maxBufferSize`, but greater than the default max size, are created.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
  - [Upstream Failure in `noise`] `--target wasm32-unknown-emscripten`
- [unrecognized subcommand "test"] Run `cargo xtask test` to run tests.
- [X] Add change to `CHANGELOG.md`. See simple instructions inside file.
