### PR TITLE
[msl-out] prevent infinite loops from being optimized out by the metal compiler

### DIFF
--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -2768,7 +2768,9 @@ impl<W: Write> Writer<W> {
                     if !continuing.is_empty() || break_if.is_some() {
                         let gate_name = self.namer.call("loop_init");
                         writeln!(self.out, "{level}bool {gate_name} = true;")?;
-                        writeln!(self.out, "{level}while(true) {{")?;
+                        // The empty inline assembly "call" will prevent the metal compiler
+                        // from optimizing out these potentially-infinte loops.
+                        writeln!(self.out, "{level}while(true) {{__asm__(\"\");")?;
                         let lif = level.next();
                         let lcontinuing = lif.next();
                         writeln!(self.out, "{lif}if (!{gate_name}) {{")?;
@@ -2783,7 +2785,7 @@ impl<W: Write> Writer<W> {
                         writeln!(self.out, "{lif}}}")?;
                         writeln!(self.out, "{lif}{gate_name} = false;")?;
                     } else {
-                        writeln!(self.out, "{level}while(true) {{")?;
+                        writeln!(self.out, "{level}while(true) {{__asm__(\"\");")?;
                     }
                     self.put_block(level.next(), body, context)?;
                     writeln!(self.out, "{level}}}")?;

--- a/naga/tests/out/msl/boids.msl
+++ b/naga/tests/out/msl/boids.msl
@@ -56,7 +56,7 @@ kernel void main_(
     metal::float2 _e14 = particlesSrc.particles[index].vel;
     vVel = _e14;
     bool loop_init = true;
-    while(true) {
+    while(true) {__asm__("");
         if (!loop_init) {
             uint _e91 = i;
             i = _e91 + 1u;

--- a/naga/tests/out/msl/break-if.msl
+++ b/naga/tests/out/msl/break-if.msl
@@ -8,7 +8,7 @@ using metal::uint;
 void breakIfEmpty(
 ) {
     bool loop_init = true;
-    while(true) {
+    while(true) {__asm__("");
         if (!loop_init) {
             if (true) {
                 break;
@@ -25,7 +25,7 @@ void breakIfEmptyBody(
     bool b = {};
     bool c = {};
     bool loop_init_1 = true;
-    while(true) {
+    while(true) {__asm__("");
         if (!loop_init_1) {
             b = a;
             bool _e2 = b;
@@ -46,7 +46,7 @@ void breakIf(
     bool d = {};
     bool e = {};
     bool loop_init_2 = true;
-    while(true) {
+    while(true) {__asm__("");
         if (!loop_init_2) {
             bool _e5 = e;
             if (a_1 == e) {
@@ -65,7 +65,7 @@ void breakIfSeparateVariable(
 ) {
     uint counter = 0u;
     bool loop_init_3 = true;
-    while(true) {
+    while(true) {__asm__("");
         if (!loop_init_3) {
             uint _e5 = counter;
             if (counter == 5u) {

--- a/naga/tests/out/msl/collatz.msl
+++ b/naga/tests/out/msl/collatz.msl
@@ -19,7 +19,7 @@ uint collatz_iterations(
     uint n = {};
     uint i = 0u;
     n = n_base;
-    while(true) {
+    while(true) {__asm__("");
         uint _e4 = n;
         if (_e4 > 1u) {
         } else {

--- a/naga/tests/out/msl/control-flow.msl
+++ b/naga/tests/out/msl/control-flow.msl
@@ -31,7 +31,7 @@ void switch_case_break(
 void loop_switch_continue(
     int x
 ) {
-    while(true) {
+    while(true) {__asm__("");
         switch(x) {
             case 1: {
                 continue;

--- a/naga/tests/out/msl/do-while.msl
+++ b/naga/tests/out/msl/do-while.msl
@@ -9,7 +9,7 @@ void fb1_(
     thread bool& cond
 ) {
     bool loop_init = true;
-    while(true) {
+    while(true) {__asm__("");
         if (!loop_init) {
             bool _e1 = cond;
             if (!(cond)) {

--- a/naga/tests/out/msl/ray-query.msl
+++ b/naga/tests/out/msl/ray-query.msl
@@ -63,7 +63,7 @@ kernel void main_(
     rq.intersector.force_opacity((_e12.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (_e12.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none);
     rq.intersector.accept_any_intersection((_e12.flags & 4) != 0);
     rq.intersection = rq.intersector.intersect(metal::raytracing::ray(_e12.origin, _e12.dir, _e12.tmin, _e12.tmax), acc_struct, _e12.cull_mask);    rq.ready = true;
-    while(true) {
+    while(true) {__asm__("");
         bool _e13 = rq.ready;
         rq.ready = false;
         if (_e13) {

--- a/naga/tests/out/msl/shadow.msl
+++ b/naga/tests/out/msl/shadow.msl
@@ -101,7 +101,7 @@ fragment fs_mainOutput fs_main(
     uint i = 0u;
     metal::float3 normal_1 = metal::normalize(in.world_normal);
     bool loop_init = true;
-    while(true) {
+    while(true) {__asm__("");
         if (!loop_init) {
             uint _e40 = i;
             i = _e40 + 1u;
@@ -151,7 +151,7 @@ fragment fs_main_without_storageOutput fs_main_without_storage(
     uint i_1 = 0u;
     metal::float3 normal_2 = metal::normalize(in_1.world_normal);
     bool loop_init_1 = true;
-    while(true) {
+    while(true) {__asm__("");
         if (!loop_init_1) {
             uint _e40 = i_1;
             i_1 = _e40 + 1u;


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/wgpu/issues/4972.