### PR TITLE
fix: only log `Device::maintain` waits if they happen

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -457,13 +457,13 @@ impl Device {
 
         // If necessary, wait for that submission to complete.
         if maintain.is_wait() {
+            log::trace!("Device::maintain: waiting for submission index {submission_index}");
             unsafe {
                 self.raw()
                     .wait(fence.as_ref(), submission_index, CLEANUP_WAIT_MS)
             }
             .map_err(|e| self.handle_hal_error(e))?;
         }
-        log::trace!("Device::maintain: waiting for submission index {submission_index}");
 
         let mut life_tracker = self.lock_life();
         let submission_closures =


### PR DESCRIPTION
**Connections**

Follow-up to @Kek5chen's question at https://github.com/gfx-rs/wgpu/pull/6044#issuecomment-2335175795, which seems pretty reasonable to me.

**Description**

Only emits a `Device::maintain` wait message if we actually make a call to wait for a submission to finish.

**Testing**

This still passes CI, so I think we're de-risked there.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ Not necessary, IMO.
