### PR TITLE
[wgpu-core] fix length of copy in `queue_write_texture`

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -781,7 +781,14 @@ impl Global {
         if stage_bytes_per_row == bytes_per_row {
             profiling::scope!("copy aligned");
             // Fast path if the data is already being aligned optimally.
-            staging_buffer.write(&data[data_layout.offset as usize..]);
+            unsafe {
+                staging_buffer.write_with_offset(
+                    data,
+                    data_layout.offset as isize,
+                    0,
+                    (data.len() as u64 - data_layout.offset) as usize,
+                );
+            }
         } else {
             profiling::scope!("copy chunked");
             // Copy row by row into the optimal alignment.


### PR DESCRIPTION
The size of the given `data` might be less than the size of the staging buffer. This issue became apparent with the refactor in 6f16ea460ab437173e14d2f5f3584ca7e1c9841d (https://github.com/gfx-rs/wgpu/pull/5946) since there is now an assert in `StagingBuffer.write()`. This means that we have been copying things past the end of `data` :grimacing:.

Ruffle ran into this in https://github.com/gfx-rs/wgpu/issues/3193#issuecomment-2231209711.
