### PR TITLE
Add Metal 3.0 and 3.1 detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ Bottom level categories:
 #### Metal
 
 - Don't depend on bind group and bind group layout entry order in HAL. This caused incorrect severely incorrect command execution and, in some cases, crashes. By @ErichDonGubler in [#5421](https://github.com/gfx-rs/wgpu/pull/5421).
+- Metal 3.0 and 3.1 detection. By @atlv24 in [#5497](https://github.com/gfx-rs/wgpu/pull/5497)
 
 #### DX12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,8 +2088,7 @@ dependencies = [
 [[package]]
 name = "metal"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+source = "git+https://github.com/gfx-rs/metal-rs?rev=ff8fd3d6dc7792852f8a015458d7e6d42d7fb352#ff8fd3d6dc7792852f8a015458d7e6d42d7fb352"
 dependencies = [
  "bitflags 2.4.2",
  "block",
@@ -2427,7 +2426,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
@@ -2451,15 +2449,6 @@ name = "objc2-encode"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
-
-[[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "object"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ winit = { version = "0.29", features = ["android-native-activity"] }
 # Metal dependencies
 block = "0.1"
 core-graphics-types = "0.1"
-metal = "0.27.0"
+metal = { version = "0.27.0", git = "https://github.com/gfx-rs/metal-rs", rev = "ff8fd3d6dc7792852f8a015458d7e6d42d7fb352" }
 objc = "0.2.5"
 
 # Vulkan dependencies

--- a/naga/xtask/src/validate.rs
+++ b/naga/xtask/src/validate.rs
@@ -208,12 +208,9 @@ fn validate_spirv(path: &Path, spirv_as: &str, spirv_val: &str) -> anyhow::Resul
         buf
     };
     let expected_header_prefix = "; Version: ";
-    let Some(version) =
-        second_line.strip_prefix(expected_header_prefix) else {
-            bail!(
-                "no {expected_header_prefix:?} header found in {path:?}"
-            );
-        };
+    let Some(version) = second_line.strip_prefix(expected_header_prefix) else {
+        bail!("no {expected_header_prefix:?} header found in {path:?}");
+    };
     let file = open_file(path)?;
     let mut spirv_as_cmd = EasyCommand::new(spirv_as, |cmd| {
         cmd.stdin(Stdio::from(file))
@@ -237,19 +234,20 @@ fn validate_metal(path: &Path, xcrun: &str) -> anyhow::Result<()> {
         buf
     };
     let expected_header_prefix = "// language: ";
-    let Some(language) =
-        first_line.strip_prefix(expected_header_prefix) else {
-            bail!(
-                "no {expected_header_prefix:?} header found in {path:?}"
-            );
-        };
+    let Some(language) = first_line.strip_prefix(expected_header_prefix) else {
+        bail!("no {expected_header_prefix:?} header found in {path:?}");
+    };
     let language = language.strip_suffix('\n').unwrap_or(language);
-
+    let std_arg = if language.starts_with("metal1") || language.starts_with("metal2") {
+        format!("-std=macos-{language}")
+    } else {
+        format!("-std={language}")
+    };
     let file = open_file(path)?;
     EasyCommand::new(xcrun, |cmd| {
         cmd.stdin(Stdio::from(file))
             .args(["-sdk", "macosx", "metal", "-mmacosx-version-min=10.11"])
-            .arg(format!("-std=macos-{language}"))
+            .arg(std_arg)
             .args(["-x", "metal", "-", "-o", "/dev/null"])
     })
     .success()
@@ -337,15 +335,16 @@ fn validate_hlsl_with_fxc(
         .target_profile
         .split('_')
         .nth(1)
-        .map(|segment| segment.parse::<u8>()) else {
-            bail!(
-                "expected target profile of the form \
+        .map(|segment| segment.parse::<u8>())
+    else {
+        bail!(
+            "expected target profile of the form \
                  `{{model}}_{{major}}_{{minor}}`, found invalid target \
                  profile {:?} in file {}",
-                config_item.target_profile,
-                file.display()
-            )
-        };
+            config_item.target_profile,
+            file.display()
+        )
+    };
     // NOTE: This isn't implemented by `fxc.exe`; see
     // <https://learn.microsoft.com/en-us/windows/win32/direct3dtools/dx-graphics-tools-fxc-syntax#profiles>.
     if shader_model_major_version < 6 {

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -155,7 +155,7 @@ d3d12 = { path = "../d3d12/", version = "0.19.0", optional = true, features = [
 # backend: Metal
 block = { version = "0.1", optional = true }
 
-metal = "0.27.0"
+metal = { version = "0.27.0", git = "https://github.com/gfx-rs/metal-rs", rev = "ff8fd3d6dc7792852f8a015458d7e6d42d7fb352" }
 objc = "0.2.5"
 core-graphics-types = "0.1"
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -562,7 +562,11 @@ impl super::PrivateCapabilities {
 
         Self {
             family_check,
-            msl_version: if os_is_xr || version.at_least((12, 0), (15, 0), os_is_mac) {
+            msl_version: if os_is_xr || version.at_least((14, 0), (17, 0), os_is_mac) {
+                MTLLanguageVersion::V3_1
+            } else if version.at_least((13, 0), (16, 0), os_is_mac) {
+                MTLLanguageVersion::V3_0
+            } else if version.at_least((12, 0), (15, 0), os_is_mac) {
                 MTLLanguageVersion::V2_4
             } else if version.at_least((11, 0), (14, 0), os_is_mac) {
                 MTLLanguageVersion::V2_3

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -88,6 +88,8 @@ impl super::Device {
                 metal::MTLLanguageVersion::V2_2 => (2, 2),
                 metal::MTLLanguageVersion::V2_3 => (2, 3),
                 metal::MTLLanguageVersion::V2_4 => (2, 4),
+                metal::MTLLanguageVersion::V3_0 => (3, 0),
+                metal::MTLLanguageVersion::V3_1 => (3, 1),
             },
             inline_samplers: Default::default(),
             spirv_cross_compatibility: false,


### PR DESCRIPTION
**Connections**
Originally for #5383, will be needed for image atomics on metal

Depends on https://github.com/gfx-rs/metal-rs/pull/304

**Description**
Detect Metal 3.0 and 3.1 when its available

**Testing**
Not tested explicitly but works in the context of #5383

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
