### PR TITLE
spv-out: implement OpArrayLength on array buffer bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Bottom level categories:
 #### Naga
 
 - Allow user to select which MSL version to use via `--metal-version` with Naga CLI. By @pcleavelin in [#5392](https://github.com/gfx-rs/wgpu/pull/5392)
+- Support `arrayLength` for runtime-sized arrays inside binding arrays (for WGSL input and SPIR-V output). By @kvark in [#5428](https://github.com/gfx-rs/wgpu/pull/5428)
 
 ### Bug Fixes
 

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -576,6 +576,15 @@ impl BlockContext<'_> {
         self.writer
             .get_constant_scalar(crate::Literal::I32(scope as _))
     }
+
+    fn get_pointer_id(
+        &mut self,
+        handle: Handle<crate::Type>,
+        class: spirv::StorageClass,
+    ) -> Result<Word, Error> {
+        self.writer
+            .get_pointer_id(&self.ir_module.types, handle, class)
+    }
 }
 
 #[derive(Clone, Copy, Default)]

--- a/naga/src/valid/type.rs
+++ b/naga/src/valid/type.rs
@@ -510,7 +510,6 @@ impl super::Validator {
                 ti.uniform_layout = Ok(Alignment::MIN_UNIFORM);
 
                 let mut min_offset = 0;
-
                 let mut prev_struct_data: Option<(u32, u32)> = None;
 
                 for (i, member) in members.iter().enumerate() {
@@ -662,6 +661,7 @@ impl super::Validator {
                     // Currently Naga only supports binding arrays of structs for non-handle types.
                     match gctx.types[base].inner {
                         crate::TypeInner::Struct { .. } => {}
+                        crate::TypeInner::Array { .. } => {}
                         _ => return Err(TypeError::BindingArrayBaseTypeNotStruct(base)),
                     };
                 }

--- a/naga/tests/in/binding-buffer-arrays.wgsl
+++ b/naga/tests/in/binding-buffer-arrays.wgsl
@@ -2,7 +2,7 @@ struct UniformIndex {
     index: u32
 }
 
-struct Foo { x: u32 }
+struct Foo { x: u32, far: array<i32> }
 @group(0) @binding(0)
 var<storage, read> storage_array: binding_array<Foo, 1>;
 @group(0) @binding(10)
@@ -22,6 +22,8 @@ fn main(fragment_in: FragmentIn) -> @location(0) u32 {
     u1 += storage_array[0].x;
     u1 += storage_array[uniform_index].x;
     u1 += storage_array[non_uniform_index].x;
+
+    u1 += arrayLength(&storage_array[0].far);
 
     return u1;
 }

--- a/naga/tests/in/binding-buffer-arrays.wgsl
+++ b/naga/tests/in/binding-buffer-arrays.wgsl
@@ -24,6 +24,8 @@ fn main(fragment_in: FragmentIn) -> @location(0) u32 {
     u1 += storage_array[non_uniform_index].x;
 
     u1 += arrayLength(&storage_array[0].far);
+    u1 += arrayLength(&storage_array[uniform_index].far);
+    u1 += arrayLength(&storage_array[non_uniform_index].far);
 
     return u1;
 }

--- a/naga/tests/out/spv/binding-buffer-arrays.spvasm
+++ b/naga/tests/out/spv/binding-buffer-arrays.spvasm
@@ -1,99 +1,110 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 61
+; Bound: 68
 OpCapability Shader
 OpCapability ShaderNonUniform
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 OpExtension "SPV_EXT_descriptor_indexing"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %23 "main" %18 %21
-OpExecutionMode %23 OriginUpperLeft
+OpEntryPoint Fragment %25 "main" %20 %23
+OpExecutionMode %25 OriginUpperLeft
 OpMemberDecorate %4 0 Offset 0
-OpMemberDecorate %5 0 Offset 0
-OpMemberDecorate %8 0 Offset 0
-OpDecorate %9 NonWritable
-OpDecorate %9 DescriptorSet 0
-OpDecorate %9 Binding 0
-OpDecorate %5 Block
-OpDecorate %13 DescriptorSet 0
-OpDecorate %13 Binding 10
-OpDecorate %14 Block
-OpMemberDecorate %14 0 Offset 0
-OpDecorate %18 Location 0
-OpDecorate %18 Flat
-OpDecorate %21 Location 0
-OpDecorate %53 NonUniform
+OpDecorate %6 ArrayStride 4
+OpMemberDecorate %7 0 Offset 0
+OpMemberDecorate %7 1 Offset 4
+OpDecorate %7 Block
+OpMemberDecorate %10 0 Offset 0
+OpDecorate %11 NonWritable
+OpDecorate %11 DescriptorSet 0
+OpDecorate %11 Binding 0
+OpDecorate %7 Block
+OpDecorate %15 DescriptorSet 0
+OpDecorate %15 Binding 10
+OpDecorate %16 Block
+OpMemberDecorate %16 0 Offset 0
+OpDecorate %20 Location 0
+OpDecorate %20 Flat
+OpDecorate %23 Location 0
+OpDecorate %55 NonUniform
 %2 = OpTypeVoid
 %3 = OpTypeInt 32 0
 %4 = OpTypeStruct %3
-%5 = OpTypeStruct %3
-%7 = OpConstant  %3  1
-%6 = OpTypeArray %5 %7
-%8 = OpTypeStruct %3
-%12 = OpConstant  %3  10
-%11 = OpTypeArray %5 %12
-%10 = OpTypePointer StorageBuffer %11
-%9 = OpVariable  %10  StorageBuffer
-%14 = OpTypeStruct %4
-%15 = OpTypePointer Uniform %14
-%13 = OpVariable  %15  Uniform
-%19 = OpTypePointer Input %3
-%18 = OpVariable  %19  Input
-%22 = OpTypePointer Output %3
-%21 = OpVariable  %22  Output
-%24 = OpTypeFunction %2
-%25 = OpTypePointer Uniform %4
-%26 = OpConstant  %3  0
-%28 = OpTypePointer StorageBuffer %6
-%30 = OpTypePointer Function %3
-%32 = OpTypePointer Uniform %3
-%36 = OpTypePointer StorageBuffer %5
-%37 = OpTypePointer StorageBuffer %3
-%43 = OpTypeBool
-%45 = OpConstantNull  %3
-%23 = OpFunction  %2  None %24
-%16 = OpLabel
-%29 = OpVariable  %30  Function %26
-%20 = OpLoad  %3  %18
-%17 = OpCompositeConstruct  %8  %20
-%27 = OpAccessChain  %25  %13 %26
-OpBranch %31
-%31 = OpLabel
-%33 = OpAccessChain  %32  %27 %26
-%34 = OpLoad  %3  %33
-%35 = OpCompositeExtract  %3  %17 0
-%38 = OpAccessChain  %37  %9 %26 %26
-%39 = OpLoad  %3  %38
-%40 = OpLoad  %3  %29
-%41 = OpIAdd  %3  %40 %39
-OpStore %29 %41
-%42 = OpULessThan  %43  %34 %7
-OpSelectionMerge %46 None
-OpBranchConditional %42 %47 %46
-%47 = OpLabel
-%44 = OpAccessChain  %37  %9 %34 %26
-%48 = OpLoad  %3  %44
-OpBranch %46
-%46 = OpLabel
-%49 = OpPhi  %3  %45 %31 %48 %47
-%50 = OpLoad  %3  %29
-%51 = OpIAdd  %3  %50 %49
-OpStore %29 %51
-%52 = OpULessThan  %43  %35 %7
-OpSelectionMerge %54 None
-OpBranchConditional %52 %55 %54
-%55 = OpLabel
-%53 = OpAccessChain  %37  %9 %35 %26
-%56 = OpLoad  %3  %53
-OpBranch %54
-%54 = OpLabel
-%57 = OpPhi  %3  %45 %46 %56 %55
-%58 = OpLoad  %3  %29
-%59 = OpIAdd  %3  %58 %57
-OpStore %29 %59
-%60 = OpLoad  %3  %29
-OpStore %21 %60
+%5 = OpTypeInt 32 1
+%6 = OpTypeRuntimeArray %5
+%7 = OpTypeStruct %3 %6
+%9 = OpConstant  %3  1
+%8 = OpTypeArray %7 %9
+%10 = OpTypeStruct %3
+%14 = OpConstant  %3  10
+%13 = OpTypeArray %7 %14
+%12 = OpTypePointer StorageBuffer %13
+%11 = OpVariable  %12  StorageBuffer
+%16 = OpTypeStruct %4
+%17 = OpTypePointer Uniform %16
+%15 = OpVariable  %17  Uniform
+%21 = OpTypePointer Input %3
+%20 = OpVariable  %21  Input
+%24 = OpTypePointer Output %3
+%23 = OpVariable  %24  Output
+%26 = OpTypeFunction %2
+%27 = OpTypePointer Uniform %4
+%28 = OpConstant  %3  0
+%30 = OpTypePointer StorageBuffer %8
+%32 = OpTypePointer Function %3
+%34 = OpTypePointer Uniform %3
+%38 = OpTypePointer StorageBuffer %7
+%39 = OpTypePointer StorageBuffer %3
+%45 = OpTypeBool
+%47 = OpConstantNull  %3
+%62 = OpTypePointer StorageBuffer %6
+%25 = OpFunction  %2  None %26
+%18 = OpLabel
+%31 = OpVariable  %32  Function %28
+%22 = OpLoad  %3  %20
+%19 = OpCompositeConstruct  %10  %22
+%29 = OpAccessChain  %27  %15 %28
+OpBranch %33
+%33 = OpLabel
+%35 = OpAccessChain  %34  %29 %28
+%36 = OpLoad  %3  %35
+%37 = OpCompositeExtract  %3  %19 0
+%40 = OpAccessChain  %39  %11 %28 %28
+%41 = OpLoad  %3  %40
+%42 = OpLoad  %3  %31
+%43 = OpIAdd  %3  %42 %41
+OpStore %31 %43
+%44 = OpULessThan  %45  %36 %9
+OpSelectionMerge %48 None
+OpBranchConditional %44 %49 %48
+%49 = OpLabel
+%46 = OpAccessChain  %39  %11 %36 %28
+%50 = OpLoad  %3  %46
+OpBranch %48
+%48 = OpLabel
+%51 = OpPhi  %3  %47 %33 %50 %49
+%52 = OpLoad  %3  %31
+%53 = OpIAdd  %3  %52 %51
+OpStore %31 %53
+%54 = OpULessThan  %45  %37 %9
+OpSelectionMerge %56 None
+OpBranchConditional %54 %57 %56
+%57 = OpLabel
+%55 = OpAccessChain  %39  %11 %37 %28
+%58 = OpLoad  %3  %55
+OpBranch %56
+%56 = OpLabel
+%59 = OpPhi  %3  %47 %48 %58 %57
+%60 = OpLoad  %3  %31
+%61 = OpIAdd  %3  %60 %59
+OpStore %31 %61
+%63 = OpAccessChain  %38  %11 %28
+%64 = OpArrayLength  %3  %63 1
+%65 = OpLoad  %3  %31
+%66 = OpIAdd  %3  %65 %64
+OpStore %31 %66
+%67 = OpLoad  %3  %31
+OpStore %23 %67
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/binding-buffer-arrays.spvasm
+++ b/naga/tests/out/spv/binding-buffer-arrays.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 68
+; Bound: 76
 OpCapability Shader
 OpCapability ShaderNonUniform
 OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -104,7 +104,17 @@ OpStore %31 %61
 %65 = OpLoad  %3  %31
 %66 = OpIAdd  %3  %65 %64
 OpStore %31 %66
-%67 = OpLoad  %3  %31
-OpStore %23 %67
+%67 = OpAccessChain  %38  %11 %36
+%68 = OpArrayLength  %3  %67 1
+%69 = OpLoad  %3  %31
+%70 = OpIAdd  %3  %69 %68
+OpStore %31 %70
+%71 = OpAccessChain  %38  %11 %37
+%72 = OpArrayLength  %3  %71 1
+%73 = OpLoad  %3  %31
+%74 = OpIAdd  %3  %73 %72
+OpStore %31 %74
+%75 = OpLoad  %3  %31
+OpStore %23 %75
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/binding-buffer-arrays.wgsl
+++ b/naga/tests/out/wgsl/binding-buffer-arrays.wgsl
@@ -33,6 +33,10 @@ fn main(fragment_in: FragmentIn) -> @location(0) @interpolate(flat) u32 {
     u1_ = (_e23 + _e22);
     let _e29 = u1_;
     u1_ = (_e29 + arrayLength((&storage_array[0].far)));
-    let _e31 = u1_;
-    return _e31;
+    let _e35 = u1_;
+    u1_ = (_e35 + arrayLength((&storage_array[uniform_index].far)));
+    let _e41 = u1_;
+    u1_ = (_e41 + arrayLength((&storage_array[non_uniform_index].far)));
+    let _e43 = u1_;
+    return _e43;
 }

--- a/naga/tests/out/wgsl/binding-buffer-arrays.wgsl
+++ b/naga/tests/out/wgsl/binding-buffer-arrays.wgsl
@@ -4,6 +4,7 @@ struct UniformIndex {
 
 struct Foo {
     x: u32,
+    far: array<i32>,
 }
 
 struct FragmentIn {
@@ -30,6 +31,8 @@ fn main(fragment_in: FragmentIn) -> @location(0) @interpolate(flat) u32 {
     let _e22 = storage_array[non_uniform_index].x;
     let _e23 = u1_;
     u1_ = (_e23 + _e22);
-    let _e25 = u1_;
-    return _e25;
+    let _e29 = u1_;
+    u1_ = (_e29 + arrayLength((&storage_array[0].far)));
+    let _e31 = u1_;
+    return _e31;
 }


### PR DESCRIPTION
**Connections**
Port of https://github.com/gfx-rs/naga/pull/2372
Fixes #4556 for SPV-out

**Description**
See #4556

**Testing**
Changes are in "binding-buffer-arrays.wgsl"

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
