### PR TITLE
Prefer `Arc::into_inner` over `Arc::try_unwrap`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ env:
   REPO_MSRV: "1.71"
   # This is the MSRV used by the `wgpu-core`, `wgpu-hal`, and `wgpu-types` crates,
   # to ensure that they can be used with firefox.
-  CORE_MSRV: "1.65"
+  CORE_MSRV: "1.70"
 
   #
   # Environment variables

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ On Linux, you can point to them using `LD_LIBRARY_PATH` environment.
 ### MSRV policy
 
 Due to complex dependants, we have two MSRV policies:
- - `d3d12`, `naga`, `wgpu-core`, `wgpu-hal`, and `wgpu-types`'s MSRV is **1.65**.
+ - `d3d12`, `naga`, `wgpu-core`, `wgpu-hal`, and `wgpu-types`'s MSRV is **1.70**.
  - The rest of the workspace has an MSRV of **1.71**.
 
 It is enforced on CI (in "/.github/workflows/ci.yml") with the `CORE_MSRV` and `REPO_MSRV` variables.

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["shader", "SPIR-V", "GLSL", "MSL"]
 license = "MIT OR Apache-2.0"
 exclude = ["bin/**/*", "tests/**/*", "Cargo.lock", "target/**/*"]
 resolver = "2"
-rust-version = "1.65"
+rust-version = "1.70"
 autotests = false
 
 [[test]]

--- a/naga/README.md
+++ b/naga/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/naga.svg?label=naga)](https://crates.io/crates/naga)
 [![Docs.rs](https://docs.rs/naga/badge.svg)](https://docs.rs/naga)
 [![Build Status](https://github.com/gfx-rs/naga/workflows/pipeline/badge.svg)](https://github.com/gfx-rs/naga/actions)
-![MSRV](https://img.shields.io/badge/rustc-1.65+-blue.svg)
+![MSRV](https://img.shields.io/badge/rustc-1.70+-blue.svg)
 [![codecov.io](https://codecov.io/gh/gfx-rs/naga/branch/master/graph/badge.svg?token=9VOKYO8BM2)](https://codecov.io/gh/gfx-rs/naga)
 
 The shader translation library for the needs of [wgpu](https://github.com/gfx-rs/wgpu).

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,6 +5,6 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "1.71" # Needed for deno & cts_runner. Firefox's MSRV is 1.65
+channel = "1.71" # Needed for deno & cts_runner. Firefox's MSRV is 1.70
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/tests/tests/regression/issue_4024.rs
+++ b/tests/tests/regression/issue_4024.rs
@@ -77,7 +77,7 @@ static QUEUE_SUBMITTED_CALLBACK_ORDERING: GpuTestConfiguration = GpuTestConfigur
         ctx.device.poll(MaintainBase::Poll);
 
         // Extract the ordering out of the arc.
-        let ordering = Arc::try_unwrap(ordering).unwrap().into_inner();
+        let ordering = Arc::into_inner(ordering).unwrap().into_inner();
 
         // There were two callbacks invoked
         assert_eq!(ordering.counter, 2);

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.65"
+rust-version = "1.70"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -288,7 +288,7 @@ impl<A: HalApi> CommandBuffer<A> {
     }
 
     pub(crate) fn from_arc_into_baked(self: Arc<Self>) -> BakedCommands<A> {
-        if let Ok(mut command_buffer) = Arc::try_unwrap(self) {
+        if let Some(mut command_buffer) = Arc::into_inner(self) {
             command_buffer.extract_baked_commands()
         } else {
             panic!("CommandBuffer cannot be destroyed because is still in use");

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1185,7 +1185,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             ));
                         }
                         if !cmdbuf.is_finished() {
-                            if let Ok(cmdbuf) = Arc::try_unwrap(cmdbuf) {
+                            if let Some(cmdbuf) = Arc::into_inner(cmdbuf) {
                                 device.destroy_command_buffer(cmdbuf);
                             } else {
                                 panic!(

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -165,7 +165,7 @@ impl<G: GlobalIdentityHandlerFactory> Drop for Global<G> {
         // destroy surfaces
         for element in surfaces_locked.map.drain(..) {
             if let Element::Occupied(arc_surface, _) = element {
-                if let Ok(surface) = Arc::try_unwrap(arc_surface) {
+                if let Some(surface) = Arc::into_inner(arc_surface) {
                     self.instance.destroy_surface(surface);
                 } else {
                     panic!("Surface cannot be destroyed because is still in use");

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -121,8 +121,8 @@ impl Instance {
         fn destroy<A: HalApi>(_: A, instance: &Option<A::Instance>, surface: AnySurface) {
             unsafe {
                 if let Some(surface) = surface.take::<A>() {
-                    if let Ok(suf) = Arc::try_unwrap(surface) {
-                        if let Ok(raw) = Arc::try_unwrap(suf.raw) {
+                    if let Some(suf) = Arc::into_inner(surface) {
+                        if let Some(raw) = Arc::into_inner(suf.raw) {
                             instance.as_ref().unwrap().destroy_surface(raw);
                         } else {
                             panic!("Surface cannot be destroyed because is still in use");
@@ -766,7 +766,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         let surface = self.surfaces.unregister(id);
-        if let Ok(surface) = Arc::try_unwrap(surface.unwrap()) {
+        if let Some(surface) = Arc::into_inner(surface.unwrap()) {
             if let Some(present) = surface.presentation.lock().take() {
                 #[cfg(all(feature = "vulkan", not(target_arch = "wasm32")))]
                 unconfigure::<_, hal::api::Vulkan>(self, &surface.raw, &present);

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.65"
+rust-version = "1.70"
 
 [package.metadata.docs.rs]
 # Ideally we would enable all the features.

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.65"
+rust-version = "1.70"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
As explained in its Rust documentation, calling `Arc::try_unwrap(a)`
where the intention is to drop `a` if it is not uniquely owned suffers
from a race condition: if two threads call `try_unwrap` simulaneously
on the last two `Arc`s referring to a value, they will both see a
reference count greater than one, and then both drop the `Err`, with
neither thread getting the value. Because `try_unwrap` returns the
`Arc` in its `Err`, there is a check-versus-use gap. `Arc::into_inner`
returns an `Option` of the result, and guarantees that checking the
count and dropping the `Arc` are indivisible.
