### PR TITLE
[d3d12] handle known error variants returned by `D3D12CreateDevice`

### DIFF
--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -66,7 +66,7 @@ impl super::Adapter {
             profiling::scope!("ID3D12Device::create_device");
             library
                 .create_device(&adapter, Direct3D::D3D_FEATURE_LEVEL_11_0)
-                .ok()?
+                .ok()??
         };
 
         profiling::scope!("feature queries");


### PR DESCRIPTION
Follow-up to https://github.com/gfx-rs/wgpu/commit/dd01b6d20967f1b4a74e9a75baec6b54545ebfec (https://github.com/gfx-rs/wgpu/pull/6200).
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1917102#c13