### PR TITLE
Fix cases in which instance creation may not create any context

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1718,7 +1718,7 @@ impl Instance {
     ///
     /// Which feature makes this method return true depends on the target platform:
     /// * MacOS/iOS: `metal`, `vulkan-portability` or `angle`
-    /// * Wasm32: `webgpu`, `webgl` or target emscripten.
+    /// * Wasm32: `webgpu`, `webgl` or Emscripten target.
     /// * All other: Always returns true
     ///
     /// TODO: Right now it's otherwise not possible yet to opt-out of all features on most platforms.

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1772,14 +1772,17 @@ impl Instance {
         }
 
         #[cfg(webgpu)]
-        if !cfg!(wgpu_core) // If wgpu-core isn't enabled we can't use anything else.
-            || (_instance_desc.backends.contains(Backends::BROWSER_WEBGPU)
-                && crate::backend::get_browser_gpu_property()
-                    .map_or(false, |gpu| !gpu.is_undefined()))
         {
-            return Self {
-                context: Arc::from(crate::backend::ContextWebGpu::init(_instance_desc)),
-            };
+            let is_only_available_backend = !cfg!(wgpu_core);
+            let requested_webgpu = _instance_desc.backends.contains(Backends::BROWSER_WEBGPU);
+            let support_webgpu =
+                crate::backend::get_browser_gpu_property().map_or(false, |gpu| !gpu.is_undefined());
+
+            if is_only_available_backend || (requested_webgpu && support_webgpu) {
+                return Self {
+                    context: Arc::from(crate::backend::ContextWebGpu::init(_instance_desc)),
+                };
+            }
         }
 
         #[cfg(wgpu_core)]


### PR DESCRIPTION
**Connections**
* Small follow-up to #5044

**Description**
See description:

* When wgpu_core isn't enabled, don't detect lack of webgpu support right away, this would lead to reaching an `unrechable!` whenever webgpu isn't supported by the browser
* `any_backend_feature_enabled` didn't take emscripten into account


**Testing**
Hit this when running an application with various feature combinations off latest trunk, this resolves it!

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- ~[ ] Run `cargo xtask test` to run tests.~
- ~[ ] Add change to `CHANGELOG.md`. See simple instructions inside file.~
