### PR TITLE
Allow 3D textures to be renderable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Bottom level categories:
 - Fix profiling with `tracy`. By @waywardmonkeys in [#5988](https://github.com/gfx-rs/wgpu/pull/5988)
 - As a workaround for [issue #4905](https://github.com/gfx-rs/wgpu/issues/4905), `wgpu-core` is undocumented unless `--cfg wgpu_core_doc` feature is enabled. By @kpreid in [#5987](https://github.com/gfx-rs/wgpu/pull/5987)
 - Bump MSRV for `d3d12`/`naga`/`wgpu-core`/`wgpu-hal`/`wgpu-types`' to 1.76. By @wumpf in [#6003](https://github.com/gfx-rs/wgpu/pull/6003)
+- Allow for 3D textures to be rendered. By @matthew-wong1 in [#6004](https://github.com/gfx-rs/wgpu/pull/6004)
 
 ## 22.0.0 (2024-07-17)
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -721,7 +721,7 @@ impl<A: HalApi> Device<A> {
 
         // Renderable textures can only be 2D or 3D
         if desc.dimension == wgt::TextureDimension::D1
-            && desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) 
+            && desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT)
         {
             return Err(CreateTextureError::InvalidDimensionUsages(
                 wgt::TextureUsages::RENDER_ATTACHMENT,
@@ -922,7 +922,7 @@ impl<A: HalApi> Device<A> {
             let dimension = match desc.dimension {
                 wgt::TextureDimension::D1 => TextureViewDimension::D1,
                 wgt::TextureDimension::D2 => TextureViewDimension::D2,
-                wgt::TextureDimension::D3 => unreachable!(),
+                wgt::TextureDimension::D3 => TextureViewDimension::D3,
             };
 
             let clear_label = hal_label(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -719,19 +719,22 @@ impl<A: HalApi> Device<A> {
             &self.limits,
         )?;
 
+        // Renderable textures can only be 2D or 3D
+        if desc.dimension == wgt::TextureDimension::D1
+            && desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) 
+        {
+            return Err(CreateTextureError::InvalidDimensionUsages(
+                wgt::TextureUsages::RENDER_ATTACHMENT,
+                desc.dimension,
+            ));
+        }
+
         if desc.dimension != wgt::TextureDimension::D2 {
             // Depth textures can only be 2D
             if desc.format.is_depth_stencil_format() {
                 return Err(CreateTextureError::InvalidDepthDimension(
                     desc.dimension,
                     desc.format,
-                ));
-            }
-            // Renderable textures can only be 2D
-            if desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) {
-                return Err(CreateTextureError::InvalidDimensionUsages(
-                    wgt::TextureUsages::RENDER_ATTACHMENT,
-                    desc.dimension,
                 ));
             }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1975,7 +1975,7 @@ impl crate::Context for ContextWgpuCore {
                 &encoder_data.error_sink,
                 cause,
                 desc.label,
-                "CommandEncoder::begin_compute_pass",
+                "CommandEncoder::begin_render_pass",
             );
         }
 


### PR DESCRIPTION
**Description**
Hi! The WebGPU spec now allows textures with a 3D dimension to be renderable but the current wgpu implementation only allows for 2D textures to be renderable. I updated the checks to not throw an error if a 3D texture has GPUTextureUsage.RENDER_ATTACHMENT. I couldn't find any open issues or pull requests related to this. Sorry if it might be a work-in-progress or if it was a conscious decision not to enable 3D textures to be renderable yet!

I think the they updated the spec for 3D textures to be renderable around November 2023. 

**Testing**
I ran `cargo xtask test` on an M2 Mac. All tests passed except 3 (the same 3 also failed on the trunk branch of wgpu). 

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
