### PR TITLE
Degenerification part 1/3: `wgpu-hal` `DynDevice` & friends

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -511,7 +511,7 @@ impl Global {
                 }
             }
 
-            Some(hal::ComputePassTimestampWrites {
+            Some(hal::PassTimestampWrites {
                 query_set: query_set.raw(),
                 beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
                 end_of_pass_write_index: tw.end_of_pass_write_index,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1041,7 +1041,7 @@ impl<'d, A: HalApi> RenderPassInfo<'d, A> {
         }
 
         let mut color_attachments_hal =
-            ArrayVec::<Option<hal::ColorAttachment<A>>, { hal::MAX_COLOR_ATTACHMENTS }>::new();
+            ArrayVec::<Option<hal::ColorAttachment<_>>, { hal::MAX_COLOR_ATTACHMENTS }>::new();
         for (index, attachment) in color_attachments.iter().enumerate() {
             let at = if let Some(attachment) = attachment.as_ref() {
                 attachment

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1192,7 +1192,7 @@ impl<'d, A: HalApi> RenderPassInfo<'d, A> {
                 pending_query_resets.use_query_set(query_set, index);
             }
 
-            Some(hal::RenderPassTimestampWrites {
+            Some(hal::PassTimestampWrites {
                 query_set: query_set.raw(),
                 beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
                 end_of_pass_write_index: tw.end_of_pass_write_index,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2072,7 +2072,7 @@ impl<A: HalApi> Device<A> {
         used: &mut BindGroupStates<A>,
         used_texture_ranges: &mut Vec<TextureInitTrackerAction<A>>,
         snatch_guard: &'a SnatchGuard<'a>,
-    ) -> Result<hal::TextureBinding<'a, A>, binding_model::CreateBindGroupError> {
+    ) -> Result<hal::TextureBinding<'a, A::TextureView>, binding_model::CreateBindGroupError> {
         view.same_device(self)?;
 
         let (pub_usage, internal_use) = self.texture_use_parameters(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1889,7 +1889,7 @@ impl<A: HalApi> Device<A> {
         used: &mut BindGroupStates<A>,
         limits: &wgt::Limits,
         snatch_guard: &'a SnatchGuard<'a>,
-    ) -> Result<hal::BufferBinding<'a, A>, binding_model::CreateBindGroupError> {
+    ) -> Result<hal::BufferBinding<'a, A::Buffer>, binding_model::CreateBindGroupError> {
         use crate::binding_model::CreateBindGroupError as Error;
 
         let (binding_ty, dynamic, min_size) = match decl.ty {

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -284,7 +284,7 @@ impl<A: HalApi> BufferTracker<A> {
     pub fn drain_transitions<'a, 'b: 'a>(
         &'b mut self,
         snatch_guard: &'a SnatchGuard<'a>,
-    ) -> impl Iterator<Item = BufferBarrier<'a, A>> {
+    ) -> impl Iterator<Item = BufferBarrier<'a, A::Buffer>> {
         let buffer_barriers = self.temp.drain(..).map(|pending| {
             let buf = unsafe { self.metadata.get_resource_unchecked(pending.id as _) };
             pending.into_hal(buf, snatch_guard)
@@ -557,7 +557,7 @@ impl<A: HalApi> DeviceBufferTracker<A> {
         &'a mut self,
         tracker: &'a BufferTracker<A>,
         snatch_guard: &'b SnatchGuard<'b>,
-    ) -> impl Iterator<Item = BufferBarrier<'a, A>> {
+    ) -> impl Iterator<Item = BufferBarrier<'a, A::Buffer>> {
         for index in tracker.metadata.owned_indices() {
             self.tracker_assert_in_bounds(index);
 

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -261,7 +261,7 @@ impl PendingTransition<hal::BufferUses> {
         self,
         buf: &'a resource::Buffer<A>,
         snatch_guard: &'a SnatchGuard<'a>,
-    ) -> hal::BufferBarrier<'a, A> {
+    ) -> hal::BufferBarrier<'a, A::Buffer> {
         let buffer = buf.raw(snatch_guard).expect("Buffer is destroyed");
         hal::BufferBarrier {
             buffer,

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -272,7 +272,10 @@ impl PendingTransition<hal::BufferUses> {
 
 impl PendingTransition<hal::TextureUses> {
     /// Produce the hal barrier corresponding to the transition.
-    pub fn into_hal<'a, A: HalApi>(self, texture: &'a A::Texture) -> hal::TextureBarrier<'a, A> {
+    pub fn into_hal<'a, T: hal::DynTexture + ?Sized>(
+        self,
+        texture: &'a T,
+    ) -> hal::TextureBarrier<'a, T> {
         // These showing up in a barrier is always a bug
         strict_assert_ne!(self.usage.start, hal::TextureUses::UNKNOWN);
         strict_assert_ne!(self.usage.end, hal::TextureUses::UNKNOWN);

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -754,7 +754,7 @@ impl<A: HalApi> DeviceTextureTracker<A> {
         &'a mut self,
         tracker: &'a TextureTracker<A>,
         snatch_guard: &'b SnatchGuard<'b>,
-    ) -> impl Iterator<Item = TextureBarrier<'a, A>> {
+    ) -> impl Iterator<Item = TextureBarrier<'a, A::Texture>> {
         for index in tracker.metadata.owned_indices() {
             self.tracker_assert_in_bounds(index);
 
@@ -798,7 +798,7 @@ impl<A: HalApi> DeviceTextureTracker<A> {
         &'a mut self,
         scope: &'a TextureUsageScope<A>,
         snatch_guard: &'b SnatchGuard<'b>,
-    ) -> impl Iterator<Item = TextureBarrier<'a, A>> {
+    ) -> impl Iterator<Item = TextureBarrier<'a, A::Texture>> {
         for index in scope.metadata.owned_indices() {
             self.tracker_assert_in_bounds(index);
 

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -310,7 +310,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn transition_buffers<'a, T>(&mut self, barriers: T)
     where
-        T: Iterator<Item = crate::BufferBarrier<'a, super::Api>>,
+        T: Iterator<Item = crate::BufferBarrier<'a, super::Buffer>>,
     {
         self.temp.barriers.clear();
 

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -1190,7 +1190,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
         _descriptors: T,
     ) where
         super::Api: 'a,
-        T: IntoIterator<Item = crate::BuildAccelerationStructureDescriptor<'a, super::Api>>,
+        T: IntoIterator<
+            Item = crate::BuildAccelerationStructureDescriptor<
+                'a,
+                super::Buffer,
+                super::AccelerationStructure,
+            >,
+        >,
     {
         // Implement using `BuildRaytracingAccelerationStructure`:
         // https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#buildraytracingaccelerationstructure

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -661,7 +661,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     // render
 
-    unsafe fn begin_render_pass(&mut self, desc: &crate::RenderPassDescriptor<super::Api>) {
+    unsafe fn begin_render_pass(
+        &mut self,
+        desc: &crate::RenderPassDescriptor<super::QuerySet, super::TextureView>,
+    ) {
         unsafe { self.begin_pass(super::PassKind::Render, desc.label) };
 
         // Start timestamp if any (before all other commands but after debug marker)
@@ -1130,7 +1133,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn begin_compute_pass<'a>(
         &mut self,
-        desc: &crate::ComputePassDescriptor<'a, super::Api>,
+        desc: &crate::ComputePassDescriptor<'a, super::QuerySet>,
     ) {
         unsafe { self.begin_pass(super::PassKind::Compute, desc.label) };
 

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -359,7 +359,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn transition_textures<'a, T>(&mut self, barriers: T)
     where
-        T: Iterator<Item = crate::TextureBarrier<'a, super::Api>>,
+        T: Iterator<Item = crate::TextureBarrier<'a, super::Texture>>,
     {
         self.temp.barriers.clear();
 

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -970,7 +970,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn set_index_buffer<'a>(
         &mut self,
-        binding: crate::BufferBinding<'a, super::Api>,
+        binding: crate::BufferBinding<'a, super::Buffer>,
         format: wgt::IndexFormat,
     ) {
         self.list.as_ref().unwrap().set_index_buffer(
@@ -982,7 +982,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     unsafe fn set_vertex_buffer<'a>(
         &mut self,
         index: u32,
-        binding: crate::BufferBinding<'a, super::Api>,
+        binding: crate::BufferBinding<'a, super::Buffer>,
     ) {
         let vb = &mut self.pass.vertex_buffers[index as usize];
         vb.BufferLocation = binding.resolve_address();

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -689,7 +689,7 @@ impl crate::Device for super::Device {
 
     unsafe fn create_command_encoder(
         &self,
-        desc: &crate::CommandEncoderDescriptor<super::Api>,
+        desc: &crate::CommandEncoderDescriptor<super::Queue>,
     ) -> Result<super::CommandEncoder, DeviceError> {
         let allocator = self
             .raw

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1104,7 +1104,13 @@ impl crate::Device for super::Device {
 
     unsafe fn create_bind_group(
         &self,
-        desc: &crate::BindGroupDescriptor<super::Api>,
+        desc: &crate::BindGroupDescriptor<
+            super::BindGroupLayout,
+            super::Buffer,
+            super::Sampler,
+            super::TextureView,
+            super::AccelerationStructure,
+        >,
     ) -> Result<super::BindGroup, DeviceError> {
         let mut cpu_views = desc
             .layout

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1745,7 +1745,7 @@ impl crate::Device for super::Device {
 
     unsafe fn get_acceleration_structure_build_sizes<'a>(
         &self,
-        _desc: &crate::GetAccelerationStructureBuildSizesDescriptor<'a, super::Api>,
+        _desc: &crate::GetAccelerationStructureBuildSizesDescriptor<'a, super::Buffer>,
     ) -> crate::AccelerationStructureBuildSizes {
         // Implement using `GetRaytracingAccelerationStructurePrebuildInfo`:
         // https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#getraytracingaccelerationstructureprebuildinfo

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -211,10 +211,10 @@ impl super::Device {
     /// allowed to be a subset of the vertex outputs.
     fn load_shader(
         &self,
-        stage: &crate::ProgrammableStage<super::Api>,
+        stage: &crate::ProgrammableStage<super::ShaderModule>,
         layout: &super::PipelineLayout,
         naga_stage: naga::ShaderStage,
-        fragment_stage: Option<&crate::ProgrammableStage<super::Api>>,
+        fragment_stage: Option<&crate::ProgrammableStage<super::ShaderModule>>,
     ) -> Result<super::CompiledShader, crate::PipelineError> {
         use naga::back::hlsl;
 
@@ -1320,7 +1320,11 @@ impl crate::Device for super::Device {
 
     unsafe fn create_render_pipeline(
         &self,
-        desc: &crate::RenderPipelineDescriptor<super::Api>,
+        desc: &crate::RenderPipelineDescriptor<
+            super::PipelineLayout,
+            super::ShaderModule,
+            super::PipelineCache,
+        >,
     ) -> Result<super::RenderPipeline, crate::PipelineError> {
         let (topology_class, topology) = conv::map_topology(desc.primitive.topology);
         let mut shader_stages = wgt::ShaderStages::VERTEX;
@@ -1515,7 +1519,11 @@ impl crate::Device for super::Device {
 
     unsafe fn create_compute_pipeline(
         &self,
-        desc: &crate::ComputePipelineDescriptor<super::Api>,
+        desc: &crate::ComputePipelineDescriptor<
+            super::PipelineLayout,
+            super::ShaderModule,
+            super::PipelineCache,
+        >,
     ) -> Result<super::ComputePipeline, crate::PipelineError> {
         let blob_cs =
             self.load_shader(&desc.stage, desc.layout, naga::ShaderStage::Compute, None)?;
@@ -1559,10 +1567,10 @@ impl crate::Device for super::Device {
     unsafe fn create_pipeline_cache(
         &self,
         _desc: &crate::PipelineCacheDescriptor<'_>,
-    ) -> Result<(), crate::PipelineCacheError> {
-        Ok(())
+    ) -> Result<super::PipelineCache, crate::PipelineCacheError> {
+        Ok(super::PipelineCache)
     }
-    unsafe fn destroy_pipeline_cache(&self, (): ()) {}
+    unsafe fn destroy_pipeline_cache(&self, _: super::PipelineCache) {}
 
     unsafe fn create_query_set(
         &self,

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -776,7 +776,7 @@ impl crate::Device for super::Device {
 
     unsafe fn create_pipeline_layout(
         &self,
-        desc: &crate::PipelineLayoutDescriptor<super::Api>,
+        desc: &crate::PipelineLayoutDescriptor<super::BindGroupLayout>,
     ) -> Result<super::PipelineLayout, DeviceError> {
         use naga::back::hlsl;
         // Pipeline layouts are implemented as RootSignature for D3D12.

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -94,6 +94,7 @@ crate::impl_dyn_resource!(
     CommandBuffer,
     CommandEncoder,
     ComputePipeline,
+    Device,
     Fence,
     PipelineCache,
     PipelineLayout,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -452,6 +452,8 @@ pub struct Texture {
     allocation: Option<suballocation::AllocationWrapper>,
 }
 
+impl crate::DynTexture for Texture {}
+
 unsafe impl Send for Texture {}
 unsafe impl Sync for Texture {}
 
@@ -490,6 +492,8 @@ pub struct TextureView {
     handle_dsv_ro: Option<descriptor::Handle>,
     handle_dsv_rw: Option<descriptor::Handle>,
 }
+
+impl crate::DynTextureView for TextureView {}
 
 unsafe impl Send for TextureView {}
 unsafe impl Sync for TextureView {}

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -413,6 +413,8 @@ pub struct CommandBuffer {
     raw: d3d12::GraphicsCommandList,
 }
 
+impl crate::DynCommandBuffer for CommandBuffer {}
+
 unsafe impl Send for CommandBuffer {}
 unsafe impl Sync for CommandBuffer {}
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -525,6 +525,8 @@ pub struct Fence {
     raw: d3d12::Fence,
 }
 
+impl crate::DynFence for Fence {}
+
 unsafe impl Send for Fence {}
 unsafe impl Sync for Fence {}
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -456,6 +456,7 @@ pub struct Texture {
 }
 
 impl crate::DynTexture for Texture {}
+impl crate::DynSurfaceTexture for Texture {}
 
 unsafe impl Send for Texture {}
 unsafe impl Sync for Texture {}

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -608,6 +608,8 @@ pub struct ShaderModule {
     raw_name: Option<ffi::CString>,
 }
 
+impl crate::DynShaderModule for ShaderModule {}
+
 pub(super) enum CompiledShader {
     #[allow(unused)]
     Dxc(Vec<u8>),

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -88,6 +88,7 @@ impl crate::Api for Api {
 }
 
 crate::impl_dyn_resource!(
+    Adapter,
     AccelerationStructure,
     BindGroup,
     BindGroupLayout,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -99,6 +99,7 @@ crate::impl_dyn_resource!(
     PipelineCache,
     PipelineLayout,
     QuerySet,
+    Queue,
     RenderPipeline,
     Sampler,
     ShaderModule,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -98,6 +98,7 @@ crate::impl_dyn_resource!(
     ComputePipeline,
     Device,
     Fence,
+    Instance,
     PipelineCache,
     PipelineLayout,
     QuerySet,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -458,6 +458,12 @@ pub struct Texture {
 impl crate::DynTexture for Texture {}
 impl crate::DynSurfaceTexture for Texture {}
 
+impl std::borrow::Borrow<dyn crate::DynTexture> for Texture {
+    fn borrow(&self) -> &dyn crate::DynTexture {
+        self
+    }
+}
+
 unsafe impl Send for Texture {}
 unsafe impl Sync for Texture {}
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -428,7 +428,7 @@ unsafe impl Sync for Buffer {}
 
 impl crate::DynBuffer for Buffer {}
 
-impl crate::BufferBinding<'_, Api> {
+impl crate::BufferBinding<'_, Buffer> {
     fn resolve_size(&self) -> wgt::BufferAddress {
         match self.size {
             Some(size) => size.get(),

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -629,6 +629,8 @@ pub struct RenderPipeline {
     vertex_strides: [Option<NonZeroU32>; crate::MAX_VERTEX_BUFFERS],
 }
 
+impl crate::DynRenderPipeline for RenderPipeline {}
+
 unsafe impl Send for RenderPipeline {}
 unsafe impl Sync for RenderPipeline {}
 
@@ -637,6 +639,8 @@ pub struct ComputePipeline {
     raw: d3d12::PipelineState,
     layout: PipelineLayoutShared,
 }
+
+impl crate::DynComputePipeline for ComputePipeline {}
 
 unsafe impl Send for ComputePipeline {}
 unsafe impl Sync for ComputePipeline {}

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -508,6 +508,8 @@ pub struct QuerySet {
     raw_ty: d3d12_ty::D3D12_QUERY_TYPE,
 }
 
+impl crate::DynQuerySet for QuerySet {}
+
 unsafe impl Send for QuerySet {}
 unsafe impl Sync for QuerySet {}
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -550,6 +550,8 @@ pub struct BindGroup {
     dynamic_buffers: Vec<d3d12::GpuAddress>,
 }
 
+impl crate::DynBindGroup for BindGroup {}
+
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     struct TableTypes: u8 {
@@ -593,6 +595,8 @@ pub struct PipelineLayout {
     bind_group_infos: ArrayVec<BindGroupInfo, { crate::MAX_BIND_GROUPS }>,
     naga_options: naga::back::hlsl::Options,
 }
+
+impl crate::DynPipelineLayout for PipelineLayout {}
 
 #[derive(Debug)]
 pub struct ShaderModule {

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -82,7 +82,7 @@ impl crate::Api for Api {
     type ShaderModule = ShaderModule;
     type RenderPipeline = RenderPipeline;
     type ComputePipeline = ComputePipeline;
-    type PipelineCache = ();
+    type PipelineCache = PipelineCache;
 
     type AccelerationStructure = AccelerationStructure;
 }
@@ -668,6 +668,11 @@ impl crate::DynComputePipeline for ComputePipeline {}
 
 unsafe impl Send for ComputePipeline {}
 unsafe impl Sync for ComputePipeline {}
+
+#[derive(Debug)]
+pub struct PipelineCache;
+
+impl crate::DynPipelineCache for PipelineCache {}
 
 #[derive(Debug)]
 pub struct AccelerationStructure {}

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -87,6 +87,25 @@ impl crate::Api for Api {
     type AccelerationStructure = AccelerationStructure;
 }
 
+crate::impl_dyn_resource!(
+    BindGroup,
+    BindGroupLayout,
+    Buffer,
+    CommandBuffer,
+    CommandEncoder,
+    ComputePipeline,
+    Fence,
+    PipelineCache,
+    PipelineLayout,
+    QuerySet,
+    RenderPipeline,
+    Sampler,
+    ShaderModule,
+    Surface,
+    Texture,
+    TextureView
+);
+
 // Limited by D3D12's root signature size of 64. Each element takes 1 or 2 entries.
 const MAX_ROOT_ELEMENTS: usize = 64;
 const ZERO_BUFFER_SIZE: wgt::BufferAddress = 256 << 10;
@@ -406,6 +425,8 @@ pub struct Buffer {
 
 unsafe impl Send for Buffer {}
 unsafe impl Sync for Buffer {}
+
+impl crate::DynBuffer for Buffer {}
 
 impl crate::BufferBinding<'_, Api> {
     fn resolve_size(&self) -> wgt::BufferAddress {

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -555,6 +555,8 @@ pub struct BindGroupLayout {
     copy_counts: Vec<u32>, // all 1's
 }
 
+impl crate::DynBindGroupLayout for BindGroupLayout {}
+
 #[derive(Debug, Clone, Copy)]
 enum BufferViewKind {
     Constant,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -88,6 +88,7 @@ impl crate::Api for Api {
 }
 
 crate::impl_dyn_resource!(
+    AccelerationStructure,
     BindGroup,
     BindGroupLayout,
     Buffer,
@@ -670,6 +671,8 @@ unsafe impl Sync for ComputePipeline {}
 
 #[derive(Debug)]
 pub struct AccelerationStructure {}
+
+impl crate::DynAccelerationStructure for AccelerationStructure {}
 
 impl SwapChain {
     unsafe fn release_resources(self) -> d3d12::ComPtr<dxgi1_4::IDXGISwapChain3> {

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -513,6 +513,8 @@ pub struct Sampler {
     handle: descriptor::Handle,
 }
 
+impl crate::DynSampler for Sampler {}
+
 unsafe impl Send for Sampler {}
 unsafe impl Sync for Sampler {}
 

--- a/wgpu-hal/src/dynamic/adapter.rs
+++ b/wgpu-hal/src/dynamic/adapter.rs
@@ -1,0 +1,56 @@
+use crate::{Adapter, DeviceError, SurfaceCapabilities, TextureFormatCapabilities};
+
+use super::{DynDevice, DynQueue, DynResource, DynResourceExt, DynSurface};
+
+pub struct DynOpenDevice {
+    pub device: Box<dyn DynDevice>,
+    pub queue: Box<dyn DynQueue>,
+}
+
+pub trait DynAdapter: DynResource {
+    unsafe fn open(
+        &self,
+        features: wgt::Features,
+        limits: &wgt::Limits,
+        memory_hints: &wgt::MemoryHints,
+    ) -> Result<DynOpenDevice, DeviceError>;
+
+    unsafe fn texture_format_capabilities(
+        &self,
+        format: wgt::TextureFormat,
+    ) -> TextureFormatCapabilities;
+
+    unsafe fn surface_capabilities(&self, surface: &dyn DynSurface) -> Option<SurfaceCapabilities>;
+
+    unsafe fn get_presentation_timestamp(&self) -> wgt::PresentationTimestamp;
+}
+
+impl<A: Adapter + DynResource> DynAdapter for A {
+    unsafe fn open(
+        &self,
+        features: wgt::Features,
+        limits: &wgt::Limits,
+        memory_hints: &wgt::MemoryHints,
+    ) -> Result<DynOpenDevice, DeviceError> {
+        unsafe { A::open(self, features, limits, memory_hints) }.map(|open_device| DynOpenDevice {
+            device: Box::new(open_device.device),
+            queue: Box::new(open_device.queue),
+        })
+    }
+
+    unsafe fn texture_format_capabilities(
+        &self,
+        format: wgt::TextureFormat,
+    ) -> TextureFormatCapabilities {
+        unsafe { A::texture_format_capabilities(self, format) }
+    }
+
+    unsafe fn surface_capabilities(&self, surface: &dyn DynSurface) -> Option<SurfaceCapabilities> {
+        let surface = surface.expect_downcast_ref();
+        unsafe { A::surface_capabilities(self, surface) }
+    }
+
+    unsafe fn get_presentation_timestamp(&self) -> wgt::PresentationTimestamp {
+        unsafe { A::get_presentation_timestamp(self) }
+    }
+}

--- a/wgpu-hal/src/dynamic/command.rs
+++ b/wgpu-hal/src/dynamic/command.rs
@@ -8,10 +8,10 @@ use crate::{
 
 use super::{
     DynBindGroup, DynBuffer, DynComputePipeline, DynPipelineLayout, DynQuerySet, DynRenderPipeline,
-    DynResourceExt as _, DynTexture, DynTextureView,
+    DynResource, DynResourceExt as _, DynTexture, DynTextureView,
 };
 
-pub trait DynCommandEncoder: std::fmt::Debug {
+pub trait DynCommandEncoder: DynResource + std::fmt::Debug {
     unsafe fn begin_encoding(&mut self, label: Label) -> Result<(), DeviceError>;
 
     unsafe fn discard_encoding(&mut self);
@@ -174,7 +174,7 @@ pub trait DynCommandEncoder: std::fmt::Debug {
     // );
 }
 
-impl<C: CommandEncoder> DynCommandEncoder for C {
+impl<C: CommandEncoder + DynResource> DynCommandEncoder for C {
     unsafe fn begin_encoding(&mut self, label: Label) -> Result<(), DeviceError> {
         unsafe { C::begin_encoding(self, label) }
     }

--- a/wgpu-hal/src/dynamic/command.rs
+++ b/wgpu-hal/src/dynamic/command.rs
@@ -1,11 +1,13 @@
 use std::ops::Range;
 
 use crate::{
-    BufferBarrier, BufferBinding, BufferCopy, CommandEncoder, DeviceError, DynBindGroup,
-    DynPipelineLayout, DynQuerySet, Label, MemoryRange,
+    BufferBarrier, BufferBinding, BufferCopy, CommandEncoder, DeviceError, Label, MemoryRange, Rect,
 };
 
-use super::{DynBuffer, DynResourceExt as _};
+use super::{
+    DynBindGroup, DynBuffer, DynComputePipeline, DynPipelineLayout, DynQuerySet, DynRenderPipeline,
+    DynResourceExt as _,
+};
 
 pub trait DynCommandEncoder: std::fmt::Debug {
     unsafe fn begin_encoding(&mut self, label: Label) -> Result<(), DeviceError>;
@@ -56,6 +58,8 @@ pub trait DynCommandEncoder: std::fmt::Debug {
         stride: wgt::BufferSize,
     );
 
+    unsafe fn set_render_pipeline(&mut self, pipeline: &dyn DynRenderPipeline);
+
     unsafe fn set_index_buffer<'a>(
         &mut self,
         binding: BufferBinding<'a, dyn DynBuffer>,
@@ -67,6 +71,75 @@ pub trait DynCommandEncoder: std::fmt::Debug {
         index: u32,
         binding: BufferBinding<'a, dyn DynBuffer>,
     );
+    unsafe fn set_viewport(&mut self, rect: &Rect<f32>, depth_range: Range<f32>);
+    unsafe fn set_scissor_rect(&mut self, rect: &Rect<u32>);
+    unsafe fn set_stencil_reference(&mut self, value: u32);
+    unsafe fn set_blend_constants(&mut self, color: &[f32; 4]);
+
+    unsafe fn draw(
+        &mut self,
+        first_vertex: u32,
+        vertex_count: u32,
+        first_instance: u32,
+        instance_count: u32,
+    );
+    unsafe fn draw_indexed(
+        &mut self,
+        first_index: u32,
+        index_count: u32,
+        base_vertex: i32,
+        first_instance: u32,
+        instance_count: u32,
+    );
+    unsafe fn draw_indirect(
+        &mut self,
+        buffer: &dyn DynBuffer,
+        offset: wgt::BufferAddress,
+        draw_count: u32,
+    );
+    unsafe fn draw_indexed_indirect(
+        &mut self,
+        buffer: &dyn DynBuffer,
+        offset: wgt::BufferAddress,
+        draw_count: u32,
+    );
+    unsafe fn draw_indirect_count(
+        &mut self,
+        buffer: &dyn DynBuffer,
+        offset: wgt::BufferAddress,
+        count_buffer: &dyn DynBuffer,
+        count_offset: wgt::BufferAddress,
+        max_count: u32,
+    );
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        buffer: &dyn DynBuffer,
+        offset: wgt::BufferAddress,
+        count_buffer: &dyn DynBuffer,
+        count_offset: wgt::BufferAddress,
+        max_count: u32,
+    );
+
+    // unsafe fn begin_compute_pass(&mut self, desc: &ComputePassDescriptor<Self::A>);
+    // unsafe fn end_compute_pass(&mut self);
+
+    unsafe fn set_compute_pipeline(&mut self, pipeline: &dyn DynComputePipeline);
+
+    unsafe fn dispatch(&mut self, count: [u32; 3]);
+    unsafe fn dispatch_indirect(&mut self, buffer: &dyn DynBuffer, offset: wgt::BufferAddress);
+
+    // unsafe fn build_acceleration_structures<'a, T>(
+    //     &mut self,
+    //     descriptor_count: u32,
+    //     descriptors: T,
+    // ) where
+    //     Self::A: 'a,
+    //     T: IntoIterator<Item = BuildAccelerationStructureDescriptor<'a, Self::A>>;
+
+    // unsafe fn place_acceleration_structure_barrier(
+    //     &mut self,
+    //     barrier: AccelerationStructureBarrier,
+    // );
 }
 
 impl<C: CommandEncoder> DynCommandEncoder for C {
@@ -176,6 +249,142 @@ impl<C: CommandEncoder> DynCommandEncoder for C {
         let set = set.expect_downcast_ref();
         let buffer = buffer.expect_downcast_ref();
         unsafe { C::copy_query_results(self, set, range, buffer, offset, stride) };
+    }
+
+    unsafe fn set_viewport(&mut self, rect: &Rect<f32>, depth_range: Range<f32>) {
+        unsafe {
+            C::set_viewport(self, rect, depth_range);
+        }
+    }
+
+    unsafe fn set_scissor_rect(&mut self, rect: &Rect<u32>) {
+        unsafe {
+            C::set_scissor_rect(self, rect);
+        }
+    }
+
+    unsafe fn set_stencil_reference(&mut self, value: u32) {
+        unsafe {
+            C::set_stencil_reference(self, value);
+        }
+    }
+
+    unsafe fn set_blend_constants(&mut self, color: &[f32; 4]) {
+        unsafe { C::set_blend_constants(self, color) };
+    }
+
+    unsafe fn draw(
+        &mut self,
+        first_vertex: u32,
+        vertex_count: u32,
+        first_instance: u32,
+        instance_count: u32,
+    ) {
+        unsafe {
+            C::draw(
+                self,
+                first_vertex,
+                vertex_count,
+                first_instance,
+                instance_count,
+            )
+        };
+    }
+
+    unsafe fn draw_indexed(
+        &mut self,
+        first_index: u32,
+        index_count: u32,
+        base_vertex: i32,
+        first_instance: u32,
+        instance_count: u32,
+    ) {
+        unsafe {
+            C::draw_indexed(
+                self,
+                first_index,
+                index_count,
+                base_vertex,
+                first_instance,
+                instance_count,
+            )
+        };
+    }
+
+    unsafe fn draw_indirect(
+        &mut self,
+        buffer: &dyn DynBuffer,
+        offset: wgt::BufferAddress,
+        draw_count: u32,
+    ) {
+        let buffer = buffer.expect_downcast_ref();
+        unsafe { C::draw_indirect(self, buffer, offset, draw_count) };
+    }
+
+    unsafe fn draw_indexed_indirect(
+        &mut self,
+        buffer: &dyn DynBuffer,
+        offset: wgt::BufferAddress,
+        draw_count: u32,
+    ) {
+        let buffer = buffer.expect_downcast_ref();
+        unsafe { C::draw_indexed_indirect(self, buffer, offset, draw_count) };
+    }
+
+    unsafe fn draw_indirect_count(
+        &mut self,
+        buffer: &dyn DynBuffer,
+        offset: wgt::BufferAddress,
+        count_buffer: &dyn DynBuffer,
+        count_offset: wgt::BufferAddress,
+        max_count: u32,
+    ) {
+        let buffer = buffer.expect_downcast_ref();
+        let count_buffer = count_buffer.expect_downcast_ref();
+        unsafe {
+            C::draw_indirect_count(self, buffer, offset, count_buffer, count_offset, max_count)
+        };
+    }
+
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        buffer: &dyn DynBuffer,
+        offset: wgt::BufferAddress,
+        count_buffer: &dyn DynBuffer,
+        count_offset: wgt::BufferAddress,
+        max_count: u32,
+    ) {
+        let buffer = buffer.expect_downcast_ref();
+        let count_buffer = count_buffer.expect_downcast_ref();
+        unsafe {
+            C::draw_indexed_indirect_count(
+                self,
+                buffer,
+                offset,
+                count_buffer,
+                count_offset,
+                max_count,
+            )
+        };
+    }
+
+    unsafe fn set_compute_pipeline(&mut self, pipeline: &dyn DynComputePipeline) {
+        let pipeline = pipeline.expect_downcast_ref();
+        unsafe { C::set_compute_pipeline(self, pipeline) };
+    }
+
+    unsafe fn dispatch(&mut self, count: [u32; 3]) {
+        unsafe { C::dispatch(self, count) };
+    }
+
+    unsafe fn dispatch_indirect(&mut self, buffer: &dyn DynBuffer, offset: wgt::BufferAddress) {
+        let buffer = buffer.expect_downcast_ref();
+        unsafe { C::dispatch_indirect(self, buffer, offset) };
+    }
+
+    unsafe fn set_render_pipeline(&mut self, pipeline: &dyn DynRenderPipeline) {
+        let pipeline = pipeline.expect_downcast_ref();
+        unsafe { C::set_render_pipeline(self, pipeline) };
     }
 
     unsafe fn set_index_buffer<'a>(

--- a/wgpu-hal/src/dynamic/command.rs
+++ b/wgpu-hal/src/dynamic/command.rs
@@ -1,8 +1,8 @@
 use std::ops::Range;
 
 use crate::{
-    BufferBarrier, BufferBinding, BufferCopy, CommandEncoder, DeviceError, DynQuerySet, Label,
-    MemoryRange,
+    BufferBarrier, BufferBinding, BufferCopy, CommandEncoder, DeviceError, DynBindGroup,
+    DynPipelineLayout, DynQuerySet, Label, MemoryRange,
 };
 
 use super::{DynBuffer, DynResourceExt as _};
@@ -21,6 +21,22 @@ pub trait DynCommandEncoder: std::fmt::Debug {
         src: &dyn DynBuffer,
         dst: &dyn DynBuffer,
         regions: &[BufferCopy],
+    );
+
+    unsafe fn set_bind_group(
+        &mut self,
+        layout: &dyn DynPipelineLayout,
+        index: u32,
+        group: &dyn DynBindGroup,
+        dynamic_offsets: &[wgt::DynamicOffset],
+    );
+
+    unsafe fn set_push_constants(
+        &mut self,
+        layout: &dyn DynPipelineLayout,
+        stages: wgt::ShaderStages,
+        offset_bytes: u32,
+        data: &[u32],
     );
 
     unsafe fn insert_debug_marker(&mut self, label: &str);
@@ -86,6 +102,29 @@ impl<C: CommandEncoder> DynCommandEncoder for C {
         unsafe {
             C::copy_buffer_to_buffer(self, src, dst, regions.iter().copied());
         }
+    }
+
+    unsafe fn set_bind_group(
+        &mut self,
+        layout: &dyn DynPipelineLayout,
+        index: u32,
+        group: &dyn DynBindGroup,
+        dynamic_offsets: &[wgt::DynamicOffset],
+    ) {
+        let layout = layout.expect_downcast_ref();
+        let group = group.expect_downcast_ref();
+        unsafe { C::set_bind_group(self, layout, index, group, dynamic_offsets) };
+    }
+
+    unsafe fn set_push_constants(
+        &mut self,
+        layout: &dyn DynPipelineLayout,
+        stages: wgt::ShaderStages,
+        offset_bytes: u32,
+        data: &[u32],
+    ) {
+        let layout = layout.expect_downcast_ref();
+        unsafe { C::set_push_constants(self, layout, stages, offset_bytes, data) };
     }
 
     unsafe fn insert_debug_marker(&mut self, label: &str) {

--- a/wgpu-hal/src/dynamic/command.rs
+++ b/wgpu-hal/src/dynamic/command.rs
@@ -1,8 +1,29 @@
-use crate::{BufferBinding, CommandEncoder};
+use crate::{
+    BufferBarrier, BufferBinding, BufferCopy, CommandEncoder, DeviceError, Label, MemoryRange,
+};
 
-use super::DynBuffer;
+use super::{DynBuffer, DynResourceExt as _};
 
-pub trait DynCommandEncoder {
+pub trait DynCommandEncoder: std::fmt::Debug {
+    unsafe fn begin_encoding(&mut self, label: Label) -> Result<(), DeviceError>;
+
+    unsafe fn discard_encoding(&mut self);
+
+    unsafe fn transition_buffers(&mut self, barriers: &[BufferBarrier<'_, dyn DynBuffer>]);
+
+    unsafe fn clear_buffer(&mut self, buffer: &dyn DynBuffer, range: MemoryRange);
+
+    unsafe fn copy_buffer_to_buffer(
+        &mut self,
+        src: &dyn DynBuffer,
+        dst: &dyn DynBuffer,
+        regions: &[BufferCopy],
+    );
+
+    unsafe fn insert_debug_marker(&mut self, label: &str);
+    unsafe fn begin_debug_marker(&mut self, group_label: &str);
+    unsafe fn end_debug_marker(&mut self);
+
     unsafe fn set_index_buffer<'a>(
         &mut self,
         binding: BufferBinding<'a, dyn DynBuffer>,
@@ -17,6 +38,58 @@ pub trait DynCommandEncoder {
 }
 
 impl<C: CommandEncoder> DynCommandEncoder for C {
+    unsafe fn begin_encoding(&mut self, label: Label) -> Result<(), DeviceError> {
+        unsafe { C::begin_encoding(self, label) }
+    }
+
+    unsafe fn discard_encoding(&mut self) {
+        unsafe { C::discard_encoding(self) }
+    }
+
+    unsafe fn transition_buffers(&mut self, barriers: &[BufferBarrier<'_, dyn DynBuffer>]) {
+        let barriers = barriers.iter().map(|barrier| BufferBarrier {
+            buffer: barrier.buffer.expect_downcast_ref(),
+            usage: barrier.usage.clone(),
+        });
+        unsafe { self.transition_buffers(barriers) };
+    }
+
+    unsafe fn clear_buffer(&mut self, buffer: &dyn DynBuffer, range: MemoryRange) {
+        let buffer = buffer.expect_downcast_ref();
+        unsafe { C::clear_buffer(self, buffer, range) };
+    }
+
+    unsafe fn copy_buffer_to_buffer(
+        &mut self,
+        src: &dyn DynBuffer,
+        dst: &dyn DynBuffer,
+        regions: &[BufferCopy],
+    ) {
+        let src = src.expect_downcast_ref();
+        let dst = dst.expect_downcast_ref();
+        unsafe {
+            C::copy_buffer_to_buffer(self, src, dst, regions.iter().copied());
+        }
+    }
+
+    unsafe fn insert_debug_marker(&mut self, label: &str) {
+        unsafe {
+            C::insert_debug_marker(self, label);
+        }
+    }
+
+    unsafe fn begin_debug_marker(&mut self, group_label: &str) {
+        unsafe {
+            C::begin_debug_marker(self, group_label);
+        }
+    }
+
+    unsafe fn end_debug_marker(&mut self) {
+        unsafe {
+            C::end_debug_marker(self);
+        }
+    }
+
     unsafe fn set_index_buffer<'a>(
         &mut self,
         binding: BufferBinding<'a, dyn DynBuffer>,

--- a/wgpu-hal/src/dynamic/command.rs
+++ b/wgpu-hal/src/dynamic/command.rs
@@ -1,14 +1,16 @@
 use std::ops::Range;
 
 use crate::{
-    Api, Attachment, BufferBarrier, BufferBinding, BufferCopy, BufferTextureCopy, ColorAttachment,
-    CommandEncoder, ComputePassDescriptor, DepthStencilAttachment, DeviceError, Label, MemoryRange,
+    AccelerationStructureBarrier, Api, Attachment, BufferBarrier, BufferBinding, BufferCopy,
+    BufferTextureCopy, BuildAccelerationStructureDescriptor, ColorAttachment, CommandEncoder,
+    ComputePassDescriptor, DepthStencilAttachment, DeviceError, Label, MemoryRange,
     PassTimestampWrites, Rect, RenderPassDescriptor, TextureBarrier, TextureCopy, TextureUses,
 };
 
 use super::{
-    DynBindGroup, DynBuffer, DynCommandBuffer, DynComputePipeline, DynPipelineLayout, DynQuerySet,
-    DynRenderPipeline, DynResource, DynResourceExt as _, DynTexture, DynTextureView,
+    DynAccelerationStructure, DynBindGroup, DynBuffer, DynCommandBuffer, DynComputePipeline,
+    DynPipelineLayout, DynQuerySet, DynRenderPipeline, DynResource, DynResourceExt as _,
+    DynTexture, DynTextureView,
 };
 
 pub trait DynCommandEncoder: DynResource + std::fmt::Debug {
@@ -164,18 +166,19 @@ pub trait DynCommandEncoder: DynResource + std::fmt::Debug {
     unsafe fn dispatch(&mut self, count: [u32; 3]);
     unsafe fn dispatch_indirect(&mut self, buffer: &dyn DynBuffer, offset: wgt::BufferAddress);
 
-    // unsafe fn build_acceleration_structures<'a, T>(
-    //     &mut self,
-    //     descriptor_count: u32,
-    //     descriptors: T,
-    // ) where
-    //     Self::A: 'a,
-    //     T: IntoIterator<Item = BuildAccelerationStructureDescriptor<'a, Self::A>>;
+    unsafe fn build_acceleration_structures<'a>(
+        &mut self,
+        descriptors: &'a [BuildAccelerationStructureDescriptor<
+            'a,
+            dyn DynBuffer,
+            dyn DynAccelerationStructure,
+        >],
+    );
 
-    // unsafe fn place_acceleration_structure_barrier(
-    //     &mut self,
-    //     barrier: AccelerationStructureBarrier,
-    // );
+    unsafe fn place_acceleration_structure_barrier(
+        &mut self,
+        barrier: AccelerationStructureBarrier,
+    );
 }
 
 impl<C: CommandEncoder + DynResource> DynCommandEncoder for C {
@@ -558,6 +561,49 @@ impl<C: CommandEncoder + DynResource> DynCommandEncoder for C {
     ) {
         let binding = binding.expect_downcast();
         unsafe { self.set_vertex_buffer(index, binding) };
+    }
+
+    unsafe fn build_acceleration_structures<'a>(
+        &mut self,
+        descriptors: &'a [BuildAccelerationStructureDescriptor<
+            'a,
+            dyn DynBuffer,
+            dyn DynAccelerationStructure,
+        >],
+    ) {
+        // Need to collect entries here so we can reference them in the descriptor.
+        // TODO: API should be redesigned to avoid this and other descriptor copies that happen due to the dyn api.
+        let descriptor_entries = descriptors
+            .iter()
+            .map(|d| d.entries.expect_downcast())
+            .collect::<Vec<_>>();
+        let descriptors = descriptors
+            .iter()
+            .zip(descriptor_entries.iter())
+            .map(|(d, entries)| BuildAccelerationStructureDescriptor::<
+                <C::A as Api>::Buffer,
+                <C::A as Api>::AccelerationStructure,
+            > {
+                entries,
+                mode: d.mode,
+                flags: d.flags,
+                source_acceleration_structure: d
+                    .source_acceleration_structure
+                    .map(|a| a.expect_downcast_ref()),
+                destination_acceleration_structure: d
+                    .destination_acceleration_structure
+                    .expect_downcast_ref(),
+                scratch_buffer: d.scratch_buffer.expect_downcast_ref(),
+                scratch_buffer_offset: d.scratch_buffer_offset,
+            });
+        unsafe { C::build_acceleration_structures(self, descriptors.len() as _, descriptors) };
+    }
+
+    unsafe fn place_acceleration_structure_barrier(
+        &mut self,
+        barrier: AccelerationStructureBarrier,
+    ) {
+        unsafe { C::place_acceleration_structure_barrier(self, barrier) };
     }
 }
 

--- a/wgpu-hal/src/dynamic/command.rs
+++ b/wgpu-hal/src/dynamic/command.rs
@@ -1,0 +1,37 @@
+use crate::{BufferBinding, CommandEncoder};
+
+use super::DynBuffer;
+
+pub trait DynCommandEncoder {
+    unsafe fn set_index_buffer<'a>(
+        &mut self,
+        binding: BufferBinding<'a, dyn DynBuffer>,
+        format: wgt::IndexFormat,
+    );
+
+    unsafe fn set_vertex_buffer<'a>(
+        &mut self,
+        index: u32,
+        binding: BufferBinding<'a, dyn DynBuffer>,
+    );
+}
+
+impl<C: CommandEncoder> DynCommandEncoder for C {
+    unsafe fn set_index_buffer<'a>(
+        &mut self,
+        binding: BufferBinding<'a, dyn DynBuffer>,
+        format: wgt::IndexFormat,
+    ) {
+        let binding = binding.expect_downcast();
+        unsafe { self.set_index_buffer(binding, format) };
+    }
+
+    unsafe fn set_vertex_buffer<'a>(
+        &mut self,
+        index: u32,
+        binding: BufferBinding<'a, dyn DynBuffer>,
+    ) {
+        let binding = binding.expect_downcast();
+        unsafe { self.set_vertex_buffer(index, binding) };
+    }
+}

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -4,15 +4,16 @@
 use crate::{
     Api, BindGroupDescriptor, BindGroupLayoutDescriptor, BufferDescriptor, BufferMapping,
     CommandEncoderDescriptor, ComputePipelineDescriptor, Device, DeviceError, DynBuffer,
-    DynResource, MemoryRange, PipelineCacheDescriptor, PipelineCacheError, PipelineError,
+    DynResource, Label, MemoryRange, PipelineCacheDescriptor, PipelineCacheError, PipelineError,
     PipelineLayoutDescriptor, RenderPipelineDescriptor, SamplerDescriptor, ShaderError,
     ShaderInput, ShaderModuleDescriptor, TextureDescriptor, TextureViewDescriptor,
 };
 
 use super::{
     DynAccelerationStructure, DynBindGroup, DynBindGroupLayout, DynCommandEncoder,
-    DynComputePipeline, DynPipelineCache, DynPipelineLayout, DynQueue, DynRenderPipeline,
-    DynResourceExt as _, DynSampler, DynShaderModule, DynTexture, DynTextureView,
+    DynComputePipeline, DynPipelineCache, DynPipelineLayout, DynQuerySet, DynQueue,
+    DynRenderPipeline, DynResourceExt as _, DynSampler, DynShaderModule, DynTexture,
+    DynTextureView,
 };
 
 pub trait DynDevice: DynResource {
@@ -116,6 +117,12 @@ pub trait DynDevice: DynResource {
         None
     }
     unsafe fn destroy_pipeline_cache(&self, cache: Box<dyn DynPipelineCache>);
+
+    unsafe fn create_query_set(
+        &self,
+        desc: &wgt::QuerySetDescriptor<Label>,
+    ) -> Result<Box<dyn DynQuerySet>, DeviceError>;
+    unsafe fn destroy_query_set(&self, set: Box<dyn DynQuerySet>);
 }
 
 impl<D: Device + DynResource> DynDevice for D {
@@ -381,5 +388,16 @@ impl<D: Device + DynResource> DynDevice for D {
 
     unsafe fn destroy_pipeline_cache(&self, pipeline_cache: Box<dyn DynPipelineCache>) {
         unsafe { D::destroy_pipeline_cache(self, pipeline_cache.unbox()) };
+    }
+
+    unsafe fn create_query_set(
+        &self,
+        desc: &wgt::QuerySetDescriptor<Label>,
+    ) -> Result<Box<dyn DynQuerySet>, DeviceError> {
+        unsafe { D::create_query_set(self, desc) }.map(|b| Box::new(b) as Box<dyn DynQuerySet>)
+    }
+
+    unsafe fn destroy_query_set(&self, query_set: Box<dyn DynQuerySet>) {
+        unsafe { D::destroy_query_set(self, query_set.unbox()) };
     }
 }

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -2,15 +2,13 @@
 #![allow(trivial_casts)]
 
 use crate::{
-    AccelerationStructureAABBs, AccelerationStructureBuildSizes, AccelerationStructureDescriptor,
-    AccelerationStructureEntries, AccelerationStructureInstances,
-    AccelerationStructureTriangleIndices, AccelerationStructureTriangleTransform,
-    AccelerationStructureTriangles, Api, BindGroupDescriptor, BindGroupLayoutDescriptor,
-    BufferDescriptor, BufferMapping, CommandEncoderDescriptor, ComputePipelineDescriptor, Device,
-    DeviceError, FenceValue, GetAccelerationStructureBuildSizesDescriptor, Label, MemoryRange,
-    PipelineCacheDescriptor, PipelineCacheError, PipelineError, PipelineLayoutDescriptor,
-    RenderPipelineDescriptor, SamplerDescriptor, ShaderError, ShaderInput, ShaderModuleDescriptor,
-    TextureDescriptor, TextureViewDescriptor,
+    AccelerationStructureBuildSizes, AccelerationStructureDescriptor, Api, BindGroupDescriptor,
+    BindGroupLayoutDescriptor, BufferDescriptor, BufferMapping, CommandEncoderDescriptor,
+    ComputePipelineDescriptor, Device, DeviceError, FenceValue,
+    GetAccelerationStructureBuildSizesDescriptor, Label, MemoryRange, PipelineCacheDescriptor,
+    PipelineCacheError, PipelineError, PipelineLayoutDescriptor, RenderPipelineDescriptor,
+    SamplerDescriptor, ShaderError, ShaderInput, ShaderModuleDescriptor, TextureDescriptor,
+    TextureViewDescriptor,
 };
 
 use super::{
@@ -495,57 +493,7 @@ impl<D: Device + DynResource> DynDevice for D {
         &self,
         desc: &GetAccelerationStructureBuildSizesDescriptor<dyn DynBuffer>,
     ) -> AccelerationStructureBuildSizes {
-        let entries = match &desc.entries {
-            AccelerationStructureEntries::Instances(instances) => {
-                AccelerationStructureEntries::Instances(AccelerationStructureInstances {
-                    buffer: instances.buffer.map(|b| b.expect_downcast_ref()),
-                    offset: instances.offset,
-                    count: instances.count,
-                })
-            }
-            AccelerationStructureEntries::Triangles(triangles) => {
-                AccelerationStructureEntries::Triangles(
-                    triangles
-                        .iter()
-                        .map(|t| AccelerationStructureTriangles {
-                            vertex_buffer: t.vertex_buffer.map(|b| b.expect_downcast_ref()),
-                            vertex_format: t.vertex_format,
-                            first_vertex: t.first_vertex,
-                            vertex_count: t.vertex_count,
-                            vertex_stride: t.vertex_stride,
-                            indices: t.indices.as_ref().map(|i| {
-                                AccelerationStructureTriangleIndices {
-                                    buffer: i.buffer.map(|b| b.expect_downcast_ref()),
-                                    format: i.format,
-                                    offset: i.offset,
-                                    count: i.count,
-                                }
-                            }),
-                            transform: t.transform.as_ref().map(|t| {
-                                AccelerationStructureTriangleTransform {
-                                    buffer: t.buffer.expect_downcast_ref(),
-                                    offset: t.offset,
-                                }
-                            }),
-                            flags: t.flags,
-                        })
-                        .collect(),
-                )
-            }
-            AccelerationStructureEntries::AABBs(entries) => AccelerationStructureEntries::AABBs(
-                entries
-                    .iter()
-                    .map(|e| AccelerationStructureAABBs {
-                        buffer: e.buffer.map(|b| b.expect_downcast_ref()),
-                        offset: e.offset,
-                        count: e.count,
-                        stride: e.stride,
-                        flags: e.flags,
-                    })
-                    .collect(),
-            ),
-        };
-
+        let entries = desc.entries.expect_downcast();
         let desc = GetAccelerationStructureBuildSizesDescriptor {
             entries: &entries,
             flags: desc.flags,

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -21,6 +21,8 @@ use super::{
 };
 
 pub trait DynDevice: DynResource {
+    unsafe fn exit(self: Box<Self>, queue: Box<dyn DynQueue>);
+
     unsafe fn create_buffer(
         &self,
         desc: &BufferDescriptor,
@@ -160,9 +162,16 @@ pub trait DynDevice: DynResource {
         &self,
         acceleration_structure: Box<dyn DynAccelerationStructure>,
     );
+
+    fn get_internal_counters(&self) -> wgt::HalCounters;
+    fn generate_allocator_report(&self) -> Option<wgt::AllocatorReport>;
 }
 
 impl<D: Device + DynResource> DynDevice for D {
+    unsafe fn exit(self: Box<Self>, queue: Box<dyn DynQueue>) {
+        unsafe { D::exit(*self, queue.unbox()) }
+    }
+
     unsafe fn create_buffer(
         &self,
         desc: &BufferDescriptor,
@@ -557,5 +566,13 @@ impl<D: Device + DynResource> DynDevice for D {
         acceleration_structure: Box<dyn DynAccelerationStructure>,
     ) {
         unsafe { D::destroy_acceleration_structure(self, acceleration_structure.unbox()) }
+    }
+
+    fn get_internal_counters(&self) -> wgt::HalCounters {
+        D::get_internal_counters(self)
+    }
+
+    fn generate_allocator_report(&self) -> Option<wgt::AllocatorReport> {
+        D::generate_allocator_report(self)
     }
 }

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -1,0 +1,13 @@
+use crate::{Device, DynBuffer};
+
+use super::DynResourceExt;
+
+pub trait DynDevice {
+    unsafe fn destroy_buffer(&self, buffer: Box<dyn DynBuffer>);
+}
+
+impl<D: Device> DynDevice for D {
+    unsafe fn destroy_buffer(&self, buffer: Box<dyn DynBuffer>) {
+        unsafe { D::destroy_buffer(self, buffer.unbox()) };
+    }
+}

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -2,12 +2,14 @@
 #![allow(trivial_casts)]
 
 use crate::{
-    Api, BufferDescriptor, BufferMapping, CommandEncoderDescriptor, Device, DeviceError, DynBuffer,
-    DynResource, MemoryRange, SamplerDescriptor, TextureDescriptor, TextureViewDescriptor,
+    Api, BindGroupLayoutDescriptor, BufferDescriptor, BufferMapping, CommandEncoderDescriptor,
+    Device, DeviceError, DynBuffer, DynResource, MemoryRange, SamplerDescriptor, TextureDescriptor,
+    TextureViewDescriptor,
 };
 
 use super::{
-    DynCommandEncoder, DynQueue, DynResourceExt as _, DynSampler, DynTexture, DynTextureView,
+    DynBindGroupLayout, DynCommandEncoder, DynQueue, DynResourceExt as _, DynSampler, DynTexture,
+    DynTextureView,
 };
 
 pub trait DynDevice: DynResource {
@@ -51,6 +53,12 @@ pub trait DynDevice: DynResource {
         desc: &CommandEncoderDescriptor<dyn DynQueue>,
     ) -> Result<Box<dyn DynCommandEncoder>, DeviceError>;
     unsafe fn destroy_command_encoder(&self, pool: Box<dyn DynCommandEncoder>);
+
+    unsafe fn create_bind_group_layout(
+        &self,
+        desc: &BindGroupLayoutDescriptor,
+    ) -> Result<Box<dyn DynBindGroupLayout>, DeviceError>;
+    unsafe fn destroy_bind_group_layout(&self, bg_layout: Box<dyn DynBindGroupLayout>);
 }
 
 impl<D: Device + DynResource> DynDevice for D {
@@ -150,5 +158,17 @@ impl<D: Device + DynResource> DynDevice for D {
 
     unsafe fn destroy_command_encoder(&self, encoder: Box<dyn DynCommandEncoder>) {
         unsafe { D::destroy_command_encoder(self, encoder.unbox()) };
+    }
+
+    unsafe fn create_bind_group_layout(
+        &self,
+        desc: &BindGroupLayoutDescriptor,
+    ) -> Result<Box<dyn DynBindGroupLayout>, DeviceError> {
+        unsafe { D::create_bind_group_layout(self, desc) }
+            .map(|b| Box::new(b) as Box<dyn DynBindGroupLayout>)
+    }
+
+    unsafe fn destroy_bind_group_layout(&self, bg_layout: Box<dyn DynBindGroupLayout>) {
+        unsafe { D::destroy_bind_group_layout(self, bg_layout.unbox()) };
     }
 }

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -1,8 +1,9 @@
 use crate::{
-    BufferDescriptor, BufferMapping, Device, DeviceError, DynBuffer, DynResource, MemoryRange,
+    Api, BufferDescriptor, BufferMapping, Device, DeviceError, DynBuffer, DynResource, MemoryRange,
+    SamplerDescriptor, TextureDescriptor, TextureViewDescriptor,
 };
 
-use super::DynResourceExt as _;
+use super::{DynResourceExt as _, DynSampler, DynTexture, DynTextureView};
 
 pub trait DynDevice: DynResource {
     unsafe fn create_buffer(
@@ -22,6 +23,23 @@ pub trait DynDevice: DynResource {
 
     unsafe fn flush_mapped_ranges(&self, buffer: &dyn DynBuffer, ranges: &[MemoryRange]);
     unsafe fn invalidate_mapped_ranges(&self, buffer: &dyn DynBuffer, ranges: &[MemoryRange]);
+
+    unsafe fn create_texture(
+        &self,
+        desc: &TextureDescriptor,
+    ) -> Result<Box<dyn DynTexture>, DeviceError>;
+    unsafe fn destroy_texture(&self, texture: Box<dyn DynTexture>);
+    unsafe fn create_texture_view(
+        &self,
+        texture: &dyn DynTexture,
+        desc: &TextureViewDescriptor,
+    ) -> Result<Box<dyn DynTextureView>, DeviceError>;
+    unsafe fn destroy_texture_view(&self, view: Box<dyn DynTextureView>);
+    unsafe fn create_sampler(
+        &self,
+        desc: &SamplerDescriptor,
+    ) -> Result<Box<dyn DynSampler>, DeviceError>;
+    unsafe fn destroy_sampler(&self, sampler: Box<dyn DynSampler>);
 }
 
 impl<D: Device + DynResource> DynDevice for D {
@@ -58,5 +76,52 @@ impl<D: Device + DynResource> DynDevice for D {
     unsafe fn invalidate_mapped_ranges(&self, buffer: &dyn DynBuffer, ranges: &[MemoryRange]) {
         let buffer = buffer.expect_downcast_ref();
         unsafe { D::invalidate_mapped_ranges(self, buffer, ranges.iter().cloned()) }
+    }
+
+    unsafe fn create_texture(
+        &self,
+        desc: &TextureDescriptor,
+    ) -> Result<Box<dyn DynTexture>, DeviceError> {
+        unsafe { D::create_texture(self, desc) }.map(|b| {
+            let boxed_texture: Box<<D::A as Api>::Texture> = Box::new(b);
+            let boxed_texture: Box<dyn DynTexture> = boxed_texture;
+            boxed_texture
+        })
+    }
+
+    unsafe fn destroy_texture(&self, texture: Box<dyn DynTexture>) {
+        unsafe { D::destroy_texture(self, texture.unbox()) };
+    }
+
+    unsafe fn create_texture_view(
+        &self,
+        texture: &dyn DynTexture,
+        desc: &TextureViewDescriptor,
+    ) -> Result<Box<dyn DynTextureView>, DeviceError> {
+        let texture = texture.expect_downcast_ref();
+        unsafe { D::create_texture_view(self, texture, desc) }.map(|b| {
+            let boxed_texture_view: Box<<D::A as Api>::TextureView> = Box::new(b);
+            let boxed_texture_view: Box<dyn DynTextureView> = boxed_texture_view;
+            boxed_texture_view
+        })
+    }
+
+    unsafe fn destroy_texture_view(&self, view: Box<dyn DynTextureView>) {
+        unsafe { D::destroy_texture_view(self, view.unbox()) };
+    }
+
+    unsafe fn create_sampler(
+        &self,
+        desc: &SamplerDescriptor,
+    ) -> Result<Box<dyn DynSampler>, DeviceError> {
+        unsafe { D::create_sampler(self, desc) }.map(|b| {
+            let boxed_sampler: Box<<D::A as Api>::Sampler> = Box::new(b);
+            let boxed_sampler: Box<dyn DynSampler> = boxed_sampler;
+            boxed_sampler
+        })
+    }
+
+    unsafe fn destroy_sampler(&self, sampler: Box<dyn DynSampler>) {
+        unsafe { D::destroy_sampler(self, sampler.unbox()) };
     }
 }

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -1,12 +1,12 @@
-use crate::{Device, DynBuffer};
+use crate::{Device, DynBuffer, DynResource};
 
 use super::DynResourceExt;
 
-pub trait DynDevice {
+pub trait DynDevice: DynResource {
     unsafe fn destroy_buffer(&self, buffer: Box<dyn DynBuffer>);
 }
 
-impl<D: Device> DynDevice for D {
+impl<D: Device + DynResource> DynDevice for D {
     unsafe fn destroy_buffer(&self, buffer: Box<dyn DynBuffer>) {
         unsafe { D::destroy_buffer(self, buffer.unbox()) };
     }

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -127,6 +127,18 @@ pub trait DynDevice: DynResource {
     unsafe fn create_fence(&self) -> Result<Box<dyn DynFence>, DeviceError>;
     unsafe fn destroy_fence(&self, fence: Box<dyn DynFence>);
     unsafe fn get_fence_value(&self, fence: &dyn DynFence) -> Result<FenceValue, DeviceError>;
+
+    unsafe fn wait(
+        &self,
+        fence: &dyn DynFence,
+        value: FenceValue,
+        timeout_ms: u32,
+    ) -> Result<bool, DeviceError>;
+
+    unsafe fn start_capture(&self) -> bool;
+    unsafe fn stop_capture(&self);
+
+    unsafe fn pipeline_cache_get_data(&self, cache: &dyn DynPipelineCache) -> Option<Vec<u8>>;
 }
 
 impl<D: Device + DynResource> DynDevice for D {
@@ -416,5 +428,28 @@ impl<D: Device + DynResource> DynDevice for D {
     unsafe fn get_fence_value(&self, fence: &dyn DynFence) -> Result<FenceValue, DeviceError> {
         let fence = fence.expect_downcast_ref();
         unsafe { D::get_fence_value(self, fence) }
+    }
+
+    unsafe fn wait(
+        &self,
+        fence: &dyn DynFence,
+        value: FenceValue,
+        timeout_ms: u32,
+    ) -> Result<bool, DeviceError> {
+        let fence = fence.expect_downcast_ref();
+        unsafe { D::wait(self, fence, value, timeout_ms) }
+    }
+
+    unsafe fn start_capture(&self) -> bool {
+        unsafe { D::start_capture(self) }
+    }
+
+    unsafe fn stop_capture(&self) {
+        unsafe { D::stop_capture(self) }
+    }
+
+    unsafe fn pipeline_cache_get_data(&self, cache: &dyn DynPipelineCache) -> Option<Vec<u8>> {
+        let cache = cache.expect_downcast_ref();
+        unsafe { D::pipeline_cache_get_data(self, cache) }
     }
 }

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -3,13 +3,13 @@
 
 use crate::{
     Api, BindGroupLayoutDescriptor, BufferDescriptor, BufferMapping, CommandEncoderDescriptor,
-    Device, DeviceError, DynBuffer, DynResource, MemoryRange, SamplerDescriptor, TextureDescriptor,
-    TextureViewDescriptor,
+    Device, DeviceError, DynBuffer, DynResource, MemoryRange, PipelineLayoutDescriptor,
+    SamplerDescriptor, TextureDescriptor, TextureViewDescriptor,
 };
 
 use super::{
-    DynBindGroupLayout, DynCommandEncoder, DynQueue, DynResourceExt as _, DynSampler, DynTexture,
-    DynTextureView,
+    DynBindGroupLayout, DynCommandEncoder, DynPipelineLayout, DynQueue, DynResourceExt as _,
+    DynSampler, DynTexture, DynTextureView,
 };
 
 pub trait DynDevice: DynResource {
@@ -59,6 +59,12 @@ pub trait DynDevice: DynResource {
         desc: &BindGroupLayoutDescriptor,
     ) -> Result<Box<dyn DynBindGroupLayout>, DeviceError>;
     unsafe fn destroy_bind_group_layout(&self, bg_layout: Box<dyn DynBindGroupLayout>);
+
+    unsafe fn create_pipeline_layout(
+        &self,
+        desc: &PipelineLayoutDescriptor<dyn DynBindGroupLayout>,
+    ) -> Result<Box<dyn DynPipelineLayout>, DeviceError>;
+    unsafe fn destroy_pipeline_layout(&self, pipeline_layout: Box<dyn DynPipelineLayout>);
 }
 
 impl<D: Device + DynResource> DynDevice for D {
@@ -170,5 +176,29 @@ impl<D: Device + DynResource> DynDevice for D {
 
     unsafe fn destroy_bind_group_layout(&self, bg_layout: Box<dyn DynBindGroupLayout>) {
         unsafe { D::destroy_bind_group_layout(self, bg_layout.unbox()) };
+    }
+
+    unsafe fn create_pipeline_layout(
+        &self,
+        desc: &PipelineLayoutDescriptor<dyn DynBindGroupLayout>,
+    ) -> Result<Box<dyn DynPipelineLayout>, DeviceError> {
+        let bind_group_layouts: Vec<_> = desc
+            .bind_group_layouts
+            .iter()
+            .map(|bgl| bgl.expect_downcast_ref())
+            .collect();
+        let desc = PipelineLayoutDescriptor {
+            label: desc.label,
+            bind_group_layouts: &bind_group_layouts,
+            push_constant_ranges: desc.push_constant_ranges,
+            flags: desc.flags,
+        };
+
+        unsafe { D::create_pipeline_layout(self, &desc) }
+            .map(|b| Box::new(b) as Box<dyn DynPipelineLayout>)
+    }
+
+    unsafe fn destroy_pipeline_layout(&self, pipeline_layout: Box<dyn DynPipelineLayout>) {
+        unsafe { D::destroy_pipeline_layout(self, pipeline_layout.unbox()) };
     }
 }

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -4,12 +4,14 @@
 use crate::{
     Api, BindGroupDescriptor, BindGroupLayoutDescriptor, BufferDescriptor, BufferMapping,
     CommandEncoderDescriptor, Device, DeviceError, DynBuffer, DynResource, MemoryRange,
-    PipelineLayoutDescriptor, SamplerDescriptor, TextureDescriptor, TextureViewDescriptor,
+    PipelineLayoutDescriptor, SamplerDescriptor, ShaderError, ShaderInput, ShaderModuleDescriptor,
+    TextureDescriptor, TextureViewDescriptor,
 };
 
 use super::{
     DynAccelerationStructure, DynBindGroup, DynBindGroupLayout, DynCommandEncoder,
-    DynPipelineLayout, DynQueue, DynResourceExt as _, DynSampler, DynTexture, DynTextureView,
+    DynPipelineLayout, DynQueue, DynResourceExt as _, DynSampler, DynShaderModule, DynTexture,
+    DynTextureView,
 };
 
 pub trait DynDevice: DynResource {
@@ -77,6 +79,13 @@ pub trait DynDevice: DynResource {
         >,
     ) -> Result<Box<dyn DynBindGroup>, DeviceError>;
     unsafe fn destroy_bind_group(&self, group: Box<dyn DynBindGroup>);
+
+    unsafe fn create_shader_module(
+        &self,
+        desc: &ShaderModuleDescriptor,
+        shader: ShaderInput,
+    ) -> Result<Box<dyn DynShaderModule>, ShaderError>;
+    unsafe fn destroy_shader_module(&self, module: Box<dyn DynShaderModule>);
 }
 
 impl<D: Device + DynResource> DynDevice for D {
@@ -260,5 +269,18 @@ impl<D: Device + DynResource> DynDevice for D {
 
     unsafe fn destroy_bind_group(&self, group: Box<dyn DynBindGroup>) {
         unsafe { D::destroy_bind_group(self, group.unbox()) };
+    }
+
+    unsafe fn create_shader_module(
+        &self,
+        desc: &ShaderModuleDescriptor,
+        shader: ShaderInput,
+    ) -> Result<Box<dyn DynShaderModule>, ShaderError> {
+        unsafe { D::create_shader_module(self, desc, shader) }
+            .map(|b| Box::new(b) as Box<dyn DynShaderModule>)
+    }
+
+    unsafe fn destroy_shader_module(&self, module: Box<dyn DynShaderModule>) {
+        unsafe { D::destroy_shader_module(self, module.unbox()) };
     }
 }

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -3,15 +3,16 @@
 
 use crate::{
     Api, BindGroupDescriptor, BindGroupLayoutDescriptor, BufferDescriptor, BufferMapping,
-    CommandEncoderDescriptor, Device, DeviceError, DynBuffer, DynResource, MemoryRange,
-    PipelineLayoutDescriptor, SamplerDescriptor, ShaderError, ShaderInput, ShaderModuleDescriptor,
-    TextureDescriptor, TextureViewDescriptor,
+    CommandEncoderDescriptor, ComputePipelineDescriptor, Device, DeviceError, DynBuffer,
+    DynResource, MemoryRange, PipelineError, PipelineLayoutDescriptor, RenderPipelineDescriptor,
+    SamplerDescriptor, ShaderError, ShaderInput, ShaderModuleDescriptor, TextureDescriptor,
+    TextureViewDescriptor,
 };
 
 use super::{
     DynAccelerationStructure, DynBindGroup, DynBindGroupLayout, DynCommandEncoder,
-    DynPipelineLayout, DynQueue, DynResourceExt as _, DynSampler, DynShaderModule, DynTexture,
-    DynTextureView,
+    DynComputePipeline, DynPipelineCache, DynPipelineLayout, DynQueue, DynRenderPipeline,
+    DynResourceExt as _, DynSampler, DynShaderModule, DynTexture, DynTextureView,
 };
 
 pub trait DynDevice: DynResource {
@@ -86,6 +87,26 @@ pub trait DynDevice: DynResource {
         shader: ShaderInput,
     ) -> Result<Box<dyn DynShaderModule>, ShaderError>;
     unsafe fn destroy_shader_module(&self, module: Box<dyn DynShaderModule>);
+
+    unsafe fn create_render_pipeline(
+        &self,
+        desc: &RenderPipelineDescriptor<
+            dyn DynPipelineLayout,
+            dyn DynShaderModule,
+            dyn DynPipelineCache,
+        >,
+    ) -> Result<Box<dyn DynRenderPipeline>, PipelineError>;
+    unsafe fn destroy_render_pipeline(&self, pipeline: Box<dyn DynRenderPipeline>);
+
+    unsafe fn create_compute_pipeline(
+        &self,
+        desc: &ComputePipelineDescriptor<
+            dyn DynPipelineLayout,
+            dyn DynShaderModule,
+            dyn DynPipelineCache,
+        >,
+    ) -> Result<Box<dyn DynComputePipeline>, PipelineError>;
+    unsafe fn destroy_compute_pipeline(&self, pipeline: Box<dyn DynComputePipeline>);
 }
 
 impl<D: Device + DynResource> DynDevice for D {
@@ -282,5 +303,58 @@ impl<D: Device + DynResource> DynDevice for D {
 
     unsafe fn destroy_shader_module(&self, module: Box<dyn DynShaderModule>) {
         unsafe { D::destroy_shader_module(self, module.unbox()) };
+    }
+
+    unsafe fn create_render_pipeline(
+        &self,
+        desc: &RenderPipelineDescriptor<
+            dyn DynPipelineLayout,
+            dyn DynShaderModule,
+            dyn DynPipelineCache,
+        >,
+    ) -> Result<Box<dyn DynRenderPipeline>, PipelineError> {
+        let desc = RenderPipelineDescriptor {
+            label: desc.label,
+            layout: desc.layout.expect_downcast_ref(),
+            vertex_buffers: desc.vertex_buffers,
+            vertex_stage: desc.vertex_stage.clone().expect_downcast(),
+            primitive: desc.primitive,
+            depth_stencil: desc.depth_stencil.clone(),
+            multisample: desc.multisample,
+            fragment_stage: desc.fragment_stage.clone().map(|f| f.expect_downcast()),
+            color_targets: desc.color_targets,
+            multiview: desc.multiview,
+            cache: desc.cache.map(|c| c.expect_downcast_ref()),
+        };
+
+        unsafe { D::create_render_pipeline(self, &desc) }
+            .map(|b| Box::new(b) as Box<dyn DynRenderPipeline>)
+    }
+
+    unsafe fn destroy_render_pipeline(&self, pipeline: Box<dyn DynRenderPipeline>) {
+        unsafe { D::destroy_render_pipeline(self, pipeline.unbox()) };
+    }
+
+    unsafe fn create_compute_pipeline(
+        &self,
+        desc: &ComputePipelineDescriptor<
+            dyn DynPipelineLayout,
+            dyn DynShaderModule,
+            dyn DynPipelineCache,
+        >,
+    ) -> Result<Box<dyn DynComputePipeline>, PipelineError> {
+        let desc = ComputePipelineDescriptor {
+            label: desc.label,
+            layout: desc.layout.expect_downcast_ref(),
+            stage: desc.stage.clone().expect_downcast(),
+            cache: desc.cache.as_ref().map(|c| c.expect_downcast_ref()),
+        };
+
+        unsafe { D::create_compute_pipeline(self, &desc) }
+            .map(|b| Box::new(b) as Box<dyn DynComputePipeline>)
+    }
+
+    unsafe fn destroy_compute_pipeline(&self, pipeline: Box<dyn DynComputePipeline>) {
+        unsafe { D::destroy_compute_pipeline(self, pipeline.unbox()) };
     }
 }

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -1,13 +1,62 @@
-use crate::{Device, DynBuffer, DynResource};
+use crate::{
+    BufferDescriptor, BufferMapping, Device, DeviceError, DynBuffer, DynResource, MemoryRange,
+};
 
-use super::DynResourceExt;
+use super::DynResourceExt as _;
 
 pub trait DynDevice: DynResource {
+    unsafe fn create_buffer(
+        &self,
+        desc: &BufferDescriptor,
+    ) -> Result<Box<dyn DynBuffer>, DeviceError>;
+
     unsafe fn destroy_buffer(&self, buffer: Box<dyn DynBuffer>);
+
+    unsafe fn map_buffer(
+        &self,
+        buffer: &dyn DynBuffer,
+        range: MemoryRange,
+    ) -> Result<BufferMapping, DeviceError>;
+
+    unsafe fn unmap_buffer(&self, buffer: &dyn DynBuffer);
+
+    unsafe fn flush_mapped_ranges(&self, buffer: &dyn DynBuffer, ranges: &[MemoryRange]);
+    unsafe fn invalidate_mapped_ranges(&self, buffer: &dyn DynBuffer, ranges: &[MemoryRange]);
 }
 
 impl<D: Device + DynResource> DynDevice for D {
+    unsafe fn create_buffer(
+        &self,
+        desc: &BufferDescriptor,
+    ) -> Result<Box<dyn DynBuffer>, DeviceError> {
+        unsafe { D::create_buffer(self, desc) }.map(|b| -> Box<dyn DynBuffer> { Box::new(b) })
+    }
+
     unsafe fn destroy_buffer(&self, buffer: Box<dyn DynBuffer>) {
         unsafe { D::destroy_buffer(self, buffer.unbox()) };
+    }
+
+    unsafe fn map_buffer(
+        &self,
+        buffer: &dyn DynBuffer,
+        range: MemoryRange,
+    ) -> Result<BufferMapping, DeviceError> {
+        let buffer = buffer.expect_downcast_ref();
+        unsafe { D::map_buffer(self, buffer, range) }
+    }
+
+    unsafe fn unmap_buffer(&self, buffer: &dyn DynBuffer) {
+        let buffer = buffer.expect_downcast_ref();
+        unsafe { D::unmap_buffer(self, buffer) }
+    }
+
+    unsafe fn flush_mapped_ranges(&self, buffer: &dyn DynBuffer, ranges: &[MemoryRange]) {
+        let buffer = buffer.expect_downcast_ref();
+        unsafe { D::flush_mapped_ranges(self, buffer, ranges.iter().cloned()) }
+    }
+
+    unsafe fn invalidate_mapped_ranges(&self, buffer: &dyn DynBuffer, ranges: &[MemoryRange]) {
+        let buffer = buffer.expect_downcast_ref();
+        unsafe { D::invalidate_mapped_ranges(self, buffer, ranges.iter().cloned()) }
     }
 }

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -4,14 +4,14 @@
 use crate::{
     Api, BindGroupDescriptor, BindGroupLayoutDescriptor, BufferDescriptor, BufferMapping,
     CommandEncoderDescriptor, ComputePipelineDescriptor, Device, DeviceError, DynBuffer,
-    DynResource, Label, MemoryRange, PipelineCacheDescriptor, PipelineCacheError, PipelineError,
-    PipelineLayoutDescriptor, RenderPipelineDescriptor, SamplerDescriptor, ShaderError,
-    ShaderInput, ShaderModuleDescriptor, TextureDescriptor, TextureViewDescriptor,
+    DynResource, FenceValue, Label, MemoryRange, PipelineCacheDescriptor, PipelineCacheError,
+    PipelineError, PipelineLayoutDescriptor, RenderPipelineDescriptor, SamplerDescriptor,
+    ShaderError, ShaderInput, ShaderModuleDescriptor, TextureDescriptor, TextureViewDescriptor,
 };
 
 use super::{
     DynAccelerationStructure, DynBindGroup, DynBindGroupLayout, DynCommandEncoder,
-    DynComputePipeline, DynPipelineCache, DynPipelineLayout, DynQuerySet, DynQueue,
+    DynComputePipeline, DynFence, DynPipelineCache, DynPipelineLayout, DynQuerySet, DynQueue,
     DynRenderPipeline, DynResourceExt as _, DynSampler, DynShaderModule, DynTexture,
     DynTextureView,
 };
@@ -123,6 +123,10 @@ pub trait DynDevice: DynResource {
         desc: &wgt::QuerySetDescriptor<Label>,
     ) -> Result<Box<dyn DynQuerySet>, DeviceError>;
     unsafe fn destroy_query_set(&self, set: Box<dyn DynQuerySet>);
+
+    unsafe fn create_fence(&self) -> Result<Box<dyn DynFence>, DeviceError>;
+    unsafe fn destroy_fence(&self, fence: Box<dyn DynFence>);
+    unsafe fn get_fence_value(&self, fence: &dyn DynFence) -> Result<FenceValue, DeviceError>;
 }
 
 impl<D: Device + DynResource> DynDevice for D {
@@ -399,5 +403,18 @@ impl<D: Device + DynResource> DynDevice for D {
 
     unsafe fn destroy_query_set(&self, query_set: Box<dyn DynQuerySet>) {
         unsafe { D::destroy_query_set(self, query_set.unbox()) };
+    }
+
+    unsafe fn create_fence(&self) -> Result<Box<dyn DynFence>, DeviceError> {
+        unsafe { D::create_fence(self) }.map(|f| Box::new(f) as Box<dyn DynFence>)
+    }
+
+    unsafe fn destroy_fence(&self, fence: Box<dyn DynFence>) {
+        unsafe { D::destroy_fence(self, fence.unbox()) };
+    }
+
+    unsafe fn get_fence_value(&self, fence: &dyn DynFence) -> Result<FenceValue, DeviceError> {
+        let fence = fence.expect_downcast_ref();
+        unsafe { D::get_fence_value(self, fence) }
     }
 }

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -2,14 +2,14 @@
 #![allow(trivial_casts)]
 
 use crate::{
-    Api, BindGroupLayoutDescriptor, BufferDescriptor, BufferMapping, CommandEncoderDescriptor,
-    Device, DeviceError, DynBuffer, DynResource, MemoryRange, PipelineLayoutDescriptor,
-    SamplerDescriptor, TextureDescriptor, TextureViewDescriptor,
+    Api, BindGroupDescriptor, BindGroupLayoutDescriptor, BufferDescriptor, BufferMapping,
+    CommandEncoderDescriptor, Device, DeviceError, DynBuffer, DynResource, MemoryRange,
+    PipelineLayoutDescriptor, SamplerDescriptor, TextureDescriptor, TextureViewDescriptor,
 };
 
 use super::{
-    DynBindGroupLayout, DynCommandEncoder, DynPipelineLayout, DynQueue, DynResourceExt as _,
-    DynSampler, DynTexture, DynTextureView,
+    DynAccelerationStructure, DynBindGroup, DynBindGroupLayout, DynCommandEncoder,
+    DynPipelineLayout, DynQueue, DynResourceExt as _, DynSampler, DynTexture, DynTextureView,
 };
 
 pub trait DynDevice: DynResource {
@@ -65,6 +65,18 @@ pub trait DynDevice: DynResource {
         desc: &PipelineLayoutDescriptor<dyn DynBindGroupLayout>,
     ) -> Result<Box<dyn DynPipelineLayout>, DeviceError>;
     unsafe fn destroy_pipeline_layout(&self, pipeline_layout: Box<dyn DynPipelineLayout>);
+
+    unsafe fn create_bind_group(
+        &self,
+        desc: &BindGroupDescriptor<
+            dyn DynBindGroupLayout,
+            dyn DynBuffer,
+            dyn DynSampler,
+            dyn DynTextureView,
+            dyn DynAccelerationStructure,
+        >,
+    ) -> Result<Box<dyn DynBindGroup>, DeviceError>;
+    unsafe fn destroy_bind_group(&self, group: Box<dyn DynBindGroup>);
 }
 
 impl<D: Device + DynResource> DynDevice for D {
@@ -200,5 +212,53 @@ impl<D: Device + DynResource> DynDevice for D {
 
     unsafe fn destroy_pipeline_layout(&self, pipeline_layout: Box<dyn DynPipelineLayout>) {
         unsafe { D::destroy_pipeline_layout(self, pipeline_layout.unbox()) };
+    }
+
+    unsafe fn create_bind_group(
+        &self,
+        desc: &BindGroupDescriptor<
+            dyn DynBindGroupLayout,
+            dyn DynBuffer,
+            dyn DynSampler,
+            dyn DynTextureView,
+            dyn DynAccelerationStructure,
+        >,
+    ) -> Result<Box<dyn DynBindGroup>, DeviceError> {
+        let buffers: Vec<_> = desc
+            .buffers
+            .iter()
+            .map(|b| b.clone().expect_downcast())
+            .collect();
+        let samplers: Vec<_> = desc
+            .samplers
+            .iter()
+            .map(|s| s.expect_downcast_ref())
+            .collect();
+        let textures: Vec<_> = desc
+            .textures
+            .iter()
+            .map(|t| t.clone().expect_downcast())
+            .collect();
+        let acceleration_structures: Vec<_> = desc
+            .acceleration_structures
+            .iter()
+            .map(|a| a.expect_downcast_ref())
+            .collect();
+
+        let desc = BindGroupDescriptor {
+            label: desc.label.to_owned(),
+            layout: desc.layout.expect_downcast_ref(),
+            buffers: &buffers,
+            samplers: &samplers,
+            textures: &textures,
+            entries: desc.entries,
+            acceleration_structures: &acceleration_structures,
+        };
+
+        unsafe { D::create_bind_group(self, &desc) }.map(|b| Box::new(b) as Box<dyn DynBindGroup>)
+    }
+
+    unsafe fn destroy_bind_group(&self, group: Box<dyn DynBindGroup>) {
+        unsafe { D::destroy_bind_group(self, group.unbox()) };
     }
 }

--- a/wgpu-hal/src/dynamic/instance.rs
+++ b/wgpu-hal/src/dynamic/instance.rs
@@ -1,0 +1,53 @@
+// Box casts are needed, alternative would be a temporaries which are more verbose and not more expressive.
+#![allow(trivial_casts)]
+
+use crate::{Capabilities, Instance, InstanceError};
+
+use super::{DynAdapter, DynResource, DynResourceExt as _, DynSurface};
+
+pub struct DynExposedAdapter {
+    pub adapter: Box<dyn DynAdapter>,
+    pub info: wgt::AdapterInfo,
+    pub features: wgt::Features,
+    pub capabilities: Capabilities,
+}
+
+pub trait DynInstance: DynResource {
+    unsafe fn create_surface(
+        &self,
+        display_handle: raw_window_handle::RawDisplayHandle,
+        window_handle: raw_window_handle::RawWindowHandle,
+    ) -> Result<Box<dyn DynSurface>, InstanceError>;
+
+    unsafe fn enumerate_adapters(
+        &self,
+        surface_hint: Option<&dyn DynSurface>,
+    ) -> Vec<DynExposedAdapter>;
+}
+
+impl<I: Instance + DynResource> DynInstance for I {
+    unsafe fn create_surface(
+        &self,
+        display_handle: raw_window_handle::RawDisplayHandle,
+        window_handle: raw_window_handle::RawWindowHandle,
+    ) -> Result<Box<dyn DynSurface>, InstanceError> {
+        unsafe { I::create_surface(self, display_handle, window_handle) }
+            .map(|surface| Box::new(surface) as Box<dyn DynSurface>)
+    }
+
+    unsafe fn enumerate_adapters(
+        &self,
+        surface_hint: Option<&dyn DynSurface>,
+    ) -> Vec<DynExposedAdapter> {
+        let surface_hint = surface_hint.map(|s| s.expect_downcast_ref());
+        unsafe { I::enumerate_adapters(self, surface_hint) }
+            .into_iter()
+            .map(|exposed| DynExposedAdapter {
+                adapter: Box::new(exposed.adapter),
+                info: exposed.info,
+                features: exposed.features,
+                capabilities: exposed.capabilities,
+            })
+            .collect()
+    }
+}

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -92,6 +92,7 @@ pub trait DynAccelerationStructure: DynResource + std::fmt::Debug {}
 pub trait DynBindGroup: DynResource + std::fmt::Debug {}
 pub trait DynBindGroupLayout: DynResource + std::fmt::Debug {}
 pub trait DynBuffer: DynResource + std::fmt::Debug {}
+pub trait DynCommandBuffer: DynResource + std::fmt::Debug {}
 pub trait DynComputePipeline: DynResource + std::fmt::Debug {}
 pub trait DynFence: DynResource + std::fmt::Debug {}
 pub trait DynPipelineCache: DynResource + std::fmt::Debug {}

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -1,0 +1,83 @@
+use std::any::Any;
+
+use wgt::WasmNotSendSync;
+
+/// Base trait for all resources, allows downcasting via [`Any`].
+pub trait DynResource: Any + WasmNotSendSync + 'static {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+/// Utility macro for implementing `DynResource` for a list of types.
+macro_rules! impl_dyn_resource {
+    ($($type:ty),*) => {
+        $(
+            impl crate::DynResource for $type {
+                fn as_any(&self) -> &dyn ::std::any::Any {
+                    self
+                }
+
+                fn as_any_mut(&mut self) -> &mut dyn ::std::any::Any {
+                    self
+                }
+            }
+        )*
+    };
+}
+pub(crate) use impl_dyn_resource;
+
+/// Extension trait for `DynResource` used by implementations of various dynamic resource traits.
+trait DynResourceExt {
+    /// # Panics
+    ///
+    /// - Panics if `self` is not downcastable to `T`.
+    fn expect_downcast_ref<T: DynResource>(&self) -> &T;
+    /// # Panics
+    ///
+    /// - Panics if `self` is not downcastable to `T`.
+    fn expect_downcast_mut<T: DynResource>(&mut self) -> &mut T;
+
+    /// Unboxes a `Box<dyn DynResource>` to a concrete type.
+    ///
+    /// # Safety
+    ///
+    /// - `self` must be the correct concrete type.
+    unsafe fn unbox<T: DynResource + 'static>(self: Box<Self>) -> T;
+}
+
+impl<R: DynResource + ?Sized> DynResourceExt for R {
+    fn expect_downcast_ref<'a, T: DynResource>(&'a self) -> &'a T {
+        self.as_any()
+            .downcast_ref()
+            .expect("Resource doesn't have the expected backend type.")
+    }
+
+    fn expect_downcast_mut<'a, T: DynResource>(&'a mut self) -> &'a mut T {
+        self.as_any_mut()
+            .downcast_mut()
+            .expect("Resource doesn't have the expected backend type.")
+    }
+
+    unsafe fn unbox<T: DynResource + 'static>(self: Box<Self>) -> T {
+        debug_assert!(
+            <Self as Any>::type_id(self.as_ref()) == std::any::TypeId::of::<T>(),
+            "Resource doesn't have the expected type, expected {:?}, got {:?}",
+            std::any::TypeId::of::<T>(),
+            <Self as Any>::type_id(self.as_ref())
+        );
+
+        let casted_ptr = Box::into_raw(self).cast::<T>();
+        // SAFETY: This is adheres to the safety contract of `Box::from_raw` because:
+        //
+        // - We are casting the value of a previously `Box`ed value, which guarantees:
+        //   - `casted_ptr` is not null.
+        //   - `casted_ptr` is valid for reads and writes, though by itself this does not mean
+        //     valid reads and writes for `T` (read on for that).
+        // - We don't change the allocator.
+        // - The contract of `Box::from_raw` requires that an initialized and aligned `T` is stored
+        //   within `casted_ptr`.
+        *unsafe { Box::from_raw(casted_ptr) }
+    }
+}
+
+pub trait DynBuffer: DynResource + std::fmt::Debug {}

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -87,6 +87,7 @@ impl<R: DynResource + ?Sized> DynResourceExt for R {
 }
 
 pub trait DynBuffer: DynResource + std::fmt::Debug {}
+pub trait DynQuerySet: DynResource + std::fmt::Debug {}
 
 impl<'a> BufferBinding<'a, dyn DynBuffer> {
     pub fn expect_downcast<B: DynBuffer>(self) -> BufferBinding<'a, B> {

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -88,10 +88,12 @@ impl<R: DynResource + ?Sized> DynResourceExt for R {
 
 pub trait DynBindGroup: DynResource + std::fmt::Debug {}
 pub trait DynBuffer: DynResource + std::fmt::Debug {}
+pub trait DynComputePipeline: DynResource + std::fmt::Debug {}
 pub trait DynPipelineLayout: DynResource + std::fmt::Debug {}
 pub trait DynQuerySet: DynResource + std::fmt::Debug {}
 pub trait DynRenderPipeline: DynResource + std::fmt::Debug {}
-pub trait DynComputePipeline: DynResource + std::fmt::Debug {}
+pub trait DynTexture: DynResource + std::fmt::Debug {}
+pub trait DynTextureView: DynResource + std::fmt::Debug {}
 
 impl<'a> BufferBinding<'a, dyn DynBuffer> {
     pub fn expect_downcast<B: DynBuffer>(self) -> BufferBinding<'a, B> {

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -1,9 +1,11 @@
 mod command;
 mod device;
+mod queue;
 mod surface;
 
 pub use command::DynCommandEncoder;
 pub use device::DynDevice;
+pub use queue::DynQueue;
 pub use surface::{DynAcquiredSurfaceTexture, DynSurface};
 
 use std::any::Any;
@@ -103,7 +105,10 @@ pub trait DynQuerySet: DynResource + std::fmt::Debug {}
 pub trait DynRenderPipeline: DynResource + std::fmt::Debug {}
 pub trait DynSampler: DynResource + std::fmt::Debug {}
 pub trait DynShaderModule: DynResource + std::fmt::Debug {}
-pub trait DynSurfaceTexture: DynResource + std::fmt::Debug {}
+pub trait DynSurfaceTexture:
+    DynResource + std::borrow::Borrow<dyn DynTexture> + std::fmt::Debug
+{
+}
 pub trait DynTexture: DynResource + std::fmt::Debug {}
 pub trait DynTextureView: DynResource + std::fmt::Debug {}
 

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -1,12 +1,14 @@
 mod adapter;
 mod command;
 mod device;
+mod instance;
 mod queue;
 mod surface;
 
 pub use adapter::{DynAdapter, DynOpenDevice};
 pub use command::DynCommandEncoder;
 pub use device::DynDevice;
+pub use instance::{DynExposedAdapter, DynInstance};
 pub use queue::DynQueue;
 pub use surface::{DynAcquiredSurfaceTexture, DynSurface};
 

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -1,6 +1,12 @@
+mod command;
+
+pub use self::command::DynCommandEncoder;
+
 use std::any::Any;
 
 use wgt::WasmNotSendSync;
+
+use crate::BufferBinding;
 
 /// Base trait for all resources, allows downcasting via [`Any`].
 pub trait DynResource: Any + WasmNotSendSync + 'static {
@@ -81,3 +87,13 @@ impl<R: DynResource + ?Sized> DynResourceExt for R {
 }
 
 pub trait DynBuffer: DynResource + std::fmt::Debug {}
+
+impl<'a> BufferBinding<'a, dyn DynBuffer> {
+    pub fn expect_downcast<B: DynBuffer>(self) -> BufferBinding<'a, B> {
+        BufferBinding {
+            buffer: self.buffer.expect_downcast_ref(),
+            offset: self.offset,
+            size: self.size,
+        }
+    }
+}

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -1,8 +1,10 @@
 mod command;
 mod device;
+mod surface;
 
-pub use self::command::DynCommandEncoder;
-pub use self::device::DynDevice;
+pub use command::DynCommandEncoder;
+pub use device::DynDevice;
+pub use surface::{DynAcquiredSurfaceTexture, DynSurface};
 
 use std::any::Any;
 

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -86,7 +86,9 @@ impl<R: DynResource + ?Sized> DynResourceExt for R {
     }
 }
 
+pub trait DynBindGroup: DynResource + std::fmt::Debug {}
 pub trait DynBuffer: DynResource + std::fmt::Debug {}
+pub trait DynPipelineLayout: DynResource + std::fmt::Debug {}
 pub trait DynQuerySet: DynResource + std::fmt::Debug {}
 
 impl<'a> BufferBinding<'a, dyn DynBuffer> {

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -88,12 +88,18 @@ impl<R: DynResource + ?Sized> DynResourceExt for R {
     }
 }
 
+pub trait DynAccelerationStructure: DynResource + std::fmt::Debug {}
 pub trait DynBindGroup: DynResource + std::fmt::Debug {}
+pub trait DynBindGroupLayout: DynResource + std::fmt::Debug {}
 pub trait DynBuffer: DynResource + std::fmt::Debug {}
 pub trait DynComputePipeline: DynResource + std::fmt::Debug {}
+pub trait DynFence: DynResource + std::fmt::Debug {}
+pub trait DynPipelineCache: DynResource + std::fmt::Debug {}
 pub trait DynPipelineLayout: DynResource + std::fmt::Debug {}
 pub trait DynQuerySet: DynResource + std::fmt::Debug {}
 pub trait DynRenderPipeline: DynResource + std::fmt::Debug {}
+pub trait DynSampler: DynResource + std::fmt::Debug {}
+pub trait DynShaderModule: DynResource + std::fmt::Debug {}
 pub trait DynTexture: DynResource + std::fmt::Debug {}
 pub trait DynTextureView: DynResource + std::fmt::Debug {}
 

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -90,6 +90,8 @@ pub trait DynBindGroup: DynResource + std::fmt::Debug {}
 pub trait DynBuffer: DynResource + std::fmt::Debug {}
 pub trait DynPipelineLayout: DynResource + std::fmt::Debug {}
 pub trait DynQuerySet: DynResource + std::fmt::Debug {}
+pub trait DynRenderPipeline: DynResource + std::fmt::Debug {}
+pub trait DynComputePipeline: DynResource + std::fmt::Debug {}
 
 impl<'a> BufferBinding<'a, dyn DynBuffer> {
     pub fn expect_downcast<B: DynBuffer>(self) -> BufferBinding<'a, B> {

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -12,7 +12,7 @@ use std::any::Any;
 
 use wgt::WasmNotSendSync;
 
-use crate::BufferBinding;
+use crate::{BufferBinding, TextureBinding};
 
 /// Base trait for all resources, allows downcasting via [`Any`].
 pub trait DynResource: Any + WasmNotSendSync + 'static {
@@ -118,6 +118,15 @@ impl<'a> BufferBinding<'a, dyn DynBuffer> {
             buffer: self.buffer.expect_downcast_ref(),
             offset: self.offset,
             size: self.size,
+        }
+    }
+}
+
+impl<'a> TextureBinding<'a, dyn DynTextureView> {
+    pub fn expect_downcast<T: DynTextureView>(self) -> TextureBinding<'a, T> {
+        TextureBinding {
+            view: self.view.expect_downcast_ref(),
+            usage: self.usage,
         }
     }
 }

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -101,6 +101,7 @@ pub trait DynQuerySet: DynResource + std::fmt::Debug {}
 pub trait DynRenderPipeline: DynResource + std::fmt::Debug {}
 pub trait DynSampler: DynResource + std::fmt::Debug {}
 pub trait DynShaderModule: DynResource + std::fmt::Debug {}
+pub trait DynSurfaceTexture: DynResource + std::fmt::Debug {}
 pub trait DynTexture: DynResource + std::fmt::Debug {}
 pub trait DynTextureView: DynResource + std::fmt::Debug {}
 

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -1,6 +1,8 @@
 mod command;
+mod device;
 
 pub use self::command::DynCommandEncoder;
+pub use self::device::DynDevice;
 
 use std::any::Any;
 

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -1,8 +1,10 @@
+mod adapter;
 mod command;
 mod device;
 mod queue;
 mod surface;
 
+pub use adapter::{DynAdapter, DynOpenDevice};
 pub use command::DynCommandEncoder;
 pub use device::DynDevice;
 pub use queue::DynQueue;

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -12,7 +12,7 @@ use std::any::Any;
 
 use wgt::WasmNotSendSync;
 
-use crate::{BufferBinding, TextureBinding};
+use crate::{BufferBinding, ProgrammableStage, TextureBinding};
 
 /// Base trait for all resources, allows downcasting via [`Any`].
 pub trait DynResource: Any + WasmNotSendSync + 'static {
@@ -127,6 +127,17 @@ impl<'a> TextureBinding<'a, dyn DynTextureView> {
         TextureBinding {
             view: self.view.expect_downcast_ref(),
             usage: self.usage,
+        }
+    }
+}
+
+impl<'a> ProgrammableStage<'a, dyn DynShaderModule> {
+    fn expect_downcast<T: DynShaderModule>(self) -> ProgrammableStage<'a, T> {
+        ProgrammableStage {
+            module: self.module.expect_downcast_ref(),
+            entry_point: self.entry_point,
+            constants: self.constants,
+            zero_initialize_workgroup_memory: self.zero_initialize_workgroup_memory,
         }
     }
 }

--- a/wgpu-hal/src/dynamic/queue.rs
+++ b/wgpu-hal/src/dynamic/queue.rs
@@ -1,0 +1,54 @@
+use crate::{
+    DeviceError, DynCommandBuffer, DynFence, DynResource, DynSurface, DynSurfaceTexture,
+    FenceValue, Queue, SurfaceError,
+};
+
+use super::DynResourceExt as _;
+
+pub trait DynQueue: DynResource {
+    unsafe fn submit(
+        &self,
+        command_buffers: &[&dyn DynCommandBuffer],
+        surface_textures: &[&dyn DynSurfaceTexture],
+        signal_fence: (&mut dyn DynFence, FenceValue),
+    ) -> Result<(), DeviceError>;
+    unsafe fn present(
+        &self,
+        surface: &dyn DynSurface,
+        texture: Box<dyn DynSurfaceTexture>,
+    ) -> Result<(), SurfaceError>;
+    unsafe fn get_timestamp_period(&self) -> f32;
+}
+
+impl<Q: Queue + DynResource> DynQueue for Q {
+    unsafe fn submit(
+        &self,
+        command_buffers: &[&dyn DynCommandBuffer],
+        surface_textures: &[&dyn DynSurfaceTexture],
+        signal_fence: (&mut dyn DynFence, FenceValue),
+    ) -> Result<(), DeviceError> {
+        let command_buffers = command_buffers
+            .iter()
+            .map(|cb| (*cb).expect_downcast_ref())
+            .collect::<Vec<_>>();
+        let surface_textures = surface_textures
+            .iter()
+            .map(|surface| (*surface).expect_downcast_ref())
+            .collect::<Vec<_>>();
+        let signal_fence = (signal_fence.0.expect_downcast_mut(), signal_fence.1);
+        unsafe { Q::submit(self, &command_buffers, &surface_textures, signal_fence) }
+    }
+
+    unsafe fn present(
+        &self,
+        surface: &dyn DynSurface,
+        texture: Box<dyn DynSurfaceTexture>,
+    ) -> Result<(), SurfaceError> {
+        let surface = surface.expect_downcast_ref();
+        unsafe { Q::present(self, surface, texture.unbox()) }
+    }
+
+    unsafe fn get_timestamp_period(&self) -> f32 {
+        unsafe { Q::get_timestamp_period(self) }
+    }
+}

--- a/wgpu-hal/src/dynamic/surface.rs
+++ b/wgpu-hal/src/dynamic/surface.rs
@@ -1,0 +1,71 @@
+use crate::{
+    DynDevice, DynFence, DynResource, DynSurfaceTexture, Surface, SurfaceConfiguration,
+    SurfaceError,
+};
+
+use super::DynResourceExt as _;
+
+#[derive(Debug)]
+pub struct DynAcquiredSurfaceTexture {
+    pub texture: Box<dyn DynSurfaceTexture>,
+    /// The presentation configuration no longer matches
+    /// the surface properties exactly, but can still be used to present
+    /// to the surface successfully.
+    pub suboptimal: bool,
+}
+
+pub trait DynSurface: DynResource {
+    unsafe fn configure(
+        &self,
+        device: &dyn DynDevice,
+        config: &SurfaceConfiguration,
+    ) -> Result<(), SurfaceError>;
+
+    unsafe fn unconfigure(&self, device: &dyn DynDevice);
+
+    unsafe fn acquire_texture(
+        &self,
+        timeout: Option<std::time::Duration>,
+        fence: &dyn DynFence,
+    ) -> Result<Option<DynAcquiredSurfaceTexture>, SurfaceError>;
+
+    unsafe fn discard_texture(&self, texture: Box<dyn DynSurfaceTexture>);
+}
+
+impl<S: Surface + DynResource> DynSurface for S {
+    unsafe fn configure(
+        &self,
+        device: &dyn DynDevice,
+        config: &SurfaceConfiguration,
+    ) -> Result<(), SurfaceError> {
+        let device = device.expect_downcast_ref();
+        unsafe { S::configure(self, device, config) }
+    }
+
+    unsafe fn unconfigure(&self, device: &dyn DynDevice) {
+        let device = device.expect_downcast_ref();
+        unsafe { S::unconfigure(self, device) }
+    }
+
+    unsafe fn acquire_texture(
+        &self,
+        timeout: Option<std::time::Duration>,
+        fence: &dyn DynFence,
+    ) -> Result<Option<DynAcquiredSurfaceTexture>, SurfaceError> {
+        let fence = fence.expect_downcast_ref();
+        unsafe { S::acquire_texture(self, timeout, fence) }.map(|acquired| {
+            acquired.map(|ast| {
+                let texture = Box::new(ast.texture);
+                let suboptimal = ast.suboptimal;
+                DynAcquiredSurfaceTexture {
+                    texture,
+                    suboptimal,
+                }
+            })
+        })
+    }
+
+    unsafe fn discard_texture(&self, texture: Box<dyn DynSurfaceTexture>) {
+        unsafe { S::discard_texture(self, texture.unbox()) }
+    }
+}

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -46,6 +46,7 @@ impl crate::DynBindGroup for Resource {}
 impl crate::DynBuffer for Resource {}
 impl crate::DynCommandBuffer for Resource {}
 impl crate::DynComputePipeline for Resource {}
+impl crate::DynFence for Resource {}
 impl crate::DynPipelineLayout for Resource {}
 impl crate::DynQuerySet for Resource {}
 impl crate::DynRenderPipeline for Resource {}

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -51,6 +51,7 @@ impl crate::DynPipelineLayout for Resource {}
 impl crate::DynQuerySet for Resource {}
 impl crate::DynRenderPipeline for Resource {}
 impl crate::DynShaderModule for Resource {}
+impl crate::DynSurfaceTexture for Resource {}
 impl crate::DynTexture for Resource {}
 impl crate::DynTextureView for Resource {}
 

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -42,7 +42,9 @@ impl crate::Api for Api {
 
 crate::impl_dyn_resource!(Context, Encoder, Resource);
 
+impl crate::DynBindGroup for Resource {}
 impl crate::DynBuffer for Resource {}
+impl crate::DynPipelineLayout for Resource {}
 impl crate::DynQuerySet for Resource {}
 
 impl crate::Instance for Context {

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -291,7 +291,7 @@ impl crate::Device for Context {
     }
     unsafe fn get_acceleration_structure_build_sizes<'a>(
         &self,
-        _desc: &crate::GetAccelerationStructureBuildSizesDescriptor<'a, Api>,
+        _desc: &crate::GetAccelerationStructureBuildSizesDescriptor<'a, Resource>,
     ) -> crate::AccelerationStructureBuildSizes {
         Default::default()
     }
@@ -494,7 +494,7 @@ impl crate::CommandEncoder for Encoder {
         descriptors: T,
     ) where
         Api: 'a,
-        T: IntoIterator<Item = crate::BuildAccelerationStructureDescriptor<'a, Api>>,
+        T: IntoIterator<Item = crate::BuildAccelerationStructureDescriptor<'a, Resource, Resource>>,
     {
     }
 

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -44,10 +44,12 @@ crate::impl_dyn_resource!(Context, Encoder, Resource);
 
 impl crate::DynBindGroup for Resource {}
 impl crate::DynBuffer for Resource {}
+impl crate::DynComputePipeline for Resource {}
 impl crate::DynPipelineLayout for Resource {}
 impl crate::DynQuerySet for Resource {}
 impl crate::DynRenderPipeline for Resource {}
-impl crate::DynComputePipeline for Resource {}
+impl crate::DynTexture for Resource {}
+impl crate::DynTextureView for Resource {}
 
 impl crate::Instance for Context {
     type A = Api;

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -40,6 +40,10 @@ impl crate::Api for Api {
     type ComputePipeline = Resource;
 }
 
+crate::impl_dyn_resource!(Context, Encoder, Resource);
+
+impl crate::DynBuffer for Resource {}
+
 impl crate::Instance for Context {
     type A = Api;
 

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -301,7 +301,7 @@ impl crate::CommandEncoder for Encoder {
 
     unsafe fn transition_buffers<'a, T>(&mut self, barriers: T)
     where
-        T: Iterator<Item = crate::BufferBarrier<'a, Api>>,
+        T: Iterator<Item = crate::BufferBarrier<'a, Resource>>,
     {
     }
 

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -44,6 +44,7 @@ crate::impl_dyn_resource!(Context, Encoder, Resource);
 
 impl crate::DynBindGroup for Resource {}
 impl crate::DynBuffer for Resource {}
+impl crate::DynCommandBuffer for Resource {}
 impl crate::DynComputePipeline for Resource {}
 impl crate::DynPipelineLayout for Resource {}
 impl crate::DynQuerySet for Resource {}

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -48,6 +48,7 @@ impl crate::DynComputePipeline for Resource {}
 impl crate::DynPipelineLayout for Resource {}
 impl crate::DynQuerySet for Resource {}
 impl crate::DynRenderPipeline for Resource {}
+impl crate::DynShaderModule for Resource {}
 impl crate::DynTexture for Resource {}
 impl crate::DynTextureView for Resource {}
 

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -46,6 +46,8 @@ impl crate::DynBindGroup for Resource {}
 impl crate::DynBuffer for Resource {}
 impl crate::DynPipelineLayout for Resource {}
 impl crate::DynQuerySet for Resource {}
+impl crate::DynRenderPipeline for Resource {}
+impl crate::DynComputePipeline for Resource {}
 
 impl crate::Instance for Context {
     type A = Api;

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -42,6 +42,7 @@ impl crate::Api for Api {
 
 crate::impl_dyn_resource!(Context, Encoder, Resource);
 
+impl crate::DynAccelerationStructure for Resource {}
 impl crate::DynBindGroup for Resource {}
 impl crate::DynBindGroupLayout for Resource {}
 impl crate::DynBuffer for Resource {}
@@ -218,7 +219,7 @@ impl crate::Device for Context {
     unsafe fn destroy_pipeline_layout(&self, pipeline_layout: Resource) {}
     unsafe fn create_bind_group(
         &self,
-        desc: &crate::BindGroupDescriptor<Api>,
+        desc: &crate::BindGroupDescriptor<Resource, Resource, Resource, Resource, Resource>,
     ) -> DeviceResult<Resource> {
         Ok(Resource)
     }

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -55,6 +55,12 @@ impl crate::DynSurfaceTexture for Resource {}
 impl crate::DynTexture for Resource {}
 impl crate::DynTextureView for Resource {}
 
+impl std::borrow::Borrow<dyn crate::DynTexture> for Resource {
+    fn borrow(&self) -> &dyn crate::DynTexture {
+        self
+    }
+}
+
 impl crate::Instance for Context {
     type A = Api;
 

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -195,7 +195,7 @@ impl crate::Device for Context {
 
     unsafe fn create_command_encoder(
         &self,
-        desc: &crate::CommandEncoderDescriptor<Api>,
+        desc: &crate::CommandEncoderDescriptor<Context>,
     ) -> DeviceResult<Encoder> {
         Ok(Encoder)
     }

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -50,6 +50,7 @@ impl crate::DynFence for Resource {}
 impl crate::DynPipelineLayout for Resource {}
 impl crate::DynQuerySet for Resource {}
 impl crate::DynRenderPipeline for Resource {}
+impl crate::DynSampler for Resource {}
 impl crate::DynShaderModule for Resource {}
 impl crate::DynSurfaceTexture for Resource {}
 impl crate::DynTexture for Resource {}

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -211,7 +211,7 @@ impl crate::Device for Context {
     unsafe fn destroy_bind_group_layout(&self, bg_layout: Resource) {}
     unsafe fn create_pipeline_layout(
         &self,
-        desc: &crate::PipelineLayoutDescriptor<Api>,
+        desc: &crate::PipelineLayoutDescriptor<Resource>,
     ) -> DeviceResult<Resource> {
         Ok(Resource)
     }

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -43,6 +43,7 @@ impl crate::Api for Api {
 crate::impl_dyn_resource!(Context, Encoder, Resource);
 
 impl crate::DynBuffer for Resource {}
+impl crate::DynQuerySet for Resource {}
 
 impl crate::Instance for Context {
     type A = Api;

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -49,6 +49,7 @@ impl crate::DynBuffer for Resource {}
 impl crate::DynCommandBuffer for Resource {}
 impl crate::DynComputePipeline for Resource {}
 impl crate::DynFence for Resource {}
+impl crate::DynPipelineCache for Resource {}
 impl crate::DynPipelineLayout for Resource {}
 impl crate::DynQuerySet for Resource {}
 impl crate::DynRenderPipeline for Resource {}
@@ -235,14 +236,14 @@ impl crate::Device for Context {
     unsafe fn destroy_shader_module(&self, module: Resource) {}
     unsafe fn create_render_pipeline(
         &self,
-        desc: &crate::RenderPipelineDescriptor<Api>,
+        desc: &crate::RenderPipelineDescriptor<Resource, Resource, Resource>,
     ) -> Result<Resource, crate::PipelineError> {
         Ok(Resource)
     }
     unsafe fn destroy_render_pipeline(&self, pipeline: Resource) {}
     unsafe fn create_compute_pipeline(
         &self,
-        desc: &crate::ComputePipelineDescriptor<Api>,
+        desc: &crate::ComputePipelineDescriptor<Resource, Resource, Resource>,
     ) -> Result<Resource, crate::PipelineError> {
         Ok(Resource)
     }

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -314,7 +314,7 @@ impl crate::CommandEncoder for Encoder {
 
     unsafe fn transition_textures<'a, T>(&mut self, barriers: T)
     where
-        T: Iterator<Item = crate::TextureBarrier<'a, Api>>,
+        T: Iterator<Item = crate::TextureBarrier<'a, Resource>>,
     {
     }
 

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -370,7 +370,8 @@ impl crate::CommandEncoder for Encoder {
 
     // render
 
-    unsafe fn begin_render_pass(&mut self, desc: &crate::RenderPassDescriptor<Api>) {}
+    unsafe fn begin_render_pass(&mut self, desc: &crate::RenderPassDescriptor<Resource, Resource>) {
+    }
     unsafe fn end_render_pass(&mut self) {}
 
     unsafe fn set_bind_group(
@@ -465,7 +466,7 @@ impl crate::CommandEncoder for Encoder {
 
     // compute
 
-    unsafe fn begin_compute_pass(&mut self, desc: &crate::ComputePassDescriptor<Api>) {}
+    unsafe fn begin_compute_pass(&mut self, desc: &crate::ComputePassDescriptor<Resource>) {}
     unsafe fn end_compute_pass(&mut self) {}
 
     unsafe fn set_compute_pipeline(&mut self, pipeline: &Resource) {}

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -43,6 +43,7 @@ impl crate::Api for Api {
 crate::impl_dyn_resource!(Context, Encoder, Resource);
 
 impl crate::DynBindGroup for Resource {}
+impl crate::DynBindGroupLayout for Resource {}
 impl crate::DynBuffer for Resource {}
 impl crate::DynCommandBuffer for Resource {}
 impl crate::DynComputePipeline for Resource {}

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -391,11 +391,15 @@ impl crate::CommandEncoder for Encoder {
 
     unsafe fn set_index_buffer<'a>(
         &mut self,
-        binding: crate::BufferBinding<'a, Api>,
+        binding: crate::BufferBinding<'a, Resource>,
         format: wgt::IndexFormat,
     ) {
     }
-    unsafe fn set_vertex_buffer<'a>(&mut self, index: u32, binding: crate::BufferBinding<'a, Api>) {
+    unsafe fn set_vertex_buffer<'a>(
+        &mut self,
+        index: u32,
+        binding: crate::BufferBinding<'a, Resource>,
+    ) {
     }
     unsafe fn set_viewport(&mut self, rect: &crate::Rect<f32>, depth_range: Range<f32>) {}
     unsafe fn set_scissor_rect(&mut self, rect: &crate::Rect<u32>) {}

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -1188,7 +1188,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
         _descriptors: T,
     ) where
         super::Api: 'a,
-        T: IntoIterator<Item = crate::BuildAccelerationStructureDescriptor<'a, super::Api>>,
+        T: IntoIterator<
+            Item = crate::BuildAccelerationStructureDescriptor<
+                'a,
+                super::Buffer,
+                super::AccelerationStructure,
+            >,
+        >,
     {
         unimplemented!()
     }

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -978,7 +978,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn set_index_buffer<'a>(
         &mut self,
-        binding: crate::BufferBinding<'a, super::Api>,
+        binding: crate::BufferBinding<'a, super::Buffer>,
         format: wgt::IndexFormat,
     ) {
         self.state.index_offset = binding.offset;
@@ -990,7 +990,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     unsafe fn set_vertex_buffer<'a>(
         &mut self,
         index: u32,
-        binding: crate::BufferBinding<'a, super::Api>,
+        binding: crate::BufferBinding<'a, super::Buffer>,
     ) {
         self.state.dirty_vbuf_mask |= 1 << index;
         let (_, ref mut vb) = self.state.vertex_buffers[index as usize];

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -273,7 +273,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn transition_buffers<'a, T>(&mut self, barriers: T)
     where
-        T: Iterator<Item = crate::BufferBarrier<'a, super::Api>>,
+        T: Iterator<Item = crate::BufferBarrier<'a, super::Buffer>>,
     {
         if !self
             .private_caps

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -298,7 +298,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn transition_textures<'a, T>(&mut self, barriers: T)
     where
-        T: Iterator<Item = crate::TextureBarrier<'a, super::Api>>,
+        T: Iterator<Item = crate::TextureBarrier<'a, super::Texture>>,
     {
         if !self
             .private_caps

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -494,7 +494,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     // render
 
-    unsafe fn begin_render_pass(&mut self, desc: &crate::RenderPassDescriptor<super::Api>) {
+    unsafe fn begin_render_pass(
+        &mut self,
+        desc: &crate::RenderPassDescriptor<super::QuerySet, super::TextureView>,
+    ) {
         debug_assert!(self.state.end_of_pass_timestamp.is_none());
         if let Some(ref t) = desc.timestamp_writes {
             if let Some(index) = t.beginning_of_pass_write_index {
@@ -1137,7 +1140,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     // compute
 
-    unsafe fn begin_compute_pass(&mut self, desc: &crate::ComputePassDescriptor<super::Api>) {
+    unsafe fn begin_compute_pass(&mut self, desc: &crate::ComputePassDescriptor<super::QuerySet>) {
         debug_assert!(self.state.end_of_pass_timestamp.is_none());
         if let Some(ref t) = desc.timestamp_writes {
             if let Some(index) = t.beginning_of_pass_write_index {

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1140,7 +1140,7 @@ impl crate::Device for super::Device {
 
     unsafe fn create_pipeline_layout(
         &self,
-        desc: &crate::PipelineLayoutDescriptor<super::Api>,
+        desc: &crate::PipelineLayoutDescriptor<super::BindGroupLayout>,
     ) -> Result<super::PipelineLayout, crate::DeviceError> {
         use naga::back::glsl;
 

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1232,7 +1232,13 @@ impl crate::Device for super::Device {
 
     unsafe fn create_bind_group(
         &self,
-        desc: &crate::BindGroupDescriptor<super::Api>,
+        desc: &crate::BindGroupDescriptor<
+            super::BindGroupLayout,
+            super::Buffer,
+            super::Sampler,
+            super::TextureView,
+            super::AccelerationStructure,
+        >,
     ) -> Result<super::BindGroup, crate::DeviceError> {
         let mut contents = Vec::new();
 
@@ -1589,7 +1595,7 @@ impl crate::Device for super::Device {
     unsafe fn create_acceleration_structure(
         &self,
         _desc: &crate::AccelerationStructureDescriptor,
-    ) -> Result<(), crate::DeviceError> {
+    ) -> Result<super::AccelerationStructure, crate::DeviceError> {
         unimplemented!()
     }
     unsafe fn get_acceleration_structure_build_sizes<'a>(
@@ -1600,11 +1606,15 @@ impl crate::Device for super::Device {
     }
     unsafe fn get_acceleration_structure_device_address(
         &self,
-        _acceleration_structure: &(),
+        _acceleration_structure: &super::AccelerationStructure,
     ) -> wgt::BufferAddress {
         unimplemented!()
     }
-    unsafe fn destroy_acceleration_structure(&self, _acceleration_structure: ()) {}
+    unsafe fn destroy_acceleration_structure(
+        &self,
+        _acceleration_structure: super::AccelerationStructure,
+    ) {
+    }
 
     fn get_internal_counters(&self) -> wgt::HalCounters {
         self.counters.clone()

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1608,7 +1608,7 @@ impl crate::Device for super::Device {
     }
     unsafe fn get_acceleration_structure_build_sizes<'a>(
         &self,
-        _desc: &crate::GetAccelerationStructureBuildSizesDescriptor<'a, super::Api>,
+        _desc: &crate::GetAccelerationStructureBuildSizesDescriptor<'a, super::Buffer>,
     ) -> crate::AccelerationStructureBuildSizes {
         unimplemented!()
     }

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::Ordering;
 
 type ShaderStage<'a> = (
     naga::ShaderStage,
-    &'a crate::ProgrammableStage<'a, super::Api>,
+    &'a crate::ProgrammableStage<'a, super::ShaderModule>,
 );
 type NameBindingMap = rustc_hash::FxHashMap<String, (super::BindingRegister, u8)>;
 
@@ -205,7 +205,7 @@ impl super::Device {
     fn create_shader(
         gl: &glow::Context,
         naga_stage: naga::ShaderStage,
-        stage: &crate::ProgrammableStage<super::Api>,
+        stage: &crate::ProgrammableStage<super::ShaderModule>,
         context: CompilationContext,
         program: glow::Program,
     ) -> Result<glow::Shader, crate::PipelineError> {
@@ -1346,7 +1346,11 @@ impl crate::Device for super::Device {
 
     unsafe fn create_render_pipeline(
         &self,
-        desc: &crate::RenderPipelineDescriptor<super::Api>,
+        desc: &crate::RenderPipelineDescriptor<
+            super::PipelineLayout,
+            super::ShaderModule,
+            super::PipelineCache,
+        >,
     ) -> Result<super::RenderPipeline, crate::PipelineError> {
         let gl = &self.shared.context.lock();
         let mut shaders = ArrayVec::new();
@@ -1436,7 +1440,11 @@ impl crate::Device for super::Device {
 
     unsafe fn create_compute_pipeline(
         &self,
-        desc: &crate::ComputePipelineDescriptor<super::Api>,
+        desc: &crate::ComputePipelineDescriptor<
+            super::PipelineLayout,
+            super::ShaderModule,
+            super::PipelineCache,
+        >,
     ) -> Result<super::ComputePipeline, crate::PipelineError> {
         let gl = &self.shared.context.lock();
         let mut shaders = ArrayVec::new();
@@ -1469,12 +1477,12 @@ impl crate::Device for super::Device {
     unsafe fn create_pipeline_cache(
         &self,
         _: &crate::PipelineCacheDescriptor<'_>,
-    ) -> Result<(), crate::PipelineCacheError> {
+    ) -> Result<super::PipelineCache, crate::PipelineCacheError> {
         // Even though the cache doesn't do anything, we still return something here
         // as the least bad option
-        Ok(())
+        Ok(super::PipelineCache)
     }
-    unsafe fn destroy_pipeline_cache(&self, (): ()) {}
+    unsafe fn destroy_pipeline_cache(&self, _: super::PipelineCache) {}
 
     #[cfg_attr(target_arch = "wasm32", allow(unused))]
     unsafe fn create_query_set(

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1109,7 +1109,7 @@ impl crate::Device for super::Device {
 
     unsafe fn create_command_encoder(
         &self,
-        _desc: &crate::CommandEncoderDescriptor<super::Api>,
+        _desc: &crate::CommandEncoderDescriptor<super::Queue>,
     ) -> Result<super::CommandEncoder, crate::DeviceError> {
         self.counters.command_encoders.add(1);
 

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -375,6 +375,7 @@ pub struct Texture {
 }
 
 impl crate::DynTexture for Texture {}
+impl crate::DynSurfaceTexture for Texture {}
 
 impl Texture {
     pub fn default_framebuffer(format: wgt::TextureFormat) -> Self {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -693,6 +693,8 @@ pub struct Fence {
     pending: Vec<(crate::FenceValue, glow::Fence)>,
 }
 
+impl crate::DynFence for Fence {}
+
 #[cfg(any(
     not(target_arch = "wasm32"),
     all(

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -542,6 +542,8 @@ pub struct ShaderModule {
     id: ShaderId,
 }
 
+impl crate::DynShaderModule for ShaderModule {}
+
 #[derive(Clone, Debug, Default)]
 struct VertexFormatDesc {
     element_count: i32,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -373,6 +373,8 @@ pub struct Texture {
     pub copy_size: CopyExtent,
 }
 
+impl crate::DynTexture for Texture {}
+
 impl Texture {
     pub fn default_framebuffer(format: wgt::TextureFormat) -> Self {
         Self {
@@ -459,6 +461,8 @@ pub struct TextureView {
     array_layers: Range<u32>,
     format: wgt::TextureFormat,
 }
+
+impl crate::DynTextureView for TextureView {}
 
 #[derive(Debug)]
 pub struct Sampler {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -477,6 +477,8 @@ pub struct Sampler {
     raw: glow::Sampler,
 }
 
+impl crate::DynSampler for Sampler {}
+
 #[derive(Debug)]
 pub struct BindGroupLayout {
     entries: Arc<[wgt::BindGroupLayoutEntry]>,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -175,6 +175,7 @@ crate::impl_dyn_resource!(
     Fence,
     PipelineLayout,
     QuerySet,
+    Queue,
     RenderPipeline,
     Sampler,
     ShaderModule,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -175,6 +175,7 @@ crate::impl_dyn_resource!(
     ComputePipeline,
     Device,
     Fence,
+    Instance,
     PipelineCache,
     PipelineLayout,
     QuerySet,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -153,7 +153,7 @@ impl crate::Api for Api {
     type Sampler = Sampler;
     type QuerySet = QuerySet;
     type Fence = Fence;
-    type AccelerationStructure = ();
+    type AccelerationStructure = AccelerationStructure;
     type PipelineCache = ();
 
     type BindGroupLayout = BindGroupLayout;
@@ -165,6 +165,7 @@ impl crate::Api for Api {
 }
 
 crate::impl_dyn_resource!(
+    AccelerationStructure,
     BindGroup,
     BindGroupLayout,
     Buffer,
@@ -749,6 +750,11 @@ impl Fence {
         self.last_completed = latest;
     }
 }
+
+#[derive(Debug)]
+pub struct AccelerationStructure;
+
+impl crate::DynAccelerationStructure for AccelerationStructure {}
 
 #[derive(Clone, Debug, PartialEq)]
 struct StencilOps {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -485,6 +485,8 @@ pub struct BindGroupLayout {
     entries: Arc<[wgt::BindGroupLayoutEntry]>,
 }
 
+impl crate::DynBindGroupLayout for BindGroupLayout {}
+
 #[derive(Debug)]
 struct BindGroupLayoutInfo {
     entries: Arc<[wgt::BindGroupLayoutEntry]>,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -154,7 +154,7 @@ impl crate::Api for Api {
     type QuerySet = QuerySet;
     type Fence = Fence;
     type AccelerationStructure = AccelerationStructure;
-    type PipelineCache = ();
+    type PipelineCache = PipelineCache;
 
     type BindGroupLayout = BindGroupLayout;
     type BindGroup = BindGroup;
@@ -174,6 +174,7 @@ crate::impl_dyn_resource!(
     ComputePipeline,
     Device,
     Fence,
+    PipelineCache,
     PipelineLayout,
     QuerySet,
     Queue,
@@ -755,6 +756,11 @@ impl Fence {
 pub struct AccelerationStructure;
 
 impl crate::DynAccelerationStructure for AccelerationStructure {}
+
+#[derive(Debug)]
+pub struct PipelineCache;
+
+impl crate::DynPipelineCache for PipelineCache {}
 
 #[derive(Clone, Debug, PartialEq)]
 struct StencilOps {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -377,6 +377,12 @@ pub struct Texture {
 impl crate::DynTexture for Texture {}
 impl crate::DynSurfaceTexture for Texture {}
 
+impl std::borrow::Borrow<dyn crate::DynTexture> for Texture {
+    fn borrow(&self) -> &dyn crate::DynTexture {
+        self
+    }
+}
+
 impl Texture {
     pub fn default_framebuffer(format: wgt::TextureFormat) -> Self {
         Self {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -670,6 +670,8 @@ pub struct QuerySet {
     target: BindTarget,
 }
 
+impl crate::DynQuerySet for QuerySet {}
+
 #[derive(Debug)]
 pub struct Fence {
     last_completed: crate::FenceValue,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -164,6 +164,24 @@ impl crate::Api for Api {
     type ComputePipeline = ComputePipeline;
 }
 
+crate::impl_dyn_resource!(
+    BindGroup,
+    BindGroupLayout,
+    Buffer,
+    CommandBuffer,
+    CommandEncoder,
+    ComputePipeline,
+    Fence,
+    PipelineLayout,
+    QuerySet,
+    RenderPipeline,
+    Sampler,
+    ShaderModule,
+    Surface,
+    Texture,
+    TextureView
+);
+
 bitflags::bitflags! {
     /// Flags that affect internal code paths but do not
     /// change the exposed feature set.
@@ -306,6 +324,8 @@ pub struct Buffer {
 unsafe impl Sync for Buffer {}
 #[cfg(send_sync)]
 unsafe impl Send for Buffer {}
+
+impl crate::DynBuffer for Buffer {}
 
 #[derive(Clone, Debug)]
 pub enum TextureInner {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -653,6 +653,8 @@ pub struct RenderPipeline {
     alpha_to_coverage_enabled: bool,
 }
 
+impl crate::DynRenderPipeline for RenderPipeline {}
+
 #[cfg(send_sync)]
 unsafe impl Sync for RenderPipeline {}
 #[cfg(send_sync)]
@@ -662,6 +664,8 @@ unsafe impl Send for RenderPipeline {}
 pub struct ComputePipeline {
     inner: Arc<PipelineInner>,
 }
+
+impl crate::DynComputePipeline for ComputePipeline {}
 
 #[cfg(send_sync)]
 unsafe impl Sync for ComputePipeline {}

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -487,6 +487,8 @@ pub struct PipelineLayout {
     naga_options: naga::back::glsl::Options,
 }
 
+impl crate::DynPipelineLayout for PipelineLayout {}
+
 impl PipelineLayout {
     fn get_slot(&self, br: &naga::ResourceBinding) -> u8 {
         let group_info = &self.group_infos[br.group as usize];
@@ -524,6 +526,8 @@ enum RawBinding {
 pub struct BindGroup {
     contents: Box<[RawBinding]>,
 }
+
+impl crate::DynBindGroup for BindGroup {}
 
 type ShaderId = u32;
 

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -165,6 +165,7 @@ impl crate::Api for Api {
 }
 
 crate::impl_dyn_resource!(
+    Adapter,
     AccelerationStructure,
     BindGroup,
     BindGroupLayout,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -171,6 +171,7 @@ crate::impl_dyn_resource!(
     CommandBuffer,
     CommandEncoder,
     ComputePipeline,
+    Device,
     Fence,
     PipelineLayout,
     QuerySet,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -988,6 +988,8 @@ pub struct CommandBuffer {
     queries: Vec<glow::Query>,
 }
 
+impl crate::DynCommandBuffer for CommandBuffer {}
+
 impl fmt::Debug for CommandBuffer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("CommandBuffer");

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1110,7 +1110,7 @@ pub trait CommandEncoder: WasmNotSendSync + fmt::Debug {
 
     unsafe fn transition_textures<'a, T>(&mut self, barriers: T)
     where
-        T: Iterator<Item = TextureBarrier<'a, Self::A>>;
+        T: Iterator<Item = TextureBarrier<'a, <Self::A as Api>::Texture>>;
 
     // copy operations
 
@@ -1990,8 +1990,8 @@ pub struct BufferBarrier<'a, B: DynBuffer + ?Sized> {
 }
 
 #[derive(Debug, Clone)]
-pub struct TextureBarrier<'a, A: Api> {
-    pub texture: &'a A::Texture,
+pub struct TextureBarrier<'a, T: DynTexture + ?Sized> {
+    pub texture: &'a T,
     pub range: wgt::ImageSubresourceRange,
     pub usage: Range<TextureUses>,
 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1103,7 +1103,7 @@ pub trait CommandEncoder: WasmNotSendSync + fmt::Debug {
 
     unsafe fn transition_buffers<'a, T>(&mut self, barriers: T)
     where
-        T: Iterator<Item = BufferBarrier<'a, Self::A>>;
+        T: Iterator<Item = BufferBarrier<'a, <Self::A as Api>::Buffer>>;
 
     unsafe fn transition_textures<'a, T>(&mut self, barriers: T)
     where
@@ -1975,8 +1975,8 @@ pub struct Rect<T> {
 }
 
 #[derive(Debug, Clone)]
-pub struct BufferBarrier<'a, A: Api> {
-    pub buffer: &'a A::Buffer,
+pub struct BufferBarrier<'a, B: DynBuffer + ?Sized> {
+    pub buffer: &'a B,
     pub usage: Range<BufferUses>,
 }
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1235,10 +1235,14 @@ pub trait CommandEncoder: WasmNotSendSync + fmt::Debug {
 
     unsafe fn set_index_buffer<'a>(
         &mut self,
-        binding: BufferBinding<'a, Self::A>,
+        binding: BufferBinding<'a, <Self::A as Api>::Buffer>,
         format: wgt::IndexFormat,
     );
-    unsafe fn set_vertex_buffer<'a>(&mut self, index: u32, binding: BufferBinding<'a, Self::A>);
+    unsafe fn set_vertex_buffer<'a>(
+        &mut self,
+        index: u32,
+        binding: BufferBinding<'a, <Self::A as Api>::Buffer>,
+    );
     unsafe fn set_viewport(&mut self, rect: &Rect<f32>, depth_range: Range<f32>);
     unsafe fn set_scissor_rect(&mut self, rect: &Rect<u32>);
     unsafe fn set_stencil_reference(&mut self, value: u32);
@@ -1736,9 +1740,9 @@ pub struct PipelineLayoutDescriptor<'a, A: Api> {
 }
 
 #[derive(Debug)]
-pub struct BufferBinding<'a, A: Api> {
+pub struct BufferBinding<'a, B: DynBuffer + ?Sized> {
     /// The buffer being bound.
-    pub buffer: &'a A::Buffer,
+    pub buffer: &'a B,
 
     /// The offset at which the bound region starts.
     ///
@@ -1762,7 +1766,7 @@ pub struct BufferBinding<'a, A: Api> {
 }
 
 // Rust gets confused about the impl requirements for `A`
-impl<A: Api> Clone for BufferBinding<'_, A> {
+impl<B: DynBuffer> Clone for BufferBinding<'_, B> {
     fn clone(&self) -> Self {
         Self {
             buffer: self.buffer,
@@ -1808,7 +1812,7 @@ pub struct BindGroupEntry {
 pub struct BindGroupDescriptor<'a, A: Api> {
     pub label: Label<'a>,
     pub layout: &'a A::BindGroupLayout,
-    pub buffers: &'a [BufferBinding<'a, A>],
+    pub buffers: &'a [BufferBinding<'a, A::Buffer>],
     pub samplers: &'a [&'a A::Sampler],
     pub textures: &'a [TextureBinding<'a, A>],
     pub entries: &'a [BindGroupEntry],

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2074,22 +2074,11 @@ pub struct DepthStencilAttachment<'a, A: Api> {
     pub clear_value: (f32, u32),
 }
 
-#[derive(Debug)]
-pub struct RenderPassTimestampWrites<'a, A: Api> {
-    pub query_set: &'a A::QuerySet,
+#[derive(Clone, Debug)]
+pub struct PassTimestampWrites<'a, Q: DynQuerySet + ?Sized> {
+    pub query_set: &'a Q,
     pub beginning_of_pass_write_index: Option<u32>,
     pub end_of_pass_write_index: Option<u32>,
-}
-
-// Rust gets confused about the impl requirements for `A`
-impl<A: Api> Clone for RenderPassTimestampWrites<'_, A> {
-    fn clone(&self) -> Self {
-        Self {
-            query_set: self.query_set,
-            beginning_of_pass_write_index: self.beginning_of_pass_write_index,
-            end_of_pass_write_index: self.end_of_pass_write_index,
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -2100,32 +2089,14 @@ pub struct RenderPassDescriptor<'a, A: Api> {
     pub color_attachments: &'a [Option<ColorAttachment<'a, A>>],
     pub depth_stencil_attachment: Option<DepthStencilAttachment<'a, A>>,
     pub multiview: Option<NonZeroU32>,
-    pub timestamp_writes: Option<RenderPassTimestampWrites<'a, A>>,
+    pub timestamp_writes: Option<PassTimestampWrites<'a, A::QuerySet>>,
     pub occlusion_query_set: Option<&'a A::QuerySet>,
-}
-
-#[derive(Debug)]
-pub struct ComputePassTimestampWrites<'a, A: Api> {
-    pub query_set: &'a A::QuerySet,
-    pub beginning_of_pass_write_index: Option<u32>,
-    pub end_of_pass_write_index: Option<u32>,
-}
-
-// Rust gets confused about the impl requirements for `A`
-impl<A: Api> Clone for ComputePassTimestampWrites<'_, A> {
-    fn clone(&self) -> Self {
-        Self {
-            query_set: self.query_set,
-            beginning_of_pass_write_index: self.beginning_of_pass_write_index,
-            end_of_pass_write_index: self.end_of_pass_write_index,
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
 pub struct ComputePassDescriptor<'a, A: Api> {
     pub label: Label<'a>,
-    pub timestamp_writes: Option<ComputePassTimestampWrites<'a, A>>,
+    pub timestamp_writes: Option<PassTimestampWrites<'a, A::QuerySet>>,
 }
 
 /// Stores the text of any validation errors that have occurred since

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -266,8 +266,9 @@ mod dynamic;
 
 pub(crate) use dynamic::impl_dyn_resource;
 pub use dynamic::{
-    DynBindGroup, DynBuffer, DynCommandEncoder, DynComputePipeline, DynDevice, DynPipelineLayout,
-    DynQuerySet, DynRenderPipeline, DynResource, DynTexture, DynTextureView,
+    DynAccelerationStructure, DynBindGroup, DynBindGroupLayout, DynBuffer, DynCommandEncoder,
+    DynComputePipeline, DynDevice, DynFence, DynPipelineCache, DynPipelineLayout, DynQuerySet,
+    DynRenderPipeline, DynResource, DynSampler, DynShaderModule, DynTexture, DynTextureView,
 };
 
 use std::{

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -435,7 +435,7 @@ pub trait Api: Clone + fmt::Debug + Sized {
     /// finished.
     type Fence: DynFence + fmt::Debug;
 
-    type BindGroupLayout: fmt::Debug + WasmNotSendSync;
+    type BindGroupLayout: DynBindGroupLayout + fmt::Debug;
     type BindGroup: DynBindGroup;
     type PipelineLayout: DynPipelineLayout;
     type ShaderModule: DynShaderModule;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -801,7 +801,7 @@ pub trait Device: WasmNotSendSync {
     unsafe fn destroy_bind_group_layout(&self, bg_layout: <Self::A as Api>::BindGroupLayout);
     unsafe fn create_pipeline_layout(
         &self,
-        desc: &PipelineLayoutDescriptor<Self::A>,
+        desc: &PipelineLayoutDescriptor<<Self::A as Api>::BindGroupLayout>,
     ) -> Result<<Self::A as Api>::PipelineLayout, DeviceError>;
     unsafe fn destroy_pipeline_layout(&self, pipeline_layout: <Self::A as Api>::PipelineLayout);
     unsafe fn create_bind_group(
@@ -1743,10 +1743,10 @@ pub struct BindGroupLayoutDescriptor<'a> {
 }
 
 #[derive(Clone, Debug)]
-pub struct PipelineLayoutDescriptor<'a, A: Api> {
+pub struct PipelineLayoutDescriptor<'a, B: DynBindGroupLayout + ?Sized> {
     pub label: Label<'a>,
     pub flags: PipelineLayoutFlags,
-    pub bind_group_layouts: &'a [&'a A::BindGroupLayout],
+    pub bind_group_layouts: &'a [&'a B],
     pub push_constant_ranges: &'a [wgt::PushConstantRange],
 }
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -265,7 +265,10 @@ pub mod api {
 mod dynamic;
 
 pub(crate) use dynamic::{impl_dyn_resource, DynResource};
-pub use dynamic::{DynBindGroup, DynBuffer, DynCommandEncoder, DynPipelineLayout, DynQuerySet};
+pub use dynamic::{
+    DynBindGroup, DynBuffer, DynCommandEncoder, DynComputePipeline, DynPipelineLayout, DynQuerySet,
+    DynRenderPipeline,
+};
 
 use std::{
     borrow::{Borrow, Cow},
@@ -434,8 +437,8 @@ pub trait Api: Clone + fmt::Debug + Sized {
     type BindGroup: DynBindGroup;
     type PipelineLayout: DynPipelineLayout;
     type ShaderModule: fmt::Debug + WasmNotSendSync;
-    type RenderPipeline: fmt::Debug + WasmNotSendSync;
-    type ComputePipeline: fmt::Debug + WasmNotSendSync;
+    type RenderPipeline: DynRenderPipeline;
+    type ComputePipeline: DynComputePipeline;
     type PipelineCache: fmt::Debug + WasmNotSendSync;
 
     type AccelerationStructure: fmt::Debug + WasmNotSendSync + 'static;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -407,13 +407,13 @@ pub trait Api: Clone + fmt::Debug + Sized {
     /// them to [`CommandEncoder::reset_all`].
     ///
     /// [`CommandEncoder`]: Api::CommandEncoder
-    type CommandBuffer: DynCommandBuffer + fmt::Debug;
+    type CommandBuffer: DynCommandBuffer;
 
     type Buffer: DynBuffer;
     type Texture: DynTexture;
-    type SurfaceTexture: DynSurfaceTexture + fmt::Debug + Borrow<Self::Texture>;
+    type SurfaceTexture: DynSurfaceTexture + Borrow<Self::Texture>;
     type TextureView: DynTextureView;
-    type Sampler: DynSampler + fmt::Debug;
+    type Sampler: DynSampler;
     type QuerySet: DynQuerySet;
 
     /// A value you can block on to wait for something to finish.
@@ -433,17 +433,17 @@ pub trait Api: Clone + fmt::Debug + Sized {
     /// before a lower-valued operation, then waiting for the fence to reach the
     /// lower value could return before the lower-valued operation has actually
     /// finished.
-    type Fence: DynFence + fmt::Debug;
+    type Fence: DynFence;
 
-    type BindGroupLayout: DynBindGroupLayout + fmt::Debug;
+    type BindGroupLayout: DynBindGroupLayout;
     type BindGroup: DynBindGroup;
     type PipelineLayout: DynPipelineLayout;
     type ShaderModule: DynShaderModule;
     type RenderPipeline: DynRenderPipeline;
     type ComputePipeline: DynComputePipeline;
-    type PipelineCache: DynPipelineCache + fmt::Debug;
+    type PipelineCache: DynPipelineCache;
 
-    type AccelerationStructure: DynAccelerationStructure + fmt::Debug + 'static;
+    type AccelerationStructure: DynAccelerationStructure + 'static;
 }
 
 pub trait Instance: Sized + WasmNotSendSync {

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -262,6 +262,11 @@ pub mod api {
     pub use super::vulkan::Api as Vulkan;
 }
 
+mod dynamic;
+
+pub use dynamic::DynBuffer;
+pub(crate) use dynamic::{impl_dyn_resource, DynResource};
+
 use std::{
     borrow::{Borrow, Cow},
     fmt,
@@ -399,7 +404,7 @@ pub trait Api: Clone + fmt::Debug + Sized {
     /// [`CommandEncoder`]: Api::CommandEncoder
     type CommandBuffer: WasmNotSendSync + fmt::Debug;
 
-    type Buffer: fmt::Debug + WasmNotSendSync + 'static;
+    type Buffer: DynBuffer;
     type Texture: fmt::Debug + WasmNotSendSync + 'static;
     type SurfaceTexture: fmt::Debug + WasmNotSendSync + Borrow<Self::Texture>;
     type TextureView: fmt::Debug + WasmNotSendSync;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -266,10 +266,10 @@ mod dynamic;
 
 pub(crate) use dynamic::impl_dyn_resource;
 pub use dynamic::{
-    DynAccelerationStructure, DynBindGroup, DynBindGroupLayout, DynBuffer, DynCommandBuffer,
-    DynCommandEncoder, DynComputePipeline, DynDevice, DynFence, DynPipelineCache,
-    DynPipelineLayout, DynQuerySet, DynRenderPipeline, DynResource, DynSampler, DynShaderModule,
-    DynSurfaceTexture, DynTexture, DynTextureView,
+    DynAccelerationStructure, DynAcquiredSurfaceTexture, DynBindGroup, DynBindGroupLayout,
+    DynBuffer, DynCommandBuffer, DynCommandEncoder, DynComputePipeline, DynDevice, DynFence,
+    DynPipelineCache, DynPipelineLayout, DynQuerySet, DynRenderPipeline, DynResource, DynSampler,
+    DynShaderModule, DynSurface, DynSurfaceTexture, DynTexture, DynTextureView,
 };
 
 use std::{

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -264,8 +264,8 @@ pub mod api {
 
 mod dynamic;
 
-pub use dynamic::DynBuffer;
 pub(crate) use dynamic::{impl_dyn_resource, DynResource};
+pub use dynamic::{DynBuffer, DynCommandEncoder};
 
 use std::{
     borrow::{Borrow, Cow},
@@ -392,7 +392,7 @@ pub trait Api: Clone + fmt::Debug + Sized {
     type Device: Device<A = Self>;
 
     type Queue: Queue<A = Self>;
-    type CommandEncoder: CommandEncoder<A = Self>;
+    type CommandEncoder: DynCommandEncoder + CommandEncoder<A = Self>;
 
     /// This API's command buffer type.
     ///

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -266,8 +266,8 @@ mod dynamic;
 
 pub(crate) use dynamic::impl_dyn_resource;
 pub use dynamic::{
-    DynBindGroup, DynBuffer, DynCommandEncoder, DynComputePipeline, DynPipelineLayout, DynQuerySet,
-    DynRenderPipeline, DynResource, DynTexture, DynTextureView,
+    DynBindGroup, DynBuffer, DynCommandEncoder, DynComputePipeline, DynDevice, DynPipelineLayout,
+    DynQuerySet, DynRenderPipeline, DynResource, DynTexture, DynTextureView,
 };
 
 use std::{

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -266,10 +266,11 @@ mod dynamic;
 
 pub(crate) use dynamic::impl_dyn_resource;
 pub use dynamic::{
-    DynAccelerationStructure, DynAcquiredSurfaceTexture, DynBindGroup, DynBindGroupLayout,
-    DynBuffer, DynCommandBuffer, DynCommandEncoder, DynComputePipeline, DynDevice, DynFence,
-    DynPipelineCache, DynPipelineLayout, DynQuerySet, DynQueue, DynRenderPipeline, DynResource,
-    DynSampler, DynShaderModule, DynSurface, DynSurfaceTexture, DynTexture, DynTextureView,
+    DynAccelerationStructure, DynAcquiredSurfaceTexture, DynAdapter, DynBindGroup,
+    DynBindGroupLayout, DynBuffer, DynCommandBuffer, DynCommandEncoder, DynComputePipeline,
+    DynDevice, DynFence, DynOpenDevice, DynPipelineCache, DynPipelineLayout, DynQuerySet, DynQueue,
+    DynRenderPipeline, DynResource, DynSampler, DynShaderModule, DynSurface, DynSurfaceTexture,
+    DynTexture, DynTextureView,
 };
 
 use std::{
@@ -393,7 +394,7 @@ impl InstanceError {
 pub trait Api: Clone + fmt::Debug + Sized {
     type Instance: Instance<A = Self>;
     type Surface: DynSurface + Surface<A = Self>;
-    type Adapter: Adapter<A = Self>;
+    type Adapter: DynAdapter + Adapter<A = Self>;
     type Device: DynDevice + Device<A = Self>;
 
     type Queue: DynQueue + Queue<A = Self>;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -437,7 +437,7 @@ pub trait Api: Clone + fmt::Debug + Sized {
     type BindGroupLayout: fmt::Debug + WasmNotSendSync;
     type BindGroup: DynBindGroup;
     type PipelineLayout: DynPipelineLayout;
-    type ShaderModule: fmt::Debug + WasmNotSendSync;
+    type ShaderModule: DynShaderModule;
     type RenderPipeline: DynRenderPipeline;
     type ComputePipeline: DynComputePipeline;
     type PipelineCache: fmt::Debug + WasmNotSendSync;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -267,7 +267,7 @@ mod dynamic;
 pub(crate) use dynamic::{impl_dyn_resource, DynResource};
 pub use dynamic::{
     DynBindGroup, DynBuffer, DynCommandEncoder, DynComputePipeline, DynPipelineLayout, DynQuerySet,
-    DynRenderPipeline,
+    DynRenderPipeline, DynTexture, DynTextureView,
 };
 
 use std::{
@@ -408,9 +408,9 @@ pub trait Api: Clone + fmt::Debug + Sized {
     type CommandBuffer: WasmNotSendSync + fmt::Debug;
 
     type Buffer: DynBuffer;
-    type Texture: fmt::Debug + WasmNotSendSync + 'static;
+    type Texture: DynTexture;
     type SurfaceTexture: fmt::Debug + WasmNotSendSync + Borrow<Self::Texture>;
-    type TextureView: fmt::Debug + WasmNotSendSync;
+    type TextureView: DynTextureView;
     type Sampler: fmt::Debug + WasmNotSendSync;
     type QuerySet: DynQuerySet;
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -268,9 +268,9 @@ pub(crate) use dynamic::impl_dyn_resource;
 pub use dynamic::{
     DynAccelerationStructure, DynAcquiredSurfaceTexture, DynAdapter, DynBindGroup,
     DynBindGroupLayout, DynBuffer, DynCommandBuffer, DynCommandEncoder, DynComputePipeline,
-    DynDevice, DynFence, DynOpenDevice, DynPipelineCache, DynPipelineLayout, DynQuerySet, DynQueue,
-    DynRenderPipeline, DynResource, DynSampler, DynShaderModule, DynSurface, DynSurfaceTexture,
-    DynTexture, DynTextureView,
+    DynDevice, DynExposedAdapter, DynFence, DynInstance, DynOpenDevice, DynPipelineCache,
+    DynPipelineLayout, DynQuerySet, DynQueue, DynRenderPipeline, DynResource, DynSampler,
+    DynShaderModule, DynSurface, DynSurfaceTexture, DynTexture, DynTextureView,
 };
 
 use std::{
@@ -392,7 +392,7 @@ impl InstanceError {
 }
 
 pub trait Api: Clone + fmt::Debug + Sized {
-    type Instance: Instance<A = Self>;
+    type Instance: DynInstance + Instance<A = Self>;
     type Surface: DynSurface + Surface<A = Self>;
     type Adapter: DynAdapter + Adapter<A = Self>;
     type Device: DynDevice + Device<A = Self>;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -265,7 +265,7 @@ pub mod api {
 mod dynamic;
 
 pub(crate) use dynamic::{impl_dyn_resource, DynResource};
-pub use dynamic::{DynBuffer, DynCommandEncoder, DynQuerySet};
+pub use dynamic::{DynBindGroup, DynBuffer, DynCommandEncoder, DynPipelineLayout, DynQuerySet};
 
 use std::{
     borrow::{Borrow, Cow},
@@ -431,8 +431,8 @@ pub trait Api: Clone + fmt::Debug + Sized {
     type Fence: fmt::Debug + WasmNotSendSync;
 
     type BindGroupLayout: fmt::Debug + WasmNotSendSync;
-    type BindGroup: fmt::Debug + WasmNotSendSync;
-    type PipelineLayout: fmt::Debug + WasmNotSendSync;
+    type BindGroup: DynBindGroup;
+    type PipelineLayout: DynPipelineLayout;
     type ShaderModule: fmt::Debug + WasmNotSendSync;
     type RenderPipeline: fmt::Debug + WasmNotSendSync;
     type ComputePipeline: fmt::Debug + WasmNotSendSync;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -265,7 +265,7 @@ pub mod api {
 mod dynamic;
 
 pub(crate) use dynamic::{impl_dyn_resource, DynResource};
-pub use dynamic::{DynBuffer, DynCommandEncoder};
+pub use dynamic::{DynBuffer, DynCommandEncoder, DynQuerySet};
 
 use std::{
     borrow::{Borrow, Cow},
@@ -409,7 +409,7 @@ pub trait Api: Clone + fmt::Debug + Sized {
     type SurfaceTexture: fmt::Debug + WasmNotSendSync + Borrow<Self::Texture>;
     type TextureView: fmt::Debug + WasmNotSendSync;
     type Sampler: fmt::Debug + WasmNotSendSync;
-    type QuerySet: fmt::Debug + WasmNotSendSync;
+    type QuerySet: DynQuerySet;
 
     /// A value you can block on to wait for something to finish.
     ///

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -413,7 +413,7 @@ pub trait Api: Clone + fmt::Debug + Sized {
     type Texture: DynTexture;
     type SurfaceTexture: DynSurfaceTexture + fmt::Debug + Borrow<Self::Texture>;
     type TextureView: DynTextureView;
-    type Sampler: fmt::Debug + WasmNotSendSync;
+    type Sampler: DynSampler + fmt::Debug;
     type QuerySet: DynQuerySet;
 
     /// A value you can block on to wait for something to finish.

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -433,7 +433,7 @@ pub trait Api: Clone + fmt::Debug + Sized {
     /// before a lower-valued operation, then waiting for the fence to reach the
     /// lower value could return before the lower-valued operation has actually
     /// finished.
-    type Fence: fmt::Debug + WasmNotSendSync;
+    type Fence: DynFence + fmt::Debug;
 
     type BindGroupLayout: fmt::Debug + WasmNotSendSync;
     type BindGroup: DynBindGroup;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -394,7 +394,7 @@ pub trait Api: Clone + fmt::Debug + Sized {
     type Instance: Instance<A = Self>;
     type Surface: Surface<A = Self>;
     type Adapter: Adapter<A = Self>;
-    type Device: Device<A = Self>;
+    type Device: DynDevice + Device<A = Self>;
 
     type Queue: Queue<A = Self>;
     type CommandEncoder: DynCommandEncoder + CommandEncoder<A = Self>;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -264,10 +264,10 @@ pub mod api {
 
 mod dynamic;
 
-pub(crate) use dynamic::{impl_dyn_resource, DynResource};
+pub(crate) use dynamic::impl_dyn_resource;
 pub use dynamic::{
     DynBindGroup, DynBuffer, DynCommandEncoder, DynComputePipeline, DynPipelineLayout, DynQuerySet,
-    DynRenderPipeline, DynTexture, DynTextureView,
+    DynRenderPipeline, DynResource, DynTexture, DynTextureView,
 };
 
 use std::{

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -269,7 +269,7 @@ pub use dynamic::{
     DynAccelerationStructure, DynBindGroup, DynBindGroupLayout, DynBuffer, DynCommandBuffer,
     DynCommandEncoder, DynComputePipeline, DynDevice, DynFence, DynPipelineCache,
     DynPipelineLayout, DynQuerySet, DynRenderPipeline, DynResource, DynSampler, DynShaderModule,
-    DynTexture, DynTextureView,
+    DynSurfaceTexture, DynTexture, DynTextureView,
 };
 
 use std::{
@@ -411,7 +411,7 @@ pub trait Api: Clone + fmt::Debug + Sized {
 
     type Buffer: DynBuffer;
     type Texture: DynTexture;
-    type SurfaceTexture: fmt::Debug + WasmNotSendSync + Borrow<Self::Texture>;
+    type SurfaceTexture: DynSurfaceTexture + fmt::Debug + Borrow<Self::Texture>;
     type TextureView: DynTextureView;
     type Sampler: fmt::Debug + WasmNotSendSync;
     type QuerySet: DynQuerySet;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -396,7 +396,7 @@ pub trait Api: Clone + fmt::Debug + Sized {
     type Adapter: Adapter<A = Self>;
     type Device: DynDevice + Device<A = Self>;
 
-    type Queue: Queue<A = Self>;
+    type Queue: DynQueue + Queue<A = Self>;
     type CommandEncoder: DynCommandEncoder + CommandEncoder<A = Self>;
 
     /// This API's command buffer type.
@@ -789,7 +789,7 @@ pub trait Device: WasmNotSendSync {
     /// The new `CommandEncoder` is in the "closed" state.
     unsafe fn create_command_encoder(
         &self,
-        desc: &CommandEncoderDescriptor<Self::A>,
+        desc: &CommandEncoderDescriptor<<Self::A as Api>::Queue>,
     ) -> Result<<Self::A as Api>::CommandEncoder, DeviceError>;
     unsafe fn destroy_command_encoder(&self, pool: <Self::A as Api>::CommandEncoder);
 
@@ -1831,9 +1831,9 @@ pub struct BindGroupDescriptor<'a, A: Api> {
 }
 
 #[derive(Clone, Debug)]
-pub struct CommandEncoderDescriptor<'a, A: Api> {
+pub struct CommandEncoderDescriptor<'a, Q: DynQueue + ?Sized> {
     pub label: Label<'a>,
-    pub queue: &'a A::Queue,
+    pub queue: &'a Q,
 }
 
 /// Naga shader module.

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -268,8 +268,8 @@ pub(crate) use dynamic::impl_dyn_resource;
 pub use dynamic::{
     DynAccelerationStructure, DynAcquiredSurfaceTexture, DynBindGroup, DynBindGroupLayout,
     DynBuffer, DynCommandBuffer, DynCommandEncoder, DynComputePipeline, DynDevice, DynFence,
-    DynPipelineCache, DynPipelineLayout, DynQuerySet, DynRenderPipeline, DynResource, DynSampler,
-    DynShaderModule, DynSurface, DynSurfaceTexture, DynTexture, DynTextureView,
+    DynPipelineCache, DynPipelineLayout, DynQuerySet, DynQueue, DynRenderPipeline, DynResource,
+    DynSampler, DynShaderModule, DynSurface, DynSurfaceTexture, DynTexture, DynTextureView,
 };
 
 use std::{
@@ -392,7 +392,7 @@ impl InstanceError {
 
 pub trait Api: Clone + fmt::Debug + Sized {
     type Instance: Instance<A = Self>;
-    type Surface: Surface<A = Self>;
+    type Surface: DynSurface + Surface<A = Self>;
     type Adapter: Adapter<A = Self>;
     type Device: DynDevice + Device<A = Self>;
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -266,9 +266,10 @@ mod dynamic;
 
 pub(crate) use dynamic::impl_dyn_resource;
 pub use dynamic::{
-    DynAccelerationStructure, DynBindGroup, DynBindGroupLayout, DynBuffer, DynCommandEncoder,
-    DynComputePipeline, DynDevice, DynFence, DynPipelineCache, DynPipelineLayout, DynQuerySet,
-    DynRenderPipeline, DynResource, DynSampler, DynShaderModule, DynTexture, DynTextureView,
+    DynAccelerationStructure, DynBindGroup, DynBindGroupLayout, DynBuffer, DynCommandBuffer,
+    DynCommandEncoder, DynComputePipeline, DynDevice, DynFence, DynPipelineCache,
+    DynPipelineLayout, DynQuerySet, DynRenderPipeline, DynResource, DynSampler, DynShaderModule,
+    DynTexture, DynTextureView,
 };
 
 use std::{
@@ -406,7 +407,7 @@ pub trait Api: Clone + fmt::Debug + Sized {
     /// them to [`CommandEncoder::reset_all`].
     ///
     /// [`CommandEncoder`]: Api::CommandEncoder
-    type CommandBuffer: WasmNotSendSync + fmt::Debug;
+    type CommandBuffer: DynCommandBuffer + fmt::Debug;
 
     type Buffer: DynBuffer;
     type Texture: DynTexture;

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -915,7 +915,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn set_index_buffer<'a>(
         &mut self,
-        binding: crate::BufferBinding<'a, super::Api>,
+        binding: crate::BufferBinding<'a, super::Buffer>,
         format: wgt::IndexFormat,
     ) {
         let (stride, raw_type) = match format {
@@ -933,7 +933,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     unsafe fn set_vertex_buffer<'a>(
         &mut self,
         index: u32,
-        binding: crate::BufferBinding<'a, super::Api>,
+        binding: crate::BufferBinding<'a, super::Buffer>,
     ) {
         let buffer_index = self.shared.private_caps.max_vertex_buffers as u64 - 1 - index as u64;
         let encoder = self.state.render.as_ref().unwrap();

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -241,7 +241,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn transition_buffers<'a, T>(&mut self, _barriers: T)
     where
-        T: Iterator<Item = crate::BufferBarrier<'a, super::Api>>,
+        T: Iterator<Item = crate::BufferBarrier<'a, super::Buffer>>,
     {
     }
 

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -501,7 +501,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     // render
 
-    unsafe fn begin_render_pass(&mut self, desc: &crate::RenderPassDescriptor<super::Api>) {
+    unsafe fn begin_render_pass(
+        &mut self,
+        desc: &crate::RenderPassDescriptor<super::QuerySet, super::TextureView>,
+    ) {
         self.begin_pass();
         self.state.index = None;
 
@@ -1128,7 +1131,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     // compute
 
-    unsafe fn begin_compute_pass(&mut self, desc: &crate::ComputePassDescriptor<super::Api>) {
+    unsafe fn begin_compute_pass(&mut self, desc: &crate::ComputePassDescriptor<super::QuerySet>) {
         self.begin_pass();
 
         debug_assert!(self.state.blit.is_none());

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -247,7 +247,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn transition_textures<'a, T>(&mut self, _barriers: T)
     where
-        T: Iterator<Item = crate::TextureBarrier<'a, super::Api>>,
+        T: Iterator<Item = crate::TextureBarrier<'a, super::Texture>>,
     {
     }
 

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1260,7 +1260,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
         _descriptors: T,
     ) where
         super::Api: 'a,
-        T: IntoIterator<Item = crate::BuildAccelerationStructureDescriptor<'a, super::Api>>,
+        T: IntoIterator<
+            Item = crate::BuildAccelerationStructureDescriptor<
+                'a,
+                super::Buffer,
+                super::AccelerationStructure,
+            >,
+        >,
     {
         unimplemented!()
     }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -776,7 +776,13 @@ impl crate::Device for super::Device {
 
     unsafe fn create_bind_group(
         &self,
-        desc: &crate::BindGroupDescriptor<super::Api>,
+        desc: &crate::BindGroupDescriptor<
+            super::BindGroupLayout,
+            super::Buffer,
+            super::Sampler,
+            super::TextureView,
+            super::AccelerationStructure,
+        >,
     ) -> DeviceResult<super::BindGroup> {
         let mut bg = super::BindGroup::default();
         for (&stage, counter) in super::NAGA_STAGES.iter().zip(bg.counters.iter_mut()) {

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -569,7 +569,7 @@ impl crate::Device for super::Device {
 
     unsafe fn create_command_encoder(
         &self,
-        desc: &crate::CommandEncoderDescriptor<super::Api>,
+        desc: &crate::CommandEncoderDescriptor<super::Queue>,
     ) -> Result<super::CommandEncoder, crate::DeviceError> {
         self.counters.command_encoders.add(1);
         Ok(super::CommandEncoder {

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -602,7 +602,7 @@ impl crate::Device for super::Device {
 
     unsafe fn create_pipeline_layout(
         &self,
-        desc: &crate::PipelineLayoutDescriptor<super::Api>,
+        desc: &crate::PipelineLayoutDescriptor<super::BindGroupLayout>,
     ) -> DeviceResult<super::PipelineLayout> {
         #[derive(Debug)]
         struct StageInfo {

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -99,7 +99,7 @@ const fn convert_vertex_format_to_naga(format: wgt::VertexFormat) -> naga::back:
 impl super::Device {
     fn load_shader(
         &self,
-        stage: &crate::ProgrammableStage<super::Api>,
+        stage: &crate::ProgrammableStage<super::ShaderModule>,
         vertex_buffer_mappings: &[naga::back::msl::VertexBufferMapping],
         layout: &super::PipelineLayout,
         primitive_class: metal::MTLPrimitiveTopologyClass,
@@ -898,7 +898,11 @@ impl crate::Device for super::Device {
 
     unsafe fn create_render_pipeline(
         &self,
-        desc: &crate::RenderPipelineDescriptor<super::Api>,
+        desc: &crate::RenderPipelineDescriptor<
+            super::PipelineLayout,
+            super::ShaderModule,
+            super::PipelineCache,
+        >,
     ) -> Result<super::RenderPipeline, crate::PipelineError> {
         objc::rc::autoreleasepool(|| {
             let descriptor = metal::RenderPipelineDescriptor::new();
@@ -1169,7 +1173,11 @@ impl crate::Device for super::Device {
 
     unsafe fn create_compute_pipeline(
         &self,
-        desc: &crate::ComputePipelineDescriptor<super::Api>,
+        desc: &crate::ComputePipelineDescriptor<
+            super::PipelineLayout,
+            super::ShaderModule,
+            super::PipelineCache,
+        >,
     ) -> Result<super::ComputePipeline, crate::PipelineError> {
         objc::rc::autoreleasepool(|| {
             let descriptor = metal::ComputePipelineDescriptor::new();
@@ -1232,10 +1240,10 @@ impl crate::Device for super::Device {
     unsafe fn create_pipeline_cache(
         &self,
         _desc: &crate::PipelineCacheDescriptor<'_>,
-    ) -> Result<(), crate::PipelineCacheError> {
-        Ok(())
+    ) -> Result<super::PipelineCache, crate::PipelineCacheError> {
+        Ok(super::PipelineCache)
     }
-    unsafe fn destroy_pipeline_cache(&self, (): ()) {}
+    unsafe fn destroy_pipeline_cache(&self, _: super::PipelineCache) {}
 
     unsafe fn create_query_set(
         &self,

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1394,7 +1394,7 @@ impl crate::Device for super::Device {
 
     unsafe fn get_acceleration_structure_build_sizes(
         &self,
-        _desc: &crate::GetAccelerationStructureBuildSizesDescriptor<super::Api>,
+        _desc: &crate::GetAccelerationStructureBuildSizesDescriptor<super::Buffer>,
     ) -> crate::AccelerationStructureBuildSizes {
         unimplemented!()
     }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -505,6 +505,8 @@ pub struct Texture {
     copy_size: crate::CopyExtent,
 }
 
+impl crate::DynTexture for Texture {}
+
 unsafe impl Send for Texture {}
 unsafe impl Sync for Texture {}
 
@@ -513,6 +515,8 @@ pub struct TextureView {
     raw: metal::Texture,
     aspects: crate::FormatAspects,
 }
+
+impl crate::DynTextureView for TextureView {}
 
 unsafe impl Send for TextureView {}
 unsafe impl Sync for TextureView {}

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -767,6 +767,8 @@ pub struct RenderPipeline {
 unsafe impl Send for RenderPipeline {}
 unsafe impl Sync for RenderPipeline {}
 
+impl crate::DynRenderPipeline for RenderPipeline {}
+
 #[derive(Debug)]
 pub struct ComputePipeline {
     raw: metal::ComputePipelineState,
@@ -779,6 +781,8 @@ pub struct ComputePipeline {
 
 unsafe impl Send for ComputePipeline {}
 unsafe impl Sync for ComputePipeline {}
+
+impl crate::DynComputePipeline for ComputePipeline {}
 
 #[derive(Debug, Clone)]
 pub struct QuerySet {

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -72,6 +72,7 @@ impl crate::Api for Api {
 }
 
 crate::impl_dyn_resource!(
+    Adapter,
     AccelerationStructure,
     BindGroup,
     BindGroupLayout,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -390,6 +390,12 @@ impl std::borrow::Borrow<Texture> for SurfaceTexture {
     }
 }
 
+impl std::borrow::Borrow<dyn crate::DynTexture> for SurfaceTexture {
+    fn borrow(&self) -> &dyn crate::DynTexture {
+        &self.texture
+    }
+}
+
 unsafe impl Send for SurfaceTexture {}
 unsafe impl Sync for SurfaceTexture {}
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -72,6 +72,7 @@ impl crate::Api for Api {
 }
 
 crate::impl_dyn_resource!(
+    AccelerationStructure,
     BindGroup,
     BindGroupLayout,
     Buffer,
@@ -931,3 +932,5 @@ unsafe impl Sync for CommandBuffer {}
 
 #[derive(Debug)]
 pub struct AccelerationStructure;
+
+impl crate::DynAccelerationStructure for AccelerationStructure {}

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -907,6 +907,8 @@ pub struct CommandBuffer {
     raw: metal::CommandBuffer,
 }
 
+impl crate::DynCommandBuffer for CommandBuffer {}
+
 unsafe impl Send for CommandBuffer {}
 unsafe impl Sync for CommandBuffer {}
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -811,6 +811,8 @@ pub struct Fence {
     pending_command_buffers: Vec<(crate::FenceValue, metal::CommandBuffer)>,
 }
 
+impl crate::DynFence for Fence {}
+
 unsafe impl Send for Fence {}
 unsafe impl Sync for Fence {}
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -542,6 +542,8 @@ pub struct Sampler {
     raw: metal::SamplerState,
 }
 
+impl crate::DynSampler for Sampler {}
+
 unsafe impl Send for Sampler {}
 unsafe impl Sync for Sampler {}
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -86,6 +86,7 @@ crate::impl_dyn_resource!(
     Sampler,
     ShaderModule,
     Surface,
+    SurfaceTexture,
     Texture,
     TextureView
 );
@@ -380,6 +381,8 @@ pub struct SurfaceTexture {
     drawable: metal::MetalDrawable,
     present_with_transaction: bool,
 }
+
+impl crate::DynSurfaceTexture for SurfaceTexture {}
 
 impl std::borrow::Borrow<Texture> for SurfaceTexture {
     fn borrow(&self) -> &Texture {

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -66,7 +66,7 @@ impl crate::Api for Api {
     type ShaderModule = ShaderModule;
     type RenderPipeline = RenderPipeline;
     type ComputePipeline = ComputePipeline;
-    type PipelineCache = ();
+    type PipelineCache = PipelineCache;
 
     type AccelerationStructure = AccelerationStructure;
 }
@@ -81,6 +81,7 @@ crate::impl_dyn_resource!(
     ComputePipeline,
     Device,
     Fence,
+    PipelineCache,
     PipelineLayout,
     QuerySet,
     Queue,
@@ -929,6 +930,11 @@ impl crate::DynCommandBuffer for CommandBuffer {}
 
 unsafe impl Send for CommandBuffer {}
 unsafe impl Sync for CommandBuffer {}
+
+#[derive(Debug)]
+pub struct PipelineCache;
+
+impl crate::DynPipelineCache for PipelineCache {}
 
 #[derive(Debug)]
 pub struct AccelerationStructure;

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -78,6 +78,7 @@ crate::impl_dyn_resource!(
     CommandBuffer,
     CommandEncoder,
     ComputePipeline,
+    Device,
     Fence,
     PipelineLayout,
     QuerySet,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -714,6 +714,8 @@ pub struct ShaderModule {
     runtime_checks: bool,
 }
 
+impl crate::DynShaderModule for ShaderModule {}
+
 #[derive(Debug, Default)]
 struct PipelineStageInfo {
     push_constants: Option<PushConstantsInfo>,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -560,6 +560,8 @@ pub struct BindGroupLayout {
     entries: Arc<[wgt::BindGroupLayoutEntry]>,
 }
 
+impl crate::DynBindGroupLayout for BindGroupLayout {}
+
 #[derive(Clone, Debug, Default)]
 struct ResourceData<T> {
     buffers: T,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -486,7 +486,7 @@ impl Buffer {
     }
 }
 
-impl crate::BufferBinding<'_, Api> {
+impl crate::BufferBinding<'_, Buffer> {
     fn resolve_size(&self) -> wgt::BufferAddress {
         match self.size {
             Some(size) => size.get(),

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -82,6 +82,7 @@ crate::impl_dyn_resource!(
     ComputePipeline,
     Device,
     Fence,
+    Instance,
     PipelineCache,
     PipelineLayout,
     QuerySet,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -624,6 +624,8 @@ pub struct PipelineLayout {
     per_stage_map: MultiStageResources,
 }
 
+impl crate::DynPipelineLayout for PipelineLayout {}
+
 trait AsNative {
     type Native;
     fn from(native: &Self::Native) -> Self;
@@ -696,6 +698,8 @@ pub struct BindGroup {
     samplers: Vec<SamplerPtr>,
     textures: Vec<TexturePtr>,
 }
+
+impl crate::DynBindGroup for BindGroup {}
 
 unsafe impl Send for BindGroup {}
 unsafe impl Sync for BindGroup {}

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -71,6 +71,24 @@ impl crate::Api for Api {
     type AccelerationStructure = AccelerationStructure;
 }
 
+crate::impl_dyn_resource!(
+    BindGroup,
+    BindGroupLayout,
+    Buffer,
+    CommandBuffer,
+    CommandEncoder,
+    ComputePipeline,
+    Fence,
+    PipelineLayout,
+    QuerySet,
+    RenderPipeline,
+    Sampler,
+    ShaderModule,
+    Surface,
+    Texture,
+    TextureView
+);
+
 pub struct Instance {
     managed_metal_layer_delegate: surface::HalManagedMetalLayerDelegate,
 }
@@ -459,6 +477,8 @@ pub struct Buffer {
 
 unsafe impl Send for Buffer {}
 unsafe impl Sync for Buffer {}
+
+impl crate::DynBuffer for Buffer {}
 
 impl Buffer {
     fn as_raw(&self) -> BufferPtr {

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -784,6 +784,8 @@ pub struct QuerySet {
     ty: wgt::QueryType,
 }
 
+impl crate::DynQuerySet for QuerySet {}
+
 unsafe impl Send for QuerySet {}
 unsafe impl Sync for QuerySet {}
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -82,6 +82,7 @@ crate::impl_dyn_resource!(
     Fence,
     PipelineLayout,
     QuerySet,
+    Queue,
     RenderPipeline,
     Sampler,
     ShaderModule,

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -156,7 +156,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn transition_textures<'a, T>(&mut self, barriers: T)
     where
-        T: Iterator<Item = crate::TextureBarrier<'a, super::Api>>,
+        T: Iterator<Item = crate::TextureBarrier<'a, super::Texture>>,
     {
         let mut src_stages = vk::PipelineStageFlags::empty();
         let mut dst_stages = vk::PipelineStageFlags::empty();

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -116,7 +116,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn transition_buffers<'a, T>(&mut self, barriers: T)
     where
-        T: Iterator<Item = crate::BufferBarrier<'a, super::Api>>,
+        T: Iterator<Item = crate::BufferBarrier<'a, super::Buffer>>,
     {
         //Note: this is done so that we never end up with empty stage flags
         let mut src_stages = vk::PipelineStageFlags::TOP_OF_PIPE;

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -644,7 +644,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
     }
     // render
 
-    unsafe fn begin_render_pass(&mut self, desc: &crate::RenderPassDescriptor<super::Api>) {
+    unsafe fn begin_render_pass(
+        &mut self,
+        desc: &crate::RenderPassDescriptor<super::QuerySet, super::TextureView>,
+    ) {
         let mut vk_clear_values =
             ArrayVec::<vk::ClearValue, { super::MAX_TOTAL_ATTACHMENTS }>::new();
         let mut vk_image_views = ArrayVec::<vk::ImageView, { super::MAX_TOTAL_ATTACHMENTS }>::new();
@@ -1067,7 +1070,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     // compute
 
-    unsafe fn begin_compute_pass(&mut self, desc: &crate::ComputePassDescriptor<'_, super::Api>) {
+    unsafe fn begin_compute_pass(
+        &mut self,
+        desc: &crate::ComputePassDescriptor<'_, super::QuerySet>,
+    ) {
         self.bind_point = vk::PipelineBindPoint::COMPUTE;
         if let Some(label) = desc.label {
             unsafe { self.begin_debug_marker(label) };

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -870,7 +870,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn set_index_buffer<'a>(
         &mut self,
-        binding: crate::BufferBinding<'a, super::Api>,
+        binding: crate::BufferBinding<'a, super::Buffer>,
         format: wgt::IndexFormat,
     ) {
         unsafe {
@@ -885,7 +885,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     unsafe fn set_vertex_buffer<'a>(
         &mut self,
         index: u32,
-        binding: crate::BufferBinding<'a, super::Api>,
+        binding: crate::BufferBinding<'a, super::Buffer>,
     ) {
         let vk_buffers = [binding.buffer.raw];
         let vk_offsets = [binding.offset];

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -408,7 +408,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
     unsafe fn build_acceleration_structures<'a, T>(&mut self, descriptor_count: u32, descriptors: T)
     where
         super::Api: 'a,
-        T: IntoIterator<Item = crate::BuildAccelerationStructureDescriptor<'a, super::Api>>,
+        T: IntoIterator<
+            Item = crate::BuildAccelerationStructureDescriptor<
+                'a,
+                super::Buffer,
+                super::AccelerationStructure,
+            >,
+        >,
     {
         const CAPACITY_OUTER: usize = 8;
         const CAPACITY_INNER: usize = 1;

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -178,7 +178,7 @@ pub fn map_vk_surface_formats(sf: vk::SurfaceFormatKHR) -> Option<wgt::TextureFo
     })
 }
 
-impl crate::Attachment<'_, super::Api> {
+impl crate::Attachment<'_, super::TextureView> {
     pub(super) fn make_attachment_key(
         &self,
         ops: crate::AttachmentOps,
@@ -192,7 +192,7 @@ impl crate::Attachment<'_, super::Api> {
     }
 }
 
-impl crate::ColorAttachment<'_, super::Api> {
+impl crate::ColorAttachment<'_, super::TextureView> {
     pub(super) unsafe fn make_vk_clear_color(&self) -> vk::ClearColorValue {
         let cv = &self.clear_value;
         match self

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -2176,7 +2176,7 @@ impl crate::Device for super::Device {
 
     unsafe fn get_acceleration_structure_build_sizes<'a>(
         &self,
-        desc: &crate::GetAccelerationStructureBuildSizesDescriptor<'a, super::Api>,
+        desc: &crate::GetAccelerationStructureBuildSizesDescriptor<'a, super::Buffer>,
     ) -> crate::AccelerationStructureBuildSizes {
         const CAPACITY: usize = 8;
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1453,7 +1453,13 @@ impl crate::Device for super::Device {
 
     unsafe fn create_bind_group(
         &self,
-        desc: &crate::BindGroupDescriptor<super::Api>,
+        desc: &crate::BindGroupDescriptor<
+            super::BindGroupLayout,
+            super::Buffer,
+            super::Sampler,
+            super::TextureView,
+            super::AccelerationStructure,
+        >,
     ) -> Result<super::BindGroup, crate::DeviceError> {
         let mut vk_sets = unsafe {
             self.desc_allocator.lock().allocate(

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1215,7 +1215,7 @@ impl crate::Device for super::Device {
 
     unsafe fn create_command_encoder(
         &self,
-        desc: &crate::CommandEncoderDescriptor<super::Api>,
+        desc: &crate::CommandEncoderDescriptor<super::Queue>,
     ) -> Result<super::CommandEncoder, crate::DeviceError> {
         let vk_info = vk::CommandPoolCreateInfo::default()
             .queue_family_index(desc.queue.family_index)

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1387,7 +1387,7 @@ impl crate::Device for super::Device {
 
     unsafe fn create_pipeline_layout(
         &self,
-        desc: &crate::PipelineLayoutDescriptor<super::Api>,
+        desc: &crate::PipelineLayoutDescriptor<super::BindGroupLayout>,
     ) -> Result<super::PipelineLayout, crate::DeviceError> {
         //Note: not bothering with on stack array here as it's low frequency
         let vk_set_layouts = desc

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -833,6 +833,8 @@ pub struct QuerySet {
     raw: vk::QueryPool,
 }
 
+impl crate::DynQuerySet for QuerySet {}
+
 /// The [`Api::Fence`] type for [`vulkan::Api`].
 ///
 /// This is an `enum` because there are two possible implementations of

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -715,6 +715,8 @@ pub struct Sampler {
     raw: vk::Sampler,
 }
 
+impl crate::DynSampler for Sampler {}
+
 #[derive(Debug)]
 pub struct BindGroupLayout {
     raw: vk::DescriptorSetLayout,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -79,6 +79,7 @@ impl crate::Api for Api {
 }
 
 crate::impl_dyn_resource!(
+    Adapter,
     AccelerationStructure,
     BindGroup,
     BindGroupLayout,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -811,6 +811,8 @@ pub struct CommandBuffer {
     raw: vk::CommandBuffer,
 }
 
+impl crate::DynCommandBuffer for CommandBuffer {}
+
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum ShaderModule {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -862,6 +862,8 @@ pub struct PipelineCache {
     raw: vk::PipelineCache,
 }
 
+impl crate::DynPipelineCache for PipelineCache {}
+
 #[derive(Debug)]
 pub struct QuerySet {
     raw: vk::QueryPool,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -94,6 +94,7 @@ crate::impl_dyn_resource!(
     Sampler,
     ShaderModule,
     Surface,
+    SurfaceTexture,
     Texture,
     TextureView
 );
@@ -376,6 +377,8 @@ pub struct SurfaceTexture {
     texture: Texture,
     surface_semaphores: Arc<Mutex<SwapchainImageSemaphores>>,
 }
+
+impl crate::DynSurfaceTexture for SurfaceTexture {}
 
 impl Borrow<Texture> for SurfaceTexture {
     fn borrow(&self) -> &Texture {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -78,6 +78,25 @@ impl crate::Api for Api {
     type ComputePipeline = ComputePipeline;
 }
 
+crate::impl_dyn_resource!(
+    BindGroup,
+    BindGroupLayout,
+    Buffer,
+    CommandBuffer,
+    CommandEncoder,
+    ComputePipeline,
+    Fence,
+    PipelineCache,
+    PipelineLayout,
+    QuerySet,
+    RenderPipeline,
+    Sampler,
+    ShaderModule,
+    Surface,
+    Texture,
+    TextureView
+);
+
 struct DebugUtils {
     extension: ext::debug_utils::Instance,
     messenger: vk::DebugUtilsMessengerEXT,
@@ -630,6 +649,8 @@ pub struct Buffer {
     raw: vk::Buffer,
     block: Option<Mutex<gpu_alloc::MemoryBlock<vk::DeviceMemory>>>,
 }
+
+impl crate::DynBuffer for Buffer {}
 
 #[derive(Debug)]
 pub struct AccelerationStructure {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -716,10 +716,14 @@ pub struct PipelineLayout {
     binding_arrays: naga::back::spv::BindingMap,
 }
 
+impl crate::DynPipelineLayout for PipelineLayout {}
+
 #[derive(Debug)]
 pub struct BindGroup {
     set: gpu_descriptor::DescriptorSet<vk::DescriptorSet>,
 }
+
+impl crate::DynBindGroup for BindGroup {}
 
 /// Miscellaneous allocation recycling pool for `CommandAllocator`.
 #[derive(Default)]

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -90,6 +90,7 @@ crate::impl_dyn_resource!(
     PipelineCache,
     PipelineLayout,
     QuerySet,
+    Queue,
     RenderPipeline,
     Sampler,
     ShaderModule,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -386,6 +386,12 @@ impl Borrow<Texture> for SurfaceTexture {
     }
 }
 
+impl Borrow<dyn crate::DynTexture> for SurfaceTexture {
+    fn borrow(&self) -> &dyn crate::DynTexture {
+        &self.texture
+    }
+}
+
 pub struct Adapter {
     raw: vk::PhysicalDevice,
     instance: Arc<InstanceShared>,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -89,6 +89,7 @@ crate::impl_dyn_resource!(
     ComputePipeline,
     Device,
     Fence,
+    Instance,
     PipelineCache,
     PipelineLayout,
     QuerySet,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -671,6 +671,8 @@ pub struct Texture {
     view_formats: Vec<wgt::TextureFormat>,
 }
 
+impl crate::DynTexture for Texture {}
+
 impl Texture {
     /// # Safety
     ///
@@ -686,6 +688,8 @@ pub struct TextureView {
     layers: NonZeroU32,
     attachment: FramebufferAttachment,
 }
+
+impl crate::DynTextureView for TextureView {}
 
 impl TextureView {
     /// # Safety

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -79,6 +79,7 @@ impl crate::Api for Api {
 }
 
 crate::impl_dyn_resource!(
+    AccelerationStructure,
     BindGroup,
     BindGroupLayout,
     Buffer,
@@ -669,6 +670,8 @@ pub struct AccelerationStructure {
     buffer: vk::Buffer,
     block: Mutex<gpu_alloc::MemoryBlock<vk::DeviceMemory>>,
 }
+
+impl crate::DynAccelerationStructure for AccelerationStructure {}
 
 #[derive(Debug)]
 pub struct Texture {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -901,6 +901,8 @@ pub enum Fence {
     },
 }
 
+impl crate::DynFence for Fence {}
+
 impl Fence {
     /// Return the highest [`FenceValue`] among the signalled fences in `active`.
     ///

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -822,10 +822,14 @@ pub struct RenderPipeline {
     raw: vk::Pipeline,
 }
 
+impl crate::DynRenderPipeline for RenderPipeline {}
+
 #[derive(Debug)]
 pub struct ComputePipeline {
     raw: vk::Pipeline,
 }
+
+impl crate::DynComputePipeline for ComputePipeline {}
 
 #[derive(Debug)]
 pub struct PipelineCache {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -821,6 +821,8 @@ pub enum ShaderModule {
     },
 }
 
+impl crate::DynShaderModule for ShaderModule {}
+
 #[derive(Debug)]
 pub struct RenderPipeline {
     raw: vk::Pipeline,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -85,6 +85,7 @@ crate::impl_dyn_resource!(
     CommandBuffer,
     CommandEncoder,
     ComputePipeline,
+    Device,
     Fence,
     PipelineCache,
     PipelineLayout,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -727,6 +727,8 @@ pub struct BindGroupLayout {
     binding_arrays: Vec<(u32, NonZeroU32)>,
 }
 
+impl crate::DynBindGroupLayout for BindGroupLayout {}
+
 #[derive(Debug)]
 pub struct PipelineLayout {
     raw: vk::PipelineLayout,


### PR DESCRIPTION
**Connections**
* Part of https://github.com/gfx-rs/wgpu/issues/5124
* Part of a series!
   * ➡️ #6098
   * #6099 
   * #6100 

**Description**
Introduces a new `Dyn` "backend" which uses dynamic dispatch & `std::any::Any` based casting while keeping changes to `wgpu-core` as minimal as possible.

Note that casts through `Any` could be avoided altogether, but right now part2 of the series relies on standard any casts, so I'd advocate to keep this as a future improvement.
Internal unboxing mechanism as proposed by @cwfitzgerald however sidesteps `Any` for the most part (except for debug assertion) which allows us to keep `wgpu-hal` backend unchanged for the most part which profits their isolation & direct consumers of ` wgpu-hal`. Concrete, this means that `destroy` methods continue to consume objects via move (which is both semantically & syntactically convenient).
Also note that this is intentionally not exposed as part of the public interface.

Speaking of future improvements:
Something that has been discussed in the maintainer group previously while this was already under way is to use `enum` based `DynResource` which would allow to trivially know the size of each resource and instead dispatch via `match`.
This PR series sticks with `Box` and `Any` in favor of expedience but is my belief that such refactors will be easier once this lands!


Commits have been cleaned up as good as possible to make them digestable for review, but there might be still some slight meandering in there hinting at earlier experimentations.


**Testing**
* Existing tests run.
* [Performance metric for the results of Part 3](https://gist.github.com/Wumpf/b72b6273c50f38c699b5995a8b5ba2fc)


**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- ~[ ] Add change to `CHANGELOG.md`. See simple instructions inside file.~ changelog in Part 3
