### PR TITLE
Move out invalidity from the `Registry`

### DIFF
--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -663,9 +663,9 @@ pub fn op_webgpu_request_device(
 
     let (device, queue) = res.map_err(|err| DomExceptionOperationError::new(&err.to_string()))?;
 
-    let device_features = instance.device_features(device)?;
+    let device_features = instance.device_features(device);
     let features = deserialize_features(&device_features);
-    let limits = instance.device_limits(device)?;
+    let limits = instance.device_limits(device);
 
     let instance = instance.clone();
     let instance2 = instance.clone();

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -414,9 +414,9 @@ pub fn op_webgpu_request_adapter(
             })
         }
     };
-    let adapter_features = instance.adapter_features(adapter)?;
+    let adapter_features = instance.adapter_features(adapter);
     let features = deserialize_features(&adapter_features);
-    let adapter_limits = instance.adapter_limits(adapter)?;
+    let adapter_limits = instance.adapter_limits(adapter);
 
     let instance = instance.clone();
 
@@ -705,7 +705,7 @@ pub fn op_webgpu_request_adapter_info(
     let adapter = adapter_resource.1;
     let instance = state.borrow::<Instance>();
 
-    let info = instance.adapter_get_info(adapter)?;
+    let info = instance.adapter_get_info(adapter);
     adapter_resource.close();
 
     Ok(GPUAdapterInfo {

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -649,7 +649,7 @@ pub fn op_webgpu_request_device(
         memory_hints: wgpu_types::MemoryHints::default(),
     };
 
-    let (device, queue, maybe_err) = instance.adapter_request_device(
+    let res = instance.adapter_request_device(
         adapter,
         &descriptor,
         std::env::var("DENO_WEBGPU_TRACE")
@@ -660,9 +660,8 @@ pub fn op_webgpu_request_device(
         None,
     );
     adapter_resource.close();
-    if let Some(err) = maybe_err {
-        return Err(DomExceptionOperationError::new(&err.to_string()).into());
-    }
+
+    let (device, queue) = res.map_err(|err| DomExceptionOperationError::new(&err.to_string()))?;
 
     let device_features = instance.device_features(device)?;
     let features = deserialize_features(&device_features);

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -78,7 +78,7 @@ fn main() {
                 )
                 .expect("Unable to find an adapter for selected backend");
 
-            let info = global.adapter_get_info(adapter).unwrap();
+            let info = global.adapter_get_info(adapter);
             log::info!("Picked '{}'", info.name);
             let device_id = wgc::id::Id::zip(1, 0, backend);
             let queue_id = wgc::id::Id::zip(1, 0, backend);

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -82,14 +82,14 @@ fn main() {
             log::info!("Picked '{}'", info.name);
             let device_id = wgc::id::Id::zip(1, 0, backend);
             let queue_id = wgc::id::Id::zip(1, 0, backend);
-            let (_, _, error) = global.adapter_request_device(
+            let res = global.adapter_request_device(
                 adapter,
                 &desc,
                 None,
                 Some(device_id),
                 Some(queue_id),
             );
-            if let Some(e) = error {
+            if let Err(e) = res {
                 panic!("{:?}", e);
             }
             (device_id, queue_id)

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -244,8 +244,8 @@ impl Corpus {
                 };
 
                 println!("\tBackend {:?}", backend);
-                let supported_features = global.adapter_features(adapter).unwrap();
-                let downlevel_caps = global.adapter_downlevel_capabilities(adapter).unwrap();
+                let supported_features = global.adapter_features(adapter);
+                let downlevel_caps = global.adapter_downlevel_capabilities(adapter);
 
                 let test = Test::load(dir.join(test_path), adapter.backend());
                 if !supported_features.contains(test.features) {

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -108,7 +108,7 @@ impl Test<'_> {
         let backend = adapter.backend();
         let device_id = wgc::id::Id::zip(test_num, 0, backend);
         let queue_id = wgc::id::Id::zip(test_num, 0, backend);
-        let (_, _, error) = global.adapter_request_device(
+        let res = global.adapter_request_device(
             adapter,
             &wgt::DeviceDescriptor {
                 label: None,
@@ -120,7 +120,7 @@ impl Test<'_> {
             Some(device_id),
             Some(queue_id),
         );
-        if let Some(e) = error {
+        if let Err(e) = res {
             panic!("{:?}", e);
         }
 

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -652,33 +652,6 @@ static DEVICE_DROP_THEN_LOST: GpuTestConfiguration = GpuTestConfiguration::new()
     });
 
 #[gpu_test]
-static DEVICE_INVALID_THEN_SET_LOST_CALLBACK: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().expect_fail(FailureCase::webgl2()))
-    .run_sync(|ctx| {
-        // This test checks that when the device is invalid, a subsequent call
-        // to set the device lost callback will immediately call the callback.
-        // Invalidating the device is done via a testing-only method. Fails on
-        // webgl because webgl doesn't implement make_invalid.
-
-        // Make the device invalid.
-        ctx.device.make_invalid();
-
-        static WAS_CALLED: AtomicBool = AtomicBool::new(false);
-
-        // Set a LoseDeviceCallback on the device.
-        let callback = Box::new(|reason, _m| {
-            WAS_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
-            assert_eq!(reason, wgt::DeviceLostReason::DeviceInvalid);
-        });
-        ctx.device.set_device_lost_callback(callback);
-
-        assert!(
-            WAS_CALLED.load(std::sync::atomic::Ordering::SeqCst),
-            "Device lost callback should have been called."
-        );
-    });
-
-#[gpu_test]
 static DEVICE_LOST_REPLACED_CALLBACK: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default())
     .run_sync(|ctx| {

--- a/tests/tests/pipeline.rs
+++ b/tests/tests/pipeline.rs
@@ -8,7 +8,7 @@ static PIPELINE_DEFAULT_LAYOUT_BAD_MODULE: GpuTestConfiguration = GpuTestConfigu
     .parameters(
         TestParameters::default()
             // https://github.com/gfx-rs/wgpu/issues/4167
-            .expect_fail(FailureCase::always().panic("Pipeline is invalid")),
+            .expect_fail(FailureCase::always().panic("Error reflecting bind group")),
     )
     .run_sync(|ctx| {
         ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);

--- a/tests/tests/resource_error.rs
+++ b/tests/tests/resource_error.rs
@@ -54,21 +54,12 @@ static BAD_TEXTURE: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(
         Some("dimension x is zero"),
     );
 
-    let error = match ctx.adapter_info.backend.to_str() {
-        "vulkan" | "vk" => "textureid id(0,1,vk) is invalid",
-        "dx12" | "d3d12" => "textureid id(0,1,d3d12) is invalid",
-        "metal" | "mtl" => "textureid id(0,1,mtl) is invalid",
-        "opengl" | "gles" | "gl" => "textureid id(0,1,gl) is invalid",
-        "webgpu" => "textureid id(0,1,webgpu) is invalid",
-        b => b,
-    };
-
     fail(
         &ctx.device,
         || {
             let _ = texture.create_view(&wgpu::TextureViewDescriptor::default());
         },
-        Some(error),
+        Some("Texture with '' label is invalid"),
     );
     valid(&ctx.device, || texture.destroy());
     valid(&ctx.device, || texture.destroy());

--- a/tests/tests/resource_error.rs
+++ b/tests/tests/resource_error.rs
@@ -17,21 +17,16 @@ static BAD_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|
         Some("`map` usage can only be combined with the opposite `copy`"),
     );
 
-    let error = match ctx.adapter_info.backend.to_str() {
-        "vulkan" | "vk" => "bufferid id(0,1,vk) is invalid",
-        "dx12" | "d3d12" => "bufferid id(0,1,d3d12) is invalid",
-        "metal" | "mtl" => "bufferid id(0,1,mtl) is invalid",
-        "opengl" | "gles" | "gl" => "bufferid id(0,1,gl) is invalid",
-        "webgpu" => "bufferid id(0,1,webgpu) is invalid",
-        b => b,
-    };
-
     fail(
         &ctx.device,
         || buffer.slice(..).map_async(wgpu::MapMode::Write, |_| {}),
-        Some(error),
+        Some("Buffer with '' label is invalid"),
     );
-    fail(&ctx.device, || buffer.unmap(), Some(error));
+    fail(
+        &ctx.device,
+        || buffer.unmap(),
+        Some("Buffer with '' label is invalid"),
+    );
     valid(&ctx.device, || buffer.destroy());
     valid(&ctx.device, || buffer.destroy());
 });

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -79,8 +79,6 @@ pub enum CreateBindGroupLayoutError {
 pub enum CreateBindGroupError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("Bind group layout is invalid")]
-    InvalidLayout,
     #[error(transparent)]
     DestroyedResource(#[from] DestroyedResourceError),
     #[error(
@@ -541,8 +539,6 @@ impl BindGroupLayout {
 pub enum CreatePipelineLayoutError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("BindGroupLayoutId {0:?} is invalid")]
-    InvalidBindGroupLayoutId(BindGroupLayoutId),
     #[error(
         "Push constant at index {index} has range bound {bound} not aligned to {}",
         wgt::PUSH_CONSTANT_ALIGNMENT
@@ -566,6 +562,8 @@ pub enum CreatePipelineLayoutError {
     TooManyBindings(BindingTypeMaxCountError),
     #[error("Bind group layout count {actual} exceeds device bind group limit {max}")]
     TooManyGroups { actual: usize, max: usize },
+    #[error(transparent)]
+    InvalidResource(#[from] InvalidResourceError),
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -1003,6 +1003,8 @@ pub enum GetBindGroupLayoutError {
     InvalidPipeline,
     #[error("Invalid group index {0}")]
     InvalidGroupIndex(u32),
+    #[error(transparent)]
+    InvalidResource(#[from] InvalidResourceError),
 }
 
 #[derive(Clone, Debug, Error, Eq, PartialEq)]

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -6,8 +6,8 @@ use crate::{
     init_tracker::{BufferInitTrackerAction, TextureInitTrackerAction},
     pipeline::{ComputePipeline, RenderPipeline},
     resource::{
-        Buffer, DestroyedResourceError, Labeled, MissingBufferUsageError, MissingTextureUsageError,
-        ResourceErrorIdent, Sampler, TextureView, TrackingData,
+        Buffer, DestroyedResourceError, InvalidResourceError, Labeled, MissingBufferUsageError,
+        MissingTextureUsageError, ResourceErrorIdent, Sampler, TextureView, TrackingData,
     },
     resource_log,
     snatch::{SnatchGuard, Snatchable},
@@ -81,8 +81,6 @@ pub enum CreateBindGroupError {
     Device(#[from] DeviceError),
     #[error("Bind group layout is invalid")]
     InvalidLayout,
-    #[error("BufferId {0:?} is invalid")]
-    InvalidBufferId(BufferId),
     #[error("TextureViewId {0:?} is invalid")]
     InvalidTextureViewId(TextureViewId),
     #[error("SamplerId {0:?} is invalid")]
@@ -188,6 +186,8 @@ pub enum CreateBindGroupError {
     StorageReadNotSupported(wgt::TextureFormat),
     #[error(transparent)]
     ResourceUsageCompatibility(#[from] ResourceUsageCompatibilityError),
+    #[error(transparent)]
+    InvalidResource(#[from] InvalidResourceError),
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -81,8 +81,6 @@ pub enum CreateBindGroupError {
     Device(#[from] DeviceError),
     #[error("Bind group layout is invalid")]
     InvalidLayout,
-    #[error("SamplerId {0:?} is invalid")]
-    InvalidSamplerId(SamplerId),
     #[error(transparent)]
     DestroyedResource(#[from] DestroyedResourceError),
     #[error(

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -999,8 +999,6 @@ crate::impl_trackable!(BindGroup);
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum GetBindGroupLayoutError {
-    #[error("Pipeline is invalid")]
-    InvalidPipeline,
     #[error("Invalid group index {0}")]
     InvalidGroupIndex(u32),
     #[error(transparent)]

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -81,8 +81,6 @@ pub enum CreateBindGroupError {
     Device(#[from] DeviceError),
     #[error("Bind group layout is invalid")]
     InvalidLayout,
-    #[error("TextureViewId {0:?} is invalid")]
-    InvalidTextureViewId(TextureViewId),
     #[error("SamplerId {0:?} is invalid")]
     InvalidSamplerId(SamplerId),
     #[error(transparent)]

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -578,7 +578,7 @@ impl RenderBundleEncoder {
 
 fn set_bind_group(
     state: &mut State,
-    bind_group_guard: &crate::lock::RwLockReadGuard<crate::storage::Storage<BindGroup>>,
+    bind_group_guard: &crate::lock::RwLockReadGuard<crate::storage::Storage<Arc<BindGroup>>>,
     dynamic_offsets: &[u32],
     index: u32,
     num_dynamic_offsets: usize,
@@ -630,7 +630,7 @@ fn set_bind_group(
 
 fn set_pipeline(
     state: &mut State,
-    pipeline_guard: &crate::lock::RwLockReadGuard<crate::storage::Storage<RenderPipeline>>,
+    pipeline_guard: &crate::lock::RwLockReadGuard<crate::storage::Storage<Arc<RenderPipeline>>>,
     context: &RenderPassContext,
     is_depth_read_only: bool,
     is_stencil_read_only: bool,
@@ -673,7 +673,7 @@ fn set_pipeline(
 
 fn set_index_buffer(
     state: &mut State,
-    buffer_guard: &crate::lock::RwLockReadGuard<crate::storage::Storage<Buffer>>,
+    buffer_guard: &crate::lock::RwLockReadGuard<crate::storage::Storage<Arc<Buffer>>>,
     buffer_id: id::Id<id::markers::Buffer>,
     index_format: wgt::IndexFormat,
     offset: u64,
@@ -708,7 +708,7 @@ fn set_index_buffer(
 
 fn set_vertex_buffer(
     state: &mut State,
-    buffer_guard: &crate::lock::RwLockReadGuard<crate::storage::Storage<Buffer>>,
+    buffer_guard: &crate::lock::RwLockReadGuard<crate::storage::Storage<Arc<Buffer>>>,
     slot: u32,
     buffer_id: id::Id<id::markers::Buffer>,
     offset: u64,
@@ -852,7 +852,7 @@ fn draw_indexed(
 fn multi_draw_indirect(
     state: &mut State,
     dynamic_offsets: &[u32],
-    buffer_guard: &crate::lock::RwLockReadGuard<crate::storage::Storage<Buffer>>,
+    buffer_guard: &crate::lock::RwLockReadGuard<crate::storage::Storage<Arc<Buffer>>>,
     buffer_id: id::Id<id::markers::Buffer>,
     offset: u64,
     indexed: bool,

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -594,7 +594,7 @@ fn set_bind_group(
 
     let bind_group_id = bind_group_id.unwrap();
 
-    let bind_group = bind_group_guard.strict_get(bind_group_id).get()?;
+    let bind_group = bind_group_guard.get(bind_group_id).get()?;
 
     bind_group.same_device(&state.device)?;
 
@@ -637,7 +637,7 @@ fn set_pipeline(
     is_stencil_read_only: bool,
     pipeline_id: id::Id<id::markers::RenderPipeline>,
 ) -> Result<(), RenderBundleErrorInner> {
-    let pipeline = pipeline_guard.strict_get(pipeline_id).get()?;
+    let pipeline = pipeline_guard.get(pipeline_id).get()?;
 
     pipeline.same_device(&state.device)?;
 
@@ -678,7 +678,7 @@ fn set_index_buffer(
     offset: u64,
     size: Option<std::num::NonZeroU64>,
 ) -> Result<(), RenderBundleErrorInner> {
-    let buffer = buffer_guard.strict_get(buffer_id).get()?;
+    let buffer = buffer_guard.get(buffer_id).get()?;
 
     state
         .trackers
@@ -720,7 +720,7 @@ fn set_vertex_buffer(
         .into());
     }
 
-    let buffer = buffer_guard.strict_get(buffer_id).get()?;
+    let buffer = buffer_guard.get(buffer_id).get()?;
 
     state
         .trackers
@@ -859,7 +859,7 @@ fn multi_draw_indirect(
     let pipeline = state.pipeline()?;
     let used_bind_groups = pipeline.used_bind_groups;
 
-    let buffer = buffer_guard.strict_get(buffer_id).get()?;
+    let buffer = buffer_guard.get(buffer_id).get()?;
 
     state
         .trackers

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -631,15 +631,13 @@ fn set_bind_group(
 
 fn set_pipeline(
     state: &mut State,
-    pipeline_guard: &crate::storage::Storage<Arc<RenderPipeline>>,
+    pipeline_guard: &crate::storage::Storage<Fallible<RenderPipeline>>,
     context: &RenderPassContext,
     is_depth_read_only: bool,
     is_stencil_read_only: bool,
     pipeline_id: id::Id<id::markers::RenderPipeline>,
 ) -> Result<(), RenderBundleErrorInner> {
-    let pipeline = pipeline_guard
-        .get_owned(pipeline_id)
-        .map_err(|_| RenderCommandError::InvalidPipelineId(pipeline_id))?;
+    let pipeline = pipeline_guard.strict_get(pipeline_id).get()?;
 
     pipeline.same_device(&state.device)?;
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -581,7 +581,7 @@ impl RenderBundleEncoder {
 
 fn set_bind_group(
     state: &mut State,
-    bind_group_guard: &crate::storage::Storage<Arc<BindGroup>>,
+    bind_group_guard: &crate::storage::Storage<Fallible<BindGroup>>,
     dynamic_offsets: &[u32],
     index: u32,
     num_dynamic_offsets: usize,
@@ -594,9 +594,7 @@ fn set_bind_group(
 
     let bind_group_id = bind_group_id.unwrap();
 
-    let bind_group = bind_group_guard
-        .get_owned(bind_group_id)
-        .map_err(|_| RenderCommandError::InvalidBindGroupId(bind_group_id))?;
+    let bind_group = bind_group_guard.strict_get(bind_group_id).get()?;
 
     bind_group.same_device(&state.device)?;
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -88,17 +88,11 @@ impl Global {
 
         let hub = &self.hub;
 
-        let cmd_buf = match hub
+        let cmd_buf = hub
             .command_buffers
-            .get(command_encoder_id.into_command_buffer_id())
-        {
-            Ok(cmd_buf) => cmd_buf,
-            Err(_) => return Err(CommandEncoderError::Invalid.into()),
-        };
-        cmd_buf.check_recording()?;
-
-        let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
+            .strict_get(command_encoder_id.into_command_buffer_id());
+        let mut cmd_buf_data = cmd_buf.try_get()?;
+        cmd_buf_data.check_recording()?;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {
@@ -177,17 +171,11 @@ impl Global {
 
         let hub = &self.hub;
 
-        let cmd_buf = match hub
+        let cmd_buf = hub
             .command_buffers
-            .get(command_encoder_id.into_command_buffer_id())
-        {
-            Ok(cmd_buf) => cmd_buf,
-            Err(_) => return Err(CommandEncoderError::Invalid.into()),
-        };
-        cmd_buf.check_recording()?;
-
-        let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
+            .strict_get(command_encoder_id.into_command_buffer_id());
+        let mut cmd_buf_data = cmd_buf.try_get()?;
+        cmd_buf_data.check_recording()?;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -90,7 +90,7 @@ impl Global {
 
         let cmd_buf = hub
             .command_buffers
-            .strict_get(command_encoder_id.into_command_buffer_id());
+            .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.try_get()?;
         cmd_buf_data.check_recording()?;
 
@@ -99,7 +99,7 @@ impl Global {
             list.push(TraceCommand::ClearBuffer { dst, offset, size });
         }
 
-        let dst_buffer = hub.buffers.strict_get(dst).get()?;
+        let dst_buffer = hub.buffers.get(dst).get()?;
 
         dst_buffer.same_device_as(cmd_buf.as_ref())?;
 
@@ -173,7 +173,7 @@ impl Global {
 
         let cmd_buf = hub
             .command_buffers
-            .strict_get(command_encoder_id.into_command_buffer_id());
+            .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.try_get()?;
         cmd_buf_data.check_recording()?;
 
@@ -189,7 +189,7 @@ impl Global {
             return Err(ClearError::MissingClearTextureFeature);
         }
 
-        let dst_texture = hub.textures.strict_get(dst).get()?;
+        let dst_texture = hub.textures.get(dst).get()?;
 
         dst_texture.same_device_as(cmd_buf.as_ref())?;
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -27,8 +27,6 @@ use wgt::{math::align_to, BufferAddress, BufferUsages, ImageSubresourceRange, Te
 pub enum ClearError {
     #[error("To use clear_texture the CLEAR_TEXTURE feature needs to be enabled")]
     MissingClearTextureFeature,
-    #[error("TextureId {0:?} is invalid")]
-    InvalidTextureId(TextureId),
     #[error(transparent)]
     DestroyedResource(#[from] DestroyedResourceError),
     #[error("{0} can not be cleared")]
@@ -203,10 +201,7 @@ impl Global {
             return Err(ClearError::MissingClearTextureFeature);
         }
 
-        let dst_texture = hub
-            .textures
-            .get(dst)
-            .map_err(|_| ClearError::InvalidTextureId(dst))?;
+        let dst_texture = hub.textures.strict_get(dst).get()?;
 
         dst_texture.same_device_as(cmd_buf.as_ref())?;
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -11,8 +11,8 @@ use crate::{
     id::{BufferId, CommandEncoderId, TextureId},
     init_tracker::{MemoryInitKind, TextureInitRange},
     resource::{
-        DestroyedResourceError, Labeled, MissingBufferUsageError, ParentDevice, ResourceErrorIdent,
-        Texture, TextureClearMode,
+        DestroyedResourceError, InvalidResourceError, Labeled, MissingBufferUsageError,
+        ParentDevice, ResourceErrorIdent, Texture, TextureClearMode,
     },
     snatch::SnatchGuard,
     track::{TextureSelector, TextureTrackerSetSingle},
@@ -27,8 +27,6 @@ use wgt::{math::align_to, BufferAddress, BufferUsages, ImageSubresourceRange, Te
 pub enum ClearError {
     #[error("To use clear_texture the CLEAR_TEXTURE feature needs to be enabled")]
     MissingClearTextureFeature,
-    #[error("BufferId {0:?} is invalid")]
-    InvalidBufferId(BufferId),
     #[error("TextureId {0:?} is invalid")]
     InvalidTextureId(TextureId),
     #[error(transparent)]
@@ -75,6 +73,8 @@ whereas subesource range specified start {subresource_base_array_layer} and coun
     Device(#[from] DeviceError),
     #[error(transparent)]
     CommandEncoderError(#[from] CommandEncoderError),
+    #[error(transparent)]
+    InvalidResource(#[from] InvalidResourceError),
 }
 
 impl Global {
@@ -107,10 +107,7 @@ impl Global {
             list.push(TraceCommand::ClearBuffer { dst, offset, size });
         }
 
-        let dst_buffer = hub
-            .buffers
-            .get(dst)
-            .map_err(|_| ClearError::InvalidBufferId(dst))?;
+        let dst_buffer = hub.buffers.strict_get(dst).get()?;
 
         dst_buffer.same_device_as(cmd_buf.as_ref())?;
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -503,7 +503,7 @@ impl Global {
             };
 
         let hal_desc = hal::ComputePassDescriptor {
-            label: hal_label(base.label.as_deref(), self.instance.flags),
+            label: hal_label(base.label.as_deref(), device.instance_flags),
             timestamp_writes,
         };
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -134,8 +134,6 @@ pub enum ComputePassErrorInner {
     InvalidParentEncoder,
     #[error("Bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
     BindGroupIndexOutOfRange { index: u32, max: u32 },
-    #[error("ComputePipelineId {0:?} is invalid")]
-    InvalidPipelineId(id::ComputePipelineId),
     #[error(transparent)]
     DestroyedResource(#[from] DestroyedResourceError),
     #[error("Indirect buffer uses bytes {offset}..{end_offset} which overruns indirect buffer of size {buffer_size}")]
@@ -1016,8 +1014,8 @@ impl Global {
         let hub = &self.hub;
         let pipeline = hub
             .compute_pipelines
-            .get(pipeline_id)
-            .map_err(|_| ComputePassErrorInner::InvalidPipelineId(pipeline_id))
+            .strict_get(pipeline_id)
+            .get()
             .map_pass_err(scope)?;
 
         base.commands.push(ArcComputeCommand::SetPipeline(pipeline));

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -132,8 +132,6 @@ pub enum ComputePassErrorInner {
     Encoder(#[from] CommandEncoderError),
     #[error("Parent encoder is invalid")]
     InvalidParentEncoder,
-    #[error("BindGroupId {0:?} is invalid")]
-    InvalidBindGroupId(id::BindGroupId),
     #[error("Bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
     BindGroupIndexOutOfRange { index: u32, max: u32 },
     #[error("ComputePipelineId {0:?} is invalid")]
@@ -985,8 +983,8 @@ impl Global {
             let hub = &self.hub;
             let bg = hub
                 .bind_groups
-                .get(bind_group_id)
-                .map_err(|_| ComputePassErrorInner::InvalidBindGroupId(bind_group_id))
+                .strict_get(bind_group_id)
+                .get()
                 .map_pass_err(scope)?;
             bind_group = Some(bg);
         }

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -292,9 +292,7 @@ impl Global {
 
         let make_err = |e, arc_desc| (ComputePass::new(None, arc_desc), Some(e));
 
-        let cmd_buf = hub
-            .command_buffers
-            .strict_get(encoder_id.into_command_buffer_id());
+        let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
 
         match cmd_buf
             .try_get()
@@ -306,7 +304,7 @@ impl Global {
         };
 
         arc_desc.timestamp_writes = if let Some(tw) = desc.timestamp_writes {
-            let query_set = match hub.query_sets.strict_get(tw.query_set).get() {
+            let query_set = match hub.query_sets.get(tw.query_set).get() {
                 Ok(query_set) => query_set,
                 Err(e) => return make_err(e.into(), arc_desc),
             };
@@ -340,7 +338,7 @@ impl Global {
             let cmd_buf = self
                 .hub
                 .command_buffers
-                .strict_get(encoder_id.into_command_buffer_id());
+                .get(encoder_id.into_command_buffer_id());
             let mut cmd_buf_data = cmd_buf.try_get().map_pass_err(pass_scope)?;
 
             if let Some(ref mut list) = cmd_buf_data.commands {
@@ -975,7 +973,7 @@ impl Global {
             let hub = &self.hub;
             let bg = hub
                 .bind_groups
-                .strict_get(bind_group_id)
+                .get(bind_group_id)
                 .get()
                 .map_pass_err(scope)?;
             bind_group = Some(bg);
@@ -1008,7 +1006,7 @@ impl Global {
         let hub = &self.hub;
         let pipeline = hub
             .compute_pipelines
-            .strict_get(pipeline_id)
+            .get(pipeline_id)
             .get()
             .map_pass_err(scope)?;
 
@@ -1080,11 +1078,7 @@ impl Global {
         let scope = PassErrorScope::Dispatch { indirect: true };
         let base = pass.base_mut(scope)?;
 
-        let buffer = hub
-            .buffers
-            .strict_get(buffer_id)
-            .get()
-            .map_pass_err(scope)?;
+        let buffer = hub.buffers.get(buffer_id).get().map_pass_err(scope)?;
 
         base.commands
             .push(ArcComputeCommand::DispatchIndirect { buffer, offset });
@@ -1151,11 +1145,7 @@ impl Global {
         let base = pass.base_mut(scope)?;
 
         let hub = &self.hub;
-        let query_set = hub
-            .query_sets
-            .strict_get(query_set_id)
-            .get()
-            .map_pass_err(scope)?;
+        let query_set = hub.query_sets.get(query_set_id).get().map_pass_err(scope)?;
 
         base.commands.push(ArcComputeCommand::WriteTimestamp {
             query_set,
@@ -1175,11 +1165,7 @@ impl Global {
         let base = pass.base_mut(scope)?;
 
         let hub = &self.hub;
-        let query_set = hub
-            .query_sets
-            .strict_get(query_set_id)
-            .get()
-            .map_pass_err(scope)?;
+        let query_set = hub.query_sets.get(query_set_id).get().map_pass_err(scope)?;
 
         base.commands
             .push(ArcComputeCommand::BeginPipelineStatisticsQuery {

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -74,7 +74,7 @@ impl ComputeCommand {
         hub: &crate::hub::Hub,
         commands: &[ComputeCommand],
     ) -> Result<Vec<ArcComputeCommand>, super::ComputePassError> {
-        use super::{ComputePassError, ComputePassErrorInner, PassErrorScope};
+        use super::{ComputePassError, PassErrorScope};
 
         let buffers_guard = hub.buffers.read();
         let bind_group_guard = hub.bind_groups.read();
@@ -114,12 +114,12 @@ impl ComputeCommand {
                         }
                     }
                     ComputeCommand::SetPipeline(pipeline_id) => ArcComputeCommand::SetPipeline(
-                        pipelines_guard
-                            .get_owned(pipeline_id)
-                            .map_err(|_| ComputePassError {
+                        pipelines_guard.strict_get(pipeline_id).get().map_err(|e| {
+                            ComputePassError {
                                 scope: PassErrorScope::SetPipelineCompute,
-                                inner: ComputePassErrorInner::InvalidPipelineId(pipeline_id),
-                            })?,
+                                inner: e.into(),
+                            }
+                        })?,
                     ),
 
                     ComputeCommand::SetPushConstant {

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -136,10 +136,10 @@ impl ComputeCommand {
 
                     ComputeCommand::DispatchIndirect { buffer_id, offset } => {
                         ArcComputeCommand::DispatchIndirect {
-                            buffer: buffers_guard.get_owned(buffer_id).map_err(|_| {
+                            buffer: buffers_guard.strict_get(buffer_id).get().map_err(|e| {
                                 ComputePassError {
                                     scope: PassErrorScope::Dispatch { indirect: true },
-                                    inner: ComputePassErrorInner::InvalidBufferId(buffer_id),
+                                    inner: e.into(),
                                 }
                             })?,
                             offset,

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -81,113 +81,115 @@ impl ComputeCommand {
         let query_set_guard = hub.query_sets.read();
         let pipelines_guard = hub.compute_pipelines.read();
 
-        let resolved_commands: Vec<ArcComputeCommand> =
-            commands
-                .iter()
-                .map(|c| -> Result<ArcComputeCommand, ComputePassError> {
-                    Ok(match *c {
-                        ComputeCommand::SetBindGroup {
-                            index,
-                            num_dynamic_offsets,
-                            bind_group_id,
-                        } => {
-                            if bind_group_id.is_none() {
-                                return Ok(ArcComputeCommand::SetBindGroup {
-                                    index,
-                                    num_dynamic_offsets,
-                                    bind_group: None,
-                                });
-                            }
-
-                            let bind_group_id = bind_group_id.unwrap();
-                            let bg = bind_group_guard.get_owned(bind_group_id).map_err(|_| {
-                                ComputePassError {
-                                    scope: PassErrorScope::SetBindGroup,
-                                    inner: ComputePassErrorInner::InvalidBindGroupId(bind_group_id),
-                                }
-                            })?;
-
-                            ArcComputeCommand::SetBindGroup {
+        let resolved_commands: Vec<ArcComputeCommand> = commands
+            .iter()
+            .map(|c| -> Result<ArcComputeCommand, ComputePassError> {
+                Ok(match *c {
+                    ComputeCommand::SetBindGroup {
+                        index,
+                        num_dynamic_offsets,
+                        bind_group_id,
+                    } => {
+                        if bind_group_id.is_none() {
+                            return Ok(ArcComputeCommand::SetBindGroup {
                                 index,
                                 num_dynamic_offsets,
-                                bind_group: Some(bg),
-                            }
+                                bind_group: None,
+                            });
                         }
-                        ComputeCommand::SetPipeline(pipeline_id) => ArcComputeCommand::SetPipeline(
-                            pipelines_guard.get_owned(pipeline_id).map_err(|_| {
+
+                        let bind_group_id = bind_group_id.unwrap();
+                        let bg = bind_group_guard
+                            .strict_get(bind_group_id)
+                            .get()
+                            .map_err(|e| ComputePassError {
+                                scope: PassErrorScope::SetBindGroup,
+                                inner: e.into(),
+                            })?;
+
+                        ArcComputeCommand::SetBindGroup {
+                            index,
+                            num_dynamic_offsets,
+                            bind_group: Some(bg),
+                        }
+                    }
+                    ComputeCommand::SetPipeline(pipeline_id) => ArcComputeCommand::SetPipeline(
+                        pipelines_guard
+                            .get_owned(pipeline_id)
+                            .map_err(|_| ComputePassError {
+                                scope: PassErrorScope::SetPipelineCompute,
+                                inner: ComputePassErrorInner::InvalidPipelineId(pipeline_id),
+                            })?,
+                    ),
+
+                    ComputeCommand::SetPushConstant {
+                        offset,
+                        size_bytes,
+                        values_offset,
+                    } => ArcComputeCommand::SetPushConstant {
+                        offset,
+                        size_bytes,
+                        values_offset,
+                    },
+
+                    ComputeCommand::Dispatch(dim) => ArcComputeCommand::Dispatch(dim),
+
+                    ComputeCommand::DispatchIndirect { buffer_id, offset } => {
+                        ArcComputeCommand::DispatchIndirect {
+                            buffer: buffers_guard.strict_get(buffer_id).get().map_err(|e| {
                                 ComputePassError {
-                                    scope: PassErrorScope::SetPipelineCompute,
-                                    inner: ComputePassErrorInner::InvalidPipelineId(pipeline_id),
+                                    scope: PassErrorScope::Dispatch { indirect: true },
+                                    inner: e.into(),
                                 }
                             })?,
-                        ),
-
-                        ComputeCommand::SetPushConstant {
                             offset,
-                            size_bytes,
-                            values_offset,
-                        } => ArcComputeCommand::SetPushConstant {
-                            offset,
-                            size_bytes,
-                            values_offset,
-                        },
-
-                        ComputeCommand::Dispatch(dim) => ArcComputeCommand::Dispatch(dim),
-
-                        ComputeCommand::DispatchIndirect { buffer_id, offset } => {
-                            ArcComputeCommand::DispatchIndirect {
-                                buffer: buffers_guard.strict_get(buffer_id).get().map_err(|e| {
-                                    ComputePassError {
-                                        scope: PassErrorScope::Dispatch { indirect: true },
-                                        inner: e.into(),
-                                    }
-                                })?,
-                                offset,
-                            }
                         }
+                    }
 
-                        ComputeCommand::PushDebugGroup { color, len } => {
-                            ArcComputeCommand::PushDebugGroup { color, len }
-                        }
+                    ComputeCommand::PushDebugGroup { color, len } => {
+                        ArcComputeCommand::PushDebugGroup { color, len }
+                    }
 
-                        ComputeCommand::PopDebugGroup => ArcComputeCommand::PopDebugGroup,
+                    ComputeCommand::PopDebugGroup => ArcComputeCommand::PopDebugGroup,
 
-                        ComputeCommand::InsertDebugMarker { color, len } => {
-                            ArcComputeCommand::InsertDebugMarker { color, len }
-                        }
+                    ComputeCommand::InsertDebugMarker { color, len } => {
+                        ArcComputeCommand::InsertDebugMarker { color, len }
+                    }
 
-                        ComputeCommand::WriteTimestamp {
-                            query_set_id,
-                            query_index,
-                        } => ArcComputeCommand::WriteTimestamp {
-                            query_set: query_set_guard.strict_get(query_set_id).get().map_err(
-                                |e| ComputePassError {
-                                    scope: PassErrorScope::WriteTimestamp,
-                                    inner: e.into(),
-                                },
-                            )?,
-                            query_index,
-                        },
+                    ComputeCommand::WriteTimestamp {
+                        query_set_id,
+                        query_index,
+                    } => ArcComputeCommand::WriteTimestamp {
+                        query_set: query_set_guard
+                            .strict_get(query_set_id)
+                            .get()
+                            .map_err(|e| ComputePassError {
+                                scope: PassErrorScope::WriteTimestamp,
+                                inner: e.into(),
+                            })?,
+                        query_index,
+                    },
 
-                        ComputeCommand::BeginPipelineStatisticsQuery {
-                            query_set_id,
-                            query_index,
-                        } => ArcComputeCommand::BeginPipelineStatisticsQuery {
-                            query_set: query_set_guard.strict_get(query_set_id).get().map_err(
-                                |e| ComputePassError {
-                                    scope: PassErrorScope::BeginPipelineStatisticsQuery,
-                                    inner: e.into(),
-                                },
-                            )?,
-                            query_index,
-                        },
+                    ComputeCommand::BeginPipelineStatisticsQuery {
+                        query_set_id,
+                        query_index,
+                    } => ArcComputeCommand::BeginPipelineStatisticsQuery {
+                        query_set: query_set_guard
+                            .strict_get(query_set_id)
+                            .get()
+                            .map_err(|e| ComputePassError {
+                                scope: PassErrorScope::BeginPipelineStatisticsQuery,
+                                inner: e.into(),
+                            })?,
+                        query_index,
+                    },
 
-                        ComputeCommand::EndPipelineStatisticsQuery => {
-                            ArcComputeCommand::EndPipelineStatisticsQuery
-                        }
-                    })
+                    ComputeCommand::EndPipelineStatisticsQuery => {
+                        ArcComputeCommand::EndPipelineStatisticsQuery
+                    }
                 })
-                .collect::<Result<Vec<_>, ComputePassError>>()?;
+            })
+            .collect::<Result<Vec<_>, ComputePassError>>()?;
         Ok(resolved_commands)
     }
 }

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -99,13 +99,12 @@ impl ComputeCommand {
                         }
 
                         let bind_group_id = bind_group_id.unwrap();
-                        let bg = bind_group_guard
-                            .strict_get(bind_group_id)
-                            .get()
-                            .map_err(|e| ComputePassError {
+                        let bg = bind_group_guard.get(bind_group_id).get().map_err(|e| {
+                            ComputePassError {
                                 scope: PassErrorScope::SetBindGroup,
                                 inner: e.into(),
-                            })?;
+                            }
+                        })?;
 
                         ArcComputeCommand::SetBindGroup {
                             index,
@@ -114,12 +113,13 @@ impl ComputeCommand {
                         }
                     }
                     ComputeCommand::SetPipeline(pipeline_id) => ArcComputeCommand::SetPipeline(
-                        pipelines_guard.strict_get(pipeline_id).get().map_err(|e| {
-                            ComputePassError {
+                        pipelines_guard
+                            .get(pipeline_id)
+                            .get()
+                            .map_err(|e| ComputePassError {
                                 scope: PassErrorScope::SetPipelineCompute,
                                 inner: e.into(),
-                            }
-                        })?,
+                            })?,
                     ),
 
                     ComputeCommand::SetPushConstant {
@@ -136,7 +136,7 @@ impl ComputeCommand {
 
                     ComputeCommand::DispatchIndirect { buffer_id, offset } => {
                         ArcComputeCommand::DispatchIndirect {
-                            buffer: buffers_guard.strict_get(buffer_id).get().map_err(|e| {
+                            buffer: buffers_guard.get(buffer_id).get().map_err(|e| {
                                 ComputePassError {
                                     scope: PassErrorScope::Dispatch { indirect: true },
                                     inner: e.into(),
@@ -160,13 +160,12 @@ impl ComputeCommand {
                         query_set_id,
                         query_index,
                     } => ArcComputeCommand::WriteTimestamp {
-                        query_set: query_set_guard
-                            .strict_get(query_set_id)
-                            .get()
-                            .map_err(|e| ComputePassError {
+                        query_set: query_set_guard.get(query_set_id).get().map_err(|e| {
+                            ComputePassError {
                                 scope: PassErrorScope::WriteTimestamp,
                                 inner: e.into(),
-                            })?,
+                            }
+                        })?,
                         query_index,
                     },
 
@@ -174,13 +173,12 @@ impl ComputeCommand {
                         query_set_id,
                         query_index,
                     } => ArcComputeCommand::BeginPipelineStatisticsQuery {
-                        query_set: query_set_guard
-                            .strict_get(query_set_id)
-                            .get()
-                            .map_err(|e| ComputePassError {
+                        query_set: query_set_guard.get(query_set_id).get().map_err(|e| {
+                            ComputePassError {
                                 scope: PassErrorScope::BeginPipelineStatisticsQuery,
                                 inner: e.into(),
-                            })?,
+                            }
+                        })?,
                         query_index,
                     },
 

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -76,8 +76,6 @@ pub enum RenderCommandError {
     VertexBufferIndexOutOfRange { index: u32, max: u32 },
     #[error("Dynamic buffer offset {0} does not respect device's requested `{1}` limit {2}")]
     UnalignedBufferOffset(u64, &'static str, u32),
-    #[error("RenderPipelineId {0:?} is invalid")]
-    InvalidPipelineId(id::RenderPipelineId),
     #[error("Render pipeline targets are incompatible with render pass")]
     IncompatiblePipelineTargets(#[from] crate::device::RenderPassCompatibilityError),
     #[error("{0} writes to depth, while the pass has read-only depth access")]

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -80,8 +80,6 @@ pub enum RenderCommandError {
     UnalignedBufferOffset(u64, &'static str, u32),
     #[error("RenderPipelineId {0:?} is invalid")]
     InvalidPipelineId(id::RenderPipelineId),
-    #[error("QuerySet {0:?} is invalid")]
-    InvalidQuerySet(id::QuerySetId),
     #[error("Render pipeline targets are incompatible with render pass")]
     IncompatiblePipelineTargets(#[from] crate::device::RenderPassCompatibilityError),
     #[error("{0} writes to depth, while the pass has read-only depth access")]

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -68,8 +68,6 @@ pub enum DrawError {
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum RenderCommandError {
-    #[error("BindGroupId {0:?} is invalid")]
-    InvalidBindGroupId(id::BindGroupId),
     #[error("Render bundle {0:?} is invalid")]
     InvalidRenderBundle(id::RenderBundleId),
     #[error("Bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -1,6 +1,5 @@
 use crate::{
     binding_model::{LateMinBufferBindingSizeMismatch, PushConstantUploadError},
-    id,
     resource::{
         DestroyedResourceError, MissingBufferUsageError, MissingTextureUsageError,
         ResourceErrorIdent,
@@ -68,8 +67,6 @@ pub enum DrawError {
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum RenderCommandError {
-    #[error("Render bundle {0:?} is invalid")]
-    InvalidRenderBundle(id::RenderBundleId),
     #[error("Bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
     BindGroupIndexOutOfRange { index: u32, max: u32 },
     #[error("Vertex buffer index {index} is greater than the device's requested `max_vertex_buffers` limit {max}")]

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -68,8 +68,6 @@ pub enum DrawError {
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum RenderCommandError {
-    #[error("BufferId {0:?} is invalid")]
-    InvalidBufferId(id::BufferId),
     #[error("BindGroupId {0:?} is invalid")]
     InvalidBindGroupId(id::BindGroupId),
     #[error("Render bundle {0:?} is invalid")]

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -83,7 +83,7 @@ pub(crate) enum CommandEncoderStatus {
     /// When a `CommandEncoder` is left in this state, we have also
     /// returned an error result from the function that encountered
     /// the problem. Future attempts to use the encoder (for example,
-    /// calls to [`CommandBuffer::check_recording`]) will also return
+    /// calls to [`CommandBufferMutable::check_recording`]) will also return
     /// errors.
     ///
     /// Calling [`Global::command_encoder_finish`] in this state
@@ -288,6 +288,106 @@ impl CommandBufferMutable {
 
         Ok((encoder, tracker))
     }
+
+    fn lock_encoder_impl(&mut self, lock: bool) -> Result<(), CommandEncoderError> {
+        match self.status {
+            CommandEncoderStatus::Recording => {
+                if lock {
+                    self.status = CommandEncoderStatus::Locked;
+                }
+                Ok(())
+            }
+            CommandEncoderStatus::Locked => {
+                // Any operation on a locked encoder is required to put it into the invalid/error state.
+                // See https://www.w3.org/TR/webgpu/#encoder-state-locked
+                self.encoder.discard();
+                self.status = CommandEncoderStatus::Error;
+                Err(CommandEncoderError::Locked)
+            }
+            CommandEncoderStatus::Finished => Err(CommandEncoderError::NotRecording),
+            CommandEncoderStatus::Error => Err(CommandEncoderError::Invalid),
+        }
+    }
+
+    /// Checks that the encoder is in the [`CommandEncoderStatus::Recording`] state.
+    fn check_recording(&mut self) -> Result<(), CommandEncoderError> {
+        self.lock_encoder_impl(false)
+    }
+
+    /// Locks the encoder by putting it in the [`CommandEncoderStatus::Locked`] state.
+    ///
+    /// Call [`CommandBufferMutable::unlock_encoder`] to put the [`CommandBuffer`] back into the [`CommandEncoderStatus::Recording`] state.
+    fn lock_encoder(&mut self) -> Result<(), CommandEncoderError> {
+        self.lock_encoder_impl(true)
+    }
+
+    /// Unlocks the [`CommandBuffer`] and puts it back into the [`CommandEncoderStatus::Recording`] state.
+    ///
+    /// This function is the counterpart to [`CommandBufferMutable::lock_encoder`].
+    /// It is only valid to call this function if the encoder is in the [`CommandEncoderStatus::Locked`] state.
+    fn unlock_encoder(&mut self) -> Result<(), CommandEncoderError> {
+        match self.status {
+            CommandEncoderStatus::Recording => Err(CommandEncoderError::Invalid),
+            CommandEncoderStatus::Locked => {
+                self.status = CommandEncoderStatus::Recording;
+                Ok(())
+            }
+            CommandEncoderStatus::Finished => Err(CommandEncoderError::Invalid),
+            CommandEncoderStatus::Error => Err(CommandEncoderError::Invalid),
+        }
+    }
+
+    pub fn check_finished(&self) -> Result<(), CommandEncoderError> {
+        match self.status {
+            CommandEncoderStatus::Finished => Ok(()),
+            _ => Err(CommandEncoderError::Invalid),
+        }
+    }
+
+    pub(crate) fn finish(&mut self, device: &Device) -> Result<(), CommandEncoderError> {
+        match self.status {
+            CommandEncoderStatus::Recording => {
+                if let Err(e) = self.encoder.close(device) {
+                    Err(e.into())
+                } else {
+                    self.status = CommandEncoderStatus::Finished;
+                    // Note: if we want to stop tracking the swapchain texture view,
+                    // this is the place to do it.
+                    Ok(())
+                }
+            }
+            CommandEncoderStatus::Locked => {
+                self.encoder.discard();
+                self.status = CommandEncoderStatus::Error;
+                Err(CommandEncoderError::Locked)
+            }
+            CommandEncoderStatus::Finished => Err(CommandEncoderError::NotRecording),
+            CommandEncoderStatus::Error => {
+                self.encoder.discard();
+                Err(CommandEncoderError::Invalid)
+            }
+        }
+    }
+
+    pub(crate) fn into_baked_commands(self) -> BakedCommands {
+        BakedCommands {
+            encoder: self.encoder.raw,
+            list: self.encoder.list,
+            trackers: self.trackers,
+            buffer_memory_init_actions: self.buffer_memory_init_actions,
+            texture_memory_actions: self.texture_memory_actions,
+        }
+    }
+
+    pub(crate) fn destroy(mut self, device: &Device) {
+        self.encoder.discard();
+        unsafe {
+            self.encoder.raw.reset_all(self.encoder.list);
+        }
+        unsafe {
+            device.raw().destroy_command_encoder(self.encoder.raw);
+        }
+    }
 }
 
 /// A buffer of commands to be submitted to the GPU for execution.
@@ -319,22 +419,15 @@ pub struct CommandBuffer {
     /// This `Option` is populated when the command buffer is first created.
     /// When this is submitted, dropped, or destroyed, its contents are
     /// extracted into a [`BakedCommands`] by
-    /// [`CommandBuffer::extract_baked_commands`].
+    /// [`CommandBufferMutable::into_baked_commands`].
     pub(crate) data: Mutex<Option<CommandBufferMutable>>,
 }
 
 impl Drop for CommandBuffer {
     fn drop(&mut self) {
         resource_log!("Drop {}", self.error_ident());
-        if self.data.lock().is_none() {
-            return;
-        }
-        let mut baked = self.extract_baked_commands();
-        unsafe {
-            baked.encoder.reset_all(baked.list);
-        }
-        unsafe {
-            self.device.raw().destroy_command_encoder(baked.encoder);
+        if let Some(data) = self.data.lock().take() {
+            data.destroy(&self.device);
         }
     }
 }
@@ -371,6 +464,15 @@ impl CommandBuffer {
                     },
                 }),
             ),
+        }
+    }
+
+    pub(crate) fn new_invalid(device: &Arc<Device>, label: &Label) -> Self {
+        CommandBuffer {
+            device: device.clone(),
+            support_clear_texture: device.features.contains(wgt::Features::CLEAR_TEXTURE),
+            label: label.to_string(),
+            data: Mutex::new(rank::COMMAND_BUFFER_DATA, None),
         }
     }
 
@@ -452,80 +554,19 @@ impl CommandBuffer {
 }
 
 impl CommandBuffer {
-    fn lock_encoder_impl(&self, lock: bool) -> Result<(), CommandEncoderError> {
-        let mut cmd_buf_data_guard = self.data.lock();
-        let cmd_buf_data = cmd_buf_data_guard.as_mut().unwrap();
-        match cmd_buf_data.status {
-            CommandEncoderStatus::Recording => {
-                if lock {
-                    cmd_buf_data.status = CommandEncoderStatus::Locked;
-                }
-                Ok(())
-            }
-            CommandEncoderStatus::Locked => {
-                // Any operation on a locked encoder is required to put it into the invalid/error state.
-                // See https://www.w3.org/TR/webgpu/#encoder-state-locked
-                cmd_buf_data.encoder.discard();
-                cmd_buf_data.status = CommandEncoderStatus::Error;
-                Err(CommandEncoderError::Locked)
-            }
-            CommandEncoderStatus::Finished => Err(CommandEncoderError::NotRecording),
-            CommandEncoderStatus::Error => Err(CommandEncoderError::Invalid),
-        }
+    pub fn try_get<'a>(
+        &'a self,
+    ) -> Result<parking_lot::MappedMutexGuard<'a, CommandBufferMutable>, InvalidResourceError> {
+        let g = self.data.lock();
+        crate::lock::MutexGuard::try_map(g, |data| data.as_mut())
+            .map_err(|_| InvalidResourceError(self.error_ident()))
     }
 
-    /// Checks that the encoder is in the [`CommandEncoderStatus::Recording`] state.
-    fn check_recording(&self) -> Result<(), CommandEncoderError> {
-        self.lock_encoder_impl(false)
-    }
-
-    /// Locks the encoder by putting it in the [`CommandEncoderStatus::Locked`] state.
-    ///
-    /// Call [`CommandBuffer::unlock_encoder`] to put the [`CommandBuffer`] back into the [`CommandEncoderStatus::Recording`] state.
-    fn lock_encoder(&self) -> Result<(), CommandEncoderError> {
-        self.lock_encoder_impl(true)
-    }
-
-    /// Unlocks the [`CommandBuffer`] and puts it back into the [`CommandEncoderStatus::Recording`] state.
-    ///
-    /// This function is the counterpart to [`CommandBuffer::lock_encoder`].
-    /// It is only valid to call this function if the encoder is in the [`CommandEncoderStatus::Locked`] state.
-    fn unlock_encoder(&self) -> Result<(), CommandEncoderError> {
-        let mut data_lock = self.data.lock();
-        let status = &mut data_lock.as_mut().unwrap().status;
-        match *status {
-            CommandEncoderStatus::Recording => Err(CommandEncoderError::Invalid),
-            CommandEncoderStatus::Locked => {
-                *status = CommandEncoderStatus::Recording;
-                Ok(())
-            }
-            CommandEncoderStatus::Finished => Err(CommandEncoderError::Invalid),
-            CommandEncoderStatus::Error => Err(CommandEncoderError::Invalid),
-        }
-    }
-
-    pub fn is_finished(&self) -> bool {
-        match self.data.lock().as_ref().unwrap().status {
-            CommandEncoderStatus::Finished => true,
-            _ => false,
-        }
-    }
-
-    pub(crate) fn extract_baked_commands(&mut self) -> BakedCommands {
-        let data = self.data.lock().take().unwrap();
-        BakedCommands {
-            encoder: data.encoder.raw,
-            list: data.encoder.list,
-            trackers: data.trackers,
-            buffer_memory_init_actions: data.buffer_memory_init_actions,
-            texture_memory_actions: data.texture_memory_actions,
-        }
-    }
-
-    pub(crate) fn from_arc_into_baked(self: Arc<Self>) -> BakedCommands {
-        let mut command_buffer = Arc::into_inner(self)
-            .expect("CommandBuffer cannot be destroyed because is still in use");
-        command_buffer.extract_baked_commands()
+    pub fn try_take<'a>(&'a self) -> Result<CommandBufferMutable, InvalidResourceError> {
+        self.data
+            .lock()
+            .take()
+            .ok_or_else(|| InvalidResourceError(self.error_ident()))
     }
 }
 
@@ -613,34 +654,17 @@ impl Global {
 
         let hub = &self.hub;
 
-        let error = match hub.command_buffers.get(encoder_id.into_command_buffer_id()) {
-            Ok(cmd_buf) => {
-                let mut cmd_buf_data = cmd_buf.data.lock();
-                let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
-                match cmd_buf_data.status {
-                    CommandEncoderStatus::Recording => {
-                        if let Err(e) = cmd_buf_data.encoder.close(&cmd_buf.device) {
-                            Some(e.into())
-                        } else {
-                            cmd_buf_data.status = CommandEncoderStatus::Finished;
-                            //Note: if we want to stop tracking the swapchain texture view,
-                            // this is the place to do it.
-                            None
-                        }
-                    }
-                    CommandEncoderStatus::Locked => {
-                        cmd_buf_data.encoder.discard();
-                        cmd_buf_data.status = CommandEncoderStatus::Error;
-                        Some(CommandEncoderError::Locked)
-                    }
-                    CommandEncoderStatus::Finished => Some(CommandEncoderError::NotRecording),
-                    CommandEncoderStatus::Error => {
-                        cmd_buf_data.encoder.discard();
-                        Some(CommandEncoderError::Invalid)
-                    }
-                }
-            }
-            Err(_) => Some(CommandEncoderError::Invalid),
+        let cmd_buf = hub
+            .command_buffers
+            .strict_get(encoder_id.into_command_buffer_id());
+
+        let error = match cmd_buf
+            .try_get()
+            .map_err(|e| e.into())
+            .and_then(|mut cmd_buf_data| cmd_buf_data.finish(&cmd_buf.device))
+        {
+            Ok(_) => None,
+            Err(e) => Some(e),
         };
 
         (encoder_id.into_command_buffer_id(), error)
@@ -656,14 +680,12 @@ impl Global {
 
         let hub = &self.hub;
 
-        let cmd_buf = match hub.command_buffers.get(encoder_id.into_command_buffer_id()) {
-            Ok(cmd_buf) => cmd_buf,
-            Err(_) => return Err(CommandEncoderError::Invalid),
-        };
-        cmd_buf.check_recording()?;
+        let cmd_buf = hub
+            .command_buffers
+            .strict_get(encoder_id.into_command_buffer_id());
+        let mut cmd_buf_data = cmd_buf.try_get()?;
+        cmd_buf_data.check_recording()?;
 
-        let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {
             list.push(TraceCommand::PushDebugGroup(label.to_string()));
@@ -692,14 +714,11 @@ impl Global {
 
         let hub = &self.hub;
 
-        let cmd_buf = match hub.command_buffers.get(encoder_id.into_command_buffer_id()) {
-            Ok(cmd_buf) => cmd_buf,
-            Err(_) => return Err(CommandEncoderError::Invalid),
-        };
-        cmd_buf.check_recording()?;
-
-        let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
+        let cmd_buf = hub
+            .command_buffers
+            .strict_get(encoder_id.into_command_buffer_id());
+        let mut cmd_buf_data = cmd_buf.try_get()?;
+        cmd_buf_data.check_recording()?;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {
@@ -728,14 +747,11 @@ impl Global {
 
         let hub = &self.hub;
 
-        let cmd_buf = match hub.command_buffers.get(encoder_id.into_command_buffer_id()) {
-            Ok(cmd_buf) => cmd_buf,
-            Err(_) => return Err(CommandEncoderError::Invalid),
-        };
-        cmd_buf.check_recording()?;
-
-        let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
+        let cmd_buf = hub
+            .command_buffers
+            .strict_get(encoder_id.into_command_buffer_id());
+        let mut cmd_buf_data = cmd_buf.try_get()?;
+        cmd_buf_data.check_recording()?;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -678,9 +678,9 @@ impl Global {
         }
 
         let cmd_buf_raw = cmd_buf_data.encoder.open(&cmd_buf.device)?;
-        if !self
-            .instance
-            .flags
+        if !cmd_buf
+            .device
+            .instance_flags
             .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS)
         {
             unsafe {
@@ -714,9 +714,9 @@ impl Global {
             list.push(TraceCommand::InsertDebugMarker(label.to_string()));
         }
 
-        if !self
-            .instance
-            .flags
+        if !cmd_buf
+            .device
+            .instance_flags
             .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS)
         {
             let cmd_buf_raw = cmd_buf_data.encoder.open(&cmd_buf.device)?;
@@ -751,9 +751,9 @@ impl Global {
         }
 
         let cmd_buf_raw = cmd_buf_data.encoder.open(&cmd_buf.device)?;
-        if !self
-            .instance
-            .flags
+        if !cmd_buf
+            .device
+            .instance_flags
             .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS)
         {
             unsafe {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -654,9 +654,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let cmd_buf = hub
-            .command_buffers
-            .strict_get(encoder_id.into_command_buffer_id());
+        let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
 
         let error = match cmd_buf
             .try_get()
@@ -680,9 +678,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let cmd_buf = hub
-            .command_buffers
-            .strict_get(encoder_id.into_command_buffer_id());
+        let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.try_get()?;
         cmd_buf_data.check_recording()?;
 
@@ -714,9 +710,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let cmd_buf = hub
-            .command_buffers
-            .strict_get(encoder_id.into_command_buffer_id());
+        let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.try_get()?;
         cmd_buf_data.check_recording()?;
 
@@ -747,9 +741,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let cmd_buf = hub
-            .command_buffers
-            .strict_get(encoder_id.into_command_buffer_id());
+        let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.try_get()?;
         cmd_buf_data.check_recording()?;
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -597,12 +597,8 @@ pub enum CommandEncoderError {
     #[error("Command encoder is locked by a previously created render/compute pass. Before recording any new commands, the pass must be ended.")]
     Locked,
 
-    #[error("QuerySet {0:?} for pass timestamp writes is invalid.")]
-    InvalidTimestampWritesQuerySetId(id::QuerySetId),
     #[error(transparent)]
     InvalidColorAttachment(#[from] ColorAttachmentError),
-    #[error("Occlusion QuerySetId {0:?} is invalid")]
-    InvalidOcclusionQuerySetId(id::QuerySetId),
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
 }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -31,7 +31,7 @@ use crate::lock::{rank, Mutex};
 use crate::snatch::SnatchGuard;
 
 use crate::init_tracker::BufferInitTrackerAction;
-use crate::resource::Labeled;
+use crate::resource::{InvalidResourceError, Labeled};
 use crate::track::{DeviceTracker, Tracker, UsageScope};
 use crate::LabelHelpers;
 use crate::{api_log, global::Global, id, resource_log, Label};
@@ -599,16 +599,12 @@ pub enum CommandEncoderError {
 
     #[error("QuerySet {0:?} for pass timestamp writes is invalid.")]
     InvalidTimestampWritesQuerySetId(id::QuerySetId),
-    #[error("Attachment TextureViewId {0:?} is invalid")]
-    InvalidAttachmentId(id::TextureViewId),
     #[error(transparent)]
     InvalidColorAttachment(#[from] ColorAttachmentError),
-    #[error("Resolve attachment TextureViewId {0:?} is invalid")]
-    InvalidResolveTargetId(id::TextureViewId),
-    #[error("Depth stencil attachment TextureViewId {0:?} is invalid")]
-    InvalidDepthStencilAttachmentId(id::TextureViewId),
     #[error("Occlusion QuerySetId {0:?} is invalid")]
     InvalidOcclusionQuerySetId(id::QuerySetId),
+    #[error(transparent)]
+    InvalidResource(#[from] InvalidResourceError),
 }
 
 impl Global {

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -103,8 +103,6 @@ pub enum QueryError {
     Resolve(#[from] ResolveError),
     #[error(transparent)]
     DestroyedResource(#[from] DestroyedResourceError),
-    #[error("QuerySetId {0:?} is invalid or destroyed")]
-    InvalidQuerySetId(id::QuerySetId),
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
 }
@@ -349,10 +347,7 @@ impl Global {
 
         let raw_encoder = encoder.open(&cmd_buf.device)?;
 
-        let query_set = hub
-            .query_sets
-            .get(query_set_id)
-            .map_err(|_| QueryError::InvalidQuerySetId(query_set_id))?;
+        let query_set = hub.query_sets.strict_get(query_set_id).get()?;
 
         let query_set = tracker.query_sets.insert_single(query_set);
 
@@ -404,10 +399,7 @@ impl Global {
             return Err(QueryError::Resolve(ResolveError::BufferOffsetAlignment));
         }
 
-        let query_set = hub
-            .query_sets
-            .get(query_set_id)
-            .map_err(|_| QueryError::InvalidQuerySetId(query_set_id))?;
+        let query_set = hub.query_sets.strict_get(query_set_id).get()?;
 
         let query_set = tracker.query_sets.insert_single(query_set);
 

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -320,7 +320,7 @@ impl Global {
 
         let cmd_buf = hub
             .command_buffers
-            .strict_get(command_encoder_id.into_command_buffer_id());
+            .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.try_get()?;
         cmd_buf_data.check_recording()?;
 
@@ -338,7 +338,7 @@ impl Global {
 
         let raw_encoder = cmd_buf_data.encoder.open(&cmd_buf.device)?;
 
-        let query_set = hub.query_sets.strict_get(query_set_id).get()?;
+        let query_set = hub.query_sets.get(query_set_id).get()?;
 
         query_set.validate_and_write_timestamp(raw_encoder, query_index, None)?;
 
@@ -360,7 +360,7 @@ impl Global {
 
         let cmd_buf = hub
             .command_buffers
-            .strict_get(command_encoder_id.into_command_buffer_id());
+            .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.try_get()?;
         cmd_buf_data.check_recording()?;
 
@@ -379,11 +379,11 @@ impl Global {
             return Err(QueryError::Resolve(ResolveError::BufferOffsetAlignment));
         }
 
-        let query_set = hub.query_sets.strict_get(query_set_id).get()?;
+        let query_set = hub.query_sets.get(query_set_id).get()?;
 
         query_set.same_device_as(cmd_buf.as_ref())?;
 
-        let dst_buffer = hub.buffers.strict_get(destination).get()?;
+        let dst_buffer = hub.buffers.get(destination).get()?;
 
         dst_buffer.same_device_as(cmd_buf.as_ref())?;
 

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -318,21 +318,15 @@ impl Global {
     ) -> Result<(), QueryError> {
         let hub = &self.hub;
 
-        let cmd_buf = match hub
+        let cmd_buf = hub
             .command_buffers
-            .get(command_encoder_id.into_command_buffer_id())
-        {
-            Ok(cmd_buf) => cmd_buf,
-            Err(_) => return Err(CommandEncoderError::Invalid.into()),
-        };
-        cmd_buf.check_recording()?;
+            .strict_get(command_encoder_id.into_command_buffer_id());
+        let mut cmd_buf_data = cmd_buf.try_get()?;
+        cmd_buf_data.check_recording()?;
 
         cmd_buf
             .device
             .require_features(wgt::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS)?;
-
-        let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {
@@ -342,16 +336,13 @@ impl Global {
             });
         }
 
-        let encoder = &mut cmd_buf_data.encoder;
-        let tracker = &mut cmd_buf_data.trackers;
-
-        let raw_encoder = encoder.open(&cmd_buf.device)?;
+        let raw_encoder = cmd_buf_data.encoder.open(&cmd_buf.device)?;
 
         let query_set = hub.query_sets.strict_get(query_set_id).get()?;
 
-        let query_set = tracker.query_sets.insert_single(query_set);
-
         query_set.validate_and_write_timestamp(raw_encoder, query_index, None)?;
+
+        cmd_buf_data.trackers.query_sets.insert_single(query_set);
 
         Ok(())
     }
@@ -367,17 +358,11 @@ impl Global {
     ) -> Result<(), QueryError> {
         let hub = &self.hub;
 
-        let cmd_buf = match hub
+        let cmd_buf = hub
             .command_buffers
-            .get(command_encoder_id.into_command_buffer_id())
-        {
-            Ok(cmd_buf) => cmd_buf,
-            Err(_) => return Err(CommandEncoderError::Invalid.into()),
-        };
-        cmd_buf.check_recording()?;
-
-        let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
+            .strict_get(command_encoder_id.into_command_buffer_id());
+        let mut cmd_buf_data = cmd_buf.try_get()?;
+        cmd_buf_data.check_recording()?;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {
@@ -390,18 +375,11 @@ impl Global {
             });
         }
 
-        let encoder = &mut cmd_buf_data.encoder;
-        let tracker = &mut cmd_buf_data.trackers;
-        let buffer_memory_init_actions = &mut cmd_buf_data.buffer_memory_init_actions;
-        let raw_encoder = encoder.open(&cmd_buf.device)?;
-
         if destination_offset % wgt::QUERY_RESOLVE_BUFFER_ALIGNMENT != 0 {
             return Err(QueryError::Resolve(ResolveError::BufferOffsetAlignment));
         }
 
         let query_set = hub.query_sets.strict_get(query_set_id).get()?;
-
-        let query_set = tracker.query_sets.insert_single(query_set);
 
         query_set.same_device_as(cmd_buf.as_ref())?;
 
@@ -409,7 +387,8 @@ impl Global {
 
         dst_buffer.same_device_as(cmd_buf.as_ref())?;
 
-        let dst_pending = tracker
+        let dst_pending = cmd_buf_data
+            .trackers
             .buffers
             .set_single(&dst_buffer, hal::BufferUses::COPY_DST);
 
@@ -455,14 +434,16 @@ impl Global {
         }
 
         // TODO(https://github.com/gfx-rs/wgpu/issues/3993): Need to track initialization state.
-        buffer_memory_init_actions.extend(dst_buffer.initialization_status.read().create_action(
-            &dst_buffer,
-            buffer_start_offset..buffer_end_offset,
-            MemoryInitKind::ImplicitlyInitialized,
-        ));
+        cmd_buf_data.buffer_memory_init_actions.extend(
+            dst_buffer.initialization_status.read().create_action(
+                &dst_buffer,
+                buffer_start_offset..buffer_end_offset,
+                MemoryInitKind::ImplicitlyInitialized,
+            ),
+        );
 
         let raw_dst_buffer = dst_buffer.try_raw(&snatch_guard)?;
-
+        let raw_encoder = cmd_buf_data.encoder.open(&cmd_buf.device)?;
         unsafe {
             raw_encoder.transition_buffers(dst_barrier.as_slice());
             raw_encoder.copy_query_results(
@@ -473,6 +454,8 @@ impl Global {
                 wgt::BufferSize::new_unchecked(stride as u64),
             );
         }
+
+        cmd_buf_data.trackers.query_sets.insert_single(query_set);
 
         Ok(())
     }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1363,14 +1363,10 @@ impl Global {
                     channel,
                 }) = color_attachment
                 {
-                    let view = texture_views
-                        .get_owned(*view_id)
-                        .map_err(|_| CommandEncoderError::InvalidAttachmentId(*view_id))?;
+                    let view = texture_views.strict_get(*view_id).get()?;
 
                     let resolve_target = if let Some(resolve_target_id) = resolve_target {
-                        let rt_arc = texture_views.get_owned(*resolve_target_id).map_err(|_| {
-                            CommandEncoderError::InvalidResolveTargetId(*resolve_target_id)
-                        })?;
+                        let rt_arc = texture_views.strict_get(*resolve_target_id).get()?;
 
                         Some(rt_arc)
                     } else {
@@ -1392,12 +1388,8 @@ impl Global {
             arc_desc.depth_stencil_attachment =
                 if let Some(depth_stencil_attachment) = desc.depth_stencil_attachment {
                     let view = texture_views
-                        .get_owned(depth_stencil_attachment.view)
-                        .map_err(|_| {
-                            CommandEncoderError::InvalidDepthStencilAttachmentId(
-                                depth_stencil_attachment.view,
-                            )
-                        })?;
+                        .strict_get(depth_stencil_attachment.view)
+                        .get()?;
 
                     Some(ArcRenderPassDepthStencilAttachment {
                         view,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -583,8 +583,6 @@ pub enum RenderPassErrorInner {
     InvalidParentEncoder,
     #[error("The format of the depth-stencil attachment ({0:?}) is not a depth-stencil format")]
     InvalidDepthStencilAttachmentFormat(wgt::TextureFormat),
-    #[error("Render pipeline {0:?} is invalid")]
-    InvalidPipeline(id::RenderPipelineId),
     #[error("Render bundle {0:?} is invalid")]
     InvalidRenderBundle(id::RenderBundleId),
     #[error("The format of the {location} ({format:?}) is not resolvable")]
@@ -2847,8 +2845,8 @@ impl Global {
         let hub = &self.hub;
         let pipeline = hub
             .render_pipelines
-            .get(pipeline_id)
-            .map_err(|_| RenderPassErrorInner::InvalidPipeline(pipeline_id))
+            .strict_get(pipeline_id)
+            .get()
             .map_pass_err(scope)?;
 
         base.commands.push(ArcRenderCommand::SetPipeline(pipeline));

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1355,10 +1355,10 @@ impl Global {
                     channel,
                 }) = color_attachment
                 {
-                    let view = texture_views.strict_get(*view_id).get()?;
+                    let view = texture_views.get(*view_id).get()?;
 
                     let resolve_target = if let Some(resolve_target_id) = resolve_target {
-                        let rt_arc = texture_views.strict_get(*resolve_target_id).get()?;
+                        let rt_arc = texture_views.get(*resolve_target_id).get()?;
 
                         Some(rt_arc)
                     } else {
@@ -1379,9 +1379,7 @@ impl Global {
 
             arc_desc.depth_stencil_attachment =
                 if let Some(depth_stencil_attachment) = desc.depth_stencil_attachment {
-                    let view = texture_views
-                        .strict_get(depth_stencil_attachment.view)
-                        .get()?;
+                    let view = texture_views.get(depth_stencil_attachment.view).get()?;
 
                     Some(ArcRenderPassDepthStencilAttachment {
                         view,
@@ -1393,7 +1391,7 @@ impl Global {
                 };
 
             arc_desc.timestamp_writes = if let Some(tw) = desc.timestamp_writes {
-                let query_set = query_sets.strict_get(tw.query_set).get()?;
+                let query_set = query_sets.get(tw.query_set).get()?;
 
                 Some(ArcPassTimestampWrites {
                     query_set,
@@ -1406,7 +1404,7 @@ impl Global {
 
             arc_desc.occlusion_query_set =
                 if let Some(occlusion_query_set) = desc.occlusion_query_set {
-                    let query_set = query_sets.strict_get(occlusion_query_set).get()?;
+                    let query_set = query_sets.get(occlusion_query_set).get()?;
 
                     Some(query_set)
                 } else {
@@ -1427,9 +1425,7 @@ impl Global {
 
         let make_err = |e, arc_desc| (RenderPass::new(None, arc_desc), Some(e));
 
-        let cmd_buf = hub
-            .command_buffers
-            .strict_get(encoder_id.into_command_buffer_id());
+        let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
 
         match cmd_buf
             .try_get()
@@ -1465,7 +1461,7 @@ impl Global {
             let cmd_buf = self
                 .hub
                 .command_buffers
-                .strict_get(encoder_id.into_command_buffer_id());
+                .get(encoder_id.into_command_buffer_id());
             let mut cmd_buf_data = cmd_buf.try_get().map_pass_err(pass_scope)?;
 
             if let Some(ref mut list) = cmd_buf_data.commands {
@@ -2746,11 +2742,7 @@ impl Global {
         buffer_id: id::Id<id::markers::Buffer>,
     ) -> Result<Arc<crate::resource::Buffer>, RenderPassError> {
         let hub = &self.hub;
-        let buffer = hub
-            .buffers
-            .strict_get(buffer_id)
-            .get()
-            .map_pass_err(scope)?;
+        let buffer = hub.buffers.get(buffer_id).get().map_pass_err(scope)?;
 
         Ok(buffer)
     }
@@ -2761,11 +2753,7 @@ impl Global {
         query_set_id: id::Id<id::markers::QuerySet>,
     ) -> Result<Arc<QuerySet>, RenderPassError> {
         let hub = &self.hub;
-        let query_set = hub
-            .query_sets
-            .strict_get(query_set_id)
-            .get()
-            .map_pass_err(scope)?;
+        let query_set = hub.query_sets.get(query_set_id).get().map_pass_err(scope)?;
 
         Ok(query_set)
     }
@@ -2801,7 +2789,7 @@ impl Global {
             let hub = &self.hub;
             let bg = hub
                 .bind_groups
-                .strict_get(bind_group_id)
+                .get(bind_group_id)
                 .get()
                 .map_pass_err(scope)?;
             bind_group = Some(bg);
@@ -2834,7 +2822,7 @@ impl Global {
         let hub = &self.hub;
         let pipeline = hub
             .render_pipelines
-            .strict_get(pipeline_id)
+            .get(pipeline_id)
             .get()
             .map_pass_err(scope)?;
 
@@ -3322,7 +3310,7 @@ impl Global {
         let bundles = hub.render_bundles.read();
 
         for &bundle_id in render_bundle_ids {
-            let bundle = bundles.strict_get(bundle_id).get().map_pass_err(scope)?;
+            let bundle = bundles.get(bundle_id).get().map_pass_err(scope)?;
 
             base.commands.push(ArcRenderCommand::ExecuteBundle(bundle));
         }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -632,8 +632,6 @@ pub enum RenderPassErrorInner {
     SurfaceTextureDropped,
     #[error("Not enough memory left for render pass")]
     OutOfMemory,
-    #[error("BindGroupId {0:?} is invalid")]
-    InvalidBindGroupId(id::BindGroupId),
     #[error("Unable to clear non-present/read-only depth")]
     InvalidDepthOps,
     #[error("Unable to clear non-present/read-only stencil")]
@@ -2816,8 +2814,8 @@ impl Global {
             let hub = &self.hub;
             let bg = hub
                 .bind_groups
-                .get(bind_group_id)
-                .map_err(|_| RenderPassErrorInner::InvalidBindGroupId(bind_group_id))
+                .strict_get(bind_group_id)
+                .get()
                 .map_pass_err(scope)?;
             bind_group = Some(bg);
         }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1567,10 +1567,10 @@ impl Global {
         };
         cmd_buf.unlock_encoder().map_pass_err(pass_scope)?;
 
-        let hal_label = hal_label(base.label.as_deref(), self.instance.flags);
-
         let device = &cmd_buf.device;
         let snatch_guard = &device.snatchable_lock.read();
+
+        let hal_label = hal_label(base.label.as_deref(), device.instance_flags);
 
         let (scope, pending_discard_init_fixups) = {
             let mut cmd_buf_data = cmd_buf.data.lock();

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -583,8 +583,6 @@ pub enum RenderPassErrorInner {
     InvalidParentEncoder,
     #[error("The format of the depth-stencil attachment ({0:?}) is not a depth-stencil format")]
     InvalidDepthStencilAttachmentFormat(wgt::TextureFormat),
-    #[error("Render bundle {0:?} is invalid")]
-    InvalidRenderBundle(id::RenderBundleId),
     #[error("The format of the {location} ({format:?}) is not resolvable")]
     UnsupportedResolveTargetFormat {
         location: AttachmentErrorLocation,
@@ -3333,10 +3331,7 @@ impl Global {
         let bundles = hub.render_bundles.read();
 
         for &bundle_id in render_bundle_ids {
-            let bundle = bundles
-                .get_owned(bundle_id)
-                .map_err(|_| RenderPassErrorInner::InvalidRenderBundle(bundle_id))
-                .map_pass_err(scope)?;
+            let bundle = bundles.strict_get(bundle_id).get().map_pass_err(scope)?;
 
             base.commands.push(ArcRenderCommand::ExecuteBundle(bundle));
         }

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -206,12 +206,13 @@ impl RenderCommand {
                         query_set_id,
                         query_index,
                     } => ArcRenderCommand::WriteTimestamp {
-                        query_set: query_set_guard.get_owned(query_set_id).map_err(|_| {
-                            RenderPassError {
+                        query_set: query_set_guard
+                            .strict_get(query_set_id)
+                            .get()
+                            .map_err(|e| RenderPassError {
                                 scope: PassErrorScope::WriteTimestamp,
-                                inner: RenderPassErrorInner::InvalidQuerySet(query_set_id),
-                            }
-                        })?,
+                                inner: e.into(),
+                            })?,
                         query_index,
                     },
 
@@ -219,12 +220,13 @@ impl RenderCommand {
                         query_set_id,
                         query_index,
                     } => ArcRenderCommand::BeginPipelineStatisticsQuery {
-                        query_set: query_set_guard.get_owned(query_set_id).map_err(|_| {
-                            RenderPassError {
+                        query_set: query_set_guard
+                            .strict_get(query_set_id)
+                            .get()
+                            .map_err(|e| RenderPassError {
                                 scope: PassErrorScope::BeginPipelineStatisticsQuery,
-                                inner: RenderPassErrorInner::InvalidQuerySet(query_set_id),
-                            }
-                        })?,
+                                inner: e.into(),
+                            })?,
                         query_index,
                     },
 

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -129,7 +129,7 @@ impl RenderCommand {
         hub: &crate::hub::Hub,
         commands: &[RenderCommand],
     ) -> Result<Vec<ArcRenderCommand>, super::RenderPassError> {
-        use super::{DrawKind, PassErrorScope, RenderCommandError, RenderPassError};
+        use super::{DrawKind, PassErrorScope, RenderPassError};
 
         let buffers_guard = hub.buffers.read();
         let bind_group_guard = hub.bind_groups.read();
@@ -376,12 +376,12 @@ impl RenderCommand {
                     RenderCommand::EndOcclusionQuery => ArcRenderCommand::EndOcclusionQuery,
 
                     RenderCommand::ExecuteBundle(bundle) => ArcRenderCommand::ExecuteBundle(
-                        render_bundles_guard
-                            .get_owned(bundle)
-                            .map_err(|_| RenderPassError {
+                        render_bundles_guard.strict_get(bundle).get().map_err(|e| {
+                            RenderPassError {
                                 scope: PassErrorScope::ExecuteBundle,
-                                inner: RenderCommandError::InvalidRenderBundle(bundle).into(),
-                            })?,
+                                inner: e.into(),
+                            }
+                        })?,
                     ),
                 })
             })

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -129,9 +129,7 @@ impl RenderCommand {
         hub: &crate::hub::Hub,
         commands: &[RenderCommand],
     ) -> Result<Vec<ArcRenderCommand>, super::RenderPassError> {
-        use super::{
-            DrawKind, PassErrorScope, RenderCommandError, RenderPassError, RenderPassErrorInner,
-        };
+        use super::{DrawKind, PassErrorScope, RenderCommandError, RenderPassError};
 
         let buffers_guard = hub.buffers.read();
         let bind_group_guard = hub.bind_groups.read();
@@ -157,12 +155,13 @@ impl RenderCommand {
                         }
 
                         let bind_group_id = bind_group_id.unwrap();
-                        let bg = bind_group_guard.get_owned(bind_group_id).map_err(|_| {
-                            RenderPassError {
+                        let bg = bind_group_guard
+                            .strict_get(bind_group_id)
+                            .get()
+                            .map_err(|e| RenderPassError {
                                 scope: PassErrorScope::SetBindGroup,
-                                inner: RenderPassErrorInner::InvalidBindGroupId(bind_group_id),
-                            }
-                        })?;
+                                inner: e.into(),
+                            })?;
 
                         ArcRenderCommand::SetBindGroup {
                             index,

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -171,12 +171,12 @@ impl RenderCommand {
                     }
 
                     RenderCommand::SetPipeline(pipeline_id) => ArcRenderCommand::SetPipeline(
-                        pipelines_guard
-                            .get_owned(pipeline_id)
-                            .map_err(|_| RenderPassError {
+                        pipelines_guard.strict_get(pipeline_id).get().map_err(|e| {
+                            RenderPassError {
                                 scope: PassErrorScope::SetPipelineRender,
-                                inner: RenderCommandError::InvalidPipelineId(pipeline_id).into(),
-                            })?,
+                                inner: e.into(),
+                            }
+                        })?,
                     ),
 
                     RenderCommand::SetPushConstant {

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -238,10 +238,10 @@ impl RenderCommand {
                         offset,
                         size,
                     } => ArcRenderCommand::SetIndexBuffer {
-                        buffer: buffers_guard.get_owned(buffer_id).map_err(|_| {
+                        buffer: buffers_guard.strict_get(buffer_id).get().map_err(|e| {
                             RenderPassError {
                                 scope: PassErrorScope::SetIndexBuffer,
-                                inner: RenderCommandError::InvalidBufferId(buffer_id).into(),
+                                inner: e.into(),
                             }
                         })?,
                         index_format,
@@ -256,10 +256,10 @@ impl RenderCommand {
                         size,
                     } => ArcRenderCommand::SetVertexBuffer {
                         slot,
-                        buffer: buffers_guard.get_owned(buffer_id).map_err(|_| {
+                        buffer: buffers_guard.strict_get(buffer_id).get().map_err(|e| {
                             RenderPassError {
                                 scope: PassErrorScope::SetVertexBuffer,
-                                inner: RenderCommandError::InvalidBufferId(buffer_id).into(),
+                                inner: e.into(),
                             }
                         })?,
                         offset,
@@ -318,7 +318,7 @@ impl RenderCommand {
                         count,
                         indexed,
                     } => ArcRenderCommand::MultiDrawIndirect {
-                        buffer: buffers_guard.get_owned(buffer_id).map_err(|_| {
+                        buffer: buffers_guard.strict_get(buffer_id).get().map_err(|e| {
                             RenderPassError {
                                 scope: PassErrorScope::Draw {
                                     kind: if count.is_some() {
@@ -328,7 +328,7 @@ impl RenderCommand {
                                     },
                                     indexed,
                                 },
-                                inner: RenderCommandError::InvalidBufferId(buffer_id).into(),
+                                inner: e.into(),
                             }
                         })?,
                         offset,
@@ -349,18 +349,17 @@ impl RenderCommand {
                             indexed,
                         };
                         ArcRenderCommand::MultiDrawIndirectCount {
-                            buffer: buffers_guard.get_owned(buffer_id).map_err(|_| {
+                            buffer: buffers_guard.strict_get(buffer_id).get().map_err(|e| {
                                 RenderPassError {
                                     scope,
-                                    inner: RenderCommandError::InvalidBufferId(buffer_id).into(),
+                                    inner: e.into(),
                                 }
                             })?,
                             offset,
-                            count_buffer: buffers_guard.get_owned(count_buffer_id).map_err(
-                                |_| RenderPassError {
+                            count_buffer: buffers_guard.strict_get(count_buffer_id).get().map_err(
+                                |e| RenderPassError {
                                     scope,
-                                    inner: RenderCommandError::InvalidBufferId(count_buffer_id)
-                                        .into(),
+                                    inner: e.into(),
                                 },
                             )?,
                             count_buffer_offset,

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -534,7 +534,7 @@ impl Global {
 
         let cmd_buf = hub
             .command_buffers
-            .strict_get(command_encoder_id.into_command_buffer_id());
+            .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.try_get()?;
         cmd_buf_data.check_recording()?;
 
@@ -554,7 +554,7 @@ impl Global {
 
         let snatch_guard = device.snatchable_lock.read();
 
-        let src_buffer = hub.buffers.strict_get(source).get()?;
+        let src_buffer = hub.buffers.get(source).get()?;
 
         src_buffer.same_device_as(cmd_buf.as_ref())?;
 
@@ -570,7 +570,7 @@ impl Global {
         // expecting only a single barrier
         let src_barrier = src_pending.map(|pending| pending.into_hal(&src_buffer, &snatch_guard));
 
-        let dst_buffer = hub.buffers.strict_get(destination).get()?;
+        let dst_buffer = hub.buffers.get(destination).get()?;
 
         dst_buffer.same_device_as(cmd_buf.as_ref())?;
 
@@ -692,7 +692,7 @@ impl Global {
 
         let cmd_buf = hub
             .command_buffers
-            .strict_get(command_encoder_id.into_command_buffer_id());
+            .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.try_get()?;
         cmd_buf_data.check_recording()?;
 
@@ -713,7 +713,7 @@ impl Global {
             return Ok(());
         }
 
-        let dst_texture = hub.textures.strict_get(destination.texture).get()?;
+        let dst_texture = hub.textures.get(destination.texture).get()?;
 
         dst_texture.same_device_as(cmd_buf.as_ref())?;
 
@@ -740,7 +740,7 @@ impl Global {
             &snatch_guard,
         )?;
 
-        let src_buffer = hub.buffers.strict_get(source.buffer).get()?;
+        let src_buffer = hub.buffers.get(source.buffer).get()?;
 
         src_buffer.same_device_as(cmd_buf.as_ref())?;
 
@@ -845,7 +845,7 @@ impl Global {
 
         let cmd_buf = hub
             .command_buffers
-            .strict_get(command_encoder_id.into_command_buffer_id());
+            .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.try_get()?;
         cmd_buf_data.check_recording()?;
 
@@ -866,7 +866,7 @@ impl Global {
             return Ok(());
         }
 
-        let src_texture = hub.textures.strict_get(source.texture).get()?;
+        let src_texture = hub.textures.get(source.texture).get()?;
 
         src_texture.same_device_as(cmd_buf.as_ref())?;
 
@@ -915,7 +915,7 @@ impl Global {
             .map(|pending| pending.into_hal(src_raw))
             .collect::<Vec<_>>();
 
-        let dst_buffer = hub.buffers.strict_get(destination.buffer).get()?;
+        let dst_buffer = hub.buffers.get(destination.buffer).get()?;
 
         dst_buffer.same_device_as(cmd_buf.as_ref())?;
 
@@ -1012,7 +1012,7 @@ impl Global {
 
         let cmd_buf = hub
             .command_buffers
-            .strict_get(command_encoder_id.into_command_buffer_id());
+            .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.try_get()?;
         cmd_buf_data.check_recording()?;
 
@@ -1035,8 +1035,8 @@ impl Global {
             return Ok(());
         }
 
-        let src_texture = hub.textures.strict_get(source.texture).get()?;
-        let dst_texture = hub.textures.strict_get(destination.texture).get()?;
+        let src_texture = hub.textures.get(source.texture).get()?;
+        let dst_texture = hub.textures.get(destination.texture).get()?;
 
         src_texture.same_device_as(cmd_buf.as_ref())?;
         dst_texture.same_device_as(cmd_buf.as_ref())?;

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -41,8 +41,6 @@ pub enum CopySide {
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum TransferError {
-    #[error("TextureId {0:?} is invalid")]
-    InvalidTextureId(TextureId),
     #[error("Source and destination cannot be the same buffer")]
     SameSourceDestinationBuffer,
     #[error(transparent)]
@@ -740,10 +738,7 @@ impl Global {
             return Ok(());
         }
 
-        let dst_texture = hub
-            .textures
-            .get(destination.texture)
-            .map_err(|_| TransferError::InvalidTextureId(destination.texture))?;
+        let dst_texture = hub.textures.strict_get(destination.texture).get()?;
 
         dst_texture.same_device_as(cmd_buf.as_ref())?;
 
@@ -904,10 +899,7 @@ impl Global {
             return Ok(());
         }
 
-        let src_texture = hub
-            .textures
-            .get(source.texture)
-            .map_err(|_| TransferError::InvalidTextureId(source.texture))?;
+        let src_texture = hub.textures.strict_get(source.texture).get()?;
 
         src_texture.same_device_as(cmd_buf.as_ref())?;
 
@@ -1082,14 +1074,8 @@ impl Global {
             return Ok(());
         }
 
-        let src_texture = hub
-            .textures
-            .get(source.texture)
-            .map_err(|_| TransferError::InvalidTextureId(source.texture))?;
-        let dst_texture = hub
-            .textures
-            .get(destination.texture)
-            .map_err(|_| TransferError::InvalidTextureId(source.texture))?;
+        let src_texture = hub.textures.strict_get(source.texture).get()?;
+        let dst_texture = hub.textures.strict_get(destination.texture).get()?;
 
         src_texture.same_device_as(cmd_buf.as_ref())?;
         dst_texture.same_device_as(cmd_buf.as_ref())?;

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -43,10 +43,7 @@ impl Global {
         let hub = &self.hub;
 
         let surface_guard = self.surfaces.read();
-        let adapter_guard = hub.adapters.read();
-        let adapter = adapter_guard
-            .get(adapter_id)
-            .map_err(|_| instance::IsSurfaceSupportedError::InvalidAdapter)?;
+        let adapter = hub.adapters.strict_get(adapter_id);
         let surface = surface_guard
             .get(surface_id)
             .map_err(|_| instance::IsSurfaceSupportedError::InvalidSurface)?;
@@ -87,15 +84,13 @@ impl Global {
         let hub = &self.hub;
 
         let surface_guard = self.surfaces.read();
-        let adapter_guard = hub.adapters.read();
-        let adapter = adapter_guard
-            .get(adapter_id)
-            .map_err(|_| instance::GetSurfaceSupportError::InvalidAdapter)?;
+        let adapter = hub.adapters.strict_get(adapter_id);
+
         let surface = surface_guard
             .get(surface_id)
             .map_err(|_| instance::GetSurfaceSupportError::InvalidSurface)?;
 
-        get_supported_callback(adapter, surface)
+        get_supported_callback(&adapter, surface)
     }
 
     pub fn device_features(&self, device_id: DeviceId) -> Result<wgt::Features, DeviceError> {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -283,7 +283,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let buffer = match hub.buffers.strict_unregister(buffer_id).get() {
+        let buffer = match hub.buffers.remove(buffer_id).get() {
             Ok(buffer) => buffer,
             Err(_) => {
                 return;
@@ -439,7 +439,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _texture = hub.textures.strict_unregister(texture_id);
+        let _texture = hub.textures.remove(texture_id);
         #[cfg(feature = "trace")]
         if let Ok(texture) = _texture.get() {
             if let Some(t) = texture.device.trace.lock().as_mut() {
@@ -502,7 +502,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _view = hub.texture_views.strict_unregister(texture_view_id);
+        let _view = hub.texture_views.remove(texture_view_id);
 
         #[cfg(feature = "trace")]
         if let Ok(view) = _view.get() {
@@ -553,7 +553,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _sampler = hub.samplers.strict_unregister(sampler_id);
+        let _sampler = hub.samplers.remove(sampler_id);
 
         #[cfg(feature = "trace")]
         if let Ok(sampler) = _sampler.get() {
@@ -625,9 +625,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _layout = hub
-            .bind_group_layouts
-            .strict_unregister(bind_group_layout_id);
+        let _layout = hub.bind_group_layouts.remove(bind_group_layout_id);
 
         #[cfg(feature = "trace")]
         if let Ok(layout) = _layout.get() {
@@ -698,7 +696,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _layout = hub.pipeline_layouts.strict_unregister(pipeline_layout_id);
+        let _layout = hub.pipeline_layouts.remove(pipeline_layout_id);
 
         #[cfg(feature = "trace")]
         if let Ok(layout) = _layout.get() {
@@ -842,7 +840,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _bind_group = hub.bind_groups.strict_unregister(bind_group_id);
+        let _bind_group = hub.bind_groups.remove(bind_group_id);
 
         #[cfg(feature = "trace")]
         if let Ok(_bind_group) = _bind_group.get() {
@@ -989,7 +987,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _shader_module = hub.shader_modules.strict_unregister(shader_module_id);
+        let _shader_module = hub.shader_modules.remove(shader_module_id);
 
         #[cfg(feature = "trace")]
         if let Ok(shader_module) = _shader_module.get() {
@@ -1038,7 +1036,7 @@ impl Global {
 
         let _cmd_buf = hub
             .command_buffers
-            .strict_unregister(command_encoder_id.into_command_buffer_id());
+            .remove(command_encoder_id.into_command_buffer_id());
     }
 
     pub fn command_buffer_drop(&self, command_buffer_id: id::CommandBufferId) {
@@ -1116,7 +1114,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _bundle = hub.render_bundles.strict_unregister(render_bundle_id);
+        let _bundle = hub.render_bundles.remove(render_bundle_id);
 
         #[cfg(feature = "trace")]
         if let Ok(bundle) = _bundle.get() {
@@ -1169,7 +1167,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _query_set = hub.query_sets.strict_unregister(query_set_id);
+        let _query_set = hub.query_sets.remove(query_set_id);
 
         #[cfg(feature = "trace")]
         if let Ok(query_set) = _query_set.get() {
@@ -1406,7 +1404,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _pipeline = hub.render_pipelines.strict_unregister(render_pipeline_id);
+        let _pipeline = hub.render_pipelines.remove(render_pipeline_id);
 
         #[cfg(feature = "trace")]
         if let Ok(pipeline) = _pipeline.get() {
@@ -1592,7 +1590,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _pipeline = hub.compute_pipelines.strict_unregister(compute_pipeline_id);
+        let _pipeline = hub.compute_pipelines.remove(compute_pipeline_id);
 
         #[cfg(feature = "trace")]
         if let Ok(pipeline) = _pipeline.get() {
@@ -1652,7 +1650,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _cache = hub.pipeline_caches.strict_unregister(pipeline_cache_id);
+        let _cache = hub.pipeline_caches.remove(pipeline_cache_id);
 
         #[cfg(feature = "trace")]
         if let Ok(cache) = _cache.get() {
@@ -2089,7 +2087,7 @@ impl Global {
         profiling::scope!("Device::drop");
         api_log!("Device::drop {device_id:?}");
 
-        let device = self.hub.devices.strict_unregister(device_id);
+        let device = self.hub.devices.remove(device_id);
         let device_lost_closure = device.lock_life().device_lost_closure.take();
         if let Some(closure) = device_lost_closure {
             closure.call(DeviceLostReason::Dropped, String::from("Device dropped."));
@@ -2168,7 +2166,7 @@ impl Global {
         profiling::scope!("Queue::drop");
         api_log!("Queue::drop {queue_id:?}");
 
-        self.hub.queues.strict_unregister(queue_id);
+        self.hub.queues.remove(queue_id);
     }
 
     pub fn buffer_map_async(

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -26,7 +26,11 @@ use crate::{
 
 use wgt::{BufferAddress, TextureFormat};
 
-use std::{borrow::Cow, ptr::NonNull, sync::atomic::Ordering};
+use std::{
+    borrow::Cow,
+    ptr::NonNull,
+    sync::{atomic::Ordering, Arc},
+};
 
 use super::{ImplicitPipelineIds, UserClosures};
 
@@ -803,9 +807,9 @@ impl Global {
 
             fn resolve_entry<'a>(
                 e: &BindGroupEntry<'a>,
-                buffer_storage: &Storage<resource::Buffer>,
-                sampler_storage: &Storage<resource::Sampler>,
-                texture_view_storage: &Storage<resource::TextureView>,
+                buffer_storage: &Storage<Arc<resource::Buffer>>,
+                sampler_storage: &Storage<Arc<resource::Sampler>>,
+                texture_view_storage: &Storage<Arc<resource::TextureView>>,
             ) -> Result<ResolvedBindGroupEntry<'a>, binding_model::CreateBindGroupError>
             {
                 let resolve_buffer = |bb: &BufferBinding| {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -42,8 +42,8 @@ impl Global {
         adapter_id: AdapterId,
         surface_id: SurfaceId,
     ) -> bool {
-        let surface = self.surfaces.strict_get(surface_id);
-        let adapter = self.hub.adapters.strict_get(adapter_id);
+        let surface = self.surfaces.get(surface_id);
+        let adapter = self.hub.adapters.get(adapter_id);
         adapter.is_surface_supported(&surface)
     }
 
@@ -75,23 +75,23 @@ impl Global {
         adapter_id: AdapterId,
         get_supported_callback: F,
     ) -> B {
-        let surface = self.surfaces.strict_get(surface_id);
-        let adapter = self.hub.adapters.strict_get(adapter_id);
+        let surface = self.surfaces.get(surface_id);
+        let adapter = self.hub.adapters.get(adapter_id);
         get_supported_callback(&adapter, &surface)
     }
 
     pub fn device_features(&self, device_id: DeviceId) -> wgt::Features {
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
         device.features
     }
 
     pub fn device_limits(&self, device_id: DeviceId) -> wgt::Limits {
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
         device.limits.clone()
     }
 
     pub fn device_downlevel_properties(&self, device_id: DeviceId) -> wgt::DownlevelCapabilities {
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
         device.downlevel.clone()
     }
 
@@ -107,7 +107,7 @@ impl Global {
         let fid = hub.buffers.prepare(device_id.backend(), id_in);
 
         let error = 'error: {
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -215,7 +215,7 @@ impl Global {
     ) -> BufferAccessResult {
         let hub = &self.hub;
 
-        let buffer = hub.buffers.strict_get(buffer_id).get()?;
+        let buffer = hub.buffers.get(buffer_id).get()?;
 
         let device = &buffer.device;
 
@@ -262,7 +262,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let buffer = hub.buffers.strict_get(buffer_id).get()?;
+        let buffer = hub.buffers.get(buffer_id).get()?;
 
         #[cfg(feature = "trace")]
         if let Some(trace) = buffer.device.trace.lock().as_mut() {
@@ -314,7 +314,7 @@ impl Global {
         let fid = hub.textures.prepare(device_id.backend(), id_in);
 
         let error = 'error: {
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -357,7 +357,7 @@ impl Global {
         let fid = hub.textures.prepare(device_id.backend(), id_in);
 
         let error = 'error: {
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             // NB: Any change done through the raw texture handle will not be
             // recorded in the replay
@@ -400,7 +400,7 @@ impl Global {
         let hub = &self.hub;
         let fid = hub.buffers.prepare(A::VARIANT, id_in);
 
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
 
         // NB: Any change done through the raw buffer handle will not be
         // recorded in the replay
@@ -423,7 +423,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let texture = hub.textures.strict_get(texture_id).get()?;
+        let texture = hub.textures.get(texture_id).get()?;
 
         #[cfg(feature = "trace")]
         if let Some(trace) = texture.device.trace.lock().as_mut() {
@@ -461,7 +461,7 @@ impl Global {
         let fid = hub.texture_views.prepare(texture_id.backend(), id_in);
 
         let error = 'error: {
-            let texture = match hub.textures.strict_get(texture_id).get() {
+            let texture = match hub.textures.get(texture_id).get() {
                 Ok(texture) => texture,
                 Err(e) => break 'error e.into(),
             };
@@ -525,7 +525,7 @@ impl Global {
         let fid = hub.samplers.prepare(device_id.backend(), id_in);
 
         let error = 'error: {
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -578,7 +578,7 @@ impl Global {
         let fid = hub.bind_group_layouts.prepare(device_id.backend(), id_in);
 
         let error = 'error: {
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -652,7 +652,7 @@ impl Global {
         let fid = hub.pipeline_layouts.prepare(device_id.backend(), id_in);
 
         let error = 'error: {
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -663,7 +663,7 @@ impl Global {
                 let bind_group_layouts_guard = hub.bind_group_layouts.read();
                 desc.bind_group_layouts
                     .iter()
-                    .map(|bgl_id| bind_group_layouts_guard.strict_get(*bgl_id).get())
+                    .map(|bgl_id| bind_group_layouts_guard.get(*bgl_id).get())
                     .collect::<Result<Vec<_>, _>>()
             };
 
@@ -720,14 +720,14 @@ impl Global {
         let fid = hub.bind_groups.prepare(device_id.backend(), id_in);
 
         let error = 'error: {
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
                 trace.add(trace::Action::CreateBindGroup(fid.id(), desc.clone()));
             }
 
-            let layout = match hub.bind_group_layouts.strict_get(desc.layout).get() {
+            let layout = match hub.bind_group_layouts.get(desc.layout).get() {
                 Ok(layout) => layout,
                 Err(e) => break 'error e.into(),
             };
@@ -741,7 +741,7 @@ impl Global {
             {
                 let resolve_buffer = |bb: &BufferBinding| {
                     buffer_storage
-                        .strict_get(bb.buffer_id)
+                        .get(bb.buffer_id)
                         .get()
                         .map(|buffer| ResolvedBufferBinding {
                             buffer,
@@ -752,13 +752,13 @@ impl Global {
                 };
                 let resolve_sampler = |id: &id::SamplerId| {
                     sampler_storage
-                        .strict_get(*id)
+                        .get(*id)
                         .get()
                         .map_err(binding_model::CreateBindGroupError::from)
                 };
                 let resolve_view = |id: &id::TextureViewId| {
                     texture_view_storage
-                        .strict_get(*id)
+                        .get(*id)
                         .get()
                         .map_err(binding_model::CreateBindGroupError::from)
                 };
@@ -882,7 +882,7 @@ impl Global {
         let fid = hub.shader_modules.prepare(device_id.backend(), id_in);
 
         let error = 'error: {
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -954,7 +954,7 @@ impl Global {
         let fid = hub.shader_modules.prepare(device_id.backend(), id_in);
 
         let error = 'error: {
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -1013,7 +1013,7 @@ impl Global {
             id_in.map(|id| id.into_command_buffer_id()),
         );
 
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
 
         let error = 'error: {
             let command_buffer = match device.create_command_encoder(&desc.label) {
@@ -1079,7 +1079,7 @@ impl Global {
             .prepare(bundle_encoder.parent().backend(), id_in);
 
         let error = 'error: {
-            let device = self.hub.devices.strict_get(bundle_encoder.parent());
+            let device = self.hub.devices.get(bundle_encoder.parent());
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -1138,7 +1138,7 @@ impl Global {
         let fid = hub.query_sets.prepare(device_id.backend(), id_in);
 
         let error = 'error: {
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -1205,7 +1205,7 @@ impl Global {
                 break 'error pipeline::ImplicitLayoutError::MissingImplicitPipelineIds.into();
             }
 
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -1218,7 +1218,7 @@ impl Global {
 
             let layout = desc
                 .layout
-                .map(|layout| hub.pipeline_layouts.strict_get(layout).get())
+                .map(|layout| hub.pipeline_layouts.get(layout).get())
                 .transpose();
             let layout = match layout {
                 Ok(layout) => layout,
@@ -1227,7 +1227,7 @@ impl Global {
 
             let cache = desc
                 .cache
-                .map(|cache| hub.pipeline_caches.strict_get(cache).get())
+                .map(|cache| hub.pipeline_caches.get(cache).get())
                 .transpose();
             let cache = match cache {
                 Ok(cache) => cache,
@@ -1237,7 +1237,7 @@ impl Global {
             let vertex = {
                 let module = hub
                     .shader_modules
-                    .strict_get(desc.vertex.stage.module)
+                    .get(desc.vertex.stage.module)
                     .get()
                     .map_err(|e| pipeline::CreateRenderPipelineError::Stage {
                         stage: wgt::ShaderStages::VERTEX,
@@ -1265,7 +1265,7 @@ impl Global {
             let fragment = if let Some(ref state) = desc.fragment {
                 let module = hub
                     .shader_modules
-                    .strict_get(state.stage.module)
+                    .get(state.stage.module)
                     .get()
                     .map_err(|e| pipeline::CreateRenderPipelineError::Stage {
                         stage: wgt::ShaderStages::FRAGMENT,
@@ -1383,7 +1383,7 @@ impl Global {
         let fid = hub.bind_group_layouts.prepare(pipeline_id.backend(), id_in);
 
         let error = 'error: {
-            let pipeline = match hub.render_pipelines.strict_get(pipeline_id).get() {
+            let pipeline = match hub.render_pipelines.get(pipeline_id).get() {
                 Ok(pipeline) => pipeline,
                 Err(e) => break 'error e.into(),
             };
@@ -1442,7 +1442,7 @@ impl Global {
                 break 'error pipeline::ImplicitLayoutError::MissingImplicitPipelineIds.into();
             }
 
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -1455,7 +1455,7 @@ impl Global {
 
             let layout = desc
                 .layout
-                .map(|layout| hub.pipeline_layouts.strict_get(layout).get())
+                .map(|layout| hub.pipeline_layouts.get(layout).get())
                 .transpose();
             let layout = match layout {
                 Ok(layout) => layout,
@@ -1464,14 +1464,14 @@ impl Global {
 
             let cache = desc
                 .cache
-                .map(|cache| hub.pipeline_caches.strict_get(cache).get())
+                .map(|cache| hub.pipeline_caches.get(cache).get())
                 .transpose();
             let cache = match cache {
                 Ok(cache) => cache,
                 Err(e) => break 'error e.into(),
             };
 
-            let module = hub.shader_modules.strict_get(desc.stage.module).get();
+            let module = hub.shader_modules.get(desc.stage.module).get();
             let module = match module {
                 Ok(module) => module,
                 Err(e) => break 'error e.into(),
@@ -1567,7 +1567,7 @@ impl Global {
         let fid = hub.bind_group_layouts.prepare(pipeline_id.backend(), id_in);
 
         let error = 'error: {
-            let pipeline = match hub.compute_pipelines.strict_get(pipeline_id).get() {
+            let pipeline = match hub.compute_pipelines.get(pipeline_id).get() {
                 Ok(pipeline) => pipeline,
                 Err(e) => break 'error e.into(),
             };
@@ -1620,7 +1620,7 @@ impl Global {
 
         let fid = hub.pipeline_caches.prepare(device_id.backend(), id_in);
         let error: pipeline::CreatePipelineCacheError = 'error: {
-            let device = self.hub.devices.strict_get(device_id);
+            let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
@@ -1789,7 +1789,7 @@ impl Global {
             // User callbacks must not be called while we are holding locks.
             let user_callbacks;
             {
-                let device = self.hub.devices.strict_get(device_id);
+                let device = self.hub.devices.get(device_id);
 
                 #[cfg(feature = "trace")]
                 if let Some(ref mut trace) = *device.trace.lock() {
@@ -1800,7 +1800,7 @@ impl Global {
                     break 'error e.into();
                 }
 
-                let surface = self.surfaces.strict_get(surface_id);
+                let surface = self.surfaces.get(surface_id);
 
                 let caps = match surface.get_capabilities(&device.adapter) {
                     Ok(caps) => caps,
@@ -1927,7 +1927,7 @@ impl Global {
     ) -> Result<bool, WaitIdleError> {
         api_log!("Device::poll {maintain:?}");
 
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
 
         let DevicePoll {
             closures,
@@ -2037,7 +2037,7 @@ impl Global {
     pub fn device_start_capture(&self, device_id: DeviceId) {
         api_log!("Device::start_capture");
 
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
 
         if !device.is_valid() {
             return;
@@ -2048,7 +2048,7 @@ impl Global {
     pub fn device_stop_capture(&self, device_id: DeviceId) {
         api_log!("Device::stop_capture");
 
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
 
         if !device.is_valid() {
             return;
@@ -2061,7 +2061,7 @@ impl Global {
         api_log!("PipelineCache::get_data");
         let hub = &self.hub;
 
-        if let Ok(cache) = hub.pipeline_caches.strict_get(id).get() {
+        if let Ok(cache) = hub.pipeline_caches.get(id).get() {
             // TODO: Is this check needed?
             if !cache.device.is_valid() {
                 return None;
@@ -2112,7 +2112,7 @@ impl Global {
         device_id: DeviceId,
         device_lost_closure: DeviceLostClosure,
     ) {
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
 
         let mut life_tracker = device.lock_life();
         if let Some(existing_closure) = life_tracker.device_lost_closure.take() {
@@ -2127,7 +2127,7 @@ impl Global {
     pub fn device_destroy(&self, device_id: DeviceId) {
         api_log!("Device::destroy {device_id:?}");
 
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
 
         // Follow the steps at
         // https://gpuweb.github.io/gpuweb/#dom-gpudevice-destroy.
@@ -2149,7 +2149,7 @@ impl Global {
     }
 
     pub fn device_get_internal_counters(&self, device_id: DeviceId) -> wgt::InternalCounters {
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
         wgt::InternalCounters {
             hal: device.get_hal_counters(),
             core: wgt::CoreCounters {},
@@ -2160,7 +2160,7 @@ impl Global {
         &self,
         device_id: DeviceId,
     ) -> Option<wgt::AllocatorReport> {
-        let device = self.hub.devices.strict_get(device_id);
+        let device = self.hub.devices.get(device_id);
         device.generate_allocator_report()
     }
 
@@ -2184,7 +2184,7 @@ impl Global {
         let hub = &self.hub;
 
         let op_and_err = 'error: {
-            let buffer = match hub.buffers.strict_get(buffer_id).get() {
+            let buffer = match hub.buffers.get(buffer_id).get() {
                 Ok(buffer) => buffer,
                 Err(e) => break 'error Some((op, e.into())),
             };
@@ -2217,7 +2217,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let buffer = hub.buffers.strict_get(buffer_id).get()?;
+        let buffer = hub.buffers.get(buffer_id).get()?;
 
         {
             let snatch_guard = buffer.device.snatchable_lock.read();
@@ -2290,7 +2290,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let buffer = hub.buffers.strict_get(buffer_id).get()?;
+        let buffer = hub.buffers.get(buffer_id).get()?;
 
         let snatch_guard = buffer.device.snatchable_lock.read();
         buffer.check_destroyed(&snatch_guard)?;

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2304,10 +2304,7 @@ impl Global {
         profiling::scope!("Queue::drop");
         api_log!("Queue::drop {queue_id:?}");
 
-        let hub = &self.hub;
-        if let Some(queue) = hub.queues.unregister(queue_id) {
-            drop(queue);
-        }
+        self.hub.queues.strict_unregister(queue_id);
     }
 
     pub fn buffer_map_async(

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -462,15 +462,11 @@ impl ImplicitPipelineIds<'_> {
             root_id: hub
                 .pipeline_layouts
                 .prepare(backend, Some(self.root_id))
-                .into_id(),
+                .id(),
             group_ids: self
                 .group_ids
                 .iter()
-                .map(|id_in| {
-                    hub.bind_group_layouts
-                        .prepare(backend, Some(*id_in))
-                        .into_id()
-                })
+                .map(|id_in| hub.bind_group_layouts.prepare(backend, Some(*id_in)).id())
                 .collect(),
         }
     }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -414,8 +414,6 @@ pub enum DeviceError {
     OutOfMemory,
     #[error("Creation of a resource failed for a reason other than running out of memory.")]
     ResourceCreationFailed,
-    #[error("DeviceId is invalid")]
-    InvalidDeviceId,
     #[error(transparent)]
     DeviceMismatch(#[from] Box<DeviceMismatch>),
 }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -465,7 +465,7 @@ impl Global {
 
         let device = &queue.device;
 
-        let staging_buffer = hub.staging_buffers.strict_unregister(staging_buffer_id);
+        let staging_buffer = hub.staging_buffers.remove(staging_buffer_id);
 
         let mut pending_writes = device.pending_writes.lock();
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -375,9 +375,9 @@ impl Global {
 
         let hub = &self.hub;
 
-        let buffer = hub.buffers.strict_get(buffer_id).get()?;
+        let buffer = hub.buffers.get(buffer_id).get()?;
 
-        let queue = hub.queues.strict_get(queue_id);
+        let queue = hub.queues.get(queue_id);
 
         let device = &queue.device;
 
@@ -437,7 +437,7 @@ impl Global {
         profiling::scope!("Queue::create_staging_buffer");
         let hub = &self.hub;
 
-        let queue = hub.queues.strict_get(queue_id);
+        let queue = hub.queues.get(queue_id);
 
         let device = &queue.device;
 
@@ -461,7 +461,7 @@ impl Global {
         profiling::scope!("Queue::write_staging_buffer");
         let hub = &self.hub;
 
-        let queue = hub.queues.strict_get(queue_id);
+        let queue = hub.queues.get(queue_id);
 
         let device = &queue.device;
 
@@ -498,7 +498,7 @@ impl Global {
         profiling::scope!("Queue::validate_write_buffer");
         let hub = &self.hub;
 
-        let buffer = hub.buffers.strict_get(buffer_id).get()?;
+        let buffer = hub.buffers.get(buffer_id).get()?;
 
         self.queue_validate_write_buffer_impl(&buffer, buffer_offset, buffer_size)?;
 
@@ -541,7 +541,7 @@ impl Global {
     ) -> Result<(), QueueWriteError> {
         let hub = &self.hub;
 
-        let dst = hub.buffers.strict_get(buffer_id).get()?;
+        let dst = hub.buffers.get(buffer_id).get()?;
 
         let transition = {
             let mut trackers = device.trackers.lock();
@@ -598,7 +598,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let queue = hub.queues.strict_get(queue_id);
+        let queue = hub.queues.get(queue_id);
 
         let device = &queue.device;
 
@@ -618,7 +618,7 @@ impl Global {
             return Ok(());
         }
 
-        let dst = hub.textures.strict_get(destination.texture).get()?;
+        let dst = hub.textures.get(destination.texture).get()?;
 
         dst.same_device_as(queue.as_ref())?;
 
@@ -827,7 +827,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let queue = hub.queues.strict_get(queue_id);
+        let queue = hub.queues.get(queue_id);
 
         let device = &queue.device;
 
@@ -855,7 +855,7 @@ impl Global {
         let src_width = source.source.width();
         let src_height = source.source.height();
 
-        let dst = hub.textures.strict_get(destination.texture).get()?;
+        let dst = hub.textures.get(destination.texture).get()?;
 
         if !conv::is_valid_external_image_copy_dst_texture_format(dst.desc.format) {
             return Err(
@@ -1034,7 +1034,7 @@ impl Global {
         let (submit_index, callbacks) = {
             let hub = &self.hub;
 
-            let queue = hub.queues.strict_get(queue_id);
+            let queue = hub.queues.get(queue_id);
 
             let device = &queue.device;
 
@@ -1074,7 +1074,7 @@ impl Global {
                         // it, so make sure to set_size on it.
                         used_surface_textures.set_size(device.tracker_indices.textures.size());
 
-                        let command_buffer = command_buffer_guard.strict_get(*command_buffer_id);
+                        let command_buffer = command_buffer_guard.get(*command_buffer_id);
 
                         // Note that we are required to invalidate all command buffers in both the success and failure paths.
                         // This is why we `continue` and don't early return via `?`.
@@ -1297,7 +1297,7 @@ impl Global {
     }
 
     pub fn queue_get_timestamp_period(&self, queue_id: QueueId) -> f32 {
-        let queue = self.hub.queues.strict_get(queue_id);
+        let queue = self.hub.queues.get(queue_id);
         unsafe { queue.raw().get_timestamp_period() }
     }
 
@@ -1309,7 +1309,7 @@ impl Global {
         api_log!("Queue::on_submitted_work_done {queue_id:?}");
 
         //TODO: flush pending writes
-        let queue = self.hub.queues.strict_get(queue_id);
+        let queue = self.hub.queues.get(queue_id);
         queue.device.lock_life().add_work_done_closure(closure);
     }
 }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -619,10 +619,7 @@ impl Global {
             return Ok(());
         }
 
-        let dst = hub
-            .textures
-            .get(destination.texture)
-            .map_err(|_| TransferError::InvalidTextureId(destination.texture))?;
+        let dst = hub.textures.strict_get(destination.texture).get()?;
 
         dst.same_device_as(queue.as_ref())?;
 
@@ -712,12 +709,6 @@ impl Global {
         }
 
         let snatch_guard = device.snatchable_lock.read();
-
-        // Re-get `dst` immutably here, so that the mutable borrow of the
-        // `texture_guard.get` above ends in time for the `clear_texture`
-        // call above. Since we've held `texture_guard` the whole time, we know
-        // the texture hasn't gone away in the mean time, so we can unwrap.
-        let dst = hub.textures.get(destination.texture).unwrap();
 
         let dst_raw = dst.try_raw(&snatch_guard)?;
 
@@ -865,7 +856,7 @@ impl Global {
         let src_width = source.source.width();
         let src_height = source.source.height();
 
-        let dst = hub.textures.get(destination.texture).unwrap();
+        let dst = hub.textures.strict_get(destination.texture).get()?;
 
         if !conv::is_valid_external_image_copy_dst_texture_format(dst.desc.format) {
             return Err(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3630,16 +3630,6 @@ impl Device {
 }
 
 impl Device {
-    pub(crate) fn destroy_command_buffer(&self, mut cmd_buf: command::CommandBuffer) {
-        let mut baked = cmd_buf.extract_baked_commands();
-        unsafe {
-            baked.encoder.reset_all(baked.list);
-        }
-        unsafe {
-            self.raw().destroy_command_encoder(baked.encoder);
-        }
-    }
-
     /// Wait for idle and remove resources that we can, before we die.
     pub(crate) fn prepare_to_die(&self) {
         self.pending_writes.lock().deactivate();

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -21,7 +21,7 @@ use crate::{
     pipeline,
     pool::ResourcePool,
     resource::{
-        self, Buffer, Labeled, ParentDevice, QuerySet, Sampler, StagingBuffer, Texture,
+        self, Buffer, Fallible, Labeled, ParentDevice, QuerySet, Sampler, StagingBuffer, Texture,
         TextureView, TextureViewNotRenderableReason, TrackingData,
     },
     resource_log,
@@ -694,11 +694,11 @@ impl Device {
         Ok(texture)
     }
 
-    pub fn create_buffer_from_hal(
+    pub(crate) fn create_buffer_from_hal(
         self: &Arc<Self>,
         hal_buffer: Box<dyn hal::DynBuffer>,
         desc: &resource::BufferDescriptor,
-    ) -> Arc<Buffer> {
+    ) -> Fallible<Buffer> {
         unsafe { self.raw().add_raw_buffer(&*hal_buffer) };
 
         let buffer = Buffer {
@@ -723,7 +723,7 @@ impl Device {
             .buffers
             .insert_single(&buffer, hal::BufferUses::empty());
 
-        buffer
+        Fallible::Valid(buffer)
     }
 
     pub(crate) fn create_texture(

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     hal_api::HalApi,
     hub::{Hub, HubReport},
@@ -23,7 +25,7 @@ impl GlobalReport {
 
 pub struct Global {
     pub instance: Instance,
-    pub(crate) surfaces: Registry<Surface>,
+    pub(crate) surfaces: Registry<Arc<Surface>>,
     pub(crate) hub: Hub,
 }
 

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -167,7 +167,7 @@ pub struct Hub {
     pub(crate) queues: Registry<Arc<Queue>>,
     pub(crate) pipeline_layouts: Registry<Arc<PipelineLayout>>,
     pub(crate) shader_modules: Registry<Arc<ShaderModule>>,
-    pub(crate) bind_group_layouts: Registry<Arc<BindGroupLayout>>,
+    pub(crate) bind_group_layouts: Registry<Fallible<BindGroupLayout>>,
     pub(crate) bind_groups: Registry<Fallible<BindGroup>>,
     pub(crate) command_buffers: Registry<Arc<CommandBuffer>>,
     pub(crate) render_bundles: Registry<Arc<RenderBundle>>,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -178,7 +178,7 @@ pub struct Hub {
     pub(crate) buffers: Registry<Fallible<Buffer>>,
     pub(crate) staging_buffers: Registry<Arc<StagingBuffer>>,
     pub(crate) textures: Registry<Fallible<Texture>>,
-    pub(crate) texture_views: Registry<Arc<TextureView>>,
+    pub(crate) texture_views: Registry<Fallible<TextureView>>,
     pub(crate) samplers: Registry<Arc<Sampler>>,
 }
 

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -177,7 +177,7 @@ pub struct Hub {
     pub(crate) query_sets: Registry<Arc<QuerySet>>,
     pub(crate) buffers: Registry<Fallible<Buffer>>,
     pub(crate) staging_buffers: Registry<Arc<StagingBuffer>>,
-    pub(crate) textures: Registry<Arc<Texture>>,
+    pub(crate) textures: Registry<Fallible<Texture>>,
     pub(crate) texture_views: Registry<Arc<TextureView>>,
     pub(crate) samplers: Registry<Arc<Sampler>>,
 }

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -107,7 +107,7 @@ use crate::{
     instance::{Adapter, Surface},
     pipeline::{ComputePipeline, PipelineCache, RenderPipeline, ShaderModule},
     registry::{Registry, RegistryReport},
-    resource::{Buffer, QuerySet, Sampler, StagingBuffer, Texture, TextureView},
+    resource::{Buffer, Fallible, QuerySet, Sampler, StagingBuffer, Texture, TextureView},
     storage::{Element, Storage},
 };
 use std::{fmt::Debug, sync::Arc};
@@ -175,7 +175,7 @@ pub struct Hub {
     pub(crate) compute_pipelines: Registry<Arc<ComputePipeline>>,
     pub(crate) pipeline_caches: Registry<Arc<PipelineCache>>,
     pub(crate) query_sets: Registry<Arc<QuerySet>>,
-    pub(crate) buffers: Registry<Arc<Buffer>>,
+    pub(crate) buffers: Registry<Fallible<Buffer>>,
     pub(crate) staging_buffers: Registry<Arc<StagingBuffer>>,
     pub(crate) textures: Registry<Arc<Texture>>,
     pub(crate) texture_views: Registry<Arc<TextureView>>,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -179,7 +179,7 @@ pub struct Hub {
     pub(crate) staging_buffers: Registry<Arc<StagingBuffer>>,
     pub(crate) textures: Registry<Fallible<Texture>>,
     pub(crate) texture_views: Registry<Fallible<TextureView>>,
-    pub(crate) samplers: Registry<Arc<Sampler>>,
+    pub(crate) samplers: Registry<Fallible<Sampler>>,
 }
 
 impl Hub {

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -110,7 +110,7 @@ use crate::{
     resource::{Buffer, QuerySet, Sampler, StagingBuffer, Texture, TextureView},
     storage::{Element, Storage},
 };
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct HubReport {
@@ -162,24 +162,24 @@ impl HubReport {
 ///
 /// [`A::hub(global)`]: HalApi::hub
 pub struct Hub {
-    pub(crate) adapters: Registry<Adapter>,
-    pub(crate) devices: Registry<Device>,
-    pub(crate) queues: Registry<Queue>,
-    pub(crate) pipeline_layouts: Registry<PipelineLayout>,
-    pub(crate) shader_modules: Registry<ShaderModule>,
-    pub(crate) bind_group_layouts: Registry<BindGroupLayout>,
-    pub(crate) bind_groups: Registry<BindGroup>,
-    pub(crate) command_buffers: Registry<CommandBuffer>,
-    pub(crate) render_bundles: Registry<RenderBundle>,
-    pub(crate) render_pipelines: Registry<RenderPipeline>,
-    pub(crate) compute_pipelines: Registry<ComputePipeline>,
-    pub(crate) pipeline_caches: Registry<PipelineCache>,
-    pub(crate) query_sets: Registry<QuerySet>,
-    pub(crate) buffers: Registry<Buffer>,
-    pub(crate) staging_buffers: Registry<StagingBuffer>,
-    pub(crate) textures: Registry<Texture>,
-    pub(crate) texture_views: Registry<TextureView>,
-    pub(crate) samplers: Registry<Sampler>,
+    pub(crate) adapters: Registry<Arc<Adapter>>,
+    pub(crate) devices: Registry<Arc<Device>>,
+    pub(crate) queues: Registry<Arc<Queue>>,
+    pub(crate) pipeline_layouts: Registry<Arc<PipelineLayout>>,
+    pub(crate) shader_modules: Registry<Arc<ShaderModule>>,
+    pub(crate) bind_group_layouts: Registry<Arc<BindGroupLayout>>,
+    pub(crate) bind_groups: Registry<Arc<BindGroup>>,
+    pub(crate) command_buffers: Registry<Arc<CommandBuffer>>,
+    pub(crate) render_bundles: Registry<Arc<RenderBundle>>,
+    pub(crate) render_pipelines: Registry<Arc<RenderPipeline>>,
+    pub(crate) compute_pipelines: Registry<Arc<ComputePipeline>>,
+    pub(crate) pipeline_caches: Registry<Arc<PipelineCache>>,
+    pub(crate) query_sets: Registry<Arc<QuerySet>>,
+    pub(crate) buffers: Registry<Arc<Buffer>>,
+    pub(crate) staging_buffers: Registry<Arc<StagingBuffer>>,
+    pub(crate) textures: Registry<Arc<Texture>>,
+    pub(crate) texture_views: Registry<Arc<TextureView>>,
+    pub(crate) samplers: Registry<Arc<Sampler>>,
 }
 
 impl Hub {
@@ -206,7 +206,7 @@ impl Hub {
         }
     }
 
-    pub(crate) fn clear(&self, surface_guard: &Storage<Surface>) {
+    pub(crate) fn clear(&self, surface_guard: &Storage<Arc<Surface>>) {
         let mut devices = self.devices.write();
         for element in devices.map.iter() {
             if let Element::Occupied(ref device, _) = *element {

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -165,7 +165,7 @@ pub struct Hub {
     pub(crate) adapters: Registry<Arc<Adapter>>,
     pub(crate) devices: Registry<Arc<Device>>,
     pub(crate) queues: Registry<Arc<Queue>>,
-    pub(crate) pipeline_layouts: Registry<Arc<PipelineLayout>>,
+    pub(crate) pipeline_layouts: Registry<Fallible<PipelineLayout>>,
     pub(crate) shader_modules: Registry<Arc<ShaderModule>>,
     pub(crate) bind_group_layouts: Registry<Fallible<BindGroupLayout>>,
     pub(crate) bind_groups: Registry<Fallible<BindGroup>>,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -168,7 +168,7 @@ pub struct Hub {
     pub(crate) pipeline_layouts: Registry<Arc<PipelineLayout>>,
     pub(crate) shader_modules: Registry<Arc<ShaderModule>>,
     pub(crate) bind_group_layouts: Registry<Arc<BindGroupLayout>>,
-    pub(crate) bind_groups: Registry<Arc<BindGroup>>,
+    pub(crate) bind_groups: Registry<Fallible<BindGroup>>,
     pub(crate) command_buffers: Registry<Arc<CommandBuffer>>,
     pub(crate) render_bundles: Registry<Arc<RenderBundle>>,
     pub(crate) render_pipelines: Registry<Arc<RenderPipeline>>,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -176,7 +176,7 @@ pub struct Hub {
     pub(crate) pipeline_caches: Registry<Arc<PipelineCache>>,
     pub(crate) query_sets: Registry<Fallible<QuerySet>>,
     pub(crate) buffers: Registry<Fallible<Buffer>>,
-    pub(crate) staging_buffers: Registry<Arc<StagingBuffer>>,
+    pub(crate) staging_buffers: Registry<StagingBuffer>,
     pub(crate) textures: Registry<Fallible<Texture>>,
     pub(crate) texture_views: Registry<Fallible<TextureView>>,
     pub(crate) samplers: Registry<Fallible<Sampler>>,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -173,7 +173,7 @@ pub struct Hub {
     pub(crate) render_bundles: Registry<Arc<RenderBundle>>,
     pub(crate) render_pipelines: Registry<Fallible<RenderPipeline>>,
     pub(crate) compute_pipelines: Registry<Fallible<ComputePipeline>>,
-    pub(crate) pipeline_caches: Registry<Arc<PipelineCache>>,
+    pub(crate) pipeline_caches: Registry<Fallible<PipelineCache>>,
     pub(crate) query_sets: Registry<Fallible<QuerySet>>,
     pub(crate) buffers: Registry<Fallible<Buffer>>,
     pub(crate) staging_buffers: Registry<StagingBuffer>,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -172,7 +172,7 @@ pub struct Hub {
     pub(crate) command_buffers: Registry<Arc<CommandBuffer>>,
     pub(crate) render_bundles: Registry<Arc<RenderBundle>>,
     pub(crate) render_pipelines: Registry<Arc<RenderPipeline>>,
-    pub(crate) compute_pipelines: Registry<Arc<ComputePipeline>>,
+    pub(crate) compute_pipelines: Registry<Fallible<ComputePipeline>>,
     pub(crate) pipeline_caches: Registry<Arc<PipelineCache>>,
     pub(crate) query_sets: Registry<Fallible<QuerySet>>,
     pub(crate) buffers: Registry<Fallible<Buffer>>,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -171,7 +171,7 @@ pub struct Hub {
     pub(crate) bind_groups: Registry<Fallible<BindGroup>>,
     pub(crate) command_buffers: Registry<Arc<CommandBuffer>>,
     pub(crate) render_bundles: Registry<Arc<RenderBundle>>,
-    pub(crate) render_pipelines: Registry<Arc<RenderPipeline>>,
+    pub(crate) render_pipelines: Registry<Fallible<RenderPipeline>>,
     pub(crate) compute_pipelines: Registry<Fallible<ComputePipeline>>,
     pub(crate) pipeline_caches: Registry<Arc<PipelineCache>>,
     pub(crate) query_sets: Registry<Fallible<QuerySet>>,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -170,7 +170,7 @@ pub struct Hub {
     pub(crate) bind_group_layouts: Registry<Fallible<BindGroupLayout>>,
     pub(crate) bind_groups: Registry<Fallible<BindGroup>>,
     pub(crate) command_buffers: Registry<Arc<CommandBuffer>>,
-    pub(crate) render_bundles: Registry<Arc<RenderBundle>>,
+    pub(crate) render_bundles: Registry<Fallible<RenderBundle>>,
     pub(crate) render_pipelines: Registry<Fallible<RenderPipeline>>,
     pub(crate) compute_pipelines: Registry<Fallible<ComputePipeline>>,
     pub(crate) pipeline_caches: Registry<Fallible<PipelineCache>>,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -174,7 +174,7 @@ pub struct Hub {
     pub(crate) render_pipelines: Registry<Arc<RenderPipeline>>,
     pub(crate) compute_pipelines: Registry<Arc<ComputePipeline>>,
     pub(crate) pipeline_caches: Registry<Arc<PipelineCache>>,
-    pub(crate) query_sets: Registry<Arc<QuerySet>>,
+    pub(crate) query_sets: Registry<Fallible<QuerySet>>,
     pub(crate) buffers: Registry<Fallible<Buffer>>,
     pub(crate) staging_buffers: Registry<Arc<StagingBuffer>>,
     pub(crate) textures: Registry<Fallible<Texture>>,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -166,7 +166,7 @@ pub struct Hub {
     pub(crate) devices: Registry<Arc<Device>>,
     pub(crate) queues: Registry<Arc<Queue>>,
     pub(crate) pipeline_layouts: Registry<Fallible<PipelineLayout>>,
-    pub(crate) shader_modules: Registry<Arc<ShaderModule>>,
+    pub(crate) shader_modules: Registry<Fallible<ShaderModule>>,
     pub(crate) bind_group_layouts: Registry<Fallible<BindGroupLayout>>,
     pub(crate) bind_groups: Registry<Fallible<BindGroup>>,
     pub(crate) command_buffers: Registry<Arc<CommandBuffer>>,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -710,9 +710,7 @@ impl Global {
             }
         }
 
-        let compatible_surface = desc
-            .compatible_surface
-            .map(|id| self.surfaces.strict_get(id));
+        let compatible_surface = desc.compatible_surface.map(|id| self.surfaces.get(id));
         let compatible_surface = compatible_surface.as_ref().map(|surface| surface.as_ref());
         let mut device_types = Vec::new();
 
@@ -844,7 +842,7 @@ impl Global {
     }
 
     pub fn adapter_get_info(&self, adapter_id: AdapterId) -> wgt::AdapterInfo {
-        let adapter = self.hub.adapters.strict_get(adapter_id);
+        let adapter = self.hub.adapters.get(adapter_id);
         adapter.raw.info.clone()
     }
 
@@ -853,17 +851,17 @@ impl Global {
         adapter_id: AdapterId,
         format: wgt::TextureFormat,
     ) -> wgt::TextureFormatFeatures {
-        let adapter = self.hub.adapters.strict_get(adapter_id);
+        let adapter = self.hub.adapters.get(adapter_id);
         adapter.get_texture_format_features(format)
     }
 
     pub fn adapter_features(&self, adapter_id: AdapterId) -> wgt::Features {
-        let adapter = self.hub.adapters.strict_get(adapter_id);
+        let adapter = self.hub.adapters.get(adapter_id);
         adapter.raw.features
     }
 
     pub fn adapter_limits(&self, adapter_id: AdapterId) -> wgt::Limits {
-        let adapter = self.hub.adapters.strict_get(adapter_id);
+        let adapter = self.hub.adapters.get(adapter_id);
         adapter.raw.capabilities.limits.clone()
     }
 
@@ -871,7 +869,7 @@ impl Global {
         &self,
         adapter_id: AdapterId,
     ) -> wgt::DownlevelCapabilities {
-        let adapter = self.hub.adapters.strict_get(adapter_id);
+        let adapter = self.hub.adapters.get(adapter_id);
         adapter.raw.capabilities.downlevel.clone()
     }
 
@@ -879,7 +877,7 @@ impl Global {
         &self,
         adapter_id: AdapterId,
     ) -> wgt::PresentationTimestamp {
-        let adapter = self.hub.adapters.strict_get(adapter_id);
+        let adapter = self.hub.adapters.get(adapter_id);
         unsafe { adapter.raw.adapter.get_presentation_timestamp() }
     }
 
@@ -907,7 +905,7 @@ impl Global {
         let device_fid = self.hub.devices.prepare(backend, device_id_in);
         let queue_fid = self.hub.queues.prepare(backend, queue_id_in);
 
-        let adapter = self.hub.adapters.strict_get(adapter_id);
+        let adapter = self.hub.adapters.get(adapter_id);
         let (device, queue) =
             adapter.create_device_and_queue(desc, self.instance.flags, trace_path)?;
 
@@ -939,7 +937,7 @@ impl Global {
         let devices_fid = self.hub.devices.prepare(backend, device_id_in);
         let queues_fid = self.hub.queues.prepare(backend, queue_id_in);
 
-        let adapter = self.hub.adapters.strict_get(adapter_id);
+        let adapter = self.hub.adapters.get(adapter_id);
         let (device, queue) = adapter.create_device_and_queue_from_hal(
             hal_device,
             desc,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -593,7 +593,7 @@ impl Global {
 
         api_log!("Surface::drop {id:?}");
 
-        let surface = self.surfaces.strict_unregister(id);
+        let surface = self.surfaces.remove(id);
         let surface =
             Arc::into_inner(surface).expect("Surface cannot be destroyed because is still in use");
 
@@ -885,7 +885,7 @@ impl Global {
         profiling::scope!("Adapter::drop");
         api_log!("Adapter::drop {adapter_id:?}");
 
-        self.hub.adapters.strict_unregister(adapter_id);
+        self.hub.adapters.remove(adapter_id);
     }
 }
 

--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -78,6 +78,15 @@ impl<T> Mutex<T> {
     }
 }
 
+impl<'a, T> MutexGuard<'a, T> {
+    pub fn try_map<U: ?Sized, F>(s: Self, f: F) -> Result<parking_lot::MappedMutexGuard<'a, U>, ()>
+    where
+        F: FnOnce(&mut T) -> Option<&mut U>,
+    {
+        parking_lot::MutexGuard::try_map(s.inner, f).map_err(|_| ())
+    }
+}
+
 impl<'a, T> std::ops::Deref for MutexGuard<'a, T> {
     type Target = T;
 

--- a/wgpu-core/src/lock/vanilla.rs
+++ b/wgpu-core/src/lock/vanilla.rs
@@ -30,6 +30,15 @@ impl<T> Mutex<T> {
     }
 }
 
+impl<'a, T> MutexGuard<'a, T> {
+    pub fn try_map<U: ?Sized, F>(s: Self, f: F) -> Result<parking_lot::MappedMutexGuard<'a, U>, ()>
+    where
+        F: FnOnce(&mut T) -> Option<&mut U>,
+    {
+        parking_lot::MutexGuard::try_map(s.0, f).map_err(|_| ())
+    }
+}
+
 impl<'a, T> std::ops::Deref for MutexGuard<'a, T> {
     type Target = T;
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -222,8 +222,6 @@ pub struct ResolvedComputePipelineDescriptor<'a> {
 pub enum CreateComputePipelineError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("Cache is invalid")]
-    InvalidCache,
     #[error("Unable to derive an implicit layout")]
     Implicit(#[from] ImplicitLayoutError),
     #[error("Error matching shader requirements against the pipeline")]
@@ -467,8 +465,6 @@ pub enum CreateRenderPipelineError {
     ColorAttachment(#[from] ColorAttachmentError),
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("Pipeline cache is invalid")]
-    InvalidCache,
     #[error("Unable to derive an implicit layout")]
     Implicit(#[from] ImplicitLayoutError),
     #[error("Color state [{0}] is invalid")]

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -4,7 +4,7 @@ use crate::{
     command::ColorAttachmentError,
     device::{Device, DeviceError, MissingDownlevelFlags, MissingFeatures, RenderPassContext},
     id::{PipelineCacheId, PipelineLayoutId, ShaderModuleId},
-    resource::{Labeled, TrackingData},
+    resource::{InvalidResourceError, Labeled, TrackingData},
     resource_log, validation, Label,
 };
 use arrayvec::ArrayVec;
@@ -222,8 +222,6 @@ pub struct ResolvedComputePipelineDescriptor<'a> {
 pub enum CreateComputePipelineError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("Pipeline layout is invalid")]
-    InvalidLayout,
     #[error("Cache is invalid")]
     InvalidCache,
     #[error("Unable to derive an implicit layout")]
@@ -236,6 +234,8 @@ pub enum CreateComputePipelineError {
     PipelineConstants(String),
     #[error(transparent)]
     MissingDownlevelFlags(#[from] MissingDownlevelFlags),
+    #[error(transparent)]
+    InvalidResource(#[from] InvalidResourceError),
 }
 
 #[derive(Debug)]
@@ -467,8 +467,6 @@ pub enum CreateRenderPipelineError {
     ColorAttachment(#[from] ColorAttachmentError),
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("Pipeline layout is invalid")]
-    InvalidLayout,
     #[error("Pipeline cache is invalid")]
     InvalidCache,
     #[error("Unable to derive an implicit layout")]
@@ -540,6 +538,8 @@ pub enum CreateRenderPipelineError {
         "but no render target for the pipeline was specified."
     ))]
     NoTargetSpecified,
+    #[error(transparent)]
+    InvalidResource(#[from] InvalidResourceError),
 }
 
 bitflags::bitflags! {

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -122,10 +122,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let surface = self
-            .surfaces
-            .get(surface_id)
-            .map_err(|_| SurfaceError::Invalid)?;
+        let surface = self.surfaces.strict_get(surface_id);
 
         let (device, config) = if let Some(ref present) = *surface.presentation.lock() {
             present.device.check_is_valid()?;
@@ -257,10 +254,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let surface = self
-            .surfaces
-            .get(surface_id)
-            .map_err(|_| SurfaceError::Invalid)?;
+        let surface = self.surfaces.strict_get(surface_id);
 
         let mut presentation = surface.presentation.lock();
         let present = match presentation.as_mut() {
@@ -332,10 +326,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let surface = self
-            .surfaces
-            .get(surface_id)
-            .map_err(|_| SurfaceError::Invalid)?;
+        let surface = self.surfaces.strict_get(surface_id);
         let mut presentation = surface.presentation.lock();
         let present = match presentation.as_mut() {
             Some(present) => present,

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -179,7 +179,7 @@ impl Global {
                 let clear_view_desc = hal::TextureViewDescriptor {
                     label: hal_label(
                         Some("(wgpu internal) clear surface texture view"),
-                        self.instance.flags,
+                        device.instance_flags,
                     ),
                     format: config.format,
                     dimension: wgt::TextureViewDimension::D2,

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -215,7 +215,7 @@ impl Global {
                     .textures
                     .insert_single(&texture, hal::TextureUses::UNINITIALIZED);
 
-                let id = fid.assign(texture);
+                let id = fid.assign(resource::Fallible::Valid(texture));
 
                 if present.acquired_texture.is_some() {
                     return Err(SurfaceError::AlreadyAcquired);
@@ -280,8 +280,8 @@ impl Global {
 
             // The texture ID got added to the device tracker by `submit()`,
             // and now we are moving it away.
-            let texture = hub.textures.unregister(texture_id);
-            if let Some(texture) = texture {
+            let texture = hub.textures.strict_unregister(texture_id).get();
+            if let Ok(texture) = texture {
                 device
                     .trackers
                     .lock()
@@ -350,9 +350,9 @@ impl Global {
 
             // The texture ID got added to the device tracker by `submit()`,
             // and now we are moving it away.
-            let texture = hub.textures.unregister(texture_id);
+            let texture = hub.textures.strict_unregister(texture_id).get();
 
-            if let Some(texture) = texture {
+            if let Ok(texture) = texture {
                 device
                     .trackers
                     .lock()

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -122,7 +122,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let surface = self.surfaces.strict_get(surface_id);
+        let surface = self.surfaces.get(surface_id);
 
         let (device, config) = if let Some(ref present) = *surface.presentation.lock() {
             present.device.check_is_valid()?;
@@ -254,7 +254,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let surface = self.surfaces.strict_get(surface_id);
+        let surface = self.surfaces.get(surface_id);
 
         let mut presentation = surface.presentation.lock();
         let present = match presentation.as_mut() {
@@ -326,7 +326,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let surface = self.surfaces.strict_get(surface_id);
+        let surface = self.surfaces.get(surface_id);
         let mut presentation = surface.presentation.lock();
         let present = match presentation.as_mut() {
             Some(present) => present,

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -280,7 +280,7 @@ impl Global {
 
             // The texture ID got added to the device tracker by `submit()`,
             // and now we are moving it away.
-            let texture = hub.textures.strict_unregister(texture_id).get();
+            let texture = hub.textures.remove(texture_id).get();
             if let Ok(texture) = texture {
                 device
                     .trackers
@@ -350,7 +350,7 @@ impl Global {
 
             // The texture ID got added to the device tracker by `submit()`,
             // and now we are moving it away.
-            let texture = hub.textures.strict_unregister(texture_id).get();
+            let texture = hub.textures.remove(texture_id).get();
 
             if let Ok(texture) = texture {
                 device

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -128,8 +128,8 @@ impl<T: StorageItem> Registry<T> {
 }
 
 impl<T: StorageItem + Clone> Registry<T> {
-    pub(crate) fn strict_get(&self, id: Id<T::Marker>) -> T {
-        self.read().strict_get(id)
+    pub(crate) fn get(&self, id: Id<T::Marker>) -> T {
+        self.read().get(id)
     }
 }
 

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -106,11 +106,6 @@ impl<T: StorageItem> Registry<T> {
     pub(crate) fn write<'a>(&'a self) -> RwLockWriteGuard<'a, Storage<T>> {
         self.storage.write()
     }
-    pub(crate) fn force_replace_with_error(&self, id: Id<T::Marker>) {
-        let mut storage = self.storage.write();
-        storage.remove(id);
-        storage.insert_error(id);
-    }
     pub(crate) fn unregister(&self, id: Id<T::Marker>) -> Option<T> {
         let value = self.storage.write().remove(id);
         // This needs to happen *after* removing it from the storage, to maintain the

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -55,12 +55,7 @@ pub(crate) struct FutureId<'a, T: StorageItem> {
 }
 
 impl<T: StorageItem> FutureId<'_, T> {
-    #[allow(dead_code)]
     pub fn id(&self) -> Id<T::Marker> {
-        self.id
-    }
-
-    pub fn into_id(self) -> Id<T::Marker> {
         self.id
     }
 

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -100,8 +100,8 @@ impl<T: StorageItem> Registry<T> {
     pub(crate) fn write<'a>(&'a self) -> RwLockWriteGuard<'a, Storage<T>> {
         self.storage.write()
     }
-    pub(crate) fn strict_unregister(&self, id: Id<T::Marker>) -> T {
-        let value = self.storage.write().strict_remove(id);
+    pub(crate) fn remove(&self, id: Id<T::Marker>) -> T {
+        let value = self.storage.write().remove(id);
         // This needs to happen *after* removing it from the storage, to maintain the
         // invariant that `self.identity` only contains ids which are actually available
         // See https://github.com/gfx-rs/wgpu/issues/5372
@@ -161,7 +161,7 @@ mod tests {
                         let value = Arc::new(TestData);
                         let new_id = registry.prepare(wgt::Backend::Empty, None);
                         let id = new_id.assign(value);
-                        registry.strict_unregister(id);
+                        registry.remove(id);
                     }
                 });
             }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1383,9 +1383,10 @@ impl Global {
 
         let hub = &self.hub;
 
-        if let Ok(cmd_buf) = hub.command_buffers.get(id.into_command_buffer_id()) {
-            let mut cmd_buf_data = cmd_buf.data.lock();
-            let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
+        let cmd_buf = hub.command_buffers.strict_get(id.into_command_buffer_id());
+        let cmd_buf_data = cmd_buf.try_get();
+
+        if let Ok(mut cmd_buf_data) = cmd_buf_data {
             let cmd_buf_raw = cmd_buf_data
                 .encoder
                 .open(&cmd_buf.device)

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1243,7 +1243,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        if let Ok(buffer) = hub.buffers.strict_get(id).get() {
+        if let Ok(buffer) = hub.buffers.get(id).get() {
             let snatch_guard = buffer.device.snatchable_lock.read();
             let hal_buffer = buffer
                 .raw(&snatch_guard)
@@ -1266,7 +1266,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        if let Ok(texture) = hub.textures.strict_get(id).get() {
+        if let Ok(texture) = hub.textures.get(id).get() {
             let snatch_guard = texture.device.snatchable_lock.read();
             let hal_texture = texture.raw(&snatch_guard);
             let hal_texture = hal_texture
@@ -1290,7 +1290,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        if let Ok(texture_view) = hub.texture_views.strict_get(id).get() {
+        if let Ok(texture_view) = hub.texture_views.get(id).get() {
             let snatch_guard = texture_view.device.snatchable_lock.read();
             let hal_texture_view = texture_view.raw(&snatch_guard);
             let hal_texture_view = hal_texture_view
@@ -1313,7 +1313,7 @@ impl Global {
         profiling::scope!("Adapter::as_hal");
 
         let hub = &self.hub;
-        let adapter = hub.adapters.strict_get(id);
+        let adapter = hub.adapters.get(id);
         let hal_adapter = adapter.raw.adapter.as_any().downcast_ref();
 
         hal_adapter_callback(hal_adapter)
@@ -1329,7 +1329,7 @@ impl Global {
     ) -> R {
         profiling::scope!("Device::as_hal");
 
-        let device = self.hub.devices.strict_get(id);
+        let device = self.hub.devices.get(id);
         let hal_device = device.raw().as_any().downcast_ref();
 
         hal_device_callback(hal_device)
@@ -1345,7 +1345,7 @@ impl Global {
     ) -> R {
         profiling::scope!("Device::fence_as_hal");
 
-        let device = self.hub.devices.strict_get(id);
+        let device = self.hub.devices.get(id);
         let fence = device.fence.read();
         hal_fence_callback(fence.as_any().downcast_ref())
     }
@@ -1359,7 +1359,7 @@ impl Global {
     ) -> R {
         profiling::scope!("Surface::as_hal");
 
-        let surface = self.surfaces.strict_get(id);
+        let surface = self.surfaces.get(id);
         let hal_surface = surface
             .raw(A::VARIANT)
             .and_then(|surface| surface.as_any().downcast_ref());
@@ -1383,7 +1383,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let cmd_buf = hub.command_buffers.strict_get(id.into_command_buffer_id());
+        let cmd_buf = hub.command_buffers.get(id.into_command_buffer_id());
         let cmd_buf_data = cmd_buf.try_get();
 
         if let Ok(mut cmd_buf_data) = cmd_buf_data {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1272,11 +1272,8 @@ impl Global {
         profiling::scope!("Adapter::as_hal");
 
         let hub = &self.hub;
-        let adapter = hub.adapters.get(id).ok();
-        let hal_adapter = adapter
-            .as_ref()
-            .map(|adapter| &adapter.raw.adapter)
-            .and_then(|adapter| adapter.as_any().downcast_ref());
+        let adapter = hub.adapters.strict_get(id);
+        let hal_adapter = adapter.raw.adapter.as_any().downcast_ref();
 
         hal_adapter_callback(hal_adapter)
     }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1327,10 +1327,9 @@ impl Global {
     ) -> R {
         profiling::scope!("Surface::as_hal");
 
-        let surface = self.surfaces.get(id).ok();
+        let surface = self.surfaces.strict_get(id);
         let hal_surface = surface
-            .as_ref()
-            .and_then(|surface| surface.raw(A::VARIANT))
+            .raw(A::VARIANT)
             .and_then(|surface| surface.as_any().downcast_ref());
 
         hal_surface_callback(hal_surface)

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1288,12 +1288,8 @@ impl Global {
     ) -> R {
         profiling::scope!("Device::as_hal");
 
-        let hub = &self.hub;
-        let device = hub.devices.get(id).ok();
-        let hal_device = device
-            .as_ref()
-            .map(|device| device.raw())
-            .and_then(|device| device.as_any().downcast_ref());
+        let device = self.hub.devices.strict_get(id);
+        let hal_device = device.raw().as_any().downcast_ref();
 
         hal_device_callback(hal_device)
     }
@@ -1308,14 +1304,9 @@ impl Global {
     ) -> R {
         profiling::scope!("Device::fence_as_hal");
 
-        let hub = &self.hub;
-
-        if let Ok(device) = hub.devices.get(id) {
-            let fence = device.fence.read();
-            hal_fence_callback(fence.as_any().downcast_ref())
-        } else {
-            hal_fence_callback(None)
-        }
+        let device = self.hub.devices.strict_get(id);
+        let fence = device.fence.read();
+        hal_fence_callback(fence.as_any().downcast_ref())
     }
 
     /// # Safety

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1266,7 +1266,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        if let Ok(texture) = hub.textures.get(id) {
+        if let Ok(texture) = hub.textures.strict_get(id).get() {
             let snatch_guard = texture.device.snatchable_lock.read();
             let hal_texture = texture.raw(&snatch_guard);
             let hal_texture = hal_texture
@@ -1646,8 +1646,6 @@ impl TextureView {
 pub enum CreateTextureViewError {
     #[error(transparent)]
     Device(#[from] DeviceError),
-    #[error("TextureId {0:?} is invalid")]
-    InvalidTextureId(TextureId),
     #[error(transparent)]
     DestroyedResource(#[from] DestroyedResourceError),
     #[error("Not enough memory left to create texture view")]
@@ -1690,6 +1688,8 @@ pub enum CreateTextureViewError {
         texture: wgt::TextureFormat,
         view: wgt::TextureFormat,
     },
+    #[error(transparent)]
+    InvalidResource(#[from] InvalidResourceError),
 }
 
 #[derive(Clone, Debug, Error)]
@@ -1862,8 +1862,6 @@ impl QuerySet {
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum DestroyError {
-    #[error("TextureId {0:?} is invalid")]
-    InvalidTextureId(TextureId),
     #[error("Resource is already destroyed")]
     AlreadyDestroyed,
     #[error(transparent)]

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1290,7 +1290,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        if let Ok(texture_view) = hub.texture_views.get(id) {
+        if let Ok(texture_view) = hub.texture_views.strict_get(id).get() {
             let snatch_guard = texture_view.device.snatchable_lock.read();
             let hal_texture_view = texture_view.raw(&snatch_guard);
             let hal_texture_view = hal_texture_view

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -96,7 +96,7 @@ where
         self.insert_impl(index as usize, epoch, Element::Occupied(value, epoch))
     }
 
-    pub(crate) fn strict_remove(&mut self, id: Id<T::Marker>) -> T {
+    pub(crate) fn remove(&mut self, id: Id<T::Marker>) -> T {
         let (index, epoch, _) = id.unzip();
         match std::mem::replace(&mut self.map[index as usize], Element::Vacant) {
             Element::Occupied(value, storage_epoch) => {

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -18,14 +18,7 @@ where
     /// There is one live id with this index, allocated at the given
     /// epoch.
     Occupied(T, Epoch),
-
-    /// Like `Occupied`, but an error occurred when creating the
-    /// resource.
-    Error(Epoch),
 }
-
-#[derive(Clone, Debug)]
-pub(crate) struct InvalidId;
 
 pub(crate) trait StorageItem: ResourceType {
     type Marker: Marker;
@@ -81,23 +74,6 @@ impl<T> Storage<T>
 where
     T: StorageItem,
 {
-    /// Get a reference to an item behind a potentially invalid ID.
-    /// Panics if there is an epoch mismatch, or the entry is empty.
-    pub(crate) fn get(&self, id: Id<T::Marker>) -> Result<&T, InvalidId> {
-        let (index, epoch, _) = id.unzip();
-        let (result, storage_epoch) = match self.map.get(index as usize) {
-            Some(&Element::Occupied(ref v, epoch)) => (Ok(v), epoch),
-            None | Some(&Element::Vacant) => panic!("{}[{:?}] does not exist", self.kind, id),
-            Some(&Element::Error(epoch)) => (Err(InvalidId), epoch),
-        };
-        assert_eq!(
-            epoch, storage_epoch,
-            "{}[{:?}] is no longer alive",
-            self.kind, id
-        );
-        result
-    }
-
     fn insert_impl(&mut self, index: usize, epoch: Epoch, element: Element<T>) {
         if index >= self.map.len() {
             self.map.resize_with(index + 1, || Element::Vacant);
@@ -112,49 +88,12 @@ where
                     T::TYPE
                 );
             }
-            Element::Error(storage_epoch) => {
-                assert_ne!(
-                    epoch,
-                    storage_epoch,
-                    "Index {index:?} of {} is already occupied with Error",
-                    T::TYPE
-                );
-            }
         }
     }
 
     pub(crate) fn insert(&mut self, id: Id<T::Marker>, value: T) {
         let (index, epoch, _backend) = id.unzip();
         self.insert_impl(index as usize, epoch, Element::Occupied(value, epoch))
-    }
-
-    pub(crate) fn insert_error(&mut self, id: Id<T::Marker>) {
-        let (index, epoch, _) = id.unzip();
-        self.insert_impl(index as usize, epoch, Element::Error(epoch))
-    }
-
-    pub(crate) fn replace_with_error(&mut self, id: Id<T::Marker>) -> Result<T, InvalidId> {
-        let (index, epoch, _) = id.unzip();
-        match std::mem::replace(&mut self.map[index as usize], Element::Error(epoch)) {
-            Element::Vacant => panic!("Cannot access vacant resource"),
-            Element::Occupied(value, storage_epoch) => {
-                assert_eq!(epoch, storage_epoch);
-                Ok(value)
-            }
-            _ => Err(InvalidId),
-        }
-    }
-
-    pub(crate) fn remove(&mut self, id: Id<T::Marker>) -> Option<T> {
-        let (index, epoch, _) = id.unzip();
-        match std::mem::replace(&mut self.map[index as usize], Element::Vacant) {
-            Element::Occupied(value, storage_epoch) => {
-                assert_eq!(epoch, storage_epoch);
-                Some(value)
-            }
-            Element::Error(_) => None,
-            Element::Vacant => panic!("Cannot remove a vacant resource"),
-        }
     }
 
     pub(crate) fn strict_remove(&mut self, id: Id<T::Marker>) -> T {
@@ -164,7 +103,6 @@ where
                 assert_eq!(epoch, storage_epoch);
                 value
             }
-            Element::Error(_) => unreachable!(),
             Element::Vacant => panic!("Cannot remove a vacant resource"),
         }
     }
@@ -190,12 +128,6 @@ impl<T> Storage<T>
 where
     T: StorageItem + Clone,
 {
-    /// Get an owned reference to an item behind a potentially invalid ID.
-    /// Panics if there is an epoch mismatch, or the entry is empty.
-    pub(crate) fn get_owned(&self, id: Id<T::Marker>) -> Result<T, InvalidId> {
-        Ok(self.get(id)?.clone())
-    }
-
     /// Get an owned reference to an item.
     /// Panics if there is an epoch mismatch, the entry is empty or in error.
     pub(crate) fn strict_get(&self, id: Id<T::Marker>) -> T {
@@ -203,7 +135,6 @@ where
         let (result, storage_epoch) = match self.map.get(index as usize) {
             Some(&Element::Occupied(ref v, epoch)) => (v.clone(), epoch),
             None | Some(&Element::Vacant) => panic!("{}[{:?}] does not exist", self.kind, id),
-            Some(&Element::Error(_)) => unreachable!(),
         };
         assert_eq!(
             epoch, storage_epoch,

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -130,7 +130,7 @@ where
 {
     /// Get an owned reference to an item.
     /// Panics if there is an epoch mismatch, the entry is empty or in error.
-    pub(crate) fn strict_get(&self, id: Id<T::Marker>) -> T {
+    pub(crate) fn get(&self, id: Id<T::Marker>) -> T {
         let (index, epoch, _) = id.unzip();
         let (result, storage_epoch) = match self.map.get(index as usize) {
             Some(&Element::Occupied(ref v, epoch)) => (v.clone(), epoch),

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1,4 +1,4 @@
-use crate::{device::bgl, FastHashMap, FastHashSet};
+use crate::{device::bgl, resource::InvalidResourceError, FastHashMap, FastHashSet};
 use arrayvec::ArrayVec;
 use std::{collections::hash_map::Entry, fmt};
 use thiserror::Error;
@@ -200,8 +200,6 @@ pub enum InputError {
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum StageError {
-    #[error("Shader module is invalid")]
-    InvalidModule,
     #[error(
         "Shader entry point's workgroup size {current:?} ({current_total} total invocations) must be less or equal to the per-dimension limit {limit:?} and the total invocation limit {total}"
     )]
@@ -241,6 +239,8 @@ pub enum StageError {
         but no entry point was specified"
     )]
     MultipleEntryPointsFound,
+    #[error(transparent)]
+    InvalidResource(#[from] InvalidResourceError),
 }
 
 fn map_storage_format_to_naga(format: wgt::TextureFormat) -> Option<naga::StorageFormat> {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7550,10 +7550,4 @@ pub enum DeviceLostReason {
     /// exactly once before it is dropped, which helps with managing the
     /// memory owned by the callback.
     ReplacedCallback = 3,
-    /// When setting the callback, but the device is already invalid
-    ///
-    /// As above, when the callback is provided, wgpu guarantees that it
-    /// will eventually be called. If the device is already invalid, wgpu
-    /// will call the callback immediately, with this reason.
-    DeviceInvalid = 4,
 }

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -464,12 +464,6 @@ impl Device {
         )
     }
 
-    /// Test-only function to make this device invalid.
-    #[doc(hidden)]
-    pub fn make_invalid(&self) {
-        DynContext::device_make_invalid(&*self.context, self.data.as_ref())
-    }
-
     /// Create a [`PipelineCache`] with initial data
     ///
     /// This can be passed to [`Device::create_compute_pipeline`]

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2012,11 +2012,6 @@ impl crate::context::Context for ContextWebGpu {
         Sendable(device_data.0.create_render_bundle_encoder(&mapped_desc))
     }
 
-    #[doc(hidden)]
-    fn device_make_invalid(&self, _device_data: &Self::DeviceData) {
-        // Unimplemented
-    }
-
     fn device_drop(&self, _device_data: &Self::DeviceData) {
         // Device is dropped automatically
     }

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -755,17 +755,11 @@ impl crate::Context for ContextWgpuCore {
     }
 
     fn device_features(&self, device_data: &Self::DeviceData) -> Features {
-        match self.0.device_features(device_data.id) {
-            Ok(features) => features,
-            Err(err) => self.handle_error_fatal(err, "Device::features"),
-        }
+        self.0.device_features(device_data.id)
     }
 
     fn device_limits(&self, device_data: &Self::DeviceData) -> Limits {
-        match self.0.device_limits(device_data.id) {
-            Ok(limits) => limits,
-            Err(err) => self.handle_error_fatal(err, "Device::limits"),
-        }
+        self.0.device_limits(device_data.id)
     }
 
     #[cfg_attr(
@@ -1311,10 +1305,6 @@ impl crate::Context for ContextWgpuCore {
             Ok(encoder) => encoder,
             Err(e) => panic!("Error in Device::create_render_bundle_encoder: {e}"),
         }
-    }
-    #[doc(hidden)]
-    fn device_make_invalid(&self, device_data: &Self::DeviceData) {
-        self.0.device_make_invalid(device_data.id);
     }
     #[cfg_attr(not(any(native, Emscripten)), allow(unused))]
     fn device_drop(&self, device_data: &Self::DeviceData) {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -651,34 +651,22 @@ impl crate::Context for ContextWgpuCore {
     }
 
     fn adapter_features(&self, adapter_data: &Self::AdapterData) -> Features {
-        match self.0.adapter_features(*adapter_data) {
-            Ok(features) => features,
-            Err(err) => self.handle_error_fatal(err, "Adapter::features"),
-        }
+        self.0.adapter_features(*adapter_data)
     }
 
     fn adapter_limits(&self, adapter_data: &Self::AdapterData) -> Limits {
-        match self.0.adapter_limits(*adapter_data) {
-            Ok(limits) => limits,
-            Err(err) => self.handle_error_fatal(err, "Adapter::limits"),
-        }
+        self.0.adapter_limits(*adapter_data)
     }
 
     fn adapter_downlevel_capabilities(
         &self,
         adapter_data: &Self::AdapterData,
     ) -> DownlevelCapabilities {
-        match self.0.adapter_downlevel_capabilities(*adapter_data) {
-            Ok(downlevel) => downlevel,
-            Err(err) => self.handle_error_fatal(err, "Adapter::downlevel_properties"),
-        }
+        self.0.adapter_downlevel_capabilities(*adapter_data)
     }
 
     fn adapter_get_info(&self, adapter_data: &Self::AdapterData) -> AdapterInfo {
-        match self.0.adapter_get_info(*adapter_data) {
-            Ok(info) => info,
-            Err(err) => self.handle_error_fatal(err, "Adapter::get_info"),
-        }
+        self.0.adapter_get_info(*adapter_data)
     }
 
     fn adapter_get_texture_format_features(
@@ -686,23 +674,15 @@ impl crate::Context for ContextWgpuCore {
         adapter_data: &Self::AdapterData,
         format: wgt::TextureFormat,
     ) -> wgt::TextureFormatFeatures {
-        match self
-            .0
+        self.0
             .adapter_get_texture_format_features(*adapter_data, format)
-        {
-            Ok(info) => info,
-            Err(err) => self.handle_error_fatal(err, "Adapter::get_texture_format_features"),
-        }
     }
 
     fn adapter_get_presentation_timestamp(
         &self,
         adapter_data: &Self::AdapterData,
     ) -> wgt::PresentationTimestamp {
-        match self.0.adapter_get_presentation_timestamp(*adapter_data) {
-            Ok(timestamp) => timestamp,
-            Err(err) => self.handle_error_fatal(err, "Adapter::correlate_presentation_timestamp"),
-        }
+        self.0.adapter_get_presentation_timestamp(*adapter_data)
     }
 
     fn surface_get_capabilities(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -641,13 +641,8 @@ impl crate::Context for ContextWgpuCore {
         adapter_data: &Self::AdapterData,
         surface_data: &Self::SurfaceData,
     ) -> bool {
-        match self
-            .0
+        self.0
             .adapter_is_surface_supported(*adapter_data, surface_data.id)
-        {
-            Ok(result) => result,
-            Err(err) => self.handle_error_fatal(err, "Adapter::is_surface_supported"),
-        }
     }
 
     fn adapter_features(&self, adapter_data: &Self::AdapterData) -> Features {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2069,13 +2069,7 @@ impl crate::Context for ContextWgpuCore {
     }
 
     fn queue_get_timestamp_period(&self, queue_data: &Self::QueueData) -> f32 {
-        let res = self.0.queue_get_timestamp_period(queue_data.id);
-        match res {
-            Ok(v) => v,
-            Err(cause) => {
-                self.handle_error_fatal(cause, "Queue::get_timestamp_period");
-            }
-        }
+        self.0.queue_get_timestamp_period(queue_data.id)
     }
 
     fn queue_on_submitted_work_done(
@@ -2084,11 +2078,7 @@ impl crate::Context for ContextWgpuCore {
         callback: crate::context::SubmittedWorkDoneCallback,
     ) {
         let closure = wgc::device::queue::SubmittedWorkDoneClosure::from_rust(callback);
-
-        let res = self.0.queue_on_submitted_work_done(queue_data.id, closure);
-        if let Err(cause) = res {
-            self.handle_error_fatal(cause, "Queue::on_submitted_work_done");
-        }
+        self.0.queue_on_submitted_work_done(queue_data.id, closure);
     }
 
     fn device_start_capture(&self, device_data: &Self::DeviceData) {

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -195,8 +195,6 @@ pub trait Context: Debug + WasmNotSendSync + Sized {
         device_data: &Self::DeviceData,
         desc: &RenderBundleEncoderDescriptor<'_>,
     ) -> Self::RenderBundleEncoderData;
-    #[doc(hidden)]
-    fn device_make_invalid(&self, device_data: &Self::DeviceData);
     fn device_drop(&self, device_data: &Self::DeviceData);
     fn device_set_device_lost_callback(
         &self,
@@ -888,8 +886,6 @@ pub(crate) trait DynContext: Debug + WasmNotSendSync {
         device_data: &crate::Data,
         desc: &RenderBundleEncoderDescriptor<'_>,
     ) -> Box<crate::Data>;
-    #[doc(hidden)]
-    fn device_make_invalid(&self, device_data: &crate::Data);
     fn device_drop(&self, device_data: &crate::Data);
     fn device_set_device_lost_callback(
         &self,
@@ -1636,12 +1632,6 @@ where
         let device_data = downcast_ref(device_data);
         let data = Context::device_create_render_bundle_encoder(self, device_data, desc);
         Box::new(data) as _
-    }
-
-    #[doc(hidden)]
-    fn device_make_invalid(&self, device_data: &crate::Data) {
-        let device_data = downcast_ref(device_data);
-        Context::device_make_invalid(self, device_data)
     }
 
     fn device_drop(&self, device_data: &crate::Data) {


### PR DESCRIPTION
Another step towards https://github.com/gfx-rs/wgpu/issues/5121.

This moves out resource invalidity from the `Registry`; by storing a new `Fallible` type in the `Registry` instead.
Note that there are a few types that can't be invalid or have internal invalidity (ex `Device`), those don't need to be wrapped in a `Fallible`.

PR doesn't need to be squashed, each commit builds by itself.