### PR TITLE
Fix Failure Case for MacOS 14.3

### DIFF
--- a/tests/tests/subgroup_operations/mod.rs
+++ b/tests/tests/subgroup_operations/mod.rs
@@ -11,10 +11,22 @@ static SUBGROUP_OPERATIONS: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .features(wgpu::Features::SUBGROUP)
             .limits(wgpu::Limits::downlevel_defaults())
-            .expect_fail(wgpu_test::FailureCase::molten_vk())
+            // Expect metal to fail on tests involving operations in divergent control flow
+            //
+            // Newlines are included in the panic message to ensure that _additional_ failures
+            // are not matched against.
             .expect_fail(
-                // Expect metal to fail on tests involving operations in divergent control flow
+                wgpu_test::FailureCase::molten_vk()
+                    // 14.3 doesn't fail test 29
+                    .panic("thread 0 failed tests: 27,\nthread 1 failed tests: 27, 28,\n")
+                    // Prior versions do.
+                    .panic("thread 0 failed tests: 27, 29,\nthread 1 failed tests: 27, 28, 29,\n"),
+            )
+            .expect_fail(
                 wgpu_test::FailureCase::backend(wgpu::Backends::METAL)
+                    // 14.3 doesn't fail test 29
+                    .panic("thread 0 failed tests: 27,\nthread 1 failed tests: 27, 28,\n")
+                    // Prior versions do.
                     .panic("thread 0 failed tests: 27, 29,\nthread 1 failed tests: 27, 28, 29,\n"),
             ),
     )

--- a/tests/tests/subgroup_operations/shader.wgsl
+++ b/tests/tests/subgroup_operations/shader.wgsl
@@ -111,6 +111,7 @@ fn main(
     add_result_to_mask(&passed, 25u, subgroup_invocation_id == 0u || subgroupShuffleUp(subgroup_invocation_id, 1u) == subgroup_invocation_id - 1u);
     add_result_to_mask(&passed, 26u, subgroupShuffleXor(subgroup_invocation_id, subgroup_size - 1u) == (subgroup_invocation_id ^ (subgroup_size - 1u)));
 
+    // Mac/Apple will fail this test.
     var passed_27 = false;
     if subgroup_invocation_id % 2u == 0u {
         passed_27 |= subgroupAdd(1u) == (subgroup_size / 2u);
@@ -119,6 +120,7 @@ fn main(
     }
     add_result_to_mask(&passed, 27u, passed_27);
 
+    // Mac/Apple will fail this test.
     var passed_28 = false;
     switch subgroup_invocation_id % 3u {
         case 0u: {
@@ -134,6 +136,7 @@ fn main(
     }
     add_result_to_mask(&passed, 28u, passed_28);
 
+    // Mac/Apple will sometimes fail this test. MacOS 14.3 passes it, so the bug in the metal compiler seems to be fixed.
     expected = 0u;
     for (var i = subgroup_size; i >= 0u; i -= 1u) {
         expected = subgroupAdd(1u);


### PR DESCRIPTION
MacOS 14 seemed to fix some issues around subgroup op re-convergence, so we have a test now succeeding when it didn't before.

Fixed the cases, but also added some commentary on what's going on.