### PR TITLE
don't panic if naga parsing of shader source fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4008,6 +4008,7 @@ dependencies = [
  "web-sys",
  "wgpu-hal",
  "wgpu-types",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4637,6 +4638,7 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3991,6 +3991,7 @@ dependencies = [
  "arrayvec 0.7.4",
  "bit-vec",
  "bitflags 2.4.2",
+ "bytemuck",
  "cfg_aliases",
  "codespan-reporting",
  "indexmap",
@@ -4008,7 +4009,6 @@ dependencies = [
  "web-sys",
  "wgpu-hal",
  "wgpu-types",
- "zerocopy",
 ]
 
 [[package]]
@@ -4638,7 +4638,6 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 

--- a/naga/src/front/glsl/error.rs
+++ b/naga/src/front/glsl/error.rs
@@ -1,7 +1,11 @@
 use super::token::TokenValue;
 use crate::{proc::ConstantEvaluatorError, Span};
+use codespan_reporting::diagnostic::{Diagnostic, Label};
+use codespan_reporting::files::SimpleFile;
+use codespan_reporting::term;
 use pp_rs::token::PreprocessorError;
 use std::borrow::Cow;
+use termcolor::{NoColor, WriteColor};
 use thiserror::Error;
 
 fn join_with_comma(list: &[ExpectedToken]) -> String {
@@ -18,7 +22,7 @@ fn join_with_comma(list: &[ExpectedToken]) -> String {
 }
 
 /// One of the expected tokens returned in [`InvalidToken`](ErrorKind::InvalidToken).
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ExpectedToken {
     /// A specific token was expected.
     Token(TokenValue),
@@ -55,7 +59,7 @@ impl std::fmt::Display for ExpectedToken {
 }
 
 /// Information about the cause of an error.
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum ErrorKind {
     /// Whilst parsing as encountered an unexpected EOF.
@@ -123,7 +127,7 @@ impl From<ConstantEvaluatorError> for ErrorKind {
 }
 
 /// Error returned during shader parsing.
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 #[error("{kind}")]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Error {
@@ -131,4 +135,57 @@ pub struct Error {
     pub kind: ErrorKind,
     /// Holds information about the range of the source code where the error happened.
     pub meta: Span,
+}
+
+/// A collection of errors returned during shader parsing.
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct ParseError {
+    errors: Vec<Error>,
+}
+
+impl ParseError {
+    pub fn emit_to_writer(&self, writer: &mut impl WriteColor, source: &str) {
+        self.emit_to_writer_with_path(writer, source, "glsl");
+    }
+
+    pub fn emit_to_writer_with_path(&self, writer: &mut impl WriteColor, source: &str, path: &str) {
+        let path = path.to_string();
+        let files = SimpleFile::new(path, source);
+        let config = codespan_reporting::term::Config::default();
+
+        for err in &self.errors {
+            let mut diagnostic = Diagnostic::error().with_message(err.kind.to_string());
+
+            if let Some(range) = err.meta.to_range() {
+                diagnostic = diagnostic.with_labels(vec![Label::primary((), range)]);
+            }
+
+            term::emit(writer, &config, &files, &diagnostic).expect("cannot write error");
+        }
+    }
+
+    pub fn emit_to_string(&self, source: &str) -> String {
+        let mut writer = NoColor::new(Vec::new());
+        self.emit_to_writer(&mut writer, source);
+        String::from_utf8(writer.into_inner()).unwrap()
+    }
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.errors.iter().map(|e| write!(f, "{e:?}")).collect()
+    }
+}
+
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+impl From<Vec<Error>> for ParseError {
+    fn from(errors: Vec<Error>) -> Self {
+        Self { errors }
+    }
 }

--- a/naga/src/front/glsl/error.rs
+++ b/naga/src/front/glsl/error.rs
@@ -174,7 +174,7 @@ impl ParseError {
 
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        self.errors.iter().map(|e| write!(f, "{e:?}")).collect()
+        self.errors.iter().try_for_each(|e| write!(f, "{e:?}"))
     }
 }
 

--- a/naga/src/front/glsl/error.rs
+++ b/naga/src/front/glsl/error.rs
@@ -141,7 +141,7 @@ pub struct Error {
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct ParseError {
-    errors: Vec<Error>,
+    pub errors: Vec<Error>,
 }
 
 impl ParseError {

--- a/naga/src/front/glsl/mod.rs
+++ b/naga/src/front/glsl/mod.rs
@@ -13,7 +13,7 @@ To begin, take a look at the documentation for the [`Frontend`].
 */
 
 pub use ast::{Precision, Profile};
-pub use error::{ParseError, Error, ErrorKind, ExpectedToken};
+pub use error::{Error, ErrorKind, ExpectedToken, ParseError};
 pub use token::TokenValue;
 
 use crate::{proc::Layouter, FastHashMap, FastHashSet, Handle, Module, ShaderStage, Span, Type};

--- a/naga/src/front/glsl/mod.rs
+++ b/naga/src/front/glsl/mod.rs
@@ -13,7 +13,7 @@ To begin, take a look at the documentation for the [`Frontend`].
 */
 
 pub use ast::{Precision, Profile};
-pub use error::{Error, ErrorKind, ExpectedToken};
+pub use error::{ParseError, Error, ErrorKind, ExpectedToken};
 pub use token::TokenValue;
 
 use crate::{proc::Layouter, FastHashMap, FastHashSet, Handle, Module, ShaderStage, Span, Type};
@@ -196,7 +196,7 @@ impl Frontend {
         &mut self,
         options: &Options,
         source: &str,
-    ) -> std::result::Result<Module, Vec<Error>> {
+    ) -> std::result::Result<Module, ParseError> {
         self.reset(options.stage);
 
         let lexer = lex::Lexer::new(source, &options.defines);
@@ -207,12 +207,12 @@ impl Frontend {
                 if self.errors.is_empty() {
                     Ok(module)
                 } else {
-                    Err(std::mem::take(&mut self.errors))
+                    Err(std::mem::take(&mut self.errors).into())
                 }
             }
             Err(e) => {
                 self.errors.push(e);
-                Err(std::mem::take(&mut self.errors))
+                Err(std::mem::take(&mut self.errors).into())
             }
         }
     }

--- a/naga/src/front/glsl/parser_tests.rs
+++ b/naga/src/front/glsl/parser_tests.rs
@@ -1,7 +1,7 @@
 use super::{
     ast::Profile,
     error::ExpectedToken,
-    error::{Error, ErrorKind},
+    error::{Error, ErrorKind, ParseError},
     token::TokenValue,
     Frontend, Options, Span,
 };
@@ -21,10 +21,12 @@ fn version() {
             )
             .err()
             .unwrap(),
-        vec![Error {
-            kind: ErrorKind::InvalidVersion(99000),
-            meta: Span::new(9, 14)
-        }],
+        ParseError {
+            errors: vec![Error {
+                kind: ErrorKind::InvalidVersion(99000),
+                meta: Span::new(9, 14)
+            }],
+        },
     );
 
     assert_eq!(
@@ -35,10 +37,12 @@ fn version() {
             )
             .err()
             .unwrap(),
-        vec![Error {
-            kind: ErrorKind::InvalidVersion(449),
-            meta: Span::new(9, 12)
-        }]
+        ParseError {
+            errors: vec![Error {
+                kind: ErrorKind::InvalidVersion(449),
+                meta: Span::new(9, 12)
+            }]
+        },
     );
 
     assert_eq!(
@@ -49,10 +53,12 @@ fn version() {
             )
             .err()
             .unwrap(),
-        vec![Error {
-            kind: ErrorKind::InvalidProfile("smart".into()),
-            meta: Span::new(13, 18),
-        }]
+        ParseError {
+            errors: vec![Error {
+                kind: ErrorKind::InvalidProfile("smart".into()),
+                meta: Span::new(13, 18),
+            }]
+        },
     );
 
     assert_eq!(
@@ -63,19 +69,21 @@ fn version() {
             )
             .err()
             .unwrap(),
-        vec![
-            Error {
-                kind: ErrorKind::PreprocessorError(PreprocessorError::UnexpectedHash,),
-                meta: Span::new(27, 28),
-            },
-            Error {
-                kind: ErrorKind::InvalidToken(
-                    TokenValue::Identifier("version".into()),
-                    vec![ExpectedToken::Eof]
-                ),
-                meta: Span::new(28, 35)
-            }
-        ]
+        ParseError {
+            errors: vec![
+                Error {
+                    kind: ErrorKind::PreprocessorError(PreprocessorError::UnexpectedHash,),
+                    meta: Span::new(27, 28),
+                },
+                Error {
+                    kind: ErrorKind::InvalidToken(
+                        TokenValue::Identifier("version".into()),
+                        vec![ExpectedToken::Eof]
+                    ),
+                    meta: Span::new(28, 35)
+                }
+            ]
+        },
     );
 
     // valid versions
@@ -447,10 +455,12 @@ fn functions() {
             )
             .err()
             .unwrap(),
-        vec![Error {
-            kind: ErrorKind::SemanticError("Function already defined".into()),
-            meta: Span::new(134, 152),
-        }]
+        ParseError {
+            errors: vec![Error {
+                kind: ErrorKind::SemanticError("Function already defined".into()),
+                meta: Span::new(134, 152),
+            }]
+        },
     );
 
     println!();
@@ -626,10 +636,12 @@ fn implicit_conversions() {
             )
             .err()
             .unwrap(),
-        vec![Error {
-            kind: ErrorKind::SemanticError("Unknown function \'test\'".into()),
-            meta: Span::new(156, 165),
-        }]
+        ParseError {
+            errors: vec![Error {
+                kind: ErrorKind::SemanticError("Unknown function \'test\'".into()),
+                meta: Span::new(156, 165),
+            }]
+        },
     );
 
     assert_eq!(
@@ -648,10 +660,12 @@ fn implicit_conversions() {
             )
             .err()
             .unwrap(),
-        vec![Error {
-            kind: ErrorKind::SemanticError("Ambiguous best function for \'test\'".into()),
-            meta: Span::new(158, 165),
-        }]
+        ParseError {
+            errors: vec![Error {
+                kind: ErrorKind::SemanticError("Ambiguous best function for \'test\'".into()),
+                meta: Span::new(158, 165),
+            }]
+        }
     );
 }
 

