### PR TITLE
Remove many uses of Option<T> and unwraps

### DIFF
--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -242,7 +242,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             encoder,
             &mut tracker.textures,
             &device.alignments,
-            device.zero_buffer.as_ref().unwrap(),
+            &device.zero_buffer,
         )
     }
 }

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -446,12 +446,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             // But no point in erroring over that nuance here!
             if let Some(range) = range {
                 unsafe {
-                    raw.reset_queries(query_set.raw.as_ref().unwrap(), range);
+                    raw.reset_queries(&query_set.raw, range);
                 }
             }
 
             Some(hal::ComputePassTimestampWrites {
-                query_set: query_set.raw.as_ref().unwrap(),
+                query_set: &query_set.raw,
                 beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
                 end_of_pass_write_index: tw.end_of_pass_write_index,
             })
@@ -582,13 +582,11 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     }
 
                     // Rebind resources
-                    if state.binder.pipeline_layout.is_none()
-                        || !state
-                            .binder
-                            .pipeline_layout
-                            .as_ref()
-                            .unwrap()
-                            .is_equal(&pipeline.layout)
+                    if state
+                        .binder
+                        .pipeline_layout
+                        .as_ref()
+                        .map_or(true, |p| !p.is_equal(&pipeline.layout))
                     {
                         let (start_index, entries) = state.binder.change_pipeline_layout(
                             &pipeline.layout,

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -155,7 +155,7 @@ pub(crate) fn fixup_discarded_surfaces<
             encoder,
             texture_tracker,
             &device.alignments,
-            device.zero_buffer.as_ref().unwrap(),
+            &device.zero_buffer,
         )
         .unwrap();
     }
@@ -309,7 +309,7 @@ impl<A: HalApi> BakedCommands<A> {
                     &mut self.encoder,
                     &mut device_tracker.textures,
                     &device.alignments,
-                    device.zero_buffer.as_ref().unwrap(),
+                    &device.zero_buffer,
                 );
 
                 // A Texture can be destroyed between the command recording

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -156,7 +156,9 @@ impl<A: HalApi> Drop for CommandBuffer<A> {
         }
         unsafe {
             use hal::Device;
-            self.device.raw().destroy_command_encoder(baked.encoder);
+            self.device
+                .raw()
+                .destroy_command_encoder(&mut baked.encoder);
         }
     }
 }

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -268,8 +268,7 @@ impl<A: HalApi> QuerySet<A> {
         unsafe {
             // If we don't have a reset state tracker which can defer resets, we must reset now.
             if needs_reset {
-                raw_encoder
-                    .reset_queries(self.raw.as_ref().unwrap(), query_index..(query_index + 1));
+                raw_encoder.reset_queries(&self.raw, query_index..(query_index + 1));
             }
             raw_encoder.begin_query(query_set, query_index);
         }
@@ -321,7 +320,7 @@ pub(super) fn end_occlusion_query<A: HalApi>(
         // We can unwrap here as the validity was validated when the active query was set
         let query_set = storage.get(query_set_id).unwrap();
 
-        unsafe { raw_encoder.end_query(query_set.raw.as_ref().unwrap(), query_index) };
+        unsafe { raw_encoder.end_query(&query_set.raw, query_index) };
 
         Ok(())
     } else {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1159,7 +1159,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
             }
 
             Some(hal::RenderPassTimestampWrites {
-                query_set: query_set.raw.as_ref().unwrap(),
+                query_set: &query_set.raw,
                 beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
                 end_of_pass_write_index: tw.end_of_pass_write_index,
             })
@@ -1173,7 +1173,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 .add_single(query_set_guard, occlusion_query_set)
                 .ok_or(RenderPassErrorInner::InvalidQuerySet(occlusion_query_set))?;
 
-            Some(query_set.raw.as_ref().unwrap())
+            Some(&query_set.raw)
         } else {
             None
         };

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -480,7 +480,7 @@ fn handle_texture_init<A: HalApi>(
                 cmd_buf_raw,
                 &mut trackers.textures,
                 &device.alignments,
-                device.zero_buffer.as_ref().unwrap(),
+                &device.zero_buffer,
             )?;
         }
     }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -401,14 +401,14 @@ impl<A: HalApi> CommandAllocator<A> {
         self.free_encoders.push(encoder);
     }
 
