### PR TITLE
Check for subgroup support when creating a naga `Validator`

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -545,25 +545,10 @@ pub fn create_validator(
         Caps::SUBGROUP_BARRIER,
         features.intersects(wgt::Features::SUBGROUP_BARRIER),
     );
-
-    let mut subgroup_stages = naga::valid::ShaderStages::empty();
-    subgroup_stages.set(
-        naga::valid::ShaderStages::COMPUTE | naga::valid::ShaderStages::FRAGMENT,
-        features.contains(wgt::Features::SUBGROUP),
-    );
-    subgroup_stages.set(
-        naga::valid::ShaderStages::VERTEX,
+    caps.set(
+        Caps::SUBGROUP_VERTEX_STAGE,
         features.contains(wgt::Features::SUBGROUP_VERTEX),
     );
 
-    let subgroup_operations = if caps.contains(Caps::SUBGROUP) {
-        use naga::valid::SubgroupOperationSet as S;
-        S::BASIC | S::VOTE | S::ARITHMETIC | S::BALLOT | S::SHUFFLE | S::SHUFFLE_RELATIVE
-    } else {
-        naga::valid::SubgroupOperationSet::empty()
-    };
-    let mut validator = naga::valid::Validator::new(flags, caps);
-    validator.subgroup_stages(subgroup_stages);
-    validator.subgroup_operations(subgroup_operations);
-    validator
+    naga::valid::Validator::new(flags, caps)
 }


### PR DESCRIPTION
**Description**
Detecting support for subgroup ops in naga validators is currently pretty ugly, as it requires creating a validator then calling 2 separate functions on it. I found this really annoying and ugly when I updated `naga_oil` to naga 0.20.

Add `SUBGROUP_VERTEX_STAGE` to naga's `Capabilities` so that naga automatically detects subgroup support when creating a validator.

**Testing**
I ran the water example and it still worked.

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
