### PR TITLE
[naga wgsl] Impl `const_assert`

### DIFF
--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -263,6 +263,8 @@ pub(crate) enum Error<'a> {
         limit: u8,
     },
     PipelineConstantIDValue(Span),
+    NotBool(Span),
+    ConstAssertFailed(Span),
 }
 
 #[derive(Clone, Debug)]
@@ -812,6 +814,22 @@ impl<'a> Error<'a> {
                 labels: vec![(
                     span,
                     "must be between 0 and 65535 inclusive".into(),
+                )],
+                notes: vec![],
+            },
+            Error::NotBool(span) => ParseError {
+                message: "must be a const-expression that resolves to a bool".to_string(),
+                labels: vec![(
+                    span,
+                    "must resolve to bool".into(),
+                )],
+                notes: vec![],
+            },
+            Error::ConstAssertFailed(span) => ParseError {
+                message: "const_assert failure".to_string(),
+                labels: vec![(
+                    span,
+                    "evaluates to false".into(),
                 )],
                 notes: vec![],
             },

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1189,6 +1189,20 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     ctx.globals
                         .insert(alias.name.name, LoweredGlobalDecl::Type(ty));
                 }
+                ast::GlobalDeclKind::ConstAssert(condition) => {
+                    let condition = self.expression(condition, &mut ctx.as_const())?;
+
+                    let span = ctx.module.global_expressions.get_span(condition);
+                    match ctx
+                        .module
+                        .to_ctx()
+                        .eval_expr_to_bool_from(condition, &ctx.module.global_expressions)
+                    {
+                        Some(true) => Ok(()),
+                        Some(false) => Err(Error::ConstAssertFailed(span)),
+                        _ => Err(Error::NotBool(span)),
+                    }?;
+                }
             }
         }
 

