### PR TITLE
refactor(naga): remove extraneous leading path qualifiers

### DIFF
--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -950,10 +950,10 @@ impl<'a> ConstantEvaluator<'a> {
         pattern: [crate::SwizzleComponent; 4],
     ) -> Result<Handle<Expression>, ConstantEvaluatorError> {
         let mut get_dst_ty = |ty| match self.types[ty].inner {
-            crate::TypeInner::Vector { size: _, scalar } => Ok(self.types.insert(
+            TypeInner::Vector { size: _, scalar } => Ok(self.types.insert(
                 Type {
                     name: None,
-                    inner: crate::TypeInner::Vector { size, scalar },
+                    inner: TypeInner::Vector { size, scalar },
                 },
                 span,
             )),
@@ -1244,13 +1244,11 @@ impl<'a> ConstantEvaluator<'a> {
             Expression::ZeroValue(ty) | Expression::Compose { ty, .. } => {
                 match self.types[ty].inner {
                     TypeInner::Array { size, .. } => match size {
-                        crate::ArraySize::Constant(len) => {
+                        ArraySize::Constant(len) => {
                             let expr = Expression::Literal(Literal::U32(len.get()));
                             self.register_evaluated_expr(expr, span)
                         }
-                        crate::ArraySize::Dynamic => {
-                            Err(ConstantEvaluatorError::ArrayLengthDynamic)
-                        }
+                        ArraySize::Dynamic => Err(ConstantEvaluatorError::ArrayLengthDynamic),
                     },
                     _ => Err(ConstantEvaluatorError::InvalidArrayLengthArg),
                 }
@@ -1313,7 +1311,7 @@ impl<'a> ConstantEvaluator<'a> {
             Expression::ZeroValue(ty)
                 if matches!(
                     self.types[ty].inner,
-                    crate::TypeInner::Scalar(crate::Scalar {
+                    TypeInner::Scalar(crate::Scalar {
                         kind: ScalarKind::Uint,
                         ..
                     })
@@ -1628,7 +1626,7 @@ impl<'a> ConstantEvaluator<'a> {
             return self.cast(expr, target, span);
         };
 
-        let crate::TypeInner::Array {
+        let TypeInner::Array {
             base: _,
             size,
             stride: _,

--- a/naga/src/proc/index.rs
+++ b/naga/src/proc/index.rs
@@ -239,7 +239,7 @@ pub enum GuardedIndex {
 pub fn find_checked_indexes(
     module: &crate::Module,
     function: &crate::Function,
-    info: &crate::valid::FunctionInfo,
+    info: &valid::FunctionInfo,
     policies: BoundsCheckPolicies,
 ) -> BitSet {
     use crate::Expression as Ex;
@@ -321,7 +321,7 @@ pub fn access_needs_check(
     mut index: GuardedIndex,
     module: &crate::Module,
     function: &crate::Function,
-    info: &crate::valid::FunctionInfo,
+    info: &valid::FunctionInfo,
 ) -> Option<IndexableLength> {
     let base_inner = info[base].ty.inner_with(&module.types);
     // Unwrap safety: `Err` here indicates unindexable base types and invalid

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -136,7 +136,7 @@ impl<E> fmt::Display for WithSpan<E>
 where
     E: fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }
@@ -304,7 +304,7 @@ impl<E> WithSpan<E> {
         use term::termcolor::NoColor;
 
         let files = files::SimpleFile::new(path, source);
-        let config = codespan_reporting::term::Config::default();
+        let config = term::Config::default();
         let mut writer = NoColor::new(Vec::new());
         term::emit(&mut writer, &config, &files, &self.diagnostic()).expect("cannot write error");
         String::from_utf8(writer.into_inner()).unwrap()

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -835,7 +835,7 @@ impl FunctionInfo {
                         let req = self.expressions[expr.index()].uniformity.requirements;
                         if self
                             .flags
-                            .contains(super::ValidationFlags::CONTROL_FLOW_UNIFORMITY)
+                            .contains(ValidationFlags::CONTROL_FLOW_UNIFORMITY)
                             && !req.is_empty()
                         {
                             if let Some(cause) = disruptor {

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -194,7 +194,7 @@ impl super::Validator {
         use crate::Expression as E;
 
         if !global_expr_kind.is_const_or_override(handle) {
-            return Err(super::ConstExpressionError::NonConstOrOverride);
+            return Err(ConstExpressionError::NonConstOrOverride);
         }
 
         match gctx.global_expressions[handle] {
@@ -211,10 +211,10 @@ impl super::Validator {
             }
             E::Splat { value, .. } => match *mod_info[value].inner_with(gctx.types) {
                 crate::TypeInner::Scalar { .. } => {}
-                _ => return Err(super::ConstExpressionError::InvalidSplatType(value)),
+                _ => return Err(ConstExpressionError::InvalidSplatType(value)),
             },
             _ if global_expr_kind.is_const(handle) || !self.allow_overrides => {
-                return Err(super::ConstExpressionError::NonFullyEvaluatedConst)
+                return Err(ConstExpressionError::NonFullyEvaluatedConst)
             }
             // the constant evaluator will report errors about override-expressions
             _ => {}


### PR DESCRIPTION
Implemented by `cargo +nightly fix -p naga --lib` on the 2023-05-31 nightly build of the Rust toolchain.