### PR TITLE
Feature gate wgpu-core's api and resource level logging

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -72,6 +72,10 @@ glsl = ["naga/glsl-in"]
 ## Enable `ShaderModuleSource::SpirV`
 spirv = ["naga/spv-in", "dep:bytemuck"]
 
+## Enable wgpu-core's extensive api and resource level logging.
+## Disabled by default as it can have a noticeable performance impact.
+enable_heavy_logs = []
+
 ## Implement `Send` and `Sync` on Wasm, but only if atomics are not enabled.
 ##
 ## WebGL/WebGPU objects can not be shared between threads.

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -314,23 +314,31 @@ macro_rules! gfx_select {
     };
 }
 
-#[cfg(feature = "api_log_info")]
+#[cfg(all(feature = "api_log_info", feature = "enable_heavy_logs"))]
 macro_rules! api_log {
     ($($arg:tt)+) => (log::info!($($arg)+))
 }
-#[cfg(not(feature = "api_log_info"))]
+#[cfg(all(not(feature = "api_log_info"), feature = "enable_heavy_logs"))]
 macro_rules! api_log {
     ($($arg:tt)+) => (log::trace!($($arg)+))
+}
+#[cfg(not(feature = "enable_heavy_logs"))]
+macro_rules! api_log {
+    ($($arg:tt)+) => {};
 }
 pub(crate) use api_log;
 
-#[cfg(feature = "resource_log_info")]
+#[cfg(all(feature = "resource_log_info", feature = "enable_heavy_logs"))]
 macro_rules! resource_log {
     ($($arg:tt)+) => (log::info!($($arg)+))
 }
-#[cfg(not(feature = "resource_log_info"))]
+#[cfg(all(not(feature = "resource_log_info"), feature = "enable_heavy_logs"))]
 macro_rules! resource_log {
     ($($arg:tt)+) => (log::trace!($($arg)+))
+}
+#[cfg(not(feature = "enable_heavy_logs"))]
+macro_rules! resource_log {
+    ($($arg:tt)+) => {};
 }
 pub(crate) use resource_log;
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -84,6 +84,9 @@ naga-ir = ["dep:naga"]
 ## to the validation carried out at public APIs in all builds.
 strict_asserts = ["wgc?/strict_asserts", "wgt/strict_asserts"]
 
+## Enable wgpu-core's extensive api and resource level logging.
+enable_heavy_logs = ["wgc?/enable_heavy_logs"]
+
 ## Enables serialization via `serde` on common wgpu types.
 serde = ["dep:serde", "wgc/serde"]
 


### PR DESCRIPTION
**Connections**
Alternative to https://github.com/gfx-rs/wgpu/pull/6010
Fixes https://github.com/gfx-rs/wgpu/pull/6010

**Description**
This gates wgpu core's `api_log` and `resource_log` macros behind an `enable_heavy_logs` cargo feature (feature could probably use a better name).

**Testing**
_Explain how this change is tested._

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
