### PR TITLE
using non alpha channeled texture

### DIFF
--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -115,12 +115,7 @@ impl super::AdapterShared {
                 glow::RGBA,
                 0,
             ),
-            Tf::Etc2Rgba8Unorm => (
-                //TODO: this is a lie, it's not sRGB
-                glow::COMPRESSED_SRGB8_ALPHA8_ETC2_EAC,
-                glow::RGBA,
-                0,
-            ),
+            Tf::Etc2Rgba8Unorm => (glow::COMPRESSED_RGBA8_ETC2_EAC, glow::RGBA, 0),
             Tf::Etc2Rgba8UnormSrgb => (glow::COMPRESSED_SRGB8_ALPHA8_ETC2_EAC, glow::RGBA, 0),
             Tf::EacR11Unorm => (glow::COMPRESSED_R11_EAC, glow::RED, 0),
             Tf::EacR11Snorm => (glow::COMPRESSED_SIGNED_R11_EAC, glow::RED, 0),


### PR DESCRIPTION
**Connections**
resolves https://github.com/gfx-rs/wgpu/issues/3824

**Description**
Textures appear darker when using the alpha channeled texture

**Testing**

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
