### PR TITLE
Fix Hang in Multithreaded Compute Test

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1136,8 +1136,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 trace.add(trace::Action::CreateBindGroup(fid.id(), desc.clone()));
             }
 
-            let bind_group_layout_guard = hub.bind_group_layouts.read();
-            let bind_group_layout = match bind_group_layout_guard.get(desc.layout) {
+            let bind_group_layout = match hub.bind_group_layouts.get(desc.layout) {
                 Ok(layout) => layout,
                 Err(..) => break binding_model::CreateBindGroupError::InvalidLayout,
             };
@@ -1146,7 +1145,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 break DeviceError::WrongDevice.into();
             }
 
-            let bind_group = match device.create_bind_group(bind_group_layout, desc, hub) {
+            let bind_group = match device.create_bind_group(&bind_group_layout, desc, hub) {
                 Ok(bind_group) => bind_group,
                 Err(e) => break e,
             };
@@ -1779,9 +1778,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let hub = A::hub(self);
 
         let error = loop {
-            let pipeline_guard = hub.compute_pipelines.read();
-
-            let pipeline = match pipeline_guard.get(pipeline_id) {
+            let pipeline = match hub.compute_pipelines.get(pipeline_id) {
                 Ok(pipeline) => pipeline,
                 Err(_) => break binding_model::GetBindGroupLayoutError::InvalidPipeline,
             };


### PR DESCRIPTION
Closes #4962 

The issue was the following lock cycle:

```
compute.rs:408:30 command_encoder_run_compute_pass_impl (read; compute; BG held)
global.rs:1154:34 device_create_bind_group (write; bind group; BGL guard)
global.rs:1790 compute_pipeline_get_bind_group_layout (write; BGL; compute guard)

Bind Group -> Compute Pipeline
Compute Pipeline -> BGL
BGL -> Bind Group
```