### PR TITLE
Reintroduce computepass->encoder lifetime constraint and make it opt-out via `wgpu::ComputePass::forget_lifetime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,13 +47,18 @@ TODO(wumpf): This is still work in progress. Should write a bit more about it. A
 
 `wgpu::ComputePass` recording methods (e.g. `wgpu::ComputePass:set_render_pipeline`) no longer impose a lifetime constraint passed in resources.
 
-Furthermore, `wgpu::ComputePass` no longer has a life time dependency on its parent `wgpu::CommandEncoder`.
+Furthermore, you can now opt out of `wgpu::ComputePass`'s life time dependency on its parent `wgpu::CommandEncoder` using `wgpu::ComputePass::make_static`:
+```rust
+fn independent_cpass<'enc>(encoder: &'enc mut wgpu::CommandEncoder) -> wgpu::ComputePass<'static> {
+    let cpass: wgpu::ComputePass<'enc> = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+    cpass.make_static()
+}
+```
 ⚠️ As long as a `wgpu::ComputePass` is pending for a given `wgpu::CommandEncoder`, creation of a compute or render pass is an error and invalidates the `wgpu::CommandEncoder`.
-Previously, this was statically enforced by a lifetime constraint.
-TODO(wumpf): There was some discussion on whether to make this life time constraint opt-in or opt-out (entirely on `wgpu` side, no changes to `wgpu-core`).
-Lifting this lifetime dependencies is very useful for library authors, but opens up an easy way for incorrect use.
+This is very useful for library authors, but opens up an easy way for incorrect use, so use with care.
+`make_static` is low overhead and has no side effects on pass recording.
 
-By @wumpf in [#5569](https://github.com/gfx-rs/wgpu/pull/5569), [#5575](https://github.com/gfx-rs/wgpu/pull/5575), [#5620](https://github.com/gfx-rs/wgpu/pull/5620).
+By @wumpf in [#5569](https://github.com/gfx-rs/wgpu/pull/5569), [#5575](https://github.com/gfx-rs/wgpu/pull/5575), [#5620](https://github.com/gfx-rs/wgpu/pull/5620), [#5768](https://github.com/gfx-rs/wgpu/pull/5768)
 
 #### Querying shader compilation errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,18 +47,18 @@ TODO(wumpf): This is still work in progress. Should write a bit more about it. A
 
 `wgpu::ComputePass` recording methods (e.g. `wgpu::ComputePass:set_render_pipeline`) no longer impose a lifetime constraint passed in resources.
 
-Furthermore, you can now opt out of `wgpu::ComputePass`'s lifetime dependency on its parent `wgpu::CommandEncoder` using `wgpu::ComputePass::make_static`:  
+Furthermore, you can now opt out of `wgpu::ComputePass`'s lifetime dependency on its parent `wgpu::CommandEncoder` using `wgpu::ComputePass::forget_lifetime`:  
 ```rust
 fn independent_cpass<'enc>(encoder: &'enc mut wgpu::CommandEncoder) -> wgpu::ComputePass<'static> {
     let cpass: wgpu::ComputePass<'enc> = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
