### PR TITLE
Vulkan: create texture from d3d11 shared handle

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -903,6 +903,11 @@ impl PhysicalDeviceProperties {
             if requested_features.contains(wgt::Features::TEXTURE_FORMAT_NV12) {
                 extensions.push(khr::sampler_ycbcr_conversion::NAME);
             }
+
+            // Optional `VK_KHR_external_memory_win32`
+            if self.supports_extension(khr::external_memory_win32::NAME) {
+                extensions.push(khr::external_memory_win32::NAME);
+            }
         }
 
         if self.device_api_version < vk::API_VERSION_1_2 {
@@ -1539,6 +1544,8 @@ impl super::Instance {
                 }),
             image_format_list: phd_capabilities.device_api_version >= vk::API_VERSION_1_2
                 || phd_capabilities.supports_extension(khr::image_format_list::NAME),
+            external_memory_win32: phd_capabilities.device_api_version >= vk::API_VERSION_1_1
+                || phd_capabilities.supports_extension(khr::external_memory_win32::NAME),
         };
         let capabilities = crate::Capabilities {
             limits: phd_capabilities.to_wgpu_limits(),

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1544,6 +1544,7 @@ impl super::Instance {
                 }),
             image_format_list: phd_capabilities.device_api_version >= vk::API_VERSION_1_2
                 || phd_capabilities.supports_extension(khr::image_format_list::NAME),
