### PR TITLE
fix: usage of `a deprecated Node.js version` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,7 +554,7 @@ jobs:
           cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: upload coverage report to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: steps.coverage.outcome == 'success'
         with:
           files: lcov.info


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories
Fixes #6300

**Description**
_Describe what problem this is solving, and how it's solved._
`.github/workflows/ci.yml` uses `codecov/codecov-action@v3`, which uses `a deprecated Node.js version`, and this pull request updates it so that it no longer does.

**Testing**
_Explain how this change is tested._
I ran `cargo xtask test` locally.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.