### PR TITLE
Remove the Destroyed state from Storage

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -489,8 +489,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let buffer = hub
             .buffers
-            .write()
-            .get_and_mark_destroyed(buffer_id)
+            .get(buffer_id)
             .map_err(|_| resource::DestroyError::Invalid)?;
 
         let _ = buffer.unmap();
@@ -732,8 +731,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let texture = hub
             .textures
-            .write()
-            .get_and_mark_destroyed(texture_id)
+            .get(texture_id)
             .map_err(|_| resource::DestroyError::Invalid)?;
 
         texture.destroy()

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1158,8 +1158,6 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         // it, so make sure to set_size on it.
                         used_surface_textures.set_size(hub.textures.read().len());
 
-                        // TODO: ideally we would use `get_and_mark_destroyed` but the code here
-                        // wants to consume the command buffer.
                         #[allow(unused_mut)]
                         let mut cmdbuf = match command_buffer_guard.replace_with_error(cmb_id) {
                             Ok(cmdbuf) => cmdbuf,

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -15,7 +15,6 @@ pub struct RegistryReport {
     pub num_allocated: usize,
     pub num_kept_from_user: usize,
     pub num_released_from_user: usize,
-    pub num_destroyed_from_user: usize,
     pub num_error: usize,
     pub element_size: usize,
 }
@@ -192,7 +191,6 @@ impl<I: id::TypedId, T: Resource<I>> Registry<I, T> {
         for element in storage.map.iter() {
             match *element {
                 Element::Occupied(..) => report.num_kept_from_user += 1,
-                Element::Destroyed(..) => report.num_destroyed_from_user += 1,
                 Element::Vacant => report.num_released_from_user += 1,
                 Element::Error(..) => report.num_error += 1,
             }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -433,6 +433,10 @@ impl<A: HalApi> Buffer<A> {
         self.raw.get(guard)
     }
 
+    pub(crate) fn is_destroyed(&self, guard: &SnatchGuard) -> bool {
+        self.raw.get(guard).is_none()
+    }
+
     // Note: This must not be called while holding a lock.
     pub(crate) fn unmap(self: &Arc<Self>) -> Result<(), BufferAccessError> {
         if let Some((mut operation, status)) = self.unmap_inner()? {
@@ -816,6 +820,10 @@ impl<A: HalApi> Drop for Texture<A> {
 impl<A: HalApi> Texture<A> {
     pub(crate) fn raw<'a>(&'a self, snatch_guard: &'a SnatchGuard) -> Option<&'a A::Texture> {
         self.inner.get(snatch_guard)?.raw()
+    }
+
+    pub(crate) fn is_destroyed(&self, guard: &SnatchGuard) -> bool {
+        self.inner.get(guard).is_none()
     }
 
     pub(crate) fn inner_mut<'a>(


### PR DESCRIPTION
**Connections**

Depends on #4896 

**Description**

Removes the logic to express destroyed resources in the registry, since we have moved to handling it in the resources themselves.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
