### PR TITLE
 Initial Support for DRM interface in vulkan backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,7 @@ ndk-sys = "0.5.0"
 #web-sys = { path = "../wasm-bindgen/crates/web-sys" }
 #js-sys = { path = "../wasm-bindgen/crates/js-sys" }
 #wasm-bindgen = { path = "../wasm-bindgen" }
+raw-window-handle = { git = "https://github.com/morr0ne/raw-window-handle", branch = "drm-connector" }
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
This pull request introduces initial support for the Linux [DRM interface](https://en.wikipedia.org/wiki/Direct_Rendering_Manager) in wgpu. This enables wgpu to be utilized in environments where a windowing system is unavailable and, more importantly, allows wgpu to function as a renderer for Wayland compositors.

For additional context, please refer to issue #1674.

The implementation is straightforward, though there are known limitations due to my limited familiarity with wgpu internals:
 - Physical device selection is mostly hardcoded, as the method to dynamically select the device used by wgpu is unclear to me.
 - Validation and error handling are lacking, making the code prone to crashes.
 - There is no mechanism to guide wgpu in selecting the appropriate display mode, defaulting to the first available mode, which may not be the correct one.

Despite these issues, the code functions, and I demonstrated this by porting the hello_triangle example, available here: https://github.com/verdiwm/diretto/blob/main/examples/wgpu.rs

I also created a [fork](https://github.com/morr0ne/raw-window-handle/tree/drm-connector) of raw-window-handle, adding the necessary connector_id for display initialization.

While this pull request is not ready for merging, I am submitting it to illustrate the feasibility of DRM support and to receive feedback from the wgpu development team.