### PR TITLE
[core] Improve resource and api logging.

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -260,7 +260,15 @@ impl Global {
             };
 
             let (id, resource) = fid.assign(Arc::new(buffer));
-            api_log!("Device::create_buffer({desc:?}) -> {id:?}");
+            api_log!(
+                "Device::create_buffer({:?}{}) -> {id:?}",
+                desc.label.as_deref().unwrap_or(""),
+                if desc.mapped_at_creation {
+                    ", mapped_at_creation"
+                } else {
+                    ""
+                }
+            );
 
             device
                 .trackers
@@ -2172,7 +2180,7 @@ impl Global {
         device_id: DeviceId,
         maintain: wgt::Maintain<queue::WrappedSubmissionIndex>,
     ) -> Result<bool, WaitIdleError> {
-        api_log!("Device::poll");
+        api_log!("Device::poll {maintain:?}");
 
         let hub = A::hub(self);
         let device = hub

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1550,6 +1550,8 @@ impl Global {
         // the closures should execute with nothing locked!
         callbacks.fire();
 
+        api_log!("Queue::submit to {queue_id:?} returned submit index {submit_index}");
+
         Ok(WrappedSubmissionIndex {
             queue_id,
             index: submit_index,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -163,7 +163,6 @@ impl<A: HalApi> std::fmt::Debug for Device<A> {
 
 impl<A: HalApi> Drop for Device<A> {
     fn drop(&mut self) {
-        resource_log!("Destroy raw Device {:?}", self.info.label());
         let raw = self.raw.take().unwrap();
         let pending_writes = self.pending_writes.lock().take().unwrap();
         pending_writes.dispose(&raw);
@@ -172,6 +171,7 @@ impl<A: HalApi> Drop for Device<A> {
             raw.destroy_buffer(self.zero_buffer.take().unwrap());
             raw.destroy_fence(self.fence.write().take().unwrap());
             let queue = self.queue_to_drop.take().unwrap();
+            resource_log!("Destroy raw Device {:?} and its Queue", self.info.label());
             raw.exit(queue);
         }
     }
@@ -427,6 +427,7 @@ impl<A: HalApi> Device<A> {
                     .map_err(DeviceError::from)?
             }
         };
+        log::info!("Device::maintain: last done index {last_done_index}");
 
         let mut life_tracker = self.lock_life();
         let submission_closures =

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -13,6 +13,7 @@ use crate::{
     id::BufferId,
     lock::{rank, Mutex},
     resource::{Buffer, Resource},
+    resource_log,
     snatch::SnatchGuard,
     storage::Storage,
     track::{
@@ -334,13 +335,27 @@ impl<A: HalApi> ResourceTracker for BufferTracker<A> {
                 //RefCount 2 means that resource is hold just by DeviceTracker and this suspected resource itself
                 //so it's already been released from user and so it's not inside Registry\Storage
                 if existing_ref_count <= 2 {
+                    resource_log!(
+                        "BufferTracker::remove_abandoned: removing {:?}",
+                        self.metadata.get_resource_unchecked(index).as_info().id()
+                    );
+
                     self.metadata.remove(index);
                     return true;
                 }
 
+                resource_log!(
+                    "BufferTracker::remove_abandoned: not removing {:?}, ref count {}",
+                    self.metadata.get_resource_unchecked(index).as_info().id(),
+                    existing_ref_count
+                );
+
                 return false;
             }
         }
+
+        resource_log!("BufferTracker::remove_abandoned: does not contain index {index:?}",);
+
         true
     }
 }

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -94,8 +94,6 @@ impl<T: Resource> ResourceTracker for StatelessTracker<T> {
             return false;
         }
 
-        resource_log!("StatelessTracker::remove_abandoned {index:?}");
-
         self.tracker_assert_in_bounds(index);
 
         unsafe {
@@ -104,13 +102,32 @@ impl<T: Resource> ResourceTracker for StatelessTracker<T> {
                 //RefCount 2 means that resource is hold just by DeviceTracker and this suspected resource itself
                 //so it's already been released from user and so it's not inside Registry\Storage
                 if existing_ref_count <= 2 {
+                    resource_log!(
+                        "StatelessTracker<{}>::remove_abandoned: removing {:?}",
+                        T::TYPE,
+                        self.metadata.get_resource_unchecked(index).as_info().id()
+                    );
+
                     self.metadata.remove(index);
                     return true;
                 }
 
+                resource_log!(
+                    "StatelessTracker<{}>::remove_abandoned: not removing {:?}, ref count {}",
+                    T::TYPE,
+                    self.metadata.get_resource_unchecked(index).as_info().id(),
+                    existing_ref_count
+                );
+
                 return false;
             }
         }
+
+        resource_log!(
+            "StatelessTracker<{}>::remove_abandoned: does not contain index {index:?}",
+            T::TYPE,
+        );
+
         true
     }
 }


### PR DESCRIPTION
Marked as draft, because this depends on #5802.

- Improve logging in `StatelessTracker::remove_abandoned` to show the
  outcome of the call.

- Add similar logging to `BufferTracker` and `TextureTracker`.

- Let `device_create_buffer`'s log only the new buffer's label, id,
  and whether it's mapped at creation. It used to show the whole
  descriptor, which is too much detail.

- Have `queue_submit` log the submission id, and have `device_poll`
  log what it was waiting for, and what actually got done.

- Have `Device::drop` log the destruction of the raw device when it
  actually happens, so it's properly ordered with respect to logging
  from other parts of the device, like `Device::command_allocator`.
