### PR TITLE
Issue SetDrawColorBuffers before clearing buffers in GLES, use clear_buffer_f32_slice instead of clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 #### GLES / OpenGL
 
 -  Fix regression on OpenGL (EGL) where non-sRGB still used sRGB [#5642](https://github.com/gfx-rs/wgpu/pull/5642)
+-  Fix `ClearColorF`, `ClearColorU` and `ClearColorI` commands being issued before `SetDrawColorBuffers` [#5666](https://github.com/gfx-rs/wgpu/pull/5666)
+-  Replace `glClear` with `glClearBufferF` because `glDrawBuffers` requires that the ith buffer must be `COLOR_ATTACHMENTi` or `NONE` [#5666](https://github.com/gfx-rs/wgpu/pull/5666)
 
 ## v0.20.0 (2024-04-28)
 

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -604,6 +604,14 @@ impl crate::CommandEncoder for super::CommandEncoder {
             depth: 0.0..1.0,
         });
 
+
+        if !rendering_to_external_framebuffer {
+            // set the draw buffers and states
+            self.cmd_buffer
+                .commands
+                .push(C::SetDrawColorBuffers(desc.color_attachments.len() as u8));
+        }
+
         // issue the clears
         for (i, cat) in desc
             .color_attachments
@@ -632,13 +640,6 @@ impl crate::CommandEncoder for super::CommandEncoder {
                     },
                 );
             }
-        }
-
-        if !rendering_to_external_framebuffer {
-            // set the draw buffers and states
-            self.cmd_buffer
-                .commands
-                .push(C::SetDrawColorBuffers(desc.color_attachments.len() as u8));
         }
 
         if let Some(ref dsat) = desc.depth_stencil_attachment {

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -604,7 +604,6 @@ impl crate::CommandEncoder for super::CommandEncoder {
             depth: 0.0..1.0,
         });
 
-
         if !rendering_to_external_framebuffer {
             // set the draw buffers and states
             self.cmd_buffer

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1075,13 +1075,7 @@ impl super::Queue {
                 {
                     unsafe { self.perform_shader_clear(gl, draw_buffer, *color) };
                 } else {
-                    // Prefer `clear` as `clear_buffer` functions have issues on Sandy Bridge
-                    // on Windows.
-                    unsafe {
-                        gl.draw_buffers(&[glow::COLOR_ATTACHMENT0 + draw_buffer]);
-                        gl.clear_color(color[0], color[1], color[2], color[3]);
-                        gl.clear(glow::COLOR_BUFFER_BIT);
-                    }
+                    unsafe { gl.clear_buffer_f32_slice(glow::COLOR, draw_buffer, color) };
                 }
             }
             C::ClearColorU(draw_buffer, ref color) => {


### PR DESCRIPTION
**Description**

Currently, CommandEncoder issues `SetDrawColorBuffers` after issuing `ClearColorF`, `ClearColorU` and `ClearColorI`. On AMD Renoir graphics on Linux, this results in `glClearBuffer` calls sometimes being ignored. I can see the `glClearBuffer` calls in RenderDoc, but the output texture is not cleared. I suspect that this may also be the cause of some of the crashes on other machines (e.g. Sandy Bridge on Windows).

It seems that the correct way to use `glClearBuffer` is to call `glDrawBuffers` before calling `glClearBuffer`.

Additionally, I've replaced the `glClear` call with `glClearBufferF` (via `glow::clear_buffer_f32_slice`), because `glDrawBuffers` does not like it when you pass `COLOR_ATTACHMENTi` as the `j`-th buffer unless `i==j`. When rendering using a WebGL backend, this results in warnings:

```
WebGL warning: drawBuffers: `buffers[i]` must be NONE or COLOR_ATTACHMENTi."
```
On native OpenGL, this doesn't seem to be an issue, but the spec for OpenGL ES 3.2 also demands this:

```
If the GL is bound to a draw framebuffer object, the ith buffer listed in bufs
must be COLOR_ATTACHMENTi or NONE.
```

(See page 398, [OpenGL ES 3.2](https://registry.khronos.org/OpenGL/specs/es/3.2/es_spec_3.2.pdf))



**Testing**
Theoretically, issuing `SetDrawColorBuffers(0)` before beginning a render pass (maybe with a non-default frame-buffer?) and attempting to clear the color buffers will result in the clear commands being ignored on some machines. Admittedly, I've only tested this in a larger application, so I don't have a self-contained test for this.

The changes regarding clearing float buffers can be verified by attempting to clear buffers as part of a render pass involving multiple color attachments in WebGL (both Firefox and Chrome produce similar warnings).

It would be great if someone could verify that this fixes their issues on Sandy Bridge on Windows, because I've removed (a part of) the workaround in hopes that the crashes were caused by this bug(or quirk).

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
