### PR TITLE
Checkpoint of pipeline caching for testing purposes only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,7 +2571,7 @@ checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "player"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "env_logger",
  "log",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "arrayvec 0.7.4",
  "cfg-if",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-examples"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4110,7 +4110,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-info"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "bitflags 2.4.2",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-macros"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "heck",
  "quote",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-test"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 homepage = "https://wgpu.rs/"
 repository = "https://github.com/gfx-rs/wgpu"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["gfx-rs developers"]
 
 [workspace.dependencies.wgc]

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -337,6 +337,7 @@ struct DeviceShared {
     workarounds: Workarounds,
     render_passes: Mutex<rustc_hash::FxHashMap<RenderPassKey, vk::RenderPass>>,
     framebuffers: Mutex<rustc_hash::FxHashMap<FramebufferKey, vk::Framebuffer>>,
+    pipeline_cache: Option<ash::vk::PipelineCache>,
 }
 
 pub struct Device {


### PR DESCRIPTION
> [!IMPORTANT]
> 
> This PR is not intended to be merged, and is instead being used to provide a stable reference to the head branch for reference in issues/code

**Connections**
- Corresponding Vello PR: linebender/vello#459
- 

**Description**
As part of my work on [Vello](https://github.com/linebender/vello/), I have been optimising our startup time on Android.
One significant aspect of this is [Vulkan pipeline caching](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPipelineCache.html).

This branch is a checkpoint of a non-idiomatic implementation of this pipeline caching, allowing us to validate that we require wgpu to provide pipeline caching.

**Testing**
I ran this on Wayland Vulkan (without the env var being provided), and on Android Vulkan (with the env var set)

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
