### PR TITLE
Yet more preempting of Rust 1.80 lints

### DIFF
--- a/examples/src/boids/mod.rs
+++ b/examples/src/boids/mod.rs
@@ -2,7 +2,7 @@
 // adapted from https://github.com/austinEng/webgpu-samples/blob/master/src/examples/computeBoids.ts
 
 use nanorand::{Rng, WyRand};
-use std::{borrow::Cow, mem};
+use std::{borrow::Cow, mem::size_of};
 use wgpu::util::DeviceExt;
 
 // number of boid particles to simulate
@@ -82,7 +82,7 @@ impl crate::framework::Example for Example {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,
                             min_binding_size: wgpu::BufferSize::new(
-                                (sim_param_data.len() * mem::size_of::<f32>()) as _,
+                                (sim_param_data.len() * size_of::<f32>()) as _,
                             ),
                         },
                         count: None,

--- a/examples/src/cube/mod.rs
+++ b/examples/src/cube/mod.rs
@@ -1,5 +1,5 @@
 use bytemuck::{Pod, Zeroable};
-use std::{borrow::Cow, f32::consts, mem};
+use std::{borrow::Cow, f32::consts, mem::size_of};
 use wgpu::util::DeviceExt;
 
 #[repr(C)]
@@ -114,7 +114,7 @@ impl crate::framework::Example for Example {
         queue: &wgpu::Queue,
     ) -> Self {
         // Create the vertex and index buffers
-        let vertex_size = mem::size_of::<Vertex>();
+        let vertex_size = size_of::<Vertex>();
         let (vertex_data, index_data) = create_vertices();
 
         let vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {

--- a/examples/src/hello_compute/mod.rs
+++ b/examples/src/hello_compute/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, str::FromStr};
+use std::{borrow::Cow, mem::size_of_val, str::FromStr};
 use wgpu::util::DeviceExt;
 
 // Indicates a u32 overflow in an intermediate Collatz value
@@ -72,7 +72,7 @@ async fn execute_gpu_inner(
     });
 
     // Gets the size in bytes of the buffer.
-    let size = std::mem::size_of_val(numbers) as wgpu::BufferAddress;
+    let size = size_of_val(numbers) as wgpu::BufferAddress;
 
     // Instantiates buffer without data.
     // `usage` of buffer specifies how it can be used:

--- a/examples/src/hello_synchronization/mod.rs
+++ b/examples/src/hello_synchronization/mod.rs
@@ -1,3 +1,5 @@
+use std::mem::size_of_val;
+
 const ARR_SIZE: usize = 128;
 
 struct ExecuteResults {
@@ -61,13 +63,13 @@ async fn execute(
 
     let storage_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
-        size: std::mem::size_of_val(local_patient_workgroup_results.as_slice()) as u64,
+        size: size_of_val(local_patient_workgroup_results.as_slice()) as u64,
         usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
         mapped_at_creation: false,
     });
     let output_staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
-        size: std::mem::size_of_val(local_patient_workgroup_results.as_slice()) as u64,
+        size: size_of_val(local_patient_workgroup_results.as_slice()) as u64,
         usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
         mapped_at_creation: false,
     });
@@ -182,7 +184,7 @@ async fn get_data<T: bytemuck::Pod>(
         0,
         staging_buffer,
         0,
-        std::mem::size_of_val(output) as u64,
+        size_of_val(output) as u64,
     );
     queue.submit(Some(command_encoder.finish()));
     let buffer_slice = staging_buffer.slice(..);

--- a/examples/src/hello_workgroups/mod.rs
+++ b/examples/src/hello_workgroups/mod.rs
@@ -7,6 +7,8 @@
 //!
 //! Only parts specific to this example will be commented.
 
+use std::mem::size_of_val;
+
 use wgpu::util::DeviceExt;
 
 async fn run() {
@@ -56,7 +58,7 @@ async fn run() {
     });
     let output_staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
-        size: std::mem::size_of_val(&local_a) as u64,
+        size: size_of_val(&local_a) as u64,
         usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
         mapped_at_creation: false,
     });
@@ -169,7 +171,7 @@ async fn get_data<T: bytemuck::Pod>(
         0,
         staging_buffer,
         0,
-        std::mem::size_of_val(output) as u64,
+        size_of_val(output) as u64,
     );
     queue.submit(Some(command_encoder.finish()));
     let buffer_slice = staging_buffer.slice(..);

--- a/examples/src/mipmap/mod.rs
+++ b/examples/src/mipmap/mod.rs
@@ -1,5 +1,5 @@
 use bytemuck::{Pod, Zeroable};
-use std::{borrow::Cow, f32::consts, mem};
+use std::{borrow::Cow, f32::consts, mem::size_of};
 use wgpu::util::DeviceExt;
 
 const TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
