### PR TITLE
Release GPU resources from device.trackers, not from lifetime_tracker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Bottom level categories:
 
 ### New features
 
+#### General
+
 - Many numeric built-ins have had a constant evaluation implementation added for them, which allows them to be used in a `const` context:
     - [#4879](https://github.com/gfx-rs/wgpu/pull/4879) by @ErichDonGubler:
         - `abs`
@@ -64,6 +66,8 @@ Bottom level categories:
         - `step`
         - `tan`
         - `tanh`
+- Eager release of GPU resources comes from device.trackers. By @bradwerth in [#5075](https://github.com/gfx-rs/wgpu/pull/5075)
+
 
 ### Bug Fixes
 

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -837,47 +837,4 @@ impl<A: HalApi> LifetimeTracker<A> {
         }
         pending_callbacks
     }
-
-    pub(crate) fn release_gpu_resources(&mut self) {
-        // This is called when the device is lost, which makes every associated
-        // resource invalid and unusable. This is an opportunity to release all of
-        // the underlying gpu resources, even though the objects remain visible to
-        // the user agent. We purge this memory naturally when resources have been
-        // moved into the appropriate buckets, so this function just needs to
-        // initiate movement into those buckets, and it can do that by calling
-        // "destroy" on all the resources we know about which aren't already marked
-        // for cleanup.
-
-        // During these iterations, we discard all errors. We don't care!
-
-        // Destroy all the mapped buffers.
-        for buffer in &self.mapped {
-            let _ = buffer.destroy();
-        }
-
-        // Destroy all the unmapped buffers.
-        for buffer in &self.ready_to_map {
-            let _ = buffer.destroy();
-        }
-
-        // Destroy all the future_suspected_buffers.
-        for buffer in &self.future_suspected_buffers {
-            let _ = buffer.destroy();
-        }
-
-        // Destroy the buffers in all active submissions.
-        for submission in &self.active {
-            for buffer in &submission.mapped {
-                let _ = buffer.destroy();
-            }
-        }
-
-        // Destroy all the future_suspected_textures.
-        // TODO: texture.destroy is not implemented
-        /*
-        for texture in &self.future_suspected_textures {
-            let _ = texture.destroy();
-        }
-        */
-    }
 }


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/4907

**Description**
This makes wgpu release all device-tracked GPU buffers and textures during "lose the device". Previously, wgpu only released buffers that had pending status changes in `life_tracker`.

**Testing**
Tested by bulk test runners like CTS, which should run out of memory less frequently.

**Checklist**

- [X] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
