### PR TITLE
[core] Documentation and cleanups for `LifetimeTracker`

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2091,7 +2091,7 @@ impl Global {
     }
 
     #[cfg(feature = "replay")]
-    /// Only triangle suspected resource IDs. This helps us to avoid ID collisions
+    /// Only triage suspected resource IDs. This helps us to avoid ID collisions
     /// upon creating new resources when re-playing a trace.
     pub fn device_maintain_ids<A: HalApi>(&self, device_id: DeviceId) -> Result<(), InvalidDevice> {
         let hub = A::hub(self);

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -517,13 +517,13 @@ impl<A: HalApi> LifetimeTracker<A> {
     fn triage_suspected_render_bundles(&mut self, trackers: &Mutex<Tracker<A>>) -> &mut Self {
         let mut trackers = trackers.lock();
         let suspected_render_bundles = &mut self.suspected_resources.render_bundles;
-        let mut removed_resources = Self::triage_resources(
+        let removed_resources = Self::triage_resources(
             suspected_render_bundles,
             self.active.as_mut_slice(),
             &mut trackers.bundles,
             |maps| &mut maps.render_bundles,
         );
-        removed_resources.drain(..).for_each(|bundle| {
+        for bundle in removed_resources {
             for v in bundle.used.buffers.write().drain_resources() {
                 self.suspected_resources
                     .buffers
@@ -549,20 +549,20 @@ impl<A: HalApi> LifetimeTracker<A> {
                     .query_sets
                     .insert(v.as_info().tracker_index(), v);
             }
-        });
+        }
         self
     }
 
     fn triage_suspected_bind_groups(&mut self, trackers: &Mutex<Tracker<A>>) -> &mut Self {
         let mut trackers = trackers.lock();
         let suspected_bind_groups = &mut self.suspected_resources.bind_groups;
-        let mut removed_resources = Self::triage_resources(
+        let removed_resources = Self::triage_resources(
             suspected_bind_groups,
             self.active.as_mut_slice(),
             &mut trackers.bind_groups,
             |maps| &mut maps.bind_groups,
         );
-        removed_resources.drain(..).for_each(|bind_group| {
+        for bind_group in removed_resources {
             for v in bind_group.used.buffers.drain_resources() {
                 self.suspected_resources
                     .buffers
@@ -588,7 +588,7 @@ impl<A: HalApi> LifetimeTracker<A> {
                 bind_group.layout.as_info().tracker_index(),
                 bind_group.layout.clone(),
             );
-        });
+        }
         self
     }
 
@@ -693,36 +693,36 @@ impl<A: HalApi> LifetimeTracker<A> {
     fn triage_suspected_compute_pipelines(&mut self, trackers: &Mutex<Tracker<A>>) -> &mut Self {
         let mut trackers = trackers.lock();
         let suspected_compute_pipelines = &mut self.suspected_resources.compute_pipelines;
-        let mut removed_resources = Self::triage_resources(
+        let removed_resources = Self::triage_resources(
             suspected_compute_pipelines,
             self.active.as_mut_slice(),
             &mut trackers.compute_pipelines,
             |maps| &mut maps.compute_pipelines,
         );
-        removed_resources.drain(..).for_each(|compute_pipeline| {
+        for compute_pipeline in removed_resources {
             self.suspected_resources.pipeline_layouts.insert(
                 compute_pipeline.layout.as_info().tracker_index(),
                 compute_pipeline.layout.clone(),
             );
-        });
+        }
         self
     }
 
     fn triage_suspected_render_pipelines(&mut self, trackers: &Mutex<Tracker<A>>) -> &mut Self {
         let mut trackers = trackers.lock();
         let suspected_render_pipelines = &mut self.suspected_resources.render_pipelines;
-        let mut removed_resources = Self::triage_resources(
+        let removed_resources = Self::triage_resources(
             suspected_render_pipelines,
             self.active.as_mut_slice(),
             &mut trackers.render_pipelines,
             |maps| &mut maps.render_pipelines,
         );
-        removed_resources.drain(..).for_each(|render_pipeline| {
+        for render_pipeline in removed_resources {
             self.suspected_resources.pipeline_layouts.insert(
                 render_pipeline.layout.as_info().tracker_index(),
                 render_pipeline.layout.clone(),
             );
-        });
+        }
         self
     }
 

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -303,8 +303,8 @@ impl<A: HalApi> ResourceTracker for BufferTracker<A> {
     ///
     /// A buffer is 'otherwise unused' when the only references to it are:
     ///
-    /// 1) the `Arc` that our caller, `LifetimeTracker::triage_suspected`, has just
-    ///    drained from `LifetimeTracker::suspected_resources`,
+    /// 1) the `Arc` that our caller, `LifetimeTracker::triage_resources`, is
+    ///    considering draining from `LifetimeTracker::suspected_resources`,
     ///
     /// 2) its `Arc` in [`self.metadata`] (owned by [`Device::trackers`]), and
     ///


### PR DESCRIPTION
- Use a `for` loop in `LifetimeTracker` triage code.

    A `for` loop is less noisy here than a `drain`, which requires:

    - a `mut` qualifier for a variable whose modified value we never
      consult

    - a method name appearing mid-line instead of a control structure name
      at the front of the line

    - a range which is always `..`, establishing no restriction at all

    - a closure instead of a block

    Structured control flow syntax has a fine pedigree, originating in,
    among other places, Dijkstrsa's efforts at designing languages in a
    way that made it easier to formally verify programs written in
    them (see "A Discipline Of Programming"). There is nothing "more
    mathematical" about a method call that takes a closure than a `for`
    loop. Since `for_each` is useless unless the closure has side effects,
    there's nothing "more functional" about `for_each` here, either.
    Obsessive use of `for_each` suggests that the author loves Haskell
    without understanding it.

- In `LifetimeTracker`s triage code, use more specific names.

    Rename `LifetimeTracker::triage_resources`'s `resources_map` argument
    to `suspected_resources`, since this always points to a field of
    `LifetimeTracker::suspected_resources`.

    In the various `triage_suspected_foo` functions, name the map
    `suspected_foos`.

- Refactor `LifetimeTracker::triage_resources`.

    Check whether the resource is abandoned first, since none of the rest
    of the work is necessary otherwise.

    Rename `non_referenced_resources` to `last_resources`. This function
    copes with various senses in which the resource might be referenced or
    not. Instead, `last_resources` is the name of the `ActiveSubmission`
    member this may point to, which is more specific.

    Move the use of `last_resources` immediately after its production.

- Doc fixes for lifetime management, minor typos.

    - Document `LifetimeTracker::triage_resources`.

    - Fix various typos and bad grammar.

