### PR TITLE
Fix double decoration if a binding array contains a struct with a runtime array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 - Added support for pipeline-overridable constants to the WebGPU backend by @DouglasDwyer in [#5688](https://github.com/gfx-rs/wgpu/pull/5688)
 
+#### Naga
+
+- In spv-out don't decorate a `BindingArray`'s type with `Block` if the type is a struct with a runtime array by @Vecvec in [#5776](https://github.com/gfx-rs/wgpu/pull/5776)
+
 ## v0.20.0 (2024-04-28)
 
 ### Major Changes

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -1768,7 +1768,11 @@ impl Writer {
                         if let crate::TypeInner::Struct { members, .. } = &ty.inner {
                             // only the last member in a struct can be dynamically sized
                             if let Some(last_member) = members.last() {
-                                if let crate::TypeInner::Array { size: crate::ArraySize::Dynamic, .. } = &ir_module.types[last_member.ty].inner {
+                                if let crate::TypeInner::Array {
+                                    size: crate::ArraySize::Dynamic,
+                                    ..
+                                } = &ir_module.types[last_member.ty].inner
+                                {
                                     should_decorate = false;
                                 }
                             }

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -1765,10 +1765,10 @@ impl Writer {
                         // Check if the type has a runtime array.
                         // A normal runtime array gets validated out,
                         // so only structs can be with runtime arrays
-                        if let crate::TypeInner::Struct { members, .. } = &ty.inner {
+                        if let crate::TypeInner::Struct { ref members, .. } = ty.inner {
                             // only the last member in a struct can be dynamically sized
                             if let Some(last_member) = members.last() {
-                                if let crate::TypeInner::Array {
+                                if let &crate::TypeInner::Array {
                                     size: crate::ArraySize::Dynamic,
                                     ..
                                 } = &ir_module.types[last_member.ty].inner

--- a/naga/tests/out/spv/binding-buffer-arrays.spvasm
+++ b/naga/tests/out/spv/binding-buffer-arrays.spvasm
@@ -19,7 +19,6 @@ OpMemberDecorate %10 0 Offset 0
 OpDecorate %11 NonWritable
 OpDecorate %11 DescriptorSet 0
 OpDecorate %11 Binding 0
-OpDecorate %7 Block
 OpDecorate %15 DescriptorSet 0
 OpDecorate %15 Binding 10
 OpDecorate %16 Block


### PR DESCRIPTION
**Connections**
Fixes #5755 

**Description**
Previously if a binding array contained a struct with a runtime array it would generate two `OpDecorate Block`s which was not allowed by the spirv specification.

**Testing**
This shader no longer produces two `OpDecorate Block`s
````wgsl
struct Array {
    arr: array<u32>,
}

@group(0) @binding(0)
var<storage> store: binding_array<Array>;
````
and a similar one inside naga's tests (binding-buffer-arrays.spvasm) also no longer produces two `OpDecorate Block`s

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - `--target wasm32-unknown-unknown` not applicable
  - `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
