### PR TITLE
[naga] Remove unneeded `PartialEq` derivations.

### DIFF
--- a/naga/src/front/glsl/variables.rs
+++ b/naga/src/front/glsl/variables.rs
@@ -475,7 +475,7 @@ impl Frontend {
                     ty,
                     init,
                 };
-                let handle = ctx.module.constants.fetch_or_append(constant, meta);
+                let handle = ctx.module.constants.append(constant, meta);
 
                 let lookup = GlobalLookup {
                     kind: GlobalLookupKind::Constant(handle, ty),

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -891,7 +891,7 @@ pub enum Literal {
 }
 
 /// Pipeline-overridable constant.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -909,7 +909,8 @@ pub struct Override {
 }
 
 /// Constant value.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -971,7 +972,7 @@ pub struct ResourceBinding {
 }
 
 /// Variable defined at module level.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -1371,7 +1372,8 @@ bitflags::bitflags! {
 ///
 /// [`Constant`]: Expression::Constant
 /// [`Override`]: Expression::Override
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]


### PR DESCRIPTION
Remove `PartialEq` derivations from various Naga IR types on which equality doesn't really make sense. In some cases, derive only in `cfg(test)` builds, so tests can check for expected output.

In the GLSL front end, use `append` to add new constants, not
`fetch_or_append`, since the latter requires `PartialEq` yet GLSL
doesn't permit duplicate declarations anyway.
