### PR TITLE
Add support for storage texture access modes ReadOnly and ReadWrite on WebGPU backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@ Bottom level categories:
 
 #### WebGPU
 
-- Add support for storage texture access modes `ReadOnly` and `ReadWrite`. By @JolifantoBamble in [#5434](https://github.com/gfx-rs/wgpu/pull/5434) 
+- Add support for storage texture access modes `ReadOnly` and `ReadWrite`. By @JolifantoBambla in [#5434](https://github.com/gfx-rs/wgpu/pull/5434) 
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@ Bottom level categories:
 
 - Allow user to select which MSL version to use via `--metal-version` with Naga CLI. By @pcleavelin in [#5392](https://github.com/gfx-rs/wgpu/pull/5392)
 
+#### WebGPU
+
+- Add support for storage texture access modes `ReadOnly` and `ReadWrite`. By @JolifantoBamble in [#5434](https://github.com/gfx-rs/wgpu/pull/5434) 
+
 ### Bug Fixes
 
 #### General

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1578,10 +1578,10 @@ impl crate::context::Context for ContextWebGpu {
                                 webgpu_sys::GpuStorageTextureAccess::WriteOnly
                             }
                             wgt::StorageTextureAccess::ReadOnly => {
-                                panic!("ReadOnly is not available")
+                                webgpu_sys::GpuStorageTextureAccess::ReadOnly
                             }
                             wgt::StorageTextureAccess::ReadWrite => {
-                                panic!("ReadWrite is not available")
+                                webgpu_sys::GpuStorageTextureAccess::ReadWrite
                             }
                         };
                         let mut storage_texture = webgpu_sys::GpuStorageTextureBindingLayout::new(


### PR DESCRIPTION
**Connections**
#2735

**Description**
WebGPU now supports `"read-only"` and `"read-write"` storage textures.
This PR adds support for these access modes for the WebGPU backend

**Testing**
I did not add any new tests.

**Checklist**

- [ x] Run `cargo fmt`.
- [ x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
