### PR TITLE
Make sure to unset current context in wgl Surface::configure/present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ Bottom level categories:
         - `tan`
         - `tanh`
 
+### Bug Fixes
+
+#### WGL
+
+- In Surface::configure and Surface::present, fix the current GL context not being unset when releasing the lock that guards access to making the context current. This was causing other threads to panic when trying to make the context current. By @Imberflur in [#5087](https://github.com/gfx-rs/wgpu/pull/5087).
+
 ## v0.19.0 (2024-01-17)
 
 This release includes:

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1092,6 +1092,7 @@ impl Surface {
             .map_err(|e| {
                 log::error!("swap_buffers failed: {}", e);
                 crate::SurfaceError::Lost
+                // TODO: should we unset the current context here?
             })?;
         self.egl
             .instance


### PR DESCRIPTION
**Connections**
None known

**Description**
When re-building pipelines in background threads on the wgl backend we encounted this panic:
```
called `Result::unwrap()` on an `Err` value: Os { code: 170, kind: ResourceBusy, message: "The requested resource is in use." }
```
which is produced by the unwrap when making a context current fails here https://github.com/gfx-rs/wgpu/blob/7774f310218bd688e27e7688f3ddf8cd39226c96/wgpu-hal/src/gles/wgl.rs#L76

I tracked this down to Surface::configure and Surface::present not unsetting the current context after setting it even though they release the associated lock used for synchronizing this.

To fix this I took advantage of the existing guard type and added a new locking + make current method (called `lock_with_dc` that allows passing in the DC that Surface::configure/Surface::present were previously passing directly to `make_current`.

Note that with this guard type, if unmake_current fails it will panic. I wasn't completely sure if this was appropriate for Surface::configure/present since they return errors instead of panicking when make_current fails. However, if unmake_current fails it seems like later calls to make_current (if called on a different thread) would also fail causing `AdapterContext::lock` to panic anyway? I'm not really familiar with what would cause unmake_current to fail though and what the behavior would be in terms of whether make_current can succeed later after such a failure.

Note, another small behavior change is that this uses the same `.try_lock_for(Duration::from_secs(CONTEXT_LOCK_TIMEOUT_SECS))`  pattern instead of just a `.lock()`.

**Testing**
To reproduce this I spawned an extra thread in the examples `framework.rs` that called `Adapter::get_texture_format_features` in a loop. This consistently produced panics when trying to make the gl context current to that thread. After this change, no panics were observed with this testing setup. Additionally, the original issue when re-building pipelines seems to be resolved.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
