### PR TITLE
Buffer as hal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 #### General
 
-- Added `as_hal` for `Buffer` to access wgpu created buffers form wgpu-hal. By @JasondeWolff in [#5721](https://github.com/gfx-rs/wgpu/pull/5721)
+- Added `as_hal` for `Buffer` to access wgpu created buffers form wgpu-hal. By @JasondeWolff in [#5724](https://github.com/gfx-rs/wgpu/pull/5724)
 
 #### Naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 #### General
 
+- Added `as_hal` for `Buffer` to access wgpu created buffers form wgpu-hal. By @JasondeWolff in [#5721](https://github.com/gfx-rs/wgpu/pull/5721)
+
 #### Naga
 
 - Implement `WGSL`'s `unpack4xI8`,`unpack4xU8`,`pack4xI8` and `pack4xU8`. By @VlaDexa in [#5424](https://github.com/gfx-rs/wgpu/pull/5424)

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -945,8 +945,11 @@ impl Global {
         let hub = A::hub(self);
         let buffer_opt = { hub.buffers.try_get(id).ok().flatten() };
         let buffer = buffer_opt.as_ref().unwrap();
-        let snatch_guard = buffer.device.snatchable_lock.read();
-        let hal_buffer = buffer.raw(&snatch_guard);
+
+        let hal_buffer = {
+            let snatch_guard = buffer.device.snatchable_lock.read();
+            buffer.raw(&snatch_guard)
+        };
 
         hal_buffer_callback(hal_buffer)
     }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -934,6 +934,25 @@ impl<A: HalApi> Texture<A> {
 impl Global {
     /// # Safety
     ///
+    /// - The raw buffer handle must not be manually destroyed
+    pub unsafe fn buffer_as_hal<A: HalApi, F: FnOnce(Option<&A::Buffer>) -> R, R>(
+        &self,
+        id: BufferId,
+        hal_buffer_callback: F,
+    ) -> R {
+        profiling::scope!("Buffer::as_hal");
+
+        let hub = A::hub(self);
+        let buffer_opt = { hub.buffers.try_get(id).ok().flatten() };
+        let buffer = buffer_opt.as_ref().unwrap();
+        let snatch_guard = buffer.device.snatchable_lock.read();
+        let hal_buffer = buffer.raw(&snatch_guard);
+
+        hal_buffer_callback(hal_buffer)
+    }
+
+    /// # Safety
+    ///
     /// - The raw texture handle must not be manually destroyed
     pub unsafe fn texture_as_hal<A: HalApi, F: FnOnce(Option<&A::Texture>) -> R, R>(
         &self,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -98,6 +98,21 @@ impl ContextWgpuCore {
         }
     }
 
+    pub unsafe fn buffer_as_hal<
+        A: wgc::hal_api::HalApi,
+        F: FnOnce(Option<&A::Buffer>) -> R,
+        R,
+    >(
+        &self,
+        id: wgc::id::BufferId,
+        hal_buffer_callback: F,
+    ) -> R {
+        unsafe {
+            self.0
+                .buffer_as_hal::<A, F, R>(id, hal_buffer_callback)
+        }
+    }
+
     pub unsafe fn create_device_from_hal<A: wgc::hal_api::HalApi>(
         &self,
         adapter: &wgc::id::AdapterId,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -98,19 +98,12 @@ impl ContextWgpuCore {
         }
     }
 
-    pub unsafe fn buffer_as_hal<
-        A: wgc::hal_api::HalApi,
-        F: FnOnce(Option<&A::Buffer>) -> R,
-        R,
-    >(
+    pub unsafe fn buffer_as_hal<A: wgc::hal_api::HalApi, F: FnOnce(Option<&A::Buffer>) -> R, R>(
         &self,
         id: wgc::id::BufferId,
         hal_buffer_callback: F,
     ) -> R {
-        unsafe {
-            self.0
-                .buffer_as_hal::<A, F, R>(id, hal_buffer_callback)
-        }
+        unsafe { self.0.buffer_as_hal::<A, F, R>(id, hal_buffer_callback) }
     }
 
     pub unsafe fn create_device_from_hal<A: wgc::hal_api::HalApi>(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3556,7 +3556,7 @@ impl Buffer {
     #[cfg(wgpu_core)]
     pub unsafe fn as_hal<A: wgc::hal_api::HalApi, F: FnOnce(Option<&A::Buffer>) -> R, R>(
         &self,
-        hal_texture_callback: F,
+        hal_buffer_callback: F,
     ) -> R {
         let id = self.id;
 
@@ -3565,9 +3565,9 @@ impl Buffer {
             .as_any()
             .downcast_ref::<crate::backend::ContextWgpuCore>()
         {
-            unsafe { ctx.buffer_as_hal::<A, F, R>(id.into(), hal_texture_callback) }
+            unsafe { ctx.buffer_as_hal::<A, F, R>(id.into(), hal_buffer_callback) }
         } else {
-            hal_texture_callback(None)
+            hal_buffer_callback(None)
         }
     }
 


### PR DESCRIPTION
**Connections**
It would be really nice to have access to wgpu buffers inside more low-level wgpu-hall passes as a user. This functionality is already exposed for the majority of structs where it's applicable, not exposing it for `Buffer` is confusing.

**Description**
Buffers created with wgpu cannot be accessed using wgpu-hal.

**Testing**
Was tested on my machine by writing and accessing into wgpu created buffers using the wgpu-hal bindgroups and command encoders.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`.
- [X] Run `cargo xtask test` to run tests.
- [X] Add change to `CHANGELOG.md`. See simple instructions inside file.
