### PR TITLE
add cli arg to choose metal version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,10 @@ By @cwfitzgerald in [#5325](https://github.com/gfx-rs/wgpu/pull/5325).
 - Cache the sample count to keep `get_texture_format_features` cheap. By @Dinnerbone in [#5346](https://github.com/gfx-rs/wgpu/pull/5346)
 - Mark `DEPTH32FLOAT_STENCIL8` as supported in GLES. By @Dinnerbone in [#5370](https://github.com/gfx-rs/wgpu/pull/5370)
 
+#### Naga
+
+- Allow user to select which MSL version to use via `--metal-version` with Naga CLI. By @pcleavelin in [#5392](https://github.com/gfx-rs/wgpu/pull/5392)
+
 ### Bug Fixes
 
 #### General


### PR DESCRIPTION
**Connections**
Addresses #5389 

**Description**
`naga-cli` has no way to select an MSL version.

**Testing**
Try to compile a `.wgsl` shader to a `.metal` shader that requires features only present in MSL versions >1.0 using the new `--metal-version` argument.
As an example, using the `@builtin(instance_index)` attribute:
```wgsl
struct Input {
    @location(0) position: vec4<f32>,
    @builtin(instance_index) instance_id: u32,
}

struct Output {
    @builtin(position) position: vec4<f32>,
}

@vertex
fn vs_main(input: Input) -> Output {
    var output: Output;

    output.position = input.position;

    return output;
}
```
and running 
```sh
$ naga test.wgsl test.metal --metal-version 1.2
```

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
