### PR TITLE
Move the trace recording of destroy events out of triage_resources

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2074,11 +2074,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         if !device.is_valid() {
             return Err(InvalidDevice);
         }
-        device.lock_life().triage_suspected(
-            &device.trackers,
-            #[cfg(feature = "trace")]
-            None,
-        );
+        device.lock_life().triage_suspected(&device.trackers);
         Ok(())
     }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -334,11 +334,7 @@ impl<A: HalApi> Device<A> {
             let mut life_tracker = self.lock_life();
             life_tracker.suspected_resources.extend(temp_suspected);
 
-            life_tracker.triage_suspected(
-                &self.trackers,
-                #[cfg(feature = "trace")]
-                self.trace.lock().as_mut(),
-            );
+            life_tracker.triage_suspected(&self.trackers);
             life_tracker.triage_mapped();
         }
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -56,8 +56,8 @@ impl<A: HalApi> Drop for ShaderModule<A> {
         if let Some(raw) = self.raw.take() {
             resource_log!("Destroy raw ShaderModule {:?}", self.info.label());
             #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *self.device.trace.lock() {
-                trace.add(trace::Action::DestroyShaderModule(self.info.id()));
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DestroyShaderModule(self.info.id()));
             }
             unsafe {
                 use hal::Device;
@@ -251,6 +251,12 @@ impl<A: HalApi> Drop for ComputePipeline<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
             resource_log!("Destroy raw ComputePipeline {:?}", self.info.label());
+
+            #[cfg(feature = "trace")]
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DestroyComputePipeline(self.info.id()));
+            }
+
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_compute_pipeline(raw);
@@ -493,6 +499,12 @@ impl<A: HalApi> Drop for RenderPipeline<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
             resource_log!("Destroy raw RenderPipeline {:?}", self.info.label());
+
+            #[cfg(feature = "trace")]
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DestroyRenderPipeline(self.info.id()));
+            }
+
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_render_pipeline(raw);

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -413,7 +413,13 @@ pub struct Buffer<A: HalApi> {
 impl<A: HalApi> Drop for Buffer<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Deallocate raw Buffer (dropped) {:?}", self.info.label());
+            resource_log!("Destroy raw Buffer (dropped) {:?}", self.info.label());
+
+            #[cfg(feature = "trace")]
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DestroyBuffer(self.info.id()));
+            }
+
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_buffer(raw);
@@ -639,7 +645,13 @@ impl<A: HalApi> DestroyedBuffer<A> {
 impl<A: HalApi> Drop for DestroyedBuffer<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Deallocate raw Buffer (destroyed) {:?}", self.label());
+            resource_log!("Destroy raw Buffer (destroyed) {:?}", self.label());
+
+            #[cfg(feature = "trace")]
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DestroyBuffer(self.id));
+            }
+
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_buffer(raw);
@@ -789,6 +801,11 @@ impl<A: HalApi> Drop for Texture<A> {
         };
 
         if let Some(TextureInner::Native { raw }) = self.inner.take() {
+            #[cfg(feature = "trace")]
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DestroyTexture(self.info.id()));
+            }
+
             unsafe {
                 self.device.raw().destroy_texture(raw);
             }
@@ -994,7 +1011,13 @@ impl<A: HalApi> DestroyedTexture<A> {
 impl<A: HalApi> Drop for DestroyedTexture<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
-            resource_log!("Deallocate raw Texture (destroyed) {:?}", self.label());
+            resource_log!("Destroy raw Texture (destroyed) {:?}", self.label());
+
+            #[cfg(feature = "trace")]
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DestroyTexture(self.id));
+            }
+
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_texture(raw);
@@ -1187,6 +1210,12 @@ impl<A: HalApi> Drop for TextureView<A> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
             resource_log!("Destroy raw TextureView {:?}", self.info.label());
+
+            #[cfg(feature = "trace")]
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DestroyTextureView(self.info.id()));
+            }
+
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_texture_view(raw);
@@ -1309,6 +1338,11 @@ impl<A: HalApi> Drop for Sampler<A> {
     fn drop(&mut self) {
         resource_log!("Destroy raw Sampler {:?}", self.info.label());
         if let Some(raw) = self.raw.take() {
+            #[cfg(feature = "trace")]
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DestroySampler(self.info.id()));
+            }
+
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_sampler(raw);
@@ -1406,6 +1440,11 @@ impl<A: HalApi> Drop for QuerySet<A> {
     fn drop(&mut self) {
         resource_log!("Destroy raw QuerySet {:?}", self.info.label());
         if let Some(raw) = self.raw.take() {
+            #[cfg(feature = "trace")]
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DestroyQuerySet(self.info.id()));
+            }
+
             unsafe {
                 use hal::Device;
                 self.device.raw().destroy_query_set(raw);


### PR DESCRIPTION
**Description**

This PR moves all of the `trace::Action::DestroyFoo(id)` out of `triage_resource`. The main motivation is to avoid holding the trace lock for a long time and let the resource `drop` impls take that lock without risking deadlocks if the reference count happens to go to zero during triage.

This will allow us to remove the `free_resource` tracker in a followup which is needed for #4917.

Incidentally I'm happy about how it simplifies the code. It makes sense for this stuff to be handled by the resources themselves instead of the lifecycle triaging code which in an ideal world wouldn't need to do resource-specific logic. `triage_resource` does not need to take an `on_remove` callback anymore.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
