### PR TITLE
[wgpu-tests] Use concrete error messages for failures

### DIFF
--- a/tests/tests/bind_group_layout_dedup.rs
+++ b/tests/tests/bind_group_layout_dedup.rs
@@ -373,7 +373,7 @@ fn separate_pipelines_have_incompatible_derived_bgls(ctx: TestingContext) {
         || {
             drop(pass);
         },
-        None,
+        Some("label at index 0 is not compatible with the corresponding bindgrouplayout"),
     );
 }
 
@@ -445,7 +445,7 @@ fn derived_bgls_incompatible_with_regular_bgls(ctx: TestingContext) {
         || {
             drop(pass);
         },
-        None,
+        Some("label at index 0 is not compatible with the corresponding bindgrouplayout"),
     )
 }
 

--- a/tests/tests/buffer.rs
+++ b/tests/tests/buffer.rs
@@ -230,7 +230,7 @@ static MINIMUM_BUFFER_BINDING_SIZE_LAYOUT: GpuTestConfiguration = GpuTestConfigu
                         cache: None,
                     });
             },
-            None,
+            Some("shader global resourcebinding { group: 0, binding: 0 } is not available in the pipeline layout"),
         );
     });
 
@@ -335,7 +335,7 @@ static MINIMUM_BUFFER_BINDING_SIZE_DISPATCH: GpuTestConfiguration = GpuTestConfi
                 drop(pass);
                 let _ = encoder.finish();
             },
-            None,
+            Some("buffer is bound with size 16 where the shader expects 32 in group[0] compact index 0"),
         );
     });
 

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -298,7 +298,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                 ctx.device
                     .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a buffer should fail.
@@ -312,7 +312,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     mapped_at_creation: false,
                 });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a texture should fail.
@@ -334,7 +334,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     view_formats: &[],
                 });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Texture clear should fail.
@@ -352,7 +352,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     },
                 );
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a compute pass should fail.
@@ -364,7 +364,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     timestamp_writes: None,
                 });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a render pass should fail.
@@ -383,7 +383,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     occlusion_query_set: None,
                 });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Copying a buffer to a buffer should fail.
@@ -398,7 +398,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     256,
                 );
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Copying a buffer to a texture should fail.
@@ -418,7 +418,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     texture_extent,
                 );
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Copying a texture to a buffer should fail.
@@ -438,7 +438,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     texture_extent,
                 );
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Copying a texture to a texture should fail.
@@ -451,7 +451,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     texture_extent,
                 );
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a bind group layout should fail.
@@ -464,7 +464,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                         entries: &[],
                     });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a bind group should fail.
@@ -482,7 +482,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     }],
                 });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a pipeline layout should fail.
@@ -496,7 +496,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                         push_constant_ranges: &[],
                     });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a shader module should fail.
@@ -509,7 +509,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                         source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed("")),
                     });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a shader module spirv should fail.
@@ -522,7 +522,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                         source: std::borrow::Cow::Borrowed(&[]),
                     });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a render pipeline should fail.
@@ -547,7 +547,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                         cache: None,
                     });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a compute pipeline should fail.
@@ -564,7 +564,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                         cache: None,
                     });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Creating a compute pipeline should fail.
@@ -581,7 +581,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                         cache: None,
                     });
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Buffer map should fail.
@@ -592,7 +592,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
                     .slice(..)
                     .map_async(wgpu::MapMode::Write, |_| ());
             },
-            None,
+            Some("device with '' label is invalid"),
         );
 
         // Buffer unmap should fail.
@@ -601,7 +601,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
             || {
                 buffer_for_unmap.unmap();
             },
-            None,
+            Some("device with '' label is invalid"),
         );
     });
 

--- a/tests/tests/encoder.rs
+++ b/tests/tests/encoder.rs
@@ -68,7 +68,7 @@ static DROP_ENCODER_AFTER_ERROR: GpuTestConfiguration = GpuTestConfiguration::ne
                 renderpass.set_viewport(0.0, 0.0, -1.0, -1.0, 0.0, 1.0);
                 drop(renderpass);
             },
-            None,
+            Some("viewport has invalid rect"),
         );
 
         // This is the actual interesting error condition. We've created

--- a/tests/tests/float32_filterable.rs
+++ b/tests/tests/float32_filterable.rs
@@ -63,7 +63,7 @@ static FLOAT32_FILTERABLE_WITHOUT_FEATURE: GpuTestConfiguration = GpuTestConfigu
             || {
                 create_texture_binding(device, wgpu::TextureFormat::R32Float, true);
             },
-            None,
+            Some("texture binding 0 expects sample type = float { filterable: true }, but given a view with format = r32float"),
         );
     });
 

--- a/tests/tests/life_cycle.rs
+++ b/tests/tests/life_cycle.rs
@@ -4,7 +4,7 @@ use wgpu_test::{fail, gpu_test, GpuTestConfiguration};
 static BUFFER_DESTROY: GpuTestConfiguration =
     GpuTestConfiguration::new().run_async(|ctx| async move {
         let buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
-            label: None,
+            label: Some("buffer"),
             size: 256,
             usage: wgpu::BufferUsages::MAP_WRITE | wgpu::BufferUsages::COPY_SRC,
             mapped_at_creation: false,
@@ -25,7 +25,7 @@ static BUFFER_DESTROY: GpuTestConfiguration =
                     .slice(..)
                     .map_async(wgpu::MapMode::Write, move |_| {});
             },
-            None,
+            Some("buffer with 'buffer' label has been destroyed"),
         );
 
         buffer.destroy();

