### PR TITLE
Make compute pass end consume the pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ TODO(wumpf): This is still work in progress. Should write a bit more about it. A
 
 `wgpu::ComputePass` recording methods (e.g. `wgpu::ComputePass:set_render_pipeline`) no longer impose a lifetime constraint passed in resources.
 
-By @wumpf in [#5569](https://github.com/gfx-rs/wgpu/pull/5569).
+By @wumpf in [#5569](https://github.com/gfx-rs/wgpu/pull/5569), [#5575](https://github.com/gfx-rs/wgpu/pull/5575).
 
 #### Querying shader compilation errors
 

--- a/deno_webgpu/compute_pass.rs
+++ b/deno_webgpu/compute_pass.rs
@@ -95,7 +95,7 @@ pub fn op_webgpu_compute_pass_end(
         .resource_table
         .take::<WebGpuComputePass>(compute_pass_rid)?;
 
-    compute_pass_resource.0.borrow_mut().run(state.borrow())?;
+    compute_pass_resource.0.borrow_mut().end(state.borrow())?;
 
     Ok(WebGpuResult::empty())
 }

--- a/deno_webgpu/compute_pass.rs
+++ b/deno_webgpu/compute_pass.rs
@@ -57,7 +57,7 @@ pub fn op_webgpu_compute_pass_dispatch_workgroups(
     compute_pass_resource
         .0
         .borrow_mut()
-        .dispatch_workgroups(state.borrow(), x, y, z);
+        .dispatch_workgroups(state.borrow(), x, y, z)?;
 
     Ok(WebGpuResult::empty())
 }
@@ -152,7 +152,7 @@ pub fn op_webgpu_compute_pass_push_debug_group(
         state.borrow(),
         group_label,
         0, // wgpu#975
-    );
+    )?;
 
     Ok(WebGpuResult::empty())
 }
@@ -170,7 +170,7 @@ pub fn op_webgpu_compute_pass_pop_debug_group(
     compute_pass_resource
         .0
         .borrow_mut()
-        .pop_debug_group(state.borrow());
+        .pop_debug_group(state.borrow())?;
 
     Ok(WebGpuResult::empty())
 }
@@ -190,7 +190,7 @@ pub fn op_webgpu_compute_pass_insert_debug_marker(
         state.borrow(),
         marker_label,
         0, // wgpu#975
-    );
+    )?;
 
     Ok(WebGpuResult::empty())
 }

