### PR TITLE
Expose adapter driver version for DX12 backend

### DIFF
--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -132,7 +132,7 @@ impl super::Adapter {
                 wgt::DeviceType::DiscreteGpu
             },
             driver: {
-                let mut i = winnt::LARGE_INTEGER::default();
+                let mut i: winnt::LARGE_INTEGER = unsafe { mem::zeroed() };
                 if 0 == unsafe {
                     adapter.CheckInterfaceSupport(&dxgi::IDXGIDevice::uuidof(), &mut i)
                 } {

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -8,7 +8,8 @@ use winapi::{
     shared::{
         dxgi, dxgi1_2, dxgiformat::DXGI_FORMAT_B8G8R8A8_UNORM, minwindef::DWORD, windef, winerror,
     },
-    um::{d3d12 as d3d12_ty, d3d12sdklayers, winuser},
+    um::{d3d12 as d3d12_ty, d3d12sdklayers, winnt, winuser},
+    Interface,
 };
 
 impl Drop for super::Adapter {
@@ -130,7 +131,24 @@ impl super::Adapter {
             } else {
                 wgt::DeviceType::DiscreteGpu
             },
-            driver: String::new(),
+            driver: {
+                let mut i = winnt::LARGE_INTEGER::default();
+                if 0 == unsafe {
+                    adapter.CheckInterfaceSupport(dxgi::IDXGIDevice::uuidof(), &mut i)
+                } {
+                    let quad_part = unsafe { *i.QuadPart() };
+                    const MASK: i64 = 0xFFFF;
+                    format!(
+                        "{}.{}.{}.{}",
+                        quad_part >> 48,
+                        (quad_part >> 32) & MASK,
+                        (quad_part >> 16) & MASK,
+                        quad_part & MASK
+                    )
+                } else {
+                    String::new()
+                }
+            },
             driver_info: String::new(),
         };
 

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -134,7 +134,7 @@ impl super::Adapter {
             driver: {
                 let mut i = winnt::LARGE_INTEGER::default();
                 if 0 == unsafe {
-                    adapter.CheckInterfaceSupport(dxgi::IDXGIDevice::uuidof(), &mut i)
+                    adapter.CheckInterfaceSupport(&dxgi::IDXGIDevice::uuidof(), &mut i)
                 } {
                     let quad_part = unsafe { *i.QuadPart() };
                     const MASK: i64 = 0xFFFF;


### PR DESCRIPTION
**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
