### PR TITLE
Fix a bounds check in remove_abandoned

### DIFF
--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -88,7 +88,7 @@ impl<A: HalApi, Id: TypedId, T: Resource<Id>> ResourceTracker<Id, T>
     fn remove_abandoned(&mut self, id: Id) -> bool {
         let index = id.unzip().0 as usize;
 
-        if index > self.metadata.size() {
+        if index >= self.metadata.size() {
             return false;
         }
 


### PR DESCRIPTION
**Connections**

May or may not be a fix for #5022 (I have not been able to reproduce so far).

**Description**

Fixes what looks like a classic off-by-one error comparing an index with a length.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
