### PR TITLE
[ci] Re-enable `cargo doc --document-private-items` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,20 +220,18 @@ jobs:
           # build docs
           cargo doc --target ${{ matrix.target }} --all-features --no-deps
 
-      # wgpu-core docs are not feasible due to <https://github.com/gfx-rs/wgpu/issues/4905>
-      #
-      # - name: check private item docs
-      #   if: matrix.kind == 'native'
-      #   shell: bash
-      #   run: |
-      #     set -e
-      #
-      #     # wgpu_core package
-      #     cargo +${{ env.DOCS_RUST_VERSION }} doc --target ${{ matrix.target }} \
-      #           --package wgpu-core \
-      #           --package wgpu-hal \
-      #           --package naga \
-      #           --all-features --no-deps --document-private-items
+      - name: check private item docs
+        if: matrix.kind == 'native'
+        shell: bash
+        run: |
+          set -e
+
+          # wgpu_core package
+          cargo +${{ env.DOCS_RUST_VERSION }} doc --target ${{ matrix.target }} \
+                --package wgpu-core \
+                --package wgpu-hal \
+                --package naga \
+                --all-features --no-deps --document-private-items
 
   # We run minimal checks on the MSRV of the core crates, ensuring that
   # its dependency tree does not cause issues for firefox.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
           set -e
 
           # wgpu_core package
-          cargo +${{ env.DOCS_RUST_VERSION }} doc --target ${{ matrix.target }} \
+          cargo doc --target ${{ matrix.target }} \
                 --package wgpu-core \
                 --package wgpu-hal \
                 --package naga \


### PR DESCRIPTION
Re-enable CI checks that naga, wgpu-core, and wgpu-hal documentation builds without warnings, even with `--document-private-items`. This was previously disabled due to #4905, which causes long build times, but with the de-generification of `wgpu_core`, that's no longer a problem: a build of all three crates' docs now takes only 7s.
