### PR TITLE
Add cfg features wgsl-in and wgsl-out to spv atomic upgrade test. Fixes #5816

### DIFF
--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -5686,6 +5686,7 @@ mod test {
         let _ = super::parse_u8_slice(&bin, &Default::default()).unwrap();
     }
 
+    #[cfg(all(feature = "wgsl-in", feature = "wgsl-out"))]
     #[test]
     fn atomic_i_inc() {
         let _ = env_logger::builder()


### PR DESCRIPTION
**Connections**
#5816 

**Description**
This puts the atomic_i_inc upgrade test behind the `wgsl-in` and `wgsl-out` features, since it translates to WGSL as part of the test. 

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
