### PR TITLE
test: fix `wgpu-test` building by itself

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -38,7 +38,7 @@ serde_json.workspace = true
 serde.workspace = true
 strum = { workspace = true, features = ["derive"] }
 wgpu-macros.workspace = true
-wgpu.workspace = true
+wgpu = { workspace = true, features = ["wgsl"] }
 wgt = { workspace = true, features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
**Connections**

N/A

**Description**

`cargo check --package wgpu-test` doesn't run, because it needs `wgpu`'s `wgsl` feature enabled for the `image` module to compile.

**Testing**

IT WORK

I wish we had a separate build step to check things like this, but I don't know if it makes sense to add tests for specifically.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ Not gonna do it here.
