### PR TITLE
Further error handling improvements

### DIFF
--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -681,30 +681,31 @@ pub enum ErrorFilter {
 }
 static_assertions::assert_impl_all!(ErrorFilter: Send, Sync);
 
+/// Lower level source of the error.
+///
+/// `Send + Sync` varies depending on configuration.
+#[cfg(send_sync)]
+#[cfg_attr(docsrs, doc(cfg(all())))]
+pub type ErrorSource = Box<dyn error::Error + Send + Sync + 'static>;
+/// Lower level source of the error.
+///
+/// `Send + Sync` varies depending on configuration.
+#[cfg(not(send_sync))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
+pub type ErrorSource = Box<dyn error::Error + 'static>;
+
 /// Error type
 #[derive(Debug)]
 pub enum Error {
     /// Out of memory error
     OutOfMemory {
         /// Lower level source of the error.
-        #[cfg(send_sync)]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
-        source: Box<dyn error::Error + Send + Sync + 'static>,
-        /// Lower level source of the error.
-        #[cfg(not(send_sync))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
-        source: Box<dyn error::Error + 'static>,
+        source: ErrorSource,
     },
     /// Validation error, signifying a bug in code or data
     Validation {
         /// Lower level source of the error.
-        #[cfg(send_sync)]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
-        source: Box<dyn error::Error + Send + Sync + 'static>,
-        /// Lower level source of the error.
-        #[cfg(not(send_sync))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
-        source: Box<dyn error::Error + 'static>,
+        source: ErrorSource,
         /// Description of the validation error.
         description: String,
     },
@@ -713,13 +714,7 @@ pub enum Error {
     /// These could be due to internal implementation or system limits being reached.
     Internal {
         /// Lower level source of the error.
-        #[cfg(send_sync)]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
-        source: Box<dyn error::Error + Send + Sync + 'static>,
-        /// Lower level source of the error.
-        #[cfg(not(send_sync))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
-        source: Box<dyn error::Error + 'static>,
+        source: ErrorSource,
         /// Description of the internal GPU error.
         description: String,
     },


### PR DESCRIPTION
**Connections**
More of #6126

**Description**
* Removed boxing of `default_error_handler` in `ErrorSinkRaw`, which apart form avoiding an allocation in a common case, also lets `#[track_caller]` to work for that handler. Panics will show location of the function that triggered the error. This is going to be a function in wgpu, rather than user code, because user code goes through `dyn` calls that "forget" the caller.
* Reduced code size in `handle_error_inner`.

**Testing**
If you trigger an error with the default error handler, it'll point to `handle_error`'s caller, rather than the contextless `panic!("wgpu error: {err}\n")` line.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
