### PR TITLE
Fix the validation for vertex limits for regular render passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Bottom level categories:
 #### General
 - Fix `panic!` when dropping `Instance` without `InstanceFlags::VALIDATION`. By @hakolao in [#5134](https://github.com/gfx-rs/wgpu/pull/5134)
 - Fix `serde` feature not compiling for `wgpu-types`. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
+- Fix the validation of vertex and index ranges. By @nical in [#5144](https://github.com/gfx-rs/wgpu/pull/5144) and [#5156](https://github.com/gfx-rs/wgpu/pull/5156)
 
 #### WGL
 


### PR DESCRIPTION
**Connections**

Similar to #5144 but for regular render passes instead of bundles.

**Description**

The previous validation:
- was skipped when the vertex stride was 0,
- did not take the "last stride" (size of the last vertex) into account.

This test fixes both problems while (unlike #5144) staying in the spirit of how the validation was implemented (presumably for performance reasons) instead of sticking to how it is described in the specification.

**Testing**

Covered by the CTS.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
