### PR TITLE
Improve test feedback and implementation

### DIFF
--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 /// Conditions under which a test should fail or be skipped.
 ///
 /// By passing a `FailureCase` to [`TestParameters::expect_fail`][expect_fail], you can
@@ -15,7 +17,7 @@
 ///     vendor: None,
 ///     adapter: Some("RTX"),
 ///     driver: None,
-///     reasons: vec![FailureReason::ValidationError(Some("Some error substring"))],
+///     reasons: vec![FailureReason::validation_error().with_message("Some error substring")],
 ///     behavior: FailureBehavior::AssertFailure,
 /// }
 /// # ;
@@ -158,7 +160,7 @@ impl FailureCase {
     /// Return the reasons why this case should fail.
     pub fn reasons(&self) -> &[FailureReason] {
         if self.reasons.is_empty() {
-            std::array::from_ref(&FailureReason::Any)
+            std::array::from_ref(&FailureReason::ANY)
         } else {
             &self.reasons
         }
@@ -170,7 +172,8 @@ impl FailureCase {
     ///
     /// If multiple reasons are pushed, will match any of them.
     pub fn validation_error(mut self, msg: &'static str) -> Self {
-        self.reasons.push(FailureReason::ValidationError(Some(msg)));
+        self.reasons
+            .push(FailureReason::validation_error().with_message(msg));
         self
     }
 
@@ -180,7 +183,7 @@ impl FailureCase {
     ///
     /// If multiple reasons are pushed, will match any of them.
     pub fn panic(mut self, msg: &'static str) -> Self {
-        self.reasons.push(FailureReason::Panic(Some(msg)));
+        self.reasons.push(FailureReason::panic().with_message(msg));
         self
     }
 
@@ -247,41 +250,21 @@ impl FailureCase {
     /// Returns true if the given failure "satisfies" this failure case.
     pub(crate) fn matches_failure(&self, failure: &FailureResult) -> bool {
         for reason in self.reasons() {
-            let result = match (reason, failure) {
-                (FailureReason::Any, _) => {
-                    log::error!("Matched failure case: Wildcard");
-                    true
-                }
-                (FailureReason::ValidationError(None), FailureResult::ValidationError(_)) => {
-                    log::error!("Matched failure case: Any Validation Error");
-                    true
-                }
-                (
-                    FailureReason::ValidationError(Some(expected)),
-                    FailureResult::ValidationError(Some(actual)),
-                ) => {
-                    let result = actual.to_lowercase().contains(&expected.to_lowercase());
-                    if result {
-                        log::error!(
-                            "Matched failure case: Validation Error containing \"{}\"",
-                            expected
-                        );
-                    }
-                    result
-                }
-                (FailureReason::Panic(None), FailureResult::Panic(_)) => {
-                    log::error!("Matched failure case: Any Panic");
-                    true
-                }
-                (FailureReason::Panic(Some(expected)), FailureResult::Panic(Some(actual))) => {
-                    let result = actual.to_lowercase().contains(&expected.to_lowercase());
-                    if result {
-                        log::error!("Matched failure case: Panic containing \"{}\"", expected);
-                    }
-                    result
-                }
-                _ => false,
-            };
+            let mut result = true;
+
+            result &= reason.kind.map_or(true, |kind| kind == failure.kind);
+
+            result &= reason
+                .message
+                .map_or(true, |message| match failure.message.as_deref() {
+                    Some(actual) => actual.to_lowercase().contains(&message.to_lowercase()),
+                    None => false,
+                });
+
+            if result {
+                let message = failure.message.as_deref().unwrap_or("*no message*");
+                log::error!("Matched {} {message}", failure.kind);
+            }
 
             if result {
                 return true;
@@ -308,18 +291,54 @@ bitflags::bitflags! {
 ///
 /// If the test fails for a different reason, the given FailureCase will be ignored.
 #[derive(Default, Debug, Clone, PartialEq)]
-pub enum FailureReason {
-    /// Matches any failure.
-    #[default]
-    Any,
-    /// Matches validation errors raised from the backend validation.
+pub struct FailureReason {
+    /// Match a particular kind of failure result.
     ///
-    /// If a string is provided, matches only validation errors that contain the string.
-    ValidationError(Option<&'static str>),
-    /// A panic was raised.
+    /// If `None`, match any result kind.
+    kind: Option<FailureResultKind>,
+    /// Match a particular message of a failure result.
     ///
-    /// If a string is provided, matches only panics that contain the string.
-    Panic(Option<&'static str>),
+    /// If `None`, matches any message. If `Some`, a case-insensitive sub-string
+    /// test is performed. Allowing `"error occured"` to match a message like
+    /// `"An unexpected Error occured!"`.
+    message: Option<&'static str>,
+}
+
+impl FailureReason {
+    /// Match any failure reason.
+    const ANY: Self = Self {
+        kind: None,
+        message: None,
+    };
+
+    /// Match a validation error.
+    #[allow(dead_code)] // Not constructed on wasm
+    pub fn validation_error() -> Self {
+        Self {
+            kind: Some(FailureResultKind::ValidationError),
+            message: None,
+        }
+    }
+
+    /// Match a panic.
+    pub fn panic() -> Self {
+        Self {
+            kind: Some(FailureResultKind::Panic),
+            message: None,
+        }
+    }
+
+    /// Match an error with a message.
+    ///
+    /// If specified, a case-insensitive sub-string test is performed. Allowing
+    /// `"error occured"` to match a message like `"An unexpected Error
+    /// occured!"`.
+    pub fn with_message(self, message: &'static str) -> Self {
+        Self {
+            message: Some(message),
+            ..self
+        }
+    }
 }
 
 #[derive(Default, Clone)]
@@ -336,11 +355,53 @@ pub enum FailureBehavior {
     Ignore,
 }
 
-#[derive(Debug)]
-pub(crate) enum FailureResult {
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum FailureResultKind {
     #[allow(dead_code)] // Not constructed on wasm
-    ValidationError(Option<String>),
-    Panic(Option<String>),
+    ValidationError,
+    Panic,
+}
+
+impl fmt::Display for FailureResultKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FailureResultKind::ValidationError => write!(f, "Validation Error"),
+            FailureResultKind::Panic => write!(f, "Panic"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct FailureResult {
+    kind: FailureResultKind,
+    message: Option<String>,
+}
+
+impl FailureResult {
+    /// Failure result is a panic.
+    pub(super) fn panic() -> Self {
+        Self {
+            kind: FailureResultKind::Panic,
+            message: None,
+        }
+    }
+
+    /// Failure result is a validation error.
+    #[allow(dead_code)] // Not constructed on wasm
+    pub(super) fn validation_error() -> Self {
+        Self {
+            kind: FailureResultKind::ValidationError,
+            message: None,
+        }
+    }
+
+    /// Message associated with a failure result.
+    pub(super) fn with_message(self, message: impl fmt::Display) -> Self {
+        Self {
+            kind: self.kind,
+            message: Some(message.to_string()),
+        }
+    }
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
@@ -393,7 +454,8 @@ pub(crate) fn expectations_match_failures(
     if !actual.is_empty() {
         result = ExpectationMatchResult::Panic;
         for failure in actual {
-            log::error!("Unexpected failure due to: {:?}", failure);
+            let message = failure.message.as_deref().unwrap_or("*no message*");
+            log::error!("{}: {message}", failure.kind);
         }
     }
 
@@ -409,11 +471,11 @@ mod test {
     };
 
     fn validation_err(msg: &'static str) -> FailureResult {
-        FailureResult::ValidationError(Some(String::from(msg)))
+        FailureResult::validation_error().with_message(msg)
     }
 
     fn panic(msg: &'static str) -> FailureResult {
-        FailureResult::Panic(Some(String::from(msg)))
+        FailureResult::panic().with_message(msg)
     }
 
     #[test]
@@ -423,7 +485,7 @@ mod test {
         // -- Unexpected failure --
 
         let expectation = vec![];
-        let actual = vec![FailureResult::ValidationError(None)];
+        let actual = vec![FailureResult::validation_error()];
 
         assert_eq!(
             super::expectations_match_failures(&expectation, actual),
@@ -443,7 +505,7 @@ mod test {
         // -- Expected failure (validation) --
 
         let expectation = vec![FailureCase::always()];
-        let actual = vec![FailureResult::ValidationError(None)];
+        let actual = vec![FailureResult::validation_error()];
 
         assert_eq!(
             super::expectations_match_failures(&expectation, actual),
@@ -453,7 +515,7 @@ mod test {
         // -- Expected failure (panic) --
 
         let expectation = vec![FailureCase::always()];
-        let actual = vec![FailureResult::Panic(None)];
+        let actual = vec![FailureResult::panic()];
 
         assert_eq!(
             super::expectations_match_failures(&expectation, actual),
@@ -469,9 +531,9 @@ mod test {
 
         let expectation: Vec<FailureCase> =
             vec![FailureCase::always().validation_error("Some StrIng")];
-        let actual = vec![FailureResult::ValidationError(Some(String::from(
+        let actual = vec![FailureResult::validation_error().with_message(
             "a very long string that contains sOmE sTrInG of different capitalization",
-        )))];
+        )];
 
         assert_eq!(
             super::expectations_match_failures(&expectation, actual),

--- a/tests/src/image.rs
+++ b/tests/src/image.rs
@@ -238,7 +238,7 @@ pub async fn compare_image_output(
     )
     .await;
     write_png(
-        difference_path,
+        &difference_path,
         width,
         height,
         &magma_image_with_alpha,
@@ -247,7 +247,7 @@ pub async fn compare_image_output(
     .await;
 
     if !all_passed {
-        panic!("Image data mismatch!")
+        panic!("Image data mismatch: {}", difference_path.display())
     }
 }
 


### PR DESCRIPTION
**Description**
I wanted to include the image path to improve test ergonomics (in the excellent test framework) when `compare_image_output` failed, and when doing so an output like this is generated:

```
[2024-01-16T07:32:51Z ERROR wgpu_test::expectations] Unexpected failure due to: Panic(Some("Image data mismatch: D:\\Repo\\wgpu\\examples/..//examples/src/water\\screenshot-dx12-Microsoft_Basic_Render_Driver--difference.png"))
```

While this is mostly fine, most UI terminals allow you to ctrl+click path-looking items to open it. However, formatting the path like this prevents it from working.

I changed the output so that the message is reported in isolation, or `*no message*` if no message is available, giving us this if a path is included in the tail like with the change I included:

```
[2024-01-16T07:35:42Z ERROR wgpu_test::expectations] Panic: Image data mismatch: D:\Repo\wgpu\examples/..//examples/src/water\screenshot-dx12-Microsoft_Basic_Render_Driver--difference.png
```

Allowing the output path to be ctrl-clicked.

In the process of doing so, I simplified how the `FailureResult` / `FailureReason` log diagnostics and are matched against each other since I noticed it.

**Testing**
Ran `cargo xtask test`.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`
- [x] Run `cargo xtask test` to run tests.

Internal change, so did not modify `CHANGELOG.md`. But will do so if it's still appropriate!
