### PR TITLE
Remove unused num-traits dependency of naga

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,7 +2153,6 @@ dependencies = [
  "hlsl-snapshots",
  "indexmap",
  "log",
- "num-traits",
  "petgraph",
  "pp-rs",
  "ron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,6 @@ log = "0.4"
 nanorand = { version = "0.7", default-features = false, features = ["wyrand"] }
 # https://github.com/Razaekel/noise-rs/issues/335 (Updated dependencies)
 noise = { version = "0.8", git = "https://github.com/Razaekel/noise-rs.git", rev = "c6942d4fb70af26db4441edcf41f90fa115333f2" }
-num-traits = { version = "0.2" }
 nv-flip = "0.1"
 obj = "0.10"
 once_cell = "1"

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -51,7 +51,6 @@ codespan-reporting = { version = "0.11.0" }
 rustc-hash = "1.1.0"
 indexmap = { version = "2", features = ["std"] }
 log = "0.4"
-num-traits = "0.2"
 spirv = { version = "0.3", optional = true }
 thiserror = "1.0.59"
 serde = { version = "1.0.200", features = ["derive"], optional = true }


### PR DESCRIPTION
**Connections**
None

**Description**
The num-traits dependency of naga is unused. Remove it.

**Testing**
N/A

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
