### PR TITLE
[core] Use `ManuallyDrop` for `wgpu_core::device::Queue::raw`.

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1601,7 +1601,7 @@ impl<A: HalApi> Device<A> {
 
         let encoder = self
             .command_allocator
-            .acquire_encoder(self.raw(), queue.raw.as_ref().unwrap())?;
+            .acquire_encoder(self.raw(), queue.raw())?;
 
         Ok(command::CommandBuffer::new(
             encoder,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -293,11 +293,7 @@ impl<A: HalApi> Adapter<A> {
             instance_flags,
         ) {
             let device = Arc::new(device);
-            let queue = Queue {
-                device: device.clone(),
-                raw: Some(hal_device.queue),
-            };
-            let queue = Arc::new(queue);
+            let queue = Arc::new(Queue::new(device.clone(), hal_device.queue));
             device.set_queue(&queue);
             return Ok((device, queue));
         }

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -326,13 +326,7 @@ impl Global {
                             log::error!("Presented frame is from a different surface");
                             Err(hal::SurfaceError::Lost)
                         } else {
-                            unsafe {
-                                queue
-                                    .raw
-                                    .as_ref()
-                                    .unwrap()
-                                    .present(suf.unwrap(), raw.take().unwrap())
-                            }
+                            unsafe { queue.raw().present(suf.unwrap(), raw.take().unwrap()) }
                         }
                     }
                     _ => unreachable!(),

--- a/wgpu-hal/src/gles/emscripten.rs
+++ b/wgpu-hal/src/gles/emscripten.rs
@@ -11,7 +11,7 @@ extern "C" {
 ///
 /// returns true on success
 ///
-/// # Safety:
+/// # Safety
 ///
 /// - opengl context MUST BE current
 /// - extension_name_null_terminated argument must be a valid string with null terminator.

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -950,7 +950,7 @@ impl crate::Surface for super::Surface {
         device: &super::Device,
         config: &crate::SurfaceConfiguration,
     ) -> Result<(), crate::SurfaceError> {
-        // Safety: `configure`'s contract guarantees there are no resources derived from the swapchain in use.
+        // SAFETY: `configure`'s contract guarantees there are no resources derived from the swapchain in use.
         let mut swap_chain = self.swapchain.write();
         let old = swap_chain
             .take()
@@ -964,7 +964,7 @@ impl crate::Surface for super::Surface {
 
     unsafe fn unconfigure(&self, device: &super::Device) {
         if let Some(sc) = self.swapchain.write().take() {
-            // Safety: `unconfigure`'s contract guarantees there are no resources derived from the swapchain in use.
+            // SAFETY: `unconfigure`'s contract guarantees there are no resources derived from the swapchain in use.
             let swapchain = unsafe { sc.release_resources(&device.shared.raw) };
             unsafe { swapchain.functor.destroy_swapchain(swapchain.raw, None) };
         }


### PR DESCRIPTION
Change the field `wgpu_core::device::Queue::raw` from an `Option<A::Queue>` to a `std::mem::ManuallyDrop<A::Queue>`. Replace various `.as_ref().unwrap()` chains with calls to a new accessor function `Queue::raw`.

An `Option` is misleading, as this field is always populated during the lifetime of a `Queue`. Instead, we simply have a field whose value needs to be moved in `<Queue as Drop>::drop`; `ManuallyDrop` is the Rust idiom for this situation.
