### PR TITLE
Validate max_vertex_buffers in render bundles

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -430,6 +430,16 @@ impl RenderBundleEncoder {
                     size,
                 } => {
                     let scope = PassErrorScope::SetVertexBuffer(buffer_id);
+
+                    let max_vertex_buffers = device.limits.max_vertex_buffers;
+                    if slot >= max_vertex_buffers {
+                        return Err(RenderCommandError::VertexBufferIndexOutOfRange {
+                            index: slot,
+                            max: max_vertex_buffers,
+                        })
+                        .map_pass_err(scope);
+                    }
+
                     let buffer = state
                         .trackers
                         .buffers


### PR DESCRIPTION
**Description**

We are hitting [crashes in CTS runs](https://treeherder.mozilla.org/logviewer?job_id=442315500&repo=try&lineNumber=1574) with out-of-bounds access to the `vertex`  `ArrayVec` in when producing render bundles. This addresses it by validating the index against `limits.max_vertex_buffers`.

**Testing**

Covered by the CTS.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
