### PR TITLE
[naga] Use `HandleVec` in `Layouter`.

### DIFF
--- a/naga/src/arena.rs
+++ b/naga/src/arena.rs
@@ -798,6 +798,7 @@ where
 ///
 /// [`insert`]: HandleVec::insert
 /// [`HashMap::insert`]: std::collections::HashMap::insert
+#[derive(Debug)]
 pub(crate) struct HandleVec<T, U> {
     inner: Vec<U>,
     as_keys: PhantomData<T>,

--- a/naga/src/proc/layouter.rs
+++ b/naga/src/proc/layouter.rs
@@ -1,4 +1,4 @@
-use crate::arena::Handle;
+use crate::arena::{Handle, HandleVec};
 use std::{fmt::Display, num::NonZeroU32, ops};
 
 /// A newtype struct where its only valid values are powers of 2
@@ -108,17 +108,15 @@ impl TypeLayout {
 ///
 /// [WGSL §4.3.7, "Memory Layout"](https://gpuweb.github.io/gpuweb/wgsl/#memory-layouts)
 #[derive(Debug, Default)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct Layouter {
-    /// Layouts for types in an arena, indexed by `Handle` index.
-    layouts: Vec<TypeLayout>,
+    /// Layouts for types in an arena.
+    layouts: HandleVec<crate::Type, TypeLayout>,
 }
 
 impl ops::Index<Handle<crate::Type>> for Layouter {
     type Output = TypeLayout;
     fn index(&self, handle: Handle<crate::Type>) -> &TypeLayout {
-        &self.layouts[handle.index()]
+        &self.layouts[handle]
     }
 }
 
@@ -243,7 +241,7 @@ impl Layouter {
                 },
             };
             debug_assert!(size <= layout.size);
-            self.layouts.push(layout);
+            self.layouts.insert(ty_handle, layout);
         }
 
         Ok(())


### PR DESCRIPTION
Change `naga::proc::layouter::Layouter::layouts` to be a `HandleVec`, not a `Vec`.
