### PR TITLE
[ci] check for untracked naga snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,6 +543,7 @@ jobs:
           cargo xtask test --llvm-cov
 
       - name: check naga snapshots
+        # git diff doesn't check untracked files, we need to stage those then compare with HEAD.
         run: git add . && git diff --exit-code HEAD naga/tests/out
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,7 +543,7 @@ jobs:
           cargo xtask test --llvm-cov
 
       - name: check naga snapshots
-        run: git diff --exit-code -- naga/tests/out
+        run: git add . && git diff --exit-code HEAD naga/tests/out
 
       - uses: actions/upload-artifact@v4
         if: always() # We want artifacts even if the tests fail.


### PR DESCRIPTION
`git diff` doesn't check untracked files, we need to stage those then compare with `HEAD`.

Avoids having to manually catch those issues (https://github.com/gfx-rs/wgpu/pull/5785).