### PR TITLE
wgpu-types: Use explicit feature for `serde`

### DIFF
--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -30,6 +30,7 @@ targets = [
 [features]
 strict_asserts = []
 fragile-send-sync-non-atomic-wasm = []
+serde = ["dep:serde"]
 # Enables some internal instrumentation for debugging purposes.
 counters = []
 


### PR DESCRIPTION
**Description**
This helps to prepare for the coming day when explicit features will be required.

**Testing**
It compiles.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
