### PR TITLE
Accept only `vec3` (not `vecN`) for the `cross` built-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ By @teoxoy [#6134](https://github.com/gfx-rs/wgpu/pull/6134).
 
 - Fix incorrect hlsl image output type conversion. By @atlv24 in [#6123](https://github.com/gfx-rs/wgpu/pull/6123)
 
+#### Naga
+
+- Accept only `vec3` (not `vecN`) for the `cross` built-in. By @ErichDonGubler in [#6171](https://github.com/gfx-rs/wgpu/pull/6171).
+
 #### General
 
 - If GL context creation fails retry with GLES. By @Rapdorian in [#5996](https://github.com/gfx-rs/wgpu/pull/5996)

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -1161,7 +1161,7 @@ impl super::Validator {
                             ));
                         }
                     }
-                    Mf::Outer | Mf::Cross | Mf::Reflect => {
+                    Mf::Outer | Mf::Reflect => {
                         let arg1_ty = match (arg1_ty, arg2_ty, arg3_ty) {
                             (Some(ty1), None, None) => ty1,
                             _ => return Err(ExpressionError::WrongArgumentCount(fun)),
@@ -1172,8 +1172,31 @@ impl super::Validator {
                                     Sc {
                                         kind: Sk::Float, ..
                                     },
-                                size: vector_size,
-                            } if fun != Mf::Cross || vector_size == crate::VectorSize::Tri => {}
+                                ..
+                            } => {}
+                            _ => return Err(ExpressionError::InvalidArgumentType(fun, 0, arg)),
+                        }
+                        if arg1_ty != arg_ty {
+                            return Err(ExpressionError::InvalidArgumentType(
+                                fun,
+                                1,
+                                arg1.unwrap(),
+                            ));
+                        }
+                    }
+                    Mf::Cross => {
+                        let arg1_ty = match (arg1_ty, arg2_ty, arg3_ty) {
+                            (Some(ty1), None, None) => ty1,
+                            _ => return Err(ExpressionError::WrongArgumentCount(fun)),
+                        };
+                        match *arg_ty {
+                            Ti::Vector {
+                                scalar:
+                                    Sc {
+                                        kind: Sk::Float, ..
+                                    },
+                                size: crate::VectorSize::Tri,
+                            } => {}
                             _ => return Err(ExpressionError::InvalidArgumentType(fun, 0, arg)),
                         }
                         if arg1_ty != arg_ty {

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -1172,8 +1172,8 @@ impl super::Validator {
                                     Sc {
                                         kind: Sk::Float, ..
                                     },
-                                ..
-                            } => {}
+                                size: vector_size,
+                            } if fun != Mf::Cross || vector_size == crate::VectorSize::Tri => {}
                             _ => return Err(ExpressionError::InvalidArgumentType(fun, 0, arg)),
                         }
                         if arg1_ty != arg_ty {

--- a/naga/tests/in/cross.wgsl
+++ b/naga/tests/in/cross.wgsl
@@ -1,0 +1,3 @@
+@compute @workgroup_size(1) fn main() {
+    let a = cross(vec3(0., 1., 2.), vec3(0., 1., 2.));
+}

--- a/naga/tests/out/glsl/cross.main.Compute.glsl
+++ b/naga/tests/out/glsl/cross.main.Compute.glsl
@@ -1,0 +1,12 @@
+#version 310 es
+
+precision highp float;
+precision highp int;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+
+void main() {
+    vec3 a = cross(vec3(0.0, 1.0, 2.0), vec3(0.0, 1.0, 2.0));
+}
+

--- a/naga/tests/out/hlsl/cross.hlsl
+++ b/naga/tests/out/hlsl/cross.hlsl
@@ -1,0 +1,5 @@
+[numthreads(1, 1, 1)]
+void main()
+{
+    float3 a = cross(float3(0.0, 1.0, 2.0), float3(0.0, 1.0, 2.0));
+}

--- a/naga/tests/out/hlsl/cross.ron
+++ b/naga/tests/out/hlsl/cross.ron
@@ -1,0 +1,12 @@
+(
+    vertex:[
+    ],
+    fragment:[
+    ],
+    compute:[
+        (
+            entry_point:"main",
+            target_profile:"cs_5_1",
+        ),
+    ],
+)

--- a/naga/tests/out/msl/cross.msl
+++ b/naga/tests/out/msl/cross.msl
@@ -1,0 +1,11 @@
+// language: metal1.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+
+kernel void main_(
+) {
+    metal::float3 a = metal::cross(metal::float3(0.0, 1.0, 2.0), metal::float3(0.0, 1.0, 2.0));
+}

--- a/naga/tests/out/spv/cross.spvasm
+++ b/naga/tests/out/spv/cross.spvasm
@@ -1,0 +1,24 @@
+; SPIR-V
+; Version: 1.1
+; Generator: rspirv
+; Bound: 14
+OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %6 "main"
+OpExecutionMode %6 LocalSize 1 1 1
+%2 = OpTypeVoid
+%4 = OpTypeFloat 32
+%3 = OpTypeVector %4 3
+%7 = OpTypeFunction %2
+%8 = OpConstant  %4  0.0
+%9 = OpConstant  %4  1.0
+%10 = OpConstant  %4  2.0
+%11 = OpConstantComposite  %3  %8 %9 %10
+%6 = OpFunction  %2  None %7
+%5 = OpLabel
+OpBranch %12
+%12 = OpLabel
+%13 = OpExtInst  %3  %1 Cross %11 %11
+OpReturn
+OpFunctionEnd

--- a/naga/tests/out/wgsl/cross.wgsl
+++ b/naga/tests/out/wgsl/cross.wgsl
@@ -1,0 +1,4 @@
+@compute @workgroup_size(1, 1, 1) 
+fn main() {
+    let a = cross(vec3<f32>(0f, 1f, 2f), vec3<f32>(0f, 1f, 2f));
+}

--- a/naga/tests/snapshots.rs
+++ b/naga/tests/snapshots.rs
@@ -910,6 +910,10 @@ fn convert_wgsl() {
             Targets::IR | Targets::SPIRV | Targets::METAL,
         ),
         ("vertex-pulling-transform", Targets::METAL),
+        (
+            "cross",
+            Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
+        ),
     ];
 
     for &(name, targets) in inputs.iter() {


### PR DESCRIPTION
**Connections**

Resolves #6153.

**Description**

Previously, we only checked that a single type of vector of floats was being used as input for the `cross` built-in. Only `vec3` should be permitted; so, narrow our checking of the vector type to 3 elements.

**Testing**

Tests have been added to ensure coverage of what we should and should not accept for the `cross` built-in.

Open questions:

- [x] ~~Do we need to permit more than just `vec3` from language frontends other than WGSL?~~ Nope!

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
