### PR TITLE
Minor rewording of ConfigureSurfaceError::TooLarge

### DIFF
--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -70,7 +70,7 @@ pub enum ConfigureSurfaceError {
     PreviousOutputExists,
     #[error("Both `Surface` width and height must be non-zero. Wait to recreate the `Surface` until the window has non-zero area.")]
     ZeroArea,
-    #[error("`Surface` width and height must be within the maximum supported texture size. Requested was ({width}, {height}), maximum extent is {max_texture_dimension_2d}.")]
+    #[error("`Surface` width and height must be within the maximum supported texture size. Requested was ({width}, {height}), maximum extent for either dimension is {max_texture_dimension_2d}.")]
     TooLarge {
         width: u32,
         height: u32,


### PR DESCRIPTION
I hit this error:
`Surface width and height must be within the maximum supported texture size. Requested was (3840, 2119), maximum extent is 2048.`
I found the error confusing since its not clear how a single dimensional maximum should be used for a 2 dimensional value.

So this PR adjusts the error to read like:
`Surface width and height must be within the maximum supported texture size. Requested was (3840, 2119), maximum extent for either dimension is 2048.`

Alternatively we could do:
`Surface width and height must be within the maximum supported texture size. Requested was (3840, 2119), maximum extent is (2048, 2048).`
But I think that would not be as good since it implies that its possible for the maximum width and maximum height to differ.