### PR TITLE
[naga] [msl-out] Add support for metal's atomic_compare_exchange_weak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 #### Naga
 
+- Added support for metal's `atomic_compare_exchange_weak` by @9291Sam in [#5675](https://github.com/gfx-rs/wgpu/pull/5675)
+
 ### Bug Fixes
 
 #### GLES / OpenGL

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -543,21 +543,3 @@ fn test_error_size() {
     use std::mem::size_of;
     assert_eq!(size_of::<Error>(), 32);
 }
-
-impl crate::AtomicFunction {
-    fn to_msl(self) -> Result<&'static str, Error> {
-        Ok(match self {
-            Self::Add => "fetch_add",
-            Self::Subtract => "fetch_sub",
-            Self::And => "fetch_and",
-            Self::InclusiveOr => "fetch_or",
-            Self::ExclusiveOr => "fetch_xor",
-            Self::Min => "fetch_min",
-            Self::Max => "fetch_max",
-            Self::Exchange { compare: None } => "exchange",
-            Self::Exchange { compare: Some(_) } => Err(Error::FeatureNotImplemented(
-                "atomic CompareExchange".to_string(),
-            ))?,
-        })
-    }
-}

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -1189,8 +1189,8 @@ impl<W: Write> Writer<W> {
                 write!(self.out, ", {NAMESPACE}::memory_order_relaxed)")?;
             }
             crate::AtomicFunction::Exchange { compare: Some(cmp) } => {
-                let result_type_name = match context.info[result].ty {
-                    TypeResolution::Handle(ty_handle) => {
+                let result_type_name =
+                    if let TypeResolution::Handle(ty_handle) = context.info[result].ty {
                         let ty_name = TypeContext {
                             handle: ty_handle,
                             gctx: context.module.to_ctx(),
@@ -1200,13 +1200,11 @@ impl<W: Write> Writer<W> {
                             first_time: false,
                         };
                         ty_name
-                    }
-                    _ => {
+                    } else {
                         return Err(Error::FeatureNotImplemented(
                             "atomic CompareExchange".to_string(),
                         ));
-                    }
-                };
+                    };
 
                 write!(
                     self.out,
@@ -3420,11 +3418,11 @@ impl<W: Write> Writer<W> {
         writeln!(
             self.out,
             r#"
-        template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {{
-            T cmp = cmp_;
-            bool exchanged = {NAMESPACE}::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, {NAMESPACE}::memory_order_relaxed, {NAMESPACE}::memory_order_relaxed);
-            return R{{cmp, exchanged}};
-        }}
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {{
+    T cmp = cmp_;
+    bool exchanged = {NAMESPACE}::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, {NAMESPACE}::memory_order_relaxed, {NAMESPACE}::memory_order_relaxed);
+    return R{{cmp, exchanged}};
+}}
         "#
         )?;
 

--- a/naga/tests/out/msl/abstract-types-const.msl
+++ b/naga/tests/out/msl/abstract-types-const.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_5 {
     float inner[2];
 };

--- a/naga/tests/out/msl/abstract-types-operators.msl
+++ b/naga/tests/out/msl/abstract-types-operators.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_3 {
     uint inner[64];
 };

--- a/naga/tests/out/msl/abstract-types-var.msl
+++ b/naga/tests/out/msl/abstract-types-var.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_5 {
     float inner[2];
 };

--- a/naga/tests/out/msl/access.msl
+++ b/naga/tests/out/msl/access.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct _mslBufferSizes {
     uint size1;
 };

--- a/naga/tests/out/msl/array-in-ctor.msl
+++ b/naga/tests/out/msl/array-in-ctor.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_1 {
     float inner[2];
 };

--- a/naga/tests/out/msl/array-in-function-return-type.msl
+++ b/naga/tests/out/msl/array-in-function-return-type.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_1 {
     float inner[2];
 };

--- a/naga/tests/out/msl/atomicCompareExchange.msl
+++ b/naga/tests/out/msl/atomicCompareExchange.msl
@@ -1,0 +1,117 @@
+// language: metal1.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+struct type_2 {
+    metal::atomic_int inner[128];
+};
+struct type_4 {
+    metal::atomic_uint inner[128];
+};
+struct _atomic_compare_exchange_resultSint4_ {
+    int old_value;
+    bool exchanged;
+};
+struct _atomic_compare_exchange_resultUint4_ {
+    uint old_value;
+    bool exchanged;
+};
+constant uint SIZE = 128u;
+
+kernel void test_atomic_compare_exchange_i32_(
+  device type_2& arr_i32_ [[user(fake0)]]
+) {
+    uint i = 0u;
+    int old = {};
+    bool exchanged = {};
+    bool loop_init = true;
+    while(true) {
+        if (!loop_init) {
+            uint _e27 = i;
+            i = _e27 + 1u;
+        }
+        loop_init = false;
+        uint _e2 = i;
+        if (_e2 < SIZE) {
+        } else {
+            break;
+        }
+        {
+            uint _e6 = i;
+            int _e8 = metal::atomic_load_explicit(&arr_i32_.inner[_e6], metal::memory_order_relaxed);
+            old = _e8;
+            exchanged = false;
+            while(true) {
+                bool _e12 = exchanged;
+                if (!(_e12)) {
+                } else {
+                    break;
+                }
+                {
+                    int _e14 = old;
+                    int new_ = as_type<int>(as_type<float>(_e14) + 1.0);
+                    uint _e20 = i;
+                    int _e22 = old;
+                    _atomic_compare_exchange_resultSint4_ _e23 = __make_atomic_cas_result<_atomic_compare_exchange_resultSint4_>(&arr_i32_.inner[_e20], _e22, new_);
+                    old = _e23.old_value;
+                    exchanged = _e23.exchanged;
+                }
+            }
+        }
+    }
+    return;
+}
+
+
+kernel void test_atomic_compare_exchange_u32_(
+  device type_4& arr_u32_ [[user(fake0)]]
+) {
+    uint i_1 = 0u;
+    uint old_1 = {};
+    bool exchanged_1 = {};
+    bool loop_init_1 = true;
+    while(true) {
+        if (!loop_init_1) {
+            uint _e27 = i_1;
+            i_1 = _e27 + 1u;
+        }
+        loop_init_1 = false;
+        uint _e2 = i_1;
+        if (_e2 < SIZE) {
+        } else {
+            break;
+        }
+        {
+            uint _e6 = i_1;
+            uint _e8 = metal::atomic_load_explicit(&arr_u32_.inner[_e6], metal::memory_order_relaxed);
+            old_1 = _e8;
+            exchanged_1 = false;
+            while(true) {
+                bool _e12 = exchanged_1;
+                if (!(_e12)) {
+                } else {
+                    break;
+                }
+                {
+                    uint _e14 = old_1;
+                    uint new_1 = as_type<uint>(as_type<float>(_e14) + 1.0);
+                    uint _e20 = i_1;
+                    uint _e22 = old_1;
+                    _atomic_compare_exchange_resultUint4_ _e23 = __make_atomic_cas_result<_atomic_compare_exchange_resultUint4_>(&arr_u32_.inner[_e20], _e22, new_1);
+                    old_1 = _e23.old_value;
+                    exchanged_1 = _e23.exchanged;
+                }
+            }
+        }
+    }
+    return;
+}

--- a/naga/tests/out/msl/atomicOps.msl
+++ b/naga/tests/out/msl/atomicOps.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_2 {
     metal::atomic_int inner[2];
 };

--- a/naga/tests/out/msl/binding-arrays.msl
+++ b/naga/tests/out/msl/binding-arrays.msl
@@ -10,6 +10,13 @@ struct DefaultConstructible {
     }
 };
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct UniformIndex {
     uint index;
 };

