### PR TITLE
[naga] Introduce `HandleVec`.

### DIFF
--- a/naga/src/arena.rs
+++ b/naga/src/arena.rs
@@ -783,3 +783,101 @@ where
         arbitrary::size_hint::and(depth_hint, (0, None))
     }
 }
+
+/// A [`Vec`] indexed by [`Handle`]s.
+///
+/// A `HandleVec<T, U>` is a [`Vec<U>`] indexed by values of type `Handle<T>`,
+/// rather than `usize`.
+///
+/// Rather than a `push` method, `HandleVec` has an [`insert`] method, analogous
+/// to [`HashMap::insert`], that requires you to provide the handle at which the
+/// new value should appear. However, since `HandleVec` only supports insertion
+/// at the end, the given handle's index must be equal to the the `HandleVec`'s
+/// current length; otherwise, the insertion will panic.
+///
+/// [`insert`]: HandleVec::insert
+/// [`HashMap::insert`]: std::collections::HashMap::insert
+pub(crate) struct HandleVec<T, U> {
+    inner: Vec<U>,
+    as_keys: PhantomData<T>,
+}
+
+impl<T, U> Default for HandleVec<T, U> {
+    fn default() -> Self {
+        Self {
+            inner: vec![],
+            as_keys: PhantomData,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl<T, U> HandleVec<T, U> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            inner: vec![],
+            as_keys: PhantomData,
+        }
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: Vec::with_capacity(capacity),
+            as_keys: PhantomData,
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Insert a mapping from `handle` to `value`.
+    ///
+    /// Unlike a [`HashMap`], a `HandleVec` can only have new entries inserted at
+    /// the end, like [`Vec::push`]. So the index of `handle` must equal
+    /// [`self.len()`].
+    ///
+    /// [`HashMap]: std::collections::HashMap
+    /// [`self.len()`]: HandleVec::len
+    pub(crate) fn insert(&mut self, handle: Handle<T>, value: U) {
+        assert_eq!(handle.index(), self.inner.len());
+        self.inner.push(value);
+    }
+
+    pub(crate) fn get(&self, handle: Handle<T>) -> Option<&U> {
+        self.inner.get(handle.index())
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.inner.clear()
+    }
+
+    pub(crate) fn resize(&mut self, len: usize, fill: U)
+    where
+        U: Clone,
+    {
+        self.inner.resize(len, fill);
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &U> {
+        self.inner.iter()
+    }
+
+    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut U> {
+        self.inner.iter_mut()
+    }
+}
+
+impl<T, U> ops::Index<Handle<T>> for HandleVec<T, U> {
+    type Output = U;
+
+    fn index(&self, handle: Handle<T>) -> &Self::Output {
+        &self.inner[handle.index()]
+    }
+}
+
+impl<T, U> ops::IndexMut<Handle<T>> for HandleVec<T, U> {
+    fn index_mut(&mut self, handle: Handle<T>) -> &mut Self::Output {
+        &mut self.inner[handle.index()]
+    }
+}

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -213,7 +213,7 @@ impl<'w> BlockContext<'w> {
 
             // The chain rule: if this `Access...`'s `base` operand was
             // previously omitted, then omit this one, too.
-            _ => self.cached.ids[expr_handle.index()] == 0,
+            _ => self.cached.ids[expr_handle] == 0,
         }
     }
 
@@ -237,7 +237,7 @@ impl<'w> BlockContext<'w> {
             crate::Expression::Literal(literal) => self.writer.get_constant_scalar(literal),
             crate::Expression::Constant(handle) => {
                 let init = self.ir_module.constants[handle].init;
-                self.writer.constant_ids[init.index()]
+                self.writer.constant_ids[init]
             }
             crate::Expression::Override(_) => return Err(Error::Override),
             crate::Expression::ZeroValue(_) => self.writer.get_constant_null(result_type_id),
@@ -430,7 +430,7 @@ impl<'w> BlockContext<'w> {
                 }
             }
             crate::Expression::GlobalVariable(handle) => {
-                self.writer.global_variables[handle.index()].access_id
+                self.writer.global_variables[handle].access_id
             }
             crate::Expression::Swizzle {
                 size,
@@ -1830,7 +1830,7 @@ impl<'w> BlockContext<'w> {
                     base
                 }
                 crate::Expression::GlobalVariable(handle) => {
-                    let gv = &self.writer.global_variables[handle.index()];
+                    let gv = &self.writer.global_variables[handle];
                     break gv.access_id;
                 }
                 crate::Expression::LocalVariable(variable) => {

--- a/naga/src/back/spv/image.rs
+++ b/naga/src/back/spv/image.rs
@@ -381,7 +381,7 @@ impl<'w> BlockContext<'w> {
     pub(super) fn get_handle_id(&mut self, expr_handle: Handle<crate::Expression>) -> Word {
         let id = match self.ir_function.expressions[expr_handle] {
             crate::Expression::GlobalVariable(handle) => {
-                self.writer.global_variables[handle.index()].handle_id
+                self.writer.global_variables[handle].handle_id
             }
             crate::Expression::FunctionArgument(i) => {
                 self.function.parameters[i as usize].handle_id
@@ -974,7 +974,7 @@ impl<'w> BlockContext<'w> {
         };
 
         if let Some(offset_const) = offset {
-            let offset_id = self.writer.constant_ids[offset_const.index()];
+            let offset_id = self.writer.constant_ids[offset_const];
             main_instruction.add_operand(offset_id);
         }
 

--- a/naga/src/back/spv/index.rs
+++ b/naga/src/back/spv/index.rs
@@ -116,7 +116,7 @@ impl<'w> BlockContext<'w> {
             _ => return Err(Error::Validation("array length expression case-4")),
         };
 
-        let gvar = self.writer.global_variables[global_handle.index()].clone();
+        let gvar = self.writer.global_variables[global_handle].clone();
         let global = &self.ir_module.global_variables[global_handle];
         let (last_member_index, gvar_id) = match opt_last_member_index {
             Some(index) => (index, gvar.access_id),

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -18,7 +18,7 @@ mod writer;
 
 pub use spirv::Capability;
 
-use crate::arena::Handle;
+use crate::arena::{Handle, HandleVec};
 use crate::proc::{BoundsCheckPolicies, TypeResolution};
 
 use spirv::Word;
@@ -420,7 +420,7 @@ enum Dimension {
 /// [emit]: index.html#expression-evaluation-time-and-scope
 #[derive(Default)]
 struct CachedExpressions {
-    ids: Vec<Word>,
+    ids: HandleVec<crate::Expression, Word>,
 }
 impl CachedExpressions {
     fn reset(&mut self, length: usize) {
@@ -431,7 +431,7 @@ impl CachedExpressions {
 impl ops::Index<Handle<crate::Expression>> for CachedExpressions {
     type Output = Word;
     fn index(&self, h: Handle<crate::Expression>) -> &Word {
-        let id = &self.ids[h.index()];
+        let id = &self.ids[h];
         if *id == 0 {
             unreachable!("Expression {:?} is not cached!", h);
         }
@@ -440,7 +440,7 @@ impl ops::Index<Handle<crate::Expression>> for CachedExpressions {
 }
 impl ops::IndexMut<Handle<crate::Expression>> for CachedExpressions {
     fn index_mut(&mut self, h: Handle<crate::Expression>) -> &mut Word {
-        let id = &mut self.ids[h.index()];
+        let id = &mut self.ids[h];
         if *id != 0 {
             unreachable!("Expression {:?} is already cached!", h);
         }
@@ -662,9 +662,9 @@ pub struct Writer {
     lookup_function: crate::FastHashMap<Handle<crate::Function>, Word>,
     lookup_function_type: crate::FastHashMap<LookupFunctionType, Word>,
     /// Indexed by const-expression handle indexes
-    constant_ids: Vec<Word>,
+    constant_ids: HandleVec<crate::Expression, Word>,
     cached_constants: crate::FastHashMap<CachedConstant, Word>,
-    global_variables: Vec<GlobalVariable>,
+    global_variables: HandleVec<crate::GlobalVariable, GlobalVariable>,
     binding_map: BindingMap,
 
     // Cached expressions are only meaningful within a BlockContext, but we

--- a/naga/src/back/spv/recyclable.rs
+++ b/naga/src/back/spv/recyclable.rs
@@ -65,3 +65,10 @@ impl<K: Ord, V> Recyclable for std::collections::BTreeMap<K, V> {
         self
     }
 }
+
+impl<K, V> Recyclable for crate::arena::HandleVec<K, V> {
+    fn recycle(mut self) -> Self {
+        self.clear();
+        self
+    }
+}


### PR DESCRIPTION
Introduce a new type, `HandleVec<T, U>`, which is basically a `Vec<U>`, except that it's indexed by values of type `Handle<T>`. This gives us a more strictly typed way to build tables of data parallel to some other `Arena`.

Change `naga::back::pipeline_constants` to use `HandleVec` instead of `Vec`. This removes many calls to `Handle::index`, and makes the types more informative.

In `naga::back::spv`, change `Writer` and `BlockContext` to use `HandleVec` instead of `Vec` for various handle-indexed tables.
