### PR TITLE
Use `derive` feature on `serde` rather than `serde_derive`

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -114,7 +114,7 @@ profiling = { version = "1", default-features = false }
 raw-window-handle = { version = "0.6", optional = true }
 ron = { version = "0.8", optional = true }
 rustc-hash = "1.1"
-serde = { version = "1", features = ["serde_derive"], optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 smallvec = "1"
 thiserror = "1"
 

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -35,7 +35,7 @@ counters = []
 
 [dependencies]
 bitflags = "2"
-serde = { version = "1", features = ["serde_derive"], optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.69"
@@ -47,5 +47,5 @@ web-sys = { version = "0.3.69", features = [
 ] }
 
 [dev-dependencies]
-serde = { version = "1", features = ["serde_derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.119"


### PR DESCRIPTION
**Description**
The current code works, but `serde` documents that the feature to use is `derive` (which then happens to use the `serde_derive` implicit feature).

See https://serde.rs/derive.html

**Testing**
Code compiles and passes tests.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