-    fn dispose(self, device: &A::Device) {
+    fn dispose(&mut self, device: &A::Device) {
         resource_log!(
             "CommandAllocator::dispose encoders {}",
             self.free_encoders.len()
         );
-        for cmd_encoder in self.free_encoders {
+        for mut cmd_encoder in self.free_encoders.drain(..) {
             unsafe {
-                device.destroy_command_encoder(cmd_encoder);
+                device.destroy_command_encoder(&mut cmd_encoder);
             }
         }
     }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -122,8 +122,8 @@ impl Instance {
             unsafe {
                 if let Some(surface) = surface.take::<A>() {
                     if let Some(suf) = Arc::into_inner(surface) {
-                        if let Some(raw) = Arc::into_inner(suf.raw) {
-                            instance.as_ref().unwrap().destroy_surface(raw);
+                        if let Some(mut raw) = Arc::into_inner(suf.raw) {
+                            instance.as_ref().unwrap().destroy_surface(&mut raw);
                         } else {
                             panic!("Surface cannot be destroyed because is still in use");
                         }

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -44,7 +44,7 @@ pub struct ShaderModuleDescriptor<'a> {
 
 #[derive(Debug)]
 pub struct ShaderModule<A: HalApi> {
-    pub(crate) raw: Option<A::ShaderModule>,
+    pub(crate) raw: A::ShaderModule,
     pub(crate) device: Arc<Device<A>>,
     pub(crate) interface: Option<validation::Interface>,
     pub(crate) info: ResourceInfo<ShaderModuleId>,
@@ -53,16 +53,14 @@ pub struct ShaderModule<A: HalApi> {
 
 impl<A: HalApi> Drop for ShaderModule<A> {
     fn drop(&mut self) {
-        if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw ShaderModule {:?}", self.info.label());
-            #[cfg(feature = "trace")]
-            if let Some(t) = self.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyShaderModule(self.info.id()));
-            }
-            unsafe {
-                use hal::Device;
-                self.device.raw().destroy_shader_module(raw);
-            }
+        resource_log!("Destroy raw ShaderModule {:?}", self.info.label());
+        #[cfg(feature = "trace")]
+        if let Some(t) = self.device.trace.lock().as_mut() {
+            t.add(trace::Action::DestroyShaderModule(self.info.id()));
+        }
+        unsafe {
+            use hal::Device;
+            self.device.raw().destroy_shader_module(&mut self.raw);
         }
     }
 }
@@ -85,7 +83,7 @@ impl<A: HalApi> Resource<ShaderModuleId> for ShaderModule<A> {
 
 impl<A: HalApi> ShaderModule<A> {
     pub(crate) fn raw(&self) -> &A::ShaderModule {
-        self.raw.as_ref().unwrap()
+        &self.raw
     }
 }
 
@@ -239,7 +237,7 @@ pub enum CreateComputePipelineError {
 
 #[derive(Debug)]
 pub struct ComputePipeline<A: HalApi> {
-    pub(crate) raw: Option<A::ComputePipeline>,
+    pub(crate) raw: A::ComputePipeline,
     pub(crate) layout: Arc<PipelineLayout<A>>,
     pub(crate) device: Arc<Device<A>>,
     pub(crate) _shader_module: Arc<ShaderModule<A>>,
@@ -249,18 +247,16 @@ pub struct ComputePipeline<A: HalApi> {
 
 impl<A: HalApi> Drop for ComputePipeline<A> {
     fn drop(&mut self) {
-        if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw ComputePipeline {:?}", self.info.label());
+        resource_log!("Destroy raw ComputePipeline {:?}", self.info.label());
 
-            #[cfg(feature = "trace")]
-            if let Some(t) = self.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyComputePipeline(self.info.id()));
-            }
+        #[cfg(feature = "trace")]
+        if let Some(t) = self.device.trace.lock().as_mut() {
+            t.add(trace::Action::DestroyComputePipeline(self.info.id()));
+        }
 
-            unsafe {
-                use hal::Device;
-                self.device.raw().destroy_compute_pipeline(raw);
-            }
+        unsafe {
+            use hal::Device;
+            self.device.raw().destroy_compute_pipeline(&mut self.raw);
         }
     }
 }
@@ -279,7 +275,7 @@ impl<A: HalApi> Resource<ComputePipelineId> for ComputePipeline<A> {
 
 impl<A: HalApi> ComputePipeline<A> {
     pub(crate) fn raw(&self) -> &A::ComputePipeline {
-        self.raw.as_ref().unwrap()
+        &self.raw
     }
 }
 
@@ -482,7 +478,7 @@ impl Default for VertexStep {
 
 #[derive(Debug)]
 pub struct RenderPipeline<A: HalApi> {
-    pub(crate) raw: Option<A::RenderPipeline>,
+    pub(crate) raw: A::RenderPipeline,
     pub(crate) device: Arc<Device<A>>,
     pub(crate) layout: Arc<PipelineLayout<A>>,
     pub(crate) _shader_modules:
@@ -497,18 +493,16 @@ pub struct RenderPipeline<A: HalApi> {
 
 impl<A: HalApi> Drop for RenderPipeline<A> {
     fn drop(&mut self) {
-        if let Some(raw) = self.raw.take() {
-            resource_log!("Destroy raw RenderPipeline {:?}", self.info.label());
+        resource_log!("Destroy raw RenderPipeline {:?}", self.info.label());
 
-            #[cfg(feature = "trace")]
-            if let Some(t) = self.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyRenderPipeline(self.info.id()));
-            }
+        #[cfg(feature = "trace")]
+        if let Some(t) = self.device.trace.lock().as_mut() {
+            t.add(trace::Action::DestroyRenderPipeline(self.info.id()));
+        }
 
-            unsafe {
-                use hal::Device;
-                self.device.raw().destroy_render_pipeline(raw);
-            }
+        unsafe {
+            use hal::Device;
+            self.device.raw().destroy_render_pipeline(&mut self.raw);
         }
     }
 }
@@ -527,6 +521,6 @@ impl<A: HalApi> Resource<RenderPipelineId> for RenderPipeline<A> {
 
 impl<A: HalApi> RenderPipeline<A> {
     pub(crate) fn raw(&self) -> &A::RenderPipeline {
-        self.raw.as_ref().unwrap()
+        &self.raw
     }
 }

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -345,13 +345,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                             unsafe { suf.unwrap().raw.discard_texture(raw.take().unwrap()) };
                             Err(hal::SurfaceError::Outdated)
                         } else {
-                            unsafe {
-                                queue
-                                    .raw
-                                    .as_ref()
-                                    .unwrap()
-                                    .present(&suf.unwrap().raw, raw.take().unwrap())
-                            }
+                            unsafe { queue.raw().present(&suf.unwrap().raw, raw.take().unwrap()) }
                         }
                     }
                     _ => unreachable!(),

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -176,8 +176,8 @@ impl<A: hal::Api> ExecutionContext<A> {
     unsafe fn wait_and_clear(&mut self, device: &A::Device) {
         device.wait(&self.fence, self.fence_value, !0).unwrap();
         self.encoder.reset_all(self.used_cmd_bufs.drain(..));
-        for view in self.used_views.drain(..) {
-            device.destroy_texture_view(view);
+        for mut view in self.used_views.drain(..) {
+            device.destroy_texture_view(&mut view);
         }
         self.frames_recorded = 0;
     }
@@ -1005,28 +1005,29 @@ impl<A: hal::Api> Example<A> {
 
             for mut ctx in self.contexts {
                 ctx.wait_and_clear(&self.device);
-                self.device.destroy_command_encoder(ctx.encoder);
-                self.device.destroy_fence(ctx.fence);
+                self.device.destroy_command_encoder(&mut ctx.encoder);
+                self.device.destroy_fence(&mut ctx.fence);
             }
 
-            self.device.destroy_bind_group(self.bind_group);
-            self.device.destroy_buffer(self.scratch_buffer);
-            self.device.destroy_buffer(self.instances_buffer);
-            self.device.destroy_buffer(self.indices_buffer);
-            self.device.destroy_buffer(self.vertices_buffer);
-            self.device.destroy_buffer(self.uniform_buffer);
-            self.device.destroy_acceleration_structure(self.tlas);
-            self.device.destroy_acceleration_structure(self.blas);
-            self.device.destroy_texture_view(self.texture_view);
-            self.device.destroy_texture(self.texture);
-            self.device.destroy_compute_pipeline(self.pipeline);
-            self.device.destroy_pipeline_layout(self.pipeline_layout);
-            self.device.destroy_bind_group_layout(self.bgl);
-            self.device.destroy_shader_module(self.shader_module);
+            self.device.destroy_bind_group(&mut self.bind_group);
+            self.device.destroy_buffer(&mut self.scratch_buffer);
+            self.device.destroy_buffer(&mut self.instances_buffer);
+            self.device.destroy_buffer(&mut self.indices_buffer);
+            self.device.destroy_buffer(&mut self.vertices_buffer);
+            self.device.destroy_buffer(&mut self.uniform_buffer);
+            self.device.destroy_acceleration_structure(&mut self.tlas);
+            self.device.destroy_acceleration_structure(&mut self.blas);
+            self.device.destroy_texture_view(&mut self.texture_view);
+            self.device.destroy_texture(&mut self.texture);
+            self.device.destroy_compute_pipeline(&mut self.pipeline);
+            self.device
+                .destroy_pipeline_layout(&mut self.pipeline_layout);
+            self.device.destroy_bind_group_layout(&mut self.bgl);
+            self.device.destroy_shader_module(&mut self.shader_module);
 
             self.surface.unconfigure(&self.device);
             self.device.exit(self.queue);
-            self.instance.destroy_surface(self.surface);
+            self.instance.destroy_surface(&mut self.surface);
             drop(self.adapter);
         }
     }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -318,7 +318,7 @@ impl super::Device {
 }
 
 impl crate::Device<super::Api> for super::Device {
-    unsafe fn exit(mut self, _queue: super::Queue) {
+    unsafe fn exit(&mut self, _queue: super::Queue) {
         self.rtv_pool.lock().free_handle(self.null_rtv_handle);
         self.mem_allocator = None;
     }
@@ -366,7 +366,7 @@ impl crate::Device<super::Api> for super::Device {
         })
     }
 
-    unsafe fn destroy_buffer(&self, mut buffer: super::Buffer) {
+    unsafe fn destroy_buffer(&self, buffer: &mut super::Buffer) {
         // Only happens when it's using the windows_rs feature and there's an allocation
         if let Some(alloc) = buffer.allocation.take() {
             super::suballocation::free_buffer_allocation(
@@ -451,7 +451,7 @@ impl crate::Device<super::Api> for super::Device {
         })
     }
 
-    unsafe fn destroy_texture(&self, mut texture: super::Texture) {
+    unsafe fn destroy_texture(&self, texture: &mut super::Texture) {
         if let Some(alloc) = texture.allocation.take() {
             super::suballocation::free_texture_allocation(
                 alloc,
@@ -564,7 +564,7 @@ impl crate::Device<super::Api> for super::Device {
             },
         })
     }
-    unsafe fn destroy_texture_view(&self, view: super::TextureView) {
+    unsafe fn destroy_texture_view(&self, view: &mut super::TextureView) {
         if view.handle_srv.is_some() || view.handle_uav.is_some() {
             let mut pool = self.srv_uav_pool.lock();
             if let Some(handle) = view.handle_srv {
@@ -626,7 +626,7 @@ impl crate::Device<super::Api> for super::Device {
 
         Ok(super::Sampler { handle })
     }
-    unsafe fn destroy_sampler(&self, sampler: super::Sampler) {
+    unsafe fn destroy_sampler(&self, sampler: &mut super::Sampler) {
         self.sampler_pool.lock().free_handle(sampler.handle);
     }
 
@@ -656,8 +656,8 @@ impl crate::Device<super::Api> for super::Device {
             end_of_pass_timer_query: None,
         })
     }
-    unsafe fn destroy_command_encoder(&self, encoder: super::CommandEncoder) {
-        if let Some(list) = encoder.list {
+    unsafe fn destroy_command_encoder(&self, encoder: &mut super::CommandEncoder) {
+        if let Some(ref list) = encoder.list {
             list.close();
         }
     }
@@ -709,7 +709,7 @@ impl crate::Device<super::Api> for super::Device {
             copy_counts: vec![1; num_views.max(num_samplers) as usize],
         })
     }
-    unsafe fn destroy_bind_group_layout(&self, _bg_layout: super::BindGroupLayout) {}
+    unsafe fn destroy_bind_group_layout(&self, _bg_layout: &mut super::BindGroupLayout) {}
 
     unsafe fn create_pipeline_layout(
         &self,
@@ -1071,7 +1071,7 @@ impl crate::Device<super::Api> for super::Device {
             },
         })
     }
-    unsafe fn destroy_pipeline_layout(&self, _pipeline_layout: super::PipelineLayout) {}
+    unsafe fn destroy_pipeline_layout(&self, _pipeline_layout: &mut super::PipelineLayout) {}
 
     unsafe fn create_bind_group(
         &self,
@@ -1240,7 +1240,7 @@ impl crate::Device<super::Api> for super::Device {
             dynamic_buffers,
         })
     }
-    unsafe fn destroy_bind_group(&self, group: super::BindGroup) {
+    unsafe fn destroy_bind_group(&self, group: &mut super::BindGroup) {
         if let Some(dual) = group.handle_views {
             self.shared.heap_views.free_slice(dual);
         }
@@ -1262,7 +1262,7 @@ impl crate::Device<super::Api> for super::Device {
             }
         }
     }
-    unsafe fn destroy_shader_module(&self, _module: super::ShaderModule) {
+    unsafe fn destroy_shader_module(&self, _module: &mut super::ShaderModule) {
         // just drop
     }
 
@@ -1449,7 +1449,7 @@ impl crate::Device<super::Api> for super::Device {
             vertex_strides,
         })
     }
-    unsafe fn destroy_render_pipeline(&self, _pipeline: super::RenderPipeline) {}
+    unsafe fn destroy_render_pipeline(&self, _pipeline: &mut super::RenderPipeline) {}
 
     unsafe fn create_compute_pipeline(
         &self,
@@ -1484,7 +1484,7 @@ impl crate::Device<super::Api> for super::Device {
             layout: desc.layout.shared.clone(),
         })
     }
-    unsafe fn destroy_compute_pipeline(&self, _pipeline: super::ComputePipeline) {}
+    unsafe fn destroy_compute_pipeline(&self, _pipeline: &mut super::ComputePipeline) {}
 
     unsafe fn create_query_set(
         &self,
@@ -1517,7 +1517,7 @@ impl crate::Device<super::Api> for super::Device {
 
         Ok(super::QuerySet { raw, raw_ty })
     }
-    unsafe fn destroy_query_set(&self, _set: super::QuerySet) {}
+    unsafe fn destroy_query_set(&self, _set: &mut super::QuerySet) {}
 
     unsafe fn create_fence(&self) -> Result<super::Fence, crate::DeviceError> {
         let mut raw = d3d12::Fence::null();
@@ -1532,7 +1532,7 @@ impl crate::Device<super::Api> for super::Device {
         hr.into_device_result("Fence creation")?;
         Ok(super::Fence { raw })
     }
-    unsafe fn destroy_fence(&self, _fence: super::Fence) {}
+    unsafe fn destroy_fence(&self, _fence: &mut super::Fence) {}
     unsafe fn get_fence_value(
         &self,
         fence: &super::Fence,
@@ -1671,7 +1671,7 @@ impl crate::Device<super::Api> for super::Device {
 
     unsafe fn destroy_acceleration_structure(
         &self,
-        _acceleration_structure: super::AccelerationStructure,
+        _acceleration_structure: &mut super::AccelerationStructure,
     ) {
         // Destroy a D3D12 resource as per-usual.
         todo!()

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -125,7 +125,7 @@ impl crate::Instance<super::Api> for super::Instance {
             ))),
         }
     }
-    unsafe fn destroy_surface(&self, _surface: super::Surface) {
+    unsafe fn destroy_surface(&self, _surface: &mut super::Surface) {
         // just drop
     }
 

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -50,7 +50,7 @@ impl crate::Instance<Api> for Context {
     ) -> Result<Context, crate::InstanceError> {
         Ok(Context)
     }
-    unsafe fn destroy_surface(&self, surface: Context) {}
+    unsafe fn destroy_surface(&self, surface: &mut Context) {}
     unsafe fn enumerate_adapters(&self) -> Vec<crate::ExposedAdapter<Api>> {
         Vec::new()
     }
@@ -122,11 +122,11 @@ impl crate::Queue<Api> for Context {
 }
 
 impl crate::Device<Api> for Context {
-    unsafe fn exit(self, queue: Context) {}
+    unsafe fn exit(&mut self, queue: Context) {}
     unsafe fn create_buffer(&self, desc: &crate::BufferDescriptor) -> DeviceResult<Resource> {
         Ok(Resource)
     }
-    unsafe fn destroy_buffer(&self, buffer: Resource) {}
+    unsafe fn destroy_buffer(&self, buffer: &mut Resource) {}
     unsafe fn map_buffer(
         &self,
         buffer: &Resource,
@@ -143,7 +143,7 @@ impl crate::Device<Api> for Context {
     unsafe fn create_texture(&self, desc: &crate::TextureDescriptor) -> DeviceResult<Resource> {
         Ok(Resource)
     }
-    unsafe fn destroy_texture(&self, texture: Resource) {}
+    unsafe fn destroy_texture(&self, texture: &mut Resource) {}
     unsafe fn create_texture_view(
         &self,
         texture: &Resource,
@@ -151,11 +151,11 @@ impl crate::Device<Api> for Context {
     ) -> DeviceResult<Resource> {
         Ok(Resource)
     }
-    unsafe fn destroy_texture_view(&self, view: Resource) {}
+    unsafe fn destroy_texture_view(&self, view: &mut Resource) {}
     unsafe fn create_sampler(&self, desc: &crate::SamplerDescriptor) -> DeviceResult<Resource> {
         Ok(Resource)
     }
-    unsafe fn destroy_sampler(&self, sampler: Resource) {}
+    unsafe fn destroy_sampler(&self, sampler: &mut Resource) {}
 
     unsafe fn create_command_encoder(
         &self,
@@ -163,7 +163,7 @@ impl crate::Device<Api> for Context {
     ) -> DeviceResult<Encoder> {
         Ok(Encoder)
     }
-    unsafe fn destroy_command_encoder(&self, encoder: Encoder) {}
+    unsafe fn destroy_command_encoder(&self, encoder: &mut Encoder) {}
 
     unsafe fn create_bind_group_layout(
         &self,
@@ -171,21 +171,21 @@ impl crate::Device<Api> for Context {
     ) -> DeviceResult<Resource> {
         Ok(Resource)
     }
-    unsafe fn destroy_bind_group_layout(&self, bg_layout: Resource) {}
+    unsafe fn destroy_bind_group_layout(&self, bg_layout: &mut Resource) {}
     unsafe fn create_pipeline_layout(
         &self,
         desc: &crate::PipelineLayoutDescriptor<Api>,
     ) -> DeviceResult<Resource> {
         Ok(Resource)
     }
-    unsafe fn destroy_pipeline_layout(&self, pipeline_layout: Resource) {}
+    unsafe fn destroy_pipeline_layout(&self, pipeline_layout: &mut Resource) {}
     unsafe fn create_bind_group(
         &self,
         desc: &crate::BindGroupDescriptor<Api>,
     ) -> DeviceResult<Resource> {
         Ok(Resource)
     }
-    unsafe fn destroy_bind_group(&self, group: Resource) {}
+    unsafe fn destroy_bind_group(&self, group: &mut Resource) {}
 
     unsafe fn create_shader_module(
         &self,
@@ -194,21 +194,21 @@ impl crate::Device<Api> for Context {
     ) -> Result<Resource, crate::ShaderError> {
         Ok(Resource)
     }
-    unsafe fn destroy_shader_module(&self, module: Resource) {}
+    unsafe fn destroy_shader_module(&self, module: &mut Resource) {}
     unsafe fn create_render_pipeline(
         &self,
         desc: &crate::RenderPipelineDescriptor<Api>,
     ) -> Result<Resource, crate::PipelineError> {
         Ok(Resource)
     }
-    unsafe fn destroy_render_pipeline(&self, pipeline: Resource) {}
+    unsafe fn destroy_render_pipeline(&self, pipeline: &mut Resource) {}
     unsafe fn create_compute_pipeline(
         &self,
         desc: &crate::ComputePipelineDescriptor<Api>,
     ) -> Result<Resource, crate::PipelineError> {
         Ok(Resource)
     }
-    unsafe fn destroy_compute_pipeline(&self, pipeline: Resource) {}
+    unsafe fn destroy_compute_pipeline(&self, pipeline: &mut Resource) {}
 
     unsafe fn create_query_set(
         &self,
@@ -216,11 +216,11 @@ impl crate::Device<Api> for Context {
     ) -> DeviceResult<Resource> {
         Ok(Resource)
     }
-    unsafe fn destroy_query_set(&self, set: Resource) {}
+    unsafe fn destroy_query_set(&self, set: &mut Resource) {}
     unsafe fn create_fence(&self) -> DeviceResult<Resource> {
         Ok(Resource)
     }
-    unsafe fn destroy_fence(&self, fence: Resource) {}
+    unsafe fn destroy_fence(&self, fence: &mut Resource) {}
     unsafe fn get_fence_value(&self, fence: &Resource) -> DeviceResult<crate::FenceValue> {
         Ok(0)
     }
@@ -255,7 +255,7 @@ impl crate::Device<Api> for Context {
     ) -> wgt::BufferAddress {
         Default::default()
     }
-    unsafe fn destroy_acceleration_structure(&self, _acceleration_structure: Resource) {}
+    unsafe fn destroy_acceleration_structure(&self, _acceleration_structure: &mut Resource) {}
 }
 
 impl crate::CommandEncoder<Api> for Encoder {

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -938,7 +938,7 @@ impl crate::Instance<super::Api> for Instance {
             srgb_kind: inner.srgb_kind,
         })
     }
-    unsafe fn destroy_surface(&self, _surface: Surface) {}
+    unsafe fn destroy_surface(&self, _surface: &mut Surface) {}
 
     unsafe fn enumerate_adapters(&self) -> Vec<crate::ExposedAdapter<super::Api>> {
         let inner = self.inner.lock();

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -170,7 +170,7 @@ impl crate::Instance<super::Api> for Instance {
         self.create_surface_from_canvas(canvas)
     }
 
-    unsafe fn destroy_surface(&self, surface: Surface) {
+    unsafe fn destroy_surface(&self, surface: &mut Surface) {
         let mut context_option_ref = self.webgl2_context.lock();
 
         if let Some(context) = context_option_ref.as_ref() {

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -531,7 +531,7 @@ impl crate::Instance<super::Api> for Instance {
             srgb_capable: self.srgb_capable,
         })
     }
-    unsafe fn destroy_surface(&self, _surface: Surface) {}
+    unsafe fn destroy_surface(&self, _surface: &mut Surface) {}
 
     unsafe fn enumerate_adapters(&self) -> Vec<crate::ExposedAdapter<super::Api>> {
         unsafe {

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -223,7 +223,7 @@ pub trait Instance<A: Api>: Sized + WasmNotSendSync {
         display_handle: raw_window_handle::RawDisplayHandle,
         window_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<A::Surface, InstanceError>;
-    unsafe fn destroy_surface(&self, surface: A::Surface);
+    unsafe fn destroy_surface(&self, surface: &mut A::Surface);
     unsafe fn enumerate_adapters(&self) -> Vec<ExposedAdapter<A>>;
 }
 
@@ -295,12 +295,12 @@ pub trait Adapter<A: Api>: WasmNotSendSync {
 
 pub trait Device<A: Api>: WasmNotSendSync {
     /// Exit connection to this logical device.
-    unsafe fn exit(self, queue: A::Queue);
+    unsafe fn exit(&mut self, queue: A::Queue);
     /// Creates a new buffer.
     ///
     /// The initial usage is `BufferUses::empty()`.
     unsafe fn create_buffer(&self, desc: &BufferDescriptor) -> Result<A::Buffer, DeviceError>;
-    unsafe fn destroy_buffer(&self, buffer: A::Buffer);
+    unsafe fn destroy_buffer(&self, buffer: &mut A::Buffer);
     //TODO: clarify if zero-sized mapping is allowed
     unsafe fn map_buffer(
         &self,
@@ -319,63 +319,63 @@ pub trait Device<A: Api>: WasmNotSendSync {
     ///
     /// The initial usage for all subresources is `TextureUses::UNINITIALIZED`.
     unsafe fn create_texture(&self, desc: &TextureDescriptor) -> Result<A::Texture, DeviceError>;
-    unsafe fn destroy_texture(&self, texture: A::Texture);
+    unsafe fn destroy_texture(&self, texture: &mut A::Texture);
     unsafe fn create_texture_view(
         &self,
         texture: &A::Texture,
         desc: &TextureViewDescriptor,
     ) -> Result<A::TextureView, DeviceError>;
-    unsafe fn destroy_texture_view(&self, view: A::TextureView);
+    unsafe fn destroy_texture_view(&self, view: &mut A::TextureView);
     unsafe fn create_sampler(&self, desc: &SamplerDescriptor) -> Result<A::Sampler, DeviceError>;
-    unsafe fn destroy_sampler(&self, sampler: A::Sampler);
+    unsafe fn destroy_sampler(&self, sampler: &mut A::Sampler);
 
     unsafe fn create_command_encoder(
         &self,
         desc: &CommandEncoderDescriptor<A>,
     ) -> Result<A::CommandEncoder, DeviceError>;
-    unsafe fn destroy_command_encoder(&self, pool: A::CommandEncoder);
+    unsafe fn destroy_command_encoder(&self, pool: &mut A::CommandEncoder);
 
     /// Creates a bind group layout.
     unsafe fn create_bind_group_layout(
         &self,
         desc: &BindGroupLayoutDescriptor,
     ) -> Result<A::BindGroupLayout, DeviceError>;
-    unsafe fn destroy_bind_group_layout(&self, bg_layout: A::BindGroupLayout);
+    unsafe fn destroy_bind_group_layout(&self, bg_layout: &mut A::BindGroupLayout);
     unsafe fn create_pipeline_layout(
         &self,
         desc: &PipelineLayoutDescriptor<A>,
     ) -> Result<A::PipelineLayout, DeviceError>;
-    unsafe fn destroy_pipeline_layout(&self, pipeline_layout: A::PipelineLayout);
+    unsafe fn destroy_pipeline_layout(&self, pipeline_layout: &mut A::PipelineLayout);
     unsafe fn create_bind_group(
         &self,
         desc: &BindGroupDescriptor<A>,
     ) -> Result<A::BindGroup, DeviceError>;
-    unsafe fn destroy_bind_group(&self, group: A::BindGroup);
+    unsafe fn destroy_bind_group(&self, group: &mut A::BindGroup);
 
     unsafe fn create_shader_module(
         &self,
         desc: &ShaderModuleDescriptor,
         shader: ShaderInput,
     ) -> Result<A::ShaderModule, ShaderError>;
-    unsafe fn destroy_shader_module(&self, module: A::ShaderModule);
+    unsafe fn destroy_shader_module(&self, module: &mut A::ShaderModule);
     unsafe fn create_render_pipeline(
         &self,
         desc: &RenderPipelineDescriptor<A>,
     ) -> Result<A::RenderPipeline, PipelineError>;
-    unsafe fn destroy_render_pipeline(&self, pipeline: A::RenderPipeline);
+    unsafe fn destroy_render_pipeline(&self, pipeline: &mut A::RenderPipeline);
     unsafe fn create_compute_pipeline(
         &self,
         desc: &ComputePipelineDescriptor<A>,
     ) -> Result<A::ComputePipeline, PipelineError>;
-    unsafe fn destroy_compute_pipeline(&self, pipeline: A::ComputePipeline);
+    unsafe fn destroy_compute_pipeline(&self, pipeline: &mut A::ComputePipeline);
 
     unsafe fn create_query_set(
         &self,
         desc: &wgt::QuerySetDescriptor<Label>,
     ) -> Result<A::QuerySet, DeviceError>;
-    unsafe fn destroy_query_set(&self, set: A::QuerySet);
+    unsafe fn destroy_query_set(&self, set: &mut A::QuerySet);
     unsafe fn create_fence(&self) -> Result<A::Fence, DeviceError>;
-    unsafe fn destroy_fence(&self, fence: A::Fence);
+    unsafe fn destroy_fence(&self, fence: &mut A::Fence);
     unsafe fn get_fence_value(&self, fence: &A::Fence) -> Result<FenceValue, DeviceError>;
     /// Calling wait with a lower value than the current fence value will immediately return.
     unsafe fn wait(
@@ -402,7 +402,7 @@ pub trait Device<A: Api>: WasmNotSendSync {
     ) -> wgt::BufferAddress;
     unsafe fn destroy_acceleration_structure(
         &self,
-        acceleration_structure: A::AccelerationStructure,
+        acceleration_structure: &mut A::AccelerationStructure,
     );
 }
 

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -274,7 +274,7 @@ impl super::Device {
 }
 
 impl crate::Device<super::Api> for super::Device {
-    unsafe fn exit(self, _queue: super::Queue) {}
+    unsafe fn exit(&mut self, _queue: super::Queue) {}
 
     unsafe fn create_buffer(&self, desc: &crate::BufferDescriptor) -> DeviceResult<super::Buffer> {
         let map_read = desc.usage.contains(crate::BufferUses::MAP_READ);
@@ -305,7 +305,7 @@ impl crate::Device<super::Api> for super::Device {
             })
         })
     }
-    unsafe fn destroy_buffer(&self, _buffer: super::Buffer) {}
+    unsafe fn destroy_buffer(&self, _buffer: &mut super::Buffer) {}
 
     unsafe fn map_buffer(
         &self,
@@ -383,7 +383,7 @@ impl crate::Device<super::Api> for super::Device {
         })
     }
 
-    unsafe fn destroy_texture(&self, _texture: super::Texture) {}
+    unsafe fn destroy_texture(&self, _texture: &mut super::Texture) {}
 
     unsafe fn create_texture_view(
         &self,
@@ -445,7 +445,7 @@ impl crate::Device<super::Api> for super::Device {
 
         Ok(super::TextureView { raw, aspects })
     }
-    unsafe fn destroy_texture_view(&self, _view: super::TextureView) {}
+    unsafe fn destroy_texture_view(&self, _view: &mut super::TextureView) {}
 
     unsafe fn create_sampler(
         &self,
@@ -505,7 +505,7 @@ impl crate::Device<super::Api> for super::Device {
             Ok(super::Sampler { raw })
         })
     }
-    unsafe fn destroy_sampler(&self, _sampler: super::Sampler) {}
+    unsafe fn destroy_sampler(&self, _sampler: &mut super::Sampler) {}
 
     unsafe fn create_command_encoder(
         &self,
@@ -519,7 +519,7 @@ impl crate::Device<super::Api> for super::Device {
             temp: super::Temp::default(),
         })
     }
-    unsafe fn destroy_command_encoder(&self, _encoder: super::CommandEncoder) {}
+    unsafe fn destroy_command_encoder(&self, _encoder: &mut super::CommandEncoder) {}
 
     unsafe fn create_bind_group_layout(
         &self,
@@ -529,7 +529,7 @@ impl crate::Device<super::Api> for super::Device {
             entries: Arc::from(desc.entries),
         })
     }
-    unsafe fn destroy_bind_group_layout(&self, _bg_layout: super::BindGroupLayout) {}
+    unsafe fn destroy_bind_group_layout(&self, _bg_layout: &mut super::BindGroupLayout) {}
 
     unsafe fn create_pipeline_layout(
         &self,
@@ -696,7 +696,7 @@ impl crate::Device<super::Api> for super::Device {
             per_stage_map,
         })
     }
-    unsafe fn destroy_pipeline_layout(&self, _pipeline_layout: super::PipelineLayout) {}
+    unsafe fn destroy_pipeline_layout(&self, _pipeline_layout: &mut super::PipelineLayout) {}
 
     unsafe fn create_bind_group(
         &self,
@@ -777,7 +777,7 @@ impl crate::Device<super::Api> for super::Device {
         Ok(bg)
     }
 
-    unsafe fn destroy_bind_group(&self, _group: super::BindGroup) {}
+    unsafe fn destroy_bind_group(&self, _group: &mut super::BindGroup) {}
 
     unsafe fn create_shader_module(
         &self,
@@ -794,7 +794,7 @@ impl crate::Device<super::Api> for super::Device {
             }
         }
     }
-    unsafe fn destroy_shader_module(&self, _module: super::ShaderModule) {}
+    unsafe fn destroy_shader_module(&self, _module: &mut super::ShaderModule) {}
 
     unsafe fn create_render_pipeline(
         &self,
@@ -1027,7 +1027,7 @@ impl crate::Device<super::Api> for super::Device {
             })
         })
     }
-    unsafe fn destroy_render_pipeline(&self, _pipeline: super::RenderPipeline) {}
+    unsafe fn destroy_render_pipeline(&self, _pipeline: &mut super::RenderPipeline) {}
 
     unsafe fn create_compute_pipeline(
         &self,
@@ -1082,7 +1082,7 @@ impl crate::Device<super::Api> for super::Device {
             })
         })
     }
-    unsafe fn destroy_compute_pipeline(&self, _pipeline: super::ComputePipeline) {}
+    unsafe fn destroy_compute_pipeline(&self, _pipeline: &mut super::ComputePipeline) {}
 
     unsafe fn create_query_set(
         &self,
@@ -1149,7 +1149,7 @@ impl crate::Device<super::Api> for super::Device {
             }
         })
     }
-    unsafe fn destroy_query_set(&self, _set: super::QuerySet) {}
+    unsafe fn destroy_query_set(&self, _set: &mut super::QuerySet) {}
 
     unsafe fn create_fence(&self) -> DeviceResult<super::Fence> {
         Ok(super::Fence {
@@ -1157,7 +1157,7 @@ impl crate::Device<super::Api> for super::Device {
             pending_command_buffers: Vec::new(),
         })
     }
-    unsafe fn destroy_fence(&self, _fence: super::Fence) {}
+    unsafe fn destroy_fence(&self, _fence: &mut super::Fence) {}
     unsafe fn get_fence_value(&self, fence: &super::Fence) -> DeviceResult<crate::FenceValue> {
         let mut max_value = fence.completed_value.load(atomic::Ordering::Acquire);
         for &(value, ref cmd_buf) in fence.pending_command_buffers.iter() {
@@ -1244,7 +1244,7 @@ impl crate::Device<super::Api> for super::Device {
 
     unsafe fn destroy_acceleration_structure(
         &self,
-        _acceleration_structure: super::AccelerationStructure,
+        _acceleration_structure: &mut super::AccelerationStructure,
     ) {
         unimplemented!()
     }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -114,7 +114,7 @@ impl crate::Instance<Api> for Instance {
         }
     }
 
-    unsafe fn destroy_surface(&self, surface: Surface) {
+    unsafe fn destroy_surface(&self, surface: &mut Surface) {
         unsafe { surface.dispose() };
     }
 

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -70,8 +70,8 @@ impl super::Surface {
         }
     }
 
-    pub unsafe fn dispose(self) {
-        if let Some(view) = self.view {
+    pub unsafe fn dispose(&mut self) {
+        if let Some(view) = self.view.take() {
             let () = msg_send![view.as_ptr(), release];
         }
     }

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -821,7 +821,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
         group: &super::BindGroup,
         dynamic_offsets: &[wgt::DynamicOffset],
     ) {
-        let sets = [*group.set.raw()];
+        let sets = [*group.set.as_ref().unwrap().raw()];
         unsafe {
             self.device.raw.cmd_bind_descriptor_sets(
                 self.active,

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -824,7 +824,7 @@ impl crate::Instance<super::Api> for super::Instance {
         }
     }
 
-    unsafe fn destroy_surface(&self, surface: super::Surface) {
+    unsafe fn destroy_surface(&self, surface: &mut super::Surface) {
         unsafe { surface.functor.destroy_surface(surface.raw, None) };
     }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -369,7 +369,7 @@ pub struct Buffer {
 pub struct AccelerationStructure {
     raw: vk::AccelerationStructureKHR,
     buffer: vk::Buffer,
-    block: Mutex<gpu_alloc::MemoryBlock<vk::DeviceMemory>>,
+    block: Option<Mutex<gpu_alloc::MemoryBlock<vk::DeviceMemory>>>,
 }
 
 #[derive(Debug)]
@@ -422,7 +422,7 @@ pub struct PipelineLayout {
 
 #[derive(Debug)]
 pub struct BindGroup {
-    set: gpu_descriptor::DescriptorSet<vk::DescriptorSet>,
+    set: Option<gpu_descriptor::DescriptorSet<vk::DescriptorSet>>,
 }
 
 #[derive(Default)]


### PR DESCRIPTION
**Description**
This is another internal refactoring I'd like to suggest.

I noticed that if we make the hal `destroy_*` functions take mutable references instead of owned values, we can avoid many internal uses of `Option<T>` effectively making the hal types more "drop friendly". Most hal types perform this kind of accounting internally where needed so the added `raw: Option<T>` does not seem to achieve anything important. To me this seems like a worthwhile tradeoff. These types are primarily used in destructors, so making this easier should be worthwhile.

The end result of this round is the removal of roughly 100 unwraps. And a handful of instances where we had to move the Option<T> into the backends themselves. This is mainly due to how `gpu-alloc` and the `gpu-descriptor` crates work in that they need to take owned values.

**Testing**
Tested locally and running the test suite.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
