### PR TITLE
Triage suspected resources after triaging submissions

### DIFF
--- a/tests/tests/mem_leaks.rs
+++ b/tests/tests/mem_leaks.rs
@@ -243,10 +243,6 @@ fn draw_test_with_reports(
 
     ctx.device
         .poll(wgpu::Maintain::WaitForSubmissionIndex(submit_index));
-    // Because of dependency between resources, A resource being destroyed during poll
-    // can cause another resource to be ready for destruction next time poll is called.
-    // Call poll twice to ensure all destroyable resources are destroyed.
-    ctx.device.poll(wgpu::Maintain::Poll);
 
     let global_report = ctx.instance.generate_report();
     let report = global_report.hub_report(ctx.adapter_info.backend);

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -319,25 +319,6 @@ impl<A: HalApi> Device<A> {
         maintain: wgt::Maintain<queue::WrappedSubmissionIndex>,
     ) -> Result<(UserClosures, bool), WaitIdleError> {
         profiling::scope!("Device::maintain");
-        {
-            // Normally, `temp_suspected` exists only to save heap
-            // allocations: it's cleared at the start of the function
-            // call, and cleared by the end. But `Global::queue_submit` is
-            // fallible; if it exits early, it may leave some resources in
-            // `temp_suspected`.
-            let temp_suspected = self
-                .temp_suspected
-                .lock()
-                .replace(ResourceMaps::new())
-                .unwrap();
-
-            let mut life_tracker = self.lock_life();
-            life_tracker.suspected_resources.extend(temp_suspected);
-
-            life_tracker.triage_suspected(&self.trackers);
-            life_tracker.triage_mapped();
-        }
-
         let last_done_index = if maintain.is_wait() {
             let index_to_wait_for = match maintain {
                 wgt::Maintain::WaitForSubmissionIndex(submission_index) => {
@@ -370,6 +351,25 @@ impl<A: HalApi> Device<A> {
             last_done_index,
             self.command_allocator.lock().as_mut().unwrap(),
         );
+
+        {
+            // Normally, `temp_suspected` exists only to save heap
+            // allocations: it's cleared at the start of the function
+            // call, and cleared by the end. But `Global::queue_submit` is
+            // fallible; if it exits early, it may leave some resources in
+            // `temp_suspected`.
+            let temp_suspected = self
+                .temp_suspected
+                .lock()
+                .replace(ResourceMaps::new())
+                .unwrap();
+
+            life_tracker.suspected_resources.extend(temp_suspected);
+
+            life_tracker.triage_suspected(&self.trackers);
+            life_tracker.triage_mapped();
+        }
+
         let mapping_closures = life_tracker.handle_mapping(self.raw(), &self.trackers);
 
         // Detect if we have been destroyed and now need to lose the device.


### PR DESCRIPTION
**Connections**

Fixes #4917

**Description**

`triage_submissions` puts some resources in the suspected list. These currently need to wait for the next `Device::maintain` but they could be released right away if the order is swapped which is what this PR basically does.

I woudldn't be surprised if the order is intentional and the story is more complicated (hopefully not), in any case @cwfitzgerald this PR also swaps the order of the temp_suspected and life locks, I know you auditted these recently so let me know if this might cause deadlocks.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
