### PR TITLE
Disable GPU based validation in tests by default but keep it on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,6 +527,8 @@ jobs:
         run: |
           set -e
 
+          export WGPU_WGPU_GPU_BASED_VALIDATION=1
+
           cargo xtask test --llvm-cov
 
       - name: check naga snapshots

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -31,7 +31,7 @@ pub fn initialize_instance() -> Instance {
     let gles_minor_version = wgpu::util::gles_minor_version_from_env().unwrap_or_default();
     Instance::new(wgpu::InstanceDescriptor {
         backends,
-        flags: wgpu::InstanceFlags::advanced_debugging().with_env(),
+        flags: wgpu::InstanceFlags::debugging().with_env(),
         dx12_shader_compiler,
         gles_minor_version,
     })

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -38,7 +38,7 @@ fn device_lifetime_check() {
         backends: wgpu::util::backend_bits_from_env().unwrap_or(wgpu::Backends::all()),
         dx12_shader_compiler: wgpu::util::dx12_shader_compiler_from_env().unwrap_or_default(),
         gles_minor_version: wgpu::util::gles_minor_version_from_env().unwrap_or_default(),
-        flags: wgpu::InstanceFlags::advanced_debugging().with_env(),
+        flags: wgpu::InstanceFlags::debugging().with_env(),
     });
 
     let adapter = wgpu::util::initialize_adapter_from_env_or_default(&instance, None)


### PR DESCRIPTION
**Description**

With gpu based validation, `cargo xtask test` immediately fills all of my RAM and makes the desktop unusable (forcing me to hard-reboot the computer) on the two computers I have handy (they have 32 and 64 GB of RAM).

I don't know if it's a mesa or AMD specific thing but it's so disruptive that I think that we need to take a more careful approach to enabling the the advanced validation stuff. This PR turns it off by default for people running tests locally (can be re-enabled using the `WGPU_GPU_BASED_VALIDATION` environment variable), but leaves it enabled on CI for now.


**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.