### PR TITLE
[core] Properly recycle `Device::temp_suspected`.

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -93,7 +93,7 @@ impl<A: HalApi> ResourceMaps<A> {
         destroyed_textures.clear();
     }
 
-    pub(crate) fn extend(&mut self, mut other: Self) {
+    pub(crate) fn extend(&mut self, other: &mut Self) {
         let ResourceMaps {
             buffers,
             staging_buffers,


### PR DESCRIPTION
Change the various uses of `Device::temp_suspected` to correctly
recycle its allocations when possible.

In the absence of errors, `Device::temp_suspected` is only used as
temporary storage within particular function calls, and is a field of
`Device` only as a way to recycle its allocations.

However, the code in `Global::queue_submit` that tries to use
`Device::temp_suspected` in this way doesn't quite pull it off.
It unconditionally replaces any prior `ResourceMaps` stored there
with a fresh empty one, clears the prior one, and then drops it,
wasting its allocations.

Rather than discard everything in `temp_selected` on every call to
`Device::maintain`, change `ResourceMaps::extend` to take the source
via `&mut` rather than by value, and have callers only obtain a `&mut`
to `Device::temp_selected`, rather than using `Option::take` to take
ownership of the value.