--- a/naga/tests/out/msl/bitcast.msl
+++ b/naga/tests/out/msl/bitcast.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 kernel void main_(
 ) {
     metal::int2 i2_ = metal::int2(0);

--- a/naga/tests/out/msl/bits.msl
+++ b/naga/tests/out/msl/bits.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 kernel void main_(
 ) {
     int i = 0;

--- a/naga/tests/out/msl/boids.msl
+++ b/naga/tests/out/msl/boids.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct _mslBufferSizes {
     uint size1;
     uint size2;

--- a/naga/tests/out/msl/bounds-check-image-restrict.msl
+++ b/naga/tests/out/msl/bounds-check-image-restrict.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 metal::float4 test_textureLoad_1d(
     int coords,
     int level,

--- a/naga/tests/out/msl/bounds-check-image-rzsw.msl
+++ b/naga/tests/out/msl/bounds-check-image-rzsw.msl
@@ -11,6 +11,13 @@ struct DefaultConstructible {
 };
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 metal::float4 test_textureLoad_1d(
     int coords,
     int level,

--- a/naga/tests/out/msl/bounds-check-restrict.msl
+++ b/naga/tests/out/msl/bounds-check-restrict.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct _mslBufferSizes {
     uint size0;
 };

--- a/naga/tests/out/msl/bounds-check-zero-atomic.msl
+++ b/naga/tests/out/msl/bounds-check-zero-atomic.msl
@@ -10,6 +10,13 @@ struct DefaultConstructible {
     }
 };
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct _mslBufferSizes {
     uint size0;
 };

--- a/naga/tests/out/msl/bounds-check-zero.msl
+++ b/naga/tests/out/msl/bounds-check-zero.msl
@@ -10,6 +10,13 @@ struct DefaultConstructible {
     }
 };
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct _mslBufferSizes {
     uint size0;
 };

--- a/naga/tests/out/msl/break-if.msl
+++ b/naga/tests/out/msl/break-if.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 void breakIfEmpty(
 ) {
     bool loop_init = true;

--- a/naga/tests/out/msl/collatz.msl
+++ b/naga/tests/out/msl/collatz.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct _mslBufferSizes {
     uint size0;
 };

--- a/naga/tests/out/msl/const-exprs.msl
+++ b/naga/tests/out/msl/const-exprs.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 constant uint TWO = 2u;
 constant int THREE = 3;
 constant int FOUR = 4;

--- a/naga/tests/out/msl/constructors.msl
+++ b/naga/tests/out/msl/constructors.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct Foo {
     metal::float4 a;
     int b;

--- a/naga/tests/out/msl/control-flow.msl
+++ b/naga/tests/out/msl/control-flow.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 void switch_default_break(
     int i
 ) {

--- a/naga/tests/out/msl/do-while.msl
+++ b/naga/tests/out/msl/do-while.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 void fb1_(
     thread bool& cond
 ) {

--- a/naga/tests/out/msl/dualsource.msl
+++ b/naga/tests/out/msl/dualsource.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct FragmentOutput {
     metal::float4 color;
     metal::float4 mask;

--- a/naga/tests/out/msl/empty-global-name.msl
+++ b/naga/tests/out/msl/empty-global-name.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_1 {
     int member;
 };

--- a/naga/tests/out/msl/empty.msl
+++ b/naga/tests/out/msl/empty.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 kernel void main_(
 ) {
     return;

--- a/naga/tests/out/msl/extra.msl
+++ b/naga/tests/out/msl/extra.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct PushConstants {
     uint index;
     char _pad1[12];

--- a/naga/tests/out/msl/fragment-output.msl
+++ b/naga/tests/out/msl/fragment-output.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct FragmentOutputVec4Vec3_ {
     metal::float4 vec4f;
     metal::int4 vec4i;

--- a/naga/tests/out/msl/functions.msl
+++ b/naga/tests/out/msl/functions.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 metal::float2 test_fma(
 ) {
     metal::float2 a = metal::float2(2.0, 2.0);

--- a/naga/tests/out/msl/globals.msl
+++ b/naga/tests/out/msl/globals.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct _mslBufferSizes {
     uint size3;
 };

--- a/naga/tests/out/msl/image.msl
+++ b/naga/tests/out/msl/image.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 struct main_Input {
 };
 kernel void main_(

--- a/naga/tests/out/msl/int64.msl
+++ b/naga/tests/out/msl/int64.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct UniformCompatible {
     uint val_u32_;
     int val_i32_;

--- a/naga/tests/out/msl/interface.msl
+++ b/naga/tests/out/msl/interface.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct VertexOutput {
     metal::float4 position;
     float _varying;

--- a/naga/tests/out/msl/interpolate.msl
+++ b/naga/tests/out/msl/interpolate.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct FragmentInput {
     metal::float4 position;
     uint _flat;

--- a/naga/tests/out/msl/math-functions.msl
+++ b/naga/tests/out/msl/math-functions.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct _modf_result_f32_ {
     float fract;
     float whole;

--- a/naga/tests/out/msl/msl-varyings.msl
+++ b/naga/tests/out/msl/msl-varyings.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct Vertex {
     metal::float2 position;
 };

--- a/naga/tests/out/msl/operators.msl
+++ b/naga/tests/out/msl/operators.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 constant metal::float4 v_f32_one = metal::float4(1.0, 1.0, 1.0, 1.0);
 constant metal::float4 v_f32_zero = metal::float4(0.0, 0.0, 0.0, 0.0);
 constant metal::float4 v_f32_half = metal::float4(0.5, 0.5, 0.5, 0.5);

--- a/naga/tests/out/msl/overrides-ray-query.msl
+++ b/naga/tests/out/msl/overrides-ray-query.msl
@@ -13,6 +13,13 @@ constexpr metal::uint _map_intersection_type(const metal::raytracing::intersecti
         ty==metal::raytracing::intersection_type::bounding_box ? 4 : 0;
 }
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct RayDesc {
     uint flags;
     uint cull_mask;

--- a/naga/tests/out/msl/overrides.msl
+++ b/naga/tests/out/msl/overrides.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 constant bool has_point_light = false;
 constant float specular_param = 2.3;
 constant float gain = 1.1;

--- a/naga/tests/out/msl/padding.msl
+++ b/naga/tests/out/msl/padding.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct S {
     metal::float3 a;
 };

--- a/naga/tests/out/msl/policy-mix.msl
+++ b/naga/tests/out/msl/policy-mix.msl
@@ -10,6 +10,13 @@ struct DefaultConstructible {
     }
 };
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_1 {
     metal::float4 inner[10];
 };

--- a/naga/tests/out/msl/quad-vert.msl
+++ b/naga/tests/out/msl/quad-vert.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_3 {
     float inner[1];
 };

--- a/naga/tests/out/msl/quad.msl
+++ b/naga/tests/out/msl/quad.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct VertexOutput {
     metal::float2 uv;
     char _pad1[8];

--- a/naga/tests/out/msl/ray-query.msl
+++ b/naga/tests/out/msl/ray-query.msl
@@ -13,6 +13,13 @@ constexpr metal::uint _map_intersection_type(const metal::raytracing::intersecti
         ty==metal::raytracing::intersection_type::bounding_box ? 4 : 0;
 }
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct Output {
     uint visible;
     char _pad1[12];

--- a/naga/tests/out/msl/resource-binding-map.msl
+++ b/naga/tests/out/msl/resource-binding-map.msl
@@ -11,6 +11,13 @@ struct DefaultConstructible {
 };
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 struct entry_point_oneInput {
 };
 struct entry_point_oneOutput {

--- a/naga/tests/out/msl/shadow.msl
+++ b/naga/tests/out/msl/shadow.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct _mslBufferSizes {
     uint size2;
 };

--- a/naga/tests/out/msl/skybox.msl
+++ b/naga/tests/out/msl/skybox.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct VertexOutput {
     metal::float4 position;
     metal::float3 uv;

--- a/naga/tests/out/msl/standard.msl
+++ b/naga/tests/out/msl/standard.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 bool test_any_and_all_for_bool(
 ) {
     return true;

--- a/naga/tests/out/msl/struct-layout.msl
+++ b/naga/tests/out/msl/struct-layout.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct NoPadding {
     metal::packed_float3 v3_;
     float f3_;

--- a/naga/tests/out/msl/subgroup-operations-s.msl
+++ b/naga/tests/out/msl/subgroup-operations-s.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 void main_1(
     thread uint& subgroup_size_1,
     thread uint& subgroup_invocation_id_1

--- a/naga/tests/out/msl/subgroup-operations.msl
+++ b/naga/tests/out/msl/subgroup-operations.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct Structure {
     uint num_subgroups;
     uint subgroup_size;

--- a/naga/tests/out/msl/texture-arg.msl
+++ b/naga/tests/out/msl/texture-arg.msl
@@ -5,6 +5,13 @@
 using metal::uint;
 
 
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
+
 metal::float4 test(
     metal::texture2d<float, metal::access::sample> Passed_Texture,
     metal::sampler Passed_Sampler

--- a/naga/tests/out/msl/unnamed-gl-per-vertex.msl
+++ b/naga/tests/out/msl/unnamed-gl-per-vertex.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_3 {
     float inner[1];
 };

--- a/naga/tests/out/msl/workgroup-uniform-load.msl
+++ b/naga/tests/out/msl/workgroup-uniform-load.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_2 {
     int inner[128];
 };

--- a/naga/tests/out/msl/workgroup-var-init.msl
+++ b/naga/tests/out/msl/workgroup-var-init.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+
+template<typename R, typename T, typename A> R __make_atomic_cas_result(device A* ptr, T cmp_, T v) {
+    T cmp = cmp_;
+    bool exchanged = metal::atomic_compare_exchange_weak_explicit(ptr, &cmp, v, metal::memory_order_relaxed, metal::memory_order_relaxed);
+    return R{cmp, exchanged};
+}
+        
 struct type_1 {
     uint inner[512];
 };

--- a/naga/tests/snapshots.rs
+++ b/naga/tests/snapshots.rs
@@ -747,7 +747,10 @@ fn convert_wgsl() {
             "atomicOps",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
         ),
-        ("atomicCompareExchange", Targets::SPIRV | Targets::WGSL),
+        (
+            "atomicCompareExchange",
+            Targets::SPIRV | Targets::WGSL | Targets::METAL,
+        ),
         (
             "padding",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,


### PR DESCRIPTION
**Connections**

Fixes [wgpu/wgpu#5257](https://github.com/gfx-rs/wgpu/issues/5257) and [wgpu/wgpu#4364](https://github.com/gfx-rs/wgpu/issues/4364)

**Description**
Adds an implementation of `naga::Statement::Atomic {fun: naga::AtomicFunction::Exchange { compare: Some(expr)  } }` to the msl-out backend.

**Testing**
Passes tests given by `cargo xtask validate msl` in file `naga/tests/out/msl/atomicCompareExchange.msl`

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
