### PR TITLE
Make `compile_fxc` accept `full_stage: &CStr`

### DIFF
--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -273,6 +273,7 @@ impl super::Device {
                 dxc_container,
             )
         } else {
+            let full_stage = ffi::CStr::from_bytes_with_nul(full_stage.as_bytes()).unwrap();
             shader_compilation::compile_fxc(
                 self,
                 &source,

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -18,7 +18,7 @@ pub(super) fn compile_fxc(
     source_name: Option<&CStr>,
     raw_ep: &std::ffi::CString,
     stage_bit: wgt::ShaderStages,
-    full_stage: String,
+    full_stage: &CStr,
 ) -> (
     Result<super::CompiledShader, crate::PipelineError>,
     log::Level,


### PR DESCRIPTION
As discussed in https://github.com/gfx-rs/wgpu/pull/5812#issuecomment-2174536813 the reason that it's acceptable to pass this String to an `LPCSTR` argument is because it's secretly a CStr. Make it be what it thinks it is, as otherwise, despite this having only one caller, it's not typesafe.