### PR TITLE
Store Arcs instead of IDs in render bundles

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -97,7 +97,7 @@ use crate::{
     id,
     init_tracker::{BufferInitTrackerAction, MemoryInitKind, TextureInitTrackerAction},
     pipeline::{PipelineFlags, RenderPipeline, VertexStep},
-    resource::{Resource, ResourceInfo, ResourceType},
+    resource::{Buffer, Resource, ResourceInfo, ResourceType},
     resource_log,
     track::RenderBundleScope,
     validation::check_buffer_usage,
@@ -110,9 +110,11 @@ use thiserror::Error;
 
 use hal::CommandEncoder as _;
 
+use super::ArcRenderCommand;
+
 /// https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-draw
-fn validate_draw(
-    vertex: &[Option<VertexState>],
+fn validate_draw<A: HalApi>(
+    vertex: &[Option<VertexState<A>>],
     step: &[VertexStep],
     first_vertex: u32,
     vertex_count: u32,
@@ -152,10 +154,10 @@ fn validate_draw(
 }
 
 // See https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-drawindexed
-fn validate_indexed_draw(
-    vertex: &[Option<VertexState>],
+fn validate_indexed_draw<A: HalApi>(
+    vertex: &[Option<VertexState<A>>],
     step: &[VertexStep],
-    index_state: &IndexState,
+    index_state: &IndexState<A>,
     first_index: u32,
     index_count: u32,
     first_instance: u32,
@@ -474,7 +476,7 @@ impl RenderBundleEncoder {
 
                     let pipeline_state = PipelineState::new(pipeline);
 
-                    commands.push(command);
+                    commands.push(ArcRenderCommand::SetPipeline(pipeline.clone()));
 
                     // If this pipeline uses push constants, zero out their values.
                     if let Some(iter) = pipeline_state.zero_push_constants() {
@@ -511,7 +513,7 @@ impl RenderBundleEncoder {
                         offset..end,
                         MemoryInitKind::NeedsInitializedMemory,
                     ));
-                    state.set_index_buffer(buffer_id, index_format, offset..end);
+                    state.set_index_buffer(buffer.clone(), index_format, offset..end);
                 }
                 RenderCommand::SetVertexBuffer {
                     slot,
@@ -550,13 +552,13 @@ impl RenderBundleEncoder {
                         offset..end,
                         MemoryInitKind::NeedsInitializedMemory,
                     ));
-                    state.vertex[slot as usize] = Some(VertexState::new(buffer_id, offset..end));
+                    state.vertex[slot as usize] = Some(VertexState::new(buffer.clone(), offset..end));
                 }
                 RenderCommand::SetPushConstant {
                     stages,
                     offset,
                     size_bytes,
-                    values_offset: _,
+                    values_offset,
                 } => {
                     let scope = PassErrorScope::SetPushConstant;
                     let end_offset = offset + size_bytes;
@@ -567,7 +569,7 @@ impl RenderBundleEncoder {
                         .validate_push_constant_ranges(stages, offset, end_offset)
                         .map_pass_err(scope)?;
 
-                    commands.push(command);
+                    commands.push(ArcRenderCommand::SetPushConstant { stages, offset, size_bytes, values_offset });
                 }
                 RenderCommand::Draw {
                     vertex_count,
@@ -595,14 +597,19 @@ impl RenderBundleEncoder {
                     if instance_count > 0 && vertex_count > 0 {
                         commands.extend(state.flush_vertices());
                         commands.extend(state.flush_binds(used_bind_groups, base.dynamic_offsets));
-                        commands.push(command);
+                        commands.push(ArcRenderCommand::Draw {
+                            vertex_count,
+                            instance_count,
+                            first_vertex,
+                            first_instance,
+                        });
                     }
                 }
                 RenderCommand::DrawIndexed {
                     index_count,
                     instance_count,
                     first_index,
-                    base_vertex: _,
+                    base_vertex,
                     first_instance,
                 } => {
                     let scope = PassErrorScope::Draw {
@@ -631,7 +638,7 @@ impl RenderBundleEncoder {
                         commands.extend(state.flush_index());
                         commands.extend(state.flush_vertices());
                         commands.extend(state.flush_binds(used_bind_groups, base.dynamic_offsets));
-                        commands.push(command);
+                        commands.push(ArcRenderCommand::DrawIndexed { index_count, instance_count, first_index, base_vertex, first_instance });
                     }
                 }
                 RenderCommand::MultiDrawIndirect {
@@ -671,7 +678,7 @@ impl RenderBundleEncoder {
 
                     commands.extend(state.flush_vertices());
                     commands.extend(state.flush_binds(used_bind_groups, base.dynamic_offsets));
-                    commands.push(command);
+                    commands.push(ArcRenderCommand::MultiDrawIndirect { buffer: buffer.clone(), offset, count: None, indexed: false });
                 }
                 RenderCommand::MultiDrawIndirect {
                     buffer_id,
@@ -716,7 +723,7 @@ impl RenderBundleEncoder {
                     commands.extend(index.flush());
                     commands.extend(state.flush_vertices());
                     commands.extend(state.flush_binds(used_bind_groups, base.dynamic_offsets));
-                    commands.push(command);
+                    commands.push(ArcRenderCommand::MultiDrawIndirect { buffer: buffer.clone(), offset, count: None, indexed: true });
                 }
                 RenderCommand::MultiDrawIndirect { .. }
                 | RenderCommand::MultiDrawIndirectCount { .. } => unimplemented!(),
@@ -827,7 +834,7 @@ pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
 pub struct RenderBundle<A: HalApi> {
     // Normalized command stream. It can be executed verbatim,
     // without re-binding anything on the pipeline change.
-    base: BasePass<RenderCommand>,
+    base: BasePass<ArcRenderCommand<A>>,
     pub(super) is_depth_read_only: bool,
     pub(super) is_stencil_read_only: bool,
     pub(crate) device: Arc<Device<A>>,
@@ -866,7 +873,6 @@ impl<A: HalApi> RenderBundle<A> {
     /// All the validation has already been done by this point.
     /// The only failure condition is if some of the used buffers are destroyed.
     pub(super) unsafe fn execute(&self, raw: &mut A::CommandEncoder) -> Result<(), ExecutionError> {
-        let trackers = &self.used;
         let mut offsets = self.base.dynamic_offsets.as_slice();
         let mut pipeline_layout = None::<Arc<PipelineLayout<A>>>;
         if !self.discard_hal_labels {
@@ -877,74 +883,65 @@ impl<A: HalApi> RenderBundle<A> {
 
         let snatch_guard = self.device.snatchable_lock.read();
 
+        use ArcRenderCommand as Cmd;
         for command in self.base.commands.iter() {
-            match *command {
-                RenderCommand::SetBindGroup {
+            match command {
+                Cmd::SetBindGroup {
                     index,
                     num_dynamic_offsets,
-                    bind_group_id,
+                    bind_group,
                 } => {
-                    let bind_groups = trackers.bind_groups.read();
-                    let bind_group = bind_groups.get(bind_group_id).unwrap();
                     let raw_bg = bind_group
                         .raw(&snatch_guard)
-                        .ok_or(ExecutionError::InvalidBindGroup(bind_group_id))?;
+                        .ok_or(ExecutionError::InvalidBindGroup(bind_group.info.id()))?;
                     unsafe {
                         raw.set_bind_group(
                             pipeline_layout.as_ref().unwrap().raw(),
-                            index,
+                            *index,
                             raw_bg,
-                            &offsets[..num_dynamic_offsets],
+                            &offsets[..*num_dynamic_offsets],
                         )
                     };
-                    offsets = &offsets[num_dynamic_offsets..];
+                    offsets = &offsets[*num_dynamic_offsets..];
                 }
-                RenderCommand::SetPipeline(pipeline_id) => {
-                    let render_pipelines = trackers.render_pipelines.read();
-                    let pipeline = render_pipelines.get(pipeline_id).unwrap();
+                Cmd::SetPipeline(pipeline) => {
                     unsafe { raw.set_render_pipeline(pipeline.raw()) };
 
                     pipeline_layout = Some(pipeline.layout.clone());
                 }
-                RenderCommand::SetIndexBuffer {
-                    buffer_id,
+                Cmd::SetIndexBuffer {
+                    buffer,
                     index_format,
                     offset,
                     size,
                 } => {
-                    let buffers = trackers.buffers.read();
-                    let buffer: &A::Buffer = buffers
-                        .get(buffer_id)
-                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?
+                    let buffer: &A::Buffer = buffer
                         .raw(&snatch_guard)
-                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?;
+                        .ok_or(ExecutionError::DestroyedBuffer(buffer.info.id()))?;
                     let bb = hal::BufferBinding {
                         buffer,
-                        offset,
-                        size,
+                        offset: *offset,
+                        size: *size,
                     };
-                    unsafe { raw.set_index_buffer(bb, index_format) };
+                    unsafe { raw.set_index_buffer(bb, *index_format) };
                 }
-                RenderCommand::SetVertexBuffer {
+                Cmd::SetVertexBuffer {
                     slot,
-                    buffer_id,
+                    buffer,
                     offset,
                     size,
                 } => {
-                    let buffers = trackers.buffers.read();
-                    let buffer = buffers
-                        .get(buffer_id)
-                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?
+                    let buffer = buffer
                         .raw(&snatch_guard)
-                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?;
+                        .ok_or(ExecutionError::DestroyedBuffer(buffer.info.id()))?;
                     let bb = hal::BufferBinding {
                         buffer,
-                        offset,
-                        size,
+                        offset: *offset,
+                        size: *size,
                     };
-                    unsafe { raw.set_vertex_buffer(slot, bb) };
+                    unsafe { raw.set_vertex_buffer(*slot, bb) };
                 }
-                RenderCommand::SetPushConstant {
+                Cmd::SetPushConstant {
                     stages,
                     offset,
                     size_bytes,
@@ -952,7 +949,7 @@ impl<A: HalApi> RenderBundle<A> {
                 } => {
                     let pipeline_layout = pipeline_layout.as_ref().unwrap();
 
-                    if let Some(values_offset) = values_offset {
+                    if let Some(values_offset) = *values_offset {
                         let values_end_offset =
                             (values_offset + size_bytes / wgt::PUSH_CONSTANT_ALIGNMENT) as usize;
                         let data_slice = &self.base.push_constant_data
@@ -961,20 +958,20 @@ impl<A: HalApi> RenderBundle<A> {
                         unsafe {
                             raw.set_push_constants(
                                 pipeline_layout.raw(),
-                                stages,
-                                offset,
+                                *stages,
+                                *offset,
                                 data_slice,
                             )
                         }
                     } else {
                         super::push_constant_clear(
-                            offset,
-                            size_bytes,
+                            *offset,
+                            *size_bytes,
                             |clear_offset, clear_data| {
                                 unsafe {
                                     raw.set_push_constants(
                                         pipeline_layout.raw(),
-                                        stages,
+                                        *stages,
                                         clear_offset,
                                         clear_data,
                                     )
@@ -983,15 +980,22 @@ impl<A: HalApi> RenderBundle<A> {
                         );
                     }
                 }
-                RenderCommand::Draw {
+                Cmd::Draw {
                     vertex_count,
                     instance_count,
                     first_vertex,
                     first_instance,
                 } => {
-                    unsafe { raw.draw(first_vertex, vertex_count, first_instance, instance_count) };
+                    unsafe {
+                        raw.draw(
+                            *first_vertex,
+                            *vertex_count,
+                            *first_instance,
+                            *instance_count,
+                        )
+                    };
                 }
-                RenderCommand::DrawIndexed {
+                Cmd::DrawIndexed {
                     index_count,
                     instance_count,
                     first_index,
@@ -1000,63 +1004,54 @@ impl<A: HalApi> RenderBundle<A> {
                 } => {
                     unsafe {
                         raw.draw_indexed(
-                            first_index,
-                            index_count,
-                            base_vertex,
-                            first_instance,
-                            instance_count,
+                            *first_index,
+                            *index_count,
+                            *base_vertex,
+                            *first_instance,
+                            *instance_count,
                         )
                     };
                 }
-                RenderCommand::MultiDrawIndirect {
-                    buffer_id,
+                Cmd::MultiDrawIndirect {
+                    buffer,
                     offset,
                     count: None,
                     indexed: false,
                 } => {
-                    let buffers = trackers.buffers.read();
-                    let buffer = buffers
-                        .get(buffer_id)
-                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?
+                    let buffer = buffer
                         .raw(&snatch_guard)
-                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?;
-                    unsafe { raw.draw_indirect(buffer, offset, 1) };
+                        .ok_or(ExecutionError::DestroyedBuffer(buffer.info.id()))?;
+                    unsafe { raw.draw_indirect(buffer, *offset, 1) };
                 }
-                RenderCommand::MultiDrawIndirect {
-                    buffer_id,
+                Cmd::MultiDrawIndirect {
+                    buffer,
                     offset,
                     count: None,
                     indexed: true,
                 } => {
-                    let buffers = trackers.buffers.read();
-                    let buffer = buffers
-                        .get(buffer_id)
-                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?
+                    let buffer = buffer
                         .raw(&snatch_guard)
-                        .ok_or(ExecutionError::DestroyedBuffer(buffer_id))?;
-                    unsafe { raw.draw_indexed_indirect(buffer, offset, 1) };
+                        .ok_or(ExecutionError::DestroyedBuffer(buffer.info.id()))?;
+                    unsafe { raw.draw_indexed_indirect(buffer, *offset, 1) };
                 }
-                RenderCommand::MultiDrawIndirect { .. }
-                | RenderCommand::MultiDrawIndirectCount { .. } => {
+                Cmd::MultiDrawIndirect { .. } | Cmd::MultiDrawIndirectCount { .. } => {
                     return Err(ExecutionError::Unimplemented("multi-draw-indirect"))
                 }
-                RenderCommand::PushDebugGroup { .. }
-                | RenderCommand::InsertDebugMarker { .. }
-                | RenderCommand::PopDebugGroup => {
+                Cmd::PushDebugGroup { .. } | Cmd::InsertDebugMarker { .. } | Cmd::PopDebugGroup => {
                     return Err(ExecutionError::Unimplemented("debug-markers"))
                 }
-                RenderCommand::WriteTimestamp { .. }
-                | RenderCommand::BeginOcclusionQuery { .. }
-                | RenderCommand::EndOcclusionQuery
-                | RenderCommand::BeginPipelineStatisticsQuery { .. }
-                | RenderCommand::EndPipelineStatisticsQuery => {
+                Cmd::WriteTimestamp { .. }
+                | Cmd::BeginOcclusionQuery { .. }
+                | Cmd::EndOcclusionQuery
+                | Cmd::BeginPipelineStatisticsQuery { .. }
+                | Cmd::EndPipelineStatisticsQuery => {
                     return Err(ExecutionError::Unimplemented("queries"))
                 }
-                RenderCommand::ExecuteBundle(_)
-                | RenderCommand::SetBlendConstant(_)
-                | RenderCommand::SetStencilReference(_)
-                | RenderCommand::SetViewport { .. }
-                | RenderCommand::SetScissor(_) => unreachable!(),
+                Cmd::ExecuteBundle(_)
+                | Cmd::SetBlendConstant(_)
+                | Cmd::SetStencilReference(_)
+                | Cmd::SetViewport { .. }
+                | Cmd::SetScissor(_) => unreachable!(),
             }
         }
 
@@ -1090,14 +1085,14 @@ impl<A: HalApi> Resource for RenderBundle<A> {
 /// and calls [`State::flush_index`] before any indexed draw command to produce
 /// a `SetIndexBuffer` command if one is necessary.
 #[derive(Debug)]
-struct IndexState {
-    buffer: id::BufferId,
+struct IndexState<A: HalApi> {
+    buffer: Arc<Buffer<A>>,
     format: wgt::IndexFormat,
     range: Range<wgt::BufferAddress>,
     is_dirty: bool,
 }
 
-impl IndexState {
+impl<A: HalApi> IndexState<A> {
     /// Return the number of entries in the current index buffer.
     ///
     /// Panic if no index buffer has been set.
@@ -1112,11 +1107,11 @@ impl IndexState {
 
     /// Generate a `SetIndexBuffer` command to prepare for an indexed draw
     /// command, if needed.
-    fn flush(&mut self) -> Option<RenderCommand> {
+    fn flush(&mut self) -> Option<ArcRenderCommand<A>> {
         if self.is_dirty {
             self.is_dirty = false;
-            Some(RenderCommand::SetIndexBuffer {
-                buffer_id: self.buffer,
+            Some(ArcRenderCommand::SetIndexBuffer {
+                buffer: self.buffer.clone(),
                 index_format: self.format,
                 offset: self.range.start,
                 size: wgt::BufferSize::new(self.range.end - self.range.start),
@@ -1137,14 +1132,14 @@ impl IndexState {
 ///
 /// [`flush`]: IndexState::flush
 #[derive(Debug)]
-struct VertexState {
-    buffer: id::BufferId,
+struct VertexState<A: HalApi> {
+    buffer: Arc<Buffer<A>>,
     range: Range<wgt::BufferAddress>,
     is_dirty: bool,
 }
 
-impl VertexState {
-    fn new(buffer: id::BufferId, range: Range<wgt::BufferAddress>) -> Self {
+impl<A: HalApi> VertexState<A> {
+    fn new(buffer: Arc<Buffer<A>>, range: Range<wgt::BufferAddress>) -> Self {
         Self {
             buffer,
             range,
@@ -1155,12 +1150,12 @@ impl VertexState {
     /// Generate a `SetVertexBuffer` command for this slot, if necessary.
     ///
     /// `slot` is the index of the vertex buffer slot that `self` tracks.
-    fn flush(&mut self, slot: u32) -> Option<RenderCommand> {
+    fn flush(&mut self, slot: u32) -> Option<ArcRenderCommand<A>> {
         if self.is_dirty {
             self.is_dirty = false;
-            Some(RenderCommand::SetVertexBuffer {
+            Some(ArcRenderCommand::SetVertexBuffer {
                 slot,
-                buffer_id: self.buffer,
+                buffer: self.buffer.clone(),
                 offset: self.range.start,
                 size: wgt::BufferSize::new(self.range.end - self.range.start),
             })
@@ -1222,7 +1217,7 @@ impl<A: HalApi> PipelineState<A> {
 
     /// Return a sequence of commands to zero the push constant ranges this
     /// pipeline uses. If no initialization is necessary, return `None`.
-    fn zero_push_constants(&self) -> Option<impl Iterator<Item = RenderCommand>> {
+    fn zero_push_constants(&self) -> Option<impl Iterator<Item = ArcRenderCommand<A>>> {
         if !self.push_constant_ranges.is_empty() {
             let nonoverlapping_ranges =
                 super::bind::compute_nonoverlapping_ranges(&self.push_constant_ranges);
@@ -1230,7 +1225,7 @@ impl<A: HalApi> PipelineState<A> {
             Some(
                 nonoverlapping_ranges
                     .into_iter()
-                    .map(|range| RenderCommand::SetPushConstant {
+                    .map(|range| ArcRenderCommand::SetPushConstant {
                         stages: range.stages,
                         offset: range.range.start,
                         size_bytes: range.range.end - range.range.start,
@@ -1264,11 +1259,11 @@ struct State<A: HalApi> {
     bind: ArrayVec<Option<BindState<A>>, { hal::MAX_BIND_GROUPS }>,
 
     /// The state of each vertex buffer slot.
-    vertex: ArrayVec<Option<VertexState>, { hal::MAX_VERTEX_BUFFERS }>,
+    vertex: ArrayVec<Option<VertexState<A>>, { hal::MAX_VERTEX_BUFFERS }>,
 
     /// The current index buffer, if one has been set. We flush this state
     /// before indexed draw commands.
-    index: Option<IndexState>,
+    index: Option<IndexState<A>>,
 
     /// Dynamic offset values used by the cleaned-up command sequence.
     ///
@@ -1378,13 +1373,13 @@ impl<A: HalApi> State<A> {
     /// Set the bundle's current index buffer and its associated parameters.
     fn set_index_buffer(
         &mut self,
-        buffer: id::BufferId,
+        buffer: Arc<Buffer<A>>,
         format: wgt::IndexFormat,
         range: Range<wgt::BufferAddress>,
     ) {
         match self.index {
             Some(ref current)
-                if current.buffer == buffer
+                if Arc::ptr_eq(&current.buffer, &buffer)
                     && current.format == format
                     && current.range == range =>
             {
@@ -1403,11 +1398,11 @@ impl<A: HalApi> State<A> {
 
     /// Generate a `SetIndexBuffer` command to prepare for an indexed draw
     /// command, if needed.
-    fn flush_index(&mut self) -> Option<RenderCommand> {
+    fn flush_index(&mut self) -> Option<ArcRenderCommand<A>> {
         self.index.as_mut().and_then(|index| index.flush())
     }
 
-    fn flush_vertices(&mut self) -> impl Iterator<Item = RenderCommand> + '_ {
+    fn flush_vertices(&mut self) -> impl Iterator<Item = ArcRenderCommand<A>> + '_ {
         self.vertex
             .iter_mut()
             .enumerate()
@@ -1419,7 +1414,7 @@ impl<A: HalApi> State<A> {
         &mut self,
         used_bind_groups: usize,
         dynamic_offsets: &[wgt::DynamicOffset],
-    ) -> impl Iterator<Item = RenderCommand> + '_ {
+    ) -> impl Iterator<Item = ArcRenderCommand<A>> + '_ {
         // Append each dirty bind group's dynamic offsets to `flat_dynamic_offsets`.
         for contents in self.bind[..used_bind_groups].iter().flatten() {
             if contents.is_dirty {
@@ -1438,9 +1433,9 @@ impl<A: HalApi> State<A> {
                     if contents.is_dirty {
                         contents.is_dirty = false;
                         let offsets = &contents.dynamic_offsets;
-                        return Some(RenderCommand::SetBindGroup {
+                        return Some(ArcRenderCommand::SetBindGroup {
                             index: i.try_into().unwrap(),
-                            bind_group_id: contents.bind_group.as_info().id(),
+                            bind_group: contents.bind_group.clone(),
                             num_dynamic_offsets: offsets.end - offsets.start,
                         });
                     }

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -2,16 +2,21 @@
 !*/
 
 use crate::{
-    binding_model::{LateMinBufferBindingSizeMismatch, PushConstantUploadError},
+    binding_model::{BindGroup, LateMinBufferBindingSizeMismatch, PushConstantUploadError},
     error::ErrorFormatter,
+    hal_api::HalApi,
     id,
+    pipeline::RenderPipeline,
+    resource::{Buffer, QuerySet},
     track::UsageConflict,
     validation::{MissingBufferUsageError, MissingTextureUsageError},
 };
 use wgt::{BufferAddress, BufferSize, Color, VertexStepMode};
 
-use std::num::NonZeroU32;
+use std::{num::NonZeroU32, sync::Arc};
 use thiserror::Error;
+
+use super::RenderBundle;
 
 /// Error validating a draw call.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
@@ -244,4 +249,116 @@ pub enum RenderCommand {
     },
     EndPipelineStatisticsQuery,
     ExecuteBundle(id::RenderBundleId),
+}
+
+/// Equivalent to `RenderCommand` with the Ids resolved into resource Arcs.
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub enum ArcRenderCommand<A: HalApi> {
+    SetBindGroup {
+        index: u32,
+        num_dynamic_offsets: usize,
+        bind_group: Arc<BindGroup<A>>,
+    },
+    SetPipeline(Arc<RenderPipeline<A>>),
+    SetIndexBuffer {
+        buffer: Arc<Buffer<A>>,
+        index_format: wgt::IndexFormat,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    },
+    SetVertexBuffer {
+        slot: u32,
+        buffer: Arc<Buffer<A>>,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    },
+    SetBlendConstant(Color),
+    SetStencilReference(u32),
+    SetViewport {
+        rect: Rect<f32>,
+        //TODO: use half-float to reduce the size?
+        depth_min: f32,
+        depth_max: f32,
+    },
+    SetScissor(Rect<u32>),
+
+    /// Set a range of push constants to values stored in [`BasePass::push_constant_data`].
+    ///
+    /// See [`wgpu::RenderPass::set_push_constants`] for a detailed explanation
+    /// of the restrictions these commands must satisfy.
+    SetPushConstant {
+        /// Which stages we are setting push constant values for.
+        stages: wgt::ShaderStages,
+
+        /// The byte offset within the push constant storage to write to.  This
+        /// must be a multiple of four.
+        offset: u32,
+
+        /// The number of bytes to write. This must be a multiple of four.
+        size_bytes: u32,
+
+        /// Index in [`BasePass::push_constant_data`] of the start of the data
+        /// to be written.
+        ///
+        /// Note: this is not a byte offset like `offset`. Rather, it is the
+        /// index of the first `u32` element in `push_constant_data` to read.
+        ///
+        /// `None` means zeros should be written to the destination range, and
+        /// there is no corresponding data in `push_constant_data`. This is used
+        /// by render bundles, which explicitly clear out any state that
+        /// post-bundle code might see.
+        values_offset: Option<u32>,
+    },
+    Draw {
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    },
+    DrawIndexed {
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+        first_instance: u32,
+    },
+    MultiDrawIndirect {
+        buffer: Arc<Buffer<A>>,
+        offset: BufferAddress,
+        /// Count of `None` represents a non-multi call.
+        count: Option<NonZeroU32>,
+        indexed: bool,
+    },
+    MultiDrawIndirectCount {
+        buffer: Arc<Buffer<A>>,
+        offset: BufferAddress,
+        count_buffer: Arc<Buffer<A>>,
+        count_buffer_offset: BufferAddress,
+        max_count: u32,
+        indexed: bool,
+    },
+    PushDebugGroup {
+        color: u32,
+        len: usize,
+    },
+    PopDebugGroup,
+    InsertDebugMarker {
+        color: u32,
+        len: usize,
+    },
+    WriteTimestamp {
+        query_set: Arc<QuerySet<A>>,
+        query_index: u32,
+    },
+    BeginOcclusionQuery {
+        query_index: u32,
+    },
+    EndOcclusionQuery,
+    BeginPipelineStatisticsQuery {
+        query_set: Arc<QuerySet<A>>,
+        query_index: u32,
+    },
+    EndPipelineStatisticsQuery,
+    ExecuteBundle(Arc<RenderBundle<A>>),
 }

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -149,20 +149,6 @@ impl<A: HalApi> BufferUsageScope<A> {
         resources.into_iter()
     }
 
-    pub fn get(&self, id: BufferId) -> Option<&Arc<Buffer<A>>> {
-        let index = id.unzip().0 as usize;
-        if index > self.metadata.size() {
-            return None;
-        }
-        self.tracker_assert_in_bounds(index);
-        unsafe {
-            if self.metadata.contains_unchecked(index) {
-                return Some(self.metadata.get_resource_unchecked(index));
-            }
-        }
-        None
-    }
-
     /// Merge the list of buffer states in the given bind group into this usage scope.
     ///
     /// If any of the resulting states is invalid, stops the merge and returns a usage

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -221,18 +221,4 @@ impl<T: Resource> StatelessTracker<T> {
             }
         }
     }
-
-    pub fn get(&self, id: Id<T::Marker>) -> Option<&Arc<T>> {
-        let index = id.unzip().0 as usize;
-        if index > self.metadata.size() {
-            return None;
-        }
-        self.tracker_assert_in_bounds(index);
-        unsafe {
-            if self.metadata.contains_unchecked(index) {
-                return Some(self.metadata.get_resource_unchecked(index));
-            }
-        }
-        None
-    }
 }


### PR DESCRIPTION
**Connections**

- https://github.com/gfx-rs/wgpu/issues/5120
- https://github.com/gfx-rs/wgpu/issues/5217
- https://github.com/gfx-rs/wgpu/pull/5141
- https://github.com/gfx-rs/wgpu/issues/4912

**Description**

This is a step towards not relying on IDs internally. It is also a dependency to not using IDs in trackers and fix our deduplicated resource leaks since the current bundle code uses trackers to store and get the actual resource arcs via IDs.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
