### PR TITLE
Fix a regression from #6223

### DIFF
--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -226,7 +226,7 @@ impl<D: Device + DynResource> DynDevice for D {
 
     unsafe fn add_raw_texture(&self, texture: &dyn DynTexture) {
         let texture = texture.expect_downcast_ref();
-        unsafe { D::add_raw_buffer(self, texture) };
+        unsafe { D::add_raw_texture(self, texture) };
     }
 
     unsafe fn create_texture_view(

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -986,7 +986,7 @@ impl crate::Device for super::Device {
         self.counters.textures.sub(1);
     }
 
-    unsafe fn add_raw_texture(&self, _buffer: &super::Texture) {
+    unsafe fn add_raw_texture(&self, _texture: &super::Texture) {
         self.counters.textures.add(1);
     }
 


### PR DESCRIPTION
**Connections**

See the regression reported in #6223

**Description**

"buffer" and "texture" got swapped in one of theses few places where the type system couldn't catch my mistake.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
