### PR TITLE
Fix AnyDevice drop implementation dropping the wrong thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Bottom level categories:
 - Print requested and supported usages on `UnsupportedUsage` error. By @VladasZ in [#6007](https://github.com/gfx-rs/wgpu/pull/6007)
 - Fix function for checking bind compatibility to error instead of panic. By @sagudev [#6012](https://github.com/gfx-rs/wgpu/pull/6012)
 - Deduplicate bind group layouts that are created from pipelines with "auto" layouts. By @teoxoy [#6049](https://github.com/gfx-rs/wgpu/pull/6049)
+- Fix crash when dropping the surface after the device. By @wumpf in [#6052](https://github.com/gfx-rs/wgpu/pull/6052)
 
 ### Dependency Updates
 

--- a/wgpu-core/src/device/any_device.rs
+++ b/wgpu-core/src/device/any_device.rs
@@ -34,7 +34,7 @@ impl AnyDevice {
         unsafe fn drop_glue<A: HalApi>(ptr: *mut ()) {
             // Drop the arc this instance is holding.
             unsafe {
-                _ = Arc::from_raw(ptr.cast::<A::Device>());
+                _ = Arc::from_raw(ptr.cast::<Device<A>>());
             }
         }
 


### PR DESCRIPTION
**Connections**
* https://github.com/emilk/egui/issues/4874
* `AnyDevice` can hopefully go away soon as part of my ongoing generification work
     *  https://github.com/gfx-rs/wgpu/pull/6002

Post-merge edit:
* Corrected fix of https://github.com/gfx-rs/wgpu/pull/5640
    * Making this the actual fix for https://github.com/gfx-rs/wgpu/issues/5637

**Description**
There is a [crash report in egui](https://github.com/emilk/egui/issues/4874) after wgpu update. Quickly realized that this happens only when the surface is destroyed _after_ the all other resources are dropped. Which leads to this simple repro in `hello_triangle` (cc: @cwfitzgerald any idea how I can unit-testify this? :/)

```diff
diff --git a/examples/src/hello_triangle/mod.rs b/examples/src/hello_triangle/mod.rs
index 7c82d49cf..418bf5c66 100644
--- a/examples/src/hello_triangle/mod.rs
+++ b/examples/src/hello_triangle/mod.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
@@ -80,6 +80,8 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         .get_default_config(&adapter, size.width, size.height)
         .unwrap();
     surface.configure(&device, &config);
+    let surface = Arc::new(surface);
+    let surface_b = surface.clone();
 
     let window = &window;
     event_loop
@@ -143,6 +145,8 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
             }
         })
         .unwrap();
+
+    drop(surface_b);
 }
 
 pub fn main() {
```


Unknown why this happened after wgpu 22.0.0 update, I strongly suspect the error is older and just surfaces (hah!) now because of improving ownership hygiene in the project.

A shining case of "How did this ever work?"
(A: this still drops the right ref count, so this is ONLY an issue if the last droping of `Arc<Device<A>>` happens through `AnyDevice` which is surprisingly rare)

**Testing**
Above manual test works now

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
