### PR TITLE
Make `GPUProgrammableStage.entryPoint` optional in `wgpu-core`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Bottom level categories:
 ```
 - `wgpu::Id` now implements `PartialOrd`/`Ord` allowing it to be put in `BTreeMap`s. By @cwfitzgerald and @9291Sam in [#5176](https://github.com/gfx-rs/wgpu/pull/5176)
 - `wgpu::CommandEncoder::write_timestamp` requires now the new `wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS` feature which is available on all native backends but not on WebGPU (due to a spec change `write_timestamp` is no longer supported on WebGPU). By @wumpf in [#5188](https://github.com/gfx-rs/wgpu/pull/5188)
+- Breaking change: [`wgpu_core::pipeline::ProgrammableStageDescriptor`](https://docs.rs/wgpu-core/latest/wgpu_core/pipeline/struct.ProgrammableStageDescriptor.html#structfield.entry_point) is now optional. By @ErichDonGubler in [#5305](https://github.com/gfx-rs/wgpu/pull/5305).
 
 #### GLES
 

--- a/deno_webgpu/pipeline.rs
+++ b/deno_webgpu/pipeline.rs
@@ -110,7 +110,7 @@ pub fn op_webgpu_create_compute_pipeline(
         layout: pipeline_layout,
         stage: wgpu_core::pipeline::ProgrammableStageDescriptor {
             module: compute_shader_module_resource.1,
-            entry_point: Cow::from(compute.entry_point),
+            entry_point: Some(Cow::from(compute.entry_point)),
             // TODO(lucacasonato): support args.compute.constants
         },
     };
@@ -355,7 +355,7 @@ pub fn op_webgpu_create_render_pipeline(
         Some(wgpu_core::pipeline::FragmentState {
             stage: wgpu_core::pipeline::ProgrammableStageDescriptor {
                 module: fragment_shader_module_resource.1,
-                entry_point: Cow::from(fragment.entry_point),
+                entry_point: Some(Cow::from(fragment.entry_point)),
             },
             targets: Cow::from(fragment.targets),
         })
@@ -377,7 +377,7 @@ pub fn op_webgpu_create_render_pipeline(
         vertex: wgpu_core::pipeline::VertexState {
             stage: wgpu_core::pipeline::ProgrammableStageDescriptor {
                 module: vertex_shader_module_resource.1,
-                entry_point: Cow::Owned(args.vertex.entry_point),
+                entry_point: Some(Cow::Owned(args.vertex.entry_point)),
             },
             buffers: Cow::Owned(vertex_buffers),
         },

--- a/player/tests/data/bind-group.ron
+++ b/player/tests/data/bind-group.ron
@@ -56,7 +56,7 @@
                 layout: Some(Id(0, 1, Empty)),
                 stage: (
                     module: Id(0, 1, Empty),
-                    entry_point: "main",
+                    entry_point: Some("main"),
                 ),
             ),
         ),

--- a/player/tests/data/bind-group.ron
+++ b/player/tests/data/bind-group.ron
@@ -56,7 +56,7 @@
                 layout: Some(Id(0, 1, Empty)),
                 stage: (
                     module: Id(0, 1, Empty),
-                    entry_point: Some("main"),
+                    entry_point: None,
                 ),
             ),
         ),

--- a/player/tests/data/pipeline-statistics-query.ron
+++ b/player/tests/data/pipeline-statistics-query.ron
@@ -29,7 +29,7 @@
                 layout: Some(Id(0, 1, Empty)),
                 stage: (
                     module: Id(0, 1, Empty),
-                    entry_point: "main",
+                    entry_point: Some("main"),
                 ),
             ),
         ),

--- a/player/tests/data/pipeline-statistics-query.ron
+++ b/player/tests/data/pipeline-statistics-query.ron
@@ -29,7 +29,7 @@
                 layout: Some(Id(0, 1, Empty)),
                 stage: (
                     module: Id(0, 1, Empty),
-                    entry_point: Some("main"),
+                    entry_point: None,
                 ),
             ),
         ),

--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -57,14 +57,14 @@
                 vertex: (
                     stage: (
                         module: Id(0, 1, Empty),
-                        entry_point: Some("vs_main"),
+                        entry_point: None,
                     ),
                     buffers: [],
                 ),
                 fragment: Some((
                     stage: (
                         module: Id(0, 1, Empty),
-                        entry_point: Some("fs_main"),
+                        entry_point: None,
                     ),
                     targets: [
                         Some((

--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -57,14 +57,14 @@
                 vertex: (
                     stage: (
                         module: Id(0, 1, Empty),
-                        entry_point: "vs_main",
+                        entry_point: Some("vs_main"),
                     ),
                     buffers: [],
                 ),
                 fragment: Some((
                     stage: (
                         module: Id(0, 1, Empty),
-                        entry_point: "fs_main",
+                        entry_point: Some("fs_main"),
                     ),
                     targets: [
                         Some((

--- a/player/tests/data/zero-init-buffer.ron
+++ b/player/tests/data/zero-init-buffer.ron
@@ -133,7 +133,7 @@
                 layout: Some(Id(0, 1, Empty)),
                 stage: (
                     module: Id(0, 1, Empty),
-                    entry_point: Some("main"),
+                    entry_point: None,
                 ),
             ),
         ),

--- a/player/tests/data/zero-init-buffer.ron
+++ b/player/tests/data/zero-init-buffer.ron
@@ -133,7 +133,7 @@
                 layout: Some(Id(0, 1, Empty)),
                 stage: (
                     module: Id(0, 1, Empty),
-                    entry_point: "main",
+                    entry_point: Some("main"),
                 ),
             ),
         ),

--- a/player/tests/data/zero-init-texture-binding.ron
+++ b/player/tests/data/zero-init-texture-binding.ron
@@ -134,7 +134,7 @@
                 layout: Some(Id(0, 1, Empty)),
                 stage: (
                     module: Id(0, 1, Empty),
-                    entry_point: "main",
+                    entry_point: Some("main"),
                 ),
             ),
         ),

--- a/player/tests/data/zero-init-texture-binding.ron
+++ b/player/tests/data/zero-init-texture-binding.ron
@@ -134,7 +134,7 @@
                 layout: Some(Id(0, 1, Empty)),
                 stage: (
                     module: Id(0, 1, Empty),
-                    entry_point: Some("main"),
+                    entry_point: None,
                 ),
             ),
         ),

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3129,6 +3129,8 @@ impl<A: HalApi> Device<A> {
                 return Err(DeviceError::WrongDevice.into());
             }
 
+            let stage_err = |error| pipeline::CreateRenderPipelineError::Stage { stage, error };
+
             if let Some(ref interface) = vertex_shader_module.interface {
                 io = interface
                     .check_stage(
@@ -3139,7 +3141,7 @@ impl<A: HalApi> Device<A> {
                         io,
                         desc.depth_stencil.as_ref().map(|d| d.depth_compare),
                     )
-                    .map_err(|error| pipeline::CreateRenderPipelineError::Stage { stage, error })?;
+                    .map_err(stage_err)?;
                 validated_stages |= stage;
             }
 
@@ -3163,6 +3165,8 @@ impl<A: HalApi> Device<A> {
                         })?,
                 );
 
+                let stage_err = |error| pipeline::CreateRenderPipelineError::Stage { stage, error };
+
                 if validated_stages == wgt::ShaderStages::VERTEX {
                     if let Some(ref interface) = shader_module.interface {
                         io = interface
@@ -3174,10 +3178,7 @@ impl<A: HalApi> Device<A> {
                                 io,
                                 desc.depth_stencil.as_ref().map(|d| d.depth_compare),
                             )
-                            .map_err(|error| pipeline::CreateRenderPipelineError::Stage {
-                                stage,
-                                error,
-                            })?;
+                            .map_err(stage_err)?;
                         validated_stages |= stage;
                     }
                 }

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -92,6 +92,19 @@ impl<A: HalApi> ShaderModule<A> {
     pub(crate) fn raw(&self) -> &A::ShaderModule {
         self.raw.as_ref().unwrap()
     }
+
+    pub(crate) fn finalize_entry_point_name(
+        &self,
+        stage_bit: wgt::ShaderStages,
+        entry_point: Option<&str>,
+    ) -> Result<String, validation::StageError> {
+        match &self.interface {
+            Some(interface) => interface.finalize_entry_point_name(stage_bit, entry_point),
+            None => entry_point
+                .map(|ep| ep.to_string())
+                .ok_or(validation::StageError::NoEntryPointFound),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -213,9 +226,13 @@ impl CreateShaderModuleError {
 pub struct ProgrammableStageDescriptor<'a> {
     /// The compiled shader module for this stage.
     pub module: ShaderModuleId,
-    /// The name of the entry point in the compiled shader. There must be a function with this name
-    /// in the shader.
-    pub entry_point: Cow<'a, str>,
+    /// The name of the entry point in the compiled shader. The name is selected using the
+    /// following logic:
+    ///
+    /// * If `Some(name)` is specified, there must be a function with this name in the shader.
+    /// * If a single entry point associated with this stage must be in the shader, then proceed as
+    ///   if `Some(…)` was specified with that entry point's name.
+    pub entry_point: Option<Cow<'a, str>>,
 }
 
 /// Number of implicit bind groups derived at pipeline creation.

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -283,6 +283,16 @@ pub enum StageError {
     },
     #[error("Location[{location}] is provided by the previous stage output but is not consumed as input by this stage.")]
     InputNotConsumed { location: wgt::ShaderLocation },
+    #[error(
+        "Unable to select an entry point: no entry point was found in the provided shader module"
+    )]
+    NoEntryPointFound,
+    #[error(
+        "Unable to select an entry point: \
+        multiple entry points were found in the provided shader module, \
+        but no entry point was specified"
+    )]
+    MultipleEntryPointsFound,
 }
 
 fn map_storage_format_to_naga(format: wgt::TextureFormat) -> Option<naga::StorageFormat> {
@@ -971,6 +981,28 @@ impl Interface {
         }
     }
 
+    pub fn finalize_entry_point_name(
+        &self,
+        stage_bit: wgt::ShaderStages,
+        entry_point_name: Option<&str>,
+    ) -> Result<String, StageError> {
+        let stage = Self::shader_stage_from_stage_bit(stage_bit);
+        entry_point_name
+            .map(|ep| ep.to_string())
+            .map(Ok)
+            .unwrap_or_else(|| {
+                let mut entry_points = self
+                    .entry_points
+                    .keys()
+                    .filter_map(|(ep_stage, name)| (ep_stage == &stage).then_some(name));
+                let first = entry_points.next().ok_or(StageError::NoEntryPointFound)?;
+                if entry_points.next().is_some() {
+                    return Err(StageError::MultipleEntryPointsFound);
+                }
+                Ok(first.clone())
+            })
+    }
+
     pub(crate) fn shader_stage_from_stage_bit(stage_bit: wgt::ShaderStages) -> naga::ShaderStage {
         match stage_bit {
             wgt::ShaderStages::VERTEX => naga::ShaderStage::Vertex,
@@ -993,10 +1025,11 @@ impl Interface {
         // we need to look for one with the right execution model.
         let shader_stage = Self::shader_stage_from_stage_bit(stage_bit);
         let pair = (shader_stage, entry_point_name.to_string());
-        let entry_point = self
-            .entry_points
-            .get(&pair)
-            .ok_or(StageError::MissingEntryPoint(pair.1))?;
+        let entry_point = match self.entry_points.get(&pair) {
+            Some(some) => some,
+            None => return Err(StageError::MissingEntryPoint(pair.1)),
+        };
+        let (_stage, entry_point_name) = pair;
 
         // check resources visibility
         for &handle in entry_point.resources.iter() {

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -971,6 +971,15 @@ impl Interface {
         }
     }
 
+    pub(crate) fn shader_stage_from_stage_bit(stage_bit: wgt::ShaderStages) -> naga::ShaderStage {
+        match stage_bit {
+            wgt::ShaderStages::VERTEX => naga::ShaderStage::Vertex,
+            wgt::ShaderStages::FRAGMENT => naga::ShaderStage::Fragment,
+            wgt::ShaderStages::COMPUTE => naga::ShaderStage::Compute,
+            _ => unreachable!(),
+        }
+    }
+
     pub fn check_stage(
         &self,
         layouts: &mut BindingLayoutSource<'_>,
@@ -982,12 +991,7 @@ impl Interface {
     ) -> Result<StageIo, StageError> {
         // Since a shader module can have multiple entry points with the same name,
         // we need to look for one with the right execution model.
-        let shader_stage = match stage_bit {
-            wgt::ShaderStages::VERTEX => naga::ShaderStage::Vertex,
-            wgt::ShaderStages::FRAGMENT => naga::ShaderStage::Fragment,
-            wgt::ShaderStages::COMPUTE => naga::ShaderStage::Compute,
-            _ => unreachable!(),
-        };
+        let shader_stage = Self::shader_stage_from_stage_bit(stage_bit);
         let pair = (shader_stage, entry_point_name.to_string());
         let entry_point = self
             .entry_points

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1102,7 +1102,7 @@ impl crate::Context for ContextWgpuCore {
             vertex: pipe::VertexState {
                 stage: pipe::ProgrammableStageDescriptor {
                     module: desc.vertex.module.id.into(),
-                    entry_point: Borrowed(desc.vertex.entry_point),
+                    entry_point: Some(Borrowed(desc.vertex.entry_point)),
                 },
                 buffers: Borrowed(&vertex_buffers),
             },
@@ -1112,7 +1112,7 @@ impl crate::Context for ContextWgpuCore {
             fragment: desc.fragment.as_ref().map(|frag| pipe::FragmentState {
                 stage: pipe::ProgrammableStageDescriptor {
                     module: frag.module.id.into(),
-                    entry_point: Borrowed(frag.entry_point),
+                    entry_point: Some(Borrowed(frag.entry_point)),
                 },
                 targets: Borrowed(frag.targets),
             }),
@@ -1160,7 +1160,7 @@ impl crate::Context for ContextWgpuCore {
             layout: desc.layout.map(|l| l.id.into()),
             stage: pipe::ProgrammableStageDescriptor {
                 module: desc.module.id.into(),
-                entry_point: Borrowed(desc.entry_point),
+                entry_point: Some(Borrowed(desc.entry_point)),
             },
         };
 


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

Part of the work necessary for <https://github.com/gfx-rs/wgpu/pull/5148>, which resolves <https://github.com/gfx-rs/wgpu/issues/5145>. Unblocks agents like Firefox implementing this in their own environment as a first, easier step.

**Description**
_Describe what problem this is solving, and how it's solved._

An optional entry point is now part of the WebGPU standard, and we should adhere to it; see also <https://github.com/gpuweb/gpuweb/issues/4342>.

**Testing**
_Explain how this change is tested._

Some tests in `player/tests/` now exercise this via traces' specification of `entry_point: None`. However, there's no `wgpu-core` API tests exercising this, ATM. I think this is fine until such time that <https://github.com/gfx-rs/wgpu/pull/5148> has merged, which _should_ have more comprehensive testing over `wgpu`.

I expect that some coverage of this will be added over time; tracking this at <https://github.com/gpuweb/cts/issues/3432>.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
