### PR TITLE
Remove the free_resources tracker

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -372,9 +372,6 @@ impl<A: HalApi> Device<A> {
         );
         let mapping_closures = life_tracker.handle_mapping(self.raw(), &self.trackers);
 
-        //Cleaning up resources and released all unused suspected ones
-        life_tracker.cleanup();
-
         // Detect if we have been destroyed and now need to lose the device.
         // If we are invalid (set at start of destroy) and our queue is empty,
         // and we have a DeviceLostClosure, return the closure to be called by
@@ -3383,7 +3380,6 @@ impl<A: HalApi> Device<A> {
             current_index,
             self.command_allocator.lock().as_mut().unwrap(),
         );
-        life_tracker.cleanup();
         #[cfg(feature = "trace")]
         {
             *self.trace.lock() = None;


### PR DESCRIPTION
**Connections**

Requires #5036 

**Description**

Don't put resources that we want to deallocate in a special tracker that is dropped at the end of poll. Instead, just let the reference count of the resource reach zero wherever it happens (usually while triaging resources).

This is a step in the direction of simplifying the resource lifecycle code. 
It is also a step towards fixing #4917, although it isn't quite enough to fix it. The remaining issue is that `triage_submissions` happens after `triage_suspected`, so if a resource is used in a submission it won't be released on the `poll` invocation where the submission is resolved as done.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.