### PR TITLE
Fix initial texture state for injected hal textures

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1057,7 +1057,7 @@ impl Texture {
                 if init {
                     TextureInitTracker::new(desc.mip_level_count, desc.array_layer_count())
                 } else {
-                    TextureInitTracker::new(0, 0)
+                    TextureInitTracker::new(desc.mip_level_count, 0)
                 },
             ),
             full_range: TextureSelector {


### PR DESCRIPTION
**Connections**
Fixes: https://github.com/gfx-rs/wgpu/issues/6248

**Description**
Brings back TextureInitTracker initial state from before https://github.com/gfx-rs/wgpu/commit/dc55cb436cdc4918b7f03500735b55fe02c4c177

Suggested [here](https://github.com/gfx-rs/wgpu/issues/6248#issuecomment-2340433765)
**Testing**
I've tested this change with test project created for #6248 and inside original project that I worked on.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
