### PR TITLE
Always serialize and deserialize ids the same way

### DIFF
--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -19,10 +19,16 @@ pub const EPOCH_MASK: u32 = (1 << (EPOCH_BITS)) - 1;
 
 /// The raw underlying representation of an identifier.
 #[repr(transparent)]
-#[cfg_attr(any(feature = "serde", feature = "trace"), derive(serde::Serialize))]
-#[cfg_attr(any(feature = "serde", feature = "replay"), derive(serde::Deserialize))]
-#[cfg_attr(feature = "trace", serde(into = "SerialId"))]
-#[cfg_attr(feature = "replay", serde(from = "SerialId"))]
+#[cfg_attr(
+    any(feature = "serde", feature = "trace"),
+    derive(serde::Serialize),
+    serde(into = "SerialId")
+)]
+#[cfg_attr(
+    any(feature = "serde", feature = "replay"),
+    derive(serde::Deserialize),
+    serde(from = "SerialId")
+)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RawId(NonZeroId);
 
@@ -129,7 +135,6 @@ enum SerialId {
     Id(Index, Epoch, Backend),
 }
 
-#[cfg(feature = "trace")]
 impl From<RawId> for SerialId {
     fn from(id: RawId) -> Self {
         let (index, epoch, backend) = id.unzip();
@@ -137,7 +142,6 @@ impl From<RawId> for SerialId {
     }
 }
 
-#[cfg(feature = "replay")]
 impl From<SerialId> for RawId {
     fn from(id: SerialId) -> Self {
         match id {


### PR DESCRIPTION
**Description**

`RawId`'s serialization/deserialization currently depends on what cargo features are enabled. If `trace` is enabled it is serialized via the `SerialId` type and if `replay` is enabled it is deserialized from `SerialId`.

This means that if an application serializes and deserializes Ids (like gecko does for some of the remoting), then having only one of `trace` and `replay` features enabled is broken. Firefox only uses the `trace` feature.

For example:

```rust
let id = wgc::id::AdapterId::zip(0, 1, wgt::Backend::Vulkan);
let mut tmp = Vec::new();
bincode::serialize_into(&mut tmp, &id).unwrap();
let de = bincode::deserialize::<wgc::id::AdapterId>(tmp.as_slice()).unwrap(); // Boom.
```

It's unclear why it used to work and only started breaking at the latest update.

With this patch PR, ids are always serialized via `SerialId`. It's probably not what we want long term, but we need the fix rather urgently so it will have to do for now.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
