### PR TITLE
Validate that a binding offset fits in the buffer

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1832,7 +1832,16 @@ impl<A: HalApi> Device<A> {
                 }
                 (size.get(), end)
             }
-            None => (buffer.size - bb.offset, buffer.size),
+            None => {
+                if buffer.size < bb.offset {
+                    return Err(Error::BindingRangeTooLarge {
+                        buffer: bb.buffer_id,
+                        range: bb.offset..bb.offset,
+                        size: buffer.size,
+                    });
+                }
+                (buffer.size - bb.offset, buffer.size)
+            }
         };
 
         if bind_size > range_limit as u64 {


### PR DESCRIPTION
**Connections**

Crash found when [running the CTS](https://treeherder.mozilla.org/logviewer?job_id=442315504&repo=try&lineNumber=1605) in Firefox.

**Description**

If the binding size is not specified we didn't validate that the offset was in the bounds of the buffer, causing an overflow panic on debug and UB/nonsense on release. This PR adds the missing validation.

**Testing**

Covered by the CTS

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.