### PR TITLE
Add OpenGL support for TEXTURE_FORMAT_16BIT_NORM on supported versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ By @cwfitzgerald in [#5325](https://github.com/gfx-rs/wgpu/pull/5325).
 #### GLES
 
 - Log an error when GLES texture format heuristics fail. By @PolyMeilex in [#5266](https://github.com/gfx-rs/wgpu/issues/5266)
+- Enable `TEXTURE_FORMAT_16BIT_NORM` for OpenGL 3.3+. By @bes in [#5330](https://github.com/gfx-rs/wgpu/pull/5330).
 
 ### Bug Fixes
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -628,6 +628,11 @@ impl super::Adapter {
             // that's the only way to get gl_InstanceID to work correctly.
             features.set(wgt::Features::INDIRECT_FIRST_INSTANCE, supported);
         }
+        // Supported by GL 3.3+, Not supported by GLES 3.0+
+        features.set(
+            wgt::Features::TEXTURE_FORMAT_16BIT_NORM,
+            es_ver.is_none() && full_ver >= Some((3, 3)),
+        );
 
         let max_texture_size = unsafe { gl.get_parameter_i32(glow::MAX_TEXTURE_SIZE) } as u32;
         let max_texture_3d_size = unsafe { gl.get_parameter_i32(glow::MAX_3D_TEXTURE_SIZE) } as u32;
@@ -1032,6 +1037,9 @@ impl crate::Adapter<super::Api> for super::Adapter {
 
         let texture_float_linear = feature_fn(wgt::Features::FLOAT32_FILTERABLE, filterable);
 
+        let texture_rgb16bit_renderable =
+            feature_fn(wgt::Features::TEXTURE_FORMAT_16BIT_NORM, renderable);
+
         match format {
             Tf::R8Unorm => filterable_renderable,
             Tf::R8Snorm => filterable,
@@ -1068,8 +1076,8 @@ impl crate::Adapter<super::Api> for super::Adapter {
             Tf::Rg32Float => unfilterable | float_renderable | texture_float_linear,
             Tf::Rgba16Uint => renderable | storage,
             Tf::Rgba16Sint => renderable | storage,
-            Tf::Rgba16Unorm => empty,
-            Tf::Rgba16Snorm => empty,
+            Tf::Rgba16Unorm => texture_rgb16bit_renderable,
+            Tf::Rgba16Snorm => texture_rgb16bit_renderable,
             Tf::Rgba16Float => filterable | storage | half_float_renderable,
             Tf::Rgba32Uint => renderable | storage,
             Tf::Rgba32Sint => renderable | storage,


### PR DESCRIPTION
**Description**
When handing wgpu an OpenGL context that has support for `TEXTURE_FORMAT_16BIT_NORM`, it was previously ignored. I have tried to add support for `TEXTURE_FORMAT_16BIT_NORM` for OpenGL versions that support it.

**Testing**

* Manually tested on macOS with an OpenGL 4.1 Context with a core profile that I got from GStreamer.
* Automatic tests (`cargo xtask test`)

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
