### PR TITLE
Don't cast the dynamic offsets count to u8

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -312,7 +312,7 @@ impl RenderBundleEncoder {
                     }
 
                     // Identify the next `num_dynamic_offsets` entries from `base.dynamic_offsets`.
-                    let num_dynamic_offsets = num_dynamic_offsets as usize;
+                    let num_dynamic_offsets = num_dynamic_offsets;
                     let offsets_range =
                         next_dynamic_offset..next_dynamic_offset + num_dynamic_offsets;
                     next_dynamic_offset = offsets_range.end;
@@ -809,10 +809,10 @@ impl<A: HalApi> RenderBundle<A> {
                             pipeline_layout.as_ref().unwrap().raw(),
                             index,
                             raw_bg,
-                            &offsets[..num_dynamic_offsets as usize],
+                            &offsets[..num_dynamic_offsets],
                         )
                     };
-                    offsets = &offsets[num_dynamic_offsets as usize..];
+                    offsets = &offsets[num_dynamic_offsets..];
                 }
                 RenderCommand::SetPipeline(pipeline_id) => {
                     let render_pipelines = trackers.render_pipelines.read();
@@ -1394,7 +1394,7 @@ impl<A: HalApi> State<A> {
                         return Some(RenderCommand::SetBindGroup {
                             index: i.try_into().unwrap(),
                             bind_group_id: contents.bind_group.as_info().id(),
-                            num_dynamic_offsets: (offsets.end - offsets.start) as u8,
+                            num_dynamic_offsets: offsets.end - offsets.start,
                         });
                     }
                 }
@@ -1497,7 +1497,7 @@ pub mod bundle_ffi {
 
         bundle.base.commands.push(RenderCommand::SetBindGroup {
             index,
-            num_dynamic_offsets: offset_length.try_into().unwrap(),
+            num_dynamic_offsets: offset_length,
             bind_group_id,
         });
     }

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -51,7 +51,7 @@ use std::{fmt, mem, str};
 pub enum ComputeCommand {
     SetBindGroup {
         index: u32,
-        num_dynamic_offsets: u8,
+        num_dynamic_offsets: usize,
         bind_group_id: id::BindGroupId,
     },
     SetPipeline(id::ComputePipelineId),
@@ -512,10 +512,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
                     temp_offsets.clear();
                     temp_offsets.extend_from_slice(
-                        &base.dynamic_offsets[dynamic_offset_count
-                            ..dynamic_offset_count + (num_dynamic_offsets as usize)],
+                        &base.dynamic_offsets
+                            [dynamic_offset_count..dynamic_offset_count + num_dynamic_offsets],
                     );
-                    dynamic_offset_count += num_dynamic_offsets as usize;
+                    dynamic_offset_count += num_dynamic_offsets;
 
                     let bind_group = tracker
                         .bind_groups
@@ -924,7 +924,7 @@ pub mod compute_ffi {
 
         pass.base.commands.push(ComputeCommand::SetBindGroup {
             index,
-            num_dynamic_offsets: offset_length.try_into().unwrap(),
+            num_dynamic_offsets: offset_length,
             bind_group_id,
         });
     }

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -147,7 +147,7 @@ pub struct Rect<T> {
 pub enum RenderCommand {
     SetBindGroup {
         index: u32,
-        num_dynamic_offsets: u8,
+        num_dynamic_offsets: usize,
         bind_group_id: id::BindGroupId,
     },
     SetPipeline(id::RenderPipelineId),

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1435,10 +1435,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
                         temp_offsets.clear();
                         temp_offsets.extend_from_slice(
-                            &base.dynamic_offsets[dynamic_offset_count
-                                ..dynamic_offset_count + (num_dynamic_offsets as usize)],
+                            &base.dynamic_offsets
+                                [dynamic_offset_count..dynamic_offset_count + num_dynamic_offsets],
                         );
-                        dynamic_offset_count += num_dynamic_offsets as usize;
+                        dynamic_offset_count += num_dynamic_offsets;
 
                         let bind_group = tracker
                             .bind_groups
@@ -2452,7 +2452,7 @@ pub mod render_ffi {
 
         pass.base.commands.push(RenderCommand::SetBindGroup {
             index,
-            num_dynamic_offsets: offset_length.try_into().unwrap(),
+            num_dynamic_offsets: offset_length,
             bind_group_id,
         });
     }


### PR DESCRIPTION
**Connections**

Supersedes #4918

**Description**

For some reason we store the dynamic offset count of the SetBindGroup command as a u8 even though it is used as an usize before and after. The conversion to u8 crashes if the number of offsets doesn't fit.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
