### PR TITLE
[wgpu-core] use the view's format not the texture's format

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1155,7 +1155,7 @@ impl<'d, A: HalApi> RenderPassInfo<'d, A> {
         let attachment_formats = AttachmentData {
             colors: color_attachments
                 .iter()
-                .map(|at| at.as_ref().map(|at| at.view.desc.texture_format))
+                .map(|at| at.as_ref().map(|at| at.view.desc.format))
                 .collect(),
             resolves: color_attachments
                 .iter()


### PR DESCRIPTION
This fixes a regression introduced in 0a76c0fa84e5e8c10c62f0a19fb54b65c0a4f6e2 (https://github.com/gfx-rs/wgpu/pull/5884).
Fixes https://github.com/gfx-rs/wgpu/issues/5904.

