### PR TITLE
D3D12 cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -385,7 +385,7 @@ checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -528,7 +528,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -558,37 +558,6 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
-
-[[package]]
-name = "com"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
-dependencies = [
- "com_macros",
-]
-
-[[package]]
-name = "com_macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
-dependencies = [
- "com_macros_support",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "com_macros_support"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "combine"
@@ -770,7 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -867,7 +836,7 @@ dependencies = [
  "quote",
  "strum",
  "strum_macros",
- "syn 2.0.75",
+ "syn",
  "thiserror",
 ]
 
@@ -940,7 +909,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -953,7 +922,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -1027,7 +996,7 @@ checksum = "b36f2ddfca91251bed7f931f24b192e4eaf0a0e0fa70cf81cfb1416a1973620e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -1148,7 +1117,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -1245,7 +1214,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -1479,21 +1448,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
-]
-
-[[package]]
-name = "hassle-rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
-dependencies = [
- "bitflags 2.6.0",
- "com",
- "libc",
- "libloading",
- "thiserror",
- "widestring",
- "winapi",
 ]
 
 [[package]]
@@ -2084,7 +2038,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -2276,7 +2230,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -2405,7 +2359,7 @@ checksum = "07c277e4e643ef00c1233393c673f655e3672cf7eb3ba08a00bdd0ea59139b5f"
 dependencies = [
  "proc-macro-rules-macros",
  "proc-macro2",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -2417,7 +2371,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -2740,7 +2694,7 @@ checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -2958,18 +2912,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]
@@ -3009,7 +2952,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -3117,7 +3060,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -3410,7 +3353,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3444,7 +3387,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3478,7 +3421,7 @@ checksum = "4b8220be1fa9e4c889b30fd207d4906657e7e90b12e0e6b0c8b8d8709f5de021"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -3730,7 +3673,6 @@ dependencies = [
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hassle-rs",
  "js-sys",
  "khronos-egl",
  "libc",
@@ -3777,7 +3719,7 @@ version = "22.0.0"
 dependencies = [
  "heck 0.5.0",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -3838,12 +3780,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"
@@ -3907,7 +3843,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -3918,7 +3854,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]
 
 [[package]]
@@ -4292,5 +4228,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,6 @@ gpu-descriptor = "0.3"
 bit-set = "0.8"
 gpu-allocator = { version = "0.27", default-features = false }
 range-alloc = "0.1"
-hassle-rs = "0.11.0"
 windows-core = { version = "0.58", default-features = false }
 
 # Gles dependencies

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -36,32 +36,23 @@ static CROSS_DEVICE_BIND_GROUP_USAGE: GpuTestConfiguration = GpuTestConfiguratio
 #[gpu_test]
 static DEVICE_LIFETIME_CHECK: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default())
