### PR TITLE
fix: add missing deferred resource destruction in `Global::poll_all_devices`

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2151,6 +2151,10 @@ impl Global {
                 all_queue_empty = all_queue_empty && queue_empty;
 
                 closures.extend(cbs);
+
+                // Some deferred destroys are scheduled in maintain so run this right after
+                // to avoid holding on to them until the next device poll.
+                device.deferred_resource_destruction();
             }
         }
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2097,16 +2097,16 @@ impl Global {
             .get(device_id)
             .map_err(|_| DeviceError::Invalid)?;
 
-        let (closures, queue_empty) = {
-            if let wgt::Maintain::WaitForSubmissionIndex(submission_index) = maintain {
-                if submission_index.queue_id != device_id.transmute() {
-                    return Err(WaitIdleError::WrongSubmissionIndex(
-                        submission_index.queue_id,
-                        device_id,
-                    ));
-                }
+        if let wgt::Maintain::WaitForSubmissionIndex(submission_index) = maintain {
+            if submission_index.queue_id != device_id.transmute() {
+                return Err(WaitIdleError::WrongSubmissionIndex(
+                    submission_index.queue_id,
+                    device_id,
+                ));
             }
+        }
 
+        let (closures, queue_empty) = {
             let fence = device.fence.read();
             let fence = fence.as_ref().unwrap();
             device.maintain(fence, maintain)?

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2127,7 +2127,7 @@ impl Global {
     ///
     /// Return `all_queue_empty` indicating whether there are more queue
     /// submissions still in flight.
-    fn poll_device<A: HalApi>(
+    fn poll_all_devices_of_api<A: HalApi>(
         &self,
         force_wait: bool,
         closures: &mut UserClosures,
@@ -2174,23 +2174,23 @@ impl Global {
 
         #[cfg(vulkan)]
         {
-            all_queue_empty =
-                self.poll_device::<hal::api::Vulkan>(force_wait, &mut closures)? && all_queue_empty;
+            all_queue_empty &=
+                self.poll_all_devices_of_api::<hal::api::Vulkan>(force_wait, &mut closures)?;
         }
         #[cfg(metal)]
         {
-            all_queue_empty =
-                self.poll_device::<hal::api::Metal>(force_wait, &mut closures)? && all_queue_empty;
+            all_queue_empty &=
+                self.poll_all_devices_of_api::<hal::api::Metal>(force_wait, &mut closures)?;
         }
         #[cfg(dx12)]
         {
-            all_queue_empty =
-                self.poll_device::<hal::api::Dx12>(force_wait, &mut closures)? && all_queue_empty;
+            all_queue_empty &=
+                self.poll_all_devices_of_api::<hal::api::Dx12>(force_wait, &mut closures)?;
         }
         #[cfg(gles)]
         {
-            all_queue_empty =
-                self.poll_device::<hal::api::Gles>(force_wait, &mut closures)? && all_queue_empty;
+            all_queue_empty &=
+                self.poll_all_devices_of_api::<hal::api::Gles>(force_wait, &mut closures)?;
         }
 
         closures.fire();

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2148,7 +2148,7 @@ impl Global {
                 let fence = device.fence.read();
                 let fence = fence.as_ref().unwrap();
                 let (cbs, queue_empty) = device.maintain(fence, maintain)?;
-                all_queue_empty = all_queue_empty && queue_empty;
+                all_queue_empty &= queue_empty;
 
                 closures.extend(cbs);
 


### PR DESCRIPTION
**Connections**

* [Firefox's bug 1863872](https://bugzilla.mozilla.org/show_bug.cgi?id=1863872) is a result of this issue.
* This bug was introduced with #5216.

**Description**
_Describe what problem this is solving, and how it's solved._

#5216 
While debugging [Firefox's bug 1863872](https://bugzilla.mozilla.org/show_bug.cgi?id=1863872), @jimblandy and @nical discovered with @sotaroikeda's help that `TextureView`s appeared to be cleaned up far later than we expected. @nical had recently changed the path of clean-up for `TextureView`s with deferring until there was no lock contention. That PR added deferred resource clean-up to `Global::device_poll`, but, notably, _not_ `Global::poll_all_devices`, which was certainly intended.

With this change, we can no longer reproduce bug 1863872, and we can confirm getting `TextureView` clean-up when we expect it again.

**Testing**

TODO: write testing

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~
