### PR TITLE
Implement the `device_set_device_lost_callback` method for `ContextWebGpu`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,11 @@ Bottom level categories:
 - Breaking change: [`wgpu_core::pipeline::ProgrammableStageDescriptor`](https://docs.rs/wgpu-core/latest/wgpu_core/pipeline/struct.ProgrammableStageDescriptor.html#structfield.entry_point) is now optional. By @ErichDonGubler in [#5305](https://github.com/gfx-rs/wgpu/pull/5305).
 - `Features::downlevel{_webgl2,}_features` was made const by @MultisampledNight in [#5343](https://github.com/gfx-rs/wgpu/pull/5343)
 
+#### WebGPU
+
+- Implement the `device_set_device_lost_callback` method for `ContextWebGpu`. By @suti in [#5438](https://github.com/gfx-rs/wgpu/pull/5438)
+
+
 #### GLES
 
 - Log an error when GLES texture format heuristics fail. By @PolyMeilex in [#5266](https://github.com/gfx-rs/wgpu/issues/5266)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,11 +109,6 @@ Bottom level categories:
 - Breaking change: [`wgpu_core::pipeline::ProgrammableStageDescriptor`](https://docs.rs/wgpu-core/latest/wgpu_core/pipeline/struct.ProgrammableStageDescriptor.html#structfield.entry_point) is now optional. By @ErichDonGubler in [#5305](https://github.com/gfx-rs/wgpu/pull/5305).
 - `Features::downlevel{_webgl2,}_features` was made const by @MultisampledNight in [#5343](https://github.com/gfx-rs/wgpu/pull/5343)
 
-#### WebGPU
-
-- Implement the `device_set_device_lost_callback` method for `ContextWebGpu`. By @suti in [#5438](https://github.com/gfx-rs/wgpu/pull/5438)
-
-
 #### GLES
 
 - Log an error when GLES texture format heuristics fail. By @PolyMeilex in [#5266](https://github.com/gfx-rs/wgpu/issues/5266)
@@ -126,6 +121,7 @@ Bottom level categories:
 
 #### WebGPU
 
+- Implement the `device_set_device_lost_callback` method for `ContextWebGpu`. By @suti in [#5438](https://github.com/gfx-rs/wgpu/pull/5438)
 - Add support for storage texture access modes `ReadOnly` and `ReadWrite`. By @JolifantoBambla in [#5434](https://github.com/gfx-rs/wgpu/pull/5434) 
 
 ### Bug Fixes

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1979,10 +1979,23 @@ impl crate::context::Context for ContextWebGpu {
     fn device_set_device_lost_callback(
         &self,
         _device: &Self::DeviceId,
-        _device_data: &Self::DeviceData,
-        _device_lost_callback: crate::context::DeviceLostCallback,
+        device_data: &Self::DeviceData,
+        device_lost_callback: crate::context::DeviceLostCallback,
     ) {
-        unimplemented!();
+        use webgpu_sys::{GpuDeviceLostInfo, GpuDeviceLostReason};
+
+        let closure = Closure::once(move |info: JsValue| {
+            let info = info.dyn_into::<GpuDeviceLostInfo>().unwrap();
+            device_lost_callback(
+                match info.reason() {
+                    GpuDeviceLostReason::Destroyed => crate::DeviceLostReason::Destroyed,
+                    GpuDeviceLostReason::Unknown => crate::DeviceLostReason::Unknown,
+                    _ => crate::DeviceLostReason::Unknown,
+                },
+                info.message(),
+            );
+        });
+        let _ = device_data.0.lost().then(&closure);
     }
 
     fn device_poll(


### PR DESCRIPTION
**Description**
Implement the `device_set_device_lost_callback` method for `ContextWebGpu`.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
