### PR TITLE
[naga const-eval] `LiteralVector` and some demo builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,6 +1893,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "log",
+ "num-traits",
  "petgraph",
  "pp-rs",
  "ron",

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -81,7 +81,8 @@ serde = { version = "1.0.214", features = ["derive"], optional = true }
 petgraph = { version = "0.6", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }
-unicode-xid = { version = "0.2.6", optional = true }
+unicode-xid = { version = "0.2.5", optional = true }
+num-traits = "0.2"
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -257,6 +257,7 @@ gen_component_wise_extractor! {
 /// Vector for each [`Literal`] type
 ///
 /// This type ensures that all elements have same type
+#[derive(Debug)]
 enum LiteralVector {
     F64(ArrayVec<f64, { crate::VectorSize::MAX }>),
     F32(ArrayVec<f32, { crate::VectorSize::MAX }>),

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -254,9 +254,7 @@ gen_component_wise_extractor! {
     ],
 }
 
-/// Vector for each [`Literal`] type
-///
-/// This type ensures that all elements have same type
+/// Vectors with a concrete element type.
 #[derive(Debug)]
 enum LiteralVector {
     F64(ArrayVec<f64, { crate::VectorSize::MAX }>),
@@ -271,20 +269,20 @@ enum LiteralVector {
 }
 
 impl LiteralVector {
-    #[allow(clippy::pattern_type_mismatch, clippy::missing_const_for_fn)]
-    fn len(&self) -> usize {
-        match self {
-            LiteralVector::F64(v) => v.len(),
-            LiteralVector::F32(v) => v.len(),
-            LiteralVector::U32(v) => v.len(),
-            LiteralVector::I32(v) => v.len(),
-            LiteralVector::U64(v) => v.len(),
-            LiteralVector::I64(v) => v.len(),
-            LiteralVector::Bool(v) => v.len(),
-            LiteralVector::AbstractInt(v) => v.len(),
-            LiteralVector::AbstractFloat(v) => v.len(),
+    const fn len(&self) -> usize {
+        match *self {
+            LiteralVector::F64(ref v) => v.len(),
+            LiteralVector::F32(ref v) => v.len(),
+            LiteralVector::U32(ref v) => v.len(),
+            LiteralVector::I32(ref v) => v.len(),
+            LiteralVector::U64(ref v) => v.len(),
+            LiteralVector::I64(ref v) => v.len(),
+            LiteralVector::Bool(ref v) => v.len(),
+            LiteralVector::AbstractInt(ref v) => v.len(),
+            LiteralVector::AbstractFloat(ref v) => v.len(),
         }
     }
+
     /// Creates [`LiteralVector`] of size 1 from single [`Literal`]
     fn from_literal(literal: Literal) -> Self {
         match literal {
@@ -300,19 +298,7 @@ impl LiteralVector {
         }
     }
 
-    #[allow(dead_code)]
-    /// Creates [`LiteralVector`] from Array of [`Literal`]s
-    ///
-    /// Panics if vector is empty
-    fn from_literal_vec(
-        components: ArrayVec<Literal, { crate::VectorSize::MAX }>,
-    ) -> Result<Self, ConstantEvaluatorError> {
-        let scalar = components[0].scalar();
-        Self::from_literal_vec_with_scalar_type(components, scalar)
-    }
-
-    /// Creates [`LiteralVector`] of type provided by scalar from Array of [`Literal`]s
-    ///
+    /// # Panics
     /// Panics if vector is empty, returns error if types do not match
     fn from_literal_vec_with_scalar_type(
         components: ArrayVec<Literal, { crate::VectorSize::MAX }>,
@@ -444,17 +430,18 @@ impl LiteralVector {
 
     /// Returns [`ArrayVec`] of [`Literal`]s
     fn to_literal_vec(&self) -> ArrayVec<Literal, { crate::VectorSize::MAX }> {
-        #[allow(clippy::pattern_type_mismatch)]
-        match self {
-            LiteralVector::F64(v) => v.iter().map(|e| (Literal::F64(*e))).collect(),
-            LiteralVector::F32(v) => v.iter().map(|e| (Literal::F32(*e))).collect(),
-            LiteralVector::U32(v) => v.iter().map(|e| (Literal::U32(*e))).collect(),
-            LiteralVector::I32(v) => v.iter().map(|e| (Literal::I32(*e))).collect(),
-            LiteralVector::U64(v) => v.iter().map(|e| (Literal::U64(*e))).collect(),
-            LiteralVector::I64(v) => v.iter().map(|e| (Literal::I64(*e))).collect(),
-            LiteralVector::Bool(v) => v.iter().map(|e| (Literal::Bool(*e))).collect(),
-            LiteralVector::AbstractInt(v) => v.iter().map(|e| (Literal::AbstractInt(*e))).collect(),
-            LiteralVector::AbstractFloat(v) => {
+        match *self {
+            LiteralVector::F64(ref v) => v.iter().map(|e| (Literal::F64(*e))).collect(),
+            LiteralVector::F32(ref v) => v.iter().map(|e| (Literal::F32(*e))).collect(),
+            LiteralVector::U32(ref v) => v.iter().map(|e| (Literal::U32(*e))).collect(),
+            LiteralVector::I32(ref v) => v.iter().map(|e| (Literal::I32(*e))).collect(),
+            LiteralVector::U64(ref v) => v.iter().map(|e| (Literal::U64(*e))).collect(),
+            LiteralVector::I64(ref v) => v.iter().map(|e| (Literal::I64(*e))).collect(),
+            LiteralVector::Bool(ref v) => v.iter().map(|e| (Literal::Bool(*e))).collect(),
+            LiteralVector::AbstractInt(ref v) => {
+                v.iter().map(|e| (Literal::AbstractInt(*e))).collect()
+            }
+            LiteralVector::AbstractFloat(ref v) => {
                 v.iter().map(|e| (Literal::AbstractFloat(*e))).collect()
             }
         }


### PR DESCRIPTION
**Connections**
Implements some #4507

**Description**
Existing macros work for component-wise cases where return type is equal to input type. But it's hard to generalize macros further. So I present `LiteralVector`:
```rust
/// Vector for each [`Literal`] type
///
/// This type ensures that all elements have same type
enum LiteralVector {
    F64(ArrayVec<f64, { crate::VectorSize::MAX }>),
    F32(ArrayVec<f32, { crate::VectorSize::MAX }>),
    U32(ArrayVec<u32, { crate::VectorSize::MAX }>),
    I32(ArrayVec<i32, { crate::VectorSize::MAX }>),
    U64(ArrayVec<u64, { crate::VectorSize::MAX }>),
    I64(ArrayVec<i64, { crate::VectorSize::MAX }>),
    Bool(ArrayVec<bool, { crate::VectorSize::MAX }>),
    AbstractInt(ArrayVec<i64, { crate::VectorSize::MAX }>),
    AbstractFloat(ArrayVec<f64, { crate::VectorSize::MAX }>),
}
```

that abstracts away at least vector obtaining logic. This makes somehow easier to implement some builtins like `dot`, `cross`, `any`, `all`, ... although with still way to much repetition (maybe macro could fix that, although I am more inclined to use num create for number traits).

**Testing**
TODO

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
