### PR TITLE
[test] allow WARP to run the zero-init workgroup memory test

### DIFF
--- a/tests/tests/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/shader/zero_init_workgroup_mem.rs
@@ -1,28 +1,21 @@
 use std::num::NonZeroU64;
 
 use wgpu::{
-    include_wgsl, Backends, BindGroupDescriptor, BindGroupEntry, BindGroupLayoutDescriptor,
+    include_wgsl, BindGroupDescriptor, BindGroupEntry, BindGroupLayoutDescriptor,
     BindGroupLayoutEntry, BindingResource, BindingType, BufferBinding, BufferBindingType,
     BufferDescriptor, BufferUsages, CommandEncoderDescriptor, ComputePassDescriptor,
     ComputePipelineDescriptor, DownlevelFlags, Limits, Maintain, MapMode, PipelineLayoutDescriptor,
     ShaderStages,
 };
 
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
 
 #[gpu_test]
 static ZERO_INIT_WORKGROUP_MEMORY: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
-            .limits(Limits::downlevel_defaults())
-            // remove once we get to https://github.com/gfx-rs/wgpu/issues/3193
-            .skip(FailureCase {
-                backends: Some(Backends::DX12),
-                vendor: Some(5140),
-                adapter: Some("Microsoft Basic Render Driver"),
-                ..FailureCase::default()
-            }),
+            .limits(Limits::downlevel_defaults()),
     )
     .run_async(|ctx| async move {
         let bgl = ctx


### PR DESCRIPTION
I pinpointed this to 438d6394efd5a41d62c07d18c8fff58dd0243a74 (https://github.com/gfx-rs/wgpu/pull/3512).
I'm not sure why I didn't remove this one in 30064ead9fd7639f9fd842b0a3188baf9dc8bee3 (https://github.com/gfx-rs/wgpu/pull/3515) as well, maybe I thought it was still failing due to early frees.
