### PR TITLE
Properly Deal with Timeouts Inside device::maintain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,6 @@ jobs:
     
     name: Test WebAssembly
     runs-on: ubuntu-latest
-    needs: [check]
 
     steps:
       - name: checkout repo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "glow"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4126,7 +4138,9 @@ dependencies = [
  "console_log",
  "ctor",
  "env_logger",
+ "flume",
  "futures-lite",
+ "gloo-timers",
  "heck",
  "image",
  "js-sys",
@@ -4145,6 +4159,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+ "web-time",
  "wgpu",
  "wgpu-macros",
  "wgpu-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ flume = "0.11"
 futures-lite = "2"
 getrandom = "0.2"
 glam = "0.25"
+gloo-timers = "0.3"
 heck = "0.4.0"
 image = { version = "0.24", default-features = false, features = ["png"] }
 ktx2 = "0.3"

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -122,8 +122,9 @@ pub async fn op_webgpu_buffer_get_map_async(
             {
                 let state = state.borrow();
                 let instance = state.borrow::<super::Instance>();
-                gfx_select!(device => instance.device_poll(device, wgpu_types::Maintain::wait()))
-                    .unwrap();
+                gfx_select!(device => instance.device_poll(device, wgpu_types::PollInfo::wait()))
+                    .unwrap()
+                    .panic_on_incomplete();
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }

--- a/examples/src/framework.rs
+++ b/examples/src/framework.rs
@@ -613,9 +613,9 @@ impl<E: Example + wgpu::WasmNotSendSync> From<ExampleTestParams<E>>
 
                 let dst_buffer_slice = dst_buffer.slice(..);
                 dst_buffer_slice.map_async(wgpu::MapMode::Read, |_| ());
-                ctx.async_poll(wgpu::Maintain::wait())
+                ctx.async_poll(wgpu::PollInfo::wait())
                     .await
-                    .panic_on_timeout();
+                    .panic_on_incomplete();
                 let bytes = dst_buffer_slice.get_mapped_range().to_vec();
 
                 wgpu_test::image::compare_image_output(

--- a/examples/src/hello_compute/mod.rs
+++ b/examples/src/hello_compute/mod.rs
@@ -152,7 +152,7 @@ async fn execute_gpu_inner(
     // Poll the device in a blocking manner so that our future resolves.
     // In an actual application, `device.poll(...)` should
     // be called in an event loop or on another thread.
-    device.poll(wgpu::Maintain::wait()).panic_on_timeout();
+    device.poll(wgpu::PollInfo::wait()).panic_on_incomplete();
 
     // Awaits until `buffer_future` can be read from
     if let Ok(Ok(())) = receiver.recv_async().await {

--- a/examples/src/hello_synchronization/mod.rs
+++ b/examples/src/hello_synchronization/mod.rs
@@ -183,7 +183,7 @@ async fn get_data<T: bytemuck::Pod>(
     let buffer_slice = staging_buffer.slice(..);
     let (sender, receiver) = flume::bounded(1);
     buffer_slice.map_async(wgpu::MapMode::Read, move |r| sender.send(r).unwrap());
-    device.poll(wgpu::Maintain::wait()).panic_on_timeout();
+    device.poll(wgpu::PollInfo::wait()).panic_on_incomplete();
     receiver.recv_async().await.unwrap().unwrap();
     output.copy_from_slice(bytemuck::cast_slice(&buffer_slice.get_mapped_range()[..]));
     staging_buffer.unmap();

--- a/examples/src/hello_workgroups/mod.rs
+++ b/examples/src/hello_workgroups/mod.rs
@@ -172,7 +172,7 @@ async fn get_data<T: bytemuck::Pod>(
     let buffer_slice = staging_buffer.slice(..);
     let (sender, receiver) = flume::bounded(1);
     buffer_slice.map_async(wgpu::MapMode::Read, move |r| sender.send(r).unwrap());
-    device.poll(wgpu::Maintain::wait()).panic_on_timeout();
+    device.poll(wgpu::PollInfo::wait()).panic_on_incomplete();
     receiver.recv_async().await.unwrap().unwrap();
     output.copy_from_slice(bytemuck::cast_slice(&buffer_slice.get_mapped_range()[..]));
     staging_buffer.unmap();

--- a/examples/src/mipmap/mod.rs
+++ b/examples/src/mipmap/mod.rs
@@ -410,7 +410,7 @@ impl crate::framework::Example for Example {
                 .slice(..)
                 .map_async(wgpu::MapMode::Read, |_| ());
             // Wait for device to be done rendering mipmaps
-            device.poll(wgpu::Maintain::wait()).panic_on_timeout();
+            device.poll(wgpu::PollInfo::wait()).panic_on_incomplete();
             // This is guaranteed to be ready.
             let timestamp_view = query_sets
                 .mapping_buffer

--- a/examples/src/render_to_texture/mod.rs
+++ b/examples/src/render_to_texture/mod.rs
@@ -131,7 +131,7 @@ async fn run(_path: Option<String>) {
     let buffer_slice = output_staging_buffer.slice(..);
     let (sender, receiver) = flume::bounded(1);
     buffer_slice.map_async(wgpu::MapMode::Read, move |r| sender.send(r).unwrap());
-    device.poll(wgpu::Maintain::wait()).panic_on_timeout();
+    device.poll(wgpu::PollInfo::wait()).panic_on_incomplete();
     receiver.recv_async().await.unwrap().unwrap();
     log::info!("Output buffer mapped.");
     {

--- a/examples/src/repeated_compute/mod.rs
+++ b/examples/src/repeated_compute/mod.rs
@@ -111,8 +111,8 @@ async fn compute(local_buffer: &mut [u32], context: &WgpuContext) {
     // `Maintain::Wait` will cause the thread to wait on native but not on WebGpu.
     context
         .device
-        .poll(wgpu::Maintain::wait())
-        .panic_on_timeout();
+        .poll(wgpu::PollInfo::wait())
+        .panic_on_incomplete();
     log::info!("Device polled.");
     // Now we await the receiving and panic if anything went wrong because we're lazy.
     receiver.recv_async().await.unwrap().unwrap();

--- a/examples/src/storage_texture/mod.rs
+++ b/examples/src/storage_texture/mod.rs
@@ -143,7 +143,7 @@ async fn run(_path: Option<String>) {
     let buffer_slice = output_staging_buffer.slice(..);
     let (sender, receiver) = flume::bounded(1);
     buffer_slice.map_async(wgpu::MapMode::Read, move |r| sender.send(r).unwrap());
-    device.poll(wgpu::Maintain::wait()).panic_on_timeout();
+    device.poll(wgpu::PollInfo::wait()).panic_on_incomplete();
     receiver.recv_async().await.unwrap().unwrap();
     log::info!("Output buffer mapped");
     {

--- a/examples/src/timestamp_queries/mod.rs
+++ b/examples/src/timestamp_queries/mod.rs
@@ -159,7 +159,7 @@ impl Queries {
         self.destination_buffer
             .slice(..)
             .map_async(wgpu::MapMode::Read, |_| ());
-        device.poll(wgpu::Maintain::wait()).panic_on_timeout();
+        device.poll(wgpu::PollInfo::wait()).panic_on_incomplete();
 
         let timestamps = {
             let timestamp_view = self

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -107,7 +107,9 @@ fn main() {
         }
 
         gfx_select!(device => global.device_stop_capture(device));
-        gfx_select!(device => global.device_poll(device, wgt::Maintain::wait())).unwrap();
+        gfx_select!(device => global.device_poll(device, wgt::PollInfo::wait()))
+            .unwrap()
+            .panic_on_incomplete();
     }
     #[cfg(feature = "winit")]
     {
@@ -189,7 +191,7 @@ fn main() {
                 },
                 Event::LoopExiting => {
                     log::info!("Closing");
-                    gfx_select!(device => global.device_poll(device, wgt::Maintain::wait())).unwrap();
+                    gfx_select!(device => global.device_poll(device, wgt::PollInfo::wait())).unwrap().panic_on_incomplete();
                 }
                 _ => {}
             }

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -110,7 +110,7 @@ impl Test<'_> {
             adapter,
             &wgt::DeviceDescriptor {
                 label: None,
-                required_features: self.features,
+                required_features: self.features | wgt::Features::NON_ZERO_POLL_TIMEOUT,
                 required_limits: wgt::Limits::default(),
             },
             None,
@@ -143,8 +143,9 @@ impl Test<'_> {
         }
 
         println!("\t\t\tWaiting...");
-        wgc::gfx_select!(device_id => global.device_poll(device_id, wgt::Maintain::wait()))
-            .unwrap();
+        wgc::gfx_select!(device_id => global.device_poll(device_id, wgt::PollInfo::wait()))
+            .unwrap()
+            .panic_on_incomplete();
 
         for expect in self.expectations {
             println!("\t\t\tChecking {}", expect.name);

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,6 +26,7 @@ bitflags.workspace = true
 bytemuck.workspace = true
 cfg-if.workspace = true
 ctor.workspace = true
+flume.workspace = true
 futures-lite.workspace = true
 heck.workspace = true
 libtest-mimic.workspace = true
@@ -36,6 +37,7 @@ pollster.workspace = true
 profiling.workspace = true
 serde_json.workspace = true
 serde.workspace = true
+
 wgpu-macros.workspace = true
 wgpu.workspace = true
 wgt = { workspace = true, features = ["serde"] }
@@ -48,7 +50,10 @@ parking_lot = { workspace = true, features = ["deadlock_detection"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log.workspace = true
 raw-window-handle.workspace = true
+js-sys.workspace = true
+gloo-timers = { workspace = true, features = ["futures"] }
 wasm-bindgen.workspace = true
+web-time.workspace = true
 web-sys = { workspace = true }
 
 [dev-dependencies]

--- a/tests/src/image.rs
+++ b/tests/src/image.rs
@@ -573,7 +573,7 @@ impl ReadbackBuffers {
     ) -> Vec<u8> {
         let buffer_slice = buffer.slice(..);
         buffer_slice.map_async(MapMode::Read, |_| ());
-        ctx.async_poll(Maintain::wait()).await.panic_on_timeout();
+        ctx.async_poll(PollInfo::wait()).await.panic_on_incomplete();
         let (block_width, block_height) = self.texture_format.block_dimensions();
         let expected_bytes_per_row = (self.texture_width / block_width)
             * self.texture_format.block_copy_size(aspect).unwrap_or(4);

--- a/tests/src/poll.rs
+++ b/tests/src/poll.rs
@@ -1,8 +1,67 @@
 use crate::TestingContext;
 
 impl TestingContext {
-    /// Utility to allow future asynchronous polling.
-    pub async fn async_poll(&self, maintain: wgpu::Maintain) -> wgpu::MaintainResult {
+    /// Utility to allow wait polling on devices that don't support wait polling.
+    ///
+    /// # Notes
+    ///
+    /// - On WebGL and WebGPU, this will ignore the submission index argument and wait
+    ///   for all submitted work to complete.
+    /// - On WebGL uses a incremental backoff with setInterval to do repeated polling.
+    #[cfg(target_arch = "wasm32")]
+    pub async fn async_poll(&self, poll_info: wgpu::PollInfo) -> wgpu::SubmissionStatus {
+        use std::time::Duration;
+        use web_time::Instant;
+
+        let timeout = match poll_info.effective_wait_duration() {
+            Some(timeout) => timeout,
+            None => return self.device.poll(poll_info),
+        };
+
+        let (sender, receiver) = flume::unbounded();
+
+        let sender_clone = sender.clone();
+        self.queue.on_submitted_work_done(move || {
+            sender_clone
+                .send(wgpu::SubmissionStatus::QueueEmpty)
+                .unwrap()
+        });
+
+        if self.adapter_info.backend == wgpu::Backend::BrowserWebGpu {
+            return receiver.recv_async().await.unwrap();
+        }
+
+        let start = Instant::now();
+        // We use exponential backoff.
+        let mut step_duration = Duration::from_millis(5);
+        loop {
+            let elapsed = start.elapsed();
+            if elapsed >= timeout {
+                return wgpu::SubmissionStatus::Incomplete;
+            };
+
+            // Either the step direction or the remaining time, whichever is smaller
+            let remaining_duration = timeout - elapsed;
+            let sleep_duration = step_duration.min(remaining_duration);
+
+            log::trace!(
+                "Waiting for {sleep_duration:?}. Remaining in wait: {remaining_duration:?}."
+            );
+            gloo_timers::future::sleep(sleep_duration).await;
+
+            // This wait is silly as it will always timeout. This is however required to make firefox make forward progress.
+            let _ = self.device.poll(wgpu::PollInfo::poll());
+
+            if let Ok(result) = receiver.try_recv() {
+                return result;
+            }
+
+            step_duration *= 2;
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn async_poll(&self, maintain: wgpu::PollInfo) -> wgpu::SubmissionStatus {
         self.device.poll(maintain)
     }
 }

--- a/tests/tests/bgra8unorm_storage.rs
+++ b/tests/tests/bgra8unorm_storage.rs
@@ -139,9 +139,9 @@ static BGRA8_UNORM_STORAGE: GpuTestConfiguration = GpuTestConfiguration::new()
 
         let buffer_slice = readback_buffer.slice(..);
         buffer_slice.map_async(wgpu::MapMode::Read, Result::unwrap);
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
 
         {
             let texels = buffer_slice.get_mapped_range();

--- a/tests/tests/bind_group_layout_dedup.rs
+++ b/tests/tests/bind_group_layout_dedup.rs
@@ -126,9 +126,9 @@ async fn bgl_dedupe(ctx: TestingContext) {
         }
     }
 
-    ctx.async_poll(wgpu::Maintain::wait())
+    ctx.async_poll(wgpu::PollInfo::wait())
         .await
-        .panic_on_timeout();
+        .panic_on_incomplete();
 
     if ctx.adapter_info.backend != wgt::Backend::BrowserWebGpu {
         // Now all of the BGL ids should be dead, so we should get the same ids again.

--- a/tests/tests/buffer.rs
+++ b/tests/tests/buffer.rs
@@ -14,9 +14,9 @@ async fn test_empty_buffer_range(ctx: &TestingContext, buffer_size: u64, label: 
         b0.slice(0..0)
             .map_async(wgpu::MapMode::Read, Result::unwrap);
 
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
 
         {
             let view = b0.slice(0..0).get_mapped_range();
@@ -50,9 +50,9 @@ async fn test_empty_buffer_range(ctx: &TestingContext, buffer_size: u64, label: 
             b0.slice(0..0)
                 .map_async(wgpu::MapMode::Write, Result::unwrap);
 
-            ctx.async_poll(wgpu::Maintain::wait())
+            ctx.async_poll(wgpu::PollInfo::wait())
                 .await
-                .panic_on_timeout();
+                .panic_on_incomplete();
 
             //{
             //    let view = b0.slice(0..0).get_mapped_range_mut();
@@ -81,9 +81,9 @@ async fn test_empty_buffer_range(ctx: &TestingContext, buffer_size: u64, label: 
 
     b1.unmap();
 
-    ctx.async_poll(wgpu::Maintain::wait())
+    ctx.async_poll(wgpu::PollInfo::wait())
         .await
-        .panic_on_timeout();
+        .panic_on_incomplete();
 }
 
 #[gpu_test]
@@ -122,9 +122,9 @@ static MAP_OFFSET: GpuTestConfiguration = GpuTestConfiguration::new().run_async(
             result.unwrap();
         });
 
-    ctx.async_poll(wgpu::Maintain::wait())
+    ctx.async_poll(wgpu::PollInfo::wait())
         .await
-        .panic_on_timeout();
+        .panic_on_incomplete();
 
     {
         let slice = write_buf.slice(32..48);
@@ -148,9 +148,9 @@ static MAP_OFFSET: GpuTestConfiguration = GpuTestConfiguration::new().run_async(
         .slice(..)
         .map_async(wgpu::MapMode::Read, Result::unwrap);
 
-    ctx.async_poll(wgpu::Maintain::wait())
+    ctx.async_poll(wgpu::PollInfo::wait())
         .await
-        .panic_on_timeout();
+        .panic_on_incomplete();
 
     let slice = read_buf.slice(..);
     let view = slice.get_mapped_range();

--- a/tests/tests/buffer_usages.rs
+++ b/tests/tests/buffer_usages.rs
@@ -123,9 +123,9 @@ async fn map_test(
         buffer.destroy();
     }
 
-    ctx.async_poll(wgpu::Maintain::wait())
+    ctx.async_poll(wgpu::PollInfo::wait())
         .await
-        .panic_on_timeout();
+        .panic_on_incomplete();
 
     if !before_unmap && !before_destroy {
         {

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -23,9 +23,9 @@ static CROSS_DEVICE_BIND_GROUP_USAGE: GpuTestConfiguration = GpuTestConfiguratio
             });
         }
 
-        ctx.async_poll(wgpu::Maintain::Poll)
+        ctx.async_poll(wgpu::PollInfo::poll())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
     });
 
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
@@ -507,7 +507,7 @@ static DEVICE_DESTROY_THEN_LOST: GpuTestConfiguration = GpuTestConfiguration::ne
         // Make sure the device queues are empty, which ensures that the closure
         // has been called.
         assert!(ctx
-            .async_poll(wgpu::Maintain::wait())
+            .async_poll(wgpu::PollInfo::wait())
             .await
             .is_queue_empty());
 

--- a/tests/tests/external_texture.rs
+++ b/tests/tests/external_texture.rs
@@ -323,9 +323,9 @@ static IMAGE_BITMAP_IMPORT: GpuTestConfiguration =
                 readback_buffer
                     .slice(..)
                     .map_async(wgpu::MapMode::Read, |_| ());
-                ctx.async_poll(wgpu::Maintain::wait())
+                ctx.async_poll(wgpu::PollInfo::wait())
                     .await
-                    .panic_on_timeout();
+                    .panic_on_incomplete();
 
                 let buffer = readback_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/life_cycle.rs
+++ b/tests/tests/life_cycle.rs
@@ -14,9 +14,9 @@ static BUFFER_DESTROY: GpuTestConfiguration =
 
         buffer.destroy();
 
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
 
         fail(&ctx.device, || {
             buffer
@@ -26,9 +26,9 @@ static BUFFER_DESTROY: GpuTestConfiguration =
 
         buffer.destroy();
 
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
 
         buffer.destroy();
 
@@ -50,9 +50,9 @@ static BUFFER_DESTROY: GpuTestConfiguration =
         }
         let buffer = ctx.device.create_buffer(&descriptor);
         buffer.destroy();
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
         let buffer = ctx.device.create_buffer(&descriptor);
         buffer.destroy();
         {
@@ -61,16 +61,16 @@ static BUFFER_DESTROY: GpuTestConfiguration =
             let buffer = ctx.device.create_buffer(&descriptor);
             buffer.destroy();
             let buffer = ctx.device.create_buffer(&descriptor);
-            ctx.async_poll(wgpu::Maintain::wait())
+            ctx.async_poll(wgpu::PollInfo::wait())
                 .await
-                .panic_on_timeout();
+                .panic_on_incomplete();
             buffer.destroy();
         }
         let buffer = ctx.device.create_buffer(&descriptor);
         buffer.destroy();
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
     });
 
 #[gpu_test]
@@ -95,15 +95,15 @@ static TEXTURE_DESTROY: GpuTestConfiguration =
 
         texture.destroy();
 
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
 
         texture.destroy();
 
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
 
         texture.destroy();
 

--- a/tests/tests/mem_leaks.rs
+++ b/tests/tests/mem_leaks.rs
@@ -241,9 +241,9 @@ async fn draw_test_with_reports(
     let report = global_report.hub_report(ctx.adapter_info.backend);
     assert_eq!(report.command_buffers.num_allocated, 0);
 
-    ctx.async_poll(wgpu::Maintain::wait_for(submit_index))
+    ctx.async_poll(wgpu::PollInfo::wait_for(submit_index))
         .await
-        .panic_on_timeout();
+        .panic_on_incomplete();
 
     let global_report = ctx.instance.generate_report().unwrap();
     let report = global_report.hub_report(ctx.adapter_info.backend);

--- a/tests/tests/occlusion_query/mod.rs
+++ b/tests/tests/occlusion_query/mod.rs
@@ -117,9 +117,9 @@ static OCCLUSION_QUERY: GpuTestConfiguration = GpuTestConfiguration::new()
         mapping_buffer
             .slice(..)
             .map_async(wgpu::MapMode::Read, |_| ());
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
         let query_buffer_view = mapping_buffer.slice(..).get_mapped_range();
         let query_data: &[u64; 3] = bytemuck::from_bytes(&query_buffer_view);
 

--- a/tests/tests/poll.rs
+++ b/tests/tests/poll.rs
@@ -4,7 +4,7 @@ use wgpu::{
     BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor,
     BindGroupLayoutEntry, BindingResource, BindingType, Buffer, BufferBindingType,
     BufferDescriptor, BufferUsages, CommandBuffer, CommandEncoderDescriptor, ComputePassDescriptor,
-    Maintain, ShaderStages,
+    PollInfo, ShaderStages,
 };
 
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestingContext};
@@ -72,7 +72,7 @@ static WAIT: GpuTestConfiguration = GpuTestConfiguration::new().run_async(|ctx| 
     let data = DummyWorkData::new(&ctx);
 
     ctx.queue.submit(Some(data.cmd_buf));
-    ctx.async_poll(Maintain::wait()).await.panic_on_timeout();
+    ctx.async_poll(PollInfo::wait()).await.panic_on_incomplete();
 });
 
 #[gpu_test]
@@ -81,8 +81,8 @@ static DOUBLE_WAIT: GpuTestConfiguration =
         let data = DummyWorkData::new(&ctx);
 
         ctx.queue.submit(Some(data.cmd_buf));
-        ctx.async_poll(Maintain::wait()).await.panic_on_timeout();
-        ctx.async_poll(Maintain::wait()).await.panic_on_timeout();
+        ctx.async_poll(PollInfo::wait()).await.panic_on_incomplete();
+        ctx.async_poll(PollInfo::wait()).await.panic_on_incomplete();
     });
 
 #[gpu_test]
@@ -91,9 +91,9 @@ static WAIT_ON_SUBMISSION: GpuTestConfiguration =
         let data = DummyWorkData::new(&ctx);
 
         let index = ctx.queue.submit(Some(data.cmd_buf));
-        ctx.async_poll(Maintain::wait_for(index))
+        ctx.async_poll(PollInfo::wait_for(index))
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
     });
 
 #[gpu_test]
@@ -102,12 +102,12 @@ static DOUBLE_WAIT_ON_SUBMISSION: GpuTestConfiguration =
         let data = DummyWorkData::new(&ctx);
 
         let index = ctx.queue.submit(Some(data.cmd_buf));
-        ctx.async_poll(Maintain::wait_for(index.clone()))
+        ctx.async_poll(PollInfo::wait_for(index.clone()))
             .await
-            .panic_on_timeout();
-        ctx.async_poll(Maintain::wait_for(index))
+            .panic_on_incomplete();
+        ctx.async_poll(PollInfo::wait_for(index))
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
     });
 
 #[gpu_test]
@@ -118,10 +118,10 @@ static WAIT_OUT_OF_ORDER: GpuTestConfiguration =
 
         let index1 = ctx.queue.submit(Some(data1.cmd_buf));
         let index2 = ctx.queue.submit(Some(data2.cmd_buf));
-        ctx.async_poll(Maintain::wait_for(index2))
+        ctx.async_poll(PollInfo::wait_for(index2))
             .await
-            .panic_on_timeout();
-        ctx.async_poll(Maintain::wait_for(index1))
+            .panic_on_incomplete();
+        ctx.async_poll(PollInfo::wait_for(index1))
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
     });

--- a/tests/tests/push_constants.rs
+++ b/tests/tests/push_constants.rs
@@ -139,9 +139,9 @@ async fn partial_update_test(ctx: TestingContext) {
     encoder.copy_buffer_to_buffer(&gpu_buffer, 0, &cpu_buffer, 0, 32);
     ctx.queue.submit([encoder.finish()]);
     cpu_buffer.slice(..).map_async(wgpu::MapMode::Read, |_| ());
-    ctx.async_poll(wgpu::Maintain::wait())
+    ctx.async_poll(wgpu::PollInfo::wait())
         .await
-        .panic_on_timeout();
+        .panic_on_incomplete();
 
     let data = cpu_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/regression/issue_3457.rs
+++ b/tests/tests/regression/issue_3457.rs
@@ -160,7 +160,7 @@ static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration =
         drop(vertex_buffer2);
 
         // Make sure the buffers are actually deleted.
-        ctx.async_poll(Maintain::wait()).await.panic_on_timeout();
+        ctx.async_poll(PollInfo::wait()).await.panic_on_incomplete();
 
         let mut encoder2 = ctx
             .device

--- a/tests/tests/regression/issue_4024.rs
+++ b/tests/tests/regression/issue_4024.rs
@@ -36,7 +36,7 @@ static QUEUE_SUBMITTED_CALLBACK_ORDERING: GpuTestConfiguration = GpuTestConfigur
         // Submit the work.
         ctx.queue.submit(Some(encoder.finish()));
         // Ensure the work is finished.
-        ctx.async_poll(Maintain::wait()).await.panic_on_timeout();
+        ctx.async_poll(PollInfo::wait()).await.panic_on_incomplete();
 
         #[derive(Debug)]
         struct OrderingContext {
@@ -74,7 +74,9 @@ static QUEUE_SUBMITTED_CALLBACK_ORDERING: GpuTestConfiguration = GpuTestConfigur
         });
 
         // No GPU work is happening at this point, but we want to process callbacks.
-        ctx.async_poll(MaintainBase::Poll).await.panic_on_timeout();
+        ctx.async_poll(MaintainBase::poll())
+            .await
+            .panic_on_incomplete();
 
         // Extract the ordering out of the arc.
         let ordering = Arc::into_inner(ordering).unwrap().into_inner();

--- a/tests/tests/regression/issue_4122.rs
+++ b/tests/tests/regression/issue_4122.rs
@@ -32,9 +32,9 @@ async fn fill_test(ctx: &TestingContext, range: Range<u64>, size: u64) -> bool {
 
     ctx.queue.submit(Some(encoder.finish()));
     cpu_buffer.slice(..).map_async(wgpu::MapMode::Read, |_| ());
-    ctx.async_poll(wgpu::Maintain::wait())
+    ctx.async_poll(wgpu::PollInfo::wait())
         .await
-        .panic_on_timeout();
+        .panic_on_incomplete();
 
     let buffer_slice = cpu_buffer.slice(..);
     let buffer_data = buffer_slice.get_mapped_range();

--- a/tests/tests/root.rs
+++ b/tests/tests/root.rs
@@ -34,6 +34,7 @@ mod shader;
 mod shader_primitive_index;
 mod shader_view_format;
 mod texture_bounds;
+mod timeout;
 mod texture_view_creation;
 mod transfer;
 mod vertex_indices;

--- a/tests/tests/shader/mod.rs
+++ b/tests/tests/shader/mod.rs
@@ -9,7 +9,7 @@ use std::{borrow::Cow, fmt::Debug};
 use wgpu::{
     Backends, BindGroupDescriptor, BindGroupEntry, BindGroupLayoutDescriptor, BindGroupLayoutEntry,
     BindingType, BufferDescriptor, BufferUsages, CommandEncoderDescriptor, ComputePassDescriptor,
-    ComputePipelineDescriptor, Maintain, MapMode, PipelineLayoutDescriptor, PushConstantRange,
+    ComputePipelineDescriptor, MapMode, PipelineLayoutDescriptor, PollInfo, PushConstantRange,
     ShaderModuleDescriptor, ShaderSource, ShaderStages,
 };
 
@@ -355,7 +355,7 @@ async fn shader_input_output_test(
         ctx.queue.submit(Some(encoder.finish()));
 
         mapping_buffer.slice(..).map_async(MapMode::Read, |_| ());
-        ctx.async_poll(Maintain::wait()).await.panic_on_timeout();
+        ctx.async_poll(PollInfo::wait()).await.panic_on_incomplete();
 
         let mapped = mapping_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/shader/zero_init_workgroup_mem.rs
@@ -4,7 +4,7 @@ use wgpu::{
     include_wgsl, Backends, BindGroupDescriptor, BindGroupEntry, BindGroupLayoutDescriptor,
     BindGroupLayoutEntry, BindingResource, BindingType, BufferBinding, BufferBindingType,
     BufferDescriptor, BufferUsages, CommandEncoderDescriptor, ComputePassDescriptor,
-    ComputePipelineDescriptor, DownlevelFlags, Limits, Maintain, MapMode, PipelineLayoutDescriptor,
+    ComputePipelineDescriptor, DownlevelFlags, Limits, MapMode, PipelineLayoutDescriptor, PollInfo,
     ShaderStages,
 };
 
@@ -134,7 +134,7 @@ static ZERO_INIT_WORKGROUP_MEMORY: GpuTestConfiguration = GpuTestConfiguration::
         ctx.queue.submit(Some(encoder.finish()));
 
         mapping_buffer.slice(..).map_async(MapMode::Read, |_| ());
-        ctx.async_poll(Maintain::wait()).await.panic_on_timeout();
+        ctx.async_poll(PollInfo::wait()).await.panic_on_incomplete();
 
         let mapped = mapping_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/shader_view_format/mod.rs
+++ b/tests/tests/shader_view_format/mod.rs
@@ -180,9 +180,9 @@ async fn reinterpret(
 
     let slice = read_buffer.slice(..);
     slice.map_async(wgpu::MapMode::Read, |_| ());
-    ctx.async_poll(wgpu::Maintain::wait())
+    ctx.async_poll(wgpu::PollInfo::wait())
         .await
-        .panic_on_timeout();
+        .panic_on_incomplete();
 
     let data: Vec<u8> = slice.get_mapped_range().to_vec();
     let tolerance_data: [[u8; 4]; 4] = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [1, 1, 1, 0]];

--- a/tests/tests/timeout.rs
+++ b/tests/tests/timeout.rs
@@ -1,0 +1,198 @@
+use std::{num::NonZeroU64, time::Duration};
+
+use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+
+#[gpu_test]
+static POLL_TIMEOUT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            // At best, this test is meaningless on the GL backend, as there are no consequences for
+            // early deleting resources before the timeout is hit.
+            //
+            // At worst, on lavapipe the test will run forever, as GL implementations are allowed to
+            // flush whenever they want, meaning that there is never any asynchronicity in the first place.
+            .skip(FailureCase::backend(wgpu::Backends::GL)),
+    )
+    .run_sync(poll_timeout);
+
+const WORKGROUP_SIZE: u32 = 256;
+const DISPATCHES: u32 = (1 << 16) - 1;
+const BUFFER_SIZE: u64 = (DISPATCHES as u64) * (WORKGROUP_SIZE as u64) * 4;
+const TIMEOUT: Duration = Duration::from_millis(250);
+
+const SHADER: &str = r#"
+    @group(0) @binding(0) var<storage, read_write> buffer_a: array<f32>;
+    @group(0) @binding(1) var<storage, read> buffer_b: array<f32>;
+
+    @compute @workgroup_size(256) fn main(@builtin(global_invocation_id) index: vec3<u32>) {
+        // arctan famously blows up to a ton of alu code.
+        buffer_a[index.x] = atan(atan(atan(buffer_b[index.x])));
+    }
+"#;
+
+/// The given work is fairly memory and alu intensive, so higher iterations should increase in time quickly.
+struct HeavyWork {
+    bind_group_layout: wgpu::BindGroupLayout,
+    pipeline: wgpu::ComputePipeline,
+}
+
+impl HeavyWork {
+    fn new(device: &wgpu::Device) -> Self {
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("bind_group_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: Some(NonZeroU64::new(4).unwrap()),
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: Some(NonZeroU64::new(4).unwrap()),
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("pipeline_layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let cs_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("cs_module"),
+            source: wgpu::ShaderSource::Wgsl(SHADER.into()),
+        });
+
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &cs_module,
+            entry_point: "main",
+        });
+
+        Self {
+            bind_group_layout,
+            pipeline,
+        }
+    }
+
+    fn perform_work(&self, ctx: &TestingContext, iterations: u32) {
+        // We intentionally create new buffers every time so that the destruction
+        // of each buffer/texture is dependant on the given submission being finished.
+        //
+        // We do not keep our handles to the resources open, so they can be destroyed as soon as
+        // the submission is finished.
+        let buffer_a = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(&format!("buffer_a iterations {iterations}")),
+            size: BUFFER_SIZE,
+            usage: wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+        let buffer_b = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(&format!("buffer_b iterations {iterations}")),
+            size: BUFFER_SIZE,
+            usage: wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+
+        let bind_group_a = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(&format!("bind_group_a iterations {iterations}")),
+            layout: &self.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: buffer_a.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: buffer_b.as_entire_binding(),
+                },
+            ],
+        });
+
+        let bind_group_b = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(&format!("bind_group_b iterations {iterations}")),
+            layout: &self.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: buffer_b.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: buffer_a.as_entire_binding(),
+                },
+            ],
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some(&format!("encoder iterations {iterations}")),
+            });
+
+        let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some(&format!("cpass iterations {iterations}")),
+            timestamp_writes: None,
+        });
+
+        cpass.set_pipeline(&self.pipeline);
+
+        for _ in 0..iterations {
+            cpass.set_bind_group(0, &bind_group_a, &[]);
+            cpass.dispatch_workgroups(DISPATCHES, 1, 1);
+
+            cpass.set_bind_group(0, &bind_group_b, &[]);
+            cpass.dispatch_workgroups(DISPATCHES, 1, 1);
+        }
+
+        drop(cpass);
+
+        ctx.queue.submit([encoder.finish()]);
+    }
+}
+
+fn poll_timeout(ctx: TestingContext) {
+    let work = HeavyWork::new(&ctx.device);
+
+    // We keep doubling the amount of iterations until we hit a timeout.
+    //
+    // We then keep increasing at least two more times, to make sure that the handling
+    // of the timeout works correctly, and does not cause early deletes, even after multiple
+    // potential timeouts.
+    let mut iterations = 1;
+    let mut timeouts = 0;
+    loop {
+        eprintln!("{iterations}: starting");
+        work.perform_work(&ctx, iterations);
+        ctx.queue.on_submitted_work_done(move || {
+            eprintln!("{iterations}: done");
+        });
+        let maintain_result = ctx.device.poll(wgpu::PollInfo {
+            submission_index: None,
+            wait_duration: wgpu::WaitDuration::Duration(TIMEOUT),
+        });
+        eprintln!("{iterations}: maintain result {maintain_result:?}");
+        if maintain_result.is_incomplete() {
+            timeouts += 1;
+            if timeouts == 3 {
+                eprintln!("three timeouts detected!");
+                break;
+            }
+        }
+        iterations *= 2;
+    }
+}

--- a/tests/tests/vertex_indices/mod.rs
+++ b/tests/tests/vertex_indices/mod.rs
@@ -428,15 +428,15 @@ async fn vertex_index_common(ctx: TestingContext) {
         // See https://github.com/gfx-rs/wgpu/issues/4732 for why this is split between two submissions
         // with a hard wait in between.
         ctx.queue.submit([encoder1.finish()]);
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
         ctx.queue.submit([encoder2.finish()]);
         let slice = cpu_buffer.slice(..);
         slice.map_async(wgpu::MapMode::Read, |_| ());
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
         let data: Vec<u32> = bytemuck::cast_slice(&slice.get_mapped_range()).to_vec();
 
         if data != expected {

--- a/tests/tests/write_texture.rs
+++ b/tests/tests/write_texture.rs
@@ -84,9 +84,9 @@ static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =
 
         let slice = read_buffer.slice(..);
         slice.map_async(wgpu::MapMode::Read, |_| ());
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
         let data: Vec<u8> = slice.get_mapped_range().to_vec();
 
         for byte in &data[..(size as usize * 2)] {
@@ -179,9 +179,9 @@ static WRITE_TEXTURE_SUBSET_3D: GpuTestConfiguration =
 
         let slice = read_buffer.slice(..);
         slice.map_async(wgpu::MapMode::Read, |_| ());
-        ctx.async_poll(wgpu::Maintain::wait())
+        ctx.async_poll(wgpu::PollInfo::wait())
             .await
-            .panic_on_timeout();
+            .panic_on_incomplete();
         let data: Vec<u8> = slice.get_mapped_range().to_vec();
 
         for byte in &data[..((size * size) as usize * 2)] {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2030,9 +2030,18 @@ impl Global {
                 // Wait for all work to finish before configuring the surface.
                 let fence = device.fence.read();
                 let fence = fence.as_ref().unwrap();
-                match device.maintain(fence, wgt::Maintain::Wait) {
-                    Ok((closures, _)) => {
+                match device.maintain(fence, wgt::PollInfo::wait()) {
+                    Ok((closures, maintain_result)) => {
                         user_callbacks = closures;
+
+                        // WebGL doesn't support waiting for idle, so this will always throw a timeout.
+                        //
+                        // WebGL on the other hand doesn't actually require us wait for idle to change
+                        // the surface. As such we just ignore the timeout if we're on web and move on.
+                        let is_webgl = cfg!(target_arch = "wasm32");
+                        if !is_webgl && maintain_result.is_incomplete() {
+                            break present::ConfigureSurfaceError::GpuWaitForIdleTimeout;
+                        }
                     }
                     Err(e) => {
                         break e.into();
@@ -2108,12 +2117,18 @@ impl Global {
     pub fn device_poll<A: HalApi>(
         &self,
         device_id: DeviceId,
-        maintain: wgt::Maintain<queue::WrappedSubmissionIndex>,
-    ) -> Result<bool, WaitIdleError> {
+        maintain: wgt::PollInfo<queue::WrappedSubmissionIndex>,
+    ) -> Result<wgt::SubmissionStatus, WaitIdleError> {
         api_log!("Device::poll");
 
-        let (closures, queue_empty) = {
-            if let wgt::Maintain::WaitForSubmissionIndex(submission_index) = maintain {
+        let (closures, maintain_result) = {
+            let hub = A::hub(self);
+            let device = hub
+                .devices
+                .get(device_id)
+                .map_err(|_| DeviceError::Invalid)?;
+
+            if let Some(submission_index) = maintain.submission_index {
                 if submission_index.queue_id != device_id.transmute() {
                     return Err(WaitIdleError::WrongSubmissionIndex(
                         submission_index.queue_id,
@@ -2122,11 +2137,10 @@ impl Global {
                 }
             }
 
-            let hub = A::hub(self);
-            let device = hub
-                .devices
-                .get(device_id)
-                .map_err(|_| DeviceError::Invalid)?;
+            if !maintain.is_poll() {
+                device.require_features(wgt::Features::NON_ZERO_POLL_TIMEOUT)?;
+            }
+
             let fence = device.fence.read();
             let fence = fence.as_ref().unwrap();
             device.maintain(fence, maintain)?
@@ -2134,7 +2148,7 @@ impl Global {
 
         closures.fire();
 
-        Ok(queue_empty)
+        Ok(maintain_result)
     }
 
     /// Poll all devices belonging to the backend `A`.
@@ -2157,14 +2171,17 @@ impl Global {
 
             for (_id, device) in device_guard.iter(A::VARIANT) {
                 let maintain = if force_wait {
-                    wgt::Maintain::Wait
+                    device.require_features(wgt::Features::NON_ZERO_POLL_TIMEOUT)?;
+
+                    wgt::PollInfo::wait()
                 } else {
-                    wgt::Maintain::Poll
+                    wgt::PollInfo::poll()
                 };
+
                 let fence = device.fence.read();
                 let fence = fence.as_ref().unwrap();
-                let (cbs, queue_empty) = device.maintain(fence, maintain)?;
-                all_queue_empty = all_queue_empty && queue_empty;
+                let (cbs, maintain_result) = device.maintain(fence, maintain)?;
+                all_queue_empty = all_queue_empty && maintain_result.is_queue_empty();
 
                 closures.extend(cbs);
             }
@@ -2250,6 +2267,11 @@ impl Global {
             if let Some(closure) = device_lost_closure {
                 closure.call(DeviceLostReason::Dropped, String::from("Device dropped."));
             }
+
+            // TODO: NO!
+            let _ = device
+                .maintain(device.fence.read().as_ref().unwrap(), wgt::PollInfo::wait())
+                .unwrap();
 
             // The things `Device::prepare_to_die` takes care are mostly
             // unnecessary here. We know our queue is empty, so we don't

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1511,11 +1511,15 @@ impl Global {
 
             // This will schedule destruction of all resources that are no longer needed
             // by the user but used in the command stream, among other things.
-            let (closures, _) = match device.maintain(fence, wgt::Maintain::Poll) {
+            let (closures, _) = match device.maintain(fence, wgt::PollInfo::poll()) {
                 Ok(closures) => closures,
                 Err(WaitIdleError::Device(err)) => return Err(QueueSubmitError::Queue(err)),
-                Err(WaitIdleError::StuckGpu) => return Err(QueueSubmitError::StuckGpu),
-                Err(WaitIdleError::WrongSubmissionIndex(..)) => unreachable!(),
+                Err(
+                    WaitIdleError::WrongSubmissionIndex(..)
+                    | WaitIdleError::ExcessiveTimeout(..)
+                    | WaitIdleError::MissingFeatures(..)
+                    | WaitIdleError::GpuWaitForIdleTimeout,
+                ) => unreachable!(),
             };
 
             // pending_write_resources has been drained, so it's empty, but we

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -98,16 +98,20 @@ pub enum ConfigureSurfaceError {
     },
     #[error("Requested usage is not supported")]
     UnsupportedUsage,
-    #[error("Gpu got stuck :(")]
-    StuckGpu,
+    #[error("Failed to wait for GPU idle. Timeout of {:?} exceeded", wgt::PollInfo::<()>::DEFAULT_TIMEOUT)]
+    GpuWaitForIdleTimeout,
 }
 
 impl From<WaitIdleError> for ConfigureSurfaceError {
     fn from(e: WaitIdleError) -> Self {
         match e {
             WaitIdleError::Device(d) => ConfigureSurfaceError::Device(d),
-            WaitIdleError::WrongSubmissionIndex(..) => unreachable!(),
-            WaitIdleError::StuckGpu => ConfigureSurfaceError::StuckGpu,
+            WaitIdleError::GpuWaitForIdleTimeout
+            | WaitIdleError::MissingFeatures(..)
+            | WaitIdleError::WrongSubmissionIndex(..)
+            | WaitIdleError::ExcessiveTimeout(..) => {
+                unreachable!("{e}");
+            }
         }
     }
 }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -250,7 +250,8 @@ impl super::Adapter {
             | wgt::Features::SHADER_PRIMITIVE_INDEX
             | wgt::Features::RG11B10UFLOAT_RENDERABLE
             | wgt::Features::DUAL_SOURCE_BLENDING
-            | wgt::Features::TEXTURE_FORMAT_NV12;
+            | wgt::Features::TEXTURE_FORMAT_NV12
+            | wgt::Features::NON_ZERO_POLL_TIMEOUT;
 
         //TODO: in order to expose this, we need to run a compute shader
         // that extract the necessary statistics out of the D3D12 result.

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -437,6 +437,10 @@ impl super::Adapter {
             | wgt::Features::CLEAR_TEXTURE
             | wgt::Features::PUSH_CONSTANTS;
         features.set(
+            wgt::Features::NON_ZERO_POLL_TIMEOUT,
+            !cfg!(target_arch = "wasm32"),
+        );
+        features.set(
             wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER | wgt::Features::ADDRESS_MODE_CLAMP_TO_ZERO,
             extensions.contains("GL_EXT_texture_border_clamp")
                 || extensions.contains("GL_ARB_texture_border_clamp"),

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -807,6 +807,7 @@ impl super::Queue {
                         None => {
                             buffer_data = dst.data.as_ref().unwrap().lock().unwrap();
                             let dst_data = &mut buffer_data.as_mut_slice()[offset as usize..];
+
                             glow::PixelPackData::Slice(dst_data)
                         }
                     };
@@ -1789,6 +1790,10 @@ impl crate::Queue<super::Api> for super::Queue {
                 .map_err(|_| crate::DeviceError::OutOfMemory)?;
             fence.pending.push((value, sync));
         }
+
+        // This is extremely important. If we don't flush, the above fences may never
+        // be signaled, particularly in headless contexts.
+        unsafe { gl.flush() };
 
         Ok(())
     }

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -825,7 +825,8 @@ impl super::PrivateCapabilities {
             | F::TEXTURE_FORMAT_16BIT_NORM
             | F::SHADER_F16
             | F::DEPTH32FLOAT_STENCIL8
-            | F::BGRA8UNORM_STORAGE;
+            | F::BGRA8UNORM_STORAGE
+            | F::NON_ZERO_POLL_TIMEOUT;
 
         features.set(F::FLOAT32_FILTERABLE, self.supports_float_filtering);
         features.set(

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -371,7 +371,8 @@ impl PhysicalDeviceFeatures {
             | F::TIMESTAMP_QUERY
             | F::TIMESTAMP_QUERY_INSIDE_PASSES
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | F::CLEAR_TEXTURE;
+            | F::CLEAR_TEXTURE
+            | F::NON_ZERO_POLL_TIMEOUT;
 
         let mut dl_flags = Df::COMPUTE_SHADERS
             | Df::BASE_VERTEX

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -10,11 +10,12 @@
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 
 #[cfg(any(feature = "serde", test))]
-use serde::Deserialize;
-#[cfg(any(feature = "serde", test))]
-use serde::Serialize;
-use std::hash::{Hash, Hasher};
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::{
+    hash::{Hash, Hasher},
+    time::Duration,
+};
 use std::{num::NonZeroU32, ops::Range};
 
 pub mod assertions;
@@ -156,12 +157,7 @@ bitflags::bitflags! {
         const METAL = 1 << Backend::Metal as u32;
         /// Supported on Windows 10
         const DX12 = 1 << Backend::Dx12 as u32;
-        /// Supported when targeting the web through webassembly with the `webgpu` feature enabled.
-        ///
-        /// The WebGPU backend is special in several ways:
-        /// It is not not implemented by `wgpu_core` and instead by the higher level `wgpu` crate.
-        /// Whether WebGPU is targeted is decided upon the creation of the `wgpu::Instance`,
-        /// *not* upon adapter creation. See `wgpu::Instance::new`.
+        /// Supported when targeting the web through webassembly
         const BROWSER_WEBGPU = 1 << Backend::BrowserWebGpu as u32;
         /// All the apis that wgpu offers first tier of support for.
         ///
@@ -792,8 +788,24 @@ bitflags::bitflags! {
         ///
         /// This is a native-only feature.
         const RAY_TRACING_ACCELERATION_STRUCTURE = 1 << 56;
-
-        // 57 available
+        /// Allows calls to device.poll() to block for a non-zero timeout
+        /// waiting for work submitted to the device to complete.
+        ///
+        /// If this is not present, all poll calls must use the Poll variant,
+        /// or a duration of zero.
+        ///
+        /// Supported platforms:
+        /// - Vulkan
+        /// - DX12
+        /// - Metal
+        /// - OpenGL
+        ///
+        /// Unsupported platforms:
+        /// - WebGPU
+        /// - WebGL
+        ///
+        /// This is a native-only feature.
+        const NON_ZERO_POLL_TIMEOUT = 1 << 57;
 
         // Shader:
 
@@ -4280,79 +4292,151 @@ impl Default for ColorWrites {
     }
 }
 
-/// Passed to `Device::poll` to control how and if it should block.
-#[derive(Clone)]
-pub enum Maintain<T> {
-    /// On wgpu-core based backends, block until the given submission has
-    /// completed execution, and any callbacks have been invoked.
+/// How long a poll can wait before timing out.
+#[derive(Debug, Copy, Clone)]
+pub enum WaitDuration {
+    /// Wait as long as possible for the submission to complete.
     ///
-    /// On WebGPU, this has no effect. Callbacks are invoked from the
-    /// window event loop.
-    WaitForSubmissionIndex(T),
-    /// Same as WaitForSubmissionIndex but waits for the most recent submission.
-    Wait,
-    /// Check the device for a single time without blocking.
-    Poll,
+    /// This is allowed to never return.
+    Unlimited,
+    /// Wait for a given duration for the submission to complete.
+    ///
+    /// The duration must be less than u32::MAX milliseconds (~2 hours).
+    Duration(Duration),
+    /// Do not wait for the submission to complete, just check its status.
+    Zero,
 }
 
-impl<T> Maintain<T> {
-    /// Construct a wait variant
+/// Passed to `Device::poll` to control the submission to wait for
+/// and how long to wait for it.
+#[derive(Debug, Copy, Clone)]
+pub struct PollInfo<SubmissionIndex> {
+    /// The submission index to check for. If `None` is specified
+    pub submission_index: Option<SubmissionIndex>,
+    /// How long the poll call should wait for the submission to complete.
+    ///
+    /// If `Zero`, the poll will not wait for the submission to complete.
+    pub wait_duration: WaitDuration,
+}
+
+impl<T> PollInfo<T> {
+    /// The default timeout used by [`Maintain::wait`].
+    pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Returns no wait.
+    pub fn poll() -> Self {
+        Self {
+            submission_index: None,
+            wait_duration: WaitDuration::Zero,
+        }
+    }
+
+    /// Returns a poll for the given submission index.
+    pub fn poll_for(submission_index: T) -> Self {
+        Self {
+            submission_index: Some(submission_index),
+            wait_duration: WaitDuration::Zero,
+        }
+    }
+
+    /// Returns a wait with a reasonable maximum timeout.
     pub fn wait() -> Self {
-        // This function seems a little silly, but it is useful to allow
-        // <https://github.com/gfx-rs/wgpu/pull/5012> to be split up, as
-        // it has meaning in that PR.
-        Self::Wait
+        Self {
+            submission_index: None,
+            wait_duration: WaitDuration::Duration(Self::DEFAULT_TIMEOUT),
+        }
     }
 
-    /// Construct a WaitForSubmissionIndex variant
+    /// Returns a wait for the given submission index with a reasonable maximum timeout.
     pub fn wait_for(submission_index: T) -> Self {
-        // This function seems a little silly, but it is useful to allow
-        // <https://github.com/gfx-rs/wgpu/pull/5012> to be split up, as
-        // it has meaning in that PR.
-        Self::WaitForSubmissionIndex(submission_index)
-    }
-
-    /// This maintain represents a wait of some kind.
-    pub fn is_wait(&self) -> bool {
-        match *self {
-            Self::WaitForSubmissionIndex(..) | Self::Wait => true,
-            Self::Poll => false,
+        Self {
+            submission_index: Some(submission_index),
+            wait_duration: WaitDuration::Duration(Self::DEFAULT_TIMEOUT),
         }
     }
 
     /// Map on the wait index type.
-    pub fn map_index<U, F>(self, func: F) -> Maintain<U>
+    pub fn map_index<U, F>(self, func: F) -> PollInfo<U>
     where
         F: FnOnce(T) -> U,
     {
-        match self {
-            Self::WaitForSubmissionIndex(i) => Maintain::WaitForSubmissionIndex(func(i)),
-            Self::Wait => Maintain::Wait,
-            Self::Poll => Maintain::Poll,
+        let Self {
+            submission_index,
+            wait_duration: timeout,
+        } = self;
+
+        PollInfo {
+            submission_index: submission_index.map(func),
+            wait_duration: timeout,
         }
+    }
+
+    /// Returns the expected duration value for the wait.
+    ///
+    /// Returns `None` if this duration is Zero.
+    pub fn effective_wait_duration(&self) -> Option<Duration> {
+        match self.wait_duration {
+            WaitDuration::Unlimited => Some(Duration::from_millis(u32::MAX as _)),
+            WaitDuration::Duration(dur) if dur.is_zero() => None,
+            WaitDuration::Duration(dur) => Some(dur),
+            WaitDuration::Zero => None,
+        }
+    }
+
+    /// Returns `true` if the maintain only polls the device.
+    #[must_use]
+    pub fn is_poll(&self) -> bool {
+        self.effective_wait_duration().is_none()
     }
 }
 
-/// Result of a maintain operation.
-pub enum MaintainResult {
-    /// There are no active submissions in flight as of the beginning of the poll call.
+/// Status of a submission as returned by Device::poll
+#[must_use]
+#[derive(Clone, Copy, Debug)]
+pub enum SubmissionStatus {
+    /// There are no active submissions in flight when we checked the queue status.
     /// Other submissions may have been queued on other threads at the same time.
     ///
     /// This implies that the given poll is complete.
-    SubmissionQueueEmpty,
-    /// More information coming soon <https://github.com/gfx-rs/wgpu/pull/5012>
-    Ok,
+    QueueEmpty,
+    /// The submission requested in the poll has completed.
+    ///
+    /// Other submissions may be in flight.
+    Complete,
+    /// The submission requested in the wait has not completed.
+    Incomplete,
 }
 
-impl MaintainResult {
-    /// Returns true if the result is [`Self::SubmissionQueueEmpty`]`.
-    pub fn is_queue_empty(&self) -> bool {
-        matches!(self, Self::SubmissionQueueEmpty)
+impl SubmissionStatus {
+    /// Panics if the result is [`Self::Incomplete`].
+    pub fn panic_on_incomplete(self) {
+        if let Self::Incomplete = self {
+            panic!("Poll(Wait) timed out!");
+        }
     }
 
-    /// Panics if the MaintainResult is not Ok.
-    pub fn panic_on_timeout(self) {
-        let _ = self;
+    /// Returns true if the queue is empty as of the beginning of the poll call.
+    pub fn is_queue_empty(&self) -> bool {
+        match self {
+            Self::QueueEmpty => true,
+            Self::Complete | Self::Incomplete => false,
+        }
+    }
+
+    /// Returns true if the poll is complete.
+    pub fn is_complete(&self) -> bool {
+        match self {
+            Self::QueueEmpty | Self::Complete => true,
+            Self::Incomplete => false,
+        }
+    }
+
+    /// Returns true if the poll is not complete.
+    pub fn is_incomplete(&self) -> bool {
+        match self {
+            Self::Incomplete => true,
+            Self::QueueEmpty | Self::Complete => false,
+        }
     }
 }
 

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -10,11 +10,11 @@ use wgt::{
 use crate::{
     AnyWasmNotSendSync, BindGroupDescriptor, BindGroupLayoutDescriptor, Buffer, BufferAsyncError,
     BufferDescriptor, CommandEncoderDescriptor, ComputePassDescriptor, ComputePipelineDescriptor,
-    DeviceDescriptor, Error, ErrorFilter, ImageCopyBuffer, ImageCopyTexture, Maintain,
-    MaintainResult, MapMode, PipelineLayoutDescriptor, QuerySetDescriptor, RenderBundleDescriptor,
+    DeviceDescriptor, Error, ErrorFilter, ImageCopyBuffer, ImageCopyTexture, MapMode,
+    PipelineLayoutDescriptor, PollInfo, QuerySetDescriptor, RenderBundleDescriptor,
     RenderBundleEncoderDescriptor, RenderPassDescriptor, RenderPipelineDescriptor,
     RequestAdapterOptions, RequestDeviceError, SamplerDescriptor, ShaderModuleDescriptor,
-    ShaderModuleDescriptorSpirV, SurfaceTargetUnsafe, Texture, TextureDescriptor,
+    ShaderModuleDescriptorSpirV, SubmissionStatus, SurfaceTargetUnsafe, Texture, TextureDescriptor,
     TextureViewDescriptor, UncapturedErrorHandler,
 };
 
@@ -286,8 +286,8 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         &self,
         device: &Self::DeviceId,
         device_data: &Self::DeviceData,
-        maintain: Maintain,
-    ) -> MaintainResult;
+        poll_info: PollInfo,
+    ) -> SubmissionStatus;
     fn device_on_uncaptured_error(
         &self,
         device: &Self::DeviceId,
@@ -1307,8 +1307,8 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        maintain: Maintain,
-    ) -> MaintainResult;
+        poll_info: PollInfo,
+    ) -> SubmissionStatus;
     fn device_on_uncaptured_error(
         &self,
         device: &ObjectId,
@@ -2389,11 +2389,11 @@ where
         &self,
         device: &ObjectId,
         device_data: &crate::Data,
-        maintain: Maintain,
-    ) -> MaintainResult {
+        poll_info: PollInfo,
+    ) -> SubmissionStatus {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
-        Context::device_poll(self, &device, device_data, maintain)
+        Context::device_poll(self, &device, device_data, poll_info)
     }
 
     fn device_on_uncaptured_error(


### PR DESCRIPTION
**Connections**

Closes #4589 
Closes #3601

**Description**

We were not properly dealing with polls which timed out. This exposed the concept of timeouts to the user so that they can properly deal with polls which time out.

This doesn't fix anything with timeouts inside surface.configure.

**Testing**

Added timeout test.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
