### PR TITLE
Renderpass take resource ownership

### DIFF
--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -186,7 +186,7 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
             .get::<WebGpuQuerySet>(timestamp_writes.query_set)?;
         let query_set = query_set_resource.1;
 
-        Some(wgpu_core::command::RenderPassTimestampWrites {
+        Some(wgpu_core::command::PassTimestampWrites {
             query_set,
             beginning_of_pass_write_index: timestamp_writes.beginning_of_pass_write_index,
             end_of_pass_write_index: timestamp_writes.end_of_pass_write_index,
@@ -245,7 +245,7 @@ pub fn op_webgpu_command_encoder_begin_compute_pass(
             .get::<WebGpuQuerySet>(timestamp_writes.query_set)?;
         let query_set = query_set_resource.1;
 
-        Some(wgpu_core::command::ComputePassTimestampWrites {
+        Some(wgpu_core::command::PassTimestampWrites {
             query_set,
             beginning_of_pass_write_index: timestamp_writes.beginning_of_pass_write_index,
             end_of_pass_write_index: timestamp_writes.end_of_pass_write_index,

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -200,6 +200,8 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
         .transpose()?
         .map(|query_set| query_set.1);
 
+    let instance = state.borrow::<super::Instance>();
+    let command_encoder = &command_encoder_resource.1;
     let descriptor = wgpu_core::command::RenderPassDescriptor {
         label: Some(label),
         color_attachments: Cow::from(color_attachments),
@@ -208,15 +210,14 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
         occlusion_query_set: occlusion_query_set_resource,
     };
 
-    let render_pass = wgpu_core::command::RenderPass::new(command_encoder_resource.1, &descriptor);
-
+    let (render_pass, error) = gfx_select!(command_encoder => instance.command_encoder_create_render_pass_dyn(*command_encoder, &descriptor));
     let rid = state
         .resource_table
         .add(super::render_pass::WebGpuRenderPass(RefCell::new(
             render_pass,
         )));
 
-    Ok(WebGpuResult::rid(rid))
+    Ok(WebGpuResult::rid_err(rid, error))
 }
 
 #[derive(Deserialize)]

--- a/tests/tests/compute_pass_ownership.rs
+++ b/tests/tests/compute_pass_ownership.rs
@@ -111,14 +111,14 @@ async fn compute_pass_query_set_ownership_pipeline_statistics(ctx: TestingContex
 }
 
 #[gpu_test]
-static COMPUTE_PASS_QUERY_TIMESTAMPS: GpuTestConfiguration =
+static COMPUTE_PASS_QUERY_SET_OWNERSHIP_TIMESTAMPS: GpuTestConfiguration =
     GpuTestConfiguration::new()
         .parameters(TestParameters::default().test_features_limits().features(
             wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES,
         ))
-        .run_async(compute_pass_query_timestamps);
+        .run_async(compute_pass_query_set_ownership_timestamps);
 
-async fn compute_pass_query_timestamps(ctx: TestingContext) {
+async fn compute_pass_query_set_ownership_timestamps(ctx: TestingContext) {
     let ResourceSetup {
         gpu_buffer,
         cpu_buffer,

--- a/tests/tests/render_pass_ownership.rs
+++ b/tests/tests/render_pass_ownership.rs
@@ -1,0 +1,305 @@
+//! Tests that render passes take ownership of resources that are associated with.
+//! I.e. once a resource is passed in to a render pass, it can be dropped.
+//!
+//! TODO: Methods that take resources that weren't tested here:
+//! * rpass.set_index_buffer(buffer_slice, index_format)
+//! * rpass.set_vertex_buffer(slot, buffer_slice)
+//! * rpass.draw_indexed_indirect(indirect_buffer, indirect_offset)
+//! * rpass.execute_bundles(render_bundles)
+//! * rpass.multi_draw_indirect(indirect_buffer, indirect_offset, count)
+//! * rpass.multi_draw_indexed_indirect(indirect_buffer, indirect_offset, count)
+//! * rpass.multi_draw_indirect_count
+//! * rpass.multi_draw_indexed_indirect_count
+//! * rpass.begin_pipeline_statistics_query
+//! * rpass.write_timestamp
+
+use std::num::NonZeroU64;
+
+use wgpu::util::DeviceExt as _;
+use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+
+// Minimal shader with buffer based side effect - only needed to check whether the render pass has executed at all.
+const SHADER_SRC: &str = "
+@group(0) @binding(0)
+var<storage, read_write> buffer: array<vec4f>;
+
+var<private> positions: array<vec2f, 3> = array<vec2f, 3>(
+    vec2f(-1.0, -3.0),
+    vec2f(-1.0, 1.0),
+    vec2f(3.0, 1.0)
+);
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
+    return vec4f(positions[vertex_index], 0.0, 1.0);
+}
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    buffer[0] *= 2.0;
+    return vec4<f32>(1.0, 0.0, 1.0, 1.0);
+}";
+
+#[gpu_test]
+static RENDER_PASS_RESOURCE_OWNERSHIP: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().test_features_limits())
+    .run_async(render_pass_resource_ownership);
+
+async fn render_pass_resource_ownership(ctx: TestingContext) {
+    let ResourceSetup {
+        gpu_buffer,
+        cpu_buffer,
+        buffer_size,
+        indirect_buffer,
+        bind_group,
+        pipeline,
+        color_attachment_view,
+        color_attachment_resolve_view,
+        depth_stencil_view,
+    } = resource_setup(&ctx);
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+
+    {
+        let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("render_pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &color_attachment_view,
+                resolve_target: Some(&color_attachment_resolve_view),
+                ops: wgpu::Operations::default(),
+            })],
+            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                view: &depth_stencil_view,
+                depth_ops: Some(wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(1.0),
+                    store: wgpu::StoreOp::Store,
+                }),
+                stencil_ops: None,
+            }),
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+
+        // Drop render pass attachments right away.
+        drop(color_attachment_view);
+        drop(color_attachment_resolve_view);
+        drop(depth_stencil_view);
+
+        rpass.set_pipeline(&pipeline);
+        rpass.set_bind_group(0, &bind_group, &[]);
+        rpass.draw_indirect(&indirect_buffer, 0);
+
+        // Now drop all resources we set. Then do a device poll to make sure the resources are really not dropped too early, no matter what.
+        drop(pipeline);
+        drop(bind_group);
+        drop(indirect_buffer);
+        ctx.async_poll(wgpu::Maintain::wait())
+            .await
+            .panic_on_timeout();
+    }
+
+    assert_render_pass_executed_normally(encoder, gpu_buffer, cpu_buffer, buffer_size, ctx).await;
+}
+
+async fn assert_render_pass_executed_normally(
+    mut encoder: wgpu::CommandEncoder,
+    gpu_buffer: wgpu::Buffer,
+    cpu_buffer: wgpu::Buffer,
+    buffer_size: u64,
+    ctx: TestingContext,
+) {
+    encoder.copy_buffer_to_buffer(&gpu_buffer, 0, &cpu_buffer, 0, buffer_size);
+    ctx.queue.submit([encoder.finish()]);
+    cpu_buffer.slice(..).map_async(wgpu::MapMode::Read, |_| ());
+    ctx.async_poll(wgpu::Maintain::wait())
+        .await
+        .panic_on_timeout();
+
+    let data = cpu_buffer.slice(..).get_mapped_range();
+
+    let floats: &[f32] = bytemuck::cast_slice(&data);
+    assert!(floats[0] >= 2.0);
+    assert!(floats[1] >= 4.0);
+    assert!(floats[2] >= 6.0);
+    assert!(floats[3] >= 8.0);
+}
+
+// Setup ------------------------------------------------------------
+
+struct ResourceSetup {
+    gpu_buffer: wgpu::Buffer,
+    cpu_buffer: wgpu::Buffer,
+    buffer_size: u64,
+
+    indirect_buffer: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+    pipeline: wgpu::RenderPipeline,
+
+    color_attachment_view: wgpu::TextureView,
+    color_attachment_resolve_view: wgpu::TextureView,
+    depth_stencil_view: wgpu::TextureView,
+}
+
+fn resource_setup(ctx: &TestingContext) -> ResourceSetup {
+    let sm = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("shader"),
+            source: wgpu::ShaderSource::Wgsl(SHADER_SRC.into()),
+        });
+
+    let buffer_size = 4 * std::mem::size_of::<f32>() as u64;
+
+    let bgl = ctx
+        .device
+        .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("bind_group_layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(buffer_size),
+                },
+                count: None,
+            }],
+        });
+
+    let gpu_buffer = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("gpu_buffer"),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            contents: bytemuck::bytes_of(&[1.0_f32, 2.0, 3.0, 4.0]),
+        });
+
+    let cpu_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("cpu_buffer"),
+        size: buffer_size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let indirect_buffer = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("gpu_buffer"),
+            usage: wgpu::BufferUsages::INDIRECT,
+            contents: wgpu::util::DrawIndirectArgs {
+                vertex_count: 3,
+                instance_count: 1,
+                first_vertex: 0,
+                first_instance: 0,
+            }
+            .as_bytes(),
+        });
+
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("bind_group"),
+        layout: &bgl,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: gpu_buffer.as_entire_binding(),
+        }],
+    });
+
+    let pipeline_layout = ctx
+        .device
+        .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("pipeline_layout"),
+            bind_group_layouts: &[&bgl],
+            push_constant_ranges: &[],
+        });
+
+    let target_size = wgpu::Extent3d {
+        width: 4,
+        height: 4,
+        depth_or_array_layers: 1,
+    };
+    let target_msaa = 4;
+    let target_format = wgpu::TextureFormat::Bgra8UnormSrgb;
+
+    let target_desc = wgpu::TextureDescriptor {
+        label: Some("target_tex"),
+        size: target_size,
+        mip_level_count: 1,
+        sample_count: target_msaa,
+        dimension: wgpu::TextureDimension::D2,
+        format: target_format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[target_format],
+    };
+    let target_tex = ctx.device.create_texture(&target_desc);
+    let target_tex_resolve = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("target_resolve"),
+        sample_count: 1,
+        ..target_desc
+    });
+
+    let color_attachment_view = target_tex.create_view(&wgpu::TextureViewDescriptor::default());
+    let color_attachment_resolve_view =
+        target_tex_resolve.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let depth_stencil_format = wgpu::TextureFormat::Depth32Float;
+    let depth_stencil = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("depth_stencil"),
+        format: depth_stencil_format,
+        view_formats: &[depth_stencil_format],
+        ..target_desc
+    });
+    let depth_stencil_view = depth_stencil.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let pipeline = ctx
+        .device
+        .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &sm,
+                entry_point: "vs_main",
+                compilation_options: Default::default(),
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &sm,
+                entry_point: "fs_main",
+                compilation_options: Default::default(),
+                targets: &[Some(target_format.into())],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                strip_index_format: Some(wgpu::IndexFormat::Uint32),
+                ..Default::default()
+            },
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: depth_stencil_format,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::LessEqual,
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState {
+                count: target_msaa,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview: None,
+            cache: None,
+        });
+
+    ResourceSetup {
+        gpu_buffer,
+        cpu_buffer,
+        buffer_size,
+        indirect_buffer,
+        bind_group,
+        pipeline,
+
+        color_attachment_view,
+        color_attachment_resolve_view,
+        depth_stencil_view,
+    }
+}

--- a/tests/tests/root.rs
+++ b/tests/tests/root.rs
@@ -29,6 +29,7 @@ mod poll;
 mod push_constants;
 mod query_set;
 mod queue_transfer;
