### PR TITLE
[glsl] add more reserved keywords from previous specs

### DIFF
--- a/naga/src/back/glsl/keywords.rs
+++ b/naga/src/back/glsl/keywords.rs
@@ -250,6 +250,14 @@ pub const RESERVED_KEYWORDS: &[&str] = &[
     "namespace",
     "using",
     "sampler3DRect",
+    // Reserved keywords that were unreserved in GLSL 4.2
+    "image1DArrayShadow",
+    "image1DShadow",
+    "image2DArrayShadow",
+    "image2DShadow",
+    // Reserved keywords that were unreserved in GLSL 4.4
+    "packed",
+    "row_major",
     //
     // GLSL 4.6 Built-In Functions, from https://github.com/KhronosGroup/OpenGL-Registry/blob/d00e11dc1a1ffba581d633f21f70202051248d5c/specs/gl/GLSLangSpec.4.60.html#L13314
     //
@@ -473,8 +481,6 @@ pub const RESERVED_KEYWORDS: &[&str] = &[
     "anyInvocation",
     "allInvocations",
     "allInvocationsEqual",
-    // Sometimes "packed" is a keyword, see https://github.com/gfx-rs/wgpu/issues/5853
-    "packed",
     //
     // entry point name (should not be shadowed)
     //


### PR DESCRIPTION
I looked at all GLSL specs and found a few previously reserved keywords that we were missing.
Follow-up to https://github.com/gfx-rs/wgpu/pull/5855.