### PR TITLE
Document WebGPU spec rule that an `Adapter` should be used only once.

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -2558,6 +2558,11 @@ impl Adapter {
     ///
     /// Returns the [`Device`] together with a [`Queue`] that executes command buffers.
     ///
+    /// [Per the WebGPU specification], an [`Adapter`] may only be used once to create a device.
+    /// If another device is wanted, call [`Instance::request_adapter()`] again to get a fresh
+    /// [`Adapter`].
+    /// However, `wgpu` does not currently enforce this restriction.
+    ///
     /// # Arguments
     ///
     /// - `desc` - Description of the features and limits requested from the given device.
@@ -2566,10 +2571,13 @@ impl Adapter {
     ///
     /// # Panics
     ///
+    /// - `request_device()` was already called on this `Adapter`.
     /// - Features specified by `desc` are not supported by this adapter.
     /// - Unsafe features were requested but not enabled when requesting the adapter.
     /// - Limits requested exceed the values provided by the adapter.
     /// - Adapter does not support all features wgpu requires to safely operate.
+    ///
+    /// [Per the WebGPU specification]: https://www.w3.org/TR/webgpu/#dom-gpuadapter-requestdevice
     pub fn request_device(
         &self,
         desc: &DeviceDescriptor<'_>,


### PR DESCRIPTION
**Description**
[The WebGPU specification says](https://www.w3.org/TR/webgpu/#dom-gpuadapter-requestdevice) that each `Adapter` only allows one `requestDevice()` call, and that applications wishing to call `requestDevice()` again should call `requestAdapter()` again.

`wgpu` does not currently implement validation for this, but _documenting_ this rule will help users structure their applications properly for when it does, rather than getting an unpleasant surprise. This PR adds that documentation.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [X] Run `cargo xtask test` to run tests.
- [X] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ Not worth mentioning.
