### PR TITLE
water test: Expect additional error from GPU validation.

### DIFF
--- a/examples/src/water/mod.rs
+++ b/examples/src/water/mod.rs
@@ -834,18 +834,8 @@ static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTest
         // To be fixed in <https://github.com/gfx-rs/wgpu/issues/5231>.
         .expect_fail(wgpu_test::FailureCase {
             backends: Some(wgpu::Backends::VULKAN),
-            reasons: vec![
-                wgpu_test::FailureReason::validation_error().with_message(concat!(
-                    "vkCmdEndRenderPass: ",
-                    "Hazard WRITE_AFTER_READ in subpass 0 for attachment 1 depth aspect ",
-                    "during store with storeOp VK_ATTACHMENT_STORE_OP_STORE. ",
-                    "Access info (",
-                    "usage: SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, ",
-                    "prior_usage: SYNC_FRAGMENT_SHADER_SHADER_SAMPLED_READ, ",
-                    "read_barriers: VkPipelineStageFlags2(0), ",
-                    "command: vkCmdDraw"
-                )),
-            ],
+            reasons: vec![wgpu_test::FailureReason::validation_error()
+                .with_message(concat!("Hazard WRITE_AFTER_"))],
             behavior: wgpu_test::FailureBehavior::AssertFailure,
             ..Default::default()
         }),


### PR DESCRIPTION
Expand the `water` test's expected error message substring to cover new validation errors reported by GPU-based validation starting in Fedora's vulkan-validation-layers-1.3.275.0-1.fc39.x86_64:

```
[2024-04-09T21:02:01Z ERROR wgpu_test::expectations] Validation Error: Validation Error: [ SYNC-HAZARD-WRITE-AFTER-WRITE ] Object 0: handle = 0x7f2fb53d44e0, type = VK_OBJECT_TYPE_QUEUE; | MessageID = 0x5c0ec5d6 | vkQueueSubmit():  Hazard WRITE_AFTER_WRITE for entry 7, VkCommandBuffer 0x7f2fb6fd5b40[], Submitted access info (submitted_usage: SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, command: vkCmdEndRenderPass, seq_no: 3, renderpass: VkRenderPass 0x2d000000002d[], reset_no: 1). Access info (prior_usage: SYNC_IMAGE_LAYOUT_TRANSITION, write_barriers: SYNC_VERTEX_SHADER_SHADER_SAMPLED_READ|SYNC_VERTEX_SHADER_SHADER_STORAGE_READ|SYNC_VERTEX_SHADER_UNIFORM_READ|SYNC_FRAGMENT_SHADER_DEPTH_STENCIL_ATTACHMENT_READ|SYNC_FRAGMENT_SHADER_SHADER_SAMPLED_READ|SYNC_FRAGMENT_SHADER_SHADER_STORAGE_READ|SYNC_FRAGMENT_SHADER_UNIFORM_READ|SYNC_EARLY_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_READ|SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_READ|SYNC_COMPUTE_SHADER_SHADER_SAMPLED_READ|SYNC_COMPUTE_SHADER_SHADER_STORAGE_READ|SYNC_COMPUTE_SHADER_UNIFORM_READ, queue: VkQueue 0x7f2fb53d44e0[], submit: 0, batch: 0, batch_tag: 28, command: vkCmdPipelineBarrier, command_buffer: VkCommandBuffer 0x7f2fb6fd43c0[Main Command Encoder], seq_no: 1, VkImage 0x1c000000001c[Reflection Render Texture], VkImage 0x1f000000001f[Depth Buffer], reset_no: 1).
```

See also #5231.