### PR TITLE
Avoid a clone when creating a Glsl shader

### DIFF
--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -852,13 +852,10 @@ impl crate::Context for ContextWgpuCore {
             ShaderSource::Glsl {
                 ref shader,
                 stage,
-                ref defines,
+                defines,
             } => {
                 // Parse the given shader code and store its representation.
-                let options = naga::front::glsl::Options {
-                    stage,
-                    defines: defines.clone(),
-                };
+                let options = naga::front::glsl::Options { stage, defines };
                 let mut parser = naga::front::glsl::Frontend::default();
                 let module = parser.parse(&options, shader).unwrap();
 


### PR DESCRIPTION
**Description**
Remove a useless `clone`.


**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
