### PR TITLE
Seperate GLES and GL version selection

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -550,21 +550,25 @@ impl Inner {
         let supports_khr_context = display_extensions.contains("EGL_KHR_create_context");
 
         //TODO: make it so `Device` == EGL Context
-        let mut context_attributes = vec![
-            khronos_egl::CONTEXT_MAJOR_VERSION,
-            3, // Request GLES 3.0 or higher
-        ];
-
-        if force_gles_minor_version != wgt::Gles3MinorVersion::Automatic {
+        let mut context_attributes = vec![];
+        if !supports_opengl {
+            context_attributes.push(khronos_egl::CONTEXT_MAJOR_VERSION);
+            context_attributes.push(3); // Request GLES 3.0 or higher
+            if force_gles_minor_version != wgt::Gles3MinorVersion::Automatic {
+                context_attributes.push(khronos_egl::CONTEXT_MINOR_VERSION);
+                context_attributes.push(match force_gles_minor_version {
+                    wgt::Gles3MinorVersion::Version0 => 0,
+                    wgt::Gles3MinorVersion::Version1 => 1,
+                    wgt::Gles3MinorVersion::Version2 => 2,
+                    _ => unreachable!(),
+                });
+            }
+        } else {
+            context_attributes.push(khronos_egl::CONTEXT_MAJOR_VERSION);
+            context_attributes.push(3);
             context_attributes.push(khronos_egl::CONTEXT_MINOR_VERSION);
-            context_attributes.push(match force_gles_minor_version {
-                wgt::Gles3MinorVersion::Version0 => 0,
-                wgt::Gles3MinorVersion::Version1 => 1,
-                wgt::Gles3MinorVersion::Version2 => 2,
-                _ => unreachable!(),
-            });
+            context_attributes.push(3);
         }
-
         if flags.contains(wgt::InstanceFlags::DEBUG) {
             if version >= (1, 5) {
                 log::debug!("\tEGL context: +debug");
@@ -594,8 +598,6 @@ impl Inner {
                 // because it's for desktop GL only, not GLES.
                 log::warn!("\tEGL context: -robust access");
             }
-
-            //TODO do we need `khronos_egl::CONTEXT_OPENGL_NOTIFICATION_STRATEGY_EXT`?
         }
         if khr_context_flags != 0 {
             context_attributes.push(EGL_CONTEXT_FLAGS_KHR);

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -549,25 +549,27 @@ impl Inner {
         let mut khr_context_flags = 0;
         let supports_khr_context = display_extensions.contains("EGL_KHR_create_context");
 
-        //TODO: make it so `Device` == EGL Context
         let mut context_attributes = vec![];
-        if !supports_opengl {
+        if supports_opengl {
+            context_attributes.push(khronos_egl::CONTEXT_MAJOR_VERSION);
+            context_attributes.push(3);
+            context_attributes.push(khronos_egl::CONTEXT_MINOR_VERSION);
+            context_attributes.push(3);
+            if force_gles_minor_version != wgt::Gles3MinorVersion::Automatic {
+                log::warn!("Ignoring specified GLES minor version as OpenGL is used");
+            }
+        } else {
             context_attributes.push(khronos_egl::CONTEXT_MAJOR_VERSION);
             context_attributes.push(3); // Request GLES 3.0 or higher
             if force_gles_minor_version != wgt::Gles3MinorVersion::Automatic {
                 context_attributes.push(khronos_egl::CONTEXT_MINOR_VERSION);
                 context_attributes.push(match force_gles_minor_version {
+                    wgt::Gles3MinorVersion::Automatic => unreachable!(),
                     wgt::Gles3MinorVersion::Version0 => 0,
                     wgt::Gles3MinorVersion::Version1 => 1,
                     wgt::Gles3MinorVersion::Version2 => 2,
-                    _ => unreachable!(),
                 });
             }
-        } else {
-            context_attributes.push(khronos_egl::CONTEXT_MAJOR_VERSION);
-            context_attributes.push(3);
-            context_attributes.push(khronos_egl::CONTEXT_MINOR_VERSION);
-            context_attributes.push(3);
         }
         if flags.contains(wgt::InstanceFlags::DEBUG) {
             if version >= (1, 5) {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7094,7 +7094,7 @@ pub struct InstanceDescriptor {
     pub flags: InstanceFlags,
     /// Which DX12 shader compiler to use.
     pub dx12_shader_compiler: Dx12Compiler,
-    /// Which OpenGL ES 3 minor version to request.
+    /// Which OpenGL ES 3 minor version to request. Will be ignored if OpenGL is available.
     pub gles_minor_version: Gles3MinorVersion,
 }
 


### PR DESCRIPTION
**Connections**

**Description**
Was wondering why compatibility profile was selected, and its because it falsely used the GLES version for Desktop GL.

Now it only applies to GLES, and for Desktop the minimum required version is 3.3

**Testing**
_Explain how this change is tested._

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
