### PR TITLE
Fix Queue::write_texture, Fix DX12 write_texture_subset_2d and re-enable the test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,10 @@ Passing an owned value `window` to `Surface` will return a `Surface<'static>`. S
 - Align `wgpu_types::CompositeAlphaMode` serde serialization to spec. By @littledivy in [#4940](https://github.com/gfx-rs/wgpu/pull/4940)
 - Fix error message of `ConfigureSurfaceError::TooLarge`. By @Dinnerbone in [#4960](https://github.com/gfx-rs/wgpu/pull/4960)
 
+#### DX12
+
+- Fixed D3D12_SUBRESOURCE_FOOTPRINT calculation for block compressed textures which caused a crash with `Queue::write_texture` on DX12. By @DTZxPorter in [#4990](https://github.com/gfx-rs/wgpu/pull/4990)
+
 #### Vulkan
 
 - Use `VK_EXT_robustness2` only when not using an outdated intel iGPU driver. By @TheoDulka in [#4602](https://github.com/gfx-rs/wgpu/pull/4602).

--- a/tests/tests/write_texture.rs
+++ b/tests/tests/write_texture.rs
@@ -1,17 +1,10 @@
 //! Tests for texture copy
 
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, GpuTestConfiguration};
 
 #[gpu_test]
-static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            // This just totally removes the device due to invalid api call.
-            //
-            // https://github.com/gfx-rs/wgpu/issues/3072
-            .expect_fail(FailureCase::backend(wgpu::Backends::DX12)),
-    )
-    .run_sync(|ctx| {
+static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =
+    GpuTestConfiguration::new().run_sync(|ctx| {
         let size = 256;
 
         let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -740,7 +740,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             // doesn't really matter because we need this only if we copy
             // more than one layer, and then we validate for this being not
             // None
-            size.height,
+            height_blocks,
         );
 
         let block_size = dst

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -20,7 +20,7 @@ impl crate::BufferTextureCopy {
         &self,
         format: wgt::TextureFormat,
     ) -> d3d12_ty::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
-        let (block_width, block_height) = format.block_dimensions();
+        let (block_width, _) = format.block_dimensions();
         d3d12_ty::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
             Offset: self.buffer_layout.offset,
             Footprint: d3d12_ty::D3D12_SUBRESOURCE_FOOTPRINT {
@@ -30,10 +30,7 @@ impl crate::BufferTextureCopy {
                 )
                 .unwrap(),
                 Width: self.size.width,
-                Height: self
-                    .buffer_layout
-                    .rows_per_image
-                    .map_or(self.size.height, |count| count * block_height),
+                Height: self.size.height,
                 Depth: self.size.depth,
                 RowPitch: {
                     let actual = self.buffer_layout.bytes_per_row.unwrap_or_else(|| {


### PR DESCRIPTION
Queue::write_texture calculated the rows_per_image incorrectly for block compressed textures. This causes the DX12 backend to fail when uploading a block compressed image. Enabled the write_texture_subset_2d test now that it passes.

**Connections**
Closes https://github.com/gfx-rs/wgpu/pull/3992  
Closes https://github.com/gfx-rs/wgpu/issues/3072

**Description**
`Queue::write_texture` fails for block compressed textures on DX12.

**Testing**
Enabled the write_texture_subset_2d test now that it passes.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
