### PR TITLE
Remove another unused A: HalApi parameter

### DIFF
--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -109,7 +109,7 @@ impl<A: HalApi> BufferBindGroupState<A> {
 pub(crate) struct BufferUsageScope<A: HalApi> {
     state: Vec<BufferUses>,
 
-    metadata: ResourceMetadata<A, Buffer<A>>,
+    metadata: ResourceMetadata<Buffer<A>>,
 }
 
 impl<A: HalApi> BufferUsageScope<A> {
@@ -287,7 +287,7 @@ pub(crate) struct BufferTracker<A: HalApi> {
     start: Vec<BufferUses>,
     end: Vec<BufferUses>,
 
-    metadata: ResourceMetadata<A, Buffer<A>>,
+    metadata: ResourceMetadata<Buffer<A>>,
 
     temp: Vec<PendingTransition<BufferUses>>,
 }
@@ -653,11 +653,11 @@ impl BufferStateProvider<'_> {
 unsafe fn insert_or_merge<A: HalApi>(
     start_states: Option<&mut [BufferUses]>,
     current_states: &mut [BufferUses],
-    resource_metadata: &mut ResourceMetadata<A, Buffer<A>>,
+    resource_metadata: &mut ResourceMetadata<Buffer<A>>,
     index32: u32,
     index: usize,
     state_provider: BufferStateProvider<'_>,
-    metadata_provider: ResourceMetadataProvider<'_, A, Buffer<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Buffer<A>>,
 ) -> Result<(), UsageConflict> {
     let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
 
@@ -708,11 +708,11 @@ unsafe fn insert_or_merge<A: HalApi>(
 unsafe fn insert_or_barrier_update<A: HalApi>(
     start_states: Option<&mut [BufferUses]>,
     current_states: &mut [BufferUses],
-    resource_metadata: &mut ResourceMetadata<A, Buffer<A>>,
+    resource_metadata: &mut ResourceMetadata<Buffer<A>>,
     index: usize,
     start_state_provider: BufferStateProvider<'_>,
     end_state_provider: Option<BufferStateProvider<'_>>,
-    metadata_provider: ResourceMetadataProvider<'_, A, Buffer<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Buffer<A>>,
     barriers: &mut Vec<PendingTransition<BufferUses>>,
 ) {
     let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
@@ -742,11 +742,11 @@ unsafe fn insert_or_barrier_update<A: HalApi>(
 unsafe fn insert<A: HalApi>(
     start_states: Option<&mut [BufferUses]>,
     current_states: &mut [BufferUses],
-    resource_metadata: &mut ResourceMetadata<A, Buffer<A>>,
+    resource_metadata: &mut ResourceMetadata<Buffer<A>>,
     index: usize,
     start_state_provider: BufferStateProvider<'_>,
     end_state_provider: Option<BufferStateProvider<'_>>,
-    metadata_provider: ResourceMetadataProvider<'_, A, Buffer<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Buffer<A>>,
 ) {
     let new_start_state = unsafe { start_state_provider.get_state(index) };
     let new_end_state =
@@ -776,7 +776,7 @@ unsafe fn merge<A: HalApi>(
     index32: u32,
     index: usize,
     state_provider: BufferStateProvider<'_>,
-    metadata_provider: ResourceMetadataProvider<'_, A, Buffer<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Buffer<A>>,
 ) -> Result<(), UsageConflict> {
     let current_state = unsafe { current_states.get_unchecked_mut(index) };
     let new_state = unsafe { state_provider.get_state(index) };

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -1,8 +1,8 @@
 //! The `ResourceMetadata` type.
 
-use crate::{hal_api::HalApi, resource::Resource, Epoch};
+use crate::{resource::Resource, Epoch};
 use bit_vec::BitVec;
-use std::{borrow::Cow, marker::PhantomData, mem, sync::Arc};
+use std::{borrow::Cow, mem, sync::Arc};
 use wgt::strict_assert;
 
 /// A set of resources, holding a `Arc<T>` and epoch for each member.
@@ -13,23 +13,19 @@ use wgt::strict_assert;
 /// members, but a bit vector tracks occupancy, so iteration touches
 /// only occupied elements.
 #[derive(Debug)]
-pub(super) struct ResourceMetadata<A: HalApi, T: Resource> {
+pub(super) struct ResourceMetadata<T: Resource> {
     /// If the resource with index `i` is a member, `owned[i]` is `true`.
     owned: BitVec<usize>,
 
     /// A vector holding clones of members' `T`s.
     resources: Vec<Option<Arc<T>>>,
-
-    /// This tells Rust that this type should be covariant with `A`.
-    _phantom: PhantomData<A>,
 }
 
-impl<A: HalApi, T: Resource> ResourceMetadata<A, T> {
+impl<T: Resource> ResourceMetadata<T> {
     pub(super) fn new() -> Self {
         Self {
             owned: BitVec::default(),
             resources: Vec::new(),
-            _phantom: PhantomData,
         }
     }
 
@@ -172,15 +168,13 @@ impl<A: HalApi, T: Resource> ResourceMetadata<A, T> {
 ///
 /// This is used to abstract over the various places
 /// trackers can get new resource metadata from.
-pub(super) enum ResourceMetadataProvider<'a, A: HalApi, T: Resource> {
+pub(super) enum ResourceMetadataProvider<'a, T: Resource> {
     /// Comes directly from explicit values.
     Direct { resource: Cow<'a, Arc<T>> },
     /// Comes from another metadata tracker.
-    Indirect {
-        metadata: &'a ResourceMetadata<A, T>,
-    },
+    Indirect { metadata: &'a ResourceMetadata<T> },
 }
-impl<A: HalApi, T: Resource> ResourceMetadataProvider<'_, A, T> {
+impl<T: Resource> ResourceMetadataProvider<'_, T> {
     /// Get the epoch and an owned refcount from this.
     ///
     /// # Safety

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -352,9 +352,9 @@ pub(crate) struct RenderBundleScope<A: HalApi> {
     pub buffers: RwLock<BufferUsageScope<A>>,
     pub textures: RwLock<TextureUsageScope<A>>,
     // Don't need to track views and samplers, they are never used directly, only by bind groups.
-    pub bind_groups: RwLock<StatelessTracker<A, binding_model::BindGroup<A>>>,
-    pub render_pipelines: RwLock<StatelessTracker<A, pipeline::RenderPipeline<A>>>,
-    pub query_sets: RwLock<StatelessTracker<A, resource::QuerySet<A>>>,
+    pub bind_groups: RwLock<StatelessTracker<binding_model::BindGroup<A>>>,
+    pub render_pipelines: RwLock<StatelessTracker<pipeline::RenderPipeline<A>>>,
+    pub query_sets: RwLock<StatelessTracker<resource::QuerySet<A>>>,
 }
 
 impl<A: HalApi> RenderBundleScope<A> {
@@ -489,13 +489,13 @@ where
 pub(crate) struct Tracker<A: HalApi> {
     pub buffers: BufferTracker<A>,
     pub textures: TextureTracker<A>,
-    pub views: StatelessTracker<A, resource::TextureView<A>>,
-    pub samplers: StatelessTracker<A, resource::Sampler<A>>,
-    pub bind_groups: StatelessTracker<A, binding_model::BindGroup<A>>,
-    pub compute_pipelines: StatelessTracker<A, pipeline::ComputePipeline<A>>,
-    pub render_pipelines: StatelessTracker<A, pipeline::RenderPipeline<A>>,
-    pub bundles: StatelessTracker<A, command::RenderBundle<A>>,
-    pub query_sets: StatelessTracker<A, resource::QuerySet<A>>,
+    pub views: StatelessTracker<resource::TextureView<A>>,
+    pub samplers: StatelessTracker<resource::Sampler<A>>,
+    pub bind_groups: StatelessTracker<binding_model::BindGroup<A>>,
+    pub compute_pipelines: StatelessTracker<pipeline::ComputePipeline<A>>,
+    pub render_pipelines: StatelessTracker<pipeline::RenderPipeline<A>>,
+    pub bundles: StatelessTracker<command::RenderBundle<A>>,
+    pub query_sets: StatelessTracker<resource::QuerySet<A>>,
 }
 
 impl<A: HalApi> Tracker<A> {

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -8,10 +8,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
-use crate::{
-    hal_api::HalApi, id::Id, resource::Resource, resource_log, storage::Storage,
-    track::ResourceMetadata,
-};
+use crate::{id::Id, resource::Resource, resource_log, storage::Storage, track::ResourceMetadata};
 
 use super::ResourceTracker;
 
@@ -73,11 +70,11 @@ impl<T: Resource> StatelessBindGroupSate<T> {
 
 /// Stores all resource state within a command buffer or device.
 #[derive(Debug)]
-pub(crate) struct StatelessTracker<A: HalApi, T: Resource> {
-    metadata: ResourceMetadata<A, T>,
+pub(crate) struct StatelessTracker<T: Resource> {
+    metadata: ResourceMetadata<T>,
 }
 
-impl<A: HalApi, T: Resource> ResourceTracker<T> for StatelessTracker<A, T> {
+impl<T: Resource> ResourceTracker<T> for StatelessTracker<T> {
     /// Try to remove the given resource from the tracker iff we have the last reference to the
     /// resource and the epoch matches.
     ///
@@ -120,7 +117,7 @@ impl<A: HalApi, T: Resource> ResourceTracker<T> for StatelessTracker<A, T> {
     }
 }
 
-impl<A: HalApi, T: Resource> StatelessTracker<A, T> {
+impl<T: Resource> StatelessTracker<T> {
     pub fn new() -> Self {
         Self {
             metadata: ResourceMetadata::new(),

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -231,7 +231,7 @@ impl TextureStateSet {
 #[derive(Debug)]
 pub(crate) struct TextureUsageScope<A: HalApi> {
     set: TextureStateSet,
-    metadata: ResourceMetadata<A, Texture<A>>,
+    metadata: ResourceMetadata<Texture<A>>,
 }
 
 impl<A: HalApi> TextureUsageScope<A> {
@@ -386,7 +386,7 @@ pub(crate) struct TextureTracker<A: HalApi> {
     start_set: TextureStateSet,
     end_set: TextureStateSet,
 
-    metadata: ResourceMetadata<A, Texture<A>>,
+    metadata: ResourceMetadata<Texture<A>>,
 
     temp: Vec<PendingTransition<TextureUses>>,
 
@@ -863,10 +863,10 @@ impl<'a> TextureStateProvider<'a> {
 unsafe fn insert_or_merge<A: HalApi>(
     texture_selector: &TextureSelector,
     current_state_set: &mut TextureStateSet,
-    resource_metadata: &mut ResourceMetadata<A, Texture<A>>,
+    resource_metadata: &mut ResourceMetadata<Texture<A>>,
     index: usize,
     state_provider: TextureStateProvider<'_>,
-    metadata_provider: ResourceMetadataProvider<'_, A, Texture<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Texture<A>>,
 ) -> Result<(), UsageConflict> {
     let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
 
@@ -919,11 +919,11 @@ unsafe fn insert_or_barrier_update<A: HalApi>(
     texture_selector: &TextureSelector,
     start_state: Option<&mut TextureStateSet>,
     current_state_set: &mut TextureStateSet,
-    resource_metadata: &mut ResourceMetadata<A, Texture<A>>,
+    resource_metadata: &mut ResourceMetadata<Texture<A>>,
     index: usize,
     start_state_provider: TextureStateProvider<'_>,
     end_state_provider: Option<TextureStateProvider<'_>>,
-    metadata_provider: ResourceMetadataProvider<'_, A, Texture<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Texture<A>>,
     barriers: &mut Vec<PendingTransition<TextureUses>>,
 ) {
     let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
@@ -972,11 +972,11 @@ unsafe fn insert<A: HalApi>(
     texture_selector: Option<&TextureSelector>,
     start_state: Option<&mut TextureStateSet>,
     end_state: &mut TextureStateSet,
-    resource_metadata: &mut ResourceMetadata<A, Texture<A>>,
+    resource_metadata: &mut ResourceMetadata<Texture<A>>,
     index: usize,
     start_state_provider: TextureStateProvider<'_>,
     end_state_provider: Option<TextureStateProvider<'_>>,
-    metadata_provider: ResourceMetadataProvider<'_, A, Texture<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Texture<A>>,
 ) {
     let start_layers = unsafe { start_state_provider.get_state(texture_selector, index) };
     match start_layers {
@@ -1059,7 +1059,7 @@ unsafe fn merge<A: HalApi>(
     current_state_set: &mut TextureStateSet,
     index: usize,
     state_provider: TextureStateProvider<'_>,
-    metadata_provider: ResourceMetadataProvider<'_, A, Texture<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Texture<A>>,
 ) -> Result<(), UsageConflict> {
     let current_simple = unsafe { current_state_set.simple.get_unchecked_mut(index) };
     let current_state = if *current_simple == TextureUses::COMPLEX {


### PR DESCRIPTION
This removes two more instances that follows from the identifier refactoring (#5108) where we're not actually using the `HalApi` parameter. This changes nothing in terms of codegen, but there's little to no point in keeping unused type complexity around.