### PR TITLE
[naga doc] Fix broken links in Naga `bitflags` types.

### DIFF
--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -271,10 +271,11 @@ bitflags::bitflags! {
     ///
     /// Note that these exactly correspond to the SPIR-V "Ray Flags" mask, and
     /// the SPIR-V backend passes them directly through to the
-    /// `OpRayQueryInitializeKHR` instruction. (We have to choose something, so
+    /// [`OpRayQueryInitializeKHR`][op] instruction. (We have to choose something, so
     /// we might as well make one back end's life easier.)
     ///
     /// [`RayDesc`]: crate::Module::generate_ray_desc_type
+    /// [op]: https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpRayQueryInitializeKHR
     #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
     pub struct RayFlag: u32 {
         const OPAQUE = 0x01;

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -682,16 +682,29 @@ bitflags::bitflags! {
     pub struct WriterFlags: u32 {
         /// Include debug labels for everything.
         const DEBUG = 0x1;
-        /// Flip Y coordinate of `BuiltIn::Position` output.
+
+        /// Flip Y coordinate of [`BuiltIn::Position`] output.
+        ///
+        /// [`BuiltIn::Position`]: crate::BuiltIn::Position
         const ADJUST_COORDINATE_SPACE = 0x2;
-        /// Emit `OpName` for input/output locations.
+
+        /// Emit [`OpName`][op] for input/output locations.
+        ///
         /// Contrary to spec, some drivers treat it as semantic, not allowing
         /// any conflicts.
+        ///
+        /// [op]: https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpName
         const LABEL_VARYINGS = 0x4;
-        /// Emit `PointSize` output builtin to vertex shaders, which is
+
+        /// Emit [`PointSize`] output builtin to vertex shaders, which is
         /// required for drawing with `PointList` topology.
+        ///
+        /// [`PointSize`]: crate::BuiltIn::PointSize
         const FORCE_POINT_SIZE = 0x8;
-        /// Clamp `BuiltIn::FragDepth` output between 0 and 1.
+
+        /// Clamp [`BuiltIn::FragDepth`] output between 0 and 1.
+        ///
+        /// [`BuiltIn::FragDepth`]: crate::BuiltIn::FragDepth
         const CLAMP_FRAG_DEPTH = 0x10;
     }
 }

--- a/naga/src/front/glsl/ast.rs
+++ b/naga/src/front/glsl/ast.rs
@@ -73,9 +73,9 @@ bitflags::bitflags! {
         const STANDARD = 1 << 0;
         /// Request overloads that use the double type
         const DOUBLE = 1 << 1;
-        /// Request overloads that use samplerCubeArray(Shadow)
+        /// Request overloads that use `samplerCubeArray(Shadow)`
         const CUBE_TEXTURES_ARRAY = 1 << 2;
-        /// Request overloads that use sampler2DMSArray
+        /// Request overloads that use `sampler2DMSArray`
         const D2_MULTI_TEXTURES_ARRAY = 1 << 3;
     }
 }

--- a/naga/src/front/glsl/builtins.rs
+++ b/naga/src/front/glsl/builtins.rs
@@ -2218,7 +2218,7 @@ pub fn sampled_to_depth(
 }
 
 bitflags::bitflags! {
-    /// Influences the operation `texture_args_generator`
+    /// Influences the operation [`texture_args_generator`]
     struct TextureArgsOptions: u32 {
         /// Generates multisampled variants of images
         const MULTI = 1 << 0;

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -1335,9 +1335,9 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
     #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
     pub struct Barrier: u32 {
-        /// Barrier affects all `AddressSpace::Storage` accesses.
+        /// Barrier affects all [`AddressSpace::Storage`] accesses.
         const STORAGE = 1 << 0;
-        /// Barrier affects all `AddressSpace::WorkGroup` accesses.
+        /// Barrier affects all [`AddressSpace::WorkGroup`] accesses.
         const WORK_GROUP = 1 << 1;
         /// Barrier synchronizes execution across all invocations within a subgroup that exectue this instruction.
         const SUB_GROUP = 1 << 2;

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -70,8 +70,10 @@ bitflags::bitflags! {
         /// subsequent statements within the current function (only!)
         /// to be executed in a non-uniform control flow.
         const MAY_RETURN = 0x1;
-        /// Control flow may be killed. Anything after `Statement::Kill` is
+        /// Control flow may be killed. Anything after [`Statement::Kill`] is
         /// considered inside non-uniform context.
+        ///
+        /// [`Statement::Kill`]: crate::Statement::Kill
         const MAY_KILL = 0x2;
     }
 }

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -78,11 +78,15 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct Capabilities: u32 {
-        /// Support for [`AddressSpace:PushConstant`].
+        /// Support for [`AddressSpace::PushConstant`][1].
+        ///
+        /// [1]: crate::AddressSpace::PushConstant
         const PUSH_CONSTANT = 0x1;
         /// Float values with width = 8.
         const FLOAT64 = 0x2;
-        /// Support for [`Builtin:PrimitiveIndex`].
+        /// Support for [`BuiltIn::PrimitiveIndex`][1].
+        ///
+        /// [1]: crate::BuiltIn::PrimitiveIndex
         const PRIMITIVE_INDEX = 0x4;
         /// Support for non-uniform indexing of sampled textures and storage buffer arrays.
         const SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING = 0x8;
@@ -90,17 +94,26 @@ bitflags::bitflags! {
         const UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING = 0x10;
         /// Support for non-uniform indexing of samplers.
         const SAMPLER_NON_UNIFORM_INDEXING = 0x20;
-        /// Support for [`Builtin::ClipDistance`].
+        /// Support for [`BuiltIn::ClipDistance`].
+        ///
+        /// [`BuiltIn::ClipDistance`]: crate::BuiltIn::ClipDistance
         const CLIP_DISTANCE = 0x40;
-        /// Support for [`Builtin::CullDistance`].
+        /// Support for [`BuiltIn::CullDistance`].
+        ///
+        /// [`BuiltIn::CullDistance`]: crate::BuiltIn::CullDistance
         const CULL_DISTANCE = 0x80;
         /// Support for 16-bit normalized storage texture formats.
         const STORAGE_TEXTURE_16BIT_NORM_FORMATS = 0x100;
         /// Support for [`BuiltIn::ViewIndex`].
+        ///
+        /// [`BuiltIn::ViewIndex`]: crate::BuiltIn::ViewIndex
         const MULTIVIEW = 0x200;
         /// Support for `early_depth_test`.
         const EARLY_DEPTH_TEST = 0x400;
-        /// Support for [`Builtin::SampleIndex`] and [`Sampling::Sample`].
+        /// Support for [`BuiltIn::SampleIndex`] and [`Sampling::Sample`].
+        ///
+        /// [`BuiltIn::SampleIndex`]: crate::BuiltIn::SampleIndex
+        /// [`Sampling::Sample`]: crate::Sampling::Sample
         const MULTISAMPLED_SHADING = 0x800;
         /// Support for ray queries and acceleration structures.
         const RAY_QUERY = 0x1000;

--- a/naga/src/valid/type.rs
+++ b/naga/src/valid/type.rs
@@ -16,23 +16,27 @@ bitflags::bitflags! {
         /// This flag is required on types of local variables, function
         /// arguments, array elements, and struct members.
         ///
-        /// This includes all types except `Image`, `Sampler`,
-        /// and some `Pointer` types.
+        /// This includes all types except [`Image`], [`Sampler`],
+        /// and some [`Pointer`] types.
+        ///
+        /// [`Image`]: crate::TypeInner::Image
+        /// [`Sampler`]: crate::TypeInner::Sampler
+        /// [`Pointer`]: crate::TypeInner::Pointer
         const DATA = 0x1;
 
         /// The data type has a size known by pipeline creation time.
         ///
         /// Unsized types are quite restricted. The only unsized types permitted
         /// by Naga, other than the non-[`DATA`] types like [`Image`] and
-        /// [`Sampler`], are dynamically-sized [`Array`s], and [`Struct`s] whose
+        /// [`Sampler`], are dynamically-sized [`Array`]s, and [`Struct`]s whose
         /// last members are such arrays. See the documentation for those types
         /// for details.
         ///
         /// [`DATA`]: TypeFlags::DATA
-        /// [`Image`]: crate::Type::Image
-        /// [`Sampler`]: crate::Type::Sampler
-        /// [`Array`]: crate::Type::Array
-        /// [`Struct`]: crate::Type::struct
+        /// [`Image`]: crate::TypeInner::Image
+        /// [`Sampler`]: crate::TypeInner::Sampler
+        /// [`Array`]: crate::TypeInner::Array
+        /// [`Struct`]: crate::TypeInner::Struct
         const SIZED = 0x2;
 
         /// The data can be copied around.
@@ -43,6 +47,8 @@ bitflags::bitflags! {
         /// This covers anything that can be in [`Location`] binding:
         /// non-bool scalars and vectors, matrices, and structs and
         /// arrays containing only interface types.
+        ///
+        /// [`Location`]: crate::Binding::Location
         const IO_SHAREABLE = 0x8;
 
         /// Can be used for host-shareable structures.


### PR DESCRIPTION
Fix links in documentation for types defined using the `bitflags!` macro.

As described in [bitflags#407], for some reason, `cargo doc` doesn't check for broken links in documentation for types or members defined using `bitflags::bitflags!`.

[bitflags#407]: https://github.com/bitflags/bitflags/issues/407
