### PR TITLE
[naga wgsl-in] allow global vars without explicit type

### DIFF
--- a/naga/src/front/wgsl/parse/ast.rs
+++ b/naga/src/front/wgsl/parse/ast.rs
@@ -142,7 +142,7 @@ pub struct GlobalVariable<'a> {
     pub name: Ident<'a>,
     pub space: crate::AddressSpace,
     pub binding: Option<ResourceBinding<'a>>,
-    pub ty: Handle<Type<'a>>,
+    pub ty: Option<Handle<Type<'a>>>,
     pub init: Option<Handle<Expression<'a>>>,
 }
 

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -991,8 +991,12 @@ impl Parser {
             lexer.expect(Token::Paren('>'))?;
         }
         let name = lexer.next_ident()?;
-        lexer.expect(Token::Separator(':'))?;
-        let ty = self.type_decl(lexer, ctx)?;
+
+        let ty = if lexer.skip(Token::Separator(':')) {
+            Some(self.type_decl(lexer, ctx)?)
+        } else {
+            None
+        };
 
         let init = if lexer.skip(Token::Operation('=')) {
             let handle = self.general_expression(lexer, ctx)?;

--- a/naga/tests/in/abstract-types-var.wgsl
+++ b/naga/tests/in/abstract-types-var.wgsl
@@ -43,6 +43,20 @@ var<private> xafpaiaf: array<f32, 2> = array(1,   2.0);
 var<private> xafpafai: array<f32, 2> = array(1.0, 2);
 var<private> xafpafaf: array<f32, 2> = array(1.0, 2.0);
 
+var<private> ivispai = vec2(1);
+var<private> ivfspaf = vec2(1.0);
+var<private> ivis_ai = vec2<i32>(1);
+var<private> ivus_ai = vec2<u32>(1);
+var<private> ivfs_ai = vec2<f32>(1);
+var<private> ivfs_af = vec2<f32>(1.0);
+
+var<private> iafafaf = array<f32, 2>(1.0, 2.0);
+var<private> iafaiai = array<f32, 2>(1, 2);
+
+var<private> iafpafaf = array(1.0, 2.0);
+var<private> iafpaiaf = array(1, 2.0);
+var<private> iafpafai = array(1.0, 2);
+
 fn all_constant_arguments() {
     var xvipaiai: vec2<i32> = vec2(42, 43);
     var xvupaiai: vec2<u32> = vec2(44, 45);

--- a/naga/tests/out/spv/abstract-types-var.spvasm
+++ b/naga/tests/out/spv/abstract-types-var.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 209
+; Bound: 220
 OpCapability Shader
 OpCapability Linkage
 %1 = OpExtInstImport "GLSL.std.450"
@@ -76,168 +76,179 @@ OpDecorate %12 ArrayStride 4
 %67 = OpVariable  %63  Private %37
 %68 = OpVariable  %63  Private %37
 %69 = OpVariable  %63  Private %37
-%72 = OpTypeFunction %2
-%74 = OpTypePointer Function %4
-%76 = OpTypePointer Function %6
-%78 = OpTypePointer Function %8
-%84 = OpTypePointer Function %9
-%100 = OpTypePointer Function %10
-%105 = OpTypePointer Function %12
-%116 = OpTypePointer Function %5
-%117 = OpConstantNull  %5
-%119 = OpTypePointer Function %3
-%120 = OpConstantNull  %3
-%122 = OpTypePointer Function %7
-%123 = OpConstantNull  %7
-%125 = OpConstantNull  %6
-%127 = OpConstantNull  %6
-%129 = OpConstantNull  %6
-%131 = OpConstantNull  %6
-%133 = OpConstantNull  %9
-%135 = OpConstantNull  %9
-%137 = OpConstantNull  %9
-%139 = OpConstantNull  %9
-%141 = OpConstantNull  %10
-%143 = OpConstantNull  %10
-%145 = OpConstantNull  %10
-%147 = OpConstantNull  %10
-%149 = OpConstantNull  %12
-%151 = OpConstantNull  %12
-%153 = OpConstantNull  %10
-%155 = OpConstantNull  %10
-%157 = OpConstantNull  %10
-%159 = OpConstantNull  %10
-%161 = OpConstantNull  %12
-%163 = OpConstantNull  %12
-%71 = OpFunction  %2  None %72
-%70 = OpLabel
-%109 = OpVariable  %100  Function %37
-%106 = OpVariable  %105  Function %39
-%102 = OpVariable  %100  Function %37
-%98 = OpVariable  %78  Function %34
-%95 = OpVariable  %74  Function %33
-%92 = OpVariable  %84  Function %31
-%89 = OpVariable  %84  Function %31
-%86 = OpVariable  %84  Function %31
-%82 = OpVariable  %76  Function %24
-%79 = OpVariable  %76  Function %24
-%73 = OpVariable  %74  Function %15
-%110 = OpVariable  %100  Function %37
-%107 = OpVariable  %105  Function %39
-%103 = OpVariable  %100  Function %37
-%99 = OpVariable  %100  Function %37
-%96 = OpVariable  %76  Function %36
-%93 = OpVariable  %74  Function %33
-%90 = OpVariable  %84  Function %31
-%87 = OpVariable  %84  Function %31
-%83 = OpVariable  %84  Function %31
-%80 = OpVariable  %76  Function %24
-%75 = OpVariable  %76  Function %18
-%111 = OpVariable  %100  Function %37
-%108 = OpVariable  %100  Function %37
-%104 = OpVariable  %105  Function %39
-%101 = OpVariable  %100  Function %37
-%97 = OpVariable  %78  Function %34
-%94 = OpVariable  %78  Function %34
-%91 = OpVariable  %84  Function %31
-%88 = OpVariable  %84  Function %31
-%85 = OpVariable  %84  Function %31
-%81 = OpVariable  %76  Function %24
-%77 = OpVariable  %78  Function %21
-OpBranch %112
-%112 = OpLabel
+%70 = OpVariable  %41  Private %33
+%71 = OpVariable  %45  Private %34
+%72 = OpVariable  %41  Private %33
+%73 = OpVariable  %43  Private %36
+%74 = OpVariable  %45  Private %34
+%75 = OpVariable  %45  Private %34
+%76 = OpVariable  %63  Private %37
+%77 = OpVariable  %63  Private %37
+%78 = OpVariable  %63  Private %37
+%79 = OpVariable  %63  Private %37
+%80 = OpVariable  %63  Private %37
+%83 = OpTypeFunction %2
+%85 = OpTypePointer Function %4
+%87 = OpTypePointer Function %6
+%89 = OpTypePointer Function %8
+%95 = OpTypePointer Function %9
+%111 = OpTypePointer Function %10
+%116 = OpTypePointer Function %12
+%127 = OpTypePointer Function %5
+%128 = OpConstantNull  %5
+%130 = OpTypePointer Function %3
+%131 = OpConstantNull  %3
+%133 = OpTypePointer Function %7
+%134 = OpConstantNull  %7
+%136 = OpConstantNull  %6
+%138 = OpConstantNull  %6
+%140 = OpConstantNull  %6
+%142 = OpConstantNull  %6
+%144 = OpConstantNull  %9
+%146 = OpConstantNull  %9
+%148 = OpConstantNull  %9
+%150 = OpConstantNull  %9
+%152 = OpConstantNull  %10
+%154 = OpConstantNull  %10
+%156 = OpConstantNull  %10
+%158 = OpConstantNull  %10
+%160 = OpConstantNull  %12
+%162 = OpConstantNull  %12
+%164 = OpConstantNull  %10
+%166 = OpConstantNull  %10
+%168 = OpConstantNull  %10
+%170 = OpConstantNull  %10
+%172 = OpConstantNull  %12
+%174 = OpConstantNull  %12
+%82 = OpFunction  %2  None %83
+%81 = OpLabel
+%120 = OpVariable  %111  Function %37
+%117 = OpVariable  %116  Function %39
+%113 = OpVariable  %111  Function %37
+%109 = OpVariable  %89  Function %34
+%106 = OpVariable  %85  Function %33
+%103 = OpVariable  %95  Function %31
+%100 = OpVariable  %95  Function %31
+%97 = OpVariable  %95  Function %31
+%93 = OpVariable  %87  Function %24
+%90 = OpVariable  %87  Function %24
+%84 = OpVariable  %85  Function %15
+%121 = OpVariable  %111  Function %37
+%118 = OpVariable  %116  Function %39
+%114 = OpVariable  %111  Function %37
+%110 = OpVariable  %111  Function %37
+%107 = OpVariable  %87  Function %36
+%104 = OpVariable  %85  Function %33
+%101 = OpVariable  %95  Function %31
+%98 = OpVariable  %95  Function %31
+%94 = OpVariable  %95  Function %31
+%91 = OpVariable  %87  Function %24
+%86 = OpVariable  %87  Function %18
+%122 = OpVariable  %111  Function %37
+%119 = OpVariable  %111  Function %37
+%115 = OpVariable  %116  Function %39
+%112 = OpVariable  %111  Function %37
+%108 = OpVariable  %89  Function %34
+%105 = OpVariable  %89  Function %34
+%102 = OpVariable  %95  Function %31
+%99 = OpVariable  %95  Function %31
+%96 = OpVariable  %95  Function %31
+%92 = OpVariable  %87  Function %24
+%88 = OpVariable  %89  Function %21
+OpBranch %123
+%123 = OpLabel
 OpReturn
 OpFunctionEnd
-%114 = OpFunction  %2  None %72
-%113 = OpLabel
-%162 = OpVariable  %105  Function %163
-%156 = OpVariable  %100  Function %157
-%150 = OpVariable  %105  Function %151
-%144 = OpVariable  %100  Function %145
-%138 = OpVariable  %84  Function %139
-%132 = OpVariable  %84  Function %133
-%126 = OpVariable  %76  Function %127
-%118 = OpVariable  %119  Function %120
-%160 = OpVariable  %105  Function %161
-%154 = OpVariable  %100  Function %155
-%148 = OpVariable  %105  Function %149
-%142 = OpVariable  %100  Function %143
-%136 = OpVariable  %84  Function %137
-%130 = OpVariable  %76  Function %131
-%124 = OpVariable  %76  Function %125
-%115 = OpVariable  %116  Function %117
-%158 = OpVariable  %100  Function %159
-%152 = OpVariable  %100  Function %153
-%146 = OpVariable  %100  Function %147
-%140 = OpVariable  %100  Function %141
-%134 = OpVariable  %84  Function %135
-%128 = OpVariable  %76  Function %129
-%121 = OpVariable  %122  Function %123
-OpBranch %164
-%164 = OpLabel
-%165 = OpLoad  %5  %115
-%166 = OpCompositeConstruct  %6  %165 %23
-OpStore %124 %166
-%167 = OpLoad  %5  %115
-%168 = OpCompositeConstruct  %6  %22 %167
-OpStore %126 %168
-%169 = OpLoad  %5  %115
-%170 = OpCompositeConstruct  %6  %169 %23
-OpStore %128 %170
-%171 = OpLoad  %5  %115
-%172 = OpCompositeConstruct  %6  %22 %171
-OpStore %130 %172
-%173 = OpLoad  %7  %121
-%174 = OpCompositeConstruct  %8  %173 %26
-%175 = OpCompositeConstruct  %9  %174 %30
-OpStore %132 %175
-%176 = OpLoad  %7  %121
-%177 = OpCompositeConstruct  %8  %25 %176
-%178 = OpCompositeConstruct  %9  %177 %30
-OpStore %134 %178
-%179 = OpLoad  %7  %121
-%180 = OpCompositeConstruct  %8  %179 %29
-%181 = OpCompositeConstruct  %9  %27 %180
-OpStore %136 %181
-%182 = OpLoad  %7  %121
-%183 = OpCompositeConstruct  %8  %28 %182
-%184 = OpCompositeConstruct  %9  %27 %183
-OpStore %138 %184
-%185 = OpLoad  %7  %121
-%186 = OpCompositeConstruct  %10  %185 %26
-OpStore %140 %186
-%187 = OpLoad  %7  %121
-%188 = OpCompositeConstruct  %10  %25 %187
-OpStore %142 %188
-%189 = OpLoad  %7  %121
-%190 = OpCompositeConstruct  %10  %189 %26
-OpStore %144 %190
-%191 = OpLoad  %7  %121
-%192 = OpCompositeConstruct  %10  %25 %191
-OpStore %146 %192
-%193 = OpLoad  %3  %118
-%194 = OpCompositeConstruct  %12  %193 %38
-OpStore %148 %194
-%195 = OpLoad  %3  %118
-%196 = OpCompositeConstruct  %12  %32 %195
-OpStore %150 %196
-%197 = OpLoad  %7  %121
-%198 = OpCompositeConstruct  %10  %197 %26
-OpStore %152 %198
-%199 = OpLoad  %7  %121
-%200 = OpCompositeConstruct  %10  %25 %199
-OpStore %154 %200
-%201 = OpLoad  %7  %121
-%202 = OpCompositeConstruct  %10  %201 %26
-OpStore %156 %202
-%203 = OpLoad  %7  %121
-%204 = OpCompositeConstruct  %10  %25 %203
-OpStore %158 %204
-%205 = OpLoad  %3  %118
-%206 = OpCompositeConstruct  %12  %205 %38
-OpStore %160 %206
-%207 = OpLoad  %3  %118
-%208 = OpCompositeConstruct  %12  %32 %207
-OpStore %162 %208
+%125 = OpFunction  %2  None %83
+%124 = OpLabel
+%173 = OpVariable  %116  Function %174
+%167 = OpVariable  %111  Function %168
+%161 = OpVariable  %116  Function %162
+%155 = OpVariable  %111  Function %156
+%149 = OpVariable  %95  Function %150
+%143 = OpVariable  %95  Function %144
+%137 = OpVariable  %87  Function %138
+%129 = OpVariable  %130  Function %131
+%171 = OpVariable  %116  Function %172
+%165 = OpVariable  %111  Function %166
+%159 = OpVariable  %116  Function %160
+%153 = OpVariable  %111  Function %154
+%147 = OpVariable  %95  Function %148
+%141 = OpVariable  %87  Function %142
+%135 = OpVariable  %87  Function %136
+%126 = OpVariable  %127  Function %128
+%169 = OpVariable  %111  Function %170
+%163 = OpVariable  %111  Function %164
+%157 = OpVariable  %111  Function %158
+%151 = OpVariable  %111  Function %152
+%145 = OpVariable  %95  Function %146
+%139 = OpVariable  %87  Function %140
+%132 = OpVariable  %133  Function %134
+OpBranch %175
+%175 = OpLabel
+%176 = OpLoad  %5  %126
+%177 = OpCompositeConstruct  %6  %176 %23
+OpStore %135 %177
+%178 = OpLoad  %5  %126
+%179 = OpCompositeConstruct  %6  %22 %178
+OpStore %137 %179
+%180 = OpLoad  %5  %126
+%181 = OpCompositeConstruct  %6  %180 %23
+OpStore %139 %181
+%182 = OpLoad  %5  %126
+%183 = OpCompositeConstruct  %6  %22 %182
+OpStore %141 %183
+%184 = OpLoad  %7  %132
+%185 = OpCompositeConstruct  %8  %184 %26
+%186 = OpCompositeConstruct  %9  %185 %30
+OpStore %143 %186
+%187 = OpLoad  %7  %132
+%188 = OpCompositeConstruct  %8  %25 %187
+%189 = OpCompositeConstruct  %9  %188 %30
+OpStore %145 %189
+%190 = OpLoad  %7  %132
+%191 = OpCompositeConstruct  %8  %190 %29
+%192 = OpCompositeConstruct  %9  %27 %191
+OpStore %147 %192
+%193 = OpLoad  %7  %132
+%194 = OpCompositeConstruct  %8  %28 %193
+%195 = OpCompositeConstruct  %9  %27 %194
+OpStore %149 %195
+%196 = OpLoad  %7  %132
+%197 = OpCompositeConstruct  %10  %196 %26
+OpStore %151 %197
+%198 = OpLoad  %7  %132
+%199 = OpCompositeConstruct  %10  %25 %198
+OpStore %153 %199
+%200 = OpLoad  %7  %132
+%201 = OpCompositeConstruct  %10  %200 %26
+OpStore %155 %201
+%202 = OpLoad  %7  %132
+%203 = OpCompositeConstruct  %10  %25 %202
+OpStore %157 %203
+%204 = OpLoad  %3  %129
+%205 = OpCompositeConstruct  %12  %204 %38
+OpStore %159 %205
+%206 = OpLoad  %3  %129
+%207 = OpCompositeConstruct  %12  %32 %206
+OpStore %161 %207
+%208 = OpLoad  %7  %132
+%209 = OpCompositeConstruct  %10  %208 %26
+OpStore %163 %209
+%210 = OpLoad  %7  %132
+%211 = OpCompositeConstruct  %10  %25 %210
+OpStore %165 %211
+%212 = OpLoad  %7  %132
+%213 = OpCompositeConstruct  %10  %212 %26
+OpStore %167 %213
+%214 = OpLoad  %7  %132
+%215 = OpCompositeConstruct  %10  %25 %214
+OpStore %169 %215
+%216 = OpLoad  %3  %129
+%217 = OpCompositeConstruct  %12  %216 %38
+OpStore %171 %217
+%218 = OpLoad  %3  %129
+%219 = OpCompositeConstruct  %12  %32 %218
+OpStore %173 %219
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/abstract-types-var.wgsl
+++ b/naga/tests/out/wgsl/abstract-types-var.wgsl
@@ -22,6 +22,17 @@ var<private> xafpaiai_1: array<i32, 2> = array<i32, 2>(1i, 2i);
 var<private> xafpaiaf_1: array<f32, 2> = array<f32, 2>(1f, 2f);
 var<private> xafpafai_1: array<f32, 2> = array<f32, 2>(1f, 2f);
 var<private> xafpafaf_1: array<f32, 2> = array<f32, 2>(1f, 2f);
+var<private> ivispai: vec2<i32> = vec2(1i);
+var<private> ivfspaf: vec2<f32> = vec2(1f);
+var<private> ivis_ai: vec2<i32> = vec2(1i);
+var<private> ivus_ai: vec2<u32> = vec2(1u);
+var<private> ivfs_ai: vec2<f32> = vec2(1f);
+var<private> ivfs_af: vec2<f32> = vec2(1f);
+var<private> iafafaf: array<f32, 2> = array<f32, 2>(1f, 2f);
+var<private> iafaiai: array<f32, 2> = array<f32, 2>(1f, 2f);
+var<private> iafpafaf: array<f32, 2> = array<f32, 2>(1f, 2f);
+var<private> iafpaiaf: array<f32, 2> = array<f32, 2>(1f, 2f);
+var<private> iafpafai: array<f32, 2> = array<f32, 2>(1f, 2f);
 
 fn all_constant_arguments() {
     var xvipaiai: vec2<i32> = vec2<i32>(42i, 43i);


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/4601

**Description**
Per spec each declaration only needs explicit type or initializer, so based on code for LocalVar I made type infer also work at module scope (GlobalVar).

**Testing**
Existing tests are updated.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
