### PR TITLE
[naga-cli] add --defines options for the glsl parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ TODO(wumpf): This is still work in progress. Should write a bit more about it. A
 
 `wgpu::ComputePass` recording methods (e.g. `wgpu::ComputePass:set_render_pipeline`) no longer impose a lifetime constraint passed in resources.
 
-Furthermore, you can now opt out of `wgpu::ComputePass`'s lifetime dependency on its parent `wgpu::CommandEncoder` using `wgpu::ComputePass::forget_lifetime`:  
+Furthermore, you can now opt out of `wgpu::ComputePass`'s lifetime dependency on its parent `wgpu::CommandEncoder` using `wgpu::ComputePass::forget_lifetime`:
 ```rust
 fn independent_cpass<'enc>(encoder: &'enc mut wgpu::CommandEncoder) -> wgpu::ComputePass<'static> {
     let cpass: wgpu::ComputePass<'enc> = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
@@ -126,6 +126,7 @@ By @atlv24 in [#5383](https://github.com/gfx-rs/wgpu/pull/5383)
 
 #### Naga
 
+- Added -D, --defines option to naga CLI to define preprocessor macros by @theomonnom in [#5859](https://github.com/gfx-rs/wgpu/pull/5859)
 - Added type upgrades to SPIR-V atomic support. Added related infrastructure. Tracking issue is [here](https://github.com/gfx-rs/wgpu/issues/4489). By @schell in [#5775](https://github.com/gfx-rs/wgpu/pull/5775).
 - Implement `WGSL`'s `unpack4xI8`,`unpack4xU8`,`pack4xI8` and `pack4xU8`. By @VlaDexa in [#5424](https://github.com/gfx-rs/wgpu/pull/5424)
 - Began work adding support for atomics to the SPIR-V frontend. Tracking issue is [here](https://github.com/gfx-rs/wgpu/issues/4489). By @schell in [#5702](https://github.com/gfx-rs/wgpu/pull/5702).

--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -133,7 +133,7 @@ struct Args {
     #[argh(positional)]
     files: Vec<String>,
 
-    /// defines to be passed to the compiler (only glsl is supported)
+    /// defines to be passed to the parser (only glsl is supported)
     #[argh(option, short = 'D')]
     defines: Vec<Defines>,
 }

--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -132,6 +132,10 @@ struct Args {
     /// In bulk validation mode, these are all input files to be validated.
     #[argh(positional)]
     files: Vec<String>,
+
+    /// defines to be passed to the compiler (only glsl is supported)
+    #[argh(option, short = 'D')]
+    defines: Vec<Defines>,
 }
 
 /// Newtype so we can implement [`FromStr`] for `BoundsCheckPolicy`.
@@ -285,6 +289,27 @@ impl FromStr for Overrides {
     }
 }
 
+#[derive(Clone, Debug)]
+struct Defines {
+    pairs: Vec<(String, String)>,
+}
+
+impl FromStr for Defines {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut pairs = vec![];
+        for pair in s.split(',') {
+            let (name, value) = match pair.split_once('=') {
+                Some((name, value)) => (name, value),
+                None => (pair, ""), // Default to an empty string if no '=' is found
+            };
+            pairs.push((name.trim().to_string(), value.trim().to_string()));
+        }
+        Ok(Defines { pairs })
+    }
+}
+
 #[derive(Default)]
 struct Parameters<'a> {
     validation_flags: naga::valid::ValidationFlags,
@@ -300,6 +325,7 @@ struct Parameters<'a> {
     hlsl: naga::back::hlsl::Options,
     input_kind: Option<InputKind>,
     shader_stage: Option<ShaderStage>,
+    defines: FastHashMap<String, String>,
 }
 
 trait PrettyResult {
@@ -393,6 +419,14 @@ fn run() -> anyhow::Result<()> {
         .flat_map(|o| &o.pairs)
         .cloned()
         .collect();
+
+    params.defines = args
+        .defines
+        .iter()
+        .flat_map(|o| &o.pairs)
+        .cloned()
+        .collect();
+
     params.spv_in = naga::front::spv::Options {
         adjust_coordinate_space: !args.keep_coordinate_space,
         strict_capabilities: false,
@@ -611,7 +645,7 @@ fn parse_input(input_path: &Path, input: Vec<u8>, params: &Parameters) -> anyhow
                     .parse(
                         &naga::front::glsl::Options {
                             stage: shader_stage.0,
-                            defines: Default::default(),
+                            defines: params.defines.clone(),
                         },
                         &input,
                     )
@@ -859,7 +893,7 @@ use codespan_reporting::{
         termcolor::{ColorChoice, StandardStream},
     },
 };
-use naga::WithSpan;
+use naga::{FastHashMap, WithSpan};
 
 pub fn emit_annotated_error<E: Error>(ann_err: &WithSpan<E>, filename: &str, source: &str) {
     let files = SimpleFile::new(filename, source);


### PR DESCRIPTION
**Description**
The motivation is to enable one glsl shader file that includes both vertex and fragment stages separated through preprocessing. This matches the behaviour of `glslangValidator`



Example of this particular glsl shader:
```glsl
#version 450 core

#ifdef VERTEX_SHADER
struct VertexInput {
    vec3 position;
    vec2 tex_coord;
};

layout(location = 0) in vec3 in_position;
layout(location = 1) in vec2 in_tex_coord;
layout(location = 0) out vec2 frag_tex_coord;

void main() {
    VertexInput vertex;
    vertex.position = in_position;
    vertex.tex_coord = in_tex_coord;

    frag_tex_coord = vertex.tex_coord;
    gl_Position = vec4(vertex.position, 1.0);
}
#endif

#ifdef FRAGMENT_SHADER
layout(location = 0) in vec2 frag_tex_coord;
layout(location = 0) out vec4 out_color;

void main() {
    out_color = vec4(frag_tex_coord, 0.0, 1.0);
}
#endif
```


**Testing**
```
cargo run -- my_shader.glsl my_shader.frag.wgsl --shader-stage fragment --entry-point main -D FRAGMENT_SHADER
cargo run -- my_shader.glsl my_shader.vert.wgsl --shader-stage vertex --entry-point main -D VERTEX_SHADER
```

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
