### PR TITLE
Remove the `link` Cargo feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 - Avoid introducing spurious features for optional dependencies. By @bjorn3 in [#5691](https://github.com/gfx-rs/wgpu/pull/5691)
 
+#### Metal
+- Removed the `link` Cargo feature.
+
+  This was used to allow weakly linking frameworks. This can be achieved with putting something like the following in your `.cargo/config.toml` instead:
+  ```toml
+  [target.'cfg(target_vendor = "apple")']
+  rustflags = ["-C", "link-args=-weak_framework Metal -weak_framework QuartzCore -weak_framework CoreGraphics"]
+  ```
+
 ### Bug Fixes
 
 ### General

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -32,16 +32,11 @@ ignored = ["cfg_aliases"]
 [lib]
 
 [features]
-default = ["link"]
-
 ## Log all API entry points at info instead of trace level.
 api_log_info = []
 
 ## Log resource lifecycle management at info instead of trace level.
 resource_log_info = []
-
-## Use static linking for libraries. Disable to manually link. Enabled by default.
-link = ["hal/link"]
 
 ## Support the Renderdoc graphics debugger:
 ## <https://renderdoc.org/>

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -37,7 +37,6 @@ ignored = ["cfg_aliases"]
 [lib]
 
 [features]
-default = ["link"]
 metal = ["naga/msl-out", "dep:block"]
 vulkan = [
     "naga/spv-out",
@@ -76,7 +75,6 @@ windows_rs = ["dep:gpu-allocator"]
 dxc_shader_compiler = ["dep:hassle-rs"]
 renderdoc = ["dep:libloading", "dep:renderdoc-sys"]
 fragile-send-sync-non-atomic-wasm = ["wgt/fragile-send-sync-non-atomic-wasm"]
-link = ["metal/link"]
 # Panic when running into an out-of-memory error (for debugging purposes).
 #
 # Only affects the d3d12 and vulkan backends.

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -17,7 +17,7 @@ use objc::{
 use parking_lot::{Mutex, RwLock};
 
 #[cfg(target_os = "macos")]
-#[cfg_attr(feature = "link", link(name = "QuartzCore", kind = "framework"))]
+#[link(name = "QuartzCore", kind = "framework")]
 extern "C" {
     #[allow(non_upper_case_globals)]
     static kCAGravityTopLeft: *mut Object;


### PR DESCRIPTION
**Connections**
Part of https://github.com/gfx-rs/wgpu/pull/5641, split out to make it so that that PR is a non-breaking change.

**Description**
Remove the `link` feature which is not available in the `objc2` crates. This was added by `@crowlKats` in https://github.com/gfx-rs/wgpu/pull/3853, but Deno doesn't actually use it, [they instead specify this using `-weak_framework`](https://github.com/denoland/deno/blob/8a636d0600dc7000d1e12b2fc4f4f46ecd70164a/.cargo/config.toml#L14-L24), which is the correct solution to this problem IMO.

**Testing**
Roughly as described in the changelog entry.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
