### PR TITLE
v0.20.2 release for `wgpu` et al., v0.21.1 release for `wgpu-{core,hal}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ Bottom level categories:
 
 ## Unreleased 
 
+## v0.20.2 (2024-06-12)
+
+This release force-bumps transitive dependencies of `wgpu` on `wgpu-core` and `wgpu-hal` to 0.21.1, to resolve some undefined behavior observable in the DX12 backend after upgrading to Rust 1.79 or later.
+
+### Bug Fixes
+
+#### DX12
+
+* Do not feed `&""` to `D3DCompile`, by @workingjubilee in [#5812](https://github.com/gfx-rs/wgpu/issues/5812).
+
 ## v0.20.1 (2024-06-12)
 
 This release included v0.21.0 of `wgpu-core` and `wgpu-hal`, due to breaking changes needed to solve vulkan validation issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ This release force-bumps transitive dependencies of `wgpu` on `wgpu-core` and `w
 
 ### Bug Fixes
 
+#### General
+
+* Fix a `CommandBuffer` leak. By @cwfitzgerald and @nical in [#5141](https://github.com/gfx-rs/wgpu/pull/5141)
+
 #### DX12
 
 * Do not feed `&""` to `D3DCompile`, by @workingjubilee in [#5812](https://github.com/gfx-rs/wgpu/issues/5812).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,7 +2619,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "player"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "env_logger",
  "log",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "arrayvec 0.7.4",
  "cfg-if",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "arrayvec 0.7.4",
  "bit-vec",
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-examples"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4138,7 +4138,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "android_system_properties",
  "arrayvec 0.7.4",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-info"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-macros"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-test"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 homepage = "https://wgpu.rs/"
 repository = "https://github.com/gfx-rs/wgpu"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["gfx-rs developers"]
 
 [workspace.dependencies.wgc]

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-core"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["gfx-rs developers"]
 edition = "2021"
 description = "WebGPU core logic on wgpu-hal"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-hal"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["gfx-rs developers"]
 edition = "2021"
 description = "WebGPU hardware abstraction layer"

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2263,6 +2263,10 @@ impl crate::Context for ContextWgpuCore {
             Err(err) => self.handle_error_fatal(err, "Queue::submit"),
         };
 
+        for cmdbuf in &temp_command_buffers {
+            wgc::gfx_select!(*queue => self.0.command_buffer_drop(*cmdbuf));
+        }
+
         (Unused, index)
     }
 


### PR DESCRIPTION
Remaining steps in the release process:

- [x] Force-push to the `v0.20` branch after this is approved.
- [x] Do a tagged release on GH.