### PR TITLE
ensure that `wgpu::Error` is `Sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ By @atlv24 in [#5383](https://github.com/gfx-rs/wgpu/pull/5383)
 #### General
 
 - Avoid introducing spurious features for optional dependencies. By @bjorn3 in [#5691](https://github.com/gfx-rs/wgpu/pull/5691)
+- `wgpu::Error` is now `Sync`, making it possible to be wrapped in `anyhow::Error` or `eyre::Report`. By @nolanderc in [#5820](https://github.com/gfx-rs/wgpu/pull/5820)
 
 #### Metal
 - Removed the `link` Cargo feature.

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -5873,7 +5873,7 @@ pub enum Error {
         /// Lower level source of the error.
         #[cfg(send_sync)]
         #[cfg_attr(docsrs, doc(cfg(all())))]
-        source: Box<dyn error::Error + Send + 'static>,
+        source: Box<dyn error::Error + Send + Sync + 'static>,
         /// Lower level source of the error.
         #[cfg(not(send_sync))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
@@ -5884,7 +5884,7 @@ pub enum Error {
         /// Lower level source of the error.
         #[cfg(send_sync)]
         #[cfg_attr(docsrs, doc(cfg(all())))]
-        source: Box<dyn error::Error + Send + 'static>,
+        source: Box<dyn error::Error + Send + Sync + 'static>,
         /// Lower level source of the error.
         #[cfg(not(send_sync))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
@@ -5899,7 +5899,7 @@ pub enum Error {
         /// Lower level source of the error.
         #[cfg(send_sync)]
         #[cfg_attr(docsrs, doc(cfg(all())))]
-        source: Box<dyn error::Error + Send + 'static>,
+        source: Box<dyn error::Error + Send + Sync + 'static>,
         /// Lower level source of the error.
         #[cfg(not(send_sync))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
@@ -5910,6 +5910,8 @@ pub enum Error {
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Error: Send);
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(Error: Sync);
 
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -5909,9 +5909,7 @@ pub enum Error {
     },
 }
 #[cfg(send_sync)]
-static_assertions::assert_impl_all!(Error: Send);
-#[cfg(send_sync)]
-static_assertions::assert_impl_all!(Error: Sync);
+static_assertions::assert_impl_all!(Error: Send, Sync);
 
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {


### PR DESCRIPTION
**Connections**
N/A

**Description**
This PR adds a `Sync` bound to the boxed `std::error::Error` within `wgpu::Error`.
This makes it possible to wrap the error in `anyhow::Error` and `eyre::Report`, which require the inner error to be `Sync`.

**Testing**
There is a static assertion.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