--- a/tests/tests/nv12_texture/mod.rs
+++ b/tests/tests/nv12_texture/mod.rs
@@ -149,7 +149,7 @@ static NV12_TEXTURE_VIEW_PLANE_ON_NON_PLANAR_FORMAT: GpuTestConfiguration =
                         ..Default::default()
                     });
                 },
-                None,
+                Some("aspect plane0 is not in the source texture format r8unorm"),
             );
         });
 
@@ -181,7 +181,7 @@ static NV12_TEXTURE_VIEW_PLANE_OUT_OF_BOUNDS: GpuTestConfiguration = GpuTestConf
                     ..Default::default()
                 });
             },
-            None,
+            Some("aspect plane2 is not in the source texture format nv12"),
         );
     });
 
@@ -213,7 +213,7 @@ static NV12_TEXTURE_BAD_FORMAT_VIEW_PLANE: GpuTestConfiguration = GpuTestConfigu
                     ..Default::default()
                 });
             },
-            None,
+            Some("unable to view texture nv12 as rg8unorm"),
         );
     });
 
@@ -241,6 +241,6 @@ static NV12_TEXTURE_BAD_SIZE: GpuTestConfiguration = GpuTestConfiguration::new()
                     view_formats: &[],
                 });
             },
-            None,
+            Some("width 255 is not a multiple of nv12's width multiple requirement"),
         );
     });

--- a/tests/tests/queue_transfer.rs
+++ b/tests/tests/queue_transfer.rs
@@ -46,6 +46,6 @@ static QUEUE_WRITE_TEXTURE_OVERFLOW: GpuTestConfiguration =
                     },
                 );
             },
-            None,
+            Some("end up overrunning the bounds of the destination texture"),
         );
     });

--- a/tests/tests/resource_error.rs
+++ b/tests/tests/resource_error.rs
@@ -14,15 +14,24 @@ static BAD_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|
                 mapped_at_creation: false,
             })
         },
-        None,
+        Some("`map` usage can only be combined with the opposite `copy`"),
     );
+
+    let error = match ctx.adapter_info.backend.to_str() {
+        "vulkan" | "vk" => "bufferid id(0,1,vk) is invalid",
+        "dx12" | "d3d12" => "bufferid id(0,1,d3d12) is invalid",
+        "metal" | "mtl" => "bufferid id(0,1,mtl) is invalid",
+        "opengl" | "gles" | "gl" => "bufferid id(0,1,gl) is invalid",
+        "webgpu" => "bufferid id(0,1,webgpu) is invalid",
+        b => b,
+    };
 
     fail(
         &ctx.device,
         || buffer.slice(..).map_async(wgpu::MapMode::Write, |_| {}),
-        None,
+        Some(error),
     );
-    fail(&ctx.device, || buffer.unmap(), None);
+    fail(&ctx.device, || buffer.unmap(), Some(error));
     valid(&ctx.device, || buffer.destroy());
     valid(&ctx.device, || buffer.destroy());
 });
@@ -47,15 +56,24 @@ static BAD_TEXTURE: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(
                 view_formats: &[],
             })
         },
-        None,
+        Some("dimension x is zero"),
     );
+
+    let error = match ctx.adapter_info.backend.to_str() {
+        "vulkan" | "vk" => "textureid id(0,1,vk) is invalid",
+        "dx12" | "d3d12" => "textureid id(0,1,d3d12) is invalid",
+        "metal" | "mtl" => "textureid id(0,1,mtl) is invalid",
+        "opengl" | "gles" | "gl" => "textureid id(0,1,gl) is invalid",
+        "webgpu" => "textureid id(0,1,webgpu) is invalid",
+        b => b,
+    };
 
     fail(
         &ctx.device,
         || {
             let _ = texture.create_view(&wgpu::TextureViewDescriptor::default());
         },
-        None,
+        Some(error),
     );
     valid(&ctx.device, || texture.destroy());
     valid(&ctx.device, || texture.destroy());

--- a/tests/tests/transfer.rs
+++ b/tests/tests/transfer.rs
@@ -64,6 +64,6 @@ static COPY_OVERFLOW_Z: GpuTestConfiguration = GpuTestConfiguration::new().run_s
             );
             ctx.queue.submit(Some(encoder.finish()));
         },
-        None,
+        Some("unable to select texture mip level"),
     );
 });

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -18,12 +18,10 @@ pub fn run_tests(shell: Shell, mut args: Arguments) -> anyhow::Result<()> {
     };
     let llvm_cov_nextest_flags: &[_] = if llvm_cov {
         &["llvm-cov", "--no-cfg-coverage", "--no-report", "nextest"]
+    } else if list {
+        &["nextest", "list"]
     } else {
-        if list {
-            &["nextest", "list"]
-        } else {
-            &["nextest", "run"]
-        }
+        &["nextest", "run"]
     };
 
     log::info!("Generating .gpuconfig file based on gpus on the system");


### PR DESCRIPTION
Partially resolves #5727 (note: edited by @ErichDonGubler).

**Connections**
https://github.com/gfx-rs/wgpu/issues/5727

**Description**
Its adding better descriptions to failure tests to avoid breaking because of regression

**Testing**
`cargo xtask test`

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ EDIT from @ErichDonGubler: Not necessary. 🙂
