### PR TITLE
wgpu-hal: add ndk-sys dependency to fix linking error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Bottom level categories:
 - Fix registry leaks with de-duplicated resources. By @nical in [#5244](https://github.com/gfx-rs/wgpu/pull/5244)
 - Fix behavior of integer `clamp` when `min` argument > `max` argument. By @cwfitzgerald in [#5300](https://github.com/gfx-rs/wgpu/pull/5300).
 - Fix missing validation for `Device::clear_buffer` where `offset + size buffer.size` was not checked when `size` was omitted. By @ErichDonGubler in [#5282](https://github.com/gfx-rs/wgpu/pull/5282).
+- Fix linking when targeting android. By @ashdnazg in [#5326](https://github.com/gfx-rs/wgpu/pull/5326).
 
 #### glsl-in
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4074,6 +4074,7 @@ dependencies = [
  "log",
  "metal",
  "naga",
+ "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
  "parking_lot",

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -166,6 +166,7 @@ libc = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_system_properties = "0.1.1"
+ndk-sys = "0.5.0"
 
 [dependencies.naga]
 path = "../naga"

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -50,16 +50,6 @@ type WlEglWindowResizeFun = unsafe extern "system" fn(
 
 type WlEglWindowDestroyFun = unsafe extern "system" fn(window: *const raw::c_void);
 
-#[cfg(target_os = "android")]
-extern "C" {
-    pub fn ANativeWindow_setBuffersGeometry(
-        window: *mut raw::c_void,
-        width: i32,
-        height: i32,
-        format: i32,
-    ) -> i32;
-}
-
 type EglLabel = *const raw::c_void;
 
 #[allow(clippy::upper_case_acronyms)]
@@ -864,7 +854,12 @@ impl crate::Instance<super::Api> for Instance {
                     .unwrap();
 
                 let ret = unsafe {
-                    ANativeWindow_setBuffersGeometry(handle.a_native_window.as_ptr(), 0, 0, format)
+                    ndk_sys::ANativeWindow_setBuffersGeometry(
+                        handle.a_native_window.as_ptr() as *mut ndk_sys::ANativeWindow,
+                        0,
+                        0,
+                        format,
+                    )
                 };
 
                 if ret != 0 {


### PR DESCRIPTION
**Description**
Compilation of an android library which depends on wgpu fails during linking with the error:
```
ld: error: undefined symbol: ANativeWindow_setBuffersGeometry
```

This isn't encountered in the tests, since the dev dependencies include `winit` which depends on `ndk-sys` when targeting android.

**Testing**
This was tested by succeeding to compile a project which did not compile previously.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
