### PR TITLE
[naga] Add `packed` as a keyword for GLSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@ By @atlv24 in [#5383](https://github.com/gfx-rs/wgpu/pull/5383)
 #### Naga
 
 - In spv-out don't decorate a `BindingArray`'s type with `Block` if the type is a struct with a runtime array by @Vecvec in [#5776](https://github.com/gfx-rs/wgpu/pull/5776)
+- Add `packed` as a keyword for GLSL by @kjarosh in [#5855](https://github.com/gfx-rs/wgpu/pull/5855)
 
 ## v0.20.0 (2024-04-28)
 

--- a/naga/src/back/glsl/keywords.rs
+++ b/naga/src/back/glsl/keywords.rs
@@ -473,6 +473,8 @@ pub const RESERVED_KEYWORDS: &[&str] = &[
     "anyInvocation",
     "allInvocations",
     "allInvocationsEqual",
+    // Sometimes "packed" is a keyword, see https://github.com/gfx-rs/wgpu/issues/5853
+    "packed",
     //
     // entry point name (should not be shadowed)
     //


### PR DESCRIPTION
Turns out that sometimes `packed` is a keyword, and the produced GLSL had syntax errors due to that.

**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/5853.

**Description**
Sometimes `packed` is a keyword in GLSL, and naga was preserving variables named that way, which caused syntax errors.

**Testing**
I executed the following command and observed that the `packed` variable name was suffixed with an underscore. The input file was the original file that caused syntax errors for some users (https://github.com/ruffle-rs/ruffle/blob/036839fb1f382852711e0c1e270fa3e69a3a540a/render/wgpu/shaders/filter/displacement_map.wgsl). Others have confirmed that renaming the identifier to something else than `packed` fixes those issues.

```
cargo run --package naga-cli displacement_map.wgsl output.vert --entry-point main_vertex
```

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy` (it produces warnings but my patch does not introduce any). If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
  - The same set of ~45 tests fail both before and after this PR, so... it's stable at least?
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
