### PR TITLE
Fix the internal buffer and texture count

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -664,6 +664,8 @@ impl Device {
             .describe_format_features(desc.format)
             .map_err(|error| resource::CreateTextureError::MissingFeatures(desc.format, error))?;
 
+        unsafe { self.raw().add_raw_texture(&*hal_texture) };
+
         let texture = Texture::new(
             self,
             resource::TextureInner::Native { raw: hal_texture },
@@ -689,6 +691,8 @@ impl Device {
         hal_buffer: Box<dyn hal::DynBuffer>,
         desc: &resource::BufferDescriptor,
     ) -> Arc<Buffer> {
+        unsafe { self.raw().add_raw_buffer(&*hal_buffer) };
+
         let buffer = Buffer {
             raw: Snatchable::new(hal_buffer),
             device: self.clone(),

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -444,6 +444,10 @@ impl crate::Device for super::Device {
         self.counters.buffers.sub(1);
     }
 
+    unsafe fn add_raw_buffer(&self, _buffer: &super::Buffer) {
+        self.counters.buffers.add(1);
+    }
+
     unsafe fn map_buffer(
         &self,
         buffer: &super::Buffer,
@@ -529,6 +533,10 @@ impl crate::Device for super::Device {
         }
 
         self.counters.textures.sub(1);
+    }
+
+    unsafe fn add_raw_texture(&self, _texture: &super::Texture) {
+        self.counters.textures.add(1);
     }
 
     unsafe fn create_texture_view(

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -24,6 +24,7 @@ pub trait DynDevice: DynResource {
     ) -> Result<Box<dyn DynBuffer>, DeviceError>;
 
     unsafe fn destroy_buffer(&self, buffer: Box<dyn DynBuffer>);
+    unsafe fn add_raw_buffer(&self, buffer: &dyn DynBuffer);
 
     unsafe fn map_buffer(
         &self,
@@ -41,6 +42,8 @@ pub trait DynDevice: DynResource {
         desc: &TextureDescriptor,
     ) -> Result<Box<dyn DynTexture>, DeviceError>;
     unsafe fn destroy_texture(&self, texture: Box<dyn DynTexture>);
+    unsafe fn add_raw_texture(&self, texture: &dyn DynTexture);
+
     unsafe fn create_texture_view(
         &self,
         texture: &dyn DynTexture,
@@ -177,6 +180,10 @@ impl<D: Device + DynResource> DynDevice for D {
     unsafe fn destroy_buffer(&self, buffer: Box<dyn DynBuffer>) {
         unsafe { D::destroy_buffer(self, buffer.unbox()) };
     }
+    unsafe fn add_raw_buffer(&self, buffer: &dyn DynBuffer) {
+        let buffer = buffer.expect_downcast_ref();
+        unsafe { D::add_raw_buffer(self, buffer) };
+    }
 
     unsafe fn map_buffer(
         &self,
@@ -215,6 +222,11 @@ impl<D: Device + DynResource> DynDevice for D {
 
     unsafe fn destroy_texture(&self, texture: Box<dyn DynTexture>) {
         unsafe { D::destroy_texture(self, texture.unbox()) };
+    }
+
+    unsafe fn add_raw_texture(&self, texture: &dyn DynTexture) {
+        let texture = texture.expect_downcast_ref();
+        unsafe { D::add_raw_buffer(self, texture) };
     }
 
     unsafe fn create_texture_view(

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -168,6 +168,8 @@ impl crate::Device for Context {
         Ok(Resource)
     }
     unsafe fn destroy_buffer(&self, buffer: Resource) {}
+    unsafe fn add_raw_buffer(&self, _buffer: &Resource) {}
+
     unsafe fn map_buffer(
         &self,
         buffer: &Resource,
@@ -183,6 +185,8 @@ impl crate::Device for Context {
         Ok(Resource)
     }
     unsafe fn destroy_texture(&self, texture: Resource) {}
+    unsafe fn add_raw_texture(&self, _texture: &Resource) {}
+
     unsafe fn create_texture_view(
         &self,
         texture: &Resource,

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -647,6 +647,10 @@ impl crate::Device for super::Device {
         self.counters.buffers.sub(1);
     }
 
+    unsafe fn add_raw_buffer(&self, _buffer: &super::Buffer) {
+        self.counters.buffers.add(1);
+    }
+
     unsafe fn map_buffer(
         &self,
         buffer: &super::Buffer,
@@ -980,6 +984,10 @@ impl crate::Device for super::Device {
         drop(texture.drop_guard);
 
         self.counters.textures.sub(1);
+    }
+
+    unsafe fn add_raw_texture(&self, _buffer: &super::Texture) {
+        self.counters.textures.add(1);
     }
 
     unsafe fn create_texture_view(

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -723,6 +723,9 @@ pub trait Device: WasmNotSendSync {
     /// - The given `buffer` must not currently be mapped.
     unsafe fn destroy_buffer(&self, buffer: <Self::A as Api>::Buffer);
 
+    /// A hook for when a wgpu-core buffer is created from a raw wgpu-hal buffer.
+    unsafe fn add_raw_buffer(&self, buffer: &<Self::A as Api>::Buffer);
+
     /// Return a pointer to CPU memory mapping the contents of `buffer`.
     ///
     /// Buffer mappings are persistent: the buffer may remain mapped on the CPU
@@ -814,6 +817,10 @@ pub trait Device: WasmNotSendSync {
         desc: &TextureDescriptor,
     ) -> Result<<Self::A as Api>::Texture, DeviceError>;
     unsafe fn destroy_texture(&self, texture: <Self::A as Api>::Texture);
+
+    /// A hook for when a wgpu-core texture is created from a raw wgpu-hal texture.
+    unsafe fn add_raw_texture(&self, texture: &<Self::A as Api>::Texture);
+
     unsafe fn create_texture_view(
         &self,
         texture: &<Self::A as Api>::Texture,

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -356,6 +356,10 @@ impl crate::Device for super::Device {
         self.counters.buffers.sub(1);
     }
 
+    unsafe fn add_raw_buffer(&self, _buffer: &super::Buffer) {
+        self.counters.buffers.add(1);
+    }
+
     unsafe fn map_buffer(
         &self,
         buffer: &super::Buffer,
@@ -434,6 +438,10 @@ impl crate::Device for super::Device {
 
     unsafe fn destroy_texture(&self, _texture: super::Texture) {
         self.counters.textures.sub(1);
+    }
+
+    unsafe fn add_raw_texture(&self, _texture: &super::Texture) {
+        self.counters.textures.add(1);
     }
 
     unsafe fn create_texture_view(

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -956,6 +956,10 @@ impl crate::Device for super::Device {
         self.counters.buffers.sub(1);
     }
 
+    unsafe fn add_raw_buffer(&self, _buffer: &super::Buffer) {
+        self.counters.buffers.add(1);
+    }
+
     unsafe fn map_buffer(
         &self,
         buffer: &super::Buffer,
@@ -1125,6 +1129,10 @@ impl crate::Device for super::Device {
         }
 
         self.counters.textures.sub(1);
+    }
+
+    unsafe fn add_raw_texture(&self, _texture: &super::Texture) {
+        self.counters.textures.add(1);
     }
 
     unsafe fn create_texture_view(


### PR DESCRIPTION
Currently, we only increment the internal buffer/texture counters when creating them in the regular way (not when creating them from externally built hal objects (create_texture_from_hal/create_buffer_from_hal). However we decrement the counter in all cases, which makes the counters incorrect when these externally created resources are involved.

This commit fixes it by adding hooks (add_raw_buffer and add_raw_texture) in the hal device abstractions to inform when buffer or textures are created externally.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
