### PR TITLE
Device mismatch validation improvements

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -8,7 +8,7 @@ use crate::{
     hal_api::HalApi,
     id::{BindGroupLayoutId, BufferId, SamplerId, TextureId, TextureViewId},
     init_tracker::{BufferInitTrackerAction, TextureInitTrackerAction},
-    resource::{Resource, ResourceInfo, ResourceType},
+    resource::{ParentDevice, Resource, ResourceInfo, ResourceType},
     resource_log,
     snatch::{SnatchGuard, Snatchable},
     track::{BindGroupStates, UsageConflict},
@@ -518,6 +518,13 @@ impl<A: HalApi> Resource for BindGroupLayout<A> {
         &self.label
     }
 }
+
+impl<A: HalApi> ParentDevice<A> for BindGroupLayout<A> {
+    fn device(&self) -> &Arc<Device<A>> {
+        &self.device
+    }
+}
+
 impl<A: HalApi> BindGroupLayout<A> {
     pub(crate) fn raw(&self) -> &A::BindGroupLayout {
         self.raw.as_ref().unwrap()
@@ -751,6 +758,12 @@ impl<A: HalApi> Resource for PipelineLayout<A> {
     }
 }
 
+impl<A: HalApi> ParentDevice<A> for PipelineLayout<A> {
+    fn device(&self) -> &Arc<Device<A>> {
+        &self.device
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -953,6 +966,12 @@ impl<A: HalApi> Resource for BindGroup<A> {
 
     fn as_info_mut(&mut self) -> &mut ResourceInfo<Self> {
         &mut self.info
+    }
+}
+
+impl<A: HalApi> ParentDevice<A> for BindGroup<A> {
+    fn device(&self) -> &Arc<Device<A>> {
+        &self.device
     }
 }
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -97,7 +97,7 @@ use crate::{
     id,
     init_tracker::{BufferInitTrackerAction, MemoryInitKind, TextureInitTrackerAction},
     pipeline::{PipelineFlags, RenderPipeline, VertexStep},
-    resource::{Buffer, Resource, ResourceInfo, ResourceType},
+    resource::{Buffer, ParentDevice, Resource, ResourceInfo, ResourceType},
     resource_log,
     snatch::SnatchGuard,
     track::RenderBundleScope,
@@ -1101,6 +1101,12 @@ impl<A: HalApi> Resource for RenderBundle<A> {
 
     fn as_info_mut(&mut self) -> &mut ResourceInfo<Self> {
         &mut self.info
+    }
+}
+
+impl<A: HalApi> ParentDevice<A> for RenderBundle<A> {
+    fn device(&self) -> &Arc<Device<A>> {
+        &self.device
     }
 }
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -104,9 +104,7 @@ impl Global {
                 .get(dst)
                 .map_err(|_| ClearError::InvalidBuffer(dst))?;
 
-            if dst_buffer.device.as_info().id() != cmd_buf.device.as_info().id() {
-                return Err(DeviceError::WrongDevice.into());
-            }
+            dst_buffer.device.same_device(&cmd_buf.device)?;
 
             cmd_buf_data
                 .trackers
@@ -203,9 +201,7 @@ impl Global {
             .get(dst)
             .map_err(|_| ClearError::InvalidTexture(dst))?;
 
-        if dst_texture.device.as_info().id() != cmd_buf.device.as_info().id() {
-            return Err(DeviceError::WrongDevice.into());
-        }
+        dst_texture.device.same_device(&cmd_buf.device)?;
 
         // Check if subresource aspects are valid.
         let clear_aspects =

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -11,7 +11,7 @@ use crate::{
     hal_api::HalApi,
     id::{BufferId, CommandEncoderId, DeviceId, TextureId},
     init_tracker::{MemoryInitKind, TextureInitRange},
-    resource::{Resource, Texture, TextureClearMode},
+    resource::{ParentDevice, Resource, Texture, TextureClearMode},
     snatch::SnatchGuard,
     track::{TextureSelector, TextureTracker},
 };
@@ -104,7 +104,7 @@ impl Global {
                 .get(dst)
                 .map_err(|_| ClearError::InvalidBuffer(dst))?;
 
-            dst_buffer.device.same_device(&cmd_buf.device)?;
+            dst_buffer.same_device_as(cmd_buf.as_ref())?;
 
             cmd_buf_data
                 .trackers
@@ -201,7 +201,7 @@ impl Global {
             .get(dst)
             .map_err(|_| ClearError::InvalidTexture(dst))?;
 
-        dst_texture.device.same_device(&cmd_buf.device)?;
+        dst_texture.same_device_as(cmd_buf.as_ref())?;
 
         // Check if subresource aspects are valid.
         let clear_aspects =

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -361,7 +361,7 @@ impl Global {
                         );
                     };
 
-                    if query_set.device.as_info().id() != cmd_buf.device.as_info().id() {
+                    if query_set.device.same_device(&cmd_buf.device).is_err() {
                         return (
                             ComputePass::new(None, arc_desc),
                             Some(CommandEncoderError::WrongDeviceForTimestampWritesQuerySet),

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -29,7 +29,7 @@ use crate::lock::{rank, Mutex};
 use crate::snatch::SnatchGuard;
 
 use crate::init_tracker::BufferInitTrackerAction;
-use crate::resource::{Resource, ResourceInfo, ResourceType};
+use crate::resource::{ParentDevice, Resource, ResourceInfo, ResourceType};
 use crate::track::{Tracker, UsageScope};
 use crate::{api_log, global::Global, hal_api::HalApi, id, resource_log, Label};
 
@@ -541,6 +541,12 @@ impl<A: HalApi> Resource for CommandBuffer<A> {
     }
 }
 
+impl<A: HalApi> ParentDevice<A> for CommandBuffer<A> {
+    fn device(&self) -> &Arc<Device<A>> {
+        &self.device
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub struct BasePassRef<'a, C> {
     pub label: Option<&'a str>,
@@ -633,11 +639,8 @@ pub enum CommandEncoderError {
     Device(#[from] DeviceError),
     #[error("Command encoder is locked by a previously created render/compute pass. Before recording any new commands, the pass must be ended.")]
     Locked,
-
     #[error("QuerySet provided for pass timestamp writes is invalid.")]
     InvalidTimestampWritesQuerySetId,
-    #[error("QuerySet provided for pass timestamp writes that was created by a different device.")]
-    WrongDeviceForTimestampWritesQuerySet,
 }
 
 impl Global {

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -9,7 +9,7 @@ use crate::{
     hal_api::HalApi,
     id::{self, Id},
     init_tracker::MemoryInitKind,
-    resource::QuerySet,
+    resource::{ParentDevice, QuerySet},
     storage::Storage,
     Epoch, FastHashMap, Index,
 };
@@ -405,7 +405,7 @@ impl Global {
             .add_single(&*query_set_guard, query_set_id)
             .ok_or(QueryError::InvalidQuerySet(query_set_id))?;
 
-        query_set.device.same_device(&cmd_buf.device)?;
+        query_set.same_device_as(cmd_buf.as_ref())?;
 
         let (dst_buffer, dst_pending) = {
             let buffer_guard = hub.buffers.read();
@@ -413,7 +413,7 @@ impl Global {
                 .get(destination)
                 .map_err(|_| QueryError::InvalidBuffer(destination))?;
 
-            dst_buffer.device.same_device(&cmd_buf.device)?;
+            dst_buffer.same_device_as(cmd_buf.as_ref())?;
 
             tracker
                 .buffers

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -9,7 +9,7 @@ use crate::{
     hal_api::HalApi,
     id::{self, Id},
     init_tracker::MemoryInitKind,
-    resource::{QuerySet, Resource},
+    resource::QuerySet,
     storage::Storage,
     Epoch, FastHashMap, Index,
 };
@@ -405,9 +405,7 @@ impl Global {
             .add_single(&*query_set_guard, query_set_id)
             .ok_or(QueryError::InvalidQuerySet(query_set_id))?;
 
-        if query_set.device.as_info().id() != cmd_buf.device.as_info().id() {
-            return Err(DeviceError::WrongDevice.into());
-        }
+        query_set.device.same_device(&cmd_buf.device)?;
 
         let (dst_buffer, dst_pending) = {
             let buffer_guard = hub.buffers.read();
@@ -415,9 +413,7 @@ impl Global {
                 .get(destination)
                 .map_err(|_| QueryError::InvalidBuffer(destination))?;
 
-            if dst_buffer.device.as_info().id() != cmd_buf.device.as_info().id() {
-                return Err(DeviceError::WrongDevice.into());
-            }
+            dst_buffer.device.same_device(&cmd_buf.device)?;
 
             tracker
                 .buffers

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -25,7 +25,7 @@ use crate::{
     hal_label, id,
     init_tracker::{MemoryInitKind, TextureInitRange, TextureInitTrackerAction},
     pipeline::{self, PipelineFlags},
-    resource::{QuerySet, Texture, TextureView, TextureViewNotRenderableReason},
+    resource::{ParentDevice, QuerySet, Texture, TextureView, TextureViewNotRenderableReason},
     storage::Storage,
     track::{TextureSelector, Tracker, UsageConflict, UsageScope},
     validation::{
@@ -1476,7 +1476,9 @@ impl Global {
                             .ok_or(RenderCommandError::InvalidBindGroup(bind_group_id))
                             .map_pass_err(scope)?;
 
-                        bind_group.device.same_device(device).map_pass_err(scope)?;
+                        bind_group
+                            .same_device_as(cmd_buf.as_ref())
+                            .map_pass_err(scope)?;
 
                         bind_group
                             .validate_dynamic_bindings(index, &temp_offsets, &cmd_buf.limits)
@@ -1542,7 +1544,9 @@ impl Global {
                             .ok_or(RenderCommandError::InvalidPipeline(pipeline_id))
                             .map_pass_err(scope)?;
 
-                        pipeline.device.same_device(device).map_pass_err(scope)?;
+                        pipeline
+                            .same_device_as(cmd_buf.as_ref())
+                            .map_pass_err(scope)?;
 
                         info.context
                             .check_compatible(
@@ -1669,7 +1673,9 @@ impl Global {
                             .merge_single(&*buffer_guard, buffer_id, hal::BufferUses::INDEX)
                             .map_pass_err(scope)?;
 
-                        buffer.device.same_device(device).map_pass_err(scope)?;
+                        buffer
+                            .same_device_as(cmd_buf.as_ref())
+                            .map_pass_err(scope)?;
 
                         check_buffer_usage(buffer_id, buffer.usage, BufferUsages::INDEX)
                             .map_pass_err(scope)?;
@@ -1720,7 +1726,9 @@ impl Global {
                             .merge_single(&*buffer_guard, buffer_id, hal::BufferUses::VERTEX)
                             .map_pass_err(scope)?;
 
-                        buffer.device.same_device(device).map_pass_err(scope)?;
+                        buffer
+                            .same_device_as(cmd_buf.as_ref())
+                            .map_pass_err(scope)?;
 
                         let max_vertex_buffers = device.limits.max_vertex_buffers;
                         if slot >= max_vertex_buffers {
@@ -2325,7 +2333,9 @@ impl Global {
                             .ok_or(RenderCommandError::InvalidRenderBundle(bundle_id))
                             .map_pass_err(scope)?;
 
-                        bundle.device.same_device(device).map_pass_err(scope)?;
+                        bundle
+                            .same_device_as(cmd_buf.as_ref())
+                            .map_pass_err(scope)?;
 
                         info.context
                             .check_compatible(

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1476,9 +1476,7 @@ impl Global {
                             .ok_or(RenderCommandError::InvalidBindGroup(bind_group_id))
                             .map_pass_err(scope)?;
 
-                        if bind_group.device.as_info().id() != device.as_info().id() {
-                            return Err(DeviceError::WrongDevice).map_pass_err(scope);
-                        }
+                        bind_group.device.same_device(device).map_pass_err(scope)?;
 
                         bind_group
                             .validate_dynamic_bindings(index, &temp_offsets, &cmd_buf.limits)
@@ -1544,9 +1542,7 @@ impl Global {
                             .ok_or(RenderCommandError::InvalidPipeline(pipeline_id))
                             .map_pass_err(scope)?;
 
-                        if pipeline.device.as_info().id() != device.as_info().id() {
-                            return Err(DeviceError::WrongDevice).map_pass_err(scope);
-                        }
+                        pipeline.device.same_device(device).map_pass_err(scope)?;
 
                         info.context
                             .check_compatible(
@@ -1673,9 +1669,7 @@ impl Global {
                             .merge_single(&*buffer_guard, buffer_id, hal::BufferUses::INDEX)
                             .map_pass_err(scope)?;
 
-                        if buffer.device.as_info().id() != device.as_info().id() {
-                            return Err(DeviceError::WrongDevice).map_pass_err(scope);
-                        }
+                        buffer.device.same_device(device).map_pass_err(scope)?;
 
                         check_buffer_usage(buffer_id, buffer.usage, BufferUsages::INDEX)
                             .map_pass_err(scope)?;
@@ -1726,9 +1720,7 @@ impl Global {
                             .merge_single(&*buffer_guard, buffer_id, hal::BufferUses::VERTEX)
                             .map_pass_err(scope)?;
 
-                        if buffer.device.as_info().id() != device.as_info().id() {
-                            return Err(DeviceError::WrongDevice).map_pass_err(scope);
-                        }
+                        buffer.device.same_device(device).map_pass_err(scope)?;
 
                         let max_vertex_buffers = device.limits.max_vertex_buffers;
                         if slot >= max_vertex_buffers {
@@ -2333,9 +2325,7 @@ impl Global {
                             .ok_or(RenderCommandError::InvalidRenderBundle(bundle_id))
                             .map_pass_err(scope)?;
 
-                        if bundle.device.as_info().id() != device.as_info().id() {
-                            return Err(DeviceError::WrongDevice).map_pass_err(scope);
-                        }
+                        bundle.device.same_device(device).map_pass_err(scope)?;
 
                         info.context
                             .check_compatible(

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -13,7 +13,7 @@ use crate::{
         has_copy_partial_init_tracker_coverage, MemoryInitKind, TextureInitRange,
         TextureInitTrackerAction,
     },
-    resource::{Resource, Texture, TextureErrorDimension},
+    resource::{ParentDevice, Resource, Texture, TextureErrorDimension},
     snatch::SnatchGuard,
     track::{TextureSelector, Tracker},
 };
@@ -602,7 +602,7 @@ impl Global {
                 .get(source)
                 .map_err(|_| TransferError::InvalidBuffer(source))?;
 
-            src_buffer.device.same_device(device)?;
+            src_buffer.same_device_as(cmd_buf.as_ref())?;
 
             cmd_buf_data
                 .trackers
@@ -626,7 +626,7 @@ impl Global {
                 .get(destination)
                 .map_err(|_| TransferError::InvalidBuffer(destination))?;
 
-            dst_buffer.device.same_device(device)?;
+            dst_buffer.same_device_as(cmd_buf.as_ref())?;
 
             cmd_buf_data
                 .trackers
@@ -777,7 +777,7 @@ impl Global {
             .get(destination.texture)
             .map_err(|_| TransferError::InvalidTexture(destination.texture))?;
 
-        dst_texture.device.same_device(device)?;
+        dst_texture.same_device_as(cmd_buf.as_ref())?;
 
         let (hal_copy_size, array_layer_count) = validate_texture_copy_range(
             destination,
@@ -810,7 +810,7 @@ impl Global {
                 .get(source.buffer)
                 .map_err(|_| TransferError::InvalidBuffer(source.buffer))?;
 
-            src_buffer.device.same_device(device)?;
+            src_buffer.same_device_as(cmd_buf.as_ref())?;
 
             tracker
                 .buffers
@@ -943,7 +943,7 @@ impl Global {
             .get(source.texture)
             .map_err(|_| TransferError::InvalidTexture(source.texture))?;
 
-        src_texture.device.same_device(device)?;
+        src_texture.same_device_as(cmd_buf.as_ref())?;
 
         let (hal_copy_size, array_layer_count) =
             validate_texture_copy_range(source, &src_texture.desc, CopySide::Source, copy_size)?;
@@ -997,7 +997,7 @@ impl Global {
                 .get(destination.buffer)
                 .map_err(|_| TransferError::InvalidBuffer(destination.buffer))?;
 
-            dst_buffer.device.same_device(device)?;
+            dst_buffer.same_device_as(cmd_buf.as_ref())?;
 
             tracker
                 .buffers
@@ -1127,8 +1127,8 @@ impl Global {
             .get(destination.texture)
             .map_err(|_| TransferError::InvalidTexture(source.texture))?;
 
-        src_texture.device.same_device(device)?;
-        dst_texture.device.same_device(device)?;
+        src_texture.same_device_as(cmd_buf.as_ref())?;
+        dst_texture.same_device_as(cmd_buf.as_ref())?;
 
         // src and dst texture format must be copy-compatible
         // https://gpuweb.github.io/gpuweb/#copy-compatible

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -602,9 +602,7 @@ impl Global {
                 .get(source)
                 .map_err(|_| TransferError::InvalidBuffer(source))?;
 
-            if src_buffer.device.as_info().id() != device.as_info().id() {
-                return Err(DeviceError::WrongDevice.into());
-            }
+            src_buffer.device.same_device(device)?;
 
             cmd_buf_data
                 .trackers
@@ -628,9 +626,7 @@ impl Global {
                 .get(destination)
                 .map_err(|_| TransferError::InvalidBuffer(destination))?;
 
-            if dst_buffer.device.as_info().id() != device.as_info().id() {
-                return Err(DeviceError::WrongDevice.into());
-            }
+            dst_buffer.device.same_device(device)?;
 
             cmd_buf_data
                 .trackers
@@ -781,9 +777,7 @@ impl Global {
             .get(destination.texture)
             .map_err(|_| TransferError::InvalidTexture(destination.texture))?;
 
-        if dst_texture.device.as_info().id() != device.as_info().id() {
-            return Err(DeviceError::WrongDevice.into());
-        }
+        dst_texture.device.same_device(device)?;
 
         let (hal_copy_size, array_layer_count) = validate_texture_copy_range(
             destination,
@@ -816,9 +810,7 @@ impl Global {
                 .get(source.buffer)
                 .map_err(|_| TransferError::InvalidBuffer(source.buffer))?;
 
-            if src_buffer.device.as_info().id() != device.as_info().id() {
-                return Err(DeviceError::WrongDevice.into());
-            }
+            src_buffer.device.same_device(device)?;
 
             tracker
                 .buffers
@@ -951,9 +943,7 @@ impl Global {
             .get(source.texture)
             .map_err(|_| TransferError::InvalidTexture(source.texture))?;
 
-        if src_texture.device.as_info().id() != device.as_info().id() {
-            return Err(DeviceError::WrongDevice.into());
-        }
+        src_texture.device.same_device(device)?;
 
         let (hal_copy_size, array_layer_count) =
             validate_texture_copy_range(source, &src_texture.desc, CopySide::Source, copy_size)?;
@@ -1007,9 +997,7 @@ impl Global {
                 .get(destination.buffer)
                 .map_err(|_| TransferError::InvalidBuffer(destination.buffer))?;
 
-            if dst_buffer.device.as_info().id() != device.as_info().id() {
-                return Err(DeviceError::WrongDevice.into());
-            }
+            dst_buffer.device.same_device(device)?;
 
             tracker
                 .buffers
@@ -1139,12 +1127,8 @@ impl Global {
             .get(destination.texture)
             .map_err(|_| TransferError::InvalidTexture(source.texture))?;
 
-        if src_texture.device.as_info().id() != device.as_info().id() {
-            return Err(DeviceError::WrongDevice.into());
-        }
-        if dst_texture.device.as_info().id() != device.as_info().id() {
-            return Err(DeviceError::WrongDevice.into());
-        }
+        src_texture.device.same_device(device)?;
+        dst_texture.device.same_device(device)?;
 
         // src and dst texture format must be copy-compatible
         // https://gpuweb.github.io/gpuweb/#copy-compatible

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -15,7 +15,6 @@ use crate::{
     pipeline, present,
     resource::{
         self, BufferAccessError, BufferAccessResult, BufferMapOperation, CreateBufferError,
-        Resource,
     },
     validation::check_buffer_usage,
     Label, LabelHelpers as _,
@@ -1125,8 +1124,8 @@ impl Global {
                 Err(..) => break 'error binding_model::CreateBindGroupError::InvalidLayout,
             };
 
-            if bind_group_layout.device.as_info().id() != device.as_info().id() {
-                break 'error DeviceError::WrongDevice.into();
+            if let Err(e) = bind_group_layout.device.same_device(&device) {
+                break 'error e.into();
             }
 
             let bind_group = match device.create_bind_group(&bind_group_layout, desc, hub) {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -15,6 +15,7 @@ use crate::{
     pipeline, present,
     resource::{
         self, BufferAccessError, BufferAccessResult, BufferMapOperation, CreateBufferError,
+        ParentDevice,
     },
     validation::check_buffer_usage,
     Label, LabelHelpers as _,
@@ -1124,7 +1125,7 @@ impl Global {
                 Err(..) => break 'error binding_model::CreateBindGroupError::InvalidLayout,
             };
 
-            if let Err(e) = bind_group_layout.device.same_device(&device) {
+            if let Err(e) = bind_group_layout.same_device(&device) {
                 break 'error e.into();
             }
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -15,7 +15,6 @@ use crate::{
     pipeline, present,
     resource::{
         self, BufferAccessError, BufferAccessResult, BufferMapOperation, CreateBufferError,
-        ParentDevice,
     },
     validation::check_buffer_usage,
     Label, LabelHelpers as _,
@@ -1124,10 +1123,6 @@ impl Global {
                 Ok(layout) => layout,
                 Err(..) => break 'error binding_model::CreateBindGroupError::InvalidLayout,
             };
-
-            if let Err(e) = bind_group_layout.same_device(&device) {
-                break 'error e.into();
-            }
 
             let bind_group = match device.create_bind_group(&bind_group_layout, desc, hub) {
                 Ok(bind_group) => bind_group,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -385,14 +385,14 @@ fn map_buffer<A: HalApi>(
 pub struct InvalidDevice;
 
 #[derive(Clone, Debug)]
-pub struct WrongDevice {
+pub struct DeviceMismatch {
     pub(super) res: ResourceErrorIdent,
     pub(super) res_device: ResourceErrorIdent,
     pub(super) target: Option<ResourceErrorIdent>,
     pub(super) target_device: ResourceErrorIdent,
 }
 
-impl std::fmt::Display for WrongDevice {
+impl std::fmt::Display for DeviceMismatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
@@ -406,7 +406,7 @@ impl std::fmt::Display for WrongDevice {
     }
 }
 
-impl std::error::Error for WrongDevice {}
+impl std::error::Error for DeviceMismatch {}
 
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
@@ -422,7 +422,7 @@ pub enum DeviceError {
     #[error("QueueId is invalid")]
     InvalidQueueId,
     #[error(transparent)]
-    WrongDevice(#[from] Box<WrongDevice>),
+    DeviceMismatch(#[from] Box<DeviceMismatch>),
 }
 
 impl From<hal::DeviceError> for DeviceError {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2065,6 +2065,9 @@ impl<A: HalApi> Device<A> {
         hub: &Hub<A>,
     ) -> Result<BindGroup<A>, binding_model::CreateBindGroupError> {
         use crate::binding_model::{BindingResource as Br, CreateBindGroupError as Error};
+
+        layout.same_device(self)?;
+
         {
             // Check that the number of entries in the descriptor matches
             // the number of entries in the layout.

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -7,7 +7,7 @@ use crate::{
     device::{Device, DeviceError, MissingDownlevelFlags, MissingFeatures, RenderPassContext},
     hal_api::HalApi,
     id::{PipelineCacheId, PipelineLayoutId, ShaderModuleId},
-    resource::{Resource, ResourceInfo, ResourceType},
+    resource::{ParentDevice, Resource, ResourceInfo, ResourceType},
     resource_log, validation, Label,
 };
 use arrayvec::ArrayVec;
@@ -87,6 +87,12 @@ impl<A: HalApi> Resource for ShaderModule<A> {
 
     fn label(&self) -> &str {
         &self.label
+    }
+}
+
+impl<A: HalApi> ParentDevice<A> for ShaderModule<A> {
+    fn device(&self) -> &Arc<Device<A>> {
+        &self.device
     }
 }
 
@@ -258,6 +264,12 @@ impl<A: HalApi> Resource for ComputePipeline<A> {
     }
 }
 
+impl<A: HalApi> ParentDevice<A> for ComputePipeline<A> {
+    fn device(&self) -> &Arc<Device<A>> {
+        &self.device
+    }
+}
+
 impl<A: HalApi> ComputePipeline<A> {
     pub(crate) fn raw(&self) -> &A::ComputePipeline {
         self.raw.as_ref().unwrap()
@@ -323,6 +335,12 @@ impl<A: HalApi> Resource for PipelineCache<A> {
 
     fn as_info_mut(&mut self) -> &mut ResourceInfo<Self> {
         &mut self.info
+    }
+}
+
+impl<A: HalApi> ParentDevice<A> for PipelineCache<A> {
+    fn device(&self) -> &Arc<Device<A>> {
+        &self.device
     }
 }
 
@@ -582,6 +600,12 @@ impl<A: HalApi> Resource for RenderPipeline<A> {
 
     fn as_info_mut(&mut self) -> &mut ResourceInfo<Self> {
         &mut self.info
+    }
+}
+
+impl<A: HalApi> ParentDevice<A> for RenderPipeline<A> {
+    fn device(&self) -> &Arc<Device<A>> {
+        &self.device
     }
 }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -3,8 +3,8 @@ use crate::device::trace;
 use crate::{
     binding_model::BindGroup,
     device::{
-        queue, resource::DeferredDestroy, BufferMapPendingClosure, Device, DeviceError, HostMap,
-        MissingDownlevelFlags, MissingFeatures, WrongDevice,
+        queue, resource::DeferredDestroy, BufferMapPendingClosure, Device, DeviceError,
+        DeviceMismatch, HostMap, MissingDownlevelFlags, MissingFeatures,
     },
     global::Global,
     hal_api::HalApi,
@@ -162,7 +162,7 @@ pub(crate) trait ParentDevice<A: HalApi>: Resource {
         Arc::ptr_eq(self.device(), other.device())
             .then_some(())
             .ok_or_else(|| {
-                DeviceError::WrongDevice(Box::new(WrongDevice {
+                DeviceError::DeviceMismatch(Box::new(DeviceMismatch {
                     res: self.error_ident(),
                     res_device: self.device().error_ident(),
                     target: Some(other.error_ident()),
@@ -175,7 +175,7 @@ pub(crate) trait ParentDevice<A: HalApi>: Resource {
         Arc::ptr_eq(self.device(), device)
             .then_some(())
             .ok_or_else(|| {
-                DeviceError::WrongDevice(Box::new(WrongDevice {
+                DeviceError::DeviceMismatch(Box::new(DeviceMismatch {
                     res: self.error_ident(),
                     res_device: self.device().error_ident(),
                     target: None,


### PR DESCRIPTION
At a high level this PR adds a new trait that children of the device implement which we use for device mismatch validation.

The validation now relies on `Arc::ptr_eq` rather than IDs.

Part of https://github.com/gfx-rs/wgpu/issues/5121.

PR doesn't need to be squashed, each commit builds by itself.