### PR TITLE
Pin Nightly Docs Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ env:
   # Corresponds to https://github.com/gfx-rs/ci-build/releases
   CI_BINARY_BUILD: "build18"
 
+  # We sometimes need nightly to use special things in CI.
+  # 
+  # In order to prevent CI regressions, we pin the nightly version.
+  NIGHTLY_VERSION: "nightly-2023-12-17"
+  # Version of rust used to build the docs with.
+  #
+  # This needs to be newer to work around https://github.com/gfx-rs/wgpu/issues/4905.
+  #
+  # Once 1.76 coes out, we can use that instead of nightly.
+  DOCS_RUST_VERSION: "nightly-2023-12-17"
   # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.
   REPO_MSRV: "1.71"
   # This is the MSRV used by the `wgpu-core`, `wgpu-hal`, and `wgpu-types` crates,
@@ -132,11 +142,11 @@ jobs:
           rustup override set ${{ env.REPO_MSRV }}
           cargo -V
 
-      # Use nightly for rustdoc, see https://github.com/gfx-rs/wgpu/issues/4905
-      - name: Install Nightly toolchain
+      # Use special toolchain for rustdoc, see https://github.com/gfx-rs/wgpu/issues/4905
+      - name: Install Rustdoc Toolchain
         run: |
-          rustup toolchain install nightly --no-self-update --profile=minimal --component rust-docs --target ${{ matrix.target }}
-          cargo +nightly -V
+          rustup toolchain install ${{ env.DOCS_RUST_VERSION }} --no-self-update --profile=minimal --component rust-docs --target ${{ matrix.target }}
+          cargo +${{ env.DOCS_RUST_VERSION }} -V
 
       - name: disable debug
         shell: bash
@@ -178,11 +188,11 @@ jobs:
           # build for WebGPU
           cargo clippy --target ${{ matrix.target }} --tests --features glsl,spirv,fragile-send-sync-non-atomic-wasm
           cargo clippy --target ${{ matrix.target }} --tests --features glsl,spirv
-          cargo +nightly doc --target ${{ matrix.target }} --no-deps --features glsl,spirv
+          cargo +${{ env.DOCS_RUST_VERSION }} doc --target ${{ matrix.target }} --no-deps --features glsl,spirv
 
           # all features
           cargo clippy --target ${{ matrix.target }} --tests --all-features
-          cargo +nightly doc --target ${{ matrix.target }} --no-deps --all-features
+          cargo +${{ env.DOCS_RUST_VERSION }} doc --target ${{ matrix.target }} --no-deps --all-features
 
       - name: check em
         if: matrix.kind == 'em'
@@ -212,7 +222,7 @@ jobs:
           cargo clippy --target ${{ matrix.target }} --tests --all-features
 
           # build docs
-          cargo +nightly doc --target ${{ matrix.target }} --all-features --no-deps
+          cargo +${{ env.DOCS_RUST_VERSION }} doc --target ${{ matrix.target }} --all-features --no-deps
 
   # We run minimal checks on the MSRV of the core crates, ensuring that
   # its dependency tree does not cause issues for firefox.
@@ -286,10 +296,11 @@ jobs:
           rustup override set ${{ env.CORE_MSRV }}
           cargo -V
 
-      - name: Install Nightly toolchain
+      # Use special toolchain for rustdoc, see https://github.com/gfx-rs/wgpu/issues/4905
+      - name: Install Nightly Toolchain
         run: |
-          rustup toolchain install nightly --no-self-update --profile=minimal --component clippy
-          cargo +nightly -V
+          rustup toolchain install ${{ env.NIGHTLY_VERSION }} --no-self-update --profile=minimal --component clippy
+          cargo +${{ env.NIGHTLY_VERSION }} -V
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2
@@ -309,7 +320,7 @@ jobs:
         run: |
           set -e
 
-          cargo +nightly hack generate-lockfile --remove-dev-deps -Z minimal-versions -p naga -p naga-cli
+          cargo +${{ env.NIGHTLY_VERSION }} hack generate-lockfile --remove-dev-deps -Z minimal-versions -p naga -p naga-cli
 
       - name: Clippy
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,18 @@
 name: Docs
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/docs.yml'
   push:
     branches:
       - trunk
 
 env:
+  # We need to use nightly for various features
+  # when building docs.rs style docs.
+  NIGHTLY_VERSION: nightly-2023-12-17
+
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
@@ -20,12 +27,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install nightly toolchain
-        run: rustup toolchain install nightly --no-self-update --profile=minimal
+      - name: Install documentation toolchain
+        run: rustup toolchain install ${{ env.NIGHTLY_VERSION }} --no-self-update --profile=minimal
 
       - name: Build the docs (nightly)
         run: |
-          cargo +nightly doc --no-deps --lib
+          cargo +${{ env.NIGHTLY_VERSION }} doc --no-deps --lib
         env:
           RUSTDOCFLAGS: --cfg docsrs
 
@@ -35,6 +42,7 @@ jobs:
 
       - name: Deploy the docs
         uses: JamesIves/github-pages-deploy-action@v4.5.0
+        if: github.ref == 'refs/heads/trunk'
         with:
           token: ${{ secrets.WEB_DEPLOY }}
           folder: target/doc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/publish.yml'
   push:
     branches:
       - trunk


### PR DESCRIPTION
In order to work around #4905, I made the docs build on nightly, which has fixed whatever performance behavior was the problem.

Of course, eventually nightly updated and caused new warnings, which broke the world. Sigh.

This pins it to beta's nightly equivalent, and we can move the main rustdoc job to 1.76 once it comes out.

