### PR TITLE
[naga] Remove `ExpressionError::DoesntExist`.

### DIFF
--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -12,8 +12,6 @@ use crate::{
 #[derive(Clone, Debug, thiserror::Error)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum ExpressionError {
-    #[error("Doesn't exist")]
-    DoesntExist,
     #[error("Used by a statement before it was introduced into the scope by any of the dominating blocks")]
     NotInScope,
     #[error("Base type {0:?} is not compatible with this expression")]

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -257,11 +257,8 @@ impl<'a> BlockContext<'a> {
             .map_err_inner(|source| FunctionError::Expression { handle, source }.with_span())
     }
 
-    fn resolve_pointer_type(
-        &self,
-        handle: Handle<crate::Expression>,
-    ) -> Result<&crate::TypeInner, FunctionError> {
-        Ok(self.info[handle].ty.inner_with(self.types))
+    fn resolve_pointer_type(&self, handle: Handle<crate::Expression>) -> &crate::TypeInner {
+        self.info[handle].ty.inner_with(self.types)
     }
 }
 
@@ -810,9 +807,6 @@ impl super::Validator {
                 S::Store { pointer, value } => {
                     let mut current = pointer;
                     loop {
-                        let _ = context
-                            .resolve_pointer_type(current)
-                            .map_err(|e| e.with_span())?;
                         match context.expressions[current] {
                             crate::Expression::Access { base, .. }
                             | crate::Expression::AccessIndex { base, .. } => current = base,
@@ -835,9 +829,7 @@ impl super::Validator {
                         _ => {}
                     }
 
-                    let pointer_ty = context
-                        .resolve_pointer_type(pointer)
-                        .map_err(|e| e.with_span())?;
+                    let pointer_ty = context.resolve_pointer_type(pointer);
 
                     let good = match *pointer_ty {
                         Ti::Pointer { base, space: _ } => match context.types[base].inner {

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -241,9 +241,7 @@ impl<'a> BlockContext<'a> {
         handle: Handle<crate::Expression>,
         valid_expressions: &BitSet,
     ) -> Result<&crate::TypeInner, WithSpan<ExpressionError>> {
-        if handle.index() >= self.expressions.len() {
-            Err(ExpressionError::DoesntExist.with_span())
-        } else if !valid_expressions.contains(handle.index()) {
+        if !valid_expressions.contains(handle.index()) {
             Err(ExpressionError::NotInScope.with_span_handle(handle, self.expressions))
         } else {
             Ok(self.info[handle].ty.inner_with(self.types))
@@ -263,14 +261,7 @@ impl<'a> BlockContext<'a> {
         &self,
         handle: Handle<crate::Expression>,
     ) -> Result<&crate::TypeInner, FunctionError> {
-        if handle.index() >= self.expressions.len() {
-            Err(FunctionError::Expression {
-                handle,
-                source: ExpressionError::DoesntExist,
-            })
-        } else {
-            Ok(self.info[handle].ty.inner_with(self.types))
-        }
+        Ok(self.info[handle].ty.inner_with(self.types))
     }
 }
 


### PR DESCRIPTION
Remove `valid::expression::ExpressionError::DoesntExist`. This error is reported
when expression validation encounters an invalid `Handle<Expression>`, but we
have already verified that the module is free of invalid handles in
`Validator::validate_module_handles`, so this condition should never arise.

Make `BlockContext::resolve_pointer_type` infallible.

Since `BlockContext::resolve_pointer_type` never returns an error,
change its result type from a `Result` to a `&TypeInner`. Adjust
callers accordingly.

Remove calls (well, there's only one) to `resolve_pointer_type`
entirely when the caller does not need the value, since
`resolve_pointer_type` is now infallible and has no side effects.
