### PR TITLE
Remove historical comment in `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,3 @@
-# If you see this, run "rustup self update" to get rustup 1.23 or newer.
-
-# NOTE: above comment is for older `rustup` (before TOML support was added),
-# which will treat the first line as the toolchain name, and therefore show it
-# to the user in the error, instead of "error: invalid channel name '[toolchain]'".
-
 [toolchain]
 channel = "1.76"                     # Needed for deno & cts_runner. Firefox's MSRV is 1.74
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
**Connections**
None

**Description**
A version of rustup which doesn't understand toml-formatted `rust-toolchain` files won't be looking in `rust-toolchain.toml`

The file was renamed to `rust-toolchain.toml` in #4204

rust-toolchain.toml support was added in rustup 1.23, which was [released on 2020-11-27](https://blog.rust-lang.org/2020/11/27/Rustup-1.23.0.html), 3 and a half years ago.

**Testing**
I have confirmed that `cargo --version` is still 1.76

**Checklist**

- [ ] Run `cargo fmt`. N/A
- [ ] Run `cargo clippy`. If applicable, add: N/A
  - [ ] `--target wasm32-unknown-unknown` N/A
  - [ ] `--target wasm32-unknown-emscripten` N/A
- [ ] Run `cargo xtask test` to run tests. N/A
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file. N/A
