### PR TITLE
Make `wgpu_test::valid` print errors it detects.

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -59,20 +59,10 @@ pub fn valid<T>(device: &wgpu::Device, callback: impl FnOnce() -> T) -> T {
     device.push_error_scope(wgpu::ErrorFilter::Validation);
     let result = callback();
     if let Some(error) = pollster::block_on(device.pop_error_scope()) {
-        use std::fmt::Write;
-        let mut message = String::new();
-        writeln!(&mut message,
-                 "`valid` block at {} encountered wgpu error",
-                 std::panic::Location::caller()).unwrap();
-        let mut error: &dyn std::error::Error = &error;
-        loop {
-            writeln!(&mut message, "{error}").unwrap();
-            let Some(source) = error.source() else {
-                break;
-            };
-            error = source;
-        }
-        panic!("{message}");
+        panic!(
+            "`valid` block at {} encountered wgpu error:\n{error}",
+            std::panic::Location::caller()
+        );
     }
 
     result


### PR DESCRIPTION
When a block passed to `wgpu_test::valid` actually raises validation errors, include the full error in the panic message.

I'm not sure this is the best place to put this. Certainly the output from the test suite when we hit this is not neat. But it seems like this is the only place that actually has the validation error in hand, so I'm not sure what else to do. It looks like this:

```
thread '<unnamed>' panicked at tests/tests/bounds_checks/buffer.rs:15:5:
`valid` block at tests/tests/bounds_checks/buffer.rs:15:5 encountered wgpu error
Validation Error

Caused by:
  In Device::create_bind_group_layout, label = 'buffer_storage'
    Too many bindings of type StorageBuffers in Stage ShaderStages(COMPUTE), limit is 0, count was 2. Check the limit `max_storage_buffers_per_shader_stage` passed to `Adapter::request_device`

In Device::create_bind_group_layout, label = 'buffer_storage'
Too many bindings of type StorageBuffers in Stage ShaderStages(COMPUTE), limit is 0, count was 2. Check the limit `max_storage_buffers_per_shader_stage` passed to `Adapter::request_device`

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[2024-08-20T19:24:25Z ERROR wgpu_test::expectations] Panic: `valid` block at tests/tests/bounds_checks/buffer.rs:15:5 encountered wgpu error
    Validation Error
    
    Caused by:
      In Device::create_bind_group_layout, label = 'buffer_storage'
        Too many bindings of type StorageBuffers in Stage ShaderStages(COMPUTE), limit is 0, count was 2. Check the limit `max_storage_buffers_per_shader_stage` passed to `Adapter::request_device`
    
    In Device::create_bind_group_layout, label = 'buffer_storage'
    Too many bindings of type StorageBuffers in Stage ShaderStages(COMPUTE), limit is 0, count was 2. Check the limit `max_storage_buffers_per_shader_stage` passed to `Adapter::request_device`
    
thread '<unnamed>' panicked at tests/src/run.rs:120:9:
tests/tests/bounds_checks/buffer.rs:5:47: test "wgpu_test::bounds_checks::buffer::buffer_storage" did not behave as expected
```

But it's definitely more helpful than not seeing the validation error.