-    cpass.make_static()
+    cpass.forget_lifetime()
 }
 ```
 ⚠️ As long as a `wgpu::ComputePass` is pending for a given `wgpu::CommandEncoder`, creation of a compute or render pass is an error and invalidates the `wgpu::CommandEncoder`.
 This is very useful for library authors, but opens up an easy way for incorrect use, so use with care.
-`make_static` is low overhead and has no side effects on pass recording.
+`forget_lifetime` is zero overhead and has no side effects on pass recording.
 
-By @wumpf in [#5569](https://github.com/gfx-rs/wgpu/pull/5569), [#5575](https://github.com/gfx-rs/wgpu/pull/5575), [#5620](https://github.com/gfx-rs/wgpu/pull/5620), [#5768](https://github.com/gfx-rs/wgpu/pull/5768)
+By @wumpf in [#5569](https://github.com/gfx-rs/wgpu/pull/5569), [#5575](https://github.com/gfx-rs/wgpu/pull/5575), [#5620](https://github.com/gfx-rs/wgpu/pull/5620), [#5768](https://github.com/gfx-rs/wgpu/pull/5768) (together with @kpreid).
 
 #### Querying shader compilation errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ TODO(wumpf): This is still work in progress. Should write a bit more about it. A
 
 `wgpu::ComputePass` recording methods (e.g. `wgpu::ComputePass:set_render_pipeline`) no longer impose a lifetime constraint passed in resources.
 
-Furthermore, you can now opt out of `wgpu::ComputePass`'s life time dependency on its parent `wgpu::CommandEncoder` using `wgpu::ComputePass::make_static`:
+Furthermore, you can now opt out of `wgpu::ComputePass`'s lifetime dependency on its parent `wgpu::CommandEncoder` using `wgpu::ComputePass::make_static`:  
 ```rust
 fn independent_cpass<'enc>(encoder: &'enc mut wgpu::CommandEncoder) -> wgpu::ComputePass<'static> {
     let cpass: wgpu::ComputePass<'enc> = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());

--- a/tests/tests/compute_pass_ownership.rs
+++ b/tests/tests/compute_pass_ownership.rs
@@ -100,7 +100,7 @@ async fn compute_pass_keep_encoder_alive(ctx: TestingContext) {
 
     // Now drop the encoder - it is kept alive by the compute pass.
     // To do so, we have to make the compute pass forget the lifetime constraint first.
-    let mut cpass = cpass.make_static();
+    let mut cpass = cpass.forget_lifetime();
     drop(encoder);
 
     ctx.async_poll(wgpu::Maintain::wait())

--- a/tests/tests/compute_pass_ownership.rs
+++ b/tests/tests/compute_pass_ownership.rs
@@ -93,13 +93,16 @@ async fn compute_pass_keep_encoder_alive(ctx: TestingContext) {
             label: Some("encoder"),
         });
 
-    let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+    let cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
         label: Some("compute_pass"),
         timestamp_writes: None,
     });
 
     // Now drop the encoder - it is kept alive by the compute pass.
+    // To do so, we have to make the compute pass forget the lifetime constraint first.
+    let mut cpass = cpass.make_static();
     drop(encoder);
+
     ctx.async_poll(wgpu::Maintain::wait())
         .await
         .panic_on_timeout();

