### PR TITLE
[naga] Use cfg aliases to enable `naga::back::continue_forward`.

### DIFF
--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -19,7 +19,7 @@ pub mod wgsl;
 #[cfg(any(hlsl_out, msl_out, spv_out, glsl_out))]
 pub mod pipeline_constants;
 
-#[cfg(any(feature = "hlsl-out", feature = "glsl-out"))]
+#[cfg(any(hlsl_out, glsl_out))]
 mod continue_forward;
 
 /// Names of vector components.


### PR DESCRIPTION
Rather than `feature = "blah"`, use the new `cfg` identifiers introduced by the `cfg_aliases` invocation in `naga/build.rs` to decide whether to compile the `naga::back::continue_forward` module, which is only used by the GLSL and HLSL backends.

The `hlsl_out` `cfg` identifer has a more complex condition than just `feature = "hlsl-out"`, introduced by #5919.

Fixes #6063.