@@ -54,8 +54,7 @@ type TimestampQueries = [TimestampData; MIP_PASS_COUNT as usize];
 type PipelineStatisticsQueries = [u64; MIP_PASS_COUNT as usize];
 
 fn pipeline_statistics_offset() -> wgpu::BufferAddress {
-    (mem::size_of::<TimestampQueries>() as wgpu::BufferAddress)
-        .max(wgpu::QUERY_RESOLVE_BUFFER_ALIGNMENT)
+    (size_of::<TimestampQueries>() as wgpu::BufferAddress).max(wgpu::QUERY_RESOLVE_BUFFER_ALIGNMENT)
 }
 
 struct Example {
@@ -363,7 +362,7 @@ impl crate::framework::Example for Example {
             // This databuffer has to store all of the query results, 2 * passes timestamp queries
             // and 1 * passes statistics queries. Each query returns a u64 value.
             let buffer_size = pipeline_statistics_offset()
-                + mem::size_of::<PipelineStatisticsQueries>() as wgpu::BufferAddress;
+                + size_of::<PipelineStatisticsQueries>() as wgpu::BufferAddress;
             let data_buffer = device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("query buffer"),
                 size: buffer_size,
@@ -420,7 +419,7 @@ impl crate::framework::Example for Example {
             // This is guaranteed to be ready.
             let timestamp_view = query_sets
                 .mapping_buffer
-                .slice(..mem::size_of::<TimestampQueries>() as wgpu::BufferAddress)
+                .slice(..size_of::<TimestampQueries>() as wgpu::BufferAddress)
                 .get_mapped_range();
             let pipeline_stats_view = query_sets
                 .mapping_buffer

--- a/examples/src/msaa_line/mod.rs
+++ b/examples/src/msaa_line/mod.rs
@@ -7,7 +7,7 @@
 //! *   Set the primitive_topology to PrimitiveTopology::LineList.
 //! *   Vertices and Indices describe the two points that make up a line.
 
-use std::{borrow::Cow, iter};
+use std::{borrow::Cow, iter, mem::size_of};
 
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
@@ -56,7 +56,7 @@ impl Example {
                 entry_point: Some("vs_main"),
                 compilation_options: Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
-                    array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
+                    array_stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x4],
                 }],

--- a/examples/src/shadow/mod.rs
+++ b/examples/src/shadow/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, f32::consts, iter, mem, ops::Range, sync::Arc};
+use std::{borrow::Cow, f32::consts, iter, mem::size_of, ops::Range, sync::Arc};
 
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::{align_to, DeviceExt};
@@ -219,7 +219,7 @@ impl crate::framework::Example for Example {
             && device.limits().max_storage_buffers_per_shader_stage > 0;
 
         // Create the vertex and index buffers
-        let vertex_size = mem::size_of::<Vertex>();
+        let vertex_size = size_of::<Vertex>();
         let (cube_vertex_data, cube_index_data) = create_cube();
         let cube_vertex_buf = Arc::new(device.create_buffer_init(
             &wgpu::util::BufferInitDescriptor {
@@ -283,7 +283,7 @@ impl crate::framework::Example for Example {
             },
         ];
 
-        let entity_uniform_size = mem::size_of::<EntityUniforms>() as wgpu::BufferAddress;
+        let entity_uniform_size = size_of::<EntityUniforms>() as wgpu::BufferAddress;
         let num_entities = 1 + cube_descs.len() as wgpu::BufferAddress;
         // Make the `uniform_alignment` >= `entity_uniform_size` and aligned to `min_uniform_buffer_offset_alignment`.
         let uniform_alignment = {
@@ -427,8 +427,7 @@ impl crate::framework::Example for Example {
                 target_view: shadow_target_views[1].take().unwrap(),
             },
         ];
-        let light_uniform_size =
-            (Self::MAX_LIGHTS * mem::size_of::<LightRaw>()) as wgpu::BufferAddress;
+        let light_uniform_size = (Self::MAX_LIGHTS * size_of::<LightRaw>()) as wgpu::BufferAddress;
         let light_storage_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
             size: light_uniform_size,
@@ -454,7 +453,7 @@ impl crate::framework::Example for Example {
         });
 
         let shadow_pass = {
-            let uniform_size = mem::size_of::<GlobalUniforms>() as wgpu::BufferAddress;
+            let uniform_size = size_of::<GlobalUniforms>() as wgpu::BufferAddress;
             // Create pipeline layout
             let bind_group_layout =
                 device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -548,7 +547,7 @@ impl crate::framework::Example for Example {
                                 ty: wgpu::BufferBindingType::Uniform,
                                 has_dynamic_offset: false,
                                 min_binding_size: wgpu::BufferSize::new(
-                                    mem::size_of::<GlobalUniforms>() as _,
+                                    size_of::<GlobalUniforms>() as _,
                                 ),
                             },
                             count: None,
@@ -737,7 +736,7 @@ impl crate::framework::Example for Example {
             for (i, light) in self.lights.iter().enumerate() {
                 queue.write_buffer(
                     &self.light_storage_buf,
-                    (i * mem::size_of::<LightRaw>()) as wgpu::BufferAddress,
+                    (i * size_of::<LightRaw>()) as wgpu::BufferAddress,
                     bytemuck::bytes_of(&light.to_raw()),
                 );
             }
@@ -757,7 +756,7 @@ impl crate::framework::Example for Example {
             // let's just copy it over to the shadow uniform buffer.
             encoder.copy_buffer_to_buffer(
                 &self.light_storage_buf,
-                (i * mem::size_of::<LightRaw>()) as wgpu::BufferAddress,
+                (i * size_of::<LightRaw>()) as wgpu::BufferAddress,
                 &self.shadow_pass.uniform_buf,
                 0,
                 64,

--- a/examples/src/skybox/mod.rs
+++ b/examples/src/skybox/mod.rs
@@ -1,5 +1,5 @@
 use bytemuck::{Pod, Zeroable};
-use std::{borrow::Cow, f32::consts};
+use std::{borrow::Cow, f32::consts, mem::size_of};
 use wgpu::{util::DeviceExt, AstcBlock, AstcChannel};
 
 const IMAGE_SIZE: u32 = 256;
@@ -231,7 +231,7 @@ impl crate::framework::Example for Example {
                 entry_point: Some("vs_entity"),
                 compilation_options: Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
-                    array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
+                    array_stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3],
                 }],

--- a/examples/src/stencil_triangles/mod.rs
+++ b/examples/src/stencil_triangles/mod.rs
@@ -1,6 +1,6 @@
 use bytemuck::{Pod, Zeroable};
 use std::borrow::Cow;
-use std::mem;
+use std::mem::size_of;
 use wgpu::util::DeviceExt;
 
 #[repr(C)]
@@ -31,7 +31,7 @@ impl crate::framework::Example for Example {
         _queue: &wgpu::Queue,
     ) -> Self {
         // Create the vertex and index buffers
-        let vertex_size = mem::size_of::<Vertex>();
+        let vertex_size = size_of::<Vertex>();
         let outer_vertices = [vertex(-1.0, -1.0), vertex(1.0, -1.0), vertex(0.0, 1.0)];
         let mask_vertices = [vertex(-0.5, 0.0), vertex(0.0, -1.0), vertex(0.5, 0.0)];
 

--- a/examples/src/storage_texture/mod.rs
+++ b/examples/src/storage_texture/mod.rs
@@ -14,6 +14,8 @@
 //! A lot of things aren't explained here via comments. See hello-compute and
 //! repeated-compute for code that is more thoroughly commented.
 
+use std::mem::size_of_val;
+
 #[cfg(not(target_arch = "wasm32"))]
 use crate::utils::output_image_native;
 #[cfg(target_arch = "wasm32")]
@@ -64,7 +66,7 @@ async fn run(_path: Option<String>) {
     let storage_texture_view = storage_texture.create_view(&wgpu::TextureViewDescriptor::default());
     let output_staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
-        size: std::mem::size_of_val(&texture_data[..]) as u64,
+        size: size_of_val(&texture_data[..]) as u64,
         usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
         mapped_at_creation: false,
     });

--- a/examples/src/texture_arrays/mod.rs
+++ b/examples/src/texture_arrays/mod.rs
@@ -1,5 +1,8 @@
 use bytemuck::{Pod, Zeroable};
-use std::num::{NonZeroU32, NonZeroU64};
+use std::{
+    mem::size_of,
+    num::{NonZeroU32, NonZeroU64},
+};
 use wgpu::util::DeviceExt;
 
 #[repr(C)]
@@ -124,7 +127,7 @@ impl crate::framework::Example for Example {
 
         println!("Using fragment entry point '{fragment_entry_point}'");
 
-        let vertex_size = std::mem::size_of::<Vertex>();
+        let vertex_size = size_of::<Vertex>();
         let vertex_data = create_vertices();
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Vertex Buffer"),

--- a/examples/src/timestamp_queries/mod.rs
+++ b/examples/src/timestamp_queries/mod.rs
@@ -17,6 +17,8 @@
 //! The period, i.e. the unit of time, of the timestamps in wgpu is undetermined and needs to be queried with `wgpu::Queue::get_timestamp_period`
 //! in order to get comparable results.
 
+use std::mem::size_of;
+
 use wgpu::util::DeviceExt;
 
 struct Queries {
@@ -123,13 +125,13 @@ impl Queries {
             }),
             resolve_buffer: device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("query resolve buffer"),
-                size: std::mem::size_of::<u64>() as u64 * num_queries,
+                size: size_of::<u64>() as u64 * num_queries,
                 usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::QUERY_RESOLVE,
                 mapped_at_creation: false,
             }),
             destination_buffer: device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("query dest buffer"),
-                size: std::mem::size_of::<u64>() as u64 * num_queries,
+                size: size_of::<u64>() as u64 * num_queries,
                 usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
                 mapped_at_creation: false,
             }),
@@ -164,7 +166,7 @@ impl Queries {
         let timestamps = {
             let timestamp_view = self
                 .destination_buffer
-                .slice(..(std::mem::size_of::<u64>() as wgpu::BufferAddress * self.num_queries))
+                .slice(..(size_of::<u64>() as wgpu::BufferAddress * self.num_queries))
                 .get_mapped_range();
             bytemuck::cast_slice(&timestamp_view).to_vec()
         };

--- a/examples/src/uniform_values/mod.rs
+++ b/examples/src/uniform_values/mod.rs
@@ -16,7 +16,7 @@
 //! The usage of the uniform buffer within the shader itself is pretty self-explanatory given
 //! some understanding of WGSL.
 
-use std::sync::Arc;
+use std::{mem::size_of, sync::Arc};
 // We won't bring StorageBuffer into scope as that might be too easy to confuse
 // with actual GPU-allocated WGPU storage buffers.
 use encase::ShaderType;
@@ -132,7 +132,7 @@ impl WgpuContext {
         // (2)
         let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
-            size: std::mem::size_of::<AppState>() as u64,
+            size: size_of::<AppState>() as u64,
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });

--- a/examples/src/water/mod.rs
+++ b/examples/src/water/mod.rs
@@ -3,7 +3,7 @@ mod point_gen;
 use bytemuck::{Pod, Zeroable};
 use glam::Vec3;
 use nanorand::{Rng, WyRand};
-use std::{borrow::Cow, f32::consts, iter, mem};
+use std::{borrow::Cow, f32::consts, iter, mem::size_of};
 use wgpu::util::DeviceExt;
 
 ///
@@ -273,12 +273,12 @@ impl crate::framework::Example for Example {
         queue: &wgpu::Queue,
     ) -> Self {
         // Size of one water vertex
-        let water_vertex_size = mem::size_of::<point_gen::WaterVertexAttributes>();
+        let water_vertex_size = size_of::<point_gen::WaterVertexAttributes>();
 
         let water_vertices = point_gen::HexWaterMesh::generate(SIZE).generate_points();
 
         // Size of one terrain vertex
-        let terrain_vertex_size = mem::size_of::<point_gen::TerrainVertexAttributes>();
+        let terrain_vertex_size = size_of::<point_gen::TerrainVertexAttributes>();
 
         // Noise generation
         let terrain_noise = noise::OpenSimplex::default();
@@ -359,7 +359,7 @@ impl crate::framework::Example for Example {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,
                             min_binding_size: wgpu::BufferSize::new(
-                                mem::size_of::<WaterUniforms>() as _,
+                                size_of::<WaterUniforms>() as _,
                             ),
                         },
                         count: None,
@@ -415,7 +415,7 @@ impl crate::framework::Example for Example {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,
                             min_binding_size: wgpu::BufferSize::new(
-                                mem::size_of::<TerrainUniforms>() as _,
+                                size_of::<TerrainUniforms>() as _
                             ),
                         },
                         count: None,
@@ -440,21 +440,21 @@ impl crate::framework::Example for Example {
 
         let water_uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Water Uniforms"),
-            size: mem::size_of::<WaterUniforms>() as _,
+            size: size_of::<WaterUniforms>() as _,
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
         let terrain_normal_uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Normal Terrain Uniforms"),
-            size: mem::size_of::<TerrainUniforms>() as _,
+            size: size_of::<TerrainUniforms>() as _,
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
         let terrain_flipped_uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Flipped Terrain Uniforms"),
-            size: mem::size_of::<TerrainUniforms>() as _,
+            size: size_of::<TerrainUniforms>() as _,
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -712,7 +712,7 @@ impl crate::framework::Example for Example {
         let (water_sin, water_cos) = ((self.current_frame as f32) / 600.0).sin_cos();
         queue.write_buffer(
             &self.water_uniform_buf,
-            mem::size_of::<[f32; 16]>() as wgpu::BufferAddress * 2,
+            size_of::<[f32; 16]>() as wgpu::BufferAddress * 2,
             bytemuck::cast_slice(&[water_sin, water_cos]),
         );
 

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -14,6 +14,7 @@ use player::GlobalPlay;
 use std::{
     fs::{read_to_string, File},
     io::{Read, Seek, SeekFrom},
+    mem::size_of,
     path::{Path, PathBuf},
     slice,
 };
@@ -35,7 +36,7 @@ impl ExpectedData {
     fn len(&self) -> usize {
         match self {
             ExpectedData::Raw(vec) => vec.len(),
-            ExpectedData::U64(vec) => vec.len() * std::mem::size_of::<u64>(),
+            ExpectedData::U64(vec) => vec.len() * size_of::<u64>(),
             ExpectedData::File(_, size) => *size,
         }
     }

--- a/tests/tests/compute_pass_ownership.rs
+++ b/tests/tests/compute_pass_ownership.rs
@@ -1,7 +1,7 @@
 //! Tests that compute passes take ownership of resources that are associated with.
 //! I.e. once a resource is passed in to a compute pass, it can be dropped.
 
-use std::num::NonZeroU64;
+use std::{mem::size_of, num::NonZeroU64};
 
 use wgpu::util::DeviceExt as _;
 use wgpu_test::{gpu_test, valid, GpuTestConfiguration, TestParameters, TestingContext};
@@ -253,7 +253,7 @@ fn resource_setup(ctx: &TestingContext) -> ResourceSetup {
             source: wgpu::ShaderSource::Wgsl(SHADER_SRC.into()),
         });
 
-    let buffer_size = 4 * std::mem::size_of::<f32>() as u64;
+    let buffer_size = 4 * size_of::<f32>() as u64;
 
     let bgl = ctx
         .device

--- a/tests/tests/occlusion_query/mod.rs
+++ b/tests/tests/occlusion_query/mod.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, mem::size_of};
 use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
 
 #[gpu_test]
@@ -100,7 +100,7 @@ static OCCLUSION_QUERY: GpuTestConfiguration = GpuTestConfiguration::new()
         // Resolve query set to buffer
         let query_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Query buffer"),
-            size: std::mem::size_of::<u64>() as u64 * 3,
+            size: size_of::<u64>() as u64 * 3,
             usage: wgpu::BufferUsages::QUERY_RESOLVE | wgpu::BufferUsages::COPY_SRC,
             mapped_at_creation: false,
         });

--- a/tests/tests/render_pass_ownership.rs
+++ b/tests/tests/render_pass_ownership.rs
@@ -9,7 +9,7 @@
 //! * rpass.multi_draw_indirect_count
 //! * rpass.multi_draw_indexed_indirect_count
 //!
-use std::num::NonZeroU64;
+use std::{mem::size_of, num::NonZeroU64};
 
 use wgpu::util::DeviceExt as _;
 use wgpu_test::{gpu_test, valid, GpuTestConfiguration, TestParameters, TestingContext};
@@ -367,7 +367,7 @@ fn resource_setup(ctx: &TestingContext) -> ResourceSetup {
             source: wgpu::ShaderSource::Wgsl(SHADER_SRC.into()),
         });
 
