### PR TITLE
d3d12: Propagate errors when closing command lists

### DIFF
--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -289,14 +289,13 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     }
     unsafe fn end_encoding(&mut self) -> Result<super::CommandBuffer, crate::DeviceError> {
         let raw = self.list.take().unwrap();
-        let closed = raw.close().into_result().is_ok();
-        Ok(super::CommandBuffer { raw, closed })
+        raw.close()
+            .into_device_result("GraphicsCommandList::close")?;
+        Ok(super::CommandBuffer { raw })
     }
     unsafe fn reset_all<I: Iterator<Item = super::CommandBuffer>>(&mut self, command_buffers: I) {
         for cmd_buf in command_buffers {
-            if cmd_buf.closed {
-                self.free_lists.push(cmd_buf.raw);
-            }
+            self.free_lists.push(cmd_buf.raw);
         }
         self.allocator.reset();
     }

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -386,7 +386,6 @@ impl fmt::Debug for CommandEncoder {
 #[derive(Debug)]
 pub struct CommandBuffer {
     raw: d3d12::GraphicsCommandList,
-    closed: bool,
 }
 
 unsafe impl Send for CommandBuffer {}


### PR DESCRIPTION
**Connections**

I run into this fairly consistently while debugging #5090

**Description**

Before this commit, command lists that we failed to close were used anyway during submit, causing device loss.

This commit propagates the error and removes the now unused closed field in CommandBuffer.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
