### PR TITLE
In readme, use emoji literals instead of shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,17 @@ We have a [wiki](https://github.com/gfx-rs/wgpu/wiki) that serves as a knowledge
 
 | API    | Windows            | Linux/Android      | macOS/iOS          | Web (wasm)         |
 | ------ | ------------------ | ------------------ | ------------------ | ------------------ |
-| Vulkan | :white_check_mark: | :white_check_mark: | :volcano:          |                    |
-| Metal  |                    |                    | :white_check_mark: |                    |
-| DX12   | :white_check_mark: |                    |                    |                    |
-| OpenGL | :ok: (GL 3.3+)     | :ok: (GL ES 3.0+)  | :triangular_ruler: | :ok: (WebGL2)      |
-| WebGPU |                    |                    |                    | :white_check_mark: |
+| Vulkan |         ✅         |         ✅         |         🌋         |                    |
+| Metal  |                    |                    |         ✅         |                    |
+| DX12   |         ✅         |                    |                    |                    |
+| OpenGL |    🆗 (GL 3.3+)    |  🆗 (GL ES 3.0+)   |         📐         |    🆗 (WebGL2)     |
+| WebGPU |                    |                    |                    |         ✅         |
 
-:white_check_mark: = First Class Support  
-:ok: = Downlevel/Best Effort Support  
-:triangular_ruler: = Requires the [ANGLE](#angle) translation layer (GL ES 3.0 only)  
-:volcano: = Requires the [MoltenVK](https://vulkan.lunarg.com/sdk/home#mac) translation layer  
-:hammer_and_wrench: = Unsupported, though open to contributions
+✅ = First Class Support  
+🆗 = Downlevel/Best Effort Support  
+📐 = Requires the [ANGLE](#angle) translation layer (GL ES 3.0 only)  
+🌋 = Requires the [MoltenVK](https://vulkan.lunarg.com/sdk/home#mac) translation layer  
+🛠️ = Unsupported, though open to contributions
 
 ### Shader Support
 


### PR DESCRIPTION
Good morning! Crates.io doesn't support emoji shortcodes like `:ok:`. While the readme's "supported platforms" listing looks great on GitHub, it's not so nice on Crates.io for that reason.

Such an issue can be moderately confusing for new users, and it's been bothering me for a while now.

Here's a minor fix to the readme that takes care of the problem! Please let me know if any changes are needed.