### PR TITLE
Try to load `libX11.so.6` in addition to `libX11.so`.

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -161,7 +161,7 @@ impl Drop for DisplayOwner {
 fn open_x_display() -> Option<DisplayOwner> {
     log::debug!("Loading X11 library to get the current display");
     unsafe {
-        let library = libloading::Library::new("libX11.so").ok()?;
+        let library = find_library(&["libX11.so.6", "libX11.so"])?;
         let func: libloading::Symbol<XOpenDisplayFun> = library.get(b"XOpenDisplay").unwrap();
         let result = func(ptr::null());
         ptr::NonNull::new(result).map(|ptr| DisplayOwner {


### PR DESCRIPTION
**Connections**

Fixes https://github.com/gfx-rs/wgpu/issues/2518.

**Description**

Not all Linux distributions (e.g: Debian and openSUSE) include a `libX11.so` symlink in the standard libX11 package.  Debian only includes `libX11.so.6` - `libX11.so` is provided by the `libx11-dev` package, which is not a dependency application maintainers should need users to install.  (openSUSE provides the `libX11.so` symlink in `libX11-devel`.)

Note that the ordering here (`libX11.so.6` before `libX11.so`) matches the order in which the Wayland client library is attempted by `wgpu` (`libwayland-client.so.0` before `libwayland-client.so`).

**Testing**

Unfortunately, I'm having trouble reproducing the issue myself.  That said, this is a very straightforward change, and seems to be acknowledged to be desirable.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
