### PR TITLE
Fix the ordering of id freeing and deleting

### DIFF
--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -165,8 +165,8 @@ impl<T: Resource> Registry<T> {
         storage.insert_error(id, label);
     }
     pub(crate) fn unregister(&self, id: Id<T::Marker>) -> Option<Arc<T>> {
-        self.identity.free(id);
         let value = self.storage.write().remove(id);
+        self.identity.free(id);
         //Returning None is legal if it's an error ID
         value
     }

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -38,6 +38,7 @@ impl RegistryReport {
 ///
 #[derive(Debug)]
 pub(crate) struct Registry<T: Resource> {
+    // Must only contain an id which has either never been used or has been released from `storage`
     identity: Arc<IdentityManager<T::Marker>>,
     storage: RwLock<Storage<T>>,
     backend: Backend,
@@ -166,6 +167,9 @@ impl<T: Resource> Registry<T> {
     }
     pub(crate) fn unregister(&self, id: Id<T::Marker>) -> Option<Arc<T>> {
         let value = self.storage.write().remove(id);
+        // This needs to happen *after* removing it from the storage, to maintain the
+        // invariant that `self.identity` only contains ids which are actually available
+        // See https://github.com/gfx-rs/wgpu/issues/5372
         self.identity.free(id);
         //Returning None is legal if it's an error ID
         value
@@ -207,5 +211,55 @@ impl<T: Resource> Registry<T> {
             }
         }
         report
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::{
+        id::Marker,
+        resource::{Resource, ResourceInfo, ResourceType},
+    };
+
+    use super::Registry;
+    struct TestData {
+        info: ResourceInfo<TestData>,
+    }
+    struct TestDataId;
+    impl Marker for TestDataId {}
+
+    impl Resource for TestData {
+        type Marker = TestDataId;
+
+        const TYPE: ResourceType = "Test data";
+
+        fn as_info(&self) -> &ResourceInfo<Self> {
+            &self.info
+        }
+
+        fn as_info_mut(&mut self) -> &mut ResourceInfo<Self> {
+            &mut self.info
+        }
+    }
+
+    #[test]
+    fn simultaneous_registration() {
+        let registry = Registry::without_backend();
+        std::thread::scope(|s| {
+            for _ in 0..5 {
+                s.spawn(|| {
+                    for _ in 0..1000 {
+                        let value = Arc::new(TestData {
+                            info: ResourceInfo::new("Test data", None),
+                        });
+                        let new_id = registry.prepare(None);
+                        let (id, _) = new_id.assign(value);
+                        registry.unregister(id);
+                    }
+                });
+            }
+        })
     }
 }


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/5372

**Description**
When creating a resource in parallel with freeing a different resource on another thread, it was possible for the id to be made available before it was removed from storage.

That is, `unregister` was racing with e.g. `prepare().assign_existing()`

**Testing**
I cloned the linked reproduction, and applied this same patch.
The new version doesn't have this crash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown` N/A
  - [ ] `--target wasm32-unknown-emscripten` N/A
- [x] Run `cargo xtask test` to run tests - no *new* failures
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.

I'm not sure about a changelog entry, as this change is fixing a bug which was introduced in the 0.20 cycle