### PR TITLE
Clean refs to died texture views

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -841,6 +841,10 @@ impl Global {
 
             {
                 let mut views = texture.views.lock();
+
+                // Remove stale weak references
+                views.retain(|view| view.strong_count() > 0);
+
                 views.push(Arc::downgrade(&resource));
             }
 
@@ -1162,10 +1166,20 @@ impl Global {
 
             let weak_ref = Arc::downgrade(&resource);
             for range in &resource.used_texture_ranges {
-                range.texture.bind_groups.lock().push(weak_ref.clone());
+                let mut bind_groups = range.texture.bind_groups.lock();
+
+                // Remove stale weak references
+                bind_groups.retain(|bg| bg.strong_count() > 0);
+
+                bind_groups.push(weak_ref.clone());
             }
             for range in &resource.used_buffer_ranges {
-                range.buffer.bind_groups.lock().push(weak_ref.clone());
+                let mut bind_groups = range.buffer.bind_groups.lock();
+
+                // Remove stale weak references
+                bind_groups.retain(|bg| bg.strong_count() > 0);
+
+                bind_groups.push(weak_ref.clone());
             }
 
             api_log!("Device::create_bind_group -> {id:?}");

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -595,7 +595,7 @@ impl<A: HalApi> LifetimeTracker<A> {
     fn triage_suspected_texture_views(&mut self, trackers: &Mutex<Tracker<A>>) -> &mut Self {
         let mut trackers = trackers.lock();
         let suspected_texture_views = &mut self.suspected_resources.texture_views;
-        let removed_views = Self::triage_resources(
+        Self::triage_resources(
             suspected_texture_views,
             self.active.as_mut_slice(),
             &mut trackers.views,
@@ -607,12 +607,6 @@ impl<A: HalApi> LifetimeTracker<A> {
         // `LifetimeTracker::suspected_resources` it remains there until it's
         // actually dropped, which for long-lived textures could be at the end
         // of execution.
-        for view in removed_views {
-            view.parent
-                .views
-                .lock()
-                .retain(|view| view.strong_count() > 1);
-        }
         self
     }
 
@@ -625,18 +619,6 @@ impl<A: HalApi> LifetimeTracker<A> {
             &mut trackers.textures,
             |maps| &mut maps.textures,
         );
-
-        // We may have been suspected because a texture view or bind group
-        // referring to us was dropped. Remove stale weak references, so that
-        // the backlink table doesn't grow without bound.
-        for texture in self.suspected_resources.textures.values() {
-            texture.views.lock().retain(|view| view.strong_count() > 0);
-            texture
-                .bind_groups
-                .lock()
-                .retain(|bg| bg.strong_count() > 0);
-        }
-
         self
     }
 
@@ -661,14 +643,6 @@ impl<A: HalApi> LifetimeTracker<A> {
             &mut trackers.buffers,
             |maps| &mut maps.buffers,
         );
-
-        // We may have been suspected because a bind group referring to us was
-        // dropped. Remove stale weak references, so that the backlink table
-        // doesn't grow without bound.
-        for buffer in self.suspected_resources.buffers.values() {
-            buffer.bind_groups.lock().retain(|bg| bg.strong_count() > 0);
-        }
-
         self
     }
 


### PR DESCRIPTION
**Connections**
Close #5707

**Description**


**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
