### PR TITLE
Add missing closing parentheses to some msl unpack functions.

### DIFF
--- a/naga/CHANGELOG.md
+++ b/naga/CHANGELOG.md
@@ -80,6 +80,7 @@ For changelogs after v0.14, see [the wgpu changelog](../CHANGELOG.md).
 - Add and fix minimum Metal version checks for optional functionality. ([#2486](https://github.com/gfx-rs/naga/pull/2486)) **@teoxoy**
 - Make varyings' struct members unique. ([#2521](https://github.com/gfx-rs/naga/pull/2521)) **@evahop**
 - Add experimental vertex pulling transform flag. ([#5254](https://github.com/gfx-rs/wgpu/pull/5254)) **@bradwerth**
+- Fixup some generated MSL for vertex buffer unpack functions. ([#5829](https://github.com/gfx-rs/wgpu/pull/5829)) **@bradwerth**
 
 #### GLSL-OUT
 

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -4389,7 +4389,7 @@ impl<W: Write> Writer<W> {
                 writeln!(
                     self.out,
                     "{}return metal::int2(as_type<int>(b3 << 24 | b2 << 16 | b1 << 8 | b0), \
-                                          as_type<int>(b7 << 24 | b6 << 16 | b5 << 8 | b4);",
+                                          as_type<int>(b7 << 24 | b6 << 16 | b5 << 8 | b4));",
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
@@ -4416,7 +4416,7 @@ impl<W: Write> Writer<W> {
                     self.out,
                     "{}return metal::int3(as_type<int>(b3 << 24 | b2 << 16 | b1 << 8 | b0), \
                                           as_type<int>(b7 << 24 | b6 << 16 | b5 << 8 | b4), \
-                                          as_type<int>(b11 << 24 | b10 << 16 | b9 << 8 | b8);",
+                                          as_type<int>(b11 << 24 | b10 << 16 | b9 << 8 | b8));",
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
@@ -4448,7 +4448,7 @@ impl<W: Write> Writer<W> {
                     "{}return metal::int4(as_type<int>(b3 << 24 | b2 << 16 | b1 << 8 | b0), \
                                           as_type<int>(b7 << 24 | b6 << 16 | b5 << 8 | b4), \
                                           as_type<int>(b11 << 24 | b10 << 16 | b9 << 8 | b8), \
-                                          as_type<int>(b15 << 24 | b14 << 16 | b13 << 8 | b12);",
+                                          as_type<int>(b15 << 24 | b14 << 16 | b13 << 8 | b12));",
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;


### PR DESCRIPTION
**Description**
This fixes syntax errors in generated MSL for some of the vertex buffer unpack functions.

**Testing**
This is tested by the CTS on agents that use the vertex_pulling_transform flag when setting up their render pipelines on Metal backends.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
