### PR TITLE
Decouple device and queue IDs

### DIFF
--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -106,6 +106,7 @@ impl Test<'_> {
     ) {
         let backend = adapter.backend();
         let device_id = wgc::id::Id::zip(test_num, 0, backend);
+        let queue_id = wgc::id::Id::zip(test_num, 0, backend);
         let (_, _, error) = wgc::gfx_select!(adapter => global.adapter_request_device(
             adapter,
             &wgt::DeviceDescriptor {
@@ -116,7 +117,7 @@ impl Test<'_> {
             },
             None,
             Some(device_id),
-            Some(device_id.into_queue_id())
+            Some(queue_id)
         ));
         if let Some(e) = error {
             panic!("{:?}", e);
@@ -125,7 +126,7 @@ impl Test<'_> {
         let mut command_buffer_id_manager = wgc::identity::IdentityManager::new();
         println!("\t\t\tRunning...");
         for action in self.actions {
-            wgc::gfx_select!(device_id => global.process(device_id, action, dir, &mut command_buffer_id_manager));
+            wgc::gfx_select!(device_id => global.process(device_id, queue_id, action, dir, &mut command_buffer_id_manager));
         }
         println!("\t\t\tMapping...");
         for expect in &self.expectations {

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -4,7 +4,6 @@ use crate::{
         DeviceError, DeviceLostClosure,
     },
     hal_api::HalApi,
-    id,
     resource::{self, Buffer, Texture, Trackable},
     snatch::SnatchGuard,
     SubmissionIndex,
@@ -112,8 +111,8 @@ impl<A: HalApi> ActiveSubmission<A> {
 pub enum WaitIdleError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("Tried to wait using a submission index from the wrong device. Submission index is from device {0:?}. Called poll on device {1:?}.")]
-    WrongSubmissionIndex(id::QueueId, id::DeviceId),
+    #[error("Tried to wait using a submission index ({0}) that has not been returned by a successful submission (last successful submission: {1})")]
+    WrongSubmissionIndex(SubmissionIndex, SubmissionIndex),
     #[error("GPU got stuck :(")]
     StuckGpu,
 }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -131,13 +131,6 @@ impl SubmittedWorkDoneClosure {
     }
 }
 
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct WrappedSubmissionIndex {
-    pub queue_id: QueueId,
-    pub index: SubmissionIndex,
-}
-
 /// A texture or buffer to be freed soon.
 ///
 /// This is just a tagged raw texture or buffer, generally about to be added to
@@ -1044,7 +1037,7 @@ impl Global {
         &self,
         queue_id: QueueId,
         command_buffer_ids: &[id::CommandBufferId],
-    ) -> Result<WrappedSubmissionIndex, QueueSubmitError> {
+    ) -> Result<SubmissionIndex, QueueSubmitError> {
         profiling::scope!("Queue::submit");
         api_log!("Queue::submit {queue_id:?}");
 
@@ -1351,10 +1344,7 @@ impl Global {
 
         api_log!("Queue::submit to {queue_id:?} returned submit index {submit_index}");
 
-        Ok(WrappedSubmissionIndex {
-            queue_id,
-            index: submit_index,
-        })
+        Ok(submit_index)
     }
 
     pub fn queue_get_timestamp_period<A: HalApi>(

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -326,12 +326,6 @@ impl CommandBufferId {
     }
 }
 
-impl DeviceId {
-    pub fn into_queue_id(self) -> QueueId {
-        Id(self.0, PhantomData)
-    }
-}
-
 #[test]
 fn test_id_backend() {
     for &b in &[

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -102,7 +102,7 @@ pub(crate) use hash_utils::*;
 /// The index of a queue submission.
 ///
 /// These are the values stored in `Device::fence`.
-type SubmissionIndex = hal::FenceValue;
+pub type SubmissionIndex = hal::FenceValue;
 
 type Index = u32;
 type Epoch = u32;

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -552,7 +552,7 @@ impl crate::Context for ContextWgpuCore {
     type SurfaceId = wgc::id::SurfaceId;
     type SurfaceData = Surface;
     type SurfaceOutputDetail = SurfaceOutputDetail;
-    type SubmissionIndexData = wgc::device::queue::WrappedSubmissionIndex;
+    type SubmissionIndexData = wgc::SubmissionIndex;
 
     type RequestAdapterFuture = Ready<Option<(Self::AdapterId, Self::AdapterData)>>;
 
@@ -666,7 +666,7 @@ impl crate::Context for ContextWgpuCore {
             id: queue_id,
             error_sink,
         };
-        ready(Ok((device_id, device, device_id.into_queue_id(), queue)))
+        ready(Ok((device_id, device, queue_id, queue)))
     }
 
     fn instance_poll_all_devices(&self, force_wait: bool) -> bool {


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/5092.

**Description**
Devices and queues can have different lifetimes, we shouldn't assume that their IDs match.
I had to slightly refactor the `WaitIdleError::WrongSubmissionIndex` error because we don't store the queue ID internally.

**Testing**
Added a test.
