### PR TITLE
Add HTMLImageElement/ImageData as external source for copying images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ By @teoxoy in [#5901](https://github.com/gfx-rs/wgpu/pull/5901)
     - `MemoryHints::MemoryUsage` favors memory usage over performance. This hint is typically useful for smaller applications or UI libraries.
     - `MemoryHints::Manual` allows the user to specify parameters for the underlying GPU memory allocator. These parameters are subject to change.
     - These hints may be ignored by some backends. Currently only the Vulkan and D3D12 backends take them into account.
+- Add `HTMLImageElement` and `ImageData` as external source for copying images. By @Valaphee in [#5668](https://github.com/gfx-rs/wgpu/pull/5668)
 
 #### Naga
 

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -501,7 +501,7 @@ impl super::Queue {
                                 v,
                             );
                         },
-                        wgt::ExternalImageSource::ImageData(ref b) => unsafe {
+                        wgt::ExternalImageSource::ImageData(ref i) => unsafe {
                             gl.tex_sub_image_3d_with_image_data(
                                 dst_target,
                                 copy.dst_base.mip_level as i32,
@@ -513,7 +513,7 @@ impl super::Queue {
                                 copy.size.depth as i32,
                                 format_desc.external,
                                 format_desc.data_type,
-                                b,
+                                i,
                             );
                         },
                         wgt::ExternalImageSource::HTMLCanvasElement(ref c) => unsafe {
@@ -576,7 +576,7 @@ impl super::Queue {
                                 v,
                             )
                         },
-                        wgt::ExternalImageSource::ImageData(ref b) => unsafe {
+                        wgt::ExternalImageSource::ImageData(ref i) => unsafe {
                             gl.tex_sub_image_2d_with_image_data_and_width_and_height(
                                 dst_target,
                                 copy.dst_base.mip_level as i32,
@@ -586,7 +586,7 @@ impl super::Queue {
                                 copy.size.height as i32,
                                 format_desc.external,
                                 format_desc.data_type,
-                                b,
+                                i,
                             );
                         },
                         wgt::ExternalImageSource::HTMLCanvasElement(ref c) => unsafe {

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -471,6 +471,21 @@ impl super::Queue {
                                 b,
                             );
                         },
+                        wgt::ExternalImageSource::HTMLImageElement(ref i) => unsafe {
+                            gl.tex_sub_image_3d_with_html_image_element(
+                                dst_target,
+                                copy.dst_base.mip_level as i32,
+                                copy.dst_base.origin.x as i32,
+                                copy.dst_base.origin.y as i32,
+                                z_offset as i32,
+                                copy.size.width as i32,
+                                copy.size.height as i32,
+                                copy.size.depth as i32,
+                                format_desc.external,
+                                format_desc.data_type,
+                                i,
+                            );
+                        },
                         wgt::ExternalImageSource::HTMLVideoElement(ref v) => unsafe {
                             gl.tex_sub_image_3d_with_html_video_element(
                                 dst_target,
@@ -484,6 +499,21 @@ impl super::Queue {
                                 format_desc.external,
                                 format_desc.data_type,
                                 v,
+                            );
+                        },
+                        wgt::ExternalImageSource::ImageData(ref b) => unsafe {
+                            gl.tex_sub_image_3d_with_image_data(
+                                dst_target,
+                                copy.dst_base.mip_level as i32,
+                                copy.dst_base.origin.x as i32,
+                                copy.dst_base.origin.y as i32,
+                                z_offset as i32,
+                                copy.size.width as i32,
+                                copy.size.height as i32,
+                                copy.size.depth as i32,
+                                format_desc.external,
+                                format_desc.data_type,
+                                b,
                             );
                         },
                         wgt::ExternalImageSource::HTMLCanvasElement(ref c) => unsafe {
@@ -520,6 +550,19 @@ impl super::Queue {
                                 b,
                             );
                         },
+                        wgt::ExternalImageSource::HTMLImageElement(ref i) => unsafe {
+                            gl.tex_sub_image_2d_with_html_image_and_width_and_height(
+                                dst_target,
+                                copy.dst_base.mip_level as i32,
+                                copy.dst_base.origin.x as i32,
+                                copy.dst_base.origin.y as i32,
+                                copy.size.width as i32,
+                                copy.size.height as i32,
+                                format_desc.external,
+                                format_desc.data_type,
+                                i,
+                            )
+                        },
                         wgt::ExternalImageSource::HTMLVideoElement(ref v) => unsafe {
                             gl.tex_sub_image_2d_with_html_video_and_width_and_height(
                                 dst_target,
@@ -532,6 +575,19 @@ impl super::Queue {
                                 format_desc.data_type,
                                 v,
                             )
+                        },
+                        wgt::ExternalImageSource::ImageData(ref b) => unsafe {
+                            gl.tex_sub_image_2d_with_image_data_and_width_and_height(
+                                dst_target,
+                                copy.dst_base.mip_level as i32,
+                                copy.dst_base.origin.x as i32,
+                                copy.dst_base.origin.y as i32,
+                                copy.size.width as i32,
+                                copy.size.height as i32,
+                                format_desc.external,
+                                format_desc.data_type,
+                                b,
+                            );
                         },
                         wgt::ExternalImageSource::HTMLCanvasElement(ref c) => unsafe {
                             gl.tex_sub_image_2d_with_html_canvas_and_width_and_height(

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -42,6 +42,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 js-sys.workspace = true
 web-sys = { workspace = true, features = [
     "ImageBitmap",
+    "ImageData",
     "HtmlVideoElement",
     "HtmlCanvasElement",
     "OffscreenCanvas",

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -6762,8 +6762,12 @@ pub struct ImageCopyExternalImage {
 pub enum ExternalImageSource {
     /// Copy from a previously-decoded image bitmap.
     ImageBitmap(web_sys::ImageBitmap),
+    /// Copy from an image element.
+    HTMLImageElement(web_sys::HtmlImageElement),
     /// Copy from a current frame of a video element.
     HTMLVideoElement(web_sys::HtmlVideoElement),
+    /// Copy from an image.
+    ImageData(web_sys::ImageData),
     /// Copy from a on-screen canvas.
     HTMLCanvasElement(web_sys::HtmlCanvasElement),
     /// Copy from a off-screen canvas.
@@ -6778,7 +6782,9 @@ impl ExternalImageSource {
     pub fn width(&self) -> u32 {
         match self {
             ExternalImageSource::ImageBitmap(b) => b.width(),
+            ExternalImageSource::HTMLImageElement(i) => i.width(),
             ExternalImageSource::HTMLVideoElement(v) => v.video_width(),
+            ExternalImageSource::ImageData(i) => i.width(),
             ExternalImageSource::HTMLCanvasElement(c) => c.width(),
             ExternalImageSource::OffscreenCanvas(c) => c.width(),
         }
@@ -6788,7 +6794,9 @@ impl ExternalImageSource {
     pub fn height(&self) -> u32 {
         match self {
             ExternalImageSource::ImageBitmap(b) => b.height(),
+            ExternalImageSource::HTMLImageElement(i) => i.height(),
             ExternalImageSource::HTMLVideoElement(v) => v.video_height(),
+            ExternalImageSource::ImageData(i) => i.height(),
             ExternalImageSource::HTMLCanvasElement(c) => c.height(),
             ExternalImageSource::OffscreenCanvas(c) => c.height(),
         }
@@ -6802,7 +6810,9 @@ impl std::ops::Deref for ExternalImageSource {
     fn deref(&self) -> &Self::Target {
         match self {
             Self::ImageBitmap(b) => b,
+            Self::HTMLImageElement(i) => i,
             Self::HTMLVideoElement(v) => v,
+            Self::ImageData(i) => i,
             Self::HTMLCanvasElement(c) => c,
             Self::OffscreenCanvas(c) => c,
         }


### PR DESCRIPTION
**Connections**
Closes https://github.com/gfx-rs/wgpu/issues/4236
Depends on https://github.com/grovesNL/glow/pull/291

**Description**
This adds the missing external sources for `HTMLImageElement` and `ImageData` which are useful for removing the need to ship an image decoder with an wasm application.

**Testing**
TODO: We should add a texture example, which on wasm loads the texture via external image source.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
