### PR TITLE
Texture snatching

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -847,10 +847,13 @@ impl<A: HalApi> Drop for BindGroup<A> {
 
 impl<A: HalApi> BindGroup<A> {
     pub(crate) fn raw(&self, guard: &SnatchGuard) -> Option<&A::BindGroup> {
+        // Clippy insist on writing it this way. The idea is to return None
+        // if any of the raw buffer is not valid anymore.
         for buffer in &self.used_buffer_ranges {
-            // Clippy insist on writing it this way. The idea is to return None
-            // if any of the raw buffer is not valid anymore.
             let _ = buffer.buffer.raw(guard)?;
+        }
+        for texture in &self.used_texture_ranges {
+            let _ = texture.texture.raw(guard)?;
         }
         self.raw.as_ref()
     }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -16,8 +16,8 @@ use crate::{
     identity::{GlobalIdentityHandlerFactory, Input},
     init_tracker::{has_copy_partial_init_tracker_coverage, TextureInitRange},
     resource::{
-        Buffer, BufferAccessError, BufferMapState, DestroyedBuffer, Resource, ResourceInfo,
-        ResourceType, StagingBuffer, Texture, TextureInner,
+        Buffer, BufferAccessError, BufferMapState, DestroyedBuffer, DestroyedTexture, Resource,
+        ResourceInfo, ResourceType, StagingBuffer, Texture, TextureInner,
     },
     resource_log, track, FastHashMap, SubmissionIndex,
 };
@@ -164,6 +164,7 @@ pub enum TempResource<A: HalApi> {
     Buffer(Arc<Buffer<A>>),
     StagingBuffer(Arc<StagingBuffer<A>>),
     DestroyedBuffer(Arc<DestroyedBuffer<A>>),
+    DestroyedTexture(Arc<DestroyedTexture<A>>),
     Texture(Arc<Texture<A>>),
 }
 


### PR DESCRIPTION
**Connections**

Most of the remaining work towards #4787
Depends on #4954 

**Description**

This is almost identical to the work that was done to snatch buffers.

- When accessing a raw bind group, check that the underlying raw textures are not destroyed.
- Add a `DestroyedTexture` structure that will hold the snatched texture until it is ready to be deleted (pending writes/submissions are done).
- Snatch the raw texture in `Texture::destroy`.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
