### PR TITLE
Free command encoders' platform resources on drop on _all_ platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Bottom level categories:
 - Fix panic when creating a surface while no backend is available. By @wumpf [#5166](https://github.com/gfx-rs/wgpu/pull/5166)
 - Correctly compute minimum buffer size for array-typed `storage` and `uniform` vars. By @jimblandy [#5222](https://github.com/gfx-rs/wgpu/pull/5222)
 - Fix timeout when presenting a surface where no work has been done. By @waywardmonkeys in [#5200](https://github.com/gfx-rs/wgpu/pull/5200)
+- Fix an issue where command encoders weren't properly freed if an error occurred during command encoding. By @ErichDonGubler in [#5251](https://github.com/gfx-rs/wgpu/pull/5251).
 
 #### WGL
 

--- a/tests/tests/bind_group_layout_dedup.rs
+++ b/tests/tests/bind_group_layout_dedup.rs
@@ -1,9 +1,6 @@
 use std::num::NonZeroU64;
 
-use wgpu_test::{
-    fail, gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext,
-};
-use wgt::Backends;
+use wgpu_test::{fail, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
 const SHADER_SRC: &str = "
 @group(0) @binding(0)
@@ -307,18 +304,10 @@ fn bgl_dedupe_derived(ctx: TestingContext) {
     ctx.queue.submit(Some(encoder.finish()));
 }
 
-const DX12_VALIDATION_ERROR: &str = "The command allocator cannot be reset because a command list is currently being recorded with the allocator.";
-
 #[gpu_test]
 static SEPARATE_PROGRAMS_HAVE_INCOMPATIBLE_DERIVED_BGLS: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(
-            TestParameters::default()
-                .test_features_limits()
-                .expect_fail(
-                    FailureCase::backend(Backends::DX12).validation_error(DX12_VALIDATION_ERROR),
-                ),
-        )
+        .parameters(TestParameters::default().test_features_limits())
         .run_sync(separate_programs_have_incompatible_derived_bgls);
 
 fn separate_programs_have_incompatible_derived_bgls(ctx: TestingContext) {
@@ -376,13 +365,7 @@ fn separate_programs_have_incompatible_derived_bgls(ctx: TestingContext) {
 #[gpu_test]
 static DERIVED_BGLS_INCOMPATIBLE_WITH_REGULAR_BGLS: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(
-            TestParameters::default()
-                .test_features_limits()
-                .expect_fail(
-                    FailureCase::backend(Backends::DX12).validation_error(DX12_VALIDATION_ERROR),
-                ),
-        )
+        .parameters(TestParameters::default().test_features_limits())
         .run_sync(derived_bgls_incompatible_with_regular_bgls);
 
 fn derived_bgls_incompatible_with_regular_bgls(ctx: TestingContext) {

--- a/tests/tests/encoder.rs
+++ b/tests/tests/encoder.rs
@@ -21,16 +21,9 @@ static DROP_QUEUE_BEFORE_CREATING_COMMAND_ENCODER: GpuTestConfiguration =
                 device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
         });
 
-// This test crashes on DX12 with the exception:
-//
-// ID3D12CommandAllocator::Reset: The command allocator cannot be reset because a
-// command list is currently being recorded with the allocator. [ EXECUTION ERROR
-// #543: COMMAND_ALLOCATOR_CANNOT_RESET]
-//
-// For now, we mark the test as failing on DX12.
 #[gpu_test]
 static DROP_ENCODER_AFTER_ERROR: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().expect_fail(FailureCase::backend(wgpu::Backends::DX12)))
+    .parameters(TestParameters::default())
     .run_sync(|ctx| {
         let mut encoder = ctx
             .device

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -75,7 +75,7 @@ impl<A: HalApi> CommandEncoder<A> {
         Ok(())
     }
 
-    fn discard(&mut self) {
+    pub(crate) fn discard(&mut self) {
         if self.is_open {
             self.is_open = false;
             unsafe { self.raw.discard_encoding() };
@@ -112,7 +112,7 @@ pub(crate) struct DestroyedBufferError(pub id::BufferId);
 pub(crate) struct DestroyedTextureError(pub id::TextureId);
 
 pub struct CommandBufferMutable<A: HalApi> {
-    encoder: CommandEncoder<A>,
+    pub(crate) encoder: CommandEncoder<A>,
     status: CommandEncoderStatus,
     pub(crate) trackers: Tracker<A>,
     buffer_memory_init_actions: Vec<BufferInitTrackerAction<A>>,

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1377,6 +1377,7 @@ impl Global {
             .command_buffers
             .unregister(command_encoder_id.transmute())
         {
+            cmd_buf.data.lock().as_mut().unwrap().encoder.discard();
             cmd_buf
                 .device
                 .untrack(&cmd_buf.data.lock().as_ref().unwrap().trackers);

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -56,6 +56,13 @@ impl super::Temp {
     }
 }
 
+impl Drop for super::CommandEncoder {
+    fn drop(&mut self) {
+        use crate::CommandEncoder;
+        unsafe { self.discard_encoding() }
+    }
+}
+
 impl super::CommandEncoder {
     unsafe fn begin_pass(&mut self, kind: super::PassKind, label: crate::Label) {
         let list = self.list.as_ref().unwrap();

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -663,11 +663,7 @@ impl crate::Device<super::Api> for super::Device {
             end_of_pass_timer_query: None,
         })
     }
-    unsafe fn destroy_command_encoder(&self, encoder: super::CommandEncoder) {
-        if let Some(list) = encoder.list {
-            list.close();
-        }
-    }
+    unsafe fn destroy_command_encoder(&self, _encoder: super::CommandEncoder) {}
 
     unsafe fn create_bind_group_layout(
         &self,

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -93,6 +93,13 @@ impl super::CommandBuffer {
     }
 }
 
+impl Drop for super::CommandEncoder {
+    fn drop(&mut self) {
+        use crate::CommandEncoder;
+        unsafe { self.discard_encoding() }
+    }
+}
+
 impl super::CommandEncoder {
     fn rebind_stencil_func(&mut self) {
         fn make(s: &super::StencilSide, face: u32) -> C {


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

This is my attempt to investigate and resolve <https://github.com/gfx-rs/wgpu/issues/3193>. ~I believe this code is ready to go, but have not yet confirmed internal details to my satisfaction. I'm leaving this as WIP for now because I will be unavailable to work on finalizing details until \~2024-02-21. If somebody wants to pick it up before then, great!~

**Description**
_Describe what problem this is solving, and how it's solved._

I believe that #3193 is caused by not freeing command encoders early enough. This is apparent on the DX12 backend, where the DX12 API actually emits an error to inform us of our mistake. This is likely causing issues in other backends (i.e., Vulkan), where the symptoms aren't as obvious. Metal has already been cared for by @bradwerth with #2077, so only the other backends need attention here.

Interestingly, we don't currently do any clean-up of command encoders when they are dropped, but we do when they're `finish`ed. This seems wrong. So, this change adds a `CommandEncoder::discard_encoding` call for command encoders within `wgpu_core::Global::command_encoder_drop`. This change also adds a similar call to the `Drop` implementation of backends that appear to be idempotent in their `CommandEncoder::discard_encoder` calls (N.B., this does not include Vulkan). This appears to resolve DX12 API errors.

To be completely clear about how each backend is changed here:

| Backend | Status before this PR     | Status after this PR |
| ------- | ------------------------- | -------------------- |
| Vulkan  | Possibly has issues       | ✅Fixed.             |
| DX12    | Reporting hard errors     | ✅No more errors!    |
| Metal   | Already handled by #2077. | -                    |
| GLES    | Possibly has issues       | ✅Fixed.             |

**Testing**
_Explain how this change is tested._

~A test (`wgpu_test::buffer::command_encoder_without_finish_fine`) has been added, demonstrating both the expected failure before the fix and resolution to "just" passing.~

This change changes numerous expected error cases for tests for `DX12`, most notably `wgpu_tests::encoder::drop_encoder_after_error`, to simply be passing.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
