### PR TITLE
Undo doing less bench iterations under `cfg(test)`

### DIFF
--- a/benches/benches/computepass.rs
+++ b/benches/benches/computepass.rs
@@ -10,20 +10,14 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::DeviceState;
 
-#[cfg(not(test))]
 const DISPATCH_COUNT: usize = 10_000;
-#[cfg(test)]
-const DISPATCH_COUNT: usize = 8; // Running with up to 8 threads.
 
 // Currently bindless is _much_ slower than with regularly resources,
 // since wgpu needs to issues barriers for all resources between each dispatch for all read/write textures & buffers.
 // This is in fact so slow that it makes the benchmark unusable when we use the same amount of
 // resources as the regular benchmark.
 // For details see https://github.com/gfx-rs/wgpu/issues/5766
-#[cfg(not(test))]
 const DISPATCH_COUNT_BINDLESS: usize = 1_000;
-#[cfg(test)]
-const DISPATCH_COUNT_BINDLESS: usize = 8; // Running with up to 8 threads.
 
 // Must match the number of textures in the computepass.wgsl shader
 const TEXTURES_PER_DISPATCH: usize = 2;

--- a/benches/benches/renderpass.rs
+++ b/benches/benches/renderpass.rs
@@ -10,10 +10,6 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::DeviceState;
 
-#[cfg(test)]
-const DRAW_COUNT: usize = 8; // Running with up to 8 threads.
-
-#[cfg(not(test))]
 const DRAW_COUNT: usize = 10_000;
 
 // Must match the number of textures in the renderpass.wgsl shader


### PR DESCRIPTION
Messed this up recently, was under the impression that this limits the iteration count only when running tests. Need to find another way to do that.

Still don't quite understand why that happens, I was fairly convinced that `cfg(test)` [is not set for benchmarks in `benches` directory](https://users.rust-lang.org/t/what-are-the-rules-for-cfg-test/54122/2).