### PR TITLE
refactor: use built-in `{integer}::power_of_two` methods

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -84,7 +84,6 @@ use crate::{
         BasePass, BindGroupStateChange, ColorAttachmentError, DrawError, MapPassErr,
         PassErrorScope, RenderCommandError, StateChange,
     },
-    conv,
     device::{
         AttachmentData, Device, DeviceError, MissingDownlevelFlags, RenderPassContext,
         SHADER_STAGE_COUNT,
@@ -287,7 +286,7 @@ impl RenderBundleEncoder {
                 },
                 sample_count: {
                     let sc = desc.sample_count;
-                    if sc == 0 || sc > 32 || !conv::is_power_of_two_u32(sc) {
+                    if sc == 0 || sc > 32 || !sc.is_power_of_two() {
                         return Err(CreateRenderBundleError::InvalidSampleCount(sc));
                     }
                     sc

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -2,14 +2,6 @@ use wgt::TextureFormatFeatures;
 
 use crate::resource::{self, TextureDescriptor};
 
-pub fn is_power_of_two_u16(val: u16) -> bool {
-    val != 0 && (val & (val - 1)) == 0
-}
-
-pub fn is_power_of_two_u32(val: u32) -> bool {
-    val != 0 && (val & (val - 1)) == 0
-}
-
 pub fn is_valid_copy_src_texture_format(
     format: wgt::TextureFormat,
     aspect: wgt::TextureAspect,
@@ -233,7 +225,7 @@ pub fn check_texture_dimension_size(
             return Err(Tde::LimitExceeded { dim, given, limit });
         }
     }
-    if sample_size == 0 || sample_size > sample_limit || !is_power_of_two_u32(sample_size) {
+    if sample_size == 0 || sample_size > sample_limit || !sample_size.is_power_of_two() {
         return Err(Tde::InvalidSampleCount(sample_size));
     }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3176,7 +3176,7 @@ impl<A: HalApi> Device<A> {
 
         let samples = {
             let sc = desc.multisample.count;
-            if sc == 0 || sc > 32 || !conv::is_power_of_two_u32(sc) {
+            if sc == 0 || sc > 32 || !sc.is_power_of_two() {
                 return Err(pipeline::CreateRenderPipelineError::InvalidSampleCount(sc));
             }
             sc

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -102,7 +102,7 @@ mod stateless;
 mod texture;
 
 use crate::{
-    binding_model, command, conv,
+    binding_model, command,
     hal_api::HalApi,
     lock::{rank, Mutex, RwLock},
     pipeline,
@@ -323,7 +323,7 @@ pub(crate) trait ResourceUses:
 fn invalid_resource_state<T: ResourceUses>(state: T) -> bool {
     // Is power of two also means "is one bit set". We check for this as if
     // we're in any exclusive state, we must only be in a single state.
-    state.any_exclusive() && !conv::is_power_of_two_u16(state.bits())
+    state.any_exclusive() && !state.bits().is_power_of_two()
 }
 
 /// Returns true if the transition from one state to another does not require


### PR DESCRIPTION
**Connections**

N/A

**Description**

This is a win overall because it can use an implementation in `std`,
_and_ can often compile to an intrinsic to save instructions.

Upstream implementation:
<https://github.com/rust-lang/rust/blob/9f877c9cd2c3f8f2f64df1e0c1804ad0682416d0/library/core/src/num/nonzero.rs#L1219>

**Testing**

I think CI is persuasive enough here.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ I don't think this is necessary.
