### PR TITLE
[wgpu-hal] Allow importing external WGL contexts as with EGL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ By @teoxoy [#6134](https://github.com/gfx-rs/wgpu/pull/6134).
 
 - Replace `winapi` code in WGL wrapper to use the `windows` crate. By @MarijnS95 in [#6006](https://github.com/gfx-rs/wgpu/pull/6006)
 - Update `glutin` to `0.31` with `glutin-winit` crate. By @MarijnS95 in [#6150](https://github.com/gfx-rs/wgpu/pull/6150) and [#6176](https://github.com/gfx-rs/wgpu/pull/6176)
+- Implement `Adapter::new_external()` for WGL (just like EGL) to import an external OpenGL ES context. By @MarijnS95 in [#6152](https://github.com/gfx-rs/wgpu/pull/6152)
 
 #### DX12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,12 +1330,14 @@ dependencies = [
  "core-foundation",
  "dispatch",
  "glutin_egl_sys",
+ "glutin_wgl_sys 0.5.0",
  "icrate",
  "libloading",
  "objc2",
  "once_cell",
  "raw-window-handle 0.5.2",
  "wayland-sys",
+ "windows-sys 0.48.0",
  "x11-dl",
 ]
 
@@ -1359,6 +1361,15 @@ checksum = "77cc5623f5309ef433c3dd4ca1223195347fe62c413da8e2fdd0eb76db2d9bcd"
 dependencies = [
  "gl_generator",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
+dependencies = [
+ "gl_generator",
 ]
 
 [[package]]
@@ -3669,7 +3680,7 @@ dependencies = [
  "glow",
  "glutin",
  "glutin-winit",
- "glutin_wgl_sys",
+ "glutin_wgl_sys 0.6.0",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -206,8 +206,8 @@ env_logger.workspace = true
 glam.workspace = true # for ray-traced-triangle example
 winit.workspace = true # for "halmark" example
 
-[target.'cfg(not(any(target_arch = "wasm32", windows, target_os = "ios")))'.dev-dependencies]
-glutin-winit = { workspace = true, features = ["egl", "wayland", "x11"] } # for "raw-gles" example
-glutin = { workspace = true, features = ["egl", "wayland", "x11"] } # for "raw-gles" example
+[target.'cfg(not(any(target_arch = "wasm32", target_os = "ios")))'.dev-dependencies]
+glutin-winit = { workspace = true, features = ["egl", "wgl", "wayland", "x11"] } # for "raw-gles" example
+glutin = { workspace = true, features = ["egl", "wgl", "wayland", "x11"] } # for "raw-gles" example
 rwh_05 = { version = "0.5", package = "raw-window-handle" } # temporary compatibility for glutin-winit in "raw-gles" example
 winit = { workspace = true, features = ["rwh_05"] } # for "raw-gles" example

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -10,7 +10,7 @@
 
 extern crate wgpu_hal as hal;
 
-#[cfg(not(any(windows, target_arch = "wasm32", target_os = "ios")))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
 fn main() {
     use std::{ffi::CString, num::NonZeroU32};
 
@@ -255,7 +255,6 @@ fn main() {
 }
 
 #[cfg(any(
-    windows,
     all(target_arch = "wasm32", not(target_os = "emscripten")),
     target_os = "ios"
 ))]
@@ -264,7 +263,6 @@ fn main() {
 }
 
 #[cfg(not(any(
-    windows,
     all(target_arch = "wasm32", not(target_os = "emscripten")),
     target_os = "ios"
 )))]

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -379,7 +379,7 @@ struct EglContextLock<'a> {
     display: khronos_egl::Display,
 }
 
-/// A guard containing a lock to an [`AdapterContext`]
+/// A guard containing a lock to an [`AdapterContext`], while the GL context is kept current.
 pub struct AdapterContextLock<'a> {
     glow: MutexGuard<'a, ManuallyDrop<glow::Context>>,
     egl: Option<EglContextLock<'a>>,
@@ -1082,7 +1082,9 @@ impl crate::Instance for Instance {
             unsafe { gl.debug_message_callback(super::gl_debug_message_callback) };
         }
 
-        // Avoid accidental drop when the context is not current.
+        // Wrap in ManuallyDrop to make it easier to "current" the GL context before dropping this
+        // GLOW context, which could also happen if a panic occurs after we uncurrent the context
+        // below but before AdapterContext is constructed.
         let gl = ManuallyDrop::new(gl);
         inner.egl.unmake_current();
 


### PR DESCRIPTION
**Connections**
Depends on #6150

**Description**
Allows importing an external WGL context into `wgpu` to run the `raw-gles` example.

**Testing**
```shell
cargo r --example raw-gles
```

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
