### PR TITLE
[core] Ensure all lock guards are properly nested.

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2033,7 +2033,6 @@ impl Global {
                 // Wait for all work to finish before configuring the surface.
                 let snatch_guard = device.snatchable_lock.read();
                 let fence = device.fence.read();
-                let fence = fence.as_ref().unwrap();
                 match device.maintain(fence, wgt::Maintain::Wait, snatch_guard) {
                     Ok((closures, _)) => {
                         user_callbacks = closures;
@@ -2146,7 +2145,6 @@ impl Global {
     ) -> Result<DevicePoll, WaitIdleError> {
         let snatch_guard = device.snatchable_lock.read();
         let fence = device.fence.read();
-        let fence = fence.as_ref().unwrap();
         let (closures, queue_empty) = device.maintain(fence, maintain, snatch_guard)?;
 
         // Some deferred destroys are scheduled in maintain so run this right after

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -281,6 +281,15 @@ impl<T> RwLock<T> {
     }
 }
 
+impl<'a, T> RwLockWriteGuard<'a, T> {
+    pub fn downgrade(this: Self) -> RwLockReadGuard<'a, T> {
+        RwLockReadGuard {
+            inner: parking_lot::RwLockWriteGuard::downgrade(this.inner),
+            saved: this.saved,
+        }
+    }
+}
+
 impl<T: std::fmt::Debug> std::fmt::Debug for RwLock<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.inner.fmt(f)

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -81,7 +81,7 @@ pub struct Mutex<T> {
 /// [mod]: crate::lock::ranked
 pub struct MutexGuard<'a, T> {
     inner: parking_lot::MutexGuard<'a, T>,
-    saved: LockState,
+    saved: LockStateGuard,
 }
 
 thread_local! {
@@ -105,6 +105,26 @@ impl LockState {
         last_acquired: None,
         depth: 0,
     };
+}
+
+/// A container that restores a [`LockState`] when dropped.
+///
+/// This type serves two purposes:
+///
+/// - Operations like `RwLockWriteGuard::downgrade` would like to be able to
+///   destructure lock guards and reassemble their pieces into new guards, but
+///   if the guard type itself implements `Drop`, we can't destructure it
+///   without unsafe code or pointless `Option`s whose state is almost always
+///   statically known.
+///
+/// - We can just implement `Drop` for this type once, and then use it in lock
+///   guards, rather than implementing `Drop` separately for each guard type.
+struct LockStateGuard(LockState);
+
+impl Drop for LockStateGuard {
+    fn drop(&mut self) {
+        release(self.0)
+    }
 }
 
 /// Check and record the acquisition of a lock with `new_rank`.
@@ -170,14 +190,8 @@ impl<T> Mutex<T> {
         let saved = acquire(self.rank, Location::caller());
         MutexGuard {
             inner: self.inner.lock(),
-            saved,
+            saved: LockStateGuard(saved),
         }
-    }
-}
-
-impl<'a, T> Drop for MutexGuard<'a, T> {
-    fn drop(&mut self) {
-        release(self.saved);
     }
 }
 
@@ -224,7 +238,7 @@ pub struct RwLock<T> {
 /// [mod]: crate::lock::ranked
 pub struct RwLockReadGuard<'a, T> {
     inner: parking_lot::RwLockReadGuard<'a, T>,
-    saved: LockState,
+    saved: LockStateGuard,
 }
 
 /// A write guard produced by locking [`RwLock`] for writing.
@@ -237,7 +251,7 @@ pub struct RwLockReadGuard<'a, T> {
 /// [mod]: crate::lock::ranked
 pub struct RwLockWriteGuard<'a, T> {
     inner: parking_lot::RwLockWriteGuard<'a, T>,
-    saved: LockState,
+    saved: LockStateGuard,
 }
 
 impl<T> RwLock<T> {
@@ -253,7 +267,7 @@ impl<T> RwLock<T> {
         let saved = acquire(self.rank, Location::caller());
         RwLockReadGuard {
             inner: self.inner.read(),
-            saved,
+            saved: LockStateGuard(saved),
         }
     }
 
@@ -262,7 +276,7 @@ impl<T> RwLock<T> {
         let saved = acquire(self.rank, Location::caller());
         RwLockWriteGuard {
             inner: self.inner.write(),
-            saved,
+            saved: LockStateGuard(saved),
         }
     }
 }
@@ -270,18 +284,6 @@ impl<T> RwLock<T> {
 impl<T: std::fmt::Debug> std::fmt::Debug for RwLock<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.inner.fmt(f)
-    }
-}
-
-impl<'a, T> Drop for RwLockReadGuard<'a, T> {
-    fn drop(&mut self) {
-        release(self.saved);
-    }
-}
-
-impl<'a, T> Drop for RwLockWriteGuard<'a, T> {
-    fn drop(&mut self) {
-        release(self.saved);
     }
 }
 

--- a/wgpu-core/src/lock/vanilla.rs
+++ b/wgpu-core/src/lock/vanilla.rs
@@ -86,6 +86,12 @@ impl<T> RwLock<T> {
     }
 }
 
+impl<'a, T> RwLockWriteGuard<'a, T> {
+    pub fn downgrade(this: Self) -> RwLockReadGuard<'a, T> {
+        RwLockReadGuard(parking_lot::RwLockWriteGuard::downgrade(this.0))
+    }
+}
+
 impl<T: std::fmt::Debug> std::fmt::Debug for RwLock<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)


### PR DESCRIPTION
The lock analyzers in the `wgpu_core::lock` module can be a bit
simpler if they can assume that locks are acquired and released in a
stack-like order: that a guard is only dropped when it is the most
recently acquired lock guard still held. So:

- Change `Device::maintain` to take a `RwLockReadGuard` for the device's hal fence, rather than just a reference to it.

- Adjust the order in which guards are dropped in `Device::maintain` and `Queue::submit`.

- Implement `downgrade` for the `lock` module's `RwLock`s.

    Implement `RwLockWriteGuard::downgrade` for `lock::vanilla` and `lock::ranked`, to downgrade a write lock to a read lock.

- Refactor `lock::ranked` to use `LockStateGuard`.

  Rather than implementing `Drop` for all three lock guard types to restore the lock analysis' per-thread state, let lock guards own values of a new type, `LockStateGuard`, with the appropriate `Drop` implementation. This is cleaner and shorter, and helps us implement `RwLock::downgrade` in a later commit.

Fixes #5610.
