### PR TITLE
Move the burden of evaluating override-expressions to users of naga's API

### DIFF
--- a/naga/benches/criterion.rs
+++ b/naga/benches/criterion.rs
@@ -193,7 +193,6 @@ fn backends(c: &mut Criterion) {
                     let pipeline_options = naga::back::spv::PipelineOptions {
                         shader_stage: ep.stage,
                         entry_point: ep.name.clone(),
-                        constants: naga::back::PipelineConstants::default(),
                     };
                     writer
                         .write(module, info, Some(&pipeline_options), &None, &mut data)
@@ -224,11 +223,10 @@ fn backends(c: &mut Criterion) {
     group.bench_function("hlsl", |b| {
         b.iter(|| {
             let options = naga::back::hlsl::Options::default();
-            let pipeline_options = naga::back::hlsl::PipelineOptions::default();
             let mut string = String::new();
             for &(ref module, ref info) in inputs.iter() {
                 let mut writer = naga::back::hlsl::Writer::new(&mut string, &options);
-                let _ = writer.write(module, info, &pipeline_options); // may fail on unimplemented things
+                let _ = writer.write(module, info); // may fail on unimplemented things
                 string.clear();
             }
         });
@@ -250,7 +248,6 @@ fn backends(c: &mut Criterion) {
                         shader_stage: ep.stage,
                         entry_point: ep.name.clone(),
                         multiview: None,
-                        constants: naga::back::PipelineConstants::default(),
                     };
 
                     // might be `Err` if missing features

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -195,14 +195,6 @@ pub struct Options {
     pub zero_initialize_workgroup_memory: bool,
 }
 
-#[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
-pub struct PipelineOptions {
-    /// Pipeline constants.
-    pub constants: back::PipelineConstants,
-}
-
 impl Default for Options {
     fn default() -> Self {
         Options {
@@ -255,8 +247,8 @@ pub enum Error {
     Unimplemented(String), // TODO: Error used only during development
     #[error("{0}")]
     Custom(String),
-    #[error(transparent)]
-    PipelineConstant(#[from] Box<back::pipeline_constants::PipelineConstantError>),
+    #[error("overrides should not be present at this stage")]
+    Override,
 }
 
 #[derive(Default)]

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -1,7 +1,7 @@
 use super::{
     help::{WrappedArrayLength, WrappedConstructor, WrappedImageQuery, WrappedStructMatrixAccess},
     storage::StoreValue,
-    BackendResult, Error, Options, PipelineOptions,
+    BackendResult, Error, Options,
 };
 use crate::{
     back,
@@ -167,16 +167,10 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         &mut self,
         module: &Module,
         module_info: &valid::ModuleInfo,
-        pipeline_options: &PipelineOptions,
     ) -> Result<super::ReflectionInfo, Error> {
-        let (module, module_info) = back::pipeline_constants::process_overrides(
-            module,
-            module_info,
-            &pipeline_options.constants,
-        )
-        .map_err(Box::new)?;
-        let module = module.as_ref();
-        let module_info = module_info.as_ref();
+        if !module.overrides.is_empty() {
+            return Err(Error::Override);
+        }
 
         self.reset(module);
 
@@ -2150,9 +2144,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                     |writer, expr| writer.write_expr(module, expr, func_ctx),
                 )?;
             }
-            Expression::Override(_) => {
-                return Err(Error::Unimplemented("overrides are WIP".into()))
-            }
+            Expression::Override(_) => return Err(Error::Override),
             // All of the multiplication can be expressed as `mul`,
             // except vector * vector, which needs to use the "*" operator.
             Expression::Binary {

--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -22,7 +22,7 @@ pub mod wgsl;
     feature = "spv-out",
     feature = "glsl-out"
 ))]
-mod pipeline_constants;
+pub mod pipeline_constants;
 
 /// Names of vector components.
 pub const COMPONENTS: &[char] = &['x', 'y', 'z', 'w'];

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -143,8 +143,8 @@ pub enum Error {
     UnsupportedArrayOfType(Handle<crate::Type>),
     #[error("ray tracing is not supported prior to MSL 2.3")]
     UnsupportedRayTracing,
-    #[error(transparent)]
-    PipelineConstant(#[from] Box<crate::back::pipeline_constants::PipelineConstantError>),
+    #[error("overrides should not be present at this stage")]
+    Override,
 }
 
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]
@@ -234,8 +234,6 @@ pub struct PipelineOptions {
     ///
     /// Enable this for vertex shaders with point primitive topologies.
     pub allow_and_force_point_size: bool,
-    /// Pipeline constants.
-    pub constants: crate::back::PipelineConstants,
 }
 
 impl Options {

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -1431,9 +1431,7 @@ impl<W: Write> Writer<W> {
                     |writer, context, expr| writer.put_expression(expr, context, true),
                 )?;
             }
-            crate::Expression::Override(_) => {
-                return Err(Error::FeatureNotImplemented("overrides are WIP".into()))
-            }
+            crate::Expression::Override(_) => return Err(Error::Override),
             crate::Expression::Access { base, .. }
             | crate::Expression::AccessIndex { base, .. } => {
                 // This is an acceptable place to generate a `ReadZeroSkipWrite` check.
@@ -3223,11 +3221,9 @@ impl<W: Write> Writer<W> {
         options: &Options,
         pipeline_options: &PipelineOptions,
     ) -> Result<TranslationInfo, Error> {
-        let (module, info) =
-            back::pipeline_constants::process_overrides(module, info, &pipeline_options.constants)
-                .map_err(Box::new)?;
-        let module = module.as_ref();
-        let info = info.as_ref();
+        if !module.overrides.is_empty() {
+            return Err(Error::Override);
+        }
 
         self.names.clear();
         self.namer.reset(

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -36,7 +36,7 @@ pub enum PipelineConstantError {
 /// fully-evaluated expressions.
 ///
 /// [`global_expressions`]: Module::global_expressions
-pub(super) fn process_overrides<'a>(
+pub fn process_overrides<'a>(
     module: &'a Module,
     module_info: &'a ModuleInfo,
     pipeline_constants: &PipelineConstants,

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -239,9 +239,7 @@ impl<'w> BlockContext<'w> {
                 let init = self.ir_module.constants[handle].init;
                 self.writer.constant_ids[init.index()]
             }
-            crate::Expression::Override(_) => {
-                return Err(Error::FeatureNotImplemented("overrides are WIP"))
-            }
+            crate::Expression::Override(_) => return Err(Error::Override),
             crate::Expression::ZeroValue(_) => self.writer.get_constant_null(result_type_id),
             crate::Expression::Compose { ty, ref components } => {
                 self.temp_list.clear();

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -70,8 +70,8 @@ pub enum Error {
     FeatureNotImplemented(&'static str),
     #[error("module is not validated properly: {0}")]
     Validation(&'static str),
-    #[error(transparent)]
-    PipelineConstant(#[from] Box<crate::back::pipeline_constants::PipelineConstantError>),
+    #[error("overrides should not be present at this stage")]
+    Override,
 }
 
 #[derive(Default)]
@@ -773,8 +773,6 @@ pub struct PipelineOptions {
     ///
     /// If no entry point that matches is found while creating a [`Writer`], a error will be thrown.
     pub entry_point: String,
-    /// Pipeline constants.
-    pub constants: crate::back::PipelineConstants,
 }
 
 pub fn write_vec(

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -2029,21 +2029,9 @@ impl Writer {
         debug_info: &Option<DebugInfo>,
         words: &mut Vec<Word>,
     ) -> Result<(), Error> {
-        let (ir_module, info) = if let Some(pipeline_options) = pipeline_options {
-            crate::back::pipeline_constants::process_overrides(
-                ir_module,
-                info,
-                &pipeline_options.constants,
-            )
-            .map_err(Box::new)?
-        } else {
-            (
-                std::borrow::Cow::Borrowed(ir_module),
-                std::borrow::Cow::Borrowed(info),
-            )
-        };
-        let ir_module = ir_module.as_ref();
-        let info = info.as_ref();
+        if !ir_module.overrides.is_empty() {
+            return Err(Error::Override);
+        }
 
         self.reset();
 

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -1205,9 +1205,7 @@ impl<W: Write> Writer<W> {
                     |writer, expr| writer.write_expr(module, expr, func_ctx),
                 )?;
             }
-            Expression::Override(_) => {
-                return Err(Error::Unimplemented("overrides are WIP".into()))
-            }
+            Expression::Override(_) => unreachable!(),
             Expression::FunctionArgument(pos) => {
                 let name_key = func_ctx.argument_key(pos);
                 let name = &self.names[&name_key];

--- a/naga/tests/in/interface.param.ron
+++ b/naga/tests/in/interface.param.ron
@@ -27,6 +27,5 @@
 	),
 	msl_pipeline: (
 		allow_and_force_point_size: true,
-		constants: {},
 	),
 )

--- a/naga/tests/out/glsl/overrides.main.Compute.glsl
+++ b/naga/tests/out/glsl/overrides.main.Compute.glsl
@@ -1,0 +1,29 @@
+#version 310 es
+
+precision highp float;
+precision highp int;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+const bool has_point_light = false;
+const float specular_param = 2.3;
+const float gain = 1.1;
+const float width = 0.0;
+const float depth = 2.3;
+const float height = 4.6;
+const float inferred_f32_ = 2.718;
+
+float gain_x_10_ = 11.0;
+
+
+void main() {
+    float t = 0.0;
+    bool x = false;
+    float gain_x_100_ = 0.0;
+    t = 23.0;
+    x = true;
+    float _e10 = gain_x_10_;
+    gain_x_100_ = (_e10 * 10.0);
+    return;
+}
+

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -218,17 +218,21 @@ impl super::Device {
         use naga::back::hlsl;
 
         let stage_bit = crate::auxil::map_naga_stage(naga_stage);
-        let module = &stage.module.naga.module;
+
+        let (module, info) = naga::back::pipeline_constants::process_overrides(
+            &stage.module.naga.module,
+            &stage.module.naga.info,
+            stage.constants,
+        )
+        .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("HLSL: {e:?}")))?;
+
         //TODO: reuse the writer
         let mut source = String::new();
         let mut writer = hlsl::Writer::new(&mut source, &layout.naga_options);
-        let pipeline_options = hlsl::PipelineOptions {
-            constants: stage.constants.to_owned(),
-        };
         let reflection_info = {
             profiling::scope!("naga::back::hlsl::write");
             writer
-                .write(module, &stage.module.naga.info, &pipeline_options)
+                .write(&module, &info)
                 .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("HLSL: {e:?}")))?
         };
 

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -69,7 +69,13 @@ impl super::Device {
     ) -> Result<CompiledShader, crate::PipelineError> {
         let stage_bit = map_naga_stage(naga_stage);
 
-        let module = &stage.module.naga.module;
+        let (module, module_info) = naga::back::pipeline_constants::process_overrides(
+            &stage.module.naga.module,
+            &stage.module.naga.info,
+            stage.constants,
+        )
+        .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("MSL: {:?}", e)))?;
+
         let ep_resources = &layout.per_stage_map[naga_stage];
 
         let bounds_check_policy = if stage.module.runtime_checks {
@@ -112,16 +118,11 @@ impl super::Device {
                 metal::MTLPrimitiveTopologyClass::Point => true,
                 _ => false,
             },
-            constants: stage.constants.to_owned(),
         };
 
-        let (source, info) = naga::back::msl::write_string(
-            module,
-            &stage.module.naga.info,
-            &options,
-            &pipeline_options,
-        )
-        .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("MSL: {:?}", e)))?;
+        let (source, info) =
+            naga::back::msl::write_string(&module, &module_info, &options, &pipeline_options)
+                .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("MSL: {:?}", e)))?;
 
         log::debug!(
             "Naga generated shader for entry point '{}' and stage {:?}\n{}",
@@ -169,7 +170,7 @@ impl super::Device {
         })?;
 
         // collect sizes indices, immutable buffers, and work group memory sizes
-        let ep_info = &stage.module.naga.info.get_entry_point(ep_index);
+        let ep_info = &module_info.get_entry_point(ep_index);
         let mut wg_memory_sizes = Vec::new();
         let mut sized_bindings = Vec::new();
         let mut immutable_buffer_mask = 0;


### PR DESCRIPTION
This PR makes it possible to evaluate override-expressions for the GLSL backend as well.