### PR TITLE
Remove `backend` from ID

### DIFF
--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -401,10 +401,7 @@ pub fn op_webgpu_request_adapter(
         force_fallback_adapter,
         compatible_surface: None, // windowless
     };
-    let res = instance.request_adapter(
-        &descriptor,
-        wgpu_core::instance::AdapterInputs::Mask(backends, |_| None),
-    );
+    let res = instance.request_adapter(&descriptor, backends, None);
 
     let adapter = match res {
         Ok(adapter) => adapter,

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -56,7 +56,7 @@ fn main() {
         global.instance_create_surface(
             window.display_handle().unwrap().into(),
             window.window_handle().unwrap().into(),
-            Some(wgc::id::Id::zip(0, 1, wgt::Backend::Empty)),
+            Some(wgc::id::Id::zip(0, 1)),
         )
     }
     .unwrap();
@@ -74,14 +74,15 @@ fn main() {
                         #[cfg(not(feature = "winit"))]
                         compatible_surface: None,
                     },
-                    wgc::instance::AdapterInputs::IdSet(&[wgc::id::AdapterId::zip(0, 0, backend)]),
+                    wgt::Backends::from(backend),
+                    Some(wgc::id::AdapterId::zip(0, 1)),
                 )
                 .expect("Unable to find an adapter for selected backend");
 
             let info = global.adapter_get_info(adapter);
             log::info!("Picked '{}'", info.name);
