### PR TITLE
Fix staging buffer ID allocation mismatch

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -350,24 +350,44 @@ impl RenderBundleEncoder {
     ) -> Result<RenderBundle<A>, RenderBundleError> {
         let bind_group_guard = hub.bind_groups.read();
         let pipeline_guard = hub.render_pipelines.read();
-        let query_set_guard = hub.query_sets.read();
         let buffer_guard = hub.buffers.read();
-        let texture_guard = hub.textures.read();
 
         let mut state = State {
-            trackers: RenderBundleScope::new(
-                &*buffer_guard,
-                &*texture_guard,
-                &*bind_group_guard,
-                &*pipeline_guard,
-                &*query_set_guard,
-            ),
+            trackers: RenderBundleScope::new(),
             pipeline: None,
             bind: (0..hal::MAX_BIND_GROUPS).map(|_| None).collect(),
             vertex: (0..hal::MAX_VERTEX_BUFFERS).map(|_| None).collect(),
             index: None,
             flat_dynamic_offsets: Vec::new(),
         };
+
+        let indices = &device.tracker_indices;
+        state
+            .trackers
+            .buffers
+            .write()
+            .set_size(indices.buffers.size());
+        state
+            .trackers
+            .textures
+            .write()
+            .set_size(indices.textures.size());
+        state
+            .trackers
+            .bind_groups
+            .write()
+            .set_size(indices.bind_groups.size());
+        state
+            .trackers
+            .render_pipelines
+            .write()
+            .set_size(indices.render_pipelines.size());
+        state
+            .trackers
+            .query_sets
+            .write()
+            .set_size(indices.query_sets.size());
+
         let mut commands = Vec::new();
         let mut buffer_memory_init_actions = Vec::new();
         let mut texture_memory_init_actions = Vec::new();

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -217,7 +217,7 @@ impl Global {
                     mapped_at_creation: false,
                 };
                 let stage = match device.create_buffer(&stage_desc, true) {
-                    Ok(stage) => stage,
+                    Ok(stage) => Arc::new(stage),
                     Err(e) => {
                         to_destroy.push(buffer);
                         break e;
@@ -230,13 +230,9 @@ impl Global {
                     Ok(mapping) => mapping,
                     Err(e) => {
                         to_destroy.push(buffer);
-                        to_destroy.push(stage);
                         break CreateBufferError::Device(e.into());
                     }
                 };
-
-                let stage_fid = hub.buffers.request();
-                let stage = stage_fid.init(stage);
 
                 assert_eq!(buffer.size % wgt::COPY_BUFFER_ALIGNMENT, 0);
                 // Zero initialize memory and then mark both staging and buffer as initialized

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -103,7 +103,6 @@ mod texture;
 
 use crate::{
     binding_model, command, conv, hal_api::HalApi, id, pipeline, resource, snatch::SnatchGuard,
-    storage::Storage,
 };
 
 use parking_lot::{Mutex, RwLock};
@@ -479,31 +478,14 @@ pub(crate) struct RenderBundleScope<A: HalApi> {
 
 impl<A: HalApi> RenderBundleScope<A> {
     /// Create the render bundle scope and pull the maximum IDs from the hubs.
-    pub fn new(
-        buffers: &Storage<resource::Buffer<A>>,
-        textures: &Storage<resource::Texture<A>>,
-        bind_groups: &Storage<binding_model::BindGroup<A>>,
-        render_pipelines: &Storage<pipeline::RenderPipeline<A>>,
-        query_sets: &Storage<resource::QuerySet<A>>,
-    ) -> Self {
-        let value = Self {
+    pub fn new() -> Self {
+        Self {
             buffers: RwLock::new(BufferUsageScope::new()),
             textures: RwLock::new(TextureUsageScope::new()),
             bind_groups: RwLock::new(StatelessTracker::new()),
             render_pipelines: RwLock::new(StatelessTracker::new()),
             query_sets: RwLock::new(StatelessTracker::new()),
-        };
-
-        value.buffers.write().set_size(buffers.len());
-        value.textures.write().set_size(textures.len());
-        value.bind_groups.write().set_size(bind_groups.len());
-        value
-            .render_pipelines
-            .write()
-            .set_size(render_pipelines.len());
-        value.query_sets.write().set_size(query_sets.len());
-
-        value
+        }
     }
 
     /// Merge the inner contents of a bind group into the render bundle tracker.


### PR DESCRIPTION
**Connections**

Followup from #5244 and #5229

**Description**

Two problems:
 - There was a mix of externally and internally allocated buffer IDs: regular buffers could be externally allocated but the temporary buffer used to initialize non-mappable-but-mapped-at-creation buffers was always internally allocated. The assertion added in #5229 caught this in gecko. To my understanding this was incorrect before since externally allocated IDs can't know about the IDs that are internally produced so they would silently stomp over one another in the registry. This is fixed by the first commit.
 - The trackers for render bundle execution were sized from the wrong source (the registry storage instead of the tracker index allocators). This is an oversight from #5244 and is fixed in the second commit.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`
- [x] Run `cargo xtask test` to run tests.
