### PR TITLE
Coherent storage

### DIFF
--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -1166,8 +1166,12 @@ impl<'a, W: Write> Writer<'a, W> {
             }
         }
 
-        if let crate::AddressSpace::Storage { access } = global.space {
+        if let crate::AddressSpace::Storage { access, coherent } = global.space {
             self.write_storage_access(access)?;
+
+            if coherent {
+                write!(self.out, "coherent ")?;
+            }
         }
 
         if let Some(storage_qualifier) = glsl_storage_qualifier(global.space) {

--- a/naga/src/back/hlsl/help.rs
+++ b/naga/src/back/hlsl/help.rs
@@ -1052,7 +1052,7 @@ impl<'a, W: Write> super::Writer<'a, W> {
                         }
                     };
                     let storage_access = match global_var.space {
-                        crate::AddressSpace::Storage { access } => access,
+                        crate::AddressSpace::Storage { access, .. } => access,
                         _ => crate::StorageAccess::default(),
                     };
                     let wal = WrappedArrayLength {

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -829,13 +829,14 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 write!(self.out, "cbuffer")?;
                 "b"
             }
-            crate::AddressSpace::Storage { access } => {
+            crate::AddressSpace::Storage { access, coherent } => {
+                let globallycoherent = if coherent { "globallycoherent " } else { "" };
                 let (prefix, register) = if access.contains(crate::StorageAccess::STORE) {
                     ("RW", "u")
                 } else {
                     ("", "t")
                 };
-                write!(self.out, "{prefix}ByteAddressBuffer")?;
+                write!(self.out, "{globallycoherent}{prefix}ByteAddressBuffer")?;
                 register
             }
             crate::AddressSpace::Handle => {
@@ -3463,7 +3464,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 };
 
                 let storage_access = match var.space {
-                    crate::AddressSpace::Storage { access } => access,
+                    crate::AddressSpace::Storage { access, .. } => access,
                     _ => crate::StorageAccess::default(),
                 };
                 let wrapped_array_length = WrappedArrayLength {

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -307,7 +307,7 @@ impl<'a> TypedGlobalVariable<'a> {
         let name = &self.names[&NameKey::GlobalVariable(self.handle)];
 
         let storage_access = match var.space {
-            crate::AddressSpace::Storage { access } => access,
+            crate::AddressSpace::Storage { access, .. } => access,
             _ => match self.module.types[var.ty].inner {
                 crate::TypeInner::Image {
                     class: crate::ImageClass::Storage { access, .. },
@@ -5138,7 +5138,7 @@ impl<W: Write> Writer<W> {
                         // supporting MSL 1.2.
                         //
                         // [what's new]: https://developer.apple.com/library/archive/documentation/Miscellaneous/Conceptual/MetalProgrammingGuide/WhatsNewiniOS10tvOS10andOSX1012/WhatsNewiniOS10tvOS10andOSX1012.html
-                        crate::AddressSpace::Storage { access }
+                        crate::AddressSpace::Storage { access, .. }
                             if access.contains(crate::StorageAccess::STORE)
                                 && ep.stage == crate::ShaderStage::Fragment =>
                         {

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -1688,7 +1688,13 @@ impl Writer {
         }
 
         let storage_access = match global_variable.space {
-            crate::AddressSpace::Storage { access } => Some(access),
+            crate::AddressSpace::Storage { access, coherent } => {
+                if coherent {
+                    self.decorate(id, Decoration::Coherent, &[]);
+                }
+
+                Some(access)
+            }
             _ => match ir_module.types[global_variable.ty].inner {
                 crate::TypeInner::Image {
                     class: crate::ImageClass::Storage { access, .. },

--- a/naga/src/front/glsl/parser/types.rs
+++ b/naga/src/front/glsl/parser/types.rs
@@ -229,6 +229,7 @@ impl<'source> ParsingContext<'source> {
                         TokenValue::Buffer => {
                             StorageQualifier::AddressSpace(AddressSpace::Storage {
                                 access: crate::StorageAccess::all(),
+                                coherent: false,
                             })
                         }
                         _ => unreachable!(),

--- a/naga/src/front/glsl/variables.rs
+++ b/naga/src/front/glsl/variables.rs
@@ -487,7 +487,7 @@ impl Frontend {
             }
             StorageQualifier::AddressSpace(mut space) => {
                 match space {
-                    AddressSpace::Storage { ref mut access } => {
+                    AddressSpace::Storage { ref mut access, .. } => {
                         if let Some((allowed_access, _)) = qualifiers.storage_access.take() {
                             *access = allowed_access;
                         }

--- a/naga/src/front/spv/convert.rs
+++ b/naga/src/front/spv/convert.rs
@@ -174,6 +174,7 @@ pub(super) fn map_storage_class(word: spirv::Word) -> Result<super::ExtendedClas
         Some(Sc::StorageBuffer) => Ec::Global(crate::AddressSpace::Storage {
             //Note: this is restricted by decorations later
             access: crate::StorageAccess::all(),
+            coherent: false, // TODO?
         }),
         // we expect the `Storage` case to be filtered out before calling this function.
         Some(Sc::Uniform) => Ec::Global(crate::AddressSpace::Uniform),

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -4825,6 +4825,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
         {
             crate::AddressSpace::Storage {
                 access: crate::StorageAccess::default(),
+                coherent: false,
             }
         } else {
             match map_storage_class(storage_class)? {
@@ -5489,13 +5490,16 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
         }
 
         let ext_class = match self.lookup_storage_buffer_types.get(&ty) {
-            Some(&access) => ExtendedClass::Global(crate::AddressSpace::Storage { access }),
+            Some(&access) => ExtendedClass::Global(crate::AddressSpace::Storage {
+                access,
+                coherent: false,
+            }),
             None => map_storage_class(storage_class)?,
         };
 
         let (inner, var) = match ext_class {
             ExtendedClass::Global(mut space) => {
-                if let crate::AddressSpace::Storage { ref mut access } = space {
+                if let crate::AddressSpace::Storage { ref mut access, .. } = space {
                     *access &= dec.flags.to_storage_access();
                 }
                 let var = crate::GlobalVariable {

--- a/naga/src/front/wgsl/parse/conv.rs
+++ b/naga/src/front/wgsl/parse/conv.rs
@@ -9,6 +9,7 @@ pub fn map_address_space(word: &str, span: Span) -> Result<crate::AddressSpace, 
         "uniform" => Ok(crate::AddressSpace::Uniform),
         "storage" => Ok(crate::AddressSpace::Storage {
             access: crate::StorageAccess::default(),
+            coherent: false,
         }),
         "push_constant" => Ok(crate::AddressSpace::PushConstant),
         "function" => Ok(crate::AddressSpace::Function),

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -3,7 +3,7 @@ use crate::front::wgsl::parse::lexer::{Lexer, Token};
 use crate::front::wgsl::parse::number::Number;
 use crate::front::wgsl::Scalar;
 use crate::front::SymbolTable;
-use crate::{Arena, FastIndexSet, Handle, ShaderStage, Span};
+use crate::{Arena, FastIndexSet, Handle, ShaderStage, Span, StorageAccess};
 
 pub mod ast;
 pub mod conv;
@@ -986,7 +986,9 @@ impl Parser {
                         crate::StorageAccess::LOAD
                     };
 
-                    let coherent = if lexer.skip(Token::Separator(',')) {
+                    let coherent = if access.contains(StorageAccess::LOAD | StorageAccess::STORE)
+                        && lexer.skip(Token::Separator(','))
+                    {
                         let (ident, span) = self.next_ident_with_span()?;
                         if ident == "coherent" {
                             Ok(true)

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -377,7 +377,10 @@ pub enum AddressSpace {
     /// Uniform buffer data.
     Uniform,
     /// Storage buffer data, potentially mutable.
-    Storage { access: StorageAccess },
+    Storage {
+        access: StorageAccess,
+        coherent: bool,
+    },
     /// Opaque handles, such as samplers and images.
     Handle,
     /// Push constants.

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -370,6 +370,7 @@ impl Resource {
                                 naga_access.set(naga::StorageAccess::STORE, !read_only);
                                 naga::AddressSpace::Storage {
                                     access: naga_access,
+                                    coherent: false,
                                 }
                             }
                         };
@@ -500,7 +501,7 @@ impl Resource {
             ResourceType::Buffer { size } => BindingType::Buffer {
                 ty: match self.class {
                     naga::AddressSpace::Uniform => wgt::BufferBindingType::Uniform,
-                    naga::AddressSpace::Storage { access } => wgt::BufferBindingType::Storage {
+                    naga::AddressSpace::Storage { access, .. } => wgt::BufferBindingType::Storage {
                         read_only: access == naga::StorageAccess::LOAD,
                     },
                     _ => return Err(BindingError::WrongType),

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -229,7 +229,7 @@ impl super::Device {
                         None => continue,
                     };
                     let storage_access_store = match var.space {
-                        naga::AddressSpace::Storage { access } => {
+                        naga::AddressSpace::Storage { access, .. } => {
                             access.contains(naga::StorageAccess::STORE)
                         }
                         _ => false,


### PR DESCRIPTION
**Connections**
Related to https://github.com/gfx-rs/wgpu/issues/4444

**Description**
Implement coherent read_write storage buffers (and storage textures?). Writes to this variable from one workgroup should be visible to another workgroup.

Syntax is `var<storage, read_write, coherent>: foo`.

**Questions/TODO**
* Where in naga's AST should this qualifier live?
* Is this allowed on storage textures?
* We need a new capability in naga, and then where do we validate this?
* Where do we validate that this is only valid with read_write access mode?
* Metal support? (requires metal 3.2)

Generally everything around the frontend I have little idea what I'm doing. 

The backend is very easy for spv (add a decoration) and hlsl (prefix RWStructuredBuffer/RWByteAddressBuffer/RWTexture2D), and mostly on glsl (goes somewhere in the variable qualifiers, order unclear), and metal I haven't even looked at.

**Testing**
_Explain how this change is tested._

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
