### PR TITLE
[fix bug #5430] index_limit judgment error in drawIndexed(indexCount)

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -166,7 +166,7 @@ fn validate_indexed_draw<A: HalApi>(
 ) -> Result<(), DrawError> {
     let last_index = first_index as u64 + index_count as u64;
     let index_limit = index_state.limit();
-    if last_index <= index_limit {
+    if last_index > index_limit {
         return Err(DrawError::IndexBeyondLimit {
             last_index,
             index_limit,


### PR DESCRIPTION
[fix bug #5430] index_limit judgment error in drawIndexed(indexCount)

**Connections**
#5430

**Description**
index_limit judgment error in drawIndexed(indexCount). 
An error should be reported only when last_index > index_limit.
https://github.com/gfx-rs/wgpu/blob/e102e59e477c54dd9c8913438b92ad97a81c491a/wgpu-core/src/command/bundle.rs#L169-L174

**Testing**
_Explain how this change is tested._
I'm not sure how to test it. Do I need to compile the entire firefox?

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
