### PR TITLE
Fix panic when creating a surface while no backend is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Bottom level categories:
 - Fix `panic!` when dropping `Instance` without `InstanceFlags::VALIDATION`. By @hakolao in [#5134](https://github.com/gfx-rs/wgpu/pull/5134)
 - Fix `serde` feature not compiling for `wgpu-types`. By @KirmesBude in [#5149](https://github.com/gfx-rs/wgpu/pull/5149)
 - Fix the validation of vertex and index ranges. By @nical in [#5144](https://github.com/gfx-rs/wgpu/pull/5144) and [#5156](https://github.com/gfx-rs/wgpu/pull/5156)
+- Fix panic when creating a surface while no backend is available. By @wumpf [#5166](https://github.com/gfx-rs/wgpu/pull/5166)
 
 #### WGL
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2812,7 +2812,7 @@ pub struct CreateSurfaceError {
 enum CreateSurfaceErrorKind {
     /// Error from [`wgpu_hal`].
     #[cfg(wgpu_core)]
-    Hal(hal::InstanceError),
+    Hal(wgc::instance::CreateSurfaceError),
 
     /// Error from WebGPU surface creation.
     #[allow(dead_code)] // may be unused depending on target and features
@@ -2847,8 +2847,8 @@ impl error::Error for CreateSurfaceError {
 }
 
 #[cfg(wgpu_core)]
-impl From<hal::InstanceError> for CreateSurfaceError {
-    fn from(e: hal::InstanceError) -> Self {
+impl From<wgc::instance::CreateSurfaceError> for CreateSurfaceError {
+    fn from(e: wgc::instance::CreateSurfaceError) -> Self {
         Self {
             inner: CreateSurfaceErrorKind::Hal(e),
         }


### PR DESCRIPTION
**Connections**
connected to 
* https://github.com/gfx-rs/wgpu/pull/4984

at first I thought I introduced the unwrap, but [it was already there](https://github.com/gfx-rs/wgpu/pull/4984/files#diff-1b40237cc7b42c2140c93d8910af3cb74461441d611f1db3f69e81617229eccbL539) (still guilty, why did I not forsee this -.-)

**Description**
Fixes crash via unwrap when trying to create a surface on an instance that has no workable backend availble (e.g. try to create a surface when an instance is limited to dx12 on a metal device)

**Testing**
It compiles and there's an `unwrap` less!

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
