### PR TITLE
build: fix individual `-p wgpu-info` builds

### DIFF
--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -16,4 +16,4 @@ env_logger.workspace = true
 pico-args.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-wgpu.workspace = true
+wgpu = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
**Connections**

<https://github.com/gfx-rs/wgpu/pull/5692> broke `cargo check -p wgpu-info` et al. ofrick! (CC @wumpf)

**Description**

Fix the above by requesting the `serde` feature from `wgpu` again.

**Testing**

_Explain how this change is tested._

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] ~~Run `cargo fmt`.~~
- [x] ~~Run `cargo clippy`. If applicable, add:~~
  - [x] ~~`--target wasm32-unknown-unknown`~~
  - [x] ~~`--target wasm32-unknown-emscripten`~~
- [x] ~~Run `cargo xtask test` to run tests.~~
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~
