### PR TITLE
Preempt `unused_qualifications` lints triggered in Rust 1.80

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -100,7 +100,7 @@ use crate::{
 };
 use arrayvec::ArrayVec;
 
-use std::{borrow::Cow, mem, num::NonZeroU32, ops::Range, sync::Arc};
+use std::{borrow::Cow, mem::size_of, num::NonZeroU32, ops::Range, sync::Arc};
 use thiserror::Error;
 
 use super::{
@@ -873,7 +873,7 @@ fn multi_draw_indirect(
         .buffer_memory_init_actions
         .extend(buffer.initialization_status.read().create_action(
             &buffer,
-            offset..(offset + mem::size_of::<wgt::DrawIndirectArgs>() as u64),
+            offset..(offset + size_of::<wgt::DrawIndirectArgs>() as u64),
             MemoryInitKind::NeedsInitializedMemory,
         ));
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -29,7 +29,7 @@ use thiserror::Error;
 use wgt::{BufferAddress, DynamicOffset};
 
 use std::sync::Arc;
-use std::{fmt, mem, str};
+use std::{fmt, mem::size_of, str};
 
 use super::{bind::BinderError, memory_init::CommandBufferTextureMemoryActions};
 
@@ -854,7 +854,7 @@ fn dispatch_indirect(
         .merge_single(&buffer, hal::BufferUses::INDIRECT)?;
     buffer.check_usage(wgt::BufferUsages::INDIRECT)?;
 
-    let end_offset = offset + mem::size_of::<wgt::DispatchIndirectArgs>() as u64;
+    let end_offset = offset + size_of::<wgt::DispatchIndirectArgs>() as u64;
     if end_offset > buffer.size {
         return Err(ComputePassErrorInner::IndirectBufferOverrun {
             offset,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -45,7 +45,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use std::sync::Arc;
-use std::{borrow::Cow, fmt, iter, mem, num::NonZeroU32, ops::Range, str};
+use std::{borrow::Cow, fmt, iter, mem::size_of, num::NonZeroU32, ops::Range, str};
 
 use super::render_command::ArcRenderCommand;
 use super::{
@@ -2442,8 +2442,8 @@ fn multi_draw_indirect(
     state.is_ready(indexed)?;
 
     let stride = match indexed {
-        false => mem::size_of::<wgt::DrawIndirectArgs>(),
-        true => mem::size_of::<wgt::DrawIndexedIndirectArgs>(),
+        false => size_of::<wgt::DrawIndirectArgs>(),
+        true => size_of::<wgt::DrawIndexedIndirectArgs>(),
     };
 
     if count.is_some() {
@@ -2520,8 +2520,8 @@ fn multi_draw_indirect_count(
     state.is_ready(indexed)?;
 
     let stride = match indexed {
-        false => mem::size_of::<wgt::DrawIndirectArgs>(),
-        true => mem::size_of::<wgt::DrawIndexedIndirectArgs>(),
+        false => size_of::<wgt::DrawIndirectArgs>(),
+        true => size_of::<wgt::DrawIndexedIndirectArgs>(),
     } as u64;
 
     state

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -498,7 +498,7 @@ impl Global {
 
             let id = self
                 .surfaces
-                .prepare(wgt::Backend::Empty, id_in) // No specific backend for Surface, since it's not specific.
+                .prepare(Backend::Empty, id_in) // No specific backend for Surface, since it's not specific.
                 .assign(Arc::new(surface));
             Ok(id)
         }

--- a/wgpu-core/src/pipeline_cache.rs
+++ b/wgpu-core/src/pipeline_cache.rs
@@ -1,7 +1,9 @@
+use std::mem::size_of;
+
 use thiserror::Error;
 use wgt::AdapterInfo;
 
-pub const HEADER_LENGTH: usize = std::mem::size_of::<PipelineCacheHeader>();
+pub const HEADER_LENGTH: usize = size_of::<PipelineCacheHeader>();
 
 #[derive(Debug, PartialEq, Eq, Clone, Error)]
 #[non_exhaustive]
@@ -112,7 +114,7 @@ pub fn add_cache_header(
 
 const MAGIC: [u8; 8] = *b"WGPUPLCH";
 const HEADER_VERSION: u32 = 1;
-const ABI: u32 = std::mem::size_of::<*const ()>() as u32;
+const ABI: u32 = size_of::<*const ()>() as u32;
 
 /// The value used to fill [`PipelineCacheHeader::hash_space`]
 ///
@@ -179,10 +181,7 @@ impl PipelineCacheHeader {
         let data_size = reader.read_u64()?;
         let data_hash = reader.read_u64()?;
 
-        assert_eq!(
-            reader.total_read,
-            std::mem::size_of::<PipelineCacheHeader>()
-        );
+        assert_eq!(reader.total_read, size_of::<PipelineCacheHeader>());
 
         Some((
             PipelineCacheHeader {

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{mem::size_of, sync::Arc};
 
 use crate::{
     id::Id,
@@ -125,7 +125,7 @@ impl<T: StorageItem> Registry<T> {
     pub(crate) fn generate_report(&self) -> RegistryReport {
         let storage = self.storage.read();
         let mut report = RegistryReport {
-            element_size: std::mem::size_of::<T>(),
+            element_size: size_of::<T>(),
             ..Default::default()
         };
         report.num_allocated = self.identity.values.lock().count();

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -1,6 +1,9 @@
 use super::{conv, Command as C};
 use arrayvec::ArrayVec;
-use std::{mem, ops::Range};
+use std::{
+    mem::{self, size_of, size_of_val},
+    ops::Range,
+};
 
 #[derive(Clone, Copy, Debug, Default)]
 struct TextureSlotDesc {
@@ -82,7 +85,7 @@ impl super::CommandBuffer {
 
     fn add_push_constant_data(&mut self, data: &[u32]) -> Range<u32> {
         let data_raw =
-            unsafe { std::slice::from_raw_parts(data.as_ptr().cast(), mem::size_of_val(data)) };
+            unsafe { std::slice::from_raw_parts(data.as_ptr().cast(), size_of_val(data)) };
         let start = self.data_bytes.len();
         assert!(start < u32::MAX as usize);
         self.data_bytes.extend_from_slice(data_raw);
@@ -1083,7 +1086,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         self.prepare_draw(0);
         for draw in 0..draw_count as wgt::BufferAddress {
             let indirect_offset =
-                offset + draw * mem::size_of::<wgt::DrawIndirectArgs>() as wgt::BufferAddress;
+                offset + draw * size_of::<wgt::DrawIndirectArgs>() as wgt::BufferAddress;
             #[allow(clippy::clone_on_copy)] // False positive when cloning glow::UniformLocation
             self.cmd_buffer.commands.push(C::DrawIndirect {
                 topology: self.state.topology,
@@ -1105,8 +1108,8 @@ impl crate::CommandEncoder for super::CommandEncoder {
             wgt::IndexFormat::Uint32 => glow::UNSIGNED_INT,
         };
         for draw in 0..draw_count as wgt::BufferAddress {
-            let indirect_offset = offset
-                + draw * mem::size_of::<wgt::DrawIndexedIndirectArgs>() as wgt::BufferAddress;
+            let indirect_offset =
+                offset + draw * size_of::<wgt::DrawIndexedIndirectArgs>() as wgt::BufferAddress;
             #[allow(clippy::clone_on_copy)] // False positive when cloning glow::UniformLocation
             self.cmd_buffer.commands.push(C::DrawIndexedIndirect {
                 topology: self.state.topology,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -2,7 +2,8 @@ use super::{conv::is_layered_target, Command as C, PrivateCapabilities};
 use arrayvec::ArrayVec;
 use glow::HasContext;
 use std::{
-    mem, slice,
+    mem::size_of,
+    slice,
     sync::{atomic::Ordering, Arc},
 };
 
@@ -1012,7 +1013,7 @@ impl super::Queue {
                     let query_data = unsafe {
                         slice::from_raw_parts(
                             temp_query_results.as_ptr().cast::<u8>(),
-                            temp_query_results.len() * mem::size_of::<u64>(),
+                            temp_query_results.len() * size_of::<u64>(),
                         )
                     };
                     match dst.raw {
@@ -1576,7 +1577,7 @@ impl super::Queue {
                 //
                 // This function is absolutely sketchy and we really should be using bytemuck.
                 unsafe fn get_data<T, const COUNT: usize>(data: &[u8], offset: u32) -> &[T; COUNT] {
-                    let data_required = mem::size_of::<T>() * COUNT;
+                    let data_required = size_of::<T>() * COUNT;
 
                     let raw = &data[(offset as usize)..][..data_required];
 

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1,6 +1,6 @@
 use super::{conv, AsNative, TimestampQuerySupport};
 use crate::CommandEncoder as _;
-use std::{borrow::Cow, mem, ops::Range};
+use std::{borrow::Cow, mem::size_of, ops::Range};
 
 // has to match `Temp::binding_sizes`
 const WORD_SIZE: usize = 4;
@@ -1083,7 +1083,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         let encoder = self.state.render.as_ref().unwrap();
         for _ in 0..draw_count {
             encoder.draw_primitives_indirect(self.state.raw_primitive_type, &buffer.raw, offset);
-            offset += mem::size_of::<wgt::DrawIndirectArgs>() as wgt::BufferAddress;
+            offset += size_of::<wgt::DrawIndirectArgs>() as wgt::BufferAddress;
         }
     }
 
@@ -1104,7 +1104,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                 &buffer.raw,
                 offset,
             );
-            offset += mem::size_of::<wgt::DrawIndexedIndirectArgs>() as wgt::BufferAddress;
+            offset += size_of::<wgt::DrawIndexedIndirectArgs>() as wgt::BufferAddress;
         }
     }
 

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -3,7 +3,11 @@ use super::conv;
 use arrayvec::ArrayVec;
 use ash::vk;
 
-use std::{mem, ops::Range, slice};
+use std::{
+    mem::{self, size_of},
+    ops::Range,
+    slice,
+};
 
 const ALLOCATION_GRANULARITY: u32 = 16;
 const DST_IMAGE_LAYOUT: vk::ImageLayout = vk::ImageLayout::TRANSFER_DST_OPTIMAL;
@@ -1012,7 +1016,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                 buffer.raw,
                 offset,
                 draw_count,
-                mem::size_of::<wgt::DrawIndirectArgs>() as u32,
+                size_of::<wgt::DrawIndirectArgs>() as u32,
             )
         };
     }
@@ -1028,7 +1032,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                 buffer.raw,
                 offset,
                 draw_count,
-                mem::size_of::<wgt::DrawIndexedIndirectArgs>() as u32,
+                size_of::<wgt::DrawIndexedIndirectArgs>() as u32,
             )
         };
     }
@@ -1040,7 +1044,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         count_offset: wgt::BufferAddress,
         max_count: u32,
     ) {
-        let stride = mem::size_of::<wgt::DrawIndirectArgs>() as u32;
+        let stride = size_of::<wgt::DrawIndirectArgs>() as u32;
         match self.device.extension_fns.draw_indirect_count {
             Some(ref t) => {
                 unsafe {
@@ -1066,7 +1070,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         count_offset: wgt::BufferAddress,
         max_count: u32,
     ) {
-        let stride = mem::size_of::<wgt::DrawIndexedIndirectArgs>() as u32;
+        let stride = size_of::<wgt::DrawIndexedIndirectArgs>() as u32;
         match self.device.extension_fns.draw_indirect_count {
             Some(ref t) => {
                 unsafe {


### PR DESCRIPTION
**Connections**

Broken out from #6105.

**Description**

Removes many warning emitted by the Rust 1.80 toolchain and newer.

**Testing**
_Explain how this change is tested._

Things still compile and run!

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ Not necessary.
