### PR TITLE
Docs surface creation no longer unsafe

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -358,7 +358,7 @@ static_assertions::assert_impl_all!(SurfaceConfiguration: Send, Sync);
 /// Handle to a presentable surface.
 ///
 /// A `Surface` represents a platform-specific surface (e.g. a window) onto which rendered images may
-/// be presented. A `Surface` may be created with the unsafe function [`Instance::create_surface`].
+/// be presented. A `Surface` may be created with the function [`Instance::create_surface`].
 ///
 /// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
 /// [`GPUCanvasContext`](https://gpuweb.github.io/gpuweb/#canvas-context)

--- a/wgpu/src/macros.rs
+++ b/wgpu/src/macros.rs
@@ -78,7 +78,16 @@ macro_rules! include_spirv_raw {
     };
 }
 
-/// Macro to load a WGSL module statically.
+/// Load WGSL source code from a file at compile time.
+///
+/// The loaded path is relative to the path of the file containing the macro call, in the same way
+/// as [`include_str!`] operates.
+///
+/// ```ignore
+/// fn main() {
+///     let module: ShaderModuleDescriptor = include_wgsl!("shader.wgsl");
+/// }
+/// ```
 #[macro_export]
 macro_rules! include_wgsl {
     ($($token:tt)*) => {


### PR DESCRIPTION
**Connections**
None

**Description**
Small changes to the docs

**Testing**
None

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
