### PR TITLE
Validate that the view dimension of a multisampled texture binding is 2d

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -38,7 +38,7 @@ pub enum BindGroupLayoutEntryError {
     ArrayUnsupported,
     #[error("Multisampled binding with sample type `TextureSampleType::Float` must have filterable set to false.")]
     SampleTypeFloatFilterableBindingMultisampled,
-    #[error("Multisampled texture binding view dimmension must be 2d, got {0:?}")]
+    #[error("Multisampled texture binding view dimension must be 2d, got {0:?}")]
     Non2DMultisampled(wgt::TextureViewDimension),
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -38,6 +38,8 @@ pub enum BindGroupLayoutEntryError {
     ArrayUnsupported,
     #[error("Multisampled binding with sample type `TextureSampleType::Float` must have filterable set to false.")]
     SampleTypeFloatFilterableBindingMultisampled,
+    #[error("Multisampled texture binding view dimmension must be 2d, got {0:?}")]
+    Non2DMultisampled(wgt::TextureViewDimension),
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
     #[error(transparent)]

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1714,10 +1714,23 @@ impl<A: HalApi> Device<A> {
                             BindGroupLayoutEntryError::SampleTypeFloatFilterableBindingMultisampled,
                     });
                 }
-                Bt::Texture { .. } => (
-                    Some(wgt::Features::TEXTURE_BINDING_ARRAY),
-                    WritableStorage::No,
-                ),
+                Bt::Texture {
+                    multisampled,
+                    view_dimension,
+                    ..
+                } => {
+                    if multisampled && view_dimension != TextureViewDimension::D2 {
+                        return Err(binding_model::CreateBindGroupLayoutError::Entry {
+                            binding: entry.binding,
+                            error: BindGroupLayoutEntryError::Non2DMultisampled(view_dimension),
+                        });
+                    }
+
+                    (
+                        Some(wgt::Features::TEXTURE_BINDING_ARRAY),
+                        WritableStorage::No,
+                    )
+                }
                 Bt::StorageTexture {
                     access,
                     view_dimension,


### PR DESCRIPTION
**Connections**

CTS test: `webgpu:api,validation,createBindGroupLayout:multisampled_validation:viewDimension=*`
Spec: https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbindgrouplayout

**Description**

The spec says that the view dimension of a multi-sampled texture must be 2d. This implements the validation accordingly.

**Testing**

Covered by the CTS.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [ ] Run `cargo xtask test` to run tests.
