### PR TITLE
buffer size mismatch: more detail in error message

### DIFF
--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -147,10 +147,10 @@ pub enum BindingError {
         binding: naga::AddressSpace,
         shader: naga::AddressSpace,
     },
-    #[error("Buffer structure size {shader}, added to one element of an unbound array, if it's the last field, ended up greater than the given `min_binding_size`, which is {binding}")]
+    #[error("Buffer structure size {buffer_size}, added to one element of an unbound array, if it's the last field, ended up greater than the given `min_binding_size`, which is {min_binding_size}")]
     WrongBufferSize {
-        binding: wgt::BufferSize,
-        shader: wgt::BufferSize,
+        buffer_size: wgt::BufferSize,
+        min_binding_size: wgt::BufferSize,
     },
     #[error("View dimension {dim:?} (is array: {is_array}) doesn't match the binding {binding:?}")]
     WrongTextureViewDimension {
@@ -389,8 +389,8 @@ impl Resource {
                 match min_size {
                     Some(non_zero) if non_zero < size => {
                         return Err(BindingError::WrongBufferSize {
-                            binding: non_zero,
-                            shader: size,
+                            buffer_size: size,
+                            min_binding_size: non_zero,
                         })
                     }
                     _ => (),

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -147,8 +147,11 @@ pub enum BindingError {
         binding: naga::AddressSpace,
         shader: naga::AddressSpace,
     },
-    #[error("Buffer structure size {0}, added to one element of an unbound array, if it's the last field, ended up greater than the given `min_binding_size`")]
-    WrongBufferSize(wgt::BufferSize),
+    #[error("Buffer structure size {shader}, added to one element of an unbound array, if it's the last field, ended up greater than the given `min_binding_size`, which is {binding}")]
+    WrongBufferSize {
+        binding: wgt::BufferSize,
+        shader: wgt::BufferSize,
+    },
     #[error("View dimension {dim:?} (is array: {is_array}) doesn't match the binding {binding:?}")]
     WrongTextureViewDimension {
         dim: naga::ImageDimension,
@@ -385,7 +388,10 @@ impl Resource {
                 };
                 match min_size {
                     Some(non_zero) if non_zero < size => {
-                        return Err(BindingError::WrongBufferSize(size))
+                        return Err(BindingError::WrongBufferSize {
+                            binding: non_zero,
+                            shader: size,
+                        })
                     }
                     _ => (),
                 }


### PR DESCRIPTION
**Connections**
N/A

**Description**
In case there is a buffer size mismatch between the shader and bindings, prints both sizes in the error message.

**Testing**
N/A

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
