### PR TITLE
Remove GPU based validation in Tests

### DIFF
--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -31,7 +31,7 @@ pub fn initialize_instance() -> Instance {
     let gles_minor_version = wgpu::util::gles_minor_version_from_env().unwrap_or_default();
     Instance::new(wgpu::InstanceDescriptor {
         backends,
-        flags: wgpu::InstanceFlags::advanced_debugging().with_env(),
+        flags: wgpu::InstanceFlags::debugging().with_env(),
         dx12_shader_compiler,
         gles_minor_version,
     })

--- a/tests/tests/shader/struct_layout.rs
+++ b/tests/tests/shader/struct_layout.rs
@@ -263,11 +263,6 @@ static UNIFORM_INPUT: GpuTestConfiguration = GpuTestConfiguration::new()
                 FailureCase::backend(wgpu::Backends::VULKAN)
                     .validation_error("a matrix with stride 8 not satisfying alignment to 16"),
             )
-            .expect_fail(
-                FailureCase::backend(wgpu::Backends::VULKAN).validation_error(
-                    "Failure to instrument shader.  Proceeding with non-instrumented shader.",
-                ),
-            )
             .limits(Limits::downlevel_defaults()),
     )
     .run_async(|ctx| {

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -795,7 +795,7 @@ impl crate::Instance<super::Api> for super::Instance {
             if validation_features_are_enabled {
                 validation_feature_list = ArrayVec::new();
 
-                // Always enable syncronization validation
+                // Always enable synchronization validation
                 validation_feature_list
                     .push(vk::ValidationFeatureEnableEXT::SYNCHRONIZATION_VALIDATION);
 

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -6,6 +6,7 @@ use std::{
     thread,
 };
 
+use arrayvec::ArrayVec;
 use ash::{
     extensions::{ext, khr},
     vk,
@@ -653,26 +654,27 @@ impl crate::Instance<super::Api> for super::Instance {
         let validation_layer_name =
             CStr::from_bytes_with_nul(b"VK_LAYER_KHRONOS_validation\0").unwrap();
         let validation_layer_properties = find_layer(&instance_layers, validation_layer_name);
-        let validation_features_are_enabled = || {
-            validation_layer_properties.is_some().then(|| {
-                let exts = Self::enumerate_instance_extension_properties(
-                    &entry,
-                    Some(validation_layer_name),
-                )?;
-                let mut ext_names = exts
-                    .iter()
-                    .filter_map(|ext| cstr_from_bytes_until_nul(&ext.extension_name));
-                let found =
-                    ext_names.any(|ext_name| ext_name == vk::ExtValidationFeaturesFn::name());
-                Ok(found)
-            })
+
+        // Determine if VK_EXT_validation_features is available, so we can enable
+        // GPU assisted validation and synchronization validation.
+        let validation_features_are_enabled = if validation_layer_properties.is_some() {
+            // Get the all the instance extension properties.
+            let exts =
+                Self::enumerate_instance_extension_properties(&entry, Some(validation_layer_name))?;
+            // Convert all the names of the extensions into an iterator of CStrs.
+            let mut ext_names = exts
+                .iter()
+                .filter_map(|ext| cstr_from_bytes_until_nul(&ext.extension_name));
+            // Find the validation features extension.
+            ext_names.any(|ext_name| ext_name == vk::ExtValidationFeaturesFn::name())
+        } else {
+            false
         };
+
         let should_enable_gpu_based_validation = desc
             .flags
             .intersects(wgt::InstanceFlags::GPU_BASED_VALIDATION)
-            && validation_features_are_enabled()
-                .transpose()?
-                .unwrap_or(false);
+            && validation_features_are_enabled;
 
         let nv_optimus_layer = CStr::from_bytes_with_nul(b"VK_LAYER_NV_optimus\0").unwrap();
         let has_nv_optimus = find_layer(&instance_layers, nv_optimus_layer).is_some();
@@ -787,14 +789,26 @@ impl crate::Instance<super::Api> for super::Instance {
                 create_info = create_info.push_next(vk_create_info);
             }
 
-            let mut gpu_assisted_validation = vk::ValidationFeaturesEXT::builder()
-                .enabled_validation_features(&[
-                    vk::ValidationFeatureEnableEXT::GPU_ASSISTED,
-                    vk::ValidationFeatureEnableEXT::GPU_ASSISTED_RESERVE_BINDING_SLOT,
-                    vk::ValidationFeatureEnableEXT::SYNCHRONIZATION_VALIDATION,
-                ]);
-            if should_enable_gpu_based_validation {
-                create_info = create_info.push_next(&mut gpu_assisted_validation);
+            // Enable explicit validation features if available
+            let mut validation_features;
+            let mut validation_feature_list: ArrayVec<_, 3>;
+            if validation_features_are_enabled {
+                validation_feature_list = ArrayVec::new();
+
+                // Always enable syncronization validation
+                validation_feature_list
+                    .push(vk::ValidationFeatureEnableEXT::SYNCHRONIZATION_VALIDATION);
+
+                // Only enable GPU assisted validation if requested.
+                if should_enable_gpu_based_validation {
+                    validation_feature_list.push(vk::ValidationFeatureEnableEXT::GPU_ASSISTED);
+                    validation_feature_list
+                        .push(vk::ValidationFeatureEnableEXT::GPU_ASSISTED_RESERVE_BINDING_SLOT);
+                }
+
+                validation_features = vk::ValidationFeaturesEXT::builder()
+                    .enabled_validation_features(&validation_feature_list);
+                create_info = create_info.push_next(&mut validation_features);
             }
 
             unsafe {


### PR DESCRIPTION
**Connections**

Supersedes #5269 

**Description**

This disabled GBV everywhere. This should fix:
- DX12 tests taking multiple minutes
- DX12 Crashes in upcoming PR in CI #5154
- Vulkan using massive amounts of memory.

This leaves synchronization validation enabled, as that's still of significant value to us.

It also cleans up some of the vulkan initialization code.

**Testing**

Tested locally on MVK. @nical can you verify this fixes the memory explosion?

