### PR TITLE
Remove more internal uses of IDs #3

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -892,7 +892,6 @@ impl<A: HalApi> BindGroup<A> {
         &self,
         bind_group_index: u32,
         offsets: &[wgt::DynamicOffset],
-        limits: &wgt::Limits,
     ) -> Result<(), BindError> {
         if self.dynamic_binding_info.len() != offsets.len() {
             return Err(BindError::MismatchedDynamicOffsetCount {
@@ -908,7 +907,8 @@ impl<A: HalApi> BindGroup<A> {
             .zip(offsets.iter())
             .enumerate()
         {
-            let (alignment, limit_name) = buffer_binding_type_alignment(limits, info.binding_type);
+            let (alignment, limit_name) =
+                buffer_binding_type_alignment(&self.device.limits, info.binding_type);
             if offset as wgt::BufferAddress % alignment as u64 != 0 {
                 return Err(BindError::UnalignedDynamicBinding {
                     group: bind_group_index,

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -438,7 +438,7 @@ impl RenderBundleEncoder {
                     offset,
                     size,
                 } => {
-                    let scope = PassErrorScope::SetIndexBuffer(buffer_id);
+                    let scope = PassErrorScope::SetIndexBuffer;
                     set_index_buffer(
                         &mut state,
                         &buffer_guard,
@@ -455,7 +455,7 @@ impl RenderBundleEncoder {
                     offset,
                     size,
                 } => {
-                    let scope = PassErrorScope::SetVertexBuffer(buffer_id);
+                    let scope = PassErrorScope::SetVertexBuffer;
                     set_vertex_buffer(&mut state, &buffer_guard, slot, buffer_id, offset, size)
                         .map_pass_err(scope)?;
                 }

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -478,7 +478,6 @@ impl RenderBundleEncoder {
                     let scope = PassErrorScope::Draw {
                         kind: DrawKind::Draw,
                         indexed: false,
-                        pipeline: state.pipeline_id(),
                     };
                     draw(
                         &mut state,
@@ -500,7 +499,6 @@ impl RenderBundleEncoder {
                     let scope = PassErrorScope::Draw {
                         kind: DrawKind::Draw,
                         indexed: true,
-                        pipeline: state.pipeline_id(),
                     };
                     draw_indexed(
                         &mut state,
@@ -522,7 +520,6 @@ impl RenderBundleEncoder {
                     let scope = PassErrorScope::Draw {
                         kind: DrawKind::DrawIndirect,
                         indexed,
-                        pipeline: state.pipeline_id(),
                     };
                     multi_draw_indirect(
                         &mut state,
@@ -705,7 +702,7 @@ fn set_pipeline<A: HalApi>(
         return Err(RenderCommandError::IncompatiblePipelineRods.into());
     }
 
-    let pipeline_state = PipelineState::new(pipeline, pipeline_id);
+    let pipeline_state = PipelineState::new(pipeline);
 
     state
         .commands
@@ -1337,8 +1334,6 @@ struct PipelineState<A: HalApi> {
     /// The pipeline
     pipeline: Arc<RenderPipeline<A>>,
 
-    pipeline_id: id::RenderPipelineId,
-
     /// How this pipeline's vertex shader traverses each vertex buffer, indexed
     /// by vertex buffer slot number.
     steps: Vec<VertexStep>,
@@ -1352,10 +1347,9 @@ struct PipelineState<A: HalApi> {
 }
 
 impl<A: HalApi> PipelineState<A> {
-    fn new(pipeline: &Arc<RenderPipeline<A>>, pipeline_id: id::RenderPipelineId) -> Self {
+    fn new(pipeline: &Arc<RenderPipeline<A>>) -> Self {
         Self {
             pipeline: pipeline.clone(),
-            pipeline_id,
             steps: pipeline.vertex_steps.to_vec(),
             push_constant_ranges: pipeline
                 .layout
@@ -1433,11 +1427,6 @@ struct State<A: HalApi> {
 }
 
 impl<A: HalApi> State<A> {
-    /// Return the id of the current pipeline, if any.
-    fn pipeline_id(&self) -> Option<id::RenderPipelineId> {
-        self.pipeline.as_ref().map(|p| p.pipeline_id)
-    }
-
     /// Return the current pipeline state. Return an error if none is set.
     fn pipeline(&self) -> Result<&PipelineState<A>, RenderBundleErrorInner> {
         self.pipeline

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -410,11 +410,27 @@ impl RenderBundleEncoder {
                     bind_group_id,
                 } => {
                     let scope = PassErrorScope::SetBindGroup(bind_group_id);
-                    set_bind_group(&mut state, &bind_group_guard, &base.dynamic_offsets, index, num_dynamic_offsets, bind_group_id).map_pass_err(scope)?;
+                    set_bind_group(
+                        &mut state,
+                        &bind_group_guard,
+                        &base.dynamic_offsets,
+                        index,
+                        num_dynamic_offsets,
+                        bind_group_id,
+                    )
+                    .map_pass_err(scope)?;
                 }
                 RenderCommand::SetPipeline(pipeline_id) => {
                     let scope = PassErrorScope::SetPipelineRender(pipeline_id);
-                    set_pipeline(&mut state, &pipeline_guard, &self.context, self.is_depth_read_only, self.is_stencil_read_only, pipeline_id).map_pass_err(scope)?;
+                    set_pipeline(
+                        &mut state,
+                        &pipeline_guard,
+                        &self.context,
+                        self.is_depth_read_only,
+                        self.is_stencil_read_only,
+                        pipeline_id,
+                    )
+                    .map_pass_err(scope)?;
                 }
                 RenderCommand::SetIndexBuffer {
                     buffer_id,
@@ -423,7 +439,15 @@ impl RenderBundleEncoder {
                     size,
                 } => {
                     let scope = PassErrorScope::SetIndexBuffer(buffer_id);
-                    set_index_buffer(&mut state, &buffer_guard, buffer_id, index_format, offset, size).map_pass_err(scope)?;
+                    set_index_buffer(
+                        &mut state,
+                        &buffer_guard,
+                        buffer_id,
+                        index_format,
+                        offset,
+                        size,
+                    )
+                    .map_pass_err(scope)?;
                 }
                 RenderCommand::SetVertexBuffer {
                     slot,
@@ -432,7 +456,8 @@ impl RenderBundleEncoder {
                     size,
                 } => {
                     let scope = PassErrorScope::SetVertexBuffer(buffer_id);
-                    set_vertex_buffer(&mut state, &buffer_guard, slot, buffer_id, offset, size).map_pass_err(scope)?;
+                    set_vertex_buffer(&mut state, &buffer_guard, slot, buffer_id, offset, size)
+                        .map_pass_err(scope)?;
                 }
                 RenderCommand::SetPushConstant {
                     stages,
@@ -441,7 +466,8 @@ impl RenderBundleEncoder {
                     values_offset,
                 } => {
                     let scope = PassErrorScope::SetPushConstant;
-                    set_push_constant(&mut state, stages, offset, size_bytes, values_offset).map_pass_err(scope)?;
+                    set_push_constant(&mut state, stages, offset, size_bytes, values_offset)
+                        .map_pass_err(scope)?;
                 }
                 RenderCommand::Draw {
                     vertex_count,
@@ -454,7 +480,15 @@ impl RenderBundleEncoder {
                         indexed: false,
                         pipeline: state.pipeline_id(),
                     };
-                    draw(&mut state, &base.dynamic_offsets, vertex_count, instance_count, first_vertex, first_instance).map_pass_err(scope)?;
+                    draw(
+                        &mut state,
+                        &base.dynamic_offsets,
+                        vertex_count,
+                        instance_count,
+                        first_vertex,
+                        first_instance,
+                    )
+                    .map_pass_err(scope)?;
                 }
                 RenderCommand::DrawIndexed {
                     index_count,
@@ -468,7 +502,16 @@ impl RenderBundleEncoder {
                         indexed: true,
                         pipeline: state.pipeline_id(),
                     };
-                    draw_indexed(&mut state, &base.dynamic_offsets, index_count, instance_count, first_index, base_vertex, first_instance).map_pass_err(scope)?;
+                    draw_indexed(
+                        &mut state,
+                        &base.dynamic_offsets,
+                        index_count,
+                        instance_count,
+                        first_index,
+                        base_vertex,
+                        first_instance,
+                    )
+                    .map_pass_err(scope)?;
                 }
                 RenderCommand::MultiDrawIndirect {
                     buffer_id,
@@ -481,7 +524,14 @@ impl RenderBundleEncoder {
                         indexed: false,
                         pipeline: state.pipeline_id(),
                     };
-                    multi_draw_indirect(&mut state, &base.dynamic_offsets, &buffer_guard, buffer_id, offset).map_pass_err(scope)?;
+                    multi_draw_indirect(
+                        &mut state,
+                        &base.dynamic_offsets,
+                        &buffer_guard,
+                        buffer_id,
+                        offset,
+                    )
+                    .map_pass_err(scope)?;
                 }
                 RenderCommand::MultiDrawIndirect {
                     buffer_id,
@@ -494,14 +544,22 @@ impl RenderBundleEncoder {
                         indexed: true,
                         pipeline: state.pipeline_id(),
                     };
-                    multi_draw_indirect2(&mut state, &base.dynamic_offsets, &buffer_guard, buffer_id, offset).map_pass_err(scope)?;
+                    multi_draw_indirect2(
+                        &mut state,
+                        &base.dynamic_offsets,
+                        &buffer_guard,
+                        buffer_id,
+                        offset,
+                    )
+                    .map_pass_err(scope)?;
                 }
                 RenderCommand::MultiDrawIndirect { .. }
                 | RenderCommand::MultiDrawIndirectCount { .. } => unimplemented!(),
                 RenderCommand::PushDebugGroup { color: _, len: _ } => unimplemented!(),
                 RenderCommand::InsertDebugMarker { color: _, len: _ } => unimplemented!(),
                 RenderCommand::PopDebugGroup => unimplemented!(),
-                RenderCommand::WriteTimestamp { .. } // Must check the TIMESTAMP_QUERY_INSIDE_PASSES feature
+                // Must check the TIMESTAMP_QUERY_INSIDE_PASSES feature
+                RenderCommand::WriteTimestamp { .. }
                 | RenderCommand::BeginOcclusionQuery { .. }
                 | RenderCommand::EndOcclusionQuery
                 | RenderCommand::BeginPipelineStatisticsQuery { .. }

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -409,7 +409,7 @@ impl RenderBundleEncoder {
                     num_dynamic_offsets,
                     bind_group_id,
                 } => {
-                    let scope = PassErrorScope::SetBindGroup(bind_group_id);
+                    let scope = PassErrorScope::SetBindGroup;
                     set_bind_group(
                         &mut state,
                         &bind_group_guard,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -603,7 +603,7 @@ impl Global {
                     num_dynamic_offsets,
                     bind_group,
                 } => {
-                    let scope = PassErrorScope::SetBindGroup(bind_group.as_info().id());
+                    let scope = PassErrorScope::SetBindGroup;
                     set_bind_group(
                         &mut state,
                         cmd_buf,
@@ -1041,7 +1041,7 @@ impl Global {
         bind_group_id: id::BindGroupId,
         offsets: &[DynamicOffset],
     ) -> Result<(), ComputePassError> {
-        let scope = PassErrorScope::SetBindGroup(bind_group_id);
+        let scope = PassErrorScope::SetBindGroup;
         let base = pass
             .base
             .as_mut()

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -592,7 +592,7 @@ impl Global {
 
                     bind_group.same_device_as(cmd_buf).map_pass_err(scope)?;
 
-                    let max_bind_groups = cmd_buf.limits.max_bind_groups;
+                    let max_bind_groups = state.device.limits.max_bind_groups;
                     if index >= max_bind_groups {
                         return Err(ComputePassErrorInner::BindGroupIndexOutOfRange {
                             index,
@@ -610,7 +610,7 @@ impl Global {
 
                     let bind_group = state.tracker.bind_groups.insert_single(bind_group);
                     bind_group
-                        .validate_dynamic_bindings(index, &state.temp_offsets, &cmd_buf.limits)
+                        .validate_dynamic_bindings(index, &state.temp_offsets)
                         .map_pass_err(scope)?;
 
                     state.buffer_memory_init_actions.extend(
@@ -766,7 +766,8 @@ impl Global {
 
                     state.flush_states(raw, None).map_pass_err(scope)?;
 
-                    let groups_size_limit = cmd_buf.limits.max_compute_workgroups_per_dimension;
+                    let groups_size_limit =
+                        state.device.limits.max_compute_workgroups_per_dimension;
 
                     if groups[0] > groups_size_limit
                         || groups[1] > groups_size_limit

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -662,14 +662,11 @@ impl Global {
                     query_index,
                 } => {
                     let scope = PassErrorScope::BeginPipelineStatisticsQuery;
-
-                    query_set.same_device_as(cmd_buf).map_pass_err(scope)?;
-
-                    let query_set = state.tracker.query_sets.insert_single(query_set);
-
                     validate_and_begin_pipeline_statistics_query(
-                        query_set.clone(),
+                        query_set,
                         raw,
+                        &mut state.tracker.query_sets,
+                        cmd_buf,
                         query_index,
                         None,
                         &mut state.active_query,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -630,12 +630,11 @@ impl Global {
                     }
                 }
                 ArcComputeCommand::SetPipeline(pipeline) => {
-                    let pipeline_id = pipeline.as_info().id();
-                    let scope = PassErrorScope::SetPipelineCompute(pipeline_id);
+                    let scope = PassErrorScope::SetPipelineCompute(pipeline.as_info().id());
 
                     pipeline.same_device_as(cmd_buf).map_pass_err(scope)?;
 
-                    state.pipeline = Some(pipeline_id);
+                    state.pipeline = Some(pipeline.as_info().id());
 
                     let pipeline = tracker.compute_pipelines.insert_single(pipeline);
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -615,7 +615,7 @@ impl Global {
                     .map_pass_err(scope)?;
                 }
                 ArcComputeCommand::SetPipeline(pipeline) => {
-                    let scope = PassErrorScope::SetPipelineCompute(pipeline.as_info().id());
+                    let scope = PassErrorScope::SetPipelineCompute;
                     set_pipeline(&mut state, cmd_buf, pipeline).map_pass_err(scope)?;
                 }
                 ArcComputeCommand::SetPushConstant {
@@ -1083,7 +1083,7 @@ impl Global {
     ) -> Result<(), ComputePassError> {
         let redundant = pass.current_pipeline.set_and_check_redundant(pipeline_id);
 
-        let scope = PassErrorScope::SetPipelineCompute(pipeline_id);
+        let scope = PassErrorScope::SetPipelineCompute;
 
         let base = pass.base_mut(scope)?;
         if redundant {

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -128,10 +128,7 @@ impl ComputeCommand {
                         ArcComputeCommand::DispatchIndirect {
                             buffer: buffers_guard.get_owned(buffer_id).map_err(|_| {
                                 ComputePassError {
-                                    scope: PassErrorScope::Dispatch {
-                                        indirect: true,
-                                        pipeline: None, // TODO: not used right now, but once we do the resolve during recording we can use this again.
-                                    },
+                                    scope: PassErrorScope::Dispatch { indirect: true },
                                     inner: ComputePassErrorInner::InvalidBufferId(buffer_id),
                                 }
                             })?,

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -97,7 +97,7 @@ impl ComputeCommand {
                         num_dynamic_offsets,
                         bind_group: bind_group_guard.get_owned(bind_group_id).map_err(|_| {
                             ComputePassError {
-                                scope: PassErrorScope::SetBindGroup(bind_group_id),
+                                scope: PassErrorScope::SetBindGroup,
                                 inner: ComputePassErrorInner::InvalidBindGroupId(bind_group_id),
                             }
                         })?,

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -107,7 +107,7 @@ impl ComputeCommand {
                         pipelines_guard
                             .get_owned(pipeline_id)
                             .map_err(|_| ComputePassError {
-                                scope: PassErrorScope::SetPipelineCompute(pipeline_id),
+                                scope: PassErrorScope::SetPipelineCompute,
                                 inner: ComputePassErrorInner::InvalidPipeline(pipeline_id),
                             })?,
                     ),

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -91,8 +91,10 @@ pub enum RenderCommandError {
     InvalidQuerySet(id::QuerySetId),
     #[error("Render pipeline targets are incompatible with render pass")]
     IncompatiblePipelineTargets(#[from] crate::device::RenderPassCompatibilityError),
-    #[error("Pipeline writes to depth/stencil, while the pass has read-only depth/stencil")]
-    IncompatiblePipelineRods,
+    #[error("{0} writes to depth, while the pass has read-only depth access")]
+    IncompatibleDepthAccess(ResourceErrorIdent),
+    #[error("{0} writes to stencil, while the pass has read-only stencil access")]
+    IncompatibleStencilAccess(ResourceErrorIdent),
     #[error(transparent)]
     ResourceUsageCompatibility(#[from] ResourceUsageCompatibilityError),
     #[error(transparent)]

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -83,8 +83,6 @@ pub enum RenderCommandError {
     VertexBufferIndexOutOfRange { index: u32, max: u32 },
     #[error("Dynamic buffer offset {0} does not respect device's requested `{1}` limit {2}")]
     UnalignedBufferOffset(u64, &'static str, u32),
-    #[error("Number of buffer offsets ({actual}) does not match the number of dynamic bindings ({expected})")]
-    InvalidDynamicOffsetCount { actual: usize, expected: usize },
     #[error("Render pipeline {0:?} is invalid")]
     InvalidPipeline(id::RenderPipelineId),
     #[error("QuerySet {0:?} is invalid")]

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -907,10 +907,7 @@ pub enum PassErrorScope {
     #[error("In a execute_bundle command")]
     ExecuteBundle,
     #[error("In a dispatch command, indirect:{indirect}")]
-    Dispatch {
-        indirect: bool,
-        pipeline: Option<id::ComputePipelineId>,
-    },
+    Dispatch { indirect: bool },
     #[error("In a push_debug_group command")]
     PushDebugGroup,
     #[error("In a pop_debug_group command")]
@@ -948,11 +945,6 @@ impl PrettyError for PassErrorScope {
                 pipeline: Some(id), ..
             } => {
                 fmt.render_pipeline_label(&id);
-            }
-            Self::Dispatch {
-                pipeline: Some(id), ..
-            } => {
-                fmt.compute_pipeline_label(&id);
             }
             _ => {}
         }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -871,7 +871,7 @@ pub enum PassErrorScope {
     #[error("In a set_pipeline command")]
     SetPipelineRender(id::RenderPipelineId),
     #[error("In a set_pipeline command")]
-    SetPipelineCompute(id::ComputePipelineId),
+    SetPipelineCompute,
     #[error("In a set_push_constant command")]
     SetPushConstant,
     #[error("In a set_vertex_buffer command")]
@@ -927,9 +927,6 @@ impl PrettyError for PassErrorScope {
             }
             Self::SetPipelineRender(id) => {
                 fmt.render_pipeline_label(&id);
-            }
-            Self::SetPipelineCompute(id) => {
-                fmt.compute_pipeline_label(&id);
             }
             _ => {}
         }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -875,9 +875,9 @@ pub enum PassErrorScope {
     #[error("In a set_push_constant command")]
     SetPushConstant,
     #[error("In a set_vertex_buffer command")]
-    SetVertexBuffer(id::BufferId),
+    SetVertexBuffer,
     #[error("In a set_index_buffer command")]
-    SetIndexBuffer(id::BufferId),
+    SetIndexBuffer,
     #[error("In a set_blend_constant command")]
     SetBlendConstant,
     #[error("In a set_stencil_reference command")]
@@ -930,12 +930,6 @@ impl PrettyError for PassErrorScope {
             }
             Self::SetPipelineCompute(id) => {
                 fmt.compute_pipeline_label(&id);
-            }
-            Self::SetVertexBuffer(id) => {
-                fmt.buffer_label(&id);
-            }
-            Self::SetIndexBuffer(id) => {
-                fmt.buffer_label(&id);
             }
             _ => {}
         }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -305,7 +305,6 @@ impl<A: HalApi> CommandBufferMutable<A> {
 ///   whose contents eventually become the property of the submission queue.
 pub struct CommandBuffer<A: HalApi> {
     pub(crate) device: Arc<Device<A>>,
-    limits: wgt::Limits,
     support_clear_texture: bool,
     pub(crate) info: ResourceInfo<CommandBuffer<A>>,
 
@@ -344,7 +343,6 @@ impl<A: HalApi> CommandBuffer<A> {
     ) -> Self {
         CommandBuffer {
             device: device.clone(),
-            limits: device.limits.clone(),
             support_clear_texture: device.features.contains(wgt::Features::CLEAR_TEXTURE),
             info: ResourceInfo::new(label, None),
             data: Mutex::new(

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -887,11 +887,7 @@ pub enum PassErrorScope {
     #[error("In a set_scissor_rect command")]
     SetScissorRect,
     #[error("In a draw command, kind: {kind:?}")]
-    Draw {
-        kind: DrawKind,
-        indexed: bool,
-        pipeline: Option<id::RenderPipelineId>,
-    },
+    Draw { kind: DrawKind, indexed: bool },
     #[error("While resetting queries after the renderpass was ran")]
     QueryReset,
     #[error("In a write_timestamp command")]
@@ -940,11 +936,6 @@ impl PrettyError for PassErrorScope {
             }
             Self::SetIndexBuffer(id) => {
                 fmt.buffer_label(&id);
-            }
-            Self::Draw {
-                pipeline: Some(id), ..
-            } => {
-                fmt.render_pipeline_label(&id);
             }
             _ => {}
         }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -869,7 +869,7 @@ pub enum PassErrorScope {
     #[error("In a set_bind_group command")]
     SetBindGroup(id::BindGroupId),
     #[error("In a set_pipeline command")]
-    SetPipelineRender(id::RenderPipelineId),
+    SetPipelineRender,
     #[error("In a set_pipeline command")]
     SetPipelineCompute,
     #[error("In a set_push_constant command")]
@@ -924,9 +924,6 @@ impl PrettyError for PassErrorScope {
             }
             Self::SetBindGroup(id) => {
                 fmt.bind_group_label(&id);
-            }
-            Self::SetPipelineRender(id) => {
-                fmt.render_pipeline_label(&id);
             }
             _ => {}
         }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -867,7 +867,7 @@ pub enum PassErrorScope {
     #[error("In a pass parameter")]
     Pass(Option<id::CommandBufferId>),
     #[error("In a set_bind_group command")]
-    SetBindGroup(id::BindGroupId),
+    SetBindGroup,
     #[error("In a set_pipeline command")]
     SetPipelineRender,
     #[error("In a set_pipeline command")]
@@ -921,9 +921,6 @@ impl PrettyError for PassErrorScope {
             }
             Self::Pass(Some(id)) => {
                 fmt.command_buffer_label(&id);
-            }
-            Self::SetBindGroup(id) => {
-                fmt.bind_group_label(&id);
             }
             _ => {}
         }

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -230,12 +230,15 @@ impl<A: HalApi> QuerySet<A> {
 pub(super) fn validate_and_begin_occlusion_query<A: HalApi>(
     query_set: Arc<QuerySet<A>>,
     raw_encoder: &mut A::CommandEncoder,
+    tracker: &mut StatelessTracker<QuerySet<A>>,
     query_index: u32,
     reset_state: Option<&mut QueryResetMap<A>>,
     active_query: &mut Option<(Arc<QuerySet<A>>, u32)>,
 ) -> Result<(), QueryUseError> {
     let needs_reset = reset_state.is_none();
     query_set.validate_query(SimplifiedQueryType::Occlusion, query_index, reset_state)?;
+
+    tracker.add_single(&query_set);
 
     if let Some((_old, old_idx)) = active_query.take() {
         return Err(QueryUseError::AlreadyStarted {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1498,10 +1498,12 @@ impl Global {
                         num_dynamic_offsets,
                         bind_group,
                     } => {
-                        let bind_group_id = bind_group.as_info().id();
-                        api_log!("RenderPass::set_bind_group {index} {bind_group_id:?}");
+                        api_log!(
+                            "RenderPass::set_bind_group {index} {}",
+                            bind_group.error_ident()
+                        );
 
-                        let scope = PassErrorScope::SetBindGroup(bind_group_id);
+                        let scope = PassErrorScope::SetBindGroup(bind_group.as_info().id());
                         let max_bind_groups = device.limits.max_bind_groups;
                         if index >= max_bind_groups {
                             return Err(RenderCommandError::BindGroupIndexOutOfRange {
@@ -1575,11 +1577,10 @@ impl Global {
                         }
                     }
                     ArcRenderCommand::SetPipeline(pipeline) => {
-                        let pipeline_id = pipeline.as_info().id();
-                        api_log!("RenderPass::set_pipeline {pipeline_id:?}");
+                        api_log!("RenderPass::set_pipeline {}", pipeline.error_ident());
 
-                        let scope = PassErrorScope::SetPipelineRender(pipeline_id);
-                        state.pipeline = Some(pipeline_id);
+                        let scope = PassErrorScope::SetPipelineRender(pipeline.as_info().id());
+                        state.pipeline = Some(pipeline.as_info().id());
 
                         let pipeline = tracker.render_pipelines.insert_single(pipeline);
 
@@ -1701,10 +1702,9 @@ impl Global {
                         offset,
                         size,
                     } => {
-                        let buffer_id = buffer.as_info().id();
-                        api_log!("RenderPass::set_index_buffer {buffer_id:?}");
+                        api_log!("RenderPass::set_index_buffer {}", buffer.error_ident());
 
-                        let scope = PassErrorScope::SetIndexBuffer(buffer_id);
+                        let scope = PassErrorScope::SetIndexBuffer(buffer.as_info().id());
 
                         info.usage_scope
                             .buffers
@@ -1724,7 +1724,7 @@ impl Global {
                             Some(s) => offset + s.get(),
                             None => buffer.size,
                         };
-                        state.index.bound_buffer_view = Some((buffer_id, offset..end));
+                        state.index.bound_buffer_view = Some((buffer.as_info().id(), offset..end));
 
                         state.index.format = Some(index_format);
                         state.index.update_limit();
@@ -1752,10 +1752,12 @@ impl Global {
                         offset,
                         size,
                     } => {
-                        let buffer_id = buffer.as_info().id();
-                        api_log!("RenderPass::set_vertex_buffer {slot} {buffer_id:?}");
+                        api_log!(
+                            "RenderPass::set_vertex_buffer {slot} {}",
+                            buffer.error_ident()
+                        );
 
-                        let scope = PassErrorScope::SetVertexBuffer(buffer_id);
+                        let scope = PassErrorScope::SetVertexBuffer(buffer.as_info().id());
 
                         info.usage_scope
                             .buffers
@@ -2041,8 +2043,10 @@ impl Global {
                         count,
                         indexed,
                     } => {
-                        let indirect_buffer_id = indirect_buffer.as_info().id();
-                        api_log!("RenderPass::draw_indirect (indexed:{indexed}) {indirect_buffer_id:?} {offset} {count:?}");
+                        api_log!(
+                            "RenderPass::draw_indirect (indexed:{indexed}) {} {offset} {count:?}",
+                            indirect_buffer.error_ident()
+                        );
 
                         let scope = PassErrorScope::Draw {
                             kind: if count.is_some() {
@@ -2118,9 +2122,11 @@ impl Global {
                         max_count,
                         indexed,
                     } => {
-                        let indirect_buffer_id = indirect_buffer.as_info().id();
-                        let count_buffer_id = count_buffer.as_info().id();
-                        api_log!("RenderPass::multi_draw_indirect_count (indexed:{indexed}) {indirect_buffer_id:?} {offset} {count_buffer_id:?} {count_buffer_offset:?} {max_count:?}");
+                        api_log!(
+                            "RenderPass::multi_draw_indirect_count (indexed:{indexed}) {} {offset} {} {count_buffer_offset:?} {max_count:?}",
+                            indirect_buffer.error_ident(),
+                            count_buffer.error_ident()
+                        );
 
                         let scope = PassErrorScope::Draw {
                             kind: DrawKind::MultiDrawIndirectCount,
@@ -2266,8 +2272,10 @@ impl Global {
                         query_set,
                         query_index,
                     } => {
-                        let query_set_id = query_set.as_info().id();
-                        api_log!("RenderPass::write_timestamps {query_set_id:?} {query_index}");
+                        api_log!(
+                            "RenderPass::write_timestamps {query_index} {}",
+                            query_set.error_ident()
+                        );
                         let scope = PassErrorScope::WriteTimestamp;
 
                         device
@@ -2318,8 +2326,10 @@ impl Global {
                         query_set,
                         query_index,
                     } => {
-                        let query_set_id = query_set.as_info().id();
-                        api_log!("RenderPass::begin_pipeline_statistics_query {query_set_id:?} {query_index}");
+                        api_log!(
+                            "RenderPass::begin_pipeline_statistics_query {query_index} {}",
+                            query_set.error_ident()
+                        );
                         let scope = PassErrorScope::BeginPipelineStatisticsQuery;
 
                         let query_set = tracker.query_sets.insert_single(query_set);
@@ -2341,8 +2351,7 @@ impl Global {
                             .map_pass_err(scope)?;
                     }
                     ArcRenderCommand::ExecuteBundle(bundle) => {
-                        let bundle_id = bundle.as_info().id();
-                        api_log!("RenderPass::execute_bundle {bundle_id:?}");
+                        api_log!("RenderPass::execute_bundle {}", bundle.error_ident());
                         let scope = PassErrorScope::ExecuteBundle;
 
                         // Have to clone the bundle arc, otherwise we keep a mutable reference to the bundle

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1560,17 +1560,7 @@ impl Global {
                         set_blend_constant(&mut state, color);
                     }
                     ArcRenderCommand::SetStencilReference(value) => {
-                        api_log!("RenderPass::set_stencil_reference {value}");
-
-                        state.stencil_reference = value;
-                        if state
-                            .pipeline_flags
-                            .contains(PipelineFlags::STENCIL_REFERENCE)
-                        {
-                            unsafe {
-                                state.raw_encoder.set_stencil_reference(value);
-                            }
-                        }
+                        set_stencil_reference(&mut state, value);
                     }
                     ArcRenderCommand::SetViewport {
                         ref rect,
@@ -2566,6 +2556,20 @@ fn set_blend_constant<A: HalApi>(state: &mut State<A>, color: &Color) {
     ];
     unsafe {
         state.raw_encoder.set_blend_constants(&array);
+    }
+}
+
+fn set_stencil_reference<A: HalApi>(state: &mut State<A>, value: u32) {
+    api_log!("RenderPass::set_stencil_reference {value}");
+
+    state.stencil_reference = value;
+    if state
+        .pipeline_flags
+        .contains(PipelineFlags::STENCIL_REFERENCE)
+    {
+        unsafe {
+            state.raw_encoder.set_stencil_reference(value);
+        }
     }
 }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1530,7 +1530,7 @@ impl Global {
                         num_dynamic_offsets,
                         bind_group,
                     } => {
-                        let scope = PassErrorScope::SetBindGroup(bind_group.as_info().id());
+                        let scope = PassErrorScope::SetBindGroup;
                         set_bind_group(
                             &mut state,
                             &cmd_buf,
@@ -2637,7 +2637,7 @@ impl Global {
         bind_group_id: id::BindGroupId,
         offsets: &[DynamicOffset],
     ) -> Result<(), RenderPassError> {
-        let scope = PassErrorScope::SetBindGroup(bind_group_id);
+        let scope = PassErrorScope::SetBindGroup;
         let base = pass
             .base
             .as_mut()

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1551,7 +1551,7 @@ impl Global {
                         offset,
                         size,
                     } => {
-                        let scope = PassErrorScope::SetIndexBuffer(buffer.as_info().id());
+                        let scope = PassErrorScope::SetIndexBuffer;
                         set_index_buffer(&mut state, &cmd_buf, buffer, index_format, offset, size)
                             .map_pass_err(scope)?;
                     }
@@ -1561,7 +1561,7 @@ impl Global {
                         offset,
                         size,
                     } => {
-                        let scope = PassErrorScope::SetVertexBuffer(buffer.as_info().id());
+                        let scope = PassErrorScope::SetVertexBuffer;
                         set_vertex_buffer(&mut state, &cmd_buf, slot, buffer, offset, size)
                             .map_pass_err(scope)?;
                     }
@@ -2697,7 +2697,7 @@ impl Global {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(), RenderPassError> {
-        let scope = PassErrorScope::SetIndexBuffer(buffer_id);
+        let scope = PassErrorScope::SetIndexBuffer;
         let base = pass.base_mut(scope)?;
 
         base.commands.push(RenderCommand::SetIndexBuffer {
@@ -2718,7 +2718,7 @@ impl Global {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(), RenderPassError> {
-        let scope = PassErrorScope::SetVertexBuffer(buffer_id);
+        let scope = PassErrorScope::SetVertexBuffer;
         let base = pass.base_mut(scope)?;
 
         base.commands.push(RenderCommand::SetVertexBuffer {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2324,11 +2324,11 @@ impl Global {
                         );
                         let scope = PassErrorScope::BeginPipelineStatisticsQuery;
 
-                        let query_set = tracker.query_sets.insert_single(query_set);
-
                         validate_and_begin_pipeline_statistics_query(
-                            query_set.clone(),
+                            query_set,
                             raw,
+                            &mut tracker.query_sets,
+                            cmd_buf.as_ref(),
                             query_index,
                             Some(&mut cmd_buf_data.pending_query_resets),
                             &mut active_query,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1522,7 +1522,7 @@ impl Global {
                             .map_pass_err(scope)?;
 
                         bind_group
-                            .validate_dynamic_bindings(index, &temp_offsets, &cmd_buf.limits)
+                            .validate_dynamic_bindings(index, &temp_offsets)
                             .map_pass_err(scope)?;
 
                         // merge the resource tracker in

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1557,18 +1557,7 @@ impl Global {
                             .map_pass_err(scope)?;
                     }
                     ArcRenderCommand::SetBlendConstant(ref color) => {
-                        api_log!("RenderPass::set_blend_constant");
-
-                        state.blend_constant = OptionalState::Set;
-                        let array = [
-                            color.r as f32,
-                            color.g as f32,
-                            color.b as f32,
-                            color.a as f32,
-                        ];
-                        unsafe {
-                            state.raw_encoder.set_blend_constants(&array);
-                        }
+                        set_blend_constant(&mut state, color);
                     }
                     ArcRenderCommand::SetStencilReference(value) => {
                         api_log!("RenderPass::set_stencil_reference {value}");
@@ -2563,6 +2552,21 @@ fn set_vertex_buffer<A: HalApi>(
     }
     state.vertex.update_limits();
     Ok(())
+}
+
+fn set_blend_constant<A: HalApi>(state: &mut State<A>, color: &Color) {
+    api_log!("RenderPass::set_blend_constant");
+
+    state.blend_constant = OptionalState::Set;
+    let array = [
+        color.r as f32,
+        color.g as f32,
+        color.b as f32,
+        color.a as f32,
+    ];
+    unsafe {
+        state.raw_encoder.set_blend_constants(&array);
+    }
 }
 
 impl Global {

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -228,7 +228,7 @@ impl RenderCommand {
                     } => ArcRenderCommand::SetIndexBuffer {
                         buffer: buffers_guard.get_owned(buffer_id).map_err(|_| {
                             RenderPassError {
-                                scope: PassErrorScope::SetIndexBuffer(buffer_id),
+                                scope: PassErrorScope::SetIndexBuffer,
                                 inner: RenderCommandError::InvalidBufferId(buffer_id).into(),
                             }
                         })?,
@@ -246,7 +246,7 @@ impl RenderCommand {
                         slot,
                         buffer: buffers_guard.get_owned(buffer_id).map_err(|_| {
                             RenderPassError {
-                                scope: PassErrorScope::SetVertexBuffer(buffer_id),
+                                scope: PassErrorScope::SetVertexBuffer,
                                 inner: RenderCommandError::InvalidBufferId(buffer_id).into(),
                             }
                         })?,

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -315,7 +315,6 @@ impl RenderCommand {
                                         DrawKind::DrawIndirect
                                     },
                                     indexed,
-                                    pipeline: None,
                                 },
                                 inner: RenderCommandError::InvalidBufferId(buffer_id).into(),
                             }
@@ -336,7 +335,6 @@ impl RenderCommand {
                         let scope = PassErrorScope::Draw {
                             kind: DrawKind::MultiDrawIndirectCount,
                             indexed,
-                            pipeline: None,
                         };
                         ArcRenderCommand::MultiDrawIndirectCount {
                             buffer: buffers_guard.get_owned(buffer_id).map_err(|_| {

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -163,7 +163,7 @@ impl RenderCommand {
                         pipelines_guard
                             .get_owned(pipeline_id)
                             .map_err(|_| RenderPassError {
-                                scope: PassErrorScope::SetPipelineRender(pipeline_id),
+                                scope: PassErrorScope::SetPipelineRender,
                                 inner: RenderCommandError::InvalidPipeline(pipeline_id).into(),
                             })?,
                     ),

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -153,7 +153,7 @@ impl RenderCommand {
                         num_dynamic_offsets,
                         bind_group: bind_group_guard.get_owned(bind_group_id).map_err(|_| {
                             RenderPassError {
-                                scope: PassErrorScope::SetBindGroup(bind_group_id),
+                                scope: PassErrorScope::SetBindGroup,
                                 inner: RenderPassErrorInner::InvalidBindGroup(index),
                             }
                         })?,


### PR DESCRIPTION
The reason I extracted the code from passes was because `PassErrorScope` is `Copy` and I wanted to replace all the resources referenced by ids in its variants with `ResourceErrorIdent`s which is not `Copy`. After going through all the work to do that, I realized I could remove the ids from all variants anyway because the inner error types already contained `ResourceErrorIdent`'s where relevant; or if they didn't I added them. I think we should still land the code extractions since we can now deduplicate some of the code; it also removes the need to keep calling `.map_pass_err()` everywhere.

Part of https://github.com/gfx-rs/wgpu/issues/5121.

PR doesn't need to be squashed, each commit builds by itself.