### PR TITLE
[tests] remove `Arc` around device field of `TestingContext`

### DIFF
--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -1,4 +1,4 @@
-use std::{panic::AssertUnwindSafe, sync::Arc};
+use std::panic::AssertUnwindSafe;
 
 use futures_lite::FutureExt;
 use wgpu::{Adapter, Device, Instance, Queue};
@@ -18,7 +18,7 @@ pub struct TestingContext {
     pub adapter: Adapter,
     pub adapter_info: wgpu::AdapterInfo,
     pub adapter_downlevel_capabilities: wgpu::DownlevelCapabilities,
-    pub device: Arc<Device>,
+    pub device: Device,
     pub device_features: wgpu::Features,
     pub device_limits: wgpu::Limits,
     pub queue: Queue,
@@ -73,7 +73,7 @@ pub async fn execute_test(
         adapter,
         adapter_info,
         adapter_downlevel_capabilities,
-        device: Arc::new(device),
+        device,
         device_features: config.params.required_features,
         device_limits: config.params.required_limits.clone(),
         queue,

--- a/tests/tests/encoder.rs
+++ b/tests/tests/encoder.rs
@@ -19,8 +19,8 @@ static DROP_QUEUE_BEFORE_CREATING_COMMAND_ENCODER: GpuTestConfiguration =
         .run_sync(|ctx| {
             // Use the device after the queue is dropped. Currently this panics
             // but it probably shouldn't
-            let device = ctx.device.clone();
-            drop(ctx);
+            let TestingContext { device, queue, .. } = ctx;
+            drop(queue);
             let _encoder =
                 device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
         });


### PR DESCRIPTION
Makes things simpler.