### PR TITLE
Add `typos` to Repository CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,7 +596,7 @@ jobs:
     # runtime is normally 15 seconds
     timeout-minutes: 2
 
-    name: Format
+    name: Format & Typos
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
@@ -612,6 +612,9 @@ jobs:
         run: |
           cargo fmt -- --check
           cargo fmt --manifest-path xtask/Cargo.toml -- --check
+
+      - name: Check for typos
+        uses: crate-ci/typos@v1.18.0
 
   check-cts-runner:
     # runtime is normally 2 minutes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -532,7 +532,7 @@ By @wumpf in [#4147](https://github.com/gfx-rs/wgpu/pull/4147)
 
 The instance descriptor grew two more fields: `flags` and `gles_minor_version`.
 
-`flags` allow you to toggle the underlying api validation layers, debug information about shaders and objects in capture programs, and the ability to discard lables
+`flags` allow you to toggle the underlying api validation layers, debug information about shaders and objects in capture programs, and the ability to discard labels
 
 `gles_minor_version` is a rather niche feature that allows you to force the GLES backend to use a specific minor version, this is useful to get ANGLE to enable more than GLES 3.0.
 
@@ -1108,11 +1108,11 @@ Additionally `Surface::get_default_config` now returns an Option and returns Non
 
 #### `Queue::copy_external_image_to_texture` on WebAssembly
 
