### PR TITLE
[naga] Use `HandleVec` in `ExpressionKindTracker`.

### DIFF
--- a/naga/src/arena.rs
+++ b/naga/src/arena.rs
@@ -798,6 +798,7 @@ where
 ///
 /// [`insert`]: HandleVec::insert
 /// [`HashMap::insert`]: std::collections::HashMap::insert
+#[derive(Debug)]
 pub(crate) struct HandleVec<T, U> {
     inner: Vec<U>,
     as_keys: PhantomData<T>,


### PR DESCRIPTION
Change `naga::proc::constant_evaluator::ExpressionKindTracker::inner` from a `Vec` to a `HandleVec`, for better type-checking and more convenient indexing. Change uses accordingly.
