### PR TITLE
d3d12: Propagate descriptor heap and handle allocation errors

### DIFF
--- a/wgpu-hal/src/dx12/descriptor.rs
+++ b/wgpu-hal/src/dx12/descriptor.rs
@@ -117,32 +117,40 @@ struct FixedSizeHeap {
 }
 
 impl FixedSizeHeap {
-    fn new(device: &d3d12::Device, ty: d3d12::DescriptorHeapType) -> Self {
-        let (heap, _hr) = device.create_descriptor_heap(
-            HEAP_SIZE_FIXED as _,
-            ty,
-            d3d12::DescriptorHeapFlags::empty(),
-            0,
-        );
+    fn new(
+        device: &d3d12::Device,
+        ty: d3d12::DescriptorHeapType,
+    ) -> Result<Self, crate::DeviceError> {
+        let heap = device
+            .create_descriptor_heap(
+                HEAP_SIZE_FIXED as _,
+                ty,
+                d3d12::DescriptorHeapFlags::empty(),
+                0,
+            )
+            .into_device_result("Descriptor heap creation")?;
 
-        Self {
+        Ok(Self {
             handle_size: device.get_descriptor_increment_size(ty) as _,
             availability: !0, // all free!
             start: heap.start_cpu_descriptor(),
             _raw: heap,
-        }
+        })
     }
 
-    fn alloc_handle(&mut self) -> d3d12::CpuDescriptor {
+    fn alloc_handle(&mut self) -> Result<d3d12::CpuDescriptor, crate::DeviceError> {
         // Find first free slot.
         let slot = self.availability.trailing_zeros() as usize;
-        assert!(slot < HEAP_SIZE_FIXED);
+        if slot >= HEAP_SIZE_FIXED {
+            log::error!("Failed to allocate a handle form a fixed size heap");
+            return Err(crate::DeviceError::OutOfMemory);
+        }
         // Set the slot as occupied.
         self.availability ^= 1 << slot;
 
-        d3d12::CpuDescriptor {
+        Ok(d3d12::CpuDescriptor {
             ptr: self.start.ptr + self.handle_size * slot,
-        }
+        })
     }
 
     fn free_handle(&mut self, handle: d3d12::CpuDescriptor) {
@@ -189,29 +197,29 @@ impl CpuPool {
         }
     }
 
-    pub(super) fn alloc_handle(&mut self) -> Handle {
+    pub(super) fn alloc_handle(&mut self) -> Result<Handle, crate::DeviceError> {
         let heap_index = self
             .avaliable_heap_indices
             .iter()
             .next()
-            .unwrap_or_else(|| {
-                // Allocate a new heap
-                let id = self.heaps.len();
-                self.heaps.push(FixedSizeHeap::new(&self.device, self.ty));
-                self.avaliable_heap_indices.insert(id);
-                id
-            });
+            .unwrap_or_else(|| self.heaps.len());
+
+        // Allocate a new heap
+        if heap_index == self.heaps.len() {
+            self.heaps.push(FixedSizeHeap::new(&self.device, self.ty)?);
+            self.avaliable_heap_indices.insert(heap_index);
+        }
 
         let heap = &mut self.heaps[heap_index];
         let handle = Handle {
-            raw: heap.alloc_handle(),
+            raw: heap.alloc_handle()?,
             heap_index,
         };
         if heap.is_full() {
             self.avaliable_heap_indices.remove(heap_index);
         }
 
-        handle
+        Ok(handle)
     }
 
     pub(super) fn free_handle(&mut self, handle: Handle) {

--- a/wgpu-hal/src/dx12/descriptor.rs
+++ b/wgpu-hal/src/dx12/descriptor.rs
@@ -202,7 +202,7 @@ impl CpuPool {
             .avaliable_heap_indices
             .iter()
             .next()
-            .unwrap_or_else(|| self.heaps.len());
+            .unwrap_or(self.heaps.len());
 
         // Allocate a new heap
         if heap_index == self.heaps.len() {


### PR DESCRIPTION
**Connections**

We are getting some crashes related to that in CTS runs ([example](https://treeherder.mozilla.org/logviewer?job_id=443130268&repo=try)).
This will turn the crashes into failures which is only slightly better, but we'll get more info out of it.

**Description**

Adds some missing error propagation in the d3d12 backend.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
