### PR TITLE
[naga xtask] Update Cargo.lock for dependabot #5241.

### DIFF
--- a/naga/xtask/Cargo.lock
+++ b/naga/xtask/Cargo.lock
@@ -122,18 +122,18 @@ dependencies = [
 
 [[package]]
 name = "nanoserde"
-version = "0.1.32"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755e7965536bc54d7c9fba2df5ada5bf835b0443fd613f0a53fa199a301839d3"
+checksum = "5de9cf844ab1e25a0353525bd74cb889843a6215fa4a0d156fd446f4857a1b99"
 dependencies = [
  "nanoserde-derive",
 ]
 
 [[package]]
 name = "nanoserde-derive"
-version = "0.1.19"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7a94da6c6181c35d043fc61c43ac96d3a5d739e7b8027f77650ba41504d6ab"
+checksum = "e943b2c21337b7e3ec6678500687cdc741b7639ad457f234693352075c082204"
 
 [[package]]
 name = "num_cpus"


### PR DESCRIPTION
The dependabot PR #5241 made `naga/hlsl-snapshots` depend on nanoserde 0.1.37, but didn't regenerate `naga/xtask/Cargo.lock`.
