### PR TITLE
Properly handle the case where Navigator.gpu is undefined and WebGPU is the only compiled backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 ### Bug Fixes
 
 - Fix incorrect hlsl image output type conversion. By @atlv24 in [#6123](https://github.com/gfx-rs/wgpu/pull/6123)
+- Fix JS `TypeError` exception in `Instance::request_adapter` when browser doesn't support WebGPU but `wgpu` not compiled with `webgl` support. By @bgr360 in [#6197](https://github.com/gfx-rs/wgpu/pull/6197).
 
 #### Naga
 

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -95,7 +95,7 @@ impl Instance {
     ///   [`Backends::BROWSER_WEBGPU`] takes a special role:
     ///   If it is set and WebGPU support is detected, this instance will *only* be able to create
     ///   WebGPU adapters. If you instead want to force use of WebGL, either
-    ///   disable the `webgpu` compile-time feature or do add the [`Backends::BROWSER_WEBGPU`]
+    ///   disable the `webgpu` compile-time feature or don't add the [`Backends::BROWSER_WEBGPU`]
     ///   flag to the the `instance_desc`'s `backends` field.
     ///   If it is set and WebGPU support is *not* detected, the instance will use wgpu-core
     ///   to create adapters. Meaning that if the `webgl` feature is enabled, it is able to create

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -118,8 +118,9 @@ impl Instance {
         {
             let is_only_available_backend = !cfg!(wgpu_core);
             let requested_webgpu = _instance_desc.backends.contains(Backends::BROWSER_WEBGPU);
-            let support_webgpu =
-                crate::backend::get_browser_gpu_property().map_or(false, |gpu| !gpu.is_undefined());
+            let support_webgpu = crate::backend::get_browser_gpu_property()
+                .map(|maybe_gpu| maybe_gpu.is_some())
+                .unwrap_or(false);
 
             if is_only_available_backend || (requested_webgpu && support_webgpu) {
                 return Self {

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -41,6 +41,7 @@ unsafe impl<T> Send for Sendable<T> {}
 unsafe impl<T> Sync for Sendable<T> {}
 
 pub(crate) struct ContextWebGpu {
+    /// `None` if browser does not advertise support for WebGPU.
     gpu: Option<DefinedNonNullJsValue<webgpu_sys::Gpu>>,
 }
 #[cfg(send_sync)]

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1242,7 +1242,7 @@ impl crate::context::Context for ContextWebGpu {
                 future_request_adapter,
             ))
         } else {
-            // Gpu is undfined; WebGPU is not supported in this browser.
+            // Gpu is undefined; WebGPU is not supported in this browser.
             OptionFuture::none()
         }
     }

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1359,11 +1359,13 @@ impl crate::context::Context for ContextWebGpu {
         let mut mapped_formats = formats.iter().map(|format| map_texture_format(*format));
         // Preferred canvas format will only be either "rgba8unorm" or "bgra8unorm".
         // https://www.w3.org/TR/webgpu/#dom-gpu-getpreferredcanvasformat
-        if let Some(gpu) = &self.gpu {
-            let preferred_format = gpu.get_preferred_canvas_format();
-            if let Some(index) = mapped_formats.position(|format| format == preferred_format) {
-                formats.swap(0, index);
-            }
+        let gpu = self
+            .gpu
+            .as_ref()
+            .expect("Caller could not have created an adapter if gpu is undefined.");
+        let preferred_format = gpu.get_preferred_canvas_format();
+        if let Some(index) = mapped_formats.position(|format| format == preferred_format) {
+            formats.swap(0, index);
         }
 
         wgt::SurfaceCapabilities {

--- a/wgpu/src/backend/webgpu/defined_non_null_js_value.rs
+++ b/wgpu/src/backend/webgpu/defined_non_null_js_value.rs
@@ -1,0 +1,46 @@
+use std::ops::{Deref, DerefMut};
+
+use wasm_bindgen::JsValue;
+
+/// Derefs to a [`JsValue`] that's known not to be `undefined` or `null`.
+#[derive(Debug)]
+pub struct DefinedNonNullJsValue<T>(T);
+
+impl<T> DefinedNonNullJsValue<T>
+where
+    T: AsRef<JsValue>,
+{
+    pub fn new(value: T) -> Option<Self> {
+        if value.as_ref().is_undefined() || value.as_ref().is_null() {
+            None
+        } else {
+            Some(Self(value))
+        }
+    }
+}
+
+impl<T> Deref for DefinedNonNullJsValue<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for DefinedNonNullJsValue<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> AsRef<T> for DefinedNonNullJsValue<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> AsMut<T> for DefinedNonNullJsValue<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}


### PR DESCRIPTION
**Connections**
Fixes #6196.

**Description**
This PR fixes a bug where `wgpu` would "crash" in the browser (JavaScript `TypeError` exception) when compiled without `webgl` support and the browser doesn't support WebGPU.

**Implementation**
This PR changes `ContextWebGPU` to avoid calling `wgpu_sys` with an `undefined` `Gpu` object. In `ContextWebGpu::request_adapter`, this involves immediately returning `None` if `self.gpu` is undefined in the browser.

**Testing**
Please advise. I have no idea how to write an automated regression test for this kind of change. I could not find any `CONTRIBUTING.md` or likewise providing any guidelines.

Additionally, I have not yet manually tested that this works. I will work on that.
EDIT: Okay I applied the patch to `wgpu` 0.20.1 locally and patched `eframe` to use it, and it does successfully get past the problem.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
  - [ ] **??** Do I need to do this on `--target wasm32-unknown-unknown` as well **??**
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
