### PR TITLE
[wgpu-hal] Make `raw-gles` runnable on X11 and Wayland platforms again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ By @teoxoy [#6134](https://github.com/gfx-rs/wgpu/pull/6134).
 #### GLES
 
 - Replace `winapi` code in WGL wrapper to use the `windows` crate. By @MarijnS95 in [#6006](https://github.com/gfx-rs/wgpu/pull/6006)
+- Update `glutin` to `0.31` with `glutin-winit` crate. By @MarijnS95 in [#6150](https://github.com/gfx-rs/wgpu/pull/6150) and [#6176](https://github.com/gfx-rs/wgpu/pull/6176)
 
 #### DX12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,8 @@ dependencies = [
  "objc2",
  "once_cell",
  "raw-window-handle 0.5.2",
+ "wayland-sys",
+ "x11-dl",
 ]
 
 [[package]]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -208,7 +208,7 @@ glam.workspace = true # for ray-traced-triangle example
 winit.workspace = true # for "halmark" example
 
 [target.'cfg(not(any(target_arch = "wasm32", windows, target_os = "ios")))'.dev-dependencies]
-glutin-winit = { workspace = true, features = ["egl"] } # for "raw-gles" example
-glutin = { workspace = true, features = ["egl"] } # for "raw-gles" example
+glutin-winit = { workspace = true, features = ["egl", "wayland", "x11"] } # for "raw-gles" example
+glutin = { workspace = true, features = ["egl", "wayland", "x11"] } # for "raw-gles" example
 rwh_05 = { version = "0.5", package = "raw-window-handle" } # temporary compatibility for glutin-winit in "raw-gles" example
 winit = { workspace = true, features = ["rwh_05"] } # for "raw-gles" example

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -16,7 +16,7 @@ fn main() {
 
     use glutin::{
         config::GlConfig as _,
-        context::{NotCurrentGlContext as _, PossiblyCurrentGlContext as _},
+        context::{NotCurrentGlContext as _, PossiblyCurrentGlContext as _, Version},
         display::{GetGlDisplay as _, GlDisplay as _},
         surface::GlSurface as _,
     };


### PR DESCRIPTION
**Connections**
#6150, #6152, closes #6174

**Description** PR #6150 suffered a much larger rebase "hell" than I anticipated.  On my Linux box I made this change, but lost it while force-pushing from Windows (and created some other compiler errors while at it...).

By disabling all features on `glutin`/`glutin-winit` (the latter only uses `x11`, and only forwards `wayland` to `glutin`) we may have dropped a lot of "unused" dependencies for other GL backends, but also made the crate unable to import X11 (Xlib/Xcb) and Wayland handles into EGL.

Also import the missing `glutin::context::Version` struct again which was added last-minute to #6150 (to make sure my Intel card on Windows creates a GLES 3.0+ instead of GLES 2.0 context) while the import was accidentally squashed into #6152 (not merged yet).

**Testing**
```console
$ DISPLAY= cargo r --example raw-gles
$ WAYLAND_DISPLAY= cargo r --example raw-gles
```

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