-            let device_id = wgc::id::Id::zip(1, 0, backend);
-            let queue_id = wgc::id::Id::zip(1, 0, backend);
+            let device_id = wgc::id::Id::zip(0, 1);
+            let queue_id = wgc::id::Id::zip(0, 1);
             let res = global.adapter_request_device(
                 adapter,
                 &desc,

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -352,11 +352,7 @@ impl GlobalPlay for wgc::global::Global {
                 let (encoder, error) = self.device_create_command_encoder(
                     device,
                     &wgt::CommandEncoderDescriptor { label: None },
-                    Some(
-                        comb_manager
-                            .process(device.backend())
-                            .into_command_encoder_id(),
-                    ),
+                    Some(comb_manager.process().into_command_encoder_id()),
                 );
                 if let Some(e) = error {
                     panic!("{e}");

--- a/player/tests/data/bind-group.ron
+++ b/player/tests/data/bind-group.ron
@@ -2,13 +2,13 @@
     features: [],
     expectations: [], //not crash!
     actions: [
-        CreateBuffer(Id(0, 1, Empty), (
+        CreateBuffer(Id(0, 1), (
             label: None,
             size: 16,
             usage: 64,
             mapped_at_creation: false,
         )),
-        CreateBindGroupLayout(Id(0, 1, Empty), (
+        CreateBindGroupLayout(Id(0, 1), (
             label: None,
             entries: [
                 (
@@ -20,29 +20,29 @@
                 ),
             ],
         )),
-        CreateBindGroup(Id(0, 1, Empty), (
+        CreateBindGroup(Id(0, 1), (
             label: None,
-            layout: Id(0, 1, Empty),
+            layout: Id(0, 1),
             entries: [
                 (
                     binding: 0,
                     resource: Buffer((
-                        buffer_id: Id(0, 1, Empty),
+                        buffer_id: Id(0, 1),
                         offset: 0,
                         size: None,
                     )),
                 )
             ],
         )),
-        CreatePipelineLayout(Id(0, 1, Empty), (
+        CreatePipelineLayout(Id(0, 1), (
             label: Some("empty"),
             bind_group_layouts: [
-                Id(0, 1, Empty),
+                Id(0, 1),
             ],
             push_constant_ranges: [],
         )),
         CreateShaderModule(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             desc: (
                 label: None,
                 flags: (bits: 3),
@@ -50,12 +50,12 @@
             data: "empty.wgsl",
         ),
         CreateComputePipeline(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             desc: (
                 label: None,
-                layout: Some(Id(0, 1, Empty)),
+                layout: Some(Id(0, 1)),
                 stage: (
-                    module: Id(0, 1, Empty),
+                    module: Id(0, 1),
                     entry_point: None,
                     constants: {},
                     zero_initialize_workgroup_memory: true,
@@ -70,9 +70,9 @@
                         SetBindGroup(
                             index: 0,
                             num_dynamic_offsets: 0,
-                            bind_group_id: Some(Id(0, 1, Empty)),
+                            bind_group_id: Some(Id(0, 1)),
                         ),
-                        SetPipeline(Id(0, 1, Empty)),
+                        SetPipeline(Id(0, 1)),
                     ],
                     dynamic_offsets: [],
                     string_data: [],

--- a/player/tests/data/buffer-copy.ron
+++ b/player/tests/data/buffer-copy.ron
@@ -10,7 +10,7 @@
     ],
     actions: [
         CreateBuffer(
-            Id(0, 1, Empty),
+            Id(0, 1),
             (
                 label: Some("dummy"),
                 size: 16,
@@ -19,7 +19,7 @@
             ),
         ),
         WriteBuffer(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             data: "data1.bin",
             range: (
                 start: 0,

--- a/player/tests/data/clear-buffer-texture.ron
+++ b/player/tests/data/clear-buffer-texture.ron
@@ -20,7 +20,7 @@
         )
     ],
     actions: [
-        CreateTexture(Id(0, 1, Empty), (
+        CreateTexture(Id(0, 1), (
             label: Some("Output Texture"),
             size: (
                 width: 64,
@@ -36,7 +36,7 @@
         // First fill the texture to ensure it wasn't just zero initialized or "happened" to be zero.
         WriteTexture(
             to: (
-                texture: Id(0, 1, Empty),
+                texture: Id(0, 1),
                 mip_level: 0,
                 array_layer: 0,
             ),
@@ -52,7 +52,7 @@
             ),
         ),
         CreateBuffer(
-            Id(0, 1, Empty),
+            Id(0, 1),
             (
                 label: Some("Output Buffer"),
                 size: 16384,
@@ -62,7 +62,7 @@
         ),
 
         CreateBuffer(
-            Id(1, 1, Empty),
+            Id(1, 1),
             (
                 label: Some("Buffer to be cleared"),
                 size: 16,
@@ -72,7 +72,7 @@
         ),
         // Make sure there is something in the buffer, otherwise it might be just zero init!
         WriteBuffer(
-            id: Id(1, 1, Empty),
+            id: Id(1, 1),
             data: "data1.bin",
             range: (
                 start: 0,
@@ -82,7 +82,7 @@
         ),
         Submit(1, [
             ClearTexture(
-                dst: Id(0, 1, Empty),
+                dst: Id(0, 1),
                 subresource_range: ImageSubresourceRange(
                     aspect: all,
                     baseMipLevel: 0,
@@ -93,12 +93,12 @@
             ),
             CopyTextureToBuffer(
                 src: (
-                    texture: Id(0, 1, Empty),
+                    texture: Id(0, 1),
                     mip_level: 0,
                     array_layer: 0,
                 ),
                 dst:  (
-                    buffer: Id(0, 1, Empty),
+                    buffer: Id(0, 1),
                     layout: (
                         offset: 0,
                         bytes_per_row: Some(256),
@@ -112,7 +112,7 @@
             ),
             // Partial clear to prove
             ClearBuffer(
-                dst: Id(1, 1, Empty),
+                dst: Id(1, 1),
                 offset: 4,
                 size: Some(8),
             )

--- a/player/tests/data/pipeline-statistics-query.ron
+++ b/player/tests/data/pipeline-statistics-query.ron
@@ -9,13 +9,13 @@
         ),
     ],
     actions: [
-        CreatePipelineLayout(Id(0, 1, Empty), (
+        CreatePipelineLayout(Id(0, 1), (
             label: Some("empty"),
             bind_group_layouts: [],
             push_constant_ranges: [],
         )),
         CreateShaderModule(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             desc: (
                 label: None,
                 flags: (bits: 3),
@@ -23,12 +23,12 @@
             data: "empty.wgsl",
         ),
         CreateComputePipeline(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             desc: (
                 label: None,
-                layout: Some(Id(0, 1, Empty)),
+                layout: Some(Id(0, 1)),
                 stage: (
-                    module: Id(0, 1, Empty),
+                    module: Id(0, 1),
                     entry_point: None,
                     constants: {},
                     zero_initialize_workgroup_memory: true,
@@ -37,7 +37,7 @@
             ),
         ),
         CreateQuerySet(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             desc: (
                 label: Some("Compute Invocation QuerySet"),
                 count: 2,
@@ -45,7 +45,7 @@
             ),
         ),
         CreateBuffer(
-            Id(0, 1, Empty),
+            Id(0, 1),
             (
                 label: Some("Compute Invocation Result Buffer"),
                 size: 16,
@@ -57,9 +57,9 @@
             RunComputePass(
                 base: (
                     commands: [
-                        SetPipeline(Id(0, 1, Empty)),
+                        SetPipeline(Id(0, 1)),
                         BeginPipelineStatisticsQuery(
-                            query_set_id: Id(0, 1, Empty),
+                            query_set_id: Id(0, 1),
                             query_index: 0,
                         ),
                         Dispatch((2, 3, 7,)),
@@ -71,10 +71,10 @@
                 ),
             ),
             ResolveQuerySet(
-                query_set_id: Id(0, 1, Empty),
+                query_set_id: Id(0, 1),
                 start_query: 0,
                 query_count: 1,
-                destination: Id(0, 1, Empty),
+                destination: Id(0, 1),
                 destination_offset: 0,
             )
         ]),

--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -10,14 +10,14 @@
     ],
     actions: [
         CreateShaderModule(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             desc: (
                 label: None,
                 flags: (bits: 3),
             ),
             data: "quad.wgsl",
         ),
-        CreateTexture(Id(0, 1, Empty), (
+        CreateTexture(Id(0, 1), (
             label: Some("Output Texture"),
             size: (
                 width: 64,
@@ -31,12 +31,12 @@
             view_formats: [],
         )),
         CreateTextureView(
-            id: Id(0, 1, Empty),
-            parent_id: Id(0, 1, Empty),
+            id: Id(0, 1),
+            parent_id: Id(0, 1),
             desc: (),
         ),
         CreateBuffer(
-            Id(0, 1, Empty),
+            Id(0, 1),
             (
                 label: Some("Output Buffer"),
                 size: 16384,
@@ -44,19 +44,19 @@
                 mapped_at_creation: false,
             ),
         ),
-        CreatePipelineLayout(Id(0, 1, Empty), (
+        CreatePipelineLayout(Id(0, 1), (
             label: None,
             bind_group_layouts: [],
             push_constant_ranges: [],
         )),
         CreateRenderPipeline(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             desc: (
                 label: None,
-                layout: Some(Id(0, 1, Empty)),
+                layout: Some(Id(0, 1)),
                 vertex: (
                     stage: (
-                        module: Id(0, 1, Empty),
+                        module: Id(0, 1),
                         entry_point: None,
                         constants: {},
                         zero_initialize_workgroup_memory: true,
@@ -66,7 +66,7 @@
                 ),
                 fragment: Some((
                     stage: (
-                        module: Id(0, 1, Empty),
+                        module: Id(0, 1),
                         entry_point: None,
                         constants: {},
                         zero_initialize_workgroup_memory: true,
@@ -84,7 +84,7 @@
             RunRenderPass(
                 base: (
                     commands: [
-                        SetPipeline(Id(0, 1, Empty)),
+                        SetPipeline(Id(0, 1)),
                         Draw(
                             vertex_count: 3,
                             instance_count: 1,
@@ -98,7 +98,7 @@
                 ),
                 target_colors: [
                     Some((
-                        view: Id(0, 1, Empty),
+                        view: Id(0, 1),
                         resolve_target: None,
                         channel: (
                             load_op: clear,
@@ -117,12 +117,12 @@
             ),
             CopyTextureToBuffer(
                 src: (
-                    texture: Id(0, 1, Empty),
+                    texture: Id(0, 1),
                     mip_level: 0,
                     array_layer: 0,
                 ),
                 dst:  (
-                    buffer: Id(0, 1, Empty),
+                    buffer: Id(0, 1),
                     layout: (
                         offset: 0,
                         bytes_per_row: Some(256),

--- a/player/tests/data/zero-init-buffer.ron
+++ b/player/tests/data/zero-init-buffer.ron
@@ -39,7 +39,7 @@
     ],
     actions: [
         CreateBuffer(
-            Id(0, 1, Empty),
+            Id(0, 1),
             (
                 label: Some("mapped_at_creation: false, with MAP_WRITE"),
                 size: 16,
@@ -48,7 +48,7 @@
             ),
         ),
         CreateBuffer(
-            Id(1, 1, Empty),
+            Id(1, 1),
             (
                 label: Some("mapped_at_creation: false, without MAP_WRITE"),
                 size: 16,
@@ -57,7 +57,7 @@
             ),
         ),
         CreateBuffer(
-            Id(2, 1, Empty),
+            Id(2, 1),
             (
                 label: Some("partially written"),
                 size: 24,
@@ -66,7 +66,7 @@
             ),
         ),
         WriteBuffer(
-            id: Id(2, 1, Empty),
+            id: Id(2, 1),
             data: "data1.bin",
             range: (
                 start: 4,
@@ -75,20 +75,20 @@
             queued: true,
         ),
         CreateShaderModule(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             desc: (
                 label: None,
                 flags: (bits: 3),
             ),
             data: "zero-init-buffer-for-binding.wgsl",
         ),
-        CreateBuffer(Id(3, 1, Empty), (
+        CreateBuffer(Id(3, 1), (
             label: Some("used in binding"),
             size: 16,
             usage: 129, // STORAGE + MAP_READ
             mapped_at_creation: false,
         )),
-        CreateBindGroupLayout(Id(0, 1, Empty), (
+        CreateBindGroupLayout(Id(0, 1), (
             label: None,
             entries: [
                 (
@@ -105,34 +105,34 @@
                 ),
             ],
         )),
-        CreateBindGroup(Id(0, 1, Empty), (
+        CreateBindGroup(Id(0, 1), (
             label: None,
-            layout: Id(0, 1, Empty),
+            layout: Id(0, 1),
             entries: [
                 (
                     binding: 0,
                     resource: Buffer((
-                        buffer_id: Id(3, 1, Empty),
+                        buffer_id: Id(3, 1),
                         offset: 0,
                         size: Some(16),
                     )),
                 ),
             ],
         )),
-        CreatePipelineLayout(Id(0, 1, Empty), (
+        CreatePipelineLayout(Id(0, 1), (
             label: None,
             bind_group_layouts: [
-                Id(0, 1, Empty),
+                Id(0, 1),
             ],
             push_constant_ranges: [],
         )),
         CreateComputePipeline(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             desc: (
                 label: None,
-                layout: Some(Id(0, 1, Empty)),
+                layout: Some(Id(0, 1)),
                 stage: (
-                    module: Id(0, 1, Empty),
+                    module: Id(0, 1),
                     entry_point: None,
                     constants: {},
                     zero_initialize_workgroup_memory: true,
@@ -145,11 +145,11 @@
                 base: (
                     label: None,
                     commands: [
-                        SetPipeline(Id(0, 1, Empty)),
+                        SetPipeline(Id(0, 1)),
                         SetBindGroup(
                             index: 0,
                             num_dynamic_offsets: 0,
-                            bind_group_id: Some(Id(0, 1, Empty)),
+                            bind_group_id: Some(Id(0, 1)),
                         ),
                         Dispatch((4, 1, 1)),
                     ],

--- a/player/tests/data/zero-init-texture-binding.ron
+++ b/player/tests/data/zero-init-texture-binding.ron
@@ -17,7 +17,7 @@
         // MISSING: Partial views
     ],
     actions: [
-        CreateTexture(Id(0, 1, Empty), (
+        CreateTexture(Id(0, 1), (
             label: Some("Sampled Texture"),
             size: (
                 width: 64,
@@ -31,12 +31,12 @@
             view_formats: [],
         )),
         CreateTextureView(
-            id: Id(0, 1, Empty),
-            parent_id: Id(0, 1, Empty),
+            id: Id(0, 1),
+            parent_id: Id(0, 1),
             desc: (),
         ),
         CreateBuffer(
-            Id(0, 1, Empty),
+            Id(0, 1),
             (
                 label: Some("Sampled Texture Buffer"),
                 size: 16384,
@@ -44,7 +44,7 @@
                 mapped_at_creation: false,
             ),
         ),
-        CreateTexture(Id(1, 1, Empty), (
+        CreateTexture(Id(1, 1), (
             label: Some("Storage Texture"),
             size: (
                 width: 64,
@@ -58,12 +58,12 @@
             view_formats: [],
         )),
         CreateTextureView(
-            id: Id(1, 1, Empty),
-            parent_id: Id(1, 1, Empty),
+            id: Id(1, 1),
+            parent_id: Id(1, 1),
             desc: (),
         ),
         CreateBuffer(
-            Id(1, 1, Empty),
+            Id(1, 1),
             (
                 label: Some("Storage Texture Buffer"),
                 size: 16384,
@@ -73,7 +73,7 @@
         ),
 
 
-        CreateBindGroupLayout(Id(0, 1, Empty), (
+        CreateBindGroupLayout(Id(0, 1), (
             label: None,
             entries: [
                 (
@@ -98,29 +98,29 @@
                 ),
             ],
         )),
-        CreateBindGroup(Id(0, 1, Empty), (
+        CreateBindGroup(Id(0, 1), (
             label: None,
-            layout: Id(0, 1, Empty),
+            layout: Id(0, 1),
             entries: [
                 (
                     binding: 0,
-                    resource: TextureView(Id(0, 1, Empty)),
+                    resource: TextureView(Id(0, 1)),
                 ),
                 (
                     binding: 1,
-                    resource: TextureView(Id(1, 1, Empty)),
+                    resource: TextureView(Id(1, 1)),
                 ),
             ],
         )),
-        CreatePipelineLayout(Id(0, 1, Empty), (
+        CreatePipelineLayout(Id(0, 1), (
             label: None,
             bind_group_layouts: [
-                Id(0, 1, Empty),
+                Id(0, 1),
             ],
             push_constant_ranges: [],
         )),
         CreateShaderModule(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             desc: (
                 label: None,
                 flags: (bits: 3),
@@ -128,12 +128,12 @@
             data: "zero-init-texture-binding.wgsl",
         ),
         CreateComputePipeline(
-            id: Id(0, 1, Empty),
+            id: Id(0, 1),
             desc: (
                 label: None,
-                layout: Some(Id(0, 1, Empty)),
+                layout: Some(Id(0, 1)),
                 stage: (
-                    module: Id(0, 1, Empty),
+                    module: Id(0, 1),
                     entry_point: None,
                     constants: {},
                     zero_initialize_workgroup_memory: true,
@@ -146,11 +146,11 @@
             RunComputePass(
                 base: (
                     commands: [
-                        SetPipeline(Id(0, 1, Empty)),
+                        SetPipeline(Id(0, 1)),
                         SetBindGroup(
                             index: 0,
                             num_dynamic_offsets: 0,
-                            bind_group_id: Some(Id(0, 1, Empty)),
+                            bind_group_id: Some(Id(0, 1)),
                         ),
                         Dispatch((4, 1, 1)),
                     ],
@@ -161,12 +161,12 @@
             ),
             CopyTextureToBuffer(
                 src: (
-                    texture: Id(0, 1, Empty),
+                    texture: Id(0, 1),
                     mip_level: 0,
                     array_layer: 0,
                 ),
                 dst:  (
-                    buffer: Id(0, 1, Empty),
+                    buffer: Id(0, 1),
                     layout: (
                         offset: 0,
                         bytes_per_row: Some(256),
@@ -180,12 +180,12 @@
             ),
             CopyTextureToBuffer(
                 src: (
-                    texture: Id(1, 1, Empty),
+                    texture: Id(1, 1),
                     mip_level: 0,
                     array_layer: 0,
                 ),
                 dst:  (
-                    buffer: Id(1, 1, Empty),
+                    buffer: Id(1, 1),
                     layout: (
                         offset: 0,
                         bytes_per_row: Some(256),

--- a/player/tests/data/zero-init-texture-copytobuffer.ron
+++ b/player/tests/data/zero-init-texture-copytobuffer.ron
@@ -10,7 +10,7 @@
         // MISSING: Partial copies
     ],
     actions: [
-        CreateTexture(Id(0, 1, Empty), (
+        CreateTexture(Id(0, 1), (
             label: Some("Copy To Buffer Texture"),
             size: (
                 width: 64,
@@ -24,7 +24,7 @@
             view_formats: [],
         )),
         CreateBuffer(
-            Id(0, 1, Empty),
+            Id(0, 1),
             (
                 label: Some("Copy to Buffer Buffer"),
                 size: 16384,
@@ -35,12 +35,12 @@
         Submit(1, [
             CopyTextureToBuffer(
                 src: (
-                    texture: Id(0, 1, Empty),
+                    texture: Id(0, 1),
                     mip_level: 0,
                     array_layer: 0,
                 ),
                 dst:  (
-                    buffer: Id(0, 1, Empty),
+                    buffer: Id(0, 1),
                     layout: (
                         offset: 0,
                         bytes_per_row: Some(256),

--- a/player/tests/data/zero-init-texture-rendertarget.ron
+++ b/player/tests/data/zero-init-texture-rendertarget.ron
@@ -10,7 +10,7 @@
         // MISSING: Partial view.
     ],
     actions: [
-        CreateTexture(Id(0, 1, Empty), (
+        CreateTexture(Id(0, 1), (
             label: Some("Render Target Texture"),
             size: (
                 width: 64,
@@ -24,12 +24,12 @@
             view_formats: [],
         )),
         CreateTextureView(
-            id: Id(0, 1, Empty),
-            parent_id: Id(0, 1, Empty),
+            id: Id(0, 1),
+            parent_id: Id(0, 1),
             desc: (),
         ),
         CreateBuffer(
-            Id(0, 1, Empty),
+            Id(0, 1),
             (
                 label: Some("Render Target Buffer"),
                 size: 16384,
@@ -48,7 +48,7 @@
                 ),
                 target_colors: [
                     Some((
-                        view: Id(0, 1, Empty),
+                        view: Id(0, 1),
                         resolve_target: None,
                         channel: (
                             load_op: load,
@@ -64,12 +64,12 @@
             ),
             CopyTextureToBuffer(
                 src: (
-                    texture: Id(0, 1, Empty),
+                    texture: Id(0, 1),
                     mip_level: 0,
                     array_layer: 0,
                 ),
                 dst:  (
-                    buffer: Id(0, 1, Empty),
+                    buffer: Id(0, 1),
                     layout: (
                         offset: 0,
                         bytes_per_row: Some(256),

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -105,9 +105,8 @@ impl Test<'_> {
         adapter: wgc::id::AdapterId,
         test_num: u32,
     ) {
-        let backend = adapter.backend();
-        let device_id = wgc::id::Id::zip(test_num, 0, backend);
-        let queue_id = wgc::id::Id::zip(test_num, 0, backend);
+        let device_id = wgc::id::Id::zip(test_num, 1);
+        let queue_id = wgc::id::Id::zip(test_num, 1);
         let res = global.adapter_request_device(
             adapter,
             &wgt::DeviceDescriptor {
@@ -137,7 +136,7 @@ impl Test<'_> {
         }
         println!("\t\t\tMapping...");
         for expect in &self.expectations {
-            let buffer = wgc::id::Id::zip(expect.buffer.index, expect.buffer.epoch, backend);
+            let buffer = wgc::id::Id::zip(expect.buffer.index, expect.buffer.epoch);
             global
                 .buffer_map_async(
                     buffer,
@@ -160,7 +159,7 @@ impl Test<'_> {
 
         for expect in self.expectations {
             println!("\t\t\tChecking {}", expect.name);
-            let buffer = wgc::id::Id::zip(expect.buffer.index, expect.buffer.epoch, backend);
+            let buffer = wgc::id::Id::zip(expect.buffer.index, expect.buffer.epoch);
             let (ptr, size) = global
                 .buffer_get_mapped_range(
                     buffer,
@@ -237,7 +236,8 @@ impl Corpus {
                         force_fallback_adapter: false,
                         compatible_surface: None,
                     },
-                    wgc::instance::AdapterInputs::IdSet(&[wgc::id::Id::zip(0, 0, backend)]),
+                    wgt::Backends::from(backend),
+                    Some(wgc::id::Id::zip(0, 1)),
                 ) {
                     Ok(adapter) => adapter,
                     Err(_) => continue,
@@ -247,7 +247,7 @@ impl Corpus {
                 let supported_features = global.adapter_features(adapter);
                 let downlevel_caps = global.adapter_downlevel_capabilities(adapter);
 
-                let test = Test::load(dir.join(test_path), adapter.backend());
+                let test = Test::load(dir.join(test_path), backend);
                 if !supported_features.contains(test.features) {
                     println!(
                         "\t\tSkipped due to missing features {:?}",

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -104,7 +104,7 @@ impl Global {
         profiling::scope!("Device::create_buffer");
 
         let hub = &self.hub;
-        let fid = hub.buffers.prepare(device_id.backend(), id_in);
+        let fid = hub.buffers.prepare(id_in);
 
         let error = 'error: {
             let device = self.hub.devices.get(device_id);
@@ -175,21 +175,19 @@ impl Global {
     /// [`wgpu_types::BufferUsages`]: wgt::BufferUsages
     pub fn create_buffer_error(
         &self,
-        backend: wgt::Backend,
         id_in: Option<id::BufferId>,
         desc: &resource::BufferDescriptor,
     ) {
-        let fid = self.hub.buffers.prepare(backend, id_in);
+        let fid = self.hub.buffers.prepare(id_in);
         fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
     }
 
     pub fn create_render_bundle_error(
         &self,
-        backend: wgt::Backend,
         id_in: Option<id::RenderBundleId>,
         desc: &command::RenderBundleDescriptor,
     ) {
-        let fid = self.hub.render_bundles.prepare(backend, id_in);
+        let fid = self.hub.render_bundles.prepare(id_in);
         fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
     }
 
@@ -198,11 +196,10 @@ impl Global {
     /// See `create_buffer_error` for more context and explanation.
     pub fn create_texture_error(
         &self,
-        backend: wgt::Backend,
         id_in: Option<id::TextureId>,
         desc: &resource::TextureDescriptor,
     ) {
-        let fid = self.hub.textures.prepare(backend, id_in);
+        let fid = self.hub.textures.prepare(id_in);
         fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
     }
 
@@ -311,7 +308,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let fid = hub.textures.prepare(device_id.backend(), id_in);
+        let fid = hub.textures.prepare(id_in);
 
         let error = 'error: {
             let device = self.hub.devices.get(device_id);
@@ -354,7 +351,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let fid = hub.textures.prepare(device_id.backend(), id_in);
+        let fid = hub.textures.prepare(id_in);
 
         let error = 'error: {
             let device = self.hub.devices.get(device_id);
@@ -398,7 +395,7 @@ impl Global {
         profiling::scope!("Device::create_buffer");
 
         let hub = &self.hub;
-        let fid = hub.buffers.prepare(A::VARIANT, id_in);
+        let fid = hub.buffers.prepare(id_in);
 
         let device = self.hub.devices.get(device_id);
 
@@ -458,7 +455,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let fid = hub.texture_views.prepare(texture_id.backend(), id_in);
+        let fid = hub.texture_views.prepare(id_in);
 
         let error = 'error: {
             let texture = match hub.textures.get(texture_id).get() {
@@ -522,7 +519,7 @@ impl Global {
         profiling::scope!("Device::create_sampler");
 
         let hub = &self.hub;
-        let fid = hub.samplers.prepare(device_id.backend(), id_in);
+        let fid = hub.samplers.prepare(id_in);
 
         let error = 'error: {
             let device = self.hub.devices.get(device_id);
@@ -575,7 +572,7 @@ impl Global {
         profiling::scope!("Device::create_bind_group_layout");
 
         let hub = &self.hub;
-        let fid = hub.bind_group_layouts.prepare(device_id.backend(), id_in);
+        let fid = hub.bind_group_layouts.prepare(id_in);
 
         let error = 'error: {
             let device = self.hub.devices.get(device_id);
@@ -647,7 +644,7 @@ impl Global {
         profiling::scope!("Device::create_pipeline_layout");
 
         let hub = &self.hub;
-        let fid = hub.pipeline_layouts.prepare(device_id.backend(), id_in);
+        let fid = hub.pipeline_layouts.prepare(id_in);
 
         let error = 'error: {
             let device = self.hub.devices.get(device_id);
@@ -715,7 +712,7 @@ impl Global {
         profiling::scope!("Device::create_bind_group");
 
         let hub = &self.hub;
-        let fid = hub.bind_groups.prepare(device_id.backend(), id_in);
+        let fid = hub.bind_groups.prepare(id_in);
 
         let error = 'error: {
             let device = self.hub.devices.get(device_id);
@@ -877,7 +874,7 @@ impl Global {
         profiling::scope!("Device::create_shader_module");
 
         let hub = &self.hub;
-        let fid = hub.shader_modules.prepare(device_id.backend(), id_in);
+        let fid = hub.shader_modules.prepare(id_in);
 
         let error = 'error: {
             let device = self.hub.devices.get(device_id);
@@ -949,7 +946,7 @@ impl Global {
         profiling::scope!("Device::create_shader_module");
 
         let hub = &self.hub;
-        let fid = hub.shader_modules.prepare(device_id.backend(), id_in);
+        let fid = hub.shader_modules.prepare(id_in);
 
         let error = 'error: {
             let device = self.hub.devices.get(device_id);
@@ -1006,10 +1003,9 @@ impl Global {
         profiling::scope!("Device::create_command_encoder");
 
         let hub = &self.hub;
-        let fid = hub.command_buffers.prepare(
-            device_id.backend(),
-            id_in.map(|id| id.into_command_buffer_id()),
-        );
+        let fid = hub
+            .command_buffers
+            .prepare(id_in.map(|id| id.into_command_buffer_id()));
 
         let device = self.hub.devices.get(device_id);
 
@@ -1072,9 +1068,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let fid = hub
-            .render_bundles
-            .prepare(bundle_encoder.parent().backend(), id_in);
+        let fid = hub.render_bundles.prepare(id_in);
 
         let error = 'error: {
             let device = self.hub.devices.get(bundle_encoder.parent());
@@ -1133,7 +1127,7 @@ impl Global {
         profiling::scope!("Device::create_query_set");
 
         let hub = &self.hub;
-        let fid = hub.query_sets.prepare(device_id.backend(), id_in);
+        let fid = hub.query_sets.prepare(id_in);
 
         let error = 'error: {
             let device = self.hub.devices.get(device_id);
@@ -1194,7 +1188,7 @@ impl Global {
         let missing_implicit_pipeline_ids =
             desc.layout.is_none() && id_in.is_some() && implicit_pipeline_ids.is_none();
 
-        let fid = hub.render_pipelines.prepare(device_id.backend(), id_in);
+        let fid = hub.render_pipelines.prepare(id_in);
         let implicit_context = implicit_pipeline_ids.map(|ipi| ipi.prepare(hub));
 
         let error = 'error: {
@@ -1378,7 +1372,7 @@ impl Global {
     ) {
         let hub = &self.hub;
 
-        let fid = hub.bind_group_layouts.prepare(pipeline_id.backend(), id_in);
+        let fid = hub.bind_group_layouts.prepare(id_in);
 
         let error = 'error: {
             let pipeline = match hub.render_pipelines.get(pipeline_id).get() {
@@ -1431,7 +1425,7 @@ impl Global {
         let missing_implicit_pipeline_ids =
             desc.layout.is_none() && id_in.is_some() && implicit_pipeline_ids.is_none();
 
-        let fid = hub.compute_pipelines.prepare(device_id.backend(), id_in);
+        let fid = hub.compute_pipelines.prepare(id_in);
         let implicit_context = implicit_pipeline_ids.map(|ipi| ipi.prepare(hub));
 
         let error = 'error: {
@@ -1562,7 +1556,7 @@ impl Global {
     ) {
         let hub = &self.hub;
 
-        let fid = hub.bind_group_layouts.prepare(pipeline_id.backend(), id_in);
+        let fid = hub.bind_group_layouts.prepare(id_in);
 
         let error = 'error: {
             let pipeline = match hub.compute_pipelines.get(pipeline_id).get() {
@@ -1616,7 +1610,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let fid = hub.pipeline_caches.prepare(device_id.backend(), id_in);
+        let fid = hub.pipeline_caches.prepare(id_in);
         let error: pipeline::CreatePipelineCacheError = 'error: {
             let device = self.hub.devices.get(device_id);
 
@@ -1881,7 +1875,7 @@ impl Global {
                 //
                 // https://github.com/gfx-rs/wgpu/issues/4105
 
-                let surface_raw = surface.raw(device_id.backend()).unwrap();
+                let surface_raw = surface.raw(device.backend()).unwrap();
                 match unsafe { surface_raw.configure(device.raw(), &hal_config) } {
                     Ok(()) => (),
                     Err(error) => {
@@ -1963,7 +1957,6 @@ impl Global {
     /// submissions still in flight.
     fn poll_all_devices_of_api(
         &self,
-        backend: wgt::Backend,
         force_wait: bool,
         closures: &mut UserClosures,
     ) -> Result<bool, WaitIdleError> {
@@ -1974,7 +1967,7 @@ impl Global {
         {
             let device_guard = hub.devices.read();
 
-            for (_id, device) in device_guard.iter(backend) {
+            for (_id, device) in device_guard.iter() {
                 let maintain = if force_wait {
                     wgt::Maintain::Wait
                 } else {
@@ -2004,28 +1997,7 @@ impl Global {
     pub fn poll_all_devices(&self, force_wait: bool) -> Result<bool, WaitIdleError> {
         api_log!("poll_all_devices");
         let mut closures = UserClosures::default();
-        let mut all_queue_empty = true;
-
-        #[cfg(vulkan)]
-        {
-            all_queue_empty &=
-                self.poll_all_devices_of_api(wgt::Backend::Vulkan, force_wait, &mut closures)?;
-        }
-        #[cfg(metal)]
-        {
-            all_queue_empty &=
-                self.poll_all_devices_of_api(wgt::Backend::Metal, force_wait, &mut closures)?;
-        }
-        #[cfg(dx12)]
-        {
-            all_queue_empty &=
-                self.poll_all_devices_of_api(wgt::Backend::Dx12, force_wait, &mut closures)?;
-        }
-        #[cfg(gles)]
-        {
-            all_queue_empty &=
-                self.poll_all_devices_of_api(wgt::Backend::Gl, force_wait, &mut closures)?;
-        }
+        let all_queue_empty = self.poll_all_devices_of_api(force_wait, &mut closures)?;
 
         closures.fire();
 

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -457,16 +457,12 @@ pub struct ImplicitPipelineIds<'a> {
 
 impl ImplicitPipelineIds<'_> {
     fn prepare(self, hub: &Hub) -> ImplicitPipelineContext {
-        let backend = self.root_id.backend();
         ImplicitPipelineContext {
-            root_id: hub
-                .pipeline_layouts
-                .prepare(backend, Some(self.root_id))
-                .id(),
+            root_id: hub.pipeline_layouts.prepare(Some(self.root_id)).id(),
             group_ids: self
                 .group_ids
                 .iter()
-                .map(|id_in| hub.bind_group_layouts.prepare(backend, Some(*id_in)).id())
+                .map(|id_in| hub.bind_group_layouts.prepare(Some(*id_in)).id())
                 .collect(),
         }
     }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -444,7 +444,7 @@ impl Global {
         let staging_buffer = StagingBuffer::new(device, buffer_size)?;
         let ptr = unsafe { staging_buffer.ptr() };
 
-        let fid = hub.staging_buffers.prepare(queue_id.backend(), id_in);
+        let fid = hub.staging_buffers.prepare(id_in);
         let id = fid.assign(staging_buffer);
         resource_log!("Queue::create_staging_buffer {id:?}");
 

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -131,7 +131,7 @@ impl Global {
             return Err(SurfaceError::NotConfigured);
         };
 
-        let fid = hub.textures.prepare(device.backend(), texture_id_in);
+        let fid = hub.textures.prepare(texture_id_in);
 
         #[cfg(feature = "trace")]
         if let Some(ref mut trace) = *device.trace.lock() {

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -70,18 +70,14 @@ impl<T: StorageItem> FutureId<'_, T> {
 }
 
 impl<T: StorageItem> Registry<T> {
-    pub(crate) fn prepare(
-        &self,
-        backend: wgt::Backend,
-        id_in: Option<Id<T::Marker>>,
-    ) -> FutureId<T> {
+    pub(crate) fn prepare(&self, id_in: Option<Id<T::Marker>>) -> FutureId<T> {
         FutureId {
             id: match id_in {
                 Some(id_in) => {
                     self.identity.mark_as_used(id_in);
                     id_in
                 }
-                None => self.identity.process(backend),
+                None => self.identity.process(),
             },
             data: &self.storage,
         }
@@ -154,7 +150,7 @@ mod tests {
                 s.spawn(|| {
                     for _ in 0..1000 {
                         let value = Arc::new(TestData);
-                        let new_id = registry.prepare(wgt::Backend::Empty, None);
+                        let new_id = registry.prepare(None);
                         let id = new_id.assign(value);
                         registry.remove(id);
                     }

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -61,8 +61,7 @@ impl ContextWgpuCore {
 
     #[cfg(native)]
     pub fn enumerate_adapters(&self, backends: wgt::Backends) -> Vec<wgc::id::AdapterId> {
-        self.0
-            .enumerate_adapters(wgc::instance::AdapterInputs::Mask(backends, |_| None))
+        self.0.enumerate_adapters(backends)
     }
 
     pub unsafe fn create_adapter_from_hal<A: wgc::hal_api::HalApi>(
@@ -589,7 +588,8 @@ impl crate::Context for ContextWgpuCore {
                     surface.id
                 }),
             },
-            wgc::instance::AdapterInputs::Mask(wgt::Backends::all(), |_| None),
+            wgt::Backends::all(),
+            None,
         );
         ready(id.ok())
     }


### PR DESCRIPTION
**Connections**
Follow-up to https://github.com/gfx-rs/wgpu/pull/6100.

**Description**
Degenerification removed the need for having registries per backend so, we can now remove the `backend` portion of the ID as it's no longer necessary.

This simplifies `enumerate_adapters` & `request_adapter` a bunch.
`enumerate_adapters` is not used by the Firefox bindings so it doesn't need a way to provide a set of IDs.

**Testing**
Existing tests.
