### PR TITLE
[d3d12] Avoid panic on instance drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ Bottom level categories:
 
 ### Bug Fixes
 
+#### General
+- Fix `panic!` when dropping `Instance` without `InstanceFlags::VALIDATION`. By @hakolao in [#5134](https://github.com/gfx-rs/wgpu/pull/5134)
+
 #### WGL
 
 - In Surface::configure and Surface::present, fix the current GL context not being unset when releasing the lock that guards access to making the context current. This was causing other threads to panic when trying to make the context current. By @Imberflur in [#5087](https://github.com/gfx-rs/wgpu/pull/5087).

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -3,11 +3,14 @@ use winapi::shared::{dxgi1_5, minwindef};
 
 use super::SurfaceTarget;
 use crate::auxil::{self, dxgi::result::HResult as _};
+use bitflags::Flags;
 use std::{mem, sync::Arc};
 
 impl Drop for super::Instance {
     fn drop(&mut self) {
-        crate::auxil::dxgi::exception::unregister_exception_handler();
+        if self.flags.contains(wgt::InstanceFlags::VALIDATION) {
+            crate::auxil::dxgi::exception::unregister_exception_handler();
+        }
     }
 }
 

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -3,7 +3,6 @@ use winapi::shared::{dxgi1_5, minwindef};
 
 use super::SurfaceTarget;
 use crate::auxil::{self, dxgi::result::HResult as _};
-use bitflags::Flags;
 use std::{mem, sync::Arc};
 
 impl Drop for super::Instance {


### PR DESCRIPTION
**Connections**
Attempts to fix #4604

**Description**
`register_exception_handler` is only called when `InstanceFlags::VALIDATION` are present. Thus `unregister` should also be only called then.

```rust
    if instance_flags.contains(wgt::InstanceFlags::VALIDATION) {
        //...
        super::exception::register_exception_handler();
    }
```

**Testing**
Tested on one of my sample projects...

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
