### PR TITLE
gles: Return the version as driver_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 ### Bug Fixes
 
-### General
+#### General
 
 - Ensure render pipelines have at least 1 target. By @ErichDonGubler in [#5715](https://github.com/gfx-rs/wgpu/pull/5715)
 
@@ -102,9 +102,10 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 #### GLES / OpenGL
 
--  Fix regression on OpenGL (EGL) where non-sRGB still used sRGB [#5642](https://github.com/gfx-rs/wgpu/pull/5642)
--  Fix `ClearColorF`, `ClearColorU` and `ClearColorI` commands being issued before `SetDrawColorBuffers` [#5666](https://github.com/gfx-rs/wgpu/pull/5666)
--  Replace `glClear` with `glClearBufferF` because `glDrawBuffers` requires that the ith buffer must be `COLOR_ATTACHMENTi` or `NONE` [#5666](https://github.com/gfx-rs/wgpu/pull/5666)
+- Fix regression on OpenGL (EGL) where non-sRGB still used sRGB [#5642](https://github.com/gfx-rs/wgpu/pull/5642)
+- Fix `ClearColorF`, `ClearColorU` and `ClearColorI` commands being issued before `SetDrawColorBuffers` [#5666](https://github.com/gfx-rs/wgpu/pull/5666)
+- Replace `glClear` with `glClearBufferF` because `glDrawBuffers` requires that the ith buffer must be `COLOR_ATTACHMENTi` or `NONE` [#5666](https://github.com/gfx-rs/wgpu/pull/5666)
+- Return the unmodified version in driver_info. By @Valaphee in [#5753](https://github.com/gfx-rs/wgpu/pull/5753)
 
 ## v0.20.0 (2024-04-28)
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -179,33 +179,13 @@ impl super::Adapter {
             0
         };
 
-        let driver;
-        let driver_info;
-        if version.starts_with("WebGL ") || version.starts_with("OpenGL ") {
-            let es_sig = " ES";
-            match version.find(es_sig) {
-                Some(pos) => {
-                    driver = version[..pos + es_sig.len()].to_owned();
-                    driver_info = version[pos + es_sig.len() + 1..].to_owned();
-                }
-                None => {
-                    let pos = version.find(' ').unwrap();
-                    driver = version[..pos].to_owned();
-                    driver_info = version[pos + 1..].to_owned();
-                }
-            }
-        } else {
-            driver = "OpenGL".to_owned();
-            driver_info = version;
-        }
-
         wgt::AdapterInfo {
             name: renderer_orig,
             vendor: vendor_id,
             device: 0,
             device_type: inferred_device_type,
-            driver,
-            driver_info,
+            driver: "".to_owned(),
+            driver_info: version,
             backend: wgt::Backend::Gl,
         }
     }


### PR DESCRIPTION
**Connections**

**Description**
While working on ruffle I noticed that on Chromium with WebGL
```
Adapter Driver Name: "WebGL 2.0 (OpenGL ES"
Adapter Driver Info: "3.0 Chromium)"
```
is split incorrectly, and theoretically there shouldn't be a driver name. It was more of a workaround to check if the adapter is OpenGL or OpenGL ES in tests (which I never used though).

This PR simplifies that by just returning the version in the driver info.

Don't know if its worth back porting.

**Testing**

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
