### PR TITLE
Prevent a few integer overflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ Passing an owned value `window` to `Surface` will return a `Surface<'static>`. S
 - `BufferMappedRange` trait is now `WasmNotSendSync`, i.e. it is `Send`/`Sync` if not on wasm or `fragile-send-sync-non-atomic-wasm` is enabled. By @wumpf in [#4818](https://github.com/gfx-rs/wgpu/pull/4818)
 - Align `wgpu_types::CompositeAlphaMode` serde serialization to spec. By @littledivy in [#4940](https://github.com/gfx-rs/wgpu/pull/4940)
 - Fix error message of `ConfigureSurfaceError::TooLarge`. By @Dinnerbone in [#4960](https://github.com/gfx-rs/wgpu/pull/4960)
+- Fixed a number of panics. by @nical in [#4999](https://github.com/gfx-rs/wgpu/pull/4999), [#5014](https://github.com/gfx-rs/wgpu/pull/5014), [#5024](https://github.com/gfx-rs/wgpu/pull/5024), [#5025](https://github.com/gfx-rs/wgpu/pull/5025), [#5026](https://github.com/gfx-rs/wgpu/pull/5026), [#5027](https://github.com/gfx-rs/wgpu/pull/5027), [#5028](https://github.com/gfx-rs/wgpu/pull/5028) and [#5042](https://github.com/gfx-rs/wgpu/pull/5042).
 
 #### DX12
 

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -29,18 +29,18 @@ pub enum DrawError {
     IncompatibleBindGroup { index: u32, diff: Vec<String> },
     #[error("Vertex {last_vertex} extends beyond limit {vertex_limit} imposed by the buffer in slot {slot}. Did you bind the correct `Vertex` step-rate vertex buffer?")]
     VertexBeyondLimit {
-        last_vertex: u32,
-        vertex_limit: u32,
+        last_vertex: u64,
+        vertex_limit: u64,
         slot: u32,
     },
     #[error("Instance {last_instance} extends beyond limit {instance_limit} imposed by the buffer in slot {slot}. Did you bind the correct `Instance` step-rate vertex buffer?")]
     InstanceBeyondLimit {
-        last_instance: u32,
-        instance_limit: u32,
+        last_instance: u64,
+        instance_limit: u64,
         slot: u32,
     },
     #[error("Index {last_index} extends beyond limit {index_limit}. Did you bind the correct index buffer?")]
-    IndexBeyondLimit { last_index: u32, index_limit: u32 },
+    IndexBeyondLimit { last_index: u64, index_limit: u64 },
     #[error(
         "Pipeline index format ({pipeline:?}) and buffer index format ({buffer:?}) do not match"
     )]


### PR DESCRIPTION
**Connections**

Found while running the CTS in Firefox.

**Description**

We have a few places with the following pattern:

```rust
let last_foo = first_foo + foo_count;
if last_foo > foo_limit {
   // error ...
}
```

With the addition in the first line vulnerable to integer overflows. This PR addresses it by making sure that the limit is always smaller than `u32::MAX` and using `saturating_add` so that cases that would have overflown are treated as errors.

**Testing**

Covered by the CTS.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
