### PR TITLE
[naga spv-in] Delete misplaced, outdated comment.

### DIFF
--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -578,7 +578,6 @@ pub struct Frontend<I> {
     lookup_type: FastHashMap<spirv::Word, LookupType>,
     lookup_void_type: Option<spirv::Word>,
     lookup_storage_buffer_types: FastHashMap<Handle<crate::Type>, crate::StorageAccess>,
-    // Lookup for samplers and sampled images, storing flags on how they are used.
     lookup_constant: FastHashMap<spirv::Word, LookupConstant>,
     lookup_variable: FastHashMap<spirv::Word, LookupVariable>,
     lookup_expression: FastHashMap<spirv::Word, LookupExpression>,


### PR DESCRIPTION
This comment had become misplaced - it belongs on
`lookup_sampled_image` - but also, that table is no longer "storing flags on how they are used". So the name of the field and type are probably documentation enough.
