### PR TITLE
When a `#[gpu_test]` test fails, print its source location.

### DIFF
--- a/tests/src/config.rs
+++ b/tests/src/config.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::{future::Future, panic::Location, pin::Pin, sync::Arc};
 
 use crate::{TestParameters, TestingContext};
 
@@ -26,14 +26,17 @@ cfg_if::cfg_if! {
 #[derive(Clone)]
 pub struct GpuTestConfiguration {
     pub(crate) name: String,
+    pub(crate) location: &'static Location<'static>,
     pub(crate) params: TestParameters,
     pub(crate) test: Option<RunTestAsync>,
 }
 
 impl GpuTestConfiguration {
+    #[track_caller]
     pub fn new() -> Self {
         Self {
             name: String::new(),
+            location: Location::caller(),
             params: TestParameters::default(),
             test: None,
         }

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -116,7 +116,10 @@ pub async fn execute_test(
 
     // The call to matches_failure will log.
     if expectations_match_failures(&test_info.failures, failures) == ExpectationMatchResult::Panic {
-        panic!();
+        panic!(
+            "{}: test {:?} did not behave as expected",
+            config.location, config.name
+        );
     }
     // Print the name of the test.
     log::info!("TEST FINISHED: {}", config.name);


### PR DESCRIPTION
Use `std::panic::Location` to record the source location of each `#[gpu_test]` test, and if it fails, include that in the error output. This is not essential, but it should make working with failures a bit more comfortable.
