### PR TITLE
[tests] delete outdated comment on `DEVICE_DESTROY_THEN_MORE` test

### DIFF
--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -147,14 +147,6 @@ async fn request_device_error_message() {
 
 // This is a test of device behavior after device.destroy. Specifically, all operations
 // should trigger errors since the device is lost.
-//
-// On DX12 this test fails with a validation error in the very artificial actions taken
-// after lose the device. The error is "ID3D12CommandAllocator::Reset: The command
-// allocator cannot be reset because a command list is currently being recorded with the
-// allocator." That may indicate that DX12 doesn't like opened command buffers staying
-// open even after they return an error. For now, this test is skipped on DX12.
-//
-// The DX12 issue may be related to https://github.com/gfx-rs/wgpu/issues/3193.
 #[gpu_test]
 static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default().features(wgpu::Features::CLEAR_TEXTURE))


### PR DESCRIPTION
This was resolved by 6e21f7a9291db4395192d6b510d906978ae2d251 (https://github.com/gfx-rs/wgpu/pull/3626).
