### PR TITLE
[naga] Document the absence of "phi" expressions.

### DIFF
--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -1684,6 +1684,10 @@ pub enum Statement {
     /// A block containing more statements, to be executed sequentially.
     Block(Block),
     /// Conditionally executes one of two blocks, based on the value of the condition.
+    ///
+    /// Naga IR does not have "phi" instructions. If you need to use
+    /// values computed in an `accept` or `reject` block after the `If`,
+    /// store them in a [`LocalVariable`].
     If {
         condition: Handle<Expression>, //bool
         accept: Block,
@@ -1702,6 +1706,10 @@ pub enum Statement {
     /// multiple values, like `case 1: case 2: case 3: { ... }`. This is
     /// represented in the IR as a series of fallthrough cases with empty
     /// bodies, except for the last.
+    ///
+    /// Naga IR does not have "phi" instructions. If you need to use
+    /// values computed in a [`SwitchCase::body`] block after the `Switch`,
+    /// store them in a [`LocalVariable`].
     ///
     /// [`value`]: SwitchCase::value
     /// [`body`]: SwitchCase::body
@@ -1736,6 +1744,10 @@ pub enum Statement {
     /// top of body as usual. The `break_if` expression corresponds to a "break
     /// if" statement in WGSL, or a loop whose back edge is an
     /// `OpBranchConditional` instruction in SPIR-V.
+    ///
+    /// Naga IR does not have "phi" instructions. If you need to use
+    /// values computed in a `body` or `continuing` block after the
+    /// `Loop`, store them in a [`LocalVariable`].
     ///
     /// [`Break`]: Statement::Break
     /// [`Continue`]: Statement::Continue


### PR DESCRIPTION
Explain that people need to introduce `LocalVariable`s to hoist values out of nested blocks.