--- a/naga/src/front/wgsl/parse/ast.rs
+++ b/naga/src/front/wgsl/parse/ast.rs
@@ -85,6 +85,7 @@ pub enum GlobalDeclKind<'a> {
     Override(Override<'a>),
     Struct(Struct<'a>),
     Type(TypeAlias<'a>),
+    ConstAssert(Handle<Expression<'a>>),
 }
 
 #[derive(Debug)]

--- a/naga/src/front/wgsl/parse/ast.rs
+++ b/naga/src/front/wgsl/parse/ast.rs
@@ -282,6 +282,7 @@ pub enum StatementKind<'a> {
     Increment(Handle<Expression<'a>>),
     Decrement(Handle<Expression<'a>>),
     Ignore(Handle<Expression<'a>>),
+    ConstAssert(Handle<Expression<'a>>),
 }
 
 #[derive(Debug)]

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -1985,6 +1985,20 @@ impl Parser {
                         lexer.expect(Token::Separator(';'))?;
                         ast::StatementKind::Kill
                     }
+                    // https://www.w3.org/TR/WGSL/#const-assert-statement
+                    "const_assert" => {
+                        let _ = lexer.next();
+                        // parentheses are optional
+                        let paren = lexer.skip(Token::Paren('('));
+
+                        let condition = self.general_expression(lexer, ctx)?;
+
+                        if paren {
+                            lexer.expect(Token::Paren(')'))?;
+                        }
+                        lexer.expect(Token::Separator(';'))?;
+                        ast::StatementKind::ConstAssert(condition)
+                    }
                     // assignment or a function call
                     _ => {
                         self.function_call_or_assignment_statement(lexer, ctx, block)?;

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -2402,6 +2402,18 @@ impl Parser {
                     ..function
                 }))
             }
+            (Token::Word("const_assert"), _) => {
+                // parentheses are optional
+                let paren = lexer.skip(Token::Paren('('));
+
+                let condition = self.general_expression(lexer, &mut ctx)?;
+
+                if paren {
+                    lexer.expect(Token::Paren(')'))?;
+                }
+                lexer.expect(Token::Separator(';'))?;
+                Some(ast::GlobalDeclKind::ConstAssert(condition))
+            }
             (Token::End, _) => return Ok(()),
             other => return Err(Error::Unexpected(other.1, ExpectedToken::GlobalItem)),
         };

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -674,6 +674,19 @@ impl GlobalCtx<'_> {
         }
     }
 
+    /// Try to evaluate the expression in the `arena` using its `handle` and return it as a `bool`.
+    #[allow(dead_code)]
+    pub(super) fn eval_expr_to_bool_from(
+        &self,
+        handle: crate::Handle<crate::Expression>,
+        arena: &crate::Arena<crate::Expression>,
+    ) -> Option<bool> {
+        match self.eval_expr_to_literal_from(handle, arena) {
+            Some(crate::Literal::Bool(value)) => Some(value),
+            _ => None,
+        }
+    }
+
     #[allow(dead_code)]
     pub(crate) fn eval_expr_to_literal(
         &self,

--- a/naga/tests/in/const_assert.wgsl
+++ b/naga/tests/in/const_assert.wgsl
@@ -1,0 +1,11 @@
+// Sourced from https://www.w3.org/TR/WGSL/#const-assert-statement
+const x = 1;
+const y = 2;
+const_assert x < y; // valid at module-scope.
+const_assert(y != 0); // parentheses are optional.
+
+fn foo() {
+  const z = x + y - 2;
+  const_assert z > 0; // valid in functions.
+  const_assert(z > 0);
+}

--- a/naga/tests/out/ir/const_assert.compact.ron
+++ b/naga/tests/out/ir/const_assert.compact.ron
@@ -1,0 +1,54 @@
+(
+    types: [
+        (
+            name: None,
+            inner: Scalar((
+                kind: Sint,
+                width: 4,
+            )),
+        ),
+    ],
+    special_types: (
+        ray_desc: None,
+        ray_intersection: None,
+        predeclared_types: {},
+    ),
+    constants: [
+        (
+            name: Some("x"),
+            ty: 0,
+            init: 0,
+        ),
+        (
+            name: Some("y"),
+            ty: 0,
+            init: 1,
+        ),
+    ],
+    overrides: [],
+    global_variables: [],
+    global_expressions: [
+        Literal(I32(1)),
+        Literal(I32(2)),
+    ],
+    functions: [
+        (
+            name: Some("foo"),
+            arguments: [],
+            result: None,
+            local_variables: [],
+            expressions: [
+                Literal(I32(1)),
+            ],
+            named_expressions: {
+                0: "z",
+            },
+            body: [
+                Return(
+                    value: None,
+                ),
+            ],
+        ),
+    ],
+    entry_points: [],
+)

--- a/naga/tests/out/ir/const_assert.ron
+++ b/naga/tests/out/ir/const_assert.ron
@@ -1,0 +1,54 @@
+(
+    types: [
+        (
+            name: None,
+            inner: Scalar((
+                kind: Sint,
+                width: 4,
+            )),
+        ),
+    ],
+    special_types: (
+        ray_desc: None,
+        ray_intersection: None,
+        predeclared_types: {},
+    ),
+    constants: [
+        (
+            name: Some("x"),
+            ty: 0,
+            init: 0,
+        ),
+        (
+            name: Some("y"),
+            ty: 0,
+            init: 1,
+        ),
+    ],
+    overrides: [],
+    global_variables: [],
+    global_expressions: [
+        Literal(I32(1)),
+        Literal(I32(2)),
+    ],
+    functions: [
+        (
+            name: Some("foo"),
+            arguments: [],
+            result: None,
+            local_variables: [],
+            expressions: [
+                Literal(I32(1)),
+            ],
+            named_expressions: {
+                0: "z",
+            },
+            body: [
+                Return(
+                    value: None,
+                ),
+            ],
+        ),
+    ],
+    entry_points: [],
+)

--- a/naga/tests/out/wgsl/const_assert.wgsl
+++ b/naga/tests/out/wgsl/const_assert.wgsl
@@ -1,0 +1,7 @@
+const x: i32 = 1i;
+const y: i32 = 2i;
+
+fn foo() {
+    return;
+}
+

--- a/naga/tests/snapshots.rs
+++ b/naga/tests/snapshots.rs
@@ -868,6 +868,7 @@ fn convert_wgsl() {
             "const-exprs",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
         ),
+        ("const_assert", Targets::WGSL | Targets::IR),
         ("separate-entry-points", Targets::SPIRV | Targets::GLSL),
         (
             "struct-layout",

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -2389,3 +2389,54 @@ fn only_one_swizzle_type() {
 "###,
     );
 }
+
+#[test]
+fn const_assert_must_be_const() {
+    check(
+        "
+        fn foo() {
+            let a = 5;
+            const_assert a != 0;
+        }
+        ",
+        r###"error: this operation is not supported in a const context
+  ┌─ wgsl:4:26
+  │
+4 │             const_assert a != 0;
+  │                          ^ operation not supported here
+
+"###,
+    );
+}
+
+#[test]
+fn const_assert_must_be_bool() {
+    check(
+        "
+            const_assert(5); // 5 is not bool
+        ",
+        r###"error: must be a const-expression that resolves to a bool
+  ┌─ wgsl:2:26
+  │
+2 │             const_assert(5); // 5 is not bool
+  │                          ^ must resolve to bool
+
+"###,
+    );
+}
+
+#[test]
+fn const_assert_failed() {
+    check(
+        "
+            const_assert(false);
+        ",
+        r###"error: const_assert failure
+  ┌─ wgsl:2:26
+  │
+2 │             const_assert(false);
+  │                          ^^^^^ evaluates to false
+
+"###,
+    );
+}


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/5391

**Description**
const_asserts are checked when lowering wgsl to naga-ir (so we do not need to add anything to naga-ir).

**Testing**
There are new test for asserts and I did CTS run in servo and looks good (except for `any`/`all` not impl as const)

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
