### PR TITLE
Rename `PhysicalDeviceCapabilities` to `PhysicalDeviceProperties`.

### DIFF
--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -189,7 +189,7 @@ pub struct Adapter {
     instance: Arc<InstanceShared>,
     //queue_families: Vec<vk::QueueFamilyProperties>,
     known_memory_flags: vk::MemoryPropertyFlags,
-    phd_capabilities: adapter::PhysicalDeviceCapabilities,
+    phd_capabilities: adapter::PhysicalDeviceProperties,
     //phd_features: adapter::PhysicalDeviceFeatures,
     downlevel_flags: wgt::DownlevelFlags,
     private_caps: PrivateCapabilities,


### PR DESCRIPTION
Since this struct's role is to hold all the relevant "VkFooProperties" structs we can get about a given physical device, and "capabilities" means something else in Vulkan (SPIR-V capabilities), it seems that `PhysicalDeviceProperties` is a better name.
