### PR TITLE
[wgpu] Remove unused `ObjectId` field of `SubmissionIndex`.

### DIFF
--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1158,7 +1158,6 @@ impl crate::context::Context for ContextWebGpu {
     type SurfaceData = Sendable<(Canvas, webgpu_sys::GpuCanvasContext)>;
 
     type SurfaceOutputDetail = SurfaceOutputDetail;
-    type SubmissionIndex = Unused;
     type SubmissionIndexData = ();
     type PipelineCacheId = Unused;
     type PipelineCacheData = ();
@@ -2950,14 +2949,12 @@ impl crate::context::Context for ContextWebGpu {
         _queue: &Self::QueueId,
         queue_data: &Self::QueueData,
         command_buffers: I,
-    ) -> (Self::SubmissionIndex, Self::SubmissionIndexData) {
+    ) -> Self::SubmissionIndexData {
         let temp_command_buffers = command_buffers
             .map(|(_, data)| data.0)
             .collect::<js_sys::Array>();
 
         queue_data.0.submit(&temp_command_buffers);
-
-        (Unused, ())
     }
 
     fn queue_get_timestamp_period(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -551,7 +551,6 @@ impl crate::Context for ContextWgpuCore {
     type SurfaceId = wgc::id::SurfaceId;
     type SurfaceData = Surface;
     type SurfaceOutputDetail = SurfaceOutputDetail;
-    type SubmissionIndex = Unused;
     type SubmissionIndexData = wgc::device::queue::WrappedSubmissionIndex;
 
     type RequestAdapterFuture = Ready<Option<(Self::AdapterId, Self::AdapterData)>>;
@@ -1525,7 +1524,7 @@ impl crate::Context for ContextWgpuCore {
         _device_data: &Self::DeviceData,
         maintain: crate::Maintain,
     ) -> wgt::MaintainResult {
-        let maintain_inner = maintain.map_index(|i| *i.1.as_ref().downcast_ref().unwrap());
+        let maintain_inner = maintain.map_index(|i| *i.0.as_ref().downcast_ref().unwrap());
         match wgc::gfx_select!(device => self.0.device_poll(
             *device,
             maintain_inner
@@ -2322,18 +2321,15 @@ impl crate::Context for ContextWgpuCore {
         queue: &Self::QueueId,
         _queue_data: &Self::QueueData,
         command_buffers: I,
-    ) -> (Self::SubmissionIndex, Self::SubmissionIndexData) {
+    ) -> Self::SubmissionIndexData {
         let temp_command_buffers = command_buffers
             .map(|(i, _)| i)
             .collect::<SmallVec<[_; 4]>>();
 
-        let index = match wgc::gfx_select!(*queue => self.0.queue_submit(*queue, &temp_command_buffers))
-        {
+        match wgc::gfx_select!(*queue => self.0.queue_submit(*queue, &temp_command_buffers)) {
             Ok(index) => index,
             Err(err) => self.handle_error_fatal(err, "Queue::submit"),
-        };
-
-        (Unused, index)
+        }
     }
 
     fn queue_get_timestamp_period(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -186,7 +186,7 @@ static_assertions::assert_impl_all!(Device: Send, Sync);
 /// This type is unique to the Rust API of `wgpu`.
 /// There is no analogue in the WebGPU specification.
 #[derive(Debug, Clone)]
-pub struct SubmissionIndex(ObjectId, Arc<crate::Data>);
+pub struct SubmissionIndex(Arc<crate::Data>);
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(SubmissionIndex: Send, Sync);
 
@@ -5397,14 +5397,14 @@ impl Queue {
             .into_iter()
             .map(|mut comb| (comb.id.take().unwrap(), comb.data.take().unwrap()));
 
-        let (raw, data) = DynContext::queue_submit(
+        let data = DynContext::queue_submit(
             &*self.context,
             &self.id,
             self.data.as_ref(),
             &mut command_buffers,
         );
 
-        SubmissionIndex(raw, data)
+        SubmissionIndex(data)
     }
 
     /// Gets the amount of nanoseconds each tick of a timestamp query represents.


### PR DESCRIPTION
This removes warnings that field 0 of `SubmissionIndex` is never used.

I only see these warnings when referring to `wgpu` via a `path` dependency, not when fetching it from `crates.io`, and I don't really understand why. I wonder if this is related to https://github.com/rust-lang/cargo/issues/8546.

---

Drop the first field of `wgpu::SubmissionIndex`, as it is unused. Adjust uses of the types' other field.

Delete the `wgpu::context::Context` trait's `SubmissionIndex` associated type. Remove it from implementations.

Drop the first field of the `Context` trait's `queue_submit` method's return value. Adjust implementations.
