### PR TITLE
Fix missing family check flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Bottom level categories:
 - Clean up weak references to texture views and bind groups to prevent memory leaks. By @xiaopengli89 in [#5595](https://github.com/gfx-rs/wgpu/pull/5595).
 - Fix segfault on exit is queue & device are dropped before surface. By @sagudev in [#5640](https://github.com/gfx-rs/wgpu/pull/5640).
 
+#### Metal
+
+- Fix unrecognized selector crash on iOS 12. By @vladasz in [#5744](https://github.com/gfx-rs/wgpu/pull/5744).
+
 #### Vulkan
 
 - Fix enablement of subgroup ops extension on Vulkan devices that don't support Vulkan 1.3. By @cwfitzgerald in [#5624](https://github.com/gfx-rs/wgpu/pull/5624).

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -738,7 +738,7 @@ impl super::PrivateCapabilities {
                 4
             },
             // Per https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
-            max_color_attachment_bytes_per_sample: if device.supports_family(MTLGPUFamily::Apple4) {
+            max_color_attachment_bytes_per_sample: if family_check && device.supports_family(MTLGPUFamily::Apple4) {
                 64
             } else {
                 32

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -738,7 +738,9 @@ impl super::PrivateCapabilities {
                 4
             },
             // Per https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
-            max_color_attachment_bytes_per_sample: if family_check && device.supports_family(MTLGPUFamily::Apple4) {
+            max_color_attachment_bytes_per_sample: if family_check
+                && device.supports_family(MTLGPUFamily::Apple4)
+            {
                 64
             } else {
                 32


### PR DESCRIPTION
**Description**
iOS 12 doesn't have `supports_family` method and it crashes when this method is called. There was already a check for that using `family_check` flag. But it was missing in one place.

Xcode crash logs:
```
2024-05-25 20:52:31.043060+0300 TestGame[355:12589] [DYMTLInitPlatform] platform initialization successful
2024-05-25 20:52:31.154605+0300 TestGame[355:12422] Metal GPU Frame Capture Enabled
2024-05-25 20:52:31.157163+0300 TestGame[355:12422] Metal API Validation Enabled
2024-05-25 20:52:31.194143+0300 TestGame[355:12422] -[MTLDebugDevice supportsFamily:]: unrecognized selector sent to instance 0x102209200
2024-05-25 20:52:31.201718+0300 TestGame[355:12422] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[MTLDebugDevice supportsFamily:]: unrecognized selector sent to instance 0x102209200'
```

**Testing**
I ran it on my iPhone 5s and it didn't crash.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
