### PR TITLE
Validating sample count based on texture features

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3043,6 +3043,17 @@ impl<A: HalApi> Device<A> {
                         break 'error Some(pipeline::ColorStateError::FormatNotColor(cs.format));
                     }
 
+                    if !format_features
+                        .flags
+                        .supported_sample_counts()
+                        .into_iter()
+                        .any(|count: u32| format_features.flags.sample_count_supported(count))
+                    {
+                        break 'error Some(pipeline::ColorStateError::UnsupportedSampleCount(
+                            desc.multisample.count,
+                        ));
+                    }
+
                     if desc.multisample.count > 1
                         && !format_features
                             .flags

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -444,6 +444,10 @@ pub enum ColorStateError {
     FormatNotBlendable(wgt::TextureFormat),
     #[error("Format {0:?} does not have a color aspect")]
     FormatNotColor(wgt::TextureFormat),
+    #[error(
+        "No texture format supports sample count {0} with the current set of adapter features."
+    )]
+    UnsupportedSampleCount(u32),
     #[error("Sample count {0} is not supported by format {1:?} on this device. The WebGPU spec guarantees {2:?} samples are supported by this format. With the TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES feature your device supports {3:?}.")]
     InvalidSampleCount(u32, wgt::TextureFormat, Vec<u32>, Vec<u32>),
     #[error("Output format {pipeline} is incompatible with the shader {shader}")]


### PR DESCRIPTION
**Connections**
#5749 

**Description**
We are validating if the sample count is valid for _any_ texture format.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