-    let buffer_size = 4 * std::mem::size_of::<f32>() as u64;
+    let buffer_size = 4 * size_of::<f32>() as u64;
 
     let bgl = ctx
         .device
@@ -418,7 +418,7 @@ fn resource_setup(ctx: &TestingContext) -> ResourceSetup {
     let vertex_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("vertex_buffer"),
         usage: wgpu::BufferUsages::VERTEX,
-        size: std::mem::size_of::<u32>() as u64 * vertex_count as u64,
+        size: size_of::<u32>() as u64 * vertex_count as u64,
         mapped_at_creation: false,
     });
 

--- a/tests/tests/subgroup_operations/mod.rs
+++ b/tests/tests/subgroup_operations/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, num::NonZeroU64};
+use std::{borrow::Cow, mem::size_of, num::NonZeroU64};
 
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
 
@@ -35,7 +35,7 @@ static SUBGROUP_OPERATIONS: GpuTestConfiguration = GpuTestConfiguration::new()
 
         let storage_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
-            size: THREAD_COUNT * std::mem::size_of::<u32>() as u64,
+            size: THREAD_COUNT * size_of::<u32>() as u64,
             usage: wgpu::BufferUsages::STORAGE
                 | wgpu::BufferUsages::COPY_DST
                 | wgpu::BufferUsages::COPY_SRC,
