### PR TITLE
[naga msl-out] Defeat the MSL compiler's infinite loop analysis.

### DIFF
--- a/naga/tests/out/msl/boids.msl
+++ b/naga/tests/out/msl/boids.msl
@@ -55,8 +55,9 @@ kernel void main_(
     vPos = _e8;
     metal::float2 _e14 = particlesSrc.particles[index].vel;
     vVel = _e14;
+#define LOOP_IS_REACHABLE if (volatile bool unpredictable_jump_over_loop = true; unpredictable_jump_over_loop)
     bool loop_init = true;
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         if (!loop_init) {
             uint _e91 = i;
             i = _e91 + 1u;

--- a/naga/tests/out/msl/break-if.msl
+++ b/naga/tests/out/msl/break-if.msl
@@ -7,8 +7,9 @@ using metal::uint;
 
 void breakIfEmpty(
 ) {
+#define LOOP_IS_REACHABLE if (volatile bool unpredictable_jump_over_loop = true; unpredictable_jump_over_loop)
     bool loop_init = true;
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         if (!loop_init) {
             if (true) {
                 break;
@@ -25,7 +26,7 @@ void breakIfEmptyBody(
     bool b = {};
     bool c = {};
     bool loop_init_1 = true;
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         if (!loop_init_1) {
             b = a;
             bool _e2 = b;
@@ -46,7 +47,7 @@ void breakIf(
     bool d = {};
     bool e = {};
     bool loop_init_2 = true;
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         if (!loop_init_2) {
             bool _e5 = e;
             if (a_1 == e) {
@@ -65,7 +66,7 @@ void breakIfSeparateVariable(
 ) {
     uint counter = 0u;
     bool loop_init_3 = true;
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         if (!loop_init_3) {
             uint _e5 = counter;
             if (counter == 5u) {

--- a/naga/tests/out/msl/collatz.msl
+++ b/naga/tests/out/msl/collatz.msl
@@ -19,7 +19,8 @@ uint collatz_iterations(
     uint n = {};
     uint i = 0u;
     n = n_base;
-    while(true) {
+#define LOOP_IS_REACHABLE if (volatile bool unpredictable_jump_over_loop = true; unpredictable_jump_over_loop)
+    LOOP_IS_REACHABLE while(true) {
         uint _e4 = n;
         if (_e4 > 1u) {
         } else {

--- a/naga/tests/out/msl/control-flow.msl
+++ b/naga/tests/out/msl/control-flow.msl
@@ -31,7 +31,8 @@ void switch_case_break(
 void loop_switch_continue(
     int x
 ) {
-    while(true) {
+#define LOOP_IS_REACHABLE if (volatile bool unpredictable_jump_over_loop = true; unpredictable_jump_over_loop)
+    LOOP_IS_REACHABLE while(true) {
         switch(x) {
             case 1: {
                 continue;
@@ -49,7 +50,7 @@ void loop_switch_continue_nesting(
     int y,
     int z
 ) {
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         switch(x_1) {
             case 1: {
                 continue;
@@ -60,7 +61,7 @@ void loop_switch_continue_nesting(
                         continue;
                     }
                     default: {
-                        while(true) {
+                        LOOP_IS_REACHABLE while(true) {
                             switch(z) {
                                 case 1: {
                                     continue;
@@ -85,7 +86,7 @@ void loop_switch_continue_nesting(
             }
         }
     }
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         switch(y) {
             case 1:
             default: {
@@ -108,7 +109,7 @@ void loop_switch_omit_continue_variable_checks(
     int w
 ) {
     int pos_1 = 0;
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         switch(x_2) {
             case 1: {
                 pos_1 = 1;
@@ -119,7 +120,7 @@ void loop_switch_omit_continue_variable_checks(
             }
         }
     }
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         switch(x_2) {
             case 1: {
                 break;

--- a/naga/tests/out/msl/do-while.msl
+++ b/naga/tests/out/msl/do-while.msl
@@ -8,8 +8,9 @@ using metal::uint;
 void fb1_(
     thread bool& cond
 ) {
+#define LOOP_IS_REACHABLE if (volatile bool unpredictable_jump_over_loop = true; unpredictable_jump_over_loop)
     bool loop_init = true;
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         if (!loop_init) {
             bool _e1 = cond;
             if (!(cond)) {

--- a/naga/tests/out/msl/overrides-ray-query.msl
+++ b/naga/tests/out/msl/overrides-ray-query.msl
@@ -33,7 +33,8 @@ kernel void main_(
     rq.intersector.force_opacity((desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none);
     rq.intersector.accept_any_intersection((desc.flags & 4) != 0);
     rq.intersection = rq.intersector.intersect(metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax), acc_struct, desc.cull_mask);    rq.ready = true;
-    while(true) {
+#define LOOP_IS_REACHABLE if (volatile bool unpredictable_jump_over_loop = true; unpredictable_jump_over_loop)
+    LOOP_IS_REACHABLE while(true) {
         bool _e31 = rq.ready;
         rq.ready = false;
         if (_e31) {

--- a/naga/tests/out/msl/ray-query.msl
+++ b/naga/tests/out/msl/ray-query.msl
@@ -53,7 +53,8 @@ RayIntersection query_loop(
     rq.intersector.force_opacity((_e8.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (_e8.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none);
     rq.intersector.accept_any_intersection((_e8.flags & 4) != 0);
     rq.intersection = rq.intersector.intersect(metal::raytracing::ray(_e8.origin, _e8.dir, _e8.tmin, _e8.tmax), acs, _e8.cull_mask);    rq.ready = true;
-    while(true) {
+#define LOOP_IS_REACHABLE if (volatile bool unpredictable_jump_over_loop = true; unpredictable_jump_over_loop)
+    LOOP_IS_REACHABLE while(true) {
         bool _e9 = rq.ready;
         rq.ready = false;
         if (_e9) {

--- a/naga/tests/out/msl/shadow.msl
+++ b/naga/tests/out/msl/shadow.msl
@@ -100,8 +100,9 @@ fragment fs_mainOutput fs_main(
     metal::float3 color = c_ambient;
     uint i = 0u;
     metal::float3 normal_1 = metal::normalize(in.world_normal);
+#define LOOP_IS_REACHABLE if (volatile bool unpredictable_jump_over_loop = true; unpredictable_jump_over_loop)
     bool loop_init = true;
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         if (!loop_init) {
             uint _e40 = i;
             i = _e40 + 1u;
@@ -151,7 +152,7 @@ fragment fs_main_without_storageOutput fs_main_without_storage(
     uint i_1 = 0u;
     metal::float3 normal_2 = metal::normalize(in_1.world_normal);
     bool loop_init_1 = true;
-    while(true) {
+    LOOP_IS_REACHABLE while(true) {
         if (!loop_init_1) {
             uint _e40 = i_1;
             i_1 = _e40 + 1u;


### PR DESCRIPTION
See the comments in the code for details.

This patch emits the definition of the macro only when the first loop is encountered. This does make that first loop's code look a bit odd: it would be more natural to define the macro at the top of the file. (See the modified files in `naga/tests/out/msl`.)

Rejected alternatives:

- We could emit the macro definition unconditionally at the top of the file. But this changes every MSL snapshot output file, whereas only eight of them actually contain loops.

- We could have the validator flag modules that contain loops. But the changes end up being not small, and spread across the validator, so this seems disproportionate. If we had other consumers of this information, it might make sense.

- We could change the MSL backend to allow text to be generated out of order, so that we can decide whether to define the macro after we've generated all the function bodies. But at the moment this seems like unnecessary complexity, although it might be worth doing in the future if we had additional uses for it - say, to conditionally emit helper function definitions.

Fixes #4972.
