### PR TITLE
Remove unnecessary Cargo.toml dependencies via `cargo machete`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,7 +1086,6 @@ dependencies = [
  "serde",
  "tokio",
  "wgpu-core",
- "wgpu-hal",
  "wgpu-types",
 ]
 
@@ -2174,7 +2173,6 @@ dependencies = [
  "bincode",
  "codespan-reporting",
  "env_logger",
- "log",
  "naga",
 ]
 
@@ -4060,7 +4058,6 @@ name = "wgpu"
 version = "0.20.0"
 dependencies = [
  "arrayvec 0.7.4",
- "cfg-if",
  "cfg_aliases",
  "document-features",
  "js-sys",
@@ -4102,7 +4099,6 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
- "web-sys",
  "wgpu-hal",
  "wgpu-types",
 ]
@@ -4121,7 +4117,6 @@ dependencies = [
  "flume",
  "getrandom",
  "glam",
- "js-sys",
  "ktx2",
  "log",
  "nanorand",
@@ -4135,7 +4130,6 @@ dependencies = [
  "web-sys",
  "web-time",
  "wgpu",
- "wgpu-hal",
  "wgpu-test",
  "winit 0.29.15",
 ]
@@ -4199,7 +4193,6 @@ dependencies = [
  "serde",
  "serde_json",
  "wgpu",
- "wgpu-types",
 ]
 
 [[package]]
@@ -4224,18 +4217,15 @@ dependencies = [
  "ctor",
  "env_logger",
  "futures-lite",
- "heck 0.5.0",
  "image",
  "js-sys",
  "libtest-mimic",
  "log",
- "naga",
  "nv-flip",
  "parking_lot",
  "png",
  "pollster",
  "profiling",
- "raw-window-handle 0.6.1",
  "serde",
  "serde_json",
  "wasm-bindgen",

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -44,11 +44,6 @@ features = ["metal"]
 workspace = true
 features = ["dx12"]
 
-[target.'cfg(windows)'.dependencies.wgpu-hal]
-version = "0.20.0"
-path = "../wgpu-hal"
-features = ["windows_rs"]
-
 # We want the wgpu-core Vulkan backend on Unix (but not Emscripten) and Windows.
 [target.'cfg(any(windows, all(unix, not(target_os = "emscripten"))))'.dependencies.wgpu-core]
 workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,6 +10,10 @@ keywords.workspace = true
 license.workspace = true
 publish = false
 
+[package.metadata.cargo-machete]
+# Cargo machete struggles with this dev dependency:
+ignored = ["wasm_bindgen_test"]
+
 [lib]
 path = "src/lib.rs"
 harness = false
@@ -47,10 +51,8 @@ env_logger.workspace = true
 console_error_panic_hook.workspace = true
 console_log.workspace = true
 fern.workspace = true
-js-sys.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
-hal = { workspace = true, optional = true }
 # We need these features in the framework examples and tests
 web-sys = { workspace = true, features = [
     "Location",

--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -19,7 +19,6 @@ test = false
 
 [dependencies]
 bincode = "1"
-log = "0.4"
 codespan-reporting = "0.11"
 env_logger = "0.11"
 argh = "0.1.5"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,7 +27,6 @@ bytemuck.workspace = true
 cfg-if.workspace = true
 ctor.workspace = true
 futures-lite.workspace = true
-heck.workspace = true
 libtest-mimic.workspace = true
 log.workspace = true
 parking_lot.workspace = true
@@ -47,12 +46,8 @@ parking_lot = { workspace = true, features = ["deadlock_detection"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log.workspace = true
-raw-window-handle.workspace = true
 wasm-bindgen.workspace = true
 web-sys = { workspace = true }
-
-[dev-dependencies]
-naga = { workspace = true, features = ["wgsl-in"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 image.workspace = true

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -25,6 +25,10 @@ targets = [
     "wasm32-unknown-unknown",
 ]
 
+[package.metadata.cargo-machete]
+# Cargo machete can't check build.rs dependencies. See https://github.com/bnjbvr/cargo-machete/issues/100
+ignored = ["cfg_aliases"]
+
 [lib]
 
 [features]
@@ -128,12 +132,6 @@ package = "wgpu-hal"
 path = "../wgpu-hal"
 version = "0.20.0"
 default_features = false
-
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-web-sys = { version = "0.3.69", features = [
-    "HtmlCanvasElement",
-    "OffscreenCanvas",
-] }
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -30,6 +30,10 @@ targets = [
     "wasm32-unknown-unknown",
 ]
 
+[package.metadata.cargo-machete]
+# Cargo machete can't check build.rs dependencies. See https://github.com/bnjbvr/cargo-machete/issues/100
+ignored = ["cfg_aliases"]
+
 [lib]
 
 [features]

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -17,4 +17,3 @@ pico-args.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 wgpu.workspace = true
-wgpu-types = { workspace = true, features = ["serde"] }

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -21,6 +21,11 @@ targets = [
     "wasm32-unknown-unknown",
 ]
 
+[package.metadata.cargo-machete]
+# Cargo machete can't check build.rs dependencies. See https://github.com/bnjbvr/cargo-machete/issues/100
+ignored = ["cfg_aliases"]
+
+
 [lib]
 
 [features]
@@ -165,7 +170,6 @@ optional = true
 
 [dependencies]
 arrayvec.workspace = true
-cfg-if.workspace = true
 document-features.workspace = true
 log.workspace = true
 parking_lot.workspace = true


### PR DESCRIPTION
**Connections**
* Got reminded by #5689 that it might be good to give some `cargo machete` love to wgpu

**Description**
Used [`cargo machete`](https://github.com/bnjbvr/cargo-machete) to clean up some unused dependencies. Nothing far reaching and nothing removed completely from the tree but why not, you never know how it helps the build tree!
Added necessary exception instructions to machete so it's smoother the next time someone runs it :)

**Testing**
it compiles

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
