### PR TITLE
add test that verifies that we can drop the queue before using the device to create a command encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Bottom level categories:
 
 - Fix intermittent crashes on Linux in the `multithreaded_compute` test. By @jimblandy in [#5129](https://github.com/gfx-rs/wgpu/pull/5129).
 - Refactor tests to read feature flags by name instead of a hardcoded hexadecimal u64. By @rodolphito in [#5155](https://github.com/gfx-rs/wgpu/pull/5155).
+- Add test that verifies that we can drop the queue before using the device to create a command encoder. By @Davidster in [#5211](https://github.com/gfx-rs/wgpu/pull/5211)
 
 ## v0.19.0 (2024-01-17)
 

--- a/tests/tests/encoder.rs
+++ b/tests/tests/encoder.rs
@@ -10,11 +10,16 @@ static DROP_ENCODER: GpuTestConfiguration = GpuTestConfiguration::new().run_sync
 
 #[gpu_test]
 static DROP_QUEUE_BEFORE_CREATING_COMMAND_ENCODER: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_sync(|ctx| {
-        let device = ctx.device.clone();
-        drop(ctx);
-        let _encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-    });
+    GpuTestConfiguration::new()
+        .parameters(TestParameters::default().expect_fail(FailureCase::always()))
+        .run_sync(|ctx| {
+            // Use the device after the queue is dropped. Currently this panics
+            // but it probably shouldn't
+            let device = ctx.device.clone();
+            drop(ctx);
+            let _encoder =
+                device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        });
 
 // This test crashes on DX12 with the exception:
 //

--- a/tests/tests/encoder.rs
+++ b/tests/tests/encoder.rs
@@ -8,6 +8,14 @@ static DROP_ENCODER: GpuTestConfiguration = GpuTestConfiguration::new().run_sync
     drop(encoder);
 });
 
+#[gpu_test]
+static DROP_QUEUE_BEFORE_CREATING_COMMAND_ENCODER: GpuTestConfiguration =
+    GpuTestConfiguration::new().run_sync(|ctx| {
+        let device = ctx.device.clone();
+        drop(ctx);
+        let _encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    });
+
 // This test crashes on DX12 with the exception:
 //
 // ID3D12CommandAllocator::Reset: The command allocator cannot be reset because a


### PR DESCRIPTION
I guess the issue would actually need to be fixed before this test gets merged?

**Connections**
n/a

**Description**
I noticed some code in the wgpu-profiler tests where the queue is dropped before we call Device::create_command_encoder. It produces the following panic:

```
thread 'src::errors::end_frame_unresolved_query' panicked at C:\Users\s\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-core-0.19.0\src\storage.rs:113:39:
Queue[Id(0,1,vk)] does not exist
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library\std\src\panicking.rs:645
   1: core::panicking::panic_fmt
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library\core\src\panicking.rs:72
   2: wgpu_core::storage::Storage<wgpu_core::device::queue::Queue<wgpu_hal::vulkan::Api>,wgpu_core::id::Id<wgpu_core::device::resource::Device<wgpu_hal::empty::Api> > >::get<wgpu_core::device::queue::Queue<wgpu_hal::vulkan::Api>,wgpu_core::id::Id<wgpu_core::dev
             at C:\Users\s\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-core-0.19.0\src\storage.rs:113
   3: wgpu_core::storage::Storage<wgpu_core::device::queue::Queue<wgpu_hal::vulkan::Api>,wgpu_core::id::Id<wgpu_core::device::resource::Device<wgpu_hal::empty::Api> > >::get_owned<wgpu_core::device::queue::Queue<wgpu_hal::vulkan::Api>,wgpu_core::id::Id<wgpu_cor
             at C:\Users\s\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-core-0.19.0\src\storage.rs:128
   4: wgpu_core::registry::Registry<wgpu_core::id::Id<wgpu_core::device::resource::Device<wgpu_hal::empty::Api> >,wgpu_core::device::queue::Queue<wgpu_hal::vulkan::Api> >::get<wgpu_core::id::Id<wgpu_core::device::resource::Device<wgpu_hal::empty::Api> >,wgpu_co
             at C:\Users\s\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-core-0.19.0\src\registry.rs:136
   5: wgpu_core::global::Global<wgpu_core::identity::IdentityManagerFactory>::device_create_command_encoder<wgpu_core::identity::IdentityManagerFactory,wgpu_hal::vulkan::Api>
             at C:\Users\s\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-core-0.19.0\src\device\global.rs:1313
   6: wgpu::backend::wgpu_core::impl$7::device_create_command_encoder
             at C:\Users\s\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-0.19.1\src\backend\wgpu_core.rs:1331
   7: wgpu::context::impl$5::device_create_command_encoder<wgpu::backend::wgpu_core::ContextWgpuCore>
             at C:\Users\s\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-0.19.1\src\context.rs:2336
   8: wgpu::Device::create_command_encoder
             at C:\Users\s\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-0.19.1\src\lib.rs:2395
   9: tests::src::errors::end_frame_unresolved_query
             at .\tests\src\errors.rs:51
  10: tests::src::errors::end_frame_unresolved_query::closure$0
             at .\tests\src\errors.rs:46
  11: core::ops::function::FnOnce::call_once<tests::src::errors::end_frame_unresolved_query::closure_env$0,tuple$<> >
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112\library\core\src\ops\function.rs:250
  12: core::ops::function::FnOnce::call_once
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library\core\src\ops\function.rs:250
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

```

This test reproduces this panic.

**Testing**
Run `cargo xtask test`

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
