### PR TITLE
chore!: remove `#[no_mangle] … extern "C" …` from `fn`s in `bundle_ffi`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 - Fix error message that is thrown in create_render_pass to no longer say `compute_pass`. By @matthew-wong1 [#6041](https://github.com/gfx-rs/wgpu/pull/6041)
 - Document `wgpu_hal` bounds-checking promises, and adapt `wgpu_core`'s lazy initialization logic to the slightly weaker-than-expected guarantees. By @jimblandy in [#6201](https://github.com/gfx-rs/wgpu/pull/6201)
 - Raise validation error instead of panicking in `{Render,Compute}Pipeline::get_bind_group_layout` on native / WebGL. By @bgr360 in [#6280](https://github.com/gfx-rs/wgpu/pull/6280).
+- **BREAKING**: Remove the last exposed C symbols in project, located in `wgpu_core::render::bundle::bundle_ffi`, to allow multiple versions of WGPU to compile together. By @ErichDonGubler in [#6272](https://github.com/gfx-rs/wgpu/pull/6272).
 
 #### GLES / OpenGL
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1584,8 +1584,7 @@ pub mod bundle_ffi {
     ///
     /// This function is unsafe as there is no guarantee that the given pointer is
     /// valid for `offset_length` elements.
-    #[no_mangle]
-    pub unsafe extern "C" fn wgpu_render_bundle_set_bind_group(
+    pub unsafe fn wgpu_render_bundle_set_bind_group(
         bundle: &mut RenderBundleEncoder,
         index: u32,
         bind_group_id: Option<id::BindGroupId>,
@@ -1612,8 +1611,7 @@ pub mod bundle_ffi {
         });
     }
 
-    #[no_mangle]
-    pub extern "C" fn wgpu_render_bundle_set_pipeline(
+    pub fn wgpu_render_bundle_set_pipeline(
         bundle: &mut RenderBundleEncoder,
         pipeline_id: id::RenderPipelineId,
     ) {
@@ -1627,8 +1625,7 @@ pub mod bundle_ffi {
             .push(RenderCommand::SetPipeline(pipeline_id));
     }
 
-    #[no_mangle]
-    pub extern "C" fn wgpu_render_bundle_set_vertex_buffer(
+    pub fn wgpu_render_bundle_set_vertex_buffer(
         bundle: &mut RenderBundleEncoder,
         slot: u32,
         buffer_id: id::BufferId,
@@ -1643,8 +1640,7 @@ pub mod bundle_ffi {
         });
     }
 
-    #[no_mangle]
-    pub extern "C" fn wgpu_render_bundle_set_index_buffer(
+    pub fn wgpu_render_bundle_set_index_buffer(
         encoder: &mut RenderBundleEncoder,
         buffer: id::BufferId,
         index_format: IndexFormat,
@@ -1658,8 +1654,7 @@ pub mod bundle_ffi {
     ///
     /// This function is unsafe as there is no guarantee that the given pointer is
     /// valid for `data` elements.
-    #[no_mangle]
-    pub unsafe extern "C" fn wgpu_render_bundle_set_push_constants(
+    pub unsafe fn wgpu_render_bundle_set_push_constants(
         pass: &mut RenderBundleEncoder,
         stages: wgt::ShaderStages,
         offset: u32,
@@ -1695,8 +1690,7 @@ pub mod bundle_ffi {
         });
     }
 
-    #[no_mangle]
-    pub extern "C" fn wgpu_render_bundle_draw(
+    pub fn wgpu_render_bundle_draw(
         bundle: &mut RenderBundleEncoder,
         vertex_count: u32,
         instance_count: u32,
@@ -1711,8 +1705,7 @@ pub mod bundle_ffi {
         });
     }
 
-    #[no_mangle]
-    pub extern "C" fn wgpu_render_bundle_draw_indexed(
+    pub fn wgpu_render_bundle_draw_indexed(
         bundle: &mut RenderBundleEncoder,
         index_count: u32,
         instance_count: u32,
@@ -1729,8 +1722,7 @@ pub mod bundle_ffi {
         });
     }
 
-    #[no_mangle]
-    pub extern "C" fn wgpu_render_bundle_draw_indirect(
+    pub fn wgpu_render_bundle_draw_indirect(
         bundle: &mut RenderBundleEncoder,
         buffer_id: id::BufferId,
         offset: BufferAddress,
@@ -1743,8 +1735,7 @@ pub mod bundle_ffi {
         });
     }
 
-    #[no_mangle]
-    pub extern "C" fn wgpu_render_bundle_draw_indexed_indirect(
+    pub fn wgpu_render_bundle_draw_indexed_indirect(
         bundle: &mut RenderBundleEncoder,
         buffer_id: id::BufferId,
         offset: BufferAddress,
@@ -1761,16 +1752,14 @@ pub mod bundle_ffi {
     ///
     /// This function is unsafe as there is no guarantee that the given `label`
     /// is a valid null-terminated string.
-    #[no_mangle]
-    pub unsafe extern "C" fn wgpu_render_bundle_push_debug_group(
+    pub unsafe fn wgpu_render_bundle_push_debug_group(
         _bundle: &mut RenderBundleEncoder,
         _label: RawString,
     ) {
         //TODO
     }
 
-    #[no_mangle]
-    pub extern "C" fn wgpu_render_bundle_pop_debug_group(_bundle: &mut RenderBundleEncoder) {
+    pub fn wgpu_render_bundle_pop_debug_group(_bundle: &mut RenderBundleEncoder) {
         //TODO
     }
 
@@ -1778,8 +1767,7 @@ pub mod bundle_ffi {
     ///
     /// This function is unsafe as there is no guarantee that the given `label`
     /// is a valid null-terminated string.
-    #[no_mangle]
-    pub unsafe extern "C" fn wgpu_render_bundle_insert_debug_marker(
+    pub unsafe fn wgpu_render_bundle_insert_debug_marker(
         _bundle: &mut RenderBundleEncoder,
         _label: RawString,
     ) {


### PR DESCRIPTION
**Connections**

Resolves #3105.

**Description**

Remove the last remaining cases that should trigger #3105 in the `wgpu_core::command::bundle::bundle_ffi` module.

**Testing**

If things still compile, we just gotta check that this doesn't break downstream. @cwfitzgerald, halp plz?

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
