### PR TITLE
Introduce error helpers in wgpu-core

### DIFF
--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -228,9 +228,10 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         }
 
         let device = &cmd_buf.device;
-        if !device.is_valid() {
-            return Err(ClearError::InvalidDevice(cmd_buf.device.as_info().id()));
-        }
+        ensure!(
+            device.is_valid(),
+            ClearError::InvalidDevice(cmd_buf.device.as_info().id())
+        );
         let (encoder, tracker) = cmd_buf_data.open_encoder_and_tracker()?;
 
         clear_texture(

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -438,18 +438,18 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
         let dst_barrier = dst_pending.map(|pending| pending.into_hal(&dst_buffer, &snatch_guard));
 
-        if !dst_buffer.usage.contains(wgt::BufferUsages::QUERY_RESOLVE) {
-            return Err(ResolveError::MissingBufferUsage.into());
-        }
+        ensure!(
+            dst_buffer.usage.contains(wgt::BufferUsages::QUERY_RESOLVE),
+            ResolveError::MissingBufferUsage
+        );
 
         let end_query = start_query + query_count;
         if end_query > query_set.desc.count {
-            return Err(ResolveError::QueryOverrun {
+            bail!(ResolveError::QueryOverrun {
                 start_query,
                 end_query,
                 query_set_size: query_set.desc.count,
-            }
-            .into());
+            });
         }
 
         let elements_per_query = match query_set.desc.ty {
@@ -464,15 +464,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let buffer_end_offset = buffer_start_offset + bytes_used;
 
         if buffer_end_offset > dst_buffer.size {
-            return Err(ResolveError::BufferOverrun {
+            bail!(ResolveError::BufferOverrun {
                 start_query,
                 end_query,
                 stride,
                 buffer_size: dst_buffer.size,
                 buffer_start_offset,
                 buffer_end_offset,
-            }
-            .into());
+            });
         }
 
         // TODO(https://github.com/gfx-rs/wgpu/issues/3993): Need to track initialization state.

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -107,10 +107,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let hub = A::hub(self);
 
         let device = hub.devices.get(device_id).map_err(|_| InvalidDevice)?;
-        if !device.is_valid() {
-            return Err(InvalidDevice);
-        }
-
+        ensure!(device.is_valid(), InvalidDevice);
         Ok(device.features)
     }
 
@@ -135,10 +132,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let hub = A::hub(self);
 
         let device = hub.devices.get(device_id).map_err(|_| InvalidDevice)?;
-        if !device.is_valid() {
-            return Err(InvalidDevice);
-        }
-
+        ensure!(device.is_valid(), InvalidDevice);
         Ok(device.downlevel.clone())
     }
 
@@ -161,6 +155,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     break DeviceError::Invalid.into();
                 }
             };
+
             if !device.is_valid() {
                 break DeviceError::Lost.into();
             }
@@ -376,9 +371,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .get(device_id)
             .map_err(|_| DeviceError::Invalid)?;
         let snatch_guard = device.snatchable_lock.read();
-        if !device.is_valid() {
-            return Err(DeviceError::Lost.into());
-        }
+
+        ensure!(device.is_valid(), DeviceError::Lost);
 
         let buffer = hub
             .buffers
@@ -437,9 +431,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             .devices
             .get(device_id)
             .map_err(|_| DeviceError::Invalid)?;
-        if !device.is_valid() {
-            return Err(DeviceError::Lost.into());
-        }
+
+        ensure!(device.is_valid(), DeviceError::Lost);
 
         let snatch_guard = device.snatchable_lock.read();
 
@@ -2075,9 +2068,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         let hub = A::hub(self);
 
         let device = hub.devices.get(device_id).map_err(|_| InvalidDevice)?;
-        if !device.is_valid() {
-            return Err(InvalidDevice);
-        }
+        ensure!(device.is_valid(), InvalidDevice);
         device.lock_life().triage_suspected(&device.trackers);
         Ok(())
     }
@@ -2364,9 +2355,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let device = &buffer.device;
-            if !device.is_valid() {
-                return Err((op, DeviceError::Lost.into()));
-            }
+            ensure!(device.is_valid(), (op, DeviceError::Lost.into()));
 
             if let Err(e) = check_buffer_usage(buffer.usage, pub_usage) {
                 return Err((op, e.into()));

--- a/wgpu-core/src/error.rs
+++ b/wgpu-core/src/error.rs
@@ -3,6 +3,23 @@ use std::error::Error;
 
 use crate::{gfx_select, global::Global, identity::IdentityManagerFactory};
 
+/// Bail with the given error using `From` to perform conversion.
+macro_rules! bail {
+    ($err:expr) => {
+        return Err(From::from($err))
+    };
+}
+
+/// Ensure that the given expression is `true`, or construct and return the
+/// given error using `From` to convert it.
+macro_rules! ensure {
+    ($expression:expr, $err:expr) => {
+        if !$expression {
+            return Err(From::from($err));
+        }
+    };
+}
+
 pub struct ErrorFormatter<'a> {
     writer: &'a mut dyn fmt::Write,
     global: &'a Global<IdentityManagerFactory>,

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -76,12 +76,13 @@
     unused_qualifications
 )]
 
+#[macro_use]
+pub mod error;
 pub mod any_surface;
 pub mod binding_model;
 pub mod command;
 mod conv;
 pub mod device;
-pub mod error;
 pub mod global;
 pub mod hal_api;
 mod hash_utils;


### PR DESCRIPTION
**Description**

I noted that wgpu crates rely on two error patterns which can be improved through methods which are fairly common in the Rust ecosystem:

The first one is:

```rust
return Err(SomeLocalError.into());
```

And the second is testing a precondition which if it fails return an error:

```rust
if !condition {
    return Err(SomeLocalError.into());
}
```

This PR introduces two local error helpers in wgpu-core, who's behavior are borrowed from the popular [`anyhow` crate](https://docs.rs/anyhow/latest/anyhow/macro.bail.html):

* `bail!` which takes an expression, converts it through `From` and returns it as an error.
* `ensure!` which takes two arguments, and if the first one is false does the same as `bail!`.

There are two potential ergonomics wins here. First uses do not have to worry about local `.into()` conversions and `ensure!` can be more concise (all though if the line is broken up isn't).

I've introduced a few example usages of each as a proposal here to garner feedback, and will mark this as a draft for now.