### PR TITLE
Fix the validation of vertex/index/instance ranges in render bundles

### DIFF
--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -8,7 +8,7 @@ use crate::{
     track::UsageConflict,
     validation::{MissingBufferUsageError, MissingTextureUsageError},
 };
-use wgt::{BufferAddress, BufferSize, Color};
+use wgt::{BufferAddress, BufferSize, Color, VertexStepMode};
 
 use std::num::NonZeroU32;
 use thiserror::Error;
@@ -31,6 +31,13 @@ pub enum DrawError {
     VertexBeyondLimit {
         last_vertex: u64,
         vertex_limit: u64,
+        slot: u32,
+    },
+    #[error("{step_mode:?} buffer out of bounds at slot {slot}. Offset {offset} beyond limit {limit}. Did you bind the correct `Vertex` step-rate vertex buffer?")]
+    VertexOutOfBounds {
+        step_mode: VertexStepMode,
+        offset: u64,
+        limit: u64,
         slot: u32,
     },
     #[error("Instance {last_instance} extends beyond limit {instance_limit} imposed by the buffer in slot {slot}. Did you bind the correct `Instance` step-rate vertex buffer?")]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -361,6 +361,7 @@ impl VertexBufferState {
         total_size: 0,
         step: pipeline::VertexStep {
             stride: 0,
+            last_stride: 0,
             mode: VertexStepMode::Vertex,
         },
         bound: false,
@@ -384,11 +385,13 @@ struct VertexState {
 
 impl VertexState {
     fn update_limits(&mut self) {
-        // Ensure that the limits are always smaller than u32::MAX so that
-        // interger overlows can be prevented via saturating additions.
-        let max = u32::MAX as u64;
-        self.vertex_limit = max;
-        self.instance_limit = max;
+        // TODO: This isn't entirely spec-compliant.
+        // We currently require that the buffer range can fit `stride` * count bytes.
+        // The spec, however, lets a buffer be a bit smaller as long as the size of the
+        // last element fits in it (the last element can be smaller than the stride between
+        // elements).
+        self.vertex_limit = u32::MAX as u64;
+        self.instance_limit = u32::MAX as u64;
         for (idx, vbs) in self.inputs.iter().enumerate() {
             if vbs.step.stride == 0 || !vbs.bound {
                 continue;

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2717,8 +2717,13 @@ impl<A: HalApi> Device<A> {
         let mut shader_expects_dual_source_blending = false;
         let mut pipeline_expects_dual_source_blending = false;
         for (i, vb_state) in desc.vertex.buffers.iter().enumerate() {
+            let mut last_stride = 0;
+            for attribute in vb_state.attributes.iter() {
+                last_stride = last_stride.max(attribute.offset + attribute.format.size());
+            }
             vertex_steps.push(pipeline::VertexStep {
                 stride: vb_state.array_stride,
+                last_stride,
                 mode: vb_state.step_mode,
             });
             if vb_state.attributes.is_empty() {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -493,6 +493,9 @@ pub struct VertexStep {
     /// The byte stride in the buffer between one attribute value and the next.
     pub stride: wgt::BufferAddress,
 
+    /// The byte size required to fit the last vertex in the stream.
+    pub last_stride: wgt::BufferAddress,
+
     /// Whether the buffer is indexed by vertex number or instance number.
     pub mode: wgt::VertexStepMode,
 }
@@ -501,6 +504,7 @@ impl Default for VertexStep {
     fn default() -> Self {
         Self {
             stride: 0,
+            last_stride: 0,
             mode: wgt::VertexStepMode::Vertex,
         }
     }


### PR DESCRIPTION
**Connections**

Spec: https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-draw

**Description**

The current bundle validation has two problems:
 - division by zero if the vertex stride is zero (we hit this in CTS runs in Firefox)
 - It is stricter than the specification by requesting that the buffer has space for `stride * count` whereas the specified formula is `stride * (count - 1) + last_stride` where `last_stride` is the space required to fit the last element (potentially smaller than the stride.

This PR addresses these issues by implementing the spec pretty much verbatim, but for render bundles only. Regular encoders are unfortunately still not up to spec. One way would be to use the same validation but it will be more expensive since it has to be done for each draw call while the current validation gets away with doing most of the calculation only when switching pipelines. I think that I can adapt that to match the spec but it's going to be more complicated.

I'm eager to get at least the render bundle part fixed so that we get rid of an outstanding CTS crash.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
