### PR TITLE
Add methods to get raw d3d12::ComPtr<dxgi1_4::IDXGISwapChain3> from DX12 `Surface`

### DIFF
--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -177,6 +177,12 @@ pub struct Surface {
 unsafe impl Send for Surface {}
 unsafe impl Sync for Surface {}
 
+impl Surface {
+    pub unsafe fn swap_chain(&self) -> Option<d3d12::ComPtr<dxgi1_4::IDXGISwapChain3>> {
+        self.swap_chain.read().as_ref().map(|sc| sc.raw())
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 enum MemoryArchitecture {
     Unified {
@@ -619,6 +625,10 @@ pub struct AccelerationStructure {}
 impl SwapChain {
     unsafe fn release_resources(self) -> d3d12::ComPtr<dxgi1_4::IDXGISwapChain3> {
         self.raw
+    }
+
+    unsafe fn raw(&self) -> d3d12::ComPtr<dxgi1_4::IDXGISwapChain3> {
+        self.raw.clone()
     }
 
     unsafe fn wait(


### PR DESCRIPTION
**Description**
This PR allows retrieving the `d3d12::ComPtr<dxgi1_4::IDXGISwapChain3>` from a DX12 `Surface` by cloning the pointer. I'm not sure if there are any conventions around exposing this kind of low-level API, so feel free to comment. I might amend this PR with methods to expose other low-level types if appropriate.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
