### PR TITLE
Add AccelerationStructure to WGSL write_value_type

### DIFF
--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -593,6 +593,7 @@ impl<W: Write> Writer<W> {
                 }
                 write!(self.out, ">")?;
             }
+            TypeInner::AccelerationStructure => write!(self.out, "acceleration_structure")?,
             _ => {
                 return Err(Error::Unimplemented(format!("write_value_type {inner:?}")));
             }


### PR DESCRIPTION
Allow writing out WGSL that contains an acceleration structure binding (used by naga_oil).