### PR TITLE
Enable GPU-based validation for DX12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,11 @@ Bottom level categories:
 - Eager release of GPU resources comes from device.trackers. By @bradwerth in [#5075](https://github.com/gfx-rs/wgpu/pull/5075)
 - `wgpu-types`'s `trace` and `replay` features have been replaced by the `serde` feature. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
 - `wgpu-core`'s `serial-pass` feature has been removed. Use `serde` instead. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
+- Added `InstanceFlags::GPU_BASED_VALIDATION`, which enables GPU-based validation for shaders. This is currently only supported on the DX12 back end; other platforms ignore this flag, for now.
+  - This has been added to the set of flags set by `InstanceFlags::debugging` and `InstanceFlags::from_build_config`. If you notice your graphics workloads running more slowly, this may be the culprit.
+  - As with other instance flags, this flag can be changed in calls to `InstanceFlags::with_env` with the new `WGPU_GPU_BASED_VALIDATION` environment variable.
+
+  By @ErichDonGubler in [#5046](https://github.com/gfx-rs/wgpu/pull/5046).
 
 
 ### Bug Fixes

--- a/d3d12/src/debug.rs
+++ b/d3d12/src/debug.rs
@@ -1,7 +1,10 @@
 use crate::com::ComPtr;
-use winapi::um::d3d12sdklayers;
 #[cfg(any(feature = "libloading", feature = "implicit-link"))]
 use winapi::Interface as _;
+use winapi::{
+    shared::{minwindef::TRUE, winerror::S_OK},
+    um::d3d12sdklayers,
+};
 
 pub type Debug = ComPtr<d3d12sdklayers::ID3D12Debug>;
 
@@ -39,5 +42,15 @@ impl Debug {
 
     pub fn enable_layer(&self) {
         unsafe { self.EnableDebugLayer() }
+    }
+
+    pub fn enable_gpu_based_validation(&self) -> bool {
+        let (ptr, hr) = unsafe { self.cast::<d3d12sdklayers::ID3D12Debug1>() };
+        if hr == S_OK {
+            unsafe { ptr.SetEnableGPUBasedValidation(TRUE) };
+            true
+        } else {
+            false
+        }
     }
 }

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -20,14 +20,25 @@ impl crate::Instance<super::Api> for super::Instance {
             crate::InstanceError::with_source(String::from("failed to load d3d12.dll"), e)
         })?;
 
-        if desc.flags.contains(wgt::InstanceFlags::VALIDATION) {
+        if desc
+            .flags
+            .intersects(wgt::InstanceFlags::VALIDATION | wgt::InstanceFlags::GPU_BASED_VALIDATION)
+        {
             // Enable debug layer
             match lib_main.get_debug_interface() {
                 Ok(pair) => match pair.into_result() {
                     Ok(debug_controller) => {
-                        debug_controller.enable_layer();
-                        if !debug_controller.enable_gpu_based_validation() {
-                            log::warn!("Failed to enable GPU-based validation");
+                        if desc.flags.intersects(wgt::InstanceFlags::VALIDATION) {
+                            debug_controller.enable_layer();
+                        }
+                        if desc
+                            .flags
+                            .intersects(wgt::InstanceFlags::GPU_BASED_VALIDATION)
+                        {
+                            #[allow(clippy::collapsible_if)]
+                            if !debug_controller.enable_gpu_based_validation() {
+                                log::warn!("Failed to enable GPU-based validation");
+                            }
                         }
                     }
                     Err(err) => {

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -26,6 +26,9 @@ impl crate::Instance<super::Api> for super::Instance {
                 Ok(pair) => match pair.into_result() {
                     Ok(debug_controller) => {
                         debug_controller.enable_layer();
+                        if !debug_controller.enable_gpu_based_validation() {
+                            log::warn!("Failed to enable GPU-based validation");
+                        }
                     }
                     Err(err) => {
                         log::warn!("Unable to enable D3D12 debug interface: {}", err);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -913,7 +913,7 @@ impl Default for InstanceFlags {
 }
 
 impl InstanceFlags {
-    /// Enable debugging and validation flags.
+    /// Enable recommended debugging and validation flags.
     pub fn debugging() -> Self {
         InstanceFlags::DEBUG | InstanceFlags::VALIDATION | InstanceFlags::GPU_BASED_VALIDATION
     }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -895,6 +895,14 @@ bitflags::bitflags! {
         /// This mainly applies to a Vulkan driver's compliance version. If the major compliance version
         /// is `0`, then the driver is ignored. This flag allows that driver to be enabled for testing.
         const ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER = 1 << 3;
+        /// Enable GPU-based validation. Currently, this only changes behavior on DX12 and Vulkan
+        /// back ends.
+        ///
+        /// Supported platforms:
+        ///
+        /// - D3D12; called ["GPU-based validation", or
+        ///   "GBV"](https://web.archive.org/web/20230206120404/https://learn.microsoft.com/en-us/windows/win32/direct3d12/using-d3d12-debug-layer-gpu-based-validation)
+        const GPU_BASED_VALIDATION = 1 << 4;
     }
 }
 
@@ -907,7 +915,7 @@ impl Default for InstanceFlags {
 impl InstanceFlags {
     /// Enable debugging and validation flags.
     pub fn debugging() -> Self {
-        InstanceFlags::DEBUG | InstanceFlags::VALIDATION
+        InstanceFlags::DEBUG | InstanceFlags::VALIDATION | InstanceFlags::GPU_BASED_VALIDATION
     }
 
     /// Infer good defaults from the build type
@@ -949,6 +957,9 @@ impl InstanceFlags {
         }
         if let Some(bit) = env("WGPU_ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER") {
             self.set(Self::ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER, bit);
+        }
+        if let Some(bit) = env("WGPU_GPU_BASED_VALIDATION") {
+            self.set(Self::GPU_BASED_VALIDATION, bit);
         }
 
         self

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -895,8 +895,8 @@ bitflags::bitflags! {
         /// This mainly applies to a Vulkan driver's compliance version. If the major compliance version
         /// is `0`, then the driver is ignored. This flag allows that driver to be enabled for testing.
         const ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER = 1 << 3;
-        /// Enable GPU-based validation. Currently, this only changes behavior on DX12 and Vulkan
-        /// back ends.
+        /// Enable GPU-based validation. Currently, this only changes behavior on the DX12
+        /// backend.
         ///
         /// Supported platforms:
         ///


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

Broken out from #5046 (which originally handled Vulkan _and_ DX12 back ends) to merge in the DX12 support that is unlikely to need more review.

Partially resolves https://github.com/gfx-rs/wgpu/issues/1709.

**Description**
_Describe what problem this is solving, and how it's solved._

See above.

**Testing**
_Explain how this change is tested._

CI passes, and the procedure for enabling this is straightforward. I feel confident in this particular change. No test coverage in this repository exists for this, that I know of.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - ~~`--target wasm32-unknown-unknown`~~
  - ~~`--target wasm32-unknown-emscripten`~~
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
