### PR TITLE
[wgpu-hal] make android dependencies optional based on features

### DIFF
--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -42,8 +42,9 @@ vulkan = [
     "gpu-descriptor",
     "libloading",
     "smallvec",
+    "android_system_properties"
 ]
-gles = ["naga/glsl-out", "glow", "glutin_wgl_sys", "khronos-egl", "libloading"]
+gles = ["naga/glsl-out", "glow", "glutin_wgl_sys", "khronos-egl", "libloading", "ndk-sys"]
 dx12 = [
     "naga/hlsl-out",
     "d3d12",
@@ -165,8 +166,8 @@ js-sys = "0.3.67"
 libc = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_system_properties = "0.1.1"
-ndk-sys = "0.5.0"
+android_system_properties = { version = "0.1.1", optional = true }
+ndk-sys = { version = "0.5.0", optional = true }
 
 [dependencies.naga]
 path = "../naga"


### PR DESCRIPTION
**Connections**
follow-up to https://github.com/gfx-rs/wgpu/pull/5326

**Description**
Makes wgpu-hal's android dependencies optional.