### PR TITLE
[core] Don't derive `Default` for `ResourceMaps`.

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 use thiserror::Error;
 
 /// A struct that keeps lists of resources that are no longer needed by the user.
-#[derive(Default)]
 pub(crate) struct ResourceMaps<A: HalApi> {
     pub buffers: FastHashMap<TrackerIndex, Arc<Buffer<A>>>,
     pub staging_buffers: FastHashMap<TrackerIndex, Arc<StagingBuffer<A>>>,


### PR DESCRIPTION
The derivation is only effective if the generic type parameter `A` also implements `Default`, which `HalApi` implementations generally don't, so this derivation never actually took place. (This is why `ResourceMaps::new` is written out the way it is.)
