### PR TITLE
gles: use already existing debug__fn private capabilty instead of checking extensions

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -220,7 +220,6 @@ impl super::Adapter {
 
         let full_ver = Self::parse_full_version(&version).ok();
         let es_ver = full_ver.map_or_else(|| Self::parse_version(&version).ok(), |_| None);
-        let web_gl = cfg!(target_arch = "wasm32");
 
         if let Some(full_ver) = full_ver {
             let core_profile = (full_ver >= (3, 2)).then_some(unsafe {

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -610,7 +610,7 @@ impl super::Adapter {
         );
         private_caps.set(
             super::PrivateCapabilities::DEBUG_FNS,
-            supported((3, 2), (4, 3)) && !web_gl,
+            gl.supports_debug(),
         );
         private_caps.set(
             super::PrivateCapabilities::INVALIDATE_FRAMEBUFFER,

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -608,10 +608,7 @@ impl super::Adapter {
             super::PrivateCapabilities::TEXTURE_STORAGE,
             supported((3, 0), (4, 2)),
         );
-        private_caps.set(
-            super::PrivateCapabilities::DEBUG_FNS,
-            gl.supports_debug(),
-        );
+        private_caps.set(super::PrivateCapabilities::DEBUG_FNS, gl.supports_debug());
         private_caps.set(
             super::PrivateCapabilities::INVALIDATE_FRAMEBUFFER,
             supported((3, 0), (4, 3)),

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -344,7 +344,7 @@ impl super::Device {
         let program = unsafe { gl.create_program() }.unwrap();
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(label) = label {
-            if gl.supports_debug() {
+            if private_caps.contains(PrivateCapabilities::DEBUG_FNS) {
                 let name = unsafe { mem::transmute(program) };
                 unsafe { gl.object_label(glow::PROGRAM, name, Some(label)) };
             }
@@ -593,7 +593,7 @@ impl crate::Device<super::Api> for super::Device {
 
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(label) = desc.label {
-            if gl.supports_debug() {
+            if self.shared.private_caps.contains(PrivateCapabilities::DEBUG_FNS) {
                 let name = unsafe { mem::transmute(raw) };
                 unsafe { gl.object_label(glow::BUFFER, name, Some(label)) };
             }
@@ -732,7 +732,7 @@ impl crate::Device<super::Api> for super::Device {
 
             #[cfg(not(target_arch = "wasm32"))]
             if let Some(label) = desc.label {
-                if gl.supports_debug() {
+                if self.shared.private_caps.contains(PrivateCapabilities::DEBUG_FNS) {
                     let name = unsafe { mem::transmute(raw) };
                     unsafe { gl.object_label(glow::RENDERBUFFER, name, Some(label)) };
                 }
@@ -896,7 +896,7 @@ impl crate::Device<super::Api> for super::Device {
 
             #[cfg(not(target_arch = "wasm32"))]
             if let Some(label) = desc.label {
-                if gl.supports_debug() {
+                if self.shared.private_caps.contains(PrivateCapabilities::DEBUG_FNS) {
                     let name = unsafe { mem::transmute(raw) };
                     unsafe { gl.object_label(glow::TEXTURE, name, Some(label)) };
                 }
@@ -1035,7 +1035,7 @@ impl crate::Device<super::Api> for super::Device {
 
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(label) = desc.label {
-            if gl.supports_debug() {
+            if self.shared.private_caps.contains(PrivateCapabilities::DEBUG_FNS) {
                 let name = unsafe { mem::transmute(raw) };
                 unsafe { gl.object_label(glow::SAMPLER, name, Some(label)) };
             }

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -593,7 +593,11 @@ impl crate::Device<super::Api> for super::Device {
 
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(label) = desc.label {
-            if self.shared.private_caps.contains(PrivateCapabilities::DEBUG_FNS) {
+            if self
+                .shared
+                .private_caps
+                .contains(PrivateCapabilities::DEBUG_FNS)
+            {
                 let name = unsafe { mem::transmute(raw) };
                 unsafe { gl.object_label(glow::BUFFER, name, Some(label)) };
             }
@@ -732,7 +736,11 @@ impl crate::Device<super::Api> for super::Device {
 
             #[cfg(not(target_arch = "wasm32"))]
             if let Some(label) = desc.label {
-                if self.shared.private_caps.contains(PrivateCapabilities::DEBUG_FNS) {
+                if self
+                    .shared
+                    .private_caps
+                    .contains(PrivateCapabilities::DEBUG_FNS)
+                {
                     let name = unsafe { mem::transmute(raw) };
                     unsafe { gl.object_label(glow::RENDERBUFFER, name, Some(label)) };
                 }
@@ -896,7 +904,11 @@ impl crate::Device<super::Api> for super::Device {
 
             #[cfg(not(target_arch = "wasm32"))]
             if let Some(label) = desc.label {
-                if self.shared.private_caps.contains(PrivateCapabilities::DEBUG_FNS) {
+                if self
+                    .shared
+                    .private_caps
+                    .contains(PrivateCapabilities::DEBUG_FNS)
+                {
                     let name = unsafe { mem::transmute(raw) };
                     unsafe { gl.object_label(glow::TEXTURE, name, Some(label)) };
                 }
@@ -1035,7 +1047,11 @@ impl crate::Device<super::Api> for super::Device {
 
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(label) = desc.label {
-            if self.shared.private_caps.contains(PrivateCapabilities::DEBUG_FNS) {
+            if self
+                .shared
+                .private_caps
+                .contains(PrivateCapabilities::DEBUG_FNS)
+            {
                 let name = unsafe { mem::transmute(raw) };
                 unsafe { gl.object_label(glow::SAMPLER, name, Some(label)) };
             }


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
Currently for labels the extensions are always checked, but there is already a private capability which indicates if debug fn are available. Check it instead where possible.

**Testing**
In RenderDoc debug labels should still exist.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
