### PR TITLE
Request INDIRECT_FIRST_INSTANCE feature in vertex_indices test

### DIFF
--- a/tests/tests/vertex_indices/mod.rs
+++ b/tests/tests/vertex_indices/mod.rs
@@ -465,6 +465,7 @@ static VERTEX_INDICES: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::VERTEX_WRITABLE_STORAGE),
+            .features(wgpu::Features::VERTEX_WRITABLE_STORAGE)
+            .features(wgpu::Features::INDIRECT_FIRST_INSTANCE),
     )
     .run_async(vertex_index_common);


### PR DESCRIPTION
**Connections**

Fixes one of the issues found in #5046

**Description**

The test is using the `INDIRECT_FIRST_INSTANCE` feature, it checks that the adapter supports it, but does not request it, causing a vulkan validation error.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
