### PR TITLE
Add a function to clear bindgroups from passes and bundles, with stub backend implementations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ TODO(wumpf): This is still work in progress. Should write a bit more about it. A
 
 `wgpu::ComputePass` recording methods (e.g. `wgpu::ComputePass:set_render_pipeline`) no longer impose a lifetime constraint passed in resources.
 
-Furthermore, you can now opt out of `wgpu::ComputePass`'s lifetime dependency on its parent `wgpu::CommandEncoder` using `wgpu::ComputePass::forget_lifetime`:  
+Furthermore, you can now opt out of `wgpu::ComputePass`'s lifetime dependency on its parent `wgpu::CommandEncoder` using `wgpu::ComputePass::forget_lifetime`:
 ```rust
 fn independent_cpass<'enc>(encoder: &'enc mut wgpu::CommandEncoder) -> wgpu::ComputePass<'static> {
     let cpass: wgpu::ComputePass<'enc> = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
@@ -117,6 +117,7 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 - Ensure render pipelines have at least 1 target. By @ErichDonGubler in [#5715](https://github.com/gfx-rs/wgpu/pull/5715)
 - `wgpu::ComputePass` now internally takes ownership of `QuerySet` for both `wgpu::ComputePassTimestampWrites` as well as timestamp writes and statistics query, fixing crashes when destroying `QuerySet` before ending the pass. By @wumpf in [#5671](https://github.com/gfx-rs/wgpu/pull/5671)
+- Stub support for passing null BindGroups to setBindGroup. By @bradwerth in [#5778](https://github.com/gfx-rs/wgpu/pull/5778)
 
 #### Metal
 

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -191,6 +191,11 @@ mod compat {
             self.make_range(index)
         }
 
+        pub fn unassign(&mut self, index: usize) -> Range<usize> {
+            self.entries[index].assigned = None;
+            self.make_range(index)
+        }
+
         pub fn list_active(&self) -> impl Iterator<Item = usize> + '_ {
             self.entries
                 .iter()
@@ -355,6 +360,16 @@ impl<A: HalApi> Binder<A> {
         }
 
         let bind_range = self.manager.assign(index, bind_group.layout.clone());
+        &self.payloads[bind_range]
+    }
+
+    pub(super) fn unassign_group<'a>(&'a mut self, index: usize) -> &'a [EntryPayload<A>] {
+        let payload = &mut self.payloads[index];
+
+        payload.group = None;
+        payload.dynamic_offsets.clear();
+
+        let bind_range = self.manager.unassign(index);
         &self.payloads[bind_range]
     }
 

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -19,6 +19,10 @@ pub enum ComputeCommand {
         bind_group_id: id::BindGroupId,
     },
 
+    ClearBindGroup {
+        index: u32,
+    },
+
     SetPipeline(id::ComputePipelineId),
 
     /// Set a range of push constants to values stored in `push_constant_data`.
@@ -102,6 +106,10 @@ impl ComputeCommand {
                             }
                         })?,
                     },
+
+                    ComputeCommand::ClearBindGroup { index } => {
+                        ArcComputeCommand::ClearBindGroup { index }
+                    }
 
                     ComputeCommand::SetPipeline(pipeline_id) => ArcComputeCommand::SetPipeline(
                         pipelines_guard
@@ -194,6 +202,10 @@ pub enum ArcComputeCommand<A: HalApi> {
         bind_group: Arc<BindGroup<A>>,
     },
 
+    ClearBindGroup {
+        index: u32,
+    },
+
     SetPipeline(Arc<ComputePipeline<A>>),
 
     /// Set a range of push constants to values stored in `push_constant_data`.
@@ -260,6 +272,10 @@ impl<A: HalApi> From<&ArcComputeCommand<A>> for ComputeCommand {
                 num_dynamic_offsets: *num_dynamic_offsets,
                 bind_group_id: bind_group.as_info().id(),
             },
+
+            ArcComputeCommand::ClearBindGroup { index } => {
+                ComputeCommand::ClearBindGroup { index: *index }
+            }
 
             ArcComputeCommand::SetPipeline(pipeline) => {
                 ComputeCommand::SetPipeline(pipeline.as_info().id())

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -148,6 +148,9 @@ pub enum RenderCommand {
         num_dynamic_offsets: usize,
         bind_group_id: id::BindGroupId,
     },
+    ClearBindGroup {
+        index: u32,
+    },
     SetPipeline(id::RenderPipelineId),
     SetIndexBuffer {
         buffer_id: id::BufferId,

--- a/wgpu-core/src/command/dyn_compute_pass.rs
+++ b/wgpu-core/src/command/dyn_compute_pass.rs
@@ -16,6 +16,11 @@ pub trait DynComputePass: std::fmt::Debug + WasmNotSendSync {
         bind_group_id: id::BindGroupId,
         offsets: &[wgt::DynamicOffset],
     ) -> Result<(), ComputePassError>;
+    fn clear_bind_group(
+        &mut self,
+        context: &global::Global,
+        index: u32,
+    ) -> Result<(), ComputePassError>;
     fn set_pipeline(
         &mut self,
         context: &global::Global,
@@ -83,6 +88,14 @@ impl<A: HalApi> DynComputePass for ComputePass<A> {
         offsets: &[wgt::DynamicOffset],
     ) -> Result<(), ComputePassError> {
         context.compute_pass_set_bind_group(self, index, bind_group_id, offsets)
+    }
+
+    fn clear_bind_group(
+        &mut self,
+        context: &global::Global,
+        index: u32,
+    ) -> Result<(), ComputePassError> {
+        context.compute_pass_clear_bind_group(self, index)
     }
 
     fn set_pipeline(

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -861,6 +861,13 @@ impl BindGroupStateChange {
         }
         false
     }
+
+    fn clear_bind_group(&mut self, index: u32) {
+        if let Some(current_bind_group) = self.last_states.get_mut(index as usize) {
+            current_bind_group.reset();
+        }
+    }
+
     fn reset(&mut self) {
         self.last_states = [StateChange::new(); hal::MAX_BIND_GROUPS];
     }
@@ -889,6 +896,8 @@ pub enum PassErrorScope {
     Pass(Option<id::CommandBufferId>),
     #[error("In a set_bind_group command")]
     SetBindGroup(id::BindGroupId),
+    #[error("In a set_bind_group command with a null BindGroup")]
+    ClearBindGroup,
     #[error("In a set_pipeline command")]
     SetPipelineRender(id::RenderPipelineId),
     #[error("In a set_pipeline command")]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1532,6 +1532,18 @@ impl Global {
                             }
                         }
                     }
+                    RenderCommand::ClearBindGroup { index } => {
+                        let pipeline_layout = state.binder.pipeline_layout.clone();
+                        let entries = state.binder.unassign_group(index as usize);
+                        if !entries.is_empty() && pipeline_layout.is_some() {
+                            let pipeline_layout = pipeline_layout.as_ref().unwrap().raw();
+                            for (i, ..) in entries.iter().enumerate() {
+                                unsafe {
+                                    raw.clear_bind_group(pipeline_layout, index + i as u32);
+                                }
+                            }
+                        }
+                    }
                     RenderCommand::SetPipeline(pipeline_id) => {
                         api_log!("RenderPass::set_pipeline {pipeline_id:?}");
 
@@ -2486,6 +2498,14 @@ pub mod render_commands {
             num_dynamic_offsets: offsets.len(),
             bind_group_id,
         });
+    }
+
+    pub fn wgpu_render_pass_clear_bind_group(pass: &mut RenderPass, index: u32) {
+        pass.current_bind_groups.clear_bind_group(index);
+
+        pass.base
+            .commands
+            .push(RenderCommand::ClearBindGroup { index });
     }
 
     pub fn wgpu_render_pass_set_pipeline(pass: &mut RenderPass, pipeline_id: id::RenderPipelineId) {

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -921,6 +921,9 @@ impl crate::CommandEncoder for super::CommandEncoder {
             self.reset_signature(&layout.shared);
         };
     }
+    unsafe fn clear_bind_group(&mut self, _layout: &super::PipelineLayout, _index: u32) {
+        // TODO.
+    }
     unsafe fn set_push_constants(
         &mut self,
         layout: &super::PipelineLayout,

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -365,6 +365,7 @@ impl crate::CommandEncoder for Encoder {
         dynamic_offsets: &[wgt::DynamicOffset],
     ) {
     }
+    unsafe fn clear_bind_group(&mut self, layout: &Resource, index: u32) {}
     unsafe fn set_push_constants(
         &mut self,
         layout: &Resource,

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -780,6 +780,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
         self.rebind_sampler_states(dirty_textures, dirty_samplers);
     }
 
+    unsafe fn clear_bind_group(&mut self, _layout: &super::PipelineLayout, _index: u32) {
+        // TODO.
+    }
+
     unsafe fn set_push_constants(
         &mut self,
         _layout: &super::PipelineLayout,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1093,6 +1093,9 @@ pub trait CommandEncoder: WasmNotSendSync + fmt::Debug {
         dynamic_offsets: &[wgt::DynamicOffset],
     );
 
+    /// Clears the bind group at `index`.
+    unsafe fn clear_bind_group(&mut self, layout: &<Self::A as Api>::PipelineLayout, index: u32);
+
     /// Sets a range in push constant data.
     ///
     /// IMPORTANT: while the data is passed as words, the offset is in bytes!

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -807,6 +807,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
         }
     }
 
+    unsafe fn clear_bind_group(&mut self, _layout: &super::PipelineLayout, _group_index: u32) {
+        // TODO.
+    }
+
     unsafe fn set_push_constants(
         &mut self,
         layout: &super::PipelineLayout,

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -820,6 +820,9 @@ impl crate::CommandEncoder for super::CommandEncoder {
             )
         };
     }
+    unsafe fn clear_bind_group(&mut self, _layout: &super::PipelineLayout, _index: u32) {
+        // TODO.
+    }
     unsafe fn set_push_constants(
         &mut self,
         layout: &super::PipelineLayout,

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -3023,6 +3023,15 @@ impl crate::context::Context for ContextWebGpu {
         }
     }
 
+    fn compute_pass_clear_bind_group(
+        &self,
+        _pass: &mut Self::ComputePassId,
+        _pass_data: &mut Self::ComputePassData,
+        _index: u32,
+    ) {
+        // TODO.
+    }
+
     fn compute_pass_set_push_constants(
         &self,
         _pass: &mut Self::ComputePassId,
@@ -3161,6 +3170,15 @@ impl crate::context::Context for ContextWebGpu {
                     offsets.len() as u32,
                 );
         }
+    }
+
+    fn render_bundle_encoder_clear_bind_group(
+        &self,
+        _encoder: &mut Self::RenderBundleEncoderId,
+        _encoder_data: &mut Self::RenderBundleEncoderData,
+        _index: u32,
+    ) {
+        // TODO.
     }
 
     fn render_bundle_encoder_set_index_buffer(
@@ -3382,6 +3400,15 @@ impl crate::context::Context for ContextWebGpu {
                     offsets.len() as u32,
                 );
         }
+    }
+
+    fn render_pass_clear_bind_group(
+        &self,
+        _pass: &mut Self::RenderPassId,
+        _pass_data: &mut Self::RenderPassData,
+        _index: u32,
+    ) {
+        // TODO.
     }
 
     fn render_pass_set_index_buffer(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2424,6 +2424,23 @@ impl crate::Context for ContextWgpuCore {
         }
     }
 
+    fn compute_pass_clear_bind_group(
+        &self,
+        _pass: &mut Self::ComputePassId,
+        pass_data: &mut Self::ComputePassData,
+        index: u32,
+    ) {
+        if let Err(cause) = pass_data.pass.clear_bind_group(&self.0, index) {
+            self.handle_error(
+                &pass_data.error_sink,
+                cause,
+                LABEL,
+                pass_data.pass.label(),
+                "ComputePass::clear_bind_group",
+            );
+        }
+    }
+
     fn compute_pass_set_push_constants(
         &self,
         _pass: &mut Self::ComputePassId,
@@ -2641,6 +2658,15 @@ impl crate::Context for ContextWgpuCore {
         }
     }
 
+    fn render_bundle_encoder_clear_bind_group(
+        &self,
+        __encoder: &mut Self::RenderBundleEncoderId,
+        encoder_data: &mut Self::RenderBundleEncoderData,
+        index: u32,
+    ) {
+        wgpu_render_bundle_clear_bind_group(encoder_data, index)
+    }
+
     fn render_bundle_encoder_set_index_buffer(
         &self,
         __encoder: &mut Self::RenderBundleEncoderId,
@@ -2816,6 +2842,15 @@ impl crate::Context for ContextWgpuCore {
         offsets: &[wgt::DynamicOffset],
     ) {
         wgpu_render_pass_set_bind_group(&mut pass_data.pass, index, *bind_group, offsets)
+    }
+
+    fn render_pass_clear_bind_group(
+        &self,
+        _pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
+        index: u32,
+    ) {
+        wgpu_render_pass_clear_bind_group(&mut pass_data.pass, index)
     }
 
     fn render_pass_set_index_buffer(

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -634,6 +634,12 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         bind_group_data: &Self::BindGroupData,
         offsets: &[DynamicOffset],
     );
+    fn compute_pass_clear_bind_group(
+        &self,
+        pass: &mut Self::ComputePassId,
+        pass_data: &mut Self::ComputePassData,
+        index: u32,
+    );
     fn compute_pass_set_push_constants(
         &self,
         pass: &mut Self::ComputePassId,
@@ -716,6 +722,12 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         bind_group: &Self::BindGroupId,
         bind_group_data: &Self::BindGroupData,
         offsets: &[DynamicOffset],
+    );
+    fn render_bundle_encoder_clear_bind_group(
+        &self,
+        encoder: &mut Self::RenderBundleEncoderId,
+        encoder_data: &mut Self::RenderBundleEncoderData,
+        index: u32,
     );
     #[allow(clippy::too_many_arguments)]
     fn render_bundle_encoder_set_index_buffer(
@@ -838,6 +850,12 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         bind_group: &Self::BindGroupId,
         bind_group_data: &Self::BindGroupData,
         offsets: &[DynamicOffset],
+    );
+    fn render_pass_clear_bind_group(
+        &self,
+        pass: &mut Self::RenderPassId,
+        pass_data: &mut Self::RenderPassData,
+        index: u32,
     );
     #[allow(clippy::too_many_arguments)]
     fn render_pass_set_index_buffer(
@@ -1627,6 +1645,12 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         bind_group_data: &crate::Data,
         offsets: &[DynamicOffset],
     );
+    fn compute_pass_clear_bind_group(
+        &self,
+        pass: &mut ObjectId,
+        pass_data: &mut crate::Data,
+        index: u32,
+    );
     fn compute_pass_set_push_constants(
         &self,
         pass: &mut ObjectId,
@@ -1701,6 +1725,12 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         bind_group: &ObjectId,
         bind_group_data: &crate::Data,
         offsets: &[DynamicOffset],
+    );
+    fn render_bundle_encoder_clear_bind_group(
+        &self,
+        encoder: &mut ObjectId,
+        encoder_data: &mut crate::Data,
+        index: u32,
     );
     #[allow(clippy::too_many_arguments)]
     fn render_bundle_encoder_set_index_buffer(
@@ -1823,6 +1853,12 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         bind_group: &ObjectId,
         bind_group_data: &crate::Data,
         offsets: &[DynamicOffset],
+    );
+    fn render_pass_clear_bind_group(
+        &self,
+        pass: &mut ObjectId,
+        pass_data: &mut crate::Data,
+        index: u32,
     );
     #[allow(clippy::too_many_arguments)]
     fn render_pass_set_index_buffer(
@@ -3128,6 +3164,17 @@ where
         )
     }
 
+    fn compute_pass_clear_bind_group(
+        &self,
+        pass: &mut ObjectId,
+        pass_data: &mut crate::Data,
+        index: u32,
+    ) {
+        let mut pass = <T::ComputePassId>::from(*pass);
+        let pass_data = downcast_mut::<T::ComputePassData>(pass_data);
+        Context::compute_pass_clear_bind_group(self, &mut pass, pass_data, index)
+    }
+
     fn compute_pass_set_push_constants(
         &self,
         pass: &mut ObjectId,
@@ -3305,6 +3352,17 @@ where
             bind_group_data,
             offsets,
         )
+    }
+
+    fn render_bundle_encoder_clear_bind_group(
+        &self,
+        encoder: &mut ObjectId,
+        encoder_data: &mut crate::Data,
+        index: u32,
+    ) {
+        let mut encoder = <T::RenderBundleEncoderId>::from(*encoder);
+        let encoder_data = downcast_mut::<T::RenderBundleEncoderData>(encoder_data);
+        Context::render_bundle_encoder_clear_bind_group(self, &mut encoder, encoder_data, index)
     }
 
     fn render_bundle_encoder_set_index_buffer(
@@ -3603,6 +3661,17 @@ where
             bind_group_data,
             offsets,
         )
+    }
+
+    fn render_pass_clear_bind_group(
+        &self,
+        pass: &mut ObjectId,
+        pass_data: &mut crate::Data,
+        index: u32,
+    ) {
+        let mut pass = <T::RenderPassId>::from(*pass);
+        let pass_data = downcast_mut::<T::RenderPassData>(pass_data);
+        Context::render_pass_clear_bind_group(self, &mut pass, pass_data, index)
     }
 
     fn render_pass_set_index_buffer(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -4194,6 +4194,17 @@ impl<'a> RenderPass<'a> {
         )
     }
 
+    /// Clear the active bind group for a given bind group index. This corresponds to
+    /// passing a null BindGroup to setBindGroup().
+    pub fn clear_bind_group(&mut self, index: u32) {
+        DynContext::render_pass_clear_bind_group(
+            &*self.parent.context,
+            &mut self.id,
+            self.data.as_mut(),
+            index,
+        )
+    }
+
     /// Sets the active render pipeline.
     ///
     /// Subsequent draw calls will exhibit the behavior defined by `pipeline`.
@@ -4811,6 +4822,17 @@ impl<'encoder> ComputePass<'encoder> {
         );
     }
 
+    /// Clear the active bind group for a given bind group index. This corresponds to
+    /// passing a null BindGroup to setBindGroup().
+    pub fn clear_bind_group(&mut self, index: u32) {
+        DynContext::compute_pass_clear_bind_group(
+            &*self.inner.context,
+            &mut self.inner.id,
+            self.inner.data.as_mut(),
+            index,
+        )
+    }
+
     /// Sets the active compute pipeline.
     pub fn set_pipeline(&mut self, pipeline: &ComputePipeline) {
         DynContext::compute_pass_set_pipeline(
@@ -4990,6 +5012,17 @@ impl<'a> RenderBundleEncoder<'a> {
             &bind_group.id,
             bind_group.data.as_ref(),
             offsets,
+        )
+    }
+
+    /// Clear the active bind group for a given bind group index. This corresponds to
+    /// passing a null BindGroup to setBindGroup().
+    pub fn clear_bind_group(&mut self, index: u32) {
+        DynContext::render_bundle_encoder_clear_bind_group(
+            &*self.parent.context,
+            &mut self.id,
+            self.data.as_mut(),
+            index,
         )
     }
 

--- a/wgpu/src/util/encoder.rs
+++ b/wgpu/src/util/encoder.rs
@@ -12,6 +12,9 @@ pub trait RenderEncoder<'a> {
     /// If the bind group have dynamic offsets, provide them in order of their declaration.
     fn set_bind_group(&mut self, index: u32, bind_group: &'a BindGroup, offsets: &[DynamicOffset]);
 
+    /// Clears the active bind group for a given bind group index.
+    fn clear_bind_group(&mut self, index: u32);
+
     /// Sets the active render pipeline.
     ///
     /// Subsequent draw calls will exhibit the behavior defined by `pipeline`.
@@ -106,6 +109,11 @@ impl<'a> RenderEncoder<'a> for RenderPass<'a> {
     }
 
     #[inline(always)]
+    fn clear_bind_group(&mut self, index: u32) {
+        Self::clear_bind_group(self, index);
+    }
+
+    #[inline(always)]
     fn set_pipeline(&mut self, pipeline: &'a RenderPipeline) {
         Self::set_pipeline(self, pipeline);
     }
@@ -154,6 +162,11 @@ impl<'a> RenderEncoder<'a> for RenderBundleEncoder<'a> {
     #[inline(always)]
     fn set_bind_group(&mut self, index: u32, bind_group: &'a BindGroup, offsets: &[DynamicOffset]) {
         Self::set_bind_group(self, index, bind_group, offsets);
+    }
+
+    #[inline(always)]
+    fn clear_bind_group(&mut self, index: u32) {
+        Self::clear_bind_group(self, index);
     }
 
     #[inline(always)]


### PR DESCRIPTION
Since the spec allows null BindGroups to be passed to setBindGroup, we need a way to clear the BindGroup associated with an index. This patch implements that through a clear_bind_group function defined in various necessary places, and implements as much of it as possible, without getting into the wgpu-hal backend implementations, which are left as TODOs.

**Connections**
N/A

**Testing**
This code is not exercised, since all of our set_bind_group entry points require a BindGroup. The CTS contains tests that set null BindGroups.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