-A new api, `Queue::copy_external_image_to_texture`, allows you to create wgpu textures from various web image primitives. Specificically from `HtmlVideoElement`, `HtmlCanvasElement`, `OffscreenCanvas`, and `ImageBitmap`. This provides multiple low-copy ways of interacting with the browser. WebGL is also supported, though WebGL has some additional restrictions, represented by the `UNRESTRICTED_EXTERNAL_IMAGE_COPIES` downlevel flag. By @cwfitzgerald in [#3288](https://github.com/gfx-rs/wgpu/pull/3288)
+A new api, `Queue::copy_external_image_to_texture`, allows you to create wgpu textures from various web image primitives. Specifically from `HtmlVideoElement`, `HtmlCanvasElement`, `OffscreenCanvas`, and `ImageBitmap`. This provides multiple low-copy ways of interacting with the browser. WebGL is also supported, though WebGL has some additional restrictions, represented by the `UNRESTRICTED_EXTERNAL_IMAGE_COPIES` downlevel flag. By @cwfitzgerald in [#3288](https://github.com/gfx-rs/wgpu/pull/3288)
 
 #### Instance creation now takes `InstanceDescriptor` instead of `Backends`
 
-`Instance::new()` and `hub::Global::new()` now take an `InstanceDescriptor` struct which cointains both the existing `Backends` selection as well as a new `Dx12Compiler` field for selecting which Dx12 shader compiler to use.
+`Instance::new()` and `hub::Global::new()` now take an `InstanceDescriptor` struct which contains both the existing `Backends` selection as well as a new `Dx12Compiler` field for selecting which Dx12 shader compiler to use.
 
 ```diff
 - let instance = Instance::new(wgpu::Backends::all());
@@ -1423,7 +1423,7 @@ both `raw_window_handle::HasRawWindowHandle` and `raw_window_handle::HasRawDispl
 - Free `StagingBuffers` even when an error occurs in the operation that consumes them. By @jimblandy in [#2961](https://github.com/gfx-rs/wgpu/pull/2961)
 - Avoid overflow when checking that texture copies fall within bounds. By @jimblandy in [#2963](https://github.com/gfx-rs/wgpu/pull/2963)
 - Improve the validation and error reporting of buffer mappings by @nical in [#2848](https://github.com/gfx-rs/wgpu/pull/2848)
-- Fix compilation errors when using wgpu-core in isolation while targetting `wasm32-unknown-unknown` by @Seamooo in [#2922](https://github.com/gfx-rs/wgpu/pull/2922)
+- Fix compilation errors when using wgpu-core in isolation while targeting `wasm32-unknown-unknown` by @Seamooo in [#2922](https://github.com/gfx-rs/wgpu/pull/2922)
 - Fixed opening of RenderDoc library by @abuffseagull in [#2930](https://github.com/gfx-rs/wgpu/pull/2930)
 - Added missing validation for `BufferUsages` mismatches when `Features::MAPPABLE_PRIMARY_BUFFERS` is not
   enabled. By @imberflur in [#3023](https://github.com/gfx-rs/wgpu/pull/3023)
@@ -1520,7 +1520,7 @@ both `raw_window_handle::HasRawWindowHandle` and `raw_window_handle::HasRawDispl
 
 ### Full API Diff
 
-Manual concatination of `cargo public-api --diff-git-checkouts v0.13.2 v0.14.0 -p wgpu` and `cargo public-api --diff-git-checkouts v0.13.2 v0.14.0 -p wgpu-types`
+Manual concatenation of `cargo public-api --diff-git-checkouts v0.13.2 v0.14.0 -p wgpu` and `cargo public-api --diff-git-checkouts v0.13.2 v0.14.0 -p wgpu-types`
 
 ```diff
 Removed items from the public API
@@ -1797,7 +1797,7 @@ DeviceDescriptor {
 - Permit non-struct, non-array types as buffers. by @jimblandy in [#2584](https://github.com/gfx-rs/wgpu/pull/2584)
 - Return `queue_empty` for Device::poll by @xiaopengli89 in [#2643](https://github.com/gfx-rs/wgpu/pull/2643)
 - Add `SHADER_FLOAT16` feature by @jinleili in [#2646](https://github.com/gfx-rs/wgpu/pull/2646)
-- Add DEPTH32FLOAT_STENCIL8 featue by @jinleili in [#2664](https://github.com/gfx-rs/wgpu/pull/2664)
+- Add DEPTH32FLOAT_STENCIL8 feature by @jinleili in [#2664](https://github.com/gfx-rs/wgpu/pull/2664)
 - Add DEPTH24UNORM_STENCIL8 feature by @jinleili in [#2689](https://github.com/gfx-rs/wgpu/pull/2689)
 - Implement submission indexes by @cwfitzgerald in [#2700](https://github.com/gfx-rs/wgpu/pull/2700)
 - [WebGL] Add a downlevel capability for rendering to floating point textures by @expenses in [#2729](https://github.com/gfx-rs/wgpu/pull/2729)
@@ -1848,7 +1848,7 @@ DeviceDescriptor {
 #### Emscripten
 
 - feature: emscripten by @caiiiycuk in [#2422](https://github.com/gfx-rs/wgpu/pull/2422)
-- feature = emscripten, compability fixes for wgpu-native by @caiiiycuk in [#2450](https://github.com/gfx-rs/wgpu/pull/2450)
+- feature = emscripten, compatibility fixes for wgpu-native by @caiiiycuk in [#2450](https://github.com/gfx-rs/wgpu/pull/2450)
 
 ### Changes
 
@@ -2351,7 +2351,7 @@ DeviceDescriptor {
   - Updated default storage buffer/image limit to `8` from `4`.
 - Fixed:
   - `Buffer::get_mapped_range` can now have a range of zero.
-  - Fixed output spirv requiring the "kernal" capability.
+  - Fixed output spirv requiring the "kernel" capability.
   - Fixed segfault due to improper drop order.
   - Fixed incorrect dynamic stencil reference for Replace ops.
   - Fixed tracking of temporary resources.

--- a/d3d12/src/com.rs
+++ b/d3d12/src/com.rs
@@ -121,7 +121,7 @@ impl<T: Interface> Hash for ComPtr<T> {
 /// Three function names need to be attached to each variant. The examples are given for the MyComObject1 variant below:
 /// - the from function (`ComPtr<actual::ComObject1> -> Self`)
 /// - the as function (`&self -> Option<ComPtr<actual::ComObject1>>`)
-/// - the unwrap function (`&self -> ComPtr<actual::ComObject1>` panicing on failure to cast)
+/// - the unwrap function (`&self -> ComPtr<actual::ComObject1>` panicking on failure to cast)
 ///
 /// ```rust
 /// # pub use d3d12::weak_com_inheritance_chain;

--- a/deno_webgpu/01_webgpu.js
+++ b/deno_webgpu/01_webgpu.js
@@ -108,7 +108,7 @@ function assertDeviceMatch(
   const resourceDevice = assertDevice(resource, prefix, resourceContext);
   if (resourceDevice.rid !== self.rid) {
     throw new DOMException(
-      `${prefix}: ${resourceContext} belongs to a diffent device than ${selfContext}.`,
+      `${prefix}: ${resourceContext} belongs to a different device than ${selfContext}.`,
       "OperationError",
     );
   }
@@ -1918,7 +1918,7 @@ class GPUBuffer {
     device.pushErrorPromise(promise);
     const err = await promise;
     if (err) {
-      throw new DOMException("validation error occured", "OperationError");
+      throw new DOMException("validation error occurred", "OperationError");
     }
     this[_state] = "mapped";
     this[_mappingRange] = [offset, offset + rangeSize];

--- a/examples/src/framework.rs
+++ b/examples/src/framework.rs
@@ -142,7 +142,7 @@ impl SurfaceWrapper {
     /// a surface (and hence a canvas) to be present to create the adapter.
     ///
     /// We cannot unconditionally create a surface here, as Android requires
-    /// us to wait until we recieve the `Resumed` event to do so.
+    /// us to wait until we receive the `Resumed` event to do so.
     fn pre_adapter(&mut self, instance: &Instance, window: Arc<Window>) {
         if cfg!(target_arch = "wasm32") {
             self.surface = Some(instance.create_surface(window).unwrap());
@@ -160,7 +160,7 @@ impl SurfaceWrapper {
         }
     }
 
-    /// Called when an event which matches [`Self::start_condition`] is recieved.
+    /// Called when an event which matches [`Self::start_condition`] is received.
     ///
     /// On all native platforms, this is where we create the surface.
     ///

--- a/examples/src/hello_workgroups/README.md
+++ b/examples/src/hello_workgroups/README.md
@@ -22,7 +22,7 @@ cargo run --bin wgpu-examples hello_workgroups
   - No two workgroups can be guaranteed to be executed in parallel.
   - No two workgroups can be guaranteed NOT to be executed in parallel.
   - No set of workgroups can be guaranteed to execute in any predictable or reliable order in relation to each other.
-- Ths size of a workgroup is defined with the `@workgroup_size` attribute on a compute shader main function.
+- The size of a workgroup is defined with the `@workgroup_size` attribute on a compute shader main function.
 - The location of an invocation within its workgroup grid can be got with `@builtin(local_invocation_id)`.
 - The location of an invocation within the entire compute shader grid can be gotten with `@builtin(global_invocation_id)`.
 - The location of an invocation's workgroup within the dispatch grid can be gotten with `@builtin(workgroup_id)`.

--- a/examples/src/repeated_compute/mod.rs
+++ b/examples/src/repeated_compute/mod.rs
@@ -101,7 +101,7 @@ async fn compute(local_buffer: &mut [u32], context: &WgpuContext) {
     // buffered and receiving will just pick that up.
     //
     // It may also be worth noting that although on native, the usage of asynchronous
-    // channels is wholely unnecessary, for the sake of portability to WASM (std channels
+    // channels is wholly unnecessary, for the sake of portability to WASM (std channels
     // don't work on WASM,) we'll use async channels that work on both native and WASM.
     let (sender, receiver) = flume::bounded(1);
     buffer_slice.map_async(wgpu::MapMode::Read, move |r| sender.send(r).unwrap());

--- a/examples/src/texture_arrays/mod.rs
+++ b/examples/src/texture_arrays/mod.rs
@@ -112,7 +112,7 @@ impl crate::framework::Example for Example {
             }
         };
         let non_uniform_shader_module;
-        // TODO: Because naga's capibilities are evaluated on validate, not on write, we cannot make a shader module with unsupported
+        // TODO: Because naga's capabilities are evaluated on validate, not on write, we cannot make a shader module with unsupported
         // capabilities even if we don't use it. So for now put it in a separate module.
         let fragment_shader_module = if !uniform_workaround {
             non_uniform_shader_module =

--- a/examples/src/uniform_values/shader.wgsl
+++ b/examples/src/uniform_values/shader.wgsl
@@ -1,6 +1,6 @@
 // Some credit to https://github.com/paulgb/wgsl-playground/tree/main.
 
-// We use seperate the x and y instead of using a vec2 to avoid wgsl padding.
+// We use separate the x and y instead of using a vec2 to avoid wgsl padding.
 struct AppState {
     pos_x: f32,
     pos_y: f32,

--- a/naga/CHANGELOG.md
+++ b/naga/CHANGELOG.md
@@ -363,7 +363,7 @@ SPV-IN
 - Fix clippy lints for 1.63 by @JCapucho in https://github.com/gfx-rs/naga/pull/2026
 - Saturate by @evahop in https://github.com/gfx-rs/naga/pull/2025
 - Use `Option::as_deref` as appropriate. by @jimblandy in https://github.com/gfx-rs/naga/pull/2040
-- Explicitely enable std for indexmap by @maxammann in https://github.com/gfx-rs/naga/pull/2062
+- Explicitly enable std for indexmap by @maxammann in https://github.com/gfx-rs/naga/pull/2062
 - Fix compiler warning by @Gordon-F in https://github.com/gfx-rs/naga/pull/2074
 
 API
@@ -466,7 +466,7 @@ Main breaking changes
   - `findLsb` -> `firstTrailingBit`
   - `findMsb` -> `firstLeadingBit`
 
-Specification Changes (relavant changes have also been applied to the WGSL backend)
+Specification Changes (relevant changes have also been applied to the WGSL backend)
 
 - Add support for `break if` ([#1993](https://github.com/gfx-rs/naga/pull/1993)) **@JCapucho**
 - Update number literal format ([#1863](https://github.com/gfx-rs/naga/pull/1863)) **@teoxoy**
@@ -479,7 +479,7 @@ Specification Changes (relavant changes have also been applied to the WGSL backe
 - Use commas to separate struct members instead of semicolons ([#1773](https://github.com/gfx-rs/naga/pull/1773)) **@Gordon-F**
 - Rename `findLsb`/`findMsb` to `firstTrailingBit`/`firstLeadingBit` ([#1735](https://github.com/gfx-rs/naga/pull/1735)) **@kvark**
 - Make parenthesis optional for `if` and `switch` statements ([#1725](https://github.com/gfx-rs/naga/pull/1725)) **@Gordon-F**
-- Declare attribtues with `@attrib` instead of `[[attrib]]` ([#1676](https://github.com/gfx-rs/naga/pull/1676)) **@kvark**
+- Declare attributes with `@attrib` instead of `[[attrib]]` ([#1676](https://github.com/gfx-rs/naga/pull/1676)) **@kvark**
 - Allow non-structure buffer types ([#1682](https://github.com/gfx-rs/naga/pull/1682)) **@kvark**
 - Remove `stride` attribute ([#1681](https://github.com/gfx-rs/naga/pull/1681)) **@kvark**
 
@@ -516,7 +516,7 @@ SPV-IN
 GLSL-IN
 
 - Don't allow empty last case in switch ([#1981](https://github.com/gfx-rs/naga/pull/1981)) **@JCapucho**
-- Fix last case falltrough and empty switch ([#1981](https://github.com/gfx-rs/naga/pull/1981)) **@JCapucho**
+- Fix last case fallthrough and empty switch ([#1981](https://github.com/gfx-rs/naga/pull/1981)) **@JCapucho**
 - Splat inputs for smoothstep if needed ([#1976](https://github.com/gfx-rs/naga/pull/1976)) **@JCapucho**
 - Fix parameter not changing to depth ([#1967](https://github.com/gfx-rs/naga/pull/1967)) **@JCapucho**
 - Fix matrix multiplication check ([#1953](https://github.com/gfx-rs/naga/pull/1953)) **@JCapucho**

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -75,7 +75,7 @@ env_logger = "0.10"
 hlsl-snapshots = { path = "./hlsl-snapshots" }
 # Require at least version 0.7.1 of ron, this version changed how floating points are
 # serialized by forcing them to always have the decimal part, this makes it backwards
-# incompatible with our tests because we do a syntatic diff and not a semantic one.
+# incompatible with our tests because we do a syntactic diff and not a semantic one.
 ron = "0.8.0"
 rspirv = { version = "0.11", git = "https://github.com/gfx-rs/rspirv", rev = "b969f175d5663258b4891e44b76c1544da9661ab" }
 serde = { version = "1.0", features = ["derive"] }

--- a/naga/src/back/glsl/features.rs
+++ b/naga/src/back/glsl/features.rs
@@ -433,7 +433,7 @@ impl<'a, W> Writer<'a, W> {
         {
             for (_, expr) in expressions.iter() {
                 match *expr {
-                // Check for queries that neeed aditonal features
+                // Check for queries that need aditonal features
                 Expression::ImageQuery {
                     image,
                     query,

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -146,7 +146,7 @@ impl Version {
         }
     }
 
-    /// Returns true if targetting WebGL
+    /// Returns true if targeting WebGL
     const fn is_webgl(&self) -> bool {
         match *self {
             Version::Desktop(_) => false,
@@ -340,9 +340,9 @@ pub struct TextureMapping {
 ///
 /// Push constants are emulated using traditional uniforms in OpenGL.
 ///
-/// These are composed of a set of primatives (scalar, vector, matrix) that
+/// These are composed of a set of primitives (scalar, vector, matrix) that
 /// are given names. Because they are not backed by the concept of a buffer,
-/// we must do the work of calculating the offset of each primative in the
+/// we must do the work of calculating the offset of each primitive in the
 /// push constant block.
 #[derive(Debug, Clone)]
 pub struct PushConstantItem {
@@ -394,11 +394,11 @@ impl IdGenerator {
     }
 }
 
-/// Assorted options needed for generting varyings.
+/// Assorted options needed for generating varyings.
 #[derive(Clone, Copy)]
 struct VaryingOptions {
     output: bool,
-    targetting_webgl: bool,
+    targeting_webgl: bool,
     draw_parameters: bool,
 }
 
@@ -406,7 +406,7 @@ impl VaryingOptions {
     const fn from_writer_options(options: &Options, output: bool) -> Self {
         Self {
             output,
-            targetting_webgl: options.version.is_webgl(),
+            targeting_webgl: options.version.is_webgl(),
             draw_parameters: options.writer_flags.contains(WriterFlags::DRAW_PARAMETERS),
         }
     }
@@ -1849,7 +1849,7 @@ impl<'a, W: Write> Writer<'a, W> {
         size: usize,
         ctx: &back::FunctionCtx,
     ) -> BackendResult {
-        // Write parantheses around the dot product expression to prevent operators
+        // Write parentheses around the dot product expression to prevent operators
         // with different precedences from applying earlier.
         write!(self.out, "(")?;
 
@@ -3795,11 +3795,11 @@ impl<'a, W: Write> Writer<'a, W> {
             // Sampled images inherit the policy from the user passed policies
             crate::ImageClass::Sampled { .. } => ("texelFetch", self.policies.image_load),
             crate::ImageClass::Storage { .. } => {
-                // OpenGL ES 3.1 mentiones in Chapter "8.22 Texture Image Loads and Stores" that:
+                // OpenGL ES 3.1 mentions in Chapter "8.22 Texture Image Loads and Stores" that:
                 // "Invalid image loads will return a vector where the value of R, G, and B components
                 // is 0 and the value of the A component is undefined."
                 //
-                // OpenGL 4.2 Core mentiones in Chapter "3.9.20 Texture Image Loads and Stores" that:
+                // OpenGL 4.2 Core mentions in Chapter "3.9.20 Texture Image Loads and Stores" that:
                 // "Invalid image loads will return zero."
                 //
                 // So, we only inject bounds checks for ES
@@ -3832,7 +3832,7 @@ impl<'a, W: Write> Writer<'a, W> {
             // expressions so we can be sure that after we test a
             // condition it will be true for the next ones
 
-            // Write parantheses around the ternary operator to prevent problems with
+            // Write parentheses around the ternary operator to prevent problems with
             // expressions emitted before or after it having more precedence
             write!(self.out, "(",)?;
 
@@ -3856,7 +3856,7 @@ impl<'a, W: Write> Writer<'a, W> {
             }
 
             // We now need to write the size checks for the coordinates and array index
-            // first we write the comparation function in case the image is 1D non arrayed
+            // first we write the comparison function in case the image is 1D non arrayed
             // (and no 1D to 2D hack was needed) we are comparing scalars so the less than
             // operator will suffice, but otherwise we'll be comparing two vectors so we'll
             // need to use the `lessThan` function but it returns a vector of booleans (one
@@ -3883,7 +3883,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 // coordinates from the image size.
                 write!(self.out, ", ")?;
             } else {
-                // If we didn't use it (ie. 1D images) we perform the comparsion
+                // If we didn't use it (ie. 1D images) we perform the comparison
                 // using the less than operator.
                 write!(self.out, " < ")?;
             }
@@ -4002,7 +4002,7 @@ impl<'a, W: Write> Writer<'a, W> {
             // Get the kind of the output value.
             let kind = match class {
                 // Only sampled images can reach here since storage images
-                // don't need bounds checks and depth images aren't implmented
+                // don't need bounds checks and depth images aren't implemented
                 crate::ImageClass::Sampled { kind, .. } => kind,
                 _ => unreachable!(),
             };
@@ -4018,7 +4018,7 @@ impl<'a, W: Write> Writer<'a, W> {
             self.write_zero_init_scalar(kind)?;
             // Close the zero value constructor
             write!(self.out, ")")?;
-            // Close the parantheses surrounding our ternary
+            // Close the parentheses surrounding our ternary
             write!(self.out, ")")?;
         }
 
@@ -4376,7 +4376,7 @@ const fn glsl_built_in(built_in: crate::BuiltIn, options: VaryingOptions) -> &'s
                 "gl_FragCoord"
             }
         }
-        Bi::ViewIndex if options.targetting_webgl => "int(gl_ViewID_OVR)",
+        Bi::ViewIndex if options.targeting_webgl => "int(gl_ViewID_OVR)",
         Bi::ViewIndex => "gl_ViewIndex",
         // vertex
         Bi::BaseInstance => "uint(gl_BaseInstance)",
@@ -4387,7 +4387,7 @@ const fn glsl_built_in(built_in: crate::BuiltIn, options: VaryingOptions) -> &'s
             if options.draw_parameters {
                 "(uint(gl_InstanceID) + uint(gl_BaseInstanceARB))"
             } else {
-                // Must match FISRT_INSTANCE_BINDING
+                // Must match FIRST_INSTANCE_BINDING
                 "(uint(gl_InstanceID) + naga_vs_first_instance)"
             }
         }

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -2269,7 +2269,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                         index: u32,
                     ) -> BackendResult {
                         match *resolved {
-                            // We specifcally lift the ValuePointer to this case. While `[0]` is valid
+                            // We specifically lift the ValuePointer to this case. While `[0]` is valid
                             // HLSL for any vector behind a value pointer, FXC completely miscompiles
                             // it and generates completely nonsensical DXBC.
                             //

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -1166,7 +1166,7 @@ impl<W: Write> Writer<W> {
         size: usize,
         context: &ExpressionContext,
     ) -> BackendResult {
-        // Write parantheses around the dot product expression to prevent operators
+        // Write parentheses around the dot product expression to prevent operators
         // with different precedences from applying earlier.
         write!(self.out, "(")?;
 

--- a/naga/src/back/spv/image.rs
+++ b/naga/src/back/spv/image.rs
@@ -64,7 +64,7 @@ trait Access {
     /// the level of detail, and `sample_id` is the index of the sample to
     /// access in a multisampled texel.
     ///
-    /// Ths method assumes that `coordinates_id` has already had the image array
+    /// This method assumes that `coordinates_id` has already had the image array
     /// index, if any, folded in, as done by `write_image_coordinates`.
     ///
     /// Return the value id produced by the instruction, if any.

--- a/naga/src/compact/mod.rs
+++ b/naga/src/compact/mod.rs
@@ -72,7 +72,7 @@ pub fn compact(module: &mut crate::Module) {
         })
         .collect();
 
-    // Similiarly, observe what each entry point actually uses.
+    // Similarly, observe what each entry point actually uses.
     log::trace!("tracing entry points");
     let entry_point_maps: Vec<FunctionMap> = module
         .entry_points

--- a/naga/src/front/glsl/ast.rs
+++ b/naga/src/front/glsl/ast.rs
@@ -98,9 +98,9 @@ pub struct EntryArg {
 #[derive(Debug, Clone)]
 pub struct VariableReference {
     pub expr: Handle<Expression>,
-    /// Wether the variable is of a pointer type (and needs loading) or not
+    /// Whether the variable is of a pointer type (and needs loading) or not
     pub load: bool,
-    /// Wether the value of the variable can be changed or not
+    /// Whether the value of the variable can be changed or not
     pub mutable: bool,
     pub constant: Option<(Handle<Constant>, Handle<Type>)>,
     pub entry_arg: Option<usize>,

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -1057,7 +1057,7 @@ impl<'a> Context<'a> {
             //
             // The ternary operator is defined to only evaluate one of the two possible
             // expressions which means that it's behavior is that of an `if` statement,
-            // and it's merely syntatic sugar for it.
+            // and it's merely syntactic sugar for it.
             HirExprKind::Conditional {
                 condition,
                 accept,
@@ -1164,7 +1164,7 @@ impl<'a> Context<'a> {
                     meta,
                 );
 
-                // Note: `Expression::Load` must be emited before it's used so make
+                // Note: `Expression::Load` must be emitted before it's used so make
                 // sure the emitter is active here.
                 self.add_expression(
                     Expression::Load {

--- a/naga/src/front/glsl/mod.rs
+++ b/naga/src/front/glsl/mod.rs
@@ -50,7 +50,7 @@ type Result<T> = std::result::Result<T, Error>;
 pub struct Options {
     /// The shader stage in the pipeline.
     pub stage: ShaderStage,
-    /// Preprocesor definitions to be used, akin to having
+    /// Preprocessor definitions to be used, akin to having
     /// ```glsl
     /// #define key value
     /// ```

--- a/naga/src/front/glsl/parser/functions.rs
+++ b/naga/src/front/glsl/parser/functions.rs
@@ -49,7 +49,7 @@ impl<'source> ParsingContext<'source> {
         }
 
         // Type names can identify either declaration statements or type constructors
-        // depending on wether the token following the type name is a `(` (LeftParen)
+        // depending on whether the token following the type name is a `(` (LeftParen)
         if self.peek_type_name(frontend) {
             // Start by consuming the type name so that we can peek the token after it
             let token = self.bump(frontend)?;

--- a/naga/src/front/glsl/parser/types.rs
+++ b/naga/src/front/glsl/parser/types.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 impl<'source> ParsingContext<'source> {
-    /// Parses an optional array_specifier returning wether or not it's present
+    /// Parses an optional array_specifier returning whether or not it's present
     /// and modifying the type handle if it exists
     pub fn parse_array_specifier(
         &mut self,

--- a/naga/src/front/mod.rs
+++ b/naga/src/front/mod.rs
@@ -151,7 +151,7 @@ impl ops::Index<Handle<crate::Expression>> for Typifier {
 
 /// Type representing a lexical scope, associating a name to a single variable
 ///
-/// The scope is generic over the variable representation and name representaion
+/// The scope is generic over the variable representation and name representation
 /// in order to allow larger flexibility on the frontends on how they might
 /// represent them.
 type Scope<Name, Var> = FastHashMap<Name, Var>;

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -2559,7 +2559,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                 }
                 Op::ShiftRightLogical => {
                     inst.expect(5)?;
-                    //TODO: convert input and result to usigned
+                    //TODO: convert input and result to unsigned
                     parse_expr_op!(crate::BinaryOperator::ShiftRight, SHIFT)?;
                 }
                 Op::ShiftRightArithmetic => {
@@ -3387,7 +3387,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
 
                         // Check if any previous case already used this target block id, if so
                         // group them together to reorder them later so that no weird
-                        // falltrough cases happen.
+                        // fallthrough cases happen.
                         if let Some(&mut (_, ref mut literals)) = self.switch_cases.get_mut(&target)
                         {
                             literals.push(literal as i32);
@@ -3411,11 +3411,11 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
 
                     // Loop trough the collected target blocks creating a new case for each
                     // literal pointing to it, only one case will have the true body and all the
-                    // others will be empty falltrough so that they all execute the same body
+                    // others will be empty fallthrough so that they all execute the same body
                     // without duplicating code.
                     //
                     // Since `switch_cases` is an indexmap the order of insertion is preserved
-                    // this is needed because spir-v defines falltrough order in the switch
+                    // this is needed because spir-v defines fallthrough order in the switch
                     // instruction.
                     let mut cases = Vec::with_capacity((inst.wc as usize - 3) / 2);
                     for &(case_body_idx, ref literals) in self.switch_cases.values() {

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -184,7 +184,7 @@ pub enum Error<'a> {
     NonPowerOfTwoAlignAttribute(Span),
     InconsistentBinding(Span),
     TypeNotConstructible(Span),
-    TypeNotInferrable(Span),
+    TypeNotInferable(Span),
     InitializationTypeMismatch {
         name: Span,
         expected: String,
@@ -500,7 +500,7 @@ impl<'a> Error<'a> {
                 labels: vec![(span, "type is not constructible".into())],
                 notes: vec![],
             },
-            Error::TypeNotInferrable(span) => ParseError {
+            Error::TypeNotInferable(span) => ParseError {
                 message: "type can't be inferred".to_string(),
                 labels: vec![(span, "type can't be inferred".into())],
                 notes: vec![],

--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -167,7 +167,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 | Constructor::PartialArray => {
                     // We have no arguments from which to infer the result type, so
                     // partial constructors aren't acceptable here.
-                    return Err(Error::TypeNotInferrable(ty_span));
+                    return Err(Error::TypeNotInferable(ty_span));
                 }
             },
 

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -765,7 +765,7 @@ pub enum TypeInner {
         space: AddressSpace,
     },
 
-    /// Homogenous list of elements.
+    /// Homogeneous list of elements.
     ///
     /// The `base` type must be a [`SIZED`], [`DATA`] type.
     ///

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -725,7 +725,7 @@ impl GlobalCtx<'_> {
 /// Normally, this would just be an iterator over `components`. However,
 /// `Compose` expressions can concatenate vectors, in which case the i'th
 /// value being composed is not generally the i'th element of `components`.
-/// This function consults `ty` to decide if this concatenation is occuring,
+/// This function consults `ty` to decide if this concatenation is occurring,
 /// and returns an iterator that produces the components of the result of
 /// the `Compose` expression in either case.
 pub fn flatten_compose<'arenas>(

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -106,7 +106,7 @@ pub enum FunctionError {
     MissingDefaultCase,
     #[error("Multiple `default` cases are present")]
     MultipleDefaultCases,
-    #[error("The last `switch` case contains a `falltrough`")]
+    #[error("The last `switch` case contains a `fallthrough`")]
     LastCaseFallTrough,
     #[error("The pointer {0:?} doesn't relate to a valid destination for a store")]
     InvalidStorePointer(Handle<crate::Expression>),

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -619,7 +619,7 @@ impl super::Validator {
             ctx.validate(fr.ty, fr.binding.as_ref())
                 .map_err_inner(|e| EntryPointError::Result(e).with_span())?;
             if ctx.second_blend_source {
-                // Only the first location may be used whhen dual source blending
+                // Only the first location may be used when dual source blending
                 if ctx.location_mask.len() == 1 && ctx.location_mask.contains(0) {
                     info.dual_source_blending = true;
                 } else {

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -104,7 +104,7 @@ bitflags::bitflags! {
         const MULTISAMPLED_SHADING = 0x800;
         /// Support for ray queries and acceleration structures.
         const RAY_QUERY = 0x1000;
-        /// Support for generating two sources for blending from fragement shaders.
+        /// Support for generating two sources for blending from fragment shaders.
         const DUAL_SOURCE_BLENDING = 0x2000;
         /// Support for arrayed cube textures.
         const CUBE_ARRAY_TEXTURES = 0x4000;

--- a/naga/tests/in/glsl/bevy-pbr.frag
+++ b/naga/tests/in/glsl/bevy-pbr.frag
@@ -296,7 +296,7 @@ vec3 point_light(PointLight light, float roughness, float NdotV, vec3 N, vec3 V,
     // f(v,l) = (f_d(v,l) + f_r(v,l)) * light_color
     // Φ is light intensity
 
-    // our rangeAttentuation = 1 / d^2 multiplied with an attenuation factor for smoothing at the edge of the non-physical maximum light radius
+    // our rangeAttenuation = 1 / d^2 multiplied with an attenuation factor for smoothing at the edge of the non-physical maximum light radius
     // It's not 100% clear where the 1/4π goes in the derivation, but we follow the filament shader and leave it out
 
     // See https://google.github.io/filament/Filament.html#mjx-eqn-pointLightLuminanceEquation

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -181,7 +181,7 @@ fn type_not_constructible() {
 }
 
 #[test]
-fn type_not_inferrable() {
+fn type_not_inferable() {
     check(
         r#"
             fn x() {

--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -292,8 +292,8 @@ pub struct FailureReason {
     /// Match a particular message of a failure result.
     ///
     /// If `None`, matches any message. If `Some`, a case-insensitive sub-string
-    /// test is performed. Allowing `"error occured"` to match a message like
-    /// `"An unexpected Error occured!"`.
+    /// test is performed. Allowing `"error occurred"` to match a message like
+    /// `"An unexpected Error occurred!"`.
     message: Option<&'static str>,
 }
 
@@ -324,8 +324,8 @@ impl FailureReason {
     /// Match an error with a message.
     ///
     /// If specified, a case-insensitive sub-string test is performed. Allowing
-    /// `"error occured"` to match a message like `"An unexpected Error
-    /// occured!"`.
+    /// `"error occurred"` to match a message like `"An unexpected Error
+    /// occurred!"`.
     pub fn with_message(self, message: &'static str) -> Self {
         Self {
             message: Some(message),

--- a/tests/src/image.rs
+++ b/tests/src/image.rs
@@ -222,7 +222,7 @@ pub async fn compare_image_output(
             all_passed &= check.check(&mut pool);
         }
 
-        // Convert the error values to a false color reprensentation
+        // Convert the error values to a false color representation
         let magma_image = error_map_flip
             .apply_color_lut(&nv_flip::magma_lut())
             .to_vec();

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -4,7 +4,7 @@ use wgpu_test::{fail, gpu_test, FailureCase, GpuTestConfiguration, TestParameter
 static CROSS_DEVICE_BIND_GROUP_USAGE: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default().expect_fail(FailureCase::always()))
     .run_async(|ctx| async move {
-        // Create a bind group uisng a layout from another device. This should be a validation
+        // Create a bind group using a layout from another device. This should be a validation
         // error but currently crashes.
         let (device2, _) =
             pollster::block_on(ctx.adapter.request_device(&Default::default(), None)).unwrap();
@@ -116,7 +116,7 @@ async fn request_device_error_message() {
 // This is a test of device behavior after device.destroy. Specifically, all operations
 // should trigger errors since the device is lost.
 //
-// On DX12 this test fails with a validation error in the very artifical actions taken
+// On DX12 this test fails with a validation error in the very artificial actions taken
 // after lose the device. The error is "ID3D12CommandAllocator::Reset: The command
 // allocator cannot be reset because a command list is currently being recorded with the
 // allocator." That may indicate that DX12 doesn't like opened command buffers staying
@@ -265,7 +265,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
         // TODO: change these fail calls to check for the specific errors which indicate that
         // the device is not valid.
 
-        // Creating a commmand encoder should fail.
+        // Creating a command encoder should fail.
         fail(&ctx.device, || {
             ctx.device
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());

--- a/tests/tests/external_texture.rs
+++ b/tests/tests/external_texture.rs
@@ -159,7 +159,7 @@ static IMAGE_BITMAP_IMPORT: GpuTestConfiguration =
                 // Layer count of the destination texture
                 let mut dest_layers = 1;
 
-                // If the test is suppoed to be valid call to copyExternal.
+                // If the test is supposed to be valid call to copyExternal.
                 let mut valid = true;
                 match case {
                     TestCase::Normal => {}

--- a/tests/tests/nv12_texture/nv12_texture.wgsl
+++ b/tests/tests/nv12_texture/nv12_texture.wgsl
@@ -21,9 +21,9 @@ fn vs_main(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
 @group(0) @binding(2) var tex_uv: texture_2d<f32>;
 
 @fragment
-fn fs_main(v_ouput: VertexOutput) -> @location(0) vec4<f32> {
-    let luminance = textureSample(tex_y, s, v_ouput.uv).r;
-    let chrominance = textureSample(tex_uv, s, v_ouput.uv).rg;
+fn fs_main(v_output: VertexOutput) -> @location(0) vec4<f32> {
+    let luminance = textureSample(tex_y, s, v_output.uv).r;
+    let chrominance = textureSample(tex_uv, s, v_output.uv).rg;
     let rgb = mat3x3<f32>(
         1.000000, 1.000000, 1.000000,
         0.000000,-0.187324, 1.855600,

--- a/tests/tests/push_constants.rs
+++ b/tests/tests/push_constants.rs
@@ -5,7 +5,7 @@ use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 /// We want to test that partial updates to push constants work as expected.
 ///
 /// As such, we dispatch two compute passes, one which writes the values
-/// before a parital update, and one which writes the values after the partial update.
+/// before a partial update, and one which writes the values after the partial update.
 ///
 /// If the update code is working correctly, the values not written to by the second update
 /// will remain unchanged.

--- a/tests/tests/regression/issue_3457.rs
+++ b/tests/tests/regression/issue_3457.rs
@@ -21,7 +21,7 @@ static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration =
             .device
             .create_shader_module(include_wgsl!("issue_3457.wgsl"));
 
-        // We use two separate vertex buffers so we can delete one in between submisions
+        // We use two separate vertex buffers so we can delete one in between submissions
         let vertex_buffer1 = ctx.device.create_buffer(&BufferDescriptor {
             label: Some("vertex buffer 1"),
             size: 3 * 16,

--- a/tests/tests/regression/issue_4024.rs
+++ b/tests/tests/regression/issue_4024.rs
@@ -11,7 +11,7 @@ use wgpu::*;
 /// callback is invoked.
 ///
 /// We previously immediately invoked on_submitted_work_done callbacks if there was no active submission
-/// to add them to. This is incorrect, as we do not immediatley invoke map_async callbacks.
+/// to add them to. This is incorrect, as we do not immediately invoke map_async callbacks.
 #[gpu_test]
 static QUEUE_SUBMITTED_CALLBACK_ORDERING: GpuTestConfiguration = GpuTestConfiguration::new()
     .run_async(|ctx| async move {

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,22 @@
+[files]
+extend-exclude = [
+    # spirv-asm isn't real source code
+    '*.spvasm'
+]
+
+# Corrections take the form of a key/value pair. The key is the incorrect word
+# and the value is the correct word. If the key and value are the same, the
+# word is treated as always correct. If the value is an empty string, the word
+# is treated as always incorrect.
+
+[default.extend-words]
+# Things that aren't typos
+lod = "lod"
+inout = "inout"
+derivate = "derivate"
+implace = "implace"
+Ded = "Ded" # This shows up in "ANDed"
+
+# Usernames
+Healthire = "Healthire"
+REASY = "REASY"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -36,7 +36,7 @@ api_log_info = []
 ## Log resource lifecycle management at info instead of trace level.
 resource_log_info = []
 
-## Use static linking for libraries. Disale to manually link. Enabled by default.
+## Use static linking for libraries. Disable to manually link. Enabled by default.
 link = ["hal/link"]
 
 ## Support the Renderdoc graphics debugger:

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -580,7 +580,7 @@ pub enum PushConstantUploadError {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PipelineLayoutDescriptor<'a> {
-    /// Debug label of the pipeine layout.
+    /// Debug label of the pipeline layout.
     ///
     /// This will show up in graphics debuggers for easy identification.
     pub label: Label<'a>,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -423,7 +423,7 @@ impl Global {
                 .map_pass_err(pass_scope)?;
 
             // Unlike in render passes we can't delay resetting the query sets since
-            // there is no auxillary pass.
+            // there is no auxiliary pass.
             let range = if let (Some(index_a), Some(index_b)) =
                 (tw.beginning_of_pass_write_index, tw.end_of_pass_write_index)
             {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -379,7 +379,7 @@ impl VertexState {
     fn update_limits(&mut self) {
         // Implements the validation from https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-draw
         // Except that the formula is shuffled to extract the number of vertices in order
-        // to carry the bulk of the computation when changing states intead of when producing
+        // to carry the bulk of the computation when changing states instead of when producing
         // draws. Draw calls tend to happen at a higher frequency. Here we determine vertex
         // limits that can be cheaply checked for each draw call.
         self.vertex_limit = u32::MAX as u64;
@@ -395,7 +395,7 @@ impl VertexState {
             } else {
                 if vbs.step.stride == 0 {
                     // We already checked that the last stride fits, the same
-                    // vertex will be repeated so this slot can accomodate any number of
+                    // vertex will be repeated so this slot can accommodate any number of
                     // vertices.
                     continue;
                 }
@@ -1640,7 +1640,7 @@ impl Global {
 
                         // Initialize each `vertex.inputs[i].step` from
                         // `pipeline.vertex_steps[i]`.  Enlarge `vertex.inputs`
-                        // as necessary to accomodate all slots in the
+                        // as necessary to accommodate all slots in the
                         // pipeline. If `vertex.inputs` is longer, fill the
                         // extra entries with default `VertexStep`s.
                         while state.vertex.inputs.len() < vertex_steps_len {

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -69,7 +69,7 @@ pub enum TransferError {
         dimension: TextureErrorDimension,
         side: CopySide,
     },
-    #[error("Unable to select texture aspect {aspect:?} from fromat {format:?}")]
+    #[error("Unable to select texture aspect {aspect:?} from format {format:?}")]
     InvalidTextureAspect {
         format: wgt::TextureFormat,
         aspect: wgt::TextureAspect,
@@ -252,7 +252,7 @@ pub(crate) fn validate_linear_texture_data(
 ) -> Result<(BufferAddress, BufferAddress), TransferError> {
     // Convert all inputs to BufferAddress (u64) to avoid some of the overflow issues
     // Note: u64 is not always enough to prevent overflow, especially when multiplying
-    // something with a potentially large depth value, so it is preferrable to validate
+    // something with a potentially large depth value, so it is preferable to validate
     // the copy size before calling this function (for example via `validate_texture_copy_range`).
     let copy_width = copy_size.width as BufferAddress;
     let copy_height = copy_size.height as BufferAddress;

--- a/wgpu-core/src/device/any_device.rs
+++ b/wgpu-core/src/device/any_device.rs
@@ -38,7 +38,7 @@ impl AnyDevice {
             }
         }
 
-        // SAFETY: The pointer returned by Arc::into_raw is gauranteed to be
+        // SAFETY: The pointer returned by Arc::into_raw is guaranteed to be
         // non-null.
         let data = unsafe { NonNull::new_unchecked(Arc::into_raw(device).cast_mut()) };
 

--- a/wgpu-core/src/device/bgl.rs
+++ b/wgpu-core/src/device/bgl.rs
@@ -20,7 +20,7 @@ pub enum Origin {
 #[derive(Debug, Default, Clone, Eq)]
 pub struct EntryMap {
     /// We use a IndexMap here so that we can sort the entries by their binding index,
-    /// guarenteeing that the hash of equivilant layouts will be the same.
+    /// guaranteeing that the hash of equivalent layouts will be the same.
     inner: FastIndexMap<u32, wgt::BindGroupLayoutEntry>,
     /// We keep track of whether the map is sorted or not, so that we can assert that
     /// it is sorted, so that PartialEq and Hash will be stable.

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -328,7 +328,7 @@ impl Global {
 
     /// Assign `id_in` an error with the given `label`.
     ///
-    /// See `create_buffer_error` for more context and explaination.
+    /// See `create_buffer_error` for more context and explanation.
     pub fn create_texture_error<A: HalApi>(&self, id_in: Option<id::TextureId>, label: Label) {
         let hub = A::hub(self);
         let fid = hub.textures.prepare(id_in);
@@ -2084,7 +2084,7 @@ impl Global {
     }
 
     #[cfg(feature = "replay")]
-    /// Only triange suspected resource IDs. This helps us to avoid ID collisions
+    /// Only triangle suspected resource IDs. This helps us to avoid ID collisions
     /// upon creating new resources when re-playing a trace.
     pub fn device_maintain_ids<A: HalApi>(&self, device_id: DeviceId) -> Result<(), InvalidDevice> {
         let hub = A::hub(self);
@@ -2519,7 +2519,7 @@ impl Global {
                     });
                 }
                 // ptr points to the beginning of the range we mapped in map_async
-                // rather thant the beginning of the buffer.
+                // rather than the beginning of the buffer.
                 let relative_offset = (offset - range.start) as isize;
                 unsafe { Ok((ptr.as_ptr().offset(relative_offset), range_size)) }
             }

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -409,7 +409,7 @@ impl<A: HalApi> LifetimeTracker<A> {
             Some(active) => {
                 active.work_done_closures.push(closure);
             }
-            // We must defer the closure until all previously occuring map_async closures
+            // We must defer the closure until all previously occurring map_async closures
             // have fired. This is required by the spec.
             None => {
                 self.work_done_closures.push(closure);
@@ -439,8 +439,8 @@ impl<A: HalApi> LifetimeTracker<A> {
             let is_removed = trackers.remove_abandoned(id);
             if is_removed {
                 removed_resources.push(resource.clone());
-                if let Some(ressources) = non_referenced_resources {
-                    get_resource_map(ressources).insert(id, resource.clone());
+                if let Some(resources) = non_referenced_resources {
+                    get_resource_map(resources).insert(id, resource.clone());
                 }
             }
             !is_removed

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -71,7 +71,7 @@ use super::{
 /// 1. `self.trace` is locked last (unenforced)
 ///
 /// Right now avoid locking twice same resource or registry in a call execution
-/// and minimize the locking to the minimum scope possibile
+/// and minimize the locking to the minimum scope possible
 /// Unless otherwise specified, no lock may be acquired while holding another lock.
 /// This means that you must inspect function calls made while a lock is held
 /// to see what locks the callee may try to acquire.

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -80,7 +80,7 @@ impl RawId {
 /// Coerce a slice of identifiers into a slice of optional raw identifiers.
 ///
 /// There's two reasons why we know this is correct:
-/// * `Option<T>` is guarnateed to be niche-filled to 0's.
+/// * `Option<T>` is guaranteed to be niche-filled to 0's.
 /// * The `T` in `Option<T>` can inhabit any representation except 0's, since
 ///   its underlying representation is `NonZero*`.
 pub fn as_option_slice<T: Marker>(ids: &[Id<T>]) -> &[Option<Id<T>>] {

--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -327,7 +327,7 @@ mod test {
             vec![900..1000]
         );
 
-        // Splitted ranges.
+        // Split ranges.
         assert_eq!(
             tracker.drain(5..1003).collect::<Vec<Range<u32>>>(),
             vec![5..21, 42..900, 1000..1003]

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - **`api_log_info`** --- Log all API entry points at info instead of trace level.
 //! - **`resource_log_info`** --- Log resource lifecycle management at info instead of trace level.
-//! - **`link`** _(enabled by default)_ --- Use static linking for libraries. Disale to manually
+//! - **`link`** _(enabled by default)_ --- Use static linking for libraries. Disable to manually
 //!   link. Enabled by default.
 //! - **`renderdoc`** --- Support the Renderdoc graphics debugger:
 //!   [https://renderdoc.org/](https://renderdoc.org/)
@@ -58,7 +58,7 @@
     clippy::needless_lifetimes,
     // No need for defaults in the internal types.
     clippy::new_without_default,
-    // Needless updates are more scaleable, easier to play with features.
+    // Needless updates are more scalable, easier to play with features.
     clippy::needless_update,
     // Need many arguments for some core functions to be able to re-use code in many situations.
     clippy::too_many_arguments,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -377,7 +377,7 @@ pub enum ColorStateError {
     FormatNotBlendable(wgt::TextureFormat),
     #[error("Format {0:?} does not have a color aspect")]
     FormatNotColor(wgt::TextureFormat),
-    #[error("Sample count {0} is not supported by format {1:?} on this device. The WebGPU spec guarentees {2:?} samples are supported by this format. With the TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES feature your device supports {3:?}.")]
+    #[error("Sample count {0} is not supported by format {1:?} on this device. The WebGPU spec guarantees {2:?} samples are supported by this format. With the TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES feature your device supports {3:?}.")]
     InvalidSampleCount(u32, wgt::TextureFormat, Vec<u32>, Vec<u32>),
     #[error("Output format {pipeline} is incompatible with the shader {shader}")]
     IncompatibleFormat {
@@ -399,7 +399,7 @@ pub enum DepthStencilStateError {
     FormatNotDepth(wgt::TextureFormat),
     #[error("Format {0:?} does not have a stencil aspect, but stencil test/write is enabled")]
     FormatNotStencil(wgt::TextureFormat),
-    #[error("Sample count {0} is not supported by format {1:?} on this device. The WebGPU spec guarentees {2:?} samples are supported by this format. With the TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES feature your device supports {3:?}.")]
+    #[error("Sample count {0} is not supported by format {1:?} on this device. The WebGPU spec guarantees {2:?} samples are supported by this format. With the TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES feature your device supports {3:?}.")]
     InvalidSampleCount(u32, wgt::TextureFormat, Vec<u32>, Vec<u32>),
 }
 

--- a/wgpu-core/src/pool.rs
+++ b/wgpu-core/src/pool.rs
@@ -61,7 +61,7 @@ impl<K: Clone + Eq + Hash, V> ResourcePool<K, V> {
 
             drop(map_guard);
 
-            // Some other thread may beat us to initializing the entry, but OnceCell guarentees that only one thread
+            // Some other thread may beat us to initializing the entry, but OnceCell guarantees that only one thread
             // will actually initialize the entry.
             //
             // We pass the strong reference outside of the closure to keep it alive while we're the only one keeping a reference to it.

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -155,7 +155,7 @@ pub trait Resource: 'static + Sized + WasmNotSendSync {
 #[repr(C)]
 #[derive(Debug)]
 pub enum BufferMapAsyncStatus {
-    /// The Buffer is sucessfully mapped, `get_mapped_range` can be called.
+    /// The Buffer is successfully mapped, `get_mapped_range` can be called.
     ///
     /// All other variants of this enum represent failures to map the buffer.
     Success,
@@ -1155,7 +1155,7 @@ pub enum CreateTextureError {
     InvalidMultisampledStorageBinding,
     #[error("Format {0:?} does not support multisampling")]
     InvalidMultisampledFormat(wgt::TextureFormat),
-    #[error("Sample count {0} is not supported by format {1:?} on this device. The WebGPU spec guarentees {2:?} samples are supported by this format. With the TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES feature your device supports {3:?}.")]
+    #[error("Sample count {0} is not supported by format {1:?} on this device. The WebGPU spec guarantees {2:?} samples are supported by this format. With the TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES feature your device supports {3:?}.")]
     InvalidSampleCount(u32, wgt::TextureFormat, Vec<u32>, Vec<u32>),
     #[error("Multisampled textures must have RENDER_ATTACHMENT usage")]
     MultisampledNotRenderAttachment,

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -12,7 +12,7 @@ pub struct ExclusiveSnatchGuard<'a>(RwLockWriteGuard<'a, ()>);
 /// it early.
 ///
 /// In order to safely access the underlying data, the device's global snatchable
-/// lock must be taken. To guarentee it, methods take a read or write guard of that
+/// lock must be taken. To guarantee it, methods take a read or write guard of that
 /// special lock.
 pub struct Snatchable<T> {
     value: UnsafeCell<Option<T>>,
@@ -68,7 +68,7 @@ impl SnatchLock {
     /// The safety of `Snatchable::get` and `Snatchable::snatch` rely on their using of the
     /// right SnatchLock (the one associated to the same device). This method is unsafe
     /// to force force sers to think twice about creating a SnatchLock. The only place this
-    /// method sould be called is when creating the device.
+    /// method should be called is when creating the device.
     pub unsafe fn new() -> Self {
         SnatchLock {
             lock: RwLock::new(()),

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -165,7 +165,7 @@ where
     }
 
     pub(crate) fn insert_error(&mut self, id: Id<T::Marker>, label: &str) {
-        log::trace!("User is insering as error {}{:?}", T::TYPE, id);
+        log::trace!("User is inserting as error {}{:?}", T::TYPE, id);
         let (index, epoch, _) = id.unzip();
         self.insert_impl(
             index as usize,

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -60,7 +60,7 @@ impl<A: HalApi> BufferBindGroupState<A> {
     /// Optimize the buffer bind group state by sorting it by ID.
     ///
     /// When this list of states is merged into a tracker, the memory
-    /// accesses will be in a constant assending order.
+    /// accesses will be in a constant ascending order.
     #[allow(clippy::pattern_type_mismatch)]
     pub(crate) fn optimize(&self) {
         let mut buffers = self.buffers.lock();

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -205,7 +205,7 @@ fn invalid_resource_state<T: ResourceUses>(state: T) -> bool {
 /// a barrier.
 fn skip_barrier<T: ResourceUses>(old_state: T, new_state: T) -> bool {
     // If the state didn't change and all the usages are ordered, the hardware
-    // will guarentee the order of accesses, so we do not need to issue a barrier at all
+    // will guarantee the order of accesses, so we do not need to issue a barrier at all
     old_state == new_state && old_state.all_ordered()
 }
 
@@ -313,7 +313,7 @@ impl<T: ResourceUses> fmt::Display for InvalidUse<T> {
 /// and may include conflicting uses. This is fully compliant by the WebGPU spec.
 ///
 /// All bind group states are sorted by their ID so that when adding to a tracker,
-/// they are added in the most efficient order possible (assending order).
+/// they are added in the most efficient order possible (ascending order).
 #[derive(Debug)]
 pub(crate) struct BindGroupStates<A: HalApi> {
     pub buffers: BufferBindGroupState<A>,
@@ -335,7 +335,7 @@ impl<A: HalApi> BindGroupStates<A> {
     /// Optimize the bind group states by sorting them by ID.
     ///
     /// When this list of states is merged into a tracker, the memory
-    /// accesses will be in a constant assending order.
+    /// accesses will be in a constant ascending order.
     pub fn optimize(&mut self) {
         self.buffers.optimize();
         self.textures.optimize();

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -31,7 +31,7 @@ impl<T: Resource> StatelessBindGroupSate<T> {
     /// Optimize the buffer bind group state by sorting it by ID.
     ///
     /// When this list of states is merged into a tracker, the memory
-    /// accesses will be in a constant assending order.
+    /// accesses will be in a constant ascending order.
     pub(crate) fn optimize(&self) {
         let mut resources = self.resources.lock();
         resources.sort_unstable_by_key(|&(id, _)| id.unzip().0);

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -1,10 +1,10 @@
 /*! Texture Trackers
  *
- * Texture trackers are signifigantly more complicated than
+ * Texture trackers are significantly more complicated than
  * the buffer trackers because textures can be in a "complex"
  * state where each individual subresource can potentially be
  * in a different state from every other subtresource. These
- * complex states are stored seperately from the simple states
+ * complex states are stored separately from the simple states
  * because they are signifignatly more difficult to track and
  * most resources spend the vast majority of their lives in
  * simple states.
@@ -170,7 +170,7 @@ impl<A: HalApi> TextureBindGroupState<A> {
     /// Optimize the texture bind group state by sorting it by ID.
     ///
     /// When this list of states is merged into a tracker, the memory
-    /// accesses will be in a constant assending order.
+    /// accesses will be in a constant ascending order.
     pub(crate) fn optimize(&self) {
         let mut textures = self.textures.lock();
         textures.sort_unstable_by_key(|v| v.texture.as_info().id().unzip().0);
@@ -1026,7 +1026,7 @@ unsafe fn insert<A: HalApi>(
 
                 log::trace!("\ttex {index}: insert end {state:?}");
 
-                // We only need to insert into the end, as there is guarenteed to be
+                // We only need to insert into the end, as there is guaranteed to be
                 // a start state provider.
                 unsafe { *end_state.simple.get_unchecked_mut(index) = state };
             }
@@ -1039,7 +1039,7 @@ unsafe fn insert<A: HalApi>(
 
                 log::trace!("\ttex {index}: insert end {complex:?}");
 
-                // We only need to insert into the end, as there is guarenteed to be
+                // We only need to insert into the end, as there is guaranteed to be
                 // a start state provider.
                 unsafe { *end_state.simple.get_unchecked_mut(index) = TextureUses::COMPLEX };
                 end_state.complex.insert(index, complex);

--- a/wgpu-hal/src/auxil/dxgi/exception.rs
+++ b/wgpu-hal/src/auxil/dxgi/exception.rs
@@ -10,12 +10,12 @@ use winapi::{
 // lock everyone out until we have registered or unregistered the
 // exception handler, otherwise really nasty races could happen.
 //
-// By routing all the registration through these functions we can guarentee
+// By routing all the registration through these functions we can guarantee
 // there is either 1 or 0 exception handlers registered, not multiple.
-static EXCEPTION_HANLDER_COUNT: Mutex<usize> = Mutex::const_new(parking_lot::RawMutex::INIT, 0);
+static EXCEPTION_HANDLER_COUNT: Mutex<usize> = Mutex::const_new(parking_lot::RawMutex::INIT, 0);
 
 pub fn register_exception_handler() {
-    let mut count_guard = EXCEPTION_HANLDER_COUNT.lock();
+    let mut count_guard = EXCEPTION_HANDLER_COUNT.lock();
     if *count_guard == 0 {
         unsafe {
             errhandlingapi::AddVectoredExceptionHandler(0, Some(output_debug_string_handler))
@@ -25,7 +25,7 @@ pub fn register_exception_handler() {
 }
 
 pub fn unregister_exception_handler() {
-    let mut count_guard = EXCEPTION_HANLDER_COUNT.lock();
+    let mut count_guard = EXCEPTION_HANDLER_COUNT.lock();
     if *count_guard == 1 {
         unsafe {
             errhandlingapi::RemoveVectoredExceptionHandler(output_debug_string_handler as *mut _)

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -57,7 +57,7 @@ pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter
     for cur_index in 0.. {
         if let Some(factory6) = factory.as_factory6() {
             profiling::scope!("IDXGIFactory6::EnumAdapterByGpuPreference");
-            // We're already at dxgi1.6, we can grab IDXGIAdapater4 directly
+            // We're already at dxgi1.6, we can grab IDXGIAdapter4 directly
             let mut adapter4 = d3d12::ComPtr::<dxgi1_6::IDXGIAdapter4>::null();
             let hr = unsafe {
                 factory6.EnumAdapterByGpuPreference(
@@ -100,7 +100,7 @@ pub fn enumerate_adapters(factory: d3d12::DxgiFactory) -> Vec<d3d12::DxgiAdapter
             continue;
         }
 
-        // Do the most aggressive casts first, skipping Adpater4 as we definitely don't have dxgi1_6.
+        // Do the most aggressive casts first, skipping Adapter4 as we definitely don't have dxgi1_6.
 
         // Adapter1 -> Adapter3
         unsafe {

--- a/wgpu-hal/src/dx12/descriptor.rs
+++ b/wgpu-hal/src/dx12/descriptor.rs
@@ -189,7 +189,7 @@ pub(super) struct CpuPool {
     device: d3d12::Device,
     ty: d3d12::DescriptorHeapType,
     heaps: Vec<FixedSizeHeap>,
-    avaliable_heap_indices: BitSet,
+    available_heap_indices: BitSet,
 }
 
 impl CpuPool {
@@ -198,13 +198,13 @@ impl CpuPool {
             device,
             ty,
             heaps: Vec::new(),
-            avaliable_heap_indices: BitSet::new(),
+            available_heap_indices: BitSet::new(),
         }
     }
 
     pub(super) fn alloc_handle(&mut self) -> Result<Handle, crate::DeviceError> {
         let heap_index = self
-            .avaliable_heap_indices
+            .available_heap_indices
             .iter()
             .next()
             .unwrap_or(self.heaps.len());
@@ -212,7 +212,7 @@ impl CpuPool {
         // Allocate a new heap
         if heap_index == self.heaps.len() {
             self.heaps.push(FixedSizeHeap::new(&self.device, self.ty)?);
-            self.avaliable_heap_indices.insert(heap_index);
+            self.available_heap_indices.insert(heap_index);
         }
 
         let heap = &mut self.heaps[heap_index];
@@ -221,7 +221,7 @@ impl CpuPool {
             heap_index,
         };
         if heap.is_full() {
-            self.avaliable_heap_indices.remove(heap_index);
+            self.available_heap_indices.remove(heap_index);
         }
 
         Ok(handle)
@@ -229,7 +229,7 @@ impl CpuPool {
 
     pub(super) fn free_handle(&mut self, handle: Handle) {
         self.heaps[handle.heap_index].free_handle(handle.raw);
-        self.avaliable_heap_indices.insert(handle.heap_index);
+        self.available_heap_indices.insert(handle.heap_index);
     }
 }
 

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -748,7 +748,7 @@ impl crate::Device<super::Api> for super::Device {
         // (bind group [2]) - Space=0
         // Special constant buffer: Space=0
 
-        //TODO: put lower bind group indices futher down the root signature. See:
+        //TODO: put lower bind group indices further down the root signature. See:
         // https://microsoft.github.io/DirectX-Specs/d3d/ResourceBinding.html#binding-model
         // Currently impossible because wgpu-core only re-binds the descriptor sets based
         // on Vulkan-like layout compatibility rules.

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -1,7 +1,7 @@
 /*!
 # DirectX12 API internals.
 
-Generally the mapping is straightforwad.
+Generally the mapping is straightforward.
 
 ## Resource transitions
 

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -776,7 +776,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
     ) {
         // There is nothing preventing the user from trying to update a single value within
         // a vector or matrix in the set_push_constant call, as to the user, all of this is
-        // just memory. However OpenGL does not allow parital uniform updates.
+        // just memory. However OpenGL does not allow partial uniform updates.
         //
         // As such, we locally keep a copy of the current state of the push constant memory
         // block. If the user tries to update a single value, we have the data to update the entirety

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -215,7 +215,7 @@ bitflags::bitflags! {
         // (https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/4972/diffs?diff_id=75888#22f5d1004713c9bbf857988c7efb81631ab88f99_323_327)
         // seems to indicate all skylake models are effected.
         const MESA_I915_SRGB_SHADER_CLEAR = 1 << 0;
-        /// Buffer map must emulated becuase it is not supported natively
+        /// Buffer map must emulated because it is not supported natively
         const EMULATE_BUFFER_MAP = 1 << 1;
     }
 }

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -179,7 +179,7 @@ fn load_gl_func(name: &str, module: Option<HMODULE>) -> *const c_void {
     ptr.cast()
 }
 
-fn extensions(extra: &Wgl, dc: HDC) -> HashSet<String> {
+fn get_extensions(extra: &Wgl, dc: HDC) -> HashSet<String> {
     if extra.GetExtensionsStringARB.is_loaded() {
         unsafe { CStr::from_ptr(extra.GetExtensionsStringARB(dc as *const _)) }
             .to_str()
@@ -449,9 +449,9 @@ impl crate::Instance<super::Api> for Instance {
         })?;
 
         let extra = Wgl::load_with(|name| load_gl_func(name, None));
-        let extentions = extensions(&extra, dc);
+        let extensions = get_extensions(&extra, dc);
 
-        let can_use_profile = extentions.contains("WGL_ARB_create_context_profile")
+        let can_use_profile = extensions.contains("WGL_ARB_create_context_profile")
             && extra.CreateContextAttribsARB.is_loaded();
 
         let context = if can_use_profile {
@@ -494,10 +494,10 @@ impl crate::Instance<super::Api> for Instance {
         };
 
         let extra = Wgl::load_with(|name| load_gl_func(name, None));
-        let extentions = extensions(&extra, dc);
+        let extensions = get_extensions(&extra, dc);
 
-        let srgb_capable = extentions.contains("WGL_EXT_framebuffer_sRGB")
-            || extentions.contains("WGL_ARB_framebuffer_sRGB")
+        let srgb_capable = extensions.contains("WGL_EXT_framebuffer_sRGB")
+            || extensions.contains("WGL_ARB_framebuffer_sRGB")
             || gl
                 .supported_extensions()
                 .contains("GL_ARB_framebuffer_sRGB");
@@ -742,8 +742,8 @@ impl crate::Surface<super::Api> for Surface {
 
         // Setup presentation mode
         let extra = Wgl::load_with(|name| load_gl_func(name, None));
-        let extentions = extensions(&extra, dc.device);
-        if !(extentions.contains("WGL_EXT_swap_control") && extra.SwapIntervalEXT.is_loaded()) {
+        let extensions = get_extensions(&extra, dc.device);
+        if !(extensions.contains("WGL_EXT_swap_control") && extra.SwapIntervalEXT.is_loaded()) {
             log::error!("WGL_EXT_swap_control is unsupported");
             return Err(crate::SurfaceError::Other(
                 "WGL_EXT_swap_control is unsupported",

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -412,7 +412,7 @@ pub trait Queue<A: Api>: WasmNotSendSync {
     /// Valid usage:
     /// - all of the command buffers were created from command pools
     ///   that are associated with this queue.
-    /// - all of the command buffers had `CommadBuffer::finish()` called.
+    /// - all of the command buffers had `CommandBuffer::finish()` called.
     /// - all surface textures that the command buffers write to must be
     ///   passed to the surface_textures argument.
     unsafe fn submit(
@@ -512,7 +512,7 @@ pub trait CommandEncoder<A: Api>: WasmNotSendSync + fmt::Debug {
     // pass common
 
     /// Sets the bind group at `index` to `group`, assuming the layout
-    /// of all the preceeding groups to be taken from `layout`.
+    /// of all the preceding groups to be taken from `layout`.
     unsafe fn set_bind_group(
         &mut self,
         layout: &A::PipelineLayout,
@@ -1465,7 +1465,7 @@ impl ValidationCanary {
         self.inner.lock().push(msg);
     }
 
-    /// Returns any API validation errors that hav occurred in this process
+    /// Returns any API validation errors that have occurred in this process
     /// since the last call to this function.
     pub fn get_and_reset(&self) -> Vec<String> {
         self.inner.lock().drain(..).collect()

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -538,7 +538,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                             .geometry(vk::AccelerationStructureGeometryDataKHR {
                                 triangles: *triangle_data,
                             })
-                            .flags(conv::map_acceleration_structure_geomety_flags(
+                            .flags(conv::map_acceleration_structure_geometry_flags(
                                 triangles.flags,
                             ));
 
@@ -570,7 +570,7 @@ impl crate::CommandEncoder<super::Api> for super::CommandEncoder {
                             .geometry(vk::AccelerationStructureGeometryDataKHR {
                                 aabbs: *aabbs_data,
                             })
-                            .flags(conv::map_acceleration_structure_geomety_flags(aabb.flags));
+                            .flags(conv::map_acceleration_structure_geometry_flags(aabb.flags));
 
                         geometries.push(*geometry);
                         ranges.push(*range);

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -924,7 +924,7 @@ pub fn map_acceleration_structure_flags(
     vk_flags
 }
 
-pub fn map_acceleration_structure_geomety_flags(
+pub fn map_acceleration_structure_geometry_flags(
     flags: crate::AccelerationStructureGeometryFlags,
 ) -> vk::GeometryFlagsKHR {
     let mut vk_flags = vk::GeometryFlagsKHR::empty();

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -2149,7 +2149,7 @@ impl crate::Device<super::Api> for super::Device {
                         .geometry(vk::AccelerationStructureGeometryDataKHR {
                             triangles: *triangle_data,
                         })
-                        .flags(conv::map_acceleration_structure_geomety_flags(
+                        .flags(conv::map_acceleration_structure_geometry_flags(
                             triangles.flags,
                         ));
 
@@ -2171,7 +2171,7 @@ impl crate::Device<super::Api> for super::Device {
                     let geometry = vk::AccelerationStructureGeometryKHR::builder()
                         .geometry_type(vk::GeometryTypeKHR::AABBS)
                         .geometry(vk::AccelerationStructureGeometryDataKHR { aabbs: *aabbs_data })
-                        .flags(conv::map_acceleration_structure_geomety_flags(aabb.flags));
+                        .flags(conv::map_acceleration_structure_geometry_flags(aabb.flags));
 
                     geometries.push(*geometry);
                     primitive_counts.push(aabb.count);

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -53,7 +53,7 @@ unsafe extern "system" fn debug_utils_messenger_callback(
     // Silence Vulkan Validation error "VUID-VkRenderPassBeginInfo-framebuffer-04627"
     // if the OBS layer is enabled. This is a bug in the OBS layer. As the OBS layer
     // does not have a version number they increment, there is no way to qualify the
-    // supression of the error to a specific version of the OBS layer.
+    // suppression of the error to a specific version of the OBS layer.
     //
     // See https://github.com/obsproject/obs-studio/issues/9353
     const VUID_VKRENDERPASSBEGININFO_FRAMEBUFFER_04627: i32 = 0x45125641;
@@ -279,7 +279,7 @@ impl super::Instance {
         }
 
         // VK_EXT_swapchain_colorspace
-        // Provid wide color gamut
+        // Provides wide color gamut
         extensions.push(vk::ExtSwapchainColorspaceFn::name());
 
         // VK_KHR_get_physical_device_properties2
@@ -968,7 +968,7 @@ impl crate::Surface<super::Api> for super::Surface {
         sc.next_surface_index += 1;
         sc.next_surface_index %= sc.surface_semaphores.len();
 
-        // special case for Intel Vulkan returning bizzare values (ugh)
+        // special case for Intel Vulkan returning bizarre values (ugh)
         if sc.device.vendor_id == crate::auxil::db::intel::VENDOR && index > 0x100 {
             return Err(crate::SurfaceError::Outdated);
         }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1550,7 +1550,7 @@ bitflags::bitflags! {
         /// If this is false, calls to `CommandEncoder::resolve_query_set` will be performed on the device (i.e. cpu) timeline
         /// and will block that timeline until the query has data. You may work around this limitation by waiting until the submit
         /// whose queries you are resolving is fully finished (through use of `queue.on_submitted_work_done`) and only
-        /// then submitting the resolve_query_set command. The queries will be guarenteed finished, so will not block.
+        /// then submitting the resolve_query_set command. The queries will be guaranteed finished, so will not block.
         ///
         /// Supported by:
         /// - Vulkan,
@@ -6400,7 +6400,7 @@ impl<T> ImageCopyTexture<T> {
     }
 }
 
-/// View of an external texture that cna be used to copy to a texture.
+/// View of an external texture that can be used to copy to a texture.
 ///
 /// Corresponds to [WebGPU `GPUImageCopyExternalImage`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopyexternalimage).
@@ -6438,7 +6438,7 @@ pub enum ExternalImageSource {
     HTMLCanvasElement(web_sys::HtmlCanvasElement),
     /// Copy from a off-screen canvas.
     ///
-    /// Requies [`DownlevelFlags::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES`]
+    /// Requires [`DownlevelFlags::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES`]
     OffscreenCanvas(web_sys::OffscreenCanvas),
 }
 

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -254,10 +254,10 @@ fn map_texture_format(texture_format: wgt::TextureFormat) -> web_sys::GpuTexture
                 wgt::AstcBlock::B12x12 => tf::Astc12x12UnormSrgb,
             },
             wgt::AstcChannel::Hdr => {
-                unimplemented!("Format {texture_format:?} has no WebGPU equivilant")
+                unimplemented!("Format {texture_format:?} has no WebGPU equivalent")
             }
         },
-        _ => unimplemented!("Format {texture_format:?} has no WebGPU equivilant"),
+        _ => unimplemented!("Format {texture_format:?} has no WebGPU equivalent"),
     }
 }
 
@@ -2152,7 +2152,7 @@ impl crate::context::Context for ContextWebGpu {
         _pipeline_layout: &Self::PipelineLayoutId,
         _pipeline_layout_data: &Self::PipelineLayoutData,
     ) {
-        // Dropped automaticaly
+        // Dropped automatically
     }
 
     fn shader_module_drop(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4936,7 +4936,7 @@ impl Surface<'_> {
 pub struct Id<T>(NonZeroU64, PhantomData<*mut T>);
 
 impl<T> Id<T> {
-    /// For testing use only. We provide no guarentees about the actual value of the ids.
+    /// For testing use only. We provide no guarantees about the actual value of the ids.
     #[doc(hidden)]
     pub fn inner(&self) -> u64 {
         self.0.get()


### PR DESCRIPTION
**Connections**

None

**Description**

We seem to have quite a few misspellings throughout the codebase, and it would be nice to enforce at least a reasonable level of spelling.

This uses a very lovely rust tool called [typos](https://github.com/crate-ci/typos) which is specifically designed for use in CI, trying to be as low-false-positive as possible. Indeed, there are only 5 words which needed to be excepted, as well as 2 usernames.

The only thing controversial about this PR is the amount of files changed, but this is a "rip the bandaid off" kinda thing.

**Testing**

Adding `typos` support in CI.
