### PR TITLE
Enforce that `InstanceFlags::GPU_BASED_VALIDATION` implies `VALIDATION` on all back ends

### DIFF
--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -115,3 +115,22 @@ impl crate::TextureCopy {
         self.size = self.size.min(&max_src_size).min(&max_dst_size);
     }
 }
+
+pub(crate) struct RequestedValidation {
+    pub gpu_based_validation: bool,
+}
+
+impl RequestedValidation {
+    pub(crate) fn from_flags(instance_flags: wgt::InstanceFlags) -> Option<Self> {
+        let any_validation_requested = instance_flags
+            .intersects(wgt::InstanceFlags::VALIDATION | wgt::InstanceFlags::GPU_BASED_VALIDATION);
+        if any_validation_requested {
+            Some(Self {
+                gpu_based_validation: instance_flags
+                    .intersects(wgt::InstanceFlags::GPU_BASED_VALIDATION),
+            })
+        } else {
+            None
+        }
+    }
+}

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1,3 +1,4 @@
+use crate::auxil::RequestedValidation;
 use glow::HasContext;
 use once_cell::sync::Lazy;
 use parking_lot::{Mutex, MutexGuard, RwLock};
@@ -792,6 +793,8 @@ impl crate::Instance for Instance {
         #[cfg(Emscripten)]
         let egl1_5: Option<&Arc<EglInstance>> = Some(&egl);
 
+        let requested_validation = RequestedValidation::from_flags(self.flags);
+
         let (display, display_owner, wsi_kind) =
             if let (Some(library), Some(egl)) = (wayland_library, egl1_5) {
                 log::info!("Using Wayland platform");
@@ -823,7 +826,7 @@ impl crate::Instance for Instance {
                     EGL_PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE as khronos_egl::Attrib,
                     EGL_PLATFORM_X11_KHR as khronos_egl::Attrib,
                     EGL_PLATFORM_ANGLE_DEBUG_LAYERS_ENABLED as khronos_egl::Attrib,
-                    usize::from(desc.flags.contains(wgt::InstanceFlags::VALIDATION)),
+                    usize::from(requested_validation.is_some()),
                     khronos_egl::ATTRIB_NONE,
                 ];
                 let display = unsafe {
@@ -855,9 +858,7 @@ impl crate::Instance for Instance {
                 (display, None, WindowKind::Unknown)
             };
 
-        if desc.flags.contains(wgt::InstanceFlags::VALIDATION)
-            && client_ext_str.contains("EGL_KHR_debug")
-        {
+        if requested_validation.is_some() && client_ext_str.contains("EGL_KHR_debug") {
             log::debug!("Enabling EGL debug output");
             let function: EglDebugMessageControlFun = {
                 let addr = egl.get_proc_address("eglDebugMessageControlKHR").unwrap();
@@ -1027,7 +1028,7 @@ impl crate::Instance for Instance {
             });
         }
 
-        if self.flags.contains(wgt::InstanceFlags::VALIDATION) && gl.supports_debug() {
+        if RequestedValidation::from_flags(self.flags).is_some() && gl.supports_debug() {
             log::debug!("Enabling GLES debug output");
             unsafe { gl.enable(glow::DEBUG_OUTPUT) };
             unsafe { gl.debug_message_callback(super::gl_debug_message_callback) };


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

* Depends on #5046.

**Description**
_Describe what problem this is solving, and how it's solved._

Enforce in all back ends that `InstanceFlags::GPU_BASED_VALIDATION` implies `InstanceFlags::GPU_BASED_VALIDATION`. ATOW, the GLES is the only remaining implemented offender.

**Testing**
_Explain how this change is tested._

No tests have been added for this.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
