### PR TITLE
Snatch texture views of destroyed textures

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -997,8 +997,9 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
 
             depth_stencil = Some(hal::DepthStencilAttachment {
                 target: hal::Attachment {
-                    view: view.raw(snatch_guard)
-                        .ok_or_else(||RenderPassErrorInner::InvalidAttachment(view.info.id()))?,
+                    view: view
+                        .raw(snatch_guard)
+                        .ok_or_else(|| RenderPassErrorInner::InvalidAttachment(view.info.id()))?,
                     usage,
                 },
                 depth_ops: at.depth.hal_ops(),
@@ -1107,16 +1108,18 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                     .push(resolve_view.to_render_attachment(hal::TextureUses::COLOR_TARGET));
 
                 hal_resolve_target = Some(hal::Attachment {
-                    view: resolve_view.raw(snatch_guard)
-                        .ok_or_else(|| RenderPassErrorInner::InvalidResolveTarget(resolve_view.info.id()))?,
+                    view: resolve_view.raw(snatch_guard).ok_or_else(|| {
+                        RenderPassErrorInner::InvalidResolveTarget(resolve_view.info.id())
+                    })?,
                     usage: hal::TextureUses::COLOR_TARGET,
                 });
             }
 
             colors.push(Some(hal::ColorAttachment {
                 target: hal::Attachment {
-                    view: color_view.raw(snatch_guard)
-                        .ok_or_else(|| RenderPassErrorInner::InvalidAttachment(color_view.info.id()))?,
+                    view: color_view.raw(snatch_guard).ok_or_else(|| {
+                        RenderPassErrorInner::InvalidAttachment(color_view.info.id())
+                    })?,
                     usage: hal::TextureUses::COLOR_TARGET,
                 },
                 resolve_target: hal_resolve_target,
@@ -1264,8 +1267,9 @@ impl<'a, A: HalApi> RenderPassInfo<'a, A> {
                 color_attachments: &[],
                 depth_stencil_attachment: Some(hal::DepthStencilAttachment {
                     target: hal::Attachment {
-                        view: view.raw(snatch_guard)
-                            .ok_or_else(|| RenderPassErrorInner::InvalidAttachment(view.info.id()))?,
+                        view: view.raw(snatch_guard).ok_or_else(|| {
+                            RenderPassErrorInner::InvalidAttachment(view.info.id())
+                        })?,
                         usage: hal::TextureUses::DEPTH_STENCIL_WRITE,
                     },
                     depth_ops,

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -818,6 +818,12 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
             };
 
             let (id, resource) = fid.assign(view);
+
+            {
+                let mut views = texture.views.lock();
+                views.push(Arc::downgrade(&resource));
+            }
+
             api_log!("Texture::create_view({texture_id:?}) -> {id:?}");
             device.trackers.lock().views.insert_single(id, resource);
             return (id, None);

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1177,7 +1177,7 @@ impl<A: HalApi> Device<A> {
         };
 
         Ok(TextureView {
-            raw: Some(raw),
+            raw: Snatchable::new(raw),
             parent: texture.clone(),
             device: self.clone(),
             desc: resource::HalTextureViewDescriptor {
@@ -2126,7 +2126,7 @@ impl<A: HalApi> Device<A> {
                     )?;
                     let res_index = hal_textures.len();
                     hal_textures.push(hal::TextureBinding {
-                        view: view.raw(),
+                        view: view.raw(&snatch_guard).ok_or(Error::InvalidTextureView((id)))?,
                         usage: internal_use,
                     });
                     (res_index, 1)
@@ -2152,7 +2152,7 @@ impl<A: HalApi> Device<A> {
                             &mut used_texture_ranges,
                         )?;
                         hal_textures.push(hal::TextureBinding {
-                            view: view.raw(),
+                            view: view.raw(&snatch_guard).ok_or(Error::InvalidTextureView(id))?,
                             usage: internal_use,
                         });
                     }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2127,7 +2127,7 @@ impl<A: HalApi> Device<A> {
                     )?;
                     let res_index = hal_textures.len();
                     hal_textures.push(hal::TextureBinding {
-                        view: view.raw(&snatch_guard).ok_or(Error::InvalidTextureView((id)))?,
+                        view: view.raw(&snatch_guard).ok_or(Error::InvalidTextureView(id))?,
                         usage: internal_use,
                     });
                     (res_index, 1)

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2127,7 +2127,9 @@ impl<A: HalApi> Device<A> {
                     )?;
                     let res_index = hal_textures.len();
                     hal_textures.push(hal::TextureBinding {
-                        view: view.raw(&snatch_guard).ok_or(Error::InvalidTextureView(id))?,
+                        view: view
+                            .raw(&snatch_guard)
+                            .ok_or(Error::InvalidTextureView(id))?,
                         usage: internal_use,
                     });
                     (res_index, 1)
@@ -2153,7 +2155,9 @@ impl<A: HalApi> Device<A> {
                             &mut used_texture_ranges,
                         )?;
                         hal_textures.push(hal::TextureBinding {
-                            view: view.raw(&snatch_guard).ok_or(Error::InvalidTextureView(id))?,
+                            view: view
+                                .raw(&snatch_guard)
+                                .ok_or(Error::InvalidTextureView(id))?,
                             usage: internal_use,
                         });
                     }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -595,6 +595,7 @@ impl<A: HalApi> Device<A> {
             },
             info: ResourceInfo::new(desc.label.borrow_or_default()),
             clear_mode: RwLock::new(clear_mode),
+            views: Mutex::new(Vec::new()),
         }
     }
 

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 use hal::{Queue as _, Surface as _};
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use thiserror::Error;
 use wgt::SurfaceStatus as Status;
 
@@ -231,6 +231,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                     clear_mode: RwLock::new(resource::TextureClearMode::Surface {
                         clear_view: Some(clear_view),
                     }),
+                    views: Mutex::new(Vec::new()),
                 };
 
                 let (id, resource) = fid.assign(texture);

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -33,8 +33,7 @@ use std::{
     ops::Range,
     ptr::NonNull,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
-        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering}, Arc, Weak
     },
 };
 
@@ -741,6 +740,7 @@ pub struct Texture<A: HalApi> {
     pub(crate) full_range: TextureSelector,
     pub(crate) info: ResourceInfo<TextureId>,
     pub(crate) clear_mode: RwLock<TextureClearMode<A>>,
+    pub(crate) views: Mutex<Vec<Weak<TextureView<A>>>>,
 }
 
 impl<A: HalApi> Drop for Texture<A> {
@@ -851,6 +851,14 @@ impl<A: HalApi> Texture<A> {
                     return Err(resource::DestroyError::AlreadyDestroyed);
                 }
             };
+
+            let mut views = self.views.lock();
+            for view in views.iter() {
+                if let Some(view) = view.upgrade() {
+
+                }
+            }
+            views.clear();
 
             queue::TempResource::DestroyedTexture(Arc::new(DestroyedTexture {
                 raw: Some(raw),

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -33,7 +33,8 @@ use std::{
     ops::Range,
     ptr::NonNull,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering}, Arc, Weak
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc, Weak,
     },
 };
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1170,7 +1170,7 @@ pub enum TextureViewNotRenderableReason {
 
 #[derive(Debug)]
 pub struct TextureView<A: HalApi> {
-    pub(crate) raw: Option<A::TextureView>,
+    pub(crate) raw: Snatchable<A::TextureView>,
     // if it's a surface texture - it's none
     pub(crate) parent: Arc<Texture<A>>,
     pub(crate) device: Arc<Device<A>>,
@@ -1203,8 +1203,8 @@ impl<A: HalApi> Drop for TextureView<A> {
 }
 
 impl<A: HalApi> TextureView<A> {
-    pub(crate) fn raw(&self) -> &A::TextureView {
-        self.raw.as_ref().unwrap()
+    pub(crate) fn raw<'a>(&'a self, snatch_guard: &'a SnatchGuard) -> Option<&'a A::TextureView> {
+        self.raw.get(snatch_guard)
     }
 }
 


### PR DESCRIPTION
**Connections**

Addresses the TextureView part of #5079.

**Description**

Keep track of the texture views associated with a texture and snatch/destroy them along with the texture.
This prevents garbage collected texture views from accumulating and maintaining resources alive. 

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
