### PR TITLE
fix: compile `raw-gles` example again after #6150

### DIFF
--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -71,7 +71,9 @@ fn main() {
     // Glutin tries to create an OpenGL context by default.  Force it to use any version of GLES.
     let context_attributes = glutin::context::ContextAttributesBuilder::new()
         // WGPU expects GLES 3.0+.
-        .with_context_api(glutin::context::ContextApi::Gles(Some(Version::new(3, 0))))
+        .with_context_api(glutin::context::ContextApi::Gles(Some(
+            glutin::context::Version::new(3, 0),
+        )))
         .build(raw_window_handle);
 
     let mut not_current_gl_context = Some(unsafe {


### PR DESCRIPTION
**Connections**

I think this was regressed by #6150?

**Description**

See above.

**Testing**

It compiles now!

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.

    Probably not necessary? Might want to add on to the `glutin` `CHANGELOG` entry. 🤔 
