### PR TITLE
Remove `allow(trivial_casts)`

### DIFF
--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -6,6 +6,8 @@ use crate::{
     proc::{self, NameKey, TypeResolution},
     valid, FastHashMap, FastHashSet,
 };
+#[cfg(test)]
+use std::ptr;
 use std::{
     fmt::{Display, Error as FmtError, Formatter, Write},
     iter,
@@ -1411,9 +1413,8 @@ impl<W: Write> Writer<W> {
     ) -> BackendResult {
         // Add to the set in order to track the stack size.
         #[cfg(test)]
-        #[allow(trivial_casts)]
         self.put_expression_stack_pointers
-            .insert(&expr_handle as *const _ as *const ());
+            .insert(ptr::from_ref(&expr_handle).cast());
 
         if let Some(name) = self.named_expressions.get(&expr_handle) {
             write!(self.out, "{name}")?;
@@ -2792,9 +2793,8 @@ impl<W: Write> Writer<W> {
     ) -> BackendResult {
         // Add to the set in order to track the stack size.
         #[cfg(test)]
-        #[allow(trivial_casts)]
         self.put_block_stack_pointers
-            .insert(&level as *const _ as *const ());
+            .insert(ptr::from_ref(&level).cast());
 
         for statement in statements {
             log::trace!("statement[{}] {:?}", level.0, statement);

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -47,7 +47,6 @@ impl super::Adapter {
         &self.raw
     }
 
-    #[allow(trivial_casts)]
     pub(super) fn expose(
         adapter: d3d12::DxgiAdapter,
         library: &Arc<d3d12::D3D12Lib>,
@@ -554,7 +553,6 @@ impl crate::Adapter for super::Adapter {
         })
     }
 
-    #[allow(trivial_casts)]
     unsafe fn texture_format_capabilities(
         &self,
         format: wgt::TextureFormat,

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -75,7 +75,6 @@ impl crate::Instance for super::Instance {
         };
 
         let mut supports_allow_tearing = false;
-        #[allow(trivial_casts)]
         if let Some(factory5) = factory.as_factory5() {
             let mut allow_tearing: minwindef::BOOL = minwindef::FALSE;
             let hr = unsafe {

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -1,6 +1,3 @@
-// Box casts are needed, alternative would be a temporaries which are more verbose and not more expressive.
-#![allow(trivial_casts)]
-
 use crate::{
     AccelerationStructureBuildSizes, AccelerationStructureDescriptor, Api, BindGroupDescriptor,
     BindGroupLayoutDescriptor, BufferDescriptor, BufferMapping, CommandEncoderDescriptor,
@@ -261,7 +258,7 @@ impl<D: Device + DynResource> DynDevice for D {
             queue: desc.queue.expect_downcast_ref(),
         };
         unsafe { D::create_command_encoder(self, &desc) }
-            .map(|b| Box::new(b) as Box<dyn DynCommandEncoder>)
+            .map(|b| -> Box<dyn DynCommandEncoder> { Box::new(b) })
     }
 
     unsafe fn destroy_command_encoder(&self, encoder: Box<dyn DynCommandEncoder>) {
@@ -273,7 +270,7 @@ impl<D: Device + DynResource> DynDevice for D {
         desc: &BindGroupLayoutDescriptor,
     ) -> Result<Box<dyn DynBindGroupLayout>, DeviceError> {
         unsafe { D::create_bind_group_layout(self, desc) }
-            .map(|b| Box::new(b) as Box<dyn DynBindGroupLayout>)
+            .map(|b| -> Box<dyn DynBindGroupLayout> { Box::new(b) })
     }
 
     unsafe fn destroy_bind_group_layout(&self, bg_layout: Box<dyn DynBindGroupLayout>) {
@@ -297,7 +294,7 @@ impl<D: Device + DynResource> DynDevice for D {
         };
 
         unsafe { D::create_pipeline_layout(self, &desc) }
-            .map(|b| Box::new(b) as Box<dyn DynPipelineLayout>)
+            .map(|b| -> Box<dyn DynPipelineLayout> { Box::new(b) })
     }
 
     unsafe fn destroy_pipeline_layout(&self, pipeline_layout: Box<dyn DynPipelineLayout>) {
@@ -345,7 +342,8 @@ impl<D: Device + DynResource> DynDevice for D {
             acceleration_structures: &acceleration_structures,
         };
 
-        unsafe { D::create_bind_group(self, &desc) }.map(|b| Box::new(b) as Box<dyn DynBindGroup>)
+        unsafe { D::create_bind_group(self, &desc) }
+            .map(|b| -> Box<dyn DynBindGroup> { Box::new(b) })
     }
 
     unsafe fn destroy_bind_group(&self, group: Box<dyn DynBindGroup>) {
@@ -358,7 +356,7 @@ impl<D: Device + DynResource> DynDevice for D {
         shader: ShaderInput,
     ) -> Result<Box<dyn DynShaderModule>, ShaderError> {
         unsafe { D::create_shader_module(self, desc, shader) }
-            .map(|b| Box::new(b) as Box<dyn DynShaderModule>)
+            .map(|b| -> Box<dyn DynShaderModule> { Box::new(b) })
     }
 
     unsafe fn destroy_shader_module(&self, module: Box<dyn DynShaderModule>) {
@@ -388,7 +386,7 @@ impl<D: Device + DynResource> DynDevice for D {
         };
 
         unsafe { D::create_render_pipeline(self, &desc) }
-            .map(|b| Box::new(b) as Box<dyn DynRenderPipeline>)
+            .map(|b| -> Box<dyn DynRenderPipeline> { Box::new(b) })
     }
 
     unsafe fn destroy_render_pipeline(&self, pipeline: Box<dyn DynRenderPipeline>) {
@@ -411,7 +409,7 @@ impl<D: Device + DynResource> DynDevice for D {
         };
 
         unsafe { D::create_compute_pipeline(self, &desc) }
-            .map(|b| Box::new(b) as Box<dyn DynComputePipeline>)
+            .map(|b| -> Box<dyn DynComputePipeline> { Box::new(b) })
     }
 
     unsafe fn destroy_compute_pipeline(&self, pipeline: Box<dyn DynComputePipeline>) {
@@ -423,7 +421,7 @@ impl<D: Device + DynResource> DynDevice for D {
         desc: &PipelineCacheDescriptor<'_>,
     ) -> Result<Box<dyn DynPipelineCache>, PipelineCacheError> {
         unsafe { D::create_pipeline_cache(self, desc) }
-            .map(|b| Box::new(b) as Box<dyn DynPipelineCache>)
+            .map(|b| -> Box<dyn DynPipelineCache> { Box::new(b) })
     }
 
     fn pipeline_cache_validation_key(&self) -> Option<[u8; 16]> {
@@ -438,7 +436,7 @@ impl<D: Device + DynResource> DynDevice for D {
         &self,
         desc: &wgt::QuerySetDescriptor<Label>,
     ) -> Result<Box<dyn DynQuerySet>, DeviceError> {
-        unsafe { D::create_query_set(self, desc) }.map(|b| Box::new(b) as Box<dyn DynQuerySet>)
+        unsafe { D::create_query_set(self, desc) }.map(|b| -> Box<dyn DynQuerySet> { Box::new(b) })
     }
 
     unsafe fn destroy_query_set(&self, query_set: Box<dyn DynQuerySet>) {
@@ -446,7 +444,7 @@ impl<D: Device + DynResource> DynDevice for D {
     }
 
     unsafe fn create_fence(&self) -> Result<Box<dyn DynFence>, DeviceError> {
-        unsafe { D::create_fence(self) }.map(|f| Box::new(f) as Box<dyn DynFence>)
+        unsafe { D::create_fence(self) }.map(|b| -> Box<dyn DynFence> { Box::new(b) })
     }
 
     unsafe fn destroy_fence(&self, fence: Box<dyn DynFence>) {
@@ -486,7 +484,7 @@ impl<D: Device + DynResource> DynDevice for D {
         desc: &AccelerationStructureDescriptor,
     ) -> Result<Box<dyn DynAccelerationStructure>, DeviceError> {
         unsafe { D::create_acceleration_structure(self, desc) }
-            .map(|b| Box::new(b) as Box<dyn DynAccelerationStructure>)
+            .map(|b| -> Box<dyn DynAccelerationStructure> { Box::new(b) })
     }
 
     unsafe fn get_acceleration_structure_build_sizes(

--- a/wgpu-hal/src/dynamic/instance.rs
+++ b/wgpu-hal/src/dynamic/instance.rs
@@ -1,6 +1,3 @@
-// Box casts are needed, alternative would be a temporaries which are more verbose and not more expressive.
-#![allow(trivial_casts)]
-
 use crate::{Api, Capabilities, ExposedAdapter, Instance, InstanceError};
 
 use super::{DynAdapter, DynResource, DynResourceExt as _, DynSurface};
@@ -50,7 +47,7 @@ impl<I: Instance + DynResource> DynInstance for I {
         window_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<Box<dyn DynSurface>, InstanceError> {
         unsafe { I::create_surface(self, display_handle, window_handle) }
-            .map(|surface| Box::new(surface) as Box<dyn DynSurface>)
+            .map(|surface| -> Box<dyn DynSurface> { Box::new(surface) })
     }
 
     unsafe fn enumerate_adapters(

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1241,7 +1241,6 @@ impl crate::Surface for Surface {
             None => {
                 let mut wl_window = None;
                 let (mut temp_xlib_handle, mut temp_xcb_handle);
-                #[allow(trivial_casts)]
                 let native_window_ptr = match (self.wsi.kind, self.raw_window_handle) {
                     (WindowKind::Unknown | WindowKind::X11, Rwh::Xlib(handle)) => {
                         temp_xlib_handle = handle.window;

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -45,11 +45,10 @@ impl HalManagedMetalLayerDelegate {
         CAML_DELEGATE_REGISTER.call_once(|| {
             type Fun = extern "C" fn(&Class, Sel, *mut Object, CGFloat, *mut Object) -> BOOL;
             let mut decl = ClassDecl::new(&class_name, class!(NSObject)).unwrap();
-            #[allow(trivial_casts)] // false positive
             unsafe {
-                decl.add_class_method(
+                decl.add_class_method::<Fun>(
                     sel!(layer:shouldInheritContentsScale:fromWindow:),
-                    layer_should_inherit_contents_scale_from_window as Fun,
+                    layer_should_inherit_contents_scale_from_window,
                 );
             }
             decl.register();

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1099,7 +1099,6 @@ impl PhysicalDeviceProperties {
 }
 
 impl super::InstanceShared {
-    #[allow(trivial_casts)] // false positives
     fn inspect(
         &self,
         phd: vk::PhysicalDevice,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1512,16 +1512,13 @@ impl crate::Device for super::Device {
                 // we can't use the safe (yet unstable) MaybeUninit::write_slice() here because of having an iterator to write
 
                 let init = {
-                    #[allow(trivial_casts)]
                     // SAFETY: The loop above has initialized exactly as many items as to_init is
                     // long, so it is safe to cast away the MaybeUninit<T> wrapper into T.
 
                     // Additional safety docs from unstable slice_assume_init_mut
                     // SAFETY: similar to safety notes for `slice_get_ref`, but we have a
                     // mutable reference which is also guaranteed to be valid for writes.
-                    unsafe {
-                        &mut *(ptr::from_mut::<[MaybeUninit<T>]>(to_init) as *mut [T])
-                    }
+                    unsafe { std::mem::transmute::<&mut [MaybeUninit<T>], &mut [T]>(to_init) }
                 };
                 (Self { remainder }, init)
             }


### PR DESCRIPTION
**Connections**

N/A

**Description**

In many portions of our codebase, we `allow(trivial_casts)` for various reasons. In all cases, they shouldn't be necessary. This PR removes them, implementing any migration of code necessary to make that fine.

**Testing**

Things still compile and run, and CI is still happy!

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ Not necessary, I think.
