### PR TITLE
Make `scalar_width` return size in bytes

### DIFF
--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -3418,7 +3418,8 @@ impl<'a, W: Write> Writer<'a, W> {
                         let scalar_bits = ctx
                             .resolve_type(arg, &self.module.types)
                             .scalar_width()
-                            .unwrap();
+                            .unwrap()
+                            * 8;
 
                         write!(self.out, "bitfieldExtract(")?;
                         self.write_expr(arg, ctx)?;
@@ -3437,7 +3438,8 @@ impl<'a, W: Write> Writer<'a, W> {
                         let scalar_bits = ctx
                             .resolve_type(arg, &self.module.types)
                             .scalar_width()
-                            .unwrap();
+                            .unwrap()
+                            * 8;
 
                         write!(self.out, "bitfieldInsert(")?;
                         self.write_expr(arg, ctx)?;

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -2593,7 +2593,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                         true
                     }
                     None => {
-                        if inner.scalar_width() == Some(64) {
+                        if inner.scalar_width() == Some(8) {
                             false
                         } else {
                             write!(self.out, "{}(", kind.to_hlsl_cast(),)?;

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -1945,7 +1945,7 @@ impl<W: Write> Writer<W> {
                     //
                     // extract_bits(e, min(offset, w), min(count, w - min(offset, w))))
 
-                    let scalar_bits = context.resolve_type(arg).scalar_width().unwrap();
+                    let scalar_bits = context.resolve_type(arg).scalar_width().unwrap() * 8;
 
                     write!(self.out, "{NAMESPACE}::extract_bits(")?;
                     self.put_expression(arg, context, true)?;
@@ -1961,7 +1961,7 @@ impl<W: Write> Writer<W> {
                     //
                     // insertBits(e, newBits, min(offset, w), min(count, w - min(offset, w))))
 
-                    let scalar_bits = context.resolve_type(arg).scalar_width().unwrap();
+                    let scalar_bits = context.resolve_type(arg).scalar_width().unwrap() * 8;
 
                     write!(self.out, "{NAMESPACE}::insert_bits(")?;
                     self.put_expression(arg, context, true)?;

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -1073,7 +1073,7 @@ impl<'w> BlockContext<'w> {
                         //
                         // bitfieldExtract(x, o, c)
 
-                        let bit_width = arg_ty.scalar_width().unwrap();
+                        let bit_width = arg_ty.scalar_width().unwrap() * 8;
                         let width_constant = self
                             .writer
                             .get_constant_scalar(crate::Literal::U32(bit_width as u32));
@@ -1129,7 +1129,7 @@ impl<'w> BlockContext<'w> {
                     Mf::InsertBits => {
                         // The behavior of InsertBits has the same undefined behavior as ExtractBits.
 
-                        let bit_width = arg_ty.scalar_width().unwrap();
+                        let bit_width = arg_ty.scalar_width().unwrap() * 8;
                         let width_constant = self
                             .writer
                             .get_constant_scalar(crate::Literal::U32(bit_width as u32));
@@ -1185,7 +1185,7 @@ impl<'w> BlockContext<'w> {
                     }
                     Mf::FindLsb => MathOp::Ext(spirv::GLOp::FindILsb),
                     Mf::FindMsb => {
-                        if arg_ty.scalar_width() == Some(32) {
+                        if arg_ty.scalar_width() == Some(4) {
                             let thing = match arg_scalar_kind {
                                 Some(crate::ScalarKind::Uint) => spirv::GLOp::FindUMsb,
                                 Some(crate::ScalarKind::Sint) => spirv::GLOp::FindSMsb,

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -279,6 +279,7 @@ impl super::TypeInner {
         self.scalar().map(|scalar| scalar.kind)
     }
 
+    /// Returns the scalar width in bytes
     pub fn scalar_width(&self) -> Option<u8> {
         self.scalar().map(|scalar| scalar.width)
     }

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -280,7 +280,7 @@ impl super::TypeInner {
     }
 
     pub fn scalar_width(&self) -> Option<u8> {
-        self.scalar().map(|scalar| scalar.width * 8)
+        self.scalar().map(|scalar| scalar.width)
     }
 
     pub const fn pointer_space(&self) -> Option<crate::AddressSpace> {


### PR DESCRIPTION
**Connections**
Resolves #5278

**Description**
`scalar_width` returns size in bits, despite the rest of the codebase dealing exclusively in byte scalar widths, and it does so with no documentation or specification in the function name. This has shot me in the foot 3 times already, so I figured its probably shooting other people's feet.

**Testing**
Existing test cases

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
