### PR TITLE
Do not feed &"" to D3DCompile

### DIFF
--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -259,12 +259,7 @@ impl super::Device {
             .as_ref()
             .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("{e}")))?;
 
-        let source_name = stage
-            .module
-            .raw_name
-            .as_ref()
-            .and_then(|cstr| cstr.to_str().ok())
-            .unwrap_or_default();
+        let source_name = stage.module.raw_name.as_deref();
 
         // Compile with DXC if available, otherwise fall back to FXC
         let (result, log_level) = if let Some(ref dxc_container) = self.dxc_container {

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -32,13 +32,21 @@ pub(super) fn compile_fxc(
     {
         compile_flags |= d3dcompiler::D3DCOMPILE_DEBUG | d3dcompiler::D3DCOMPILE_SKIP_OPTIMIZATION;
     }
+
+    // If no name has been set, D3DCompile wants the null pointer.
+    let source_name = if source_name.is_empty() {
+        ptr::null()
+    } else {
+        source_name.as_ptr()
+    };
+
     let mut error = d3d12::Blob::null();
     let hr = unsafe {
         profiling::scope!("d3dcompiler::D3DCompile");
         d3dcompiler::D3DCompile(
             source.as_ptr().cast(),
             source.len(),
-            source_name.as_ptr().cast(),
+            source_name.cast(),
             ptr::null(),
             ptr::null_mut(),
             raw_ep.as_ptr(),

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -1,3 +1,4 @@
+use std::ffi::CStr;
 use std::ptr;
 
 pub(super) use dxc::{compile_dxc, get_dxc_container, DxcContainer};
@@ -14,7 +15,7 @@ use crate::auxil::dxgi::result::HResult;
 pub(super) fn compile_fxc(
     device: &super::Device,
     source: &str,
-    source_name: &str,
+    source_name: Option<&CStr>,
     raw_ep: &std::ffi::CString,
     stage_bit: wgt::ShaderStages,
     full_stage: String,
@@ -34,11 +35,7 @@ pub(super) fn compile_fxc(
     }
 
     // If no name has been set, D3DCompile wants the null pointer.
-    let source_name = if source_name.is_empty() {
-        ptr::null()
-    } else {
-        source_name.as_ptr()
-    };
+    let source_name = source_name.map(|cstr| cstr.as_ptr()).unwrap_or(ptr::null());
 
     let mut error = d3d12::Blob::null();
     let hr = unsafe {
@@ -86,6 +83,7 @@ pub(super) fn compile_fxc(
 // The Dxc implementation is behind a feature flag so that users who don't want to use dxc can disable the feature.
 #[cfg(feature = "dxc_shader_compiler")]
 mod dxc {
+    use std::ffi::CStr;
     use std::path::PathBuf;
 
     // Destructor order should be fine since _dxil and _dxc don't rely on each other.
@@ -140,7 +138,7 @@ mod dxc {
     pub(crate) fn compile_dxc(
         device: &crate::dx12::Device,
         source: &str,
-        source_name: &str,
+        source_name: Option<&CStr>,
         raw_ep: &str,
         stage_bit: wgt::ShaderStages,
         full_stage: String,
@@ -173,6 +171,10 @@ mod dxc {
             Ok(blob) => blob,
             Err(e) => return (Err(e), log::Level::Error),
         };
+
+        let source_name = source_name
+            .and_then(|cstr| cstr.to_str().ok())
+            .unwrap_or("");
 
         let compiled = dxc_container.compiler.compile(
             &blob,
@@ -271,6 +273,7 @@ mod dxc {
 // These are stubs for when the `dxc_shader_compiler` feature is disabled.
 #[cfg(not(feature = "dxc_shader_compiler"))]
 mod dxc {
+    use std::ffi::CStr;
     use std::path::PathBuf;
 
     pub(crate) struct DxcContainer {}
@@ -288,7 +291,7 @@ mod dxc {
     pub(crate) fn compile_dxc(
         _device: &crate::dx12::Device,
         _source: &str,
-        _source_name: &str,
+        _source_name: Option<&CStr>,
         _raw_ep: &str,
         _stage_bit: wgt::ShaderStages,
         _full_stage: String,


### PR DESCRIPTION
A recent change by rustc, now in 1.79-stable, makes empty str constants point to the same location: 0x01. This is an optimization of sorts, not stable behavior. Code must not rely on constants having stable addresses nor should it pass &"" to APIs expecting CStrs or NULL addresses. D3DCompile will segfault if you give it such a pointer, or worse: read random garbage addresses!

- Pass the NULL pointer to D3DCompile if wgpu lacks a decent CString.
- For {d,f}xc_compile, accept `source_name: Option<&CStr>`, as otherwise the API must be `unsafe`.

refs:
- https://learn.microsoft.com/en-us/windows/win32/api/d3dcompiler/nf-d3dcompiler-d3dcompile
- https://github.com/rust-lang/rust/issues/126442