### PR TITLE
deps: Update `ahash` to fix "unknown feature `stdsimd`" error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
 dependencies = [
  "cfg-if",
  "getrandom",


### PR DESCRIPTION
Rust has removed the `stdsimd` feature: https://github.com/rust-lang/rust/pull/117372
This broke `ahash` for versions prior to `0.8.7`: https://github.com/tkaitchuck/aHash/pull/183

**Connections**
* https://github.com/rust-lang/rust/pull/117372
* https://github.com/tkaitchuck/aHash/pull/183

**Description**
Due to the above, the `wgpu` repository won't build with a nightly build of Rust.

**Testing**
`wgpu` can build with a nightly compiler.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
