### PR TITLE
Fix the validation of max_bindings_per_bind_group

### DIFF
--- a/wgpu-core/src/device/bgl.rs
+++ b/wgpu-core/src/device/bgl.rs
@@ -68,7 +68,7 @@ impl EntryMap {
     ) -> Result<Self, binding_model::CreateBindGroupLayoutError> {
         let mut inner = FastIndexMap::with_capacity_and_hasher(entries.len(), Default::default());
         for entry in entries {
-            if entry.binding > device_limits.max_bindings_per_bind_group {
+            if entry.binding >= device_limits.max_bindings_per_bind_group {
                 return Err(
                     binding_model::CreateBindGroupLayoutError::InvalidBindingIndex {
                         binding: entry.binding,


### PR DESCRIPTION
**Connections**

Cts test `webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:createBindGroupLayout,at_over:limitTest="atDefault";testValueName="overLimit"`

**Description**

We need to ensure that the provided index is strictly inferior to `max_bindings_per_bind_group`.

**Testing**

Covered by the aforementioned CTS test.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
