### PR TITLE
Re-export public dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@ Bottom level categories:
 
 ## Unreleased
 
+### All Public Dependencies Are Re-Exported
+
+All of wgpu's public dependencies are now re-exported at the top level so that users don't need to take their own dependencies.
+This includes:
+- wgpu-core
+- wgpu-hal
+- naga
+- raw_window_handle
+- web_sys
+
+### `naga-ir` Shaders Have Dedicated Feature
+
+The `naga-ir` feature has been added to allow you to add naga module shaders without guessing about what other features needed to be enabled to get access to it.
+
 ### Direct3D 11 backend removal
 
 This backend had no functionality, and with the recent support for GL on Desktop, which allows wgpu to run on older devices, there is no need to keep the backend.

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -105,6 +105,7 @@ mod track;
 pub mod validation;
 
 pub use hal::{api, MAX_BIND_GROUPS, MAX_COLOR_ATTACHMENTS, MAX_VERTEX_BUFFERS};
+pub use naga;
 
 use std::{borrow::Cow, os::raw::c_char};
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -45,7 +45,7 @@ angle = ["wgc?/gles"]
 vulkan-portability = ["wgc?/vulkan"]
 
 ## Enables the WebGPU backend on Wasm. Disabled when targeting `emscripten`.
-webgpu = []
+webgpu = ["naga?/wgsl-out"]
 
 ## Enables the GLES backend on Wasm
 ##
@@ -63,6 +63,9 @@ glsl = ["naga/glsl-in"]
 
 ## Enable accepting WGSL shaders as input.
 wgsl = ["wgc?/wgsl"]
+
+## Enable accepting naga IR shaders as input.
+naga-ir = ["naga"]
 
 #! ### Logging & Tracing
 # --------------------------------------------------------------------
@@ -177,10 +180,6 @@ cfg_aliases.workspace = true
 [dev-dependencies.naga]
 workspace = true
 features = ["wgsl-in"]
-
-[target.'cfg(target_arch = "wasm32")'.dependencies.naga]
-workspace = true
-features = ["wgsl-out"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { workspace = true, features = [

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -10,6 +10,9 @@ fn main() {
             all(feature = "fragile-send-sync-non-atomic-wasm", not(target_feature = "atomics"))
         ) },
         dx12: { all(target_os = "windows", feature = "dx12") },
-        metal: { all(any(target_os = "ios", target_os = "macos"), feature = "metal") }
+        metal: { all(any(target_os = "ios", target_os = "macos"), feature = "metal") },
+        // This alias is _only_ if _we_ need naga in the wrapper. wgpu-core provides
+        // its own re-export of naga, which can be used in other situations
+        naga: { any(feature = "naga-ir", feature = "spirv", feature = "glsl") },
     }
 }

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1400,7 +1400,7 @@ impl crate::context::Context for ContextWebGpu {
             feature = "spirv",
             feature = "glsl",
             feature = "wgsl",
-            feature = "naga"
+            feature = "naga-ir"
         )),
         allow(unreachable_code, unused_variables)
     )]
@@ -1411,7 +1411,7 @@ impl crate::context::Context for ContextWebGpu {
         desc: crate::ShaderModuleDescriptor<'_>,
         _shader_bound_checks: wgt::ShaderBoundChecks,
     ) -> (Self::ShaderModuleId, Self::ShaderModuleData) {
-        let mut descriptor = match desc.source {
+        let mut descriptor: web_sys::GpuShaderModuleDescriptor = match desc.source {
             #[cfg(feature = "spirv")]
             crate::ShaderSource::SpirV(ref spv) => {
                 use naga::{back, front, valid};
@@ -1465,7 +1465,7 @@ impl crate::context::Context for ContextWebGpu {
             }
             #[cfg(feature = "wgsl")]
             crate::ShaderSource::Wgsl(ref code) => web_sys::GpuShaderModuleDescriptor::new(code),
-            #[cfg(feature = "naga")]
+            #[cfg(feature = "naga-ir")]
             crate::ShaderSource::Naga(module) => {
                 use naga::{back, valid};
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -838,7 +838,7 @@ impl crate::Context for ContextWgpuCore {
             feature = "spirv",
             feature = "glsl",
             feature = "wgsl",
-            feature = "naga"
+            feature = "naga-ir"
         )),
         allow(unreachable_code, unused_variables)
     )]
@@ -885,7 +885,7 @@ impl crate::Context for ContextWgpuCore {
             }
             #[cfg(feature = "wgsl")]
             ShaderSource::Wgsl(ref code) => wgc::pipeline::ShaderModuleSource::Wgsl(Borrowed(code)),
-            #[cfg(feature = "naga")]
+            #[cfg(feature = "naga-ir")]
             ShaderSource::Naga(module) => wgc::pipeline::ShaderModuleSource::Naga(module),
             ShaderSource::Dummy(_) => panic!("found `ShaderSource::Dummy`"),
         };

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -2,13 +2,13 @@ use wgt::{Backends, PowerPreference, RequestAdapterOptions};
 
 use crate::{Adapter, Instance, Surface};
 
-#[cfg(not(webgpu))]
+#[cfg(wgpu_core)]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 pub use wgc::instance::parse_backends_from_comma_list;
-/// Always returns WEBGPU on wasm over webgpu.
-#[cfg(webgpu)]
+/// Just return ALL, if wgpu_core is not enabled.
+#[cfg(not(wgpu_core))]
 pub fn parse_backends_from_comma_list(_string: &str) -> Backends {
-    Backends::BROWSER_WEBGPU
+    Backends::all()
 }
 
 /// Get a set of backend bits from the environment variable WGPU_BACKEND.


### PR DESCRIPTION
Closes #5054.

Useful enough to have, and doesn't clutter things too much.

This re-organizes our naga dependency a bit, notably that it's now properly optional on wasm, only enabled if you enable a feature that requires transpilation, or a direct mention in our public interface.

![image](https://github.com/gfx-rs/wgpu/assets/7861353/86a2d88c-d388-4bcf-87c3-4e4bb1416ddf)