@@ -50,9 +50,7 @@ static SUBGROUP_OPERATIONS: GpuTestConfiguration = GpuTestConfiguration::new()
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Storage { read_only: false },
                     has_dynamic_offset: false,
-                    min_binding_size: NonZeroU64::new(
-                        THREAD_COUNT * std::mem::size_of::<u32>() as u64,
-                    ),
+                    min_binding_size: NonZeroU64::new(THREAD_COUNT * size_of::<u32>() as u64),
                 },
                 count: None,
             }],

--- a/tests/tests/vertex_formats/mod.rs
+++ b/tests/tests/vertex_formats/mod.rs
@@ -1,6 +1,6 @@
 //! Tests that vertex formats pass through to vertex shaders accurately.
 
-use std::num::NonZeroU64;
+use std::{mem::size_of_val, num::NonZeroU64};
 
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 
@@ -273,7 +273,7 @@ async fn vertex_formats_common(ctx: TestingContext, tests: &[Test<'_>]) {
         let pipeline = ctx.device.create_render_pipeline(&pipeline_desc);
 
         let expected = test.checksums;
-        let buffer_size = (std::mem::size_of_val(&expected[0]) * expected.len()) as u64;
+        let buffer_size = (size_of_val(&expected[0]) * expected.len()) as u64;
         let cpu_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
             size: buffer_size,

--- a/tests/tests/vertex_indices/mod.rs
+++ b/tests/tests/vertex_indices/mod.rs
@@ -3,7 +3,7 @@
 //! We need tests for these as the backends use various schemes to work around the lack
 //! of support for things like `gl_BaseInstance` in shaders.
 
-use std::{num::NonZeroU64, ops::Range};
+use std::{mem::size_of_val, num::NonZeroU64, ops::Range};
 
 use itertools::Itertools;
 use strum::IntoEnumIterator;
@@ -341,7 +341,7 @@ async fn vertex_index_common(ctx: TestingContext) {
 
         let expected = test.expectation(&ctx);
 
-        let buffer_size = (std::mem::size_of_val(&expected[0]) * expected.len()) as u64;
+        let buffer_size = (size_of_val(&expected[0]) * expected.len()) as u64;
         let cpu_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
             size: buffer_size,

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -14,7 +14,9 @@ use winit::{
 
 use std::{
     borrow::{Borrow, Cow},
-    iter, mem, ptr,
+    iter,
+    mem::size_of,
+    ptr,
     time::Instant,
 };
 
@@ -193,7 +195,7 @@ impl<A: hal::Api> Example<A> {
                     ty: wgt::BindingType::Buffer {
                         ty: wgt::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: wgt::BufferSize::new(mem::size_of::<Globals>() as _),
+                        min_binding_size: wgt::BufferSize::new(size_of::<Globals>() as _),
                     },
                     count: None,
                 },
@@ -228,7 +230,7 @@ impl<A: hal::Api> Example<A> {
                 ty: wgt::BindingType::Buffer {
                     ty: wgt::BufferBindingType::Uniform,
                     has_dynamic_offset: true,
-                    min_binding_size: wgt::BufferSize::new(mem::size_of::<Locals>() as _),
+                    min_binding_size: wgt::BufferSize::new(size_of::<Locals>() as _),
                 },
                 count: None,
             }],
@@ -394,7 +396,7 @@ impl<A: hal::Api> Example<A> {
 
         let global_buffer_desc = hal::BufferDescriptor {
             label: Some("global"),
-            size: mem::size_of::<Globals>() as wgt::BufferAddress,
+            size: size_of::<Globals>() as wgt::BufferAddress,
             usage: hal::BufferUses::MAP_WRITE | hal::BufferUses::UNIFORM,
             memory_flags: hal::MemoryFlags::PREFER_COHERENT,
         };
@@ -406,7 +408,7 @@ impl<A: hal::Api> Example<A> {
             ptr::copy_nonoverlapping(
                 &globals as *const Globals as *const u8,
                 mapping.ptr.as_ptr(),
-                mem::size_of::<Globals>(),
+                size_of::<Globals>(),
             );
             device.unmap_buffer(&buffer);
             assert!(mapping.is_coherent);
@@ -414,7 +416,7 @@ impl<A: hal::Api> Example<A> {
         };
 
         let local_alignment = wgt::math::align_to(
-            mem::size_of::<Locals>() as u32,
+            size_of::<Locals>() as u32,
             capabilities.limits.min_uniform_buffer_offset_alignment,
         );
         let local_buffer_desc = hal::BufferDescriptor {
@@ -476,7 +478,7 @@ impl<A: hal::Api> Example<A> {
             let local_buffer_binding = hal::BufferBinding {
                 buffer: &local_buffer,
                 offset: 0,
-                size: wgt::BufferSize::new(mem::size_of::<Locals>() as _),
+                size: wgt::BufferSize::new(size_of::<Locals>() as _),
             };
             let local_group_desc = hal::BindGroupDescriptor {
                 label: Some("local"),

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -8,7 +8,9 @@ use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use glam::{Affine3A, Mat4, Vec3};
 use std::{
     borrow::{Borrow, Cow},
-    iter, mem, ptr,
+    iter,
+    mem::size_of,
+    ptr,
     time::Instant,
 };
 use winit::window::WindowButtons;
@@ -304,7 +306,7 @@ impl<A: hal::Api> Example<A> {
                     ty: wgt::BindingType::Buffer {
                         ty: wgt::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: wgt::BufferSize::new(mem::size_of::<Uniforms>() as _),
+                        min_binding_size: wgt::BufferSize::new(size_of::<Uniforms>() as _),
                     },
                     count: None,
                 },
@@ -516,7 +518,7 @@ impl<A: hal::Api> Example<A> {
             }
         };
 
-        let uniforms_size = std::mem::size_of::<Uniforms>();
+        let uniforms_size = size_of::<Uniforms>();
 
         let uniform_buffer = unsafe {
             let uniform_buffer = device
@@ -657,8 +659,7 @@ impl<A: hal::Api> Example<A> {
             ),
         ];
 
-        let instances_buffer_size =
-            instances.len() * std::mem::size_of::<AccelerationStructureInstance>();
+        let instances_buffer_size = instances.len() * size_of::<AccelerationStructureInstance>();
 
         let instances_buffer = unsafe {
             let instances_buffer = device
@@ -828,7 +829,7 @@ impl<A: hal::Api> Example<A> {
         };
 
         let instances_buffer_size =
-            self.instances.len() * std::mem::size_of::<AccelerationStructureInstance>();
+            self.instances.len() * size_of::<AccelerationStructureInstance>();
 
         let tlas_flags = hal::AccelerationStructureBuildFlags::PREFER_FAST_TRACE
             | hal::AccelerationStructureBuildFlags::ALLOW_UPDATE;

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -1,4 +1,9 @@
-use std::{mem, ptr, sync::Arc, thread};
+use std::{
+    mem::{size_of, size_of_val},
+    ptr,
+    sync::Arc,
+    thread,
+};
 
 use parking_lot::Mutex;
 use windows::{
@@ -92,7 +97,7 @@ impl super::Adapter {
             device.CheckFeatureSupport(
                 Direct3D12::D3D12_FEATURE_FEATURE_LEVELS,
                 <*mut _>::cast(&mut device_levels),
-                mem::size_of_val(&device_levels) as u32,
+                size_of_val(&device_levels) as u32,
             )
         }
         .unwrap();
@@ -110,7 +115,7 @@ impl super::Adapter {
             device.CheckFeatureSupport(
                 Direct3D12::D3D12_FEATURE_ARCHITECTURE,
                 <*mut _>::cast(&mut features_architecture),
-                mem::size_of_val(&features_architecture) as u32,
+                size_of_val(&features_architecture) as u32,
             )
         }
         .unwrap();
@@ -154,7 +159,7 @@ impl super::Adapter {
             device.CheckFeatureSupport(
                 Direct3D12::D3D12_FEATURE_D3D12_OPTIONS,
                 <*mut _>::cast(&mut options),
-                mem::size_of_val(&options) as u32,
+                size_of_val(&options) as u32,
             )
         }
         .unwrap();
@@ -165,7 +170,7 @@ impl super::Adapter {
                 device.CheckFeatureSupport(
                     Direct3D12::D3D12_FEATURE_D3D12_OPTIONS2,
                     <*mut _>::cast(&mut features2),
-                    mem::size_of_val(&features2) as u32,
+                    size_of_val(&features2) as u32,
                 )
             }
             .is_ok()
@@ -178,7 +183,7 @@ impl super::Adapter {
                 device.CheckFeatureSupport(
                     Direct3D12::D3D12_FEATURE_D3D12_OPTIONS3,
                     <*mut _>::cast(&mut features3),
-                    mem::size_of_val(&features3) as u32,
+                    size_of_val(&features3) as u32,
                 )
             }
             .is_ok()
@@ -194,7 +199,7 @@ impl super::Adapter {
                 device.CheckFeatureSupport(
                     Direct3D12::D3D12_FEATURE_D3D12_OPTIONS7,
                     <*mut _>::cast(&mut features7),
-                    mem::size_of_val(&features7) as u32,
+                    size_of_val(&features7) as u32,
                 )
             }
             .is_ok()
@@ -224,7 +229,7 @@ impl super::Adapter {
                         device.CheckFeatureSupport(
                             Direct3D12::D3D12_FEATURE_SHADER_MODEL,
                             <*mut _>::cast(&mut sm),
-                            mem::size_of_val(&sm) as u32,
+                            size_of_val(&sm) as u32,
                         )
                     }
                     .is_ok()
@@ -354,7 +359,7 @@ impl super::Adapter {
                 device.CheckFeatureSupport(
                     Direct3D12::D3D12_FEATURE_FORMAT_SUPPORT,
                     <*mut _>::cast(&mut bgra8unorm_info),
-                    mem::size_of_val(&bgra8unorm_info) as u32,
+                    size_of_val(&bgra8unorm_info) as u32,
                 )
             };
             hr.is_ok()
@@ -372,7 +377,7 @@ impl super::Adapter {
             device.CheckFeatureSupport(
                 Direct3D12::D3D12_FEATURE_D3D12_OPTIONS1,
                 <*mut _>::cast(&mut features1),
-                mem::size_of_val(&features1) as u32,
+                size_of_val(&features1) as u32,
             )
         };
 
@@ -396,7 +401,7 @@ impl super::Adapter {
                 device.CheckFeatureSupport(
                     Direct3D12::D3D12_FEATURE_D3D12_OPTIONS9,
                     <*mut _>::cast(&mut features9),
-                    mem::size_of_val(&features9) as u32,
+                    size_of_val(&features9) as u32,
                 )
             }
             .is_ok()
@@ -604,7 +609,7 @@ impl crate::Adapter for super::Adapter {
             self.device.CheckFeatureSupport(
                 Direct3D12::D3D12_FEATURE_FORMAT_SUPPORT,
                 <*mut _>::cast(&mut data),
-                mem::size_of_val(&data) as u32,
+                size_of_val(&data) as u32,
             )
         }
         .unwrap();
@@ -622,7 +627,7 @@ impl crate::Adapter for super::Adapter {
                 self.device.CheckFeatureSupport(
                     Direct3D12::D3D12_FEATURE_FORMAT_SUPPORT,
                     ptr::addr_of_mut!(data_srv_uav).cast(),
-                    mem::size_of::<Direct3D12::D3D12_FEATURE_DATA_FORMAT_SUPPORT>() as u32,
+                    size_of::<Direct3D12::D3D12_FEATURE_DATA_FORMAT_SUPPORT>() as u32,
                 )
             }
             .unwrap();
@@ -718,7 +723,7 @@ impl crate::Adapter for super::Adapter {
                 self.device.CheckFeatureSupport(
                     Direct3D12::D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
                     <*mut _>::cast(&mut ms_levels),
-                    mem::size_of_val(&ms_levels) as u32,
+                    size_of_val(&ms_levels) as u32,
                 )
             }
             .is_ok()

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1,5 +1,6 @@
 use std::{
-    ffi, mem,
+    ffi,
+    mem::{self, size_of},
     num::NonZeroU32,
     ptr,
     sync::Arc,
@@ -121,7 +122,7 @@ impl super::Device {
             cmd_signatures: super::CommandSignatures {
                 draw: create_command_signature(
                     &raw,
-                    mem::size_of::<wgt::DrawIndirectArgs>(),
+                    size_of::<wgt::DrawIndirectArgs>(),
                     &[Direct3D12::D3D12_INDIRECT_ARGUMENT_DESC {
                         Type: Direct3D12::D3D12_INDIRECT_ARGUMENT_TYPE_DRAW,
                         ..Default::default()
@@ -130,7 +131,7 @@ impl super::Device {
                 )?,
                 draw_indexed: create_command_signature(
                     &raw,
-                    mem::size_of::<wgt::DrawIndexedIndirectArgs>(),
+                    size_of::<wgt::DrawIndexedIndirectArgs>(),
                     &[Direct3D12::D3D12_INDIRECT_ARGUMENT_DESC {
                         Type: Direct3D12::D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED,
                         ..Default::default()
@@ -139,7 +140,7 @@ impl super::Device {
                 )?,
                 dispatch: create_command_signature(
                     &raw,
-                    mem::size_of::<wgt::DispatchIndirectArgs>(),
+                    size_of::<wgt::DispatchIndirectArgs>(),
                     &[Direct3D12::D3D12_INDIRECT_ARGUMENT_DESC {
                         Type: Direct3D12::D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH,
                         ..Default::default()

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{mem::size_of_val, sync::Arc};
 
 use parking_lot::RwLock;
 use windows::{
@@ -91,7 +91,7 @@ impl crate::Instance for super::Instance {
                 factory5.CheckFeatureSupport(
                     Dxgi::DXGI_FEATURE_PRESENT_ALLOW_TEARING,
                     <*mut _>::cast(&mut allow_tearing),
-                    std::mem::size_of_val(&allow_tearing) as u32,
+                    size_of_val(&allow_tearing) as u32,
                 )
             };
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -621,7 +621,7 @@ struct PassState {
 
 #[test]
 fn test_dirty_mask() {
-    assert_eq!(MAX_ROOT_ELEMENTS, mem::size_of::<u64>() * 8);
+    assert_eq!(MAX_ROOT_ELEMENTS, u64::BITS as usize);
 }
 
 impl PassState {

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -367,7 +367,7 @@ pub struct Instance {
 }
 
 impl Instance {
-    pub unsafe fn create_surface_from_visual(&self, visual: *mut std::ffi::c_void) -> Surface {
+    pub unsafe fn create_surface_from_visual(&self, visual: *mut ffi::c_void) -> Surface {
         let visual = unsafe { DirectComposition::IDCompositionVisual::from_raw_borrowed(&visual) }
             .expect("COM pointer should not be NULL");
         Surface {
@@ -381,7 +381,7 @@ impl Instance {
 
     pub unsafe fn create_surface_from_surface_handle(
         &self,
-        surface_handle: *mut std::ffi::c_void,
+        surface_handle: *mut ffi::c_void,
     ) -> Surface {
         // TODO: We're not given ownership, so we shouldn't call HANDLE::free(). This puts an extra burden on the caller to keep it alive.
         // https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-duplicatehandle could help us, even though DirectComposition is not in the list?
@@ -398,7 +398,7 @@ impl Instance {
 
     pub unsafe fn create_surface_from_swap_chain_panel(
         &self,
-        swap_chain_panel: *mut std::ffi::c_void,
+        swap_chain_panel: *mut ffi::c_void,
     ) -> Surface {
         let swap_chain_panel =
             unsafe { types::ISwapChainPanelNative::from_raw_borrowed(&swap_chain_panel) }

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -9,7 +9,7 @@ use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use std::{
     collections::HashSet,
     ffi::{c_void, CStr, CString},
-    mem::{self, ManuallyDrop},
+    mem::{self, size_of, size_of_val, ManuallyDrop},
     os::raw::c_int,
     ptr,
     sync::{
@@ -196,7 +196,7 @@ unsafe fn setup_pixel_format(dc: Gdi::HDC) -> Result<(), crate::InstanceError> {
     {
         let format = OpenGL::PIXELFORMATDESCRIPTOR {
             nVersion: 1,
-            nSize: mem::size_of::<OpenGL::PIXELFORMATDESCRIPTOR>() as u16,
+            nSize: size_of::<OpenGL::PIXELFORMATDESCRIPTOR>() as u16,
             dwFlags: OpenGL::PFD_DRAW_TO_WINDOW
                 | OpenGL::PFD_SUPPORT_OPENGL
                 | OpenGL::PFD_DOUBLEBUFFER,
@@ -232,12 +232,7 @@ unsafe fn setup_pixel_format(dc: Gdi::HDC) -> Result<(), crate::InstanceError> {
         }
         let mut format = Default::default();
         if unsafe {
-            OpenGL::DescribePixelFormat(
-                dc,
-                index,
-                mem::size_of_val(&format) as u32,
-                Some(&mut format),
-            )
+            OpenGL::DescribePixelFormat(dc, index, size_of_val(&format) as u32, Some(&mut format))
         } == 0
         {
             return Err(crate::InstanceError::with_source(
@@ -280,7 +275,7 @@ fn create_global_window_class() -> Result<CString, crate::InstanceError> {
     }
 
     let window_class = WindowsAndMessaging::WNDCLASSEXA {
-        cbSize: mem::size_of::<WindowsAndMessaging::WNDCLASSEXA>() as u32,
+        cbSize: size_of::<WindowsAndMessaging::WNDCLASSEXA>() as u32,
         style: WindowsAndMessaging::CS_OWNDC,
         lpfnWndProc: Some(wnd_proc),
         cbClsExtra: 0,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -327,7 +327,7 @@ impl Drop for DropGuard {
 }
 
 #[cfg(any(gles, vulkan))]
-impl std::fmt::Debug for DropGuard {
+impl fmt::Debug for DropGuard {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DropGuard").finish()
     }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 #[cfg(any(feature = "serde", test))]
 use serde::Serialize;
 use std::hash::{Hash, Hasher};
+use std::mem::size_of;
 use std::path::PathBuf;
 use std::{num::NonZeroU32, ops::Range};
 
@@ -7228,7 +7229,7 @@ impl DrawIndirectArgs {
         unsafe {
             std::mem::transmute(std::slice::from_raw_parts(
                 std::ptr::from_ref(self).cast::<u8>(),
-                std::mem::size_of::<Self>(),
+                size_of::<Self>(),
             ))
         }
     }
@@ -7259,7 +7260,7 @@ impl DrawIndexedIndirectArgs {
         unsafe {
             std::mem::transmute(std::slice::from_raw_parts(
                 std::ptr::from_ref(self).cast::<u8>(),
-                std::mem::size_of::<Self>(),
+                size_of::<Self>(),
             ))
         }
     }
@@ -7284,7 +7285,7 @@ impl DispatchIndirectArgs {
         unsafe {
             std::mem::transmute(std::slice::from_raw_parts(
                 std::ptr::from_ref(self).cast::<u8>(),
-                std::mem::size_of::<Self>(),
+                size_of::<Self>(),
             ))
         }
     }

--- a/wgpu/src/macros.rs
+++ b/wgpu/src/macros.rs
@@ -32,12 +32,14 @@ macro_rules! vertex_attr_array {
 
 #[test]
 fn test_vertex_attr_array() {
+    use std::mem::size_of;
+
     let attrs = vertex_attr_array![0 => Float32x2, 3 => Uint16x4];
     // VertexAttribute does not support PartialEq, so we cannot test directly
     assert_eq!(attrs.len(), 2);
     assert_eq!(attrs[0].offset, 0);
     assert_eq!(attrs[0].shader_location, 0);
-    assert_eq!(attrs[1].offset, std::mem::size_of::<(f32, f32)>() as u64);
+    assert_eq!(attrs[1].offset, size_of::<(f32, f32)>() as u64);
     assert_eq!(attrs[1].shader_location, 3);
 }
 


### PR DESCRIPTION
**Connections**

Offloading some diff. complexity from #6105.

**Description**

Fixes more lints that will definitely affect us with Rust upgrades later.

**Testing**

Things still compile, so woot!

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ Not necessary.