--- a/tests/tests/encoder.rs
+++ b/tests/tests/encoder.rs
@@ -257,7 +257,9 @@ fn encoder_operations_fail_while_compute_pass_alive(ctx: TestingContext) {
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
 
-        let pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        let pass = encoder
+            .begin_compute_pass(&wgpu::ComputePassDescriptor::default())
+            .make_static();
 
         ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
 
@@ -287,7 +289,9 @@ fn encoder_operations_fail_while_compute_pass_alive(ctx: TestingContext) {
         let mut encoder = ctx
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-        let pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        let pass = encoder
+            .begin_compute_pass(&wgpu::ComputePassDescriptor::default())
+            .make_static();
         fail(
             &ctx.device,
             || encoder.finish(),

--- a/tests/tests/encoder.rs
+++ b/tests/tests/encoder.rs
@@ -259,7 +259,7 @@ fn encoder_operations_fail_while_compute_pass_alive(ctx: TestingContext) {
 
         let pass = encoder
             .begin_compute_pass(&wgpu::ComputePassDescriptor::default())
-            .make_static();
+            .forget_lifetime();
 
         ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
 
@@ -291,7 +291,7 @@ fn encoder_operations_fail_while_compute_pass_alive(ctx: TestingContext) {
             .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
         let pass = encoder
             .begin_compute_pass(&wgpu::ComputePassDescriptor::default())
-            .make_static();
+            .forget_lifetime();
         fail(
             &ctx.device,
             || encoder.finish(),

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3910,10 +3910,10 @@ impl CommandEncoder {
     /// by calling [`ComputePass::make_static`].
     /// This can be useful for runtime handling of the encoder->pass
     /// dependency e.g. when pass and encoder are stored in the same data structure.
-    pub fn begin_compute_pass<'a>(
-        &'a mut self,
+    pub fn begin_compute_pass<'encoder>(
+        &'encoder mut self,
         desc: &ComputePassDescriptor<'_>,
-    ) -> ComputePass<'a> {
+    ) -> ComputePass<'encoder> {
         let id = self.id.as_ref().unwrap();
         let (id, data) = DynContext::command_encoder_begin_compute_pass(
             &*self.context,
@@ -4767,7 +4767,7 @@ impl<'a> Drop for RenderPass<'a> {
     }
 }
 
-impl<'a> ComputePass<'a> {
+impl<'encoder> ComputePass<'encoder> {
     /// Drops the lifetime relationship to the parent command encoder, making usage of
     /// the encoder while this pass is recorded a run-time error instead.
     ///
@@ -4896,7 +4896,7 @@ impl<'a> ComputePass<'a> {
 }
 
 /// [`Features::PUSH_CONSTANTS`] must be enabled on the device in order to call these functions.
-impl<'a> ComputePass<'a> {
+impl<'encoder> ComputePass<'encoder> {
     /// Set push constant data for subsequent dispatch calls.
     ///
     /// Write the bytes in `data` at offset `offset` within push constant
@@ -4917,7 +4917,7 @@ impl<'a> ComputePass<'a> {
 }
 
 /// [`Features::TIMESTAMP_QUERY_INSIDE_PASSES`] must be enabled on the device in order to call these functions.
-impl<'a> ComputePass<'a> {
+impl<'encoder> ComputePass<'encoder> {
     /// Issue a timestamp command at this point in the queue. The timestamp will be written to the specified query set, at the specified index.
     ///
     /// Must be multiplied by [`Queue::get_timestamp_period`] to get
@@ -4937,7 +4937,7 @@ impl<'a> ComputePass<'a> {
 }
 
 /// [`Features::PIPELINE_STATISTICS_QUERY`] must be enabled on the device in order to call these functions.
-impl<'a> ComputePass<'a> {
+impl<'encoder> ComputePass<'encoder> {
     /// Start a pipeline statistics query on this compute pass. It can be ended with
     /// `end_pipeline_statistics_query`. Pipeline statistics queries may not be nested.
     pub fn begin_pipeline_statistics_query(&mut self, query_set: &QuerySet, query_index: u32) {
@@ -4962,7 +4962,7 @@ impl<'a> ComputePass<'a> {
     }
 }
 
-impl<'a> Drop for ComputePass<'a> {
+impl<'encoder> Drop for ComputePass<'encoder> {
     fn drop(&mut self) {
         if !thread::panicking() && self.call_end_on_drop {
             self.call_end_on_drop = false;

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4772,14 +4772,14 @@ impl<'encoder> ComputePass<'encoder> {
     /// the encoder while this pass is recorded a run-time error instead.
     ///
     /// Attention: As long as the compute pass has not been ended, any mutating operation on the parent
-    /// command encoder will cause a runtime error and invalidate it!
-    /// By default the lifetime constraint protects from this, but it can be useful
-    /// to handle this at run time, for example in order to store the pass and encoder in the same
+    /// command encoder will cause a run-time error and invalidate it!
+    /// By default the lifetime constraint prevents this, but it can be useful
+    /// to handle this at run time, such as when storing the pass and encoder in the same
     /// data structure.
     ///
     /// This operation has no effect on pass recording and is considered low overhead.
     /// It's a safe operation, since [`CommandEncoder`] is in a locked state as long as the pass is active
-    /// regardless of here lifted lifetime constraint.
+    /// regardless of the lifetime constraint or its absence.
     pub fn make_static(mut self) -> ComputePass<'static> {
         // It's tempting to simply transmute the object, but that would be unsound
         // since `repr(rust)` objects have no guarantees about padding or alignment

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3907,7 +3907,7 @@ impl CommandEncoder {
     /// As long as the returned  [`ComputePass`] has not ended,
     /// any mutating operation on this command encoder causes an error and invalidates it.
     /// Note that the `'encoder` lifetime relationship protects against this,
-    /// but it is possible to opt out of it by calling [`ComputePass::make_static`].
+    /// but it is possible to opt out of it by calling [`ComputePass::forget_lifetime`].
     /// This can be useful for runtime handling of the encoder->pass
     /// dependency e.g. when pass and encoder are stored in the same data structure.
     pub fn begin_compute_pass<'encoder>(
@@ -4781,7 +4781,7 @@ impl<'encoder> ComputePass<'encoder> {
     /// This operation has no effect on pass recording.
     /// It's a safe operation, since [`CommandEncoder`] is in a locked state as long as the pass is active
     /// regardless of the lifetime constraint or its absence.
-    pub fn make_static(self) -> ComputePass<'static> {
+    pub fn forget_lifetime(self) -> ComputePass<'static> {
         ComputePass {
             inner: self.inner,
             encoder_guard: PhantomData,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3906,8 +3906,8 @@ impl CommandEncoder {
     ///
     /// As long as the returned  [`ComputePass`] has not ended,
     /// any mutating operation on this command encoder causes an error and invalidates it.
-    /// Note that the lifetime constraint protects against this, but it is possible to opt out of it
-    /// by calling [`ComputePass::make_static`].
+    /// Note that the `'encoder` lifetime relationship protects against this,
+    /// but it is possible to opt out of it by calling [`ComputePass::make_static`].
     /// This can be useful for runtime handling of the encoder->pass
     /// dependency e.g. when pass and encoder are stored in the same data structure.
     pub fn begin_compute_pass<'encoder>(
@@ -4771,10 +4771,10 @@ impl<'encoder> ComputePass<'encoder> {
     /// Drops the lifetime relationship to the parent command encoder, making usage of
     /// the encoder while this pass is recorded a run-time error instead.
     ///
-    /// Attention: As long as the compute pass has not been ended, any mutable operation on the parent
+    /// Attention: As long as the compute pass has not been ended, any mutating operation on the parent
     /// command encoder will cause a runtime error and invalidate it!
     /// By default the lifetime constraint protects from this, but it can be useful
-    /// to handle this at runtime, for example in order to store the pass and encoder in the same
+    /// to handle this at run time, for example in order to store the pass and encoder in the same
     /// data structure.
     ///
     /// This operation has no effect on pass recording and is considered low overhead.

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4774,7 +4774,7 @@ impl<'encoder> ComputePass<'encoder> {
     ///
     /// Attention: As long as the compute pass has not been ended, any mutating operation on the parent
     /// command encoder will cause a run-time error and invalidate it!
-    /// By default the lifetime constraint prevents this, but it can be useful
+    /// By default, the lifetime constraint prevents this, but it can be useful
     /// to handle this at run time, such as when storing the pass and encoder in the same
     /// data structure.
     ///


### PR DESCRIPTION
**Connections**
* Part of the wider story of #1453
* Follow-up to #5620

**Description**
As suggested on Matrix chat by @kpreid.

In  #5620, `wgpu::ComputePass` lost its explicit lifetime constraint to `wgpu::CommandEncoder`. This constraint prevented use of the command encoder while a pass is recorded. This is still an error, but now a runtime error. While removing this lifetime is very useful especially for library authors, it also prevented trivial incorrect api usage, i.e. that PR was great but also created a massive footgun ;-).

Here, we remedy this issue by re-introducing the exact same lifetime constraint but making it opt-out with a zero-overhead `forget_lifetime` method.

**Testing**
Existing tests have been adjusted - compilation failed as expected without these adjustments!

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
