### PR TITLE
Make Vulkan error handling more robust

### DIFF
--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -404,6 +404,7 @@ impl From<hal::DeviceError> for DeviceError {
             hal::DeviceError::Lost => DeviceError::Lost,
             hal::DeviceError::OutOfMemory => DeviceError::OutOfMemory,
             hal::DeviceError::ResourceCreationFailed => DeviceError::ResourceCreationFailed,
+            hal::DeviceError::Unexpected => DeviceError::Lost,
         }
     }
 }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -342,6 +342,7 @@ impl Adapter {
             hal::DeviceError::Lost => RequestDeviceError::DeviceLost,
             hal::DeviceError::OutOfMemory => RequestDeviceError::OutOfMemory,
             hal::DeviceError::ResourceCreationFailed => RequestDeviceError::Internal,
+            hal::DeviceError::Unexpected => RequestDeviceError::DeviceLost,
         })?;
 
         self.create_device_and_queue_from_hal(open, desc, instance_flags, trace_path)

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -314,6 +314,8 @@ pub enum DeviceError {
     Lost,
     #[error("Creation of a resource failed for a reason other than running out of memory.")]
     ResourceCreationFailed,
+    #[error("Unexpected error variant (driver implementation is at fault)")]
+    Unexpected,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Error)]

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -62,7 +62,12 @@ impl crate::CommandEncoder for super::CommandEncoder {
             let vk_info = vk::CommandBufferAllocateInfo::default()
                 .command_pool(self.raw)
                 .command_buffer_count(ALLOCATION_GRANULARITY);
-            let cmd_buf_vec = unsafe { self.device.raw.allocate_command_buffers(&vk_info)? };
+            let cmd_buf_vec = unsafe {
+                self.device
+                    .raw
+                    .allocate_command_buffers(&vk_info)
+                    .map_err(super::map_host_device_oom_err)?
+            };
             self.free.extend(cmd_buf_vec);
         }
         let raw = self.free.pop().unwrap();
@@ -76,7 +81,8 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
         let vk_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
-        unsafe { self.device.raw.begin_command_buffer(raw, &vk_info) }?;
+        unsafe { self.device.raw.begin_command_buffer(raw, &vk_info) }
+            .map_err(super::map_host_device_oom_err)?;
         self.active = raw;
 
         Ok(())
@@ -85,7 +91,12 @@ impl crate::CommandEncoder for super::CommandEncoder {
     unsafe fn end_encoding(&mut self) -> Result<super::CommandBuffer, crate::DeviceError> {
         let raw = self.active;
         self.active = vk::CommandBuffer::null();
-        unsafe { self.device.raw.end_command_buffer(raw) }?;
+        unsafe { self.device.raw.end_command_buffer(raw) }.map_err(map_err)?;
+        fn map_err(err: vk::Result) -> crate::DeviceError {
+            // We don't use VK_KHR_video_encode_queue
+            // VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR
+            super::map_host_device_oom_err(err)
+        }
         Ok(super::CommandBuffer { raw })
     }
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -2496,7 +2496,9 @@ impl From<gpu_alloc::MapError> for crate::DeviceError {
 }
 impl From<gpu_descriptor::AllocationError> for crate::DeviceError {
     fn from(error: gpu_descriptor::AllocationError) -> Self {
-        log::error!("descriptor allocation: {:?}", error);
-        Self::OutOfMemory
+        use gpu_descriptor::AllocationError as Ae;
+        match error {
+            Ae::OutOfDeviceMemory | Ae::OutOfHostMemory | Ae::Fragmentation => Self::OutOfMemory,
+        }
     }
 }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -322,7 +322,6 @@ impl gpu_alloc::MemoryDevice<vk::DeviceMemory> for super::DeviceShared {
             Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY) => {
                 Err(gpu_alloc::OutOfMemory::OutOfHostMemory)
             }
-            Err(vk::Result::ERROR_TOO_MANY_OBJECTS) => panic!("Too many objects"),
             Err(err) => panic!("Unexpected Vulkan error: `{err}`"),
         }
     }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -2559,7 +2559,7 @@ impl From<gpu_descriptor::AllocationError> for crate::DeviceError {
     }
 }
 
-/// We usually map unexpected vulkan errors to the [`crate::DeviceError::Lost`]
+/// We usually map unexpected vulkan errors to the [`crate::DeviceError::Unexpected`]
 /// variant to be more robust even in cases where the driver is not
 /// complying with the spec.
 ///

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -1266,14 +1266,14 @@ fn map_pipeline_err(err: vk::Result) -> crate::DeviceError {
     map_host_device_oom_err(err)
 }
 
-/// Returns [`crate::DeviceError::Lost`] or panics if the `internal_error_panic`
+/// Returns [`crate::DeviceError::Unexpected`] or panics if the `internal_error_panic`
 /// feature flag is enabled.
 fn get_unexpected_err(_err: vk::Result) -> crate::DeviceError {
     #[cfg(feature = "internal_error_panic")]
     panic!("Unexpected Vulkan error: {_err:?}");
 
     #[allow(unreachable_code)]
-    crate::DeviceError::Lost
+    crate::DeviceError::Unexpected
 }
 
 /// Returns [`crate::DeviceError::OutOfMemory`] or panics if the `oom_panic`

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -1199,3 +1199,7 @@ impl From<vk::Result> for crate::DeviceError {
         }
     }
 }
+
+fn hal_usage_error<T: fmt::Display>(txt: T) -> ! {
+    panic!("wgpu-hal invariant was violated (usage error): {txt}")
+}


### PR DESCRIPTION
This PR makes it obvious which error variants are handled and how.

This started with me looking into handling device loss in `wgpu-core` and I wanted to make sure that all variants are handled properly in `wgpu-hal` first.