### PR TITLE
wgc: Use explicit feature for `raw-window-handle`

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -60,6 +60,9 @@ trace = ["dep:ron", "serde", "naga/serialize"]
 ## Enable API replaying
 replay = ["serde", "naga/deserialize"]
 
+## Enable creating instances using raw-window-handle
+raw-window-handle = ["dep:raw-window-handle"]
+
 ## Enable `ShaderModuleSource::Wgsl`
 wgsl = ["naga/wgsl-in"]
 


### PR DESCRIPTION
**Description**
The 2024 edition of Rust is planning to not allow implicit features. Here, we now use an explicit feature for `raw-window-handle` in `wgpu-core`. This also removes an implicit feature for `ron` which was not needed (shown when doing a `cargo add wgpu-core`).

This helps to prepare for the coming day when explicit features will be required.

**Testing**
Compiles and passes tests.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
