### PR TITLE
Fix a `clippy::doc_lazy_continuation` lint

### DIFF
--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -714,7 +714,7 @@ pub trait Device: WasmNotSendSync {
     /// - Zero-sized mappings are not allowed.
     ///
     /// - The returned [`BufferMapping::ptr`] must not be used after a call to
-    /// [`Device::unmap_buffer`].
+    ///   [`Device::unmap_buffer`].
     ///
     /// [`MAP_READ`]: BufferUses::MAP_READ
     /// [`MAP_WRITE`]: BufferUses::MAP_WRITE


### PR DESCRIPTION
**Description**
Rust 1.80 arriving tomorrow brings with it a new `clippy::doc_lazy_continuation` lint. This is the last one remaining once  #5999 lands.

**Testing**
Ran `cargo +beta clippy`

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
