### PR TITLE
[v0.19] Wire up Timestamp Queries in WebGPU Backend

### DIFF
--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2311,6 +2311,20 @@ impl crate::context::Context for ContextWebGpu {
         if let Some(label) = desc.label {
             mapped_desc.label(label);
         }
+
+        if let Some(ref timestamp_writes) = desc.timestamp_writes {
+            let query_set: &<ContextWebGpu as crate::Context>::QuerySetData =
+                downcast_ref(timestamp_writes.query_set.data.as_ref());
+            let mut writes = webgpu_sys::GpuComputePassTimestampWrites::new(&query_set.0);
+            if let Some(index) = timestamp_writes.beginning_of_pass_write_index {
+                writes.beginning_of_pass_write_index(index);
+            }
+            if let Some(index) = timestamp_writes.end_of_pass_write_index {
+                writes.end_of_pass_write_index(index);
+            }
+            mapped_desc.timestamp_writes(&writes);
+        }
+
         create_identified(
             encoder_data
                 .0
@@ -2408,6 +2422,19 @@ impl crate::context::Context for ContextWebGpu {
             }
             mapped_depth_stencil_attachment.stencil_read_only(dsa.stencil_ops.is_none());
             mapped_desc.depth_stencil_attachment(&mapped_depth_stencil_attachment);
+        }
+
+        if let Some(ref timestamp_writes) = desc.timestamp_writes {
+            let query_set: &<ContextWebGpu as crate::Context>::QuerySetData =
+                downcast_ref(timestamp_writes.query_set.data.as_ref());
+            let mut writes = webgpu_sys::GpuRenderPassTimestampWrites::new(&query_set.0);
+            if let Some(index) = timestamp_writes.beginning_of_pass_write_index {
+                writes.beginning_of_pass_write_index(index);
+            }
+            if let Some(index) = timestamp_writes.end_of_pass_write_index {
+                writes.end_of_pass_write_index(index);
+            }
+            mapped_desc.timestamp_writes(&writes);
         }
 
         create_identified(encoder_data.0.begin_render_pass(&mapped_desc))


### PR DESCRIPTION
We had never wired up timestamp queries, this is a small lift change, so I wanted to add it directly to 0.19

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
