### PR TITLE
snatch: Use a reentrant but unfair read lock

### DIFF
--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -77,7 +77,7 @@ impl SnatchLock {
 
     /// Request read access to snatchable resources.
     pub fn read(&self) -> SnatchGuard {
-        SnatchGuard(self.lock.read())
+        SnatchGuard(self.lock.read_recursive())
     }
 
     /// Request write access to snatchable resources.


### PR DESCRIPTION
**Connections**
Should fix https://github.com/gfx-rs/wgpu/issues/5279 

**Description**
`RwLock`s typically use some mechanism to ensure that readers cannot starve waiting writers, even if they continually re-acquire new read locks. This means that attempts to acquire a read lock can block when a writer is trying to acquire the lock, even if there is already an existing read lock.

This mechanism has the unfortunate consequence of making deadlocks possible the instant a single thread wants to acquire 2 reads locks at the same time (and wgpu is full of code that does that).

Luckily, parking_lot also offers an explicitly reentrant but unfair way to acquire a read lock. This PR switches the snatch lock to use that, hopefully resolving the deadlock.

**Testing**
Ran my workload. It didn't deadlock. Previously it deadlocked within a fraction of a second.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
