### PR TITLE
Don't create shader-clear program on GLES if it's not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ By @cwfitzgerald in [#5325](https://github.com/gfx-rs/wgpu/pull/5325).
 #### GLES
 
 - Fixes for being able to use an OpenGL 4.1 core context provided by macOS with wgpu. By @bes in [#5331](https://github.com/gfx-rs/wgpu/pull/5331).
+- Don't create a program for shader-clearing if that workaround isn't required. By @Dinnerbone in [#5348](https://github.com/gfx-rs/wgpu/pull/5348).
 
 ## v0.19.0 (2024-01-17)
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -4,6 +4,7 @@ use std::sync::{atomic::AtomicU8, Arc};
 use wgt::AstcChannel;
 
 use crate::auxil::db;
+use crate::gles::ShaderClearProgram;
 
 // https://webgl2fundamentals.org/webgl/lessons/webgl-data-textures.html
 
@@ -875,7 +876,7 @@ impl super::Adapter {
     unsafe fn create_shader_clear_program(
         gl: &glow::Context,
         es: bool,
-    ) -> Option<(glow::Program, glow::UniformLocation)> {
+    ) -> Option<ShaderClearProgram> {
         let program = unsafe { gl.create_program() }.expect("Could not create shader program");
         let vertex = unsafe {
             Self::compile_shader(
@@ -911,7 +912,10 @@ impl super::Adapter {
         unsafe { gl.delete_shader(vertex) };
         unsafe { gl.delete_shader(fragment) };
 
-        Some((program, color_uniform_location))
+        Some(ShaderClearProgram {
+            program,
+            color_uniform_location,
+        })
     }
 }
 
@@ -937,7 +941,7 @@ impl crate::Adapter<super::Api> for super::Adapter {
         // Compile the shader program we use for doing manual clears to work around Mesa fastclear
         // bug.
 
-        let (shader_clear_program, shader_clear_program_color_uniform_location) = unsafe {
+        let shader_clear_program = unsafe {
             Self::create_shader_clear_program(gl, self.shared.es)
                 .ok_or(crate::DeviceError::ResourceCreationFailed)?
         };
@@ -957,7 +961,6 @@ impl crate::Adapter<super::Api> for super::Adapter {
                 copy_fbo: unsafe { gl.create_framebuffer() }
                     .map_err(|_| crate::DeviceError::OutOfMemory)?,
                 shader_clear_program,
-                shader_clear_program_color_uniform_location,
                 zero_buffer,
                 temp_query_results: Mutex::new(Vec::new()),
                 draw_buffer_count: AtomicU8::new(1),

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -941,9 +941,18 @@ impl crate::Adapter<super::Api> for super::Adapter {
         // Compile the shader program we use for doing manual clears to work around Mesa fastclear
         // bug.
 
-        let shader_clear_program = unsafe {
-            Self::create_shader_clear_program(gl, self.shared.es)
-                .ok_or(crate::DeviceError::ResourceCreationFailed)?
+        let shader_clear_program = if self
+            .shared
+            .workarounds
+            .contains(super::Workarounds::MESA_I915_SRGB_SHADER_CLEAR)
+        {
+            Some(unsafe {
+                Self::create_shader_clear_program(gl, self.shared.es)
+                    .ok_or(crate::DeviceError::ResourceCreationFailed)?
+            })
+        } else {
+            // If we don't need the workaround, don't waste time and resources compiling the clear program
+            None
         };
 
         Ok(crate::OpenDevice {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -276,7 +276,7 @@ pub struct Queue {
     copy_fbo: glow::Framebuffer,
     /// Shader program used to clear the screen for [`Workarounds::MESA_I915_SRGB_SHADER_CLEAR`]
     /// devices.
-    shader_clear_program: ShaderClearProgram,
+    shader_clear_program: Option<ShaderClearProgram>,
     /// Keep a reasonably large buffer filled with zeroes, so that we can implement `ClearBuffer` of
     /// zeroes by copying from it.
     zero_buffer: glow::Buffer,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -264,6 +264,11 @@ pub struct Device {
     render_doc: crate::auxil::renderdoc::RenderDoc,
 }
 
+pub struct ShaderClearProgram {
+    pub program: glow::Program,
+    pub color_uniform_location: glow::UniformLocation,
+}
+
 pub struct Queue {
     shared: Arc<AdapterShared>,
     features: wgt::Features,
@@ -271,9 +276,7 @@ pub struct Queue {
     copy_fbo: glow::Framebuffer,
     /// Shader program used to clear the screen for [`Workarounds::MESA_I915_SRGB_SHADER_CLEAR`]
     /// devices.
-    shader_clear_program: glow::Program,
-    /// The uniform location of the color uniform in the shader clear program
-    shader_clear_program_color_uniform_location: glow::UniformLocation,
+    shader_clear_program: ShaderClearProgram,
     /// Keep a reasonably large buffer filled with zeroes, so that we can implement `ClearBuffer` of
     /// zeroes by copying from it.
     zero_buffer: glow::Buffer,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -40,10 +40,10 @@ fn get_z_offset(target: u32, base: &crate::TextureCopyBase) -> u32 {
 impl super::Queue {
     /// Performs a manual shader clear, used as a workaround for a clearing bug on mesa
     unsafe fn perform_shader_clear(&self, gl: &glow::Context, draw_buffer: u32, color: [f32; 4]) {
-        unsafe { gl.use_program(Some(self.shader_clear_program)) };
+        unsafe { gl.use_program(Some(self.shader_clear_program.program)) };
         unsafe {
             gl.uniform_4_f32(
-                Some(&self.shader_clear_program_color_uniform_location),
+                Some(&self.shader_clear_program.color_uniform_location),
                 color[0],
                 color[1],
                 color[2],

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -40,10 +40,14 @@ fn get_z_offset(target: u32, base: &crate::TextureCopyBase) -> u32 {
 impl super::Queue {
     /// Performs a manual shader clear, used as a workaround for a clearing bug on mesa
     unsafe fn perform_shader_clear(&self, gl: &glow::Context, draw_buffer: u32, color: [f32; 4]) {
-        unsafe { gl.use_program(Some(self.shader_clear_program.program)) };
+        let shader_clear = self
+            .shader_clear_program
+            .as_ref()
+            .expect("shader_clear_program should always be set if the workaround is enabled");
+        unsafe { gl.use_program(Some(shader_clear.program)) };
         unsafe {
             gl.uniform_4_f32(
-                Some(&self.shader_clear_program.color_uniform_location),
+                Some(&shader_clear.color_uniform_location),
                 color[0],
                 color[1],
                 color[2],


### PR DESCRIPTION
**Connections**
n/a

**Description**
We've noticed this before in Ruffle, that the built in "shader clear program" can contribute to the startup times on webgl. We've seen each shader program take as much as 100ms to compile before, and they really add up.

wgpu doesn't actually need this in most cases though, so it's wasteful to spend the time creating it. This reduces it down to an `Option`, that's only populated if the workaround flag is enabled.

I was contemplating removing `Workarounds.MESA_I915_SRGB_SHADER_CLEAR` and having it simply be "this value is `Some()` if needed, `None` if not", which feels much more natural - but the workaround is stored per Adapter and the program per Queue right now, so I opted to leave it\*. I'm also unsure if wgpu prefers to have these things listed as clear workarounds instead, as I do see the merit there.

*\*though this did leave me to question: why are we making so many resources per Queue on gles, rather than Adapter? If you opened up two queues you have two shader clear programs, two zero buffers, two draw fbos, etc. I feel like we can move those to Adapter and save some potential waste, in a future PR.*

**Testing**
It passes tests and seems to run fine!

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
