### PR TITLE
[core] Correctly check mipmap-filtering samplers against the layout.

### DIFF
--- a/tests/tests/bind_groups.rs
+++ b/tests/tests/bind_groups.rs
@@ -1,0 +1,116 @@
+use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+
+/// Test `descriptor` against a bind group layout that requires non-filtering sampler.
+fn try_sampler_nonfiltering_layout(
+    ctx: TestingContext,
+    descriptor: &wgpu::SamplerDescriptor,
+    good: bool,
+) {
+    let label = descriptor.label;
+    let bind_group_layout = ctx
+        .device
+        .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label,
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                count: None,
+            }],
+        });
+
+    let sampler = ctx.device.create_sampler(descriptor);
+
+    let create_bind_group = || {
+        ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label,
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Sampler(&sampler),
+            }],
+        });
+    };
+
+    if good {
+        wgpu_test::valid(&ctx.device, create_bind_group);
+    } else {
+        wgpu_test::fail(
+            &ctx.device,
+            create_bind_group,
+            Some("but given a sampler with filtering"),
+        );
+    }
+}
+
+#[gpu_test]
+static BIND_GROUP_NONFILTERING_LAYOUT_NONFILTERING_SAMPLER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(TestParameters::default())
+        .run_sync(|ctx| {
+            try_sampler_nonfiltering_layout(
+                ctx,
+                &wgpu::SamplerDescriptor {
+                    label: Some("bind_group_non_filtering_layout_nonfiltering_sampler"),
+                    min_filter: wgpu::FilterMode::Nearest,
+                    mag_filter: wgpu::FilterMode::Nearest,
+                    mipmap_filter: wgpu::FilterMode::Nearest,
+                    ..wgpu::SamplerDescriptor::default()
+                },
+                true,
+            );
+        });
+
+#[gpu_test]
+static BIND_GROUP_NONFILTERING_LAYOUT_MIN_SAMPLER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(TestParameters::default())
+        .run_sync(|ctx| {
+            try_sampler_nonfiltering_layout(
+                ctx,
+                &wgpu::SamplerDescriptor {
+                    label: Some("bind_group_non_filtering_layout_min_sampler"),
+                    min_filter: wgpu::FilterMode::Linear,
+                    mag_filter: wgpu::FilterMode::Nearest,
+                    mipmap_filter: wgpu::FilterMode::Nearest,
+                    ..wgpu::SamplerDescriptor::default()
+                },
+                false,
+            );
+        });
+
+#[gpu_test]
+static BIND_GROUP_NONFILTERING_LAYOUT_MAG_SAMPLER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(TestParameters::default())
+        .run_sync(|ctx| {
+            try_sampler_nonfiltering_layout(
+                ctx,
+                &wgpu::SamplerDescriptor {
+                    label: Some("bind_group_non_filtering_layout_mag_sampler"),
+                    min_filter: wgpu::FilterMode::Nearest,
+                    mag_filter: wgpu::FilterMode::Linear,
+                    mipmap_filter: wgpu::FilterMode::Nearest,
+                    ..wgpu::SamplerDescriptor::default()
+                },
+                false,
+            );
+        });
+
+#[gpu_test]
+static BIND_GROUP_NONFILTERING_LAYOUT_MIPMAP_SAMPLER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(TestParameters::default())
+        .run_sync(|ctx| {
+            try_sampler_nonfiltering_layout(
+                ctx,
+                &wgpu::SamplerDescriptor {
+                    label: Some("bind_group_non_filtering_layout_mipmap_sampler"),
+                    min_filter: wgpu::FilterMode::Nearest,
+                    mag_filter: wgpu::FilterMode::Nearest,
+                    mipmap_filter: wgpu::FilterMode::Linear,
+                    ..wgpu::SamplerDescriptor::default()
+                },
+                false,
+            );
+        });

--- a/tests/tests/root.rs
+++ b/tests/tests/root.rs
@@ -8,6 +8,7 @@ mod regression {
 
 mod bgra8unorm_storage;
 mod bind_group_layout_dedup;
+mod bind_groups;
 mod buffer;
 mod buffer_copy;
 mod buffer_usages;

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1380,7 +1380,8 @@ impl<A: HalApi> Device<A> {
             tracking_data: TrackingData::new(self.tracker_indices.samplers.clone()),
             comparison: desc.compare.is_some(),
             filtering: desc.min_filter == wgt::FilterMode::Linear
-                || desc.mag_filter == wgt::FilterMode::Linear,
+                || desc.mag_filter == wgt::FilterMode::Linear
+                || desc.mipmap_filter == wgt::FilterMode::Linear,
         };
 
         let sampler = Arc::new(sampler);


### PR DESCRIPTION
Ensure that samplers using non-`Nearest` mipmap filtering are considered "filtering samplers" when deciding bind group layout compatibility.

Add tests for layout `NonFiltering` validation.

Fixes #5948.
