### PR TITLE
Reduce string allocations related to labels and logging.

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -514,8 +514,8 @@ impl<A: HalApi> Resource for BindGroupLayout<A> {
         &mut self.info
     }
 
-    fn label(&self) -> String {
-        self.label.clone()
+    fn label(&self) -> &str {
+        &self.label
     }
 }
 impl<A: HalApi> BindGroupLayout<A> {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -471,14 +471,6 @@ impl<A: HalApi> Resource for CommandBuffer<A> {
     fn as_info_mut(&mut self) -> &mut ResourceInfo<Self> {
         &mut self.info
     }
-
-    fn label(&self) -> String {
-        let str = match self.data.lock().as_ref().unwrap().encoder.label.as_ref() {
-            Some(label) => label.clone(),
-            _ => String::new(),
-        };
-        str
-    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -333,13 +333,7 @@ impl<A: HalApi> CommandBuffer<A> {
             device: device.clone(),
             limits: device.limits.clone(),
             support_clear_texture: device.features.contains(wgt::Features::CLEAR_TEXTURE),
-            info: ResourceInfo::new(
-                label
-                    .as_ref()
-                    .unwrap_or(&String::from("<CommandBuffer>"))
-                    .as_str(),
-                None,
-            ),
+            info: ResourceInfo::new(label.as_deref().unwrap_or("<CommandBuffer>"), None),
             data: Mutex::new(
                 rank::COMMAND_BUFFER_DATA,
                 Some(CommandBufferMutable {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1363,9 +1363,7 @@ impl Global {
                 &device,
                 #[cfg(feature = "trace")]
                 device.trace.lock().is_some(),
-                desc.label
-                    .to_hal(device.instance_flags)
-                    .map(|s| s.to_string()),
+                desc.label.to_hal(device.instance_flags).map(str::to_owned),
             );
 
             let (id, _) = fid.assign(Arc::new(command_buffer));

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -159,8 +159,8 @@ impl Resource for Surface {
         &mut self.info
     }
 
-    fn label(&self) -> String {
-        String::from("<Surface>")
+    fn label(&self) -> &str {
+        "<Surface>"
     }
 }
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -84,8 +84,8 @@ impl<A: HalApi> Resource for ShaderModule<A> {
         &mut self.info
     }
 
-    fn label(&self) -> String {
-        self.label.clone()
+    fn label(&self) -> &str {
+        &self.label
     }
 }
 

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -182,7 +182,7 @@ impl<T: Resource> Registry<T> {
                 if label.is_empty() {
                     format!("<{}-{:?}>", type_name, id.unzip())
                 } else {
-                    label
+                    label.to_owned()
                 }
             }
             Err(_) => format!(

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -84,7 +84,8 @@ impl<T: Resource> Drop for ResourceInfo<T> {
 }
 
 impl<T: Resource> ResourceInfo<T> {
-    #[allow(unused_variables)]
+    // Note: Abstractly, this function should take `label: String` to minimize string cloning.
+    // But as actually used, every input is a literal or borrowed `&str`, so this is convenient.
     pub(crate) fn new(
         label: &str,
         tracker_indices: Option<Arc<SharedTrackerIndexAllocator>>,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -150,9 +150,16 @@ pub(crate) trait Resource: 'static + Sized + WasmNotSendSync {
     const TYPE: ResourceType;
     fn as_info(&self) -> &ResourceInfo<Self>;
     fn as_info_mut(&mut self) -> &mut ResourceInfo<Self>;
-    fn label(&self) -> String {
-        self.as_info().label.clone()
+
+    /// Returns a string identifying this resource for logging and errors.
+    ///
+    /// It may be a user-provided string or it may be a placeholder from wgpu.
+    ///
+    /// It is non-empty unless the user-provided string was empty.
+    fn label(&self) -> &str {
+        &self.as_info().label
     }
+
     fn ref_count(self: &Arc<Self>) -> usize {
         Arc::strong_count(self)
     }
@@ -719,8 +726,8 @@ impl<A: HalApi> Resource for StagingBuffer<A> {
         &mut self.info
     }
 
-    fn label(&self) -> String {
-        String::from("<StagingBuffer>")
+    fn label(&self) -> &str {
+        "<StagingBuffer>"
     }
 }
 


### PR DESCRIPTION
**Description**
* `Resource::label()` is (occasionally, for destroyed resources specifically) called for logging, but always allocated a `String`, which would not necessarily be skipped by the logging macro (if the level filter is met, a `format_args!()` is constructed even if it is skipped). Avoid that by making it return `&str` instead.
    * This has one behavior change: `wgpu_core::command::CommandBuffer` will return the `"<CommandBuffer>"` placeholder string instead of `""`. This avoids taking a lock in addition to the allocation, but it also means `Registry::label_for_resource()` won't produce a placeholder with ID. But if that behavior is desirable, surely it should be done more broadly (have `Resource::label` return empty strings consistently), instead of only for `CommandBuffer`?
* Also avoid allocating a throwaway `String` when creating an unlabeled `CommandBuffer`.

**Testing**

Ran `cargo xtask test`. All failures on my machine are unrelated to label strings as far as I know.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [X] Run `cargo xtask test` to run tests.
- [X] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ Not worth mentioning.
