### PR TITLE
fix: move 0-dimension check for transfers to be after validation

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -649,12 +649,6 @@ impl Global {
             .into());
         }
 
-        if size == 0 {
-            log::trace!("Ignoring copy_buffer_to_buffer of size 0");
-            cmd_buf_data_guard.mark_successful();
-            return Ok(());
-        }
-
         // Make sure source is initialized memory and mark dest as initialized.
         cmd_buf_data.buffer_memory_init_actions.extend(
             dst_buffer.initialization_status.read().create_action(
@@ -723,12 +717,6 @@ impl Global {
                 dst: *destination,
                 size: *copy_size,
             });
-        }
-
-        if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
-            log::trace!("Ignoring copy_buffer_to_texture of size 0");
-            cmd_buf_data_guard.mark_successful();
-            return Ok(());
         }
 
         let dst_texture = hub.textures.get(destination.texture).get()?;
@@ -880,12 +868,6 @@ impl Global {
                 dst: *destination,
                 size: *copy_size,
             });
-        }
-
-        if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
-            log::trace!("Ignoring copy_texture_to_buffer of size 0");
-            cmd_buf_data_guard.mark_successful();
-            return Ok(());
         }
 
         let src_texture = hub.textures.get(source.texture).get()?;
@@ -1053,12 +1035,6 @@ impl Global {
                 dst: *destination,
                 size: *copy_size,
             });
-        }
-
-        if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
-            log::trace!("Ignoring copy_texture_to_texture of size 0");
-            cmd_buf_data_guard.mark_successful();
-            return Ok(());
         }
 
         let src_texture = hub.textures.get(source.texture).get()?;


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

Discovered with Firefox's [bug 1848866](https://bugzilla.mozilla.org/show_bug.cgi?id=1848866).

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
