### PR TITLE
chore: satisfy `clippy::ref_as_ptr`

### DIFF
--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -369,16 +369,16 @@ impl ObservationLog {
         self.write_location(new_location);
         self.write_action(&Action::Acquisition {
             older_rank: older_lock.rank.bit.number(),
-            older_location: older_lock.location as *const _ as usize,
+            older_location: std::ptr::from_ref(older_lock.location) as usize,
             newer_rank: new_rank.bit.number(),
-            newer_location: new_location as *const _ as usize,
+            newer_location: std::ptr::from_ref(new_location) as usize,
         });
     }
 
     fn write_location(&mut self, location: &'static Location<'static>) {
         if self.locations_seen.insert(location) {
             self.write_action(&Action::Location {
-                address: location as *const _ as usize,
+                address: std::ptr::from_ref(location) as usize,
                 file: location.file(),
                 line: location.line(),
                 column: location.column(),

--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -369,16 +369,16 @@ impl ObservationLog {
         self.write_location(new_location);
         self.write_action(&Action::Acquisition {
             older_rank: older_lock.rank.bit.number(),
-            older_location: std::ptr::from_ref(older_lock.location) as usize,
+            older_location: addr(older_lock.location),
             newer_rank: new_rank.bit.number(),
-            newer_location: std::ptr::from_ref(new_location) as usize,
+            newer_location: addr(new_location),
         });
     }
 
     fn write_location(&mut self, location: &'static Location<'static>) {
         if self.locations_seen.insert(location) {
             self.write_action(&Action::Location {
-                address: std::ptr::from_ref(location) as usize,
+                address: addr(location),
                 file: location.file(),
                 line: location.line(),
                 column: location.column(),
@@ -472,4 +472,9 @@ impl LockRankSet {
     fn number(self) -> u32 {
         self.bits().trailing_zeros()
     }
+}
+
+/// Convenience for `std::ptr::from_ref(t) as usize`.
+fn addr<T>(t: &T) -> usize {
+    std::ptr::from_ref(t) as usize
 }


### PR DESCRIPTION
**Connections**

N/A

**Description**

Rust 1.76 added the `std::ptr::{from_ref,from_mut}` APIs, which allow several `as` casts to be eliminated as potential footguns. Because our MSRV is Rust 1.76, we can (and, IMO, should) migrate to these APIs. This PR just takes on the `from_ref` case; I haven't tried `from_mut` yet.

Rust 1.78's Clippy adds (allow-by-default) lints to check for cases where these APIs can be used instead (i.e., [`clippy::ref_as_ptr`](https://rust-lang.github.io/rust-clippy/stable/index.html#/ref_as_ptr)), but as our MSRV does not use Rust 1.78 yet, this PR does not set these lints to warn.

**Testing**

Things still compile, tests still run!

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ Not necessary.
