### PR TITLE
[d3d12] handle absence of Windows SDK

### DIFF
--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -138,7 +138,7 @@ pub fn create_factory(
         // The `DXGI_CREATE_FACTORY_DEBUG` flag is only allowed to be passed to
         // `CreateDXGIFactory2` if the debug interface is actually available. So
         // we check for whether it exists first.
-        if lib_dxgi.debug_interface1().is_ok() {
+        if let Ok(Some(_)) = lib_dxgi.debug_interface1() {
             factory_flags |= Dxgi::DXGI_CREATE_FACTORY_DEBUG;
         }
 

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -34,7 +34,7 @@ impl crate::Instance for super::Instance {
             .intersects(wgt::InstanceFlags::VALIDATION | wgt::InstanceFlags::GPU_BASED_VALIDATION)
         {
             // Enable debug layer
-            if let Ok(debug_controller) = lib_main.debug_interface() {
+            if let Ok(Some(debug_controller)) = lib_main.debug_interface() {
                 if desc.flags.intersects(wgt::InstanceFlags::VALIDATION) {
                     unsafe { debug_controller.EnableDebugLayer() }
                 }


### PR DESCRIPTION
**Connections**
Similar to https://github.com/gfx-rs/wgpu/pull/6241.

**Description**
Explicitly handle `DXGI_ERROR_SDK_COMPONENT_MISSING` so that we don't panic when the `internal_error_panic` feature flag is enabled.