### PR TITLE
[hal/vulkan] Use `Option::insert` and avoid an `unwrap`.

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -923,9 +923,10 @@ impl super::InstanceShared {
 
                 let mut builder = vk::PhysicalDeviceProperties2KHR::builder();
                 if supports_maintenance3 {
-                    capabilities.maintenance_3 =
-                        Some(vk::PhysicalDeviceMaintenance3Properties::default());
-                    builder = builder.push_next(capabilities.maintenance_3.as_mut().unwrap());
+                    let next = capabilities
+                        .maintenance_3
+                        .insert(vk::PhysicalDeviceMaintenance3Properties::default());
+                    builder = builder.push_next(next);
                 }
 
                 if supports_descriptor_indexing {


### PR DESCRIPTION
In `wgpu_hal::vulkan::InstanceShared::inspect`, handle `PhysicalDeviceCapabilities::maintenance_3` more like the way we handle other extension-provided physical device properties. Specifically, use `Option::insert` to populate the `Option` and borrow a mutable reference to its value, rather than calling `.as_mut().unwrap()`.

This change should have no observable effect on behavior. It simply replaces a runtime check (`unwrap`) with a statically checked borrow (`insert`).
