### PR TITLE
Fix docs.rs Builds

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["Cargo.lock"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--cfg", "web_sys_unstable_apis"]
 targets = [
     "x86_64-unknown-linux-gnu",
     "x86_64-apple-darwin",


### PR DESCRIPTION
**Connections**

Between this and https://github.com/gfx-rs/metal-rs/pull/303, all targets should work on docs.rs again.

**Description**

We were just missing the `--cfg web_sys_unstable_apis` for wasm.