### PR TITLE
Suggestion to introduce wgpu-sync for lock profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "wgpu-info",
     "wgpu-macros",
     "wgpu-types",
+    "wgpu-sync",
     "wgpu",
 ]
 exclude = []
@@ -56,6 +57,11 @@ version = "0.19.0"
 [workspace.dependencies.wgt]
 package = "wgpu-types"
 path = "./wgpu-types"
+version = "0.19.0"
+
+[workspace.dependencies.wgs]
+package = "wgpu-sync"
+path = "./wgpu-sync"
 version = "0.19.0"
 
 [workspace.dependencies.hal]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -51,7 +51,7 @@ strict_asserts = ["wgt/strict_asserts"]
 serde = ["dep:serde", "wgt/serde", "arrayvec/serde"]
 
 ## Enable API tracing.
-trace = ["ron", "serde", "naga/serialize"]
+trace = ["ron", "serde", "naga/serialize", "wgs/trace"]
 
 ## Enable API replaying
 replay = ["serde", "naga/deserialize"]
@@ -104,8 +104,6 @@ codespan-reporting = "0.11"
 indexmap = "2"
 log = "0.4"
 once_cell = "1"
-# parking_lot 0.12 switches from `winapi` to `windows`; permit either
-parking_lot = ">=0.11,<0.13"
 profiling = { version = "1", default-features = false }
 raw-window-handle = { version = "0.6", optional = true }
 ron = { version = "0.8", optional = true }
@@ -127,6 +125,12 @@ version = "0.19.0"
 [dependencies.hal]
 package = "wgpu-hal"
 path = "../wgpu-hal"
+version = "0.19.0"
+default_features = false
+
+[dependencies.wgs]
+package = "wgpu-sync"
+path = "../wgpu-sync"
 version = "0.19.0"
 default_features = false
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -30,8 +30,8 @@ use crate::track::{Tracker, UsageScope};
 use crate::{api_log, global::Global, hal_api::HalApi, id, resource_log, Label};
 
 use hal::CommandEncoder as _;
-use parking_lot::Mutex;
 use thiserror::Error;
+use wgs::Mutex;
 
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use arrayvec::ArrayVec;
 use hal::Device as _;
-use parking_lot::RwLock;
+use wgs::RwLock;
 
 use wgt::{BufferAddress, TextureFormat};
 

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -21,9 +21,9 @@ use crate::{
 };
 use smallvec::SmallVec;
 
-use parking_lot::Mutex;
 use std::sync::Arc;
 use thiserror::Error;
+use wgs::Mutex;
 
 /// A struct that keeps lists of resources that are no longer needed by the user.
 #[derive(Default)]

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -22,8 +22,8 @@ use crate::{
 };
 
 use hal::{CommandEncoder as _, Device as _, Queue as _};
-use parking_lot::Mutex;
 use smallvec::SmallVec;
