### PR TITLE
Remove latest_submission_index

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -43,4 +43,4 @@ pollster.workspace = true
 profiling.workspace = true
 rayon.workspace = true
 tracy-client = { workspace = true, optional = true }
-wgpu = { workspace = true, features = ["wgsl"] }
+wgpu = { workspace = true, features = ["wgsl", "metal", "dx12"] }

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -5,13 +5,13 @@ use crate::{
     },
     hal_api::HalApi,
     id,
-    resource::{self, Buffer, Labeled, Trackable},
+    resource::{self, Buffer, Labeled, Texture, Trackable},
     snatch::SnatchGuard,
     SubmissionIndex,
 };
 use smallvec::SmallVec;
 
-use std::sync::Arc;
+use std::{mem, sync::Arc};
 use thiserror::Error;
 
 /// A command submitted to the GPU for execution.
@@ -53,6 +53,58 @@ struct ActiveSubmission<A: HalApi> {
     /// List of queue "on_submitted_work_done" closures to be called once this
     /// submission has completed.
     work_done_closures: SmallVec<[SubmittedWorkDoneClosure; 1]>,
+}
+
+impl<A: HalApi> ActiveSubmission<A> {
+    /// Returns true if this submission contains the given buffer.
+    /// 
+    /// This only uses constant-time operations.
+    pub fn contains_buffer(&self, buffer: &Buffer<A>) -> bool {
+        for encoder in &self.encoders {
+            // The ownership location of buffers depends on where the command encoder
+            // came from. If it is the staging command encoder on the queue, it is
+            // in the pending buffer list. If it came from a user command encoder,
+            // it is in the tracker.
+
+            if encoder.trackers.buffers.contains(buffer) {
+                return true;
+            }
+
+            if encoder
+                .pending_buffers
+                .contains_key(&buffer.tracker_index())
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Returns true if this submission contains the given texture.
+    /// 
+    /// This only uses constant-time operations.
+    pub fn contains_texture(&self, texture: &Texture<A>) -> bool {
+        for encoder in &self.encoders {
+            // The ownership location of textures depends on where the command encoder
+            // came from. If it is the staging command encoder on the queue, it is
+            // in the pending buffer list. If it came from a user command encoder,
+            // it is in the tracker.
+
+            if encoder.trackers.textures.contains(texture) {
+                return true;
+            }
+
+            if encoder
+                .pending_textures
+                .contains_key(&texture.tracker_index())
+            {
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
 #[derive(Clone, Debug, Error)]
@@ -165,6 +217,40 @@ impl<A: HalApi> LifetimeTracker<A> {
         self.mapped.push(value.clone());
     }
 
+    /// Returns the submission index of the most recent submission that uses the
+    /// given buffer.
+    pub fn get_buffer_latest_submission_index(
+        &self,
+        buffer: &Buffer<A>,
+    ) -> Option<SubmissionIndex> {
+        // We iterate in reverse order, so that we can bail out early as soon
+        // as we find a hit.
+        self.active.iter().rev().find_map(|submission| {
+            if submission.contains_buffer(buffer) {
+                Some(submission.index)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Returns the submission index of the most recent submission that uses the
+    /// given texture.
+    pub fn get_texture_latest_submission_index(
+        &self,
+        texture: &Texture<A>,
+    ) -> Option<SubmissionIndex> {
+        // We iterate in reverse order, so that we can bail out early as soon
+        // as we find a hit.
+        self.active.iter().rev().find_map(|submission| {
+            if submission.contains_texture(texture) {
+                Some(submission.index)
+            } else {
+                None
+            }
+        })
+    }
+
     /// Sort out the consequences of completed submissions.
     ///
     /// Assume that all submissions up through `last_done` have completed.
@@ -236,9 +322,7 @@ impl<A: HalApi> LifetimeTracker<A> {
             }
         }
     }
-}
 
-impl<A: HalApi> LifetimeTracker<A> {
     /// Determine which buffers are ready to map, and which must wait for the
     /// GPU.
     ///
@@ -248,21 +332,29 @@ impl<A: HalApi> LifetimeTracker<A> {
             return;
         }
 
-        for buffer in self.mapped.drain(..) {
-            let submit_index = buffer.submission_index();
+        // To avoid a borrow checker conflict between the mutable borrow of `self.mapped`
+        // and get_buffer_latest_submission_index, we steal the vector, drain it, then put it back.
+        //
+        // This way we still re-use the memory allocation, without the conflict.
+        let mut mapped = mem::take(&mut self.mapped);
+        for buffer in mapped.drain(..) {
+            let submit_index = self.get_buffer_latest_submission_index(&buffer);
             log::trace!(
                 "Mapping of {} at submission {:?} gets assigned to active {:?}",
                 buffer.error_ident(),
                 submit_index,
-                self.active.iter().position(|a| a.index == submit_index)
+                self.active
+                    .iter()
+                    .position(|a| Some(a.index) == submit_index)
             );
 
             self.active
                 .iter_mut()
-                .find(|a| a.index == submit_index)
+                .find(|a| Some(a.index) == submit_index)
                 .map_or(&mut self.ready_to_map, |a| &mut a.mapped)
                 .push(buffer);
         }
+        self.mapped = mapped;
     }
 
     /// Map the buffers in `self.ready_to_map`.

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -57,7 +57,7 @@ struct ActiveSubmission<A: HalApi> {
 
 impl<A: HalApi> ActiveSubmission<A> {
     /// Returns true if this submission contains the given buffer.
-    /// 
+    ///
     /// This only uses constant-time operations.
     pub fn contains_buffer(&self, buffer: &Buffer<A>) -> bool {
         for encoder in &self.encoders {
@@ -82,7 +82,7 @@ impl<A: HalApi> ActiveSubmission<A> {
     }
 
     /// Returns true if this submission contains the given texture.
-    /// 
+    ///
     /// This only uses constant-time operations.
     pub fn contains_texture(&self, texture: &Texture<A>) -> bool {
         for encoder in &self.encoders {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1007,7 +1007,6 @@ impl Global {
                     .drain(init_layer_range);
             }
         }
-        dst.use_at(device.active_submission_index.load(Ordering::Relaxed) + 1);
 
         let snatch_guard = device.snatchable_lock.read();
         let dst_raw = dst.try_raw(&snatch_guard)?;

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -14,7 +14,7 @@ use crate::{
     resource_log,
     snatch::{ExclusiveSnatchGuard, SnatchGuard, Snatchable},
     track::{SharedTrackerIndexAllocator, TextureSelector, TrackerIndex},
-    Label, LabelHelpers, SubmissionIndex,
+    Label, LabelHelpers,
 };
 
 use hal::CommandEncoder;
@@ -28,10 +28,7 @@ use std::{
     mem::{self, ManuallyDrop},
     ops::Range,
     ptr::NonNull,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc, Weak,
-    },
+    sync::{Arc, Weak},
 };
 
 /// Information about the wgpu-core resource.
@@ -57,14 +54,6 @@ use std::{
 pub(crate) struct TrackingData {
     tracker_index: TrackerIndex,
     tracker_indices: Arc<SharedTrackerIndexAllocator>,
-    /// The index of the last queue submission in which the resource
-    /// was used.
-    ///
-    /// Each queue submission is fenced and assigned an index number
-    /// sequentially. Thus, when a queue submission completes, we know any
-    /// resources used in that submission and any lower-numbered submissions are
-    /// no longer in use by the GPU.
-    submission_index: AtomicUsize,
 }
 
 impl Drop for TrackingData {
@@ -78,23 +67,11 @@ impl TrackingData {
         Self {
             tracker_index: tracker_indices.alloc(),
             tracker_indices,
-            submission_index: AtomicUsize::new(0),
         }
     }
 
     pub(crate) fn tracker_index(&self) -> TrackerIndex {
         self.tracker_index
-    }
-
-    /// Record that this resource will be used by the queue submission with the
-    /// given index.
-    pub(crate) fn use_at(&self, submit_index: SubmissionIndex) {
-        self.submission_index
-            .store(submit_index as _, Ordering::Release);
-    }
-
-    pub(crate) fn submission_index(&self) -> SubmissionIndex {
-        self.submission_index.load(Ordering::Acquire) as _
     }
 }
 
@@ -197,10 +174,6 @@ macro_rules! impl_labeled {
 
 pub(crate) trait Trackable: Labeled {
     fn tracker_index(&self) -> TrackerIndex;
-    /// Record that this resource will be used by the queue submission with the
-    /// given index.
-    fn use_at(&self, submit_index: SubmissionIndex);
-    fn submission_index(&self) -> SubmissionIndex;
 }
 
 #[macro_export]
@@ -209,12 +182,6 @@ macro_rules! impl_trackable {
         impl<A: HalApi> $crate::resource::Trackable for $ty<A> {
             fn tracker_index(&self) -> $crate::track::TrackerIndex {
                 self.tracking_data.tracker_index()
-            }
-            fn use_at(&self, submit_index: $crate::SubmissionIndex) {
-                self.tracking_data.use_at(submit_index)
-            }
-            fn submission_index(&self) -> $crate::SubmissionIndex {
-                self.tracking_data.submission_index()
             }
         }
     };
@@ -665,7 +632,6 @@ impl<A: HalApi> Buffer<A> {
 
                 let staging_buffer = staging_buffer.flush();
 
-                self.use_at(device.active_submission_index.load(Ordering::Relaxed) + 1);
                 let region = wgt::BufferSize::new(self.size).map(|size| hal::BufferCopy {
                     src_offset: 0,
                     dst_offset: 0,
@@ -754,10 +720,11 @@ impl<A: HalApi> Buffer<A> {
         if pending_writes.contains_buffer(self) {
             pending_writes.consume_temp(temp);
         } else {
-            let last_submit_index = self.submission_index();
-            device
-                .lock_life()
-                .schedule_resource_destruction(temp, last_submit_index);
+            let mut life_lock = device.lock_life();
+            let last_submit_index = life_lock.get_buffer_latest_submission_index(self);
+            if let Some(last_submit_index) = last_submit_index {
+                life_lock.schedule_resource_destruction(temp, last_submit_index);
+            }
         }
 
         Ok(())
@@ -1218,10 +1185,11 @@ impl<A: HalApi> Texture<A> {
         if pending_writes.contains_texture(self) {
             pending_writes.consume_temp(temp);
         } else {
-            let last_submit_index = self.submission_index();
-            device
-                .lock_life()
-                .schedule_resource_destruction(temp, last_submit_index);
+            let mut life_lock = device.lock_life();
+            let last_submit_index = life_lock.get_texture_latest_submission_index(self);
+            if let Some(last_submit_index) = last_submit_index {
+                life_lock.schedule_resource_destruction(temp, last_submit_index);
+            }
         }
 
         Ok(())

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -277,6 +277,11 @@ impl<A: HalApi> BufferTracker<A> {
         }
     }
 
+    /// Returns true if the given buffer is tracked.
+    pub fn contains(&self, buffer: &Buffer<A>) -> bool {
+        self.metadata.contains(buffer.tracker_index().as_usize())
+    }
+
     /// Returns a list of all buffers tracked.
     pub fn used_resources(&self) -> impl Iterator<Item = Arc<Buffer<A>>> + '_ {
         self.metadata.owned_resources()

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -67,7 +67,7 @@ impl<T: Clone> ResourceMetadata<T> {
 
     /// Returns true if the set contains the resource with the given index.
     pub(super) fn contains(&self, index: usize) -> bool {
-        self.owned[index]
+        self.owned.get(index).unwrap_or(false)
     }
 
     /// Returns true if the set contains the resource with the given index.

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -34,12 +34,6 @@ impl<T: Trackable> StatelessBindGroupState<T> {
         resources.sort_unstable_by_key(|resource| resource.tracker_index());
     }
 
-    /// Returns a list of all resources tracked. May contain duplicates.
-    pub fn used_resources(&self) -> impl Iterator<Item = Arc<T>> + '_ {
-        let resources = self.resources.lock();
-        resources.iter().cloned().collect::<Vec<_>>().into_iter()
-    }
-
     /// Adds the given resource.
     pub fn add_single(&self, resource: &Arc<T>) {
         let mut resources = self.resources.lock();
@@ -77,11 +71,6 @@ impl<T: Trackable> StatelessTracker<T> {
         if index >= self.metadata.size() {
             self.set_size(index + 1);
         }
-    }
-
-    /// Returns a list of all resources tracked.
-    pub fn used_resources(&self) -> impl Iterator<Item = Arc<T>> + '_ {
-        self.metadata.owned_resources()
     }
 
     /// Inserts a single resource into the resource tracker.

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -446,6 +446,11 @@ impl<A: HalApi> TextureTracker<A> {
         }
     }
 
+    /// Returns true if the tracker owns the given texture.
+    pub fn contains(&self, texture: &Texture<A>) -> bool {
+        self.metadata.contains(texture.tracker_index().as_usize())
+    }
+
     /// Returns a list of all textures tracked.
     pub fn used_resources(&self) -> impl Iterator<Item = Arc<Texture<A>>> + '_ {
         self.metadata.owned_resources()


### PR DESCRIPTION
**Description**

This PR flips how latest_submission_index is computed. Previously every submit told each resource that it was used. Now we run through the list of active submissions to see if any of them contain the buffer.

The act of incrementing the value for all resources was quite expensive for the few times we actually needed to know it. 

**Testing**

Tests pass, wrote comments explaining my code

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