-    .run_sync(|_| {
-        use pollster::FutureExt as _;
+    .run_sync(|ctx| {
+        ctx.instance.poll_all(false);
 
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::util::backend_bits_from_env().unwrap_or(wgpu::Backends::all()),
-            dx12_shader_compiler: wgpu::util::dx12_shader_compiler_from_env().unwrap_or_default(),
-            gles_minor_version: wgpu::util::gles_minor_version_from_env().unwrap_or_default(),
-            flags: wgpu::InstanceFlags::advanced_debugging().with_env(),
-        });
+        let pre_report = ctx.instance.generate_report().unwrap();
 
-        let adapter = wgpu::util::initialize_adapter_from_env_or_default(&instance, None)
-            .block_on()
-            .expect("failed to create adapter");
-
-        let (device, queue) = adapter
-            .request_device(&wgpu::DeviceDescriptor::default(), None)
-            .block_on()
-            .expect("failed to create device");
-
-        instance.poll_all(false);
-
-        let pre_report = instance.generate_report().unwrap();
+        let TestingContext {
+            instance,
+            device,
+            queue,
+            ..
+        } = ctx;
 
         drop(queue);
         drop(device);
+
         let post_report = instance.generate_report().unwrap();
+
         assert_ne!(
             pre_report, post_report,
             "Queue and Device has not been dropped as expected"
@@ -72,29 +63,16 @@ static DEVICE_LIFETIME_CHECK: GpuTestConfiguration = GpuTestConfiguration::new()
 #[gpu_test]
 static MULTIPLE_DEVICES: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default())
-    .run_sync(|_| {
+    .run_sync(|ctx| {
         use pollster::FutureExt as _;
-
-        fn create_device_and_queue() -> (wgpu::Device, wgpu::Queue) {
-            let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-                backends: wgpu::util::backend_bits_from_env().unwrap_or(wgpu::Backends::all()),
-                dx12_shader_compiler: wgpu::util::dx12_shader_compiler_from_env()
-                    .unwrap_or_default(),
-                gles_minor_version: wgpu::util::gles_minor_version_from_env().unwrap_or_default(),
-                flags: wgpu::InstanceFlags::advanced_debugging().with_env(),
-            });
-
-            let adapter = wgpu::util::initialize_adapter_from_env_or_default(&instance, None)
-                .block_on()
-                .expect("failed to create adapter");
-
-            adapter
-                .request_device(&wgpu::DeviceDescriptor::default(), None)
-                .block_on()
-                .expect("failed to create device")
-        }
-
-        let _ = vec![create_device_and_queue(), create_device_and_queue()];
+        ctx.adapter
+            .request_device(&wgpu::DeviceDescriptor::default(), None)
+            .block_on()
+            .expect("failed to create device");
+        ctx.adapter
+            .request_device(&wgpu::DeviceDescriptor::default(), None)
+            .block_on()
+            .expect("failed to create device");
     });
 
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -78,6 +78,7 @@ dx12 = [
     "gpu-allocator/d3d12",
     "naga/hlsl-out-if-target-windows",
     "windows/Win32_Graphics_Direct3D_Fxc",
+    "windows/Win32_Graphics_Direct3D_Dxc",
     "windows/Win32_Graphics_Direct3D",
     "windows/Win32_Graphics_Direct3D12",
     "windows/Win32_Graphics_DirectComposition",
@@ -89,7 +90,6 @@ dx12 = [
     "windows/Win32_System_Threading",
     "windows/Win32_UI_WindowsAndMessaging",
 ]
-dxc_shader_compiler = ["dep:hassle-rs"]
 renderdoc = ["dep:libloading", "dep:renderdoc-sys"]
 fragile-send-sync-non-atomic-wasm = ["wgt/fragile-send-sync-non-atomic-wasm"]
 # Panic when running into an out-of-memory error (for debugging purposes).
@@ -156,7 +156,6 @@ windows = { workspace = true, optional = true }
 bit-set = { workspace = true, optional = true }
 range-alloc = { workspace = true, optional = true }
 gpu-allocator = { workspace = true, optional = true }
-hassle-rs = { workspace = true, optional = true }
 # For core macros. This crate is also reexported as windows::core.
 windows-core = { workspace = true, optional = true }
 

--- a/wgpu-hal/src/auxil/dxgi/time.rs
+++ b/wgpu-hal/src/auxil/dxgi/time.rs
@@ -62,7 +62,7 @@ impl PresentationTimer {
         let kernelbase =
             libloading::os::windows::Library::open_already_loaded("kernelbase.dll").unwrap();
         // No concerns about lifetimes here as kernelbase is always there.
-        let ptr = unsafe { kernelbase.get(b"QueryInterruptTimePrecise").unwrap() };
+        let ptr = unsafe { kernelbase.get(b"QueryInterruptTimePrecise\0").unwrap() };
         Self::IPresentationManager {
             fnQueryInterruptTimePrecise: *ptr,
         }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -95,7 +95,7 @@ impl super::Adapter {
 
         // We have found a possible adapter.
         // Acquire the device information.
-        let desc = unsafe { adapter.unwrap_adapter2().GetDesc2() }.unwrap();
+        let desc = unsafe { adapter.GetDesc2() }.unwrap();
 
         let device_name = auxil::dxgi::conv::map_adapter_name(desc.Description);
 

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -64,19 +64,9 @@ impl super::Adapter {
         // Create the device so that we can get the capabilities.
         let device = {
             profiling::scope!("ID3D12Device::create_device");
-            match library.create_device(&adapter, Direct3D::D3D_FEATURE_LEVEL_11_0) {
-                Ok(pair) => match pair {
-                    Ok(device) => device,
-                    Err(err) => {
-                        log::warn!("Device creation failed: {}", err);
-                        return None;
-                    }
-                },
-                Err(err) => {
-                    log::warn!("Device creation function is not found: {:?}", err);
-                    return None;
-                }
-            }
+            library
+                .create_device(&adapter, Direct3D::D3D_FEATURE_LEVEL_11_0)
+                .ok()?
         };
 
         profiling::scope!("feature queries");

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -85,7 +85,7 @@ impl super::Device {
         }
         .into_device_result("Zero buffer creation")?;
 
-        let zero_buffer = zero_buffer.ok_or(crate::DeviceError::ResourceCreationFailed)?;
+        let zero_buffer = zero_buffer.ok_or(crate::DeviceError::Unexpected)?;
 
         // Note: without `D3D12_HEAP_FLAG_CREATE_NOT_ZEROED`
         // this resource is zeroed by default.
@@ -114,7 +114,7 @@ impl super::Device {
                 )
             }
             .into_device_result("Command signature creation")?;
-            signature.ok_or(crate::DeviceError::ResourceCreationFailed)
+            signature.ok_or(crate::DeviceError::Unexpected)
         }
 
         let shared = super::DeviceShared {
@@ -1637,7 +1637,7 @@ impl crate::Device for super::Device {
         }
         .into_device_result("Query heap creation")?;
 
-        let raw = raw.ok_or(crate::DeviceError::ResourceCreationFailed)?;
+        let raw = raw.ok_or(crate::DeviceError::Unexpected)?;
 
         if let Some(label) = desc.label {
             unsafe { raw.SetName(&windows::core::HSTRING::from(label)) }

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -52,11 +52,7 @@ impl crate::Instance for super::Instance {
             }
         }
 
-        // Create DXGIFactory4
-        let (lib_dxgi, factory) = auxil::dxgi::factory::create_factory(
-            auxil::dxgi::factory::DxgiFactoryType::Factory4,
-            desc.flags,
-        )?;
+        let (lib_dxgi, factory) = auxil::dxgi::factory::create_factory(desc.flags)?;
 
         // Create IDXGIFactoryMedia
         let factory_media = lib_dxgi.create_factory_media().ok();

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -116,7 +116,7 @@ impl D3D12Lib {
             riid: *const windows_core::GUID,
             ppdevice: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"D3D12CreateDevice") }?;
+        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"D3D12CreateDevice\0") }?;
 
         let mut result__ = None;
 
@@ -148,7 +148,7 @@ impl D3D12Lib {
             pperrorblob: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
         let func: libloading::Symbol<Fun> =
-            unsafe { self.lib.get(b"D3D12SerializeRootSignature") }?;
+            unsafe { self.lib.get(b"D3D12SerializeRootSignature\0") }?;
 
         let desc = Direct3D12::D3D12_ROOT_SIGNATURE_DESC {
             NumParameters: parameters.len() as _,
@@ -187,7 +187,7 @@ impl D3D12Lib {
             riid: *const windows_core::GUID,
             ppvdebug: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"D3D12GetDebugInterface") }?;
+        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"D3D12GetDebugInterface\0") }?;
 
         let mut result__ = None;
 
@@ -217,7 +217,7 @@ impl DxgiLib {
             riid: *const windows_core::GUID,
             pdebug: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"DXGIGetDebugInterface1") }?;
+        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"DXGIGetDebugInterface1\0") }?;
 
         let mut result__ = None;
 
@@ -239,7 +239,7 @@ impl DxgiLib {
             riid: *const windows_core::GUID,
             ppfactory: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"CreateDXGIFactory2") }?;
+        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"CreateDXGIFactory2\0") }?;
 
         let mut result__ = None;
 
@@ -261,7 +261,7 @@ impl DxgiLib {
             riid: *const windows_core::GUID,
             ppfactory: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"CreateDXGIFactory1") }?;
