### PR TITLE
[naga wgsl] all swizzle components must be either color or dimension

### DIFF
--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -870,43 +870,6 @@ enum Components {
     },
 }
 
-#[derive(Copy, Clone)]
-enum SwizzleComponentType {
-    /// xyzw
-    Dimension,
-    /// rgba
-    Color,
-    /// Nothing was read yet or invalid
-    Any,
-}
-
-impl SwizzleComponentType {
-    const fn from_letter(letter: char) -> Self {
-        use SwizzleComponentType::*;
-        match letter {
-            'x' | 'y' | 'z' | 'w' => Dimension,
-            'r' | 'g' | 'b' | 'a' => Color,
-            _ => Any,
-        }
-    }
-
-    fn is_expected_type(&mut self, read: Self) -> bool {
-        use SwizzleComponentType::*;
-        match (*self, read) {
-            (Any, Dimension) => {
-                *self = Dimension;
-                true
-            }
-            (Any, Color) => {
-                *self = Color;
-                true
-            }
-            (Color, Color) | (Dimension, Dimension) => true,
-            _ => false,
-        }
-    }
-}
-
 impl Components {
     const fn letter_component(letter: char) -> Option<crate::SwizzleComponent> {
         use crate::SwizzleComponent as Sc;
@@ -940,15 +903,17 @@ impl Components {
         };
 
         let mut pattern = [crate::SwizzleComponent::X; 4];
-        let mut expected_swizzle_type = SwizzleComponentType::Any;
         for (comp, ch) in pattern.iter_mut().zip(name.chars()) {
             *comp = Self::letter_component(ch).ok_or(Error::BadAccessor(name_span))?;
-            if !expected_swizzle_type.is_expected_type(SwizzleComponentType::from_letter(ch)) {
-                return Err(Error::BadAccessor(name_span));
-            }
         }
 
-        Ok(Components::Swizzle { size, pattern })
+        if name.chars().all(|c| matches!(c, 'x' | 'y' | 'z' | 'w'))
+            || name.chars().all(|c| matches!(c, 'r' | 'g' | 'b' | 'a'))
+        {
+            Ok(Components::Swizzle { size, pattern })
+        } else {
+            Err(Error::BadAccessor(name_span))
+        }
     }
 }
 

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -2371,3 +2371,21 @@ fn local_const_from_global_var() {
 "###,
     );
 }
+
+#[test]
+fn only_one_swizzle_type() {
+    check(
+        "
+        const ok1 = vec2(0.0, 0.0).xy;
+        const ok2 = vec2(0.0, 0.0).rg;
+        const err = vec2(0.0, 0.0).xg;
+        ",
+        r###"error: invalid field accessor `xg`
+  ┌─ wgsl:4:36
+  │
+4 │         const err = vec2(0.0, 0.0).xg;
+  │                                    ^^ invalid accessor
+
+"###,
+    );
+}


### PR DESCRIPTION
**Connections**
fixes #6184

**Description**
Added check that all swizzle components are either dimension (xyzw) or color (rgba).

**Testing**
There is new test and I will do CTS run in servo.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
