### PR TITLE
Update docs for `Backend` and implement `std::fmt::Display`

### DIFF
--- a/tests/src/image.rs
+++ b/tests/src/image.rs
@@ -183,7 +183,7 @@ pub async fn compare_image_output(
     let file_stem = reference_path.file_stem().unwrap().to_string_lossy();
     let renderer = format!(
         "{}-{}-{}",
-        adapter_info.backend.to_str(),
+        adapter_info.backend,
         sanitize_for_path(&adapter_info.name),
         sanitize_for_path(&adapter_info.driver)
     );

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -104,7 +104,7 @@ pub enum Backend {
     Metal = 2,
     /// Direct3D-12 (Windows)
     Dx12 = 3,
-    /// OpenGL ES-3 (Linux, Android, WebGL, Windows, MacOS via Angle)
+    /// OpenGL 3.3+ (Windows), OpenGL ES 3.0+ (Linux, Android, MacOS via Angle), and WebGL2
     Gl = 4,
     /// WebGPU in the browser
     BrowserWebGpu = 5,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -98,13 +98,13 @@ pub const QUERY_SIZE: u32 = 8;
 pub enum Backend {
     /// Dummy backend, used for testing.
     Empty = 0,
-    /// Vulkan API
+    /// Vulkan API (Windows, Linux, Android, MacOS via `vulkan-portability`/MoltenVK)
     Vulkan = 1,
     /// Metal API (Apple platforms)
     Metal = 2,
     /// Direct3D-12 (Windows)
     Dx12 = 3,
-    /// OpenGL ES-3 (Linux, Android)
+    /// OpenGL ES-3 (Linux, Android, WebGL, Windows, MacOS via Angle)
     Gl = 4,
     /// WebGPU in the browser
     BrowserWebGpu = 5,
@@ -112,7 +112,7 @@ pub enum Backend {
 
 impl Backend {
     /// Returns the string name of the backend.
-    pub fn to_str(self) -> &'static str {
+    pub const fn to_str(self) -> &'static str {
         match self {
             Backend::Empty => "empty",
             Backend::Vulkan => "vulkan",
@@ -121,6 +121,12 @@ impl Backend {
             Backend::Gl => "gl",
             Backend::BrowserWebGpu => "webgpu",
         }
+    }
+}
+
+impl std::fmt::Display for Backend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.to_str())
     }
 }
 


### PR DESCRIPTION
**Connections**
n/a

**Description**
kept `to_str` and made it `const` because why not

**Testing**
uhm.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- ~[ ] Add change to `CHANGELOG.md`. See simple instructions inside file.~ too trivial
