### PR TITLE
[wgpu-hal.gles] Error log for failed GLES heuristics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ Bottom level categories:
 
 #### GLES
 
-- Long an error when GLES texture format heuristics fail. By @PolyMeilex in [#5266](https://github.com/gfx-rs/wgpu/issues/5266)
+- Log an error when GLES texture format heuristics fail. By @PolyMeilex in [#5266](https://github.com/gfx-rs/wgpu/issues/5266)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,10 @@ Bottom level categories:
 - `wgpu::Id` now implements `PartialOrd`/`Ord` allowing it to be put in `BTreeMap`s. By @cwfitzgerald and @9291Sam in [#5176](https://github.com/gfx-rs/wgpu/pull/5176)
 - `wgpu::CommandEncoder::write_timestamp` requires now the new `wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS` feature which is available on all native backends but not on WebGPU (due to a spec change `write_timestamp` is no longer supported on WebGPU). By @wumpf in [#5188](https://github.com/gfx-rs/wgpu/pull/5188)
 
+#### GLES
+
+- Long an error when GLES texture format heuristics fail. By @PolyMeilex in [#5266](https://github.com/gfx-rs/wgpu/issues/5266)
+
 ### Bug Fixes
 
 #### General

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1202,7 +1202,7 @@ impl crate::Device<super::Api> for super::Device {
                     }
                     let (raw, target) = view.inner.as_native();
 
-                    super::Texture::validate_target_heuristics(view_dimension, target);
+                    super::Texture::log_failing_target_heuristics(view_dimension, target);
 
                     super::RawBinding::Texture {
                         raw,

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1194,13 +1194,16 @@ impl crate::Device<super::Api> for super::Device {
                     let sampler = desc.samplers[entry.resource_index as usize];
                     super::RawBinding::Sampler(sampler.raw)
                 }
-                wgt::BindingType::Texture { .. } => {
+                wgt::BindingType::Texture { view_dimension, .. } => {
                     let view = desc.textures[entry.resource_index as usize].view;
                     if view.array_layers.start != 0 {
                         log::error!("Unable to create a sampled texture binding for non-zero array layer.\n{}",
                             "This is an implementation problem of wgpu-hal/gles backend.")
                     }
                     let (raw, target) = view.inner.as_native();
+
+                    super::Texture::validate_target_heuristics(view_dimension, target);
+
                     super::RawBinding::Texture {
                         raw,
                         target,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -366,6 +366,7 @@ impl Texture {
     /// Returns the `target`, whether the image is 3d and whether the image is a cubemap.
     fn get_info_from_desc(desc: &TextureDescriptor) -> u32 {
         match desc.dimension {
+            // TODO: Why `TEXTURE_2D` rather than `TEXTURE_1D`?
             wgt::TextureDimension::D1 => glow::TEXTURE_2D,
             wgt::TextureDimension::D2 => {
                 // HACK: detect a cube map; forces cube compatible textures to be cube textures
@@ -378,6 +379,43 @@ impl Texture {
             }
             wgt::TextureDimension::D3 => glow::TEXTURE_3D,
         }
+    }
+
+    /// More information can be found in issues #1614 and #1574
+    fn validate_target_heuristics(view_dimension: wgt::TextureViewDimension, target: u32) {
+        let expected_target = match view_dimension {
+            wgt::TextureViewDimension::D1 => glow::TEXTURE_2D,
+            wgt::TextureViewDimension::D2 => glow::TEXTURE_2D,
+            wgt::TextureViewDimension::D2Array => glow::TEXTURE_2D_ARRAY,
+            wgt::TextureViewDimension::Cube => glow::TEXTURE_CUBE_MAP,
+            wgt::TextureViewDimension::CubeArray => glow::TEXTURE_CUBE_MAP_ARRAY,
+            wgt::TextureViewDimension::D3 => glow::TEXTURE_3D,
+        };
+
+        if expected_target == target {
+            return;
+        }
+
+        let buffer;
+        let got = match target {
+            glow::TEXTURE_2D => "D2",
+            glow::TEXTURE_2D_ARRAY => "D2Array",
+            glow::TEXTURE_CUBE_MAP => "Cube",
+            glow::TEXTURE_CUBE_MAP_ARRAY => "CubeArray",
+            glow::TEXTURE_3D => "D3",
+            target => {
+                buffer = target.to_string();
+                &buffer
+            }
+        };
+
+        log::error!(
+            "wgpu-hal heuristics assumed that the view dimension will be equal to `{got}` rather than `{view_dimension:?}`.\n{}\n{}\n{}\n{}",
+            "`D2` textures with `depth_or_array_layers == 1` are assumed to have view dimension `D2`",
+            "`D2` textures with `depth_or_array_layers > 1` are assumed to have view dimension `D2Array`",
+            "`D2` textures with `depth_or_array_layers == 6` are assumed to have view dimension `Cube`",
+            "`D2` textures with `depth_or_array_layers > 6 && depth_or_array_layers % 6 == 0` are assumed to have view dimension `CubeArray`",
+        );
     }
 }
 

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -366,7 +366,8 @@ impl Texture {
     /// Returns the `target`, whether the image is 3d and whether the image is a cubemap.
     fn get_info_from_desc(desc: &TextureDescriptor) -> u32 {
         match desc.dimension {
-            // TODO: Why `TEXTURE_2D` rather than `TEXTURE_1D`?
+            // WebGL (1 and 2) as well as some GLES versions do not have 1D textures, so we are
+            // doing `TEXTURE_2D` instead
             wgt::TextureDimension::D1 => glow::TEXTURE_2D,
             wgt::TextureDimension::D2 => {
                 // HACK: detect a cube map; forces cube compatible textures to be cube textures
@@ -382,7 +383,7 @@ impl Texture {
     }
 
     /// More information can be found in issues #1614 and #1574
-    fn validate_target_heuristics(view_dimension: wgt::TextureViewDimension, target: u32) {
+    fn log_failing_target_heuristics(view_dimension: wgt::TextureViewDimension, target: u32) {
         let expected_target = match view_dimension {
             wgt::TextureViewDimension::D1 => glow::TEXTURE_2D,
             wgt::TextureViewDimension::D2 => glow::TEXTURE_2D,


### PR DESCRIPTION
GLES backend guesses the texture type, and it often guesses wrong, let's save people some debugging time by informing them about this madness until there is a proper solution.

Info about those limitations in #1614 and #1574
Related iced bug that took way too long to debug https://github.com/iced-rs/iced/pull/2259