### PR TITLE
Validate for device mismatch during compute pass recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 - Ensure render pipelines have at least 1 target. By @ErichDonGubler in [#5715](https://github.com/gfx-rs/wgpu/pull/5715)
 - `wgpu::ComputePass` now internally takes ownership of `QuerySet` for both `wgpu::ComputePassTimestampWrites` as well as timestamp writes and statistics query, fixing crashes when destroying `QuerySet` before ending the pass. By @wumpf in [#5671](https://github.com/gfx-rs/wgpu/pull/5671)
+- Validate resources passed during compute pass recording for mismatching device. By @wumpf in [#5779](https://github.com/gfx-rs/wgpu/pull/5779)
 
 #### Metal
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -53,6 +53,11 @@ pub struct ComputePass<A: HalApi> {
     // Resource binding dedupe state.
     current_bind_groups: BindGroupStateChange,
     current_pipeline: StateChange<id::ComputePipelineId>,
+
+    /// The device that this pass is associated with.
+    ///
+    /// Used for quick validation during recording.
+    device_id: id::DeviceId,
 }
 
 impl<A: HalApi> ComputePass<A> {
@@ -976,6 +981,10 @@ impl Global {
             .map_err(|_| ComputePassErrorInner::InvalidBindGroup(index))
             .map_pass_err(scope)?;
 
+        if bind_group.device.as_info().id() != pass.device_id {
+            return Err(DeviceError::WrongDevice).map_pass_err(scope);
+        }
+
         base.commands.push(ArcComputeCommand::SetBindGroup {
             index,
             num_dynamic_offsets: offsets.len(),
@@ -993,8 +1002,9 @@ impl Global {
         let redundant = pass.current_pipeline.set_and_check_redundant(pipeline_id);
 
         let scope = PassErrorScope::SetPipelineCompute(pipeline_id);
-        let base = pass.base_mut(scope)?;
 
+        let device_id = pass.device_id;
+        let base = pass.base_mut(scope)?;
         if redundant {
             // Do redundant early-out **after** checking whether the pass is ended or not.
             return Ok(());
@@ -1007,6 +1017,10 @@ impl Global {
             .get_owned(pipeline_id)
             .map_err(|_| ComputePassErrorInner::InvalidPipeline(pipeline_id))
             .map_pass_err(scope)?;
+
+        if pipeline.device.as_info().id() != device_id {
+            return Err(DeviceError::WrongDevice).map_pass_err(scope);
+        }
 
         base.commands.push(ArcComputeCommand::SetPipeline(pipeline));
 
@@ -1081,6 +1095,7 @@ impl Global {
             indirect: true,
             pipeline: pass.current_pipeline.last_state,
         };
+        let device_id = pass.device_id;
         let base = pass.base_mut(scope)?;
 
         let buffer = hub
@@ -1089,6 +1104,10 @@ impl Global {
             .get_owned(buffer_id)
             .map_err(|_| ComputePassErrorInner::InvalidBuffer(buffer_id))
             .map_pass_err(scope)?;
+
+        if buffer.device.as_info().id() != device_id {
+            return Err(DeviceError::WrongDevice).map_pass_err(scope);
+        }
 
         base.commands
             .push(ArcComputeCommand::<A>::DispatchIndirect { buffer, offset });
@@ -1153,6 +1172,7 @@ impl Global {
         query_index: u32,
     ) -> Result<(), ComputePassError> {
         let scope = PassErrorScope::WriteTimestamp;
+        let device_id = pass.device_id;
         let base = pass.base_mut(scope)?;
 
         let hub = A::hub(self);
@@ -1162,6 +1182,10 @@ impl Global {
             .get_owned(query_set_id)
             .map_err(|_| ComputePassErrorInner::InvalidQuerySet(query_set_id))
             .map_pass_err(scope)?;
+
+        if query_set.device.as_info().id() != device_id {
+            return Err(DeviceError::WrongDevice).map_pass_err(scope);
+        }
 
         base.commands.push(ArcComputeCommand::WriteTimestamp {
             query_set,
@@ -1178,6 +1202,7 @@ impl Global {
         query_index: u32,
     ) -> Result<(), ComputePassError> {
         let scope = PassErrorScope::BeginPipelineStatisticsQuery;
+        let device_id = pass.device_id;
         let base = pass.base_mut(scope)?;
 
         let hub = A::hub(self);
@@ -1187,6 +1212,10 @@ impl Global {
             .get_owned(query_set_id)
             .map_err(|_| ComputePassErrorInner::InvalidQuerySet(query_set_id))
             .map_pass_err(scope)?;
+
+        if query_set.device.as_info().id() != device_id {
+            return Err(DeviceError::WrongDevice).map_pass_err(scope);
+        }
 
         base.commands
             .push(ArcComputeCommand::BeginPipelineStatisticsQuery {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -633,8 +633,11 @@ pub enum CommandEncoderError {
     Device(#[from] DeviceError),
     #[error("Command encoder is locked by a previously created render/compute pass. Before recording any new commands, the pass must be ended.")]
     Locked,
+
     #[error("QuerySet provided for pass timestamp writes is invalid.")]
     InvalidTimestampWritesQuerySetId,
+    #[error("QuerySet provided for pass timestamp writes that was created by a different device.")]
+    WrongDeviceForTimestampWritesQuerySet,
 }
 
 impl Global {


### PR DESCRIPTION
**Description**
Noticed in passing that compute pass (unlike render pass) didn't do any validation on pipeline/buffer/bindgroup/etc. having the correct device.

**Testing**
Todo! This sort of thing needs more general test coverage. Another time!

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
