### PR TITLE
Differentiate between device loss caused by error/drop

### DIFF
--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -531,8 +531,8 @@ static DEVICE_DROP_THEN_LOST: GpuTestConfiguration = GpuTestConfiguration::new()
         let callback = Box::new(move |reason, message| {
             was_called_clone.store(true, std::sync::atomic::Ordering::SeqCst);
             assert!(
-                matches!(reason, wgt::DeviceLostReason::Unknown),
-                "Device lost info reason should match DeviceLostReason::Unknown."
+                matches!(reason, wgt::DeviceLostReason::Dropped),
+                "Device lost info reason should match DeviceLostReason::Dropped."
             );
             assert!(
                 message == "Device dropped.",

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2237,7 +2237,7 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         if let Some(device) = hub.devices.unregister(device_id) {
             let device_lost_closure = device.lock_life().device_lost_closure.take();
             if let Some(closure) = device_lost_closure {
-                closure.call(DeviceLostReason::Unknown, String::from("Device dropped."));
+                closure.call(DeviceLostReason::Dropped, String::from("Device dropped."));
             }
 
             // The things `Device::prepare_to_die` takes care are mostly

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7099,4 +7099,11 @@ pub enum DeviceLostReason {
     Unknown = 0,
     /// After Device::destroy
     Destroyed = 1,
+    /// After Device::drop
+    ///
+    /// WebGPU does not invoke the device lost callback when the device is
+    /// dropped to prevent garbage collection from being observable. In wgpu,
+    /// we invoke the callback on drop to help with managing memory owned by
+    /// the callback.
+    Dropped = 2,
 }


### PR DESCRIPTION
**Description**

We need this in order to help with detecting internal errors during testing/fuzzing. In other words we'd like fuzzing to detect when the device loss reason is `Unknown` (interpreted as an internal error) without treating dropped devices as an error.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
