### PR TITLE
[naga] add `Expression::Override` to `needs_pre_emit`

### DIFF
--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -533,6 +533,7 @@ impl crate::Expression {
         match *self {
             Self::Literal(_)
             | Self::Constant(_)
+            | Self::Override(_)
             | Self::ZeroValue(_)
             | Self::FunctionArgument(_)
             | Self::GlobalVariable(_)

--- a/naga/tests/in/overrides.wgsl
+++ b/naga/tests/in/overrides.wgsl
@@ -14,6 +14,7 @@
 override inferred_f32 = 2.718;
 
 var<private> gain_x_10: f32 = gain * 10.;
+var<private> store_override: f32;
 
 @compute @workgroup_size(1)
 fn main() {
@@ -22,4 +23,6 @@ fn main() {
     var x = a;
 
     var gain_x_100 = gain_x_10 * 10.;
+
+    store_override = gain;
 }

--- a/naga/tests/out/analysis/overrides.info.ron
+++ b/naga/tests/out/analysis/overrides.info.ron
@@ -16,6 +16,7 @@
             sampling_set: [],
             global_uses: [
                 ("READ"),
+                ("WRITE"),
             ],
             expressions: [
                 (
@@ -137,6 +138,27 @@
                         base: 2,
                         space: Function,
                     )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(12),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(2),
+                    ty: Value(Pointer(
+                        base: 2,
+                        space: Private,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(2),
                 ),
             ],
             sampling: [],

--- a/naga/tests/out/glsl/overrides.main.Compute.glsl
+++ b/naga/tests/out/glsl/overrides.main.Compute.glsl
@@ -15,6 +15,8 @@ const float inferred_f32_ = 2.718;
 
 float gain_x_10_ = 11.0;
 
+float store_override = 0.0;
+
 
 void main() {
     float t = 23.0;
@@ -23,6 +25,7 @@ void main() {
     x = true;
     float _e9 = gain_x_10_;
     gain_x_100_ = (_e9 * 10.0);
+    store_override = gain;
     return;
 }
 

--- a/naga/tests/out/hlsl/overrides.hlsl
+++ b/naga/tests/out/hlsl/overrides.hlsl
@@ -7,6 +7,7 @@ static const float height = 4.6;
 static const float inferred_f32_ = 2.718;
 
 static float gain_x_10_ = 11.0;
+static float store_override = (float)0;
 
 [numthreads(1, 1, 1)]
 void main()
@@ -18,5 +19,6 @@ void main()
     x = true;
     float _expr9 = gain_x_10_;
     gain_x_100_ = (_expr9 * 10.0);
+    store_override = gain;
     return;
 }

--- a/naga/tests/out/ir/overrides.compact.ron
+++ b/naga/tests/out/ir/overrides.compact.ron
@@ -73,6 +73,13 @@
             ty: 2,
             init: Some(10),
         ),
+        (
+            name: Some("store_override"),
+            space: Private,
+            binding: None,
+            ty: 2,
+            init: None,
+        ),
     ],
     global_expressions: [
         Literal(Bool(true)),
@@ -147,6 +154,8 @@
                         right: 9,
                     ),
                     LocalVariable(3),
+                    GlobalVariable(2),
+                    Override(3),
                 ],
                 named_expressions: {
                     5: "a",
@@ -175,6 +184,10 @@
                     Store(
                         pointer: 11,
                         value: 10,
+                    ),
+                    Store(
+                        pointer: 12,
+                        value: 13,
                     ),
                     Return(
                         value: None,

--- a/naga/tests/out/ir/overrides.ron
+++ b/naga/tests/out/ir/overrides.ron
@@ -73,6 +73,13 @@
             ty: 2,
             init: Some(10),
         ),
+        (
+            name: Some("store_override"),
+            space: Private,
+            binding: None,
+            ty: 2,
+            init: None,
+        ),
     ],
     global_expressions: [
         Literal(Bool(true)),
@@ -147,6 +154,8 @@
                         right: 9,
                     ),
                     LocalVariable(3),
+                    GlobalVariable(2),
+                    Override(3),
                 ],
                 named_expressions: {
                     5: "a",
@@ -175,6 +184,10 @@
                     Store(
                         pointer: 11,
                         value: 10,
+                    ),
+                    Store(
+                        pointer: 12,
+                        value: 13,
                     ),
                     Return(
                         value: None,

--- a/naga/tests/out/msl/overrides.msl
+++ b/naga/tests/out/msl/overrides.msl
@@ -15,11 +15,13 @@ constant float inferred_f32_ = 2.718;
 kernel void main_(
 ) {
     float gain_x_10_ = 11.0;
+    float store_override = {};
     float t = 23.0;
     bool x = {};
     float gain_x_100_ = {};
     x = true;
     float _e9 = gain_x_10_;
     gain_x_100_ = _e9 * 10.0;
+    store_override = gain;
     return;
 }

--- a/naga/tests/out/spv/overrides.main.spvasm
+++ b/naga/tests/out/spv/overrides.main.spvasm
@@ -1,12 +1,12 @@
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 31
+; Bound: 33
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %18 "main"
-OpExecutionMode %18 LocalSize 1 1 1
+OpEntryPoint GLCompute %20 "main"
+OpExecutionMode %20 LocalSize 1 1 1
 %2 = OpTypeVoid
 %3 = OpTypeBool
 %4 = OpTypeFloat 32
@@ -22,22 +22,25 @@ OpExecutionMode %18 LocalSize 1 1 1
 %14 = OpConstant  %4  11.0
 %16 = OpTypePointer Private %4
 %15 = OpVariable  %16  Private %14
-%19 = OpTypeFunction %2
-%20 = OpConstant  %4  23.0
-%22 = OpTypePointer Function %4
-%24 = OpTypePointer Function %3
-%25 = OpConstantNull  %3
-%27 = OpConstantNull  %4
-%18 = OpFunction  %2  None %19
-%17 = OpLabel
-%21 = OpVariable  %22  Function %20
-%23 = OpVariable  %24  Function %25
-%26 = OpVariable  %22  Function %27
-OpBranch %28
-%28 = OpLabel
-OpStore %23 %5
-%29 = OpLoad  %4  %15
-%30 = OpFMul  %4  %29 %13
-OpStore %26 %30
+%18 = OpConstantNull  %4
+%17 = OpVariable  %16  Private %18
+%21 = OpTypeFunction %2
+%22 = OpConstant  %4  23.0
+%24 = OpTypePointer Function %4
+%26 = OpTypePointer Function %3
+%27 = OpConstantNull  %3
+%29 = OpConstantNull  %4
+%20 = OpFunction  %2  None %21
+%19 = OpLabel
+%23 = OpVariable  %24  Function %22
+%25 = OpVariable  %26  Function %27
+%28 = OpVariable  %24  Function %29
+OpBranch %30
+%30 = OpLabel
+OpStore %25 %5
+%31 = OpLoad  %4  %15
+%32 = OpFMul  %4  %31 %13
+OpStore %28 %32
+OpStore %17 %9
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
We need to add `Expression::Override` to `needs_pre_emit` or else we get `ExpressionError::NotInScope` on the updated snapshot.