### PR TITLE
Document Wayland specifics related to SurfaceTexture::present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ Bottom level categories:
 - Hal
 -->
 
+## Unreleased
+
+### Documentation
+
+- Document Wayland specific behavior related to `SurfaceTexture::present`. By @i509VCB in [#5092](https://github.com/gfx-rs/wgpu/pull/5092).
+
 ## v0.19.0 (2024-01-17)
 
 This release includes:

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4738,6 +4738,12 @@ impl SurfaceTexture {
     /// Schedule this texture to be presented on the owning surface.
     ///
     /// Needs to be called after any work on the texture is scheduled via [`Queue::submit`].
+    ///
+    /// # Platform dependent behavior
+    ///
+    /// On Wayland, `present` will attach a `wl_buffer` to the underlying `wl_surface` and commit the new surface
+    /// state. If it is desired to do things such as request a frame callback, scale the surface using the viewporter
+    /// or synchronize other double buffered state, then these operations should be done before the call to `present`.
     pub fn present(mut self) {
         self.presented = true;
         DynContext::surface_present(


### PR DESCRIPTION
**Connections**
This is related to an issue wezterm had that was brought up on the wgpu matrix channel as a result of directly using wayland-client with wgpu. It wasn't very clear what SurfaceTexture::present did under the hood. Sure it's been like 6 months since that, but better late than never.

The documentation is largely based off the Vulkan and EGL specification's Wayland platforms.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
