### PR TITLE
hal: cargo feature to allow using `VK_GOOGLE_display_timing` unsafely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ By @wumpf in [#6069](https://github.com/gfx-rs/wgpu/pull/6069), [#6099](https://
 
 * Support constant evaluation for `firstLeadingBit` and `firstTrailingBit` numeric built-ins in WGSL. Front-ends that translate to these built-ins also benefit from constant evaluation. By @ErichDonGubler in [#5101](https://github.com/gfx-rs/wgpu/pull/5101).
 
+#### Vulkan
+
+- Allow using [VK_GOOGLE_display_timing](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html) unsafely. By @DJMcNab in [#6149](https://github.com/gfx-rs/wgpu/pull/6149)
+
 ### Bug Fixes
 
 - Fix incorrect hlsl image output type conversion. By @atlv24 in [#6123](https://github.com/gfx-rs/wgpu/pull/6123)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ By @wumpf in [#6069](https://github.com/gfx-rs/wgpu/pull/6069), [#6099](https://
 
 #### Vulkan
 
-- Allow using [VK_GOOGLE_display_timing](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html) unsafely. By @DJMcNab in [#6149](https://github.com/gfx-rs/wgpu/pull/6149)
+- Allow using [VK_GOOGLE_display_timing](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html) unsafely with the `VULKAN_GOOGLE_DISPLAY_TIMING` feature. By @DJMcNab in [#6149](https://github.com/gfx-rs/wgpu/pull/6149)
 
 ### Bug Fixes
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -105,7 +105,6 @@ device_lost_panic = []
 # Only affects the d3d12 and vulkan backends.
 internal_error_panic = []
 
-
 [[example]]
 name = "halmark"
 
@@ -205,8 +204,8 @@ features = ["wgsl-in"]
 [dev-dependencies]
 cfg-if.workspace = true
 env_logger.workspace = true
-glam.workspace = true # for ray-traced-triangle example
-winit.workspace = true # for "halmark" example
+glam.workspace = true       # for ray-traced-triangle example
+winit.workspace = true      # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 glutin.workspace = true # for "gles" example

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -209,8 +209,8 @@ features = ["wgsl-in"]
 [dev-dependencies]
 cfg-if.workspace = true
 env_logger.workspace = true
-glam.workspace = true       # for ray-traced-triangle example
-winit.workspace = true      # for "halmark" example
+glam.workspace = true # for ray-traced-triangle example
+winit.workspace = true # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 glutin.workspace = true # for "gles" example

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -105,6 +105,11 @@ device_lost_panic = []
 # Only affects the d3d12 and vulkan backends.
 internal_error_panic = []
 
+# Enable the VK_GOOGLE_display_timing Vulkan extension if supported.
+# This API has no stability guarantees.
+# https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html
+unstable_vulkan_google_display_timing = []
+
 [[example]]
 name = "halmark"
 
@@ -204,8 +209,8 @@ features = ["wgsl-in"]
 [dev-dependencies]
 cfg-if.workspace = true
 env_logger.workspace = true
-glam.workspace = true # for ray-traced-triangle example
-winit.workspace = true # for "halmark" example
+glam.workspace = true       # for ray-traced-triangle example
+winit.workspace = true      # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 glutin.workspace = true # for "gles" example

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -204,8 +204,8 @@ features = ["wgsl-in"]
 [dev-dependencies]
 cfg-if.workspace = true
 env_logger.workspace = true
-glam.workspace = true       # for ray-traced-triangle example
-winit.workspace = true      # for "halmark" example
+glam.workspace = true # for ray-traced-triangle example
+winit.workspace = true # for "halmark" example
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 glutin.workspace = true # for "gles" example

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -105,10 +105,6 @@ device_lost_panic = []
 # Only affects the d3d12 and vulkan backends.
 internal_error_panic = []
 
-# Enable the VK_GOOGLE_display_timing Vulkan extension if supported.
-# This API has no stability guarantees.
-# https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html
-unstable_vulkan_google_display_timing = []
 
 [[example]]
 name = "halmark"

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1,6 +1,6 @@
 use super::conv;
 
-use ash::{amd, ext, khr, vk};
+use ash::{amd, ext, google, khr, vk};
 use parking_lot::Mutex;
 
 use std::{collections::BTreeMap, ffi::CStr, sync::Arc};
@@ -1004,6 +1004,12 @@ impl PhysicalDeviceProperties {
             extensions.push(khr::shader_atomic_int64::NAME);
         }
 
+        #[cfg(feature = "unstable_vulkan_google_display_timing")]
+        // Support VK_GOOGLE_display_timing if it is requested *and* available.
+        if self.supports_extension(google::display_timing::NAME) {
+            extensions.push(google::display_timing::NAME);
+        }
+
         extensions
     }
 
@@ -1812,6 +1818,9 @@ impl super::Adapter {
             0, 0, 0, 0,
         ];
 
+        #[cfg(feature = "unstable_vulkan_google_display_timing")]
+        let has_display_timing = enabled_extensions.contains(&google::display_timing::NAME);
+
         let shared = Arc::new(super::DeviceShared {
             raw: raw_device,
             family_index,
@@ -1821,6 +1830,8 @@ impl super::Adapter {
             instance: Arc::clone(&self.instance),
             physical_device: self.raw,
             enabled_extensions: enabled_extensions.into(),
+            #[cfg(feature = "unstable_vulkan_google_display_timing")]
+            has_google_display_timing_extension: has_display_timing,
             extension_fns: super::DeviceExtensionFunctions {
                 debug_utils: debug_utils_fn,
                 draw_indirect_count: indirect_count_fn,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1011,7 +1011,7 @@ impl PhysicalDeviceProperties {
 
         // Require `VK_GOOGLE_display_timing` if the associated feature was requested
         if requested_features.contains(wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING) {
-            extensions.push(ash::google::display_timing::NAME);
+            extensions.push(google::display_timing::NAME);
         }
 
         extensions

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1009,7 +1009,7 @@ impl PhysicalDeviceProperties {
             extensions.push(khr::shader_atomic_int64::NAME);
         }
 
-        // Require `VK_GOOGLE_display_timing` if the associated feature was requested
+        // Require VK_GOOGLE_display_timing if the associated feature was requested
         if requested_features.contains(wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING) {
             extensions.push(google::display_timing::NAME);
         }

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1,6 +1,6 @@
 use super::conv;
 
-use ash::{amd, ext, google, khr, vk};
+use ash::{amd, ext, khr, vk};
 use parking_lot::Mutex;
 
 use std::{collections::BTreeMap, ffi::CStr, sync::Arc};
@@ -1006,8 +1006,8 @@ impl PhysicalDeviceProperties {
 
         #[cfg(feature = "unstable_vulkan_google_display_timing")]
         // Support VK_GOOGLE_display_timing if it is requested *and* available.
-        if self.supports_extension(google::display_timing::NAME) {
-            extensions.push(google::display_timing::NAME);
+        if self.supports_extension(ash::google::display_timing::NAME) {
+            extensions.push(ash::google::display_timing::NAME);
         }
 
         extensions
@@ -1819,7 +1819,7 @@ impl super::Adapter {
         ];
 
         #[cfg(feature = "unstable_vulkan_google_display_timing")]
-        let has_display_timing = enabled_extensions.contains(&google::display_timing::NAME);
+        let has_display_timing = enabled_extensions.contains(&ash::google::display_timing::NAME);
 
         let shared = Arc::new(super::DeviceShared {
             raw: raw_device,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -642,7 +642,6 @@ impl super::Device {
             view_formats: wgt_view_formats,
             surface_semaphores,
             next_semaphore_index: 0,
-            #[cfg(feature = "unstable_vulkan_google_display_timing")]
             next_present_times: None,
         })
     }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -642,6 +642,7 @@ impl super::Device {
             view_formats: wgt_view_formats,
             surface_semaphores,
             next_semaphore_index: 0,
+            next_present_times: None,
         })
     }
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -642,6 +642,7 @@ impl super::Device {
             view_formats: wgt_view_formats,
             surface_semaphores,
             next_semaphore_index: 0,
+            #[cfg(feature = "unstable_vulkan_google_display_timing")]
             next_present_times: None,
         })
     }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -642,7 +642,7 @@ impl super::Device {
             view_formats: wgt_view_formats,
             surface_semaphores,
             next_semaphore_index: 0,
-            next_present_times: None,
+            next_present_time: None,
         })
     }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -357,7 +357,7 @@ struct Swapchain {
     next_semaphore_index: usize,
     /// The times which will be set in the next present times.
     ///
-    /// SAFETY: This is only set if [wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING] is enabled, and
+    /// SAFETY: This is only set if [`wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING`] is enabled, and
     /// so the `VK_GOOGLE_display_timing` extension is present.
     next_present_times: Option<vk::PresentTimeGOOGLE>,
 }
@@ -383,7 +383,7 @@ pub struct Surface {
 impl Surface {
     /// Get the raw Vulkan swapchain associated with this surface.
     ///
-    /// Returns `None` if the surface is not configured.
+    /// Returns [`None`] if the surface is not configured.
     pub fn raw_swapchain(&self) -> Option<vk::SwapchainKHR> {
         let read = self.swapchain.read();
         read.as_ref().map(|it| it.raw)
@@ -1206,7 +1206,7 @@ impl crate::Queue for Queue {
             display_timing = vk::PresentTimesInfoGOOGLE::default();
             present_times = [present_time];
             display_timing = display_timing.times(&present_times);
-            // Safety: We know that VK_GOOGLE_display_timing is present because of the safety contract on `next_present_times`.
+            // SAFETY: We know that VK_GOOGLE_display_timing is present because of the safety contract on `next_present_times`.
             vk_info.push_next(&mut display_timing)
         } else {
             vk_info

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -355,9 +355,9 @@ struct Swapchain {
     /// index as the image index, but we need to specify the semaphore as an argument
     /// to the acquire_next_image function which is what tells us which image to use.
     next_semaphore_index: usize,
-    /// The present timing information which will be set in the next call to [`present`](crate::Queue::present).
+    /// The present timing information which will be set in the next call to [`present()`](crate::Queue::present()).
     ///
-    /// # SAFETY
+    /// # Safety
     ///
     /// This must only be set if [`wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING`] is enabled, and
     /// so the VK_GOOGLE_display_timing extension is present.
@@ -1215,9 +1215,8 @@ impl crate::Queue for Queue {
                     .contains(wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING),
                 "`next_present_times` should only be set if `VULKAN_GOOGLE_DISPLAY_TIMING` is enabled"
             );
-            display_timing = vk::PresentTimesInfoGOOGLE::default();
             present_times = [present_time];
-            display_timing = display_timing.times(&present_times);
+            display_timing = vk::PresentTimesInfoGOOGLE::default().times(&present_times);
             // SAFETY: We know that VK_GOOGLE_display_timing is present because of the safety contract on `next_present_times`.
             vk_info.push_next(&mut display_timing)
         } else {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -40,10 +40,7 @@ use std::{
 };
 
 use arrayvec::ArrayVec;
-use ash::{
-    ext, khr,
-    vk::{self, PresentTimeGOOGLE},
-};
+use ash::{ext, khr, vk};
 use parking_lot::{Mutex, RwLock};
 use wgt::InternalCounter;
 
@@ -359,7 +356,7 @@ struct Swapchain {
     /// to the acquire_next_image function which is what tells us which image to use.
     next_semaphore_index: usize,
     #[cfg(feature = "unstable_vulkan_google_display_timing")]
-    next_present_times: Option<PresentTimeGOOGLE>,
+    next_present_times: Option<vk::PresentTimeGOOGLE>,
 }
 
 impl Swapchain {
@@ -398,7 +395,7 @@ impl Surface {
     /// If the surface hasn't been configured.
     #[cfg(feature = "unstable_vulkan_google_display_timing")]
     #[track_caller]
-    pub fn set_next_present_times(&self, present_timing: PresentTimeGOOGLE) {
+    pub fn set_next_present_times(&self, present_timing: vk::PresentTimeGOOGLE) {
         let mut swapchain = self.swapchain.write();
         let swapchain = swapchain
             .as_mut()

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -361,7 +361,7 @@ struct Swapchain {
     ///
     /// This must only be set if [`wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING`] is enabled, and
     /// so the VK_GOOGLE_display_timing extension is present.
-    next_present_times: Option<vk::PresentTimeGOOGLE>,
+    next_present_time: Option<vk::PresentTimeGOOGLE>,
 }
 
 impl Swapchain {
@@ -415,7 +415,7 @@ impl Surface {
             .expect("Surface should have been configured");
         let features = wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING;
         if swapchain.device.features.contains(features) {
-            swapchain.next_present_times = Some(present_timing);
+            swapchain.next_present_time = Some(present_timing);
         } else {
             // Ideally we'd use something like `device.required_features` here, but that's in `wgpu-core`, which we are a dependency of
             panic!("Tried to set display timing properties without the corresponding feature ({features:?}) enabled.");
@@ -1208,7 +1208,7 @@ impl crate::Queue for Queue {
 
         let mut display_timing;
         let present_times;
-        let vk_info = if let Some(present_time) = ssc.next_present_times.take() {
+        let vk_info = if let Some(present_time) = ssc.next_present_time.take() {
             debug_assert!(
                 ssc.device
                     .features

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -358,7 +358,7 @@ struct Swapchain {
     /// The times which will be set in the next present times.
     ///
     /// SAFETY: This is only set if [wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING] is enabled, and
-    /// so `VK_GOOGLE_display_timing` is set.
+    /// so the `VK_GOOGLE_display_timing` extension is present.
     next_present_times: Option<vk::PresentTimeGOOGLE>,
 }
 
@@ -1193,6 +1193,7 @@ impl crate::Queue for Queue {
             .swapchains(&swapchains)
             .image_indices(&image_indices)
             .wait_semaphores(swapchain_semaphores.get_present_wait_semaphores());
+
         let mut display_timing;
         let present_times;
         let vk_info = if let Some(present_time) = ssc.next_present_times.take() {
@@ -1210,6 +1211,7 @@ impl crate::Queue for Queue {
         } else {
             vk_info
         };
+
         let suboptimal = {
             profiling::scope!("vkQueuePresentKHR");
             unsafe { self.swapchain_fn.queue_present(self.raw, &vk_info) }.map_err(|error| {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -391,7 +391,15 @@ impl Surface {
         read.as_ref().map(|it| it.raw)
     }
 
-    /// Set the present timing information which will be used for the next presentation using [VK_GOOGLE_display_timing].
+    /// Set the present timing information which will be used for the next [presentation](crate::Queue::present) of this surface,
+    /// using [VK_GOOGLE_display_timing].
+    ///
+    /// This can be used to give an id to presentations, for future use of `VkPastPresentationTimingGOOGLE`.
+    /// Note that `wgpu-hal` does *not* provide a way to use that API - you should manually access this through `ash`.
+    ///
+    /// This can also be used to add a "not before" timestamp to the presentation.
+    ///
+    /// The exact semantics of the fields are also documented in the [specification](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPresentTimeGOOGLE.html) for the extension.
     ///
     /// # Panics
     ///
@@ -400,7 +408,7 @@ impl Surface {
     ///
     /// [VK_GOOGLE_display_timing]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html
     #[track_caller]
-    pub fn set_next_present_times(&self, present_timing: vk::PresentTimeGOOGLE) {
+    pub fn set_next_present_time(&self, present_timing: vk::PresentTimeGOOGLE) {
         let mut swapchain = self.swapchain.write();
         let swapchain = swapchain
             .as_mut()

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -357,8 +357,10 @@ struct Swapchain {
     next_semaphore_index: usize,
     /// The times which will be set in the next present times.
     ///
-    /// SAFETY: This is only set if [`wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING`] is enabled, and
-    /// so the `VK_GOOGLE_display_timing` extension is present.
+    /// # SAFETY
+    ///
+    /// This must only be set if [`wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING`] is enabled, and
+    /// so the VK_GOOGLE_display_timing extension is present.
     next_present_times: Option<vk::PresentTimeGOOGLE>,
 }
 
@@ -389,12 +391,14 @@ impl Surface {
         read.as_ref().map(|it| it.raw)
     }
 
-    /// Set the present timing information which will be used for the next presentation using `VK_GOOGLE_display_timing`.
+    /// Set the present timing information which will be used for the next presentation using [VK_GOOGLE_display_timing].
     ///
     /// # Panics
     ///
     /// - If the surface hasn't been configured.
     /// - If the device doesn't [support present timing](wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING).
+    ///
+    /// [VK_GOOGLE_display_timing]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html
     #[track_caller]
     pub fn set_next_present_times(&self, present_timing: vk::PresentTimeGOOGLE) {
         let mut swapchain = self.swapchain.write();

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -375,6 +375,16 @@ pub struct Surface {
     swapchain: RwLock<Option<Swapchain>>,
 }
 
+impl Surface {
+    /// Get the raw Vulkan swapchain associated with this surface.
+    ///
+    /// Returns `None` if the surface is not configured.
+    pub fn raw_swapchain(&self) -> Option<vk::SwapchainKHR> {
+        let read = self.swapchain.read();
+        read.as_ref().map(|it| it.raw)
+    }
+}
+
 #[derive(Debug)]
 pub struct SurfaceTexture {
     index: u32,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -355,7 +355,7 @@ struct Swapchain {
     /// index as the image index, but we need to specify the semaphore as an argument
     /// to the acquire_next_image function which is what tells us which image to use.
     next_semaphore_index: usize,
-    /// The times which will be set in the next present times.
+    /// The present timing information which will be set in the next call to [`present`](crate::Queue::present).
     ///
     /// # SAFETY
     ///

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -953,10 +953,12 @@ bitflags::bitflags! {
         /// This is a native only feature.
         const SHADER_INT64_ATOMIC_ALL_OPS = 1 << 61;
         /// Allows using the [VK_GOOGLE_display_timing] Vulkan extension.
+        ///
         /// This is used for frame pacing to reduce latency, and is generally only available on Android.
         ///
-        /// This feature does not have a `wgpu`-level API, and must be accessed via `wgpu-hal`,
-        /// through various `as_hal` functions.
+        /// This feature does not have a `wgpu`-level API, and so users of wgpu wishing
+        /// to use this functionality must access it using various `as_hal` functions,
+        /// primarily [`Surface::as_hal`], to then use.
         ///
         /// Supported platforms:
         /// - Vulkan (with [VK_GOOGLE_display_timing])
@@ -964,6 +966,7 @@ bitflags::bitflags! {
         /// This is a native only feature.
         ///
         /// [VK_GOOGLE_display_timing]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html
+        /// [`Surface::as_hal`]: https://docs.rs/wgpu/latest/wgpu/struct.Surface.html#method.as_hal
         const VULKAN_GOOGLE_DISPLAY_TIMING = 1 << 62;
     }
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -952,6 +952,19 @@ bitflags::bitflags! {
         ///
         /// This is a native only feature.
         const SHADER_INT64_ATOMIC_ALL_OPS = 1 << 61;
+        /// Allows using the [VK_GOOGLE_display_timing] Vulkan extension.
+        /// This is used for frame pacing to reduce latency, and is generally only available on Android.
+        ///
+        /// This feature does not have a `wgpu`-level API, and must be accessed via `wgpu-hal`,
+        /// through various `as_hal` functions.
+        ///
+        /// Supported platforms:
+        /// - Vulkan (with [VK_GOOGLE_display_timing])
+        ///
+        /// This is a native only feature.
+        ///
+        /// [VK_GOOGLE_display_timing]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html
+        const VULKAN_GOOGLE_DISPLAY_TIMING = 1 << 62;
     }
 }
 


### PR DESCRIPTION
**Connections**
- https://raphlinus.github.io/ui/graphics/gpu/2021/10/22/swapchain-frame-pacing.html
- [#gpu > Latency Investigation](https://xi.zulipchat.com/#narrow/stream/197075-gpu/topic/Latency.20Investigation) on the Linebender Zulip.
- https://github.com/gfx-rs/wgpu/issues/2869

**Description**
In many applications, you need to do frame pacing properly to get acceptable latency performance.
On Android, this is exposed through the [VK_GOOGLE_display_timing](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html) device extension. However, for applications using `wgpu`, it is currently impossible to use this extension for three reasons, each of which are addressed in this PR:
1) It is impossible to access the raw vulkan swapchain object (e.g. to call [`vkGetPastPresentationTimingGOOGLE`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetPastPresentationTimingGOOGLE.html)
2) It is impossible to create a device with this extension enabled.
3) It is impossible to extend the `present` call with the [`VkPresentTimesInfoGOOGLE`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPresentTimesInfoGOOGLE.html)

The solution here addresses the first of these by adding a `raw_swapchain` method to `wgpu_hal::vulkan::Surface`.
The remaining two are addressed using targeted hacks, both protected by the new perma-unstable `wgpu-hal` feature `unstable_vulkan_google_display_timing`. The extension is always enabled if available when the feature is set, and the additional present information for the "next" presentation is cached on the `wgpu-hal::vulkan::Surface` object, which will be accessed using [`wgpu::Surface::as_hal`](https://docs.rs/wgpu/latest/wgpu/struct.Surface.html#method.as_hal).

This PR does not change the high-level `wgpu` API, and instead requires users of this feature to add a dependency on `wgpu-hal` themselves.

**Testing**
This feature is currently not tested. My intention is to integrate this PR with [Vello](https://github.com/linebender/vello/) before this is merged.

I don't think it is possible to automate testing of this PR, as we do not have any tests running on Android, and only MoltenVK implements this outside of Android.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown` N/A
  - [ ] `--target wasm32-unknown-emscripten` N/A
- [ ] Run `cargo xtask test` to run tests. These kill my editor and any terminal emulator at the moment, but I can't imagine this changes anything.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
