### PR TITLE
Store the device's queue via a weak ref instead of an ID

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1330,9 +1330,8 @@ impl Global {
             if !device.is_valid() {
                 break DeviceError::Lost;
             }
-            let queue = match hub.queues.get(device.queue_id.read().unwrap()) {
-                Ok(queue) => queue,
-                Err(_) => break DeviceError::InvalidQueueId,
+            let Some(queue) = device.get_queue() else {
+                break DeviceError::InvalidQueueId;
             };
             let encoder = match device
                 .command_allocator

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1072,10 +1072,10 @@ impl Global {
             let device = hub.devices.get(device_id).unwrap();
             queue.device = Some(device.clone());
 
-            let (queue_id, _) = queue_fid.assign(queue);
+            let (queue_id, queue) = queue_fid.assign(queue);
             resource_log!("Created Queue {:?}", queue_id);
 
-            device.queue_id.write().replace(queue_id);
+            device.set_queue(queue);
 
             return (device_id, queue_id, None);
         };
@@ -1124,10 +1124,10 @@ impl Global {
             let device = hub.devices.get(device_id).unwrap();
             queue.device = Some(device.clone());
 
-            let (queue_id, _) = queues_fid.assign(queue);
+            let (queue_id, queue) = queues_fid.assign(queue);
             resource_log!("Created Queue {:?}", queue_id);
 
-            device.queue_id.write().replace(queue_id);
+            device.set_queue(queue);
 
             return (device_id, queue_id, None);
         };

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -294,8 +294,7 @@ impl Global {
         if !device.is_valid() {
             return Err(DeviceError::Lost.into());
         }
-        let queue_id = device.queue_id.read().unwrap();
-        let queue = hub.queues.get(queue_id).unwrap();
+        let queue = device.get_queue().unwrap();
 
         #[cfg(feature = "trace")]
         if let Some(ref mut trace) = *device.trace.lock() {


### PR DESCRIPTION
**Connections**

 - #5120
 - #5211

**Description**

This is one of the internal uses of IDs instead of Arc/Weak references.

With this PR the Queue has an strong reference to the device and the device has a weak ref to the queue.
I think that to align with the WebGPU spec we should do the opposite (The device owns the queue). However that's more complicated to do this way because of the way the device and queue are destroyed currently (not impossible but more complicated).

This does not quite fix the test  from #5211, but it turns the panic into a validation error in `create_command_encoder`.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
