### PR TITLE
remove old depth and/or stencil texture copy validation

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -125,8 +125,6 @@ pub enum TransferError {
         "Copying to textures with format {0:?} is forbidden when copying from external texture"
     )]
     ExternalCopyToForbiddenTextureFormat(wgt::TextureFormat),
-    #[error("The entire texture must be copied when copying from depth texture")]
-    InvalidDepthTextureExtent,
     #[error(
         "Source format ({src_format:?}) and destination format ({dst_format:?}) are not copy-compatible (they may only differ in srgb-ness)"
     )]
@@ -366,10 +364,6 @@ pub(crate) fn validate_texture_copy_range(
     )?;
     // physical size can be larger than the virtual
     let extent = extent_virtual.physical_size(desc.format);
-
-    if desc.format.is_depth_stencil_format() && *copy_size != extent {
-        return Err(TransferError::InvalidDepthTextureExtent);
-    }
 
     /// Return `Ok` if a run `size` texels long starting at `start_offset` falls
     /// entirely within `texture_size`. Otherwise, return an appropriate a`Err`.


### PR DESCRIPTION
This was previously added in #2230 but I don't think it was necessary. #901 already implemented the buffer <-> texture validation for those formats. It's also not a requirement in the spec.

Fixes https://github.com/gfx-rs/wgpu/issues/5699.