### PR TITLE
Compile with context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,27 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
 
 - Implement `WGSL`'s `unpack4xI8`,`unpack4xU8`,`pack4xI8` and `pack4xU8`. By @VlaDexa in [#5424](https://github.com/gfx-rs/wgpu/pull/5424)
 - Began work adding support for atomics to the SPIR-V frontend. Tracking issue is [here](https://github.com/gfx-rs/wgpu/issues/4489). By @schell in [#5702](https://github.com/gfx-rs/wgpu/pull/5702).
+- Compile shaders with a "base module". This allows for cleanly implementing imports, or shadertoy-like environments. By @stefnotch in [#5791](https://github.com/gfx-rs/wgpu/pull/5791).
+  ```rust
+  use naga::front::wgsl::Frontend;
+
+  let base_module = Frontend::new()
+      .parse("
+      fn main_image(frag_coord: vec2f) -> vec4f {
+          return vec4f(sin(frag_coord.x), cos(frag_coord.y), 0.0, 1.0);
+      }").unwrap();
+  // For bonus points: Process the base_module to rename all globals except for `main_image`.
+  let result = Frontend::new()
+      .parse_to_ast("
+      @fragment
+      fn fs_main(@builtin(position) pos : vec4f, @location(0) uv: vec2f) -> vec4f {
+          return main_image(uv);
+      }")
+      .unwrap()
+      .to_module(Some(&base_module))
+      .unwrap();
+  ```
+
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ By @stefnotch in [#5410](https://github.com/gfx-rs/wgpu/pull/5410)
       fn main_image(frag_coord: vec2f) -> vec4f {
           return vec4f(sin(frag_coord.x), cos(frag_coord.y), 0.0, 1.0);
       }").unwrap();
-  // For bonus points: Process the base_module to rename all globals except for `main_image`.
+  // A full shadertoy implementation would rename all globals from base_module, except for `main_image`.
   let result = Frontend::new()
       .parse_to_ast("
       @fragment

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -974,12 +974,12 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 ast::GlobalDeclKind::Type(ref t) => t.name,
             };
             if let Some(old) = ctx.globals.get(ident.name) {
-                let span = match old {
-                    LoweredGlobalDecl::Function(handle) => ctx.module.functions.get_span(*handle),
-                    LoweredGlobalDecl::Var(handle) => ctx.module.global_variables.get_span(*handle),
-                    LoweredGlobalDecl::Const(handle) => ctx.module.constants.get_span(*handle),
-                    LoweredGlobalDecl::Override(handle) => ctx.module.overrides.get_span(*handle),
-                    LoweredGlobalDecl::Type(handle) => ctx.module.types.get_span(*handle),
+                let span = match *old {
+                    LoweredGlobalDecl::Function(handle) => ctx.module.functions.get_span(handle),
+                    LoweredGlobalDecl::Var(handle) => ctx.module.global_variables.get_span(handle),
+                    LoweredGlobalDecl::Const(handle) => ctx.module.constants.get_span(handle),
+                    LoweredGlobalDecl::Override(handle) => ctx.module.overrides.get_span(handle),
+                    LoweredGlobalDecl::Type(handle) => ctx.module.types.get_span(handle),
                     // We don't have good spans for entry points
                     LoweredGlobalDecl::EntryPoint => Default::default(),
                 };

--- a/naga/src/front/wgsl/mod.rs
+++ b/naga/src/front/wgsl/mod.rs
@@ -18,7 +18,9 @@ use thiserror::Error;
 
 pub use crate::front::wgsl::error::ParseError;
 use crate::front::wgsl::lower::Lowerer;
-use crate::Scalar;
+use crate::{Arena, FastHashMap, Scalar};
+
+use self::parse::ast::TranslationUnit;
 
 pub struct Frontend {
     parser: Parser,
@@ -32,18 +34,56 @@ impl Frontend {
     }
 
     pub fn parse(&mut self, source: &str) -> Result<crate::Module, ParseError> {
-        self.inner(source).map_err(|x| x.as_parse_error(source))
+        self.inner_to_ast(source)
+            .map_err(|x| x.as_parse_error(source))
+            .and_then(|v| v.to_module())
     }
 
-    fn inner<'a>(&mut self, source: &'a str) -> Result<crate::Module, Error<'a>> {
-        let tu = self.parser.parse(source)?;
-        let index = index::Index::generate(&tu)?;
-        let module = Lowerer::new(&index).lower(&tu)?;
+    /// Two-step module conversion, can be used to modify the intermediate structure before it becomes a module.
+    pub fn parse_to_ast<'a>(&mut self, source: &'a str) -> Result<ParsedWgsl<'a>, ParseError> {
+        self.inner_to_ast(source)
+            .map_err(|x| x.as_parse_error(source))
+    }
 
-        Ok(module)
+    fn inner_to_ast<'a>(&mut self, source: &'a str) -> Result<ParsedWgsl<'a>, Error<'a>> {
+        let mut result = ParsedWgsl {
+            source,
+            translation_unit: self.parser.parse(source)?,
+            index: index::Index::empty(),
+            globals: Default::default(),
+        };
+        result.index = index::Index::generate(&result.translation_unit)?;
+        Ok(result)
     }
 }
 
+pub enum ProvidedGlobalDecl {
+    Function(crate::Function),
+    Var(crate::GlobalVariable),
+    Const(crate::Constant),
+    Override(crate::Override),
+    Type(crate::Type),
+    EntryPoint(crate::EntryPoint),
+}
+
+pub struct ParsedWgsl<'a> {
+    source: &'a str,
+    translation_unit: TranslationUnit<'a>,
+    index: index::Index<'a>,
+    // global_names: Arena<String>,
+    globals: FastHashMap<String, ProvidedGlobalDecl>,
+}
+impl<'a> ParsedWgsl<'a> {
+    pub fn to_module(&self) -> Result<crate::Module, ParseError> {
+        Lowerer::new(&self.index)
+            .lower(&self.translation_unit, &self.globals)
+            .map_err(|x| x.as_parse_error(self.source))
+    }
+
+    pub fn add_global(&mut self, name: String, value: ProvidedGlobalDecl) {
+        self.globals.insert(name, value);
+    }
+}
 /// <div class="warning">
 // NOTE: Keep this in sync with `wgpu::Device::create_shader_module`!
 // NOTE: Keep this in sync with `wgpu_core::Global::device_create_shader_module`!

