### PR TITLE
Reduced verbosity for 'Device::maintain: waiting for submission index…

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -443,7 +443,7 @@ impl<A: HalApi> Device<A> {
                     .map_err(DeviceError::from)?
             };
         }
-        log::info!("Device::maintain: waiting for submission index {submission_index}");
+        log::debug!("Device::maintain: waiting for submission index {submission_index}");
 
         let mut life_tracker = self.lock_life();
         let submission_closures =

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -443,7 +443,7 @@ impl<A: HalApi> Device<A> {
                     .map_err(DeviceError::from)?
             };
         }
-        log::debug!("Device::maintain: waiting for submission index {submission_index}");
+        log::trace!("Device::maintain: waiting for submission index {submission_index}");
 
         let mut life_tracker = self.lock_life();
         let submission_closures =


### PR DESCRIPTION
Quick fix for #6043.

**Description**
Reduces verbosity of obnoxiously common log message from info to debug that was introduced in wgpu v22.0.0.
