### PR TITLE
Fix soundness issue with Snatchable

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1472,23 +1472,25 @@ impl Global {
                 )
                 .collect::<Vec<_>>();
 
-            let mut submit_surface_textures =
-                SmallVec::<[_; 2]>::with_capacity(submit_surface_textures_owned.len());
+            {
+                let mut submit_surface_textures =
+                    SmallVec::<[_; 2]>::with_capacity(submit_surface_textures_owned.len());
 
-            for texture in submit_surface_textures_owned.values() {
-                submit_surface_textures.extend(match texture.inner.get(&snatch_guard) {
-                    Some(TextureInner::Surface { raw, .. }) => raw.as_ref(),
-                    _ => None,
-                });
-            }
+                for texture in submit_surface_textures_owned.values() {
+                    submit_surface_textures.extend(match texture.inner.get(&snatch_guard) {
+                        Some(TextureInner::Surface { raw, .. }) => raw.as_ref(),
+                        _ => None,
+                    });
+                }
 
-            unsafe {
-                queue
-                    .raw
-                    .as_ref()
-                    .unwrap()
-                    .submit(&refs, &submit_surface_textures, (fence, submit_index))
-                    .map_err(DeviceError::from)?;
+                unsafe {
+                    queue
+                        .raw
+                        .as_ref()
+                        .unwrap()
+                        .submit(&refs, &submit_surface_textures, (fence, submit_index))
+                        .map_err(DeviceError::from)?;
+                }
             }
 
             profiling::scope!("cleanup");

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -467,7 +467,7 @@ impl<A: HalApi> Drop for Buffer<A> {
 }
 
 impl<A: HalApi> Buffer<A> {
-    pub(crate) fn raw(&self, guard: &SnatchGuard) -> Option<&A::Buffer> {
+    pub(crate) fn raw<'a>(&'a self, guard: &'a SnatchGuard) -> Option<&'a A::Buffer> {
         self.raw.get(guard)
     }
 
@@ -1054,7 +1054,7 @@ impl<A: HalApi> Texture<A> {
 
     pub(crate) fn inner_mut<'a>(
         &'a self,
-        guard: &mut ExclusiveSnatchGuard,
+        guard: &'a mut ExclusiveSnatchGuard,
     ) -> Option<&'a mut TextureInner<A>> {
         self.inner.get_mut(guard)
     }
@@ -1153,10 +1153,8 @@ impl Global {
         let buffer_opt = { hub.buffers.try_get(id).ok().flatten() };
         let buffer = buffer_opt.as_ref().unwrap();
 
-        let hal_buffer = {
-            let snatch_guard = buffer.device.snatchable_lock.read();
-            buffer.raw(&snatch_guard)
-        };
+        let snatch_guard = buffer.device.snatchable_lock.read();
+        let hal_buffer = buffer.raw(&snatch_guard);
 
         hal_buffer_callback(hal_buffer)
     }

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -33,12 +33,12 @@ impl<T> Snatchable<T> {
     }
 
     /// Get read access to the value. Requires a the snatchable lock's read guard.
-    pub fn get(&self, _guard: &SnatchGuard) -> Option<&T> {
+    pub fn get<'a>(&'a self, _guard: &'a SnatchGuard) -> Option<&'a T> {
         unsafe { (*self.value.get()).as_ref() }
     }
 
     /// Get write access to the value. Requires a the snatchable lock's write guard.
-    pub fn get_mut(&self, _guard: &mut ExclusiveSnatchGuard) -> Option<&mut T> {
+    pub fn get_mut<'a>(&'a self, _guard: &'a mut ExclusiveSnatchGuard) -> Option<&'a mut T> {
         unsafe { (*self.value.get()).as_mut() }
     }
 


### PR DESCRIPTION
The code was written with the incorrect assumption that if no lifetime is specified in a method definition, then all lifetimes are elided to the lifetime of self. In fact only lifetimes in the returned value are elided to the lifetime of self, and other parameters get their own lifetimes.

Kudos to @teoxoy for catching the issue!

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
