### PR TITLE
Add more hal methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,11 @@ Bottom level categories:
 - Breaking change: [`wgpu_core::pipeline::ProgrammableStageDescriptor`](https://docs.rs/wgpu-core/latest/wgpu_core/pipeline/struct.ProgrammableStageDescriptor.html#structfield.entry_point) is now optional. By @ErichDonGubler in [#5305](https://github.com/gfx-rs/wgpu/pull/5305).
 - `Features::downlevel{_webgl2,}_features` was made const by @MultisampledNight in [#5343](https://github.com/gfx-rs/wgpu/pull/5343)
 
+- More as_hal methods and improvements by @JMS55 in [#5452](https://github.com/gfx-rs/wgpu/pull/5452)
+  - Added `wgpu::CommandEncoder::as_hal_mut`
+  - Added `wgpu::TextureView::as_hal`
+  - `wgpu::Texture::as_hal` now returns a user-defined type to match the other as_hal functions
+
 #### GLES
 
 - Log an error when GLES texture format heuristics fail. By @PolyMeilex in [#5266](https://github.com/gfx-rs/wgpu/issues/5266)
@@ -122,7 +127,7 @@ Bottom level categories:
 #### WebGPU
 
 - Implement the `device_set_device_lost_callback` method for `ContextWebGpu`. By @suti in [#5438](https://github.com/gfx-rs/wgpu/pull/5438)
-- Add support for storage texture access modes `ReadOnly` and `ReadWrite`. By @JolifantoBambla in [#5434](https://github.com/gfx-rs/wgpu/pull/5434) 
+- Add support for storage texture access modes `ReadOnly` and `ReadWrite`. By @JolifantoBambla in [#5434](https://github.com/gfx-rs/wgpu/pull/5434)
 
 ### Bug Fixes
 
@@ -168,7 +173,7 @@ This release includes `wgpu`, `wgpu-core`, and `wgpu-hal`. All other crates are 
 
 ### Major Changes
 
-#### Vendored WebGPU Bindings from `web_sys` 
+#### Vendored WebGPU Bindings from `web_sys`
 
 **`--cfg=web_sys_unstable_apis` is no longer needed in your `RUSTFLAGS` to compile for WebGPU!!!**
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -82,7 +82,7 @@ impl<A: HalApi> CommandEncoder<A> {
         }
     }
 
-    fn open(&mut self) -> Result<&mut A::CommandEncoder, DeviceError> {
+    pub(crate) fn open(&mut self) -> Result<&mut A::CommandEncoder, DeviceError> {
         if !self.is_open {
             self.is_open = true;
             let label = self.label.as_deref();

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -924,11 +924,11 @@ impl Global {
     /// # Safety
     ///
     /// - The raw texture handle must not be manually destroyed
-    pub unsafe fn texture_as_hal<A: HalApi, F: FnOnce(Option<&A::Texture>)>(
+    pub unsafe fn texture_as_hal<A: HalApi, F: FnOnce(Option<&A::Texture>) -> R, R>(
         &self,
         id: TextureId,
         hal_texture_callback: F,
-    ) {
+    ) -> R {
         profiling::scope!("Texture::as_hal");
 
         let hub = A::hub(self);
@@ -937,7 +937,7 @@ impl Global {
         let snatch_guard = texture.device.snatchable_lock.read();
         let hal_texture = texture.raw(&snatch_guard);
 
-        hal_texture_callback(hal_texture);
+        hal_texture_callback(hal_texture)
     }
 
     /// # Safety

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -413,6 +413,15 @@ pub struct TextureView {
     attachment: FramebufferAttachment,
 }
 
+impl TextureView {
+    /// # Safety
+    ///
+    /// - The image view handle must not be manually destroyed
+    pub unsafe fn raw_handle(&self) -> vk::ImageView {
+        self.raw
+    }
+}
+
 #[derive(Debug)]
 pub struct Sampler {
     raw: vk::Sampler,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -490,6 +490,15 @@ pub struct CommandEncoder {
     end_of_pass_timer_query: Option<(vk::QueryPool, u32)>,
 }
 
+impl CommandEncoder {
+    /// # Safety
+    ///
+    /// - The command buffer handle must not be manually destroyed
+    pub unsafe fn raw_handle(&self) -> vk::CommandBuffer {
+        self.active
+    }
+}
+
 impl fmt::Debug for CommandEncoder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CommandEncoder")

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -22,8 +22,11 @@ use std::{
     slice,
     sync::Arc,
 };
-use wgc::command::{bundle_ffi::*, compute_ffi::*, render_ffi::*};
 use wgc::device::DeviceLostClosure;
+use wgc::{
+    command::{bundle_ffi::*, compute_ffi::*, render_ffi::*},
+    id::TextureViewId,
+};
 use wgt::WasmNotSendSync;
 
 const LABEL: &str = "label";
@@ -219,6 +222,21 @@ impl ContextWgpuCore {
         unsafe {
             self.0
                 .texture_as_hal::<A, F, R>(texture.id, hal_texture_callback)
+        }
+    }
+
+    pub unsafe fn texture_view_as_hal<
+        A: wgc::hal_api::HalApi,
+        F: FnOnce(Option<&A::TextureView>) -> R,
+        R,
+    >(
+        &self,
+        texture_view_id: TextureViewId,
+        hal_texture_view_callback: F,
+    ) -> R {
+        unsafe {
+            self.0
+                .texture_view_as_hal::<A, F, R>(texture_view_id, hal_texture_view_callback)
         }
     }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -240,6 +240,7 @@ impl ContextWgpuCore {
         }
     }
 
+    /// This method will start the wgpu_core level command recording.
     pub unsafe fn command_encoder_as_hal_mut<
         A: wgc::hal_api::HalApi,
         F: FnOnce(Option<&mut A::CommandEncoder>) -> R,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -207,14 +207,18 @@ impl ContextWgpuCore {
         }
     }
 
-    pub unsafe fn texture_as_hal<A: wgc::hal_api::HalApi, F: FnOnce(Option<&A::Texture>)>(
+    pub unsafe fn texture_as_hal<
+        A: wgc::hal_api::HalApi,
+        F: FnOnce(Option<&A::Texture>) -> R,
+        R,
+    >(
         &self,
         texture: &Texture,
         hal_texture_callback: F,
-    ) {
+    ) -> R {
         unsafe {
             self.0
-                .texture_as_hal::<A, F>(texture.id, hal_texture_callback)
+                .texture_as_hal::<A, F, R>(texture.id, hal_texture_callback)
         }
     }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -22,10 +22,10 @@ use std::{
     slice,
     sync::Arc,
 };
-use wgc::device::DeviceLostClosure;
 use wgc::{
     command::{bundle_ffi::*, compute_ffi::*, render_ffi::*},
-    id::TextureViewId,
+    device::DeviceLostClosure,
+    id::{CommandEncoderId, TextureViewId},
 };
 use wgt::WasmNotSendSync;
 
@@ -237,6 +237,23 @@ impl ContextWgpuCore {
         unsafe {
             self.0
                 .texture_view_as_hal::<A, F, R>(texture_view_id, hal_texture_view_callback)
+        }
+    }
+
+    pub unsafe fn command_encoder_as_hal_mut<
+        A: wgc::hal_api::HalApi,
+        F: FnOnce(Option<&mut A::CommandEncoder>) -> R,
+        R,
+    >(
+        &self,
+        command_encoder_id: CommandEncoderId,
+        hal_command_encoder_callback: F,
+    ) -> R {
+        unsafe {
+            self.0.command_encoder_as_hal_mut::<A, F, R>(
+                command_encoder_id,
+                hal_command_encoder_callback,
+            )
         }
     }
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3115,10 +3115,10 @@ impl Texture {
     ///
     /// - The raw handle obtained from the hal Texture must not be manually destroyed
     #[cfg(wgpu_core)]
-    pub unsafe fn as_hal<A: wgc::hal_api::HalApi, F: FnOnce(Option<&A::Texture>)>(
+    pub unsafe fn as_hal<A: wgc::hal_api::HalApi, F: FnOnce(Option<&A::Texture>) -> R, R>(
         &self,
         hal_texture_callback: F,
-    ) {
+    ) -> R {
         let texture = self.data.as_ref().downcast_ref().unwrap();
 
         if let Some(ctx) = self
@@ -3126,7 +3126,7 @@ impl Texture {
             .as_any()
             .downcast_ref::<crate::backend::ContextWgpuCore>()
         {
-            unsafe { ctx.texture_as_hal::<A, F>(texture, hal_texture_callback) }
+            unsafe { ctx.texture_as_hal::<A, F, R>(texture, hal_texture_callback) }
         } else {
             hal_texture_callback(None)
         }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3474,6 +3474,8 @@ impl CommandEncoder {
     /// Returns the inner hal CommandEncoder using a callback. The hal command encoder will be `None` if the
     /// backend type argument does not match with this wgpu CommandEncoder
     ///
+    /// This method will start the wgpu_core level command recording.
+    ///
     /// # Safety
     ///
     /// - The raw handle obtained from the hal CommandEncoder must not be manually destroyed


### PR DESCRIPTION
**Connections**
Revival of https://github.com/gfx-rs/wgpu/pull/3966

**Description**
* Adds CommandEncoder::as_hal_mut()
* Adds TextureView::as_hal()
* Adds a return value to Texture::has_hal()

Enable some interop with native graphics APIs. I'm not convinced that this is in any way a good idea. Users have to be extremely careful about not accidentally taking locks on or destroying resources while using them from native dispatches. They also have to consider pipeline barriers and image transitions themselves, with no help from wgpu in tracking them. To work around this in Bevy, I plan to bind the resources to a dummy compute pass that does nothing, but that's run before+after my native graphics API to try and coerce wgpu into tracking the lifetimes and barriers appropriately. This is very much a band-aid patch while I wait for a proper fix in https://github.com/gfx-rs/wgpu/issues/4067.

**Testing**
Will be tested as part of Bevy's FSR integration https://github.com/bevyengine/bevy/pull/12768.

**Checklist**

- [ x ] Run `cargo fmt`.
- [ x ] Run `cargo clippy`. If applicable, add:
  - [ x ] `--target wasm32-unknown-unknown`
  - [ x ] `--target wasm32-unknown-emscripten`
- [ x ] Run `cargo xtask test` to run tests.
- [ x ] Add change to `CHANGELOG.md`. See simple instructions inside file.
