### PR TITLE
Avoid recursive snatch lock acquisitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ Bottom level categories:
 - fix resource leak for buffers/textures dropped while having pending writes. By @robtfm in [#5413](https://github.com/gfx-rs/wgpu/pull/5413)
 - Failing to set the device lost closure will call the closure before returning. By @bradwerth in [#5358](https://github.com/gfx-rs/wgpu/pull/5358).
 - Use memory pooling for UsageScopes to avoid frequent large allocations. by @robtfm in [#5414](https://github.com/gfx-rs/wgpu/pull/5414)
+- Fix deadlocks caused by recursive read-write lock acquisitions [#5426](https://github.com/gfx-rs/wgpu/pull/5426).
 
 #### Naga
 - In spv-in, remove unnecessary "gl_PerVertex" name check so unused builtins will always be skipped. By @Imberflur in [#5227](https://github.com/gfx-rs/wgpu/pull/5227).

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -99,6 +99,7 @@ use crate::{
     pipeline::{PipelineFlags, RenderPipeline, VertexStep},
     resource::{Buffer, Resource, ResourceInfo, ResourceType},
     resource_log,
+    snatch::SnatchGuard,
     track::RenderBundleScope,
     validation::check_buffer_usage,
     Label, LabelHelpers,
@@ -894,7 +895,11 @@ impl<A: HalApi> RenderBundle<A> {
     /// Note that the function isn't expected to fail, generally.
     /// All the validation has already been done by this point.
     /// The only failure condition is if some of the used buffers are destroyed.
-    pub(super) unsafe fn execute(&self, raw: &mut A::CommandEncoder) -> Result<(), ExecutionError> {
+    pub(super) unsafe fn execute(
+        &self,
+        raw: &mut A::CommandEncoder,
+        snatch_guard: &SnatchGuard,
+    ) -> Result<(), ExecutionError> {
         let mut offsets = self.base.dynamic_offsets.as_slice();
         let mut pipeline_layout = None::<Arc<PipelineLayout<A>>>;
         if !self.discard_hal_labels {
@@ -902,8 +907,6 @@ impl<A: HalApi> RenderBundle<A> {
                 unsafe { raw.begin_debug_marker(label) };
             }
         }
-
-        let snatch_guard = self.device.snatchable_lock.read();
 
         use ArcRenderCommand as Cmd;
         for command in self.base.commands.iter() {
@@ -914,7 +917,7 @@ impl<A: HalApi> RenderBundle<A> {
                     bind_group,
                 } => {
                     let raw_bg = bind_group
-                        .raw(&snatch_guard)
+                        .raw(snatch_guard)
                         .ok_or(ExecutionError::InvalidBindGroup(bind_group.info.id()))?;
                     unsafe {
                         raw.set_bind_group(
@@ -938,7 +941,7 @@ impl<A: HalApi> RenderBundle<A> {
                     size,
                 } => {
                     let buffer: &A::Buffer = buffer
-                        .raw(&snatch_guard)
+                        .raw(snatch_guard)
                         .ok_or(ExecutionError::DestroyedBuffer(buffer.info.id()))?;
                     let bb = hal::BufferBinding {
                         buffer,
@@ -954,7 +957,7 @@ impl<A: HalApi> RenderBundle<A> {
                     size,
                 } => {
                     let buffer = buffer
-                        .raw(&snatch_guard)
+                        .raw(snatch_guard)
                         .ok_or(ExecutionError::DestroyedBuffer(buffer.info.id()))?;
                     let bb = hal::BufferBinding {
                         buffer,
@@ -1041,7 +1044,7 @@ impl<A: HalApi> RenderBundle<A> {
                     indexed: false,
                 } => {
                     let buffer = buffer
-                        .raw(&snatch_guard)
+                        .raw(snatch_guard)
                         .ok_or(ExecutionError::DestroyedBuffer(buffer.info.id()))?;
                     unsafe { raw.draw_indirect(buffer, *offset, 1) };
                 }
@@ -1052,7 +1055,7 @@ impl<A: HalApi> RenderBundle<A> {
                     indexed: true,
                 } => {
                     let buffer = buffer
-                        .raw(&snatch_guard)
+                        .raw(snatch_guard)
                         .ok_or(ExecutionError::DestroyedBuffer(buffer.info.id()))?;
                     unsafe { raw.draw_indexed_indirect(buffer, *offset, 1) };
                 }

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -12,6 +12,7 @@ use crate::{
     id::{BufferId, CommandEncoderId, DeviceId, TextureId},
     init_tracker::{MemoryInitKind, TextureInitRange},
     resource::{Resource, Texture, TextureClearMode},
+    snatch::SnatchGuard,
     track::{TextureSelector, TextureTracker},
 };
 
@@ -239,6 +240,7 @@ impl Global {
         }
         let (encoder, tracker) = cmd_buf_data.open_encoder_and_tracker()?;
 
+        let snatch_guard = device.snatchable_lock.read();
         clear_texture(
             &dst_texture,
             TextureInitRange {
@@ -249,6 +251,7 @@ impl Global {
             &mut tracker.textures,
             &device.alignments,
             device.zero_buffer.as_ref().unwrap(),
+            &snatch_guard,
         )
     }
 }
@@ -260,10 +263,10 @@ pub(crate) fn clear_texture<A: HalApi>(
     texture_tracker: &mut TextureTracker<A>,
     alignments: &hal::Alignments,
     zero_buffer: &A::Buffer,
+    snatch_guard: &SnatchGuard<'_>,
 ) -> Result<(), ClearError> {
-    let snatch_guard = dst_texture.device.snatchable_lock.read();
     let dst_raw = dst_texture
-        .raw(&snatch_guard)
+        .raw(snatch_guard)
         .ok_or_else(|| ClearError::InvalidTexture(dst_texture.as_info().id()))?;
 
     // Issue the right barrier.

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -868,6 +868,7 @@ impl Global {
             transit,
             &mut tracker.textures,
             device,
+            &snatch_guard,
         );
         CommandBuffer::insert_barriers_from_tracker(
             transit,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2374,7 +2374,7 @@ impl Global {
                                 .extend(texture_memory_actions.register_init_action(action));
                         }
 
-                        unsafe { bundle.execute(raw) }
+                        unsafe { bundle.execute(raw, &snatch_guard) }
                             .map_err(|e| match e {
                                 ExecutionError::DestroyedBuffer(id) => {
                                     RenderCommandError::DestroyedBuffer(id)
@@ -2427,6 +2427,7 @@ impl Global {
                 transit,
                 &mut tracker.textures,
                 &cmd_buf.device,
+                &snatch_guard,
             );
 
             cmd_buf_data

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -14,6 +14,7 @@ use crate::{
         TextureInitTrackerAction,
     },
     resource::{Resource, Texture, TextureErrorDimension},
+    snatch::SnatchGuard,
     track::{TextureSelector, Tracker},
 };
 
@@ -452,6 +453,7 @@ fn handle_texture_init<A: HalApi>(
     copy_texture: &ImageCopyTexture,
     copy_size: &Extent3d,
     texture: &Arc<Texture<A>>,
+    snatch_guard: &SnatchGuard<'_>,
 ) -> Result<(), ClearError> {
     let init_action = TextureInitTrackerAction {
         texture: texture.clone(),
@@ -480,6 +482,7 @@ fn handle_texture_init<A: HalApi>(
                 &mut trackers.textures,
                 &device.alignments,
                 device.zero_buffer.as_ref().unwrap(),
+                snatch_guard,
             )?;
         }
     }
@@ -499,6 +502,7 @@ fn handle_src_texture_init<A: HalApi>(
     source: &ImageCopyTexture,
     copy_size: &Extent3d,
     texture: &Arc<Texture<A>>,
+    snatch_guard: &SnatchGuard<'_>,
 ) -> Result<(), TransferError> {
     handle_texture_init(
         MemoryInitKind::NeedsInitializedMemory,
@@ -509,6 +513,7 @@ fn handle_src_texture_init<A: HalApi>(
         source,
         copy_size,
         texture,
+        snatch_guard,
     )?;
     Ok(())
 }
@@ -525,6 +530,7 @@ fn handle_dst_texture_init<A: HalApi>(
     destination: &ImageCopyTexture,
     copy_size: &Extent3d,
     texture: &Arc<Texture<A>>,
+    snatch_guard: &SnatchGuard<'_>,
 ) -> Result<(), TransferError> {
     // Attention: If we don't write full texture subresources, we need to a full
     // clear first since we don't track subrects. This means that in rare cases
@@ -549,6 +555,7 @@ fn handle_dst_texture_init<A: HalApi>(
         destination,
         copy_size,
         texture,
+        snatch_guard,
     )?;
     Ok(())
 }
@@ -779,6 +786,8 @@ impl Global {
 
         let (dst_range, dst_base) = extract_texture_selector(destination, copy_size, &dst_texture)?;
 
+        let snatch_guard = device.snatchable_lock.read();
+
         // Handle texture init *before* dealing with barrier transitions so we
         // have an easier time inserting "immediate-inits" that may be required
         // by prior discards in rare cases.
@@ -790,9 +799,8 @@ impl Global {
             destination,
             copy_size,
             &dst_texture,
+            &snatch_guard,
         )?;
-
-        let snatch_guard = device.snatchable_lock.read();
 
         let (src_buffer, src_pending) = {
             let buffer_guard = hub.buffers.read();
@@ -935,6 +943,8 @@ impl Global {
 
         let (src_range, src_base) = extract_texture_selector(source, copy_size, &src_texture)?;
 
+        let snatch_guard = device.snatchable_lock.read();
+
         // Handle texture init *before* dealing with barrier transitions so we
         // have an easier time inserting "immediate-inits" that may be required
         // by prior discards in rare cases.
@@ -946,9 +956,8 @@ impl Global {
             source,
             copy_size,
             &src_texture,
+            &snatch_guard,
         )?;
-
-        let snatch_guard = device.snatchable_lock.read();
 
         let src_pending = tracker
             .textures
@@ -1152,6 +1161,7 @@ impl Global {
             source,
             copy_size,
             &src_texture,
+            &snatch_guard,
         )?;
         handle_dst_texture_init(
             encoder,
@@ -1161,6 +1171,7 @@ impl Global {
             destination,
             copy_size,
             &dst_texture,
+            &snatch_guard,
         )?;
 
         let src_pending = cmd_buf_data

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -188,11 +188,19 @@ impl Global {
                 hal::BufferUses::empty()
             } else if desc.usage.contains(wgt::BufferUsages::MAP_WRITE) {
                 // buffer is mappable, so we are just doing that at start
+                let snatch_guard = device.snatchable_lock.read();
                 let map_size = buffer.size;
                 let ptr = if map_size == 0 {
                     std::ptr::NonNull::dangling()
                 } else {
-                    match map_buffer(device.raw(), &buffer, 0, map_size, HostMap::Write) {
+                    match map_buffer(
+                        device.raw(),
+                        &buffer,
+                        0,
+                        map_size,
+                        HostMap::Write,
+                        &snatch_guard,
+                    ) {
                         Ok(ptr) => ptr,
                         Err(e) => {
                             to_destroy.push(buffer);
@@ -2008,9 +2016,10 @@ impl Global {
                 }
 
                 // Wait for all work to finish before configuring the surface.
+                let snatch_guard = device.snatchable_lock.read();
                 let fence = device.fence.read();
                 let fence = fence.as_ref().unwrap();
-                match device.maintain(fence, wgt::Maintain::Wait) {
+                match device.maintain(fence, wgt::Maintain::Wait, &snatch_guard) {
                     Ok((closures, _)) => {
                         user_callbacks = closures;
                     }
@@ -2120,9 +2129,10 @@ impl Global {
         device: &crate::device::Device<A>,
         maintain: wgt::Maintain<queue::WrappedSubmissionIndex>,
     ) -> Result<DevicePoll, WaitIdleError> {
+        let snatch_guard = device.snatchable_lock.read();
         let fence = device.fence.read();
         let fence = fence.as_ref().unwrap();
-        let (closures, queue_empty) = device.maintain(fence, maintain)?;
+        let (closures, queue_empty) = device.maintain(fence, maintain, &snatch_guard)?;
 
         // Some deferred destroys are scheduled in maintain so run this right after
         // to avoid holding on to them until the next device poll.

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -188,11 +188,11 @@ impl Global {
                 hal::BufferUses::empty()
             } else if desc.usage.contains(wgt::BufferUsages::MAP_WRITE) {
                 // buffer is mappable, so we are just doing that at start
-                let snatch_guard = device.snatchable_lock.read();
                 let map_size = buffer.size;
                 let ptr = if map_size == 0 {
                     std::ptr::NonNull::dangling()
                 } else {
+                    let snatch_guard = device.snatchable_lock.read();
                     match map_buffer(
                         device.raw(),
                         &buffer,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3,9 +3,10 @@ use crate::{
     hal_api::HalApi,
     hub::Hub,
     id::{BindGroupLayoutId, PipelineLayoutId},
-    resource::{Buffer, BufferAccessResult},
-    resource::{BufferAccessError, BufferMapOperation},
-    resource_log, Label, DOWNLEVEL_ERROR_MESSAGE,
+    resource::{Buffer, BufferAccessError, BufferAccessResult, BufferMapOperation},
+    resource_log,
+    snatch::SnatchGuard,
+    Label, DOWNLEVEL_ERROR_MESSAGE,
 };
 
 use arrayvec::ArrayVec;
@@ -317,10 +318,10 @@ fn map_buffer<A: HalApi>(
     offset: BufferAddress,
     size: BufferAddress,
     kind: HostMap,
+    snatch_guard: &SnatchGuard,
 ) -> Result<ptr::NonNull<u8>, BufferAccessError> {
-    let snatch_guard = buffer.device.snatchable_lock.read();
     let raw_buffer = buffer
-        .raw(&snatch_guard)
+        .raw(snatch_guard)
         .ok_or(BufferAccessError::Destroyed)?;
     let mapping = unsafe {
         raw.map_buffer(raw_buffer, offset..offset + size)

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1149,7 +1149,9 @@ impl Global {
 
             let device = queue.device.as_ref().unwrap();
 
-            let mut fence = device.fence.write();
+            let snatch_guard = device.snatchable_lock.read();
+
+            let mut fence = device.fence.write(); // snatch(r) -> fence(w)
             let fence = fence.as_mut().unwrap();
             let submit_index = device
                 .active_submission_index
@@ -1158,8 +1160,6 @@ impl Global {
             let mut active_executions = Vec::new();
 
             let mut used_surface_textures = track::TextureUsageScope::default();
-
-            let snatch_guard = device.snatchable_lock.read();
 
             let mut submit_surface_textures_owned = SmallVec::<[_; 2]>::new();
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1151,7 +1151,8 @@ impl Global {
 
             let snatch_guard = device.snatchable_lock.read();
 
-            let mut fence = device.fence.write(); // snatch(r) -> fence(w)
+            // Fence lock must be acquired after the snatch lock everywhere to avoid deadlocks.
+            let mut fence = device.fence.write();
             let fence = fence.as_mut().unwrap();
             let submit_index = device
                 .active_submission_index

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -815,6 +815,7 @@ impl Global {
                         &mut trackers.textures,
                         &device.alignments,
                         device.zero_buffer.as_ref().unwrap(),
+                        &device.snatchable_lock.read(),
                     )
                     .map_err(QueueWriteError::from)?;
                 }
@@ -1084,6 +1085,7 @@ impl Global {
                         &mut trackers.textures,
                         &device.alignments,
                         device.zero_buffer.as_ref().unwrap(),
+                        &device.snatchable_lock.read(),
                     )
                     .map_err(QueueWriteError::from)?;
                 }
@@ -1391,10 +1393,10 @@ impl Global {
                         //Note: locking the trackers has to be done after the storages
                         let mut trackers = device.trackers.lock();
                         baked
-                            .initialize_buffer_memory(&mut *trackers)
+                            .initialize_buffer_memory(&mut *trackers, &snatch_guard)
                             .map_err(|err| QueueSubmitError::DestroyedBuffer(err.0))?;
                         baked
-                            .initialize_texture_memory(&mut *trackers, device)
+                            .initialize_texture_memory(&mut *trackers, device, &snatch_guard)
                             .map_err(|err| QueueSubmitError::DestroyedTexture(err.0))?;
                         //Note: stateless trackers are not merged:
                         // device already knows these resources exist.
@@ -1542,7 +1544,7 @@ impl Global {
 
             // This will schedule destruction of all resources that are no longer needed
             // by the user but used in the command stream, among other things.
-            let (closures, _) = match device.maintain(fence, wgt::Maintain::Poll) {
+            let (closures, _) = match device.maintain(fence, wgt::Maintain::Poll, &snatch_guard) {
                 Ok(closures) => closures,
                 Err(WaitIdleError::Device(err)) => return Err(QueueSubmitError::Queue(err)),
                 Err(WaitIdleError::StuckGpu) => return Err(QueueSubmitError::StuckGpu),

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -392,6 +392,7 @@ impl<A: HalApi> Device<A> {
         &'this self,
         fence: &A::Fence,
         maintain: wgt::Maintain<queue::WrappedSubmissionIndex>,
+        snatch_guard: &SnatchGuard,
     ) -> Result<(UserClosures, bool), WaitIdleError> {
         profiling::scope!("Device::maintain");
         let last_done_index = if maintain.is_wait() {
@@ -445,7 +446,8 @@ impl<A: HalApi> Device<A> {
             life_tracker.triage_mapped();
         }
 
-        let mapping_closures = life_tracker.handle_mapping(self.raw(), &self.trackers);
+        let mapping_closures =
+            life_tracker.handle_mapping(self.raw(), &self.trackers, snatch_guard);
 
         let queue_empty = life_tracker.queue_empty();
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -100,6 +100,7 @@ pub struct Device<A: HalApi> {
     pub(crate) command_allocator: Mutex<Option<CommandAllocator<A>>>,
     //Note: The submission index here corresponds to the last submission that is done.
     pub(crate) active_submission_index: AtomicU64, //SubmissionIndex,
+    // NOTE: if both are needed, the `snatchable_lock` must be acquired before the `fence`
     pub(crate) fence: RwLock<Option<A::Fence>>,
     pub(crate) snatchable_lock: SnatchLock,
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -100,7 +100,8 @@ pub struct Device<A: HalApi> {
     pub(crate) command_allocator: Mutex<Option<CommandAllocator<A>>>,
     //Note: The submission index here corresponds to the last submission that is done.
     pub(crate) active_submission_index: AtomicU64, //SubmissionIndex,
-    // NOTE: if both are needed, the `snatchable_lock` must be acquired before the `fence`
+    // NOTE: if both are needed, the `snatchable_lock` must be consistently acquired before the
+    // `fence` lock to avoid deadlocks.
     pub(crate) fence: RwLock<Option<A::Fence>>,
     pub(crate) snatchable_lock: SnatchLock,
 

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -1,7 +1,12 @@
 #![allow(unused)]
 
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use std::cell::UnsafeCell;
+use std::{
+    backtrace::Backtrace,
+    cell::{Cell, RefCell, UnsafeCell},
+    panic::{self, Location},
+    thread,
+};
 
 /// A guard that provides read access to snatchable data.
 pub struct SnatchGuard<'a>(RwLockReadGuard<'a, ()>);
@@ -59,6 +64,10 @@ impl<T> std::fmt::Debug for Snatchable<T> {
 
 unsafe impl<T> Sync for Snatchable<T> {}
 
+thread_local! {
+    static READ_LOCK_LOCATION: Cell<Option<(&'static Location<'static>, Backtrace)>> = const { Cell::new(None) };
+}
+
 /// A Device-global lock for all snatchable data.
 pub struct SnatchLock {
     lock: RwLock<()>,
@@ -76,7 +85,24 @@ impl SnatchLock {
     }
 
     /// Request read access to snatchable resources.
+    #[track_caller]
     pub fn read(&self) -> SnatchGuard {
+        if cfg!(debug_assertions) {
+            let caller = Location::caller();
+            let backtrace = Backtrace::force_capture();
+            if let Some((prev, bt)) = READ_LOCK_LOCATION.take() {
+                let current = thread::current();
+                let name = current.name().unwrap_or("<unnamed>");
+                panic!(
+                    "thread '{name}' attempted to acquire a snatch read lock recursively.\n
+                    - {prev}\n{bt}\n
+                    - {caller}\n{backtrace}"
+                );
+            } else {
+                READ_LOCK_LOCATION.set(Some((caller, backtrace)));
+            }
+        }
+
         SnatchGuard(self.lock.read())
     }
 
@@ -87,5 +113,12 @@ impl SnatchLock {
     /// wgpu work.
     pub fn write(&self) -> ExclusiveSnatchGuard {
         ExclusiveSnatchGuard(self.lock.write())
+    }
+}
+
+impl Drop for SnatchGuard<'_> {
+    fn drop(&mut self) {
+        #[cfg(debug_assertions)]
+        READ_LOCK_LOCATION.take();
     }
 }

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -89,7 +89,7 @@ impl SnatchLock {
     pub fn read(&self) -> SnatchGuard {
         if cfg!(debug_assertions) {
             let caller = Location::caller();
-            let backtrace = Backtrace::force_capture();
+            let backtrace = Backtrace::capture();
             if let Some((prev, bt)) = READ_LOCK_LOCATION.take() {
                 let current = thread::current();
                 let name = current.name().unwrap_or("<unnamed>");


### PR DESCRIPTION
**Connections**
Bug report: https://github.com/gfx-rs/wgpu/issues/5279

This PR is an alternative to https://github.com/gfx-rs/wgpu/pull/5400.

**Description**
Pass `&SnatchGuard` down to all functions needing it, instead of having them recursively acquire one.

This also adds some instrumentation to the `SnatchLock` API that will panic on any attempts to acquire it recursively (gated behind `cfg(debug_assertions)`). That should allow the test suite to catch any future misuse of the API, instead of silently making wgpu more deadlock-prone in multi-threaded applications.

**Testing**
`cargo xtask test` locally and on CI

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
