### PR TITLE
Refactor tests to be feature flag bit-width agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Bottom level categories:
 #### Tests
 
 - Fix intermittent crashes on Linux in the `multithreaded_compute` test. By @jimblandy in [#5129](https://github.com/gfx-rs/wgpu/pull/5129).
+- Refactor tests to read feature flags by name instead of a hardcoded hexadecimal u64. By @rodolphito in [#5155](https://github.com/gfx-rs/wgpu/pull/5155).
 
 ## v0.19.0 (2024-01-17)
 
@@ -193,7 +194,7 @@ let surface = instance.create_surface(my_window.clone())?;
 ```
 
 All platform specific surface creation using points have moved into `SurfaceTargetUnsafe` as well.
-For example: 
+For example:
 
 Safety by @daxpedda in [#4597](https://github.com/gfx-rs/wgpu/pull/4597)
 Unification by @wumpf in [#4984](https://github.com/gfx-rs/wgpu/pull/4984)

--- a/player/tests/data/bind-group.ron
+++ b/player/tests/data/bind-group.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0,
+    features: [],
     expectations: [], //not crash!
     actions: [
         CreateBuffer(Id(0, 1, Empty), (

--- a/player/tests/data/buffer-copy.ron
+++ b/player/tests/data/buffer-copy.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0000_0004_0000_0000, // MAPPABLE_PRIMARY_BUFFERS
+    features: ["MAPPABLE_PRIMARY_BUFFERS"],
     expectations: [
         (
             name: "basic",

--- a/player/tests/data/clear-buffer-texture.ron
+++ b/player/tests/data/clear-buffer-texture.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0004_0004_0000_0000, // MAPPABLE_PRIMARY_BUFFERS | CLEAR_TEXTURE
+    features: ["MAPPABLE_PRIMARY_BUFFERS", "CLEAR_TEXTURE"],
     expectations: [
         (
             name: "Quad",

--- a/player/tests/data/pipeline-statistics-query.ron
+++ b/player/tests/data/pipeline-statistics-query.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0000_0005_0000_0000, // MAPPABLE_PRIMARY_BUFFERS | PIPELINE_STATISTICS_QUERY
+    features: ["MAPPABLE_PRIMARY_BUFFERS", "PIPELINE_STATISTICS_QUERY"],
     expectations: [
         (
             name: "Queried number of compute invocations is correct",

--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0,
+    features: [],
     expectations: [
         (
             name: "Quad",

--- a/player/tests/data/zero-init-buffer.ron
+++ b/player/tests/data/zero-init-buffer.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0000_0004_0000_0000, // MAPPABLE_PRIMARY_BUFFERS
+    features: ["MAPPABLE_PRIMARY_BUFFERS"],
     expectations: [
         // Ensuring that mapping zero-inits buffers.
         (

--- a/player/tests/data/zero-init-texture-binding.ron
+++ b/player/tests/data/zero-init-texture-binding.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0,
+    features: [],
     expectations: [
         (
             name: "Sampled Texture",
@@ -56,7 +56,7 @@
             format: "rgba8unorm",
             usage: 9, // STORAGE + COPY_SRC
             view_formats: [],
-        )),        
+        )),
         CreateTextureView(
             id: Id(1, 1, Empty),
             parent_id: Id(1, 1, Empty),

--- a/player/tests/data/zero-init-texture-copytobuffer.ron
+++ b/player/tests/data/zero-init-texture-copytobuffer.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0,
+    features: [],
     expectations: [
         (
             name: "Copy to Buffer",

--- a/player/tests/data/zero-init-texture-rendertarget.ron
+++ b/player/tests/data/zero-init-texture-rendertarget.ron
@@ -1,5 +1,5 @@
 (
-    features: 0x0,
+    features: [],
     expectations: [
         (
             name: "Render Target",


### PR DESCRIPTION
**Connections**
Part of an incoming series of PRs needed by #5123
Others in this series: #5154
Ultimately for bevy meshlets pipeline https://github.com/bevyengine/bevy/pull/10164

**Description**
Refactor tests to be feature flag bit-width agnostic. This is to make it possible to easily change Features from u64 to u128 in the future. This will be needed because we are out of feature flag space to add new ones.

**Testing**
This only affects existing tests, and the tests still pass.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