+        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"CreateDXGIFactory1\0") }?;
 
         let mut result__ = None;
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -49,7 +49,7 @@ use std::{ffi, fmt, mem, num::NonZeroU32, ops::Deref, sync::Arc};
 use arrayvec::ArrayVec;
 use parking_lot::{Mutex, RwLock};
 use windows::{
-    core::{Free, Interface, Param as _},
+    core::{Free, Interface},
     Win32::{
         Foundation,
         Graphics::{Direct3D, Direct3D12, DirectComposition, Dxgi},
@@ -118,7 +118,7 @@ impl D3D12Lib {
         let mut result__ = None;
 
         (func)(
-            unsafe { adapter.param().abi() },
+            adapter.as_raw(),
             feature_level,
             // TODO: Generic?
             &Direct3D12::ID3D12Device::IID,

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -1,11 +1,11 @@
+use crate::auxil::dxgi::result::HResult;
 use std::ffi::CStr;
-use std::ptr;
+use std::path::PathBuf;
+use windows::{
+    core::{Interface, PCSTR, PCWSTR},
+    Win32::Graphics::Direct3D::{Dxc, Fxc},
+};
 
-pub(super) use dxc::{compile_dxc, get_dxc_container, DxcContainer};
-use windows::Win32::Graphics::Direct3D;
-
-// This exists so that users who don't want to use dxc can disable the dxc_shader_compiler feature
-// and not have to compile hassle_rs.
 // Currently this will use Dxc if it is chosen as the dx12 compiler at `Instance` creation time, and will
 // fallback to FXC if the Dxc libraries (dxil.dll and dxcompiler.dll) are not found, or if Fxc is chosen at'
 // `Instance` creation time.
@@ -14,40 +14,41 @@ pub(super) fn compile_fxc(
     device: &super::Device,
     source: &str,
     source_name: Option<&CStr>,
-    raw_ep: &CStr,
+    raw_ep: &str,
     stage_bit: wgt::ShaderStages,
-    full_stage: &CStr,
-) -> (
-    Result<super::CompiledShader, crate::PipelineError>,
-    log::Level,
-) {
+    full_stage: &str,
+) -> Result<super::CompiledShader, crate::PipelineError> {
     profiling::scope!("compile_fxc");
     let mut shader_data = None;
-    let mut compile_flags = Direct3D::Fxc::D3DCOMPILE_ENABLE_STRICTNESS;
+    let mut compile_flags = Fxc::D3DCOMPILE_ENABLE_STRICTNESS;
     if device
         .private_caps
         .instance_flags
         .contains(wgt::InstanceFlags::DEBUG)
     {
-        compile_flags |=
-            Direct3D::Fxc::D3DCOMPILE_DEBUG | Direct3D::Fxc::D3DCOMPILE_SKIP_OPTIMIZATION;
+        compile_flags |= Fxc::D3DCOMPILE_DEBUG | Fxc::D3DCOMPILE_SKIP_OPTIMIZATION;
     }
 
+    let raw_ep = std::ffi::CString::new(raw_ep).unwrap();
+    let full_stage = std::ffi::CString::new(full_stage).unwrap();
+
     // If no name has been set, D3DCompile wants the null pointer.
-    let source_name = source_name.map(|cstr| cstr.as_ptr()).unwrap_or(ptr::null());
+    let source_name = source_name
+        .map(|cstr| cstr.as_ptr().cast())
+        .unwrap_or(core::ptr::null());
 
     let mut error = None;
     let hr = unsafe {
-        profiling::scope!("Direct3D::Fxc::D3DCompile");
-        Direct3D::Fxc::D3DCompile(
+        profiling::scope!("Fxc::D3DCompile");
+        Fxc::D3DCompile(
             // TODO: Update low-level bindings to accept a slice here
             source.as_ptr().cast(),
             source.len(),
-            windows::core::PCSTR(source_name.cast()),
+            PCSTR(source_name),
             None,
             None,
-            windows::core::PCSTR(raw_ep.as_ptr().cast()),
-            windows::core::PCSTR(full_stage.as_ptr().cast()),
+            PCSTR(raw_ep.as_ptr().cast()),
+            PCSTR(full_stage.as_ptr().cast()),
             compile_flags,
             0,
             &mut shader_data,
@@ -58,10 +59,7 @@ pub(super) fn compile_fxc(
     match hr {
         Ok(()) => {
             let shader_data = shader_data.unwrap();
-            (
-                Ok(super::CompiledShader::Fxc(shader_data)),
-                log::Level::Info,
-            )
+            Ok(super::CompiledShader::Fxc(shader_data))
         }
         Err(e) => {
             let mut full_msg = format!("FXC D3DCompile error ({e})");
@@ -75,234 +73,237 @@ pub(super) fn compile_fxc(
                 };
                 let _ = write!(full_msg, ": {}", String::from_utf8_lossy(message));
             }
-            (
-                Err(crate::PipelineError::Linkage(stage_bit, full_msg)),
-                log::Level::Warn,
-            )
+            Err(crate::PipelineError::Linkage(stage_bit, full_msg))
         }
     }
 }
 
-// The Dxc implementation is behind a feature flag so that users who don't want to use dxc can disable the feature.
-#[cfg(feature = "dxc_shader_compiler")]
-mod dxc {
-    use std::ffi::CStr;
-    use std::path::PathBuf;
+trait DxcObj: Interface {
+    const CLSID: windows::core::GUID;
+}
+impl DxcObj for Dxc::IDxcCompiler3 {
+    const CLSID: windows::core::GUID = Dxc::CLSID_DxcCompiler;
+}
+impl DxcObj for Dxc::IDxcUtils {
+    const CLSID: windows::core::GUID = Dxc::CLSID_DxcUtils;
+}
+impl DxcObj for Dxc::IDxcValidator {
+    const CLSID: windows::core::GUID = Dxc::CLSID_DxcValidator;
+}
 
-    // Destructor order should be fine since _dxil and _dxc don't rely on each other.
-    pub(crate) struct DxcContainer {
-        compiler: hassle_rs::DxcCompiler,
-        library: hassle_rs::DxcLibrary,
-        validator: hassle_rs::DxcValidator,
-        // Has to be held onto for the lifetime of the device otherwise shaders will fail to compile.
-        _dxc: hassle_rs::Dxc,
-        // Also Has to be held onto for the lifetime of the device otherwise shaders will fail to validate.
-        _dxil: hassle_rs::Dxil,
-    }
+#[derive(Debug)]
+struct DxcLib {
+    lib: crate::dx12::DynLib,
+}
 
-    pub(crate) fn get_dxc_container(
-        dxc_path: Option<PathBuf>,
-        dxil_path: Option<PathBuf>,
-    ) -> Result<Option<DxcContainer>, crate::DeviceError> {
-        // Make sure that dxil.dll exists.
-        let dxil = match hassle_rs::Dxil::new(dxil_path) {
-            Ok(dxil) => dxil,
-            Err(e) => {
-                log::warn!("Failed to load dxil.dll. Defaulting to FXC instead: {}", e);
-                return Ok(None);
+impl DxcLib {
+    fn new(lib_path: Option<PathBuf>, lib_name: &'static str) -> Result<Self, libloading::Error> {
+        let lib_path = if let Some(lib_path) = lib_path {
+            if lib_path.is_file() {
+                lib_path
+            } else {
+                lib_path.join(lib_name)
             }
+        } else {
+            PathBuf::from(lib_name)
         };
-
-        // Needed for explicit validation.
-        let validator = dxil.create_validator()?;
-
-        let dxc = match hassle_rs::Dxc::new(dxc_path) {
-            Ok(dxc) => dxc,
-            Err(e) => {
-                log::warn!(
-                    "Failed to load dxcompiler.dll. Defaulting to FXC instead: {}",
-                    e
-                );
-                return Ok(None);
-            }
-        };
-        let compiler = dxc.create_compiler()?;
-        let library = dxc.create_library()?;
-
-        Ok(Some(DxcContainer {
-            _dxc: dxc,
-            compiler,
-            library,
-            _dxil: dxil,
-            validator,
-        }))
+        unsafe { crate::dx12::DynLib::new(lib_path).map(|lib| Self { lib }) }
     }
 
-    pub(crate) fn compile_dxc(
-        device: &crate::dx12::Device,
-        source: &str,
-        source_name: Option<&CStr>,
-        raw_ep: &str,
-        stage_bit: wgt::ShaderStages,
-        full_stage: String,
-        dxc_container: &DxcContainer,
-    ) -> (
-        Result<crate::dx12::CompiledShader, crate::PipelineError>,
-        log::Level,
-    ) {
-        profiling::scope!("compile_dxc");
-        let mut compile_flags = arrayvec::ArrayVec::<&str, 6>::new_const();
-        compile_flags.push("-Ges"); // Direct3D::Fxc::D3DCOMPILE_ENABLE_STRICTNESS
-        compile_flags.push("-Vd"); // Disable implicit validation to work around bugs when dxil.dll isn't in the local directory.
-        compile_flags.push("-HV"); // Use HLSL 2018, Naga doesn't supported 2021 yet.
-        compile_flags.push("2018");
+    pub fn create_instance<T: DxcObj>(&self) -> Result<T, crate::DeviceError> {
+        type Fun = extern "system" fn(
+            rclsid: *const windows_core::GUID,
+            riid: *const windows_core::GUID,
+            ppv: *mut *mut core::ffi::c_void,
+        ) -> windows_core::HRESULT;
+        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"DxcCreateInstance\0") }?;
 
-        if device
-            .private_caps
-            .instance_flags
-            .contains(wgt::InstanceFlags::DEBUG)
-        {
-            compile_flags.push("-Zi"); // Direct3D::Fxc::D3DCOMPILE_SKIP_OPTIMIZATION
-            compile_flags.push("-Od"); // Direct3D::Fxc::D3DCOMPILE_DEBUG
-        }
-
-        let blob = match dxc_container
-            .library
-            .create_blob_with_encoding_from_str(source)
-            .map_err(|e| crate::PipelineError::Linkage(stage_bit, format!("DXC blob error: {e}")))
-        {
-            Ok(blob) => blob,
-            Err(e) => return (Err(e), log::Level::Error),
-        };
-
-        let source_name = source_name
-            .and_then(|cstr| cstr.to_str().ok())
-            .unwrap_or("");
-
-        let compiled = dxc_container.compiler.compile(
-            &blob,
-            source_name,
-            raw_ep,
-            &full_stage,
-            &compile_flags,
-            None,
-            &[],
-        );
-
-        let (result, log_level) = match compiled {
-            Ok(dxc_result) => match dxc_result.get_result() {
-                Ok(dxc_blob) => {
-                    // Validate the shader.
-                    match dxc_container.validator.validate(dxc_blob) {
-                        Ok(validated_blob) => (
-                            Ok(crate::dx12::CompiledShader::Dxc(validated_blob.to_vec())),
-                            log::Level::Info,
-                        ),
-                        Err(e) => (
-                            Err(crate::PipelineError::Linkage(
-                                stage_bit,
-                                format!(
-                                    "DXC validation error: {:?}\n{:?}",
-                                    get_error_string_from_dxc_result(&dxc_container.library, &e.0)
-                                        .unwrap_or_default(),
-                                    e.1
-                                ),
-                            )),
-                            log::Level::Error,
-                        ),
-                    }
-                }
-                Err(e) => (
-                    Err(crate::PipelineError::Linkage(
-                        stage_bit,
-                        format!("DXC compile error: {e}"),
-                    )),
-                    log::Level::Error,
-                ),
-            },
-            Err(e) => (
-                Err(crate::PipelineError::Linkage(
-                    stage_bit,
-                    format!(
-                        "DXC compile error: {}",
-                        get_error_string_from_dxc_result(&dxc_container.library, &e.0)
-                            .unwrap_or_default()
-                    ),
-                )),
-                log::Level::Error,
-            ),
-        };
-
-        (result, log_level)
-    }
-
-    impl From<hassle_rs::HassleError> for crate::DeviceError {
-        fn from(value: hassle_rs::HassleError) -> Self {
-            match value {
-                hassle_rs::HassleError::Win32Error(e) => {
-                    // TODO: This returns an HRESULT, should we try and use the associated Windows error message?
-                    log::error!("Win32 error: {e:?}");
-                    crate::DeviceError::Lost
-                }
-                hassle_rs::HassleError::LoadLibraryError { filename, inner } => {
-                    log::error!("Failed to load dxc library {filename:?}. Inner error: {inner:?}");
-                    crate::DeviceError::Lost
-                }
-                hassle_rs::HassleError::LibLoadingError(e) => {
-                    log::error!("Failed to load dxc library. {e:?}");
-                    crate::DeviceError::Lost
-                }
-                hassle_rs::HassleError::WindowsOnly(e) => {
-                    log::error!("Signing with dxil.dll is only supported on Windows. {e:?}");
-                    crate::DeviceError::Lost
-                }
-                // `ValidationError` and `CompileError` should never happen in a context involving `DeviceError`
-                hassle_rs::HassleError::ValidationError(_e) => unimplemented!(),
-                hassle_rs::HassleError::CompileError(_e) => unimplemented!(),
-            }
-        }
-    }
-
-    fn get_error_string_from_dxc_result(
-        library: &hassle_rs::DxcLibrary,
-        error: &hassle_rs::DxcOperationResult,
-    ) -> Result<String, hassle_rs::HassleError> {
-        error
-            .get_error_buffer()
-            .and_then(|error| library.get_blob_as_string(&hassle_rs::DxcBlob::from(error)))
+        let mut result__ = None;
+        (func)(&T::CLSID, &T::IID, <*mut _>::cast(&mut result__))
+            .ok()
+            .into_device_result("DxcCreateInstance")?;
+        result__.ok_or(crate::DeviceError::Unexpected)
     }
 }
 
-// These are stubs for when the `dxc_shader_compiler` feature is disabled.
-#[cfg(not(feature = "dxc_shader_compiler"))]
-mod dxc {
-    use std::ffi::CStr;
-    use std::path::PathBuf;
+// Destructor order should be fine since _dxil and _dxc don't rely on each other.
+pub(super) struct DxcContainer {
+    compiler: Dxc::IDxcCompiler3,
+    utils: Dxc::IDxcUtils,
+    validator: Dxc::IDxcValidator,
+    // Has to be held onto for the lifetime of the device otherwise shaders will fail to compile.
+    _dxc: DxcLib,
+    // Also Has to be held onto for the lifetime of the device otherwise shaders will fail to validate.
+    _dxil: DxcLib,
+}
 
-    pub(crate) struct DxcContainer {}
+pub(super) fn get_dxc_container(
+    dxc_path: Option<PathBuf>,
+    dxil_path: Option<PathBuf>,
+) -> Result<Option<DxcContainer>, crate::DeviceError> {
+    let dxc = match DxcLib::new(dxc_path, "dxcompiler.dll") {
+        Ok(dxc) => dxc,
+        Err(e) => {
+            log::warn!(
+                "Failed to load dxcompiler.dll. Defaulting to FXC instead: {}",
+                e
+            );
+            return Ok(None);
+        }
+    };
 
-    pub(crate) fn get_dxc_container(
-        _dxc_path: Option<PathBuf>,
-        _dxil_path: Option<PathBuf>,
-    ) -> Result<Option<DxcContainer>, crate::DeviceError> {
-        // Falls back to Fxc and logs an error.
-        log::error!("DXC shader compiler was requested on Instance creation, but the DXC feature is disabled. Enable the `dxc_shader_compiler` feature on wgpu_hal to use DXC.");
-        Ok(None)
+    let dxil = match DxcLib::new(dxil_path, "dxil.dll") {
+        Ok(dxil) => dxil,
+        Err(e) => {
+            log::warn!("Failed to load dxil.dll. Defaulting to FXC instead: {}", e);
+            return Ok(None);
+        }
+    };
+
+    let compiler = dxc.create_instance::<Dxc::IDxcCompiler3>()?;
+    let utils = dxc.create_instance::<Dxc::IDxcUtils>()?;
+    let validator = dxil.create_instance::<Dxc::IDxcValidator>()?;
+
+    Ok(Some(DxcContainer {
+        compiler,
+        utils,
+        validator,
+        _dxc: dxc,
+        _dxil: dxil,
+    }))
+}
+
+/// Owned PCWSTR
+#[allow(clippy::upper_case_acronyms)]
+struct OPCWSTR {
+    inner: Vec<u16>,
+}
+
+impl OPCWSTR {
+    fn new(s: &str) -> Self {
+        let mut inner: Vec<_> = s.encode_utf16().collect();
+        inner.push(0);
+        Self { inner }
     }
 
-    // It shouldn't be possible that this gets called with the `dxc_shader_compiler` feature disabled.
-    pub(crate) fn compile_dxc(
-        _device: &crate::dx12::Device,
-        _source: &str,
-        _source_name: Option<&CStr>,
-        _raw_ep: &str,
-        _stage_bit: wgt::ShaderStages,
-        _full_stage: String,
-        _dxc_container: &DxcContainer,
-    ) -> (
-        Result<crate::dx12::CompiledShader, crate::PipelineError>,
-        log::Level,
-    ) {
-        unimplemented!("Something went really wrong, please report this. Attempted to compile shader with DXC, but the DXC feature is disabled. Enable the `dxc_shader_compiler` feature on wgpu_hal to use DXC.");
+    fn ptr(&self) -> PCWSTR {
+        PCWSTR(self.inner.as_ptr())
     }
+}
+
+fn get_output<T: Interface>(
+    res: &Dxc::IDxcResult,
+    kind: Dxc::DXC_OUT_KIND,
+) -> Result<T, crate::DeviceError> {
+    let mut result__: Option<T> = None;
+    unsafe { res.GetOutput::<T>(kind, &mut None, <*mut _>::cast(&mut result__)) }
+        .into_device_result("GetOutput")?;
+    result__.ok_or(crate::DeviceError::Unexpected)
+}
+
+fn as_err_str(blob: &Dxc::IDxcBlobUtf8) -> Result<&str, crate::DeviceError> {
+    let ptr = unsafe { blob.GetStringPointer() };
+    let len = unsafe { blob.GetStringLength() };
+    core::str::from_utf8(unsafe { core::slice::from_raw_parts(ptr.0, len) })
+        .map_err(|_| crate::DeviceError::Unexpected)
+}
+
+pub(super) fn compile_dxc(
+    device: &crate::dx12::Device,
+    source: &str,
+    source_name: Option<&CStr>,
+    raw_ep: &str,
+    stage_bit: wgt::ShaderStages,
+    full_stage: &str,
+    dxc_container: &DxcContainer,
+) -> Result<crate::dx12::CompiledShader, crate::PipelineError> {
+    profiling::scope!("compile_dxc");
+
+    let source_name = source_name.and_then(|cstr| cstr.to_str().ok());
+
+    let source_name = source_name.map(OPCWSTR::new);
+    let raw_ep = OPCWSTR::new(raw_ep);
+    let full_stage = OPCWSTR::new(full_stage);
+
+    let mut compile_args = arrayvec::ArrayVec::<PCWSTR, 12>::new_const();
+
+    if let Some(source_name) = source_name.as_ref() {
+        compile_args.push(source_name.ptr())
+    }
+
+    compile_args.extend([
+        windows::core::w!("-E"),
+        raw_ep.ptr(),
+        windows::core::w!("-T"),
+        full_stage.ptr(),
+        windows::core::w!("-HV"),
+        windows::core::w!("2018"), // Use HLSL 2018, Naga doesn't supported 2021 yet.
+        windows::core::w!("-no-warnings"),
+        Dxc::DXC_ARG_ENABLE_STRICTNESS,
+        Dxc::DXC_ARG_SKIP_VALIDATION, // Disable implicit validation to work around bugs when dxil.dll isn't in the local directory.
+    ]);
+
+    if device
+        .private_caps
+        .instance_flags
+        .contains(wgt::InstanceFlags::DEBUG)
+    {
+        compile_args.push(Dxc::DXC_ARG_DEBUG);
+        compile_args.push(Dxc::DXC_ARG_SKIP_OPTIMIZATIONS);
+    }
+
+    let buffer = Dxc::DxcBuffer {
+        Ptr: source.as_ptr().cast(),
+        Size: source.len(),
+        Encoding: Dxc::DXC_CP_UTF8.0,
+    };
+
+    let compile_res: Dxc::IDxcResult = unsafe {
+        dxc_container
+            .compiler
+            .Compile(&buffer, Some(&compile_args), None)
+    }
+    .into_device_result("Compile")?;
+
+    drop(compile_args);
+    drop(source_name);
+    drop(raw_ep);
+    drop(full_stage);
+
+    let err_blob = get_output::<Dxc::IDxcBlobUtf8>(&compile_res, Dxc::DXC_OUT_ERRORS)?;
+
+    let len = unsafe { err_blob.GetStringLength() };
+    if len != 0 {
+        let err = as_err_str(&err_blob)?;
+        return Err(crate::PipelineError::Linkage(
+            stage_bit,
+            format!("DXC compile error: {err}"),
+        ));
+    }
+
+    let blob = get_output::<Dxc::IDxcBlob>(&compile_res, Dxc::DXC_OUT_OBJECT)?;
+
+    let err_blob = {
+        let res = unsafe {
+            dxc_container
+                .validator
+                .Validate(&blob, Dxc::DxcValidatorFlags_InPlaceEdit)
+        }
+        .into_device_result("Validate")?;
+
+        unsafe { res.GetErrorBuffer() }.into_device_result("GetErrorBuffer")?
+    };
+
+    let size = unsafe { err_blob.GetBufferSize() };
+    if size != 0 {
+        let err_blob = unsafe { dxc_container.utils.GetBlobAsUtf8(&err_blob) }
+            .into_device_result("GetBlobAsUtf8")?;
+        let err = as_err_str(&err_blob)?;
+        return Err(crate::PipelineError::Linkage(
+            stage_bit,
+            format!("DXC validation error: {err}"),
+        ));
+    }
+
+    Ok(crate::dx12::CompiledShader::Dxc(blob))
 }

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -94,7 +94,7 @@ pub(crate) fn create_buffer_resource(
     }
     .into_device_result("Placed buffer creation")?;
 
-    let resource = resource.ok_or(crate::DeviceError::ResourceCreationFailed)?;
+    let resource = resource.ok_or(crate::DeviceError::Unexpected)?;
 
     device
         .counters
@@ -141,7 +141,7 @@ pub(crate) fn create_texture_resource(
     }
     .into_device_result("Placed texture creation")?;
 
-    let resource = resource.ok_or(crate::DeviceError::ResourceCreationFailed)?;
+    let resource = resource.ok_or(crate::DeviceError::Unexpected)?;
 
     device
         .counters
@@ -265,7 +265,7 @@ pub(crate) fn create_committed_buffer_resource(
     }
     .into_device_result("Committed buffer creation")?;
 
-    resource.ok_or(crate::DeviceError::ResourceCreationFailed)
+    resource.ok_or(crate::DeviceError::Unexpected)
 }
 
 pub(crate) fn create_committed_texture_resource(
@@ -302,5 +302,5 @@ pub(crate) fn create_committed_texture_resource(
     }
     .into_device_result("Committed texture creation")?;
 
-    resource.ok_or(crate::DeviceError::ResourceCreationFailed)
+    resource.ok_or(crate::DeviceError::Unexpected)
 }

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -52,14 +52,14 @@ pub(crate) fn create_buffer_resource(
     device: &crate::dx12::Device,
     desc: &crate::BufferDescriptor,
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
-    resource: &mut Option<Direct3D12::ID3D12Resource>,
-) -> Result<Option<AllocationWrapper>, crate::DeviceError> {
+) -> Result<(Direct3D12::ID3D12Resource, Option<AllocationWrapper>), crate::DeviceError> {
     let is_cpu_read = desc.usage.contains(crate::BufferUses::MAP_READ);
     let is_cpu_write = desc.usage.contains(crate::BufferUses::MAP_WRITE);
 
     // Workaround for Intel Xe drivers
     if !device.private_caps.suballocation_supported {
-        return create_committed_buffer_resource(device, desc, raw_desc, resource).map(|()| None);
+        return create_committed_buffer_resource(device, desc, raw_desc)
+            .map(|resource| (resource, None));
     }
 
     let location = match (is_cpu_read, is_cpu_write) {
@@ -80,6 +80,7 @@ pub(crate) fn create_buffer_resource(
         location,
     );
     let allocation = allocator.allocator.allocate(&allocation_desc)?;
+    let mut resource = None;
 
     unsafe {
         device.raw.CreatePlacedResource(
@@ -88,32 +89,30 @@ pub(crate) fn create_buffer_resource(
             &raw_desc,
             Direct3D12::D3D12_RESOURCE_STATE_COMMON,
             None,
-            resource,
+            &mut resource,
         )
     }
     .into_device_result("Placed buffer creation")?;
 
-    if resource.is_none() {
-        return Err(crate::DeviceError::ResourceCreationFailed);
-    }
+    let resource = resource.ok_or(crate::DeviceError::ResourceCreationFailed)?;
 
     device
         .counters
         .buffer_memory
         .add(allocation.size() as isize);
 
-    Ok(Some(AllocationWrapper { allocation }))
+    Ok((resource, Some(AllocationWrapper { allocation })))
 }
 
 pub(crate) fn create_texture_resource(
     device: &crate::dx12::Device,
     desc: &crate::TextureDescriptor,
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
-    resource: &mut Option<Direct3D12::ID3D12Resource>,
-) -> Result<Option<AllocationWrapper>, crate::DeviceError> {
+) -> Result<(Direct3D12::ID3D12Resource, Option<AllocationWrapper>), crate::DeviceError> {
     // Workaround for Intel Xe drivers
     if !device.private_caps.suballocation_supported {
-        return create_committed_texture_resource(device, desc, raw_desc, resource).map(|()| None);
+        return create_committed_texture_resource(device, desc, raw_desc)
+            .map(|resource| (resource, None));
     }
 
     let location = MemoryLocation::GpuOnly;
@@ -128,6 +127,7 @@ pub(crate) fn create_texture_resource(
         location,
     );
     let allocation = allocator.allocator.allocate(&allocation_desc)?;
+    let mut resource = None;
 
     unsafe {
         device.raw.CreatePlacedResource(
@@ -136,21 +136,19 @@ pub(crate) fn create_texture_resource(
             &raw_desc,
             Direct3D12::D3D12_RESOURCE_STATE_COMMON,
             None, // clear value
-            resource,
+            &mut resource,
         )
     }
     .into_device_result("Placed texture creation")?;
 
-    if resource.is_none() {
-        return Err(crate::DeviceError::ResourceCreationFailed);
-    }
+    let resource = resource.ok_or(crate::DeviceError::ResourceCreationFailed)?;
 
     device
         .counters
         .texture_memory
         .add(allocation.size() as isize);
 
-    Ok(Some(AllocationWrapper { allocation }))
+    Ok((resource, Some(AllocationWrapper { allocation })))
 }
 
 pub(crate) fn free_buffer_allocation(
@@ -226,8 +224,7 @@ pub(crate) fn create_committed_buffer_resource(
     device: &crate::dx12::Device,
     desc: &crate::BufferDescriptor,
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
-    resource: &mut Option<Direct3D12::ID3D12Resource>,
-) -> Result<(), crate::DeviceError> {
+) -> Result<Direct3D12::ID3D12Resource, crate::DeviceError> {
     let is_cpu_read = desc.usage.contains(crate::BufferUses::MAP_READ);
     let is_cpu_write = desc.usage.contains(crate::BufferUses::MAP_WRITE);
 
@@ -250,6 +247,8 @@ pub(crate) fn create_committed_buffer_resource(
         VisibleNodeMask: 0,
     };
 
+    let mut resource = None;
+
     unsafe {
         device.raw.CreateCommittedResource(
             &heap_properties,
@@ -261,24 +260,19 @@ pub(crate) fn create_committed_buffer_resource(
             &raw_desc,
             Direct3D12::D3D12_RESOURCE_STATE_COMMON,
             None,
-            resource,
+            &mut resource,
         )
     }
     .into_device_result("Committed buffer creation")?;
 
-    if resource.is_none() {
-        return Err(crate::DeviceError::ResourceCreationFailed);
-    }
-
-    Ok(())
+    resource.ok_or(crate::DeviceError::ResourceCreationFailed)
 }
 
 pub(crate) fn create_committed_texture_resource(
     device: &crate::dx12::Device,
     _desc: &crate::TextureDescriptor,
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
-    resource: &mut Option<Direct3D12::ID3D12Resource>,
-) -> Result<(), crate::DeviceError> {
+) -> Result<Direct3D12::ID3D12Resource, crate::DeviceError> {
     let heap_properties = Direct3D12::D3D12_HEAP_PROPERTIES {
         Type: Direct3D12::D3D12_HEAP_TYPE_CUSTOM,
         CPUPageProperty: Direct3D12::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE,
@@ -289,6 +283,8 @@ pub(crate) fn create_committed_texture_resource(
         CreationNodeMask: 0,
         VisibleNodeMask: 0,
     };
+
+    let mut resource = None;
 
     unsafe {
         device.raw.CreateCommittedResource(
@@ -301,14 +297,10 @@ pub(crate) fn create_committed_texture_resource(
             &raw_desc,
             Direct3D12::D3D12_RESOURCE_STATE_COMMON,
             None, // clear value
-            resource,
+            &mut resource,
         )
     }
     .into_device_result("Committed texture creation")?;
 
-    if resource.is_none() {
-        return Err(crate::DeviceError::ResourceCreationFailed);
-    }
-
-    Ok(())
+    resource.ok_or(crate::DeviceError::ResourceCreationFailed)
 }

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -143,7 +143,7 @@ impl Drop for DisplayOwner {
         match self.display {
             DisplayRef::X11(ptr) => unsafe {
                 let func: libloading::Symbol<XCloseDisplayFun> =
-                    self.library.get(b"XCloseDisplay").unwrap();
+                    self.library.get(b"XCloseDisplay\0").unwrap();
                 func(ptr.as_ptr());
             },
             DisplayRef::Wayland => {}
@@ -155,7 +155,7 @@ fn open_x_display() -> Option<DisplayOwner> {
     log::debug!("Loading X11 library to get the current display");
     unsafe {
         let library = find_library(&["libX11.so.6", "libX11.so"])?;
-        let func: libloading::Symbol<XOpenDisplayFun> = library.get(b"XOpenDisplay").unwrap();
+        let func: libloading::Symbol<XOpenDisplayFun> = library.get(b"XOpenDisplay\0").unwrap();
         let result = func(ptr::null());
         ptr::NonNull::new(result).map(|ptr| DisplayOwner {
             display: DisplayRef::X11(ptr),
@@ -182,9 +182,9 @@ fn test_wayland_display() -> Option<DisplayOwner> {
     let library = unsafe {
         let client_library = find_library(&["libwayland-client.so.0", "libwayland-client.so"])?;
         let wl_display_connect: libloading::Symbol<WlDisplayConnectFun> =
-            client_library.get(b"wl_display_connect").unwrap();
+            client_library.get(b"wl_display_connect\0").unwrap();
         let wl_display_disconnect: libloading::Symbol<WlDisplayDisconnectFun> =
-            client_library.get(b"wl_display_disconnect").unwrap();
+            client_library.get(b"wl_display_disconnect\0").unwrap();
         let display = ptr::NonNull::new(wl_display_connect(ptr::null()))?;
         wl_display_disconnect(display.as_ptr());
         find_library(&["libwayland-egl.so.1", "libwayland-egl.so"])?
@@ -1294,7 +1294,7 @@ impl crate::Surface for Surface {
                     (WindowKind::Wayland, Rwh::Wayland(handle)) => {
                         let library = &self.wsi.display_owner.as_ref().unwrap().library;
                         let wl_egl_window_create: libloading::Symbol<WlEglWindowCreateFun> =
-                            unsafe { library.get(b"wl_egl_window_create") }.unwrap();
+                            unsafe { library.get(b"wl_egl_window_create\0") }.unwrap();
                         let window =
                             unsafe { wl_egl_window_create(handle.surface.as_ptr(), 640, 480) }
                                 .cast();
@@ -1403,7 +1403,7 @@ impl crate::Surface for Surface {
         if let Some(window) = wl_window {
             let library = &self.wsi.display_owner.as_ref().unwrap().library;
             let wl_egl_window_resize: libloading::Symbol<WlEglWindowResizeFun> =
-                unsafe { library.get(b"wl_egl_window_resize") }.unwrap();
+                unsafe { library.get(b"wl_egl_window_resize\0") }.unwrap();
             unsafe {
                 wl_egl_window_resize(
                     window,
@@ -1475,7 +1475,7 @@ impl crate::Surface for Surface {
                     .expect("unsupported window")
                     .library;
                 let wl_egl_window_destroy: libloading::Symbol<WlEglWindowDestroyFun> =
-                    unsafe { library.get(b"wl_egl_window_destroy") }.unwrap();
+                    unsafe { library.get(b"wl_egl_window_destroy\0") }.unwrap();
                 unsafe { wl_egl_window_destroy(window) };
             }
         }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -345,6 +345,12 @@ pub enum DeviceError {
     Unexpected,
 }
 
+#[allow(dead_code)] // may be unused on some platforms
+#[cold]
+fn hal_usage_error<T: fmt::Display>(txt: T) -> ! {
+    panic!("wgpu-hal invariant was violated (usage error): {txt}")
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
 pub enum ShaderError {
     #[error("Compilation failed: {0:?}")]

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -351,6 +351,12 @@ fn hal_usage_error<T: fmt::Display>(txt: T) -> ! {
     panic!("wgpu-hal invariant was violated (usage error): {txt}")
 }
 
+#[allow(dead_code)] // may be unused on some platforms
+#[cold]
+fn hal_internal_error<T: fmt::Display>(txt: T) -> ! {
+    panic!("wgpu-hal ran into a preventable internal error: {txt}")
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
 pub enum ShaderError {
     #[error("Compilation failed: {0:?}")]

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -2010,7 +2010,7 @@ impl crate::Adapter for super::Adapter {
                 vk::Result::ERROR_TOO_MANY_OBJECTS => crate::DeviceError::OutOfMemory,
                 vk::Result::ERROR_INITIALIZATION_FAILED => crate::DeviceError::Lost,
                 vk::Result::ERROR_EXTENSION_NOT_PRESENT | vk::Result::ERROR_FEATURE_NOT_PRESENT => {
-                    super::hal_usage_error(err)
+                    crate::hal_usage_error(err)
                 }
                 other => super::map_host_device_oom_and_lost_err(other),
             }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -970,14 +970,14 @@ impl crate::Device for super::Device {
                 .contains(gpu_alloc::MemoryPropertyFlags::HOST_COHERENT);
             Ok(crate::BufferMapping { ptr, is_coherent })
         } else {
-            super::hal_usage_error("tried to map external buffer")
+            crate::hal_usage_error("tried to map external buffer")
         }
     }
     unsafe fn unmap_buffer(&self, buffer: &super::Buffer) {
         if let Some(ref block) = buffer.block {
             unsafe { block.lock().unmap(&*self.shared) };
         } else {
-            super::hal_usage_error("tried to unmap external buffer")
+            crate::hal_usage_error("tried to unmap external buffer")
         }
     }
 
@@ -2520,7 +2520,7 @@ impl super::DeviceShared {
                             }
                         }
                         None => {
-                            super::hal_usage_error(format!(
+                            crate::hal_usage_error(format!(
                                 "no signals reached value {}",
                                 wait_value
                             ));
@@ -2537,7 +2537,7 @@ impl From<gpu_alloc::AllocationError> for crate::DeviceError {
         use gpu_alloc::AllocationError as Ae;
         match error {
             Ae::OutOfDeviceMemory | Ae::OutOfHostMemory | Ae::TooManyObjects => Self::OutOfMemory,
-            Ae::NoCompatibleMemoryTypes => super::hal_usage_error(error),
+            Ae::NoCompatibleMemoryTypes => crate::hal_usage_error(error),
         }
     }
 }
@@ -2546,7 +2546,7 @@ impl From<gpu_alloc::MapError> for crate::DeviceError {
         use gpu_alloc::MapError as Me;
         match error {
             Me::OutOfDeviceMemory | Me::OutOfHostMemory | Me::MapFailed => Self::OutOfMemory,
-            Me::NonHostVisible | Me::AlreadyMapped => super::hal_usage_error(error),
+            Me::NonHostVisible | Me::AlreadyMapped => crate::hal_usage_error(error),
         }
     }
 }

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -1360,8 +1360,3 @@ fn get_lost_err() -> crate::DeviceError {
     #[allow(unreachable_code)]
     crate::DeviceError::Lost
 }
-
-#[cold]
-fn hal_usage_error<T: fmt::Display>(txt: T) -> ! {
-    panic!("wgpu-hal invariant was violated (usage error): {txt}")
-}

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7334,10 +7334,6 @@ impl Default for ShaderBoundChecks {
 
 /// Selects which DX12 shader compiler to use.
 ///
-/// If the `wgpu-hal/dx12-shader-compiler` feature isn't enabled then this will fall back
-/// to the Fxc compiler at runtime and log an error.
-/// This feature is always enabled when using `wgpu`.
-///
 /// If the `Dxc` option is selected, but `dxcompiler.dll` and `dxil.dll` files aren't found,
 /// then this will fall back to the Fxc compiler at runtime and log an error.
 ///
@@ -7354,6 +7350,10 @@ pub enum Dx12Compiler {
     ///
     /// However, it requires both `dxcompiler.dll` and `dxil.dll` to be shipped with the application.
     /// These files can be downloaded from <https://github.com/microsoft/DirectXShaderCompiler/releases>.
+    ///
+    /// Minimum supported version: [v1.5.2010](https://github.com/microsoft/DirectXShaderCompiler/releases/tag/v1.5.2010)
+    ///
+    /// It also requires WDDM 2.1 (Windows 10 version 1607).
     Dxc {
         /// Path to the `dxil.dll` file, or path to the directory containing `dxil.dll` file. Passing `None` will use standard platform specific dll loading rules.
         dxil_path: Option<PathBuf>,

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -161,10 +161,7 @@ hal = { workspace = true }
 hal = { workspace = true, features = ["renderdoc"] }
 
 [target.'cfg(windows)'.dependencies]
-hal = { workspace = true, features = [
-    "dxc_shader_compiler",
-    "renderdoc",
-] }
+hal = { workspace = true, features = ["renderdoc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.hal]
 workspace = true


### PR DESCRIPTION
**Connections**
Follow-up to https://github.com/gfx-rs/wgpu/pull/5956.

**Description**
Mainly cleans-up usage of the D3D12 API.
Also fixes an issue where only high performance adapters would be enumerated if DXGI 1.6 is available.
I will have another follow-up to this that will go over and handle errors on a case-by-case basis (similar to https://github.com/gfx-rs/wgpu/pull/6119).

**Testing**
Existing tests. I also tested DXC locally with the changes to shader compilation.

PR doesn't need to be squashed, each commit builds by itself.