### PR TITLE
Skip `compute_pass_resource_ownership` on GL/AMD Radeon Pro WX 3200.

### DIFF
--- a/tests/tests/compute_pass_ownership.rs
+++ b/tests/tests/compute_pass_ownership.rs
@@ -17,7 +17,15 @@ var<storage, read_write> buffer: array<vec4f>;
 
 #[gpu_test]
 static COMPUTE_PASS_RESOURCE_OWNERSHIP: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().test_features_limits())
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            // https://github.com/gfx-rs/wgpu/issues/5800
+            .skip(wgpu_test::FailureCase::backend_adapter(
+                wgpu::Backends::GL,
+                "AMD Radeon Pro WX 3200",
+            )),
+    )
     .run_async(compute_pass_resource_ownership);
 
 async fn compute_pass_resource_ownership(ctx: TestingContext) {


### PR DESCRIPTION
Skip
`wgpu_test::compute_pass_ownership::compute_pass_resource_ownership` on the GL backend on AMD Radeon Pro WX 3200, to avoid the kernel crash described in #5800.
