### PR TITLE
[d3d12] use plane 1 for stencil only views

### DIFF
--- a/tests/tests/root.rs
+++ b/tests/tests/root.rs
@@ -34,6 +34,7 @@ mod shader;
 mod shader_primitive_index;
 mod shader_view_format;
 mod texture_bounds;
+mod texture_view_creation;
 mod transfer;
 mod vertex_indices;
 mod write_texture;

--- a/tests/tests/texture_view_creation.rs
+++ b/tests/tests/texture_view_creation.rs
@@ -1,9 +1,14 @@
 use wgpu::*;
-use wgpu_test::{gpu_test, GpuTestConfiguration};
+use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
 
 #[gpu_test]
-static STENCIL_ONLY_VIEW_CREATION: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_async(|ctx| async move {
+static STENCIL_ONLY_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .skip(FailureCase::webgl2()) // WebGL doesn't have stencil only views
+            .limits(wgpu::Limits::downlevel_defaults()),
+    )
+    .run_async(|ctx| async move {
         for format in [TextureFormat::Stencil8, TextureFormat::Depth24PlusStencil8] {
             let texture = ctx.device.create_texture(&TextureDescriptor {
                 label: None,

--- a/tests/tests/texture_view_creation.rs
+++ b/tests/tests/texture_view_creation.rs
@@ -1,0 +1,60 @@
+use wgpu::*;
+use wgpu_test::{gpu_test, GpuTestConfiguration};
+
+#[gpu_test]
+static STENCIL_ONLY_VIEW_CREATION: GpuTestConfiguration =
+    GpuTestConfiguration::new().run_async(|ctx| async move {
+        for format in [TextureFormat::Stencil8, TextureFormat::Depth24PlusStencil8] {
+            let texture = ctx.device.create_texture(&TextureDescriptor {
+                label: None,
+                size: Extent3d {
+                    width: 256,
+                    height: 256,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: TextureDimension::D2,
+                format,
+                usage: TextureUsages::COPY_DST
+                    | TextureUsages::COPY_SRC
+                    | TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            });
+            let _view = texture.create_view(&TextureViewDescriptor {
+                aspect: TextureAspect::StencilOnly,
+                ..Default::default()
+            });
+        }
+    });
+
+#[gpu_test]
+static DEPTH_ONLY_VIEW_CREATION: GpuTestConfiguration =
+    GpuTestConfiguration::new().run_async(|ctx| async move {
+        for format in [
+            TextureFormat::Depth16Unorm,
+            TextureFormat::Depth24Plus,
+            TextureFormat::Depth24PlusStencil8,
+        ] {
+            let texture = ctx.device.create_texture(&TextureDescriptor {
+                label: None,
+                size: Extent3d {
+                    width: 256,
+                    height: 256,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: TextureDimension::D2,
+                format,
+                usage: TextureUsages::COPY_DST
+                    | TextureUsages::COPY_SRC
+                    | TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            });
+            let _view = texture.create_view(&TextureViewDescriptor {
+                aspect: TextureAspect::DepthOnly,
+                ..Default::default()
+            });
+        }
+    });

--- a/wgpu-hal/src/dx12/view.rs
+++ b/wgpu-hal/src/dx12/view.rs
@@ -36,6 +36,7 @@ impl crate::TextureViewDescriptor<'_> {
 
 fn aspects_to_plane(aspects: crate::FormatAspects) -> u32 {
     match aspects {
+        crate::FormatAspects::STENCIL => 1,
         crate::FormatAspects::PLANE_1 => 1,
         crate::FormatAspects::PLANE_2 => 2,
         _ => 0,


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/wgpu/issues/5097.