### PR TITLE
Add infrastructure for counting and reporting internal resources

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -32,6 +32,9 @@ ignored = ["cfg_aliases"]
 [lib]
 
 [features]
+## Internally count resources and events for debugging purposes. If the counters
+## feature is disabled, the counting infrastructure is removed from the build and
+## the exposed counters always return 0.
 counters = ["wgt/counters"]
 
 ## Log all API entry points at info instead of trace level.

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -32,6 +32,8 @@ ignored = ["cfg_aliases"]
 [lib]
 
 [features]
+counters = ["wgt/counters"]
+
 ## Log all API entry points at info instead of trace level.
 api_log_info = []
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2403,6 +2403,21 @@ impl Global {
         }
     }
 
+    pub fn device_get_internal_counters<A: HalApi>(
+        &self,
+        device_id: DeviceId,
+    ) -> wgt::InternalCounters {
+        let hub = A::hub(self);
+        if let Ok(device) = hub.devices.get(device_id) {
+            wgt::InternalCounters {
+                hal: device.get_hal_counters(),
+                core: wgt::CoreCounters {},
+            }
+        } else {
+            Default::default()
+        }
+    }
+
     pub fn queue_drop<A: HalApi>(&self, queue_id: QueueId) {
         profiling::scope!("Queue::drop");
         api_log!("Queue::drop {queue_id:?}");

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3641,6 +3641,10 @@ impl<A: HalApi> Device<A> {
     pub(crate) fn new_usage_scope(&self) -> UsageScope<'_, A> {
         UsageScope::new_pooled(&self.usage_scopes, &self.tracker_indices)
     }
+
+    pub fn get_hal_counters(&self) -> &hal::InternalCounters {
+        self.raw.as_ref().unwrap().get_internal_counters()
+    }
 }
 
 impl<A: HalApi> Device<A> {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -404,6 +404,7 @@ impl<A: HalApi> Device<A> {
         snatch_guard: SnatchGuard,
     ) -> Result<(UserClosures, bool), WaitIdleError> {
         profiling::scope!("Device::maintain");
+
         let fence = fence_guard.as_ref().unwrap();
         let last_done_index = if maintain.is_wait() {
             let index_to_wait_for = match maintain {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3643,8 +3643,11 @@ impl<A: HalApi> Device<A> {
         UsageScope::new_pooled(&self.usage_scopes, &self.tracker_indices)
     }
 
-    pub fn get_hal_counters(&self) -> &hal::InternalCounters {
-        self.raw.as_ref().unwrap().get_internal_counters()
+    pub fn get_hal_counters(&self) -> wgt::HalCounters {
+        self.raw
+            .as_ref()
+            .map(|raw| raw.get_internal_counters())
+            .unwrap_or_default()
     }
 }
 

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1,7 +1,7 @@
 use crate::{
     auxil::{self, dxgi::result::HResult as _},
     dx12::shader_compilation,
-    DeviceError, InternalCounters,
+    DeviceError,
 };
 use d3d12::ComPtr;
 
@@ -391,6 +391,7 @@ impl crate::Device for super::Device {
         // Only happens when it's using the windows_rs feature and there's an allocation
         if let Some(alloc) = buffer.allocation.take() {
             super::suballocation::free_buffer_allocation(
+                self,
                 alloc,
                 // SAFETY: for allocations to exist, the allocator must exist
                 unsafe { self.mem_allocator.as_ref().unwrap_unchecked() },
@@ -480,6 +481,7 @@ impl crate::Device for super::Device {
     unsafe fn destroy_texture(&self, mut texture: super::Texture) {
         if let Some(alloc) = texture.allocation.take() {
             super::suballocation::free_texture_allocation(
+                self,
                 alloc,
                 // SAFETY: for allocations to exist, the allocator must exist
                 unsafe { self.mem_allocator.as_ref().unwrap_unchecked() },
@@ -1772,7 +1774,7 @@ impl crate::Device for super::Device {
         todo!()
     }
 
-    fn get_internal_counters(&self) -> &InternalCounters {
-        &self.counters
+    fn get_internal_counters(&self) -> wgt::HalCounters {
+        self.counters.clone()
     }
 }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1,7 +1,7 @@
 use crate::{
     auxil::{self, dxgi::result::HResult as _},
     dx12::shader_compilation,
-    DeviceError,
+    DeviceError, InternalCounters,
 };
 use d3d12::ComPtr;
 
@@ -181,6 +181,7 @@ impl super::Device {
             null_rtv_handle,
             mem_allocator,
             dxc_container,
+            counters: Default::default(),
         })
     }
 
@@ -1710,5 +1711,9 @@ impl crate::Device for super::Device {
     ) {
         // Destroy a D3D12 resource as per-usual.
         todo!()
+    }
+
+    fn get_internal_counters(&self) -> &InternalCounters {
+        &self.counters
     }
 }

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -46,7 +46,6 @@ mod view;
 
 use crate::auxil::{self, dxgi::result::HResult as _};
 
-use crate::InternalCounters;
 use arrayvec::ArrayVec;
 use parking_lot::{Mutex, RwLock};
 use std::{ffi, fmt, mem, num::NonZeroU32, sync::Arc};
@@ -262,7 +261,7 @@ pub struct Device {
     null_rtv_handle: descriptor::Handle,
     mem_allocator: Option<Mutex<suballocation::GpuAllocatorWrapper>>,
     dxc_container: Option<Arc<shader_compilation::DxcContainer>>,
-    counters: InternalCounters,
+    counters: wgt::HalCounters,
 }
 
 unsafe impl Send for Device {}

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -46,6 +46,7 @@ mod view;
 
 use crate::auxil::{self, dxgi::result::HResult as _};
 
+use crate::InternalCounters;
 use arrayvec::ArrayVec;
 use parking_lot::{Mutex, RwLock};
 use std::{ffi, fmt, mem, num::NonZeroU32, sync::Arc};
@@ -261,6 +262,7 @@ pub struct Device {
     null_rtv_handle: descriptor::Handle,
     mem_allocator: Option<Mutex<suballocation::GpuAllocatorWrapper>>,
     dxc_container: Option<Arc<shader_compilation::DxcContainer>>,
+    counters: InternalCounters,
 }
 
 unsafe impl Send for Device {}

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -118,6 +118,8 @@ mod placed {
 
         null_comptr_check(resource)?;
 
+        device.counters.buffer_memory.add(allocation.size as isize);
+
         Ok((hr, Some(AllocationWrapper { allocation })))
     }
 
@@ -167,6 +169,8 @@ mod placed {
 
         null_comptr_check(resource)?;
 
+        device.counters.texture_memory.add(allocation.size() as isize);
+
         Ok((hr, Some(AllocationWrapper { allocation })))
     }
 
@@ -174,6 +178,7 @@ mod placed {
         allocation: AllocationWrapper,
         allocator: &Mutex<GpuAllocatorWrapper>,
     ) {
+        device.counters.buffer_memory.sub(allocation.allocation.size() as isize);
         match allocator.lock().allocator.free(allocation.allocation) {
             Ok(_) => (),
             // TODO: Don't panic here
@@ -185,6 +190,7 @@ mod placed {
         allocation: AllocationWrapper,
         allocator: &Mutex<GpuAllocatorWrapper>,
     ) {
+        device.counters.texture_memory.sub(allocation.allocation.size() as isize);
         match allocator.lock().allocator.free(allocation.allocation) {
             Ok(_) => (),
             // TODO: Don't panic here

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -118,7 +118,10 @@ mod placed {
 
         null_comptr_check(resource)?;
 
-        device.counters.buffer_memory.add(allocation.size as isize);
+        device
+            .counters
+            .buffer_memory
+            .add(allocation.size() as isize);
 
         Ok((hr, Some(AllocationWrapper { allocation })))
     }
@@ -169,16 +172,23 @@ mod placed {
 
         null_comptr_check(resource)?;
 
-        device.counters.texture_memory.add(allocation.size() as isize);
+        device
+            .counters
+            .texture_memory
+            .add(allocation.size() as isize);
 
         Ok((hr, Some(AllocationWrapper { allocation })))
     }
 
     pub(crate) fn free_buffer_allocation(
+        device: &crate::dx12::Device,
         allocation: AllocationWrapper,
         allocator: &Mutex<GpuAllocatorWrapper>,
     ) {
-        device.counters.buffer_memory.sub(allocation.allocation.size() as isize);
+        device
+            .counters
+            .buffer_memory
+            .sub(allocation.allocation.size() as isize);
         match allocator.lock().allocator.free(allocation.allocation) {
             Ok(_) => (),
             // TODO: Don't panic here
@@ -187,10 +197,14 @@ mod placed {
     }
 
     pub(crate) fn free_texture_allocation(
+        device: &crate::dx12::Device,
         allocation: AllocationWrapper,
         allocator: &Mutex<GpuAllocatorWrapper>,
     ) {
-        device.counters.texture_memory.sub(allocation.allocation.size() as isize);
+        device
+            .counters
+            .texture_memory
+            .sub(allocation.allocation.size() as isize);
         match allocator.lock().allocator.free(allocation.allocation) {
             Ok(_) => (),
             // TODO: Don't panic here
@@ -358,6 +372,7 @@ mod committed {
 
     #[allow(unused)]
     pub(crate) fn free_buffer_allocation(
+        _device: &crate::dx12::Device,
         _allocation: AllocationWrapper,
         _allocator: &Mutex<GpuAllocatorWrapper>,
     ) {
@@ -366,6 +381,7 @@ mod committed {
 
     #[allow(unused)]
     pub(crate) fn free_texture_allocation(
+        _device: &crate::dx12::Device,
         _allocation: AllocationWrapper,
         _allocator: &Mutex<GpuAllocatorWrapper>,
     ) {

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -276,6 +276,10 @@ impl crate::Device for Context {
         Default::default()
     }
     unsafe fn destroy_acceleration_structure(&self, _acceleration_structure: Resource) {}
+
+    fn get_internal_counters(&self) -> &crate::InternalCounters {
+        unreachable!();
+    }
 }
 
 impl crate::CommandEncoder for Encoder {

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -277,8 +277,8 @@ impl crate::Device for Context {
     }
     unsafe fn destroy_acceleration_structure(&self, _acceleration_structure: Resource) {}
 
-    fn get_internal_counters(&self) -> &crate::InternalCounters {
-        unreachable!();
+    fn get_internal_counters(&self) -> wgt::HalCounters {
+        Default::default()
     }
 }
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -967,6 +967,7 @@ impl crate::Adapter for super::Adapter {
                 main_vao,
                 #[cfg(all(native, feature = "renderdoc"))]
                 render_doc: Default::default(),
+                counters: Default::default(),
             },
             queue: super::Queue {
                 shared: Arc::clone(&self.shared),

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1604,8 +1604,8 @@ impl crate::Device for super::Device {
     }
     unsafe fn destroy_acceleration_structure(&self, _acceleration_structure: ()) {}
 
-    fn get_internal_counters(&self) -> &crate::InternalCounters {
-        &self.counters
+    fn get_internal_counters(&self) -> wgt::HalCounters {
+        self.counters.clone()
     }
 }
 

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1542,6 +1542,10 @@ impl crate::Device for super::Device {
         unimplemented!()
     }
     unsafe fn destroy_acceleration_structure(&self, _acceleration_structure: ()) {}
+
+    fn get_internal_counters(&self) -> &crate::InternalCounters {
+        &self.counters
+    }
 }
 
 #[cfg(send_sync)]

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -632,6 +632,8 @@ impl crate::Device for super::Device {
             None
         };
 
+        self.counters.buffers.add(1);
+
         Ok(super::Buffer {
             raw,
             target,
@@ -640,11 +642,14 @@ impl crate::Device for super::Device {
             data,
         })
     }
+
     unsafe fn destroy_buffer(&self, buffer: super::Buffer) {
         if let Some(raw) = buffer.raw {
             let gl = &self.shared.context.lock();
             unsafe { gl.delete_buffer(raw) };
         }
+
+        self.counters.buffers.sub(1);
     }
 
     unsafe fn map_buffer(
@@ -941,6 +946,8 @@ impl crate::Device for super::Device {
             super::TextureInner::Texture { raw, target }
         };
 
+        self.counters.textures.add(1);
+
         Ok(super::Texture {
             inner,
             drop_guard: None,
@@ -951,6 +958,7 @@ impl crate::Device for super::Device {
             copy_size: desc.copy_extent(),
         })
     }
+
     unsafe fn destroy_texture(&self, texture: super::Texture) {
         if texture.drop_guard.is_none() {
             let gl = &self.shared.context.lock();
@@ -970,6 +978,8 @@ impl crate::Device for super::Device {
         // For clarity, we explicitly drop the drop guard. Although this has no real semantic effect as the
         // end of the scope will drop the drop guard since this function takes ownership of the texture.
         drop(texture.drop_guard);
+
+        self.counters.textures.sub(1);
     }
 
     unsafe fn create_texture_view(
@@ -977,6 +987,7 @@ impl crate::Device for super::Device {
         texture: &super::Texture,
         desc: &crate::TextureViewDescriptor,
     ) -> Result<super::TextureView, crate::DeviceError> {
+        self.counters.texture_views.add(1);
         Ok(super::TextureView {
             //TODO: use `conv::map_view_dimension(desc.dimension)`?
             inner: texture.inner.clone(),
@@ -986,7 +997,10 @@ impl crate::Device for super::Device {
             format: texture.format,
         })
     }
-    unsafe fn destroy_texture_view(&self, _view: super::TextureView) {}
+
+    unsafe fn destroy_texture_view(&self, _view: super::TextureView) {
+        self.counters.texture_views.sub(1);
+    }
 
     unsafe fn create_sampler(
         &self,
@@ -1080,34 +1094,47 @@ impl crate::Device for super::Device {
             }
         }
 
+        self.counters.samplers.add(1);
+
         Ok(super::Sampler { raw })
     }
+
     unsafe fn destroy_sampler(&self, sampler: super::Sampler) {
         let gl = &self.shared.context.lock();
         unsafe { gl.delete_sampler(sampler.raw) };
+        self.counters.samplers.sub(1);
     }
 
     unsafe fn create_command_encoder(
         &self,
         _desc: &crate::CommandEncoderDescriptor<super::Api>,
     ) -> Result<super::CommandEncoder, crate::DeviceError> {
+        self.counters.command_encoders.add(1);
+
         Ok(super::CommandEncoder {
             cmd_buffer: super::CommandBuffer::default(),
             state: Default::default(),
             private_caps: self.shared.private_caps,
         })
     }
-    unsafe fn destroy_command_encoder(&self, _encoder: super::CommandEncoder) {}
+
+    unsafe fn destroy_command_encoder(&self, _encoder: super::CommandEncoder) {
+        self.counters.command_encoders.sub(1);
+    }
 
     unsafe fn create_bind_group_layout(
         &self,
         desc: &crate::BindGroupLayoutDescriptor,
     ) -> Result<super::BindGroupLayout, crate::DeviceError> {
+        self.counters.bind_group_layouts.add(1);
         Ok(super::BindGroupLayout {
             entries: Arc::from(desc.entries),
         })
     }
-    unsafe fn destroy_bind_group_layout(&self, _bg_layout: super::BindGroupLayout) {}
+
+    unsafe fn destroy_bind_group_layout(&self, _bg_layout: super::BindGroupLayout) {
+        self.counters.bind_group_layouts.sub(1);
+    }
 
     unsafe fn create_pipeline_layout(
         &self,
@@ -1184,6 +1211,8 @@ impl crate::Device for super::Device {
             });
         }
 
+        self.counters.pipeline_layouts.add(1);
+
         Ok(super::PipelineLayout {
             group_infos: group_infos.into_boxed_slice(),
             naga_options: glsl::Options {
@@ -1194,7 +1223,10 @@ impl crate::Device for super::Device {
             },
         })
     }
-    unsafe fn destroy_pipeline_layout(&self, _pipeline_layout: super::PipelineLayout) {}
+
+    unsafe fn destroy_pipeline_layout(&self, _pipeline_layout: super::PipelineLayout) {
+        self.counters.pipeline_layouts.sub(1);
+    }
 
     unsafe fn create_bind_group(
         &self,
@@ -1270,17 +1302,24 @@ impl crate::Device for super::Device {
             contents.push(binding);
         }
 
+        self.counters.bind_groups.add(1);
+
         Ok(super::BindGroup {
             contents: contents.into_boxed_slice(),
         })
     }
-    unsafe fn destroy_bind_group(&self, _group: super::BindGroup) {}
+
+    unsafe fn destroy_bind_group(&self, _group: super::BindGroup) {
+        self.counters.bind_groups.sub(1);
+    }
 
     unsafe fn create_shader_module(
         &self,
         desc: &crate::ShaderModuleDescriptor,
         shader: crate::ShaderInput,
     ) -> Result<super::ShaderModule, crate::ShaderError> {
+        self.counters.shader_modules.add(1);
+
         Ok(super::ShaderModule {
             naga: match shader {
                 crate::ShaderInput::SpirV(_) => {
@@ -1292,7 +1331,10 @@ impl crate::Device for super::Device {
             id: self.shared.next_shader_id.fetch_add(1, Ordering::Relaxed),
         })
     }
-    unsafe fn destroy_shader_module(&self, _module: super::ShaderModule) {}
+
+    unsafe fn destroy_shader_module(&self, _module: super::ShaderModule) {
+        self.counters.shader_modules.sub(1);
+    }
 
     unsafe fn create_render_pipeline(
         &self,
@@ -1341,6 +1383,8 @@ impl crate::Device for super::Device {
             targets.into_boxed_slice()
         };
 
+        self.counters.render_pipelines.add(1);
+
         Ok(super::RenderPipeline {
             inner,
             primitive: desc.primitive,
@@ -1363,6 +1407,7 @@ impl crate::Device for super::Device {
             alpha_to_coverage_enabled: desc.multisample.alpha_to_coverage_enabled,
         })
     }
+
     unsafe fn destroy_render_pipeline(&self, pipeline: super::RenderPipeline) {
         let mut program_cache = self.shared.program_cache.lock();
         // If the pipeline only has 2 strong references remaining, they're `pipeline` and `program_cache`
@@ -1377,6 +1422,8 @@ impl crate::Device for super::Device {
             let gl = &self.shared.context.lock();
             unsafe { gl.delete_program(pipeline.inner.program) };
         }
+
+        self.counters.render_pipelines.sub(1);
     }
 
     unsafe fn create_compute_pipeline(
@@ -1388,8 +1435,11 @@ impl crate::Device for super::Device {
         shaders.push((naga::ShaderStage::Compute, &desc.stage));
         let inner = unsafe { self.create_pipeline(gl, shaders, desc.layout, desc.label, None) }?;
 
+        self.counters.compute_pipelines.add(1);
+
         Ok(super::ComputePipeline { inner })
     }
+
     unsafe fn destroy_compute_pipeline(&self, pipeline: super::ComputePipeline) {
         let mut program_cache = self.shared.program_cache.lock();
         // If the pipeline only has 2 strong references remaining, they're `pipeline` and `program_cache``
@@ -1404,6 +1454,8 @@ impl crate::Device for super::Device {
             let gl = &self.shared.context.lock();
             unsafe { gl.delete_program(pipeline.inner.program) };
         }
+
+        self.counters.compute_pipelines.sub(1);
     }
 
     unsafe fn create_pipeline_cache(
@@ -1437,6 +1489,8 @@ impl crate::Device for super::Device {
             queries.push(query);
         }
 
+        self.counters.query_sets.add(1);
+
         Ok(super::QuerySet {
             queries: queries.into_boxed_slice(),
             target: match desc.ty {
@@ -1446,24 +1500,31 @@ impl crate::Device for super::Device {
             },
         })
     }
+
     unsafe fn destroy_query_set(&self, set: super::QuerySet) {
         let gl = &self.shared.context.lock();
         for &query in set.queries.iter() {
             unsafe { gl.delete_query(query) };
         }
+        self.counters.query_sets.sub(1);
     }
+
     unsafe fn create_fence(&self) -> Result<super::Fence, crate::DeviceError> {
+        self.counters.fences.add(1);
         Ok(super::Fence {
             last_completed: 0,
             pending: Vec::new(),
         })
     }
+
     unsafe fn destroy_fence(&self, fence: super::Fence) {
         let gl = &self.shared.context.lock();
         for (_, sync) in fence.pending {
             unsafe { gl.delete_sync(sync) };
         }
+        self.counters.fences.sub(1);
     }
+
     unsafe fn get_fence_value(
         &self,
         fence: &super::Fence,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -268,6 +268,7 @@ pub struct Device {
     main_vao: glow::VertexArray,
     #[cfg(all(native, feature = "renderdoc"))]
     render_doc: crate::auxil::renderdoc::RenderDoc,
+    counters: crate::InternalCounters,
 }
 
 pub struct ShaderClearProgram {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -268,7 +268,7 @@ pub struct Device {
     main_vao: glow::VertexArray,
     #[cfg(all(native, feature = "renderdoc"))]
     render_doc: crate::auxil::renderdoc::RenderDoc,
-    counters: crate::InternalCounters,
+    counters: wgt::HalCounters,
 }
 
 pub struct ShaderClearProgram {

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -280,7 +280,7 @@ use std::{
 use bitflags::bitflags;
 use parking_lot::Mutex;
 use thiserror::Error;
-use wgt::{InternalCounter, WasmNotSendSync};
+use wgt::WasmNotSendSync;
 
 // - Vertex + Fragment
 // - Compute
@@ -885,7 +885,7 @@ pub trait Device: WasmNotSendSync {
         acceleration_structure: <Self::A as Api>::AccelerationStructure,
     );
 
-    fn get_internal_counters(&self) -> &InternalCounters;
+    fn get_internal_counters(&self) -> wgt::HalCounters;
 }
 
 pub trait Queue: WasmNotSendSync {
@@ -2278,26 +2278,4 @@ bitflags::bitflags! {
 #[derive(Debug, Clone)]
 pub struct AccelerationStructureBarrier {
     pub usage: Range<AccelerationStructureUses>,
-}
-
-#[derive(Default)]
-pub struct InternalCounters {
-    // API objects
-    pub buffers: InternalCounter,
-    pub textures: InternalCounter,
-    pub texture_views: InternalCounter,
-    pub bind_groups: InternalCounter,
-    pub bind_group_layouts: InternalCounter,
-    pub render_pipelines: InternalCounter,
-    pub compute_pipelines: InternalCounter,
-    pub pipeline_layouts: InternalCounter,
-    pub samplers: InternalCounter,
-    pub command_encoders: InternalCounter,
-    pub shader_modules: InternalCounter,
-    pub query_sets: InternalCounter,
-    pub fences: InternalCounter,
-    // Resources
-    pub buffer_memory: InternalCounter,
-    pub texture_memory: InternalCounter,
-    pub memory_allocations: InternalCounter,
 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -280,7 +280,7 @@ use std::{
 use bitflags::bitflags;
 use parking_lot::Mutex;
 use thiserror::Error;
-use wgt::WasmNotSendSync;
+use wgt::{InternalCounter, WasmNotSendSync};
 
 // - Vertex + Fragment
 // - Compute
@@ -884,6 +884,8 @@ pub trait Device: WasmNotSendSync {
         &self,
         acceleration_structure: <Self::A as Api>::AccelerationStructure,
     );
+
+    fn get_internal_counters(&self) -> &InternalCounters;
 }
 
 pub trait Queue: WasmNotSendSync {
@@ -2276,4 +2278,12 @@ bitflags::bitflags! {
 #[derive(Debug, Clone)]
 pub struct AccelerationStructureBarrier {
     pub usage: Range<AccelerationStructureUses>,
+}
+
+#[derive(Default)]
+pub struct InternalCounters {
+    // Resources
+    pub buffer_memory: InternalCounter,
+    pub texture_memory: InternalCounter,
+    pub memory_allocations: InternalCounter,
 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2282,6 +2282,20 @@ pub struct AccelerationStructureBarrier {
 
 #[derive(Default)]
 pub struct InternalCounters {
+    // API objects
+    pub buffers: InternalCounter,
+    pub textures: InternalCounter,
+    pub texture_views: InternalCounter,
+    pub bind_groups: InternalCounter,
+    pub bind_group_layouts: InternalCounter,
+    pub render_pipelines: InternalCounter,
+    pub compute_pipelines: InternalCounter,
+    pub pipeline_layouts: InternalCounter,
+    pub samplers: InternalCounter,
+    pub command_encoders: InternalCounter,
+    pub shader_modules: InternalCounter,
+    pub query_sets: InternalCounter,
+    pub fences: InternalCounter,
     // Resources
     pub buffer_memory: InternalCounter,
     pub texture_memory: InternalCounter,

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -62,6 +62,7 @@ impl crate::Adapter for super::Adapter {
             device: super::Device {
                 shared: Arc::clone(&self.shared),
                 features,
+                counters: Default::default(),
             },
             queue: super::Queue {
                 raw: Arc::new(Mutex::new(queue)),

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -8,7 +8,6 @@ use std::{
 
 use super::conv;
 use crate::auxil::map_naga_stage;
-use crate::InternalCounters;
 
 type DeviceResult<T> = Result<T, crate::DeviceError>;
 
@@ -1410,7 +1409,7 @@ impl crate::Device for super::Device {
         unimplemented!()
     }
 
-    fn get_internal_counters(&self) -> &InternalCounters {
-        &self.counters
+    fn get_internal_counters(&self) -> wgt::HalCounters {
+        self.counters.clone()
     }
 }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -347,13 +347,16 @@ impl crate::Device for super::Device {
             if let Some(label) = desc.label {
                 raw.set_label(label);
             }
+            self.counters.buffers.add(1);
             Ok(super::Buffer {
                 raw,
                 size: desc.size,
             })
         })
     }
-    unsafe fn destroy_buffer(&self, _buffer: super::Buffer) {}
+    unsafe fn destroy_buffer(&self, _buffer: super::Buffer) {
+        self.counters.buffers.sub(1);
+    }
 
     unsafe fn map_buffer(
         &self,
@@ -420,6 +423,8 @@ impl crate::Device for super::Device {
                 raw.set_label(label);
             }
 
+            self.counters.textures.add(1);
+
             Ok(super::Texture {
                 raw,
                 format: desc.format,
@@ -431,7 +436,9 @@ impl crate::Device for super::Device {
         })
     }
 
-    unsafe fn destroy_texture(&self, _texture: super::Texture) {}
+    unsafe fn destroy_texture(&self, _texture: super::Texture) {
+        self.counters.textures.sub(1);
+    }
 
     unsafe fn create_texture_view(
         &self,
@@ -491,9 +498,14 @@ impl crate::Device for super::Device {
             })
         };
 
+        self.counters.texture_views.add(1);
+
         Ok(super::TextureView { raw, aspects })
     }
-    unsafe fn destroy_texture_view(&self, _view: super::TextureView) {}
+
+    unsafe fn destroy_texture_view(&self, _view: super::TextureView) {
+        self.counters.texture_views.sub(1);
+    }
 
     unsafe fn create_sampler(
         &self,
@@ -550,15 +562,20 @@ impl crate::Device for super::Device {
             }
             let raw = self.shared.device.lock().new_sampler(&descriptor);
 
+            self.counters.samplers.add(1);
+
             Ok(super::Sampler { raw })
         })
     }
-    unsafe fn destroy_sampler(&self, _sampler: super::Sampler) {}
+    unsafe fn destroy_sampler(&self, _sampler: super::Sampler) {
+        self.counters.samplers.sub(1);
+    }
 
     unsafe fn create_command_encoder(
         &self,
         desc: &crate::CommandEncoderDescriptor<super::Api>,
     ) -> Result<super::CommandEncoder, crate::DeviceError> {
+        self.counters.command_encoders.add(1);
         Ok(super::CommandEncoder {
             shared: Arc::clone(&self.shared),
             raw_queue: Arc::clone(&desc.queue.raw),
@@ -567,17 +584,25 @@ impl crate::Device for super::Device {
             temp: super::Temp::default(),
         })
     }
-    unsafe fn destroy_command_encoder(&self, _encoder: super::CommandEncoder) {}
+
+    unsafe fn destroy_command_encoder(&self, _encoder: super::CommandEncoder) {
+        self.counters.command_encoders.sub(1);
+    }
 
     unsafe fn create_bind_group_layout(
         &self,
         desc: &crate::BindGroupLayoutDescriptor,
     ) -> DeviceResult<super::BindGroupLayout> {
+        self.counters.bind_group_layouts.add(1);
+
         Ok(super::BindGroupLayout {
             entries: Arc::from(desc.entries),
         })
     }
-    unsafe fn destroy_bind_group_layout(&self, _bg_layout: super::BindGroupLayout) {}
+
+    unsafe fn destroy_bind_group_layout(&self, _bg_layout: super::BindGroupLayout) {
+        self.counters.bind_group_layouts.sub(1);
+    }
 
     unsafe fn create_pipeline_layout(
         &self,
@@ -738,6 +763,8 @@ impl crate::Device for super::Device {
             resources: info.resources,
         });
 
+        self.counters.pipeline_layouts.add(1);
+
         Ok(super::PipelineLayout {
             bind_group_infos,
             push_constants_infos,
@@ -746,7 +773,10 @@ impl crate::Device for super::Device {
             per_stage_map,
         })
     }
-    unsafe fn destroy_pipeline_layout(&self, _pipeline_layout: super::PipelineLayout) {}
+
+    unsafe fn destroy_pipeline_layout(&self, _pipeline_layout: super::PipelineLayout) {
+        self.counters.pipeline_layouts.sub(1);
+    }
 
     unsafe fn create_bind_group(
         &self,
@@ -833,16 +863,22 @@ impl crate::Device for super::Device {
             }
         }
 
+        self.counters.bind_groups.add(1);
+
         Ok(bg)
     }
 
-    unsafe fn destroy_bind_group(&self, _group: super::BindGroup) {}
+    unsafe fn destroy_bind_group(&self, _group: super::BindGroup) {
+        self.counters.bind_groups.sub(1);
+    }
 
     unsafe fn create_shader_module(
         &self,
         desc: &crate::ShaderModuleDescriptor,
         shader: crate::ShaderInput,
     ) -> Result<super::ShaderModule, crate::ShaderError> {
+        self.counters.shader_modules.add(1);
+
         match shader {
             crate::ShaderInput::Naga(naga) => Ok(super::ShaderModule {
                 naga,
@@ -853,7 +889,10 @@ impl crate::Device for super::Device {
             }
         }
     }
-    unsafe fn destroy_shader_module(&self, _module: super::ShaderModule) {}
+
+    unsafe fn destroy_shader_module(&self, _module: super::ShaderModule) {
+        self.counters.shader_modules.sub(1);
+    }
 
     unsafe fn create_render_pipeline(
         &self,
@@ -1096,6 +1135,8 @@ impl crate::Device for super::Device {
                     )
                 })?;
 
+            self.counters.render_pipelines.add(1);
+
             Ok(super::RenderPipeline {
                 raw,
                 vs_lib,
@@ -1119,7 +1160,10 @@ impl crate::Device for super::Device {
             })
         })
     }
-    unsafe fn destroy_render_pipeline(&self, _pipeline: super::RenderPipeline) {}
+
+    unsafe fn destroy_render_pipeline(&self, _pipeline: super::RenderPipeline) {
+        self.counters.render_pipelines.sub(1);
+    }
 
     unsafe fn create_compute_pipeline(
         &self,
@@ -1167,6 +1211,8 @@ impl crate::Device for super::Device {
                     )
                 })?;
 
+            self.counters.compute_pipelines.add(1);
+
             Ok(super::ComputePipeline {
                 raw,
                 cs_info,
@@ -1176,7 +1222,10 @@ impl crate::Device for super::Device {
             })
         })
     }
-    unsafe fn destroy_compute_pipeline(&self, _pipeline: super::ComputePipeline) {}
+
+    unsafe fn destroy_compute_pipeline(&self, _pipeline: super::ComputePipeline) {
+        self.counters.compute_pipelines.sub(1);
+    }
 
     unsafe fn create_pipeline_cache(
         &self,
@@ -1239,6 +1288,8 @@ impl crate::Device for super::Device {
                             }
                         };
 
+                    self.counters.query_sets.add(1);
+
                     Ok(super::QuerySet {
                         raw_buffer: destination_buffer,
                         counter_sample_buffer: Some(counter_sample_buffer),
@@ -1251,15 +1302,23 @@ impl crate::Device for super::Device {
             }
         })
     }
-    unsafe fn destroy_query_set(&self, _set: super::QuerySet) {}
+
+    unsafe fn destroy_query_set(&self, _set: super::QuerySet) {
+        self.counters.query_sets.add(1);
+    }
 
     unsafe fn create_fence(&self) -> DeviceResult<super::Fence> {
+        self.counters.fences.add(1);
         Ok(super::Fence {
             completed_value: Arc::new(atomic::AtomicU64::new(0)),
             pending_command_buffers: Vec::new(),
         })
     }
-    unsafe fn destroy_fence(&self, _fence: super::Fence) {}
+
+    unsafe fn destroy_fence(&self, _fence: super::Fence) {
+        self.counters.fences.sub(1);
+    }
+
     unsafe fn get_fence_value(&self, fence: &super::Fence) -> DeviceResult<crate::FenceValue> {
         let mut max_value = fence.completed_value.load(atomic::Ordering::Acquire);
         for &(value, ref cmd_buf) in fence.pending_command_buffers.iter() {

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -8,6 +8,7 @@ use std::{
 
 use super::conv;
 use crate::auxil::map_naga_stage;
+use crate::InternalCounters;
 
 type DeviceResult<T> = Result<T, crate::DeviceError>;
 
@@ -305,6 +306,7 @@ impl super::Device {
         super::Device {
             shared: Arc::new(super::AdapterShared::new(raw)),
             features,
+            counters: Default::default(),
         }
     }
 
@@ -1347,5 +1349,9 @@ impl crate::Device for super::Device {
         _acceleration_structure: super::AccelerationStructure,
     ) {
         unimplemented!()
+    }
+
+    fn get_internal_counters(&self) -> &InternalCounters {
+        &self.counters
     }
 }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -36,7 +36,6 @@ use arrayvec::ArrayVec;
 use bitflags::bitflags;
 use metal::foreign_types::ForeignTypeRef as _;
 use parking_lot::{Mutex, RwLock};
-use crate::InternalCounters;
 
 #[derive(Clone, Debug)]
 pub struct Api;
@@ -340,7 +339,7 @@ impl Queue {
 pub struct Device {
     shared: Arc<AdapterShared>,
     features: wgt::Features,
-    counters: InternalCounters,
+    counters: wgt::HalCounters,
 }
 
 pub struct Surface {

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -36,6 +36,7 @@ use arrayvec::ArrayVec;
 use bitflags::bitflags;
 use metal::foreign_types::ForeignTypeRef as _;
 use parking_lot::{Mutex, RwLock};
+use crate::InternalCounters;
 
 #[derive(Clone, Debug)]
 pub struct Api;
@@ -339,6 +340,7 @@ impl Queue {
 pub struct Device {
     shared: Arc<AdapterShared>,
     features: wgt::Features,
+    counters: InternalCounters,
 }
 
 pub struct Surface {

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1819,6 +1819,7 @@ impl super::Adapter {
             workarounds: self.workarounds,
             render_passes: Mutex::new(Default::default()),
             framebuffers: Mutex::new(Default::default()),
+            memory_allocations_counter: Default::default(),
         });
 
         let relay_semaphores = super::RelaySemaphores::new(&shared)?;
@@ -1881,6 +1882,7 @@ impl super::Adapter {
             naga_options,
             #[cfg(feature = "renderdoc")]
             render_doc: Default::default(),
+            counters: Default::default(),
         };
 
         Ok(crate::OpenDevice { device, queue })

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1,5 +1,4 @@
 use super::{conv, PipelineCache};
-use crate::InternalCounters;
 
 use arrayvec::ArrayVec;
 use ash::{khr, vk};
@@ -2388,10 +2387,12 @@ impl crate::Device for super::Device {
         }
     }
 
-    fn get_internal_counters(&self) -> &InternalCounters {
-        self.counters.memory_allocations.set(self.shared.memory_allocations_counter.read());
+    fn get_internal_counters(&self) -> wgt::HalCounters {
+        self.counters
+            .memory_allocations
+            .set(self.shared.memory_allocations_counter.read());
 
-        &self.counters
+        self.counters.clone()
     }
 }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -43,6 +43,7 @@ use std::{
 use arrayvec::ArrayVec;
 use ash::{ext, khr, vk};
 use parking_lot::{Mutex, RwLock};
+use wgt::InternalCounter;
 
 const MILLIS_TO_NANOS: u64 = 1_000_000;
 const MAX_TOTAL_ATTACHMENTS: usize = crate::MAX_COLOR_ATTACHMENTS * 2 + 1;
@@ -527,6 +528,7 @@ struct DeviceShared {
     features: wgt::Features,
     render_passes: Mutex<rustc_hash::FxHashMap<RenderPassKey, vk::RenderPass>>,
     framebuffers: Mutex<rustc_hash::FxHashMap<FramebufferKey, vk::Framebuffer>>,
+    memory_allocations_counter: InternalCounter,
 }
 
 pub struct Device {
@@ -538,6 +540,7 @@ pub struct Device {
     naga_options: naga::back::spv::Options<'static>,
     #[cfg(feature = "renderdoc")]
     render_doc: crate::auxil::renderdoc::RenderDoc,
+    counters: crate::InternalCounters,
 }
 
 /// Semaphores for forcing queue submissions to run in order.

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -540,7 +540,7 @@ pub struct Device {
     naga_options: naga::back::spv::Options<'static>,
     #[cfg(feature = "renderdoc")]
     render_doc: crate::auxil::renderdoc::RenderDoc,
-    counters: crate::InternalCounters,
+    counters: wgt::HalCounters,
 }
 
 /// Semaphores for forcing queue submissions to run in order.

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -30,6 +30,8 @@ targets = [
 [features]
 strict_asserts = []
 fragile-send-sync-non-atomic-wasm = []
+# Enables some internal instrumentation for debugging purposes.
+counters = []
 
 [dependencies]
 bitflags = "2"

--- a/wgpu-types/src/counters.rs
+++ b/wgpu-types/src/counters.rs
@@ -1,0 +1,153 @@
+#[cfg(feature = "counters")]
+use std::sync::atomic::{AtomicIsize, Ordering};
+
+/// An internal counter for debugging purposes
+///
+/// Internally represented as an atomic isize if the `counters` feature is enabled,
+/// or compiles to nothing otherwise.
+pub struct InternalCounter {
+    #[cfg(feature = "counters")]
+    value: AtomicIsize,
+}
+
+impl InternalCounter {
+    /// Creates a counter with value 0.
+    #[inline]
+    pub const fn new() -> Self {
+        InternalCounter {
+            #[cfg(feature = "counters")]
+            value: AtomicIsize::new(0),
+        }
+    }
+
+    /// Get the counter's value.
+    #[cfg(feature = "counters")]
+    #[inline]
+    pub fn read(&self) -> isize {
+        self.value.load(Ordering::Relaxed)
+    }
+
+    /// Get the counter's value.
+    ///
+    /// Always returns 0 if the `counters` feature is not enabled.
+    #[cfg(not(feature = "counters"))]
+    #[inline]
+    pub fn read(&self) -> isize {
+        0
+    }
+
+    /// Get and reset the counter's value.
+    ///
+    /// Always returns 0 if the `counters` feature is not enabled.
+    #[cfg(feature = "counters")]
+    #[inline]
+    pub fn take(&self) -> isize {
+        self.value.swap(0, Ordering::Relaxed)
+    }
+
+    /// Get and reset the counter's value.
+    ///
+    /// Always returns 0 if the `counters` feature is not enabled.
+    #[cfg(not(feature = "counters"))]
+    #[inline]
+    pub fn take(&self) -> isize {
+        0
+    }
+
+    /// Increment the counter by the provided amount.
+    #[inline]
+    pub fn add(&self, _val: isize) {
+        #[cfg(feature = "counters")]
+        self.value.fetch_add(_val, Ordering::Relaxed);
+    }
+
+    /// Decrement the counter by the provided amount.
+    #[inline]
+    pub fn sub(&self, _val: isize) {
+        #[cfg(feature = "counters")]
+        self.value.fetch_add(-_val, Ordering::Relaxed);
+    }
+
+    /// Sets the counter to the provided value.
+    #[inline]
+    pub fn set(&self, _val: isize) {
+        #[cfg(feature = "counters")]
+        self.value.store(_val, Ordering::Relaxed);
+    }
+}
+
+impl Clone for InternalCounter {
+    fn clone(&self) -> Self {
+        InternalCounter {
+            #[cfg(feature = "counters")]
+            value: AtomicIsize::new(self.read()),
+        }
+    }
+}
+
+impl Default for InternalCounter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for InternalCounter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.read().fmt(f)
+    }
+}
+
+/// `wgpu-hal`'s internal counters.
+#[derive(Clone, Default)]
+pub struct HalCounters {
+    // API objects
+    ///
+    pub buffers: InternalCounter,
+    ///
+    pub textures: InternalCounter,
+    ///
+    pub texture_views: InternalCounter,
+    ///
+    pub bind_groups: InternalCounter,
+    ///
+    pub bind_group_layouts: InternalCounter,
+    ///
+    pub render_pipelines: InternalCounter,
+    ///
+    pub compute_pipelines: InternalCounter,
+    ///
+    pub pipeline_layouts: InternalCounter,
+    ///
+    pub samplers: InternalCounter,
+    ///
+    pub command_encoders: InternalCounter,
+    ///
+    pub shader_modules: InternalCounter,
+    ///
+    pub query_sets: InternalCounter,
+    ///
+    pub fences: InternalCounter,
+
+    // Resources
+    /// Amount of allocated gpu memory attributed to buffers, in bytes.
+    pub buffer_memory: InternalCounter,
+    /// Amount of allocated gpu memory attributed to textures, in bytes.
+    pub texture_memory: InternalCounter,
+    /// Number of gpu memory allocations.
+    pub memory_allocations: InternalCounter,
+}
+
+/// `wgpu-core`'s internal counters.
+#[derive(Clone, Default)]
+pub struct CoreCounters {
+    // TODO
+}
+
+/// All internal counters, exposed for debugging purposes.
+#[derive(Clone, Default)]
+pub struct InternalCounters {
+    /// `wgpu-core` counters.
+    pub core: CoreCounters,
+    /// `wgpu-hal` counters.
+    pub hal: HalCounters,
+}

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -15,9 +15,9 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
-use std::{num::NonZeroU32, ops::Range};
 #[cfg(feature = "counters")]
 use std::sync::atomic::{AtomicIsize, Ordering};
+use std::{num::NonZeroU32, ops::Range};
 
 pub mod assertions;
 pub mod math;
@@ -7365,6 +7365,61 @@ impl Default for InternalCounter {
 
 impl std::fmt::Debug for InternalCounter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-       self.read().fmt(f)
+        self.read().fmt(f)
     }
+}
+
+/// `wgpu-hal`'s internal counters.
+#[derive(Clone, Default)]
+pub struct HalCounters {
+    // API objects
+    ///
+    pub buffers: InternalCounter,
+    ///
+    pub textures: InternalCounter,
+    ///
+    pub texture_views: InternalCounter,
+    ///
+    pub bind_groups: InternalCounter,
+    ///
+    pub bind_group_layouts: InternalCounter,
+    ///
+    pub render_pipelines: InternalCounter,
+    ///
+    pub compute_pipelines: InternalCounter,
+    ///
+    pub pipeline_layouts: InternalCounter,
+    ///
+    pub samplers: InternalCounter,
+    ///
+    pub command_encoders: InternalCounter,
+    ///
+    pub shader_modules: InternalCounter,
+    ///
+    pub query_sets: InternalCounter,
+    ///
+    pub fences: InternalCounter,
+
+    // Resources
+    /// Amount of allocated gpu memory attributed to buffers, in bytes.
+    pub buffer_memory: InternalCounter,
+    /// Amount of allocated gpu memory attributed to textures, in bytes.
+    pub texture_memory: InternalCounter,
+    /// Number of gpu memory allocations.
+    pub memory_allocations: InternalCounter,
+}
+
+/// `wgpu-core`'s internal counters.
+#[derive(Clone, Default)]
+pub struct CoreCounters {
+    // TODO
+}
+
+/// All internal counters, exposed for debugging purposes.
+#[derive(Clone, Default)]
+pub struct InternalCounters {
+    /// `wgpu-core` counters.
+    pub core: CoreCounters,
+    /// `wgpu-hal` counters.
+    pub hal: HalCounters,
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -15,12 +15,13 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
-#[cfg(feature = "counters")]
-use std::sync::atomic::{AtomicIsize, Ordering};
 use std::{num::NonZeroU32, ops::Range};
 
 pub mod assertions;
 pub mod math;
+mod counters;
+
+pub use counters::*;
 
 // Use this macro instead of the one provided by the bitflags_serde_shim crate
 // because the latter produces an error when deserializing bits that are not
@@ -7271,155 +7272,4 @@ pub enum DeviceLostReason {
     /// will eventually be called. If the device is already invalid, wgpu
     /// will call the callback immediately, with this reason.
     DeviceInvalid = 4,
-}
-
-/// An internal counter for debugging purposes
-///
-/// Internally represented as an atomic isize if the `counters` feature is enabled,
-/// or compiles to nothing otherwise.
-pub struct InternalCounter {
-    #[cfg(feature = "counters")]
-    value: AtomicIsize,
-}
-
-impl InternalCounter {
-    /// Creates a counter with value 0.
-    #[inline]
-    pub const fn new() -> Self {
-        InternalCounter {
-            #[cfg(feature = "counters")]
-            value: AtomicIsize::new(0),
-        }
-    }
-
-    /// Get the counter's value.
-    #[cfg(feature = "counters")]
-    #[inline]
-    pub fn read(&self) -> isize {
-        self.value.load(Ordering::Relaxed)
-    }
-
-    /// Get the counter's value.
-    ///
-    /// Always returns 0 if the `counters` feature is not enabled.
-    #[cfg(not(feature = "counters"))]
-    #[inline]
-    pub fn read(&self) -> isize {
-        0
-    }
-
-    /// Get and reset the counter's value.
-    ///
-    /// Always returns 0 if the `counters` feature is not enabled.
-    #[cfg(feature = "counters")]
-    #[inline]
-    pub fn take(&self) -> isize {
-        self.value.swap(0, Ordering::Relaxed)
-    }
-
-    /// Get and reset the counter's value.
-    ///
-    /// Always returns 0 if the `counters` feature is not enabled.
-    #[cfg(not(feature = "counters"))]
-    #[inline]
-    pub fn take(&self) -> isize {
-        0
-    }
-
-    /// Increment the counter by the provided amount.
-    #[inline]
-    pub fn add(&self, _val: isize) {
-        #[cfg(feature = "counters")]
-        self.value.fetch_add(_val, Ordering::Relaxed);
-    }
-
-    /// Decrement the counter by the provided amount.
-    #[inline]
-    pub fn sub(&self, _val: isize) {
-        #[cfg(feature = "counters")]
-        self.value.fetch_add(-_val, Ordering::Relaxed);
-    }
-
-    /// Sets the counter to the provided value.
-    #[inline]
-    pub fn set(&self, _val: isize) {
-        #[cfg(feature = "counters")]
-        self.value.store(_val, Ordering::Relaxed);
-    }
-}
-
-impl Clone for InternalCounter {
-    fn clone(&self) -> Self {
-        InternalCounter {
-            #[cfg(feature = "counters")]
-            value: AtomicIsize::new(self.read()),
-        }
-    }
-}
-
-impl Default for InternalCounter {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl std::fmt::Debug for InternalCounter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.read().fmt(f)
-    }
-}
-
-/// `wgpu-hal`'s internal counters.
-#[derive(Clone, Default)]
-pub struct HalCounters {
-    // API objects
-    ///
-    pub buffers: InternalCounter,
-    ///
-    pub textures: InternalCounter,
-    ///
-    pub texture_views: InternalCounter,
-    ///
-    pub bind_groups: InternalCounter,
-    ///
-    pub bind_group_layouts: InternalCounter,
-    ///
-    pub render_pipelines: InternalCounter,
-    ///
-    pub compute_pipelines: InternalCounter,
-    ///
-    pub pipeline_layouts: InternalCounter,
-    ///
-    pub samplers: InternalCounter,
-    ///
-    pub command_encoders: InternalCounter,
-    ///
-    pub shader_modules: InternalCounter,
-    ///
-    pub query_sets: InternalCounter,
-    ///
-    pub fences: InternalCounter,
-
-    // Resources
-    /// Amount of allocated gpu memory attributed to buffers, in bytes.
-    pub buffer_memory: InternalCounter,
-    /// Amount of allocated gpu memory attributed to textures, in bytes.
-    pub texture_memory: InternalCounter,
-    /// Number of gpu memory allocations.
-    pub memory_allocations: InternalCounter,
-}
-
-/// `wgpu-core`'s internal counters.
-#[derive(Clone, Default)]
-pub struct CoreCounters {
-    // TODO
-}
-
-/// All internal counters, exposed for debugging purposes.
-#[derive(Clone, Default)]
-pub struct InternalCounters {
-    /// `wgpu-core` counters.
-    pub core: CoreCounters,
-    /// `wgpu-hal` counters.
-    pub hal: HalCounters,
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -18,8 +18,8 @@ use std::path::PathBuf;
 use std::{num::NonZeroU32, ops::Range};
 
 pub mod assertions;
-pub mod math;
 mod counters;
+pub mod math;
 
 pub use counters::*;
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -97,6 +97,11 @@ replay = ["serde", "wgc/replay"]
 #! ### Other
 # --------------------------------------------------------------------
 
+## Internally count resources and events for debugging purposes. If the counters
+## feature is disabled, the counting infrastructure is removed from the build and
+## the exposed counters always return 0.
+counters = ["wgc/counters"]
+
 ## Implement `Send` and `Sync` on Wasm, but only if atomics are not enabled.
 ##
 ## WebGL/WebGPU objects can not be shared between threads.

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2978,7 +2978,11 @@ impl crate::context::Context for ContextWebGpu {
     fn device_start_capture(&self, _device: &Self::DeviceId, _device_data: &Self::DeviceData) {}
     fn device_stop_capture(&self, _device: &Self::DeviceId, _device_data: &Self::DeviceData) {}
 
-    fn device_get_internal_counters(&self, _device: &Self::DeviceId, _device_data: &Self::DeviceData) -> wgt::InternalCounters {
+    fn device_get_internal_counters(
+        &self,
+        _device: &Self::DeviceId,
+        _device_data: &Self::DeviceData,
+    ) -> wgt::InternalCounters {
         Default::default()
     }
 

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2978,6 +2978,10 @@ impl crate::context::Context for ContextWebGpu {
     fn device_start_capture(&self, _device: &Self::DeviceId, _device_data: &Self::DeviceData) {}
     fn device_stop_capture(&self, _device: &Self::DeviceId, _device_data: &Self::DeviceData) {}
 
+    fn device_get_internal_counters(&self, _device: &Self::DeviceId, _device_data: &Self::DeviceData) -> wgt::InternalCounters {
+        Default::default()
+    }
+
     fn pipeline_cache_get_data(
         &self,
         _: &Self::PipelineCacheId,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2370,6 +2370,10 @@ impl crate::Context for ContextWgpuCore {
         wgc::gfx_select!(device => self.0.device_stop_capture(*device));
     }
 
+    fn device_get_internal_counters(&self, device: &Self::DeviceId, _device_data: &Self::DeviceData) -> wgt::InternalCounters {
+        wgc::gfx_select!(device => self.0.device_get_internal_counters(*device))
+    }
+
     fn pipeline_cache_get_data(
         &self,
         cache: &Self::PipelineCacheId,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2370,7 +2370,11 @@ impl crate::Context for ContextWgpuCore {
         wgc::gfx_select!(device => self.0.device_stop_capture(*device));
     }
 
-    fn device_get_internal_counters(&self, device: &Self::DeviceId, _device_data: &Self::DeviceData) -> wgt::InternalCounters {
+    fn device_get_internal_counters(
+        &self,
+        device: &Self::DeviceId,
+        _device_data: &Self::DeviceData,
+    ) -> wgt::InternalCounters {
         wgc::gfx_select!(device => self.0.device_get_internal_counters(*device))
     }
 

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -612,7 +612,11 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
     fn device_start_capture(&self, device: &Self::DeviceId, device_data: &Self::DeviceData);
     fn device_stop_capture(&self, device: &Self::DeviceId, device_data: &Self::DeviceData);
 
-    fn device_get_internal_counters(&self, device: &Self::DeviceId, _device_data: &Self::DeviceData) -> wgt::InternalCounters;
+    fn device_get_internal_counters(
+        &self,
+        device: &Self::DeviceId,
+        _device_data: &Self::DeviceData,
+    ) -> wgt::InternalCounters;
 
     fn pipeline_cache_get_data(
         &self,
@@ -1607,7 +1611,11 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
     fn device_start_capture(&self, device: &ObjectId, data: &crate::Data);
     fn device_stop_capture(&self, device: &ObjectId, data: &crate::Data);
 
-    fn device_get_internal_counters(&self, device: &ObjectId, device_data: &crate::Data) -> wgt::InternalCounters;
+    fn device_get_internal_counters(
+        &self,
+        device: &ObjectId,
+        device_data: &crate::Data,
+    ) -> wgt::InternalCounters;
 
     fn pipeline_cache_get_data(
         &self,
@@ -3083,7 +3091,11 @@ where
         Context::device_stop_capture(self, &device, device_data)
     }
 
-    fn device_get_internal_counters(&self, device: &ObjectId, device_data: &crate::Data) -> wgt::InternalCounters {
+    fn device_get_internal_counters(
+        &self,
+        device: &ObjectId,
+        device_data: &crate::Data,
+    ) -> wgt::InternalCounters {
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
         Context::device_get_internal_counters(self, &device, device_data)

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -611,6 +611,9 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
 
     fn device_start_capture(&self, device: &Self::DeviceId, device_data: &Self::DeviceData);
     fn device_stop_capture(&self, device: &Self::DeviceId, device_data: &Self::DeviceData);
+
+    fn device_get_internal_counters(&self, device: &Self::DeviceId, _device_data: &Self::DeviceData) -> wgt::InternalCounters;
+
     fn pipeline_cache_get_data(
         &self,
         cache: &Self::PipelineCacheId,
@@ -1603,6 +1606,8 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
 
     fn device_start_capture(&self, device: &ObjectId, data: &crate::Data);
     fn device_stop_capture(&self, device: &ObjectId, data: &crate::Data);
+
+    fn device_get_internal_counters(&self, device: &ObjectId, device_data: &crate::Data) -> wgt::InternalCounters;
 
     fn pipeline_cache_get_data(
         &self,
@@ -3076,6 +3081,12 @@ where
         let device = <T::DeviceId>::from(*device);
         let device_data = downcast_ref(device_data);
         Context::device_stop_capture(self, &device, device_data)
+    }
+
+    fn device_get_internal_counters(&self, device: &ObjectId, device_data: &crate::Data) -> wgt::InternalCounters {
+        let device = <T::DeviceId>::from(*device);
+        let device_data = downcast_ref(device_data);
+        Context::device_get_internal_counters(self, &device, device_data)
     }
 
     fn pipeline_cache_get_data(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3167,6 +3167,16 @@ impl Device {
         DynContext::device_stop_capture(&*self.context, &self.id, self.data.as_ref())
     }
 
+    /// Query internal counters from the native backend for debugging purposes.
+    ///
+    /// Some backends may not set all counters, or may not set any counter at all.
+    /// The `counters` cargo feature must be enabled for any counter to be set.
+    ///
+    /// If a counter is not set, its contains its default value (zero).
+    pub fn get_internal_counters(&self) -> wgt::InternalCounters {
+        DynContext::device_get_internal_counters(&*self.context, &self.id, self.data.as_ref())
+    }
+
     /// Apply a callback to this `Device`'s underlying backend device.
     ///
     /// If this `Device` is implemented by the backend API given by `A` (Vulkan,


### PR DESCRIPTION
... for debugging purposes

Fixes #5546

The PR is a first step, let's discuss the approach before I add more on top of it.

This adds an `InternalCounter` type which is internally a relaxed atomic isize when the `counters` feature is enabled and compiles to nothing otherwise.

These internal counters can be modified from anywhere with an `&self` reference. The idea is that a user of wgpu-core (and wgpu?) could query these internal counters and log them or display them using some custom [overlay](https://github.com/nical/rust_debug/tree/master/font/overlay) mechanism.

My primary motivation for this is to help with investigating resource lifetime/leak issues in wgpu, but I think that it would also be useful for users of wgpu.

The third commit might look a bit intimidating: I'm counting all textures, buffers, views, etc. in all hal backends. That's a fair amount of repetition, but I ended taking this route because wgpu-core internally creates some resources that aren't exposed to the API (like staging buffers), that would have to be tracked manually and generally I have more confidence in these counters staying up to date if they are in hal.
That said I expect to add more counters in both core and hal for whatever information will aid debugging.

Next steps:
- [x] Properly expose these in wgpu-core and wgpu.
- Add an API to generate memory reports that would be provided by the underlying gpu memory allocator (when there is one). I opened a PR in gpu-allocator https://github.com/Traverse-Research/gpu-allocator/pull/226 to expose the relevant information, I have to figure out if/why I have to do the same in the `gpu-alloc` crate that the vulkan backend uses.