### PR TITLE
style: use `concat!(…)` in `DOWNLEVEL_*_MESSAGE`

### DIFF
--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -128,16 +128,26 @@ pub fn hal_label(opt: Option<&str>, flags: wgt::InstanceFlags) -> Option<&str> {
     opt
 }
 
-const DOWNLEVEL_WARNING_MESSAGE: &str = "The underlying API or device in use does not \
-support enough features to be a fully compliant implementation of WebGPU. A subset of the features can still be used. \
-If you are running this program on native and not in a browser and wish to limit the features you use to the supported subset, \
-call Adapter::downlevel_properties or Device::downlevel_properties to get a listing of the features the current \
-platform supports.";
-const DOWNLEVEL_ERROR_MESSAGE: &str = "This is not an invalid use of WebGPU: the underlying API or device does not \
-support enough features to be a fully compliant implementation. A subset of the features can still be used. \
-If you are running this program on native and not in a browser and wish to work around this issue, call \
-Adapter::downlevel_properties or Device::downlevel_properties to get a listing of the features the current \
-platform supports.";
+const DOWNLEVEL_WARNING_MESSAGE: &str = concat!(
+    "The underlying API or device in use does not ",
+    "support enough features to be a fully compliant implementation of WebGPU. ",
+    "A subset of the features can still be used. ",
+    "If you are running this program on native and not in a browser and wish to limit ",
+    "the features you use to the supported subset, ",
+    "call Adapter::downlevel_properties or Device::downlevel_properties to get ",
+    "a listing of the features the current ",
+    "platform supports."
+);
+
+const DOWNLEVEL_ERROR_MESSAGE: &str = concat!(
+    "This is not an invalid use of WebGPU: the underlying API or device does not ",
+    "support enough features to be a fully compliant implementation. ",
+    "A subset of the features can still be used. ",
+    "If you are running this program on native and not in a browser ",
+    "and wish to work around this issue, call ",
+    "Adapter::downlevel_properties or Device::downlevel_properties ",
+    "to get a listing of the features the current platform supports."
+);
 
 #[cfg(feature = "api_log_info")]
 macro_rules! api_log {


### PR DESCRIPTION
This plays _much_ better with `rustfmt`, and we should likely be using this in many more places.