### PR TITLE
Remove redundant code in module interface validation

### DIFF
--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -915,15 +915,6 @@ impl Interface {
                     class,
                 },
                 naga::TypeInner::Sampler { comparison } => ResourceType::Sampler { comparison },
-                naga::TypeInner::Array { stride, size, .. } => {
-                    let size = match size {
-                        naga::ArraySize::Constant(size) => size.get() * stride,
-                        naga::ArraySize::Dynamic => stride,
-                    };
-                    ResourceType::Buffer {
-                        size: wgt::BufferSize::new(size as u64).unwrap(),
-                    }
-                }
                 ref other => ResourceType::Buffer {
                     size: wgt::BufferSize::new(other.size(module.to_ctx()) as u64).unwrap(),
                 },


### PR DESCRIPTION
`TypeInner.size()` already handles the array case.