### PR TITLE
Propagate errors when openning/closing a command encoder

### DIFF
--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
 
 use self::memory_init::CommandBufferTextureMemoryActions;
 
-use crate::device::Device;
+use crate::device::{Device, DeviceError};
 use crate::error::{ErrorFormatter, PrettyError};
 use crate::hub::Hub;
 use crate::id::CommandBufferId;
@@ -58,20 +58,24 @@ pub(crate) struct CommandEncoder<A: HalApi> {
 //TODO: handle errors better
 impl<A: HalApi> CommandEncoder<A> {
     /// Closes the live encoder
-    fn close_and_swap(&mut self) {
+    fn close_and_swap(&mut self) -> Result<(), DeviceError> {
         if self.is_open {
             self.is_open = false;
-            let new = unsafe { self.raw.end_encoding().unwrap() };
+            let new = unsafe { self.raw.end_encoding()? };
             self.list.insert(self.list.len() - 1, new);
         }
+
+        Ok(())
     }
 
-    fn close(&mut self) {
+    fn close(&mut self) -> Result<(), DeviceError> {
         if self.is_open {
             self.is_open = false;
-            let cmd_buf = unsafe { self.raw.end_encoding().unwrap() };
+            let cmd_buf = unsafe { self.raw.end_encoding()? };
             self.list.push(cmd_buf);
         }
+
+        Ok(())
     }
 
     fn discard(&mut self) {
@@ -81,18 +85,21 @@ impl<A: HalApi> CommandEncoder<A> {
         }
     }
 
-    fn open(&mut self) -> &mut A::CommandEncoder {
+    fn open(&mut self) -> Result<&mut A::CommandEncoder, DeviceError> {
         if !self.is_open {
             self.is_open = true;
             let label = self.label.as_deref();
-            unsafe { self.raw.begin_encoding(label).unwrap() };
+            unsafe { self.raw.begin_encoding(label)? };
         }
-        &mut self.raw
+
+        Ok(&mut self.raw)
     }
 
-    fn open_pass(&mut self, label: Option<&str>) {
+    fn open_pass(&mut self, label: Option<&str>) -> Result<(), DeviceError> {
         self.is_open = true;
-        unsafe { self.raw.begin_encoding(label).unwrap() };
+        unsafe { self.raw.begin_encoding(label)? };
+
+        Ok(())
     }
 }
 
@@ -119,10 +126,13 @@ pub struct CommandBufferMutable<A: HalApi> {
 }
 
 impl<A: HalApi> CommandBufferMutable<A> {
-    pub(crate) fn open_encoder_and_tracker(&mut self) -> (&mut A::CommandEncoder, &mut Tracker<A>) {
-        let encoder = self.encoder.open();
+    pub(crate) fn open_encoder_and_tracker(
+        &mut self,
+    ) -> Result<(&mut A::CommandEncoder, &mut Tracker<A>), DeviceError> {
+        let encoder = self.encoder.open()?;
         let tracker = &mut self.trackers;
-        (encoder, tracker)
+
+        Ok((encoder, tracker))
     }
 }
 
@@ -401,6 +411,8 @@ pub enum CommandEncoderError {
     Invalid,
     #[error("Command encoder must be active")]
     NotRecording,
+    #[error(transparent)]
+    Device(#[from] DeviceError),
 }
 
 impl<G: GlobalIdentityHandlerFactory> Global<G> {
@@ -419,12 +431,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
                 match cmd_buf_data.status {
                     CommandEncoderStatus::Recording => {
-                        cmd_buf_data.encoder.close();
-                        cmd_buf_data.status = CommandEncoderStatus::Finished;
-                        //Note: if we want to stop tracking the swapchain texture view,
-                        // this is the place to do it.
-                        log::trace!("Command buffer {:?}", encoder_id);
-                        None
+                        if let Err(e) = cmd_buf_data.encoder.close() {
+                            Some(e.into())
+                        } else {
+                            cmd_buf_data.status = CommandEncoderStatus::Finished;
+                            //Note: if we want to stop tracking the swapchain texture view,
+                            // this is the place to do it.
+                            log::trace!("Command buffer {:?}", encoder_id);
+                            None
+                        }
                     }
                     CommandEncoderStatus::Finished => Some(CommandEncoderError::NotRecording),
                     CommandEncoderStatus::Error => {
@@ -457,7 +472,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             list.push(TraceCommand::PushDebugGroup(label.to_string()));
         }
 
-        let cmd_buf_raw = cmd_buf_data.encoder.open();
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
         if !self
             .instance
             .flags
@@ -494,7 +509,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .flags
             .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS)
         {
-            let cmd_buf_raw = cmd_buf_data.encoder.open();
+            let cmd_buf_raw = cmd_buf_data.encoder.open()?;
             unsafe {
                 cmd_buf_raw.insert_debug_marker(label);
             }
@@ -520,7 +535,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             list.push(TraceCommand::PopDebugGroup);
         }
 
-        let cmd_buf_raw = cmd_buf_data.encoder.open();
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
         if !self
             .instance
             .flags

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1312,11 +1312,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS);
         let label = hal_label(base.label, self.instance.flags);
 
-        let init_scope = PassErrorScope::Pass(encoder_id);
+        let pass_scope = PassErrorScope::Pass(encoder_id);
 
         let hub = A::hub(self);
 
-        let cmd_buf = CommandBuffer::get_encoder(hub, encoder_id).map_pass_err(init_scope)?;
+        let cmd_buf = CommandBuffer::get_encoder(hub, encoder_id).map_pass_err(pass_scope)?;
         let device = &cmd_buf.device;
         let snatch_guard = device.snatchable_lock.read();
 
@@ -1336,7 +1336,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             }
 
             if !device.is_valid() {
-                return Err(DeviceError::Lost).map_pass_err(init_scope);
+                return Err(DeviceError::Lost).map_pass_err(pass_scope);
             }
 
             let encoder = &mut cmd_buf_data.encoder;
@@ -1349,10 +1349,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             // We automatically keep extending command buffers over time, and because
             // we want to insert a command buffer _before_ what we're about to record,
             // we need to make sure to close the previous one.
-            encoder.close();
+            encoder.close().map_pass_err(pass_scope)?;
             // We will reset this to `Recording` if we succeed, acts as a fail-safe.
             *status = CommandEncoderStatus::Error;
-            encoder.open_pass(label);
+            encoder.open_pass(label).map_pass_err(pass_scope)?;
 
             let bundle_guard = hub.render_bundles.read();
             let bind_group_guard = hub.bind_groups.read();
@@ -1383,7 +1383,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 &*texture_guard,
                 &*query_set_guard,
             )
-            .map_pass_err(init_scope)?;
+            .map_pass_err(pass_scope)?;
 
             tracker.set_size(
                 Some(&*buffer_guard),
@@ -2364,9 +2364,9 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             log::trace!("Merging renderpass into cmd_buf {:?}", encoder_id);
             let (trackers, pending_discard_init_fixups) =
-                info.finish(raw).map_pass_err(init_scope)?;
+                info.finish(raw).map_pass_err(pass_scope)?;
 
-            encoder.close();
+            encoder.close().map_pass_err(pass_scope)?;
             (trackers, pending_discard_init_fixups)
         };
 
@@ -2381,7 +2381,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let tracker = &mut cmd_buf_data.trackers;
 
         {
-            let transit = encoder.open();
+            let transit = encoder.open().map_pass_err(pass_scope)?;
 
             fixup_discarded_surfaces(
                 pending_discard_init_fixups.into_iter(),
@@ -2409,7 +2409,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         *status = CommandEncoderStatus::Recording;
-        encoder.close_and_swap();
+        encoder.close_and_swap().map_pass_err(pass_scope)?;
 
         Ok(())
     }

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -4,7 +4,7 @@ use crate::{
     api_log,
     command::{clear_texture, CommandBuffer, CommandEncoderError},
     conv,
-    device::{Device, MissingDownlevelFlags},
+    device::{Device, DeviceError, MissingDownlevelFlags},
     error::{ErrorFormatter, PrettyError},
     global::Global,
     hal_api::HalApi,
@@ -25,7 +25,7 @@ use wgt::{BufferAddress, BufferUsages, Extent3d, TextureUsages};
 
 use std::{iter, sync::Arc};
 
-use super::{memory_init::CommandBufferTextureMemoryActions, CommandEncoder};
+use super::{memory_init::CommandBufferTextureMemoryActions, ClearError, CommandEncoder};
 
 pub type ImageCopyBuffer = wgt::ImageCopyBuffer<BufferId>;
 pub type ImageCopyTexture = wgt::ImageCopyTexture<TextureId>;
@@ -135,7 +135,7 @@ pub enum TransferError {
         dst_format: wgt::TextureFormat,
     },
     #[error(transparent)]
-    MemoryInitFailure(#[from] super::ClearError),
+    MemoryInitFailure(#[from] ClearError),
     #[error("Cannot encode this copy because of a missing downelevel flag")]
     MissingDownlevelFlags(#[from] MissingDownlevelFlags),
     #[error("Source texture sample count must be 1, got {sample_count}")]
@@ -184,6 +184,12 @@ pub enum CopyError {
     Encoder(#[from] CommandEncoderError),
     #[error("Copy error")]
     Transfer(#[from] TransferError),
+}
+
+impl From<DeviceError> for CopyError {
+    fn from(err: DeviceError) -> Self {
+        CopyError::Encoder(CommandEncoderError::Device(err))
+    }
 }
 
 pub(crate) fn extract_texture_selector<A: HalApi>(
@@ -447,7 +453,7 @@ fn handle_texture_init<A: HalApi>(
     copy_texture: &ImageCopyTexture,
     copy_size: &Extent3d,
     texture: &Arc<Texture<A>>,
-) {
+) -> Result<(), ClearError> {
     let init_action = TextureInitTrackerAction {
         texture: texture.clone(),
         range: TextureInitRange {
@@ -463,7 +469,7 @@ fn handle_texture_init<A: HalApi>(
 
     // In rare cases we may need to insert an init operation immediately onto the command buffer.
     if !immediate_inits.is_empty() {
-        let cmd_buf_raw = encoder.open();
+        let cmd_buf_raw = encoder.open()?;
         for init in immediate_inits {
             clear_texture(
                 &init.texture,
@@ -475,10 +481,11 @@ fn handle_texture_init<A: HalApi>(
                 &mut trackers.textures,
                 &device.alignments,
                 device.zero_buffer.as_ref().unwrap(),
-            )
-            .unwrap();
+            )?;
         }
     }
+
+    Ok(())
 }
 
 /// Prepare a transfer's source texture.
@@ -503,7 +510,7 @@ fn handle_src_texture_init<A: HalApi>(
         source,
         copy_size,
         texture,
-    );
+    )?;
     Ok(())
 }
 
@@ -543,7 +550,7 @@ fn handle_dst_texture_init<A: HalApi>(
         destination,
         copy_size,
         texture,
-    );
+    )?;
     Ok(())
 }
 
@@ -707,7 +714,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             dst_offset: destination_offset,
             size: wgt::BufferSize::new(size).unwrap(),
         };
-        let cmd_buf_raw = cmd_buf_data.encoder.open();
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
         unsafe {
             cmd_buf_raw.transition_buffers(src_barrier.into_iter().chain(dst_barrier));
             cmd_buf_raw.copy_buffer_to_buffer(src_raw, dst_raw, iter::once(region));
@@ -867,7 +874,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             }
         });
 
-        let cmd_buf_raw = encoder.open();
+        let cmd_buf_raw = encoder.open()?;
         unsafe {
             cmd_buf_raw.transition_textures(dst_barrier.into_iter());
             cmd_buf_raw.transition_buffers(src_barrier.into_iter());
@@ -1035,7 +1042,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 size: hal_copy_size,
             }
         });
-        let cmd_buf_raw = encoder.open();
+        let cmd_buf_raw = encoder.open()?;
         unsafe {
             cmd_buf_raw.transition_buffers(dst_barrier.into_iter());
             cmd_buf_raw.transition_textures(src_barrier.into_iter());
@@ -1207,7 +1214,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 size: hal_copy_size,
             }
         });
-        let cmd_buf_raw = cmd_buf_data.encoder.open();
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
         unsafe {
             cmd_buf_raw.transition_textures(barriers.into_iter());
             cmd_buf_raw.copy_texture_to_texture(


### PR DESCRIPTION
**Connections**

Downstream bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1873047

**Description**

There are a few `unwrap`s in `CommandEncoder` (with TODO comment about dealing with the errors), which Firefox's fuzzer is too good at hitting. This PR just does the plumbing to propagate the errors instead of packing.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
