### PR TITLE
Vulkan: Avoid undefined behaviour with adversarial debug label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,10 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 
 - Fix GL debug message callbacks not being properly cleaned up (causing UB). By @Imberflur in [#6114](https://github.com/gfx-rs/wgpu/pull/6114)
 
+#### Vulkan
+
+- Vulkan debug labels assumed no interior nul byte. By @DJMcNab in [#6257](https://github.com/gfx-rs/wgpu/pull/6257)
+
 ### Changes
 
 - `wgpu_hal::gles::Adapter::new_external` now requires the context to be current when dropping the adapter and related objects. By @Imberflur in [#6114](https://github.com/gfx-rs/wgpu/pull/6114).

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -15,6 +15,13 @@ use std::{
 };
 
 impl super::DeviceShared {
+    /// Set the name of `object` to `name`.
+    ///
+    /// If `name` contains an interior null byte, then the name set will be truncated to that byte.
+    ///
+    /// # Safety
+    ///
+    /// It must be valid to set `object`'s debug name
     pub(super) unsafe fn set_object_name(&self, object: impl vk::Handle, name: &str) {
         let Some(extension) = self.extension_fns.debug_utils.as_ref() else {
             return;
@@ -44,7 +51,7 @@ impl super::DeviceShared {
             &buffer_vec
         };
 
-        let name = unsafe { CStr::from_bytes_with_nul_unchecked(name_bytes) };
+        let name = CStr::from_bytes_until_nul(name_bytes).expect("We have added a null byte");
 
         let _result = unsafe {
             extension.set_debug_utils_object_name(


### PR DESCRIPTION
**Connections**

This method was first added in https://github.com/gfx-rs/wgpu/pull/1471
There was no discussion at the time about this use of unsafe, and the [original code in `gfx-hal`](https://github.com/gfx-rs/gfx/blob/master/src/backend/vulkan/src/lib.rs#L911) does not have this unsoundness.

**Description**
In Rust, it is [valid](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b3cc55a7df1db3a36fd6c9f96f7bb25d) for an `&str` to contain an interior nul byte.
However, the Vulkan debug object name code uses [`CStr::from_bytes_with_nul_unchecked`](https://doc.rust-lang.org/stable/std/ffi/struct.CStr.html#method.from_bytes_with_nul_unchecked) with a user-provided `&str`, on which as far as I can see there is no additional validation.

This is technically an unsoundness fix, but I don't think it's a significant security issue, and so would not recommend backporting this fix.

The tradeoff I have chosen to make in the case of an interior nul-byte is to truncate to that byte.
Alternatives include:
- Replacing it with another ascii byte (`0`?)
- Panicking

It's also not clear to me why `set_object_name` is unsafe, as there are no provided preconditions.
I guessed at some, but would be happier just removing the `unsafe` marker entirely.

**Testing**
This change is untested.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`
- [x] Run `cargo xtask test` to run tests. (Same behaviour as on main of crashing my editor)
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
