### PR TITLE
Prefer `default-features` instead of `default_features`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ gpu-descriptor = "0.3"
 
 # DX dependencies
 bit-set = "0.5"
-gpu-allocator = { version = "0.26", default_features = false, features = [
+gpu-allocator = { version = "0.26", default-features = false, features = [
     "d3d12",
     "public-winapi",
 ] }

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -131,7 +131,7 @@ version = "0.20.0"
 package = "wgpu-hal"
 path = "../wgpu-hal"
 version = "0.20.0"
-default_features = false
+default-features = false
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -138,7 +138,7 @@ libloading = { version = ">=0.7, <0.9", optional = true }
 # backend: Dx12
 bit-set = { version = "0.5", optional = true }
 range-alloc = { version = "0.1", optional = true }
-gpu-allocator = { version = "0.26", default_features = false, features = [
+gpu-allocator = { version = "0.26", default-features = false, features = [
     "d3d12",
     "public-winapi",
 ], optional = true }


### PR DESCRIPTION
**Description**
The latter is being deprecated and not allowed in Rust 2024 Edition.

This fixes a warning when doing a build with a nightly compiler.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
