### PR TITLE
typos: More precise config, remove refs to "implace"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: weekly
     # This allows dependabot to update _all_ lockfile packages.
     #
-    # These will be grouped into the existing group update PRs, so shoudn't generate additional jobs.
+    # These will be grouped into the existing group update PRs, so shouldn't generate additional jobs.
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"

--- a/typos.toml
+++ b/typos.toml
@@ -1,5 +1,8 @@
 [files]
+# Include .github, .cargo, etc.
+ignore-hidden = false
 extend-exclude = [
+    '/.git',
     # spirv-asm isn't real source code
     '*.spvasm',
     'etc/big-picture.xml',
@@ -13,15 +16,22 @@ extend-exclude = [
 [default.extend-words]
 # Things that aren't typos
 lod = "lod"
-inout = "inout"
-derivate = "derivate"
-implace = "implace"
-Ded = "Ded"           # This shows up in "ANDed"
-pn = "pn"             # used as a normal name in debug-symbol-terrain.wgsl
 
 # Usernames
 Healthire = "Healthire"
 REASY = "REASY"
 
 [type.rust.extend-identifiers]
+ANDed = "ANDed"
 D3DCOLORtoUBYTE4 = "D3DCOLORtoUBYTE4"
+Derivate = "Derivate"
+inout = "inout"
+
+[type.wgsl]
+extend-glob = ["*.wgsl"]
+
+[type.wgsl.extend-identifiers]
+pn = "pn"
+
+[type.yaml.extend-words]
+dota = "dota"

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -7,7 +7,6 @@ Ash expects slices, which we don't generally have available.
 We cope with this requirement by the combination of the following ways:
   - temporarily allocating `Vec` on heap, where overhead is permitted
   - growing temporary local storage
-  - using `implace_it` on iterators
 
 ## Framebuffers and Render passes
 
@@ -714,7 +713,6 @@ impl Temp {
         self.marker.clear();
         self.buffer_barriers.clear();
         self.image_barriers.clear();
-        //see also - https://github.com/NotIntMan/inplace_it/issues/8
     }
 
     fn make_c_str(&mut self, name: &str) -> &CStr {


### PR DESCRIPTION
**Description**
The config can be made more precise so as to not accidentally ignore some issues due to case (in-)sensitivity and searching for substrings with `extend-words`.

Additionally, we can check the configuration directories as well like `.github`.

The usage of `implace_it` went away some time ago, but not all references were removed.

**Testing**
Running `typos`

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
