### PR TITLE
Add `VideoFrame` to `ExternalImageSource` enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ By @teoxoy [#6134](https://github.com/gfx-rs/wgpu/pull/6134).
 - Deduplicate bind group layouts that are created from pipelines with "auto" layouts. By @teoxoy [#6049](https://github.com/gfx-rs/wgpu/pull/6049)
 - Fix crash when dropping the surface after the device. By @wumpf in [#6052](https://github.com/gfx-rs/wgpu/pull/6052)
 - Fix error message that is thrown in create_render_pass to no longer say `compute_pass`. By @matthew-wong1 [#6041](https://github.com/gfx-rs/wgpu/pull/6041)
+- Add `VideoFrame` to `ExternalImageSource` enum. By @jprochazk in [#6170](https://github.com/gfx-rs/wgpu/pull/6170)
 
 #### GLES / OpenGL
 

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -502,6 +502,21 @@ impl super::Queue {
                                 v,
                             );
                         },
+                        wgt::ExternalImageSource::VideoFrame(ref v) => unsafe {
+                            gl.tex_sub_image_3d_with_video_frame(
+                                dst_target,
+                                copy.dst_base.mip_level as i32,
+                                copy.dst_base.origin.x as i32,
+                                copy.dst_base.origin.y as i32,
+                                z_offset as i32,
+                                copy.size.width as i32,
+                                copy.size.height as i32,
+                                copy.size.depth as i32,
+                                format_desc.external,
+                                format_desc.data_type,
+                                v,
+                            )
+                        },
                         wgt::ExternalImageSource::ImageData(ref i) => unsafe {
                             gl.tex_sub_image_3d_with_image_data(
                                 dst_target,
@@ -566,6 +581,19 @@ impl super::Queue {
                         },
                         wgt::ExternalImageSource::HTMLVideoElement(ref v) => unsafe {
                             gl.tex_sub_image_2d_with_html_video_and_width_and_height(
+                                dst_target,
+                                copy.dst_base.mip_level as i32,
+                                copy.dst_base.origin.x as i32,
+                                copy.dst_base.origin.y as i32,
+                                copy.size.width as i32,
+                                copy.size.height as i32,
+                                format_desc.external,
+                                format_desc.data_type,
+                                v,
+                            )
+                        },
+                        wgt::ExternalImageSource::VideoFrame(ref v) => unsafe {
+                            gl.tex_sub_image_2d_with_video_frame_and_width_and_height(
                                 dst_target,
                                 copy.dst_base.mip_level as i32,
                                 copy.dst_base.origin.x as i32,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -502,6 +502,7 @@ impl super::Queue {
                                 v,
                             );
                         },
+                        #[cfg(web_sys_unstable_apis)]
                         wgt::ExternalImageSource::VideoFrame(ref v) => unsafe {
                             gl.tex_sub_image_3d_with_video_frame(
                                 dst_target,
@@ -592,6 +593,7 @@ impl super::Queue {
                                 v,
                             )
                         },
+                        #[cfg(web_sys_unstable_apis)]
                         wgt::ExternalImageSource::VideoFrame(ref v) => unsafe {
                             gl.tex_sub_image_2d_with_video_frame_and_width_and_height(
                                 dst_target,

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -46,6 +46,7 @@ web-sys = { workspace = true, features = [
     "HtmlVideoElement",
     "HtmlCanvasElement",
     "OffscreenCanvas",
+    "VideoFrame",
 ] }
 
 [dev-dependencies]

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -43,6 +43,7 @@ js-sys.workspace = true
 web-sys = { workspace = true, features = [
     "ImageBitmap",
     "ImageData",
+    "HtmlImageElement",
     "HtmlVideoElement",
     "HtmlCanvasElement",
     "OffscreenCanvas",

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -6856,6 +6856,7 @@ pub enum ExternalImageSource {
     /// Requires [`DownlevelFlags::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES`]
     OffscreenCanvas(web_sys::OffscreenCanvas),
     /// Copy from a video frame.
+    #[cfg(web_sys_unstable_apis)]
     VideoFrame(web_sys::VideoFrame),
 }
 
@@ -6870,6 +6871,7 @@ impl ExternalImageSource {
             ExternalImageSource::ImageData(i) => i.width(),
             ExternalImageSource::HTMLCanvasElement(c) => c.width(),
             ExternalImageSource::OffscreenCanvas(c) => c.width(),
+            #[cfg(web_sys_unstable_apis)]
             ExternalImageSource::VideoFrame(v) => v.display_width(),
         }
     }
@@ -6883,6 +6885,7 @@ impl ExternalImageSource {
             ExternalImageSource::ImageData(i) => i.height(),
             ExternalImageSource::HTMLCanvasElement(c) => c.height(),
             ExternalImageSource::OffscreenCanvas(c) => c.height(),
+            #[cfg(web_sys_unstable_apis)]
             ExternalImageSource::VideoFrame(v) => v.display_height(),
         }
     }
@@ -6900,6 +6903,7 @@ impl std::ops::Deref for ExternalImageSource {
             Self::ImageData(i) => i,
             Self::HTMLCanvasElement(c) => c,
             Self::OffscreenCanvas(c) => c,
+            #[cfg(web_sys_unstable_apis)]
             Self::VideoFrame(v) => v,
         }
     }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -6855,6 +6855,8 @@ pub enum ExternalImageSource {
     ///
     /// Requires [`DownlevelFlags::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES`]
     OffscreenCanvas(web_sys::OffscreenCanvas),
+    /// Copy from a video frame.
+    VideoFrame(web_sys::VideoFrame),
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -6868,6 +6870,7 @@ impl ExternalImageSource {
             ExternalImageSource::ImageData(i) => i.width(),
             ExternalImageSource::HTMLCanvasElement(c) => c.width(),
             ExternalImageSource::OffscreenCanvas(c) => c.width(),
+            ExternalImageSource::VideoFrame(v) => v.display_width(),
         }
     }
 
@@ -6880,6 +6883,7 @@ impl ExternalImageSource {
             ExternalImageSource::ImageData(i) => i.height(),
             ExternalImageSource::HTMLCanvasElement(c) => c.height(),
             ExternalImageSource::OffscreenCanvas(c) => c.height(),
+            ExternalImageSource::VideoFrame(v) => v.display_height(),
         }
     }
 }
@@ -6896,6 +6900,7 @@ impl std::ops::Deref for ExternalImageSource {
             Self::ImageData(i) => i,
             Self::HTMLCanvasElement(c) => c,
             Self::OffscreenCanvas(c) => c,
+            Self::VideoFrame(v) => v,
         }
     }
 }


### PR DESCRIPTION
**Connections**
* Closes https://github.com/gfx-rs/wgpu/issues/6167

**Description**
Adds missing `VideoFrame` type as a possible external image source.

The enum variant is gated behind `cfg(web_sys_unstable_apis)`, as `web_sys::VideoFrame` is unavailable without it.

**Testing**
Tested manually by using it in place of this hack: https://github.com/rerun-io/rerun/pull/7261/files#diff-213f45076b49c7bbe3d7a1f0c7383b3b9e0edb4c02c21bab32709573155a2e63R403-R414
It would be nice to have a Wasm-only example that renders a media stream using `VideoDecoder`, but I'm not sure how adding such an example would work.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
