### PR TITLE
[naga] Fix docs generated by `gen_component_wise_extractor`.

### DIFF
--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -31,7 +31,7 @@ macro_rules! gen_component_wise_extractor {
             $(
                 #[doc = concat!(
                     "Maps to [`Literal::",
-                    stringify!($mapping),
+                    stringify!($literal),
                     "`]",
                 )]
                 $mapping([$ty; N]),


### PR DESCRIPTION
Let `naga::proc::constant_evaluator:gen_component_wise_extractor` generate proper references to `Literal` variants in the doc strings for the generated `$target` enum.
