### PR TITLE
[wgpu-core] fix trying to create 0 sized staging buffers when creating mapped_at_creation buffers

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -591,13 +591,16 @@ impl<A: HalApi> Device<A> {
             };
             hal::BufferUses::MAP_WRITE
         } else {
-            let (staging_buffer, staging_buffer_ptr) =
-                queue::prepare_staging_buffer(self, desc.size, self.instance_flags)?;
+            let (staging_buffer, staging_buffer_ptr) = queue::prepare_staging_buffer(
+                self,
+                wgt::BufferSize::new(aligned_size).unwrap(),
+                self.instance_flags,
+            )?;
 
             // Zero initialize memory and then mark the buffer as initialized
             // (it's guaranteed that this is the case by the time the buffer is usable)
-            unsafe { std::ptr::write_bytes(staging_buffer_ptr.as_ptr(), 0, buffer.size as usize) };
-            buffer.initialization_status.write().drain(0..buffer.size);
+            unsafe { std::ptr::write_bytes(staging_buffer_ptr.as_ptr(), 0, aligned_size as usize) };
+            buffer.initialization_status.write().drain(0..aligned_size);
 
             *buffer.map_state.lock() = resource::BufferMapState::Init {
                 staging_buffer,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -867,7 +867,7 @@ impl<A: HalApi> Drop for DestroyedBuffer<A> {
 pub struct StagingBuffer<A: HalApi> {
     pub(crate) raw: Mutex<Option<A::Buffer>>,
     pub(crate) device: Arc<Device<A>>,
-    pub(crate) size: wgt::BufferAddress,
+    pub(crate) size: wgt::BufferSize,
     pub(crate) is_coherent: bool,
 }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2203,7 +2203,7 @@ impl crate::Context for ContextWgpuCore {
         size: wgt::BufferSize,
     ) -> Option<()> {
         match wgc::gfx_select!(
-            *queue => self.0.queue_validate_write_buffer(*queue, *buffer, offset, size.get())
+            *queue => self.0.queue_validate_write_buffer(*queue, *buffer, offset, size)
         ) {
             Ok(()) => Some(()),
             Err(err) => {


### PR DESCRIPTION
This issue was introduced by fabbca294ae6c4b271688a4d0d3456082f1cba3f (https://github.com/gfx-rs/wgpu/pull/5910).

Kudos to @nical for tracking it down.