--- a/deno_webgpu/render_pass.rs
+++ b/deno_webgpu/render_pass.rs
@@ -186,21 +186,16 @@ pub fn op_webgpu_render_pass_execute_bundles(
 #[serde]
 pub fn op_webgpu_render_pass_end(
     state: &mut OpState,
-    #[smi] command_encoder_rid: ResourceId,
     #[smi] render_pass_rid: ResourceId,
 ) -> Result<WebGpuResult, AnyError> {
-    let command_encoder_resource =
-        state
-            .resource_table
-            .get::<super::command_encoder::WebGpuCommandEncoder>(command_encoder_rid)?;
-    let command_encoder = command_encoder_resource.1;
     let render_pass_resource = state
         .resource_table
         .take::<WebGpuRenderPass>(render_pass_rid)?;
     let render_pass = &render_pass_resource.0.borrow();
+    let command_encoder = render_pass.parent_id();
     let instance = state.borrow::<super::Instance>();
 
-    gfx_ok!(command_encoder => instance.command_encoder_run_render_pass(command_encoder, render_pass))
+    gfx_ok!(command_encoder => instance.render_pass_end(render_pass))
 }
 
 #[op2]

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -99,7 +99,7 @@ impl GlobalPlay for wgc::global::Global {
                     base,
                     timestamp_writes,
                 } => {
-                    self.command_encoder_run_compute_pass_with_unresolved_commands::<A>(
+                    self.compute_pass_end_with_unresolved_commands::<A>(
                         encoder,
                         base.as_ref(),
                         timestamp_writes.as_ref(),
@@ -113,7 +113,7 @@ impl GlobalPlay for wgc::global::Global {
                     timestamp_writes,
                     occlusion_query_set_id,
                 } => {
-                    self.command_encoder_run_render_pass_impl::<A>(
+                    self.render_pass_end_impl::<A>(
                         encoder,
                         base.as_ref(),
                         &target_colors,

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -101,7 +101,7 @@ impl GlobalPlay for wgc::global::Global {
                 } => {
                     self.compute_pass_end_with_unresolved_commands::<A>(
                         encoder,
-                        base.as_ref(),
+                        base,
                         timestamp_writes.as_ref(),
                     )
                     .unwrap();

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -888,7 +888,7 @@ unsafe impl<A: HalApi> Sync for RenderBundle<A> {}
 impl<A: HalApi> RenderBundle<A> {
     /// Actually encode the contents into a native command buffer.
     ///
-    /// This is partially duplicating the logic of `command_encoder_run_render_pass`.
+    /// This is partially duplicating the logic of `render_pass_end`.
     /// However the point of this function is to be lighter, since we already had
     /// a chance to go through the commands in `render_bundle_encoder_finish`.
     ///

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -65,6 +65,10 @@ impl<A: HalApi> ComputePass<A> {
         self.parent_id
     }
 
+    pub fn label(&self) -> Option<&str> {
+        self.base.as_ref().and_then(|base| base.label.as_deref())
+    }
+
     fn base_mut<'a>(
         &'a mut self,
         scope: PassErrorScope,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -279,11 +279,11 @@ impl Global {
         Box::new(ComputePass::<A>::new(parent_id, desc))
     }
 
-    pub fn command_encoder_run_compute_pass<A: HalApi>(
+    pub fn compute_pass_end<A: HalApi>(
         &self,
         pass: &ComputePass<A>,
     ) -> Result<(), ComputePassError> {
-        self.command_encoder_run_compute_pass_impl(
+        self.compute_pass_end_impl(
             pass.parent_id,
             pass.base.as_ref(),
             pass.timestamp_writes.as_ref(),
@@ -291,7 +291,7 @@ impl Global {
     }
 
     #[doc(hidden)]
-    pub fn command_encoder_run_compute_pass_with_unresolved_commands<A: HalApi>(
+    pub fn compute_pass_end_with_unresolved_commands<A: HalApi>(
         &self,
         encoder_id: id::CommandEncoderId,
         base: BasePassRef<ComputeCommand>,
@@ -300,7 +300,7 @@ impl Global {
         let resolved_commands =
             ComputeCommand::resolve_compute_command_ids(A::hub(self), base.commands)?;
 
-        self.command_encoder_run_compute_pass_impl::<A>(
+        self.compute_pass_end_impl::<A>(
             encoder_id,
             BasePassRef {
                 label: base.label,
@@ -313,7 +313,7 @@ impl Global {
         )
     }
 
-    fn command_encoder_run_compute_pass_impl<A: HalApi>(
+    fn compute_pass_end_impl<A: HalApi>(
         &self,
         encoder_id: id::CommandEncoderId,
         base: BasePassRef<ArcComputeCommand<A>>,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -61,10 +61,12 @@ impl<A: HalApi> ComputePass<A> {
         }
     }
 
+    #[inline]
     pub fn parent_id(&self) -> id::CommandEncoderId {
         self.parent_id
     }
 
+    #[inline]
     pub fn label(&self) -> Option<&str> {
         self.base.as_ref().and_then(|base| base.label.as_deref())
     }

--- a/wgpu-core/src/command/dyn_compute_pass.rs
+++ b/wgpu-core/src/command/dyn_compute_pass.rs
@@ -9,7 +9,7 @@ use super::{ComputePass, ComputePassError};
 // Practically speaking this allows us merge gfx_select with type erasure:
 // The alternative would be to introduce ComputePassId which then first needs to be looked up and then dispatch via gfx_select.
 pub trait DynComputePass: std::fmt::Debug + WasmNotSendSync {
-    fn run(&mut self, context: &global::Global) -> Result<(), ComputePassError>;
+    fn end(&mut self, context: &global::Global) -> Result<(), ComputePassError>;
     fn set_bind_group(
         &mut self,
         context: &global::Global,
@@ -55,8 +55,8 @@ pub trait DynComputePass: std::fmt::Debug + WasmNotSendSync {
 }
 
 impl<A: HalApi> DynComputePass for ComputePass<A> {
-    fn run(&mut self, context: &global::Global) -> Result<(), ComputePassError> {
-        context.command_encoder_run_compute_pass(self)
+    fn end(&mut self, context: &global::Global) -> Result<(), ComputePassError> {
+        context.compute_pass_end(self)
     }
 
     fn set_bind_group(

--- a/wgpu-core/src/command/dyn_compute_pass.rs
+++ b/wgpu-core/src/command/dyn_compute_pass.rs
@@ -70,6 +70,8 @@ pub trait DynComputePass: std::fmt::Debug + WasmNotSendSync {
         context: &global::Global,
     ) -> Result<(), ComputePassError>;
     fn end(&mut self, context: &global::Global) -> Result<(), ComputePassError>;
+
+    fn label(&self) -> Option<&str>;
 }
 
 impl<A: HalApi> DynComputePass for ComputePass<A> {
@@ -168,5 +170,9 @@ impl<A: HalApi> DynComputePass for ComputePass<A> {
 
     fn end(&mut self, context: &global::Global) -> Result<(), ComputePassError> {
         context.compute_pass_end(self)
+    }
+
+    fn label(&self) -> Option<&str> {
+        self.label()
     }
 }

--- a/wgpu-core/src/command/dyn_compute_pass.rs
+++ b/wgpu-core/src/command/dyn_compute_pass.rs
@@ -9,7 +9,6 @@ use super::{ComputePass, ComputePassError};
 // Practically speaking this allows us merge gfx_select with type erasure:
 // The alternative would be to introduce ComputePassId which then first needs to be looked up and then dispatch via gfx_select.
 pub trait DynComputePass: std::fmt::Debug + WasmNotSendSync {
-    fn end(&mut self, context: &global::Global) -> Result<(), ComputePassError>;
     fn set_bind_group(
         &mut self,
         context: &global::Global,
@@ -22,23 +21,38 @@ pub trait DynComputePass: std::fmt::Debug + WasmNotSendSync {
         context: &global::Global,
         pipeline_id: id::ComputePipelineId,
     ) -> Result<(), ComputePassError>;
-    fn set_push_constant(&mut self, context: &global::Global, offset: u32, data: &[u8]);
+    fn set_push_constant(
+        &mut self,
+        context: &global::Global,
+        offset: u32,
+        data: &[u8],
+    ) -> Result<(), ComputePassError>;
     fn dispatch_workgroups(
         &mut self,
         context: &global::Global,
         groups_x: u32,
         groups_y: u32,
         groups_z: u32,
-    );
+    ) -> Result<(), ComputePassError>;
     fn dispatch_workgroups_indirect(
         &mut self,
         context: &global::Global,
         buffer_id: id::BufferId,
         offset: wgt::BufferAddress,
     ) -> Result<(), ComputePassError>;
-    fn push_debug_group(&mut self, context: &global::Global, label: &str, color: u32);
-    fn pop_debug_group(&mut self, context: &global::Global);
-    fn insert_debug_marker(&mut self, context: &global::Global, label: &str, color: u32);
+    fn push_debug_group(
+        &mut self,
+        context: &global::Global,
+        label: &str,
+        color: u32,
+    ) -> Result<(), ComputePassError>;
+    fn pop_debug_group(&mut self, context: &global::Global) -> Result<(), ComputePassError>;
+    fn insert_debug_marker(
+        &mut self,
+        context: &global::Global,
+        label: &str,
+        color: u32,
+    ) -> Result<(), ComputePassError>;
     fn write_timestamp(
         &mut self,
         context: &global::Global,
@@ -51,14 +65,14 @@ pub trait DynComputePass: std::fmt::Debug + WasmNotSendSync {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), ComputePassError>;
-    fn end_pipeline_statistics_query(&mut self, context: &global::Global);
+    fn end_pipeline_statistics_query(
+        &mut self,
+        context: &global::Global,
+    ) -> Result<(), ComputePassError>;
+    fn end(&mut self, context: &global::Global) -> Result<(), ComputePassError>;
 }
 
 impl<A: HalApi> DynComputePass for ComputePass<A> {
-    fn end(&mut self, context: &global::Global) -> Result<(), ComputePassError> {
-        context.compute_pass_end(self)
-    }
-
     fn set_bind_group(
         &mut self,
         context: &global::Global,
@@ -77,7 +91,12 @@ impl<A: HalApi> DynComputePass for ComputePass<A> {
         context.compute_pass_set_pipeline(self, pipeline_id)
     }
 
-    fn set_push_constant(&mut self, context: &global::Global, offset: u32, data: &[u8]) {
+    fn set_push_constant(
+        &mut self,
+        context: &global::Global,
+        offset: u32,
+        data: &[u8],
+    ) -> Result<(), ComputePassError> {
         context.compute_pass_set_push_constant(self, offset, data)
     }
 
@@ -87,7 +106,7 @@ impl<A: HalApi> DynComputePass for ComputePass<A> {
         groups_x: u32,
         groups_y: u32,
         groups_z: u32,
-    ) {
+    ) -> Result<(), ComputePassError> {
         context.compute_pass_dispatch_workgroups(self, groups_x, groups_y, groups_z)
     }
 
@@ -100,15 +119,25 @@ impl<A: HalApi> DynComputePass for ComputePass<A> {
         context.compute_pass_dispatch_workgroups_indirect(self, buffer_id, offset)
     }
 
-    fn push_debug_group(&mut self, context: &global::Global, label: &str, color: u32) {
+    fn push_debug_group(
+        &mut self,
+        context: &global::Global,
+        label: &str,
+        color: u32,
+    ) -> Result<(), ComputePassError> {
         context.compute_pass_push_debug_group(self, label, color)
     }
 
-    fn pop_debug_group(&mut self, context: &global::Global) {
+    fn pop_debug_group(&mut self, context: &global::Global) -> Result<(), ComputePassError> {
         context.compute_pass_pop_debug_group(self)
     }
 
-    fn insert_debug_marker(&mut self, context: &global::Global, label: &str, color: u32) {
+    fn insert_debug_marker(
+        &mut self,
+        context: &global::Global,
+        label: &str,
+        color: u32,
+    ) -> Result<(), ComputePassError> {
         context.compute_pass_insert_debug_marker(self, label, color)
     }
 
@@ -130,7 +159,14 @@ impl<A: HalApi> DynComputePass for ComputePass<A> {
         context.compute_pass_begin_pipeline_statistics_query(self, query_set_id, query_index)
     }
 
-    fn end_pipeline_statistics_query(&mut self, context: &global::Global) {
+    fn end_pipeline_statistics_query(
+        &mut self,
+        context: &global::Global,
+    ) -> Result<(), ComputePassError> {
         context.compute_pass_end_pipeline_statistics_query(self)
+    }
+
+    fn end(&mut self, context: &global::Global) -> Result<(), ComputePassError> {
+        context.compute_pass_end(self)
     }
 }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -48,11 +48,11 @@ pub(crate) enum CommandEncoderStatus {
     /// Ready to record commands. An encoder's initial state.
     ///
     /// Command building methods like [`command_encoder_clear_buffer`] and
-    /// [`command_encoder_run_compute_pass`] require the encoder to be in this
+    /// [`compute_pass_end`] require the encoder to be in this
     /// state.
     ///
     /// [`command_encoder_clear_buffer`]: Global::command_encoder_clear_buffer
-    /// [`command_encoder_run_compute_pass`]: Global::command_encoder_run_compute_pass
+    /// [`compute_pass_end`]: Global::compute_pass_end
     Recording,
 
     /// Command recording is complete, and the buffer is ready for submission.

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -847,8 +847,12 @@ pub enum PassErrorScope {
         indirect: bool,
         pipeline: Option<id::ComputePipelineId>,
     },
+    #[error("In a push_debug_group command")]
+    PushDebugGroup,
     #[error("In a pop_debug_group command")]
     PopDebugGroup,
+    #[error("In a insert_debug_marker command")]
+    InsertDebugMarker,
 }
 
 impl PrettyError for PassErrorScope {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -247,8 +247,14 @@ impl RenderPass {
         }
     }
 
+    #[inline]
     pub fn parent_id(&self) -> id::CommandEncoderId {
         self.parent_id
+    }
+
+    #[inline]
+    pub fn label(&self) -> Option<&str> {
+        self.base.label.as_deref()
     }
 
     #[cfg(feature = "trace")]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1303,13 +1303,9 @@ impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
 // Common routines between render/compute
 
 impl Global {
-    pub fn command_encoder_run_render_pass<A: HalApi>(
-        &self,
-        encoder_id: id::CommandEncoderId,
-        pass: &RenderPass,
-    ) -> Result<(), RenderPassError> {
-        self.command_encoder_run_render_pass_impl::<A>(
-            encoder_id,
+    pub fn render_pass_end<A: HalApi>(&self, pass: &RenderPass) -> Result<(), RenderPassError> {
+        self.render_pass_end_impl::<A>(
+            pass.parent_id(),
             pass.base.as_ref(),
             &pass.color_targets,
             pass.depth_stencil_target.as_ref(),
@@ -1319,7 +1315,7 @@ impl Global {
     }
 
     #[doc(hidden)]
-    pub fn command_encoder_run_render_pass_impl<A: HalApi>(
+    pub fn render_pass_end_impl<A: HalApi>(
         &self,
         encoder_id: id::CommandEncoderId,
         base: BasePassRef<RenderCommand>,

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2559,16 +2559,6 @@ impl crate::context::Context for ContextWebGpu {
         )
     }
 
-    fn command_encoder_end_compute_pass(
-        &self,
-        _encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
-        _pass: &mut Self::ComputePassId,
-        pass_data: &mut Self::ComputePassData,
-    ) {
-        pass_data.0.end();
-    }
-
     fn command_encoder_begin_render_pass(
         &self,
         _encoder: &Self::CommandEncoderId,
@@ -2665,16 +2655,6 @@ impl crate::context::Context for ContextWebGpu {
         }
 
         create_identified(encoder_data.0.begin_render_pass(&mapped_desc))
-    }
-
-    fn command_encoder_end_render_pass(
-        &self,
-        _encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
-        _pass: &mut Self::RenderPassId,
-        pass_data: &mut Self::RenderPassData,
-    ) {
-        pass_data.0.end();
     }
 
     fn command_encoder_finish(
@@ -3129,6 +3109,14 @@ impl crate::context::Context for ContextWebGpu {
             &indirect_buffer_data.0.buffer,
             indirect_offset as f64,
         );
+    }
+
+    fn compute_pass_end(
+        &self,
+        _pass: &mut Self::ComputePassId,
+        pass_data: &mut Self::ComputePassData,
+    ) {
+        pass_data.0.end();
     }
 
     fn render_bundle_encoder_set_pipeline(
@@ -3709,6 +3697,14 @@ impl crate::context::Context for ContextWebGpu {
             .map(|(_, bundle_data)| &bundle_data.0)
             .collect::<js_sys::Array>();
         pass_data.0.execute_bundles(&mapped);
+    }
+
+    fn render_pass_end(
+        &self,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
+    ) {
+        pass_data.0.end();
     }
 }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -485,6 +485,12 @@ pub struct ComputePass {
 }
 
 #[derive(Debug)]
+pub struct RenderPass {
+    pass: wgc::command::RenderPass,
+    error_sink: ErrorSink,
+}
+
+#[derive(Debug)]
 pub struct CommandEncoder {
     error_sink: ErrorSink,
     open: bool,
@@ -526,7 +532,7 @@ impl crate::Context for ContextWgpuCore {
     type ComputePassId = Unused;
     type ComputePassData = ComputePass;
     type RenderPassId = Unused;
-    type RenderPassData = wgc::command::RenderPass;
+    type RenderPassData = RenderPass;
     type CommandBufferId = wgc::id::CommandBufferId;
     type CommandBufferData = ();
     type RenderBundleEncoderId = Unused;
@@ -1916,29 +1922,10 @@ impl crate::Context for ContextWgpuCore {
         )
     }
 
-    fn command_encoder_end_compute_pass(
-        &self,
-        encoder: &Self::CommandEncoderId,
-        encoder_data: &Self::CommandEncoderData,
-        _pass: &mut Self::ComputePassId,
-        pass_data: &mut Self::ComputePassData,
-    ) {
-        if let Err(cause) = pass_data.pass.run(&self.0) {
-            let name = wgc::gfx_select!(encoder => self.0.command_buffer_label(encoder.into_command_buffer_id()));
-            self.handle_error(
-                &encoder_data.error_sink,
-                cause,
-                "encoder",
-                Some(&name),
-                "a ComputePass",
-            );
-        }
-    }
-
     fn command_encoder_begin_render_pass(
         &self,
         encoder: &Self::CommandEncoderId,
-        _encoder_data: &Self::CommandEncoderData,
+        encoder_data: &Self::CommandEncoderData,
         desc: &crate::RenderPassDescriptor<'_, '_>,
     ) -> (Self::RenderPassId, Self::RenderPassData) {
         if desc.color_attachments.len() > wgc::MAX_COLOR_ATTACHMENTS {
@@ -1982,40 +1969,22 @@ impl crate::Context for ContextWgpuCore {
 
         (
             Unused,
-            wgc::command::RenderPass::new(
-                *encoder,
-                &wgc::command::RenderPassDescriptor {
-                    label: desc.label.map(Borrowed),
-                    color_attachments: Borrowed(&colors),
-                    depth_stencil_attachment: depth_stencil.as_ref(),
-                    timestamp_writes: timestamp_writes.as_ref(),
-                    occlusion_query_set: desc
-                        .occlusion_query_set
-                        .map(|query_set| query_set.id.into()),
-                },
-            ),
+            RenderPass {
+                pass: wgc::command::RenderPass::new(
+                    *encoder,
+                    &wgc::command::RenderPassDescriptor {
+                        label: desc.label.map(Borrowed),
+                        color_attachments: Borrowed(&colors),
+                        depth_stencil_attachment: depth_stencil.as_ref(),
+                        timestamp_writes: timestamp_writes.as_ref(),
+                        occlusion_query_set: desc
+                            .occlusion_query_set
+                            .map(|query_set| query_set.id.into()),
+                    },
+                ),
+                error_sink: encoder_data.error_sink.clone(),
+            },
         )
-    }
-
-    fn command_encoder_end_render_pass(
-        &self,
-        encoder: &Self::CommandEncoderId,
-        encoder_data: &Self::CommandEncoderData,
-        _pass: &mut Self::RenderPassId,
-        pass_data: &mut Self::RenderPassData,
-    ) {
-        if let Err(cause) =
-            wgc::gfx_select!(encoder => self.0.command_encoder_run_render_pass(*encoder, pass_data))
-        {
-            let name = wgc::gfx_select!(encoder => self.0.command_buffer_label(encoder.into_command_buffer_id()));
-            self.handle_error(
-                &encoder_data.error_sink,
-                cause,
-                "encoder",
-                Some(&name),
-                "a RenderPass",
-            );
-        }
     }
 
     fn command_encoder_finish(
@@ -2530,6 +2499,16 @@ impl crate::Context for ContextWgpuCore {
         }
     }
 
+    fn compute_pass_end(
+        &self,
+        _pass: &mut Self::ComputePassId,
+        pass_data: &mut Self::ComputePassData,
+    ) {
+        if let Err(cause) = pass_data.pass.end(&self.0) {
+            self.handle_error_nolabel(&pass_data.error_sink, cause, "ComputePass::end");
+        }
+    }
+
     fn render_bundle_encoder_set_pipeline(
         &self,
         _encoder: &mut Self::RenderBundleEncoderId,
@@ -2722,7 +2701,7 @@ impl crate::Context for ContextWgpuCore {
         pipeline: &Self::RenderPipelineId,
         _pipeline_data: &Self::RenderPipelineData,
     ) {
-        wgpu_render_pass_set_pipeline(pass_data, *pipeline)
+        wgpu_render_pass_set_pipeline(&mut pass_data.pass, *pipeline)
     }
 
     fn render_pass_set_bind_group(
@@ -2734,7 +2713,7 @@ impl crate::Context for ContextWgpuCore {
         _bind_group_data: &Self::BindGroupData,
         offsets: &[wgt::DynamicOffset],
     ) {
-        wgpu_render_pass_set_bind_group(pass_data, index, *bind_group, offsets)
+        wgpu_render_pass_set_bind_group(&mut pass_data.pass, index, *bind_group, offsets)
     }
 
     fn render_pass_set_index_buffer(
@@ -2747,7 +2726,9 @@ impl crate::Context for ContextWgpuCore {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
-        pass_data.set_index_buffer(*buffer, index_format, offset, size)
+        pass_data
+            .pass
+            .set_index_buffer(*buffer, index_format, offset, size)
     }
 
     fn render_pass_set_vertex_buffer(
@@ -2760,7 +2741,7 @@ impl crate::Context for ContextWgpuCore {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
-        wgpu_render_pass_set_vertex_buffer(pass_data, slot, *buffer, offset, size)
+        wgpu_render_pass_set_vertex_buffer(&mut pass_data.pass, slot, *buffer, offset, size)
     }
 
     fn render_pass_set_push_constants(
@@ -2771,7 +2752,7 @@ impl crate::Context for ContextWgpuCore {
         offset: u32,
         data: &[u8],
     ) {
-        wgpu_render_pass_set_push_constants(pass_data, stages, offset, data)
+        wgpu_render_pass_set_push_constants(&mut pass_data.pass, stages, offset, data)
     }
 
     fn render_pass_draw(
@@ -2782,7 +2763,7 @@ impl crate::Context for ContextWgpuCore {
         instances: Range<u32>,
     ) {
         wgpu_render_pass_draw(
-            pass_data,
+            &mut pass_data.pass,
             vertices.end - vertices.start,
             instances.end - instances.start,
             vertices.start,
@@ -2799,7 +2780,7 @@ impl crate::Context for ContextWgpuCore {
         instances: Range<u32>,
     ) {
         wgpu_render_pass_draw_indexed(
-            pass_data,
+            &mut pass_data.pass,
             indices.end - indices.start,
             instances.end - instances.start,
             indices.start,
@@ -2816,7 +2797,7 @@ impl crate::Context for ContextWgpuCore {
         _indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        wgpu_render_pass_draw_indirect(pass_data, *indirect_buffer, indirect_offset)
+        wgpu_render_pass_draw_indirect(&mut pass_data.pass, *indirect_buffer, indirect_offset)
     }
 
     fn render_pass_draw_indexed_indirect(
@@ -2827,7 +2808,11 @@ impl crate::Context for ContextWgpuCore {
         _indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        wgpu_render_pass_draw_indexed_indirect(pass_data, *indirect_buffer, indirect_offset)
+        wgpu_render_pass_draw_indexed_indirect(
+            &mut pass_data.pass,
+            *indirect_buffer,
+            indirect_offset,
+        )
     }
 
     fn render_pass_multi_draw_indirect(
@@ -2839,7 +2824,12 @@ impl crate::Context for ContextWgpuCore {
         indirect_offset: wgt::BufferAddress,
         count: u32,
     ) {
-        wgpu_render_pass_multi_draw_indirect(pass_data, *indirect_buffer, indirect_offset, count)
+        wgpu_render_pass_multi_draw_indirect(
+            &mut pass_data.pass,
+            *indirect_buffer,
+            indirect_offset,
+            count,
+        )
     }
 
     fn render_pass_multi_draw_indexed_indirect(
@@ -2852,7 +2842,7 @@ impl crate::Context for ContextWgpuCore {
         count: u32,
     ) {
         wgpu_render_pass_multi_draw_indexed_indirect(
-            pass_data,
+            &mut pass_data.pass,
             *indirect_buffer,
             indirect_offset,
             count,
@@ -2872,7 +2862,7 @@ impl crate::Context for ContextWgpuCore {
         max_count: u32,
     ) {
         wgpu_render_pass_multi_draw_indirect_count(
-            pass_data,
+            &mut pass_data.pass,
             *indirect_buffer,
             indirect_offset,
             *count_buffer,
@@ -2894,7 +2884,7 @@ impl crate::Context for ContextWgpuCore {
         max_count: u32,
     ) {
         wgpu_render_pass_multi_draw_indexed_indirect_count(
-            pass_data,
+            &mut pass_data.pass,
             *indirect_buffer,
             indirect_offset,
             *count_buffer,
@@ -2909,7 +2899,7 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::RenderPassData,
         color: wgt::Color,
     ) {
-        wgpu_render_pass_set_blend_constant(pass_data, &color)
+        wgpu_render_pass_set_blend_constant(&mut pass_data.pass, &color)
     }
 
     fn render_pass_set_scissor_rect(
@@ -2921,7 +2911,7 @@ impl crate::Context for ContextWgpuCore {
         width: u32,
         height: u32,
     ) {
-        wgpu_render_pass_set_scissor_rect(pass_data, x, y, width, height)
+        wgpu_render_pass_set_scissor_rect(&mut pass_data.pass, x, y, width, height)
     }
 
     fn render_pass_set_viewport(
@@ -2935,7 +2925,15 @@ impl crate::Context for ContextWgpuCore {
         min_depth: f32,
         max_depth: f32,
     ) {
-        wgpu_render_pass_set_viewport(pass_data, x, y, width, height, min_depth, max_depth)
+        wgpu_render_pass_set_viewport(
+            &mut pass_data.pass,
+            x,
+            y,
+            width,
+            height,
+            min_depth,
+            max_depth,
+        )
     }
 
     fn render_pass_set_stencil_reference(
@@ -2944,7 +2942,7 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::RenderPassData,
         reference: u32,
     ) {
-        wgpu_render_pass_set_stencil_reference(pass_data, reference)
+        wgpu_render_pass_set_stencil_reference(&mut pass_data.pass, reference)
     }
 
     fn render_pass_insert_debug_marker(
@@ -2953,7 +2951,7 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::RenderPassData,
         label: &str,
     ) {
-        wgpu_render_pass_insert_debug_marker(pass_data, label, 0);
+        wgpu_render_pass_insert_debug_marker(&mut pass_data.pass, label, 0);
     }
 
     fn render_pass_push_debug_group(
@@ -2962,7 +2960,7 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::RenderPassData,
         group_label: &str,
     ) {
-        wgpu_render_pass_push_debug_group(pass_data, group_label, 0);
+        wgpu_render_pass_push_debug_group(&mut pass_data.pass, group_label, 0);
     }
 
     fn render_pass_pop_debug_group(
@@ -2970,7 +2968,7 @@ impl crate::Context for ContextWgpuCore {
         _pass: &mut Self::RenderPassId,
         pass_data: &mut Self::RenderPassData,
     ) {
-        wgpu_render_pass_pop_debug_group(pass_data);
+        wgpu_render_pass_pop_debug_group(&mut pass_data.pass);
     }
 
     fn render_pass_write_timestamp(
@@ -2981,7 +2979,7 @@ impl crate::Context for ContextWgpuCore {
         _query_set_data: &Self::QuerySetData,
         query_index: u32,
     ) {
-        wgpu_render_pass_write_timestamp(pass_data, *query_set, query_index)
+        wgpu_render_pass_write_timestamp(&mut pass_data.pass, *query_set, query_index)
     }
 
     fn render_pass_begin_occlusion_query(
@@ -2990,7 +2988,7 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::RenderPassData,
         query_index: u32,
     ) {
-        wgpu_render_pass_begin_occlusion_query(pass_data, query_index)
+        wgpu_render_pass_begin_occlusion_query(&mut pass_data.pass, query_index)
     }
 
     fn render_pass_end_occlusion_query(
@@ -2998,7 +2996,7 @@ impl crate::Context for ContextWgpuCore {
         _pass: &mut Self::RenderPassId,
         pass_data: &mut Self::RenderPassData,
     ) {
-        wgpu_render_pass_end_occlusion_query(pass_data)
+        wgpu_render_pass_end_occlusion_query(&mut pass_data.pass)
     }
 
     fn render_pass_begin_pipeline_statistics_query(
@@ -3009,7 +3007,11 @@ impl crate::Context for ContextWgpuCore {
         _query_set_data: &Self::QuerySetData,
         query_index: u32,
     ) {
-        wgpu_render_pass_begin_pipeline_statistics_query(pass_data, *query_set, query_index)
+        wgpu_render_pass_begin_pipeline_statistics_query(
+            &mut pass_data.pass,
+            *query_set,
+            query_index,
+        )
     }
 
     fn render_pass_end_pipeline_statistics_query(
@@ -3017,7 +3019,7 @@ impl crate::Context for ContextWgpuCore {
         _pass: &mut Self::RenderPassId,
         pass_data: &mut Self::RenderPassData,
     ) {
-        wgpu_render_pass_end_pipeline_statistics_query(pass_data)
+        wgpu_render_pass_end_pipeline_statistics_query(&mut pass_data.pass)
     }
 
     fn render_pass_execute_bundles(
@@ -3027,7 +3029,18 @@ impl crate::Context for ContextWgpuCore {
         render_bundles: &mut dyn Iterator<Item = (Self::RenderBundleId, &Self::RenderBundleData)>,
     ) {
         let temp_render_bundles = render_bundles.map(|(i, _)| i).collect::<SmallVec<[_; 4]>>();
-        wgpu_render_pass_execute_bundles(pass_data, &temp_render_bundles)
+        wgpu_render_pass_execute_bundles(&mut pass_data.pass, &temp_render_bundles)
+    }
+
+    fn render_pass_end(
+        &self,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
+    ) {
+        let encoder = pass_data.pass.parent_id();
+        if let Err(cause) = wgc::gfx_select!(encoder => self.0.render_pass_end(&pass_data.pass)) {
+            self.handle_error_nolabel(&pass_data.error_sink, cause, "RenderPass::end");
+        }
     }
 }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2393,7 +2393,13 @@ impl crate::Context for ContextWgpuCore {
         offset: u32,
         data: &[u8],
     ) {
-        pass_data.pass.set_push_constant(&self.0, offset, data);
+        if let Err(cause) = pass_data.pass.set_push_constant(&self.0, offset, data) {
+            self.handle_error_nolabel(
+                &pass_data.error_sink,
+                cause,
+                "ComputePass::set_push_constant",
+            );
+        }
     }
 
     fn compute_pass_insert_debug_marker(
@@ -2402,7 +2408,13 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::ComputePassData,
         label: &str,
     ) {
-        pass_data.pass.insert_debug_marker(&self.0, label, 0);
+        if let Err(cause) = pass_data.pass.insert_debug_marker(&self.0, label, 0) {
+            self.handle_error_nolabel(
+                &pass_data.error_sink,
+                cause,
+                "ComputePass::insert_debug_marker",
+            );
+        }
     }
 
     fn compute_pass_push_debug_group(
@@ -2411,7 +2423,13 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::ComputePassData,
         group_label: &str,
     ) {
-        pass_data.pass.push_debug_group(&self.0, group_label, 0);
+        if let Err(cause) = pass_data.pass.push_debug_group(&self.0, group_label, 0) {
+            self.handle_error_nolabel(
+                &pass_data.error_sink,
+                cause,
+                "ComputePass::push_debug_group",
+            );
+        }
     }
 
     fn compute_pass_pop_debug_group(
@@ -2419,7 +2437,9 @@ impl crate::Context for ContextWgpuCore {
         _pass: &mut Self::ComputePassId,
         pass_data: &mut Self::ComputePassData,
     ) {
-        pass_data.pass.pop_debug_group(&self.0);
+        if let Err(cause) = pass_data.pass.pop_debug_group(&self.0) {
+            self.handle_error_nolabel(&pass_data.error_sink, cause, "ComputePass::pop_debug_group");
+        }
     }
 
     fn compute_pass_write_timestamp(
@@ -2464,7 +2484,13 @@ impl crate::Context for ContextWgpuCore {
         _pass: &mut Self::ComputePassId,
         pass_data: &mut Self::ComputePassData,
     ) {
-        pass_data.pass.end_pipeline_statistics_query(&self.0);
+        if let Err(cause) = pass_data.pass.end_pipeline_statistics_query(&self.0) {
+            self.handle_error_nolabel(
+                &pass_data.error_sink,
+                cause,
+                "ComputePass::end_pipeline_statistics_query",
+            );
+        }
     }
 
     fn compute_pass_dispatch_workgroups(
@@ -2475,7 +2501,13 @@ impl crate::Context for ContextWgpuCore {
         y: u32,
         z: u32,
     ) {
-        pass_data.pass.dispatch_workgroups(&self.0, x, y, z);
+        if let Err(cause) = pass_data.pass.dispatch_workgroups(&self.0, x, y, z) {
+            self.handle_error_nolabel(
+                &pass_data.error_sink,
+                cause,
+                "ComputePass::dispatch_workgroups",
+            );
+        }
     }
 
     fn compute_pass_dispatch_workgroups_indirect(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2365,7 +2365,13 @@ impl crate::Context for ContextWgpuCore {
         _pipeline_data: &Self::ComputePipelineData,
     ) {
         if let Err(cause) = pass_data.pass.set_pipeline(&self.0, *pipeline) {
-            self.handle_error_nolabel(&pass_data.error_sink, cause, "ComputePass::set_pipeline");
+            self.handle_error(
+                &pass_data.error_sink,
+                cause,
+                LABEL,
+                pass_data.pass.label(),
+                "ComputePass::set_pipeline",
+            );
         }
     }
 
@@ -2382,7 +2388,13 @@ impl crate::Context for ContextWgpuCore {
             .pass
             .set_bind_group(&self.0, index, *bind_group, offsets)
         {
-            self.handle_error_nolabel(&pass_data.error_sink, cause, "ComputePass::set_bind_group");
+            self.handle_error(
+                &pass_data.error_sink,
+                cause,
+                LABEL,
+                pass_data.pass.label(),
+                "ComputePass::set_bind_group",
+            );
         }
     }
 
@@ -2394,9 +2406,11 @@ impl crate::Context for ContextWgpuCore {
         data: &[u8],
     ) {
         if let Err(cause) = pass_data.pass.set_push_constant(&self.0, offset, data) {
-            self.handle_error_nolabel(
+            self.handle_error(
                 &pass_data.error_sink,
                 cause,
+                LABEL,
+                pass_data.pass.label(),
                 "ComputePass::set_push_constant",
             );
         }
@@ -2409,9 +2423,11 @@ impl crate::Context for ContextWgpuCore {
         label: &str,
     ) {
         if let Err(cause) = pass_data.pass.insert_debug_marker(&self.0, label, 0) {
-            self.handle_error_nolabel(
+            self.handle_error(
                 &pass_data.error_sink,
                 cause,
+                LABEL,
+                pass_data.pass.label(),
                 "ComputePass::insert_debug_marker",
             );
         }
@@ -2424,9 +2440,11 @@ impl crate::Context for ContextWgpuCore {
         group_label: &str,
     ) {
         if let Err(cause) = pass_data.pass.push_debug_group(&self.0, group_label, 0) {
-            self.handle_error_nolabel(
+            self.handle_error(
                 &pass_data.error_sink,
                 cause,
+                LABEL,
+                pass_data.pass.label(),
                 "ComputePass::push_debug_group",
             );
         }
@@ -2438,7 +2456,13 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::ComputePassData,
     ) {
         if let Err(cause) = pass_data.pass.pop_debug_group(&self.0) {
-            self.handle_error_nolabel(&pass_data.error_sink, cause, "ComputePass::pop_debug_group");
+            self.handle_error(
+                &pass_data.error_sink,
+                cause,
+                LABEL,
+                pass_data.pass.label(),
+                "ComputePass::pop_debug_group",
+            );
         }
     }
 
@@ -2454,7 +2478,13 @@ impl crate::Context for ContextWgpuCore {
             .pass
             .write_timestamp(&self.0, *query_set, query_index)
         {
-            self.handle_error_nolabel(&pass_data.error_sink, cause, "ComputePass::write_timestamp");
+            self.handle_error(
+                &pass_data.error_sink,
+                cause,
+                LABEL,
+                pass_data.pass.label(),
+                "ComputePass::write_timestamp",
+            );
         }
     }
 
@@ -2471,9 +2501,11 @@ impl crate::Context for ContextWgpuCore {
                 .pass
                 .begin_pipeline_statistics_query(&self.0, *query_set, query_index)
         {
-            self.handle_error_nolabel(
+            self.handle_error(
                 &pass_data.error_sink,
                 cause,
+                LABEL,
+                pass_data.pass.label(),
                 "ComputePass::begin_pipeline_statistics_query",
             );
         }
@@ -2485,9 +2517,11 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::ComputePassData,
     ) {
         if let Err(cause) = pass_data.pass.end_pipeline_statistics_query(&self.0) {
-            self.handle_error_nolabel(
+            self.handle_error(
                 &pass_data.error_sink,
                 cause,
+                LABEL,
+                pass_data.pass.label(),
                 "ComputePass::end_pipeline_statistics_query",
             );
         }
@@ -2502,9 +2536,11 @@ impl crate::Context for ContextWgpuCore {
         z: u32,
     ) {
         if let Err(cause) = pass_data.pass.dispatch_workgroups(&self.0, x, y, z) {
-            self.handle_error_nolabel(
+            self.handle_error(
                 &pass_data.error_sink,
                 cause,
+                LABEL,
+                pass_data.pass.label(),
                 "ComputePass::dispatch_workgroups",
             );
         }
@@ -2523,9 +2559,11 @@ impl crate::Context for ContextWgpuCore {
                 .pass
                 .dispatch_workgroups_indirect(&self.0, *indirect_buffer, indirect_offset)
         {
-            self.handle_error_nolabel(
+            self.handle_error(
                 &pass_data.error_sink,
                 cause,
+                LABEL,
+                pass_data.pass.label(),
                 "ComputePass::dispatch_workgroups_indirect",
             );
         }
@@ -2537,7 +2575,13 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::ComputePassData,
     ) {
         if let Err(cause) = pass_data.pass.end(&self.0) {
-            self.handle_error_nolabel(&pass_data.error_sink, cause, "ComputePass::end");
+            self.handle_error(
+                &pass_data.error_sink,
+                cause,
+                LABEL,
+                pass_data.pass.label(),
+                "ComputePass::end",
+            );
         }
     }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -3115,7 +3115,13 @@ impl crate::Context for ContextWgpuCore {
     ) {
         let encoder = pass_data.pass.parent_id();
         if let Err(cause) = wgc::gfx_select!(encoder => self.0.render_pass_end(&pass_data.pass)) {
-            self.handle_error_nolabel(&pass_data.error_sink, cause, "RenderPass::end");
+            self.handle_error(
+                &pass_data.error_sink,
+                cause,
+                LABEL,
+                pass_data.pass.label(),
+                "RenderPass::end",
+            );
         }
     }
 }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4697,13 +4697,9 @@ impl<'a> RenderPass<'a> {
 impl<'a> Drop for RenderPass<'a> {
     fn drop(&mut self) {
         if !thread::panicking() {
-            let parent_id = self.parent.id.as_ref().unwrap();
-            self.parent.context.command_encoder_end_render_pass(
-                parent_id,
-                self.parent.data.as_ref(),
-                &mut self.id,
-                self.data.as_mut(),
-            );
+            self.parent
+                .context
+                .render_pass_end(&mut self.id, self.data.as_mut());
         }
     }
 }
@@ -4875,13 +4871,9 @@ impl<'a> ComputePass<'a> {
 impl<'a> Drop for ComputePass<'a> {
     fn drop(&mut self) {
         if !thread::panicking() {
-            let parent_id = self.parent.id.as_ref().unwrap();
-            self.parent.context.command_encoder_end_compute_pass(
-                parent_id,
-                self.parent.data.as_ref(),
-                &mut self.id,
-                self.data.as_mut(),
-            );
+            self.parent
+                .context
+                .compute_pass_end(&mut self.id, self.data.as_mut());
         }
     }
 }


### PR DESCRIPTION
**Connections**
* Follow-up & based on #5570
     * ⚠️ Will rebase once #5570lands as this contains all the changes again.
* Puzzle piece, or rather "convenience refactor" on the way to #1453

Part of a series towards lifetime removal on compute passes:
* #5409
* #5432
* #5570
* ➡️ #5575
* #5620
* #5671


**Description**

* **avoid copies on compute pass end:**
   Some work in #5432 highlighted that a compute pass (render pass as well, but let's ignore this for now) isn't fully consumed during pass ending which means we have to do a couple of copies despite the fact that a pass can not be consumed twice.
* **error on ending compute pass twice:**
Any operation on an ended compute pass now causes an validation error (as it should per spec!). As expected this allows to remove a few copies (including needless reference count increment + decrement!). Naturally, this means now that *all* operations on the compute pass are failable
* **rename run to end, make end operation part of compute pass:**
Previously, ending a pass was seen as an operation on the command encoder across the api/crate layers. Now it is part of the render/compute pass in accordance with the WebGPU spec. This is relatively minor but also comes with an error check.
* **improve error handling:**
Compute pass errors make now use of its label

**Testing**
Existing tests still pass, should be enough for this one.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
