### PR TITLE
Add a wgpu-core feature flag for turning device lost errors into panics

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,6 +36,9 @@ api_log_info = []
 ## Log resource lifecycle management at info instead of trace level.
 resource_log_info = []
 
+## Panic when the device is lost.
+device_lost_panic = []
+
 ## Use static linking for libraries. Disale to manually link. Enabled by default.
 link = ["hal/link"]
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -438,7 +438,13 @@ pub enum DeviceError {
 impl From<hal::DeviceError> for DeviceError {
     fn from(error: hal::DeviceError) -> Self {
         match error {
-            hal::DeviceError::Lost => DeviceError::Lost,
+            hal::DeviceError::Lost => {
+                #[cfg(feature = "device_lost_panic")]
+                panic!("Device lost");
+
+                #[allow(unused)]
+                DeviceError::Lost
+            }
             hal::DeviceError::OutOfMemory => DeviceError::OutOfMemory,
             hal::DeviceError::ResourceCreationFailed => DeviceError::ResourceCreationFailed,
         }


### PR DESCRIPTION
This is intended to help flush out invalid API usage when testing wgpu. For example Firefox's fuzzing infrastructure only detects bugs that cause the process crash.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