--- a/naga/src/front/glsl/token.rs
+++ b/naga/src/front/glsl/token.rs
@@ -20,7 +20,7 @@ pub struct Token {
 ///
 /// This type is exported since it's returned in the
 /// [`InvalidToken`](super::ErrorKind::InvalidToken) error.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TokenValue {
     Identifier(String),
 

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -687,7 +687,7 @@ pub enum ImageClass {
 }
 
 /// A data type declared in the module.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "clone", derive(Clone))]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
@@ -700,7 +700,7 @@ pub struct Type {
 }
 
 /// Enum with additional information, depending on the kind of type.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "clone", derive(Clone))]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -688,7 +688,6 @@ pub enum ImageClass {
 
 /// A data type declared in the module.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "clone", derive(Clone))]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -701,7 +700,6 @@ pub struct Type {
 
 /// Enum with additional information, depending on the kind of type.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "clone", derive(Clone))]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -63,7 +63,7 @@ wgsl = ["naga/wgsl-in"]
 glsl = ["naga/glsl-in"]
 
 ## Enable `ShaderModuleSource::SpirV`
-spirv = ["naga/spv-in", "dep:zerocopy"]
+spirv = ["naga/spv-in", "dep:bytemuck"]
 
 ## Implement `Send` and `Sync` on Wasm, but only if atomics are not enabled.
 ##
@@ -99,6 +99,7 @@ dx12 = ["hal/dx12"]
 arrayvec = "0.7"
 bit-vec = "0.6"
 bitflags = "2"
+bytemuck = { version = "1.14", optional = true }
 codespan-reporting = "0.11"
 indexmap = "2"
 log = "0.4"
@@ -112,7 +113,6 @@ rustc-hash = "1.1"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 smallvec = "1"
 thiserror = "1"
-zerocopy = { version = "0.7", optional = true }
 
 [dependencies.naga]
 path = "../naga"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -59,6 +59,9 @@ serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
 ## Enable `ShaderModuleSource::Wgsl`
 wgsl = ["naga/wgsl-in"]
 
+## Enable `ShaderModuleSource::Glsl`
+glsl = ["naga/glsl-in"]
+
 ## Implement `Send` and `Sync` on Wasm, but only if atomics are not enabled.
 ##
 ## WebGL/WebGPU objects can not be shared between threads.

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -62,6 +62,9 @@ wgsl = ["naga/wgsl-in"]
 ## Enable `ShaderModuleSource::Glsl`
 glsl = ["naga/glsl-in"]
 
+## Enable `ShaderModuleSource::SpirV`
+spirv = ["naga/spv-in", "dep:zerocopy"]
+
 ## Implement `Send` and `Sync` on Wasm, but only if atomics are not enabled.
 ##
 ## WebGL/WebGPU objects can not be shared between threads.
@@ -109,6 +112,7 @@ rustc-hash = "1.1"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 smallvec = "1"
 thiserror = "1"
+zerocopy = { version = "0.7", optional = true }
 
 [dependencies.naga]
 path = "../naga"

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -22,6 +22,8 @@ use crate::{
 use arrayvec::ArrayVec;
 use hal::Device as _;
 use parking_lot::RwLock;
+#[cfg(feature = "spirv")]
+use zerocopy::AsBytes;
 
 use wgt::{BufferAddress, TextureFormat};
 
@@ -1192,6 +1194,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     #[cfg(feature = "glsl")]
                     pipeline::ShaderModuleSource::Glsl(ref code, _) => {
                         trace.make_binary("glsl", code.as_bytes())
+                    }
+                    #[cfg(feature = "spirv")]
+                    pipeline::ShaderModuleSource::SpirV(ref code, _) => {
+                        trace.make_binary("spirv", code.as_bytes())
                     }
                     pipeline::ShaderModuleSource::Naga(ref module) => {
                         let string =

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -22,8 +22,6 @@ use crate::{
 use arrayvec::ArrayVec;
 use hal::Device as _;
 use parking_lot::RwLock;
-#[cfg(feature = "spirv")]
-use {bytemuck::cast_slice, std::borrow::Borrow};
 
 use wgt::{BufferAddress, TextureFormat};
 
@@ -1197,7 +1195,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                     #[cfg(feature = "spirv")]
                     pipeline::ShaderModuleSource::SpirV(ref code, _) => {
-                        trace.make_binary("spirv", cast_slice::<u32, u8>(code.borrow()))
+                        trace.make_binary("spirv", bytemuck::cast_slice::<u32, u8>(&code))
                     }
                     pipeline::ShaderModuleSource::Naga(ref module) => {
                         let string =

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1195,7 +1195,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                     #[cfg(feature = "spirv")]
                     pipeline::ShaderModuleSource::SpirV(ref code, _) => {
-                        trace.make_binary("spirv", bytemuck::cast_slice::<u32, u8>(&code))
+                        trace.make_binary("spirv", bytemuck::cast_slice::<u32, u8>(code))
                     }
                     pipeline::ShaderModuleSource::Naga(ref module) => {
                         let string =

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1189,6 +1189,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     pipeline::ShaderModuleSource::Wgsl(ref code) => {
                         trace.make_binary("wgsl", code.as_bytes())
                     }
+                    #[cfg(feature = "glsl")]
+                    pipeline::ShaderModuleSource::Glsl(ref code, _) => {
+                        trace.make_binary("glsl", code.as_bytes())
+                    }
                     pipeline::ShaderModuleSource::Naga(ref module) => {
                         let string =
                             ron::ser::to_string_pretty(module, ron::ser::PrettyConfig::default())

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -23,7 +23,7 @@ use arrayvec::ArrayVec;
 use hal::Device as _;
 use parking_lot::RwLock;
 #[cfg(feature = "spirv")]
-use zerocopy::AsBytes;
+use {bytemuck::cast_slice, std::borrow::Borrow};
 
 use wgt::{BufferAddress, TextureFormat};
 
@@ -1197,7 +1197,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
                     #[cfg(feature = "spirv")]
                     pipeline::ShaderModuleSource::SpirV(ref code, _) => {
-                        trace.make_binary("spirv", code.as_bytes())
+                        trace.make_binary("spirv", cast_slice::<u32, u8>(code.borrow()))
                     }
                     pipeline::ShaderModuleSource::Naga(ref module) => {
                         let string =

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1309,9 +1309,22 @@ impl<A: HalApi> Device<A> {
         let (module, source) = match source {
             #[cfg(feature = "wgsl")]
             pipeline::ShaderModuleSource::Wgsl(code) => {
-                profiling::scope!("naga::wgsl::parse_str");
+                profiling::scope!("naga::front::wgsl::parse_str");
                 let module = naga::front::wgsl::parse_str(&code).map_err(|inner| {
                     pipeline::CreateShaderModuleError::Parsing(pipeline::ShaderError {
+                        source: code.to_string(),
+                        label: desc.label.as_ref().map(|l| l.to_string()),
+                        inner: Box::new(inner),
+                    })
+                })?;
+                (Cow::Owned(module), code.into_owned())
+            }
+            #[cfg(feature = "glsl")]
+            pipeline::ShaderModuleSource::Glsl(code, options) => {
+                profiling::scope!("naga::front::glsl::parse_str");
+                let mut parser = naga::front::glsl::Frontend::default();
+                let module = parser.parse(&options, &code).map_err(|inner| {
+                    pipeline::CreateShaderModuleError::ParsingGlsl(pipeline::ShaderError {
                         source: code.to_string(),
                         label: desc.label.as_ref().map(|l| l.to_string()),
                         inner: Box::new(inner),

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1321,8 +1321,8 @@ impl<A: HalApi> Device<A> {
             }
             #[cfg(feature = "glsl")]
             pipeline::ShaderModuleSource::Glsl(code, options) => {
-                profiling::scope!("naga::front::glsl::parse_str");
                 let mut parser = naga::front::glsl::Frontend::default();
+                profiling::scope!("naga::front::glsl::Frontend.parse");
                 let module = parser.parse(&options, &code).map_err(|inner| {
                     pipeline::CreateShaderModuleError::ParsingGlsl(pipeline::ShaderError {
                         source: code.to_string(),

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -107,6 +107,7 @@ impl fmt::Display for ShaderError<naga::front::wgsl::ParseError> {
         write!(f, "\nShader '{label}' parsing {string}")
     }
 }
+#[cfg(feature = "glsl")]
 impl fmt::Display for ShaderError<naga::front::glsl::ParseError> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let label = self.label.as_deref().unwrap_or_default();
@@ -114,6 +115,7 @@ impl fmt::Display for ShaderError<naga::front::glsl::ParseError> {
         write!(f, "\nShader '{label}' parsing {string}")
     }
 }
+#[cfg(feature = "spirv")]
 impl fmt::Display for ShaderError<naga::front::spv::Error> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let label = self.label.as_deref().unwrap_or_default();

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -160,6 +160,7 @@ pub enum CreateShaderModuleError {
     #[cfg(feature = "wgsl")]
     #[error(transparent)]
     Parsing(#[from] ShaderError<naga::front::wgsl::ParseError>),
+    #[cfg(feature = "glsl")]
     #[error(transparent)]
     ParsingGlsl(#[from] ShaderError<naga::front::glsl::ParseError>),
     #[error("Failed to generate the backend-specific code")]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -56,10 +56,10 @@ webgl = ["hal", "wgc/gles"]
 # --------------------------------------------------------------------
 
 ## Enable accepting SPIR-V shaders as input.
-spirv = ["naga/spv-in"]
+spirv = ["naga/spv-in", "wgc/spirv"]
 
 ## Enable accepting GLSL shaders as input.
-glsl = ["naga/glsl-in"]
+glsl = ["naga/glsl-in", "wgc/glsl"]
 
 ## Enable accepting WGSL shaders as input.
 wgsl = ["wgc?/wgsl"]

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -858,7 +858,7 @@ impl crate::Context for ContextWgpuCore {
                     stage,
                     defines: defines.clone(),
                 };
-                wgc::pipline::ShaderModuleSource::Glsl(shader, options)
+                wgc::pipeline::ShaderModuleSource::Glsl(Borrowed(shader), options)
             }
             #[cfg(feature = "wgsl")]
             ShaderSource::Wgsl(ref code) => wgc::pipeline::ShaderModuleSource::Wgsl(Borrowed(code)),

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -852,10 +852,7 @@ impl crate::Context for ContextWgpuCore {
                 stage,
                 defines,
             } => {
-                let options = naga::front::glsl::Options {
-                    stage,
-                    defines: defines.clone(),
-                };
+                let options = naga::front::glsl::Options { stage, defines };
                 wgc::pipeline::ShaderModuleSource::Glsl(Borrowed(shader), options)
             }
             #[cfg(feature = "wgsl")]

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -854,12 +854,11 @@ impl crate::Context for ContextWgpuCore {
                 stage,
                 defines,
             } => {
-                // Parse the given shader code and store its representation.
-                let options = naga::front::glsl::Options { stage, defines };
-                let mut parser = naga::front::glsl::Frontend::default();
-                let module = parser.parse(&options, shader).unwrap();
-
-                wgc::pipeline::ShaderModuleSource::Naga(Owned(module))
+                let options = naga::front::glsl::Options {
+                    stage,
+                    defines: defines.clone(),
+                };
+                wgc::pipline::ShaderModuleSource::Glsl(shader, options)
             }
             #[cfg(feature = "wgsl")]
             ShaderSource::Wgsl(ref code) => wgc::pipeline::ShaderModuleSource::Wgsl(Borrowed(code)),

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -844,9 +844,7 @@ impl crate::Context for ContextWgpuCore {
                     strict_capabilities: true,
                     block_ctx_dump_prefix: None,
                 };
-                let parser = naga::front::spv::Frontend::new(spv.iter().cloned(), &options);
-                let module = parser.parse().unwrap();
-                wgc::pipeline::ShaderModuleSource::Naga(Owned(module))
+                wgc::pipeline::ShaderModuleSource::SpirV(Borrowed(spv), options)
             }
             #[cfg(feature = "glsl")]
             ShaderSource::Glsl {


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/5019

fixes https://github.com/gfx-rs/wgpu/issues/2545

**Description**
In my application shaders are meant to be hot-reloaded on filesystem changes.
If there is a syntax issue with the newly-updated shader source `naga` parsing
of the file can fail. In current trunk, the `Result` returned by `naga` parsing
is simply unwrapped.

This PR removes the `naga` parse unwrap and instead bubbles the `Result` up
through the call stack so to be handled by the calling code.

I am opening this PR prior to updating the changelog and getting `cargo xtask
test` to run just to start discussion (should have commits addressing those
shortly after opening it).

**Testing**
I've updated the examples and test cases that were already calling
`Device.create_shader_module`.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
