### PR TITLE
[naga] Use `HandleVec` in `Typeifier`.

### DIFF
--- a/naga/src/arena.rs
+++ b/naga/src/arena.rs
@@ -798,6 +798,7 @@ where
 ///
 /// [`insert`]: HandleVec::insert
 /// [`HashMap::insert`]: std::collections::HashMap::insert
+#[derive(Debug)]
 pub(crate) struct HandleVec<T, U> {
     inner: Vec<U>,
     as_keys: PhantomData<T>,


### PR DESCRIPTION
Change `naga::front::Typifier::resolutions` to be a `HandleVec<Expression, TypeResolution>`, not a plain `Vec`.
