### PR TITLE
[naga] Clarify `Debug` form of `arena::Range`.

### DIFF
--- a/naga/src/arena/range.rs
+++ b/naga/src/arena/range.rs
@@ -68,7 +68,7 @@ impl<T> Clone for Range<T> {
 
 impl<T> fmt::Debug for Range<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "[{}..{}]", self.inner.start, self.inner.end - 1)
+        write!(formatter, "[{}..{}]", self.inner.start, self.inner.end)
     }
 }
 


### PR DESCRIPTION
Change the `std::fmt::Debug` impl for `naga::arena::Range` to print a start-inclusive, end-exclusive range.

- This is more consistent with Rust's `std::ops::Range`.

- This is consistent with the serialization form used in snapshots, which simply uses the serialization of `std::ops::Range`.

- It is not consistent with Naga's constructor function `Range::new_from_bounds`, which takes an inclusive end value, or with `Range::first_and_last`, which returns an inclusive end value. Both of these need to represent ranges' end points as `Handle`s, but exclusive end values might not be valid `Handle` values. I think this divergence is tolerable.
