### PR TITLE
Pin `web-sys` to `0.3.67` since we are using unstable APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ js-sys = "0.3.67"
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.40"
 wasm-bindgen-test = "0.3"
-web-sys = "0.3.67"
+web-sys = "=0.3.67"
 web-time = "0.2.4"
 
 # deno dependencies


### PR DESCRIPTION
**Connections**
- https://github.com/rustwasm/wasm-bindgen/issues/3834

**Description**
`wgpu` relies on unstable APIs of the `web-sys` crate and the latest `0.3.68` version breaks types related to WebGPU.

Since semantic versioning isn't enforced for unstable APIs in `web-sys`, we should rely instead on a specific crate version to avoid broken builds in the future.

**Testing**
N/A

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
