### PR TITLE
Feature/serde feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,12 +67,15 @@ Bottom level categories:
         - `tan`
         - `tanh`
 - Eager release of GPU resources comes from device.trackers. By @bradwerth in [#5075](https://github.com/gfx-rs/wgpu/pull/5075)
+- `wgpu`, `wgpu-core` and `wgpu-types` now have `serialize` and `deserialize` features. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
+- `wgpu-types`'s `trace` and `replay` features have been replaced by `serialize` and `deserialize` respectively. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
 
 
 ### Bug Fixes
 
 #### General
 - Fix `panic!` when dropping `Instance` without `InstanceFlags::VALIDATION`. By @hakolao in [#5134](https://github.com/gfx-rs/wgpu/pull/5134)
+- Fix `serde` feature not compiling for `wgpu-types`. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
 
 #### WGL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,8 @@ Bottom level categories:
         - `tan`
         - `tanh`
 - Eager release of GPU resources comes from device.trackers. By @bradwerth in [#5075](https://github.com/gfx-rs/wgpu/pull/5075)
-- `wgpu`, `wgpu-core` and `wgpu-types` now have `serialize` and `deserialize` features. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
 - `wgpu-types`'s `trace` and `replay` features have been replaced by `serialize` and `deserialize` respectively. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
+- `wgpu-core`'s `serial-pass` feature has been removed. Use `serde` instead. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Bottom level categories:
         - `tan`
         - `tanh`
 - Eager release of GPU resources comes from device.trackers. By @bradwerth in [#5075](https://github.com/gfx-rs/wgpu/pull/5075)
-- `wgpu-types`'s `trace` and `replay` features have been replaced by `serialize` and `deserialize` respectively. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
+- `wgpu-types`'s `trace` and `replay` features have been replaced by the `serde` feature. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
 - `wgpu-core`'s `serial-pass` feature has been removed. Use `serde` instead. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
 
 

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -22,7 +22,7 @@ surface = ["wgpu-core/raw-window-handle", "dep:raw-window-handle"]
 deno_core.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
-wgpu-types = { workspace = true, features = ["trace", "replay", "serde"] }
+wgpu-types = { workspace = true, features = ["serde"] }
 raw-window-handle = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgpu-core]

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -29,7 +29,7 @@ winit = { workspace = true, optional = true }
 
 [dependencies.wgt]
 workspace = true
-features = ["deserialize"]
+features = ["serde"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
 workspace = true

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -29,7 +29,7 @@ winit = { workspace = true, optional = true }
 
 [dependencies.wgt]
 workspace = true
-features = ["replay"]
+features = ["deserialize"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
 workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -38,7 +38,7 @@ serde_json.workspace = true
 serde.workspace = true
 wgpu-macros.workspace = true
 wgpu.workspace = true
-wgt = { workspace = true, features = ["deserialize"] }
+wgt = { workspace = true, features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -38,7 +38,7 @@ serde_json.workspace = true
 serde.workspace = true
 wgpu-macros.workspace = true
 wgpu.workspace = true
-wgt = { workspace = true, features = ["replay"] }
+wgt = { workspace = true, features = ["deserialize"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger.workspace = true

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -48,7 +48,7 @@ renderdoc = ["hal/renderdoc"]
 strict_asserts = ["wgt/strict_asserts"]
 
 ## serde
-serde = ["serialize", "deserialize", "wgt/serde"]
+serde = ["serialize", "deserialize", "serial-pass", "wgt/serde"]
 
 ## serialize
 serialize = ["dep:serde", "wgt/serialize", "arrayvec/serde"]
@@ -63,7 +63,7 @@ trace = ["ron", "serialize", "naga/serialize"]
 replay = ["deserialize", "naga/deserialize"]
 
 ## Enable serializable compute/render passes, and bundle encoders.
-serial-pass = ["serde", "wgt/serde"]
+serial-pass = ["dep:serde", "wgt/serde", "arrayvec/serde"]
 
 ## Enable `ShaderModuleSource::Wgsl`
 wgsl = ["naga/wgsl-in"]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -51,10 +51,10 @@ strict_asserts = ["wgt/strict_asserts"]
 serde = ["serialize", "deserialize", "serial-pass", "wgt/serde"]
 
 ## Enables serialize functionality on common wgpu types.
-serialize = ["dep:serde", "wgt/serialize", "arrayvec/serde"]
+serialize = ["dep:serde", "wgt/serde", "arrayvec/serde"]
 
 ## Enables deserialize functionality on common wgpu types.
-deserialize = ["dep:serde", "wgt/deserialize", "arrayvec/serde"]
+deserialize = ["dep:serde", "wgt/serde", "arrayvec/serde"]
 
 ## Enable API tracing.
 trace = ["ron", "serialize", "naga/serialize"]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -47,7 +47,7 @@ renderdoc = ["hal/renderdoc"]
 ## to the validation carried out at public APIs in all builds.
 strict_asserts = ["wgt/strict_asserts"]
 
-## Enables serde functionality on common wgpu types.
+## Enables serialization via `serde` on common wgpu types.
 serde = ["dep:serde", "wgt/serde", "arrayvec/serde"]
 
 ## Enable API tracing.

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -51,19 +51,19 @@ strict_asserts = ["wgt/strict_asserts"]
 serde = ["serialize", "deserialize", "wgt/serde"]
 
 ## serialize
-serialize = ["dep:serde", "wgt/serialize"]
+serialize = ["dep:serde", "wgt/serialize", "arrayvec/serde"]
 
 ## deserialize
-deserialize = ["dep:serde", "wgt/deserialize"]
+deserialize = ["dep:serde", "wgt/deserialize", "arrayvec/serde"]
 
 ## Enable API tracing.
-trace = ["ron", "serialize", "arrayvec/serde", "naga/serialize"]
+trace = ["ron", "serialize", "naga/serialize"]
 
 ## Enable API replaying
-replay = ["deserialize", "arrayvec/serde", "naga/deserialize"]
+replay = ["deserialize", "naga/deserialize"]
 
 ## Enable serializable compute/render passes, and bundle encoders.
-serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]
+serial-pass = ["serde", "wgt/serde"]
 
 ## Enable `ShaderModuleSource::Wgsl`
 wgsl = ["naga/wgsl-in"]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -47,11 +47,20 @@ renderdoc = ["hal/renderdoc"]
 ## to the validation carried out at public APIs in all builds.
 strict_asserts = ["wgt/strict_asserts"]
 
+## serde
+serde = ["serialize", "deserialize", "wgt/serde"]
+
+## serialize
+serialize = ["dep:serde", "wgt/serialize"]
+
+## deserialize
+deserialize = ["dep:serde", "wgt/deserialize"]
+
 ## Enable API tracing.
-trace = ["ron", "serde", "wgt/trace", "arrayvec/serde", "naga/serialize"]
+trace = ["ron", "serialize", "arrayvec/serde", "naga/serialize"]
 
 ## Enable API replaying
-replay = ["serde", "wgt/replay", "arrayvec/serde", "naga/deserialize"]
+replay = ["deserialize", "arrayvec/serde", "naga/deserialize"]
 
 ## Enable serializable compute/render passes, and bundle encoders.
 serial-pass = ["serde", "wgt/serde", "arrayvec/serde"]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -47,13 +47,13 @@ renderdoc = ["hal/renderdoc"]
 ## to the validation carried out at public APIs in all builds.
 strict_asserts = ["wgt/strict_asserts"]
 
-## serde
+## Enables serde functionality on common wgpu types.
 serde = ["serialize", "deserialize", "serial-pass", "wgt/serde"]
 
-## serialize
+## Enables serialize functionality on common wgpu types.
 serialize = ["dep:serde", "wgt/serialize", "arrayvec/serde"]
 
-## deserialize
+## Enables deserialize functionality on common wgpu types.
 deserialize = ["dep:serde", "wgt/deserialize", "arrayvec/serde"]
 
 ## Enable API tracing.

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -48,22 +48,13 @@ renderdoc = ["hal/renderdoc"]
 strict_asserts = ["wgt/strict_asserts"]
 
 ## Enables serde functionality on common wgpu types.
-serde = ["serialize", "deserialize", "serial-pass", "wgt/serde"]
-
-## Enables serialize functionality on common wgpu types.
-serialize = ["dep:serde", "wgt/serde", "arrayvec/serde"]
-
-## Enables deserialize functionality on common wgpu types.
-deserialize = ["dep:serde", "wgt/serde", "arrayvec/serde"]
+serde = ["dep:serde", "wgt/serde", "arrayvec/serde"]
 
 ## Enable API tracing.
-trace = ["ron", "serialize", "naga/serialize"]
+trace = ["ron", "serde", "naga/serialize"]
 
 ## Enable API replaying
-replay = ["deserialize", "naga/deserialize"]
-
-## Enable serializable compute/render passes, and bundle encoders.
-serial-pass = ["dep:serde", "wgt/serde", "arrayvec/serde"]
+replay = ["serde", "naga/deserialize"]
 
 ## Enable `ShaderModuleSource::Wgsl`
 wgsl = ["naga/wgsl-in"]

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -21,9 +21,8 @@ use crate::{
 
 use arrayvec::ArrayVec;
 
-#[cfg(feature = "deserialize")]
+#[cfg(feature = "serde")]
 use serde::Deserialize;
-#[cfg(feature = "serialize")]
 use serde::Serialize;
 
 use std::{borrow::Cow, ops::Range, sync::Arc};
@@ -406,8 +405,7 @@ impl BindingTypeMaxCountValidator {
 
 /// Bindable resource and the slot to bind it to.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BindGroupEntry<'a> {
     /// Slot for which binding provides resource. Corresponds to an entry of the same
     /// binding index in the [`BindGroupLayoutDescriptor`].
@@ -418,8 +416,7 @@ pub struct BindGroupEntry<'a> {
 
 /// Describes a group of bindings and the resources to be bound.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BindGroupDescriptor<'a> {
     /// Debug label of the bind group.
     ///
@@ -433,8 +430,7 @@ pub struct BindGroupDescriptor<'a> {
 
 /// Describes a [`BindGroupLayout`].
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BindGroupLayoutDescriptor<'a> {
     /// Debug label of the bind group layout.
     ///
@@ -582,8 +578,7 @@ pub enum PushConstantUploadError {
 ///
 /// A `PipelineLayoutDescriptor` can be used to create a pipeline layout.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PipelineLayoutDescriptor<'a> {
     /// Debug label of the pipeine layout.
     ///
@@ -734,8 +729,7 @@ impl<A: HalApi> Resource<PipelineLayoutId> for PipelineLayout<A> {
 
 #[repr(C)]
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BufferBinding {
     pub buffer_id: BufferId,
     pub offset: wgt::BufferAddress,
@@ -745,8 +739,7 @@ pub struct BufferBinding {
 // Note: Duplicated in `wgpu-rs` as `BindingResource`
 // They're different enough that it doesn't make sense to share a common type
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BindingResource<'a> {
     Buffer(BufferBinding),
     BufferArray(Cow<'a, [BufferBinding]>),

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -23,6 +23,7 @@ use arrayvec::ArrayVec;
 
 #[cfg(feature = "serde")]
 use serde::Deserialize;
+#[cfg(feature = "serde")]
 use serde::Serialize;
 
 use std::{borrow::Cow, ops::Range, sync::Arc};

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -21,9 +21,9 @@ use crate::{
 
 use arrayvec::ArrayVec;
 
-#[cfg(feature = "replay")]
+#[cfg(feature = "deserialize")]
 use serde::Deserialize;
-#[cfg(feature = "trace")]
+#[cfg(feature = "serialize")]
 use serde::Serialize;
 
 use std::{borrow::Cow, ops::Range, sync::Arc};
@@ -406,8 +406,8 @@ impl BindingTypeMaxCountValidator {
 
 /// Bindable resource and the slot to bind it to.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub struct BindGroupEntry<'a> {
     /// Slot for which binding provides resource. Corresponds to an entry of the same
     /// binding index in the [`BindGroupLayoutDescriptor`].
@@ -418,8 +418,8 @@ pub struct BindGroupEntry<'a> {
 
 /// Describes a group of bindings and the resources to be bound.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub struct BindGroupDescriptor<'a> {
     /// Debug label of the bind group.
     ///
@@ -433,8 +433,8 @@ pub struct BindGroupDescriptor<'a> {
 
 /// Describes a [`BindGroupLayout`].
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct BindGroupLayoutDescriptor<'a> {
     /// Debug label of the bind group layout.
     ///
@@ -582,8 +582,8 @@ pub enum PushConstantUploadError {
 ///
 /// A `PipelineLayoutDescriptor` can be used to create a pipeline layout.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "trace", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub struct PipelineLayoutDescriptor<'a> {
     /// Debug label of the pipeine layout.
     ///
@@ -734,8 +734,8 @@ impl<A: HalApi> Resource<PipelineLayoutId> for PipelineLayout<A> {
 
 #[repr(C)]
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "trace", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub struct BufferBinding {
     pub buffer_id: BufferId,
     pub offset: wgt::BufferAddress,
@@ -745,8 +745,8 @@ pub struct BufferBinding {
 // Note: Duplicated in `wgpu-rs` as `BindingResource`
 // They're different enough that it doesn't make sense to share a common type
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub enum BindingResource<'a> {
     Buffer(BufferBinding),
     BufferArray(Cow<'a, [BufferBinding]>),

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -197,8 +197,7 @@ fn validate_indexed_draw(
 
 /// Describes a [`RenderBundleEncoder`].
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderBundleEncoderDescriptor<'a> {
     /// Debug label of the render bundle encoder.
     ///
@@ -226,7 +225,7 @@ pub struct RenderBundleEncoderDescriptor<'a> {
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "serial-pass", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RenderBundleEncoder {
     base: BasePass<RenderCommand>,
     parent_id: id::DeviceId,
@@ -235,9 +234,9 @@ pub struct RenderBundleEncoder {
     pub(crate) is_stencil_read_only: bool,
 
     // Resource binding dedupe state.
-    #[cfg_attr(feature = "serial-pass", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     current_bind_groups: BindGroupStateChange,
-    #[cfg_attr(feature = "serial-pass", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     current_pipeline: StateChange<id::RenderPipelineId>,
 }
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -197,8 +197,8 @@ fn validate_indexed_draw(
 
 /// Describes a [`RenderBundleEncoder`].
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct RenderBundleEncoderDescriptor<'a> {
     /// Debug label of the render bundle encoder.
     ///

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -29,9 +29,9 @@ use crate::{
 };
 
 use hal::CommandEncoder as _;
-#[cfg(any(feature = "deserialize", feature = "serial-pass"))]
+#[cfg(feature = "serde")]
 use serde::Deserialize;
-#[cfg(any(feature = "serialize", feature = "serial-pass"))]
+#[cfg(feature = "serde")]
 use serde::Serialize;
 
 use thiserror::Error;
@@ -40,14 +40,8 @@ use std::{fmt, mem, str};
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(
-    any(feature = "serialize", feature = "serial-pass"),
-    derive(serde::Serialize)
-)]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub enum ComputeCommand {
     SetBindGroup {
         index: u32,
@@ -98,16 +92,16 @@ pub enum ComputeCommand {
     EndPipelineStatisticsQuery,
 }
 
-#[cfg_attr(feature = "serial-pass", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ComputePass {
     base: BasePass<ComputeCommand>,
     parent_id: id::CommandEncoderId,
     timestamp_writes: Option<ComputePassTimestampWrites>,
 
     // Resource binding dedupe state.
-    #[cfg_attr(feature = "serial-pass", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     current_bind_groups: BindGroupStateChange,
-    #[cfg_attr(feature = "serial-pass", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     current_pipeline: StateChange<id::ComputePipelineId>,
 }
 
@@ -151,11 +145,8 @@ impl fmt::Debug for ComputePass {
 /// Describes the writing of timestamp values in a compute pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct ComputePassTimestampWrites {
     /// The query set to write the timestamps to.
     pub query_set: id::QuerySetId,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -40,8 +40,7 @@ use std::{fmt, mem, str};
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ComputeCommand {
     SetBindGroup {
         index: u32,
@@ -145,8 +144,7 @@ impl fmt::Debug for ComputePass {
 /// Describes the writing of timestamp values in a compute pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
-#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ComputePassTimestampWrites {
     /// The query set to write the timestamps to.
     pub query_set: id::QuerySetId,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -40,14 +40,8 @@ use std::{fmt, mem, str};
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize)
-)]
-#[cfg_attr(
-    feature = "deserialize",
-    derive(serde::Deserialize)
-)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub enum ComputeCommand {
     SetBindGroup {
         index: u32,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -29,9 +29,9 @@ use crate::{
 };
 
 use hal::CommandEncoder as _;
-#[cfg(feature = "deserialize")]
+#[cfg(any(feature = "deserialize", feature = "serial-pass"))]
 use serde::Deserialize;
-#[cfg(feature = "serialize")]
+#[cfg(any(feature = "serialize", feature = "serial-pass"))]
 use serde::Serialize;
 
 use thiserror::Error;
@@ -40,8 +40,8 @@ use std::{fmt, mem, str};
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(serde::Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(serde::Deserialize))]
 pub enum ComputeCommand {
     SetBindGroup {
         index: u32,
@@ -145,8 +145,8 @@ impl fmt::Debug for ComputePass {
 /// Describes the writing of timestamp values in a compute pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
 pub struct ComputePassTimestampWrites {
     /// The query set to write the timestamps to.
     pub query_set: id::QuerySetId,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -40,8 +40,14 @@ use std::{fmt, mem, str};
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(serde::Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(serde::Deserialize))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "serial-pass"),
+    derive(serde::Serialize)
+)]
+#[cfg_attr(
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(serde::Deserialize)
+)]
 pub enum ComputeCommand {
     SetBindGroup {
         index: u32,
@@ -146,7 +152,10 @@ impl fmt::Debug for ComputePass {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
+#[cfg_attr(
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(Deserialize)
+)]
 pub struct ComputePassTimestampWrites {
     /// The query set to write the timestamps to.
     pub query_set: id::QuerySetId,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -29,9 +29,9 @@ use crate::{
 };
 
 use hal::CommandEncoder as _;
-#[cfg(any(feature = "serial-pass", feature = "replay"))]
+#[cfg(feature = "deserialize")]
 use serde::Deserialize;
-#[cfg(any(feature = "serial-pass", feature = "trace"))]
+#[cfg(feature = "serialize")]
 use serde::Serialize;
 
 use thiserror::Error;
@@ -41,11 +41,11 @@ use std::{fmt, mem, str};
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(
-    any(feature = "serial-pass", feature = "trace"),
+    feature = "serialize",
     derive(serde::Serialize)
 )]
 #[cfg_attr(
-    any(feature = "serial-pass", feature = "replay"),
+    feature = "deserialize",
     derive(serde::Deserialize)
 )]
 pub enum ComputeCommand {
@@ -151,8 +151,8 @@ impl fmt::Debug for ComputePass {
 /// Describes the writing of timestamp values in a compute pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(any(feature = "serial-pass", feature = "trace"), derive(Serialize))]
-#[cfg_attr(any(feature = "serial-pass", feature = "replay"), derive(Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub struct ComputePassTimestampWrites {
     /// The query set to write the timestamps to.
     pub query_set: id::QuerySetId,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -126,14 +126,8 @@ impl crate::error::PrettyError for RenderCommandError {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize)
-)]
-#[cfg_attr(
-    feature = "deserialize",
-    derive(serde::Deserialize)
-)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct Rect<T> {
     pub x: T,
     pub y: T,
@@ -143,14 +137,8 @@ pub struct Rect<T> {
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize)
-)]
-#[cfg_attr(
-    feature = "deserialize",
-    derive(serde::Deserialize)
-)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub enum RenderCommand {
     SetBindGroup {
         index: u32,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -126,8 +126,8 @@ impl crate::error::PrettyError for RenderCommandError {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(serde::Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(serde::Deserialize))]
 pub struct Rect<T> {
     pub x: T,
     pub y: T,
@@ -137,8 +137,8 @@ pub struct Rect<T> {
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(serde::Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(serde::Deserialize))]
 pub enum RenderCommand {
     SetBindGroup {
         index: u32,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -126,8 +126,14 @@ impl crate::error::PrettyError for RenderCommandError {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(serde::Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(serde::Deserialize))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "serial-pass"),
+    derive(serde::Serialize)
+)]
+#[cfg_attr(
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(serde::Deserialize)
+)]
 pub struct Rect<T> {
     pub x: T,
     pub y: T,
@@ -137,8 +143,14 @@ pub struct Rect<T> {
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(serde::Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(serde::Deserialize))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "serial-pass"),
+    derive(serde::Serialize)
+)]
+#[cfg_attr(
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(serde::Deserialize)
+)]
 pub enum RenderCommand {
     SetBindGroup {
         index: u32,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -126,8 +126,7 @@ impl crate::error::PrettyError for RenderCommandError {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rect<T> {
     pub x: T,
     pub y: T,
@@ -137,8 +136,7 @@ pub struct Rect<T> {
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum RenderCommand {
     SetBindGroup {
         index: u32,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -126,14 +126,8 @@ impl crate::error::PrettyError for RenderCommandError {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(
-    any(feature = "serialize", feature = "serial-pass"),
-    derive(serde::Serialize)
-)]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct Rect<T> {
     pub x: T,
     pub y: T,
@@ -143,14 +137,8 @@ pub struct Rect<T> {
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(
-    any(feature = "serialize", feature = "serial-pass"),
-    derive(serde::Serialize)
-)]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub enum RenderCommand {
     SetBindGroup {
         index: u32,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -127,11 +127,11 @@ impl crate::error::PrettyError for RenderCommandError {
 
 #[derive(Clone, Copy, Debug, Default)]
 #[cfg_attr(
-    any(feature = "serial-pass", feature = "trace"),
+    feature = "serialize",
     derive(serde::Serialize)
 )]
 #[cfg_attr(
-    any(feature = "serial-pass", feature = "replay"),
+    feature = "deserialize",
     derive(serde::Deserialize)
 )]
 pub struct Rect<T> {
@@ -144,11 +144,11 @@ pub struct Rect<T> {
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(
-    any(feature = "serial-pass", feature = "trace"),
+    feature = "serialize",
     derive(serde::Serialize)
 )]
 #[cfg_attr(
-    any(feature = "serial-pass", feature = "replay"),
+    feature = "deserialize",
     derive(serde::Deserialize)
 )]
 pub enum RenderCommand {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -338,8 +338,8 @@ pub struct BasePassRef<'a, C> {
 /// [`InsertDebugMarker`]: RenderCommand::InsertDebugMarker
 #[doc(hidden)]
 #[derive(Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(serde::Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(serde::Deserialize))]
 pub struct BasePass<C> {
     pub label: Option<String>,
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -338,14 +338,8 @@ pub struct BasePassRef<'a, C> {
 /// [`InsertDebugMarker`]: RenderCommand::InsertDebugMarker
 #[doc(hidden)]
 #[derive(Debug)]
-#[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize)
-)]
-#[cfg_attr(
-    feature = "deserialize",
-    derive(serde::Deserialize)
-)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct BasePass<C> {
     pub label: Option<String>,
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -339,11 +339,11 @@ pub struct BasePassRef<'a, C> {
 #[doc(hidden)]
 #[derive(Debug)]
 #[cfg_attr(
-    any(feature = "serial-pass", feature = "trace"),
+    feature = "serialize",
     derive(serde::Serialize)
 )]
 #[cfg_attr(
-    any(feature = "serial-pass", feature = "replay"),
+    feature = "deserialize",
     derive(serde::Deserialize)
 )]
 pub struct BasePass<C> {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -338,8 +338,7 @@ pub struct BasePassRef<'a, C> {
 /// [`InsertDebugMarker`]: RenderCommand::InsertDebugMarker
 #[doc(hidden)]
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BasePass<C> {
     pub label: Option<String>,
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -338,8 +338,14 @@ pub struct BasePassRef<'a, C> {
 /// [`InsertDebugMarker`]: RenderCommand::InsertDebugMarker
 #[doc(hidden)]
 #[derive(Debug)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(serde::Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(serde::Deserialize))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "serial-pass"),
+    derive(serde::Serialize)
+)]
+#[cfg_attr(
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(serde::Deserialize)
+)]
 pub struct BasePass<C> {
     pub label: Option<String>,
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -338,14 +338,8 @@ pub struct BasePassRef<'a, C> {
 /// [`InsertDebugMarker`]: RenderCommand::InsertDebugMarker
 #[doc(hidden)]
 #[derive(Debug)]
-#[cfg_attr(
-    any(feature = "serialize", feature = "serial-pass"),
-    derive(serde::Serialize)
-)]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct BasePass<C> {
     pub label: Option<String>,
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -40,9 +40,9 @@ use wgt::{
     TextureViewDimension, VertexStepMode,
 };
 
-#[cfg(any(feature = "deserialize", feature = "serial-pass"))]
+#[cfg(feature = "serde")]
 use serde::Deserialize;
-#[cfg(any(feature = "serialize", feature = "serial-pass"))]
+#[cfg(feature = "serde")]
 use serde::Serialize;
 
 use std::sync::Arc;
@@ -56,19 +56,8 @@ use super::{
 /// Operation to perform to the output attachment at the start of a renderpass.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(Deserialize)
-)]
-#[cfg_attr(
-    any(
-        feature = "serialize",
-        feature = "deserialize",
-        feature = "serial-pass"
-    ),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum LoadOp {
     /// Clear the output attachment with the clear color. Clearing is faster than loading.
     Clear = 0,
@@ -79,19 +68,8 @@ pub enum LoadOp {
 /// Operation to perform to the output attachment at the end of a renderpass.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(Deserialize)
-)]
-#[cfg_attr(
-    any(
-        feature = "serialize",
-        feature = "deserialize",
-        feature = "serial-pass"
-    ),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum StoreOp {
     /// Discards the content of the render target.
     ///
@@ -104,11 +82,8 @@ pub enum StoreOp {
 /// Describes an individual channel within a render pass, such as color, depth, or stencil.
 #[repr(C)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct PassChannel<V> {
     /// Operation to perform to the output attachment at the start of a
     /// renderpass.
@@ -145,11 +120,8 @@ impl<V> PassChannel<V> {
 /// Describes a color attachment to a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct RenderPassColorAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
@@ -162,11 +134,8 @@ pub struct RenderPassColorAttachment {
 /// Describes a depth/stencil attachment to a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct RenderPassDepthStencilAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
@@ -217,19 +186,8 @@ impl RenderPassDepthStencilAttachment {
 /// Location to write a timestamp to (beginning or end of the pass).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(Deserialize)
-)]
-#[cfg_attr(
-    any(
-        feature = "serialize",
-        feature = "deserialize",
-        feature = "serial-pass"
-    ),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum RenderPassTimestampLocation {
     Beginning = 0,
     End = 1,
@@ -238,11 +196,8 @@ pub enum RenderPassTimestampLocation {
 /// Describes the writing of timestamp values in a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(
-    any(feature = "deserialize", feature = "serial-pass"),
-    derive(Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct RenderPassTimestampWrites {
     /// The query set to write the timestamp to.
     pub query_set: id::QuerySetId,
@@ -266,7 +221,7 @@ pub struct RenderPassDescriptor<'a> {
     pub occlusion_query_set: Option<id::QuerySetId>,
 }
 
-#[cfg_attr(feature = "serial-pass", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct RenderPass {
     base: BasePass<RenderCommand>,
     parent_id: id::CommandEncoderId,
@@ -276,9 +231,9 @@ pub struct RenderPass {
     occlusion_query_set_id: Option<id::QuerySetId>,
 
     // Resource binding dedupe state.
-    #[cfg_attr(feature = "serial-pass", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     current_bind_groups: BindGroupStateChange,
-    #[cfg_attr(feature = "serial-pass", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     current_pipeline: StateChange<id::RenderPipelineId>,
 }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -58,7 +58,10 @@ use super::{
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum LoadOp {
     /// Clear the output attachment with the clear color. Clearing is faster than loading.
     Clear = 0,
@@ -71,7 +74,10 @@ pub enum LoadOp {
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum StoreOp {
     /// Discards the content of the render target.
     ///
@@ -190,7 +196,10 @@ impl RenderPassDepthStencilAttachment {
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum RenderPassTimestampLocation {
     Beginning = 0,
     End = 1,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -40,9 +40,9 @@ use wgt::{
     TextureViewDimension, VertexStepMode,
 };
 
-#[cfg(feature = "deserialize")]
+#[cfg(any(feature = "deserialize", feature = "serial-pass"))]
 use serde::Deserialize;
-#[cfg(feature = "serialize")]
+#[cfg(any(feature = "serialize", feature = "serial-pass"))]
 use serde::Serialize;
 
 use std::sync::Arc;
@@ -56,10 +56,10 @@ use super::{
 /// Operation to perform to the output attachment at the start of a renderpass.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
 #[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
+    any(feature = "serialize", feature = "deserialize", feature = "serial-pass"),
     serde(rename_all = "kebab-case")
 )]
 pub enum LoadOp {
@@ -72,10 +72,10 @@ pub enum LoadOp {
 /// Operation to perform to the output attachment at the end of a renderpass.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
 #[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
+    any(feature = "serialize", feature = "deserialize", feature = "serial-pass"),
     serde(rename_all = "kebab-case")
 )]
 pub enum StoreOp {
@@ -90,8 +90,8 @@ pub enum StoreOp {
 /// Describes an individual channel within a render pass, such as color, depth, or stencil.
 #[repr(C)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
 pub struct PassChannel<V> {
     /// Operation to perform to the output attachment at the start of a
     /// renderpass.
@@ -128,8 +128,8 @@ impl<V> PassChannel<V> {
 /// Describes a color attachment to a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
 pub struct RenderPassColorAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
@@ -142,8 +142,8 @@ pub struct RenderPassColorAttachment {
 /// Describes a depth/stencil attachment to a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
 pub struct RenderPassDepthStencilAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
@@ -194,10 +194,10 @@ impl RenderPassDepthStencilAttachment {
 /// Location to write a timestamp to (beginning or end of the pass).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
 #[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
+    any(feature = "serialize", feature = "deserialize", feature = "serial-pass"),
     serde(rename_all = "kebab-case")
 )]
 pub enum RenderPassTimestampLocation {
@@ -208,8 +208,8 @@ pub enum RenderPassTimestampLocation {
 /// Describes the writing of timestamp values in a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
+#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
 pub struct RenderPassTimestampWrites {
     /// The query set to write the timestamp to.
     pub query_set: id::QuerySetId,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -40,9 +40,9 @@ use wgt::{
     TextureViewDimension, VertexStepMode,
 };
 
-#[cfg(any(feature = "serial-pass", feature = "replay"))]
+#[cfg(feature = "deserialize")]
 use serde::Deserialize;
-#[cfg(any(feature = "serial-pass", feature = "trace"))]
+#[cfg(feature = "serialize")]
 use serde::Serialize;
 
 use std::sync::Arc;
@@ -56,9 +56,9 @@ use super::{
 /// Operation to perform to the output attachment at the start of a renderpass.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(any(feature = "serial-pass", feature = "trace"), derive(Serialize))]
-#[cfg_attr(any(feature = "serial-pass", feature = "replay"), derive(Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
 pub enum LoadOp {
     /// Clear the output attachment with the clear color. Clearing is faster than loading.
     Clear = 0,
@@ -69,9 +69,9 @@ pub enum LoadOp {
 /// Operation to perform to the output attachment at the end of a renderpass.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(any(feature = "serial-pass", feature = "trace"), derive(Serialize))]
-#[cfg_attr(any(feature = "serial-pass", feature = "replay"), derive(Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
 pub enum StoreOp {
     /// Discards the content of the render target.
     ///
@@ -84,8 +84,8 @@ pub enum StoreOp {
 /// Describes an individual channel within a render pass, such as color, depth, or stencil.
 #[repr(C)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(feature = "serial-pass", feature = "trace"), derive(Serialize))]
-#[cfg_attr(any(feature = "serial-pass", feature = "replay"), derive(Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub struct PassChannel<V> {
     /// Operation to perform to the output attachment at the start of a
     /// renderpass.
@@ -122,8 +122,8 @@ impl<V> PassChannel<V> {
 /// Describes a color attachment to a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(any(feature = "serial-pass", feature = "trace"), derive(Serialize))]
-#[cfg_attr(any(feature = "serial-pass", feature = "replay"), derive(Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub struct RenderPassColorAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
@@ -136,8 +136,8 @@ pub struct RenderPassColorAttachment {
 /// Describes a depth/stencil attachment to a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(any(feature = "serial-pass", feature = "trace"), derive(Serialize))]
-#[cfg_attr(any(feature = "serial-pass", feature = "replay"), derive(Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub struct RenderPassDepthStencilAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
@@ -188,9 +188,9 @@ impl RenderPassDepthStencilAttachment {
 /// Location to write a timestamp to (beginning or end of the pass).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(any(feature = "serial-pass", feature = "trace"), derive(Serialize))]
-#[cfg_attr(any(feature = "serial-pass", feature = "replay"), derive(Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
 pub enum RenderPassTimestampLocation {
     Beginning = 0,
     End = 1,
@@ -199,8 +199,8 @@ pub enum RenderPassTimestampLocation {
 /// Describes the writing of timestamp values in a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(any(feature = "serial-pass", feature = "trace"), derive(Serialize))]
-#[cfg_attr(any(feature = "serial-pass", feature = "replay"), derive(Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub struct RenderPassTimestampWrites {
     /// The query set to write the timestamp to.
     pub query_set: id::QuerySetId,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -57,9 +57,16 @@ use super::{
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
 #[cfg_attr(
-    any(feature = "serialize", feature = "deserialize", feature = "serial-pass"),
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(Deserialize)
+)]
+#[cfg_attr(
+    any(
+        feature = "serialize",
+        feature = "deserialize",
+        feature = "serial-pass"
+    ),
     serde(rename_all = "kebab-case")
 )]
 pub enum LoadOp {
@@ -73,9 +80,16 @@ pub enum LoadOp {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
 #[cfg_attr(
-    any(feature = "serialize", feature = "deserialize", feature = "serial-pass"),
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(Deserialize)
+)]
+#[cfg_attr(
+    any(
+        feature = "serialize",
+        feature = "deserialize",
+        feature = "serial-pass"
+    ),
     serde(rename_all = "kebab-case")
 )]
 pub enum StoreOp {
@@ -91,7 +105,10 @@ pub enum StoreOp {
 #[repr(C)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
+#[cfg_attr(
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(Deserialize)
+)]
 pub struct PassChannel<V> {
     /// Operation to perform to the output attachment at the start of a
     /// renderpass.
@@ -129,7 +146,10 @@ impl<V> PassChannel<V> {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
+#[cfg_attr(
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(Deserialize)
+)]
 pub struct RenderPassColorAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
@@ -143,7 +163,10 @@ pub struct RenderPassColorAttachment {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
+#[cfg_attr(
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(Deserialize)
+)]
 pub struct RenderPassDepthStencilAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
@@ -195,9 +218,16 @@ impl RenderPassDepthStencilAttachment {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
 #[cfg_attr(
-    any(feature = "serialize", feature = "deserialize", feature = "serial-pass"),
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(Deserialize)
+)]
+#[cfg_attr(
+    any(
+        feature = "serialize",
+        feature = "deserialize",
+        feature = "serial-pass"
+    ),
     serde(rename_all = "kebab-case")
 )]
 pub enum RenderPassTimestampLocation {
@@ -209,7 +239,10 @@ pub enum RenderPassTimestampLocation {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(feature = "serialize", feature = "serial-pass"), derive(Serialize))]
-#[cfg_attr(any(feature = "deserialize", feature = "serial-pass"), derive(Deserialize))]
+#[cfg_attr(
+    any(feature = "deserialize", feature = "serial-pass"),
+    derive(Deserialize)
+)]
 pub struct RenderPassTimestampWrites {
     /// The query set to write the timestamp to.
     pub query_set: id::QuerySetId,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -82,8 +82,7 @@ pub enum StoreOp {
 /// Describes an individual channel within a render pass, such as color, depth, or stencil.
 #[repr(C)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
-#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PassChannel<V> {
     /// Operation to perform to the output attachment at the start of a
     /// renderpass.
@@ -120,8 +119,7 @@ impl<V> PassChannel<V> {
 /// Describes a color attachment to a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
-#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RenderPassColorAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
@@ -134,8 +132,7 @@ pub struct RenderPassColorAttachment {
 /// Describes a depth/stencil attachment to a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
-#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RenderPassDepthStencilAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
@@ -196,8 +193,7 @@ pub enum RenderPassTimestampLocation {
 /// Describes the writing of timestamp values in a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
-#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RenderPassTimestampWrites {
     /// The query set to write the timestamp to.
     pub query_set: id::QuerySetId,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -42,8 +42,8 @@ pub type DeviceDescriptor<'a> = wgt::DeviceDescriptor<Label<'a>>;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub enum HostMap {
     Read,
     Write,
@@ -457,8 +457,8 @@ pub struct MissingFeatures(pub wgt::Features);
 pub struct MissingDownlevelFlags(pub wgt::DownlevelFlags);
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct ImplicitPipelineContext {
     pub root_id: id::PipelineLayoutId,
     pub group_ids: ArrayVec<id::BindGroupLayoutId, { hal::MAX_BIND_GROUPS }>,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -42,15 +42,14 @@ pub type DeviceDescriptor<'a> = wgt::DeviceDescriptor<Label<'a>>;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum HostMap {
     Read,
     Write,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq)]
-#[cfg_attr(feature = "serial-pass", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) struct AttachmentData<T> {
     pub colors: ArrayVec<Option<T>, { hal::MAX_COLOR_ATTACHMENTS }>,
     pub resolves: ArrayVec<T, { hal::MAX_COLOR_ATTACHMENTS }>,
@@ -74,7 +73,7 @@ pub enum RenderPassCompatibilityCheckType {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq)]
-#[cfg_attr(feature = "serial-pass", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) struct RenderPassContext {
     pub attachments: AttachmentData<TextureFormat>,
     pub sample_count: u32,
@@ -457,8 +456,7 @@ pub struct MissingFeatures(pub wgt::Features);
 pub struct MissingDownlevelFlags(pub wgt::DownlevelFlags);
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImplicitPipelineContext {
     pub root_id: id::PipelineLayoutId,
     pub group_ids: ArrayVec<id::BindGroupLayoutId, { hal::MAX_BIND_GROUPS }>,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -33,8 +33,8 @@ pub(crate) fn new_render_bundle_encoder_descriptor<'a>(
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub enum Action<'a> {
     Init {
         desc: crate::device::DeviceDescriptor<'a>,
@@ -126,8 +126,8 @@ pub enum Action<'a> {
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub enum Command {
     CopyBufferToBuffer {
         src: id::BufferId,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -33,8 +33,7 @@ pub(crate) fn new_render_bundle_encoder_descriptor<'a>(
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Action<'a> {
     Init {
         desc: crate::device::DeviceDescriptor<'a>,
@@ -126,8 +125,7 @@ pub enum Action<'a> {
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Command {
     CopyBufferToBuffer {
         src: id::BufferId,

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -56,25 +56,18 @@ type Dummy = hal::api::Empty;
     serde(from = "SerialId")
 )]
 #[cfg_attr(
-    all(
-        any(feature = "serialize", feature = "serial-pass"),
-        not(feature = "trace")
-    ),
+    all(feature = "serde", not(feature = "trace")),
     derive(serde::Serialize)
 )]
 #[cfg_attr(
-    all(
-        any(feature = "deserialize", feature = "serial-pass"),
-        not(feature = "replay")
-    ),
+    all(feature = "serde", not(feature = "replay")),
     derive(serde::Deserialize)
 )]
 pub struct Id<T: 'static + WasmNotSendSync>(NonZeroId, PhantomData<T>);
 
 // This type represents Id in a more readable (and editable) way.
 #[allow(dead_code)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 enum SerialId {
     // The only variant forces RON to not ignore "Id"
     Id(Index, Epoch, Backend),

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -56,19 +56,19 @@ type Dummy = hal::api::Empty;
     serde(from = "SerialId")
 )]
 #[cfg_attr(
-    all(feature = "serde", not(feature = "trace")),
+    all(feature = "serialize", not(feature = "trace")),
     derive(serde::Serialize)
 )]
 #[cfg_attr(
-    all(feature = "serde", not(feature = "replay")),
+    all(feature = "deserialize", not(feature = "replay")),
     derive(serde::Deserialize)
 )]
 pub struct Id<T: 'static + WasmNotSendSync>(NonZeroId, PhantomData<T>);
 
 // This type represents Id in a more readable (and editable) way.
 #[allow(dead_code)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 enum SerialId {
     // The only variant forces RON to not ignore "Id"
     Id(Index, Epoch, Backend),

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -56,11 +56,17 @@ type Dummy = hal::api::Empty;
     serde(from = "SerialId")
 )]
 #[cfg_attr(
-    all(feature = "serialize", not(feature = "trace")),
+    all(
+        any(feature = "serialize", feature = "serial-pass"),
+        not(feature = "trace")
+    ),
     derive(serde::Serialize)
 )]
 #[cfg_attr(
-    all(feature = "deserialize", not(feature = "replay")),
+    all(
+        any(feature = "deserialize", feature = "serial-pass"),
+        not(feature = "replay")
+    ),
     derive(serde::Deserialize)
 )]
 pub struct Id<T: 'static + WasmNotSendSync>(NonZeroId, PhantomData<T>);

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -13,6 +13,9 @@
 //!   [https://renderdoc.org/](https://renderdoc.org/)
 //! - **`strict_asserts`** --- Apply run-time checks, even in release builds. These are in addition
 //!   to the validation carried out at public APIs in all builds.
+//! - **`serde`** --- Enables serde functionality on common wgpu types.
+//! - **`serialize`** ---Enables serialize functionality on common wgpu types.
+//! - **`deserialize`** --- Enables deserialize functionality on common wgpu types.
 //! - **`trace`** --- Enable API tracing.
 //! - **`replay`** --- Enable API replaying
 //! - **`serial-pass`** --- Enable serializable compute/render passes, and bundle encoders.

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -13,7 +13,7 @@
 //!   [https://renderdoc.org/](https://renderdoc.org/)
 //! - **`strict_asserts`** --- Apply run-time checks, even in release builds. These are in addition
 //!   to the validation carried out at public APIs in all builds.
-//! - **`serde`** --- Enables serde functionality on common wgpu types.
+//! - **`serde`** --- Enables serialization via `serde` on common wgpu types.
 //! - **`trace`** --- Enable API tracing.
 //! - **`replay`** --- Enable API replaying
 //! - **`wgsl`** --- Enable `ShaderModuleSource::Wgsl`

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -14,11 +14,8 @@
 //! - **`strict_asserts`** --- Apply run-time checks, even in release builds. These are in addition
 //!   to the validation carried out at public APIs in all builds.
 //! - **`serde`** --- Enables serde functionality on common wgpu types.
-//! - **`serialize`** ---Enables serialize functionality on common wgpu types.
-//! - **`deserialize`** --- Enables deserialize functionality on common wgpu types.
 //! - **`trace`** --- Enable API tracing.
 //! - **`replay`** --- Enable API replaying
-//! - **`serial-pass`** --- Enable serializable compute/render passes, and bundle encoders.
 //! - **`wgsl`** --- Enable `ShaderModuleSource::Wgsl`
 //! - **`fragile-send-sync-non-atomic-wasm`** --- Implement `Send` and `Sync` on Wasm, but only if
 //!   atomics are not enabled.

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -38,11 +38,11 @@ pub enum ShaderModuleSource<'a> {
 }
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct ShaderModuleDescriptor<'a> {
     pub label: Label<'a>,
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
     pub shader_bound_checks: wgt::ShaderBoundChecks,
 }
 
@@ -208,8 +208,8 @@ impl CreateShaderModuleError {
 
 /// Describes a programmable pipeline stage.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct ProgrammableStageDescriptor<'a> {
     /// The compiled shader module for this stage.
     pub module: ShaderModuleId,
@@ -236,8 +236,8 @@ pub enum ImplicitLayoutError {
 
 /// Describes a compute pipeline.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct ComputePipelineDescriptor<'a> {
     pub label: Label<'a>,
     /// The layout of bind groups for this pipeline.
@@ -311,9 +311,9 @@ impl<A: HalApi> ComputePipeline<A> {
 
 /// Describes how the vertex buffer is interpreted.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
 pub struct VertexBufferLayout<'a> {
     /// The stride, in bytes, between elements of this buffer.
     pub array_stride: wgt::BufferAddress,
@@ -325,8 +325,8 @@ pub struct VertexBufferLayout<'a> {
 
 /// Describes the vertex process in a render pipeline.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct VertexState<'a> {
     /// The compiled vertex stage and its entry point.
     pub stage: ProgrammableStageDescriptor<'a>,
@@ -336,8 +336,8 @@ pub struct VertexState<'a> {
 
 /// Describes fragment processing in a render pipeline.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct FragmentState<'a> {
     /// The compiled fragment stage and its entry point.
     pub stage: ProgrammableStageDescriptor<'a>,
@@ -347,8 +347,8 @@ pub struct FragmentState<'a> {
 
 /// Describes a render (graphics) pipeline.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct RenderPipelineDescriptor<'a> {
     pub label: Label<'a>,
     /// The layout of bind groups for this pipeline.
@@ -356,13 +356,13 @@ pub struct RenderPipelineDescriptor<'a> {
     /// The vertex processing state for this pipeline.
     pub vertex: VertexState<'a>,
     /// The properties of the pipeline at the primitive assembly and rasterization level.
-    #[cfg_attr(any(feature = "replay", feature = "trace"), serde(default))]
+    #[cfg_attr(any(feature = "deserialize", feature = "serialize"), serde(default))]
     pub primitive: wgt::PrimitiveState,
     /// The effect of draw calls on the depth and stencil aspects of the output target, if any.
-    #[cfg_attr(any(feature = "replay", feature = "trace"), serde(default))]
+    #[cfg_attr(any(feature = "deserialize", feature = "serialize"), serde(default))]
     pub depth_stencil: Option<wgt::DepthStencilState>,
     /// The multi-sampling properties of the pipeline.
-    #[cfg_attr(any(feature = "replay", feature = "trace"), serde(default))]
+    #[cfg_attr(any(feature = "deserialize", feature = "serialize"), serde(default))]
     pub multisample: wgt::MultisampleState,
     /// The fragment processing state for this pipeline.
     pub fragment: Option<FragmentState<'a>>,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -38,11 +38,10 @@ pub enum ShaderModuleSource<'a> {
 }
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ShaderModuleDescriptor<'a> {
     pub label: Label<'a>,
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub shader_bound_checks: wgt::ShaderBoundChecks,
 }
 
@@ -208,8 +207,7 @@ impl CreateShaderModuleError {
 
 /// Describes a programmable pipeline stage.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProgrammableStageDescriptor<'a> {
     /// The compiled shader module for this stage.
     pub module: ShaderModuleId,
@@ -236,8 +234,7 @@ pub enum ImplicitLayoutError {
 
 /// Describes a compute pipeline.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ComputePipelineDescriptor<'a> {
     pub label: Label<'a>,
     /// The layout of bind groups for this pipeline.
@@ -311,12 +308,8 @@ impl<A: HalApi> ComputePipeline<A> {
 
 /// Describes how the vertex buffer is interpreted.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct VertexBufferLayout<'a> {
     /// The stride, in bytes, between elements of this buffer.
     pub array_stride: wgt::BufferAddress,
@@ -328,8 +321,7 @@ pub struct VertexBufferLayout<'a> {
 
 /// Describes the vertex process in a render pipeline.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VertexState<'a> {
     /// The compiled vertex stage and its entry point.
     pub stage: ProgrammableStageDescriptor<'a>,
@@ -339,8 +331,7 @@ pub struct VertexState<'a> {
 
 /// Describes fragment processing in a render pipeline.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FragmentState<'a> {
     /// The compiled fragment stage and its entry point.
     pub stage: ProgrammableStageDescriptor<'a>,
@@ -350,8 +341,7 @@ pub struct FragmentState<'a> {
 
 /// Describes a render (graphics) pipeline.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderPipelineDescriptor<'a> {
     pub label: Label<'a>,
     /// The layout of bind groups for this pipeline.
@@ -359,13 +349,13 @@ pub struct RenderPipelineDescriptor<'a> {
     /// The vertex processing state for this pipeline.
     pub vertex: VertexState<'a>,
     /// The properties of the pipeline at the primitive assembly and rasterization level.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub primitive: wgt::PrimitiveState,
     /// The effect of draw calls on the depth and stencil aspects of the output target, if any.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub depth_stencil: Option<wgt::DepthStencilState>,
     /// The multi-sampling properties of the pipeline.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub multisample: wgt::MultisampleState,
     /// The fragment processing state for this pipeline.
     pub fragment: Option<FragmentState<'a>>,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -42,7 +42,7 @@ pub enum ShaderModuleSource<'a> {
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct ShaderModuleDescriptor<'a> {
     pub label: Label<'a>,
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub shader_bound_checks: wgt::ShaderBoundChecks,
 }
 
@@ -359,13 +359,13 @@ pub struct RenderPipelineDescriptor<'a> {
     /// The vertex processing state for this pipeline.
     pub vertex: VertexState<'a>,
     /// The properties of the pipeline at the primitive assembly and rasterization level.
-    #[cfg_attr(any(feature = "deserialize", feature = "serialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub primitive: wgt::PrimitiveState,
     /// The effect of draw calls on the depth and stencil aspects of the output target, if any.
-    #[cfg_attr(any(feature = "deserialize", feature = "serialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub depth_stencil: Option<wgt::DepthStencilState>,
     /// The multi-sampling properties of the pipeline.
-    #[cfg_attr(any(feature = "deserialize", feature = "serialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub multisample: wgt::MultisampleState,
     /// The fragment processing state for this pipeline.
     pub fragment: Option<FragmentState<'a>>,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -313,7 +313,10 @@ impl<A: HalApi> ComputePipeline<A> {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct VertexBufferLayout<'a> {
     /// The stride, in bytes, between elements of this buffer.
     pub array_stride: wgt::BufferAddress,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1186,8 +1186,8 @@ impl<A: HalApi> Borrow<TextureSelector> for Texture<A> {
 
 /// Describes a [`TextureView`].
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize), serde(default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize), serde(default))]
 pub struct TextureViewDescriptor<'a> {
     /// Debug label of the texture view.
     ///
@@ -1343,8 +1343,8 @@ impl<A: HalApi> Resource<TextureViewId> for TextureView<A> {
 
 /// Describes a [`Sampler`]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct SamplerDescriptor<'a> {
     /// Debug label of the sampler.
     ///

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1186,8 +1186,8 @@ impl<A: HalApi> Borrow<TextureSelector> for Texture<A> {
 
 /// Describes a [`TextureView`].
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize), serde(default))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct TextureViewDescriptor<'a> {
     /// Debug label of the texture view.
     ///
@@ -1343,8 +1343,7 @@ impl<A: HalApi> Resource<TextureViewId> for TextureView<A> {
 
 /// Describes a [`Sampler`]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SamplerDescriptor<'a> {
     /// Debug label of the sampler.
     ///

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -17,4 +17,4 @@ pico-args.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 wgpu.workspace = true
-wgpu-types = { workspace = true, features = ["trace", "replay"] }
+wgpu-types = { workspace = true, features = ["serde"] }

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -28,9 +28,6 @@ targets = [
 [lib]
 
 [features]
-serde = ["serialize", "deserialize"]
-serialize = ["dep:serde"]
-deserialize = ["dep:serde"]
 strict_asserts = []
 fragile-send-sync-non-atomic-wasm = []
 

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -28,8 +28,9 @@ targets = [
 [lib]
 
 [features]
-trace = ["serde"]
-replay = ["serde"]
+serde = ["serialize", "deserialize"]
+serialize = ["dep:serde"]
+deserialize = ["dep:serde"]
 strict_asserts = []
 fragile-send-sync-non-atomic-wasm = []
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -11,6 +11,7 @@
 
 #[cfg(any(feature = "serde", test))]
 use serde::Deserialize;
+#[cfg(any(feature = "serde", test))]
 use serde::Serialize;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2021,10 +2021,10 @@ pub struct ColorTargetState {
     /// [CEbrp]: ../wgpu/struct.CommandEncoder.html#method.begin_render_pass
     pub format: TextureFormat,
     /// The blending that is used for this pipeline.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub blend: Option<BlendState>,
     /// Mask which enables/disables writes to different color/alpha channel.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub write_mask: ColorWrites,
 }
 
@@ -2162,25 +2162,25 @@ pub struct PrimitiveState {
     pub topology: PrimitiveTopology,
     /// When drawing strip topologies with indices, this is the required format for the index buffer.
     /// This has no effect on non-indexed or non-strip draws.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub strip_index_format: Option<IndexFormat>,
     /// The face to consider the front for the purpose of culling and stencil operations.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub front_face: FrontFace,
     /// The face culling mode.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub cull_mode: Option<Face>,
     /// If set to true, the polygon depth is not clipped to 0-1 before rasterization.
     ///
     /// Enabling this requires `Features::DEPTH_CLIP_CONTROL` to be enabled.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub unclipped_depth: bool,
     /// Controls the way each polygon is rasterized. Can be either `Fill` (default), `Line` or `Point`
     ///
     /// Setting this to `Line` requires `Features::POLYGON_MODE_LINE` to be enabled.
     ///
     /// Setting this to `Point` requires `Features::POLYGON_MODE_POINT` to be enabled.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub polygon_mode: PolygonMode,
     /// If set to true, the primitives are rendered with conservative overestimation. I.e. any rastered pixel touched by it is filled.
     /// Only valid for PolygonMode::Fill!
@@ -4547,10 +4547,10 @@ pub struct DepthStencilState {
     /// Comparison function used to compare depth values in the depth test.
     pub depth_compare: CompareFunction,
     /// Stencil state.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub stencil: StencilState,
     /// Depth bias state.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub bias: DepthBiasState,
 }
 
@@ -5554,7 +5554,7 @@ pub struct Extent3d {
     pub height: u32,
     /// The depth of the extent or the number of array layers
     #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
+        feature = "deserialize",
         serde(default = "default_depth")
     )]
     pub depth_or_array_layers: u32,
@@ -6365,7 +6365,7 @@ pub enum BindingType {
         /// for each dynamic binding in increasing order of binding number.
         ///
         /// [RPsbg]: ../wgpu/struct.RenderPass.html#method.set_bind_group
-        #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+        #[cfg_attr(feature = "deserialize", serde(default))]
         has_dynamic_offset: bool,
 
         /// The minimum size for a [`BufferBinding`] matching this entry, in bytes.
@@ -6393,7 +6393,7 @@ pub enum BindingType {
         /// [minimum buffer binding size]: https://www.w3.org/TR/webgpu/#minimum-buffer-binding-size
         /// [`create_render_pipeline`]: ../wgpu/struct.Device.html#method.create_render_pipeline
         /// [`create_compute_pipeline`]: ../wgpu/struct.Device.html#method.create_compute_pipeline
-        #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+        #[cfg_attr(feature = "deserialize", serde(default))]
         min_binding_size: Option<BufferSize>,
     },
     /// A sampler that can be used to sample a texture.
@@ -6513,7 +6513,7 @@ pub struct BindGroupLayoutEntry {
     /// If this value is Some and `ty` is `BindingType::Texture`, [`Features::TEXTURE_BINDING_ARRAY`] must be supported.
     ///
     /// If this value is Some and `ty` is any other variant, bind group creation will fail.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub count: Option<NonZeroU32>,
 }
 
@@ -6548,10 +6548,10 @@ pub struct ImageCopyTexture<T> {
     /// The base texel of the texture in the selected `mip_level`. Together
     /// with the `copy_size` argument to copy functions, defines the
     /// sub-region of the texture to copy.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub origin: Origin3d,
     /// The copy aspect.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default))]
+    #[cfg_attr(feature = "deserialize", serde(default))]
     pub aspect: TextureAspect,
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -9,9 +9,8 @@
 )]
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 
-#[cfg(any(feature = "deserialize", test))]
+#[cfg(any(feature = "serde", test))]
 use serde::Deserialize;
-#[cfg(any(feature = "serialize", test))]
 use serde::Serialize;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
@@ -28,7 +27,7 @@ pub mod math;
 // behavior to this macro (unspecified bit do not produce an error).
 macro_rules! impl_bitflags {
     ($name:ident) => {
-        #[cfg(feature = "serialize")]
+        #[cfg(feature = "serde")]
         impl serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -38,7 +37,7 @@ macro_rules! impl_bitflags {
             }
         }
 
-        #[cfg(feature = "deserialize")]
+        #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for $name {
             fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
             where
@@ -94,8 +93,7 @@ pub const QUERY_SIZE: u32 = 8;
 /// Backends supported by wgpu.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Backend {
     /// Dummy backend, used for testing.
     Empty = 0,
@@ -131,12 +129,8 @@ impl Backend {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpupowerpreference).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum PowerPreference {
     #[default]
     /// Power usage is not considered when choosing an adapter.
@@ -203,8 +197,7 @@ impl From<Backend> for Backends {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpurequestadapteroptions).
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RequestAdapterOptions<S> {
     /// Power preference for the adapter.
     pub power_preference: PowerPreference,
@@ -995,34 +988,21 @@ impl InstanceFlags {
 /// [`downlevel_defaults()`]: Limits::downlevel_defaults
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase", default)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase", default))]
 pub struct Limits {
     /// Maximum allowed value for the `size.width` of a texture created with `TextureDimension::D1`.
     /// Defaults to 8192. Higher is "better".
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "maxTextureDimension1D")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "maxTextureDimension1D"))]
     pub max_texture_dimension_1d: u32,
     /// Maximum allowed value for the `size.width` and `size.height` of a texture created with `TextureDimension::D2`.
     /// Defaults to 8192. Higher is "better".
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "maxTextureDimension2D")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "maxTextureDimension2D"))]
     pub max_texture_dimension_2d: u32,
     /// Maximum allowed value for the `size.width`, `size.height`, and `size.depth_or_array_layers`
     /// of a texture created with `TextureDimension::D3`.
     /// Defaults to 2048. Higher is "better".
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "maxTextureDimension3D")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "maxTextureDimension3D"))]
     pub max_texture_dimension_3d: u32,
     /// Maximum allowed value for the `size.depth_or_array_layers` of a texture created with `TextureDimension::D2`.
     /// Defaults to 256. Higher is "better".
@@ -1387,8 +1367,7 @@ impl Limits {
 /// Represents the sets of additional limits on an adapter,
 /// which take place when running on downlevel backends.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DownlevelLimits {}
 
 #[allow(unknown_lints)] // derivable_impls is nightly only currently
@@ -1401,8 +1380,7 @@ impl Default for DownlevelLimits {
 
 /// Lists various ways the underlying platform does not conform to the WebGPU standard.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DownlevelCapabilities {
     /// Combined boolean flags.
     pub flags: DownlevelFlags,
@@ -1611,8 +1589,7 @@ impl DownlevelFlags {
 /// Collections of shader features a device supports if they support less than WebGPU normally allows.
 // TODO: Fill out the differences between shader models more completely
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ShaderModel {
     /// Extremely limited shaders, including a total instruction limit.
     Sm2,
@@ -1625,8 +1602,7 @@ pub enum ShaderModel {
 /// Supported physical device types.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceType {
     /// Other or Unknown.
     Other,
@@ -1644,8 +1620,7 @@ pub enum DeviceType {
 
 /// Information about an adapter.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AdapterInfo {
     /// Adapter name
     pub name: String,
@@ -1688,8 +1663,7 @@ pub struct AdapterInfo {
 /// https://gpuweb.github.io/gpuweb/#gpudevicedescriptor).
 #[repr(C)]
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DeviceDescriptor<L> {
     /// Debug label for the device.
     pub label: L,
@@ -1751,45 +1725,26 @@ impl_bitflags!(ShaderStages);
 /// https://gpuweb.github.io/gpuweb/#enumdef-gputextureviewdimension).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TextureViewDimension {
     /// A one dimensional texture. `texture_1d` in WGSL and `texture1D` in GLSL.
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "1d")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "1d"))]
     D1,
     /// A two dimensional texture. `texture_2d` in WGSL and `texture2D` in GLSL.
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "2d")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "2d"))]
     #[default]
     D2,
     /// A two dimensional array texture. `texture_2d_array` in WGSL and `texture2DArray` in GLSL.
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "2d-array")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "2d-array"))]
     D2Array,
     /// A cubemap texture. `texture_cube` in WGSL and `textureCube` in GLSL.
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "cube")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "cube"))]
     Cube,
     /// A cubemap array texture. `texture_cube_array` in WGSL and `textureCubeArray` in GLSL.
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "cube-array")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "cube-array"))]
     CubeArray,
     /// A three dimensional texture. `texture_3d` in WGSL and `texture3D` in GLSL.
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "3d")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "3d"))]
     D3,
 }
 
@@ -1814,12 +1769,8 @@ impl TextureViewDimension {
 /// used with the first render target.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum BlendFactor {
     /// 0.0
     Zero = 0,
@@ -1880,12 +1831,8 @@ impl BlendFactor {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpublendoperation).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum BlendOperation {
     /// Src + Dst
     #[default]
@@ -1906,12 +1853,8 @@ pub enum BlendOperation {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpublendcomponent).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct BlendComponent {
     /// Multiplier for the source, which is produced by the fragment shader.
     pub src_factor: BlendFactor,
@@ -1965,12 +1908,8 @@ impl Default for BlendComponent {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpublendstate).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct BlendState {
     /// Color equation.
     pub color: BlendComponent,
@@ -2008,12 +1947,8 @@ impl BlendState {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpucolortargetstate).
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct ColorTargetState {
     /// The [`TextureFormat`] of the image that this pipeline will render to. Must match the format
     /// of the corresponding color attachment in [`CommandEncoder::begin_render_pass`][CEbrp]
@@ -2021,10 +1956,10 @@ pub struct ColorTargetState {
     /// [CEbrp]: ../wgpu/struct.CommandEncoder.html#method.begin_render_pass
     pub format: TextureFormat,
     /// The blending that is used for this pipeline.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub blend: Option<BlendState>,
     /// Mask which enables/disables writes to different color/alpha channel.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub write_mask: ColorWrites,
 }
 
@@ -2044,12 +1979,8 @@ impl From<TextureFormat> for ColorTargetState {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpuprimitivetopology).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum PrimitiveTopology {
     /// Vertex data is a list of points. Each vertex is a new point.
     PointList = 0,
@@ -2088,12 +2019,8 @@ impl PrimitiveTopology {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpufrontface).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum FrontFace {
     /// Triangles with vertices in counter clockwise order are considered the front face.
     ///
@@ -2113,12 +2040,8 @@ pub enum FrontFace {
 /// except that the `"none"` value is represented using `Option<Face>` instead.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum Face {
     /// Front face
     Front = 0,
@@ -2129,12 +2052,8 @@ pub enum Face {
 /// Type of drawing mode for polygons
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum PolygonMode {
     /// Polygons are filled
     #[default]
@@ -2151,36 +2070,32 @@ pub enum PolygonMode {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuprimitivestate).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct PrimitiveState {
     /// The primitive topology used to interpret vertices.
     pub topology: PrimitiveTopology,
     /// When drawing strip topologies with indices, this is the required format for the index buffer.
     /// This has no effect on non-indexed or non-strip draws.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub strip_index_format: Option<IndexFormat>,
     /// The face to consider the front for the purpose of culling and stencil operations.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub front_face: FrontFace,
     /// The face culling mode.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub cull_mode: Option<Face>,
     /// If set to true, the polygon depth is not clipped to 0-1 before rasterization.
     ///
     /// Enabling this requires `Features::DEPTH_CLIP_CONTROL` to be enabled.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub unclipped_depth: bool,
     /// Controls the way each polygon is rasterized. Can be either `Fill` (default), `Line` or `Point`
     ///
     /// Setting this to `Line` requires `Features::POLYGON_MODE_LINE` to be enabled.
     ///
     /// Setting this to `Point` requires `Features::POLYGON_MODE_POINT` to be enabled.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub polygon_mode: PolygonMode,
     /// If set to true, the primitives are rendered with conservative overestimation. I.e. any rastered pixel touched by it is filled.
     /// Only valid for PolygonMode::Fill!
@@ -2195,12 +2110,8 @@ pub struct PrimitiveState {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpumultisamplestate).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct MultisampleState {
     /// The number of samples calculated per pixel (for MSAA). For non-multisampled textures,
     /// this should be `1`
@@ -2287,8 +2198,7 @@ impl_bitflags!(TextureFormatFeatureFlags);
 ///
 /// Features are defined by WebGPU specification unless `Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES` is enabled.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextureFormatFeatures {
     /// Valid bits for `TextureDescriptor::Usage` provided for format creation.
     pub allowed_usages: TextureUsages,
@@ -2299,8 +2209,7 @@ pub struct TextureFormatFeatures {
 /// ASTC block dimensions
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AstcBlock {
     /// 4x4 block compressed texture. 16 bytes per block (8 bit/px).
     B4x4,
@@ -2335,8 +2244,7 @@ pub enum AstcBlock {
 /// ASTC RGBA channel
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AstcChannel {
     /// 8 bit integer RGBA, [0, 255] converted to/from linear-color float [0, 1] in shader.
     ///
@@ -2665,7 +2573,7 @@ pub enum TextureFormat {
     },
 }
 
-#[cfg(any(feature = "deserialize", test))]
+#[cfg(any(feature = "serde", test))]
 impl<'de> Deserialize<'de> for TextureFormat {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -2804,7 +2712,7 @@ impl<'de> Deserialize<'de> for TextureFormat {
     }
 }
 
-#[cfg(any(feature = "serialize", test))]
+#[cfg(any(feature = "serde", test))]
 impl Serialize for TextureFormat {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -4444,8 +4352,7 @@ impl MaintainResult {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpudepthstencilstate).
 #[repr(C)]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct StencilState {
     /// Front face mode.
     pub front: StencilFaceState,
@@ -4492,8 +4399,7 @@ impl StencilState {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpudepthstencilstate).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DepthBiasState {
     /// Constant depth biasing factor, in basic units of the depth format.
     pub constant: i32,
@@ -4534,8 +4440,7 @@ impl Eq for DepthBiasState {}
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpudepthstencilstate).
 #[repr(C)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DepthStencilState {
     /// Format of the depth/stencil buffer, must be special depth format. Must match the format
     /// of the depth/stencil attachment in [`CommandEncoder::begin_render_pass`][CEbrp].
@@ -4547,10 +4452,10 @@ pub struct DepthStencilState {
     /// Comparison function used to compare depth values in the depth test.
     pub depth_compare: CompareFunction,
     /// Stencil state.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub stencil: StencilState,
     /// Depth bias state.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bias: DepthBiasState,
 }
 
@@ -4582,12 +4487,8 @@ impl DepthStencilState {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpuindexformat).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum IndexFormat {
     /// Indices are 16 bit unsigned integers.
     Uint16 = 0,
@@ -4602,12 +4503,8 @@ pub enum IndexFormat {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpustenciloperation).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum StencilOperation {
     /// Keep stencil value unchanged.
     #[default]
@@ -4639,12 +4536,8 @@ pub enum StencilOperation {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpustencilfacestate).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct StencilFaceState {
     /// Comparison function that determines if the fail_op or pass_op is used on the stencil buffer.
     pub compare: CompareFunction,
@@ -4693,12 +4586,8 @@ impl Default for StencilFaceState {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpucomparefunction).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum CompareFunction {
     /// Function never passes
     Never = 1,
@@ -4791,12 +4680,8 @@ impl CompareFunction {
 /// [`Instance`]: VertexStepMode::Instance
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum VertexStepMode {
     /// Vertex data is advanced every vertex.
     #[default]
@@ -4816,12 +4701,8 @@ pub enum VertexStepMode {
 /// [`vertex_attr_array`]: ../wgpu/macro.vertex_attr_array.html
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct VertexAttribute {
     /// Format of the input
     pub format: VertexFormat,
@@ -4837,12 +4718,8 @@ pub struct VertexAttribute {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpuvertexformat).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "lowercase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum VertexFormat {
     /// Two unsigned bytes (u8). `vec2<u32>` in shaders.
     Uint8x2 = 0,
@@ -5000,8 +4877,7 @@ impl_bitflags!(BufferUsages);
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpubufferdescriptor).
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BufferDescriptor<L> {
     /// Debug label of a buffer. This will show up in graphics debuggers for easy identification.
     pub label: L,
@@ -5035,8 +4911,7 @@ impl<L> BufferDescriptor<L> {
 /// Corresponds to [WebGPU `GPUCommandEncoderDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpucommandencoderdescriptor).
 #[repr(C)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CommandEncoderDescriptor<L> {
     /// Debug label for the command encoder. This will show up in graphics debuggers for easy identification.
@@ -5061,8 +4936,7 @@ impl<T> Default for CommandEncoderDescriptor<Option<T>> {
 /// Behavior of the presentation engine based on frame rate.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum PresentMode {
     /// Chooses FifoRelaxed -> Fifo based on availability.
     ///
@@ -5134,12 +5008,8 @@ pub enum PresentMode {
 /// compositing.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "lowercase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum CompositeAlphaMode {
     /// Chooses either `Opaque` or `Inherit` automatically，depending on the
     /// `alpha_mode` that the current surface can support.
@@ -5237,8 +5107,7 @@ impl Default for SurfaceCapabilities {
 /// [`Surface`]: ../wgpu/struct.Surface.html
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SurfaceConfiguration<V> {
     /// The usage of the swap chain. The only supported usage is `RENDER_ATTACHMENT`.
     pub usage: TextureUsages,
@@ -5364,12 +5233,8 @@ impl PresentationTimestamp {
 /// This is not to be used as a generic color type, only for specific wgpu interfaces.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Color {
     /// Red component of the color
     pub r: f64,
@@ -5427,26 +5292,16 @@ impl Color {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gputexturedimension).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TextureDimension {
     /// 1D texture
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "1d")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "1d"))]
     D1,
     /// 2D texture
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "2d")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "2d"))]
     D2,
     /// 3D texture
-    #[cfg_attr(
-        any(feature = "serialize", feature = "deserialize"),
-        serde(rename = "3d")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "3d"))]
     D3,
 }
 
@@ -5456,12 +5311,8 @@ pub enum TextureDimension {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuorigin2ddict).
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Origin2d {
     ///
     pub x: u32,
@@ -5495,12 +5346,8 @@ impl std::fmt::Debug for Origin2d {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuorigin3ddict).
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Origin3d {
     /// X position of the origin
     pub x: u32,
@@ -5541,19 +5388,15 @@ impl std::fmt::Debug for Origin3d {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuextent3ddict).
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Extent3d {
     /// Width of the extent
     pub width: u32,
     /// Height of the extent
     pub height: u32,
     /// The depth of the extent or the number of array layers
-    #[cfg_attr(feature = "deserialize", serde(default = "default_depth"))]
+    #[cfg_attr(feature = "serde", serde(default = "default_depth"))]
     pub depth_or_array_layers: u32,
 }
 
@@ -5563,7 +5406,7 @@ impl std::fmt::Debug for Extent3d {
     }
 }
 
-#[cfg(feature = "deserialize")]
+#[cfg(feature = "serde")]
 fn default_depth() -> u32 {
     1
 }
@@ -5744,8 +5587,7 @@ fn test_max_mips() {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gputexturedescriptor).
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TextureDescriptor<L, V> {
     /// Debug label of the texture. This will show up in graphics debuggers for easy identification.
     pub label: L,
@@ -5876,12 +5718,8 @@ impl<L, V> TextureDescriptor<L, V> {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gputextureaspect).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum TextureAspect {
     /// Depth, Stencil, and Color.
     #[default]
@@ -5904,12 +5742,8 @@ pub enum TextureAspect {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpuaddressmode).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum AddressMode {
     /// Clamp the value to the edge of the texture
     ///
@@ -5941,12 +5775,8 @@ pub enum AddressMode {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpufiltermode).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum FilterMode {
     /// Nearest neighbor sampling.
     ///
@@ -5961,8 +5791,7 @@ pub enum FilterMode {
 
 /// A range of push constant memory to pass to a shader stage.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PushConstantRange {
     /// Stage push constant range is visible from. Each stage can only be served by at most one range.
     /// One range can serve multiple stages however.
@@ -5978,8 +5807,7 @@ pub struct PushConstantRange {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpucommandbufferdescriptor).
 #[repr(C)]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CommandBufferDescriptor<L> {
     /// Debug label of this command buffer.
     pub label: L,
@@ -6000,8 +5828,7 @@ impl<L> CommandBufferDescriptor<L> {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpurenderbundleencoderdescriptor).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderBundleDepthStencil {
     /// Format of the attachment.
     pub format: TextureFormat,
@@ -6028,8 +5855,7 @@ pub struct RenderBundleDepthStencil {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpurenderbundledescriptor).
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RenderBundleDescriptor<L> {
     /// Debug label of the render bundle encoder. This will show up in graphics debuggers for easy identification.
     pub label: L,
@@ -6065,8 +5891,7 @@ impl<T> Default for RenderBundleDescriptor<Option<T>> {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagedatalayout).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageDataLayout {
     /// Offset into the buffer that is the start of the texture. Must be a multiple of texture block size.
     /// For non-compressed textures, this is 1.
@@ -6106,8 +5931,7 @@ pub struct ImageDataLayout {
 /// Corresponds to [WebGPU `GPUBufferBindingType`](
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpubufferbindingtype).
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum BufferBindingType {
     /// A buffer for uniform values.
     ///
@@ -6172,8 +5996,7 @@ pub enum BufferBindingType {
 /// Corresponds to [WebGPU `GPUTextureSampleType`](
 /// https://gpuweb.github.io/gpuweb/#enumdef-gputexturesampletype).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TextureSampleType {
     /// Sampling returns floats.
     ///
@@ -6255,12 +6078,8 @@ impl Default for TextureSampleType {
 /// Corresponds to [WebGPU `GPUStorageTextureAccess`](
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpustoragetextureaccess).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum StorageTextureAccess {
     /// The texture can only be written in the shader and it:
     /// - may or may not be annotated with `write` (WGSL).
@@ -6321,12 +6140,8 @@ pub enum StorageTextureAccess {
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpusamplerbindingtype).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum SamplerBindingType {
     /// The sampling result is produced based on more than a single color sample from a texture,
     /// e.g. when bilinear interpolation is enabled.
@@ -6345,8 +6160,7 @@ pub enum SamplerBindingType {
 /// Corresponds to WebGPU's mutually exclusive fields within [`GPUBindGroupLayoutEntry`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpubindgrouplayoutentry).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum BindingType {
     /// A buffer binding.
     ///
@@ -6362,7 +6176,7 @@ pub enum BindingType {
         /// for each dynamic binding in increasing order of binding number.
         ///
         /// [RPsbg]: ../wgpu/struct.RenderPass.html#method.set_bind_group
-        #[cfg_attr(feature = "deserialize", serde(default))]
+        #[cfg_attr(feature = "serde", serde(default))]
         has_dynamic_offset: bool,
 
         /// The minimum size for a [`BufferBinding`] matching this entry, in bytes.
@@ -6390,7 +6204,7 @@ pub enum BindingType {
         /// [minimum buffer binding size]: https://www.w3.org/TR/webgpu/#minimum-buffer-binding-size
         /// [`create_render_pipeline`]: ../wgpu/struct.Device.html#method.create_render_pipeline
         /// [`create_compute_pipeline`]: ../wgpu/struct.Device.html#method.create_compute_pipeline
-        #[cfg_attr(feature = "deserialize", serde(default))]
+        #[cfg_attr(feature = "serde", serde(default))]
         min_binding_size: Option<BufferSize>,
     },
     /// A sampler that can be used to sample a texture.
@@ -6495,8 +6309,7 @@ impl BindingType {
 /// Corresponds to [WebGPU `GPUBindGroupLayoutEntry`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpubindgrouplayoutentry).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BindGroupLayoutEntry {
     /// Binding index. Must match shader index and be unique inside a BindGroupLayout. A binding
     /// of index 1, would be described as `layout(set = 0, binding = 1) uniform` in shaders.
@@ -6510,7 +6323,7 @@ pub struct BindGroupLayoutEntry {
     /// If this value is Some and `ty` is `BindingType::Texture`, [`Features::TEXTURE_BINDING_ARRAY`] must be supported.
     ///
     /// If this value is Some and `ty` is any other variant, bind group creation will fail.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub count: Option<NonZeroU32>,
 }
 
@@ -6520,8 +6333,7 @@ pub struct BindGroupLayoutEntry {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopybuffer).
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageCopyBuffer<B> {
     /// The buffer to be copied to/from.
     pub buffer: B,
@@ -6535,8 +6347,7 @@ pub struct ImageCopyBuffer<B> {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopytexture).
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageCopyTexture<T> {
     /// The texture to be copied to/from.
     pub texture: T,
@@ -6545,10 +6356,10 @@ pub struct ImageCopyTexture<T> {
     /// The base texel of the texture in the selected `mip_level`. Together
     /// with the `copy_size` argument to copy functions, defines the
     /// sub-region of the texture to copy.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub origin: Origin3d,
     /// The copy aspect.
-    #[cfg_attr(feature = "deserialize", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub aspect: TextureAspect,
 }
 
@@ -6668,12 +6479,8 @@ unsafe impl Sync for ExternalImageSource {}
 /// Corresponds to [HTML Canvas `PredefinedColorSpace`](
 /// https://html.spec.whatwg.org/multipage/canvas.html#predefinedcolorspace).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "kebab-case")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum PredefinedColorSpace {
     /// sRGB color space
     Srgb,
@@ -6687,8 +6494,7 @@ pub enum PredefinedColorSpace {
 /// Corresponds to [WebGPU `GPUImageCopyTextureTagged`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopytexturetagged).
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageCopyTextureTagged<T> {
     /// The texture to be copied to/from.
     pub texture: T,
@@ -6719,12 +6525,8 @@ impl<T: Copy> ImageCopyTextureTagged<T> {
 /// Subresource range within an image
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
-#[cfg_attr(
-    any(feature = "serialize", feature = "deserialize"),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct ImageSubresourceRange {
     /// Aspect of the texture. Color textures must be [`TextureAspect::All`][TAA].
     ///
@@ -6824,8 +6626,7 @@ impl ImageSubresourceRange {
 /// Color variation to use when sampler addressing mode is [`AddressMode::ClampToBorder`]
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SamplerBorderColor {
     /// [0, 0, 0, 0]
     TransparentBlack,
@@ -6847,8 +6648,7 @@ pub enum SamplerBorderColor {
 /// Corresponds to [WebGPU `GPUQuerySetDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuquerysetdescriptor).
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QuerySetDescriptor<L> {
     /// Debug label for the query set.
     pub label: L,
@@ -6875,8 +6675,7 @@ impl<L> QuerySetDescriptor<L> {
 /// Corresponds to [WebGPU `GPUQueryType`](
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpuquerytype).
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum QueryType {
     /// Query returns a single 64-bit number, serving as an occlusion boolean.
     Occlusion,
@@ -7022,8 +6821,7 @@ impl DispatchIndirectArgs {
 
 /// Describes how shader bound checks should be performed.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ShaderBoundChecks {
     runtime_checks: bool,
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -5553,10 +5553,7 @@ pub struct Extent3d {
     /// Height of the extent
     pub height: u32,
     /// The depth of the extent or the number of array layers
-    #[cfg_attr(
-        feature = "deserialize",
-        serde(default = "default_depth")
-    )]
+    #[cfg_attr(feature = "deserialize", serde(default = "default_depth"))]
     pub depth_or_array_layers: u32,
 }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -9,10 +9,10 @@
 )]
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 
-#[cfg(any(feature = "serialize", test))]
-use serde::Serialize;
 #[cfg(any(feature = "deserialize", test))]
 use serde::Deserialize;
+#[cfg(any(feature = "serialize", test))]
+use serde::Serialize;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::{num::NonZeroU32, ops::Range};
@@ -133,7 +133,10 @@ impl Backend {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum PowerPreference {
     #[default]
     /// Power usage is not considered when choosing an adapter.
@@ -994,20 +997,32 @@ impl InstanceFlags {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase", default))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase", default)
+)]
 pub struct Limits {
     /// Maximum allowed value for the `size.width` of a texture created with `TextureDimension::D1`.
     /// Defaults to 8192. Higher is "better".
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "maxTextureDimension1D"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "maxTextureDimension1D")
+    )]
     pub max_texture_dimension_1d: u32,
     /// Maximum allowed value for the `size.width` and `size.height` of a texture created with `TextureDimension::D2`.
     /// Defaults to 8192. Higher is "better".
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "maxTextureDimension2D"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "maxTextureDimension2D")
+    )]
     pub max_texture_dimension_2d: u32,
     /// Maximum allowed value for the `size.width`, `size.height`, and `size.depth_or_array_layers`
     /// of a texture created with `TextureDimension::D3`.
     /// Defaults to 2048. Higher is "better".
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "maxTextureDimension3D"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "maxTextureDimension3D")
+    )]
     pub max_texture_dimension_3d: u32,
     /// Maximum allowed value for the `size.depth_or_array_layers` of a texture created with `TextureDimension::D2`.
     /// Defaults to 256. Higher is "better".
@@ -1740,23 +1755,41 @@ impl_bitflags!(ShaderStages);
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub enum TextureViewDimension {
     /// A one dimensional texture. `texture_1d` in WGSL and `texture1D` in GLSL.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "1d"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "1d")
+    )]
     D1,
     /// A two dimensional texture. `texture_2d` in WGSL and `texture2D` in GLSL.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "2d"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "2d")
+    )]
     #[default]
     D2,
     /// A two dimensional array texture. `texture_2d_array` in WGSL and `texture2DArray` in GLSL.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "2d-array"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "2d-array")
+    )]
     D2Array,
     /// A cubemap texture. `texture_cube` in WGSL and `textureCube` in GLSL.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "cube"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "cube")
+    )]
     Cube,
     /// A cubemap array texture. `texture_cube_array` in WGSL and `textureCubeArray` in GLSL.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "cube-array"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "cube-array")
+    )]
     CubeArray,
     /// A three dimensional texture. `texture_3d` in WGSL and `texture3D` in GLSL.
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "3d"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "3d")
+    )]
     D3,
 }
 
@@ -1783,7 +1816,10 @@ impl TextureViewDimension {
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum BlendFactor {
     /// 0.0
     Zero = 0,
@@ -1846,7 +1882,10 @@ impl BlendFactor {
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum BlendOperation {
     /// Src + Dst
     #[default]
@@ -1869,7 +1908,10 @@ pub enum BlendOperation {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct BlendComponent {
     /// Multiplier for the source, which is produced by the fragment shader.
     pub src_factor: BlendFactor,
@@ -1925,7 +1967,10 @@ impl Default for BlendComponent {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct BlendState {
     /// Color equation.
     pub color: BlendComponent,
@@ -1965,7 +2010,10 @@ impl BlendState {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct ColorTargetState {
     /// The [`TextureFormat`] of the image that this pipeline will render to. Must match the format
     /// of the corresponding color attachment in [`CommandEncoder::begin_render_pass`][CEbrp]
@@ -1998,7 +2046,10 @@ impl From<TextureFormat> for ColorTargetState {
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum PrimitiveTopology {
     /// Vertex data is a list of points. Each vertex is a new point.
     PointList = 0,
@@ -2039,7 +2090,10 @@ impl PrimitiveTopology {
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum FrontFace {
     /// Triangles with vertices in counter clockwise order are considered the front face.
     ///
@@ -2061,7 +2115,10 @@ pub enum FrontFace {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum Face {
     /// Front face
     Front = 0,
@@ -2074,7 +2131,10 @@ pub enum Face {
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum PolygonMode {
     /// Polygons are filled
     #[default]
@@ -2093,7 +2153,10 @@ pub enum PolygonMode {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct PrimitiveState {
     /// The primitive topology used to interpret vertices.
     pub topology: PrimitiveTopology,
@@ -2134,7 +2197,10 @@ pub struct PrimitiveState {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct MultisampleState {
     /// The number of samples calculated per pixel (for MSAA). For non-multisampled textures,
     /// this should be `1`
@@ -4518,7 +4584,10 @@ impl DepthStencilState {
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum IndexFormat {
     /// Indices are 16 bit unsigned integers.
     Uint16 = 0,
@@ -4535,7 +4604,10 @@ pub enum IndexFormat {
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum StencilOperation {
     /// Keep stencil value unchanged.
     #[default]
@@ -4569,7 +4641,10 @@ pub enum StencilOperation {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct StencilFaceState {
     /// Comparison function that determines if the fail_op or pass_op is used on the stencil buffer.
     pub compare: CompareFunction,
@@ -4620,7 +4695,10 @@ impl Default for StencilFaceState {
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum CompareFunction {
     /// Function never passes
     Never = 1,
@@ -4715,7 +4793,10 @@ impl CompareFunction {
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum VertexStepMode {
     /// Vertex data is advanced every vertex.
     #[default]
@@ -4737,7 +4818,10 @@ pub enum VertexStepMode {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct VertexAttribute {
     /// Format of the input
     pub format: VertexFormat,
@@ -4755,7 +4839,10 @@ pub struct VertexAttribute {
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "lowercase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "lowercase")
+)]
 pub enum VertexFormat {
     /// Two unsigned bytes (u8). `vec2<u32>` in shaders.
     Uint8x2 = 0,
@@ -5049,7 +5136,10 @@ pub enum PresentMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "lowercase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "lowercase")
+)]
 pub enum CompositeAlphaMode {
     /// Chooses either `Opaque` or `Inherit` automatically，depending on the
     /// `alpha_mode` that the current surface can support.
@@ -5276,7 +5366,10 @@ impl PresentationTimestamp {
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct Color {
     /// Red component of the color
     pub r: f64,
@@ -5338,13 +5431,22 @@ impl Color {
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub enum TextureDimension {
     /// 1D texture
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "1d"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "1d")
+    )]
     D1,
     /// 2D texture
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "2d"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "2d")
+    )]
     D2,
     /// 3D texture
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename = "3d"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "3d")
+    )]
     D3,
 }
 
@@ -5356,7 +5458,10 @@ pub enum TextureDimension {
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct Origin2d {
     ///
     pub x: u32,
@@ -5392,7 +5497,10 @@ impl std::fmt::Debug for Origin2d {
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct Origin3d {
     /// X position of the origin
     pub x: u32,
@@ -5435,14 +5543,20 @@ impl std::fmt::Debug for Origin3d {
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct Extent3d {
     /// Width of the extent
     pub width: u32,
     /// Height of the extent
     pub height: u32,
     /// The depth of the extent or the number of array layers
-    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(default = "default_depth"))]
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(default = "default_depth")
+    )]
     pub depth_or_array_layers: u32,
 }
 
@@ -5767,7 +5881,10 @@ impl<L, V> TextureDescriptor<L, V> {
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum TextureAspect {
     /// Depth, Stencil, and Color.
     #[default]
@@ -5792,7 +5909,10 @@ pub enum TextureAspect {
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum AddressMode {
     /// Clamp the value to the edge of the texture
     ///
@@ -5826,7 +5946,10 @@ pub enum AddressMode {
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum FilterMode {
     /// Nearest neighbor sampling.
     ///
@@ -6137,7 +6260,10 @@ impl Default for TextureSampleType {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum StorageTextureAccess {
     /// The texture can only be written in the shader and it:
     /// - may or may not be annotated with `write` (WGSL).
@@ -6200,7 +6326,10 @@ pub enum StorageTextureAccess {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum SamplerBindingType {
     /// The sampling result is produced based on more than a single color sample from a texture,
     /// e.g. when bilinear interpolation is enabled.
@@ -6544,7 +6673,10 @@ unsafe impl Sync for ExternalImageSource {}
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "kebab-case")
+)]
 pub enum PredefinedColorSpace {
     /// sRGB color space
     Srgb,
@@ -6592,7 +6724,10 @@ impl<T: Copy> ImageCopyTextureTagged<T> {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
-#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    any(feature = "serialize", feature = "deserialize"),
+    serde(rename_all = "camelCase")
+)]
 pub struct ImageSubresourceRange {
     /// Aspect of the texture. Color textures must be [`TextureAspect::All`][TAA].
     ///

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -78,13 +78,13 @@ strict_asserts = ["wgc?/strict_asserts", "wgt/strict_asserts"]
 ## Log all API entry points at info instead of trace level.
 api_log_info = ["wgc/api_log_info"]
 
-## serde
+## Enables serde functionality on common wgpu types.
 serde = ["serialize", "deserialize", "wgc/serde"]
 
-## serialize
+## Enables serialize functionality on common wgpu types.
 serialize = ["dep:serde", "wgc/serialize"]
 
-## deserialize
+## Enables deserialize functionality on common wgpu types.
 deserialize = ["dep:serde", "wgc/deserialize"]
 
 ## Allow writing of trace capture files.

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -78,13 +78,22 @@ strict_asserts = ["wgc?/strict_asserts", "wgt/strict_asserts"]
 ## Log all API entry points at info instead of trace level.
 api_log_info = ["wgc/api_log_info"]
 
+## serde
+serde = ["serialize", "deserialize", "wgc/serde"]
+
+## serialize
+serialize = ["dep:serde", "wgc/serialize"]
+
+## deserialize
+deserialize = ["dep:serde", "wgc/deserialize"]
+
 ## Allow writing of trace capture files.
 ## See [`Adapter::request_device`].
-trace = ["serde", "wgc/trace"]
+trace = ["serialize", "wgc/trace"]
 
 ## Allow deserializing of trace capture files that were written with the `trace` feature.
 ## To replay a trace file use the [wgpu player](https://github.com/gfx-rs/wgpu/tree/trunk/player).
-replay = ["serde", "wgc/replay"]
+replay = ["deserialize", "wgc/replay"]
 
 #! ### Other
 # --------------------------------------------------------------------

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -78,7 +78,7 @@ strict_asserts = ["wgc?/strict_asserts", "wgt/strict_asserts"]
 ## Log all API entry points at info instead of trace level.
 api_log_info = ["wgc/api_log_info"]
 
-## Enables serde functionality on common wgpu types.
+## Enables serialization via `serde` on common wgpu types.
 serde = ["dep:serde", "wgc/serde"]
 
 ## Allow writing of trace capture files.

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -79,21 +79,15 @@ strict_asserts = ["wgc?/strict_asserts", "wgt/strict_asserts"]
 api_log_info = ["wgc/api_log_info"]
 
 ## Enables serde functionality on common wgpu types.
-serde = ["serialize", "deserialize", "wgc/serde"]
-
-## Enables serialize functionality on common wgpu types.
-serialize = ["dep:serde", "wgc/serialize"]
-
-## Enables deserialize functionality on common wgpu types.
-deserialize = ["dep:serde", "wgc/deserialize"]
+serde = ["dep:serde", "wgc/serde"]
 
 ## Allow writing of trace capture files.
 ## See [`Adapter::request_device`].
-trace = ["serialize", "wgc/trace"]
+trace = ["serde", "wgc/trace"]
 
 ## Allow deserializing of trace capture files that were written with the `trace` feature.
 ## To replay a trace file use the [wgpu player](https://github.com/gfx-rs/wgpu/tree/trunk/player).
-replay = ["deserialize", "wgc/replay"]
+replay = ["serde", "wgc/replay"]
 
 #! ### Other
 # --------------------------------------------------------------------

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -37,7 +37,7 @@
 //! - **`strict_asserts`** --- Apply run-time checks, even in release builds. These are in addition
 //!   to the validation carried out at public APIs in all builds.
 //! - **`api_log_info`** --- Log all API entry points at info instead of trace level.
-//! - **`serde`** --- Enables serde functionality on common wgpu types.
+//! - **`serde`** --- Enables serialization via `serde` on common wgpu types.
 //! - **`trace`** --- Allow writing of trace capture files. See [`Adapter::request_device`].
 //! - **`replay`** --- Allow deserializing of trace capture files that were written with the `trace`
 //!   feature. To replay a trace file use the [wgpu

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -38,8 +38,6 @@
 //!   to the validation carried out at public APIs in all builds.
 //! - **`api_log_info`** --- Log all API entry points at info instead of trace level.
 //! - **`serde`** --- Enables serde functionality on common wgpu types.
-//! - **`serialize`** ---Enables serialize functionality on common wgpu types.
-//! - **`deserialize`** --- Enables deserialize functionality on common wgpu types.
 //! - **`trace`** --- Allow writing of trace capture files. See [`Adapter::request_device`].
 //! - **`replay`** --- Allow deserializing of trace capture files that were written with the `trace`
 //!   feature. To replay a trace file use the [wgpu
@@ -1118,8 +1116,7 @@ static_assertions::assert_impl_all!(BufferBinding<'_>: Send, Sync);
 /// Corresponds to [WebGPU `GPULoadOp`](https://gpuweb.github.io/gpuweb/#enumdef-gpuloadop),
 /// plus the corresponding clearValue.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LoadOp<V> {
     /// Loads the specified value for this attachment into the render pass.
     ///
@@ -1146,8 +1143,7 @@ impl<V: Default> Default for LoadOp<V> {
 ///
 /// Corresponds to [WebGPU `GPUStoreOp`](https://gpuweb.github.io/gpuweb/#enumdef-gpustoreop).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Default)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StoreOp {
     /// Stores the resulting value of the render pass for this attachment.
     #[default]
@@ -1169,8 +1165,7 @@ pub enum StoreOp {
 /// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
 /// separate `loadOp` and `storeOp` fields are used instead.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Operations<V> {
     /// How data should be read through this attachment.
     pub load: LoadOp<V>,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1115,8 +1115,8 @@ static_assertions::assert_impl_all!(BufferBinding<'_>: Send, Sync);
 /// Corresponds to [WebGPU `GPULoadOp`](https://gpuweb.github.io/gpuweb/#enumdef-gpuloadop),
 /// plus the corresponding clearValue.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub enum LoadOp<V> {
     /// Loads the specified value for this attachment into the render pass.
     ///
@@ -1143,8 +1143,8 @@ impl<V: Default> Default for LoadOp<V> {
 ///
 /// Corresponds to [WebGPU `GPUStoreOp`](https://gpuweb.github.io/gpuweb/#enumdef-gpustoreop).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Default)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub enum StoreOp {
     /// Stores the resulting value of the render pass for this attachment.
     #[default]
@@ -1166,8 +1166,8 @@ pub enum StoreOp {
 /// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
 /// separate `loadOp` and `storeOp` fields are used instead.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "trace", derive(serde::Serialize))]
-#[cfg_attr(feature = "replay", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct Operations<V> {
     /// How data should be read through this attachment.
     pub load: LoadOp<V>,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -37,6 +37,9 @@
 //! - **`strict_asserts`** --- Apply run-time checks, even in release builds. These are in addition
 //!   to the validation carried out at public APIs in all builds.
 //! - **`api_log_info`** --- Log all API entry points at info instead of trace level.
+//! - **`serde`** --- Enables serde functionality on common wgpu types.
+//! - **`serialize`** ---Enables serialize functionality on common wgpu types.
+//! - **`deserialize`** --- Enables deserialize functionality on common wgpu types.
 //! - **`trace`** --- Allow writing of trace capture files. See [`Adapter::request_device`].
 //! - **`replay`** --- Allow deserializing of trace capture files that were written with the `trace`
 //!   feature. To replay a trace file use the [wgpu


### PR DESCRIPTION
**Connections**
#3609

**Description**
Allows using feature `serde` on `wgpu`, `wgpu-core` and `wgpu-types`.
`wgpu-types` no longer has `trace` and `replay` features, but an implicit `serde` feature.
`wgpu-core` has an explicit `serde` feature and removes the `serial-pass` feature.
`wgpu` now has an explicit `serde` feature.

Almost all occurrences of `cfg_attr(feature = "trace")` and `cfg_attr(feature = "replay")` have been replaced with `cfg_attr(feature = "serialize")` and `cfg_attr(feature = "deserialize")` respectively.
For `wgpu` and `wgpu-core` the usage for `trace` and `replay`  should not have changed. If you are using `serial-pass` you should use `serde` instead. For `wgpu-types` if you have previously enabled the `trace` or `replay` feature you need to migrate to `serde`.

**Testing**
`cargo test --package <package> --features <feature>`
for the following packages: `wgpu-types`, `wgpu-core`, `wgpu`
for the following features: `"None"`, `serde`, (`trace`, `replay`)[if available] [*no combinations]

**Compile timings**
Comparing 273684f1b with f748c43 on debug.
With default features takes about 25 sec.
With serde takes around the same time (38 sec).
With deserialize (on first commit) takes about the same amount of time (38 sec).
With serialize takes about 27 sec.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten` (fails somewhere in winit)
- [x] Run `cargo xtask test` to run tests. (yes, and it fails in some places, no sure what to do with the results)
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
