### PR TITLE
[metal] Improve layer initialization and resizing

### DIFF
--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -96,9 +96,7 @@ crate::impl_dyn_resource!(
     TextureView
 );
 
-pub struct Instance {
-    managed_metal_layer_delegate: surface::HalManagedMetalLayerDelegate,
-}
+pub struct Instance {}
 
 impl Instance {
     pub fn create_surface_from_layer(&self, layer: &metal::MetalLayerRef) -> Surface {
@@ -113,9 +111,7 @@ impl crate::Instance for Instance {
         profiling::scope!("Init Metal Backend");
         // We do not enable metal validation based on the validation flags as it affects the entire
         // process. Instead, we enable the validation inside the test harness itself in tests/src/native.rs.
-        Ok(Instance {
-            managed_metal_layer_delegate: surface::HalManagedMetalLayerDelegate::new(),
-        })
+        Ok(Instance {})
     }
 
     unsafe fn create_surface(
@@ -126,16 +122,12 @@ impl crate::Instance for Instance {
         match window_handle {
             #[cfg(target_os = "ios")]
             raw_window_handle::RawWindowHandle::UiKit(handle) => {
-                let _ = &self.managed_metal_layer_delegate;
-                Ok(unsafe { Surface::from_view(handle.ui_view.cast(), None) })
+                Ok(unsafe { Surface::from_view(handle.ui_view.cast()) })
             }
             #[cfg(target_os = "macos")]
-            raw_window_handle::RawWindowHandle::AppKit(handle) => Ok(unsafe {
-                Surface::from_view(
-                    handle.ns_view.cast(),
-                    Some(&self.managed_metal_layer_delegate),
-                )
-            }),
+            raw_window_handle::RawWindowHandle::AppKit(handle) => {
+                Ok(unsafe { Surface::from_view(handle.ns_view.cast()) })
+            }
             _ => Err(crate::InstanceError::new(format!(
                 "window handle {window_handle:?} is not a Metal-compatible handle"
             ))),

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -127,12 +127,12 @@ impl crate::Instance for Instance {
             #[cfg(target_os = "ios")]
             raw_window_handle::RawWindowHandle::UiKit(handle) => {
                 let _ = &self.managed_metal_layer_delegate;
-                Ok(unsafe { Surface::from_view(handle.ui_view.as_ptr(), None) })
+                Ok(unsafe { Surface::from_view(handle.ui_view.cast(), None) })
             }
             #[cfg(target_os = "macos")]
             raw_window_handle::RawWindowHandle::AppKit(handle) => Ok(unsafe {
                 Surface::from_view(
-                    handle.ns_view.as_ptr(),
+                    handle.ns_view.cast(),
                     Some(&self.managed_metal_layer_delegate),
                 )
             }),

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -367,7 +367,6 @@ pub struct Device {
 }
 
 pub struct Surface {
-    view: Option<NonNull<objc::runtime::Object>>,
     render_layer: Mutex<metal::MetalLayer>,
     swapchain_format: RwLock<Option<wgt::TextureFormat>>,
     extent: RwLock<wgt::Extent3d>,

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -24,7 +24,7 @@ use parking_lot::{Mutex, RwLock};
 #[link(name = "QuartzCore", kind = "framework")]
 extern "C" {
     #[allow(non_upper_case_globals)]
-    static kCAGravityTopLeft: *mut Object;
+    static kCAGravityResize: *mut Object;
 }
 
 extern "C" fn layer_should_inherit_contents_scale_from_window(
@@ -239,7 +239,15 @@ impl super::Surface {
             let frame: CGRect = msg_send![root_layer, bounds];
             let () = msg_send![new_layer, setFrame: frame];
 
-            let _: () = msg_send![new_layer, setContentsGravity: unsafe { kCAGravityTopLeft }];
+            // The desired content gravity is `kCAGravityResize`, because it
+            // masks / alleviates issues with resizing when
+            // `present_with_transaction` is disabled, and behaves better when
+            // moving the window between monitors.
+            //
+            // Unfortunately, it also makes it harder to see changes to
+            // `width` and `height` in `configure`. When debugging resize
+            // issues, swap this for `kCAGravityTopLeft` instead.
+            let _: () = msg_send![new_layer, setContentsGravity: unsafe { kCAGravityResize }];
 
             // Set initial scale factor of the layer. This is kept in sync by
             // `configure` (on UIKit), and the delegate below (on AppKit).

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -1,11 +1,15 @@
 #![allow(clippy::let_unit_value)] // `let () =` being used to constrain result type
 
-use std::{os::raw::c_void, ptr::NonNull, sync::Once, thread};
+use std::ffi::c_uint;
+use std::ptr::NonNull;
+use std::sync::Once;
+use std::thread;
 
 use core_graphics_types::{
     base::CGFloat,
     geometry::{CGRect, CGSize},
 };
+use metal::foreign_types::ForeignType;
 use objc::{
     class,
     declare::ClassDecl,
@@ -16,7 +20,6 @@ use objc::{
 };
 use parking_lot::{Mutex, RwLock};
 
-#[cfg(target_os = "macos")]
 #[link(name = "QuartzCore", kind = "framework")]
 extern "C" {
     #[allow(non_upper_case_globals)]
@@ -46,6 +49,7 @@ impl HalManagedMetalLayerDelegate {
             type Fun = extern "C" fn(&Class, Sel, *mut Object, CGFloat, *mut Object) -> BOOL;
             let mut decl = ClassDecl::new(&class_name, class!(NSObject)).unwrap();
             unsafe {
+                // <https://developer.apple.com/documentation/appkit/nsviewlayercontentscaledelegate/3005294-layer?language=objc>
                 decl.add_class_method::<Fun>(
                     sel!(layer:shouldInheritContentsScale:fromWindow:),
                     layer_should_inherit_contents_scale_from_window,
@@ -72,26 +76,15 @@ impl super::Surface {
     /// If not called on the main thread, this will panic.
     #[allow(clippy::transmute_ptr_to_ref)]
     pub unsafe fn from_view(
-        view: *mut c_void,
+        view: NonNull<Object>,
         delegate: Option<&HalManagedMetalLayerDelegate>,
     ) -> Self {
-        let view = view.cast::<Object>();
-        let render_layer = {
-            let layer = unsafe { Self::get_metal_layer(view, delegate) };
-            let layer = layer.cast::<metal::MetalLayerRef>();
-            // SAFETY: This pointer…
-            //
-            // - …is properly aligned.
-            // - …is dereferenceable to a `MetalLayerRef` as an invariant of the `metal`
-            //   field.
-            // - …points to an _initialized_ `MetalLayerRef`.
-            // - …is only ever aliased via an immutable reference that lives within this
-            //   lexical scope.
-            unsafe { &*layer }
-        }
-        .to_owned();
-        let _: *mut c_void = msg_send![view, retain];
-        Self::new(NonNull::new(view), render_layer)
+        let layer = unsafe { Self::get_metal_layer(view, delegate) };
+        // SAFETY: The layer is an initialized instance of `CAMetalLayer`.
+        let layer = unsafe { metal::MetalLayer::from_ptr(layer.cast()) };
+        let view: *mut Object = msg_send![view.as_ptr(), retain];
+        let view = NonNull::new(view).expect("retain should return the same object");
+        Self::new(Some(view), layer)
     }
 
     pub unsafe fn from_layer(layer: &metal::MetalLayerRef) -> Self {
@@ -101,52 +94,155 @@ impl super::Surface {
         Self::new(None, layer.to_owned())
     }
 
-    /// If not called on the main thread, this will panic.
+    /// Get or create a new `CAMetalLayer` associated with the given `NSView`
+    /// or `UIView`.
+    ///
+    /// # Panics
+    ///
+    /// If called from a thread that is not the main thread, this will panic.
+    ///
+    /// # Safety
+    ///
+    /// The `view` must be a valid instance of `NSView` or `UIView`.
     pub(crate) unsafe fn get_metal_layer(
-        view: *mut Object,
+        view: NonNull<Object>,
         delegate: Option<&HalManagedMetalLayerDelegate>,
     ) -> *mut Object {
-        if view.is_null() {
-            panic!("window does not have a valid contentView");
-        }
-
         let is_main_thread: BOOL = msg_send![class!(NSThread), isMainThread];
         if is_main_thread == NO {
             panic!("get_metal_layer cannot be called in non-ui thread.");
         }
 
-        let main_layer: *mut Object = msg_send![view, layer];
-        let class = class!(CAMetalLayer);
-        let is_valid_layer: BOOL = msg_send![main_layer, isKindOfClass: class];
+        // Ensure that the view is layer-backed.
+        // Views are always layer-backed in UIKit.
+        #[cfg(target_os = "macos")]
+        let () = msg_send![view.as_ptr(), setWantsLayer: YES];
 
-        if is_valid_layer == YES {
-            main_layer
+        let root_layer: *mut Object = msg_send![view.as_ptr(), layer];
+        // `-[NSView layer]` can return `NULL`, while `-[UIView layer]` should
+        // always be available.
+        assert!(!root_layer.is_null(), "failed making the view layer-backed");
+
+        // NOTE: We explicitly do not touch properties such as
+        // `layerContentsPlacement`, `needsDisplayOnBoundsChange` and
+        // `contentsGravity` etc. on the root layer, both since we would like
+        // to give the user full control over them, and because the default
+        // values suit us pretty well (especially the contents placement being
+        // `NSViewLayerContentsRedrawDuringViewResize`, which allows the view
+        // to receive `drawRect:`/`updateLayer` calls).
+
+        let is_metal_layer: BOOL = msg_send![root_layer, isKindOfClass: class!(CAMetalLayer)];
+        if is_metal_layer == YES {
+            // The view has a `CAMetalLayer` as the root layer, which can
+            // happen for example if user overwrote `-[NSView layerClass]` or
+            // the view is `MTKView`.
+            //
+            // This is easily handled: We take "ownership" over the layer, and
+            // render directly into that; after all, the user passed a view
+            // with an explicit Metal layer to us, so this is very likely what
+            // they expect us to do.
+            root_layer
         } else {
-            // If the main layer is not a CAMetalLayer, we create a CAMetalLayer and use it.
-            let new_layer: *mut Object = msg_send![class, new];
-            let frame: CGRect = msg_send![main_layer, bounds];
+            // The view does not have a `CAMetalLayer` as the root layer (this
+            // is the default for most views).
+            //
+            // This case is trickier! We cannot use the existing layer with
+            // Metal, so we must do something else. There are a few options:
+            //
+            // 1. Panic here, and require the user to pass a view with a
+            //    `CAMetalLayer` layer.
+            //
+            //    While this would "work", it doesn't solve the problem, and
+            //    instead passes the ball onwards to the user and ecosystem to
+            //    figure it out.
+            //
+            // 2. Override the existing layer with a newly created layer.
+            //
+            //    If we overlook that this does not work in UIKit since
+            //    `UIView`'s `layer` is `readonly`, and that as such we will
+            //    need to do something different there anyhow, this is
+            //    actually a fairly good solution, and was what the original
+            //    implementation did.
+            //
+            //    It has some problems though, due to:
+            //
+            //    a. `wgpu` in our API design choosing not to register a
+            //       callback with `-[CALayerDelegate displayLayer:]`, but
+            //       instead leaves it up to the user to figure out when to
+            //       redraw. That is, we rely on other libraries' callbacks
+            //       telling us when to render.
+            //
+            //       (If this were an API only for Metal, we would probably
+            //       make the user provide a `render` closure that we'd call
+            //       in the right situations. But alas, we have to be
+            //       cross-platform here).
+            //
+            //    b. Overwriting the `layer` on `NSView` makes the view
+            //       "layer-hosting", see [wantsLayer], which disables drawing
+            //       functionality on the view like `drawRect:`/`updateLayer`.
+            //
+            //    These two in combination makes it basically impossible for
+            //    crates like Winit to provide a robust rendering callback
+            //    that integrates with the system's built-in mechanisms for
+            //    redrawing, exactly because overwriting the layer would be
+            //    implicitly disabling those mechanisms!
+            //
+            //    [wantsLayer]: https://developer.apple.com/documentation/appkit/nsview/1483695-wantslayer?language=objc
+            //
+            // 3. Create a sublayer.
+            //
+            //    `CALayer` has the concept of "sublayers", which we can use
+            //    instead of overriding the layer.
+            //
+            //    This is also the recommended solution on UIKit, so it's nice
+            //    that we can use (almost) the same implementation for these.
+            //
+            //    It _might_, however, perform ever so slightly worse than
+            //    overriding the layer directly.
+            //
+            // 4. Create a new `MTKView` (or a custom view), and add it as a
+            //    subview.
+            //
+            //    Similar to creating a sublayer (see above), but also
+            //    provides a bunch of event handling that we don't need.
+            //
+            // Option 3 seems like the most robust solution, so this is what
+            // we're going to do.
+
+            // Create a new sublayer.
+            let new_layer: *mut Object = msg_send![class!(CAMetalLayer), new];
+            let () = msg_send![root_layer, addSublayer: new_layer];
+
+            // Automatically resize the sublayer's frame to match the
+            // superlayer's bounds.
+            //
+            // Note that there is a somewhat hidden design decision in this:
+            // We define the `width` and `height` in `configure` to control
+            // the `drawableSize` of the layer, while `bounds` and `frame` are
+            // outside of the user's direct control - instead, though, they
+            // can control the size of the view (or root layer), and get the
+            // desired effect that way.
+            //
+            // We _could_ also let `configure` set the `bounds` size, however
+            // that would be inconsistent with using the root layer directly
+            // (as we may do, see above).
+            let width_sizable = 1 << 1; // kCALayerWidthSizable
+            let height_sizable = 1 << 4; // kCALayerHeightSizable
+            let mask: c_uint = width_sizable | height_sizable;
+            let () = msg_send![new_layer, setAutoresizingMask: mask];
+
+            // Specify the relative size that the auto resizing mask above
+            // will keep (i.e. tell it to fill out its superlayer).
+            let frame: CGRect = msg_send![root_layer, bounds];
             let () = msg_send![new_layer, setFrame: frame];
-            #[cfg(target_os = "ios")]
-            {
-                // Unlike NSView, UIView does not allow to replace main layer.
-                let () = msg_send![main_layer, addSublayer: new_layer];
-                // On iOS, "from_view" may be called before the application initialization is complete,
-                // `msg_send![view, window]` and `msg_send![window, screen]` will get null.
-                let screen: *mut Object = msg_send![class!(UIScreen), mainScreen];
-                let scale_factor: CGFloat = msg_send![screen, nativeScale];
-                let () = msg_send![view, setContentScaleFactor: scale_factor];
-            };
-            #[cfg(target_os = "macos")]
-            {
-                let () = msg_send![view, setLayer: new_layer];
-                let () = msg_send![view, setWantsLayer: YES];
-                let () = msg_send![new_layer, setContentsGravity: unsafe { kCAGravityTopLeft }];
-                let window: *mut Object = msg_send![view, window];
-                if !window.is_null() {
-                    let scale_factor: CGFloat = msg_send![window, backingScaleFactor];
-                    let () = msg_send![new_layer, setContentsScale: scale_factor];
-                }
-            };
+
+            let _: () = msg_send![new_layer, setContentsGravity: unsafe { kCAGravityTopLeft }];
+
+            // Set initial scale factor of the layer. This is kept in sync by
+            // `configure` (on UIKit), and the delegate below (on AppKit).
+            let scale_factor: CGFloat = msg_send![root_layer, contentsScale];
+            let () = msg_send![new_layer, setContentsScale: scale_factor];
+
             if let Some(delegate) = delegate {
                 let () = msg_send![new_layer, setDelegate: delegate.0];
             }
@@ -210,19 +306,28 @@ impl crate::Surface for super::Surface {
             _ => (),
         }
 
-        let device_raw = device.shared.device.lock();
-        // On iOS, unless the user supplies a view with a CAMetalLayer, we
-        // create one as a sublayer. However, when the view changes size,
-        // its sublayers are not automatically resized, and we must resize
-        // it here. The drawable size and the layer size don't correlate
-        #[cfg(target_os = "ios")]
+        // AppKit / UIKit automatically sets the correct scale factor for
+        // layers attached to a view. Our layer, however, may not be directly
+        // attached to the view; in those cases, we need to set the scale
+        // factor ourselves.
+        //
+        // For AppKit, we do so by adding a delegate on the layer with the
+        // `layer:shouldInheritContentsScale:fromWindow:` method returning
+        // `true` - this tells the system to automatically update the scale
+        // factor when it changes.
+        //
+        // For UIKit, we manually update the scale factor here.
+        //
+        // TODO: Is there a way that we could listen to such changes instead?
+        #[cfg(not(target_os = "macos"))]
         {
             if let Some(view) = self.view {
-                let main_layer: *mut Object = msg_send![view.as_ptr(), layer];
-                let bounds: CGRect = msg_send![main_layer, bounds];
-                let () = msg_send![*render_layer, setFrame: bounds];
+                let scale_factor: CGFloat = msg_send![view.as_ptr(), contentScaleFactor];
+                let () = msg_send![render_layer.as_ptr(), setContentsScale: scale_factor];
             }
         }
+
+        let device_raw = device.shared.device.lock();
         render_layer.set_device(&device_raw);
         render_layer.set_pixel_format(caps.map_format(config.format));
         render_layer.set_framebuffer_only(framebuffer_only);

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -230,6 +230,9 @@ impl super::Surface {
             let frame: CGRect = msg_send![root_layer, bounds];
             let () = msg_send![new_layer, setFrame: frame];
 
+            // The gravity to use when the layer's `drawableSize` isn't the
+            // same as the bounds rectangle.
+            //
             // The desired content gravity is `kCAGravityResize`, because it
             // masks / alleviates issues with resizing when
             // `present_with_transaction` is disabled, and behaves better when

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -518,7 +518,7 @@ impl super::Instance {
             )));
         }
 
-        let layer = unsafe { crate::metal::Surface::get_metal_layer(view.cast(), None) };
+        let layer = unsafe { crate::metal::Surface::get_metal_layer(view.cast()) };
         // NOTE: The layer is retained by Vulkan's `vkCreateMetalSurfaceEXT`,
         // so no need to retain it beyond the scope of this function.
         let layer_ptr = (*layer).cast();

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -510,7 +510,7 @@ impl super::Instance {
     #[cfg(metal)]
     fn create_surface_from_view(
         &self,
-        view: *mut c_void,
+        view: std::ptr::NonNull<c_void>,
     ) -> Result<super::Surface, crate::InstanceError> {
         if !self.shared.extensions.contains(&ext::metal_surface::NAME) {
             return Err(crate::InstanceError::new(String::from(
@@ -518,9 +518,7 @@ impl super::Instance {
             )));
         }
 
-        let layer = unsafe {
-            crate::metal::Surface::get_metal_layer(view.cast::<objc::runtime::Object>(), None)
-        };
+        let layer = unsafe { crate::metal::Surface::get_metal_layer(view.cast(), None) };
 
         let surface = {
             let metal_loader =
@@ -870,13 +868,13 @@ impl crate::Instance for super::Instance {
             (Rwh::AppKit(handle), _)
                 if self.shared.extensions.contains(&ext::metal_surface::NAME) =>
             {
-                self.create_surface_from_view(handle.ns_view.as_ptr())
+                self.create_surface_from_view(handle.ns_view)
             }
             #[cfg(all(target_os = "ios", feature = "metal"))]
             (Rwh::UiKit(handle), _)
                 if self.shared.extensions.contains(&ext::metal_surface::NAME) =>
             {
-                self.create_surface_from_view(handle.ui_view.as_ptr())
+                self.create_surface_from_view(handle.ui_view)
             }
             (_, _) => Err(crate::InstanceError::new(format!(
                 "window handle {window_handle:?} is not a Vulkan-compatible handle"

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -519,13 +519,16 @@ impl super::Instance {
         }
 
         let layer = unsafe { crate::metal::Surface::get_metal_layer(view.cast(), None) };
+        // NOTE: The layer is retained by Vulkan's `vkCreateMetalSurfaceEXT`,
+        // so no need to retain it beyond the scope of this function.
+        let layer_ptr = (*layer).cast();
 
         let surface = {
             let metal_loader =
                 ext::metal_surface::Instance::new(&self.shared.entry, &self.shared.raw);
             let vk_info = vk::MetalSurfaceCreateInfoEXT::default()
                 .flags(vk::MetalSurfaceCreateFlagsEXT::empty())
-                .layer(layer.cast());
+                .layer(layer_ptr);
 
             unsafe { metal_loader.create_metal_surface(&vk_info, None).unwrap() }
         };

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -5530,8 +5530,18 @@ pub struct SurfaceConfiguration<V> {
     /// `Bgra8Unorm` and `Bgra8UnormSrgb`
     pub format: TextureFormat,
     /// Width of the swap chain. Must be the same size as the surface, and nonzero.
+    ///
+    /// If this is not the same size as the underlying surface (e.g. if it is
+    /// set once, and the window is later resized), the behaviour is defined
+    /// but platform-specific, and may change in the future (currently macOS
+    /// scales the surface, other platforms may do something else).
     pub width: u32,
     /// Height of the swap chain. Must be the same size as the surface, and nonzero.
+    ///
+    /// If this is not the same size as the underlying surface (e.g. if it is
+    /// set once, and the window is later resized), the behaviour is defined
+    /// but platform-specific, and may change in the future (currently macOS
+    /// scales the surface, other platforms may do something else).
     pub height: u32,
     /// Presentation mode of the swap chain. Fifo is the only mode guaranteed to be supported.
     /// FifoRelaxed, Immediate, and Mailbox will crash if unsupported, while AutoVsync and


### PR DESCRIPTION
## Description
Overriding the `layer` on `NSView`, as is currently done, makes the view "layer-hosting", see [`wantsLayer`](https://developer.apple.com/documentation/appkit/nsview/1483695-wantslayer?language=objc).

This prevents Winit from emitting the `RedrawRequested` event at the desired frame, because overwriting the layer implicitly disables the [`drawRect:`](https://developer.apple.com/documentation/appkit/nsview/1483686-drawrect?language=objc)/[`updateLayer`](https://developer.apple.com/documentation/appkit/nsview/1483580-updatelayer?language=objc) mechanisms that we need to use. Instead, Winit is currently forced to emit the event after all other events have been processed, which is hacky, and does not integrate well with redraws.

In this PR, I've changed it so that `wgpu`, when it is given a view without a `CAMetalLayer`, instead creates a new sublayer that it renders into (as is already done on iOS).

Note that this might theoretically have a slight performance impact, since the system now has to do more state-tracking, but I suspect it's miniscule (wasn't able to measure it with `bunnymark`), and I'd argue that it's a small price to pay for correctness.

I guess that another solution would be to properly implement the `CALayerDelegate`, and call `drawRect:`/`updateLayer` in there ourselves - though that's a can of worms I'm not really prepared to open.

## Connections
Fixes https://github.com/gfx-rs/wgpu/issues/1168, mostly by using `kCAGravityResize`, but the situation will also be properly fixed in the future, since Winit can clean up its current redrawing hacks.

Related similar issues: https://github.com/gfx-rs/wgpu/issues/249, https://github.com/gfx-rs/wgpu-rs/issues/536, https://github.com/rust-windowing/glutin/issues/1340, https://github.com/rust-windowing/winit/pull/1901 and https://github.com/rust-windowing/winit/issues/2640.

Also makes the situation better for https://github.com/gfx-rs/wgpu/issues/3756, if the user enables `present_with_transaction`, resizing becomes perfectly smooth.

Finally, it removes our dependence on having access to `NSView`, paving the way for [a future where `raw-window-handle` may only provide `CALayer`](https://github.com/rust-windowing/raw-window-handle/issues/123#issuecomment-2308505694).

## Testing
See [this repo](https://github.com/madsmtm/wgpu-objc2-example) which contains roughly the "minimal" setup needed to get `wgpu` working on macOS and iOS without Winit. The crate renders a triangle whose top corner is at a fixed location from the right edge of the window, which is useful for testing that redrawing works as it should. It also has a few different features that you can try out to see how things look using some of the different methods for rendering that macOS/iOS provides. Use the `patch` key in `Cargo.toml` to test it with and without this PR.

I've also tested this with Winit on macOS and Mac Catalyst, by resizing the `hello_triangle` window, and moving it between an external monitors.

### Current behaviour:

https://github.com/user-attachments/assets/2cf9b55c-ea1f-4b9e-9e90-34c70b7176fc

### With this PR:

https://github.com/user-attachments/assets/2588ce7e-375b-4fb9-b8f9-3caccbe8138a

## Checklist

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.

## TODO (though can still be reviewed in the meantime)
- [x] Test drawing in non-fullwindow views (and maybe scaled / transformed / rotated / weird views?).
  - Tested, it's broken, see https://github.com/gfx-rs/wgpu/pull/6107#issuecomment-2319599762
  - But will be fixed by using `raw-window-metal`, or by using .
- [x] Test passing a MTKView to `wgpu`.
  - See [sample repo](https://github.com/madsmtm/wgpu-objc2-example), pass `--features=mtkview`.
- [x] Test with SDL and other such "window providers" in the Rust ecosystem? I'll need some help with this!
  - `sdl2`'s [example](https://github.com/Rust-SDL2/rust-sdl2/blob/400e033411b239de10b680f20de800dcb70e9ade/examples/raw-window-handle-with-wgpu/main.rs) seems to work fine (they're using a custom view with a `CAMetalLayer` as the root layer, so shouldn't be affected by most of this).
