### PR TITLE
spv-out: configure source language in debug info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ By @teoxoy [#6134](https://github.com/gfx-rs/wgpu/pull/6134).
 #### Naga
 
 - Accept only `vec3` (not `vecN`) for the `cross` built-in. By @ErichDonGubler in [#6171](https://github.com/gfx-rs/wgpu/pull/6171).
+- Configure `SourceLanguage` when enabling debug info in SPV-out. By @kvark in [#6256](https://github.com/gfx-rs/wgpu/pull/6256)
 
 #### General
 

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -16,7 +16,7 @@ mod selection;
 mod subgroup;
 mod writer;
 
-pub use spirv::Capability;
+pub use spirv::{Capability, SourceLanguage};
 
 use crate::arena::{Handle, HandleVec};
 use crate::proc::{BoundsCheckPolicies, TypeResolution};
@@ -89,6 +89,7 @@ impl IdGenerator {
 pub struct DebugInfo<'a> {
     pub source_code: &'a str,
     pub file_name: &'a std::path::Path,
+    pub language: SourceLanguage,
 }
 
 /// A SPIR-V block to which we are still adding instructions.

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -1967,7 +1967,7 @@ impl Writer {
                     source_file_id,
                 });
                 self.debugs.append(&mut Instruction::source_auto_continued(
-                    spirv::SourceLanguage::Unknown,
+                    debug_info.language,
                     0,
                     &debug_info_inner,
                 ));

--- a/naga/tests/snapshots.rs
+++ b/naga/tests/snapshots.rs
@@ -354,6 +354,10 @@ fn check_targets(
         let debug_info = source_code.map(|code| naga::back::spv::DebugInfo {
             source_code: code,
             file_name: name.as_ref(),
+            // wgpu#6266: we technically know all the information here to
+            // produce the valid language but it's not too important for
+            // validation purposes
+            language: naga::back::spv::SourceLanguage::Unknown,
         });
 
         if targets.contains(Targets::SPIRV) {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -762,6 +762,7 @@ impl super::Device {
                         temp_options.debug_info = Some(naga::back::spv::DebugInfo {
                             source_code: &debug.source_code,
                             file_name: debug.file_name.as_ref().as_ref(),
+                            language: naga::back::spv::SourceLanguage::WGSL,
                         })
                     }
                     if !stage.zero_initialize_workgroup_memory {
@@ -1727,6 +1728,7 @@ impl crate::Device for super::Device {
                         .map(|d| naga::back::spv::DebugInfo {
                             source_code: d.source_code.as_ref(),
                             file_name: d.file_name.as_ref().as_ref(),
+                            language: naga::back::spv::SourceLanguage::WGSL,
                         });
                 if !desc.runtime_checks {
                     naga_options.bounds_check_policies = naga::proc::BoundsCheckPolicies {


### PR DESCRIPTION
**Connections**
Resolves #6252

**Description**
Tools are sensitive to the kind of shader they get on the input. Setting UNKNOWN was confusing NSight.

**Testing**
Build with debug info, load into NSight.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
