### PR TITLE
Disable naga-cli's Docs

### DIFF
--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -11,6 +11,10 @@ license = "MIT OR Apache-2.0"
 [[bin]]
 name = "naga"
 path = "src/bin/naga.rs"
+# This _must_ be false, as this conflicts with `naga`'s docs.
+#
+# See https://github.com/gfx-rs/wgpu/issues/4997
+doc = false
 test = false
 
 [dependencies]


### PR DESCRIPTION
Closes #4997 

naga-cli doesn't actually need docs, and it conflicts with `naga`'s docs causing CI flakes and other nonsense. Apparently this is automatically false if the bin/lib have the same name in the same package.