### PR TITLE
naga: Remove feature `std` for `indexmap`

### DIFF
--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -67,7 +67,7 @@ termcolor = { version = "1.4.1" }
 # https://github.com/brendanzab/codespan/commit/e99c867339a877731437e7ee6a903a3d03b5439e
 codespan-reporting = { version = "0.11.0" }
 rustc-hash = "1.1.0"
-indexmap = { version = "2", features = ["std"] }
+indexmap = "2"
 log = "0.4"
 spirv = { version = "0.3", optional = true }
 thiserror = "1.0.63"


### PR DESCRIPTION
**Description**
This was added in https://github.com/gfx-rs/naga/pull/2062

This was needed before version 2, but not in version 2, so it should be safe to remove now as it is enabled by default.

**Testing**
Compilation.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ EDIT from @ErichDonGubler: Not necessary. 🙂
