### PR TITLE
Add support for f64 in vertex format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,9 +1558,8 @@ checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
 
 [[package]]
 name = "glow"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+version = "0.13.0"
+source = "git+https://github.com/grovesNL/glow.git#e4a9a702111c425abdf9febef3ec2f2ce4822c26"
 dependencies = [
  "js-sys",
  "slotmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ hassle-rs = "0.11.0"
 
 # Gles dependencies
 khronos-egl = "6"
-glow = "0.13.1"
+glow = { git = "https://github.com/grovesNL/glow.git" }
 glutin = "0.29.1"
 
 # wasm32 dependencies

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -105,7 +105,7 @@ rustc-hash = "1.1"
 log = "0.4"
 
 # backend: Gles
-glow = { version = "0.13.1", optional = true }
+glow = { git = "https://github.com/grovesNL/glow.git", optional = true }
 
 [dependencies.wgt]
 package = "wgpu-types"

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -574,9 +574,15 @@ impl super::Adapter {
                 || extensions.contains("GL_EXT_color_buffer_float")
                 || extensions.contains("OES_texture_float_linear"),
         );
-
-        if es_ver.is_none() {
-            features |= wgt::Features::POLYGON_MODE_LINE | wgt::Features::POLYGON_MODE_POINT;
+        features.set(
+            wgt::Features::POLYGON_MODE_LINE | wgt::Features::POLYGON_MODE_POINT,
+            full_ver.is_some(),
+        );
+        if let Some(full_ver) = full_ver {
+            features.set(
+                wgt::Features::VERTEX_ATTRIBUTE_64BIT | wgt::Features::SHADER_F64,
+                full_ver >= (4, 1),
+            );
         }
 
         // We *might* be able to emulate bgra8unorm-storage but currently don't attempt to.

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -213,7 +213,10 @@ pub(super) fn describe_vertex_format(vertex_format: wgt::VertexFormat) -> super:
         Vf::Sint32x4 => (4, glow::INT, Vak::Integer),
         Vf::Float32x4 => (4, glow::FLOAT, Vak::Float),
         Vf::Unorm10_10_10_2 => (4, glow::UNSIGNED_INT_10_10_10_2, Vak::Float),
-        Vf::Float64 | Vf::Float64x2 | Vf::Float64x3 | Vf::Float64x4 => unimplemented!(),
+        Vf::Float64 => (1, glow::DOUBLE, Vak::Double),
+        Vf::Float64x2 => (2, glow::DOUBLE, Vak::Double),
+        Vf::Float64x3 => (3, glow::DOUBLE, Vak::Double),
+        Vf::Float64x4 => (4, glow::DOUBLE, Vak::Double),
     };
 
     super::VertexFormatDesc {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -224,9 +224,9 @@ type BindTarget = u32;
 
 #[derive(Debug, Clone, Copy)]
 enum VertexAttribKind {
-    Float, // glVertexAttribPointer
+    Float,   // glVertexAttribPointer
     Integer, // glVertexAttribIPointer
-           //Double,  // glVertexAttribLPointer
+    Double,  // glVertexAttribLPointer
 }
 
 impl Default for VertexAttribKind {

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1227,6 +1227,14 @@ impl super::Queue {
                                 vat.offset,
                             )
                         },
+                        super::VertexAttribKind::Double => unsafe {
+                            gl.vertex_attrib_format_f64(
+                                vat.location,
+                                vat.format_desc.element_count,
+                                vat.format_desc.element_format,
+                                vat.offset,
+                            )
+                        },
                     }
 
                     //Note: there is apparently a bug on AMD 3500U:
@@ -1246,6 +1254,15 @@ impl super::Queue {
                         },
                         super::VertexAttribKind::Integer => unsafe {
                             gl.vertex_attrib_pointer_i32(
+                                vat.location,
+                                vat.format_desc.element_count,
+                                vat.format_desc.element_format,
+                                buffer_desc.stride as i32,
+                                vat.offset as i32,
+                            )
+                        },
+                        super::VertexAttribKind::Double => unsafe {
+                            gl.vertex_attrib_pointer_f64(
                                 vat.location,
                                 vat.format_desc.element_count,
                                 vat.format_desc.element_format,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -477,7 +477,8 @@ impl PhysicalDeviceFeatures {
             | F::TIMESTAMP_QUERY_INSIDE_ENCODERS
             | F::TIMESTAMP_QUERY_INSIDE_PASSES
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | F::CLEAR_TEXTURE;
+            | F::CLEAR_TEXTURE
+            | F::VERTEX_ATTRIBUTE_64BIT;
 
         let mut dl_flags = Df::COMPUTE_SHADERS
             | Df::BASE_VERTEX


### PR DESCRIPTION
**Connections**
GL depends on https://github.com/grovesNL/glow/pull/275
https://github.com/gpuweb/gpuweb/issues/2805

**Description**
At the moment no backend seems to support f64 in vertex formats (even Vulkan). This pr tries to implement f64 for all backends except metal.

**Testing**

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
