### PR TITLE
chore: Fix `legacy_numeric_constants` lints

### DIFF
--- a/examples/src/mipmap/mod.rs
+++ b/examples/src/mipmap/mod.rs
@@ -30,7 +30,7 @@ fn create_texels(size: usize, cx: f32, cy: f32) -> Vec<u8> {
             iter::once(0xFF - (count * 2) as u8)
                 .chain(iter::once(0xFF - (count * 5) as u8))
                 .chain(iter::once(0xFF - (count * 13) as u8))
-                .chain(iter::once(std::u8::MAX))
+                .chain(iter::once(u8::MAX))
         })
         .collect()
 }

--- a/examples/src/water/point_gen.rs
+++ b/examples/src/water/point_gen.rs
@@ -124,7 +124,7 @@ impl HexTerrainMesh {
         let width = q_given_r(radius);
         let half_width = (width / 2) as isize;
         let mut map = HashMap::new();
-        let mut max = std::f32::NEG_INFINITY;
+        let mut max = f32::NEG_INFINITY;
         for i in -half_width..=half_width {
             let x_o = i as f32;
             for j in -half_width..=half_width {

--- a/wgpu-core/src/init_tracker/texture.rs
+++ b/wgpu-core/src/init_tracker/texture.rs
@@ -61,10 +61,10 @@ impl TextureInitTracker {
         &self,
         action: &TextureInitTrackerAction<A>,
     ) -> Option<TextureInitTrackerAction<A>> {
-        let mut mip_range_start = std::usize::MAX;
-        let mut mip_range_end = std::usize::MIN;
-        let mut layer_range_start = std::u32::MAX;
-        let mut layer_range_end = std::u32::MIN;
+        let mut mip_range_start = usize::MAX;
+        let mut mip_range_end = usize::MIN;
+        let mut layer_range_start = u32::MAX;
+        let mut layer_range_end = u32::MIN;
 
         for (i, mip_tracker) in self
             .mips

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -797,7 +797,7 @@ impl super::Adapter {
             },
             max_compute_workgroups_per_dimension,
             max_buffer_size: i32::MAX as u64,
-            max_non_sampler_bindings: std::u32::MAX,
+            max_non_sampler_bindings: u32::MAX,
         };
 
         let mut workarounds = super::Workarounds::empty();

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -981,7 +981,7 @@ impl super::PrivateCapabilities {
                 max_compute_workgroup_size_z: self.max_threads_per_group,
                 max_compute_workgroups_per_dimension: 0xFFFF,
                 max_buffer_size: self.max_buffer_size,
-                max_non_sampler_bindings: std::u32::MAX,
+                max_non_sampler_bindings: u32::MAX,
             },
             alignments: crate::Alignments {
                 buffer_copy_offset: wgt::BufferSize::new(self.buffer_alignment).unwrap(),

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1047,7 +1047,7 @@ impl PhysicalDeviceProperties {
             max_compute_workgroup_size_z: max_compute_workgroup_sizes[2],
             max_compute_workgroups_per_dimension,
             max_buffer_size,
-            max_non_sampler_bindings: std::u32::MAX,
+            max_non_sampler_bindings: u32::MAX,
         }
     }
 
@@ -1807,7 +1807,7 @@ impl super::Adapter {
                 if let Some(maintenance_3) = self.phd_capabilities.maintenance_3 {
                     maintenance_3.max_memory_allocation_size
                 } else {
-                    u64::max_value()
+                    u64::MAX
                 };
             let properties = gpu_alloc::DeviceProperties {
                 max_memory_allocation_count: limits.max_memory_allocation_count,

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -28,7 +28,7 @@ pub use wgt::{math::*, DispatchIndirectArgs, DrawIndexedIndirectArgs, DrawIndire
 /// This function panics if:
 ///
 /// - Input length isn't multiple of 4
-/// - Input is longer than [`usize::max_value`]
+/// - Input is longer than [`usize::MAX`]
 /// - Input is empty
 /// - SPIR-V magic number is missing from beginning of stream
 #[cfg(feature = "spirv")]


### PR DESCRIPTION
**Description**
These are being deprecated in the future in favor of the associated constants (which are already being used in some code here), so this consistently uses the preferred forms.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
