### PR TITLE
[naga msl-out] Tolerate use of `IndexMap::remove`, for Firefox.

### DIFF
--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -3048,6 +3048,13 @@ impl<W: Write> Writer<W> {
         for statement in statements {
             if let crate::Statement::Emit(ref range) = *statement {
                 for handle in range.clone() {
+                    // `IndexMap::remove` was deprecated in `indexmap` 2.2.0,
+                    // with `swap_remove` as the appropriate replacement here.
+                    // Unfortunately, Naga can't adopt that until Firefox stops
+                    // kludging `indexmap` 2.0 to 1.0:
+                    //
+                    // https://searchfox.org/mozilla-central/rev/da49863c3d6f34038d00f5ba701b9a2ad9cbadba/Cargo.toml#156-157
+                    #[allow(deprecated)]
                     self.named_expressions.remove(&handle);
                 }
             }


### PR DESCRIPTION
`IndexMap::remove` was deprecated in `indexmap` 2.2.0, with `swap_remove` as the appropriate replacement for its use by Naga's `NamedExpressions` type. Unfortunately, Firefox [patches] `indexmap` to always use version 1, so Naga can't use any `indexmap` 2 features until that patch is removed.

I believe Firefox's patch is there to avoid vendoring two copies of `indexmap`. Once all of Firefox's uses move to indexmap 2, Firefox's patch will be removed, and we can remove this commit and update Naga's `IndexMap` usage.

[patches]: https://searchfox.org/mozilla-central/rev/da49863c3d6f34038d00f5ba701b9a2ad9cbadba/Cargo.toml#156-157