+mod render_pass_ownership;
 mod resource_descriptor_accessor;
 mod resource_error;
 mod scissor_tests;

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -4,7 +4,7 @@ use crate::{
     },
     command::{
         bind::Binder,
-        compute_command::{ArcComputeCommand, ComputeCommand},
+        compute_command::ArcComputeCommand,
         end_pipeline_statistics_query,
         memory_init::{fixup_discarded_surfaces, SurfacesInDiscardState},
         validate_and_begin_pipeline_statistics_query, ArcPassTimestampWrites, BasePass,
@@ -405,17 +405,19 @@ impl Global {
     }
 
     #[doc(hidden)]
+    #[cfg(feature = "replay")]
     pub fn compute_pass_end_with_unresolved_commands<A: HalApi>(
         &self,
         encoder_id: id::CommandEncoderId,
-        base: BasePass<ComputeCommand>,
+        base: BasePass<super::ComputeCommand>,
         timestamp_writes: Option<&PassTimestampWrites>,
     ) -> Result<(), ComputePassError> {
         let hub = A::hub(self);
         let scope = PassErrorScope::PassEncoder(encoder_id);
 
         let cmd_buf = CommandBuffer::get_encoder(hub, encoder_id).map_pass_err(scope)?;
-        let commands = ComputeCommand::resolve_compute_command_ids(A::hub(self), &base.commands)?;
+        let commands =
+            super::ComputeCommand::resolve_compute_command_ids(A::hub(self), &base.commands)?;
 
         let timestamp_writes = if let Some(tw) = timestamp_writes {
             Some(ArcPassTimestampWrites {

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1076,7 +1076,7 @@ impl Global {
         Ok(())
     }
 
-    pub fn compute_pass_set_push_constant<A: HalApi>(
+    pub fn compute_pass_set_push_constants<A: HalApi>(
         &self,
         pass: &mut ComputePass<A>,
         offset: u32,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -344,7 +344,9 @@ impl Global {
                     let Ok(query_set) = hub.query_sets.read().get_owned(tw.query_set) else {
                         return (
                             ComputePass::new(None, arc_desc),
-                            Some(CommandEncoderError::InvalidTimestampWritesQuerySetId),
+                            Some(CommandEncoderError::InvalidTimestampWritesQuerySetId(
+                                tw.query_set,
+                            )),
                         );
                     };
 

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -8,8 +8,6 @@ use crate::{
     resource::{Buffer, QuerySet},
 };
 
-use super::{ComputePassError, ComputePassErrorInner, PassErrorScope};
-
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ComputeCommand {
@@ -72,13 +70,13 @@ pub enum ComputeCommand {
 
 impl ComputeCommand {
     /// Resolves all ids in a list of commands into the corresponding resource Arc.
-    //
-    // TODO: Once resolving is done on-the-fly during recording, this function should be only needed with the replay feature:
-    // #[cfg(feature = "replay")]
+    #[cfg(feature = "replay")]
     pub fn resolve_compute_command_ids<A: HalApi>(
         hub: &crate::hub::Hub<A>,
         commands: &[ComputeCommand],
-    ) -> Result<Vec<ArcComputeCommand<A>>, ComputePassError> {
+    ) -> Result<Vec<ArcComputeCommand<A>>, super::ComputePassError> {
+        use super::{ComputePassError, ComputePassErrorInner, PassErrorScope};
+
         let buffers_guard = hub.buffers.read();
         let bind_group_guard = hub.bind_groups.read();
         let query_set_guard = hub.query_sets.read();

--- a/wgpu-core/src/command/dyn_compute_pass.rs
+++ b/wgpu-core/src/command/dyn_compute_pass.rs
@@ -21,7 +21,7 @@ pub trait DynComputePass: std::fmt::Debug + WasmNotSendSync {
         context: &global::Global,
         pipeline_id: id::ComputePipelineId,
     ) -> Result<(), ComputePassError>;
-    fn set_push_constant(
+    fn set_push_constants(
         &mut self,
         context: &global::Global,
         offset: u32,
@@ -93,13 +93,13 @@ impl<A: HalApi> DynComputePass for ComputePass<A> {
         context.compute_pass_set_pipeline(self, pipeline_id)
     }
 
-    fn set_push_constant(
+    fn set_push_constants(
         &mut self,
         context: &global::Global,
         offset: u32,
         data: &[u8],
     ) -> Result<(), ComputePassError> {
-        context.compute_pass_set_push_constant(self, offset, data)
+        context.compute_pass_set_push_constants(self, offset, data)
     }
 
     fn dispatch_workgroups(

--- a/wgpu-core/src/command/dyn_render_pass.rs
+++ b/wgpu-core/src/command/dyn_render_pass.rs
@@ -1,0 +1,458 @@
+use wgt::WasmNotSendSync;
+
+use crate::{global, hal_api::HalApi, id};
+
+use super::{RenderPass, RenderPassError};
+
+/// Trait for type erasing RenderPass.
+// TODO(#5124): wgpu-core's RenderPass trait should not be hal type dependent.
+// Practically speaking this allows us merge gfx_select with type erasure:
+// The alternative would be to introduce RenderPassId which then first needs to be looked up and then dispatch via gfx_select.
+pub trait DynRenderPass: std::fmt::Debug + WasmNotSendSync {
+    fn set_bind_group(
+        &mut self,
+        context: &global::Global,
+        index: u32,
+        bind_group_id: id::BindGroupId,
+        offsets: &[wgt::DynamicOffset],
+    ) -> Result<(), RenderPassError>;
+    fn set_index_buffer(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        index_format: wgt::IndexFormat,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) -> Result<(), RenderPassError>;
+    fn set_vertex_buffer(
+        &mut self,
+        context: &global::Global,
+        slot: u32,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) -> Result<(), RenderPassError>;
+    fn set_pipeline(
+        &mut self,
+        context: &global::Global,
+        pipeline_id: id::RenderPipelineId,
+    ) -> Result<(), RenderPassError>;
+    fn set_push_constants(
+        &mut self,
+        context: &global::Global,
+        stages: wgt::ShaderStages,
+        offset: u32,
+        data: &[u8],
+    ) -> Result<(), RenderPassError>;
+    fn draw(
+        &mut self,
+        context: &global::Global,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) -> Result<(), RenderPassError>;
+    fn draw_indexed(
+        &mut self,
+        context: &global::Global,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+        first_instance: u32,
+    ) -> Result<(), RenderPassError>;
+    fn draw_indirect(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+    ) -> Result<(), RenderPassError>;
+    fn draw_indexed_indirect(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+    ) -> Result<(), RenderPassError>;
+    fn multi_draw_indirect(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+        count: u32,
+    ) -> Result<(), RenderPassError>;
+    fn multi_draw_indexed_indirect(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+        count: u32,
+    ) -> Result<(), RenderPassError>;
+    fn multi_draw_indirect_count(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+        count_buffer_id: id::BufferId,
+        count_buffer_offset: wgt::BufferAddress,
+        max_count: u32,
+    ) -> Result<(), RenderPassError>;
+    fn multi_draw_indexed_indirect_count(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+        count_buffer_id: id::BufferId,
+        count_buffer_offset: wgt::BufferAddress,
+        max_count: u32,
+    ) -> Result<(), RenderPassError>;
+    fn set_blend_constant(
+        &mut self,
+        context: &global::Global,
+        color: wgt::Color,
+    ) -> Result<(), RenderPassError>;
+    fn set_scissor_rect(
+        &mut self,
+        context: &global::Global,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Result<(), RenderPassError>;
+    fn set_viewport(
+        &mut self,
+        context: &global::Global,
+        x: f32,
+        y: f32,
+        width: f32,
+        height: f32,
+        min_depth: f32,
+        max_depth: f32,
+    ) -> Result<(), RenderPassError>;
+    fn set_stencil_reference(
+        &mut self,
+        context: &global::Global,
+        reference: u32,
+    ) -> Result<(), RenderPassError>;
+    fn push_debug_group(
+        &mut self,
+        context: &global::Global,
+        label: &str,
+        color: u32,
+    ) -> Result<(), RenderPassError>;
+    fn pop_debug_group(&mut self, context: &global::Global) -> Result<(), RenderPassError>;
+    fn insert_debug_marker(
+        &mut self,
+        context: &global::Global,
+        label: &str,
+        color: u32,
+    ) -> Result<(), RenderPassError>;
+    fn write_timestamp(
+        &mut self,
+        context: &global::Global,
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    ) -> Result<(), RenderPassError>;
+    fn begin_occlusion_query(
+        &mut self,
+        context: &global::Global,
+        query_index: u32,
+    ) -> Result<(), RenderPassError>;
+    fn end_occlusion_query(&mut self, context: &global::Global) -> Result<(), RenderPassError>;
+    fn begin_pipeline_statistics_query(
+        &mut self,
+        context: &global::Global,
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    ) -> Result<(), RenderPassError>;
+    fn end_pipeline_statistics_query(
+        &mut self,
+        context: &global::Global,
+    ) -> Result<(), RenderPassError>;
+    fn execute_bundles(
+        &mut self,
+        context: &global::Global,
+        bundles: &[id::RenderBundleId],
+    ) -> Result<(), RenderPassError>;
+    fn end(&mut self, context: &global::Global) -> Result<(), RenderPassError>;
+
+    fn label(&self) -> Option<&str>;
+}
+
+impl<A: HalApi> DynRenderPass for RenderPass<A> {
+    fn set_index_buffer(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        index_format: wgt::IndexFormat,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_set_index_buffer(self, buffer_id, index_format, offset, size)
+    }
+
+    fn set_vertex_buffer(
+        &mut self,
+        context: &global::Global,
+        slot: u32,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_set_vertex_buffer(self, slot, buffer_id, offset, size)
+    }
+
+    fn set_bind_group(
+        &mut self,
+        context: &global::Global,
+        index: u32,
+        bind_group_id: id::BindGroupId,
+        offsets: &[wgt::DynamicOffset],
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_set_bind_group(self, index, bind_group_id, offsets)
+    }
+
+    fn set_pipeline(
+        &mut self,
+        context: &global::Global,
+        pipeline_id: id::RenderPipelineId,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_set_pipeline(self, pipeline_id)
+    }
+
+    fn set_push_constants(
+        &mut self,
+        context: &global::Global,
+        stages: wgt::ShaderStages,
+        offset: u32,
+        data: &[u8],
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_set_push_constants(self, stages, offset, data)
+    }
+
+    fn draw(
+        &mut self,
+        context: &global::Global,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_draw(
+            self,
+            vertex_count,
+            instance_count,
+            first_vertex,
+            first_instance,
+        )
+    }
+
+    fn draw_indexed(
+        &mut self,
+        context: &global::Global,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+        first_instance: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_draw_indexed(
+            self,
+            index_count,
+            instance_count,
+            first_index,
+            base_vertex,
+            first_instance,
+        )
+    }
+
+    fn draw_indirect(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_draw_indirect(self, buffer_id, offset)
+    }
+
+    fn draw_indexed_indirect(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_draw_indexed_indirect(self, buffer_id, offset)
+    }
+
+    fn multi_draw_indirect(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+        count: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_multi_draw_indirect(self, buffer_id, offset, count)
+    }
+
+    fn multi_draw_indexed_indirect(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+        count: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_multi_draw_indexed_indirect(self, buffer_id, offset, count)
+    }
+
+    fn multi_draw_indirect_count(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+        count_buffer_id: id::BufferId,
+        count_buffer_offset: wgt::BufferAddress,
+        max_count: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_multi_draw_indirect_count(
+            self,
+            buffer_id,
+            offset,
+            count_buffer_id,
+            count_buffer_offset,
+            max_count,
+        )
+    }
+
+    fn multi_draw_indexed_indirect_count(
+        &mut self,
+        context: &global::Global,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+        count_buffer_id: id::BufferId,
+        count_buffer_offset: wgt::BufferAddress,
+        max_count: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_multi_draw_indexed_indirect_count(
+            self,
+            buffer_id,
+            offset,
+            count_buffer_id,
+            count_buffer_offset,
+            max_count,
+        )
+    }
+
+    fn set_blend_constant(
+        &mut self,
+        context: &global::Global,
+        color: wgt::Color,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_set_blend_constant(self, color)
+    }
+
+    fn set_scissor_rect(
+        &mut self,
+        context: &global::Global,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_set_scissor_rect(self, x, y, width, height)
+    }
+
+    fn set_viewport(
+        &mut self,
+        context: &global::Global,
+        x: f32,
+        y: f32,
+        width: f32,
+        height: f32,
+        min_depth: f32,
+        max_depth: f32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_set_viewport(self, x, y, width, height, min_depth, max_depth)
+    }
+
+    fn set_stencil_reference(
+        &mut self,
+        context: &global::Global,
+        reference: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_set_stencil_reference(self, reference)
+    }
+
+    fn push_debug_group(
+        &mut self,
+        context: &global::Global,
+        label: &str,
+        color: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_push_debug_group(self, label, color)
+    }
+
+    fn pop_debug_group(&mut self, context: &global::Global) -> Result<(), RenderPassError> {
+        context.render_pass_pop_debug_group(self)
+    }
+
+    fn insert_debug_marker(
+        &mut self,
+        context: &global::Global,
+        label: &str,
+        color: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_insert_debug_marker(self, label, color)
+    }
+
+    fn write_timestamp(
+        &mut self,
+        context: &global::Global,
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_write_timestamp(self, query_set_id, query_index)
+    }
+
+    fn begin_occlusion_query(
+        &mut self,
+        context: &global::Global,
+        query_index: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_begin_occlusion_query(self, query_index)
+    }
+
+    fn end_occlusion_query(&mut self, context: &global::Global) -> Result<(), RenderPassError> {
+        context.render_pass_end_occlusion_query(self)
+    }
+
+    fn begin_pipeline_statistics_query(
+        &mut self,
+        context: &global::Global,
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_begin_pipeline_statistics_query(self, query_set_id, query_index)
+    }
+
+    fn end_pipeline_statistics_query(
+        &mut self,
+        context: &global::Global,
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_end_pipeline_statistics_query(self)
+    }
+
+    fn execute_bundles(
+        &mut self,
+        context: &global::Global,
+        bundles: &[id::RenderBundleId],
+    ) -> Result<(), RenderPassError> {
+        context.render_pass_execute_bundles(self, bundles)
+    }
+
+    fn end(&mut self, context: &global::Global) -> Result<(), RenderPassError> {
+        context.render_pass_end(self)
+    }
+
+    fn label(&self) -> Option<&str> {
+        self.label()
+    }
+}

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -6,6 +6,7 @@ mod compute;
 mod compute_command;
 mod draw;
 mod dyn_compute_pass;
+mod dyn_render_pass;
 mod memory_init;
 mod query;
 mod render;
@@ -18,8 +19,8 @@ use std::sync::Arc;
 pub(crate) use self::clear::clear_texture;
 pub use self::{
     bundle::*, clear::ClearError, compute::*, compute_command::ComputeCommand, draw::*,
-    dyn_compute_pass::DynComputePass, query::*, render::*, render_command::RenderCommand,
-    transfer::*,
+    dyn_compute_pass::DynComputePass, dyn_render_pass::DynRenderPass, query::*, render::*,
+    render_command::RenderCommand, transfer::*,
 };
 pub(crate) use allocator::CommandAllocator;
 
@@ -608,8 +609,28 @@ pub enum CommandEncoderError {
     Device(#[from] DeviceError),
     #[error("Command encoder is locked by a previously created render/compute pass. Before recording any new commands, the pass must be ended.")]
     Locked,
-    #[error("QuerySet provided for pass timestamp writes is invalid.")]
-    InvalidTimestampWritesQuerySetId,
+
+    #[error("QuerySet {0:?} for pass timestamp writes is invalid.")]
+    InvalidTimestampWritesQuerySetId(id::QuerySetId),
+    #[error("Attachment texture view {0:?} is invalid")]
+    InvalidAttachment(id::TextureViewId),
+    #[error("Attachment texture view {0:?} for resolve is invalid")]
+    InvalidResolveTarget(id::TextureViewId),
+    #[error("Depth stencil attachment view {0:?}  is invalid")]
+    InvalidDepthStencilAttachment(id::TextureViewId),
+    #[error("Occlusion query set {0:?} is invalid")]
+    InvalidOcclusionQuerySetId(id::QuerySetId),
+}
+
+impl PrettyError for CommandEncoderError {
+    fn fmt_pretty(&self, fmt: &mut ErrorFormatter) {
+        fmt.error(self);
+        if let Self::InvalidAttachment(id) = *self {
+            fmt.texture_view_label_with_key(&id, "attachment");
+        } else if let Self::InvalidResolveTarget(id) = *self {
+            fmt.texture_view_label_with_key(&id, "resolve target");
+        };
+    }
 }
 
 impl Global {
@@ -864,10 +885,7 @@ pub enum PassErrorScope {
     #[error("In a bundle parameter")]
     Bundle,
     #[error("In a pass parameter")]
-    // TODO: To be removed in favor of `Pass`.
-    // ComputePass is already operating on command buffer instead,
-    // same should apply to RenderPass in the future.
-    PassEncoder(id::CommandEncoderId),
+    PassEncoder(id::CommandEncoderId), // Needed only for ending pass via tracing.
     #[error("In a pass parameter")]
     Pass(Option<id::CommandBufferId>),
     #[error("In a set_bind_group command")]

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -10,6 +10,7 @@ mod memory_init;
 mod query;
 mod render;
 mod render_command;
+mod timestamp_writes;
 mod transfer;
 
 use std::sync::Arc;
@@ -21,6 +22,9 @@ pub use self::{
     transfer::*,
 };
 pub(crate) use allocator::CommandAllocator;
+
+pub(crate) use timestamp_writes::ArcPassTimestampWrites;
+pub use timestamp_writes::PassTimestampWrites;
 
 use self::memory_init::CommandBufferTextureMemoryActions;
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -13,9 +13,9 @@ use crate::{
         bind::Binder,
         end_occlusion_query, end_pipeline_statistics_query,
         memory_init::{fixup_discarded_surfaces, SurfacesInDiscardState},
-        BasePass, BindGroupStateChange, CommandBuffer, CommandEncoderError, CommandEncoderStatus,
-        DrawError, ExecutionError, MapPassErr, PassErrorScope, QueryUseError, RenderCommandError,
-        StateChange,
+        ArcPassTimestampWrites, BasePass, BindGroupStateChange, CommandBuffer, CommandEncoderError,
+        CommandEncoderStatus, DrawError, ExecutionError, MapPassErr, PassErrorScope,
+        PassTimestampWrites, QueryUseError, RenderCommandError, StateChange,
     },
     device::{
         AttachmentData, Device, DeviceError, MissingDownlevelFlags, MissingFeatures,
@@ -31,7 +31,6 @@ use crate::{
         DestroyedResourceError, MissingBufferUsageError, MissingTextureUsageError, ParentDevice,
         QuerySet, Texture, TextureView, TextureViewNotRenderableReason,
     },
-    storage::Storage,
     track::{ResourceUsageCompatibilityError, TextureSelector, Tracker, UsageScope},
     Label,
 };
@@ -50,14 +49,14 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use std::sync::Arc;
-use std::{borrow::Cow, fmt, iter, marker::PhantomData, mem, num::NonZeroU32, ops::Range, str};
+use std::{borrow::Cow, fmt, iter, mem, num::NonZeroU32, ops::Range, str};
 
 use super::render_command::{ArcRenderCommand, RenderCommand};
 use super::{
     memory_init::TextureSurfaceDiscard, CommandBufferTextureMemoryActions, CommandEncoder,
     QueryResetMap,
 };
-use super::{DrawKind, PassTimestampWrites, Rect};
+use super::{DrawKind, DynRenderPass, Rect};
 
 /// Operation to perform to the output attachment at the start of a renderpass.
 #[repr(C)]
@@ -135,6 +134,17 @@ pub struct RenderPassColorAttachment {
     pub channel: PassChannel<Color>,
 }
 
+/// Describes a color attachment to a render pass.
+#[derive(Debug)]
+struct ArcRenderPassColorAttachment<A: HalApi> {
+    /// The view to use as an attachment.
+    pub view: Arc<TextureView<A>>,
+    /// The view that will receive the resolved output if multisampling is used.
+    pub resolve_target: Option<Arc<TextureView<A>>>,
+    /// What operations will be performed on this color attachment.
+    pub channel: PassChannel<Color>,
+}
+
 /// Describes a depth/stencil attachment to a render pass.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -147,8 +157,18 @@ pub struct RenderPassDepthStencilAttachment {
     /// What operations will be performed on the stencil part of the attachment.
     pub stencil: PassChannel<u32>,
 }
+/// Describes a depth/stencil attachment to a render pass.
+#[derive(Debug)]
+pub struct ArcRenderPassDepthStencilAttachment<A: HalApi> {
+    /// The view to use as an attachment.
+    pub view: Arc<TextureView<A>>,
+    /// What operations will be performed on the depth part of the attachment.
+    pub depth: PassChannel<f32>,
+    /// What operations will be performed on the stencil part of the attachment.
+    pub stencil: PassChannel<u32>,
+}
 
-impl RenderPassDepthStencilAttachment {
+impl<A: HalApi> ArcRenderPassDepthStencilAttachment<A> {
     /// Validate the given aspects' read-only flags against their load
     /// and store ops.
     ///
@@ -200,37 +220,61 @@ pub struct RenderPassDescriptor<'a> {
     pub occlusion_query_set: Option<id::QuerySetId>,
 }
 
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-pub struct RenderPass {
+/// Describes the attachments of a render pass.
+struct ArcRenderPassDescriptor<'a, A: HalApi> {
+    pub label: &'a Label<'a>,
+    /// The color attachments of the render pass.
+    pub color_attachments:
+        ArrayVec<Option<ArcRenderPassColorAttachment<A>>, { hal::MAX_COLOR_ATTACHMENTS }>,
+    /// The depth and stencil attachment of the render pass, if any.
+    pub depth_stencil_attachment: Option<ArcRenderPassDepthStencilAttachment<A>>,
+    /// Defines where and when timestamp values will be written for this pass.
+    pub timestamp_writes: Option<ArcPassTimestampWrites<A>>,
+    /// Defines where the occlusion query results will be stored for this pass.
+    pub occlusion_query_set: Option<Arc<QuerySet<A>>>,
+}
+
+pub struct RenderPass<A: HalApi> {
     /// All pass data & records is stored here.
     ///
     /// If this is `None`, the pass is in the 'ended' state and can no longer be used.
     /// Any attempt to record more commands will result in a validation error.
-    // TODO: this is soon to become `ArcRenderCommand<A>`
-    base: Option<BasePass<RenderCommand>>,
+    base: Option<BasePass<ArcRenderCommand<A>>>,
 
-    parent_id: id::CommandEncoderId,
-    color_targets: ArrayVec<Option<RenderPassColorAttachment>, { hal::MAX_COLOR_ATTACHMENTS }>,
-    depth_stencil_target: Option<RenderPassDepthStencilAttachment>,
-    timestamp_writes: Option<PassTimestampWrites>,
-    occlusion_query_set_id: Option<id::QuerySetId>,
+    /// Parent command buffer that this pass records commands into.
+    ///
+    /// If it is none, this pass is invalid and any operation on it will return an error.
+    parent: Option<Arc<CommandBuffer<A>>>,
+
+    color_attachments:
+        ArrayVec<Option<ArcRenderPassColorAttachment<A>>, { hal::MAX_COLOR_ATTACHMENTS }>,
+    depth_stencil_attachment: Option<ArcRenderPassDepthStencilAttachment<A>>,
+    timestamp_writes: Option<ArcPassTimestampWrites<A>>,
+    occlusion_query_set: Option<Arc<QuerySet<A>>>,
 
     // Resource binding dedupe state.
-    #[cfg_attr(feature = "serde", serde(skip))]
     current_bind_groups: BindGroupStateChange,
-    #[cfg_attr(feature = "serde", serde(skip))]
     current_pipeline: StateChange<id::RenderPipelineId>,
 }
 
-impl RenderPass {
-    pub fn new(parent_id: id::CommandEncoderId, desc: &RenderPassDescriptor) -> Self {
+impl<A: HalApi> RenderPass<A> {
+    /// If the parent command buffer is invalid, the returned pass will be invalid.
+    fn new(parent: Option<Arc<CommandBuffer<A>>>, desc: ArcRenderPassDescriptor<A>) -> Self {
+        let ArcRenderPassDescriptor {
+            label,
+            timestamp_writes,
+            color_attachments,
+            depth_stencil_attachment,
+            occlusion_query_set,
+        } = desc;
+
         Self {
-            base: Some(BasePass::new(&desc.label)),
-            parent_id,
-            color_targets: desc.color_attachments.iter().cloned().collect(),
-            depth_stencil_target: desc.depth_stencil_attachment.cloned(),
-            timestamp_writes: desc.timestamp_writes.cloned(),
-            occlusion_query_set_id: desc.occlusion_query_set,
+            base: Some(BasePass::new(label)),
+            parent,
+            color_attachments,
+            depth_stencil_attachment,
+            timestamp_writes,
+            occlusion_query_set,
 
             current_bind_groups: BindGroupStateChange::new(),
             current_pipeline: StateChange::new(),
@@ -238,8 +282,8 @@ impl RenderPass {
     }
 
     #[inline]
-    pub fn parent_id(&self) -> id::CommandEncoderId {
-        self.parent_id
+    pub fn parent_id(&self) -> Option<id::CommandBufferId> {
+        self.parent.as_ref().map(|cmd_buf| cmd_buf.as_info().id())
     }
 
     #[inline]
@@ -250,7 +294,7 @@ impl RenderPass {
     fn base_mut<'a>(
         &'a mut self,
         scope: PassErrorScope,
-    ) -> Result<&'a mut BasePass<RenderCommand>, RenderPassError> {
+    ) -> Result<&'a mut BasePass<ArcRenderCommand<A>>, RenderPassError> {
         self.base
             .as_mut()
             .ok_or(RenderPassErrorInner::PassEnded)
@@ -258,12 +302,12 @@ impl RenderPass {
     }
 }
 
-impl fmt::Debug for RenderPass {
+impl<A: HalApi> fmt::Debug for RenderPass<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RenderPass")
-            .field("encoder_id", &self.parent_id)
-            .field("color_targets", &self.color_targets)
-            .field("depth_stencil_target", &self.depth_stencil_target)
+            .field("encoder_id", &self.parent_id())
+            .field("color_attachments", &self.color_attachments)
+            .field("depth_stencil_target", &self.depth_stencil_attachment)
             .field(
                 "command count",
                 &self.base.as_ref().map_or(0, |base| base.commands.len()),
@@ -408,7 +452,7 @@ impl VertexState {
     }
 }
 
-struct State<'attachment, 'scope, 'snatch_guard, 'cmd_buf, 'raw_encoder, A: HalApi> {
+struct State<'scope, 'snatch_guard, 'cmd_buf, 'raw_encoder, A: HalApi> {
     pipeline_flags: PipelineFlags,
     binder: Binder<A>,
     blend_constant: OptionalState,
@@ -418,7 +462,7 @@ struct State<'attachment, 'scope, 'snatch_guard, 'cmd_buf, 'raw_encoder, A: HalA
     vertex: VertexState,
     debug_scope_depth: u32,
 
-    info: RenderPassInfo<'attachment, 'scope, A>,
+    info: RenderPassInfo<'scope, A>,
 
     snatch_guard: &'snatch_guard SnatchGuard<'snatch_guard>,
 
@@ -436,8 +480,8 @@ struct State<'attachment, 'scope, 'snatch_guard, 'cmd_buf, 'raw_encoder, A: HalA
     active_query: Option<(Arc<QuerySet<A>>, u32)>,
 }
 
-impl<'attachment, 'scope, 'snatch_guard, 'cmd_buf, 'raw_encoder, A: HalApi>
-    State<'attachment, 'scope, 'snatch_guard, 'cmd_buf, 'raw_encoder, A>
+impl<'scope, 'snatch_guard, 'cmd_buf, 'raw_encoder, A: HalApi>
+    State<'scope, 'snatch_guard, 'cmd_buf, 'raw_encoder, A>
 {
     fn is_ready(&self, indexed: bool) -> Result<(), DrawError> {
         if let Some(pipeline) = self.pipeline.as_ref() {
@@ -548,10 +592,22 @@ pub enum RenderPassErrorInner {
     ColorAttachment(#[from] ColorAttachmentError),
     #[error(transparent)]
     Encoder(#[from] CommandEncoderError),
-    #[error("Attachment texture view Id {0:?} is invalid")]
+    #[error("Parent encoder is invalid")]
+    InvalidParentEncoder,
+    #[error("Attachment texture view {0:?} is invalid")]
     InvalidAttachmentId(id::TextureViewId),
+    #[error("Attachment texture view {0:?} is invalid")]
+    InvalidResolveTargetId(id::TextureViewId),
     #[error("The format of the depth-stencil attachment ({0:?}) is not a depth-stencil format")]
     InvalidDepthStencilAttachmentFormat(wgt::TextureFormat),
+    #[error("Buffer {0:?} is invalid or destroyed")]
+    InvalidBuffer(id::BufferId),
+    #[error("Render pipeline {0:?} is invalid")]
+    InvalidPipeline(id::RenderPipelineId),
+    #[error("QuerySet {0:?} is invalid")]
+    InvalidQuerySet(id::QuerySetId),
+    #[error("Render bundle {0:?} is invalid")]
+    InvalidRenderBundle(id::RenderBundleId),
     #[error("The format of the {location} ({format:?}) is not resolvable")]
     UnsupportedResolveTargetFormat {
         location: AttachmentErrorLocation,
@@ -661,8 +717,6 @@ pub enum RenderPassErrorInner {
         "Multiview pass texture views with more than one array layer must have D2Array dimension"
     )]
     MultiViewDimensionMismatch,
-    #[error("QuerySet {0:?} is invalid")]
-    InvalidQuerySet(id::QuerySetId),
     #[error("missing occlusion query set")]
     MissingOcclusionQuerySet,
     #[error(transparent)]
@@ -732,9 +786,9 @@ where
     }
 }
 
-struct RenderAttachment<'a, A: HalApi> {
+struct RenderAttachment<A: HalApi> {
     texture: Arc<Texture<A>>,
-    selector: &'a TextureSelector,
+    selector: TextureSelector,
     usage: hal::TextureUses,
 }
 
@@ -742,7 +796,7 @@ impl<A: HalApi> TextureView<A> {
     fn to_render_attachment(&self, usage: hal::TextureUses) -> RenderAttachment<A> {
         RenderAttachment {
             texture: self.parent.clone(),
-            selector: &self.selector,
+            selector: self.selector.clone(),
             usage,
         }
     }
@@ -751,22 +805,21 @@ impl<A: HalApi> TextureView<A> {
 const MAX_TOTAL_ATTACHMENTS: usize = hal::MAX_COLOR_ATTACHMENTS + hal::MAX_COLOR_ATTACHMENTS + 1;
 type AttachmentDataVec<T> = ArrayVec<T, MAX_TOTAL_ATTACHMENTS>;
 
-struct RenderPassInfo<'a, 'd, A: HalApi> {
+struct RenderPassInfo<'d, A: HalApi> {
     context: RenderPassContext,
     usage_scope: UsageScope<'d, A>,
     /// All render attachments, including depth/stencil
-    render_attachments: AttachmentDataVec<RenderAttachment<'a, A>>,
+    render_attachments: AttachmentDataVec<RenderAttachment<A>>,
     is_depth_read_only: bool,
     is_stencil_read_only: bool,
     extent: wgt::Extent3d,
-    _phantom: PhantomData<A>,
 
     pending_discard_init_fixups: SurfacesInDiscardState<A>,
-    divergent_discarded_depth_stencil_aspect: Option<(wgt::TextureAspect, &'a TextureView<A>)>,
+    divergent_discarded_depth_stencil_aspect: Option<(wgt::TextureAspect, Arc<TextureView<A>>)>,
     multiview: Option<NonZeroU32>,
 }
 
-impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
+impl<'d, A: HalApi> RenderPassInfo<'d, A> {
     fn add_pass_texture_init_actions<V>(
         channel: &PassChannel<V>,
         texture_memory_actions: &mut CommandBufferTextureMemoryActions<A>,
@@ -804,17 +857,18 @@ impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
     fn start(
         device: &'d Device<A>,
         hal_label: Option<&str>,
-        color_attachments: &[Option<RenderPassColorAttachment>],
-        depth_stencil_attachment: Option<&RenderPassDepthStencilAttachment>,
-        timestamp_writes: Option<&PassTimestampWrites>,
-        occlusion_query_set: Option<Arc<QuerySet<A>>>,
+        color_attachments: ArrayVec<
+            Option<ArcRenderPassColorAttachment<A>>,
+            { hal::MAX_COLOR_ATTACHMENTS },
+        >,
+        mut depth_stencil_attachment: Option<ArcRenderPassDepthStencilAttachment<A>>,
+        mut timestamp_writes: Option<ArcPassTimestampWrites<A>>,
+        mut occlusion_query_set: Option<Arc<QuerySet<A>>>,
         encoder: &mut CommandEncoder<A>,
         trackers: &mut Tracker<A>,
         texture_memory_actions: &mut CommandBufferTextureMemoryActions<A>,
         pending_query_resets: &mut QueryResetMap<A>,
-        view_guard: &'a Storage<TextureView<A>>,
-        query_set_guard: &'a Storage<QuerySet<A>>,
-        snatch_guard: &SnatchGuard<'a>,
+        snatch_guard: &SnatchGuard<'_>,
     ) -> Result<Self, RenderPassErrorInner> {
         profiling::scope!("RenderPassInfo::start");
 
@@ -899,19 +953,10 @@ impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
             Ok(())
         };
 
-        let mut colors =
-            ArrayVec::<Option<hal::ColorAttachment<A>>, { hal::MAX_COLOR_ATTACHMENTS }>::new();
         let mut depth_stencil = None;
 
-        if let Some(at) = depth_stencil_attachment {
-            let view = view_guard
-                .get(at.view)
-                .map_err(|_| RenderPassErrorInner::InvalidAttachmentId(at.view))?;
-
-            trackers.views.add_single(view);
-
-            let view = view.as_ref();
-
+        if let Some(at) = depth_stencil_attachment.as_ref() {
+            let view = &at.view;
             check_multiview(view)?;
             add_view(view, AttachmentErrorLocation::Depth)?;
 
@@ -994,7 +1039,7 @@ impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
                         } else {
                             wgt::TextureAspect::StencilOnly
                         },
-                        view,
+                        view.clone(),
                     ));
                 } else if at.depth.store_op == StoreOp::Discard {
                     // Both are discarded using the regular path.
@@ -1032,20 +1077,16 @@ impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
             });
         }
 
+        let mut color_attachments_hal =
+            ArrayVec::<Option<hal::ColorAttachment<A>>, { hal::MAX_COLOR_ATTACHMENTS }>::new();
         for (index, attachment) in color_attachments.iter().enumerate() {
             let at = if let Some(attachment) = attachment.as_ref() {
                 attachment
             } else {
-                colors.push(None);
+                color_attachments_hal.push(None);
                 continue;
             };
-
-            let color_view = view_guard
-                .get(at.view)
-                .map_err(|_| RenderPassErrorInner::InvalidAttachmentId(at.view))?;
-
-            trackers.views.add_single(color_view);
-
+            let color_view: &TextureView<A> = &at.view;
             check_multiview(color_view)?;
             add_view(
                 color_view,
@@ -1075,13 +1116,7 @@ impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
                 .push(color_view.to_render_attachment(hal::TextureUses::COLOR_TARGET));
 
             let mut hal_resolve_target = None;
-            if let Some(resolve_target) = at.resolve_target {
-                let resolve_view = view_guard
-                    .get(resolve_target)
-                    .map_err(|_| RenderPassErrorInner::InvalidAttachmentId(resolve_target))?;
-
-                trackers.views.add_single(resolve_view);
-
+            if let Some(resolve_view) = &at.resolve_target {
                 check_multiview(resolve_view)?;
 
                 let resolve_location = AttachmentErrorLocation::Color {
@@ -1141,7 +1176,7 @@ impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
                 });
             }
 
-            colors.push(Some(hal::ColorAttachment {
+            color_attachments_hal.push(Some(hal::ColorAttachment {
                 target: hal::Attachment {
                     view: color_view.try_raw(snatch_guard)?,
                     usage: hal::TextureUses::COLOR_TARGET,
@@ -1155,36 +1190,34 @@ impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
         let extent = extent.ok_or(RenderPassErrorInner::MissingAttachments)?;
         let multiview = detected_multiview.expect("Multiview was not detected, no attachments");
 
-        let view_data = AttachmentData {
+        let attachment_formats = AttachmentData {
             colors: color_attachments
                 .iter()
-                .map(|at| at.as_ref().map(|at| view_guard.get(at.view).unwrap()))
+                .map(|at| at.as_ref().map(|at| at.view.desc.texture_format))
                 .collect(),
             resolves: color_attachments
                 .iter()
-                .filter_map(|at| match *at {
-                    Some(RenderPassColorAttachment {
-                        resolve_target: Some(resolve),
-                        ..
-                    }) => Some(view_guard.get(resolve).unwrap()),
-                    _ => None,
+                .filter_map(|at| {
+                    at.as_ref().and_then(|at| {
+                        at.resolve_target
+                            .as_ref()
+                            .map(|resolve| resolve.desc.format)
+                    })
                 })
                 .collect(),
-            depth_stencil: depth_stencil_attachment.map(|at| view_guard.get(at.view).unwrap()),
+            depth_stencil: depth_stencil_attachment
+                .as_ref()
+                .map(|at| at.view.desc.format),
         };
 
         let context = RenderPassContext {
-            attachments: view_data.map(|view| view.desc.format),
+            attachments: attachment_formats,
             sample_count,
             multiview,
         };
 
-        let timestamp_writes = if let Some(tw) = timestamp_writes {
-            let query_set = query_set_guard
-                .get(tw.query_set)
-                .map_err(|_| RenderPassErrorInner::InvalidQuerySet(tw.query_set))?;
-
-            trackers.query_sets.add_single(query_set);
+        let timestamp_writes_hal = timestamp_writes.as_ref().map(|tw| {
+            let query_set = &tw.query_set;
 
             if let Some(index) = tw.beginning_of_pass_write_index {
                 pending_query_resets.use_query_set(query_set, index);
@@ -1193,35 +1226,48 @@ impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
                 pending_query_resets.use_query_set(query_set, index);
             }
 
-            Some(hal::RenderPassTimestampWrites {
+            hal::RenderPassTimestampWrites {
                 query_set: query_set.raw.as_ref().unwrap(),
                 beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
                 end_of_pass_write_index: tw.end_of_pass_write_index,
-            })
-        } else {
-            None
-        };
+            }
+        });
 
-        let occlusion_query_set = if let Some(query_set) = occlusion_query_set {
-            let query_set = trackers.query_sets.insert_single(query_set);
-            Some(query_set.raw.as_ref().unwrap())
-        } else {
-            None
-        };
+        let occlusion_query_set_hal = occlusion_query_set
+            .as_ref()
+            .map(|query_set| query_set.raw.as_ref().unwrap());
 
         let hal_desc = hal::RenderPassDescriptor {
             label: hal_label,
             extent,
             sample_count,
-            color_attachments: &colors,
+            color_attachments: &color_attachments_hal,
             depth_stencil_attachment: depth_stencil,
             multiview,
-            timestamp_writes,
-            occlusion_query_set,
+            timestamp_writes: timestamp_writes_hal,
+            occlusion_query_set: occlusion_query_set_hal,
         };
         unsafe {
             encoder.raw.begin_render_pass(&hal_desc);
         };
+        drop(color_attachments_hal); // Drop, so we can consume `color_attachments` for the tracker.
+
+        // Can't borrow the tracker more than once, so have to add to the tracker after the `begin_render_pass` hal call.
+        if let Some(tw) = timestamp_writes.take() {
+            trackers.query_sets.insert_single(tw.query_set);
+        };
+        if let Some(occlusion_query_set) = occlusion_query_set.take() {
+            trackers.query_sets.insert_single(occlusion_query_set);
+        };
+        if let Some(at) = depth_stencil_attachment.take() {
+            trackers.views.insert_single(at.view.clone());
+        }
+        for at in color_attachments.into_iter().flatten() {
+            trackers.views.insert_single(at.view.clone());
+            if let Some(resolve_target) = at.resolve_target {
+                trackers.views.insert_single(resolve_target);
+            }
+        }
 
         Ok(Self {
             context,
@@ -1230,7 +1276,6 @@ impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
             is_depth_read_only,
             is_stencil_read_only,
             extent,
-            _phantom: PhantomData,
             pending_discard_init_fixups,
             divergent_discarded_depth_stencil_aspect,
             multiview,
@@ -1311,22 +1356,141 @@ impl<'a, 'd, A: HalApi> RenderPassInfo<'a, 'd, A> {
 }
 
 impl Global {
-    pub fn render_pass_end<A: HalApi>(&self, pass: &mut RenderPass) -> Result<(), RenderPassError> {
-        let scope = PassErrorScope::PassEncoder(pass.parent_id);
-        let base = pass
-            .base
-            .take()
-            .ok_or(RenderPassErrorInner::PassEnded)
-            .map_pass_err(scope)?;
+    /// Creates a render pass.
+    ///
+    /// If creation fails, an invalid pass is returned.
+    /// Any operation on an invalid pass will return an error.
+    ///
+    /// If successful, puts the encoder into the [`CommandEncoderStatus::Locked`] state.
+    pub fn command_encoder_create_render_pass<A: HalApi>(
+        &self,
+        encoder_id: id::CommandEncoderId,
+        desc: &RenderPassDescriptor<'_>,
+    ) -> (RenderPass<A>, Option<CommandEncoderError>) {
+        fn fill_arc_desc<A: HalApi>(
+            hub: &crate::hub::Hub<A>,
+            device: &Arc<Device<A>>,
+            desc: &RenderPassDescriptor<'_>,
+            arc_desc: &mut ArcRenderPassDescriptor<A>,
+        ) -> Result<(), CommandEncoderError> {
+            let query_sets = hub.query_sets.read();
+            let texture_views = hub.texture_views.read();
 
-        self.render_pass_end_with_unresolved_commands::<A>(
-            pass.parent_id,
-            base,
-            &pass.color_targets,
-            pass.depth_stencil_target.as_ref(),
-            pass.timestamp_writes.as_ref(),
-            pass.occlusion_query_set_id,
-        )
+            for color_attachment in desc.color_attachments.iter() {
+                if let Some(RenderPassColorAttachment {
+                    view: view_id,
+                    resolve_target,
+                    channel,
+                }) = color_attachment
+                {
+                    let view = texture_views
+                        .get_owned(*view_id)
+                        .map_err(|_| CommandEncoderError::InvalidAttachment(*view_id))?;
+                    view.same_device(device)?;
+
+                    let resolve_target = if let Some(resolve_target_id) = resolve_target {
+                        let rt_arc = texture_views.get_owned(*resolve_target_id).map_err(|_| {
+                            CommandEncoderError::InvalidResolveTarget(*resolve_target_id)
+                        })?;
+                        rt_arc.same_device(device)?;
+
+                        Some(rt_arc)
+                    } else {
+                        None
+                    };
+
+                    arc_desc
+                        .color_attachments
+                        .push(Some(ArcRenderPassColorAttachment {
+                            view,
+                            resolve_target,
+                            channel: channel.clone(),
+                        }));
+                } else {
+                    arc_desc.color_attachments.push(None);
+                }
+            }
+
+            arc_desc.depth_stencil_attachment =
+                if let Some(depth_stencil_attachment) = desc.depth_stencil_attachment {
+                    let view = texture_views
+                        .get_owned(depth_stencil_attachment.view)
+                        .map_err(|_| {
+                            CommandEncoderError::InvalidDepthStencilAttachment(
+                                depth_stencil_attachment.view,
+                            )
+                        })?;
+                    view.same_device(device)?;
+
+                    Some(ArcRenderPassDepthStencilAttachment {
+                        view,
+                        depth: depth_stencil_attachment.depth.clone(),
+                        stencil: depth_stencil_attachment.stencil.clone(),
+                    })
+                } else {
+                    None
+                };
+
+            arc_desc.timestamp_writes = if let Some(tw) = desc.timestamp_writes {
+                let query_set = query_sets.get_owned(tw.query_set).map_err(|_| {
+                    CommandEncoderError::InvalidTimestampWritesQuerySetId(tw.query_set)
+                })?;
+                query_set.same_device(device)?;
+
+                Some(ArcPassTimestampWrites {
+                    query_set,
+                    beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
+                    end_of_pass_write_index: tw.end_of_pass_write_index,
+                })
+            } else {
+                None
+            };
+
+            arc_desc.occlusion_query_set =
+                if let Some(occlusion_query_set) = desc.occlusion_query_set {
+                    let query_set = query_sets.get_owned(occlusion_query_set).map_err(|_| {
+                        CommandEncoderError::InvalidOcclusionQuerySetId(occlusion_query_set)
+                    })?;
+                    query_set.same_device(device)?;
+
+                    Some(query_set)
+                } else {
+                    None
+                };
+
+            Ok(())
+        }
+
+        let hub = A::hub(self);
+        let mut arc_desc = ArcRenderPassDescriptor {
+            label: &desc.label,
+            timestamp_writes: None,
+            color_attachments: ArrayVec::new(),
+            depth_stencil_attachment: None,
+            occlusion_query_set: None,
+        };
+
+        let cmd_buf = match CommandBuffer::lock_encoder(hub, encoder_id) {
+            Ok(cmd_buf) => cmd_buf,
+            Err(e) => return (RenderPass::new(None, arc_desc), Some(e)),
+        };
+
+        let err = fill_arc_desc(hub, &cmd_buf.device, desc, &mut arc_desc).err();
+
+        (RenderPass::new(Some(cmd_buf), arc_desc), err)
+    }
+
+    /// Creates a type erased render pass.
+    ///
+    /// If creation fails, an invalid pass is returned.
+    /// Any operation on an invalid pass will return an error.
+    pub fn command_encoder_create_render_pass_dyn<A: HalApi>(
+        &self,
+        encoder_id: id::CommandEncoderId,
+        desc: &RenderPassDescriptor<'_>,
+    ) -> (Box<dyn DynRenderPass>, Option<CommandEncoderError>) {
+        let (pass, err) = self.command_encoder_create_render_pass::<A>(encoder_id, desc);
+        (Box::new(pass), err)
     }
 
     #[doc(hidden)]
@@ -1337,62 +1501,78 @@ impl Global {
         color_attachments: &[Option<RenderPassColorAttachment>],
         depth_stencil_attachment: Option<&RenderPassDepthStencilAttachment>,
         timestamp_writes: Option<&PassTimestampWrites>,
-        occlusion_query_set_id: Option<id::QuerySetId>,
+        occlusion_query_set: Option<id::QuerySetId>,
     ) -> Result<(), RenderPassError> {
-        let pass_scope = PassErrorScope::PassEncoder(encoder_id);
+        let BasePass {
+            label,
+            commands,
+            dynamic_offsets,
+            string_data,
+            push_constant_data,
+        } = base;
+
+        let (mut render_pass, encoder_error) = self.command_encoder_create_render_pass::<A>(
+            encoder_id,
+            &RenderPassDescriptor {
+                label: label.as_deref().map(Cow::Borrowed),
+                color_attachments: Cow::Borrowed(color_attachments),
+                depth_stencil_attachment,
+                timestamp_writes,
+                occlusion_query_set,
+            },
+        );
+        if let Some(err) = encoder_error {
+            return Err(RenderPassError {
+                scope: PassErrorScope::PassEncoder(encoder_id),
+                inner: err.into(),
+            });
+        };
 
         let hub = A::hub(self);
+        render_pass.base = Some(BasePass {
+            label,
+            commands: RenderCommand::resolve_render_command_ids(hub, &commands)?,
+            dynamic_offsets,
+            string_data,
+            push_constant_data,
+        });
 
-        let commands = RenderCommand::resolve_render_command_ids(hub, &base.commands)?;
-
-        let occlusion_query_set = occlusion_query_set_id
-            .map(|id| {
-                hub.query_sets
-                    .get(id)
-                    .map_err(|_| RenderPassErrorInner::InvalidQuerySet(id))
+        if let Some(err) = encoder_error {
+            Err(RenderPassError {
+                scope: PassErrorScope::PassEncoder(encoder_id),
+                inner: err.into(),
             })
-            .transpose()
-            .map_pass_err(pass_scope)?;
-
-        self.render_pass_end_impl::<A>(
-            encoder_id,
-            BasePass {
-                label: base.label,
-                commands,
-                dynamic_offsets: base.dynamic_offsets,
-                string_data: base.string_data,
-                push_constant_data: base.push_constant_data,
-            },
-            color_attachments,
-            depth_stencil_attachment,
-            timestamp_writes,
-            occlusion_query_set,
-        )
+        } else {
+            self.render_pass_end(&mut render_pass)
+        }
     }
 
     #[doc(hidden)]
-    pub fn render_pass_end_impl<A: HalApi>(
+    pub fn render_pass_end<A: HalApi>(
         &self,
-        encoder_id: id::CommandEncoderId,
-        base: BasePass<ArcRenderCommand<A>>,
-        color_attachments: &[Option<RenderPassColorAttachment>],
-        depth_stencil_attachment: Option<&RenderPassDepthStencilAttachment>,
-        timestamp_writes: Option<&PassTimestampWrites>,
-        occlusion_query_set: Option<Arc<QuerySet<A>>>,
+        pass: &mut RenderPass<A>,
     ) -> Result<(), RenderPassError> {
+        let pass_scope = PassErrorScope::Pass(pass.parent_id());
+
+        let base = pass
+            .base
+            .take()
+            .ok_or(RenderPassErrorInner::PassEnded)
+            .map_pass_err(pass_scope)?;
+
         profiling::scope!(
             "CommandEncoder::run_render_pass {}",
             base.label.unwrap_or("")
         );
 
+        let Some(cmd_buf) = pass.parent.as_ref() else {
+            return Err(RenderPassErrorInner::InvalidParentEncoder).map_pass_err(pass_scope);
+        };
+        cmd_buf.unlock_encoder().map_pass_err(pass_scope)?;
+        let cmd_buf_id = cmd_buf.as_info().id();
+
         let hal_label = hal_label(base.label.as_deref(), self.instance.flags);
 
-        let pass_scope = PassErrorScope::PassEncoder(encoder_id);
-
-        let hub = A::hub(self);
-
-        let cmd_buf: Arc<CommandBuffer<A>> =
-            CommandBuffer::get_encoder(hub, encoder_id).map_pass_err(pass_scope)?;
         let device = &cmd_buf.device;
         let snatch_guard = &device.snatchable_lock.read();
 
@@ -1410,12 +1590,35 @@ impl Global {
                         string_data: base.string_data.to_vec(),
                         push_constant_data: base.push_constant_data.to_vec(),
                     },
-                    target_colors: color_attachments.to_vec(),
-                    target_depth_stencil: depth_stencil_attachment.cloned(),
-                    timestamp_writes: timestamp_writes.cloned(),
-                    occlusion_query_set_id: occlusion_query_set
+                    target_colors: pass
+                        .color_attachments
+                        .iter()
+                        .map(|attachment| {
+                            attachment.as_ref().map(|a| RenderPassColorAttachment {
+                                view: a.view.as_info().id(),
+                                resolve_target: a.resolve_target.as_ref().map(|a| a.as_info().id()),
+                                channel: a.channel.clone(),
+                            })
+                        })
+                        .collect(),
+                    target_depth_stencil: pass.depth_stencil_attachment.as_ref().map(|d| {
+                        RenderPassDepthStencilAttachment {
+                            view: d.view.as_info().id(),
+                            depth: d.depth.clone(),
+                            stencil: d.stencil.clone(),
+                        }
+                    }),
+                    timestamp_writes: pass.timestamp_writes.as_ref().map(|tw| {
+                        PassTimestampWrites {
+                            query_set: tw.query_set.as_info().id(),
+                            beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
+                            end_of_pass_write_index: tw.end_of_pass_write_index,
+                        }
+                    }),
+                    occlusion_query_set_id: pass
+                        .occlusion_query_set
                         .as_ref()
-                        .map(|query_set| query_set.as_info().id()),
+                        .map(|q| q.as_info().id()),
                 });
             }
 
@@ -1436,27 +1639,24 @@ impl Global {
             *status = CommandEncoderStatus::Error;
             encoder.open_pass(hal_label).map_pass_err(pass_scope)?;
 
-            let query_set_guard = hub.query_sets.read();
-            let view_guard = hub.texture_views.read();
-
             log::trace!(
                 "Encoding render pass begin in command buffer {:?}",
-                encoder_id
+                cmd_buf_id
             );
 
             let info = RenderPassInfo::start(
                 device,
                 hal_label,
-                color_attachments,
-                depth_stencil_attachment,
-                timestamp_writes,
-                occlusion_query_set.clone(),
+                pass.color_attachments.take(),
+                pass.depth_stencil_attachment.take(),
+                pass.timestamp_writes.take(),
+                // Still needed down the line.
+                // TODO(wumpf): by restructuring the code, we could get rid of some of this Arc clone.
+                pass.occlusion_query_set.clone(),
                 encoder,
                 tracker,
                 texture_memory_actions,
                 pending_query_resets,
-                &*view_guard,
-                &*query_set_guard,
                 snatch_guard,
             )
             .map_pass_err(pass_scope)?;
@@ -1510,7 +1710,7 @@ impl Global {
                         let scope = PassErrorScope::SetBindGroup;
                         set_bind_group(
                             &mut state,
-                            &cmd_buf,
+                            cmd_buf,
                             &base.dynamic_offsets,
                             index,
                             num_dynamic_offsets,
@@ -1520,7 +1720,7 @@ impl Global {
                     }
                     ArcRenderCommand::SetPipeline(pipeline) => {
                         let scope = PassErrorScope::SetPipelineRender;
-                        set_pipeline(&mut state, &cmd_buf, pipeline).map_pass_err(scope)?;
+                        set_pipeline(&mut state, cmd_buf, pipeline).map_pass_err(scope)?;
                     }
                     ArcRenderCommand::SetIndexBuffer {
                         buffer,
@@ -1529,7 +1729,7 @@ impl Global {
                         size,
                     } => {
                         let scope = PassErrorScope::SetIndexBuffer;
-                        set_index_buffer(&mut state, &cmd_buf, buffer, index_format, offset, size)
+                        set_index_buffer(&mut state, cmd_buf, buffer, index_format, offset, size)
                             .map_pass_err(scope)?;
                     }
                     ArcRenderCommand::SetVertexBuffer {
@@ -1539,7 +1739,7 @@ impl Global {
                         size,
                     } => {
                         let scope = PassErrorScope::SetVertexBuffer;
-                        set_vertex_buffer(&mut state, &cmd_buf, slot, buffer, offset, size)
+                        set_vertex_buffer(&mut state, cmd_buf, slot, buffer, offset, size)
                             .map_pass_err(scope)?;
                     }
                     ArcRenderCommand::SetBlendConstant(ref color) => {
@@ -1684,7 +1884,8 @@ impl Global {
                         api_log!("RenderPass::begin_occlusion_query {query_index}");
                         let scope = PassErrorScope::BeginOcclusionQuery;
 
-                        let query_set = occlusion_query_set
+                        let query_set = pass
+                            .occlusion_query_set
                             .clone()
                             .ok_or(RenderPassErrorInner::MissingOcclusionQuerySet)
                             .map_pass_err(scope)?;
@@ -1736,12 +1937,12 @@ impl Global {
                     }
                     ArcRenderCommand::ExecuteBundle(bundle) => {
                         let scope = PassErrorScope::ExecuteBundle;
-                        execute_bundle(&mut state, &cmd_buf, bundle).map_pass_err(scope)?;
+                        execute_bundle(&mut state, cmd_buf, bundle).map_pass_err(scope)?;
                     }
                 }
             }
 
-            log::trace!("Merging renderpass into cmd_buf {:?}", encoder_id);
+            log::trace!("Merging renderpass into cmd_buf {:?}", cmd_buf_id);
             let (trackers, pending_discard_init_fixups) = state
                 .info
                 .finish(state.raw_encoder, state.snatch_guard)
@@ -1751,10 +1952,6 @@ impl Global {
             (trackers, pending_discard_init_fixups)
         };
 
-        let cmd_buf = hub
-            .command_buffers
-            .get(encoder_id.into_command_buffer_id())
-            .unwrap();
         let mut cmd_buf_data = cmd_buf.data.lock();
         let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
 
@@ -2607,9 +2804,41 @@ fn execute_bundle<A: HalApi>(
 }
 
 impl Global {
-    pub fn render_pass_set_bind_group(
+    fn resolve_render_pass_buffer_id<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        scope: PassErrorScope,
+        buffer_id: id::Id<id::markers::Buffer>,
+    ) -> Result<Arc<crate::resource::Buffer<A>>, RenderPassError> {
+        let hub = A::hub(self);
+        let buffer = hub
+            .buffers
+            .read()
+            .get_owned(buffer_id)
+            .map_err(|_| RenderPassErrorInner::InvalidBuffer(buffer_id))
+            .map_pass_err(scope)?;
+
+        Ok(buffer)
+    }
+
+    fn resolve_render_pass_query_set<A: HalApi>(
+        &self,
+        scope: PassErrorScope,
+        query_set_id: id::Id<id::markers::QuerySet>,
+    ) -> Result<Arc<QuerySet<A>>, RenderPassError> {
+        let hub = A::hub(self);
+        let query_set = hub
+            .query_sets
+            .read()
+            .get_owned(query_set_id)
+            .map_err(|_| RenderPassErrorInner::InvalidQuerySet(query_set_id))
+            .map_pass_err(scope)?;
+
+        Ok(query_set)
+    }
+
+    pub fn render_pass_set_bind_group<A: HalApi>(
+        &self,
+        pass: &mut RenderPass<A>,
         index: u32,
         bind_group_id: id::BindGroupId,
         offsets: &[DynamicOffset],
@@ -2631,18 +2860,26 @@ impl Global {
             return Ok(());
         }
 
-        base.commands.push(RenderCommand::SetBindGroup {
+        let hub = A::hub(self);
+        let bind_group = hub
+            .bind_groups
+            .read()
+            .get_owned(bind_group_id)
+            .map_err(|_| RenderPassErrorInner::InvalidBindGroup(index))
+            .map_pass_err(scope)?;
+
+        base.commands.push(ArcRenderCommand::SetBindGroup {
             index,
             num_dynamic_offsets: offsets.len(),
-            bind_group_id,
+            bind_group,
         });
 
         Ok(())
     }
 
-    pub fn render_pass_set_pipeline(
+    pub fn render_pass_set_pipeline<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         pipeline_id: id::RenderPipelineId,
     ) -> Result<(), RenderPassError> {
         let scope = PassErrorScope::SetPipelineRender;
@@ -2655,14 +2892,22 @@ impl Global {
             return Ok(());
         }
 
-        base.commands.push(RenderCommand::SetPipeline(pipeline_id));
+        let hub = A::hub(self);
+        let pipeline = hub
+            .render_pipelines
+            .read()
+            .get_owned(pipeline_id)
+            .map_err(|_| RenderPassErrorInner::InvalidPipeline(pipeline_id))
+            .map_pass_err(scope)?;
+
+        base.commands.push(ArcRenderCommand::SetPipeline(pipeline));
 
         Ok(())
     }
 
-    pub fn render_pass_set_index_buffer(
+    pub fn render_pass_set_index_buffer<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         buffer_id: id::BufferId,
         index_format: IndexFormat,
         offset: BufferAddress,
@@ -2671,8 +2916,8 @@ impl Global {
         let scope = PassErrorScope::SetIndexBuffer;
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::SetIndexBuffer {
-            buffer_id,
+        base.commands.push(ArcRenderCommand::SetIndexBuffer {
+            buffer: self.resolve_render_pass_buffer_id(scope, buffer_id)?,
             index_format,
             offset,
             size,
@@ -2681,9 +2926,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_set_vertex_buffer(
+    pub fn render_pass_set_vertex_buffer<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         slot: u32,
         buffer_id: id::BufferId,
         offset: BufferAddress,
@@ -2692,9 +2937,9 @@ impl Global {
         let scope = PassErrorScope::SetVertexBuffer;
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::SetVertexBuffer {
+        base.commands.push(ArcRenderCommand::SetVertexBuffer {
             slot,
-            buffer_id,
+            buffer: self.resolve_render_pass_buffer_id(scope, buffer_id)?,
             offset,
             size,
         });
@@ -2702,36 +2947,37 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_set_blend_constant(
+    pub fn render_pass_set_blend_constant<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
-        color: &Color,
+        pass: &mut RenderPass<A>,
+        color: Color,
     ) -> Result<(), RenderPassError> {
         let scope = PassErrorScope::SetBlendConstant;
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::SetBlendConstant(*color));
+        base.commands
+            .push(ArcRenderCommand::SetBlendConstant(color));
 
         Ok(())
     }
 
-    pub fn render_pass_set_stencil_reference(
+    pub fn render_pass_set_stencil_reference<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         value: u32,
     ) -> Result<(), RenderPassError> {
         let scope = PassErrorScope::SetStencilReference;
         let base = pass.base_mut(scope)?;
 
         base.commands
-            .push(RenderCommand::SetStencilReference(value));
+            .push(ArcRenderCommand::SetStencilReference(value));
 
         Ok(())
     }
 
-    pub fn render_pass_set_viewport(
+    pub fn render_pass_set_viewport<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         x: f32,
         y: f32,
         w: f32,
@@ -2742,7 +2988,7 @@ impl Global {
         let scope = PassErrorScope::SetViewport;
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::SetViewport {
+        base.commands.push(ArcRenderCommand::SetViewport {
             rect: Rect { x, y, w, h },
             depth_min,
             depth_max,
@@ -2751,9 +2997,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_set_scissor_rect(
+    pub fn render_pass_set_scissor_rect<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         x: u32,
         y: u32,
         w: u32,
@@ -2763,14 +3009,14 @@ impl Global {
         let base = pass.base_mut(scope)?;
 
         base.commands
-            .push(RenderCommand::SetScissor(Rect { x, y, w, h }));
+            .push(ArcRenderCommand::SetScissor(Rect { x, y, w, h }));
 
         Ok(())
     }
 
-    pub fn render_pass_set_push_constants(
+    pub fn render_pass_set_push_constants<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         stages: ShaderStages,
         offset: u32,
         data: &[u8],
@@ -2797,7 +3043,7 @@ impl Global {
                 .map(|arr| u32::from_ne_bytes([arr[0], arr[1], arr[2], arr[3]])),
         );
 
-        base.commands.push(RenderCommand::SetPushConstant {
+        base.commands.push(ArcRenderCommand::SetPushConstant {
             stages,
             offset,
             size_bytes: data.len() as u32,
@@ -2807,9 +3053,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_draw(
+    pub fn render_pass_draw<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         vertex_count: u32,
         instance_count: u32,
         first_vertex: u32,
@@ -2821,7 +3067,7 @@ impl Global {
         };
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::Draw {
+        base.commands.push(ArcRenderCommand::Draw {
             vertex_count,
             instance_count,
             first_vertex,
@@ -2831,9 +3077,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_draw_indexed(
+    pub fn render_pass_draw_indexed<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         index_count: u32,
         instance_count: u32,
         first_index: u32,
@@ -2846,7 +3092,7 @@ impl Global {
         };
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::DrawIndexed {
+        base.commands.push(ArcRenderCommand::DrawIndexed {
             index_count,
             instance_count,
             first_index,
@@ -2857,9 +3103,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_draw_indirect(
+    pub fn render_pass_draw_indirect<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), RenderPassError> {
@@ -2869,8 +3115,8 @@ impl Global {
         };
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::MultiDrawIndirect {
-            buffer_id,
+        base.commands.push(ArcRenderCommand::MultiDrawIndirect {
+            buffer: self.resolve_render_pass_buffer_id(scope, buffer_id)?,
             offset,
             count: None,
             indexed: false,
@@ -2879,9 +3125,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_draw_indexed_indirect(
+    pub fn render_pass_draw_indexed_indirect<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), RenderPassError> {
@@ -2891,8 +3137,8 @@ impl Global {
         };
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::MultiDrawIndirect {
-            buffer_id,
+        base.commands.push(ArcRenderCommand::MultiDrawIndirect {
+            buffer: self.resolve_render_pass_buffer_id(scope, buffer_id)?,
             offset,
             count: None,
             indexed: true,
@@ -2901,9 +3147,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_multi_draw_indirect(
+    pub fn render_pass_multi_draw_indirect<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         buffer_id: id::BufferId,
         offset: BufferAddress,
         count: u32,
@@ -2914,8 +3160,8 @@ impl Global {
         };
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::MultiDrawIndirect {
-            buffer_id,
+        base.commands.push(ArcRenderCommand::MultiDrawIndirect {
+            buffer: self.resolve_render_pass_buffer_id(scope, buffer_id)?,
             offset,
             count: NonZeroU32::new(count),
             indexed: false,
@@ -2924,9 +3170,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_multi_draw_indexed_indirect(
+    pub fn render_pass_multi_draw_indexed_indirect<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         buffer_id: id::BufferId,
         offset: BufferAddress,
         count: u32,
@@ -2937,8 +3183,8 @@ impl Global {
         };
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::MultiDrawIndirect {
-            buffer_id,
+        base.commands.push(ArcRenderCommand::MultiDrawIndirect {
+            buffer: self.resolve_render_pass_buffer_id(scope, buffer_id)?,
             offset,
             count: NonZeroU32::new(count),
             indexed: true,
@@ -2947,9 +3193,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_multi_draw_indirect_count(
+    pub fn render_pass_multi_draw_indirect_count<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         buffer_id: id::BufferId,
         offset: BufferAddress,
         count_buffer_id: id::BufferId,
@@ -2962,21 +3208,34 @@ impl Global {
         };
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::MultiDrawIndirectCount {
-            buffer_id,
-            offset,
-            count_buffer_id,
-            count_buffer_offset,
-            max_count,
-            indexed: false,
-        });
+        // Don't use resolve_render_pass_buffer_id here, because we don't want to take the read-lock twice.
+        let hub = A::hub(self);
+        let buffers = hub.buffers.read();
+        let buffer = buffers
+            .get_owned(buffer_id)
+            .map_err(|_| RenderPassErrorInner::InvalidBuffer(buffer_id))
+            .map_pass_err(scope)?;
+        let count_buffer = buffers
+            .get_owned(buffer_id)
+            .map_err(|_| RenderPassErrorInner::InvalidBuffer(count_buffer_id))
+            .map_pass_err(scope)?;
+
+        base.commands
+            .push(ArcRenderCommand::MultiDrawIndirectCount {
+                buffer,
+                offset,
+                count_buffer,
+                count_buffer_offset,
+                max_count,
+                indexed: false,
+            });
 
         Ok(())
     }
 
-    pub fn render_pass_multi_draw_indexed_indirect_count(
+    pub fn render_pass_multi_draw_indexed_indirect_count<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         buffer_id: id::BufferId,
         offset: BufferAddress,
         count_buffer_id: id::BufferId,
@@ -2989,21 +3248,35 @@ impl Global {
         };
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::MultiDrawIndirectCount {
-            buffer_id,
-            offset,
-            count_buffer_id,
-            count_buffer_offset,
-            max_count,
-            indexed: true,
-        });
+        // Don't use resolve_render_pass_buffer_id here, because we don't want to take the read-lock twice.
+        let hub = A::hub(self);
+        let buffers = hub.buffers.read();
+        let buffer = buffers
+            .get_owned(buffer_id)
+            .map_err(|_| RenderPassErrorInner::InvalidBuffer(buffer_id))
+            .map_pass_err(scope)?;
+
+        let count_buffer = buffers
+            .get_owned(buffer_id)
+            .map_err(|_| RenderPassErrorInner::InvalidBuffer(count_buffer_id))
+            .map_pass_err(scope)?;
+
+        base.commands
+            .push(ArcRenderCommand::MultiDrawIndirectCount {
+                buffer,
+                offset,
+                count_buffer,
+                count_buffer_offset,
+                max_count,
+                indexed: true,
+            });
 
         Ok(())
     }
 
-    pub fn render_pass_push_debug_group(
+    pub fn render_pass_push_debug_group<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         label: &str,
         color: u32,
     ) -> Result<(), RenderPassError> {
@@ -3012,7 +3285,7 @@ impl Global {
         let bytes = label.as_bytes();
         base.string_data.extend_from_slice(bytes);
 
-        base.commands.push(RenderCommand::PushDebugGroup {
+        base.commands.push(ArcRenderCommand::PushDebugGroup {
             color,
             len: bytes.len(),
         });
@@ -3020,20 +3293,20 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_pop_debug_group(
+    pub fn render_pass_pop_debug_group<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
     ) -> Result<(), RenderPassError> {
         let base = pass.base_mut(PassErrorScope::PopDebugGroup)?;
 
-        base.commands.push(RenderCommand::PopDebugGroup);
+        base.commands.push(ArcRenderCommand::PopDebugGroup);
 
         Ok(())
     }
 
-    pub fn render_pass_insert_debug_marker(
+    pub fn render_pass_insert_debug_marker<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         label: &str,
         color: u32,
     ) -> Result<(), RenderPassError> {
@@ -3042,7 +3315,7 @@ impl Global {
         let bytes = label.as_bytes();
         base.string_data.extend_from_slice(bytes);
 
-        base.commands.push(RenderCommand::InsertDebugMarker {
+        base.commands.push(ArcRenderCommand::InsertDebugMarker {
             color,
             len: bytes.len(),
         });
@@ -3050,52 +3323,52 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_write_timestamp(
+    pub fn render_pass_write_timestamp<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), RenderPassError> {
         let scope = PassErrorScope::WriteTimestamp;
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::WriteTimestamp {
-            query_set_id,
+        base.commands.push(ArcRenderCommand::WriteTimestamp {
+            query_set: self.resolve_render_pass_query_set(scope, query_set_id)?,
             query_index,
         });
 
         Ok(())
     }
 
-    pub fn render_pass_begin_occlusion_query(
+    pub fn render_pass_begin_occlusion_query<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         query_index: u32,
     ) -> Result<(), RenderPassError> {
         let scope = PassErrorScope::BeginOcclusionQuery;
         let base = pass.base_mut(scope)?;
 
         base.commands
-            .push(RenderCommand::BeginOcclusionQuery { query_index });
+            .push(ArcRenderCommand::BeginOcclusionQuery { query_index });
 
         Ok(())
     }
 
-    pub fn render_pass_end_occlusion_query(
+    pub fn render_pass_end_occlusion_query<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
     ) -> Result<(), RenderPassError> {
         let scope = PassErrorScope::EndOcclusionQuery;
         let base = pass.base_mut(scope)?;
 
-        base.commands.push(RenderCommand::EndOcclusionQuery);
+        base.commands.push(ArcRenderCommand::EndOcclusionQuery);
 
         Ok(())
     }
 
-    pub fn render_pass_begin_pipeline_statistics_query(
+    pub fn render_pass_begin_pipeline_statistics_query<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), RenderPassError> {
@@ -3103,37 +3376,45 @@ impl Global {
         let base = pass.base_mut(scope)?;
 
         base.commands
-            .push(RenderCommand::BeginPipelineStatisticsQuery {
-                query_set_id,
+            .push(ArcRenderCommand::BeginPipelineStatisticsQuery {
+                query_set: self.resolve_render_pass_query_set(scope, query_set_id)?,
                 query_index,
             });
 
         Ok(())
     }
 
-    pub fn render_pass_end_pipeline_statistics_query(
+    pub fn render_pass_end_pipeline_statistics_query<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
     ) -> Result<(), RenderPassError> {
         let scope = PassErrorScope::EndPipelineStatisticsQuery;
         let base = pass.base_mut(scope)?;
 
         base.commands
-            .push(RenderCommand::EndPipelineStatisticsQuery);
+            .push(ArcRenderCommand::EndPipelineStatisticsQuery);
 
         Ok(())
     }
 
-    pub fn render_pass_execute_bundles(
+    pub fn render_pass_execute_bundles<A: HalApi>(
         &self,
-        pass: &mut RenderPass,
+        pass: &mut RenderPass<A>,
         render_bundle_ids: &[id::RenderBundleId],
     ) -> Result<(), RenderPassError> {
         let scope = PassErrorScope::ExecuteBundle;
         let base = pass.base_mut(scope)?;
 
+        let hub = A::hub(self);
+        let bundles = hub.render_bundles.read();
+
         for &bundle_id in render_bundle_ids {
-            base.commands.push(RenderCommand::ExecuteBundle(bundle_id));
+            let bundle = bundles
+                .get_owned(bundle_id)
+                .map_err(|_| RenderPassErrorInner::InvalidRenderBundle(bundle_id))
+                .map_pass_err(scope)?;
+
+            base.commands.push(ArcRenderCommand::ExecuteBundle(bundle));
         }
         pass.current_pipeline.reset();
         pass.current_bind_groups.reset();

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -51,7 +51,7 @@ use serde::Serialize;
 use std::sync::Arc;
 use std::{borrow::Cow, fmt, iter, mem, num::NonZeroU32, ops::Range, str};
 
-use super::render_command::{ArcRenderCommand, RenderCommand};
+use super::render_command::ArcRenderCommand;
 use super::{
     memory_init::TextureSurfaceDiscard, CommandBufferTextureMemoryActions, CommandEncoder,
     QueryResetMap,
@@ -1496,10 +1496,11 @@ impl Global {
     }
 
     #[doc(hidden)]
+    #[cfg(feature = "replay")]
     pub fn render_pass_end_with_unresolved_commands<A: HalApi>(
         &self,
         encoder_id: id::CommandEncoderId,
-        base: BasePass<RenderCommand>,
+        base: BasePass<super::RenderCommand>,
         color_attachments: &[Option<RenderPassColorAttachment>],
         depth_stencil_attachment: Option<&RenderPassDepthStencilAttachment>,
         timestamp_writes: Option<&PassTimestampWrites>,
@@ -1533,7 +1534,7 @@ impl Global {
         let hub = A::hub(self);
         render_pass.base = Some(BasePass {
             label,
-            commands: RenderCommand::resolve_render_command_ids(hub, &commands)?,
+            commands: super::RenderCommand::resolve_render_command_ids(hub, &commands)?,
             dynamic_offsets,
             string_data,
             push_constant_data,

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -9,10 +9,7 @@ use wgt::{BufferAddress, BufferSize, Color};
 
 use std::{num::NonZeroU32, sync::Arc};
 
-use super::{
-    DrawKind, PassErrorScope, Rect, RenderBundle, RenderCommandError, RenderPassError,
-    RenderPassErrorInner,
-};
+use super::{Rect, RenderBundle};
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
@@ -128,13 +125,15 @@ pub enum RenderCommand {
 
 impl RenderCommand {
     /// Resolves all ids in a list of commands into the corresponding resource Arc.
-    //
-    // TODO: Once resolving is done on-the-fly during recording, this function should be only needed with the replay feature:
-    // #[cfg(feature = "replay")]
+    #[cfg(feature = "replay")]
     pub fn resolve_render_command_ids<A: HalApi>(
         hub: &crate::hub::Hub<A>,
         commands: &[RenderCommand],
-    ) -> Result<Vec<ArcRenderCommand<A>>, RenderPassError> {
+    ) -> Result<Vec<ArcRenderCommand<A>>, super::RenderPassError> {
+        use super::{
+            DrawKind, PassErrorScope, RenderCommandError, RenderPassError, RenderPassErrorInner,
+        };
+
         let buffers_guard = hub.buffers.read();
         let bind_group_guard = hub.bind_groups.read();
         let query_set_guard = hub.query_sets.read();

--- a/wgpu-core/src/command/timestamp_writes.rs
+++ b/wgpu-core/src/command/timestamp_writes.rs
@@ -1,0 +1,25 @@
+use std::sync::Arc;
+
+use crate::{hal_api::HalApi, id};
+
+/// Describes the writing of timestamp values in a render or compute pass.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PassTimestampWrites {
+    /// The query set to write the timestamps to.
+    pub query_set: id::QuerySetId,
+    /// The index of the query set at which a start timestamp of this pass is written, if any.
+    pub beginning_of_pass_write_index: Option<u32>,
+    /// The index of the query set at which an end timestamp of this pass is written, if any.
+    pub end_of_pass_write_index: Option<u32>,
+}
+
+/// Describes the writing of timestamp values in a render or compute pass with the query set resolved.
+pub struct ArcPassTimestampWrites<A: HalApi> {
+    /// The query set to write the timestamps to.
+    pub query_set: Arc<crate::resource::QuerySet<A>>,
+    /// The index of the query set at which a start timestamp of this pass is written, if any.
+    pub beginning_of_pass_write_index: Option<u32>,
+    /// The index of the query set at which an end timestamp of this pass is written, if any.
+    pub end_of_pass_write_index: Option<u32>,
+}

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -60,15 +60,6 @@ pub(crate) struct AttachmentData<T> {
     pub depth_stencil: Option<T>,
 }
 impl<T: PartialEq> Eq for AttachmentData<T> {}
-impl<T> AttachmentData<T> {
-    pub(crate) fn map<U, F: Fn(&T) -> U>(&self, fun: F) -> AttachmentData<U> {
-        AttachmentData {
-            colors: self.colors.iter().map(|c| c.as_ref().map(&fun)).collect(),
-            resolves: self.resolves.iter().map(&fun).collect(),
-            depth_stencil: self.depth_stencil.as_ref().map(&fun),
-        }
-    }
-}
 
 #[derive(Clone, Debug, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -179,13 +179,13 @@ pub enum Command {
     InsertDebugMarker(String),
     RunComputePass {
         base: crate::command::BasePass<crate::command::ComputeCommand>,
-        timestamp_writes: Option<crate::command::ComputePassTimestampWrites>,
+        timestamp_writes: Option<crate::command::PassTimestampWrites>,
     },
     RunRenderPass {
         base: crate::command::BasePass<crate::command::RenderCommand>,
         target_colors: Vec<Option<crate::command::RenderPassColorAttachment>>,
         target_depth_stencil: Option<crate::command::RenderPassDepthStencilAttachment>,
-        timestamp_writes: Option<crate::command::RenderPassTimestampWrites>,
+        timestamp_writes: Option<crate::command::PassTimestampWrites>,
         occlusion_query_set_id: Option<id::QuerySetId>,
     },
 }

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2570,7 +2570,7 @@ impl crate::context::Context for ContextWebGpu {
         &self,
         _encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        desc: &crate::RenderPassDescriptor<'_, '_>,
+        desc: &crate::RenderPassDescriptor<'_>,
     ) -> (Self::RenderPassId, Self::RenderPassData) {
         let mapped_color_attachments = desc
             .color_attachments

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -490,7 +490,7 @@ pub struct ComputePass {
 
 #[derive(Debug)]
 pub struct RenderPass {
-    pass: wgc::command::RenderPass,
+    pass: Box<dyn wgc::command::DynRenderPass>,
     error_sink: ErrorSink,
 }
 
@@ -1988,21 +1988,28 @@ impl crate::Context for ContextWgpuCore {
                     end_of_pass_write_index: tw.end_of_pass_write_index,
                 });
 
+        let (pass, err) = gfx_select!(encoder => self.0.command_encoder_create_render_pass_dyn(*encoder, &wgc::command::RenderPassDescriptor {
+            label: desc.label.map(Borrowed),
+            timestamp_writes: timestamp_writes.as_ref(),
+            color_attachments: std::borrow::Cow::Borrowed(&colors),
+            depth_stencil_attachment: depth_stencil.as_ref(),
+            occlusion_query_set: desc.occlusion_query_set.map(|query_set| query_set.id.into()),
+        }));
+
+        if let Some(cause) = err {
+            self.handle_error(
+                &encoder_data.error_sink,
+                cause,
+                LABEL,
+                desc.label,
+                "CommandEncoder::begin_compute_pass",
+            );
+        }
+
         (
             Unused,
-            RenderPass {
-                pass: wgc::command::RenderPass::new(
-                    *encoder,
-                    &wgc::command::RenderPassDescriptor {
-                        label: desc.label.map(Borrowed),
-                        color_attachments: Borrowed(&colors),
-                        depth_stencil_attachment: depth_stencil.as_ref(),
-                        timestamp_writes: timestamp_writes.as_ref(),
-                        occlusion_query_set: desc
-                            .occlusion_query_set
-                            .map(|query_set| query_set.id.into()),
-                    },
-                ),
+            Self::RenderPassData {
+                pass,
                 error_sink: encoder_data.error_sink.clone(),
             },
         )
@@ -2810,10 +2817,7 @@ impl crate::Context for ContextWgpuCore {
         pipeline: &Self::RenderPipelineId,
         _pipeline_data: &Self::RenderPipelineData,
     ) {
-        if let Err(cause) = self
-            .0
-            .render_pass_set_pipeline(&mut pass_data.pass, *pipeline)
-        {
+        if let Err(cause) = pass_data.pass.set_pipeline(&self.0, *pipeline) {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -2833,9 +2837,9 @@ impl crate::Context for ContextWgpuCore {
         _bind_group_data: &Self::BindGroupData,
         offsets: &[wgt::DynamicOffset],
     ) {
-        if let Err(cause) =
-            self.0
-                .render_pass_set_bind_group(&mut pass_data.pass, index, *bind_group, offsets)
+        if let Err(cause) = pass_data
+            .pass
+            .set_bind_group(&self.0, index, *bind_group, offsets)
         {
             self.handle_error(
                 &pass_data.error_sink,
@@ -2857,13 +2861,11 @@ impl crate::Context for ContextWgpuCore {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
-        if let Err(cause) = self.0.render_pass_set_index_buffer(
-            &mut pass_data.pass,
-            *buffer,
-            index_format,
-            offset,
-            size,
-        ) {
+        if let Err(cause) =
+            pass_data
+                .pass
+                .set_index_buffer(&self.0, *buffer, index_format, offset, size)
+        {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -2884,9 +2886,9 @@ impl crate::Context for ContextWgpuCore {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
-        if let Err(cause) =
-            self.0
-                .render_pass_set_vertex_buffer(&mut pass_data.pass, slot, *buffer, offset, size)
+        if let Err(cause) = pass_data
+            .pass
+            .set_vertex_buffer(&self.0, slot, *buffer, offset, size)
         {
             self.handle_error(
                 &pass_data.error_sink,
@@ -2906,9 +2908,9 @@ impl crate::Context for ContextWgpuCore {
         offset: u32,
         data: &[u8],
     ) {
-        if let Err(cause) =
-            self.0
-                .render_pass_set_push_constants(&mut pass_data.pass, stages, offset, data)
+        if let Err(cause) = pass_data
+            .pass
+            .set_push_constants(&self.0, stages, offset, data)
         {
             self.handle_error(
                 &pass_data.error_sink,
@@ -2927,8 +2929,8 @@ impl crate::Context for ContextWgpuCore {
         vertices: Range<u32>,
         instances: Range<u32>,
     ) {
-        if let Err(cause) = self.0.render_pass_draw(
-            &mut pass_data.pass,
+        if let Err(cause) = pass_data.pass.draw(
+            &self.0,
             vertices.end - vertices.start,
             instances.end - instances.start,
             vertices.start,
@@ -2952,8 +2954,8 @@ impl crate::Context for ContextWgpuCore {
         base_vertex: i32,
         instances: Range<u32>,
     ) {
-        if let Err(cause) = self.0.render_pass_draw_indexed(
-            &mut pass_data.pass,
+        if let Err(cause) = pass_data.pass.draw_indexed(
+            &self.0,
             indices.end - indices.start,
             instances.end - instances.start,
             indices.start,
@@ -2978,9 +2980,9 @@ impl crate::Context for ContextWgpuCore {
         _indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        if let Err(cause) =
-            self.0
-                .render_pass_draw_indirect(&mut pass_data.pass, *indirect_buffer, indirect_offset)
+        if let Err(cause) = pass_data
+            .pass
+            .draw_indirect(&self.0, *indirect_buffer, indirect_offset)
         {
             self.handle_error(
                 &pass_data.error_sink,
@@ -3000,11 +3002,11 @@ impl crate::Context for ContextWgpuCore {
         _indirect_buffer_data: &Self::BufferData,
         indirect_offset: wgt::BufferAddress,
     ) {
-        if let Err(cause) = self.0.render_pass_draw_indexed_indirect(
-            &mut pass_data.pass,
-            *indirect_buffer,
-            indirect_offset,
-        ) {
+        if let Err(cause) =
+            pass_data
+                .pass
+                .draw_indexed_indirect(&self.0, *indirect_buffer, indirect_offset)
+        {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3024,12 +3026,11 @@ impl crate::Context for ContextWgpuCore {
         indirect_offset: wgt::BufferAddress,
         count: u32,
     ) {
-        if let Err(cause) = self.0.render_pass_multi_draw_indirect(
-            &mut pass_data.pass,
-            *indirect_buffer,
-            indirect_offset,
-            count,
-        ) {
+        if let Err(cause) =
+            pass_data
+                .pass
+                .multi_draw_indirect(&self.0, *indirect_buffer, indirect_offset, count)
+        {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3049,8 +3050,8 @@ impl crate::Context for ContextWgpuCore {
         indirect_offset: wgt::BufferAddress,
         count: u32,
     ) {
-        if let Err(cause) = self.0.render_pass_multi_draw_indexed_indirect(
-            &mut pass_data.pass,
+        if let Err(cause) = pass_data.pass.multi_draw_indexed_indirect(
+            &self.0,
             *indirect_buffer,
             indirect_offset,
             count,
@@ -3077,8 +3078,8 @@ impl crate::Context for ContextWgpuCore {
         count_buffer_offset: wgt::BufferAddress,
         max_count: u32,
     ) {
-        if let Err(cause) = self.0.render_pass_multi_draw_indirect_count(
-            &mut pass_data.pass,
+        if let Err(cause) = pass_data.pass.multi_draw_indirect_count(
+            &self.0,
             *indirect_buffer,
             indirect_offset,
             *count_buffer,
@@ -3107,8 +3108,8 @@ impl crate::Context for ContextWgpuCore {
         count_buffer_offset: wgt::BufferAddress,
         max_count: u32,
     ) {
-        if let Err(cause) = self.0.render_pass_multi_draw_indexed_indirect_count(
-            &mut pass_data.pass,
+        if let Err(cause) = pass_data.pass.multi_draw_indexed_indirect_count(
+            &self.0,
             *indirect_buffer,
             indirect_offset,
             *count_buffer,
@@ -3131,10 +3132,7 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::RenderPassData,
         color: wgt::Color,
     ) {
-        if let Err(cause) = self
-            .0
-            .render_pass_set_blend_constant(&mut pass_data.pass, &color)
-        {
+        if let Err(cause) = pass_data.pass.set_blend_constant(&self.0, color) {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3154,9 +3152,9 @@ impl crate::Context for ContextWgpuCore {
         width: u32,
         height: u32,
     ) {
-        if let Err(cause) =
-            self.0
-                .render_pass_set_scissor_rect(&mut pass_data.pass, x, y, width, height)
+        if let Err(cause) = pass_data
+            .pass
+            .set_scissor_rect(&self.0, x, y, width, height)
         {
             self.handle_error(
                 &pass_data.error_sink,
@@ -3179,15 +3177,10 @@ impl crate::Context for ContextWgpuCore {
         min_depth: f32,
         max_depth: f32,
     ) {
-        if let Err(cause) = self.0.render_pass_set_viewport(
-            &mut pass_data.pass,
-            x,
-            y,
-            width,
-            height,
-            min_depth,
-            max_depth,
-        ) {
+        if let Err(cause) = pass_data
+            .pass
+            .set_viewport(&self.0, x, y, width, height, min_depth, max_depth)
+        {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3204,10 +3197,7 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::RenderPassData,
         reference: u32,
     ) {
-        if let Err(cause) = self
-            .0
-            .render_pass_set_stencil_reference(&mut pass_data.pass, reference)
-        {
+        if let Err(cause) = pass_data.pass.set_stencil_reference(&self.0, reference) {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3224,10 +3214,7 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::RenderPassData,
         label: &str,
     ) {
-        if let Err(cause) = self
-            .0
-            .render_pass_insert_debug_marker(&mut pass_data.pass, label, 0)
-        {
+        if let Err(cause) = pass_data.pass.insert_debug_marker(&self.0, label, 0) {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3244,10 +3231,7 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::RenderPassData,
         group_label: &str,
     ) {
-        if let Err(cause) = self
-            .0
-            .render_pass_push_debug_group(&mut pass_data.pass, group_label, 0)
-        {
+        if let Err(cause) = pass_data.pass.push_debug_group(&self.0, group_label, 0) {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3263,7 +3247,7 @@ impl crate::Context for ContextWgpuCore {
         _pass: &mut Self::RenderPassId,
         pass_data: &mut Self::RenderPassData,
     ) {
-        if let Err(cause) = self.0.render_pass_pop_debug_group(&mut pass_data.pass) {
+        if let Err(cause) = pass_data.pass.pop_debug_group(&self.0) {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3282,9 +3266,9 @@ impl crate::Context for ContextWgpuCore {
         _query_set_data: &Self::QuerySetData,
         query_index: u32,
     ) {
-        if let Err(cause) =
-            self.0
-                .render_pass_write_timestamp(&mut pass_data.pass, *query_set, query_index)
+        if let Err(cause) = pass_data
+            .pass
+            .write_timestamp(&self.0, *query_set, query_index)
         {
             self.handle_error(
                 &pass_data.error_sink,
@@ -3302,10 +3286,7 @@ impl crate::Context for ContextWgpuCore {
         pass_data: &mut Self::RenderPassData,
         query_index: u32,
     ) {
-        if let Err(cause) = self
-            .0
-            .render_pass_begin_occlusion_query(&mut pass_data.pass, query_index)
-        {
+        if let Err(cause) = pass_data.pass.begin_occlusion_query(&self.0, query_index) {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3321,7 +3302,7 @@ impl crate::Context for ContextWgpuCore {
         _pass: &mut Self::RenderPassId,
         pass_data: &mut Self::RenderPassData,
     ) {
-        if let Err(cause) = self.0.render_pass_end_occlusion_query(&mut pass_data.pass) {
+        if let Err(cause) = pass_data.pass.end_occlusion_query(&self.0) {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3340,11 +3321,11 @@ impl crate::Context for ContextWgpuCore {
         _query_set_data: &Self::QuerySetData,
         query_index: u32,
     ) {
-        if let Err(cause) = self.0.render_pass_begin_pipeline_statistics_query(
-            &mut pass_data.pass,
-            *query_set,
-            query_index,
-        ) {
+        if let Err(cause) =
+            pass_data
+                .pass
+                .begin_pipeline_statistics_query(&self.0, *query_set, query_index)
+        {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3360,10 +3341,7 @@ impl crate::Context for ContextWgpuCore {
         _pass: &mut Self::RenderPassId,
         pass_data: &mut Self::RenderPassData,
     ) {
-        if let Err(cause) = self
-            .0
-            .render_pass_end_pipeline_statistics_query(&mut pass_data.pass)
-        {
+        if let Err(cause) = pass_data.pass.end_pipeline_statistics_query(&self.0) {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,
@@ -3381,9 +3359,9 @@ impl crate::Context for ContextWgpuCore {
         render_bundles: &mut dyn Iterator<Item = (Self::RenderBundleId, &Self::RenderBundleData)>,
     ) {
         let temp_render_bundles = render_bundles.map(|(i, _)| i).collect::<SmallVec<[_; 4]>>();
-        if let Err(cause) = self
-            .0
-            .render_pass_execute_bundles(&mut pass_data.pass, &temp_render_bundles)
+        if let Err(cause) = pass_data
+            .pass
+            .execute_bundles(&self.0, &temp_render_bundles)
         {
             self.handle_error(
                 &pass_data.error_sink,
@@ -3400,9 +3378,7 @@ impl crate::Context for ContextWgpuCore {
         _pass: &mut Self::RenderPassId,
         pass_data: &mut Self::RenderPassData,
     ) {
-        let encoder = pass_data.pass.parent_id();
-        if let Err(cause) = wgc::gfx_select!(encoder => self.0.render_pass_end(&mut pass_data.pass))
-        {
+        if let Err(cause) = pass_data.pass.end(&self.0) {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1947,7 +1947,7 @@ impl crate::Context for ContextWgpuCore {
         &self,
         encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        desc: &crate::RenderPassDescriptor<'_, '_>,
+        desc: &crate::RenderPassDescriptor<'_>,
     ) -> (Self::RenderPassId, Self::RenderPassData) {
         if desc.color_attachments.len() > wgc::MAX_COLOR_ATTACHMENTS {
             self.handle_error_fatal(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1913,7 +1913,7 @@ impl crate::Context for ContextWgpuCore {
         let timestamp_writes =
             desc.timestamp_writes
                 .as_ref()
-                .map(|tw| wgc::command::ComputePassTimestampWrites {
+                .map(|tw| wgc::command::PassTimestampWrites {
                     query_set: tw.query_set.id.into(),
                     beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
                     end_of_pass_write_index: tw.end_of_pass_write_index,
@@ -1982,7 +1982,7 @@ impl crate::Context for ContextWgpuCore {
         let timestamp_writes =
             desc.timestamp_writes
                 .as_ref()
-                .map(|tw| wgc::command::RenderPassTimestampWrites {
+                .map(|tw| wgc::command::PassTimestampWrites {
                     query_set: tw.query_set.id.into(),
                     beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
                     end_of_pass_write_index: tw.end_of_pass_write_index,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2438,7 +2438,7 @@ impl crate::Context for ContextWgpuCore {
         offset: u32,
         data: &[u8],
     ) {
-        if let Err(cause) = pass_data.pass.set_push_constant(&self.0, offset, data) {
+        if let Err(cause) = pass_data.pass.set_push_constants(&self.0, offset, data) {
             self.handle_error(
                 &pass_data.error_sink,
                 cause,

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -470,7 +470,7 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         &self,
         encoder: &Self::CommandEncoderId,
         encoder_data: &Self::CommandEncoderData,
-        desc: &RenderPassDescriptor<'_, '_>,
+        desc: &RenderPassDescriptor<'_>,
     ) -> (Self::RenderPassId, Self::RenderPassData);
     fn command_encoder_finish(
         &self,
@@ -1477,7 +1477,7 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        desc: &RenderPassDescriptor<'_, '_>,
+        desc: &RenderPassDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>);
     fn command_encoder_finish(
         &self,
@@ -2799,7 +2799,7 @@ where
         &self,
         encoder: &ObjectId,
         encoder_data: &crate::Data,
-        desc: &RenderPassDescriptor<'_, '_>,
+        desc: &RenderPassDescriptor<'_>,
     ) -> (ObjectId, Box<crate::Data>) {
         let encoder = <T::CommandEncoderId>::from(*encoder);
         let encoder_data = downcast_ref(encoder_data);


### PR DESCRIPTION
**Connections**
* Fixes https://github.com/gfx-rs/wgpu/issues/1453
    * 🥳🥳🥳  
* Follow-up to #5794
* Equivalent to previous compute pass prs:
   * https://github.com/gfx-rs/wgpu/pull/5575
   * https://github.com/gfx-rs/wgpu/pull/5620
   * https://github.com/gfx-rs/wgpu/pull/5671 
   * #5768

**Description**
Just like ComputePass before, we now take ownership of all ingoing resources to a RenderPass right away. We also take ownership of the parent encoder, making it possible to convert `RenderPass<'a>`->`RenderPass<'static>` (as opt-in)

**Testing**
New ownership tests added (very similar to what we added for compute pass previously)

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