+use wgs::Mutex;
 
 use std::{
     iter, mem, ptr,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -36,7 +36,7 @@ use crate::{
 
 use arrayvec::ArrayVec;
 use hal::{CommandEncoder as _, Device as _};
-use parking_lot::{Mutex, MutexGuard, RwLock};
+use wgs::{Mutex, MutexGuard, RwLock};
 
 use smallvec::SmallVec;
 use thiserror::Error;

--- a/wgpu-core/src/identity.rs
+++ b/wgpu-core/src/identity.rs
@@ -1,4 +1,4 @@
-use parking_lot::Mutex;
+use wgs::Mutex;
 use wgt::Backend;
 
 use crate::{

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -13,7 +13,7 @@ use crate::{
     resource_log, LabelHelpers, DOWNLEVEL_WARNING_MESSAGE,
 };
 
-use parking_lot::Mutex;
+use wgs::Mutex;
 use wgt::{Backend, Backends, PowerPreference};
 
 use hal::{Adapter as _, Instance as _, OpenDevice};

--- a/wgpu-core/src/pool.rs
+++ b/wgpu-core/src/pool.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use once_cell::sync::OnceCell;
-use parking_lot::Mutex;
+use wgs::Mutex;
 
 use crate::{PreHashedKey, PreHashedMap};
 

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -30,8 +30,8 @@ use crate::{
 };
 
 use hal::{Queue as _, Surface as _};
-use parking_lot::{Mutex, RwLock};
 use thiserror::Error;
+use wgs::{Mutex, RwLock};
 use wgt::SurfaceStatus as Status;
 
 const FRAME_TIMEOUT_MS: u32 = 1000;

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use wgs::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use wgt::Backend;
 
 use crate::{

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -19,9 +19,9 @@ use crate::{
 };
 
 use hal::CommandEncoder;
-use parking_lot::{Mutex, RwLock};
 use smallvec::SmallVec;
 use thiserror::Error;
+use wgs::{Mutex, RwLock};
 use wgt::WasmNotSendSync;
 
 use std::{

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 
-use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::cell::UnsafeCell;
+use wgs::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// A guard that provides read access to snatchable data.
 pub struct SnatchGuard<'a>(RwLockReadGuard<'a, ()>);

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 use hal::{BufferBarrier, BufferUses};
-use parking_lot::Mutex;
+use wgs::Mutex;
 use wgt::{strict_assert, strict_assert_eq};
 
 impl ResourceUses for BufferUses {

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -110,9 +110,9 @@ use crate::{
     storage::Storage,
 };
 
-use parking_lot::RwLock;
 use std::{fmt, ops};
 use thiserror::Error;
+use wgs::RwLock;
 
 pub(crate) use buffer::{BufferBindGroupState, BufferTracker, BufferUsageScope};
 use metadata::{ResourceMetadata, ResourceMetadataProvider};

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use parking_lot::Mutex;
+use wgs::Mutex;
 
 use crate::{id::Id, resource::Resource, resource_log, storage::Storage, track::ResourceMetadata};
 

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -35,7 +35,7 @@ use hal::TextureUses;
 use arrayvec::ArrayVec;
 use naga::FastHashMap;
 
-use parking_lot::Mutex;
+use wgs::Mutex;
 use wgt::{strict_assert, strict_assert_eq};
 
 use std::{borrow::Cow, iter, marker::PhantomData, ops::Range, sync::Arc, vec::Drain};

--- a/wgpu-sync/Cargo.toml
+++ b/wgpu-sync/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "wgpu-sync"
+version = "0.19.0"
+authors = ["gfx-rs developers"]
+edition = "2021"
+description = "Instrumentation for synchronization primitives used in wgpu"
+homepage = "https://wgpu.rs/"
+repository = "https://github.com/gfx-rs/wgpu"
+keywords = ["graphics"]
+license = "MIT OR Apache-2.0"
+
+[features]
+default = []
+trace = ["unlock/trace", "unlock/parking_lot"]
+
+[dependencies]
+unlock = { version = "0.0.11", default-features = false }
+# parking_lot 0.12 switches from `winapi` to `windows`; permit either
+parking_lot = ">=0.11,<0.13"

--- a/wgpu-sync/src/lib.rs
+++ b/wgpu-sync/src/lib.rs
@@ -1,0 +1,9 @@
+//! Helpers for tracing internal wgpu locks in multithreaded code.
+
+#[cfg(feature = "trace")]
+pub use unlock::*;
+
+#[cfg(not(feature = "trace"))]
+pub use parking_lot::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+#[cfg(not(feature = "trace"))]
+pub use unlock::{capture, drain};

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -83,7 +83,7 @@ serde = ["dep:serde", "wgc/serde"]
 
 ## Allow writing of trace capture files.
 ## See [`Adapter::request_device`].
-trace = ["serde", "wgc/trace"]
+trace = ["serde", "wgc/trace", "wgs/trace"]
 
 ## Allow deserializing of trace capture files that were written with the `trace` feature.
 ## To replay a trace file use the [wgpu player](https://github.com/gfx-rs/wgpu/tree/trunk/player).
@@ -141,6 +141,10 @@ features = ["gles"]
 
 [dependencies.wgt]
 workspace = true
+
+[dependencies.wgs]
+workspace = true
+optional = true
 
 # We need wgpu-hal unless we're targeting the web APIs.
 [target.'cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))'.dependencies]

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -119,6 +119,9 @@ pub use wgt::{
 #[doc(inline)]
 pub use ::wgc as core;
 
+#[doc(inline)]
+pub use ::wgs as sync;
+
 /// Re-export of our `wgpu-hal` dependency.
 ///
 ///


### PR DESCRIPTION
**Connections**
Initially I started working on this to introduce loom tests, but I figured building a face like this would be useful to troubleshoot potential issues and bottlenecks caused by locks.

Could be used to troubleshoot issues which ask whether things have become slower with arcanization and increased use of locks in wgpu, such as #5180.

**Description**
This introduces a compatible layer which conditionally replaces Mutexes and RwLocks with facades which efficiently captures events into a global collection. This is compile-time enabled with the `"trace"` feature. Using this, users of `wgpu` can capture a lock trace, and generate a html report like this:

```rust
    if condition {
        wgpu::sync::capture();
    }

    /* do some wgpu work */

    if condition {
        let events = wgpu::sync::drain();

        let f = std::fs::File::create("trace.html").context("Creating trace.html")?;
        wgpu::sync::html::write(f, &events).context("Writing trace.html")?;
        println!("Wrote trace.html");
    }
```

I've included an example report I've generated from one of my projects here:
https://udoprog.github.io/trace.html

Note that if the `"trace"` feature is disabled, wgpu-sync instead provides the original parking_lot implementations without using facades.

This is a draft for now. Please take a look and tell me if y'all are interested in adopting something like this.
