### PR TITLE
Add support for running on OpenGL 4.1 with a core profile on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,10 @@ By @cwfitzgerald in [#5325](https://github.com/gfx-rs/wgpu/pull/5325).
 - Refactor tests to read feature flags by name instead of a hardcoded hexadecimal u64. By @rodolphito in [#5155](https://github.com/gfx-rs/wgpu/pull/5155).
 - Add test that verifies that we can drop the queue before using the device to create a command encoder. By @Davidster in [#5211](https://github.com/gfx-rs/wgpu/pull/5211)
 
+#### GLES
+
+- Fixes for being able to use an OpenGL 4.1 core context provided by macOS with wgpu. By @bes in [#5331](https://github.com/gfx-rs/wgpu/pull/5331).
+
 ## v0.19.0 (2024-01-17)
 
 This release includes:

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -729,9 +729,19 @@ impl super::Adapter {
             max_push_constant_size: super::MAX_PUSH_CONSTANTS as u32 * 4,
             min_uniform_buffer_offset_alignment,
             min_storage_buffer_offset_alignment,
-            max_inter_stage_shader_components: unsafe {
-                gl.get_parameter_i32(glow::MAX_VARYING_COMPONENTS)
-            } as u32,
+            max_inter_stage_shader_components: {
+                // MAX_VARYING_COMPONENTS may return 0, because it is deprecated since OpenGL 3.2 core,
+                // and an OpenGL Context with the core profile and with forward-compatibility=true,
+                // will make deprecated constants unavailable.
+                let max_varying_components =
+                    unsafe { gl.get_parameter_i32(glow::MAX_VARYING_COMPONENTS) } as u32;
+                if max_varying_components == 0 {
+                    // default value for max_inter_stage_shader_components
+                    60
+                } else {
+                    max_varying_components
+                }
+            },
             max_color_attachments,
             max_color_attachment_bytes_per_sample,
             max_compute_workgroup_storage_size: if supports_work_group_params {
@@ -837,7 +847,14 @@ impl super::Adapter {
         let source = if es {
             format!("#version 300 es\nprecision lowp float;\n{source}")
         } else {
-            format!("#version 130\n{source}")
+            let version = gl.version();
+            if version.major == 3 && version.minor == 0 {
+                // OpenGL 3.0 only supports this format
+                format!("#version 130\n{source}")
+            } else {
+                // OpenGL 3.1+ support this format
+                format!("#version 140\n{source}")
+            }
         };
         let shader = unsafe { gl.create_shader(shader_type) }.expect("Could not create shader");
         unsafe { gl.shader_source(shader, &source) };


### PR DESCRIPTION
**Description**

When running wgpu with an OpenGL context on macOS that is created with a core profile and with the forward-compatibility bit set, the MAX_VARYING_COMPONENTS constant returns 0 when queried. The default value is 60, so we return the default value if the query returns 0.

We also need to use `#version 140` on macOS since `#version 130` isn't accepted. Since `#version 140` should be available from OpenGL 3.1, we use that everywhere. That way we don't need any specific macOS flags or features.

**Testing**

* Manually tested on macOS with an OpenGL 4.1 Context with a core profile that I got from GStreamer.
* Automatic tests (`cargo xtask test`)

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
