### PR TITLE
ci: Update to macos-14, xlarge runner is no longer needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,18 +92,18 @@ jobs:
 
           # MacOS
           - name: MacOS x86_64
-            os: macos-12
+            os: macos-14
             target: x86_64-apple-darwin
             kind: native
 
           - name: MacOS aarch64
-            os: macos-12
+            os: macos-14
             target: aarch64-apple-darwin
             kind: native
 
           # IOS
           - name: IOS aarch64
-            os: macos-12
+            os: macos-14
             target: aarch64-apple-ios
             kind: native
 
@@ -249,7 +249,7 @@ jobs:
 
           # MacOS
           - name: MacOS x86_64
-            os: macos-12
+            os: macos-14
             target: x86_64-apple-darwin
 
           # Linux
@@ -383,7 +383,7 @@ jobs:
 
           # Mac
           - name: Mac aarch64
-            os: macos-13-xlarge
+            os: macos-14
 
           # Linux
           - name: Linux x86_64

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -62,7 +62,7 @@ jobs:
 
   naga-validate-macos:
     name: "Validate: MSL"
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
**Connections**
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

**Description**
The new macos-14 runner seems to be equivalent to macos-13-xlarge, save for less CPU cores. However it's faster than 13 (seemingly), so that might be okay.

It's not documented to have a GPU - but it does, and seems to run tests fine. @cwfitzgerald suggested to try and switch :D

Clippy macos goes from nearly 11m to 4m
GPU test macos goes from 2m to 3m. But it's free now!

**Testing**
n/a

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
