### PR TITLE
fix: ensure render pipelines have at least 1 target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 ### Bug Fixes
 
+### General
+
+- Ensure render pipelines have at least 1 target. By @ErichDonGubler in [#5715](https://github.com/gfx-rs/wgpu/pull/5715)
+
 #### Vulkan
 
 - Fix enablement of subgroup ops extension on Vulkan devices that don't support Vulkan 1.3. By @cwfitzgerald in [#5624](https://github.com/gfx-rs/wgpu/pull/5624).

--- a/tests/tests/pipeline.rs
+++ b/tests/tests/pipeline.rs
@@ -35,3 +35,46 @@ static PIPELINE_DEFAULT_LAYOUT_BAD_MODULE: GpuTestConfiguration = GpuTestConfigu
             pipeline.get_bind_group_layout(0);
         });
     });
+
+const TRIVIAL_VERTEX_SHADER_DESC: wgpu::ShaderModuleDescriptor = wgpu::ShaderModuleDescriptor {
+    label: Some("trivial vertex shader"),
+    source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
+        "@vertex fn main() -> @builtin(position) vec4<f32> { return vec4<f32>(0); }",
+    )),
+};
+
+#[gpu_test]
+static NO_TARGETLESS_RENDER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default())
+    .run_sync(|ctx| {
+        fail(&ctx.device, || {
+            // Testing multisampling is important, because some backends don't behave well if one
+            // tries to compile code in an unsupported multisample count. Failing to validate here
+            // has historically resulted in requesting the back end to compile code.
+            for power_of_two in [1, 2, 4, 8, 16, 32, 64] {
+                ctx.device
+                    .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                        label: None,
+                        layout: None,
+                        vertex: wgpu::VertexState {
+                            module: &ctx.device.create_shader_module(TRIVIAL_VERTEX_SHADER_DESC),
+                            entry_point: "main",
+                            compilation_options: Default::default(),
+                            buffers: &[],
+                        },
+                        primitive: Default::default(),
+                        depth_stencil: None,
+                        multisample: wgpu::MultisampleState {
+                            count: power_of_two,
+                            ..Default::default()
+                        },
+                        fragment: None,
+                        multiview: None,
+                        cache: None,
+                    });
+            }
+        })
+        // TODO: concrete error message:
+        // At least one color attachment or depth-stencil attachment was expected, but no
+        // render target for the pipeline was specified.
+    });

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -495,6 +495,11 @@ pub enum CreateRenderPipelineError {
     PipelineExpectsShaderToUseDualSourceBlending,
     #[error("Shader entry point expects the pipeline to make use of dual-source blending.")]
     ShaderExpectsPipelineToUseDualSourceBlending,
+    #[error("{}", concat!(
+        "At least one color attachment or depth-stencil attachment was expected, ",
+        "but no render target for the pipeline was specified."
+    ))]
+    NoTargetSpecified,
 }
 
 bitflags::bitflags! {


### PR DESCRIPTION
**Connections**

None of note.

**Description**

Important validation is performed on render pipeline configuration (like multisampling) against render targets. However, when no targets are specified, WGPU still compiles pipelines. It misses not just this validation[^1], but also the case mandated by WebGPU spec., section 10.3.1. (`Render Pipeline Creation`), which [states](https://www.w3.org/TR/webgpu/#abstract-opdef-validating-gpurenderpipelinedescriptor) in the subsection titled `validating GPURenderPipelineDescriptor(descriptor, layout, device)`:

> There must exist at least one attachment, either:
> 
> -   A non-`null` value in descriptor.[`fragment`](https://www.w3.org/TR/webgpu/#dom-gpurenderpipelinedescriptor-fragment).[`targets`](https://www.w3.org/TR/webgpu/#dom-gpufragmentstate-targets), or
>     
> -   A descriptor.[`depthStencil`](https://www.w3.org/TR/webgpu/#dom-gpurenderpipelinedescriptor-depthstencil).

Even if the entire space of possible render targets would have rejected the pipeline's configuration, `wgpu-core` still asks backends to compile pipelines using potentially invalid configuration when no targets are specified. These backends can then misbehave in _very_ different ways, which I've tested with https://github.com/ErichDonGubler/wgpu/pull/82 for multisampling specifically; examples:

1. [No issues](https://github.com/ErichDonGubler/wgpu/actions/runs/9131383163/job/25111119884?pr=82) are observed on MacOS CI. Perhaps because it supports the specific offending configurations I've tested?
2. DX12 [rejects](https://github.com/ErichDonGubler/wgpu/actions/runs/9131383163/job/25111119686?pr=82#step:13:820) the graphics pipeline creation on API call, resulting in an internal error.
3. Vulkan on Linux simply [segfaults](https://github.com/ErichDonGubler/wgpu/actions/runs/9131390138/job/25111107225?pr=82#step:13:2179). 😬

[^1]: While not germane to this bug, specifying a render target is the only way to get a _usable_ render pipeline, so functioning applications are unlikely to do this in shipped code.

While there are valid use cases for executing render pipelines with no render targets (DX12 and Vulkan support this, for instance), the WebGPU standard currently does not enable them.

**Testing**

Tests have been added in this PR; see the changes in `tests/` for more details. As described above, these tests were cherry-picked separately and tested in <https://github.com/ErichDonGubler/wgpu/pull/82>; this PR definitely fixes them.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.