### PR TITLE
Improve Instance::available_backend_features() on macOS.

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1791,9 +1791,9 @@ impl Instance {
                 backends = backends.union(Backends::VULKAN);
             }
 
-            // GL Vulkan on Mac is only available through angle.
+            // GL on Mac is only available through angle.
             if cfg!(target_os = "macos") && cfg!(feature = "angle") {
-                backends = backends.union(Backends::VULKAN);
+                backends = backends.union(Backends::GL);
             }
         } else {
             if cfg!(webgpu) {


### PR DESCRIPTION
The check for macOS and Angle should add `Backends::GL` not `Backends::VULKAN`. Similarly, the comment gets updated to not refer to Vulkan.

This code was introduced in #5167.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.

The change that this is fixing is already covered in the changeling and hasn't been released yet.