### PR TITLE
Reduce code size of error handling

### DIFF
--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -326,6 +326,8 @@ trait PrettyResult {
     fn unwrap_pretty(self) -> Self::Target;
 }
 
+#[cold]
+#[inline(never)]
 fn print_err(error: &dyn Error) {
     eprint!("{error}");
 

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -278,6 +278,8 @@ pub enum Error<'a> {
 }
 
 impl<'a> Error<'a> {
+    #[cold]
+    #[inline(never)]
     pub(crate) fn as_parse_error(&self, source: &'a str) -> ParseError {
         match *self {
             Error::Unexpected(unexpected_span, expected) => {

--- a/wgpu-core/src/error.rs
+++ b/wgpu-core/src/error.rs
@@ -3,6 +3,11 @@ use std::{error::Error, sync::Arc};
 
 use thiserror::Error;
 
+#[cfg(send_sync)]
+pub type ContextErrorSource = Box<dyn Error + Send + Sync + 'static>;
+#[cfg(not(send_sync))]
+pub type ContextErrorSource = Box<dyn Error + 'static>;
+
 #[derive(Debug, Error)]
 #[error(
     "In {fn_ident}{}{}{}",
@@ -13,10 +18,7 @@ use thiserror::Error;
 pub struct ContextError {
     pub fn_ident: &'static str,
     #[source]
-    #[cfg(send_sync)]
-    pub source: Box<dyn Error + Send + Sync + 'static>,
-    #[cfg(not(send_sync))]
-    pub source: Box<dyn Error + 'static>,
+    pub source: ContextErrorSource,
     pub label: String,
 }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -1296,6 +1296,7 @@ fn get_lost_err() -> crate::DeviceError {
     crate::DeviceError::Lost
 }
 
+#[cold]
 fn hal_usage_error<T: fmt::Display>(txt: T) -> ! {
     panic!("wgpu-hal invariant was violated (usage error): {txt}")
 }


### PR DESCRIPTION
**Description**
Moves error handling to cold out-of-line functions, which prevents this code from being inlined and duplicated in a lot of callers.

**Testing**
`cargo-show-asm`, e.g. `ContextWgpuCore::device_create_pipeline_cache` that just forwards the call got a lot smaller:

```diff
--- before	2024-08-18 13:55:08
+++ after	2024-08-18 13:55:08
@@ -11,9 +11,6 @@
 	stp x0, x0, [sp, #0]
 	stp x0, x0, [sp, #0]
 	stp x0, x0, [sp, #0]
-	stp x0, x0, [sp, #0]
-	stp x0, x0, [sp, #0]
-	stp x0, x0, [sp, #0]
 	add x0, sp, #0
 	.cfi_def_cfa w0, 0
 	.cfi_offset w0, -0
@@ -22,12 +19,6 @@
 	.cfi_offset w0, -0
 	.cfi_offset w0, -0
 	.cfi_offset w0, -0
-	.cfi_offset w0, -0
-	.cfi_offset w0, -0
-	.cfi_offset w0, -0
-	.cfi_offset w0, -0
-	.cfi_offset w0, -0
-	.cfi_offset w0, -0
 	.cfi_remember_state
 	mov x0, x0
 	ldp x0, x0, [x0]
@@ -47,20 +38,22 @@
 	add x0, sp, #0
 	mov x0, #0
 	bl wgpu_core::device::global::<impl wgpu_core::global::Global>::device_create_pipeline_cache
-	add x0, sp, #0
+	ldp x0, x0, [x0, #-0]
+	ldur q0, [x0, #-0]
+	ldur q0, [x0, #-0]
+	stp q0, q0, [sp, #0]
+	ldur x0, [x0, #-0]
+	str x0, [sp, #0]
 	mov x0, #0
 	movk x0, #0, lsl #0
-	ldur x0, [x0, #-0]
-	ldur q0, [x0, #0]
-	ldur q0, [x0, #0]
-	stp q0, q0, [sp, #0]
-	ldur q0, [x0, #0]
-	str q0, [sp, #0]
-	ldr x0, [sp, #0]
 	cmp x0, x0
 	b.eq LBB0_0
-	str x0, [sp, #0]
+	ldp q0, q0, [sp, #0]
+	stp q0, q0, [x0, #-0]
+	ldr x0, [sp, #0]
+	stur x0, [x0, #-0]
 	ldr x0, [x0, #0]
+	stur x0, [x0, #-0]
 Lloh0:
 	adrp x0, ___rust_no_alloc_shim_is_unstable@GOTPAGE
 Lloh0:
@@ -70,260 +63,30 @@
 	mov w0, #0
 	bl ___rust_alloc
 	cbz x0, LBB0_0
-	mov x0, x0
-	ldp q0, q0, [sp, #0]
+	ldur q0, [x0, #-0]
+	ldur q0, [x0, #-0]
 	stp q0, q0, [x0]
-	ldr q0, [sp, #0]
+	ldur q0, [x0, #-0]
 	str q0, [x0, #0]
-Lloh0:
-	adrp x0, l_anon@PAGE
-Lloh0:
-	add x0, x0, l_anon@PAGEOFF
-	stp x0, x0, [x0, #-0]
-	cmp x0, #0
-	csel x0, xzr, x0, eq
-Lloh0:
-	adrp x0, l_anon@PAGE
-Lloh0:
-	add x0, x0, l_anon@PAGEOFF
-	csel x0, x0, x0, eq
-	mov w0, #0
-	cbz x0, LBB0_0
-	tbnz x0, #0, LBB0_0
-	ldrb wzr, [x0]
-	mov x0, x0
-	mov w0, #0
-	bl ___rust_alloc
-	mov x0, x0
-	cbnz x0, LBB0_0
-	mov w0, #0
-	mov x0, x0
-	bl alloc::alloc::handle_alloc_error
-	b LBB0_0
-	mov w0, #0
 	add x0, x0, #0
-	mov x0, x0
-	mov x0, x0
-	mov x0, x0
-	mov x0, x0
-	bl _memcpy
-	mov w0, #0
 Lloh0:
 	adrp x0, l_anon@PAGE
 Lloh0:
 	add x0, x0, l_anon@PAGEOFF
-	mov w0, #0
-	stp x0, x0, [sp, #0]
-	str x0, [sp, #0]
-	stp x0, x0, [sp, #0]
-	stp x0, x0, [sp, #0]
-	casab w0, w0, [x0]
-	cmp w0, #0
-	b.eq LBB0_0
-	mov x0, x0
-	mov w0, #0
-	movk w0, #0, lsl #0
-	bl parking_lot::raw_mutex::RawMutex::lock_slow
-LBB0_0:
-	str x0, [sp, #0]
 Lloh0:
 	adrp x0, l_anon@PAGE
 Lloh0:
 	add x0, x0, l_anon@PAGEOFF
-	add x0, sp, #0
-	mov x0, #0
-	movk x0, #0, lsl #0
-	movk x0, #0, lsl #0
-	movk x0, #0, lsl #0
-	mov x0, #0
-	movk x0, #0, lsl #0
-	movk x0, #0, lsl #0
-	movk x0, #0, lsl #0
-	mov x0, #-0
 	mov x0, x0
-	ldr x0, [x0, #0]
 	mov x0, x0
-	blr x0
-	cmp x0, x0
-	ccmp x0, x0, #0, eq
-	b.ne LBB0_0
-	ldr x0, [x0]
-	cmp x0, x0
-	b.eq LBB0_0
-LBB0_0:
-	ldr x0, [x0, #0]
 	mov x0, x0
-	blr x0
-	mov x0, x0
-	mov x0, x0
-	cbnz x0, LBB0_0
 	mov w0, #0
-	sub x0, x0, #0
-	add x0, sp, #0
-	bl wgpu::backend::wgpu_core::ContextWgpuCore::format_error
-	ldp q0, q0, [sp, #0]
-	stp q0, q0, [x0, #0]
-	ldr q0, [x0, #0]
-	str q0, [x0, #0]
-	ldr x0, [sp, #0]
-	stur x0, [x0, #-0]
-	ldrb wzr, [x0]
-	mov w0, #0
-	mov w0, #0
-	bl ___rust_alloc
-	cbz x0, LBB0_0
-	ldp q0, q0, [x0, #0]
-	stp q0, q0, [x0]
-	ldr q0, [x0, #0]
-	str q0, [x0, #0]
-	ldur x0, [x0, #-0]
-	str x0, [x0, #0]
-	ldur q0, [x0, #-0]
-	stur q0, [x0, #0]
-	ldur x0, [x0, #-0]
-	stp x0, x0, [sp, #0]
-	str x0, [sp, #0]
-	mov w0, #0
-	str x0, [sp, #0]
-	ldp x0, x0, [x0, #0]
-	lsl x0, x0, #0
-	sub x0, x0, x0, lsl #0
-	add x0, x0, x0
+	bl wgpu::backend::wgpu_core::ContextWgpuCore::handle_error_inner
 LBB0_0:
-	cbz x0, LBB0_0
-	ldurb w0, [x0, #-0]
-	sub x0, x0, #0
-	sub x0, x0, #0
-	cmp w0, #0
-	b.ne LBB0_0
-	add x0, x0, x0
-	ldr x0, [x0]
-	cmp x0, #0
-	b.ne LBB0_0
-	ldur q0, [sp, #0]
-	ldur q0, [sp, #0]
-	stp q0, q0, [x0]
-	ldur q0, [sp, #0]
-	str q0, [x0, #0]
-	b LBB0_0
-LBB0_0:
-	ldp q0, q0, [sp, #0]
-	stp q0, q0, [x0, #0]
-	ldr q0, [x0, #0]
-	str q0, [x0, #0]
 	ldr x0, [sp, #0]
-	stur x0, [x0, #-0]
-	ldrb wzr, [x0]
-	mov w0, #0
-	mov w0, #0
-	bl ___rust_alloc
-	cbz x0, LBB0_0
-	ldp q0, q0, [x0, #0]
-	stp q0, q0, [x0]
-	ldr q0, [x0, #0]
-	str q0, [x0, #0]
-	ldur x0, [x0, #-0]
-	str x0, [x0, #0]
-	stp x0, x0, [sp, #0]
-	str xzr, [sp, #0]
-	ldp x0, x0, [x0, #0]
-	lsl x0, x0, #0
-	sub x0, x0, x0, lsl #0
-	add x0, x0, x0
-	cbz x0, LBB0_0
-	ldurb w0, [x0, #-0]
-	sub x0, x0, #0
-	sub x0, x0, #0
-	cbnz w0, LBB0_0
-	add x0, x0, x0
-	ldr x0, [x0]
-	cmp x0, #0
-	b.ne LBB0_0
-	ldur q0, [sp, #0]
-	ldur q0, [sp, #0]
-	stp q0, q0, [x0]
-	ldur q0, [sp, #0]
-	str q0, [x0, #0]
-	b LBB0_0
-	ldur q0, [sp, #0]
-	ldur q0, [sp, #0]
-	stp q0, q0, [x0, #0]
-	ldur q0, [sp, #0]
-	str q0, [x0, #0]
-	ldp x0, x0, [x0, #0]
-	ldr x0, [x0, #0]
-	mov w0, #0
-	sub x0, x0, #0
-	blr x0
-	b LBB0_0
-	ldur q0, [sp, #0]
-	ldur q0, [sp, #0]
-	stp q0, q0, [x0, #0]
-	ldur q0, [sp, #0]
-	str q0, [x0, #0]
-	ldp x0, x0, [x0, #0]
-	ldr x0, [x0, #0]
-	mov w0, #0
-	sub x0, x0, #0
-	blr x0
-	b LBB0_0
-LBB0_0:
-	mov w0, #0
-	add x0, sp, #0
-	bl core::ptr::drop_in_place<wgpu::api::device::Error>
-LBB0_0:
-	mov w0, #0
-	ldr x0, [sp, #0]
-	caslb w0, wzr, [x0]
-	cmp w0, #0
-	b.eq LBB0_0
-	mov w0, #0
-	bl parking_lot::raw_mutex::RawMutex::unlock_slow
-	b LBB0_0
-LBB0_0:
-	mov w0, #0
-	add x0, sp, #0
-	bl core::ptr::drop_in_place<wgpu::api::device::Error>
-LBB0_0:
-	mov w0, #0
-	ldr x0, [sp, #0]
-	caslb w0, wzr, [x0]
-	cmp w0, #0
-	b.eq LBB0_0
-	mov w0, #0
-	bl parking_lot::raw_mutex::RawMutex::unlock_slow
-LBB0_0:
-	ldr x0, [sp, #0]
 	mov x0, #0
 	movk x0, #0, lsl #0
 	cmp x0, x0
-	b.ne LBB0_0
-	ldr x0, [sp, #0]
-	cmp x0, x0
-	b.eq LBB0_0
-	add x0, x0, x0
-	sub x0, x0, #0
-	mov x0, #0
-	add x0, x0, x0
-	cmp x0, #0
-	csel x0, x0, xzr, lo
-	sub x0, x0, #0
-	cmp x0, #0
-	b.lo LBB0_0
-	cbnz x0, LBB0_0
-	add x0, sp, #0
-	bl core::ptr::drop_in_place<wgpu_core::device::DeviceError>
-	b LBB0_0
-	ldr x0, [sp, #0]
-	cbz x0, LBB0_0
-	ldr x0, [sp, #0]
-	mov w0, #0
-	bl ___rust_dealloc
-LBB0_0:
-	ldr x0, [sp, #0]
-	mov x0, #0
-	movk x0, #0, lsl #0
-	cmp x0, x0
 	b.lt LBB0_0
 	cbz x0, LBB0_0
 	ldr x0, [sp, #0]
@@ -343,9 +106,6 @@
 	ldp x0, x0, [sp, #0]
 	ldp x0, x0, [sp, #0]
 	ldp x0, x0, [sp, #0]
-	ldp x0, x0, [sp, #0]
-	ldp x0, x0, [sp, #0]
-	ldp x0, x0, [sp, #0]
 	add sp, sp, #0
 	.cfi_def_cfa_offset 0
 	.cfi_restore w0
@@ -354,97 +114,29 @@
 	.cfi_restore w0
 	.cfi_restore w0
 	.cfi_restore w0
-	.cfi_restore w0
-	.cfi_restore w0
-	.cfi_restore w0
-	.cfi_restore w0
-	.cfi_restore w0
-	.cfi_restore w0
 	ret
 	.cfi_restore_state
 	mov w0, #0
 	mov w0, #0
 	bl alloc::alloc::handle_alloc_error
-	b LBB0_0
-	mov w0, #0
-	mov w0, #0
-	bl alloc::alloc::handle_alloc_error
-	b LBB0_0
-	bl alloc::raw_vec::capacity_overflow
-	b LBB0_0
-	mov w0, #0
-	mov w0, #0
-	bl alloc::alloc::handle_alloc_error
-LBB0_0:
 	brk #0x0
 	mov x0, x0
-	sub x0, x0, #0
-	bl core::ptr::drop_in_place<wgpu_core::error::ContextError>
-	b LBB0_0
-	bl core::panicking::panic_in_cleanup
-	mov x0, x0
 	add x0, sp, #0
 	bl core::ptr::drop_in_place<wgpu_core::pipeline::PipelineCacheDescriptor>
 	mov x0, x0
 	bl __Unwind_Resume
 	mov x0, x0
-	b LBB0_0
-	mov x0, x0
 	sub x0, x0, #0
-	bl core::ptr::drop_in_place<wgpu_core::error::ContextError>
-	ldur x0, [x0, #-0]
-	cbnz x0, LBB0_0
-LBB0_0:
-	mov w0, #0
-	b LBB0_0
-	ldur x0, [x0, #-0]
-	mov w0, #0
-	bl ___rust_dealloc
-	mov w0, #0
-	b LBB0_0
-	bl core::panicking::panic_in_cleanup
-	mov x0, x0
-	add x0, sp, #0
 	bl core::ptr::drop_in_place<wgpu_core::pipeline::CreatePipelineCacheError>
 	add x0, sp, #0
 	bl core::ptr::drop_in_place<wgpu_core::pipeline::PipelineCacheDescriptor>
 	mov x0, x0
 	bl __Unwind_Resume
 	mov x0, x0
-	sub x0, x0, #0
-	bl core::ptr::drop_in_place<alloc::boxed::Box<dyn core::error::Error+core::marker::Sync+core::marker::Send>>
-	b LBB0_0
-	mov x0, x0
-	b LBB0_0
-	mov x0, x0
 	add x0, sp, #0
 	bl core::ptr::drop_in_place<wgpu_core::pipeline::PipelineCacheDescriptor>
 	mov x0, x0
 	bl __Unwind_Resume
-	mov x0, x0
-	mov w0, #0
-LBB0_0:
-	mov w0, #0
-	ldr x0, [sp, #0]
-	caslb w0, wzr, [x0]
-	cmp w0, #0
-	b.eq LBB0_0
-	ldr x0, [sp, #0]
-	mov w0, #0
-	bl parking_lot::raw_mutex::RawMutex::unlock_slow
-LBB0_0:
-	cbz w0, LBB0_0
-LBB0_0:
-	add x0, sp, #0
-	bl core::ptr::drop_in_place<wgpu_core::error::ContextError>
-LBB0_0:
-	add x0, sp, #0
-	bl core::ptr::drop_in_place<wgpu_core::pipeline::PipelineCacheDescriptor>
-	mov x0, x0
-	bl __Unwind_Resume
-	bl core::panicking::panic_in_cleanup
 	.loh AdrpLdrGot	Lloh0, Lloh0
-	.loh AdrpAdd	Lloh0, Lloh0
-	.loh AdrpAdd	Lloh0, Lloh0
 	.loh AdrpAdd	Lloh0, Lloh0
 	.loh AdrpAdd	Lloh0, Lloh0
```

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
