### PR TITLE
[core] Add checked `RwLock`.

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -11,6 +11,7 @@ use crate::{
     id::{self, AdapterId, DeviceId, QueueId, SurfaceId},
     init_tracker::TextureInitTracker,
     instance::{self, Adapter, Surface},
+    lock::{rank, RwLock},
     pipeline, present,
     resource::{self, BufferAccessResult},
     resource::{BufferAccessError, BufferMapOperation, CreateBufferError, Resource},
@@ -20,7 +21,6 @@ use crate::{
 
 use arrayvec::ArrayVec;
 use hal::Device as _;
-use parking_lot::RwLock;
 
 use wgt::{BufferAddress, TextureFormat};
 
@@ -643,8 +643,10 @@ impl Global {
                 texture.hal_usage |= hal::TextureUses::COPY_DST;
             }
 
-            texture.initialization_status =
-                RwLock::new(TextureInitTracker::new(desc.mip_level_count, 0));
+            texture.initialization_status = RwLock::new(
+                rank::TEXTURE_INITIALIZATION_STATUS,
+                TextureInitTracker::new(desc.mip_level_count, 0),
+            );
 
             let (id, resource) = fid.assign(Arc::new(texture));
             api_log!("Device::create_texture({desc:?}) -> {id:?}");

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -18,7 +18,7 @@ use crate::{
         TextureInitTracker, TextureInitTrackerAction,
     },
     instance::Adapter,
-    lock::{rank, Mutex, MutexGuard},
+    lock::{rank, Mutex, MutexGuard, RwLock},
     pipeline,
     pool::ResourcePool,
     registry::Registry,
@@ -42,7 +42,6 @@ use crate::{
 use arrayvec::ArrayVec;
 use hal::{CommandEncoder as _, Device as _};
 use once_cell::sync::OnceCell;
-use parking_lot::RwLock;
 
 use smallvec::SmallVec;
 use thiserror::Error;
@@ -272,7 +271,7 @@ impl<A: HalApi> Device<A> {
             info: ResourceInfo::new("<device>", None),
             command_allocator,
             active_submission_index: AtomicU64::new(0),
-            fence: RwLock::new(Some(fence)),
+            fence: RwLock::new(rank::DEVICE_FENCE, Some(fence)),
             snatchable_lock: unsafe { SnatchLock::new(rank::DEVICE_SNATCHABLE_LOCK) },
             valid: AtomicBool::new(true),
             trackers: Mutex::new(rank::DEVICE_TRACKERS, Tracker::new()),
@@ -656,7 +655,10 @@ impl<A: HalApi> Device<A> {
             device: self.clone(),
             usage: desc.usage,
             size: desc.size,
-            initialization_status: RwLock::new(BufferInitTracker::new(aligned_size)),
+            initialization_status: RwLock::new(
+                rank::BUFFER_INITIALIZATION_STATUS,
+                BufferInitTracker::new(aligned_size),
+            ),
             sync_mapped_writes: Mutex::new(rank::BUFFER_SYNC_MAPPED_WRITES, None),
             map_state: Mutex::new(rank::BUFFER_MAP_STATE, resource::BufferMapState::Idle),
             info: ResourceInfo::new(
@@ -683,10 +685,10 @@ impl<A: HalApi> Device<A> {
             desc: desc.map_label(|_| ()),
             hal_usage,
             format_features,
-            initialization_status: RwLock::new(TextureInitTracker::new(
-                desc.mip_level_count,
-                desc.array_layer_count(),
-            )),
+            initialization_status: RwLock::new(
+                rank::TEXTURE_INITIALIZATION_STATUS,
+                TextureInitTracker::new(desc.mip_level_count, desc.array_layer_count()),
+            ),
             full_range: TextureSelector {
                 mips: 0..desc.mip_level_count,
                 layers: 0..desc.array_layer_count(),
@@ -695,7 +697,7 @@ impl<A: HalApi> Device<A> {
                 desc.label.borrow_or_default(),
                 Some(self.tracker_indices.textures.clone()),
             ),
-            clear_mode: RwLock::new(clear_mode),
+            clear_mode: RwLock::new(rank::TEXTURE_CLEAR_MODE, clear_mode),
             views: Mutex::new(rank::TEXTURE_VIEWS, Vec::new()),
             bind_groups: Mutex::new(rank::TEXTURE_BIND_GROUPS, Vec::new()),
         }
@@ -713,7 +715,10 @@ impl<A: HalApi> Device<A> {
             device: self.clone(),
             usage: desc.usage,
             size: desc.size,
-            initialization_status: RwLock::new(BufferInitTracker::new(0)),
+            initialization_status: RwLock::new(
+                rank::BUFFER_INITIALIZATION_STATUS,
+                BufferInitTracker::new(0),
+            ),
             sync_mapped_writes: Mutex::new(rank::BUFFER_SYNC_MAPPED_WRITES, None),
             map_state: Mutex::new(rank::BUFFER_MAP_STATE, resource::BufferMapState::Idle),
             info: ResourceInfo::new(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -273,7 +273,7 @@ impl<A: HalApi> Device<A> {
             command_allocator,
             active_submission_index: AtomicU64::new(0),
             fence: RwLock::new(Some(fence)),
-            snatchable_lock: unsafe { SnatchLock::new() },
+            snatchable_lock: unsafe { SnatchLock::new(rank::DEVICE_SNATCHABLE_LOCK) },
             valid: AtomicBool::new(true),
             trackers: Mutex::new(rank::DEVICE_TRACKERS, Tracker::new()),
             tracker_indices: TrackerIndexAllocators::new(),

--- a/wgpu-core/src/lock/mod.rs
+++ b/wgpu-core/src/lock/mod.rs
@@ -35,7 +35,7 @@ mod ranked;
 mod vanilla;
 
 #[cfg(wgpu_validate_locks)]
-pub use ranked::{Mutex, MutexGuard};
+pub use ranked::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[cfg(not(wgpu_validate_locks))]
-pub use vanilla::{Mutex, MutexGuard};
+pub use vanilla::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -55,9 +55,9 @@ macro_rules! define_lock_ranks {
         bitflags::bitflags! {
             #[derive(Debug, Copy, Clone, Eq, PartialEq)]
             /// A bitflags type representing a set of lock ranks.
-            pub struct LockRankSet: u32 {
+            pub struct LockRankSet: u64 {
                 $(
-                    const $name = 1 << (LockRankNumber:: $name as u32);
+                    const $name = 1 << (LockRankNumber:: $name as u64);
                 )*
             }
         }
@@ -143,6 +143,11 @@ define_lock_ranks! {
     rank DEVICE_USAGE_SCOPES "Device::usage_scopes" followed by { }
     rank IDENTITY_MANAGER_VALUES "IdentityManager::values" followed by { }
     rank REGISTRY_STORAGE "Registry::storage" followed by { }
+    rank RENDER_BUNDLE_SCOPE_BUFFERS "RenderBundleScope::buffers" followed by { }
+    rank RENDER_BUNDLE_SCOPE_TEXTURES "RenderBundleScope::textures" followed by { }
+    rank RENDER_BUNDLE_SCOPE_BIND_GROUPS "RenderBundleScope::bind_groups" followed by { }
+    rank RENDER_BUNDLE_SCOPE_RENDER_PIPELINES "RenderBundleScope::render_pipelines" followed by { }
+    rank RENDER_BUNDLE_SCOPE_QUERY_SETS "RenderBundleScope::query_sets" followed by { }
     rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { }
     rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { }
     rank STAGING_BUFFER_RAW "StagingBuffer::raw" followed by { }

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -142,6 +142,7 @@ define_lock_ranks! {
     rank DEVICE_TRACKERS "Device::trackers" followed by { }
     rank DEVICE_USAGE_SCOPES "Device::usage_scopes" followed by { }
     rank IDENTITY_MANAGER_VALUES "IdentityManager::values" followed by { }
+    rank REGISTRY_STORAGE "Registry::storage" followed by { }
     rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { }
     rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { }
     rank STAGING_BUFFER_RAW "StagingBuffer::raw" followed by { }

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -133,8 +133,10 @@ define_lock_ranks! {
 
     rank BUFFER_BIND_GROUPS "Buffer::bind_groups" followed by { }
     rank BUFFER_BIND_GROUP_STATE_BUFFERS "BufferBindGroupState::buffers" followed by { }
+    rank BUFFER_INITIALIZATION_STATUS "Buffer::initialization_status" followed by { }
     rank BUFFER_SYNC_MAPPED_WRITES "Buffer::sync_mapped_writes" followed by { }
     rank DEVICE_DEFERRED_DESTROY "Device::deferred_destroy" followed by { }
+    rank DEVICE_FENCE "Device::fence" followed by { }
     #[allow(dead_code)]
     rank DEVICE_TRACE "Device::trace" followed by { }
     rank DEVICE_TRACKERS "Device::trackers" followed by { }
@@ -147,6 +149,8 @@ define_lock_ranks! {
     rank SURFACE_PRESENTATION "Surface::presentation" followed by { }
     rank TEXTURE_BIND_GROUPS "Texture::bind_groups" followed by { }
     rank TEXTURE_BIND_GROUP_STATE_TEXTURES "TextureBindGroupState::textures" followed by { }
+    rank TEXTURE_INITIALIZATION_STATUS "Texture::initialization_status" followed by { }
+    rank TEXTURE_CLEAR_MODE "Texture::clear_mode" followed by { }
     rank TEXTURE_VIEWS "Texture::views" followed by { }
 
     #[cfg(test)]

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -45,7 +45,7 @@ macro_rules! define_lock_ranks {
     {
         $(
             $( #[ $attr:meta ] )*
-            rank $name:ident $member:literal followed by { $( $follower:ident ),* $(,)? };
+            rank $name:ident $member:literal followed by { $( $follower:ident ),* $(,)? }
         )*
     } => {
         // An enum that assigns a unique number to each rank.
@@ -94,50 +94,50 @@ define_lock_ranks! {
         TEXTURE_BIND_GROUP_STATE_TEXTURES,
         BUFFER_MAP_STATE,
         STATELESS_BIND_GROUP_STATE_RESOURCES,
-    };
-    rank STAGING_BUFFER_RAW "StagingBuffer::raw" followed by { };
+    }
+    rank STAGING_BUFFER_RAW "StagingBuffer::raw" followed by { }
     rank COMMAND_ALLOCATOR_FREE_ENCODERS "CommandAllocator::free_encoders" followed by {
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
-    };
-    rank DEVICE_TRACKERS "Device::trackers" followed by { };
+    }
+    rank DEVICE_TRACKERS "Device::trackers" followed by { }
     rank DEVICE_LIFE_TRACKER "Device::life_tracker" followed by {
         COMMAND_ALLOCATOR_FREE_ENCODERS,
         // Uncomment this to see an interesting cycle.
         // DEVICE_TEMP_SUSPECTED,
-    };
+    }
     rank DEVICE_TEMP_SUSPECTED "Device::temp_suspected" followed by {
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
         COMMAND_BUFFER_DATA,
         DEVICE_TRACKERS,
-    };
+    }
     rank DEVICE_PENDING_WRITES "Device::pending_writes" followed by {
         COMMAND_ALLOCATOR_FREE_ENCODERS,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
         DEVICE_LIFE_TRACKER,
-    };
-    rank DEVICE_DEFERRED_DESTROY "Device::deferred_destroy" followed by { };
+    }
+    rank DEVICE_DEFERRED_DESTROY "Device::deferred_destroy" followed by { }
     #[allow(dead_code)]
-    rank DEVICE_TRACE "Device::trace" followed by { };
-    rank DEVICE_USAGE_SCOPES "Device::usage_scopes" followed by { };
-    rank BUFFER_SYNC_MAPPED_WRITES "Buffer::sync_mapped_writes" followed by { };
-    rank BUFFER_MAP_STATE "Buffer::map_state" followed by { DEVICE_PENDING_WRITES };
-    rank BUFFER_BIND_GROUPS "Buffer::bind_groups" followed by { };
-    rank TEXTURE_VIEWS "Texture::views" followed by { };
-    rank TEXTURE_BIND_GROUPS "Texture::bind_groups" followed by { };
-    rank IDENTITY_MANAGER_VALUES "IdentityManager::values" followed by { };
-    rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { };
-    rank BUFFER_BIND_GROUP_STATE_BUFFERS "BufferBindGroupState::buffers" followed by { };
-    rank STATELESS_BIND_GROUP_STATE_RESOURCES "StatelessBindGroupState::resources" followed by { };
-    rank TEXTURE_BIND_GROUP_STATE_TEXTURES "TextureBindGroupState::textures" followed by { };
-    rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { };
-    rank SURFACE_PRESENTATION "Surface::presentation" followed by { };
+    rank DEVICE_TRACE "Device::trace" followed by { }
+    rank DEVICE_USAGE_SCOPES "Device::usage_scopes" followed by { }
+    rank BUFFER_SYNC_MAPPED_WRITES "Buffer::sync_mapped_writes" followed by { }
+    rank BUFFER_MAP_STATE "Buffer::map_state" followed by { DEVICE_PENDING_WRITES }
+    rank BUFFER_BIND_GROUPS "Buffer::bind_groups" followed by { }
+    rank TEXTURE_VIEWS "Texture::views" followed by { }
+    rank TEXTURE_BIND_GROUPS "Texture::bind_groups" followed by { }
+    rank IDENTITY_MANAGER_VALUES "IdentityManager::values" followed by { }
+    rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { }
+    rank BUFFER_BIND_GROUP_STATE_BUFFERS "BufferBindGroupState::buffers" followed by { }
+    rank STATELESS_BIND_GROUP_STATE_RESOURCES "StatelessBindGroupState::resources" followed by { }
+    rank TEXTURE_BIND_GROUP_STATE_TEXTURES "TextureBindGroupState::textures" followed by { }
+    rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { }
+    rank SURFACE_PRESENTATION "Surface::presentation" followed by { }
 
     #[cfg(test)]
-    rank PAWN "pawn" followed by { ROOK, BISHOP };
+    rank PAWN "pawn" followed by { ROOK, BISHOP }
     #[cfg(test)]
-    rank ROOK "rook" followed by { KNIGHT };
+    rank ROOK "rook" followed by { KNIGHT }
     #[cfg(test)]
-    rank KNIGHT "knight" followed by { };
+    rank KNIGHT "knight" followed by { }
     #[cfg(test)]
-    rank BISHOP "bishop" followed by { };
+    rank BISHOP "bishop" followed by { }
 }

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -87,7 +87,13 @@ macro_rules! define_lock_ranks {
 }
 
 define_lock_ranks! {
+    rank DEVICE_TEMP_SUSPECTED "Device::temp_suspected" followed by {
+        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
+        COMMAND_BUFFER_DATA,
+        DEVICE_TRACKERS,
+    }
     rank COMMAND_BUFFER_DATA "CommandBuffer::data" followed by {
+        DEVICE_SNATCHABLE_LOCK,
         DEVICE_USAGE_SCOPES,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
         BUFFER_BIND_GROUP_STATE_BUFFERS,
@@ -95,42 +101,53 @@ define_lock_ranks! {
         BUFFER_MAP_STATE,
         STATELESS_BIND_GROUP_STATE_RESOURCES,
     }
-    rank STAGING_BUFFER_RAW "StagingBuffer::raw" followed by { }
-    rank COMMAND_ALLOCATOR_FREE_ENCODERS "CommandAllocator::free_encoders" followed by {
+    rank DEVICE_SNATCHABLE_LOCK "Device::snatchable_lock" followed by {
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
-    }
-    rank DEVICE_TRACKERS "Device::trackers" followed by { }
-    rank DEVICE_LIFE_TRACKER "Device::life_tracker" followed by {
-        COMMAND_ALLOCATOR_FREE_ENCODERS,
+        DEVICE_TRACE,
+        BUFFER_MAP_STATE,
+        BUFFER_BIND_GROUP_STATE_BUFFERS,
+        TEXTURE_BIND_GROUP_STATE_TEXTURES,
+        STATELESS_BIND_GROUP_STATE_RESOURCES,
         // Uncomment this to see an interesting cycle.
-        // DEVICE_TEMP_SUSPECTED,
+        // COMMAND_BUFFER_DATA,
     }
-    rank DEVICE_TEMP_SUSPECTED "Device::temp_suspected" followed by {
+    rank BUFFER_MAP_STATE "Buffer::map_state" followed by {
+        DEVICE_PENDING_WRITES,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
-        COMMAND_BUFFER_DATA,
-        DEVICE_TRACKERS,
+        DEVICE_TRACE,
     }
     rank DEVICE_PENDING_WRITES "Device::pending_writes" followed by {
         COMMAND_ALLOCATOR_FREE_ENCODERS,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
         DEVICE_LIFE_TRACKER,
     }
+    rank DEVICE_LIFE_TRACKER "Device::life_tracker" followed by {
+        COMMAND_ALLOCATOR_FREE_ENCODERS,
+        // Uncomment this to see an interesting cycle.
+        // DEVICE_TEMP_SUSPECTED,
+        DEVICE_TRACE,
+    }
+    rank COMMAND_ALLOCATOR_FREE_ENCODERS "CommandAllocator::free_encoders" followed by {
+        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
+    }
+
+    rank BUFFER_BIND_GROUPS "Buffer::bind_groups" followed by { }
+    rank BUFFER_BIND_GROUP_STATE_BUFFERS "BufferBindGroupState::buffers" followed by { }
+    rank BUFFER_SYNC_MAPPED_WRITES "Buffer::sync_mapped_writes" followed by { }
     rank DEVICE_DEFERRED_DESTROY "Device::deferred_destroy" followed by { }
     #[allow(dead_code)]
     rank DEVICE_TRACE "Device::trace" followed by { }
+    rank DEVICE_TRACKERS "Device::trackers" followed by { }
     rank DEVICE_USAGE_SCOPES "Device::usage_scopes" followed by { }
-    rank BUFFER_SYNC_MAPPED_WRITES "Buffer::sync_mapped_writes" followed by { }
-    rank BUFFER_MAP_STATE "Buffer::map_state" followed by { DEVICE_PENDING_WRITES }
-    rank BUFFER_BIND_GROUPS "Buffer::bind_groups" followed by { }
-    rank TEXTURE_VIEWS "Texture::views" followed by { }
-    rank TEXTURE_BIND_GROUPS "Texture::bind_groups" followed by { }
     rank IDENTITY_MANAGER_VALUES "IdentityManager::values" followed by { }
     rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { }
-    rank BUFFER_BIND_GROUP_STATE_BUFFERS "BufferBindGroupState::buffers" followed by { }
-    rank STATELESS_BIND_GROUP_STATE_RESOURCES "StatelessBindGroupState::resources" followed by { }
-    rank TEXTURE_BIND_GROUP_STATE_TEXTURES "TextureBindGroupState::textures" followed by { }
     rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { }
+    rank STAGING_BUFFER_RAW "StagingBuffer::raw" followed by { }
+    rank STATELESS_BIND_GROUP_STATE_RESOURCES "StatelessBindGroupState::resources" followed by { }
     rank SURFACE_PRESENTATION "Surface::presentation" followed by { }
+    rank TEXTURE_BIND_GROUPS "Texture::bind_groups" followed by { }
+    rank TEXTURE_BIND_GROUP_STATE_TEXTURES "TextureBindGroupState::textures" followed by { }
+    rank TEXTURE_VIEWS "Texture::views" followed by { }
 
     #[cfg(test)]
     rank PAWN "pawn" followed by { ROOK, BISHOP }

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -104,7 +104,6 @@ impl LockState {
 }
 
 impl<T> Mutex<T> {
-    #[inline]
     pub fn new(rank: LockRank, value: T) -> Mutex<T> {
         Mutex {
             inner: parking_lot::Mutex::new(value),
@@ -112,7 +111,6 @@ impl<T> Mutex<T> {
         }
     }
 
-    #[inline]
     #[track_caller]
     pub fn lock(&self) -> MutexGuard<T> {
         let state = LOCK_STATE.get();

--- a/wgpu-core/src/lock/vanilla.rs
+++ b/wgpu-core/src/lock/vanilla.rs
@@ -21,12 +21,10 @@ pub struct Mutex<T>(parking_lot::Mutex<T>);
 pub struct MutexGuard<'a, T>(parking_lot::MutexGuard<'a, T>);
 
 impl<T> Mutex<T> {
-    #[inline]
     pub fn new(_rank: super::rank::LockRank, value: T) -> Mutex<T> {
         Mutex(parking_lot::Mutex::new(value))
     }
 
-    #[inline]
     pub fn lock(&self) -> MutexGuard<T> {
         MutexGuard(self.0.lock())
     }

--- a/wgpu-core/src/lock/vanilla.rs
+++ b/wgpu-core/src/lock/vanilla.rs
@@ -6,7 +6,7 @@
 /// A plain wrapper around [`parking_lot::Mutex`].
 ///
 /// This is just like [`parking_lot::Mutex`], except that our [`new`]
-/// method takes a rank, indicating where the new mutex should sitc in
+/// method takes a rank, indicating where the new mutex should sit in
 /// `wgpu-core`'s lock ordering. The rank is ignored.
 ///
 /// See the [`lock`] module documentation for other wrappers.
@@ -47,5 +47,69 @@ impl<'a, T> std::ops::DerefMut for MutexGuard<'a, T> {
 impl<T: std::fmt::Debug> std::fmt::Debug for Mutex<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+/// A plain wrapper around [`parking_lot::RwLock`].
+///
+/// This is just like [`parking_lot::RwLock`], except that our [`new`]
+/// method takes a rank, indicating where the new mutex should sit in
+/// `wgpu-core`'s lock ordering. The rank is ignored.
+///
+/// See the [`lock`] module documentation for other wrappers.
+///
+/// [`new`]: RwLock::new
+/// [`lock`]: crate::lock
+pub struct RwLock<T>(parking_lot::RwLock<T>);
+
+/// A read guard produced by locking [`RwLock`] as a reader.
+///
+/// This is just a wrapper around a [`parking_lot::RwLockReadGuard`].
+pub struct RwLockReadGuard<'a, T>(parking_lot::RwLockReadGuard<'a, T>);
+
+/// A write guard produced by locking [`RwLock`] as a writer.
+///
+/// This is just a wrapper around a [`parking_lot::RwLockWriteGuard`].
+pub struct RwLockWriteGuard<'a, T>(parking_lot::RwLockWriteGuard<'a, T>);
+
+impl<T> RwLock<T> {
+    pub fn new(_rank: super::rank::LockRank, value: T) -> RwLock<T> {
+        RwLock(parking_lot::RwLock::new(value))
+    }
+
+    pub fn read(&self) -> RwLockReadGuard<T> {
+        RwLockReadGuard(self.0.read())
+    }
+
+    pub fn write(&self) -> RwLockWriteGuard<T> {
+        RwLockWriteGuard(self.0.write())
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for RwLock<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'a, T> std::ops::Deref for RwLockReadGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<'a, T> std::ops::Deref for RwLockWriteGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<'a, T> std::ops::DerefMut for RwLockWriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.deref_mut()
     }
 }

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -21,14 +21,13 @@ use crate::{
     hal_api::HalApi,
     hal_label, id,
     init_tracker::TextureInitTracker,
-    lock::{rank, Mutex},
+    lock::{rank, Mutex, RwLock},
     resource::{self, ResourceInfo},
     snatch::Snatchable,
     track,
 };
 
 use hal::{Queue as _, Surface as _};
-use parking_lot::RwLock;
 use thiserror::Error;
 use wgt::SurfaceStatus as Status;
 
@@ -216,7 +215,10 @@ impl Global {
                     desc: texture_desc,
                     hal_usage,
                     format_features,
-                    initialization_status: RwLock::new(TextureInitTracker::new(1, 1)),
+                    initialization_status: RwLock::new(
+                        rank::TEXTURE_INITIALIZATION_STATUS,
+                        TextureInitTracker::new(1, 1),
+                    ),
                     full_range: track::TextureSelector {
                         layers: 0..1,
                         mips: 0..1,
@@ -225,9 +227,12 @@ impl Global {
                         "<Surface Texture>",
                         Some(device.tracker_indices.textures.clone()),
                     ),
-                    clear_mode: RwLock::new(resource::TextureClearMode::Surface {
-                        clear_view: Some(clear_view),
-                    }),
+                    clear_mode: RwLock::new(
+                        rank::TEXTURE_CLEAR_MODE,
+                        resource::TextureClearMode::Surface {
+                            clear_view: Some(clear_view),
+                        },
+                    ),
                     views: Mutex::new(rank::TEXTURE_VIEWS, Vec::new()),
                     bind_groups: Mutex::new(rank::TEXTURE_BIND_GROUPS, Vec::new()),
                 };

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use wgt::Backend;
 
 use crate::{
     id::Id,
     identity::IdentityManager,
+    lock::{rank, RwLock, RwLockReadGuard, RwLockWriteGuard},
     resource::Resource,
     storage::{Element, InvalidId, Storage},
 };
@@ -48,7 +48,7 @@ impl<T: Resource> Registry<T> {
     pub(crate) fn new(backend: Backend) -> Self {
         Self {
             identity: Arc::new(IdentityManager::new()),
-            storage: RwLock::new(Storage::new()),
+            storage: RwLock::new(rank::REGISTRY_STORAGE, Storage::new()),
             backend,
         }
     }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -13,7 +13,7 @@ use crate::{
         TextureViewId,
     },
     init_tracker::{BufferInitTracker, TextureInitTracker},
-    lock::Mutex,
+    lock::{Mutex, RwLock},
     resource, resource_log,
     snatch::{ExclusiveSnatchGuard, SnatchGuard, Snatchable},
     track::{SharedTrackerIndexAllocator, TextureSelector, TrackerIndex},
@@ -22,7 +22,6 @@ use crate::{
 };
 
 use hal::CommandEncoder;
-use parking_lot::RwLock;
 use smallvec::SmallVec;
 use thiserror::Error;
 use wgt::WasmNotSendSync;

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -1,12 +1,14 @@
 #![allow(unused)]
 
-use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use crate::lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{
     backtrace::Backtrace,
     cell::{Cell, RefCell, UnsafeCell},
     panic::{self, Location},
     thread,
 };
+
+use crate::lock::rank;
 
 /// A guard that provides read access to snatchable data.
 pub struct SnatchGuard<'a>(RwLockReadGuard<'a, ()>);
@@ -128,9 +130,9 @@ impl SnatchLock {
     /// right SnatchLock (the one associated to the same device). This method is unsafe
     /// to force force sers to think twice about creating a SnatchLock. The only place this
     /// method should be called is when creating the device.
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(rank: rank::LockRank) -> Self {
         SnatchLock {
-            lock: RwLock::new(()),
+            lock: RwLock::new(rank, ()),
         }
     }
 

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -105,12 +105,11 @@ use crate::{
     binding_model, command, conv,
     hal_api::HalApi,
     id,
-    lock::{rank, Mutex},
+    lock::{rank, Mutex, RwLock},
     pipeline, resource,
     snatch::SnatchGuard,
 };
 
-use parking_lot::RwLock;
 use std::{fmt, ops, sync::Arc};
 use thiserror::Error;
 
@@ -489,11 +488,26 @@ impl<A: HalApi> RenderBundleScope<A> {
     /// Create the render bundle scope and pull the maximum IDs from the hubs.
     pub fn new() -> Self {
         Self {
-            buffers: RwLock::new(BufferUsageScope::default()),
-            textures: RwLock::new(TextureUsageScope::default()),
-            bind_groups: RwLock::new(StatelessTracker::new()),
-            render_pipelines: RwLock::new(StatelessTracker::new()),
-            query_sets: RwLock::new(StatelessTracker::new()),
+            buffers: RwLock::new(
+                rank::RENDER_BUNDLE_SCOPE_BUFFERS,
+                BufferUsageScope::default(),
+            ),
+            textures: RwLock::new(
+                rank::RENDER_BUNDLE_SCOPE_TEXTURES,
+                TextureUsageScope::default(),
+            ),
+            bind_groups: RwLock::new(
+                rank::RENDER_BUNDLE_SCOPE_BIND_GROUPS,
+                StatelessTracker::new(),
+            ),
+            render_pipelines: RwLock::new(
+                rank::RENDER_BUNDLE_SCOPE_RENDER_PIPELINES,
+                StatelessTracker::new(),
+            ),
+            query_sets: RwLock::new(
+                rank::RENDER_BUNDLE_SCOPE_QUERY_SETS,
+                StatelessTracker::new(),
+            ),
         }
     }
 


### PR DESCRIPTION
Add a ranked wrapper for `RwLock` to `wgpu_core::lock`, with `vanilla` and `ranked` implementations, the latter selected with the `wgpu_validate_locks` cfg. Use this wrapper everywhere in `wgpu-core` instead of `parking_lot::RwLock`.

-   [core] Use `lock::RwLock` in `RenderBundleScope`.
    
    This requires bumping the `LockRankSet` bitset from `u32` to `u64`.

-   [core] Use `lock::RwLock` in `Registry`.

-   [core] Use `lock::RwLock` in `Buffer` and `Texture`.

-   [core] Include `SnatchLock` in lock rankings.

-   [core] Add checked `RwLock`.

-   [core] Abstract out checking code in `lock::ranked`.
    
    Introduce two new private functions, `acquire` and `release`, to the
    `lock::ranked` module, to perform validation for acquiring and
    releasing locks. Change `Mutex::lock` and `MutexGuard::drop` to use
    those functions, rather than writing out their contents.

-   [core] Remove unnecessary `#[inline]` attributes in `lock` module.

-   [core] Remove semicolon from lock rank macro syntax.
    
    In `define_lock_ranks!` macro invocations, don't require a semicolon
    after each rank's "followed by" list.
