### PR TITLE
Error on missing web_sys_unstable_apis

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,6 @@ xtask = "run --manifest-path xtask/Cargo.toml"
 rustflags = [
 "--cfg=web_sys_unstable_apis"
 ]
+rustdocflags = [
+"--cfg=web_sys_unstable_apis"
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ env:
   RUST_BACKTRACE: full
   PKG_CONFIG_ALLOW_CROSS: 1 # allow android to work
   RUSTFLAGS: --cfg=web_sys_unstable_apis -D warnings
-  RUSTDOCFLAGS: -Dwarnings
+  RUSTDOCFLAGS: --cfg=web_sys_unstable_apis -D warnings
   WASM_BINDGEN_TEST_TIMEOUT: 300 # 5 minutes
   CACHE_SUFFIX: c # cache busting
 

--- a/wgpu/src/backend/mod.rs
+++ b/wgpu/src/backend/mod.rs
@@ -1,9 +1,23 @@
-#[cfg(webgpu)]
+#[cfg(all(webgpu, web_sys_unstable_apis))]
 mod webgpu;
-#[cfg(webgpu)]
+#[cfg(all(webgpu, web_sys_unstable_apis))]
 pub(crate) use webgpu::{get_browser_gpu_property, ContextWebGpu};
+
+#[cfg(all(webgpu, not(web_sys_unstable_apis)))]
+compile_error!(
+    "webgpu feature used without web_sys_unstable_apis config:
+Here are some ways to resolve this:
+* If you wish to use webgpu backend, create a .cargo/config.toml in the root of the repo containing:
+    [build]
+    rustflags = [ \"--cfg=web_sys_unstable_apis\" ]
+    rustdocflags = [ \"--cfg=web_sys_unstable_apis\" ]
+* If you wish to disable webgpu backend and instead use webgl backend, change your wgpu Cargo.toml entry to:
+    wgpu = { version = \"\", default-features = false, features = [\"webgl\"] }
+"
+);
 
 #[cfg(wgpu_core)]
 mod wgpu_core;
+
 #[cfg(wgpu_core)]
 pub(crate) use wgpu_core::ContextWgpuCore;

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1812,7 +1812,7 @@ impl Instance {
             );
         }
 
-        #[cfg(webgpu)]
+        #[cfg(all(webgpu, web_sys_unstable_apis))]
         {
             let is_only_available_backend = !cfg!(wgpu_core);
             let requested_webgpu = _instance_desc.backends.contains(Backends::BROWSER_WEBGPU);
@@ -3086,7 +3086,7 @@ impl<'a> BufferSlice<'a> {
     /// this function directly hands you the ArrayBuffer that we mapped the data into in js.
     ///
     /// This is only available on WebGPU, on any other backends this will return `None`.
-    #[cfg(webgpu)]
+    #[cfg(all(webgpu, web_sys_unstable_apis))]
     pub fn get_mapped_range_as_array_buffer(&self) -> Option<js_sys::ArrayBuffer> {
         self.buffer
             .context


### PR DESCRIPTION
closes https://github.com/gfx-rs/wgpu/issues/5095

I thought about this some more and I think we can and should just give the user a helpful error when they are missing the unstable cfg.
With this we no longer need to take up prime documentation real estate with it.
I imagine resources like sotrh's learn wgpu will push users towards using `wgpu = { .. default-features = false, features = ["webgl"] }` to make it easy for users to run on the web and then this error will catch the user when they get that slightly wrong.


**Testing**

I created a seperate crate that depends on wgpu and tested the following cases:
This compiles successfully:
```toml
wgpu = {version = "0.19", path = "", features = ["webgl"], default-features = false}
```

This compiles successfully:
```toml
wgpu = {version = "0.19", path = "", default-features = false}
```

This fails to compile with the new error:
```toml
wgpu = {version = "0.19", path = "" }
```

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