--- a/naga/src/front/wgsl/mod.rs
+++ b/naga/src/front/wgsl/mod.rs
@@ -51,6 +51,13 @@ impl Frontend {
             index,
         })
     }
+
+    fn inner<'a>(&mut self, source: &'a str) -> Result<crate::Module, Error<'a>> {
+        let tu = self.parser.parse(source)?;
+        let index = index::Index::generate(&tu)?;
+        let module = Lowerer::new(&index).lower(&tu, None)?;
+        Ok(module)
+    }
 }
 
 pub struct ParsedWgsl<'a> {

--- a/naga/src/front/wgsl/mod.rs
+++ b/naga/src/front/wgsl/mod.rs
@@ -37,7 +37,7 @@ impl Frontend {
         self.parse_to_ast(source)?.to_module(None)
     }
 
-    /// Two-step module conversion, can be used to modify the intermediate structure before it becomes a module.
+    /// Two-step module conversion, can be used to compile with a "base module".
     pub fn parse_to_ast<'a>(&mut self, source: &'a str) -> Result<ParsedWgsl<'a>, ParseError> {
         self.inner_to_ast(source)
             .map_err(|x| x.as_parse_error(source))

--- a/naga/src/front/wgsl/tests.rs
+++ b/naga/src/front/wgsl/tests.rs
@@ -877,23 +877,3 @@ fn parse_base_module_storage_buffers() {
         .to_module(Some(&base_module))
         .unwrap();
 }
-
-/* Add this test once https://github.com/gfx-rs/wgpu/issues/5787 is fixed
-#[test]
-fn parse_base_module_storage_buffers_conflict() {
-    use crate::front::wgsl::Frontend;
-
-    let base_module = parse_str(
-        "@group(0) @binding(0)
-        var<storage,read_write> foo: array<u32>;",
-    )
-    .unwrap();
-    let shader = "@group(0) @binding(0)
-    var<storage,read_write> bar: array<u32>;";
-    let result = Frontend::new()
-        .parse_to_ast(shader)
-        .unwrap()
-        .to_module(Some(&base_module));
-    assert!(result.is_err());
-}
- */

--- a/naga/src/front/wgsl/tests.rs
+++ b/naga/src/front/wgsl/tests.rs
@@ -822,7 +822,7 @@ fn parse_base_module_const_local() {
     // Const in base module with same name as a local variable in the actual module shouldn't cause conflicts
 
     let base_module = parse_str("const foo: vec3f = vec3f(1.0);").unwrap();
-    let shader = "fn foo() -> f32 { let foo: f32 = 2.0; return foo; }";
+    let shader = "fn bar() -> f32 { let foo: f32 = 2.0; return foo; }";
     Frontend::new()
         .parse_to_ast(shader)
         .unwrap()


### PR DESCRIPTION
**Connections**
Fix #5713 

**Description**
This makes it possible to take a compiled module, and use it as a "base" for compiling another module. The semantics is
1. Compile the base module. Assume it exports every global (function, struct, alias, etc).
2. Compile the next module, and give it every global from the base module.

To only make individual items importable, one can first pre-process the base module. 
1. Generate UUID
2. Iterate over every global in the base module, and rename it to "UUID_name_of_the_global".

This particular implementation avoids exposing internals that weren't exposed before.

**Testing**
I added a comprehensive list of tests to naga/src/front/wgsl/tests.rs . There are 3 commented out tests that I would like to add, but currently cannot, due to other naga limitations. How should I best deal with those? 

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
