### PR TITLE
Use workspace dependencies more.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,10 +71,11 @@ version = "22.0.0"
 
 [workspace.dependencies]
 anyhow = "1.0.86"
+argh = "0.1.5"
 arrayvec = "0.7"
 bincode = "1"
 bit-vec = "0.8"
-bitflags = "2"
+bitflags = "2.6"
 bytemuck = { version = "1.16", features = ["derive"] }
 cfg_aliases = "0.1"
 cfg-if = "1"
@@ -91,6 +92,7 @@ getrandom = "0.2"
 glam = "0.28"
 heck = "0.5.0"
 image = { version = "0.24", default-features = false, features = ["png"] }
+indexmap = "2"
 itertools = { version = "0.10.5" }
 ktx2 = "0.3"
 libc = "0.2"
@@ -103,7 +105,7 @@ nanorand = { version = "0.7", default-features = false, features = ["wyrand"] }
 noise = { version = "0.8", git = "https://github.com/Razaekel/noise-rs.git", rev = "c6942d4fb70af26db4441edcf41f90fa115333f2" }
 nv-flip = "0.1"
 obj = "0.10"
-once_cell = "1"
+once_cell = "1.19.0"
 parking_lot = ">=0.11, <0.13" # parking_lot 0.12 switches from `winapi` to `windows`; permit either
 pico-args = { version = "0.5.0", features = [
     "eq-separator",
@@ -124,7 +126,7 @@ smallvec = "1"
 static_assertions = "1.1.0"
 strum = { version = "0.25.0", features = ["derive"] }
 tracy-client = "0.17"
-thiserror = "1"
+thiserror = "1.0.63"
 wgpu = { version = "22.0.0", path = "./wgpu", default-features = false }
 wgpu-core = { version = "22.0.0", path = "./wgpu-core" }
 wgpu-macros = { version = "22.0.0", path = "./wgpu-macros" }
@@ -146,7 +148,7 @@ gpu-descriptor = "0.3"
 
 # DX dependencies
 bit-set = "0.8"
-gpu-allocator = { version = "0.26", default-features = false, features = [
+gpu-allocator = { version = "0.27", default-features = false, features = [
     "d3d12",
     "public-winapi",
 ] }
@@ -159,6 +161,7 @@ hassle-rs = "0.11.0"
 khronos-egl = "6"
 glow = "0.14.0"
 glutin = "0.29.1"
+glutin_wgl_sys = "0.6"
 
 # DX and GLES dependencies
 windows = { version = "0.58", default-features = false }
@@ -182,6 +185,9 @@ deno_webidl = "0.143.0"
 deno_webgpu = { version = "0.118.0", path = "./deno_webgpu" }
 tokio = "1.38.1"
 termcolor = "1.4.1"
+
+# android dependencies
+ndk-sys = "0.5.0"
 
 [patch."https://github.com/gfx-rs/naga"]
 

--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -18,10 +18,10 @@ doc = false
 test = false
 
 [dependencies]
-bincode = "1"
-codespan-reporting = "0.11"
-env_logger = "0.11"
-argh = "0.1.5"
+bincode.workspace = true
+codespan-reporting.workspace = true
+env_logger.workspace = true
+argh.workspace = true
 anyhow.workspace = true
 
 [dependencies.naga]

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -59,31 +59,31 @@ compact = []
 
 [dependencies]
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
-bitflags = "2.6"
-bit-set = "0.8"
+arrayvec.workspace = true
+bitflags.workspace = true
+bit-set.workspace = true
 termcolor = { version = "1.4.1" }
 # remove termcolor dep when updating to the next version of codespan-reporting
 # termcolor minimum version was wrong and was fixed in
 # https://github.com/brendanzab/codespan/commit/e99c867339a877731437e7ee6a903a3d03b5439e
 codespan-reporting = { version = "0.11.0" }
-rustc-hash = "1.1.0"
-indexmap = "2"
+rustc-hash.workspace = true
+indexmap.workspace = true
 log = "0.4"
 spirv = { version = "0.3", optional = true }
-thiserror = "1.0.63"
+thiserror.workspace = true
 serde = { version = "1.0.204", features = ["derive"], optional = true }
 petgraph = { version = "0.6", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }
 unicode-xid = { version = "0.2.3", optional = true }
-arrayvec.workspace = true
 
 [build-dependencies]
 cfg_aliases.workspace = true
 
 [dev-dependencies]
 diff = "0.1"
-env_logger = "0.11"
+env_logger.workspace = true
 # This _cannot_ have a version specified. If it does, crates.io will look
 # for a version of the package on crates when we publish naga. Path dependencies
 # are allowed through though.
@@ -93,5 +93,5 @@ hlsl-snapshots = { path = "./hlsl-snapshots" }
 # incompatible with our tests because we do a syntactic diff and not a semantic one.
 ron = "0.8.0"
 rspirv = { version = "0.11", git = "https://github.com/gfx-rs/rspirv", rev = "b969f175d5663258b4891e44b76c1544da9661ab" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 spirv = { version = "0.3", features = ["deserialize"] }

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -103,23 +103,22 @@ gles = ["hal/gles"]
 dx12 = ["hal/dx12"]
 
 [dependencies]
-arrayvec = "0.7"
-bit-vec = "0.8"
-bitflags = "2"
-bytemuck = { version = "1.16", optional = true }
+arrayvec.workspace = true
+bit-vec.workspace = true
+bitflags.workspace = true
+bytemuck = { workspace = true, optional = true }
 document-features.workspace = true
-indexmap = "2"
-log = "0.4"
-once_cell = "1"
-# parking_lot 0.12 switches from `winapi` to `windows`; permit either
-parking_lot = ">=0.11, <0.13"
-profiling = { version = "1", default-features = false }
-raw-window-handle = { version = "0.6", optional = true }
-ron = { version = "0.8", optional = true }
-rustc-hash = "1.1"
-serde = { version = "1", features = ["derive"], optional = true }
-smallvec = "1"
-thiserror = "1"
+indexmap.workspace = true
+log.workspace = true
+once_cell.workspace = true
+parking_lot.workspace = true
+profiling = { workspace = true, default-features = false }
+raw-window-handle = { workspace = true, optional = true }
+ron = { workspace = true, optional = true }
+rustc-hash.workspace = true
+serde = { workspace = true, features = ["derive"], optional = true }
+smallvec.workspace = true
+thiserror.workspace = true
 
 [dependencies.naga]
 path = "../naga"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -110,20 +110,20 @@ name = "raw-gles"
 required-features = ["gles"]
 
 [dependencies]
-bitflags = "2"
-parking_lot = ">=0.11, <0.13"
-profiling = { version = "1", default-features = false }
-raw-window-handle = "0.6"
-thiserror = "1"
-once_cell = "1.19.0"
+bitflags.workspace = true
+parking_lot.workspace = true
+profiling = { workspace = true, default-features = false }
+raw-window-handle.workspace = true
+thiserror.workspace = true
+once_cell.workspace = true
 
 # backends common
-arrayvec = "0.7"
-rustc-hash = "1.1"
-log = "0.4"
+arrayvec.workspace = true
+rustc-hash.workspace = true
+log.workspace = true
 
 # backend: Gles
-glow = { version = "0.14.0", optional = true }
+glow = { workspace = true, optional = true }
 
 [dependencies.wgt]
 package = "wgpu-types"
@@ -132,33 +132,31 @@ version = "22.0.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # backend: Vulkan
-ash = { version = "0.38.0", optional = true }
-gpu-alloc = { version = "0.6", optional = true }
-gpu-descriptor = { version = "0.3", optional = true }
-smallvec = { version = "1", optional = true, features = ["union"] }
+ash = { workspace = true, optional = true }
+gpu-alloc = { workspace = true, optional = true }
+gpu-descriptor = { workspace = true, optional = true }
+smallvec = { workspace = true, optional = true, features = ["union"] }
 
-khronos-egl = { version = "6", features = ["dynamic"], optional = true }
-libloading = { version = ">=0.7, <0.9", optional = true }
-renderdoc-sys = { version = "1.1.0", optional = true }
+khronos-egl = { workspace = true, features = ["dynamic"], optional = true }
+libloading = { workspace = true, optional = true }
+renderdoc-sys = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-khronos-egl = { version = "6", features = ["static", "no-pkg-config"] }
+khronos-egl = { workspace = true, features = ["static", "no-pkg-config"] }
 #Note: it's unused by emscripten, but we keep it to have single code base in egl.rs
-libloading = { version = ">=0.7, <0.9", optional = true }
+libloading = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # backend: Dx12 and Gles
 windows = { workspace = true, optional = true }
 # backend: Dx12
-bit-set = { version = "0.8", optional = true }
-range-alloc = { version = "0.1", optional = true }
-gpu-allocator = { version = "0.27", default-features = false, features = [
-    "d3d12",
-    "public-winapi",
-], optional = true }
-hassle-rs = { version = "0.11", optional = true }
+bit-set = { workspace = true, optional = true }
+range-alloc = { workspace = true, optional = true }
+gpu-allocator = { workspace = true, optional = true }
+hassle-rs = { workspace = true, optional = true }
+
 # backend: Gles
-glutin_wgl_sys = { version = "0.6", optional = true }
+glutin_wgl_sys = { workspace = true, optional = true }
 
 winapi = { version = "0.3", features = [
     "profileapi",
@@ -172,28 +170,28 @@ d3d12 = { path = "../d3d12/", version = "22.0.0", optional = true, features = [
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
 # backend: Metal
-block = { version = "0.1", optional = true }
+block = { workspace = true, optional = true }
 
-metal = { version = "0.29.0" }
-objc = "0.2.5"
-core-graphics-types = "0.1"
+metal.workspace = true
+objc.workspace = true
+core-graphics-types.workspace = true
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-wasm-bindgen = "0.2.87"
-web-sys = { version = "0.3.69", features = [
+wasm-bindgen.workspace = true
+web-sys = { workspace = true, features = [
     "Window",
     "HtmlCanvasElement",
     "WebGl2RenderingContext",
     "OffscreenCanvas",
 ] }
-js-sys = "0.3.69"
+js-sys.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_system_properties = { version = "0.1.1", optional = true }
-ndk-sys = { version = "0.5.0", optional = true }
+android_system_properties = { workspace = true, optional = true }
+ndk-sys = { workspace = true, optional = true }
 
 [dependencies.naga]
 path = "../naga"
@@ -209,12 +207,10 @@ version = "22.0.0"
 features = ["wgsl-in"]
 
 [dev-dependencies]
-cfg-if = "1"
-env_logger = "0.11"
+cfg-if.workspace = true
+env_logger.workspace = true
 glam.workspace = true # for ray-traced-triangle example
-winit = { version = "0.29", features = [
-    "android-native-activity",
-] } # for "halmark" example
+winit.workspace = true # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-glutin = "0.29.1" # for "gles" example
+glutin.workspace = true # for "gles" example

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -35,12 +35,12 @@ serde = ["dep:serde"]
 counters = []
 
 [dependencies]
-bitflags = "2"
-serde = { version = "1", features = ["derive"], optional = true }
+bitflags.workspace = true
+serde = { workspace = true, features = ["derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.69"
-web-sys = { version = "0.3.69", features = [
+js-sys.workspace = true
+web-sys = { workspace = true, features = [
     "ImageBitmap",
     "HtmlVideoElement",
     "HtmlCanvasElement",
@@ -48,5 +48,5 @@ web-sys = { version = "0.3.69", features = [
 ] }
 
 [dev-dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1.0.120"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true


### PR DESCRIPTION
**Description**
In the past, workspace dependencies couldn't be used everywhere due to complications in the Firefox environment. These are believed to be resolved and so we can try using them again to reduce version management overhead and duplicated information.

This patch makes some dependencies into workspace dependencies.

The `bitflags` dependency is changed to version `2.6` to match what was in naga rather than the bare `2` used elsewhere.

**Testing**
Compilation.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [X] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ EDIT by @ErichDonGubler: Not necessary. 🙂
