### PR TITLE
chore: un-regress `unused_qualifications` lint in `naga::front::spv`

### DIFF
--- a/naga/src/front/spv/error.rs
+++ b/naga/src/front/spv/error.rs
@@ -162,6 +162,6 @@ impl Error {
 
 impl From<atomic_upgrade::Error> for Error {
     fn from(source: atomic_upgrade::Error) -> Self {
-        crate::front::spv::Error::AtomicUpgradeError(source)
+        Error::AtomicUpgradeError(source)
     }
 }


### PR DESCRIPTION
Regressed in #5824.
