### PR TITLE
docs: Fix incorrect git URL in README for naga-cli installation

### DIFF
--- a/naga/README.md
+++ b/naga/README.md
@@ -42,7 +42,7 @@ First, install `naga-cli` from crates.io or directly from GitHub.
 cargo install naga-cli
 
 # development version
-cargo install naga-cli --git https://github.com/gfx-rs/naga.git
+cargo install naga-cli --git https://github.com/gfx-rs/wgpu.git
 ```
 
 Then, you can run `naga` command.


### PR DESCRIPTION
**Connections**
n/a

**Description**
The naga README pointed readers to the now-archived repo [gfx-rs/naga](https://github.com/gfx-rs/naga), resulting in an old version of `naga-cli` (0.14.0) being installed.
Switching the URL to this repository fixes the issue.

**Testing**
n/a

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
