### PR TITLE
Remove the triage suspected machinery and break cycles with weak refs

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -1,9 +1,5 @@
 /*! This is a player library for WebGPU traces.
  *
- * # Notes
- * - we call device_maintain_ids() before creating any refcounted resource,
- *   which is basically everything except for BGL and shader modules,
- *   so that we don't accidentally try to use the same ID.
 !*/
 #![cfg(not(target_arch = "wasm32"))]
 #![warn(unsafe_op_in_unsafe_fn)]
@@ -153,7 +149,6 @@ impl GlobalPlay for wgc::global::Global {
                 panic!("Unexpected Surface action: winit feature is not enabled")
             }
             Action::CreateBuffer(id, desc) => {
-                self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_buffer::<A>(device, &desc, Some(id));
                 if let Some(e) = error {
                     panic!("{e}");
@@ -166,7 +161,6 @@ impl GlobalPlay for wgc::global::Global {
                 self.buffer_drop::<A>(id, true);
             }
             Action::CreateTexture(id, desc) => {
-                self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_texture::<A>(device, &desc, Some(id));
                 if let Some(e) = error {
                     panic!("{e}");
@@ -183,7 +177,6 @@ impl GlobalPlay for wgc::global::Global {
                 parent_id,
                 desc,
             } => {
-                self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.texture_create_view::<A>(parent_id, &desc, Some(id));
                 if let Some(e) = error {
                     panic!("{e}");
@@ -193,7 +186,6 @@ impl GlobalPlay for wgc::global::Global {
                 self.texture_view_drop::<A>(id, true).unwrap();
             }
             Action::CreateSampler(id, desc) => {
-                self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_sampler::<A>(device, &desc, Some(id));
                 if let Some(e) = error {
                     panic!("{e}");
@@ -203,7 +195,6 @@ impl GlobalPlay for wgc::global::Global {
                 self.sampler_drop::<A>(id);
             }
             Action::GetSurfaceTexture { id, parent_id } => {
-                self.device_maintain_ids::<A>(device).unwrap();
                 self.surface_get_current_texture::<A>(parent_id, Some(id))
                     .unwrap()
                     .texture_id
@@ -219,7 +210,6 @@ impl GlobalPlay for wgc::global::Global {
                 self.bind_group_layout_drop::<A>(id);
             }
             Action::CreatePipelineLayout(id, desc) => {
-                self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_pipeline_layout::<A>(device, &desc, Some(id));
                 if let Some(e) = error {
                     panic!("{e}");
@@ -229,7 +219,6 @@ impl GlobalPlay for wgc::global::Global {
                 self.pipeline_layout_drop::<A>(id);
             }
             Action::CreateBindGroup(id, desc) => {
-                self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_bind_group::<A>(device, &desc, Some(id));
                 if let Some(e) = error {
                     panic!("{e}");
@@ -263,7 +252,6 @@ impl GlobalPlay for wgc::global::Global {
                 desc,
                 implicit_context,
             } => {
-                self.device_maintain_ids::<A>(device).unwrap();
                 let implicit_ids =
                     implicit_context
                         .as_ref()
@@ -285,7 +273,6 @@ impl GlobalPlay for wgc::global::Global {
                 desc,
                 implicit_context,
             } => {
-                self.device_maintain_ids::<A>(device).unwrap();
                 let implicit_ids =
                     implicit_context
                         .as_ref()
@@ -324,7 +311,6 @@ impl GlobalPlay for wgc::global::Global {
                 self.render_bundle_drop::<A>(id);
             }
             Action::CreateQuerySet { id, desc } => {
-                self.device_maintain_ids::<A>(device).unwrap();
                 let (_, error) = self.device_create_query_set::<A>(device, &desc, Some(id));
                 if let Some(e) = error {
                     panic!("{e}");

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -154,7 +154,7 @@ impl Test<'_> {
             let (ptr, size) =
                 wgc::gfx_select!(device_id => global.buffer_get_mapped_range(buffer, expect.offset, Some(expect.data.len() as wgt::BufferAddress)))
                     .unwrap();
-            let contents = unsafe { slice::from_raw_parts(ptr, size as usize) };
+            let contents = unsafe { slice::from_raw_parts(ptr.as_ptr(), size as usize) };
             let expected_data = match expect.data {
                 ExpectedData::Raw(vec) => vec,
                 ExpectedData::File(name, size) => {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -583,12 +583,6 @@ impl RenderBundleEncoder {
 
         let render_bundle = Arc::new(render_bundle);
 
-        device
-            .trackers
-            .lock()
-            .bundles
-            .insert_single(render_bundle.clone());
-
         Ok(render_bundle)
     }
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -16,7 +16,7 @@ use crate::{
         Texture, TextureClearMode,
     },
     snatch::SnatchGuard,
-    track::{TextureSelector, TextureTracker},
+    track::{TextureSelector, TextureTrackerSetSingle},
 };
 
 use hal::CommandEncoder as _;
@@ -269,11 +269,11 @@ impl Global {
     }
 }
 
-pub(crate) fn clear_texture<A: HalApi>(
+pub(crate) fn clear_texture<A: HalApi, T: TextureTrackerSetSingle<A>>(
     dst_texture: &Arc<Texture<A>>,
     range: TextureInitRange,
     encoder: &mut A::CommandEncoder,
-    texture_tracker: &mut TextureTracker<A>,
+    texture_tracker: &mut T,
     alignments: &hal::Alignments,
     zero_buffer: &A::Buffer,
     snatch_guard: &SnatchGuard<'_>,

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -8,7 +8,7 @@ use crate::{
     init_tracker::*,
     resource::{DestroyedResourceError, ParentDevice, Texture, Trackable},
     snatch::SnatchGuard,
-    track::{TextureTracker, Tracker},
+    track::{DeviceTracker, TextureTracker},
     FastHashMap,
 };
 
@@ -167,7 +167,7 @@ impl<A: HalApi> BakedCommands<A> {
     // executing the commands and updates resource init states accordingly
     pub(crate) fn initialize_buffer_memory(
         &mut self,
-        device_tracker: &mut Tracker<A>,
+        device_tracker: &mut DeviceTracker<A>,
         snatch_guard: &SnatchGuard<'_>,
     ) -> Result<(), DestroyedResourceError> {
         profiling::scope!("initialize_buffer_memory");
@@ -267,7 +267,7 @@ impl<A: HalApi> BakedCommands<A> {
     // uninitialized
     pub(crate) fn initialize_texture_memory(
         &mut self,
-        device_tracker: &mut Tracker<A>,
+        device_tracker: &mut DeviceTracker<A>,
         device: &Device<A>,
         snatch_guard: &SnatchGuard<'_>,
     ) -> Result<(), DestroyedResourceError> {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -430,10 +430,11 @@ impl<A: HalApi> CommandBuffer<A> {
     ) {
         profiling::scope!("insert_barriers_from_device_tracker");
 
-        base.buffers.set_from_tracker(&head.buffers);
-        base.textures.set_from_tracker(&head.textures);
+        let buffer_barriers = base
+            .buffers
+            .set_from_tracker_and_drain_transitions(&head.buffers, snatch_guard);
 
-        let buffer_barriers = base.buffers.drain_transitions(snatch_guard);
+        base.textures.set_from_tracker(&head.textures);
         let (transitions, textures) = base.textures.drain_transitions(snatch_guard);
         let texture_barriers = transitions
             .into_iter()

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -35,7 +35,7 @@ use crate::snatch::SnatchGuard;
 
 use crate::init_tracker::BufferInitTrackerAction;
 use crate::resource::Labeled;
-use crate::track::{Tracker, UsageScope};
+use crate::track::{DeviceTracker, Tracker, UsageScope};
 use crate::LabelHelpers;
 use crate::{api_log, global::Global, hal_api::HalApi, id, resource_log, Label};
 
@@ -408,6 +408,30 @@ impl<A: HalApi> CommandBuffer<A> {
         snatch_guard: &SnatchGuard,
     ) {
         profiling::scope!("drain_barriers");
+
+        let buffer_barriers = base.buffers.drain_transitions(snatch_guard);
+        let (transitions, textures) = base.textures.drain_transitions(snatch_guard);
+        let texture_barriers = transitions
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| p.into_hal(textures[i].unwrap().raw().unwrap()));
+
+        unsafe {
+            raw.transition_buffers(buffer_barriers);
+            raw.transition_textures(texture_barriers);
+        }
+    }
+
+    pub(crate) fn insert_barriers_from_device_tracker(
+        raw: &mut A::CommandEncoder,
+        base: &mut DeviceTracker<A>,
+        head: &Tracker<A>,
+        snatch_guard: &SnatchGuard,
+    ) {
+        profiling::scope!("insert_barriers_from_device_tracker");
+
+        base.buffers.set_from_tracker(&head.buffers);
+        base.textures.set_from_tracker(&head.textures);
 
         let buffer_barriers = base.buffers.drain_transitions(snatch_guard);
         let (transitions, textures) = base.textures.drain_transitions(snatch_guard);

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -434,12 +434,9 @@ impl<A: HalApi> CommandBuffer<A> {
             .buffers
             .set_from_tracker_and_drain_transitions(&head.buffers, snatch_guard);
 
-        base.textures.set_from_tracker(&head.textures);
-        let (transitions, textures) = base.textures.drain_transitions(snatch_guard);
-        let texture_barriers = transitions
-            .into_iter()
-            .enumerate()
-            .map(|(i, p)| p.into_hal(textures[i].unwrap().raw().unwrap()));
+        let texture_barriers = base
+            .textures
+            .set_from_tracker_and_drain_transitions(&head.textures, snatch_guard);
 
         unsafe {
             raw.transition_buffers(buffer_barriers);

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -15,20 +15,18 @@ use crate::{
     track::{StatelessTracker, TrackerIndex},
     FastHashMap,
 };
-use std::{iter, marker::PhantomData, sync::Arc};
+use std::{iter, sync::Arc};
 use thiserror::Error;
 use wgt::BufferAddress;
 
 #[derive(Debug)]
 pub(crate) struct QueryResetMap<A: HalApi> {
     map: FastHashMap<TrackerIndex, (Vec<bool>, Arc<QuerySet<A>>)>,
-    _phantom: PhantomData<A>,
 }
 impl<A: HalApi> QueryResetMap<A> {
     pub fn new() -> Self {
         Self {
             map: FastHashMap::default(),
-            _phantom: PhantomData,
         }
     }
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -433,21 +433,11 @@ impl Global {
 
         let device = buffer.device.clone();
 
-        if device
-            .pending_writes
-            .lock()
-            .as_ref()
-            .unwrap()
-            .contains_buffer(&buffer)
-        {
-            device.lock_life().future_suspected_buffers.push(buffer);
-        } else {
-            device
-                .lock_life()
-                .suspected_resources
-                .buffers
-                .insert(buffer.tracker_index(), buffer);
-        }
+        device
+            .lock_life()
+            .suspected_resources
+            .buffers
+            .insert(buffer.tracker_index(), buffer);
 
         if wait {
             match device.wait_for_submit(last_submit_index) {
@@ -626,26 +616,12 @@ impl Global {
             let last_submit_index = texture.submission_index();
 
             let device = &texture.device;
-            {
-                if device
-                    .pending_writes
-                    .lock()
-                    .as_ref()
-                    .unwrap()
-                    .contains_texture(&texture)
-                {
-                    device
-                        .lock_life()
-                        .future_suspected_textures
-                        .push(texture.clone());
-                } else {
-                    device
-                        .lock_life()
-                        .suspected_resources
-                        .textures
-                        .insert(texture.tracker_index(), texture.clone());
-                }
-            }
+
+            device
+                .lock_life()
+                .suspected_resources
+                .textures
+                .insert(texture.tracker_index(), texture.clone());
 
             if wait {
                 match device.wait_for_submit(last_submit_index) {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2247,23 +2247,6 @@ impl Global {
         Some(error)
     }
 
-    #[cfg(feature = "replay")]
-    /// Only triage suspected resource IDs. This helps us to avoid ID collisions
-    /// upon creating new resources when re-playing a trace.
-    pub fn device_maintain_ids<A: HalApi>(&self, device_id: DeviceId) -> Result<(), DeviceError> {
-        let hub = A::hub(self);
-
-        let device = hub
-            .devices
-            .get(device_id)
-            .map_err(|_| DeviceError::InvalidDeviceId)?;
-
-        device.check_is_valid()?;
-
-        device.lock_life().triage_suspected(&device.trackers);
-        Ok(())
-    }
-
     /// Check `device_id` for freeable resources and completed buffer mappings.
     ///
     /// Return `queue_empty` indicating whether there are more queue submissions still in flight.

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -316,17 +316,17 @@ impl<A: HalApi> LifetimeTracker<A> {
                 TempResource::StagingBuffer(raw) => {
                     last_resources
                         .staging_buffers
-                        .insert(raw.tracker_index(), raw);
+                        .insert(raw.tracker_index(), Arc::new(raw));
                 }
                 TempResource::DestroyedBuffer(destroyed) => {
                     last_resources
                         .destroyed_buffers
-                        .insert(destroyed.tracker_index, destroyed);
+                        .insert(destroyed.tracker_index, Arc::new(destroyed));
                 }
                 TempResource::DestroyedTexture(destroyed) => {
                     last_resources
                         .destroyed_textures
-                        .insert(destroyed.tracker_index, destroyed);
+                        .insert(destroyed.tracker_index, Arc::new(destroyed));
                 }
             }
         }
@@ -417,17 +417,19 @@ impl<A: HalApi> LifetimeTracker<A> {
         if let Some(resources) = resources {
             match temp_resource {
                 TempResource::StagingBuffer(raw) => {
-                    resources.staging_buffers.insert(raw.tracker_index(), raw);
+                    resources
+                        .staging_buffers
+                        .insert(raw.tracker_index(), Arc::new(raw));
                 }
                 TempResource::DestroyedBuffer(destroyed) => {
                     resources
                         .destroyed_buffers
-                        .insert(destroyed.tracker_index, destroyed);
+                        .insert(destroyed.tracker_index, Arc::new(destroyed));
                 }
                 TempResource::DestroyedTexture(destroyed) => {
                     resources
                         .destroyed_textures
-                        .insert(destroyed.tracker_index, destroyed);
+                        .insert(destroyed.tracker_index, Arc::new(destroyed));
                 }
             }
         }

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -326,9 +326,6 @@ impl<A: HalApi> LifetimeTracker<A> {
                         .destroyed_buffers
                         .insert(destroyed.tracker_index, destroyed);
                 }
-                TempResource::Texture(raw) => {
-                    last_resources.textures.insert(raw.tracker_index(), raw);
-                }
                 TempResource::DestroyedTexture(destroyed) => {
                     last_resources
                         .destroyed_textures
@@ -432,9 +429,6 @@ impl<A: HalApi> LifetimeTracker<A> {
                     resources
                         .destroyed_buffers
                         .insert(destroyed.tracker_index, destroyed);
-                }
-                TempResource::Texture(raw) => {
-                    resources.textures.insert(raw.tracker_index(), raw);
                 }
                 TempResource::DestroyedTexture(destroyed) => {
                     resources

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -313,9 +313,6 @@ impl<A: HalApi> LifetimeTracker<A> {
         let mut last_resources = ResourceMaps::new();
         for res in temp_resources {
             match res {
-                TempResource::Buffer(raw) => {
-                    last_resources.buffers.insert(raw.tracker_index(), raw);
-                }
                 TempResource::StagingBuffer(raw) => {
                     last_resources
                         .staging_buffers
@@ -419,9 +416,6 @@ impl<A: HalApi> LifetimeTracker<A> {
             .map(|a| &mut a.last_resources);
         if let Some(resources) = resources {
             match temp_resource {
-                TempResource::Buffer(raw) => {
-                    resources.buffers.insert(raw.tracker_index(), raw);
-                }
                 TempResource::StagingBuffer(raw) => {
                     resources.staging_buffers.insert(raw.tracker_index(), raw);
                 }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1343,15 +1343,12 @@ impl Global {
                                     ))
                                     .map_err(DeviceError::from)?
                             };
-                            trackers
+                            let texture_barriers = trackers
                                 .textures
-                                .set_from_usage_scope(&used_surface_textures);
-                            let (transitions, textures) =
-                                trackers.textures.drain_transitions(&snatch_guard);
-                            let texture_barriers = transitions
-                                .into_iter()
-                                .enumerate()
-                                .map(|(i, p)| p.into_hal(textures[i].unwrap().raw().unwrap()));
+                                .set_from_usage_scope_and_drain_transitions(
+                                    &used_surface_textures,
+                                    &snatch_guard,
+                                );
                             let present = unsafe {
                                 baked.encoder.transition_textures(texture_barriers);
                                 baked.encoder.end_encoding().unwrap()
@@ -1401,15 +1398,12 @@ impl Global {
                 if !used_surface_textures.is_empty() {
                     let mut trackers = device.trackers.lock();
 
-                    trackers
+                    let texture_barriers = trackers
                         .textures
-                        .set_from_usage_scope(&used_surface_textures);
-                    let (transitions, textures) =
-                        trackers.textures.drain_transitions(&snatch_guard);
-                    let texture_barriers = transitions
-                        .into_iter()
-                        .enumerate()
-                        .map(|(i, p)| p.into_hal(textures[i].unwrap().raw().unwrap()));
+                        .set_from_usage_scope_and_drain_transitions(
+                            &used_surface_textures,
+                            &snatch_guard,
+                        );
                     unsafe {
                         pending_writes
                             .command_encoder

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -317,7 +317,7 @@ impl<A: HalApi> PendingWrites<A> {
     }
 }
 
-fn prepare_staging_buffer<A: HalApi>(
+pub(crate) fn prepare_staging_buffer<A: HalApi>(
     device: &Arc<Device<A>>,
     size: wgt::BufferAddress,
     instance_flags: wgt::InstanceFlags,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -18,7 +18,7 @@ use crate::{
     resource::{
         Buffer, BufferAccessError, BufferMapState, DestroyedBuffer, DestroyedResourceError,
         DestroyedTexture, Labeled, ParentDevice, ResourceErrorIdent, StagingBuffer, Texture,
-        TextureInner, Trackable, TrackingData,
+        TextureInner, Trackable,
     },
     resource_log,
     track::{self, TrackerIndex},
@@ -138,11 +138,8 @@ pub struct WrappedSubmissionIndex {
 /// - `PendingWrites::temp_resources`: resources used by queue writes and
 ///   unmaps, waiting to be folded in with the next queue submission
 ///
-/// - `ActiveSubmission::last_resources`: temporary resources used by a queue
+/// - `ActiveSubmission::temp_resources`: temporary resources used by a queue
 ///   submission, to be freed when it completes
-///
-/// - `LifetimeTracker::free_resources`: resources to be freed in the next
-///   `maintain` call, no longer used anywhere
 #[derive(Debug)]
 pub enum TempResource<A: HalApi> {
     StagingBuffer(StagingBuffer<A>),
@@ -336,7 +333,6 @@ pub(crate) fn prepare_staging_buffer<A: HalApi>(
         raw: Mutex::new(rank::STAGING_BUFFER_RAW, Some(buffer)),
         device: device.clone(),
         size,
-        tracking_data: TrackingData::new(device.tracker_indices.staging_buffers.clone()),
         is_coherent: mapping.is_coherent,
     };
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -148,7 +148,6 @@ pub enum TempResource<A: HalApi> {
     StagingBuffer(Arc<StagingBuffer<A>>),
     DestroyedBuffer(Arc<DestroyedBuffer<A>>),
     DestroyedTexture(Arc<DestroyedTexture<A>>),
-    Texture(Arc<Texture<A>>),
 }
 
 /// A series of raw [`CommandBuffer`]s that have been submitted to a

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -145,7 +145,6 @@ pub struct WrappedSubmissionIndex {
 ///   `maintain` call, no longer used anywhere
 #[derive(Debug)]
 pub enum TempResource<A: HalApi> {
-    Buffer(Arc<Buffer<A>>),
     StagingBuffer(Arc<StagingBuffer<A>>),
     DestroyedBuffer(Arc<DestroyedBuffer<A>>),
     DestroyedTexture(Arc<DestroyedTexture<A>>),

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1320,7 +1320,7 @@ impl Global {
                         baked.initialize_texture_memory(&mut *trackers, device, &snatch_guard)?;
                         //Note: stateless trackers are not merged:
                         // device already knows these resources exist.
-                        CommandBuffer::insert_barriers_from_tracker(
+                        CommandBuffer::insert_barriers_from_device_tracker(
                             &mut baked.encoder,
                             &mut *trackers,
                             &baked.trackers,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -76,11 +76,6 @@ use super::{
 /// This means that you must inspect function calls made while a lock is held
 /// to see what locks the callee may try to acquire.
 ///
-/// As far as this point:
-/// device_maintain_ids locks Device::lifetime_tracker, and calls...
-/// triage_suspected locks Device::trackers, and calls...
-/// Registry::unregister locks Registry::storage
-///
 /// Important:
 /// When locking pending_writes please check that trackers is not locked
 /// trackers should be locked only when needed for the shortest time possible

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3549,7 +3549,9 @@ impl<A: HalApi> Device<A> {
         // During these iterations, we discard all errors. We don't care!
         let trackers = self.trackers.lock();
         for buffer in trackers.buffers.used_resources() {
-            let _ = buffer.destroy();
+            if let Some(buffer) = Weak::upgrade(&buffer) {
+                let _ = buffer.destroy();
+            }
         }
         for texture in trackers.textures.used_resources() {
             let _ = texture.destroy();

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -430,8 +430,7 @@ impl<A: HalApi> Device<A> {
 
         life_tracker.triage_mapped();
 
-        let mapping_closures =
-            life_tracker.handle_mapping(self.raw(), &self.trackers, &snatch_guard);
+        let mapping_closures = life_tracker.handle_mapping(self.raw(), &snatch_guard);
 
         let queue_empty = life_tracker.queue_empty();
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -690,7 +690,7 @@ impl<A: HalApi> Device<A> {
             buffer.initialization_status.write().drain(0..buffer.size);
 
             *buffer.map_state.lock() = resource::BufferMapState::Init {
-                staging_buffer: Arc::new(staging_buffer),
+                staging_buffer,
                 ptr: staging_buffer_ptr,
             };
             hal::BufferUses::COPY_DST

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3554,7 +3554,9 @@ impl<A: HalApi> Device<A> {
             }
         }
         for texture in trackers.textures.used_resources() {
-            let _ = texture.destroy();
+            if let Some(texture) = Weak::upgrade(&texture) {
+                let _ = texture.destroy();
+            }
         }
     }
 

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -87,11 +87,6 @@ macro_rules! define_lock_ranks {
 }
 
 define_lock_ranks! {
-    rank DEVICE_TEMP_SUSPECTED "Device::temp_suspected" followed by {
-        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
-        COMMAND_BUFFER_DATA,
-        DEVICE_TRACKERS,
-    }
     rank COMMAND_BUFFER_DATA "CommandBuffer::data" followed by {
         DEVICE_SNATCHABLE_LOCK,
         DEVICE_USAGE_SCOPES,
@@ -123,8 +118,6 @@ define_lock_ranks! {
     }
     rank DEVICE_LIFE_TRACKER "Device::life_tracker" followed by {
         COMMAND_ALLOCATOR_FREE_ENCODERS,
-        // Uncomment this to see an interesting cycle.
-        // DEVICE_TEMP_SUSPECTED,
         DEVICE_TRACE,
     }
     rank COMMAND_ALLOCATOR_FREE_ENCODERS "CommandAllocator::free_encoders" followed by {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -260,7 +260,7 @@ pub enum BufferMapAsyncStatus {
 pub(crate) enum BufferMapState<A: HalApi> {
     /// Mapped at creation.
     Init {
-        staging_buffer: Arc<StagingBuffer<A>>,
+        staging_buffer: StagingBuffer<A>,
         ptr: NonNull<u8>,
     },
     /// Waiting for GPU to be done before mapping
@@ -767,14 +767,14 @@ impl<A: HalApi> Buffer<A> {
                 mem::take(&mut *guard)
             };
 
-            queue::TempResource::DestroyedBuffer(Arc::new(DestroyedBuffer {
+            queue::TempResource::DestroyedBuffer(DestroyedBuffer {
                 raw: Some(raw),
                 device: Arc::clone(&self.device),
                 submission_index: self.submission_index(),
                 tracker_index: self.tracker_index(),
                 label: self.label().to_owned(),
                 bind_groups,
-            }))
+            })
         };
 
         let mut pending_writes = device.pending_writes.lock();
@@ -1136,7 +1136,7 @@ impl<A: HalApi> Texture<A> {
                 mem::take(&mut *guard)
             };
 
-            queue::TempResource::DestroyedTexture(Arc::new(DestroyedTexture {
+            queue::TempResource::DestroyedTexture(DestroyedTexture {
                 raw: Some(raw),
                 views,
                 bind_groups,
@@ -1144,7 +1144,7 @@ impl<A: HalApi> Texture<A> {
                 tracker_index: self.tracker_index(),
                 submission_index: self.submission_index(),
                 label: self.label().to_owned(),
-            }))
+            })
         };
 
         let mut pending_writes = device.pending_writes.lock();

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -609,14 +609,13 @@ impl<A: HalApi> Buffer<A> {
             };
         }
 
-        let snatch_guard = device.snatchable_lock.read();
-        {
-            let mut trackers = device.as_ref().trackers.lock();
-            trackers.buffers.set_single(self, internal_use);
-            //TODO: Check if draining ALL buffers is correct!
-            let _ = trackers.buffers.drain_transitions(&snatch_guard);
-        }
-        drop(snatch_guard);
+        // TODO: we are ignoring the transition here, I think we need to add a barrier
+        // at the end of the submission
+        device
+            .trackers
+            .lock()
+            .buffers
+            .set_single(self, internal_use);
 
         device.lock_life().map(self);
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -770,8 +770,6 @@ impl<A: HalApi> Buffer<A> {
             queue::TempResource::DestroyedBuffer(DestroyedBuffer {
                 raw: Some(raw),
                 device: Arc::clone(&self.device),
-                submission_index: self.submission_index(),
-                tracker_index: self.tracker_index(),
                 label: self.label().to_owned(),
                 bind_groups,
             })
@@ -823,8 +821,6 @@ pub struct DestroyedBuffer<A: HalApi> {
     raw: Option<A::Buffer>,
     device: Arc<Device<A>>,
     label: String,
-    pub(crate) tracker_index: TrackerIndex,
-    pub(crate) submission_index: u64,
     bind_groups: Vec<Weak<BindGroup<A>>>,
 }
 
@@ -878,7 +874,6 @@ pub struct StagingBuffer<A: HalApi> {
     pub(crate) device: Arc<Device<A>>,
     pub(crate) size: wgt::BufferAddress,
     pub(crate) is_coherent: bool,
-    pub(crate) tracking_data: TrackingData,
 }
 
 impl<A: HalApi> Drop for StagingBuffer<A> {
@@ -902,7 +897,6 @@ impl<A: HalApi> Labeled for StagingBuffer<A> {
 }
 crate::impl_parent_device!(StagingBuffer);
 crate::impl_storage_item!(StagingBuffer);
-crate::impl_trackable!(StagingBuffer);
 
 pub type TextureDescriptor<'a> = wgt::TextureDescriptor<Label<'a>, Vec<wgt::TextureFormat>>;
 
@@ -1141,8 +1135,6 @@ impl<A: HalApi> Texture<A> {
                 views,
                 bind_groups,
                 device: Arc::clone(&self.device),
-                tracker_index: self.tracker_index(),
-                submission_index: self.submission_index(),
                 label: self.label().to_owned(),
             })
         };
@@ -1333,8 +1325,6 @@ pub struct DestroyedTexture<A: HalApi> {
     bind_groups: Vec<Weak<BindGroup<A>>>,
     device: Arc<Device<A>>,
     label: String,
-    pub(crate) tracker_index: TrackerIndex,
-    pub(crate) submission_index: u64,
 }
 
 impl<A: HalApi> DestroyedTexture<A> {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -200,10 +200,6 @@ pub(crate) trait Trackable: Labeled {
     /// given index.
     fn use_at(&self, submit_index: SubmissionIndex);
     fn submission_index(&self) -> SubmissionIndex;
-
-    fn is_unique(self: &Arc<Self>) -> bool {
-        Arc::strong_count(self) == 1
-    }
 }
 
 #[macro_export]

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -87,7 +87,7 @@ impl<A: HalApi> BufferBindGroupState<A> {
 #[derive(Debug)]
 pub(crate) struct BufferUsageScope<A: HalApi> {
     state: Vec<BufferUses>,
-    metadata: ResourceMetadata<Buffer<A>>,
+    metadata: ResourceMetadata<Arc<Buffer<A>>>,
 }
 
 impl<A: HalApi> Default for BufferUsageScope<A> {
@@ -240,7 +240,7 @@ pub(crate) struct BufferTracker<A: HalApi> {
     start: Vec<BufferUses>,
     end: Vec<BufferUses>,
 
-    metadata: ResourceMetadata<Buffer<A>>,
+    metadata: ResourceMetadata<Arc<Buffer<A>>>,
 
     temp: Vec<PendingTransition<BufferUses>>,
 }
@@ -552,11 +552,11 @@ impl BufferStateProvider<'_> {
 unsafe fn insert_or_merge<A: HalApi>(
     start_states: Option<&mut [BufferUses]>,
     current_states: &mut [BufferUses],
-    resource_metadata: &mut ResourceMetadata<Buffer<A>>,
+    resource_metadata: &mut ResourceMetadata<Arc<Buffer<A>>>,
     index32: u32,
     index: usize,
     state_provider: BufferStateProvider<'_>,
-    metadata_provider: ResourceMetadataProvider<'_, Buffer<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Arc<Buffer<A>>>,
 ) -> Result<(), ResourceUsageCompatibilityError> {
     let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
 
@@ -607,11 +607,11 @@ unsafe fn insert_or_merge<A: HalApi>(
 unsafe fn insert_or_barrier_update<A: HalApi>(
     start_states: Option<&mut [BufferUses]>,
     current_states: &mut [BufferUses],
-    resource_metadata: &mut ResourceMetadata<Buffer<A>>,
+    resource_metadata: &mut ResourceMetadata<Arc<Buffer<A>>>,
     index: usize,
     start_state_provider: BufferStateProvider<'_>,
     end_state_provider: Option<BufferStateProvider<'_>>,
-    metadata_provider: ResourceMetadataProvider<'_, Buffer<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Arc<Buffer<A>>>,
     barriers: &mut Vec<PendingTransition<BufferUses>>,
 ) {
     let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
@@ -641,11 +641,11 @@ unsafe fn insert_or_barrier_update<A: HalApi>(
 unsafe fn insert<A: HalApi>(
     start_states: Option<&mut [BufferUses]>,
     current_states: &mut [BufferUses],
-    resource_metadata: &mut ResourceMetadata<Buffer<A>>,
+    resource_metadata: &mut ResourceMetadata<Arc<Buffer<A>>>,
     index: usize,
     start_state_provider: BufferStateProvider<'_>,
     end_state_provider: Option<BufferStateProvider<'_>>,
-    metadata_provider: ResourceMetadataProvider<'_, Buffer<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Arc<Buffer<A>>>,
 ) {
     let new_start_state = unsafe { start_state_provider.get_state(index) };
     let new_end_state =
@@ -675,7 +675,7 @@ unsafe fn merge<A: HalApi>(
     index32: u32,
     index: usize,
     state_provider: BufferStateProvider<'_>,
-    metadata_provider: ResourceMetadataProvider<'_, Buffer<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Arc<Buffer<A>>>,
 ) -> Result<(), ResourceUsageCompatibilityError> {
     let current_state = unsafe { current_states.get_unchecked_mut(index) };
     let new_state = unsafe { state_provider.get_state(index) };

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -5,7 +5,7 @@
  * one subresource, they have no selector.
 !*/
 
-use std::{marker::PhantomData, sync::Arc};
+use std::sync::Arc;
 
 use super::{PendingTransition, TrackerIndex};
 use crate::{
@@ -43,15 +43,11 @@ impl ResourceUses for BufferUses {
 #[derive(Debug)]
 pub(crate) struct BufferBindGroupState<A: HalApi> {
     buffers: Mutex<Vec<(Arc<Buffer<A>>, BufferUses)>>,
-
-    _phantom: PhantomData<A>,
 }
 impl<A: HalApi> BufferBindGroupState<A> {
     pub fn new() -> Self {
         Self {
             buffers: Mutex::new(rank::BUFFER_BIND_GROUP_STATE_BUFFERS, Vec::new()),
-
-            _phantom: PhantomData,
         }
     }
 

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -492,21 +492,6 @@ impl<A: HalApi> BufferTracker<A> {
             unsafe { scope.metadata.remove(index) };
         }
     }
-
-    #[allow(dead_code)]
-    pub fn get(&self, index: TrackerIndex) -> Option<&Arc<Buffer<A>>> {
-        let index = index.as_usize();
-        if index > self.metadata.size() {
-            return None;
-        }
-        self.tracker_assert_in_bounds(index);
-        unsafe {
-            if self.metadata.contains_unchecked(index) {
-                return Some(self.metadata.get_resource_unchecked(index));
-            }
-        }
-        None
-    }
 }
 
 /// Source of Buffer State.

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -5,7 +5,7 @@
  * one subresource, they have no selector.
 !*/
 
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use super::{PendingTransition, TrackerIndex};
 use crate::{
@@ -231,7 +231,7 @@ impl<A: HalApi> BufferUsageScope<A> {
     }
 }
 
-/// Stores all buffer state within a command buffer or device.
+/// Stores all buffer state within a command buffer.
 pub(crate) struct BufferTracker<A: HalApi> {
     start: Vec<BufferUses>,
     end: Vec<BufferUses>,
@@ -292,38 +292,6 @@ impl<A: HalApi> BufferTracker<A> {
             pending.into_hal(buf, snatch_guard)
         });
         buffer_barriers
-    }
-
-    /// Inserts a single buffer and its state into the resource tracker.
-    ///
-    /// If the resource already exists in the tracker, this will panic.
-    ///
-    /// If the ID is higher than the length of internal vectors,
-    /// the vectors will be extended. A call to set_size is not needed.
-    pub fn insert_single(&mut self, resource: &Arc<Buffer<A>>, state: BufferUses) {
-        let index = resource.tracker_index().as_usize();
-
-        self.allow_index(index);
-
-        self.tracker_assert_in_bounds(index);
-
-        unsafe {
-            let currently_owned = self.metadata.contains_unchecked(index);
-
-            if currently_owned {
-                panic!("Tried to insert buffer already tracked");
-            }
-
-            insert(
-                Some(&mut self.start),
-                &mut self.end,
-                &mut self.metadata,
-                index,
-                BufferStateProvider::Direct { state },
-                None,
-                ResourceMetadataProvider::Direct { resource },
-            )
-        }
     }
 
     /// Sets the state of a single buffer.
@@ -494,6 +462,131 @@ impl<A: HalApi> BufferTracker<A> {
     }
 }
 
+/// Stores all buffer state within a device.
+pub(crate) struct DeviceBufferTracker<A: HalApi> {
+    current_states: Vec<BufferUses>,
+    metadata: ResourceMetadata<Weak<Buffer<A>>>,
+    temp: Vec<PendingTransition<BufferUses>>,
+}
+
+impl<A: HalApi> DeviceBufferTracker<A> {
+    pub fn new() -> Self {
+        Self {
+            current_states: Vec::new(),
+            metadata: ResourceMetadata::new(),
+            temp: Vec::new(),
+        }
+    }
+
+    fn tracker_assert_in_bounds(&self, index: usize) {
+        strict_assert!(index < self.current_states.len());
+        self.metadata.tracker_assert_in_bounds(index);
+    }
+
+    /// Extend the vectors to let the given index be valid.
+    fn allow_index(&mut self, index: usize) {
+        if index >= self.current_states.len() {
+            self.current_states.resize(index + 1, BufferUses::empty());
+            self.metadata.set_size(index + 1);
+        }
+    }
+
+    /// Returns a list of all buffers tracked.
+    pub fn used_resources(&self) -> impl Iterator<Item = Weak<Buffer<A>>> + '_ {
+        self.metadata.owned_resources()
+    }
+
+    /// Inserts a single buffer and its state into the resource tracker.
+    ///
+    /// If the resource already exists in the tracker, it will be overwritten.
+    pub fn insert_single(&mut self, buffer: &Arc<Buffer<A>>, state: BufferUses) {
+        let index = buffer.tracker_index().as_usize();
+
+        self.allow_index(index);
+
+        self.tracker_assert_in_bounds(index);
+
+        unsafe {
+            insert(
+                None,
+                &mut self.current_states,
+                &mut self.metadata,
+                index,
+                BufferStateProvider::Direct { state },
+                None,
+                ResourceMetadataProvider::Direct {
+                    resource: &Arc::downgrade(buffer),
+                },
+            )
+        }
+    }
+
+    /// Sets the state of a single buffer.
+    ///
+    /// If a transition is needed to get the buffer into the given state, that transition
+    /// is returned. No more than one transition is needed.
+    pub fn set_single(
+        &mut self,
+        buffer: &Arc<Buffer<A>>,
+        state: BufferUses,
+    ) -> Option<PendingTransition<BufferUses>> {
+        let index: usize = buffer.tracker_index().as_usize();
+
+        self.tracker_assert_in_bounds(index);
+
+        let start_state_provider = BufferStateProvider::Direct { state };
+
+        unsafe {
+            barrier(
+                &mut self.current_states,
+                index,
+                start_state_provider.clone(),
+                &mut self.temp,
+            )
+        };
+        unsafe { update(&mut self.current_states, index, start_state_provider) };
+
+        strict_assert!(self.temp.len() <= 1);
+
+        self.temp.pop()
+    }
+
+    /// Sets the given state for all buffers in the given tracker.
+    ///
+    /// If a transition is needed to get the buffers into the needed state,
+    /// those transitions are returned.
+    pub fn set_from_tracker_and_drain_transitions<'a, 'b: 'a>(
+        &'a mut self,
+        tracker: &'a BufferTracker<A>,
+        snatch_guard: &'b SnatchGuard<'b>,
+    ) -> impl Iterator<Item = BufferBarrier<'a, A>> {
+        for index in tracker.metadata.owned_indices() {
+            self.tracker_assert_in_bounds(index);
+
+            let start_state_provider = BufferStateProvider::Indirect {
+                state: &tracker.start,
+            };
+            let end_state_provider = BufferStateProvider::Indirect {
+                state: &tracker.end,
+            };
+            unsafe {
+                barrier(
+                    &mut self.current_states,
+                    index,
+                    start_state_provider,
+                    &mut self.temp,
+                )
+            };
+            unsafe { update(&mut self.current_states, index, end_state_provider) };
+        }
+
+        self.temp.drain(..).map(|pending| {
+            let buf = unsafe { tracker.metadata.get_resource_unchecked(pending.id as _) };
+            pending.into_hal(buf, snatch_guard)
+        })
+    }
+}
+
 /// Source of Buffer State.
 #[derive(Debug, Clone)]
 enum BufferStateProvider<'a> {
@@ -619,14 +712,14 @@ unsafe fn insert_or_barrier_update<A: HalApi>(
 }
 
 #[inline(always)]
-unsafe fn insert<A: HalApi>(
+unsafe fn insert<T: Clone>(
     start_states: Option<&mut [BufferUses]>,
     current_states: &mut [BufferUses],
-    resource_metadata: &mut ResourceMetadata<Arc<Buffer<A>>>,
+    resource_metadata: &mut ResourceMetadata<T>,
     index: usize,
     start_state_provider: BufferStateProvider<'_>,
     end_state_provider: Option<BufferStateProvider<'_>>,
-    metadata_provider: ResourceMetadataProvider<'_, Arc<Buffer<A>>>,
+    metadata_provider: ResourceMetadataProvider<'_, T>,
 ) {
     let new_start_state = unsafe { start_state_provider.get_state(index) };
     let new_end_state =

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -1,7 +1,7 @@
 //! The `ResourceMetadata` type.
 
 use bit_vec::BitVec;
-use std::{mem, sync::Arc};
+use std::mem;
 use wgt::strict_assert;
 
 /// A set of resources, holding a `Arc<T>` and epoch for each member.
@@ -12,15 +12,15 @@ use wgt::strict_assert;
 /// members, but a bit vector tracks occupancy, so iteration touches
 /// only occupied elements.
 #[derive(Debug)]
-pub(super) struct ResourceMetadata<T> {
+pub(super) struct ResourceMetadata<T: Clone> {
     /// If the resource with index `i` is a member, `owned[i]` is `true`.
     owned: BitVec<usize>,
 
     /// A vector holding clones of members' `T`s.
-    resources: Vec<Option<Arc<T>>>,
+    resources: Vec<Option<T>>,
 }
 
-impl<T> ResourceMetadata<T> {
+impl<T: Clone> ResourceMetadata<T> {
     pub(super) fn new() -> Self {
         Self {
             owned: BitVec::default(),
@@ -94,7 +94,7 @@ impl<T> ResourceMetadata<T> {
     /// The given `index` must be in bounds for this `ResourceMetadata`'s
     /// existing tables. See `tracker_assert_in_bounds`.
     #[inline(always)]
-    pub(super) unsafe fn insert(&mut self, index: usize, resource: Arc<T>) -> &Arc<T> {
+    pub(super) unsafe fn insert(&mut self, index: usize, resource: T) -> &T {
         self.owned.set(index, true);
         let resource_dst = unsafe { self.resources.get_unchecked_mut(index) };
         resource_dst.insert(resource)
@@ -107,7 +107,7 @@ impl<T> ResourceMetadata<T> {
     /// The given `index` must be in bounds for this `ResourceMetadata`'s
     /// existing tables. See `tracker_assert_in_bounds`.
     #[inline(always)]
-    pub(super) unsafe fn get_resource_unchecked(&self, index: usize) -> &Arc<T> {
+    pub(super) unsafe fn get_resource_unchecked(&self, index: usize) -> &T {
         unsafe {
             self.resources
                 .get_unchecked(index)
@@ -117,7 +117,7 @@ impl<T> ResourceMetadata<T> {
     }
 
     /// Returns an iterator over the resources owned by `self`.
-    pub(super) fn owned_resources(&self) -> impl Iterator<Item = Arc<T>> + '_ {
+    pub(super) fn owned_resources(&self) -> impl Iterator<Item = T> + '_ {
         if !self.owned.is_empty() {
             self.tracker_assert_in_bounds(self.owned.len() - 1)
         };
@@ -148,20 +148,20 @@ impl<T> ResourceMetadata<T> {
 ///
 /// This is used to abstract over the various places
 /// trackers can get new resource metadata from.
-pub(super) enum ResourceMetadataProvider<'a, T> {
+pub(super) enum ResourceMetadataProvider<'a, T: Clone> {
     /// Comes directly from explicit values.
-    Direct { resource: &'a Arc<T> },
+    Direct { resource: &'a T },
     /// Comes from another metadata tracker.
     Indirect { metadata: &'a ResourceMetadata<T> },
 }
-impl<T> ResourceMetadataProvider<'_, T> {
+impl<T: Clone> ResourceMetadataProvider<'_, T> {
     /// Get a reference to the resource from this.
     ///
     /// # Safety
     ///
     /// - The index must be in bounds of the metadata tracker if this uses an indirect source.
     #[inline(always)]
-    pub(super) unsafe fn get(&self, index: usize) -> &Arc<T> {
+    pub(super) unsafe fn get(&self, index: usize) -> &T {
         match self {
             ResourceMetadataProvider::Direct { resource } => resource,
             ResourceMetadataProvider::Indirect { metadata } => {

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -116,17 +116,6 @@ impl<T> ResourceMetadata<T> {
         }
     }
 
-    /// Get the reference count of the resource with the given index.
-    ///
-    /// # Safety
-    ///
-    /// The given `index` must be in bounds for this `ResourceMetadata`'s
-    /// existing tables. See `tracker_assert_in_bounds`.
-    #[inline(always)]
-    pub(super) unsafe fn get_ref_count_unchecked(&self, index: usize) -> usize {
-        unsafe { Arc::strong_count(self.get_resource_unchecked(index)) }
-    }
-
     /// Returns an iterator over the resources owned by `self`.
     pub(super) fn owned_resources(&self) -> impl Iterator<Item = Arc<T>> + '_ {
         if !self.owned.is_empty() {
@@ -136,21 +125,6 @@ impl<T> ResourceMetadata<T> {
             let resource = unsafe { self.resources.get_unchecked(index) };
             resource.as_ref().unwrap().clone()
         })
-    }
-
-    /// Returns an iterator over the resources owned by `self`.
-    pub(super) fn drain_resources(&mut self) -> Vec<Arc<T>> {
-        if !self.owned.is_empty() {
-            self.tracker_assert_in_bounds(self.owned.len() - 1)
-        };
-        let mut resources = Vec::new();
-        iterate_bitvec_indices(&self.owned).for_each(|index| {
-            let resource = unsafe { self.resources.get_unchecked(index) };
-            resources.push(resource.as_ref().unwrap().clone());
-        });
-        self.owned.clear();
-        self.resources.clear();
-        resources
     }
 
     /// Returns an iterator over the indices of all resources owned by `self`.

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -119,7 +119,8 @@ pub(crate) use buffer::{
 use metadata::{ResourceMetadata, ResourceMetadataProvider};
 pub(crate) use stateless::{StatelessBindGroupState, StatelessTracker};
 pub(crate) use texture::{
-    TextureBindGroupState, TextureSelector, TextureTracker, TextureUsageScope,
+    DeviceTextureTracker, TextureBindGroupState, TextureSelector, TextureTracker,
+    TextureTrackerSetSingle, TextureUsageScope,
 };
 use wgt::strict_assert_ne;
 
@@ -603,14 +604,14 @@ impl<'a, A: HalApi> UsageScope<'a, A> {
 /// A tracker used by Device.
 pub(crate) struct DeviceTracker<A: HalApi> {
     pub buffers: DeviceBufferTracker<A>,
-    pub textures: TextureTracker<A>,
+    pub textures: DeviceTextureTracker<A>,
 }
 
 impl<A: HalApi> DeviceTracker<A> {
     pub fn new() -> Self {
         Self {
             buffers: DeviceBufferTracker::new(),
-            textures: TextureTracker::new(),
+            textures: DeviceTextureTracker::new(),
         }
     }
 }

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -213,7 +213,6 @@ impl SharedTrackerIndexAllocator {
 
 pub(crate) struct TrackerIndexAllocators {
     pub buffers: Arc<SharedTrackerIndexAllocator>,
-    pub staging_buffers: Arc<SharedTrackerIndexAllocator>,
     pub textures: Arc<SharedTrackerIndexAllocator>,
     pub texture_views: Arc<SharedTrackerIndexAllocator>,
     pub samplers: Arc<SharedTrackerIndexAllocator>,
@@ -231,7 +230,6 @@ impl TrackerIndexAllocators {
     pub fn new() -> Self {
         TrackerIndexAllocators {
             buffers: Arc::new(SharedTrackerIndexAllocator::new()),
-            staging_buffers: Arc::new(SharedTrackerIndexAllocator::new()),
             textures: Arc::new(SharedTrackerIndexAllocator::new()),
             texture_views: Arc::new(SharedTrackerIndexAllocator::new()),
             samplers: Arc::new(SharedTrackerIndexAllocator::new()),

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -113,7 +113,9 @@ use crate::{
 use std::{fmt, ops, sync::Arc};
 use thiserror::Error;
 
-pub(crate) use buffer::{BufferBindGroupState, BufferTracker, BufferUsageScope};
+pub(crate) use buffer::{
+    BufferBindGroupState, BufferTracker, BufferUsageScope, DeviceBufferTracker,
+};
 use metadata::{ResourceMetadata, ResourceMetadataProvider};
 pub(crate) use stateless::{StatelessBindGroupState, StatelessTracker};
 pub(crate) use texture::{
@@ -600,14 +602,14 @@ impl<'a, A: HalApi> UsageScope<'a, A> {
 
 /// A tracker used by Device.
 pub(crate) struct DeviceTracker<A: HalApi> {
-    pub buffers: BufferTracker<A>,
+    pub buffers: DeviceBufferTracker<A>,
     pub textures: TextureTracker<A>,
 }
 
 impl<A: HalApi> DeviceTracker<A> {
     pub fn new() -> Self {
         Self {
-            buffers: BufferTracker::new(),
+            buffers: DeviceBufferTracker::new(),
             textures: TextureTracker::new(),
         }
     }

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -598,10 +598,6 @@ impl<'a, A: HalApi> UsageScope<'a, A> {
     }
 }
 
-pub(crate) trait ResourceTracker {
-    fn remove_abandoned(&mut self, index: TrackerIndex) -> bool;
-}
-
 /// A full double sided tracker used by CommandBuffers and the Device.
 pub(crate) struct Tracker<A: HalApi> {
     pub buffers: BufferTracker<A>,

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -598,12 +598,26 @@ impl<'a, A: HalApi> UsageScope<'a, A> {
     }
 }
 
-/// A full double sided tracker used by CommandBuffers and the Device.
+/// A tracker used by Device.
+pub(crate) struct DeviceTracker<A: HalApi> {
+    pub buffers: BufferTracker<A>,
+    pub textures: TextureTracker<A>,
+}
+
+impl<A: HalApi> DeviceTracker<A> {
+    pub fn new() -> Self {
+        Self {
+            buffers: BufferTracker::new(),
+            textures: TextureTracker::new(),
+        }
+    }
+}
+
+/// A full double sided tracker used by CommandBuffers.
 pub(crate) struct Tracker<A: HalApi> {
     pub buffers: BufferTracker<A>,
     pub textures: TextureTracker<A>,
     pub views: StatelessTracker<resource::TextureView<A>>,
-    pub samplers: StatelessTracker<resource::Sampler<A>>,
     pub bind_groups: StatelessTracker<binding_model::BindGroup<A>>,
     pub compute_pipelines: StatelessTracker<pipeline::ComputePipeline<A>>,
     pub render_pipelines: StatelessTracker<pipeline::RenderPipeline<A>>,
@@ -617,7 +631,6 @@ impl<A: HalApi> Tracker<A> {
             buffers: BufferTracker::new(),
             textures: TextureTracker::new(),
             views: StatelessTracker::new(),
-            samplers: StatelessTracker::new(),
             bind_groups: StatelessTracker::new(),
             compute_pipelines: StatelessTracker::new(),
             render_pipelines: StatelessTracker::new(),

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -50,7 +50,7 @@ impl<T: Trackable> StatelessBindGroupState<T> {
 /// Stores all resource state within a command buffer or device.
 #[derive(Debug)]
 pub(crate) struct StatelessTracker<T: Trackable> {
-    metadata: ResourceMetadata<T>,
+    metadata: ResourceMetadata<Arc<T>>,
 }
 
 impl<T: Trackable> StatelessTracker<T> {

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -9,11 +9,8 @@ use std::sync::Arc;
 use crate::{
     lock::{rank, Mutex},
     resource::Trackable,
-    resource_log,
     track::ResourceMetadata,
 };
-
-use super::{ResourceTracker, TrackerIndex};
 
 /// Stores all the resources that a bind group stores.
 #[derive(Debug)]
@@ -43,12 +40,6 @@ impl<T: Trackable> StatelessBindGroupState<T> {
         resources.iter().cloned().collect::<Vec<_>>().into_iter()
     }
 
-    /// Returns a list of all resources tracked. May contain duplicates.
-    pub fn drain_resources(&self) -> impl Iterator<Item = Arc<T>> + '_ {
-        let mut resources = self.resources.lock();
-        resources.drain(..).collect::<Vec<_>>().into_iter()
-    }
-
     /// Adds the given resource.
     pub fn add_single(&self, resource: &Arc<T>) {
         let mut resources = self.resources.lock();
@@ -60,59 +51,6 @@ impl<T: Trackable> StatelessBindGroupState<T> {
 #[derive(Debug)]
 pub(crate) struct StatelessTracker<T: Trackable> {
     metadata: ResourceMetadata<T>,
-}
-
-impl<T: Trackable> ResourceTracker for StatelessTracker<T> {
-    /// Try to remove the given resource from the tracker iff we have the last reference to the
-    /// resource and the epoch matches.
-    ///
-    /// Returns true if the resource was removed or if not existing in metadata.
-    ///
-    /// If the ID is higher than the length of internal vectors,
-    /// false will be returned.
-    fn remove_abandoned(&mut self, index: TrackerIndex) -> bool {
-        let index = index.as_usize();
-
-        if index >= self.metadata.size() {
-            return false;
-        }
-
-        self.tracker_assert_in_bounds(index);
-
-        unsafe {
-            if self.metadata.contains_unchecked(index) {
-                let existing_ref_count = self.metadata.get_ref_count_unchecked(index);
-                //RefCount 2 means that resource is hold just by DeviceTracker and this suspected resource itself
-                //so it's already been released from user and so it's not inside Registry\Storage
-                if existing_ref_count <= 2 {
-                    resource_log!(
-                        "StatelessTracker<{}>::remove_abandoned: removing {}",
-                        T::TYPE,
-                        self.metadata.get_resource_unchecked(index).error_ident()
-                    );
-
-                    self.metadata.remove(index);
-                    return true;
-                }
-
-                resource_log!(
-                    "StatelessTracker<{}>::remove_abandoned: not removing {}, ref count {}",
-                    T::TYPE,
-                    self.metadata.get_resource_unchecked(index).error_ident(),
-                    existing_ref_count
-                );
-
-                return false;
-            }
-        }
-
-        resource_log!(
-            "StatelessTracker<{}>::remove_abandoned: does not contain index {index:?}",
-            T::TYPE,
-        );
-
-        true
-    }
 }
 
 impl<T: Trackable> StatelessTracker<T> {
@@ -144,12 +82,6 @@ impl<T: Trackable> StatelessTracker<T> {
     /// Returns a list of all resources tracked.
     pub fn used_resources(&self) -> impl Iterator<Item = Arc<T>> + '_ {
         self.metadata.owned_resources()
-    }
-
-    /// Returns a list of all resources tracked.
-    pub fn drain_resources(&mut self) -> impl Iterator<Item = Arc<T>> + '_ {
-        let resources = self.metadata.drain_resources();
-        resources.into_iter()
     }
 
     /// Inserts a single resource into the resource tracker.

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -37,7 +37,7 @@ use naga::FastHashMap;
 
 use wgt::{strict_assert, strict_assert_eq};
 
-use std::{iter, marker::PhantomData, ops::Range, sync::Arc, vec::Drain};
+use std::{iter, ops::Range, sync::Arc, vec::Drain};
 
 /// Specifies a particular set of subresources in a texture.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -378,8 +378,6 @@ pub(crate) struct TextureTracker<A: HalApi> {
     metadata: ResourceMetadata<Arc<Texture<A>>>,
 
     temp: Vec<PendingTransition<TextureUses>>,
-
-    _phantom: PhantomData<A>,
 }
 
 impl<A: HalApi> TextureTracker<A> {
@@ -391,8 +389,6 @@ impl<A: HalApi> TextureTracker<A> {
             metadata: ResourceMetadata::new(),
 
             temp: Vec::new(),
-
-            _phantom: PhantomData,
         }
     }
 

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -220,7 +220,7 @@ impl TextureStateSet {
 #[derive(Debug)]
 pub(crate) struct TextureUsageScope<A: HalApi> {
     set: TextureStateSet,
-    metadata: ResourceMetadata<Texture<A>>,
+    metadata: ResourceMetadata<Arc<Texture<A>>>,
 }
 
 impl<A: HalApi> Default for TextureUsageScope<A> {
@@ -375,7 +375,7 @@ pub(crate) struct TextureTracker<A: HalApi> {
     start_set: TextureStateSet,
     end_set: TextureStateSet,
 
-    metadata: ResourceMetadata<Texture<A>>,
+    metadata: ResourceMetadata<Arc<Texture<A>>>,
 
     temp: Vec<PendingTransition<TextureUses>>,
 
@@ -806,10 +806,10 @@ impl<'a> TextureStateProvider<'a> {
 unsafe fn insert_or_merge<A: HalApi>(
     texture_selector: &TextureSelector,
     current_state_set: &mut TextureStateSet,
-    resource_metadata: &mut ResourceMetadata<Texture<A>>,
+    resource_metadata: &mut ResourceMetadata<Arc<Texture<A>>>,
     index: usize,
     state_provider: TextureStateProvider<'_>,
-    metadata_provider: ResourceMetadataProvider<'_, Texture<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Arc<Texture<A>>>,
 ) -> Result<(), ResourceUsageCompatibilityError> {
     let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
 
@@ -862,11 +862,11 @@ unsafe fn insert_or_barrier_update<A: HalApi>(
     texture_selector: &TextureSelector,
     start_state: Option<&mut TextureStateSet>,
     current_state_set: &mut TextureStateSet,
-    resource_metadata: &mut ResourceMetadata<Texture<A>>,
+    resource_metadata: &mut ResourceMetadata<Arc<Texture<A>>>,
     index: usize,
     start_state_provider: TextureStateProvider<'_>,
     end_state_provider: Option<TextureStateProvider<'_>>,
-    metadata_provider: ResourceMetadataProvider<'_, Texture<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Arc<Texture<A>>>,
     barriers: &mut Vec<PendingTransition<TextureUses>>,
 ) {
     let currently_owned = unsafe { resource_metadata.contains_unchecked(index) };
@@ -915,11 +915,11 @@ unsafe fn insert<A: HalApi>(
     texture_selector: Option<&TextureSelector>,
     start_state: Option<&mut TextureStateSet>,
     end_state: &mut TextureStateSet,
-    resource_metadata: &mut ResourceMetadata<Texture<A>>,
+    resource_metadata: &mut ResourceMetadata<Arc<Texture<A>>>,
     index: usize,
     start_state_provider: TextureStateProvider<'_>,
     end_state_provider: Option<TextureStateProvider<'_>>,
-    metadata_provider: ResourceMetadataProvider<'_, Texture<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Arc<Texture<A>>>,
 ) {
     let start_layers = unsafe { start_state_provider.get_state(texture_selector, index) };
     match start_layers {
@@ -1002,7 +1002,7 @@ unsafe fn merge<A: HalApi>(
     current_state_set: &mut TextureStateSet,
     index: usize,
     state_provider: TextureStateProvider<'_>,
-    metadata_provider: ResourceMetadataProvider<'_, Texture<A>>,
+    metadata_provider: ResourceMetadataProvider<'_, Arc<Texture<A>>>,
 ) -> Result<(), ResourceUsageCompatibilityError> {
     let current_simple = unsafe { current_state_set.simple.get_unchecked_mut(index) };
     let current_state = if *current_simple == TextureUses::COMPLEX {

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -30,14 +30,19 @@ use crate::{
         ResourceUsageCompatibilityError, ResourceUses,
     },
 };
-use hal::TextureUses;
+use hal::{TextureBarrier, TextureUses};
 
 use arrayvec::ArrayVec;
 use naga::FastHashMap;
 
 use wgt::{strict_assert, strict_assert_eq};
 
-use std::{iter, ops::Range, sync::Arc, vec::Drain};
+use std::{
+    iter,
+    ops::Range,
+    sync::{Arc, Weak},
+    vec::Drain,
+};
 
 /// Specifies a particular set of subresources in a texture.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -370,7 +375,16 @@ impl<A: HalApi> TextureUsageScope<A> {
     }
 }
 
-/// Stores all texture state within a command buffer or device.
+pub(crate) trait TextureTrackerSetSingle<A: HalApi> {
+    fn set_single(
+        &mut self,
+        texture: &Arc<Texture<A>>,
+        selector: TextureSelector,
+        new_state: TextureUses,
+    ) -> Drain<'_, PendingTransition<TextureUses>>;
+}
+
+/// Stores all texture state within a command buffer.
 pub(crate) struct TextureTracker<A: HalApi> {
     start_set: TextureStateSet,
     end_set: TextureStateSet,
@@ -453,39 +467,6 @@ impl<A: HalApi> TextureTracker<A> {
             })
             .collect();
         (transitions, textures)
-    }
-
-    /// Inserts a single texture and a state into the resource tracker.
-    ///
-    /// If the resource already exists in the tracker, this will panic.
-    ///
-    /// If the ID is higher than the length of internal vectors,
-    /// the vectors will be extended. A call to set_size is not needed.
-    pub fn insert_single(&mut self, resource: &Arc<Texture<A>>, usage: TextureUses) {
-        let index = resource.tracker_index().as_usize();
-
-        self.allow_index(index);
-
-        self.tracker_assert_in_bounds(index);
-
-        unsafe {
-            let currently_owned = self.metadata.contains_unchecked(index);
-
-            if currently_owned {
-                panic!("Tried to insert texture already tracked");
-            }
-
-            insert(
-                None,
-                Some(&mut self.start_set),
-                &mut self.end_set,
-                &mut self.metadata,
-                index,
-                TextureStateProvider::KnownSingle { state: usage },
-                None,
-                ResourceMetadataProvider::Direct { resource },
-            )
-        };
     }
 
     /// Sets the state of a single texture.
@@ -659,12 +640,218 @@ impl<A: HalApi> TextureTracker<A> {
             unsafe { scope.metadata.remove(index) };
         }
     }
+}
+
+impl<A: HalApi> TextureTrackerSetSingle<A> for TextureTracker<A> {
+    fn set_single(
+        &mut self,
+        texture: &Arc<Texture<A>>,
+        selector: TextureSelector,
+        new_state: TextureUses,
+    ) -> Drain<'_, PendingTransition<TextureUses>> {
+        self.set_single(texture, selector, new_state)
+    }
+}
+
+/// Stores all texture state within a device.
+pub(crate) struct DeviceTextureTracker<A: HalApi> {
+    current_state_set: TextureStateSet,
+    metadata: ResourceMetadata<Weak<Texture<A>>>,
+    temp: Vec<PendingTransition<TextureUses>>,
+}
+
+impl<A: HalApi> DeviceTextureTracker<A> {
+    pub fn new() -> Self {
+        Self {
+            current_state_set: TextureStateSet::new(),
+            metadata: ResourceMetadata::new(),
+            temp: Vec::new(),
+        }
+    }
+
+    fn tracker_assert_in_bounds(&self, index: usize) {
+        self.metadata.tracker_assert_in_bounds(index);
+
+        strict_assert!(index < self.current_state_set.simple.len());
+
+        strict_assert!(if self.metadata.contains(index)
+            && self.current_state_set.simple[index] == TextureUses::COMPLEX
+        {
+            self.current_state_set.complex.contains_key(&index)
+        } else {
+            true
+        });
+    }
+
+    /// Extend the vectors to let the given index be valid.
+    fn allow_index(&mut self, index: usize) {
+        if index >= self.current_state_set.simple.len() {
+            self.current_state_set.set_size(index + 1);
+            self.metadata.set_size(index + 1);
+        }
+    }
+
+    /// Returns a list of all textures tracked.
+    pub fn used_resources(&self) -> impl Iterator<Item = Weak<Texture<A>>> + '_ {
+        self.metadata.owned_resources()
+    }
+
+    /// Inserts a single texture and a state into the resource tracker.
+    ///
+    /// If the resource already exists in the tracker, it will be overwritten.
+    pub fn insert_single(&mut self, texture: &Arc<Texture<A>>, usage: TextureUses) {
+        let index = texture.tracker_index().as_usize();
+
+        self.allow_index(index);
+
+        self.tracker_assert_in_bounds(index);
+
+        unsafe {
+            insert(
+                None,
+                None,
+                &mut self.current_state_set,
+                &mut self.metadata,
+                index,
+                TextureStateProvider::KnownSingle { state: usage },
+                None,
+                ResourceMetadataProvider::Direct {
+                    resource: &Arc::downgrade(texture),
+                },
+            )
+        };
+    }
+
+    /// Sets the state of a single texture.
+    ///
+    /// If a transition is needed to get the texture into the given state, that transition
+    /// is returned.
+    pub fn set_single(
+        &mut self,
+        texture: &Arc<Texture<A>>,
+        selector: TextureSelector,
+        new_state: TextureUses,
+    ) -> Drain<'_, PendingTransition<TextureUses>> {
+        let index = texture.tracker_index().as_usize();
+
+        self.allow_index(index);
+
+        self.tracker_assert_in_bounds(index);
+
+        let start_state_provider = TextureStateProvider::Selector {
+            selector,
+            state: new_state,
+        };
+        unsafe {
+            barrier(
+                &texture.full_range,
+                &self.current_state_set,
+                index,
+                start_state_provider.clone(),
+                &mut self.temp,
+            )
+        };
+        unsafe {
+            update(
+                &texture.full_range,
+                None,
+                &mut self.current_state_set,
+                index,
+                start_state_provider,
+            )
+        };
+
+        self.temp.drain(..)
+    }
+
+    /// Sets the given state for all texture in the given tracker.
+    ///
+    /// If a transition is needed to get the texture into the needed state,
+    /// those transitions are returned.
+    pub fn set_from_tracker_and_drain_transitions<'a, 'b: 'a>(
+        &'a mut self,
+        tracker: &'a TextureTracker<A>,
+        snatch_guard: &'b SnatchGuard<'b>,
+    ) -> impl Iterator<Item = TextureBarrier<'a, A>> {
+        for index in tracker.metadata.owned_indices() {
+            self.tracker_assert_in_bounds(index);
+
+            let start_state_provider = TextureStateProvider::TextureSet {
+                set: &tracker.start_set,
+            };
+            let end_state_provider = TextureStateProvider::TextureSet {
+                set: &tracker.end_set,
+            };
+            unsafe {
+                let texture_selector = &tracker.metadata.get_resource_unchecked(index).full_range;
+                barrier(
+                    texture_selector,
+                    &self.current_state_set,
+                    index,
+                    start_state_provider,
+                    &mut self.temp,
+                );
+                update(
+                    texture_selector,
+                    None,
+                    &mut self.current_state_set,
+                    index,
+                    end_state_provider,
+                );
+            }
+        }
+
+        self.temp.drain(..).map(|pending| {
+            let tex = unsafe { tracker.metadata.get_resource_unchecked(pending.id as _) };
+            let tex = tex.try_raw(snatch_guard).unwrap();
+            pending.into_hal(tex)
+        })
+    }
+
+    /// Sets the given state for all textures in the given UsageScope.
+    ///
+    /// If a transition is needed to get the textures into the needed state,
+    /// those transitions are returned.
+    pub fn set_from_usage_scope_and_drain_transitions<'a, 'b: 'a>(
+        &'a mut self,
+        scope: &'a TextureUsageScope<A>,
+        snatch_guard: &'b SnatchGuard<'b>,
+    ) -> impl Iterator<Item = TextureBarrier<'a, A>> {
+        for index in scope.metadata.owned_indices() {
+            self.tracker_assert_in_bounds(index);
+
+            let start_state_provider = TextureStateProvider::TextureSet { set: &scope.set };
+            unsafe {
+                let texture_selector = &scope.metadata.get_resource_unchecked(index).full_range;
+                barrier(
+                    texture_selector,
+                    &self.current_state_set,
+                    index,
+                    start_state_provider.clone(),
+                    &mut self.temp,
+                );
+                update(
+                    texture_selector,
+                    None,
+                    &mut self.current_state_set,
+                    index,
+                    start_state_provider,
+                );
+            }
+        }
+
+        self.temp.drain(..).map(|pending| {
+            let tex = unsafe { scope.metadata.get_resource_unchecked(pending.id as _) };
+            let tex = tex.try_raw(snatch_guard).unwrap();
+            pending.into_hal(tex)
+        })
+    }
 
     /// Unconditionally removes the given resource from the tracker.
     ///
     /// Returns true if the resource was removed.
     ///
-    /// If the ID is higher than the length of internal vectors,
+    /// If the index is higher than the length of internal vectors,
     /// false will be returned.
     pub fn remove(&mut self, index: TrackerIndex) -> bool {
         let index = index.as_usize();
@@ -677,14 +864,24 @@ impl<A: HalApi> TextureTracker<A> {
 
         unsafe {
             if self.metadata.contains_unchecked(index) {
-                self.start_set.complex.remove(&index);
-                self.end_set.complex.remove(&index);
+                self.current_state_set.complex.remove(&index);
                 self.metadata.remove(index);
                 return true;
             }
         }
 
         false
+    }
+}
+
+impl<A: HalApi> TextureTrackerSetSingle<A> for DeviceTextureTracker<A> {
+    fn set_single(
+        &mut self,
+        texture: &Arc<Texture<A>>,
+        selector: TextureSelector,
+        new_state: TextureUses,
+    ) -> Drain<'_, PendingTransition<TextureUses>> {
+        self.set_single(texture, selector, new_state)
     }
 }
 
@@ -893,12 +1090,10 @@ unsafe fn insert_or_barrier_update<A: HalApi>(
             barriers,
         )
     };
-
-    let start_state_set = start_state.unwrap();
     unsafe {
         update(
             texture_selector,
-            start_state_set,
+            start_state,
             current_state_set,
             index,
             update_state_provider,
@@ -907,15 +1102,15 @@ unsafe fn insert_or_barrier_update<A: HalApi>(
 }
 
 #[inline(always)]
-unsafe fn insert<A: HalApi>(
+unsafe fn insert<T: Clone>(
     texture_selector: Option<&TextureSelector>,
     start_state: Option<&mut TextureStateSet>,
     end_state: &mut TextureStateSet,
-    resource_metadata: &mut ResourceMetadata<Arc<Texture<A>>>,
+    resource_metadata: &mut ResourceMetadata<T>,
     index: usize,
     start_state_provider: TextureStateProvider<'_>,
     end_state_provider: Option<TextureStateProvider<'_>>,
-    metadata_provider: ResourceMetadataProvider<'_, Arc<Texture<A>>>,
+    metadata_provider: ResourceMetadataProvider<'_, T>,
 ) {
     let start_layers = unsafe { start_state_provider.get_state(texture_selector, index) };
     match start_layers {
@@ -1273,19 +1468,21 @@ unsafe fn barrier(
 #[inline(always)]
 unsafe fn update(
     texture_selector: &TextureSelector,
-    start_state_set: &mut TextureStateSet,
+    start_state_set: Option<&mut TextureStateSet>,
     current_state_set: &mut TextureStateSet,
     index: usize,
     state_provider: TextureStateProvider<'_>,
 ) {
-    let start_simple = unsafe { *start_state_set.simple.get_unchecked(index) };
-
     // We only ever need to update the start state here if the state is complex.
     //
     // If the state is simple, the first insert to the tracker would cover it.
     let mut start_complex = None;
-    if start_simple == TextureUses::COMPLEX {
-        start_complex = Some(unsafe { start_state_set.complex.get_mut(&index).unwrap_unchecked() });
+    if let Some(start_state_set) = start_state_set {
+        let start_simple = unsafe { *start_state_set.simple.get_unchecked(index) };
+        if start_simple == TextureUses::COMPLEX {
+            start_complex =
+                Some(unsafe { start_state_set.complex.get_mut(&index).unwrap_unchecked() });
+        }
     }
 
     let current_simple = unsafe { current_state_set.simple.get_unchecked_mut(index) };

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -20,6 +20,7 @@ use std::{
     fmt,
     future::{ready, Ready},
     ops::Range,
+    ptr::NonNull,
     slice,
     sync::Arc,
 };
@@ -3471,7 +3472,7 @@ impl crate::context::QueueWriteBuffer for QueueWriteBuffer {
 
 #[derive(Debug)]
 pub struct BufferMappedRange {
-    ptr: *mut u8,
+    ptr: NonNull<u8>,
     size: usize,
 }
 
@@ -3483,12 +3484,12 @@ unsafe impl Sync for BufferMappedRange {}
 impl crate::context::BufferMappedRange for BufferMappedRange {
     #[inline]
     fn slice(&self) -> &[u8] {
-        unsafe { slice::from_raw_parts(self.ptr, self.size) }
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.size) }
     }
 
     #[inline]
     fn slice_mut(&mut self) -> &mut [u8] {
-        unsafe { slice::from_raw_parts_mut(self.ptr, self.size) }
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.size) }
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/gfx-rs/wgpu/issues/5560.
Resolves https://github.com/gfx-rs/wgpu/issues/5120.
Resolves https://github.com/gfx-rs/wgpu/issues/5592 & resolves https://github.com/gfx-rs/wgpu/issues/5583 by removing `Device::temp_suspected`.

PR doesn't need to be squashed, each commit builds by itself.