### PR TITLE
docs: mention primitive restart in the description of strip_index_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ By @cwfitzgerald in [#5325](https://github.com/gfx-rs/wgpu/pull/5325).
 ### Documentation
 
 - Document Wayland specific behavior related to `SurfaceTexture::present`. By @i509VCB in [#5092](https://github.com/gfx-rs/wgpu/pull/5092).
+- Add mention of primitive restart in the description of `PrimitiveState::strip_index_format`. By @cpsdqs in [#5350](https://github.com/gfx-rs/wgpu/pull/5350)
 
 ### New features
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2129,6 +2129,9 @@ pub struct PrimitiveState {
     pub topology: PrimitiveTopology,
     /// When drawing strip topologies with indices, this is the required format for the index buffer.
     /// This has no effect on non-indexed or non-strip draws.
+    ///
+    /// Specifying this value enables primitive restart, allowing individual strips to be separated
+    /// with the index value `0xFFFF` when using `Uint16`, or `0xFFFFFFFF` when using `Uint32`.
     #[cfg_attr(feature = "serde", serde(default))]
     pub strip_index_format: Option<IndexFormat>,
     /// The face to consider the front for the purpose of culling and stencil operations.


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_
N/A

**Description**
_Describe what problem this is solving, and how it's solved._
Currently, the wgpu documentation is rather unclear on why `PrimitiveState::strip_index_format` exists and what its purpose is, unless you’ve read the webgpu spec and know that it enables primitive restart. Since primitive restart is also never mentioned anywhere else in the documentation, I thought it would be nice to clarify this doc comment to include it here.

(Though, after a cursory look at the implementation, strip_index_format only seems to be actually required on Vulkan and DX12, as Metal has it [always enabled](https://developer.apple.com/documentation/metal/mtlrendercommandencoder/1515520-drawindexedprimitives#discussion)? I’m not sure if that would be worth mentioning as an implementation quirk…)

**Testing**
_Explain how this change is tested._
this PR contains no code changes, but all tests still pass!

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
