### PR TITLE
refactor: `vertex_index_common`: remove footguns in `tests` matrix init. (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,7 @@ dependencies = [
  "env_logger",
  "futures-lite",
  "image",
+ "itertools",
  "js-sys",
  "libtest-mimic",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4394,6 +4394,7 @@ dependencies = [
  "profiling",
  "serde",
  "serde_json",
+ "strum",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ getrandom = "0.2"
 glam = "0.27"
 heck = "0.5.0"
 image = { version = "0.24", default-features = false, features = ["png"] }
+itertools = { version = "0.10.5" }
 ktx2 = "0.3"
 libc = "0.2"
 # libloading 0.8 switches from `winapi` to `windows-sys`; permit either

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ serde = "1"
 serde_json = "1.0.119"
 smallvec = "1"
 static_assertions = "1.1.0"
+strum = { version = "0.25.0", features = ["derive"] }
 tracy-client = "0.17"
 thiserror = "1"
 wgpu = { version = "0.20.0", path = "./wgpu", default-features = false }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,6 +27,7 @@ bytemuck.workspace = true
 cfg-if.workspace = true
 ctor.workspace = true
 futures-lite.workspace = true
+itertools.workspace = true
 libtest-mimic.workspace = true
 log.workspace = true
 parking_lot.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -35,6 +35,7 @@ pollster.workspace = true
 profiling.workspace = true
 serde_json.workspace = true
 serde.workspace = true
+strum = { workspace = true, features = ["derive"] }
 wgpu-macros.workspace = true
 wgpu.workspace = true
 wgt = { workspace = true, features = ["serde"] }

--- a/tests/tests/vertex_indices/mod.rs
+++ b/tests/tests/vertex_indices/mod.rs
@@ -5,6 +5,7 @@
 
 use std::{num::NonZeroU64, ops::Range};
 
+use strum::IntoEnumIterator;
 use wgpu::util::{BufferInitDescriptor, DeviceExt, RenderEncoder};
 
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
@@ -79,7 +80,7 @@ impl Draw {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, strum::EnumIter)]
 enum TestCase {
     /// A single draw call with 6 vertices
     Draw,
@@ -94,14 +95,6 @@ enum TestCase {
 }
 
 impl TestCase {
-    const ARRAY: [Self; 5] = [
-        Self::Draw,
-        Self::DrawNonZeroFirstVertex,
-        Self::DrawBaseVertex,
-        Self::DrawInstanced,
-        Self::DrawNonZeroFirstInstance,
-    ];
-
     // Get the draw calls for this test case
     fn draws(&self) -> &'static [Draw] {
         match self {
@@ -148,7 +141,7 @@ impl TestCase {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, strum::EnumIter)]
 enum IdSource {
     /// Use buffers to load the vertex and instance index
     Buffers,
@@ -156,28 +149,16 @@ enum IdSource {
     Builtins,
 }
 
-impl IdSource {
-    const ARRAY: [Self; 2] = [Self::Buffers, Self::Builtins];
-}
-
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, strum::EnumIter)]
 enum DrawCallKind {
     Direct,
     Indirect,
 }
 
-impl DrawCallKind {
-    const ARRAY: [Self; 2] = [Self::Direct, Self::Indirect];
-}
-
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, strum::EnumIter)]
 enum EncoderKind {
     RenderPass,
     RenderBundle,
-}
-
-impl EncoderKind {
-    const ARRAY: [Self; 2] = [Self::RenderPass, Self::RenderBundle];
 }
 
 struct Test {
@@ -356,11 +337,17 @@ async fn vertex_index_common(ctx: TestingContext) {
         )
         .create_view(&wgpu::TextureViewDescriptor::default());
 
-    let mut tests = Vec::with_capacity(5 * 2 * 2 * 2);
-    for case in TestCase::ARRAY {
-        for id_source in IdSource::ARRAY {
-            for draw_call_kind in DrawCallKind::ARRAY {
-                for encoder_kind in EncoderKind::ARRAY {
+    let mut tests = Vec::with_capacity(
+        TestCase::iter().count()
+            * IdSource::iter().count()
+            * DrawCallKind::iter().count()
+            * EncoderKind::iter().count()
+            * [false, true].iter().count(),
+    );
+    for case in TestCase::iter() {
+        for id_source in IdSource::iter() {
+            for draw_call_kind in DrawCallKind::iter() {
+                for encoder_kind in EncoderKind::iter() {
                     for vertex_pulling_transform in [false, true] {
                         tests.push(Test {
                             case,

--- a/tests/tests/vertex_indices/mod.rs
+++ b/tests/tests/vertex_indices/mod.rs
@@ -8,7 +8,6 @@ use std::{num::NonZeroU64, ops::Range};
 use itertools::Itertools;
 use strum::IntoEnumIterator;
 use wgpu::util::{BufferInitDescriptor, DeviceExt, RenderEncoder};
-
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 use wgt::RenderBundleDescriptor;
 
@@ -379,7 +378,7 @@ async fn vertex_index_common(ctx: TestingContext) {
 
         let expected = test.expectation(&ctx);
 
-        let buffer_size = 4 * expected.len() as u64;
+        let buffer_size = (std::mem::size_of_val(&expected[0]) * expected.len()) as u64;
         let cpu_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
             size: buffer_size,


### PR DESCRIPTION
Re-file of <https://github.com/gfx-rs/wgpu/pull/5840>, but actually targeting `trunk` this time. 😅