### PR TITLE
wgpu-core: Inform user about possible fix

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -221,7 +221,7 @@ pub enum BindingZone {
 }
 
 #[derive(Clone, Debug, Error)]
-#[error("Too many bindings of type {kind:?} in {zone}, limit is {limit}, count was {count}")]
+#[error("Too many bindings of type {kind:?} in {zone}, limit is {limit}, count was {count}. Check the limit `{}` passed to `Adapter::request_device`", .kind.to_config_str())]
 pub struct BindingTypeMaxCountError {
     pub kind: BindingTypeMaxCountErrorKind,
     pub zone: BindingZone,
@@ -238,6 +238,28 @@ pub enum BindingTypeMaxCountErrorKind {
     StorageBuffers,
     StorageTextures,
     UniformBuffers,
+}
+
+impl BindingTypeMaxCountErrorKind {
+    fn to_config_str(&self) -> &'static str {
+        match self {
+            BindingTypeMaxCountErrorKind::DynamicUniformBuffers => {
+                "max_dynamic_uniform_buffers_per_pipeline_layout"
+            }
+            BindingTypeMaxCountErrorKind::DynamicStorageBuffers => {
+                "max_dynamic_storage_buffers_per_pipeline_layout"
+            }
+            BindingTypeMaxCountErrorKind::SampledTextures => {
+                "max_sampled_textures_per_shader_stage"
+            }
+            BindingTypeMaxCountErrorKind::Samplers => "max_samplers_per_shader_stage",
+            BindingTypeMaxCountErrorKind::StorageBuffers => "max_storage_buffers_per_shader_stage",
+            BindingTypeMaxCountErrorKind::StorageTextures => {
+                "max_storage_textures_per_shader_stage"
+            }
+            BindingTypeMaxCountErrorKind::UniformBuffers => "max_uniform_buffers_per_shader_stage",
+        }
+    }
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
**Connections**

None

**Description**

I'm inexperienced with the API, and wrote a test using `Limits::downlevel_webgl2_defaults()`. The only reason I realized the validation error for the number of bindings was not a hardware capability issue is because I had gone over an working example on https://webgpufundamentals.org/.

Adding a bit more of context to the error message should help new users realize this is a configuration issue instead of hardware/support and guide them to a possible fix.

This changes the error from:

```
wgpu error: Validation Error

Caused by:
    In Device::create_bind_group_layout
    Too many bindings of type StorageBuffers in Stage ShaderStages(VERTEX | FRAGMENT), limit is 0, count was 1
```

To:

```
wgpu error: Validation Error

Caused by:
    In Device::create_bind_group_layout
    Too many bindings of type StorageBuffers in Stage ShaderStages(VERTEX | FRAGMENT), limit is 0, count was 1. Check the required limit max_storage_buffers_per_shader_stage used on request_device
```

**Testing**

With `cargo xtask test`

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
