### PR TITLE
Allow using include_wgsl! in const contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ By @atlv24 in [#5383](https://github.com/gfx-rs/wgpu/pull/5383)
 - Implement `WGSL`'s `unpack4xI8`,`unpack4xU8`,`pack4xI8` and `pack4xU8`. By @VlaDexa in [#5424](https://github.com/gfx-rs/wgpu/pull/5424)
 - Began work adding support for atomics to the SPIR-V frontend. Tracking issue is [here](https://github.com/gfx-rs/wgpu/issues/4489). By @schell in [#5702](https://github.com/gfx-rs/wgpu/pull/5702).
 
+#### WebGPU
+
+- `include_wgsl!` is now callable in const contexts by @9SMTM6 in [#5872](https://github.com/gfx-rs/wgpu/pull/5872)
+
 ### Changes
 
 #### General

--- a/wgpu/src/macros.rs
+++ b/wgpu/src/macros.rs
@@ -95,7 +95,7 @@ macro_rules! include_wgsl {
             //log::info!("including '{}'", $($token)*);
             $crate::ShaderModuleDescriptor {
                 label: Some($($token)*),
-                source: $crate::ShaderSource::Wgsl(include_str!($($token)*).into()),
+                source: $crate::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(include_str!($($token)*))),
             }
         }
     };


### PR DESCRIPTION
Its not possible to call into in const contexts. But what into does here under the hood is what i replaced in, and since thats just the creation of an enum variant, one can do that in const contexts.

**Connections**
Nada.

**Description**
I want my shader module in a constant (no lifetimes to deal with, can be static), and I'd like to use the provided macro for it.

**Testing**
Try to call the old include_wgsl! to create a constant, see that it doesn't work. Repeat with this version, hussa it works now.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
