### PR TITLE
Remove the lock around TextureView::parent

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -714,7 +714,7 @@ struct RenderAttachment<'a, A: HalApi> {
 impl<A: HalApi> TextureView<A> {
     fn to_render_attachment(&self, usage: hal::TextureUses) -> RenderAttachment<A> {
         RenderAttachment {
-            texture: self.parent.read().as_ref().unwrap().clone(),
+            texture: self.parent.clone(),
             selector: &self.selector,
             usage,
         }
@@ -749,7 +749,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
         if channel.load_op == LoadOp::Load {
             pending_discard_init_fixups.extend(texture_memory_actions.register_init_action(
                 &TextureInitTrackerAction {
-                    texture: view.parent.read().as_ref().unwrap().clone(),
+                    texture: view.parent.clone(),
                     range: TextureInitRange::from(view.selector.clone()),
                     // Note that this is needed even if the target is discarded,
                     kind: MemoryInitKind::NeedsInitializedMemory,
@@ -758,7 +758,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
         } else if channel.store_op == StoreOp::Store {
             // Clear + Store
             texture_memory_actions.register_implicit_init(
-                view.parent.read().as_ref().unwrap(),
+                &view.parent,
                 TextureInitRange::from(view.selector.clone()),
             );
         }
@@ -767,7 +767,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
             // discard right away be alright since the texture can't be used
             // during the pass anyways
             texture_memory_actions.discard(TextureSurfaceDiscard {
-                texture: view.parent.read().as_ref().unwrap().clone(),
+                texture: view.parent.clone(),
                 mip_level: view.selector.mips.start,
                 layer: view.selector.layers.start,
             });
@@ -936,7 +936,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 if need_init_beforehand {
                     pending_discard_init_fixups.extend(
                         texture_memory_actions.register_init_action(&TextureInitTrackerAction {
-                            texture: view.parent.read().as_ref().unwrap().clone(),
+                            texture: view.parent.clone(),
                             range: TextureInitRange::from(view.selector.clone()),
                             kind: MemoryInitKind::NeedsInitializedMemory,
                         }),
@@ -954,7 +954,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 if at.depth.store_op != at.stencil.store_op {
                     if !need_init_beforehand {
                         texture_memory_actions.register_implicit_init(
-                            view.parent.read().as_ref().unwrap(),
+                            &view.parent,
                             TextureInitRange::from(view.selector.clone()),
                         );
                     }
@@ -969,7 +969,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 } else if at.depth.store_op == StoreOp::Discard {
                     // Both are discarded using the regular path.
                     discarded_surfaces.push(TextureSurfaceDiscard {
-                        texture: view.parent.read().as_ref().unwrap().clone(),
+                        texture: view.parent.clone(),
                         mip_level: view.selector.mips.start,
                         layer: view.selector.layers.start,
                     });
@@ -1095,7 +1095,7 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 }
 
                 texture_memory_actions.register_implicit_init(
-                    resolve_view.parent.read().as_ref().unwrap(),
+                    &resolve_view.parent,
                     TextureInitRange::from(resolve_view.selector.clone()),
                 );
                 render_attachments

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -525,20 +525,12 @@ impl<A: HalApi> LifetimeTracker<A> {
     fn triage_suspected_texture_views(&mut self, trackers: &Mutex<Tracker<A>>) -> &mut Self {
         let mut trackers = trackers.lock();
         let resource_map = &mut self.suspected_resources.texture_views;
-        let mut removed_resources = Self::triage_resources(
+        Self::triage_resources(
             resource_map,
             self.active.as_mut_slice(),
             &mut trackers.views,
             |maps| &mut maps.texture_views,
         );
-        removed_resources.drain(..).for_each(|texture_view| {
-            let mut lock = texture_view.parent.write();
-            if let Some(parent_texture) = lock.take() {
-                self.suspected_resources
-                    .textures
-                    .insert(parent_texture.as_info().id(), parent_texture);
-            }
-        });
         self
     }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1178,7 +1178,7 @@ impl<A: HalApi> Device<A> {
 
         Ok(TextureView {
             raw: Some(raw),
-            parent: RwLock::new(Some(texture.clone())),
+            parent: texture.clone(),
             device: self.clone(),
             desc: resource::HalTextureViewDescriptor {
                 texture_format: texture.desc.format,
@@ -1892,17 +1892,13 @@ impl<A: HalApi> Device<A> {
         used: &mut BindGroupStates<A>,
         used_texture_ranges: &mut Vec<TextureInitTrackerAction<A>>,
     ) -> Result<(), binding_model::CreateBindGroupError> {
-        let texture = view.parent.read();
-        let texture_id = texture.as_ref().unwrap().as_info().id();
+        let texture = &view.parent;
+        let texture_id = texture.as_info().id();
         // Careful here: the texture may no longer have its own ref count,
         // if it was deleted by the user.
         let texture = used
             .textures
-            .add_single(
-                texture.as_ref().unwrap(),
-                Some(view.selector.clone()),
-                internal_use,
-            )
+            .add_single(texture, Some(view.selector.clone()), internal_use)
             .ok_or(binding_model::CreateBindGroupError::InvalidTexture(
                 texture_id,
             ))?;

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1172,7 +1172,7 @@ pub enum TextureViewNotRenderableReason {
 pub struct TextureView<A: HalApi> {
     pub(crate) raw: Option<A::TextureView>,
     // if it's a surface texture - it's none
-    pub(crate) parent: RwLock<Option<Arc<Texture<A>>>>,
+    pub(crate) parent: Arc<Texture<A>>,
     pub(crate) device: Arc<Device<A>>,
     //TODO: store device_id for quick access?
     pub(crate) desc: HalTextureViewDescriptor,


### PR DESCRIPTION
**Description**

We don't need to remove the reference during triage anymore, instead the texture's reference count will be decremented automatically when the texture view is dropped. So `parent` can be immutable and no longer needs a lock.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
