### PR TITLE
Update parking_lot dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,10 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 
 - Replace `winapi` code to use the `windows` crate. By @MarijnS95 in [#5956](https://github.com/gfx-rs/wgpu/pull/5956) and [#6173](https://github.com/gfx-rs/wgpu/pull/6173)
 
+#### HAL
+
+- Update `parking_lot` to `0.12`. By @mahkoh in [#6287](https://github.com/gfx-rs/wgpu/pull/6287)
+
 ## 22.0.0 (2024-07-17)
 
 ### Overview

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ noise = { version = "0.8", git = "https://github.com/Razaekel/noise-rs.git", rev
 nv-flip = "0.1"
 obj = "0.10"
 once_cell = "1.19.0"
-parking_lot = ">=0.11, <0.13" # parking_lot 0.12 switches from `winapi` to `windows`; permit either
+parking_lot = "0.12.1"
 pico-args = { version = "0.5.0", features = [
     "eq-separator",
     "short-space-opt",


### PR DESCRIPTION
**Connections**

None

**Description**

wgpu-hal does not compile with parking_lot versions that don't contain const Mutex::new.

**Testing**

Not at all. I used the github web UI for this change.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
