### PR TITLE
Add feature flags in hal to panic when running into some types of errors

### DIFF
--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -63,6 +63,18 @@ dxc_shader_compiler = ["hassle-rs"]
 renderdoc = ["libloading", "renderdoc-sys"]
 fragile-send-sync-non-atomic-wasm = ["wgt/fragile-send-sync-non-atomic-wasm"]
 link = ["metal/link"]
+# Panic when running into an out-of-memory error (for debugging purposes).
+#
+# Only affects the d3d12 and vulkan backends.
+oom_panic = []
+# Panic when running into a device lost error (for debugging purposes).
+# Only affects the d3d12 and vulkan backends.
+device_lost_panic = []
+# Panic when running into an internal error other than out-of-memory and device lost
+# (for debugging purposes).
+#
+# Only affects the d3d12 and vulkan backends.
+internal_error_panic = []
 
 [[example]]
 name = "halmark"

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -724,13 +724,25 @@ impl crate::Queue<Api> for Queue {
 
 impl From<vk::Result> for crate::DeviceError {
     fn from(result: vk::Result) -> Self {
+        #![allow(unreachable_code)]
         match result {
             vk::Result::ERROR_OUT_OF_HOST_MEMORY | vk::Result::ERROR_OUT_OF_DEVICE_MEMORY => {
+                #[cfg(feature = "oom_panic")]
+                panic!("Out of memory ({result:?})");
+
                 Self::OutOfMemory
             }
-            vk::Result::ERROR_DEVICE_LOST => Self::Lost,
+            vk::Result::ERROR_DEVICE_LOST => {
+                #[cfg(feature = "device_lost_panic")]
+                panic!("Device lost");
+
+                Self::Lost
+            }
             _ => {
-                log::warn!("Unrecognized device error {:?}", result);
+                #[cfg(feature = "internal_error_panic")]
+                panic!("Internal error: {result:?}");
+
+                log::warn!("Unrecognized device error {result:?}");
                 Self::Lost
             }
         }


### PR DESCRIPTION
**Description**

This is for debugging purposes and does not have to be long term. Right now hal backends don't report much information about what failed and why. This makes debugging some issues a bit difficult.

Having panics with with more context (the stacktrace and HResult code for example) would pretty dramatically speed up the process of debugging the d3d12 issues I'm investigating right now.

This PR adds three feature flags in hal, each causing panics for their respective category of error close to where the error is produced. 
 - `oom_panic`
 - `device_lost_panic`
 - `internal_error_panic`

I implemented the panics in vulkan and d3d12 but did not add the corresponding glue for the metal and GL backends.

Longer term we could address this better by producing more descriptive errors in hal.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
