### PR TITLE
Discard draws when the instance/vertex/index count is zero

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -514,9 +514,12 @@ impl RenderBundleEncoder {
                         })
                         .map_pass_err(scope);
                     }
-                    commands.extend(state.flush_vertices());
-                    commands.extend(state.flush_binds(used_bind_groups, base.dynamic_offsets));
-                    commands.push(command);
+
+                    if instance_count > 0 && vertex_count > 0 {
+                        commands.extend(state.flush_vertices());
+                        commands.extend(state.flush_binds(used_bind_groups, base.dynamic_offsets));
+                        commands.push(command);
+                    }
                 }
                 RenderCommand::DrawIndexed {
                     index_count,
@@ -556,10 +559,13 @@ impl RenderBundleEncoder {
                         })
                         .map_pass_err(scope);
                     }
-                    commands.extend(state.flush_index());
-                    commands.extend(state.flush_vertices());
-                    commands.extend(state.flush_binds(used_bind_groups, base.dynamic_offsets));
-                    commands.push(command);
+
+                    if instance_count > 0 && index_count > 0 {
+                        commands.extend(state.flush_index());
+                        commands.extend(state.flush_vertices());
+                        commands.extend(state.flush_binds(used_bind_groups, base.dynamic_offsets));
+                        commands.push(command);
+                    }
                 }
                 RenderCommand::MultiDrawIndirect {
                     buffer_id,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1917,7 +1917,14 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
 
                         unsafe {
-                            raw.draw(first_vertex, vertex_count, first_instance, instance_count);
+                            if instance_count > 0 && vertex_count > 0 {
+                                raw.draw(
+                                    first_vertex,
+                                    vertex_count,
+                                    first_instance,
+                                    instance_count,
+                                );
+                            }
                         }
                     }
                     RenderCommand::DrawIndexed {
@@ -1958,13 +1965,15 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                         }
 
                         unsafe {
-                            raw.draw_indexed(
-                                first_index,
-                                index_count,
-                                base_vertex,
-                                first_instance,
-                                instance_count,
-                            );
+                            if instance_count > 0 && index_count > 0 {
+                                raw.draw_indexed(
+                                    first_index,
+                                    index_count,
+                                    base_vertex,
+                                    first_instance,
+                                    instance_count,
+                                );
+                            }
                         }
                     }
                     RenderCommand::MultiDrawIndirect {


### PR DESCRIPTION
**Connections**

Fixes #1879

**Description**

Discard draws when the instance/vertex/index count is zero

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
