### PR TITLE
Avoid leaking submitted command encoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ By @atlv24 in [#5383](https://github.com/gfx-rs/wgpu/pull/5383)
 - Ensure render pipelines have at least 1 target. By @ErichDonGubler in [#5715](https://github.com/gfx-rs/wgpu/pull/5715)
 - `wgpu::ComputePass` now internally takes ownership of `QuerySet` for both `wgpu::ComputePassTimestampWrites` as well as timestamp writes and statistics query, fixing crashes when destroying `QuerySet` before ending the pass. By @wumpf in [#5671](https://github.com/gfx-rs/wgpu/pull/5671)
 - Validate resources passed during compute pass recording for mismatching device. By @wumpf in [#5779](https://github.com/gfx-rs/wgpu/pull/5779)
+- Fix a `CommandBuffer` leak. By @cwfitzgerald and @nical in [#5141](https://github.com/gfx-rs/wgpu/pull/5141)
 
 #### DX12
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2326,10 +2326,16 @@ impl crate::Context for ContextWgpuCore {
             .map(|(i, _)| i)
             .collect::<SmallVec<[_; 4]>>();
 
-        match wgc::gfx_select!(*queue => self.0.queue_submit(*queue, &temp_command_buffers)) {
+        let index = match wgc::gfx_select!(*queue => self.0.queue_submit(*queue, &temp_command_buffers)) {
             Ok(index) => index,
             Err(err) => self.handle_error_fatal(err, "Queue::submit"),
+        };
+
+        for cmdbuf in &temp_command_buffers {
+            wgc::gfx_select!(*queue => self.0.command_buffer_drop(*cmdbuf));
         }
+
+        index
     }
 
     fn queue_get_timestamp_period(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2326,7 +2326,8 @@ impl crate::Context for ContextWgpuCore {
             .map(|(i, _)| i)
             .collect::<SmallVec<[_; 4]>>();
 
-        let index = match wgc::gfx_select!(*queue => self.0.queue_submit(*queue, &temp_command_buffers)) {
+        let index = match wgc::gfx_select!(*queue => self.0.queue_submit(*queue, &temp_command_buffers))
+        {
             Ok(index) => index,
             Err(err) => self.handle_error_fatal(err, "Queue::submit"),
         };


### PR DESCRIPTION
**Connections**

Part of #4660 got [accidentally clobbered by arcanization](https://github.com/gfx-rs/wgpu/pull/3626/files?file-filters%5B%5D=.rs&show-viewed-files=true#diff-620fd073d10cd5d6302171f28dd7db7ddf66d6b78eca56b2fd90cc01d318ed9fL2348) 

**Description**

unlike `wgpu-core`, `wgpu` consumes command buffers during submit so it needs to drop them

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
