### PR TITLE
Use a unique tracker index per resource instead of the ID in trackers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Bottom level categories:
 - Fix timeout when presenting a surface where no work has been done. By @waywardmonkeys in [#5200](https://github.com/gfx-rs/wgpu/pull/5200)
 - Simplify and speed up the allocation of internal IDs. By @nical in [#5229](https://github.com/gfx-rs/wgpu/pull/5229)
 - Fix an issue where command encoders weren't properly freed if an error occurred during command encoding. By @ErichDonGubler in [#5251](https://github.com/gfx-rs/wgpu/pull/5251).
+- Fix registry leaks with de-duplicated resources. By @nical in [#5244](https://github.com/gfx-rs/wgpu/pull/5244)
 
 #### WGL
 

--- a/tests/tests/mem_leaks.rs
+++ b/tests/tests/mem_leaks.rs
@@ -127,7 +127,7 @@ async fn draw_test_with_reports(
 
     let global_report = ctx.instance.generate_report().unwrap();
     let report = global_report.hub_report(ctx.adapter_info.backend);
-    assert_eq!(report.shader_modules.num_allocated, 1);
+    assert_eq!(report.shader_modules.num_allocated, 0);
     assert_eq!(report.shader_modules.num_kept_from_user, 0);
     assert_eq!(report.textures.num_allocated, 0);
     assert_eq!(report.texture_views.num_allocated, 0);
@@ -166,7 +166,7 @@ async fn draw_test_with_reports(
     assert_eq!(report.buffers.num_allocated, 1);
     assert_eq!(report.texture_views.num_allocated, 1);
     assert_eq!(report.texture_views.num_kept_from_user, 1);
-    assert_eq!(report.textures.num_allocated, 1);
+    assert_eq!(report.textures.num_allocated, 0);
     assert_eq!(report.textures.num_kept_from_user, 0);
 
     let mut encoder = ctx
@@ -204,7 +204,7 @@ async fn draw_test_with_reports(
     assert_eq!(report.command_buffers.num_allocated, 1);
     assert_eq!(report.render_bundles.num_allocated, 0);
     assert_eq!(report.texture_views.num_allocated, 1);
-    assert_eq!(report.textures.num_allocated, 1);
+    assert_eq!(report.textures.num_allocated, 0);
 
     function(&mut rpass);
 
@@ -227,19 +227,20 @@ async fn draw_test_with_reports(
     assert_eq!(report.texture_views.num_kept_from_user, 0);
     assert_eq!(report.textures.num_kept_from_user, 0);
     assert_eq!(report.command_buffers.num_allocated, 1);
-    assert_eq!(report.render_pipelines.num_allocated, 1);
-    assert_eq!(report.pipeline_layouts.num_allocated, 1);
-    assert_eq!(report.bind_group_layouts.num_allocated, 1);
-    assert_eq!(report.bind_groups.num_allocated, 1);
-    assert_eq!(report.buffers.num_allocated, 1);
-    assert_eq!(report.texture_views.num_allocated, 1);
-    assert_eq!(report.textures.num_allocated, 1);
+    assert_eq!(report.render_pipelines.num_allocated, 0);
+    assert_eq!(report.pipeline_layouts.num_allocated, 0);
+    assert_eq!(report.bind_group_layouts.num_allocated, 0);
+    assert_eq!(report.bind_groups.num_allocated, 0);
+    assert_eq!(report.buffers.num_allocated, 0);
+    assert_eq!(report.texture_views.num_allocated, 0);
+    assert_eq!(report.textures.num_allocated, 0);
 
     let submit_index = ctx.queue.submit(Some(encoder.finish()));
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report(ctx.adapter_info.backend);
-    assert_eq!(report.command_buffers.num_allocated, 0);
+    // TODO: fix in https://github.com/gfx-rs/wgpu/pull/5141
+    // let global_report = ctx.instance.generate_report().unwrap();
+    // let report = global_report.hub_report(ctx.adapter_info.backend);
+    // assert_eq!(report.command_buffers.num_allocated, 0);
 
     ctx.async_poll(wgpu::Maintain::wait_for(submit_index))
         .await

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -758,7 +758,10 @@ impl RenderBundleEncoder {
             buffer_memory_init_actions,
             texture_memory_init_actions,
             context: self.context,
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(
+                desc.label.borrow_or_default(),
+                Some(device.tracker_indices.bundles.clone()),
+            ),
             discard_hal_labels: device
                 .instance_flags
                 .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS),

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -453,17 +453,13 @@ impl Global {
         let snatch_guard = device.snatchable_lock.read();
 
         let indices = &device.tracker_indices;
-        tracker.buffers.set_size(indices.buffers.lock().size());
-        tracker.textures.set_size(indices.textures.lock().size());
-        tracker
-            .bind_groups
-            .set_size(indices.bind_groups.lock().size());
+        tracker.buffers.set_size(indices.buffers.size());
+        tracker.textures.set_size(indices.textures.size());
+        tracker.bind_groups.set_size(indices.bind_groups.size());
         tracker
             .compute_pipelines
-            .set_size(indices.compute_pipelines.lock().size());
-        tracker
-            .query_sets
-            .set_size(indices.query_sets.lock().size());
+            .set_size(indices.compute_pipelines.size());
+        tracker.query_sets.set_size(indices.query_sets.size());
 
         let discard_hal_labels = self
             .instance

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1,6 +1,7 @@
 use crate::device::DeviceError;
 use crate::resource::Resource;
 use crate::snatch::SnatchGuard;
+use crate::track::TrackerIndex;
 use crate::{
     binding_model::{
         BindError, BindGroup, LateMinBufferBindingSizeMismatch, PushConstantUploadError,
@@ -305,7 +306,7 @@ impl<A: HalApi> State<A> {
         raw_encoder: &mut A::CommandEncoder,
         base_trackers: &mut Tracker<A>,
         bind_group_guard: &Storage<BindGroup<A>>,
-        indirect_buffer: Option<id::BufferId>,
+        indirect_buffer: Option<TrackerIndex>,
         snatch_guard: &SnatchGuard,
     ) -> Result<(), UsageConflict> {
         for id in self.binder.list_active() {
@@ -402,12 +403,11 @@ impl Global {
         let pipeline_guard = hub.compute_pipelines.read();
         let query_set_guard = hub.query_sets.read();
         let buffer_guard = hub.buffers.read();
-        let texture_guard = hub.textures.read();
 
         let mut state = State {
             binder: Binder::new(),
             pipeline: None,
-            scope: UsageScope::new(&*buffer_guard, &*texture_guard),
+            scope: UsageScope::new(&device.tracker_indices),
             debug_scope_depth: 0,
         };
         let mut temp_offsets = Vec::new();
@@ -452,17 +452,18 @@ impl Global {
 
         let snatch_guard = device.snatchable_lock.read();
 
-        tracker.set_size(
-            Some(&*buffer_guard),
-            Some(&*texture_guard),
-            None,
-            None,
-            Some(&*bind_group_guard),
-            Some(&*pipeline_guard),
-            None,
-            None,
-            Some(&*query_set_guard),
-        );
+        let indices = &device.tracker_indices;
+        tracker.buffers.set_size(indices.buffers.lock().size());
+        tracker.textures.set_size(indices.textures.lock().size());
+        tracker
+            .bind_groups
+            .set_size(indices.bind_groups.lock().size());
+        tracker
+            .compute_pipelines
+            .set_size(indices.compute_pipelines.lock().size());
+        tracker
+            .query_sets
+            .set_size(indices.query_sets.lock().size());
 
         let discard_hal_labels = self
             .instance
@@ -757,7 +758,7 @@ impl Global {
                             raw,
                             &mut intermediate_trackers,
                             &*bind_group_guard,
-                            Some(buffer_id),
+                            Some(indirect_buffer.as_info().tracker_index()),
                             &snatch_guard,
                         )
                         .map_pass_err(scope)?;

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -277,7 +277,6 @@ pub enum ArcRenderCommand<A: HalApi> {
     SetStencilReference(u32),
     SetViewport {
         rect: Rect<f32>,
-        //TODO: use half-float to reduce the size?
         depth_min: f32,
         depth_max: f32,
     },

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -174,6 +174,7 @@ impl<A: HalApi> CommandBuffer<A> {
                     .as_ref()
                     .unwrap_or(&String::from("<CommandBuffer>"))
                     .as_str(),
+                None,
             ),
             data: Mutex::new(Some(CommandBufferMutable {
                 encoder: CommandEncoder {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1411,19 +1411,15 @@ impl Global {
             .map_pass_err(pass_scope)?;
 
             let indices = &device.tracker_indices;
-            tracker.buffers.set_size(indices.buffers.lock().size());
-            tracker.textures.set_size(indices.textures.lock().size());
-            tracker.views.set_size(indices.texture_views.lock().size());
-            tracker
-                .bind_groups
-                .set_size(indices.bind_groups.lock().size());
+            tracker.buffers.set_size(indices.buffers.size());
+            tracker.textures.set_size(indices.textures.size());
+            tracker.views.set_size(indices.texture_views.size());
+            tracker.bind_groups.set_size(indices.bind_groups.size());
             tracker
                 .render_pipelines
-                .set_size(indices.render_pipelines.lock().size());
-            tracker.bundles.set_size(indices.bundles.lock().size());
-            tracker
-                .query_sets
-                .set_size(indices.query_sets.lock().size());
+                .set_size(indices.render_pipelines.size());
+            tracker.bundles.set_size(indices.bundles.size());
+            tracker.query_sets.set_size(indices.query_sets.size());
 
             let raw = &mut encoder.raw;
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -260,7 +260,7 @@ impl Global {
                 .trackers
                 .lock()
                 .buffers
-                .insert_single(id, resource, buffer_use);
+                .insert_single(resource, buffer_use);
 
             return (id, None);
         };
@@ -527,7 +527,7 @@ impl Global {
                 .lock_life()
                 .suspected_resources
                 .buffers
-                .insert(buffer_id, buffer);
+                .insert(buffer.info.tracker_index(), buffer);
         }
 
         if wait {
@@ -571,11 +571,11 @@ impl Global {
             let (id, resource) = fid.assign(texture);
             api_log!("Device::create_texture({desc:?}) -> {id:?}");
 
-            device.trackers.lock().textures.insert_single(
-                id,
-                resource,
-                hal::TextureUses::UNINITIALIZED,
-            );
+            device
+                .trackers
+                .lock()
+                .textures
+                .insert_single(resource, hal::TextureUses::UNINITIALIZED);
 
             return (id, None);
         };
@@ -645,11 +645,11 @@ impl Global {
             let (id, resource) = fid.assign(texture);
             api_log!("Device::create_texture({desc:?}) -> {id:?}");
 
-            device.trackers.lock().textures.insert_single(
-                id,
-                resource,
-                hal::TextureUses::UNINITIALIZED,
-            );
+            device
+                .trackers
+                .lock()
+                .textures
+                .insert_single(resource, hal::TextureUses::UNINITIALIZED);
 
             return (id, None);
         };
@@ -702,7 +702,7 @@ impl Global {
                 .trackers
                 .lock()
                 .buffers
-                .insert_single(id, buffer, hal::BufferUses::empty());
+                .insert_single(buffer, hal::BufferUses::empty());
 
             return (id, None);
         };
@@ -762,7 +762,7 @@ impl Global {
                         .lock_life()
                         .suspected_resources
                         .textures
-                        .insert(texture_id, texture.clone());
+                        .insert(texture.info.tracker_index(), texture.clone());
                 }
             }
 
@@ -822,7 +822,7 @@ impl Global {
             }
 
             api_log!("Texture::create_view({texture_id:?}) -> {id:?}");
-            device.trackers.lock().views.insert_single(id, resource);
+            device.trackers.lock().views.insert_single(resource);
             return (id, None);
         };
 
@@ -852,7 +852,7 @@ impl Global {
                 .lock_life()
                 .suspected_resources
                 .texture_views
-                .insert(texture_view_id, view.clone());
+                .insert(view.info.tracker_index(), view.clone());
 
             if wait {
                 match view.device.wait_for_submit(last_submit_index) {
@@ -898,7 +898,7 @@ impl Global {
 
             let (id, resource) = fid.assign(sampler);
             api_log!("Device::create_sampler -> {id:?}");
-            device.trackers.lock().samplers.insert_single(id, resource);
+            device.trackers.lock().samplers.insert_single(resource);
 
             return (id, None);
         };
@@ -923,7 +923,7 @@ impl Global {
                 .lock_life()
                 .suspected_resources
                 .samplers
-                .insert(sampler_id, sampler.clone());
+                .insert(sampler.info.tracker_index(), sampler.clone());
         }
     }
 
@@ -1022,7 +1022,7 @@ impl Global {
                 .lock_life()
                 .suspected_resources
                 .bind_group_layouts
-                .insert(bind_group_layout_id, layout.clone());
+                .insert(layout.info.tracker_index(), layout.clone());
         }
     }
 
@@ -1083,7 +1083,7 @@ impl Global {
                 .lock_life()
                 .suspected_resources
                 .pipeline_layouts
-                .insert(pipeline_layout_id, layout.clone());
+                .insert(layout.info.tracker_index(), layout.clone());
         }
     }
 
@@ -1138,11 +1138,7 @@ impl Global {
 
             api_log!("Device::create_bind_group -> {id:?}");
 
-            device
-                .trackers
-                .lock()
-                .bind_groups
-                .insert_single(id, resource);
+            device.trackers.lock().bind_groups.insert_single(resource);
             return (id, None);
         };
 
@@ -1166,7 +1162,7 @@ impl Global {
                 .lock_life()
                 .suspected_resources
                 .bind_groups
-                .insert(bind_group_id, bind_group.clone());
+                .insert(bind_group.info.tracker_index(), bind_group.clone());
         }
     }
 
@@ -1448,7 +1444,7 @@ impl Global {
 
             let (id, resource) = fid.assign(render_bundle);
             api_log!("RenderBundleEncoder::finish -> {id:?}");
-            device.trackers.lock().bundles.insert_single(id, resource);
+            device.trackers.lock().bundles.insert_single(resource);
             return (id, None);
         };
 
@@ -1472,7 +1468,7 @@ impl Global {
                 .lock_life()
                 .suspected_resources
                 .render_bundles
-                .insert(render_bundle_id, bundle.clone());
+                .insert(bundle.info.tracker_index(), bundle.clone());
         }
     }
 
@@ -1511,11 +1507,7 @@ impl Global {
 
             let (id, resource) = fid.assign(query_set);
             api_log!("Device::create_query_set -> {id:?}");
-            device
-                .trackers
-                .lock()
-                .query_sets
-                .insert_single(id, resource);
+            device.trackers.lock().query_sets.insert_single(resource);
 
             return (id, None);
         };
@@ -1542,7 +1534,7 @@ impl Global {
                 .lock_life()
                 .suspected_resources
                 .query_sets
-                .insert(query_set_id, query_set.clone());
+                .insert(query_set.info.tracker_index(), query_set.clone());
         }
     }
 
@@ -1598,7 +1590,7 @@ impl Global {
                 .trackers
                 .lock()
                 .render_pipelines
-                .insert_single(id, resource);
+                .insert_single(resource);
 
             return (id, None);
         };
@@ -1670,18 +1662,17 @@ impl Global {
         let hub = A::hub(self);
 
         if let Some(pipeline) = hub.render_pipelines.unregister(render_pipeline_id) {
-            let layout_id = pipeline.layout.as_info().id();
             let device = &pipeline.device;
             let mut life_lock = device.lock_life();
             life_lock
                 .suspected_resources
                 .render_pipelines
-                .insert(render_pipeline_id, pipeline.clone());
+                .insert(pipeline.info.tracker_index(), pipeline.clone());
 
-            life_lock
-                .suspected_resources
-                .pipeline_layouts
-                .insert(layout_id, pipeline.layout.clone());
+            life_lock.suspected_resources.pipeline_layouts.insert(
+                pipeline.layout.info.tracker_index(),
+                pipeline.layout.clone(),
+            );
         }
     }
 
@@ -1732,7 +1723,7 @@ impl Global {
                 .trackers
                 .lock()
                 .compute_pipelines
-                .insert_single(id, resource);
+                .insert_single(resource);
             return (id, None);
         };
 
@@ -1802,17 +1793,16 @@ impl Global {
         let hub = A::hub(self);
 
         if let Some(pipeline) = hub.compute_pipelines.unregister(compute_pipeline_id) {
-            let layout_id = pipeline.layout.as_info().id();
             let device = &pipeline.device;
             let mut life_lock = device.lock_life();
             life_lock
                 .suspected_resources
                 .compute_pipelines
-                .insert(compute_pipeline_id, pipeline.clone());
-            life_lock
-                .suspected_resources
-                .pipeline_layouts
-                .insert(layout_id, pipeline.layout.clone());
+                .insert(pipeline.info.tracker_index(), pipeline.clone());
+            life_lock.suspected_resources.pipeline_layouts.insert(
+                pipeline.layout.info.tracker_index(),
+                pipeline.layout.clone(),
+            );
         }
     }
 

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -6,17 +6,13 @@ use crate::{
         DeviceError, DeviceLostClosure,
     },
     hal_api::HalApi,
-    id::{
-        self, BindGroupId, BindGroupLayoutId, BufferId, ComputePipelineId, Id, PipelineLayoutId,
-        QuerySetId, RenderBundleId, RenderPipelineId, SamplerId, StagingBufferId, TextureId,
-        TextureViewId,
-    },
+    id,
     pipeline::{ComputePipeline, RenderPipeline},
     resource::{
         self, Buffer, DestroyedBuffer, DestroyedTexture, QuerySet, Resource, Sampler,
         StagingBuffer, Texture, TextureView,
     },
-    track::{ResourceTracker, Tracker},
+    track::{ResourceTracker, Tracker, TrackerIndex},
     FastHashMap, SubmissionIndex,
 };
 use smallvec::SmallVec;
@@ -28,20 +24,20 @@ use thiserror::Error;
 /// A struct that keeps lists of resources that are no longer needed by the user.
 #[derive(Default)]
 pub(crate) struct ResourceMaps<A: HalApi> {
-    pub buffers: FastHashMap<BufferId, Arc<Buffer<A>>>,
-    pub staging_buffers: FastHashMap<StagingBufferId, Arc<StagingBuffer<A>>>,
-    pub textures: FastHashMap<TextureId, Arc<Texture<A>>>,
-    pub texture_views: FastHashMap<TextureViewId, Arc<TextureView<A>>>,
-    pub samplers: FastHashMap<SamplerId, Arc<Sampler<A>>>,
-    pub bind_groups: FastHashMap<BindGroupId, Arc<BindGroup<A>>>,
-    pub bind_group_layouts: FastHashMap<BindGroupLayoutId, Arc<BindGroupLayout<A>>>,
-    pub render_pipelines: FastHashMap<RenderPipelineId, Arc<RenderPipeline<A>>>,
-    pub compute_pipelines: FastHashMap<ComputePipelineId, Arc<ComputePipeline<A>>>,
-    pub pipeline_layouts: FastHashMap<PipelineLayoutId, Arc<PipelineLayout<A>>>,
-    pub render_bundles: FastHashMap<RenderBundleId, Arc<RenderBundle<A>>>,
-    pub query_sets: FastHashMap<QuerySetId, Arc<QuerySet<A>>>,
-    pub destroyed_buffers: FastHashMap<BufferId, Arc<DestroyedBuffer<A>>>,
-    pub destroyed_textures: FastHashMap<TextureId, Arc<DestroyedTexture<A>>>,
+    pub buffers: FastHashMap<TrackerIndex, Arc<Buffer<A>>>,
+    pub staging_buffers: FastHashMap<TrackerIndex, Arc<StagingBuffer<A>>>,
+    pub textures: FastHashMap<TrackerIndex, Arc<Texture<A>>>,
+    pub texture_views: FastHashMap<TrackerIndex, Arc<TextureView<A>>>,
+    pub samplers: FastHashMap<TrackerIndex, Arc<Sampler<A>>>,
+    pub bind_groups: FastHashMap<TrackerIndex, Arc<BindGroup<A>>>,
+    pub bind_group_layouts: FastHashMap<TrackerIndex, Arc<BindGroupLayout<A>>>,
+    pub render_pipelines: FastHashMap<TrackerIndex, Arc<RenderPipeline<A>>>,
+    pub compute_pipelines: FastHashMap<TrackerIndex, Arc<ComputePipeline<A>>>,
+    pub pipeline_layouts: FastHashMap<TrackerIndex, Arc<PipelineLayout<A>>>,
+    pub render_bundles: FastHashMap<TrackerIndex, Arc<RenderBundle<A>>>,
+    pub query_sets: FastHashMap<TrackerIndex, Arc<QuerySet<A>>>,
+    pub destroyed_buffers: FastHashMap<TrackerIndex, Arc<DestroyedBuffer<A>>>,
+    pub destroyed_textures: FastHashMap<TrackerIndex, Arc<DestroyedTexture<A>>>,
 }
 
 impl<A: HalApi> ResourceMaps<A> {
@@ -276,25 +272,29 @@ impl<A: HalApi> LifetimeTracker<A> {
         for res in temp_resources {
             match res {
                 TempResource::Buffer(raw) => {
-                    last_resources.buffers.insert(raw.as_info().id(), raw);
+                    last_resources
+                        .buffers
+                        .insert(raw.as_info().tracker_index(), raw);
                 }
                 TempResource::StagingBuffer(raw) => {
                     last_resources
                         .staging_buffers
-                        .insert(raw.as_info().id(), raw);
+                        .insert(raw.as_info().tracker_index(), raw);
                 }
                 TempResource::DestroyedBuffer(destroyed) => {
                     last_resources
                         .destroyed_buffers
-                        .insert(destroyed.id, destroyed);
+                        .insert(destroyed.tracker_index, destroyed);
                 }
                 TempResource::Texture(raw) => {
-                    last_resources.textures.insert(raw.as_info().id(), raw);
+                    last_resources
+                        .textures
+                        .insert(raw.as_info().tracker_index(), raw);
                 }
                 TempResource::DestroyedTexture(destroyed) => {
                     last_resources
                         .destroyed_textures
-                        .insert(destroyed.id, destroyed);
+                        .insert(destroyed.tracker_index, destroyed);
                 }
             }
         }
@@ -310,12 +310,14 @@ impl<A: HalApi> LifetimeTracker<A> {
 
     pub fn post_submit(&mut self) {
         for v in self.future_suspected_buffers.drain(..).take(1) {
-            self.suspected_resources.buffers.insert(v.as_info().id(), v);
+            self.suspected_resources
+                .buffers
+                .insert(v.as_info().tracker_index(), v);
         }
         for v in self.future_suspected_textures.drain(..).take(1) {
             self.suspected_resources
                 .textures
-                .insert(v.as_info().id(), v);
+                .insert(v.as_info().tracker_index(), v);
         }
     }
 
@@ -386,19 +388,27 @@ impl<A: HalApi> LifetimeTracker<A> {
         if let Some(resources) = resources {
             match temp_resource {
                 TempResource::Buffer(raw) => {
-                    resources.buffers.insert(raw.as_info().id(), raw);
+                    resources.buffers.insert(raw.as_info().tracker_index(), raw);
                 }
                 TempResource::StagingBuffer(raw) => {
-                    resources.staging_buffers.insert(raw.as_info().id(), raw);
+                    resources
+                        .staging_buffers
+                        .insert(raw.as_info().tracker_index(), raw);
                 }
                 TempResource::DestroyedBuffer(destroyed) => {
-                    resources.destroyed_buffers.insert(destroyed.id, destroyed);
+                    resources
+                        .destroyed_buffers
+                        .insert(destroyed.tracker_index, destroyed);
                 }
                 TempResource::Texture(raw) => {
-                    resources.textures.insert(raw.as_info().id(), raw);
+                    resources
+                        .textures
+                        .insert(raw.as_info().tracker_index(), raw);
                 }
                 TempResource::DestroyedTexture(destroyed) => {
-                    resources.destroyed_textures.insert(destroyed.id, destroyed);
+                    resources
+                        .destroyed_textures
+                        .insert(destroyed.tracker_index, destroyed);
                 }
             }
         }
@@ -420,27 +430,27 @@ impl<A: HalApi> LifetimeTracker<A> {
 
 impl<A: HalApi> LifetimeTracker<A> {
     fn triage_resources<R>(
-        resources_map: &mut FastHashMap<Id<R::Marker>, Arc<R>>,
+        resources_map: &mut FastHashMap<TrackerIndex, Arc<R>>,
         active: &mut [ActiveSubmission<A>],
-        trackers: &mut impl ResourceTracker<R>,
-        get_resource_map: impl Fn(&mut ResourceMaps<A>) -> &mut FastHashMap<Id<R::Marker>, Arc<R>>,
+        trackers: &mut impl ResourceTracker,
+        get_resource_map: impl Fn(&mut ResourceMaps<A>) -> &mut FastHashMap<TrackerIndex, Arc<R>>,
     ) -> Vec<Arc<R>>
     where
         R: Resource,
     {
         let mut removed_resources = Vec::new();
-        resources_map.retain(|&id, resource| {
+        resources_map.retain(|&index, resource| {
             let submit_index = resource.as_info().submission_index();
             let non_referenced_resources = active
                 .iter_mut()
                 .find(|a| a.index == submit_index)
                 .map(|a| &mut a.last_resources);
 
-            let is_removed = trackers.remove_abandoned(id);
+            let is_removed = trackers.remove_abandoned(index);
             if is_removed {
                 removed_resources.push(resource.clone());
                 if let Some(resources) = non_referenced_resources {
-                    get_resource_map(resources).insert(id, resource.clone());
+                    get_resource_map(resources).insert(index, resource.clone());
                 }
             }
             !is_removed
@@ -459,27 +469,29 @@ impl<A: HalApi> LifetimeTracker<A> {
         );
         removed_resources.drain(..).for_each(|bundle| {
             for v in bundle.used.buffers.write().drain_resources() {
-                self.suspected_resources.buffers.insert(v.as_info().id(), v);
+                self.suspected_resources
+                    .buffers
+                    .insert(v.as_info().tracker_index(), v);
             }
             for v in bundle.used.textures.write().drain_resources() {
                 self.suspected_resources
                     .textures
-                    .insert(v.as_info().id(), v);
+                    .insert(v.as_info().tracker_index(), v);
             }
             for v in bundle.used.bind_groups.write().drain_resources() {
                 self.suspected_resources
                     .bind_groups
-                    .insert(v.as_info().id(), v);
+                    .insert(v.as_info().tracker_index(), v);
             }
             for v in bundle.used.render_pipelines.write().drain_resources() {
                 self.suspected_resources
                     .render_pipelines
-                    .insert(v.as_info().id(), v);
+                    .insert(v.as_info().tracker_index(), v);
             }
             for v in bundle.used.query_sets.write().drain_resources() {
                 self.suspected_resources
                     .query_sets
-                    .insert(v.as_info().id(), v);
+                    .insert(v.as_info().tracker_index(), v);
             }
         });
         self
@@ -496,27 +508,30 @@ impl<A: HalApi> LifetimeTracker<A> {
         );
         removed_resource.drain(..).for_each(|bind_group| {
             for v in bind_group.used.buffers.drain_resources() {
-                self.suspected_resources.buffers.insert(v.as_info().id(), v);
+                self.suspected_resources
+                    .buffers
+                    .insert(v.as_info().tracker_index(), v);
             }
             for v in bind_group.used.textures.drain_resources() {
                 self.suspected_resources
                     .textures
-                    .insert(v.as_info().id(), v);
+                    .insert(v.as_info().tracker_index(), v);
             }
             for v in bind_group.used.views.drain_resources() {
                 self.suspected_resources
                     .texture_views
-                    .insert(v.as_info().id(), v);
+                    .insert(v.as_info().tracker_index(), v);
             }
             for v in bind_group.used.samplers.drain_resources() {
                 self.suspected_resources
                     .samplers
-                    .insert(v.as_info().id(), v);
+                    .insert(v.as_info().tracker_index(), v);
             }
 
-            self.suspected_resources
-                .bind_group_layouts
-                .insert(bind_group.layout.as_info().id(), bind_group.layout.clone());
+            self.suspected_resources.bind_group_layouts.insert(
+                bind_group.layout.as_info().tracker_index(),
+                bind_group.layout.clone(),
+            );
         });
         self
     }
@@ -605,7 +620,7 @@ impl<A: HalApi> LifetimeTracker<A> {
         );
         removed_resources.drain(..).for_each(|compute_pipeline| {
             self.suspected_resources.pipeline_layouts.insert(
-                compute_pipeline.layout.as_info().id(),
+                compute_pipeline.layout.as_info().tracker_index(),
                 compute_pipeline.layout.clone(),
             );
         });
@@ -623,7 +638,7 @@ impl<A: HalApi> LifetimeTracker<A> {
         );
         removed_resources.drain(..).for_each(|render_pipeline| {
             self.suspected_resources.pipeline_layouts.insert(
-                render_pipeline.layout.as_info().id(),
+                render_pipeline.layout.as_info().tracker_index(),
                 render_pipeline.layout.clone(),
             );
         });
@@ -642,7 +657,7 @@ impl<A: HalApi> LifetimeTracker<A> {
             for bgl in &pipeline_layout.bind_group_layouts {
                 self.suspected_resources
                     .bind_group_layouts
-                    .insert(bgl.as_info().id(), bgl.clone());
+                    .insert(bgl.as_info().tracker_index(), bgl.clone());
             }
         });
         self
@@ -773,14 +788,14 @@ impl<A: HalApi> LifetimeTracker<A> {
             Vec::with_capacity(self.ready_to_map.len());
 
         for buffer in self.ready_to_map.drain(..) {
-            let buffer_id = buffer.info.id();
+            let tracker_index = buffer.info.tracker_index();
             let is_removed = {
                 let mut trackers = trackers.lock();
-                trackers.buffers.remove_abandoned(buffer_id)
+                trackers.buffers.remove_abandoned(tracker_index)
             };
             if is_removed {
                 *buffer.map_state.lock() = resource::BufferMapState::Idle;
-                log::trace!("Buffer ready to map {:?} is not tracked anymore", buffer_id);
+                log::trace!("Buffer ready to map {tracker_index:?} is not tracked anymore");
             } else {
                 let mapping = match std::mem::replace(
                     &mut *buffer.map_state.lock(),
@@ -798,7 +813,7 @@ impl<A: HalApi> LifetimeTracker<A> {
                     _ => panic!("No pending mapping."),
                 };
                 let status = if mapping.range.start != mapping.range.end {
-                    log::debug!("Buffer {:?} map state -> Active", buffer_id);
+                    log::debug!("Buffer {tracker_index:?} map state -> Active");
                     let host = mapping.op.host;
                     let size = mapping.range.end - mapping.range.start;
                     match super::map_buffer(raw, &buffer, mapping.range.start, size, host) {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -28,7 +28,7 @@ use crate::{
     resource_log,
     snatch::{SnatchGuard, SnatchLock, Snatchable},
     storage::Storage,
-    track::{BindGroupStates, TextureSelector, Tracker},
+    track::{BindGroupStates, TextureSelector, Tracker, TrackerIndexAllocators},
     validation::{
         self, check_buffer_usage, check_texture_usage, validate_color_attachment_bytes_per_sample,
     },
@@ -118,6 +118,7 @@ pub struct Device<A: HalApi> {
     /// Has to be locked temporarily only (locked last)
     /// and never before pending_writes
     pub(crate) trackers: Mutex<Tracker<A>>,
+    pub(crate) tracker_indices: TrackerIndexAllocators,
     // Life tracker should be locked right after the device and before anything else.
     life_tracker: Mutex<LifetimeTracker<A>>,
     /// Temporary storage for resource management functions. Cleared at the end
@@ -263,13 +264,14 @@ impl<A: HalApi> Device<A> {
             queue: OnceCell::new(),
             queue_to_drop: OnceCell::new(),
             zero_buffer: Some(zero_buffer),
-            info: ResourceInfo::new("<device>"),
+            info: ResourceInfo::new("<device>", None),
             command_allocator: Mutex::new(Some(com_alloc)),
             active_submission_index: AtomicU64::new(0),
             fence: RwLock::new(Some(fence)),
             snatchable_lock: unsafe { SnatchLock::new() },
             valid: AtomicBool::new(true),
             trackers: Mutex::new(Tracker::new()),
+            tracker_indices: TrackerIndexAllocators::new(),
             life_tracker: Mutex::new(life::LifetimeTracker::new()),
             temp_suspected: Mutex::new(Some(life::ResourceMaps::new())),
             bgl_pool: ResourcePool::new(),
@@ -493,56 +495,56 @@ impl<A: HalApi> Device<A> {
                 if resource.is_unique() {
                     temp_suspected
                         .buffers
-                        .insert(resource.as_info().id(), resource.clone());
+                        .insert(resource.as_info().tracker_index(), resource.clone());
                 }
             }
             for resource in trackers.textures.used_resources() {
                 if resource.is_unique() {
                     temp_suspected
                         .textures
-                        .insert(resource.as_info().id(), resource.clone());
+                        .insert(resource.as_info().tracker_index(), resource.clone());
                 }
             }
             for resource in trackers.views.used_resources() {
                 if resource.is_unique() {
                     temp_suspected
                         .texture_views
-                        .insert(resource.as_info().id(), resource.clone());
+                        .insert(resource.as_info().tracker_index(), resource.clone());
                 }
             }
             for resource in trackers.bind_groups.used_resources() {
                 if resource.is_unique() {
                     temp_suspected
                         .bind_groups
-                        .insert(resource.as_info().id(), resource.clone());
+                        .insert(resource.as_info().tracker_index(), resource.clone());
                 }
             }
             for resource in trackers.samplers.used_resources() {
                 if resource.is_unique() {
                     temp_suspected
                         .samplers
-                        .insert(resource.as_info().id(), resource.clone());
+                        .insert(resource.as_info().tracker_index(), resource.clone());
                 }
             }
             for resource in trackers.compute_pipelines.used_resources() {
                 if resource.is_unique() {
                     temp_suspected
                         .compute_pipelines
-                        .insert(resource.as_info().id(), resource.clone());
+                        .insert(resource.as_info().tracker_index(), resource.clone());
                 }
             }
             for resource in trackers.render_pipelines.used_resources() {
                 if resource.is_unique() {
                     temp_suspected
                         .render_pipelines
-                        .insert(resource.as_info().id(), resource.clone());
+                        .insert(resource.as_info().tracker_index(), resource.clone());
                 }
             }
             for resource in trackers.query_sets.used_resources() {
                 if resource.is_unique() {
                     temp_suspected
                         .query_sets
-                        .insert(resource.as_info().id(), resource.clone());
+                        .insert(resource.as_info().tracker_index(), resource.clone());
                 }
             }
         }
@@ -643,7 +645,10 @@ impl<A: HalApi> Device<A> {
             initialization_status: RwLock::new(BufferInitTracker::new(aligned_size)),
             sync_mapped_writes: Mutex::new(None),
             map_state: Mutex::new(resource::BufferMapState::Idle),
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(
+                desc.label.borrow_or_default(),
+                Some(self.tracker_indices.buffers.clone()),
+            ),
             bind_groups: Mutex::new(Vec::new()),
         })
     }
@@ -672,7 +677,10 @@ impl<A: HalApi> Device<A> {
                 mips: 0..desc.mip_level_count,
                 layers: 0..desc.array_layer_count(),
             },
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(
+                desc.label.borrow_or_default(),
+                Some(self.tracker_indices.textures.clone()),
+            ),
             clear_mode: RwLock::new(clear_mode),
             views: Mutex::new(Vec::new()),
             bind_groups: Mutex::new(Vec::new()),
@@ -694,7 +702,10 @@ impl<A: HalApi> Device<A> {
             initialization_status: RwLock::new(BufferInitTracker::new(0)),
             sync_mapped_writes: Mutex::new(None),
             map_state: Mutex::new(resource::BufferMapState::Idle),
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(
+                desc.label.borrow_or_default(),
+                Some(self.tracker_indices.buffers.clone()),
+            ),
             bind_groups: Mutex::new(Vec::new()),
         }
     }
@@ -1272,7 +1283,10 @@ impl<A: HalApi> Device<A> {
             render_extent,
             samples: texture.desc.sample_count,
             selector,
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(
+                desc.label.borrow_or_default(),
+                Some(self.tracker_indices.texture_views.clone()),
+            ),
         })
     }
 
@@ -1376,7 +1390,10 @@ impl<A: HalApi> Device<A> {
         Ok(Sampler {
             raw: Some(raw),
             device: self.clone(),
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(
+                desc.label.borrow_or_default(),
+                Some(self.tracker_indices.samplers.clone()),
+            ),
             comparison: desc.compare.is_some(),
             filtering: desc.min_filter == wgt::FilterMode::Linear
                 || desc.mag_filter == wgt::FilterMode::Linear,
@@ -1569,7 +1586,7 @@ impl<A: HalApi> Device<A> {
             raw: Some(raw),
             device: self.clone(),
             interface: Some(interface),
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(desc.label.borrow_or_default(), None),
             label: desc.label.borrow_or_default().to_string(),
         })
     }
@@ -1610,7 +1627,7 @@ impl<A: HalApi> Device<A> {
             raw: Some(raw),
             device: self.clone(),
             interface: None,
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(desc.label.borrow_or_default(), None),
             label: desc.label.borrow_or_default().to_string(),
         })
     }
@@ -1863,7 +1880,10 @@ impl<A: HalApi> Device<A> {
             entries: entry_map,
             origin,
             binding_count_validator: count_validator,
-            info: ResourceInfo::new(label.unwrap_or("<BindGroupLayout>")),
+            info: ResourceInfo::new(
+                label.unwrap_or("<BindGroupLayout>"),
+                Some(self.tracker_indices.bind_group_layouts.clone()),
+            ),
             label: label.unwrap_or_default().to_string(),
         })
     }
@@ -2296,7 +2316,10 @@ impl<A: HalApi> Device<A> {
             raw: Snatchable::new(raw),
             device: self.clone(),
             layout: layout.clone(),
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(
+                desc.label.borrow_or_default(),
+                Some(self.tracker_indices.bind_groups.clone()),
+            ),
             used,
             used_buffer_ranges,
             used_texture_ranges,
@@ -2578,7 +2601,10 @@ impl<A: HalApi> Device<A> {
         Ok(binding_model::PipelineLayout {
             raw: Some(raw),
             device: self.clone(),
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(
+                desc.label.borrow_or_default(),
+                Some(self.tracker_indices.pipeline_layouts.clone()),
+            ),
             bind_group_layouts,
             push_constant_ranges: desc.push_constant_ranges.iter().cloned().collect(),
         })
@@ -2743,7 +2769,10 @@ impl<A: HalApi> Device<A> {
             device: self.clone(),
             _shader_module: shader_module,
             late_sized_buffer_groups,
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(
+                desc.label.borrow_or_default(),
+                Some(self.tracker_indices.compute_pipelines.clone()),
+            ),
         };
         Ok(pipeline)
     }
@@ -3337,7 +3366,10 @@ impl<A: HalApi> Device<A> {
             strip_index_format: desc.primitive.strip_index_format,
             vertex_steps,
             late_sized_buffer_groups,
-            info: ResourceInfo::new(desc.label.borrow_or_default()),
+            info: ResourceInfo::new(
+                desc.label.borrow_or_default(),
+                Some(self.tracker_indices.render_pipelines.clone()),
+            ),
         };
         Ok(pipeline)
     }
@@ -3450,7 +3482,7 @@ impl<A: HalApi> Device<A> {
         Ok(QuerySet {
             raw: Some(unsafe { self.raw().create_query_set(&hal_desc).unwrap() }),
             device: self.clone(),
-            info: ResourceInfo::new(""),
+            info: ResourceInfo::new("", Some(self.tracker_indices.query_sets.clone())),
             desc: desc.map_label(|_| ()),
         })
     }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -198,7 +198,7 @@ impl<A: HalApi> Adapter<A> {
 
         Self {
             raw,
-            info: ResourceInfo::new("<Adapter>"),
+            info: ResourceInfo::new("<Adapter>", None),
         }
     }
 
@@ -303,7 +303,7 @@ impl<A: HalApi> Adapter<A> {
             let queue = Queue {
                 device: None,
                 raw: Some(hal_device.queue),
-                info: ResourceInfo::new("<Queue>"),
+                info: ResourceInfo::new("<Queue>", None),
             };
             return Ok((device, queue));
         }
@@ -521,7 +521,7 @@ impl Global {
 
         let surface = Surface {
             presentation: Mutex::new(None),
-            info: ResourceInfo::new("<Surface>"),
+            info: ResourceInfo::new("<Surface>", None),
             raw: hal_surface,
         };
 
@@ -542,7 +542,7 @@ impl Global {
 
         let surface = Surface {
             presentation: Mutex::new(None),
-            info: ResourceInfo::new("<Surface>"),
+            info: ResourceInfo::new("<Surface>", None),
             raw: {
                 let hal_surface = self
                     .instance
@@ -575,7 +575,7 @@ impl Global {
 
         let surface = Surface {
             presentation: Mutex::new(None),
-            info: ResourceInfo::new("<Surface>"),
+            info: ResourceInfo::new("<Surface>", None),
             raw: {
                 let hal_surface = self
                     .instance
@@ -604,7 +604,7 @@ impl Global {
 
         let surface = Surface {
             presentation: Mutex::new(None),
-            info: ResourceInfo::new("<Surface>"),
+            info: ResourceInfo::new("<Surface>", None),
             raw: {
                 let hal_surface = self
                     .instance
@@ -633,7 +633,7 @@ impl Global {
 
         let surface = Surface {
             presentation: Mutex::new(None),
-            info: ResourceInfo::new("<Surface>"),
+            info: ResourceInfo::new("<Surface>", None),
             raw: {
                 let hal_surface = self
                     .instance

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -60,7 +60,6 @@ impl<T: Resource> Registry<T> {
 #[must_use]
 pub(crate) struct FutureId<'a, T: Resource> {
     id: Id<T::Marker>,
-    identity: Arc<IdentityManager<T::Marker>>,
     data: &'a RwLock<Storage<T>>,
 }
 
@@ -75,7 +74,7 @@ impl<T: Resource> FutureId<'_, T> {
     }
 
     pub fn init(&self, mut value: T) -> Arc<T> {
-        value.as_info_mut().set_id(self.id, &self.identity);
+        value.as_info_mut().set_id(self.id);
         Arc::new(value)
     }
 
@@ -117,7 +116,6 @@ impl<T: Resource> Registry<T> {
                 }
                 None => self.identity.process(self.backend),
             },
-            identity: self.identity.clone(),
             data: &self.storage,
         }
     }
@@ -125,7 +123,6 @@ impl<T: Resource> Registry<T> {
     pub(crate) fn request(&self) -> FutureId<T> {
         FutureId {
             id: self.identity.process(self.backend),
-            identity: self.identity.clone(),
             data: &self.storage,
         }
     }
@@ -147,7 +144,7 @@ impl<T: Resource> Registry<T> {
     }
     pub fn force_replace(&self, id: Id<T::Marker>, mut value: T) {
         let mut storage = self.storage.write();
-        value.as_info_mut().set_id(id, &self.identity);
+        value.as_info_mut().set_id(id);
         storage.force_replace(id, value)
     }
     pub fn force_replace_with_error(&self, id: Id<T::Marker>, label: &str) {

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -142,6 +142,7 @@ impl<T: Resource> Registry<T> {
         self.storage.write()
     }
     pub fn unregister_locked(&self, id: Id<T::Marker>, storage: &mut Storage<T>) -> Option<Arc<T>> {
+        self.identity.free(id);
         storage.remove(id)
     }
     pub fn force_replace(&self, id: Id<T::Marker>, mut value: T) {
@@ -155,6 +156,7 @@ impl<T: Resource> Registry<T> {
         storage.insert_error(id, label);
     }
     pub(crate) fn unregister(&self, id: Id<T::Marker>) -> Option<Arc<T>> {
+        self.identity.free(id);
         let value = self.storage.write().remove(id);
         //Returning None is legal if it's an error ID
         value

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -72,15 +72,6 @@ pub struct ResourceInfo<T: Resource> {
     pub(crate) label: String,
 }
 
-impl<T: Resource> Drop for ResourceInfo<T> {
-    fn drop(&mut self) {
-        if let Some(identity) = self.identity.as_ref() {
-            let id = self.id.as_ref().unwrap();
-            identity.free(*id);
-        }
-    }
-}
-
 impl<T: Resource> ResourceInfo<T> {
     #[allow(unused_variables)]
     pub(crate) fn new(label: &str) -> Self {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -89,7 +89,7 @@ impl<T: Resource> ResourceInfo<T> {
         let tracker_index = tracker_indices
             .as_ref()
             .map(|indices| indices.lock().alloc())
-            .unwrap_or(TrackerIndex::MAX);
+            .unwrap_or(TrackerIndex::INVALID);
         Self {
             id: None,
             tracker_index,
@@ -119,7 +119,7 @@ impl<T: Resource> ResourceInfo<T> {
     }
 
     pub(crate) fn tracker_index(&self) -> TrackerIndex {
-        debug_assert!(self.tracker_index != TrackerIndex::MAX);
+        debug_assert!(self.tracker_index != TrackerIndex::INVALID);
         self.tracker_index
     }
 

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -167,7 +167,7 @@ impl<A: HalApi> BufferUsageScope<A> {
     ) -> Result<(), UsageConflict> {
         let buffers = bind_group.buffers.lock();
         for &(ref resource, state) in &*buffers {
-            let index = resource.as_info().tracker_index() as usize;
+            let index = resource.as_info().tracker_index().as_usize();
 
             unsafe {
                 insert_or_merge(
@@ -241,7 +241,7 @@ impl<A: HalApi> BufferUsageScope<A> {
             .get(id)
             .map_err(|_| UsageConflict::BufferInvalid { id })?;
 
-        let index = buffer.info.tracker_index() as usize;
+        let index = buffer.info.tracker_index().as_usize();
 
         self.allow_index(index);
 
@@ -300,7 +300,7 @@ impl<A: HalApi> ResourceTracker for BufferTracker<A> {
     /// [`self.metadata`]: BufferTracker::metadata
     /// [`Hub::buffers`]: crate::hub::Hub::buffers
     fn remove_abandoned(&mut self, index: TrackerIndex) -> bool {
-        let index = index as usize;
+        let index = index.as_usize();
 
         if index > self.metadata.size() {
             return false;
@@ -385,7 +385,7 @@ impl<A: HalApi> BufferTracker<A> {
     /// If the ID is higher than the length of internal vectors,
     /// the vectors will be extended. A call to set_size is not needed.
     pub fn insert_single(&mut self, resource: Arc<Buffer<A>>, state: BufferUses) {
-        let index = resource.info.tracker_index() as usize;
+        let index = resource.info.tracker_index().as_usize();
 
         self.allow_index(index);
 
@@ -420,7 +420,7 @@ impl<A: HalApi> BufferTracker<A> {
     /// If the ID is higher than the length of internal vectors,
     /// the vectors will be extended. A call to set_size is not needed.
     pub fn set_single(&mut self, buffer: &Arc<Buffer<A>>, state: BufferUses) -> SetSingleResult<A> {
-        let index: usize = buffer.as_info().tracker_index() as usize;
+        let index: usize = buffer.as_info().tracker_index().as_usize();
 
         self.allow_index(index);
 
@@ -549,7 +549,7 @@ impl<A: HalApi> BufferTracker<A> {
         }
 
         for index in index_source {
-            let index = index as usize;
+            let index = index.as_usize();
 
             scope.tracker_assert_in_bounds(index);
 
@@ -579,7 +579,7 @@ impl<A: HalApi> BufferTracker<A> {
 
     #[allow(dead_code)]
     pub fn get(&self, index: TrackerIndex) -> Option<&Arc<Buffer<A>>> {
-        let index = index as usize;
+        let index = index.as_usize();
         if index > self.metadata.size() {
             return None;
         }

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -7,7 +7,7 @@
 
 use std::{borrow::Cow, marker::PhantomData, sync::Arc};
 
-use super::{PendingTransition, ResourceTracker};
+use super::{PendingTransition, ResourceTracker, TrackerIndex};
 use crate::{
     hal_api::HalApi,
     id::BufferId,
@@ -64,16 +64,16 @@ impl<A: HalApi> BufferBindGroupState<A> {
     #[allow(clippy::pattern_type_mismatch)]
     pub(crate) fn optimize(&self) {
         let mut buffers = self.buffers.lock();
-        buffers.sort_unstable_by_key(|(b, _)| b.as_info().id().unzip().0);
+        buffers.sort_unstable_by_key(|(b, _)| b.as_info().tracker_index());
     }
 
     /// Returns a list of all buffers tracked. May contain duplicates.
     #[allow(clippy::pattern_type_mismatch)]
-    pub fn used_ids(&self) -> impl Iterator<Item = BufferId> + '_ {
+    pub fn used_tracker_indices(&self) -> impl Iterator<Item = TrackerIndex> + '_ {
         let buffers = self.buffers.lock();
         buffers
             .iter()
-            .map(|(ref b, _)| b.as_info().id())
+            .map(|(ref b, _)| b.as_info().tracker_index())
             .collect::<Vec<_>>()
             .into_iter()
     }
@@ -167,7 +167,7 @@ impl<A: HalApi> BufferUsageScope<A> {
     ) -> Result<(), UsageConflict> {
         let buffers = bind_group.buffers.lock();
         for &(ref resource, state) in &*buffers {
-            let index = resource.as_info().id().unzip().0 as usize;
+            let index = resource.as_info().tracker_index() as usize;
 
             unsafe {
                 insert_or_merge(
@@ -241,7 +241,7 @@ impl<A: HalApi> BufferUsageScope<A> {
             .get(id)
             .map_err(|_| UsageConflict::BufferInvalid { id })?;
 
-        let index = id.unzip().0 as usize;
+        let index = buffer.info.tracker_index() as usize;
 
         self.allow_index(index);
 
@@ -278,7 +278,7 @@ pub(crate) struct BufferTracker<A: HalApi> {
     temp: Vec<PendingTransition<BufferUses>>,
 }
 
-impl<A: HalApi> ResourceTracker<Buffer<A>> for BufferTracker<A> {
+impl<A: HalApi> ResourceTracker for BufferTracker<A> {
     /// Try to remove the buffer `id` from this tracker if it is otherwise unused.
     ///
     /// A buffer is 'otherwise unused' when the only references to it are:
@@ -299,8 +299,8 @@ impl<A: HalApi> ResourceTracker<Buffer<A>> for BufferTracker<A> {
     /// [`Device::trackers`]: crate::device::Device
     /// [`self.metadata`]: BufferTracker::metadata
     /// [`Hub::buffers`]: crate::hub::Hub::buffers
-    fn remove_abandoned(&mut self, id: BufferId) -> bool {
-        let index = id.unzip().0 as usize;
+    fn remove_abandoned(&mut self, index: TrackerIndex) -> bool {
+        let index = index as usize;
 
         if index > self.metadata.size() {
             return false;
@@ -315,16 +315,10 @@ impl<A: HalApi> ResourceTracker<Buffer<A>> for BufferTracker<A> {
                 //so it's already been released from user and so it's not inside Registry\Storage
                 if existing_ref_count <= 2 {
                     self.metadata.remove(index);
-                    log::trace!("Buffer {:?} is not tracked anymore", id,);
                     return true;
-                } else {
-                    log::trace!(
-                        "Buffer {:?} is still referenced from {}",
-                        id,
-                        existing_ref_count
-                    );
-                    return false;
                 }
+
+                return false;
             }
         }
         true
@@ -390,8 +384,8 @@ impl<A: HalApi> BufferTracker<A> {
     ///
     /// If the ID is higher than the length of internal vectors,
     /// the vectors will be extended. A call to set_size is not needed.
-    pub fn insert_single(&mut self, id: BufferId, resource: Arc<Buffer<A>>, state: BufferUses) {
-        let index = id.unzip().0 as usize;
+    pub fn insert_single(&mut self, resource: Arc<Buffer<A>>, state: BufferUses) {
+        let index = resource.info.tracker_index() as usize;
 
         self.allow_index(index);
 
@@ -426,7 +420,7 @@ impl<A: HalApi> BufferTracker<A> {
     /// If the ID is higher than the length of internal vectors,
     /// the vectors will be extended. A call to set_size is not needed.
     pub fn set_single(&mut self, buffer: &Arc<Buffer<A>>, state: BufferUses) -> SetSingleResult<A> {
-        let index: usize = buffer.as_info().id().unzip().0 as usize;
+        let index: usize = buffer.as_info().tracker_index() as usize;
 
         self.allow_index(index);
 
@@ -547,16 +541,15 @@ impl<A: HalApi> BufferTracker<A> {
     pub unsafe fn set_and_remove_from_usage_scope_sparse(
         &mut self,
         scope: &mut BufferUsageScope<A>,
-        id_source: impl IntoIterator<Item = BufferId>,
+        index_source: impl IntoIterator<Item = TrackerIndex>,
     ) {
         let incoming_size = scope.state.len();
         if incoming_size > self.start.len() {
             self.set_size(incoming_size);
         }
 
-        for id in id_source {
-            let (index32, _, _) = id.unzip();
-            let index = index32 as usize;
+        for index in index_source {
+            let index = index as usize;
 
             scope.tracker_assert_in_bounds(index);
 
@@ -585,8 +578,8 @@ impl<A: HalApi> BufferTracker<A> {
     }
 
     #[allow(dead_code)]
-    pub fn get(&self, id: BufferId) -> Option<&Arc<Buffer<A>>> {
-        let index = id.unzip().0 as usize;
+    pub fn get(&self, index: TrackerIndex) -> Option<&Arc<Buffer<A>>> {
+        let index = index as usize;
         if index > self.metadata.size() {
             return None;
         }
@@ -771,11 +764,7 @@ unsafe fn merge<A: HalApi>(
 
     if invalid_resource_state(merged_state) {
         return Err(UsageConflict::from_buffer(
-            BufferId::zip(
-                index32,
-                unsafe { metadata_provider.get_epoch(index) },
-                A::VARIANT,
-            ),
+            unsafe { metadata_provider.get_own(index).info.id() },
             *current_state,
             new_state,
         ));

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -1,6 +1,6 @@
 //! The `ResourceMetadata` type.
 
-use crate::{resource::Resource, Epoch};
+use crate::resource::Resource;
 use bit_vec::BitVec;
 use std::{borrow::Cow, mem, sync::Arc};
 use wgt::strict_assert;
@@ -193,15 +193,6 @@ impl<T: Resource> ResourceMetadataProvider<'_, T> {
                 }
             }
         }
-    }
-    /// Get the epoch from this.
-    ///
-    /// # Safety
-    ///
-    /// - The index must be in bounds of the metadata tracker if this uses an indirect source.
-    #[inline(always)]
-    pub(super) unsafe fn get_epoch(self, index: usize) -> Epoch {
-        unsafe { self.get_own(index).as_info().id().unzip().1 }
     }
 }
 

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -102,16 +102,12 @@ mod stateless;
 mod texture;
 
 use crate::{
-    binding_model, command, conv,
-    hal_api::HalApi,
-    id::{self, Id},
-    pipeline, resource,
-    snatch::SnatchGuard,
+    binding_model, command, conv, hal_api::HalApi, id, pipeline, resource, snatch::SnatchGuard,
     storage::Storage,
 };
 
-use parking_lot::RwLock;
-use std::{fmt, ops};
+use parking_lot::{Mutex, RwLock};
+use std::{fmt, ops, sync::Arc};
 use thiserror::Error;
 
 pub(crate) use buffer::{BufferBindGroupState, BufferTracker, BufferUsageScope};
@@ -121,6 +117,92 @@ pub(crate) use texture::{
     TextureBindGroupState, TextureSelector, TextureTracker, TextureUsageScope,
 };
 use wgt::strict_assert_ne;
+
+pub type TrackerIndex = u32;
+
+/// wgpu-core internally use some array-like storage for tracking resources.
+/// To that end, there needs to be a uniquely assigned index for each live resource
+/// of a certain type. This index is separate from the resource ID for various reasons:
+/// - There can be multiple resource IDs pointing the the same resource.
+/// - IDs of dead handles can be recycled while resources are internally held alive (and tracked).
+/// - The plan is to remove IDs in the long run (https://github.com/gfx-rs/wgpu/issues/5121).
+/// In order to produce these tracker indices, there is a shared TrackerIndexAllocator
+/// per resource type. Indices have the same lifetime as the internal resource they
+/// are associated to (alloc happens when creating the resource and free is called when
+/// the resource is dropped).
+pub(crate) struct TrackerIndexAllocator {
+    unused: Vec<TrackerIndex>,
+    next_index: TrackerIndex,
+}
+
+impl TrackerIndexAllocator {
+    pub fn new() -> Self {
+        TrackerIndexAllocator {
+            unused: Vec::new(),
+            next_index: 0,
+        }
+    }
+
+    pub fn alloc(&mut self) -> TrackerIndex {
+        if let Some(index) = self.unused.pop() {
+            return index;
+        }
+
+        let index = self.next_index;
+        self.next_index += 1;
+
+        index
+    }
+
+    pub fn free(&mut self, index: TrackerIndex) {
+        self.unused.push(index);
+    }
+
+    // This is used to pre-allocate the tracker storage.
+    pub fn size(&self) -> usize {
+        self.next_index as usize
+    }
+}
+
+impl std::fmt::Debug for TrackerIndexAllocator {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        Ok(())
+    }
+}
+
+pub(crate) struct TrackerIndexAllocators {
+    pub buffers: Arc<Mutex<TrackerIndexAllocator>>,
+    pub staging_buffers: Arc<Mutex<TrackerIndexAllocator>>,
+    pub textures: Arc<Mutex<TrackerIndexAllocator>>,
+    pub texture_views: Arc<Mutex<TrackerIndexAllocator>>,
+    pub samplers: Arc<Mutex<TrackerIndexAllocator>>,
+    pub bind_groups: Arc<Mutex<TrackerIndexAllocator>>,
+    pub bind_group_layouts: Arc<Mutex<TrackerIndexAllocator>>,
+    pub compute_pipelines: Arc<Mutex<TrackerIndexAllocator>>,
+    pub render_pipelines: Arc<Mutex<TrackerIndexAllocator>>,
+    pub pipeline_layouts: Arc<Mutex<TrackerIndexAllocator>>,
+    pub bundles: Arc<Mutex<TrackerIndexAllocator>>,
+    pub query_sets: Arc<Mutex<TrackerIndexAllocator>>,
+}
+
+impl TrackerIndexAllocators {
+    pub fn new() -> Self {
+        TrackerIndexAllocators {
+            buffers: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+            staging_buffers: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+            textures: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+            texture_views: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+            samplers: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+            bind_groups: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+            bind_group_layouts: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+            compute_pipelines: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+            render_pipelines: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+            pipeline_layouts: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+            bundles: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+            query_sets: Arc::new(Mutex::new(TrackerIndexAllocator::new())),
+        }
+    }
+}
 
 /// A structure containing all the information about a particular resource
 /// transition. User code should be able to generate a pipeline barrier
@@ -420,17 +502,18 @@ pub(crate) struct UsageScope<A: HalApi> {
 
 impl<A: HalApi> UsageScope<A> {
     /// Create the render bundle scope and pull the maximum IDs from the hubs.
-    pub fn new(
-        buffers: &Storage<resource::Buffer<A>>,
-        textures: &Storage<resource::Texture<A>>,
-    ) -> Self {
+    pub fn new(tracker_indices: &TrackerIndexAllocators) -> Self {
         let mut value = Self {
             buffers: BufferUsageScope::new(),
             textures: TextureUsageScope::new(),
         };
 
-        value.buffers.set_size(buffers.len());
-        value.textures.set_size(textures.len());
+        value
+            .buffers
+            .set_size(tracker_indices.buffers.lock().size());
+        value
+            .textures
+            .set_size(tracker_indices.textures.lock().size());
 
         value
     }
@@ -478,11 +561,8 @@ impl<A: HalApi> UsageScope<A> {
     }
 }
 
-pub(crate) trait ResourceTracker<R>
-where
-    R: resource::Resource,
-{
-    fn remove_abandoned(&mut self, id: Id<R::Marker>) -> bool;
+pub(crate) trait ResourceTracker {
+    fn remove_abandoned(&mut self, index: TrackerIndex) -> bool;
 }
 
 /// A full double sided tracker used by CommandBuffers and the Device.
@@ -511,48 +591,6 @@ impl<A: HalApi> Tracker<A> {
             bundles: StatelessTracker::new(),
             query_sets: StatelessTracker::new(),
         }
-    }
-
-    /// Pull the maximum IDs from the hubs.
-    pub fn set_size(
-        &mut self,
-        buffers: Option<&Storage<resource::Buffer<A>>>,
-        textures: Option<&Storage<resource::Texture<A>>>,
-        views: Option<&Storage<resource::TextureView<A>>>,
-        samplers: Option<&Storage<resource::Sampler<A>>>,
-        bind_groups: Option<&Storage<binding_model::BindGroup<A>>>,
-        compute_pipelines: Option<&Storage<pipeline::ComputePipeline<A>>>,
-        render_pipelines: Option<&Storage<pipeline::RenderPipeline<A>>>,
-        bundles: Option<&Storage<command::RenderBundle<A>>>,
-        query_sets: Option<&Storage<resource::QuerySet<A>>>,
-    ) {
-        if let Some(buffers) = buffers {
-            self.buffers.set_size(buffers.len());
-        };
-        if let Some(textures) = textures {
-            self.textures.set_size(textures.len());
-        };
-        if let Some(views) = views {
-            self.views.set_size(views.len());
-        };
-        if let Some(samplers) = samplers {
-            self.samplers.set_size(samplers.len());
-        };
-        if let Some(bind_groups) = bind_groups {
-            self.bind_groups.set_size(bind_groups.len());
-        };
-        if let Some(compute_pipelines) = compute_pipelines {
-            self.compute_pipelines.set_size(compute_pipelines.len());
-        }
-        if let Some(render_pipelines) = render_pipelines {
-            self.render_pipelines.set_size(render_pipelines.len());
-        };
-        if let Some(bundles) = bundles {
-            self.bundles.set_size(bundles.len());
-        };
-        if let Some(query_sets) = query_sets {
-            self.query_sets.set_size(query_sets.len());
-        };
     }
 
     /// Iterates through all resources in the given bind group and adopts
@@ -585,7 +623,7 @@ impl<A: HalApi> Tracker<A> {
         unsafe {
             self.buffers.set_and_remove_from_usage_scope_sparse(
                 &mut scope.buffers,
-                bind_group.buffers.used_ids(),
+                bind_group.buffers.used_tracker_indices(),
             )
         };
         unsafe {

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -10,7 +10,7 @@ use parking_lot::Mutex;
 
 use crate::{id::Id, resource::Resource, resource_log, storage::Storage, track::ResourceMetadata};
 
-use super::ResourceTracker;
+use super::{ResourceTracker, TrackerIndex};
 
 /// Satisfy clippy.
 type Pair<T> = (Id<<T as Resource>::Marker>, Arc<T>);
@@ -74,7 +74,7 @@ pub(crate) struct StatelessTracker<T: Resource> {
     metadata: ResourceMetadata<T>,
 }
 
-impl<T: Resource> ResourceTracker<T> for StatelessTracker<T> {
+impl<T: Resource> ResourceTracker for StatelessTracker<T> {
     /// Try to remove the given resource from the tracker iff we have the last reference to the
     /// resource and the epoch matches.
     ///
@@ -82,14 +82,14 @@ impl<T: Resource> ResourceTracker<T> for StatelessTracker<T> {
     ///
     /// If the ID is higher than the length of internal vectors,
     /// false will be returned.
-    fn remove_abandoned(&mut self, id: Id<T::Marker>) -> bool {
-        let index = id.unzip().0 as usize;
+    fn remove_abandoned(&mut self, index: TrackerIndex) -> bool {
+        let index = index as usize;
 
         if index >= self.metadata.size() {
             return false;
         }
 
-        resource_log!("StatelessTracker::remove_abandoned {id:?}");
+        resource_log!("StatelessTracker::remove_abandoned {index:?}");
 
         self.tracker_assert_in_bounds(index);
 
@@ -100,17 +100,10 @@ impl<T: Resource> ResourceTracker<T> for StatelessTracker<T> {
                 //so it's already been released from user and so it's not inside Registry\Storage
                 if existing_ref_count <= 2 {
                     self.metadata.remove(index);
-                    log::trace!("{} {:?} is not tracked anymore", T::TYPE, id,);
                     return true;
-                } else {
-                    log::trace!(
-                        "{} {:?} is still referenced from {}",
-                        T::TYPE,
-                        id,
-                        existing_ref_count
-                    );
-                    return false;
                 }
+
+                return false;
             }
         }
         true
@@ -160,9 +153,8 @@ impl<T: Resource> StatelessTracker<T> {
     ///
     /// If the ID is higher than the length of internal vectors,
     /// the vectors will be extended. A call to set_size is not needed.
-    pub fn insert_single(&mut self, id: Id<T::Marker>, resource: Arc<T>) {
-        let (index32, _epoch, _) = id.unzip();
-        let index = index32 as usize;
+    pub fn insert_single(&mut self, resource: Arc<T>) {
+        let index = resource.as_info().tracker_index() as usize;
 
         self.allow_index(index);
 
@@ -184,8 +176,7 @@ impl<T: Resource> StatelessTracker<T> {
     ) -> Option<&'a Arc<T>> {
         let resource = storage.get(id).ok()?;
 
-        let (index32, _epoch, _) = id.unzip();
-        let index = index32 as usize;
+        let index = resource.as_info().tracker_index() as usize;
 
         self.allow_index(index);
 

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -83,7 +83,7 @@ impl<T: Resource> ResourceTracker for StatelessTracker<T> {
     /// If the ID is higher than the length of internal vectors,
     /// false will be returned.
     fn remove_abandoned(&mut self, index: TrackerIndex) -> bool {
-        let index = index as usize;
+        let index = index.as_usize();
 
         if index >= self.metadata.size() {
             return false;
@@ -154,7 +154,7 @@ impl<T: Resource> StatelessTracker<T> {
     /// If the ID is higher than the length of internal vectors,
     /// the vectors will be extended. A call to set_size is not needed.
     pub fn insert_single(&mut self, resource: Arc<T>) {
-        let index = resource.as_info().tracker_index() as usize;
+        let index = resource.as_info().tracker_index().as_usize();
 
         self.allow_index(index);
 
@@ -176,7 +176,7 @@ impl<T: Resource> StatelessTracker<T> {
     ) -> Option<&'a Arc<T>> {
         let resource = storage.get(id).ok()?;
 
-        let index = resource.as_info().tracker_index() as usize;
+        let index = resource.as_info().tracker_index().as_usize();
 
         self.allow_index(index);
 

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -360,7 +360,7 @@ impl<A: HalApi> TextureUsageScope<A> {
         selector: Option<TextureSelector>,
         new_state: TextureUses,
     ) -> Result<(), UsageConflict> {
-        let index = texture.as_info().tracker_index() as usize;
+        let index = texture.as_info().tracker_index().as_usize();
 
         self.tracker_assert_in_bounds(index);
 
@@ -403,7 +403,7 @@ impl<A: HalApi> ResourceTracker for TextureTracker<A> {
     /// If the ID is higher than the length of internal vectors,
     /// false will be returned.
     fn remove_abandoned(&mut self, index: TrackerIndex) -> bool {
-        let index = index as usize;
+        let index = index.as_usize();
 
         if index >= self.metadata.size() {
             return false;
@@ -514,7 +514,7 @@ impl<A: HalApi> TextureTracker<A> {
     /// If the ID is higher than the length of internal vectors,
     /// the vectors will be extended. A call to set_size is not needed.
     pub fn insert_single(&mut self, resource: Arc<Texture<A>>, usage: TextureUses) {
-        let index = resource.info.tracker_index() as usize;
+        let index = resource.info.tracker_index().as_usize();
 
         self.allow_index(index);
 
@@ -555,7 +555,7 @@ impl<A: HalApi> TextureTracker<A> {
         selector: TextureSelector,
         new_state: TextureUses,
     ) -> Option<Drain<'_, PendingTransition<TextureUses>>> {
-        let index = texture.as_info().tracker_index() as usize;
+        let index = texture.as_info().tracker_index().as_usize();
 
         self.allow_index(index);
 
@@ -689,7 +689,7 @@ impl<A: HalApi> TextureTracker<A> {
 
         let textures = bind_group_state.textures.lock();
         for t in textures.iter() {
-            let index = t.texture.as_info().tracker_index() as usize;
+            let index = t.texture.as_info().tracker_index().as_usize();
             scope.tracker_assert_in_bounds(index);
 
             if unsafe { !scope.metadata.contains_unchecked(index) } {
@@ -723,7 +723,7 @@ impl<A: HalApi> TextureTracker<A> {
     /// If the ID is higher than the length of internal vectors,
     /// false will be returned.
     pub fn remove(&mut self, index: TrackerIndex) -> bool {
-        let index = index as usize;
+        let index = index.as_usize();
 
         if index >= self.metadata.size() {
             return false;

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -19,10 +19,11 @@
  *   will treat the contents as junk.
 !*/
 
-use super::{range::RangedStates, PendingTransition, PendingTransitionList, ResourceTracker};
+use super::{
+    range::RangedStates, PendingTransition, PendingTransitionList, ResourceTracker, TrackerIndex,
+};
 use crate::{
     hal_api::HalApi,
-    id::TextureId,
     resource::{Resource, Texture, TextureInner},
     snatch::SnatchGuard,
     track::{
@@ -173,7 +174,7 @@ impl<A: HalApi> TextureBindGroupState<A> {
     /// accesses will be in a constant ascending order.
     pub(crate) fn optimize(&self) {
         let mut textures = self.textures.lock();
-        textures.sort_unstable_by_key(|v| v.texture.as_info().id().unzip().0);
+        textures.sort_unstable_by_key(|v| v.texture.as_info().tracker_index());
     }
 
     /// Returns a list of all textures tracked. May contain duplicates.
@@ -359,7 +360,7 @@ impl<A: HalApi> TextureUsageScope<A> {
         selector: Option<TextureSelector>,
         new_state: TextureUses,
     ) -> Result<(), UsageConflict> {
-        let index = texture.as_info().id().unzip().0 as usize;
+        let index = texture.as_info().tracker_index() as usize;
 
         self.tracker_assert_in_bounds(index);
 
@@ -393,7 +394,7 @@ pub(crate) struct TextureTracker<A: HalApi> {
     _phantom: PhantomData<A>,
 }
 
-impl<A: HalApi> ResourceTracker<Texture<A>> for TextureTracker<A> {
+impl<A: HalApi> ResourceTracker for TextureTracker<A> {
     /// Try to remove the given resource from the tracker iff we have the last reference to the
     /// resource and the epoch matches.
     ///
@@ -401,10 +402,10 @@ impl<A: HalApi> ResourceTracker<Texture<A>> for TextureTracker<A> {
     ///
     /// If the ID is higher than the length of internal vectors,
     /// false will be returned.
-    fn remove_abandoned(&mut self, id: TextureId) -> bool {
-        let index = id.unzip().0 as usize;
+    fn remove_abandoned(&mut self, index: TrackerIndex) -> bool {
+        let index = index as usize;
 
-        if index > self.metadata.size() {
+        if index >= self.metadata.size() {
             return false;
         }
 
@@ -419,16 +420,10 @@ impl<A: HalApi> ResourceTracker<Texture<A>> for TextureTracker<A> {
                     self.start_set.complex.remove(&index);
                     self.end_set.complex.remove(&index);
                     self.metadata.remove(index);
-                    log::trace!("Texture {:?} is not tracked anymore", id,);
                     return true;
-                } else {
-                    log::trace!(
-                        "Texture {:?} is still referenced from {}",
-                        id,
-                        existing_ref_count
-                    );
-                    return false;
                 }
+
+                return false;
             }
         }
         true
@@ -518,8 +513,8 @@ impl<A: HalApi> TextureTracker<A> {
     ///
     /// If the ID is higher than the length of internal vectors,
     /// the vectors will be extended. A call to set_size is not needed.
-    pub fn insert_single(&mut self, id: TextureId, resource: Arc<Texture<A>>, usage: TextureUses) {
-        let index = id.unzip().0 as usize;
+    pub fn insert_single(&mut self, resource: Arc<Texture<A>>, usage: TextureUses) {
+        let index = resource.info.tracker_index() as usize;
 
         self.allow_index(index);
 
@@ -560,7 +555,7 @@ impl<A: HalApi> TextureTracker<A> {
         selector: TextureSelector,
         new_state: TextureUses,
     ) -> Option<Drain<'_, PendingTransition<TextureUses>>> {
-        let index = texture.as_info().id().unzip().0 as usize;
+        let index = texture.as_info().tracker_index() as usize;
 
         self.allow_index(index);
 
@@ -694,7 +689,7 @@ impl<A: HalApi> TextureTracker<A> {
 
         let textures = bind_group_state.textures.lock();
         for t in textures.iter() {
-            let index = t.texture.as_info().id().unzip().0 as usize;
+            let index = t.texture.as_info().tracker_index() as usize;
             scope.tracker_assert_in_bounds(index);
 
             if unsafe { !scope.metadata.contains_unchecked(index) } {
@@ -727,10 +722,10 @@ impl<A: HalApi> TextureTracker<A> {
     ///
     /// If the ID is higher than the length of internal vectors,
     /// false will be returned.
-    pub fn remove(&mut self, id: TextureId) -> bool {
-        let index = id.unzip().0 as usize;
+    pub fn remove(&mut self, index: TrackerIndex) -> bool {
+        let index = index as usize;
 
-        if index > self.metadata.size() {
+        if index >= self.metadata.size() {
             return false;
         }
 
@@ -1080,11 +1075,7 @@ unsafe fn merge<A: HalApi>(
 
             if invalid_resource_state(merged_state) {
                 return Err(UsageConflict::from_texture(
-                    TextureId::zip(
-                        index as _,
-                        unsafe { metadata_provider.get_epoch(index) },
-                        A::VARIANT,
-                    ),
+                    unsafe { metadata_provider.get_own(index).info.id() },
                     texture_selector.clone(),
                     *current_simple,
                     new_simple,
@@ -1111,11 +1102,7 @@ unsafe fn merge<A: HalApi>(
 
                 if invalid_resource_state(merged_state) {
                     return Err(UsageConflict::from_texture(
-                        TextureId::zip(
-                            index as _,
-                            unsafe { metadata_provider.get_epoch(index) },
-                            A::VARIANT,
-                        ),
+                        unsafe { metadata_provider.get_own(index).info.id() },
                         selector,
                         *current_simple,
                         new_state,
@@ -1156,11 +1143,7 @@ unsafe fn merge<A: HalApi>(
 
                     if invalid_resource_state(merged_state) {
                         return Err(UsageConflict::from_texture(
-                            TextureId::zip(
-                                index as _,
-                                unsafe { metadata_provider.get_epoch(index) },
-                                A::VARIANT,
-                            ),
+                            unsafe { metadata_provider.get_own(index).info.id() },
                             TextureSelector {
                                 mips: mip_id..mip_id + 1,
                                 layers: layers.clone(),
@@ -1201,11 +1184,7 @@ unsafe fn merge<A: HalApi>(
 
                         if invalid_resource_state(merged_state) {
                             return Err(UsageConflict::from_texture(
-                                TextureId::zip(
-                                    index as _,
-                                    unsafe { metadata_provider.get_epoch(index) },
-                                    A::VARIANT,
-                                ),
+                                unsafe { metadata_provider.get_own(index).info.id() },
                                 TextureSelector {
                                     mips: mip_id..mip_id + 1,
                                     layers: layers.clone(),


### PR DESCRIPTION
**Connections**

Fixes #5217
Fixes #4912
Required for fixing #5141
An important step towards #5120

**Description**

Before this PR, trackers use the ID's index to manage per-resource information. This gets in the way of a lot of things (see linked issues). This PR adds a per-resource tracker index that is independent from the resource ID. Separating the two concepts lets us handle deduplicated IDs which point to the same resource and is an important step towards removing the IDs in favor of exposing the Arcs.

This PR also lets IDs be recycled as soon as their user-facing handle is dropped, which fixes the de-duplicated resource leaks and will allow Gecko to fix the recycling of handles.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
