### PR TITLE
Resolve lints for Rust 1.78-1.81 that can be preempted before upgrade

### DIFF
--- a/benches/benches/computepass.rs
+++ b/benches/benches/computepass.rs
@@ -447,7 +447,7 @@ fn run_bench(ctx: &mut Criterion) {
             };
 
             group.bench_function(
-                &format!("{cpasses} computepasses x {dispatch_per_pass} dispatches ({label})"),
+                format!("{cpasses} computepasses x {dispatch_per_pass} dispatches ({label})"),
                 |b| {
                     Lazy::force(&state);
 
@@ -496,7 +496,7 @@ fn run_bench(ctx: &mut Criterion) {
     for threads in [2, 4, 8] {
         let dispatch_per_pass = dispatch_count / threads;
         group.bench_function(
-            &format!("{threads} threads x {dispatch_per_pass} dispatch"),
+            format!("{threads} threads x {dispatch_per_pass} dispatch"),
             |b| {
                 Lazy::force(&state);
 
@@ -537,7 +537,7 @@ fn run_bench(ctx: &mut Criterion) {
     let mut group = ctx.benchmark_group("Computepass: Bindless");
     group.throughput(Throughput::Elements(dispatch_count_bindless as _));
 
-    group.bench_function(&format!("{dispatch_count_bindless} dispatch"), |b| {
+    group.bench_function(format!("{dispatch_count_bindless} dispatch"), |b| {
         Lazy::force(&state);
 
         b.iter_custom(|iters| {

--- a/benches/benches/renderpass.rs
+++ b/benches/benches/renderpass.rs
@@ -448,7 +448,7 @@ fn run_bench(ctx: &mut Criterion) {
             };
 
             group.bench_function(
-                &format!("{rpasses} renderpasses x {draws_per_pass} draws ({label})"),
+                format!("{rpasses} renderpasses x {draws_per_pass} draws ({label})"),
                 |b| {
                     Lazy::force(&state);
 
@@ -501,41 +501,38 @@ fn run_bench(ctx: &mut Criterion) {
 
     for threads in [2, 4, 8] {
         let draws_per_pass = draw_count / threads;
-        group.bench_function(
-            &format!("{threads} threads x {draws_per_pass} draws"),
-            |b| {
-                Lazy::force(&state);
+        group.bench_function(format!("{threads} threads x {draws_per_pass} draws"), |b| {
+            Lazy::force(&state);
 
-                b.iter_custom(|iters| {
-                    profiling::scope!("benchmark invocation");
+            b.iter_custom(|iters| {
+                profiling::scope!("benchmark invocation");
 
-                    // This benchmark hangs on Apple Paravirtualized GPUs. No idea why.
-                    if state.device_state.adapter_info.name.contains("Paravirtual") {
-                        return Duration::from_secs_f32(1.0);
-                    }
+                // This benchmark hangs on Apple Paravirtualized GPUs. No idea why.
+                if state.device_state.adapter_info.name.contains("Paravirtual") {
+                    return Duration::from_secs_f32(1.0);
+                }
 
-                    let mut duration = Duration::ZERO;
+                let mut duration = Duration::ZERO;
 
-                    for _ in 0..iters {
-                        profiling::scope!("benchmark iteration");
+                for _ in 0..iters {
+                    profiling::scope!("benchmark iteration");
 
-                        let start = Instant::now();
+                    let start = Instant::now();
 
-                        let buffers = (0..threads)
-                            .into_par_iter()
-                            .map(|i| state.run_subpass(i, threads, draw_count))
-                            .collect::<Vec<_>>();
+                    let buffers = (0..threads)
+                        .into_par_iter()
+                        .map(|i| state.run_subpass(i, threads, draw_count))
+                        .collect::<Vec<_>>();
 
-                        duration += start.elapsed();
+                    duration += start.elapsed();
 
-                        state.device_state.queue.submit(buffers);
-                        state.device_state.device.poll(wgpu::Maintain::Wait);
-                    }
+                    state.device_state.queue.submit(buffers);
+                    state.device_state.device.poll(wgpu::Maintain::Wait);
+                }
 
-                    duration
-                })
-            },
-        );
+                duration
+            })
+        });
     }
     group.finish();
 
@@ -543,7 +540,7 @@ fn run_bench(ctx: &mut Criterion) {
     let mut group = ctx.benchmark_group("Renderpass: Bindless");
     group.throughput(Throughput::Elements(draw_count as _));
 
-    group.bench_function(&format!("{draw_count} draws"), |b| {
+    group.bench_function(format!("{draw_count} draws"), |b| {
         Lazy::force(&state);
 
         b.iter_custom(|iters| {

--- a/benches/benches/resource_creation.rs
+++ b/benches/benches/resource_creation.rs
@@ -17,7 +17,7 @@ fn run_bench(ctx: &mut Criterion) {
     for threads in [1, 2, 4, 8] {
         let resources_per_thread = RESOURCES_TO_CREATE / threads;
         group.bench_function(
-            &format!("{threads} threads x {resources_per_thread} resource"),
+            format!("{threads} threads x {resources_per_thread} resource"),
             |b| {
                 Lazy::force(&state);
 

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -215,6 +215,7 @@ pub enum ArcComputeCommand {
     },
 
     PushDebugGroup {
+        #[cfg_attr(target_os = "emscripten", allow(dead_code))]
         color: u32,
         len: usize,
     },
@@ -222,6 +223,7 @@ pub enum ArcComputeCommand {
     PopDebugGroup,
 
     InsertDebugMarker {
+        #[cfg_attr(target_os = "emscripten", allow(dead_code))]
         color: u32,
         len: usize,
     },

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -464,11 +464,13 @@ pub enum ArcRenderCommand {
         indexed: bool,
     },
     PushDebugGroup {
+        #[cfg_attr(target_os = "emscripten", allow(dead_code))]
         color: u32,
         len: usize,
     },
     PopDebugGroup,
     InsertDebugMarker {
+        #[cfg_attr(target_os = "emscripten", allow(dead_code))]
         color: u32,
         len: usize,
     },

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -442,10 +442,9 @@ impl TextureTracker {
         let transitions = self
             .temp
             .drain(..)
-            .map(|pending| {
+            .inspect(|pending| {
                 let tex = unsafe { self.metadata.get_resource_unchecked(pending.id as _) };
                 textures.push(tex.inner.get(snatch_guard));
-                pending
             })
             .collect();
         (transitions, textures)

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -554,10 +554,9 @@ impl Drop for super::InstanceShared {
     fn drop(&mut self) {
         unsafe {
             // Keep du alive since destroy_instance may also log
-            let _du = self.debug_utils.take().map(|du| {
+            let _du = self.debug_utils.take().inspect(|du| {
                 du.extension
                     .destroy_debug_utils_messenger(du.messenger, None);
-                du
             });
             if self.drop_guard.is_none() {
                 self.raw.destroy_instance(None);

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -37,7 +37,10 @@ impl Drop for Queue {
 /// This type is unique to the Rust API of `wgpu`.
 /// There is no analogue in the WebGPU specification.
 #[derive(Debug, Clone)]
-pub struct SubmissionIndex(pub(crate) Arc<crate::Data>);
+pub struct SubmissionIndex {
+    #[cfg_attr(not(native), allow(dead_code))]
+    pub(crate) data: Arc<crate::Data>,
+}
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(SubmissionIndex: Send, Sync);
 
@@ -248,7 +251,7 @@ impl Queue {
         let data =
             DynContext::queue_submit(&*self.context, self.data.as_ref(), &mut command_buffers);
 
-        SubmissionIndex(data)
+        SubmissionIndex { data }
     }
 
     /// Gets the amount of nanoseconds each tick of a timestamp query represents.

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1403,14 +1403,6 @@ impl crate::context::Context for ContextWebGpu {
         map_wgt_limits(device_data.0.limits())
     }
 
-    fn device_downlevel_properties(
-        &self,
-        _device_data: &Self::DeviceData,
-    ) -> wgt::DownlevelCapabilities {
-        // WebGPU is assumed to be fully compliant
-        wgt::DownlevelCapabilities::default()
-    }
-
     #[cfg_attr(
         not(any(
             feature = "spirv",
@@ -2031,12 +2023,6 @@ impl crate::context::Context for ContextWebGpu {
 
     fn device_destroy(&self, device_data: &Self::DeviceData) {
         device_data.0.destroy();
-    }
-
-    fn device_mark_lost(&self, _device_data: &Self::DeviceData, _message: &str) {
-        // TODO: figure out the GPUDevice implementation of this, including resolving
-        // the device.lost promise, which will require a different invocation pattern
-        // with a callback.
     }
 
     fn queue_drop(&self, _queue_data: &Self::QueueData) {
@@ -3021,52 +3007,6 @@ impl crate::context::Context for ContextWebGpu {
         encoder_data
             .0
             .draw_indexed_indirect_with_f64(&indirect_buffer_data.0.buffer, indirect_offset as f64);
-    }
-
-    fn render_bundle_encoder_multi_draw_indirect(
-        &self,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        _indirect_buffer_data: &Self::BufferData,
-        _indirect_offset: wgt::BufferAddress,
-        _count: u32,
-    ) {
-        panic!("MULTI_DRAW_INDIRECT feature must be enabled to call multi_draw_indirect")
-    }
-
-    fn render_bundle_encoder_multi_draw_indexed_indirect(
-        &self,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        _indirect_buffer_data: &Self::BufferData,
-        _indirect_offset: wgt::BufferAddress,
-        _count: u32,
-    ) {
-        panic!("MULTI_DRAW_INDIRECT feature must be enabled to call multi_draw_indexed_indirect")
-    }
-
-    fn render_bundle_encoder_multi_draw_indirect_count(
-        &self,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        _indirect_buffer_data: &Self::BufferData,
-        _indirect_offset: wgt::BufferAddress,
-        _count_buffer_data: &Self::BufferData,
-        _count_buffer_offset: wgt::BufferAddress,
-        _max_count: u32,
-    ) {
-        panic!(
-            "MULTI_DRAW_INDIRECT_COUNT feature must be enabled to call multi_draw_indirect_count"
-        )
-    }
-
-    fn render_bundle_encoder_multi_draw_indexed_indirect_count(
-        &self,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        _indirect_buffer_data: &Self::BufferData,
-        _indirect_offset: wgt::BufferAddress,
-        _count_buffer_data: &Self::BufferData,
-        _count_buffer_offset: wgt::BufferAddress,
-        _max_count: u32,
-    ) {
-        panic!("MULTI_DRAW_INDIRECT_COUNT feature must be enabled to call multi_draw_indexed_indirect_count")
     }
 
     fn render_pass_set_pipeline(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -793,13 +793,6 @@ impl crate::Context for ContextWgpuCore {
         }
     }
 
-    fn device_downlevel_properties(&self, device_data: &Self::DeviceData) -> DownlevelCapabilities {
-        match self.0.device_downlevel_properties(device_data.id) {
-            Ok(limits) => limits,
-            Err(err) => self.handle_error_fatal(err, "Device::downlevel_properties"),
-        }
-    }
-
     #[cfg_attr(
         not(any(
             feature = "spirv",
@@ -1373,11 +1366,6 @@ impl crate::Context for ContextWgpuCore {
     }
     fn device_destroy(&self, device_data: &Self::DeviceData) {
         self.0.device_destroy(device_data.id);
-    }
-    fn device_mark_lost(&self, device_data: &Self::DeviceData, message: &str) {
-        // We do not provide a reason to device_lose, because all reasons other than
-        // destroyed (which this is not) are "unknown".
-        self.0.device_mark_lost(device_data.id, message);
     }
     fn device_poll(
         &self,
@@ -2482,50 +2470,6 @@ impl crate::Context for ContextWgpuCore {
             indirect_buffer_data.id,
             indirect_offset,
         )
-    }
-
-    fn render_bundle_encoder_multi_draw_indirect(
-        &self,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        _indirect_buffer_data: &Self::BufferData,
-        _indirect_offset: wgt::BufferAddress,
-        _count: u32,
-    ) {
-        unimplemented!()
-    }
-
-    fn render_bundle_encoder_multi_draw_indexed_indirect(
-        &self,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        _indirect_buffer_data: &Self::BufferData,
-        _indirect_offset: wgt::BufferAddress,
-        _count: u32,
-    ) {
-        unimplemented!()
-    }
-
-    fn render_bundle_encoder_multi_draw_indirect_count(
-        &self,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        _indirect_buffer_data: &Self::BufferData,
-        _indirect_offset: wgt::BufferAddress,
-        _count_buffer_data: &Self::BufferData,
-        _count_buffer_offset: wgt::BufferAddress,
-        _max_count: u32,
-    ) {
-        unimplemented!()
-    }
-
-    fn render_bundle_encoder_multi_draw_indexed_indirect_count(
-        &self,
-        _encoder_data: &mut Self::RenderBundleEncoderData,
-        _indirect_buffer_data: &Self::BufferData,
-        _indirect_offset: wgt::BufferAddress,
-        _count_buffer_data: &Self::BufferData,
-        _count_buffer_offset: wgt::BufferAddress,
-        _max_count: u32,
-    ) {
-        unimplemented!()
     }
 
     fn render_pass_set_pipeline(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1372,7 +1372,7 @@ impl crate::Context for ContextWgpuCore {
         device_data: &Self::DeviceData,
         maintain: crate::Maintain,
     ) -> wgt::MaintainResult {
-        let maintain_inner = maintain.map_index(|i| *i.0.as_ref().downcast_ref().unwrap());
+        let maintain_inner = maintain.map_index(|i| *i.data.as_ref().downcast_ref().unwrap());
         match self.0.device_poll(device_data.id, maintain_inner) {
             Ok(done) => match done {
                 true => wgt::MaintainResult::SubmissionQueueEmpty,

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -122,7 +122,6 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
 
     fn device_features(&self, device_data: &Self::DeviceData) -> Features;
     fn device_limits(&self, device_data: &Self::DeviceData) -> Limits;
-    fn device_downlevel_properties(&self, device_data: &Self::DeviceData) -> DownlevelCapabilities;
     fn device_create_shader_module(
         &self,
         device_data: &Self::DeviceData,
@@ -203,7 +202,6 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         device_lost_callback: DeviceLostCallback,
     );
     fn device_destroy(&self, device_data: &Self::DeviceData);
-    fn device_mark_lost(&self, device_data: &Self::DeviceData, message: &str);
     fn queue_drop(&self, queue_data: &Self::QueueData);
     fn device_poll(&self, device_data: &Self::DeviceData, maintain: Maintain) -> MaintainResult;
     fn device_on_uncaptured_error(
@@ -547,40 +545,6 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         indirect_buffer_data: &Self::BufferData,
         indirect_offset: BufferAddress,
     );
-    fn render_bundle_encoder_multi_draw_indirect(
-        &self,
-        encoder_data: &mut Self::RenderBundleEncoderData,
-        indirect_buffer_data: &Self::BufferData,
-        indirect_offset: BufferAddress,
-        count: u32,
-    );
-    fn render_bundle_encoder_multi_draw_indexed_indirect(
-        &self,
-        encoder_data: &mut Self::RenderBundleEncoderData,
-        indirect_buffer_data: &Self::BufferData,
-        indirect_offset: BufferAddress,
-        count: u32,
-    );
-    #[allow(clippy::too_many_arguments)]
-    fn render_bundle_encoder_multi_draw_indirect_count(
-        &self,
-        encoder_data: &mut Self::RenderBundleEncoderData,
-        indirect_buffer_data: &Self::BufferData,
-        indirect_offset: BufferAddress,
-        count_buffer_data: &Self::BufferData,
-        count_buffer_offset: BufferAddress,
-        max_count: u32,
-    );
-    #[allow(clippy::too_many_arguments)]
-    fn render_bundle_encoder_multi_draw_indexed_indirect_count(
-        &self,
-        encoder_data: &mut Self::RenderBundleEncoderData,
-        indirect_buffer_data: &Self::BufferData,
-        indirect_offset: BufferAddress,
-        count_buffer_data: &Self::BufferData,
-        count_buffer_offset: BufferAddress,
-        max_count: u32,
-    );
 
     fn render_pass_set_pipeline(
         &self,
@@ -850,7 +814,6 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
 
     fn device_features(&self, device_data: &crate::Data) -> Features;
     fn device_limits(&self, device_data: &crate::Data) -> Limits;
-    fn device_downlevel_properties(&self, device_data: &crate::Data) -> DownlevelCapabilities;
     fn device_create_shader_module(
         &self,
         device_data: &crate::Data,
@@ -931,7 +894,6 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         device_lost_callback: DeviceLostCallback,
     );
     fn device_destroy(&self, device_data: &crate::Data);
-    fn device_mark_lost(&self, device_data: &crate::Data, message: &str);
     fn queue_drop(&self, queue_data: &crate::Data);
     fn device_poll(&self, device_data: &crate::Data, maintain: Maintain) -> MaintainResult;
     fn device_on_uncaptured_error(
@@ -1243,40 +1205,6 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         indirect_buffer_data: &crate::Data,
         indirect_offset: BufferAddress,
     );
-    fn render_bundle_encoder_multi_draw_indirect(
-        &self,
-        encoder_data: &mut crate::Data,
-        indirect_buffer_data: &crate::Data,
-        indirect_offset: BufferAddress,
-        count: u32,
-    );
-    fn render_bundle_encoder_multi_draw_indexed_indirect(
-        &self,
-        encoder_data: &mut crate::Data,
-        indirect_buffer_data: &crate::Data,
-        indirect_offset: BufferAddress,
-        count: u32,
-    );
-    #[allow(clippy::too_many_arguments)]
-    fn render_bundle_encoder_multi_draw_indirect_count(
-        &self,
-        encoder_data: &mut crate::Data,
-        indirect_buffer_data: &crate::Data,
-        indirect_offset: BufferAddress,
-        count_buffer_data: &crate::Data,
-        count_buffer_offset: BufferAddress,
-        max_count: u32,
-    );
-    #[allow(clippy::too_many_arguments)]
-    fn render_bundle_encoder_multi_draw_indexed_indirect_count(
-        &self,
-        encoder_data: &mut crate::Data,
-        indirect_buffer_data: &crate::Data,
-        indirect_offset: BufferAddress,
-        command_buffer_data: &crate::Data,
-        count_buffer_offset: BufferAddress,
-        max_count: u32,
-    );
 
     fn render_pass_set_pipeline(&self, pass_data: &mut crate::Data, pipeline_data: &crate::Data);
     fn render_pass_set_bind_group(
@@ -1564,11 +1492,6 @@ where
         Context::device_limits(self, device_data)
     }
 
-    fn device_downlevel_properties(&self, device_data: &crate::Data) -> DownlevelCapabilities {
-        let device_data = downcast_ref(device_data);
-        Context::device_downlevel_properties(self, device_data)
-    }
-
     fn device_create_shader_module(
         &self,
         device_data: &crate::Data,
@@ -1734,11 +1657,6 @@ where
     fn device_destroy(&self, device_data: &crate::Data) {
         let device_data = downcast_ref(device_data);
         Context::device_destroy(self, device_data)
-    }
-
-    fn device_mark_lost(&self, device_data: &crate::Data, message: &str) {
-        let device_data = downcast_ref(device_data);
-        Context::device_mark_lost(self, device_data, message)
     }
 
     fn queue_drop(&self, queue_data: &crate::Data) {
@@ -2471,88 +2389,6 @@ where
             encoder_data,
             indirect_buffer_data,
             indirect_offset,
-        )
-    }
-
-    fn render_bundle_encoder_multi_draw_indirect(
-        &self,
-        encoder_data: &mut crate::Data,
-        indirect_buffer_data: &crate::Data,
-        indirect_offset: BufferAddress,
-        count: u32,
-    ) {
-        let encoder_data = downcast_mut::<T::RenderBundleEncoderData>(encoder_data);
-        let indirect_buffer_data = downcast_ref(indirect_buffer_data);
-        Context::render_bundle_encoder_multi_draw_indirect(
-            self,
-            encoder_data,
-            indirect_buffer_data,
-            indirect_offset,
-            count,
-        )
-    }
-
-    fn render_bundle_encoder_multi_draw_indexed_indirect(
-        &self,
-        encoder_data: &mut crate::Data,
-        indirect_buffer_data: &crate::Data,
-        indirect_offset: BufferAddress,
-        count: u32,
-    ) {
-        let encoder_data = downcast_mut::<T::RenderBundleEncoderData>(encoder_data);
-        let indirect_buffer_data = downcast_ref(indirect_buffer_data);
-        Context::render_bundle_encoder_multi_draw_indexed_indirect(
-            self,
-            encoder_data,
-            indirect_buffer_data,
-            indirect_offset,
-            count,
-        )
-    }
-
-    fn render_bundle_encoder_multi_draw_indirect_count(
-        &self,
-        encoder_data: &mut crate::Data,
-        indirect_buffer_data: &crate::Data,
-        indirect_offset: BufferAddress,
-        count_buffer_data: &crate::Data,
-        count_buffer_offset: BufferAddress,
-        max_count: u32,
-    ) {
-        let encoder_data = downcast_mut::<T::RenderBundleEncoderData>(encoder_data);
-        let indirect_buffer_data = downcast_ref(indirect_buffer_data);
-        let count_buffer_data = downcast_ref(count_buffer_data);
-        Context::render_bundle_encoder_multi_draw_indirect_count(
-            self,
-            encoder_data,
-            indirect_buffer_data,
-            indirect_offset,
-            count_buffer_data,
-            count_buffer_offset,
-            max_count,
-        )
-    }
-
-    fn render_bundle_encoder_multi_draw_indexed_indirect_count(
-        &self,
-        encoder_data: &mut crate::Data,
-        indirect_buffer_data: &crate::Data,
-        indirect_offset: BufferAddress,
-        count_buffer_data: &crate::Data,
-        count_buffer_offset: BufferAddress,
-        max_count: u32,
-    ) {
-        let encoder_data = downcast_mut::<T::RenderBundleEncoderData>(encoder_data);
-        let indirect_buffer_data = downcast_ref(indirect_buffer_data);
-        let count_buffer_data = downcast_ref(count_buffer_data);
-        Context::render_bundle_encoder_multi_draw_indexed_indirect_count(
-            self,
-            encoder_data,
-            indirect_buffer_data,
-            indirect_offset,
-            count_buffer_data,
-            count_buffer_offset,
-            max_count,
         )
     }
 

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -21,6 +21,7 @@ use crate::{
 /// Meta trait for an data associated with an id tracked by a context.
 ///
 /// There is no need to manually implement this trait since there is a blanket implementation for this trait.
+#[cfg_attr(target_os = "emscripten", allow(dead_code))]
 pub trait ContextData: Debug + WasmNotSendSync + 'static {}
 impl<T: Debug + WasmNotSendSync + 'static> ContextData for T {}
 
@@ -59,6 +60,7 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
 
     type CompilationInfoFuture: Future<Output = CompilationInfo> + WasmNotSend + 'static;
 
+    #[cfg(not(target_os = "emscripten"))]
     fn init(instance_desc: wgt::InstanceDescriptor) -> Self;
     unsafe fn instance_create_surface(
         &self,
@@ -752,6 +754,7 @@ pub type DeviceLostCallback = Box<dyn Fn(DeviceLostReason, String) + 'static>;
 
 /// An object safe variant of [`Context`] implemented by all types that implement [`Context`].
 pub(crate) trait DynContext: Debug + WasmNotSendSync {
+    #[cfg(not(target_os = "emscripten"))]
     fn as_any(&self) -> &dyn Any;
 
     unsafe fn instance_create_surface(
@@ -1350,6 +1353,7 @@ impl<T> DynContext for T
 where
     T: Context + 'static,
 {
+    #[cfg(not(target_os = "emscripten"))]
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -2700,6 +2704,7 @@ pub trait QueueWriteBuffer: WasmNotSendSync + Debug {
 
     fn slice_mut(&mut self) -> &mut [u8];
 
+    #[cfg(not(target_os = "emscripten"))]
     fn as_any(&self) -> &dyn Any;
 }
 


### PR DESCRIPTION
**Connections**

#6105 handles some migrations that are necessary for Rust 1.80 also. Unlike in this PR, it is only possible to implement the migrations there with an upgrade to the MSRV.

**Description**

These outstanding lints are obstacles to eventual upgrade to these Rust versions, and can be resolved now. We should do so!

Each commit is intended to be [atomic](https://www.aleksandrhovhannisyan.com/blog/atomic-git-commits/) for eventual rebase-and-merge.

**Testing**

Things still compile and are green in CI.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ Not necessary.
