### PR TITLE
refactor: satisfy `clippy::never_loop`

### DIFF
--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -678,7 +678,7 @@ impl super::Validator {
         }
 
         {
-            let used_push_constants = module
+            let mut used_push_constants = module
                 .global_variables
                 .iter()
                 .filter(|&(_, var)| var.space == crate::AddressSpace::PushConstant)
@@ -686,8 +686,7 @@ impl super::Validator {
                 .filter(|&handle| !info[handle].is_empty());
             // Check if there is more than one push constant, and error if so.
             // Use a loop for when returning multiple errors is supported.
-            #[allow(clippy::never_loop)]
-            for handle in used_push_constants.skip(1) {
+            if let Some(handle) = used_push_constants.nth(1) {
                 return Err(EntryPointError::MoreThanOnePushConstantUsed
                     .with_span_handle(handle, &module.global_variables));
             }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1099,15 +1099,15 @@ impl Global {
         let device_fid = hub.devices.prepare(device_id_in);
         let queue_fid = hub.queues.prepare(queue_id_in);
 
-        let error = loop {
+        let error = 'error: {
             let adapter = match hub.adapters.get(adapter_id) {
                 Ok(adapter) => adapter,
-                Err(_) => break RequestDeviceError::InvalidAdapter,
+                Err(_) => break 'error RequestDeviceError::InvalidAdapter,
             };
             let (device, mut queue) =
                 match adapter.create_device_and_queue(desc, self.instance.flags, trace_path) {
                     Ok((device, queue)) => (device, queue),
-                    Err(e) => break e,
+                    Err(e) => break 'error e,
                 };
             let (device_id, _) = device_fid.assign(Arc::new(device));
             resource_log!("Created Device {:?}", device_id);
@@ -1147,10 +1147,10 @@ impl Global {
         let devices_fid = hub.devices.prepare(device_id_in);
         let queues_fid = hub.queues.prepare(queue_id_in);
 
-        let error = loop {
+        let error = 'error: {
             let adapter = match hub.adapters.get(adapter_id) {
                 Ok(adapter) => adapter,
-                Err(_) => break RequestDeviceError::InvalidAdapter,
+                Err(_) => break 'error RequestDeviceError::InvalidAdapter,
             };
             let (device, mut queue) = match adapter.create_device_and_queue_from_hal(
                 hal_device,
@@ -1159,7 +1159,7 @@ impl Global {
                 trace_path,
             ) {
                 Ok(device) => device,
-                Err(e) => break e,
+                Err(e) => break 'error e,
             };
             let (device_id, _) = devices_fid.assign(Arc::new(device));
             resource_log!("Created Device {:?}", device_id);

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -20,8 +20,6 @@
 #![allow(
     // It is much clearer to assert negative conditions with eq! false
     clippy::bool_assert_comparison,
-    // We use loops for getting early-out of scope without closures.
-    clippy::never_loop,
     // We don't use syntax sugar where it's not necessary.
     clippy::match_like_matches_macro,
     // Redundant matching is more explicit.

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -209,8 +209,6 @@
     clippy::arc_with_non_send_sync,
     // for `if_then_panic` until it reaches stable
     unknown_lints,
-    // We use loops for getting early-out of scope without closures.
-    clippy::never_loop,
     // We don't use syntax sugar where it's not necessary.
     clippy::match_like_matches_macro,
     // Redundant matching is more explicit.


### PR DESCRIPTION
Recommended review experience: commit-by-commit.

**Connections**

None of note.

**Description**

It turns out that many usages of `loop` in `wgpu-core` were written to access a `break` flow, but _not_ to actually jump to the beginning of a block again, i.e.:

```rust
let val = 'b: loop {
    if fails_validation(thing) {
        break 'b Err(…);
    }
    break 'b Ok(…);
};
```

This is the case for much validation code, seemingly as a stable alternative to the nascent [`try` block syntax](https://doc.rust-lang.org/beta/unstable-book/language-features/try-blocks.html). This particular usage of `loop` has been superseded (for a long time) by labeled scopes, which can also `break`, like so:

```rust
let val = 'b: {
    if fails_validation(thing) {
        break 'b Err(…);
    }
    Ok(…)
};
```

This is easier to read and understand, _and_ avoids a footgun of actually looping when we have no intention to do so.

**Testing**

I rest my case with CI's verdict. 🙂

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] ~~Run `cargo clippy`. If applicable, add:~~
  - [x] ~~`--target wasm32-unknown-unknown`~~
  - [x] ~~`--target wasm32-unknown-emscripten`~~
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
