### PR TITLE
Fix Subgroup Ops on VK 1.2 Device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Bug Fixes
+
+#### Vulkan
+
+- Fix enablement of subgroup ops extension on Vulkan devices that don't support Vulkan 1.3. By @cwfitzgerald in [#5624](https://github.com/gfx-rs/wgpu/pull/5624).
+
 ## v0.20.0 (2024-04-28)
 
 ### Major Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,10 +78,13 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 #### Vulkan
 
+- Fix enablement of subgroup ops extension on Vulkan devices that don't support Vulkan 1.3. By @cwfitzgerald in [#5624](https://github.com/gfx-rs/wgpu/pull/5624).
+
+#### GLES / OpenGL
+
 -  Fix regression on OpenGL (EGL) where non-sRGB still used sRGB [#5642](https://github.com/gfx-rs/wgpu/pull/5642)
 -  Fix `ClearColorF`, `ClearColorU` and `ClearColorI` commands being issued before `SetDrawColorBuffers` [#5666](https://github.com/gfx-rs/wgpu/pull/5666)
 -  Replace `glClear` with `glClearBufferF` because `glDrawBuffers` requires that the ith buffer must be `COLOR_ATTACHMENTi` or `NONE` [#5666](https://github.com/gfx-rs/wgpu/pull/5666)
-- Fix enablement of subgroup ops extension on Vulkan devices that don't support Vulkan 1.3. By @cwfitzgerald in [#5624](https://github.com/gfx-rs/wgpu/pull/5624).
 
 ## v0.20.0 (2024-04-28)
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -952,8 +952,8 @@ impl PhysicalDeviceProperties {
                 extensions.push(vk::ExtImageRobustnessFn::name());
             }
 
-            // Require `VK_EXT_subgroup_size_control` if the associated feature was requested
-            if requested_features.contains(wgt::Features::SUBGROUP) {
+            // Require `VK_EXT_subgroup_size_control` if it is available
+            if self.supports_extension(vk::ExtSubgroupSizeControlFn::name()) {
                 extensions.push(vk::ExtSubgroupSizeControlFn::name());
             }
         }

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -953,7 +953,7 @@ impl PhysicalDeviceProperties {
             }
 
             // Require `VK_EXT_subgroup_size_control` if it is available
-            if self.supports_extension(vk::ExtSubgroupSizeControlFn::name()) {
+            if requested_features.contains(wgt::Features::SUBGROUP) {
                 extensions.push(vk::ExtSubgroupSizeControlFn::name());
             }
         }
@@ -1485,9 +1485,6 @@ impl super::Instance {
                 }),
             image_format_list: phd_capabilities.device_api_version >= vk::API_VERSION_1_2
                 || phd_capabilities.supports_extension(vk::KhrImageFormatListFn::name()),
-            subgroup_size_control: phd_features
-                .subgroup_size_control
-                .map_or(false, |ext| ext.subgroup_size_control == vk::TRUE),
         };
         let capabilities = crate::Capabilities {
             limits: phd_capabilities.to_wgpu_limits(),
@@ -1792,6 +1789,7 @@ impl super::Adapter {
             vendor_id: self.phd_capabilities.properties.vendor_id,
             timestamp_period: self.phd_capabilities.properties.limits.timestamp_period,
             private_caps: self.private_caps.clone(),
+            features,
             workarounds: self.workarounds,
             render_passes: Mutex::new(Default::default()),
             framebuffers: Mutex::new(Default::default()),

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -918,7 +918,7 @@ impl PhysicalDeviceProperties {
                 extensions.push(ext::image_robustness::NAME);
             }
 
-            // Require `VK_EXT_subgroup_size_control` if it is available
+            // Require `VK_EXT_subgroup_size_control` if the associated feature was requested
             if requested_features.contains(wgt::Features::SUBGROUP) {
                 extensions.push(ext::subgroup_size_control::NAME);
             }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -789,7 +789,7 @@ impl super::Device {
         };
 
         let mut flags = vk::PipelineShaderStageCreateFlags::empty();
-        if self.shared.private_caps.subgroup_size_control {
+        if self.shared.features.contains(wgt::Features::SUBGROUP) {
             flags |= vk::PipelineShaderStageCreateFlags::ALLOW_VARYING_SUBGROUP_SIZE
         }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -238,7 +238,6 @@ struct PrivateCapabilities {
     robust_image_access2: bool,
     zero_initialize_workgroup_memory: bool,
     image_format_list: bool,
-    subgroup_size_control: bool,
 }
 
 bitflags::bitflags!(
@@ -344,6 +343,7 @@ struct DeviceShared {
     timestamp_period: f32,
     private_caps: PrivateCapabilities,
     workarounds: Workarounds,
+    features: wgt::Features,
     render_passes: Mutex<rustc_hash::FxHashMap<RenderPassKey, vk::RenderPass>>,
     framebuffers: Mutex<rustc_hash::FxHashMap<FramebufferKey, vk::Framebuffer>>,
 }


### PR DESCRIPTION
**Connections**

Closes #5551 

**Description**

Our subgroup code assumed that if the physical device supported it, we would enable the extension. However the extension enablement code checked if the user actually asked for subgroup ops.
