### PR TITLE
Revert "Add OpenGL support for TEXTURE_FORMAT_16BIT_NORM on supported…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,6 @@ By @cwfitzgerald in [#5325](https://github.com/gfx-rs/wgpu/pull/5325).
 #### GLES
 
 - Log an error when GLES texture format heuristics fail. By @PolyMeilex in [#5266](https://github.com/gfx-rs/wgpu/issues/5266)
-- Enable `TEXTURE_FORMAT_16BIT_NORM` for OpenGL 3.3+. By @bes in [#5330](https://github.com/gfx-rs/wgpu/pull/5330).
 
 ### Bug Fixes
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -628,11 +628,6 @@ impl super::Adapter {
             // that's the only way to get gl_InstanceID to work correctly.
             features.set(wgt::Features::INDIRECT_FIRST_INSTANCE, supported);
         }
-        // Supported by GL 3.3+, Not supported by GLES 3.0+
-        features.set(
-            wgt::Features::TEXTURE_FORMAT_16BIT_NORM,
-            es_ver.is_none() && full_ver >= Some((3, 3)),
-        );
 
         let max_texture_size = unsafe { gl.get_parameter_i32(glow::MAX_TEXTURE_SIZE) } as u32;
         let max_texture_3d_size = unsafe { gl.get_parameter_i32(glow::MAX_3D_TEXTURE_SIZE) } as u32;
@@ -1054,9 +1049,6 @@ impl crate::Adapter<super::Api> for super::Adapter {
 
         let texture_float_linear = feature_fn(wgt::Features::FLOAT32_FILTERABLE, filterable);
 
-        let texture_rgb16bit_renderable =
-            feature_fn(wgt::Features::TEXTURE_FORMAT_16BIT_NORM, renderable);
-
         match format {
             Tf::R8Unorm => filterable_renderable,
             Tf::R8Snorm => filterable,
@@ -1093,8 +1085,8 @@ impl crate::Adapter<super::Api> for super::Adapter {
             Tf::Rg32Float => unfilterable | float_renderable | texture_float_linear,
             Tf::Rgba16Uint => renderable | storage,
             Tf::Rgba16Sint => renderable | storage,
-            Tf::Rgba16Unorm => texture_rgb16bit_renderable,
-            Tf::Rgba16Snorm => texture_rgb16bit_renderable,
+            Tf::Rgba16Unorm => empty,
+            Tf::Rgba16Snorm => empty,
             Tf::Rgba16Float => filterable | storage | half_float_renderable,
             Tf::Rgba32Uint => renderable | storage,
             Tf::Rgba32Sint => renderable | storage,


### PR DESCRIPTION
… versions (#5330)"

This reverts commit 352cb3d40b7d9dacceb2511e693d035844ca8a7c.

**Connections**

* #5330

**Description**

The commit #5330 was mistakenly merged by @Wumpf before being fully tested by @bes.

**Testing**

After testing some more on my MR, I am mostly convinced that it should not have been merged, and that it is unnecessary. Please accept my apologies.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Remove~Add~ change to `CHANGELOG.md`. See simple instructions inside file.
