### PR TITLE
Add check to ensure `vulkan::CommandEncoder::discard_encoding` is not called multiple times in a row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,10 @@ Bottom level categories:
 - Implement the `device_set_device_lost_callback` method for `ContextWebGpu`. By @suti in [#5438](https://github.com/gfx-rs/wgpu/pull/5438)
 - Add support for storage texture access modes `ReadOnly` and `ReadWrite`. By @JolifantoBambla in [#5434](https://github.com/gfx-rs/wgpu/pull/5434)
 
+#### Vulkan
+
+- Make `CommandEncoder::discard_encoding` do nothing if called multiple times, and implement `Drop` for `CommandEncoder` to call `discard_encoding`. By @villuna
+
 ### Bug Fixes
 
 #### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,10 +137,6 @@ Bottom level categories:
 - Implement the `device_set_device_lost_callback` method for `ContextWebGpu`. By @suti in [#5438](https://github.com/gfx-rs/wgpu/pull/5438)
 - Add support for storage texture access modes `ReadOnly` and `ReadWrite`. By @JolifantoBambla in [#5434](https://github.com/gfx-rs/wgpu/pull/5434)
 
-#### Vulkan
-
-- Make `CommandEncoder::discard_encoding` do nothing if called multiple times, and implement `Drop` for `CommandEncoder` to call `discard_encoding`. By @villuna
-
 ### Bug Fixes
 
 #### General
@@ -184,6 +180,7 @@ Bottom level categories:
 #### Vulkan
 
 - Set object labels when the DEBUG flag is set, even if the VALIDATION flag is disabled. By @DJMcNab in [#5345](https://github.com/gfx-rs/wgpu/pull/5345).
+- Add safety check to `wgpu_hal::vulkan::CommandEncoder` to make sure `discard_encoding` is not called in the closed state. By @villuna in [#5557](https://github.com/gfx-rs/wgpu/pull/5557)
 
 #### Metal
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -617,6 +617,10 @@ pub trait Queue: WasmNotSendSync {
 ///   live `CommandBuffers` built from it. All the `CommandBuffer`s
 ///   are destroyed, and their resources are freed.
 ///
+/// You may want to implement the [core::ops::Drop] trait to discard
+/// the current commands before the encoder is dropped (e.g. using
+/// [CommandEncoder::discard_encoding]).
+///
 /// # Safety
 ///
 /// - The `CommandEncoder` must be in the states described above to
@@ -651,6 +655,10 @@ pub trait CommandEncoder: WasmNotSendSync + fmt::Debug {
     /// is the only safe thing to do with the encoder.
     ///
     /// This puts this `CommandEncoder` in the "closed" state.
+    ///
+    /// Implementations of this function must be idempotent, i.e.
+    /// if the function has just been called, calling it again should
+    /// not do anything.
     ///
     /// # Safety
     ///

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -657,8 +657,8 @@ pub trait CommandEncoder: WasmNotSendSync + fmt::Debug {
     /// This `CommandEncoder` must be in the "recording" state.
     ///
     /// Callers must not assume that implementations of this
-    /// function is idempotent. Calling it multiple times in a
-    /// row might not necessarily be safe.
+    /// function are idempotent, so should not call it
+    /// multiple times in a row.
     unsafe fn discard_encoding(&mut self);
 
     /// Return a fresh [`CommandBuffer`] holding the recorded commands.

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -617,10 +617,6 @@ pub trait Queue: WasmNotSendSync {
 ///   live `CommandBuffers` built from it. All the `CommandBuffer`s
 ///   are destroyed, and their resources are freed.
 ///
-/// You may want to implement the [core::ops::Drop] trait to discard
-/// the current commands before the encoder is dropped (e.g. using
-/// [CommandEncoder::discard_encoding]).
-///
 /// # Safety
 ///
 /// - The `CommandEncoder` must be in the states described above to
@@ -656,13 +652,13 @@ pub trait CommandEncoder: WasmNotSendSync + fmt::Debug {
     ///
     /// This puts this `CommandEncoder` in the "closed" state.
     ///
-    /// Implementations of this function must be idempotent, i.e.
-    /// if the function has just been called, calling it again should
-    /// not do anything.
-    ///
     /// # Safety
     ///
     /// This `CommandEncoder` must be in the "recording" state.
+    ///
+    /// Callers must not assume that implementations of this
+    /// function is idempotent. Calling it multiple times in a
+    /// row might not necessarily be safe.
     unsafe fn discard_encoding(&mut self);
 
     /// Return a fresh [`CommandBuffer`] holding the recorded commands.

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -645,7 +645,7 @@ pub trait CommandEncoder: WasmNotSendSync + fmt::Debug {
     /// This `CommandEncoder` must be in the "closed" state.
     unsafe fn begin_encoding(&mut self, label: Label) -> Result<(), DeviceError>;
 
-    /// Discard the command list under construction, if any.
+    /// Discard the command list under construction.
     ///
     /// If an error has occurred while recording commands, this
     /// is the only safe thing to do with the encoder.
@@ -657,7 +657,7 @@ pub trait CommandEncoder: WasmNotSendSync + fmt::Debug {
     /// This `CommandEncoder` must be in the "recording" state.
     ///
     /// Callers must not assume that implementations of this
-    /// function are idempotent, so should not call it
+    /// function are idempotent, and thus should not call it
     /// multiple times in a row.
     unsafe fn discard_encoding(&mut self);
 

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -45,6 +45,13 @@ impl super::DeviceShared {
     }
 }
 
+impl Drop for super::CommandEncoder {
+    fn drop(&mut self) {
+        use crate::CommandEncoder;
+        unsafe { self.discard_encoding() }
+    }
+}
+
 impl super::CommandEncoder {
     fn write_pass_end_timestamp_if_requested(&mut self) {
         if let Some((query_set, index)) = self.end_of_pass_timer_query.take() {

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -104,8 +104,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
     }
 
     unsafe fn discard_encoding(&mut self) {
-        self.discarded.push(self.active);
-        self.active = vk::CommandBuffer::null();
+        if self.active != vk::CommandBuffer::null() {
+            self.discarded.push(self.active);
+            self.active = vk::CommandBuffer::null();
+        }
     }
 
     unsafe fn reset_all<I>(&mut self, cmd_bufs: I)

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -45,13 +45,6 @@ impl super::DeviceShared {
     }
 }
 
-impl Drop for super::CommandEncoder {
-    fn drop(&mut self) {
-        use crate::CommandEncoder;
-        unsafe { self.discard_encoding() }
-    }
-}
-
 impl super::CommandEncoder {
     fn write_pass_end_timestamp_if_requested(&mut self) {
         if let Some((query_set, index)) = self.end_of_pass_timer_query.take() {

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -111,10 +111,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
     }
 
     unsafe fn discard_encoding(&mut self) {
-        if self.active != vk::CommandBuffer::null() {
-            self.discarded.push(self.active);
-            self.active = vk::CommandBuffer::null();
-        }
+        // Safe use requires this is not called in the close state, so the buffer
+        // shouldn't be null. Assert this to make sure we're not pushing null
+        // buffers to the discard pile.
+        assert_ne!(self.active, vk::CommandBuffer::null());
+
+        self.discarded.push(self.active);
+        self.active = vk::CommandBuffer::null();
     }
 
     unsafe fn reset_all<I>(&mut self, cmd_bufs: I)

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -104,7 +104,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     }
 
     unsafe fn discard_encoding(&mut self) {
-        // Safe use requires this is not called in the close state, so the buffer
+        // Safe use requires this is not called in the "closed" state, so the buffer
         // shouldn't be null. Assert this to make sure we're not pushing null
         // buffers to the discard pile.
         assert_ne!(self.active, vk::CommandBuffer::null());


### PR DESCRIPTION
**Connections**
Addresses https://github.com/gfx-rs/wgpu/issues/5255

**Description**
I just followed the (very helpful) todo list in Erich's issue, so the info is mostly there.

The vulkan implementation for `CommandEncoder` was previously pushing its active CommandBuffer handle to its discard vector every time the `discard_encoding` function was called, even if the handle was null. So I made it only do this if the active handle is non-null, so as to make the function idempotent.

**Testing**
No new tests but I ran the existing test suite on Vulkan (on an Nvidia GTX1050) and it ran the same as on the trunk branch.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown` 
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests - I got one error every now and then, but this also happened on the main branch so I think it's fine.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
