### PR TITLE
Reduce size of parse error

### DIFF
--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -530,11 +530,11 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
             // Bad conversion (type cast)
             (Components::One { span, ty_inner, .. }, constructor) => {
-                let from_type = ty_inner.to_wgsl(&ctx.module.to_ctx());
+                let from_type = ty_inner.to_wgsl(&ctx.module.to_ctx()).into();
                 return Err(Error::BadTypeCast {
                     span,
                     from_type,
-                    to_type: constructor.to_error_string(ctx),
+                    to_type: constructor.to_error_string(ctx).into(),
                 });
             }
 


### PR DESCRIPTION
**Description**
Reduces size of parse error from 112 bytes to 48 bytes. This should help with stack usage during parsing, which is especially important given [the huge warning about heavy stack usage](https://docs.rs/naga/latest/naga/front/wgsl/fn.parse_str.html).

**Testing**
There's a test asserting the new size.

It has a noticeable performance improvement:

```text
front/shader: wgsl-in   time:   [5.3159 ms 5.3196 ms 5.3245 ms]
                        thrpt:  [291.07 MiB/s 291.34 MiB/s 291.54 MiB/s]
                 change:
                        time:   [-6.7480% -4.1415% -1.9554%] (p = 0.00 < 0.05)
                        thrpt:  [+1.9944% +4.3204% +7.2363%]
                        Performance has improved.
```




**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