+            #[cfg(windows)]
             external_memory_win32: phd_capabilities.device_api_version >= vk::API_VERSION_1_1
                 || phd_capabilities.supports_extension(khr::external_memory_win32::NAME),
         };

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1545,8 +1545,8 @@ impl super::Instance {
             image_format_list: phd_capabilities.device_api_version >= vk::API_VERSION_1_2
                 || phd_capabilities.supports_extension(khr::image_format_list::NAME),
             #[cfg(windows)]
-            external_memory_win32: phd_capabilities.device_api_version >= vk::API_VERSION_1_1
-                || phd_capabilities.supports_extension(khr::external_memory_win32::NAME),
+            external_memory_win32: phd_capabilities
+                .supports_extension(khr::external_memory_win32::NAME),
         };
         let capabilities = crate::Capabilities {
             limits: phd_capabilities.to_wgpu_limits(),

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -903,11 +903,6 @@ impl PhysicalDeviceProperties {
             if requested_features.contains(wgt::Features::TEXTURE_FORMAT_NV12) {
                 extensions.push(khr::sampler_ycbcr_conversion::NAME);
             }
-
-            // Optional `VK_KHR_external_memory_win32`
-            if self.supports_extension(khr::external_memory_win32::NAME) {
-                extensions.push(khr::external_memory_win32::NAME);
-            }
         }
 
         if self.device_api_version < vk::API_VERSION_1_2 {
@@ -973,6 +968,11 @@ impl PhysicalDeviceProperties {
         // Optional `VK_EXT_robustness2`
         if self.supports_extension(ext::robustness2::NAME) {
             extensions.push(ext::robustness2::NAME);
+        }
+
+        // Optional `VK_KHR_external_memory_win32`
+        if self.supports_extension(khr::external_memory_win32::NAME) {
+            extensions.push(khr::external_memory_win32::NAME);
         }
 
         // Require `VK_KHR_draw_indirect_count` if the associated feature was requested

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -699,8 +699,8 @@ impl super::Device {
     #[cfg(windows)]
     fn find_memory_type_index(
         &self,
-        type_bits: u32,
-        flags: vk::MemoryPropertyFlags,
+        type_bits_req: u32,
+        flags_req: vk::MemoryPropertyFlags,
     ) -> Option<usize> {
         let mem_properties = unsafe {
             self.shared
@@ -711,7 +711,10 @@ impl super::Device {
 
         // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceMemoryProperties.html
         for (i, mem_ty) in mem_properties.memory_types_as_slice().iter().enumerate() {
-            if type_bits & (1 << i) != 0 && mem_ty.property_flags & flags == flags {
+            let types_bits = 1 << i;
+            let is_required_memory_type = type_bits_req & types_bits != 0;
+            let has_required_properties = mem_ty.property_flags & flags_req == flags_req;
+            if is_required_memory_type && has_required_properties {
                 return Some(i);
             }
         }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -800,13 +800,19 @@ impl super::Device {
     }
 
     /// # Safety
-    /// The `d3d11_shared_handle` must be valid and respecting `desc`.
+    ///
+    /// - Vulkan 1.1+ (or VK_KHR_external_memory)
+    /// - The `d3d11_shared_handle` must be valid and respecting `desc`
     #[cfg(windows)]
     pub unsafe fn texture_from_d3d11_shared_handle(
         &self,
         d3d11_shared_handle: *mut std::ffi::c_void,
         desc: &crate::TextureDescriptor,
     ) -> Result<super::Texture, crate::DeviceError> {
+        if !self.shared.private_caps.external_memory_win32 {
+            return Err(crate::DeviceError::ResourceCreationFailed);
+        }
+
         let mut external_memory_image_info = vk::ExternalMemoryImageCreateInfo::default()
             .handle_types(vk::ExternalMemoryHandleTypeFlags::D3D11_TEXTURE_KMT);
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1255,7 +1255,7 @@ impl crate::Device for super::Device {
             unsafe { self.shared.raw.destroy_image(texture.raw, None) };
         }
         if let Some(memory) = texture.external_memory {
-            self.shared.raw.free_memory(memory, None);
+            unsafe { self.shared.raw.free_memory(memory, None) };
         }
         if let Some(block) = texture.block {
             self.counters.texture_memory.sub(block.size() as isize);

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -697,16 +697,17 @@ impl super::Device {
     }
 
     #[cfg(windows)]
-    unsafe fn find_memory_type_index(
+    fn find_memory_type_index(
         &self,
         type_bits: u32,
         flags: vk::MemoryPropertyFlags,
     ) -> Option<usize> {
-        let mem_properties = self
-            .shared
-            .instance
-            .raw
-            .get_physical_device_memory_properties(self.shared.physical_device);
+        let mem_properties = unsafe {
+            self.shared
+                .instance
+                .raw
+                .get_physical_device_memory_properties(self.shared.physical_device)
+        };
 
         for (i, mem_ty) in mem_properties
             .memory_types_as_slice()

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -723,11 +723,11 @@ impl super::Device {
     }
 
     /// # Safety
-    ///
+    /// The `d3d11_shared_handle` must be valid and respecting `desc`.
     #[cfg(windows)]
     pub unsafe fn texture_from_d3d11_shared_handle(
         &self,
-        d3d11_shared_handle: vk::HANDLE,
+        d3d11_shared_handle: *mut std::ffi::c_void,
         desc: &crate::TextureDescriptor,
     ) -> ash::prelude::VkResult<super::Texture> {
         let copy_size = desc.copy_extent();
@@ -786,7 +786,7 @@ impl super::Device {
 
         let mut import_memory_info = vk::ImportMemoryWin32HandleInfoKHR::default()
             .handle_type(vk::ExternalMemoryHandleTypeFlags::D3D11_TEXTURE_KMT)
-            .handle(d3d11_shared_handle);
+            .handle(d3d11_shared_handle as _);
 
         let Some(mem_type_index) = self
             .find_memory_type_index(req.memory_type_bits, vk::MemoryPropertyFlags::DEVICE_LOCAL)

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -1095,6 +1095,7 @@ impl crate::Surface for super::Surface {
                 raw: swapchain.images[index as usize],
                 drop_guard: None,
                 block: None,
+                external_memory: None,
                 usage: swapchain.config.usage,
                 format: swapchain.config.format,
                 raw_flags,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -532,6 +532,7 @@ struct PrivateCapabilities {
     robust_image_access2: bool,
     zero_initialize_workgroup_memory: bool,
     image_format_list: bool,
+    #[cfg(windows)]
     external_memory_win32: bool,
 }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -760,6 +760,7 @@ impl crate::DynAccelerationStructure for AccelerationStructure {}
 pub struct Texture {
     raw: vk::Image,
     drop_guard: Option<crate::DropGuard>,
+    external_memory: Option<vk::DeviceMemory>,
     block: Option<gpu_alloc::MemoryBlock<vk::DeviceMemory>>,
     usage: crate::TextureUses,
     format: wgt::TextureFormat,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -532,6 +532,7 @@ struct PrivateCapabilities {
     robust_image_access2: bool,
     zero_initialize_workgroup_memory: bool,
     image_format_list: bool,
+    external_memory_win32: bool,
 }
 
 bitflags::bitflags!(


### PR DESCRIPTION
**Description**
[VK_KHR_external_memory_win32](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_memory_win32.html) extension enables application to import Vulkan memory objects from Windows handles.

**Testing**
1. Create D3D11 texture with [D3D11_RESOURCE_MISC_SHARED_NTHANDLE](https://learn.microsoft.com/en-us/windows/desktop/api/d3d11/ne-d3d11-d3d11_resource_misc_flag) and [D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX](https://learn.microsoft.com/en-us/windows/desktop/api/d3d11/ne-d3d11-d3d11_resource_misc_flag) flags
2. Create shared handle with [IDXGIResource1::CreateSharedHandle](https://learn.microsoft.com/en-us/windows/desktop/api/dxgi1_2/nf-dxgi1_2-idxgiresource1-createsharedhandle)
3. Create vulkan texture with `texture_from_d3d11_shared_handle`

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
