### PR TITLE
fix(const_eval): use component count, not arg. count, for component-wise iter.

### DIFF
--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -97,7 +97,7 @@ macro_rules! gen_component_wise_extractor {
                         .and_then(|comps| Ok(handler(comps)?.into())),
                 )+
                 &Expression::Compose { ty, ref components } => match &eval.types[ty].inner {
-                    &TypeInner::Vector { size: _, scalar } => match scalar.kind {
+                    &TypeInner::Vector { size, scalar } => match scalar.kind {
                         $(ScalarKind::$scalar_kind)|* => {
                             let first_ty = ty;
                             let mut component_groups =
@@ -132,7 +132,7 @@ macro_rules! gen_component_wise_extractor {
                             let component_groups = component_groups.into_inner().unwrap();
                             let mut new_components =
                                 ArrayVec::<_, { crate::VectorSize::MAX }>::new();
-                            for idx in 0..N {
+                            for idx in 0..(size as u8).into() {
                                 let group = component_groups
                                     .iter()
                                     .map(|cs| cs[idx])


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

Fixes a regression/bug introduced by #4879 (sorry!). 😅

**Description**
_Describe what problem this is solving, and how it's solved._

Previously, the arg. count was being used for iterating over component groups, but the count of components should have been used instead. This PR fixes that.

**Testing**
_Explain how this change is tested._

It's a bug-fix, so I consider it tested! I would be open to a request for more coverage in addition to this.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - ~~`--target wasm32-unknown-unknown`~~
  - ~~`--target wasm32-unknown-emscripten`~~
- [x] Run `cargo xtask test` to run tests.
- ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ I don't consider this necessar, since #4879 hasn't shipped yet, but I can do it if requested.
