### PR TITLE
More eagerly destroy buffers and texture on the web backend

### DIFF
--- a/wgpu/src/backend/web.rs
+++ b/wgpu/src/backend/web.rs
@@ -2098,7 +2098,7 @@ impl crate::context::Context for Context {
     }
 
     fn buffer_drop(&self, _buffer: &Self::BufferId, _buffer_data: &Self::BufferData) {
-        // Dropped automatically
+        buffer_data.0.buffer.destroy();
     }
 
     fn texture_destroy(&self, _texture: &Self::TextureId, texture_data: &Self::TextureData) {
@@ -2106,7 +2106,7 @@ impl crate::context::Context for Context {
     }
 
     fn texture_drop(&self, _texture: &Self::TextureId, _texture_data: &Self::TextureData) {
-        // Dropped automatically
+        texture_data.0.destroy();
     }
 
     fn texture_view_drop(


### PR DESCRIPTION
**Description**

Since the web backend is run in a garbage collected environment, it is important to eagerly destroy resources when we know they won't be used anymore (when the handle is dropped) rather that wait for GC to kick off and get the dropped resource deallocated. Especially since the GC doesn't know about gpu memory pressure.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
