### PR TITLE
GL actually supports DEPTH32FLOAT_STENCIL8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ By @cwfitzgerald in [#5325](https://github.com/gfx-rs/wgpu/pull/5325).
 
 - Log an error when GLES texture format heuristics fail. By @PolyMeilex in [#5266](https://github.com/gfx-rs/wgpu/issues/5266)
 - Cache the sample count to keep `get_texture_format_features` cheap. By @Dinnerbone in [#5346](https://github.com/gfx-rs/wgpu/pull/5346)
+- Mark `DEPTH32FLOAT_STENCIL8` as supported in GLES. By @Dinnerbone in [#5370](https://github.com/gfx-rs/wgpu/pull/5370)
 
 ### Bug Fixes
 

--- a/tests/tests/clear_texture.rs
+++ b/tests/tests/clear_texture.rs
@@ -375,6 +375,7 @@ static CLEAR_TEXTURE_DEPTH32_STENCIL8: GpuTestConfiguration = GpuTestConfigurati
     .parameters(
         TestParameters::default()
             .features(wgpu::Features::CLEAR_TEXTURE | wgpu::Features::DEPTH32FLOAT_STENCIL8)
+            .downlevel_flags(wgpu::DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES)
             // https://github.com/gfx-rs/wgpu/issues/5016
             .skip(FailureCase::adapter("Apple Paravirtual device")),
     )

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -436,7 +436,8 @@ impl super::Adapter {
         let mut features = wgt::Features::empty()
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | wgt::Features::CLEAR_TEXTURE
-            | wgt::Features::PUSH_CONSTANTS;
+            | wgt::Features::PUSH_CONSTANTS
+            | wgt::Features::DEPTH32FLOAT_STENCIL8;
         features.set(
             wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER | wgt::Features::ADDRESS_MODE_CLAMP_TO_ZERO,
             extensions.contains("GL_EXT_texture_border_clamp")

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -274,6 +274,7 @@ bitflags::bitflags! {
         /// - Vulkan (mostly)
         /// - DX12
         /// - Metal
+        /// - OpenGL
         ///
         /// This is a web and native feature.
         const DEPTH32FLOAT_STENCIL8 = 1 << 1;


### PR DESCRIPTION
**Connections**
n/a

**Description**
Noticed this recently, the GL backend didn't allow the use of `Depth32FloatStencil8` because the `DEPTH32FLOAT_STENCIL8` feature isn't claimed to be supported.

It actually is supported, so this fixes that and allows for the use of `Depth32FloatStencil8` on GLES/WebGL.

**Testing**
I manually changed the stencil test to use `Depth32FloatStencil8` and it works as expected.

The `wgpu_test::clear_texture::clear_texture_depth32_stencil8` test had to be configured to also require `wgpu::DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES` as that's not supported on the GLES backend, as otherwise that test tries to now run on GLES but fails.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
