### PR TITLE
fix: get CONTEXT_PROFILE_MASK in invalid version

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -222,7 +222,7 @@ impl super::Adapter {
         let es_ver = full_ver.map_or_else(|| Self::parse_version(&version).ok(), |_| None);
 
         if let Some(full_ver) = full_ver {
-            let core_profile = (full_ver >= (3, 2)).then_some(unsafe {
+            let core_profile = (full_ver >= (3, 2)).then(|| unsafe {
                 gl.get_parameter_i32(glow::CONTEXT_PROFILE_MASK)
                     & glow::CONTEXT_CORE_PROFILE_BIT as i32
                     != 0


### PR DESCRIPTION
tldr: the code inside bool::then_some is always executed, but the code in the closure from bool::then is only executed if is true.

This is UB, because the bool::then_some is a function that takes a bool and a generic value, because of that, the value inside of it is always evaluated, independent if the bool is true/false.

it's clear if the desugarize the syntax:

```rust
// first we get the true/false for the condition
let cond: bool = full_ver >= (3, 2);
// then we evaluate the expression to pass the value as parameter
// UB here, the is executed always, independent of the cond being true/false
let value = unsafe {
  gl.get_parameter_i32(glow::CONTEXT_PROFILE_MASK) & glow::CONTEXT_CORE_PROFILE_BIT as i32
!= 0};
// then we call the function `bool::then_some`.
bool::then_some(cond, value)
```

The solution is simply change it to bool::then, because the parameter it's a closure, it's lazy evaluated, and only executed if the condition is true.

As mentioned at https://github.com/rust-lang/rust/blob/5cb2e7dfc362662b0036faad3bab88d73027fd05/src/tools/clippy/clippy_lints/src/transmute/mod.rs#L468-L520

And presented at https://youtu.be/hBjQ3HqCfxs?si=nrIz6ZHnxEHO6Pik&t=53
