### PR TITLE
Give `wgpu_test::compute_pass_ownership` buffers unique labels.

### DIFF
--- a/tests/tests/compute_pass_ownership.rs
+++ b/tests/tests/compute_pass_ownership.rs
@@ -289,7 +289,7 @@ fn resource_setup(ctx: &TestingContext) -> ResourceSetup {
     let indirect_buffer = ctx
         .device
         .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("gpu_buffer"),
+            label: Some("indirect_buffer"),
             usage: wgpu::BufferUsages::INDIRECT,
             contents: wgpu::util::DispatchIndirectArgs { x: 1, y: 1, z: 1 }.as_bytes(),
         });


### PR DESCRIPTION
Give each buffer in the
`wgpu_test::compute_pass_ownership::compute_pass_resource_ownership` test a unique label, for easier debugging.
