### PR TITLE
[naga] Support pipeline overrides in the WGSL backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 - Support constant evaluation for `firstLeadingBit` and `firstTrailingBit` numeric built-ins in WGSL. Front-ends that translate to these built-ins also benefit from constant evaluation. By @ErichDonGubler in [#5101](https://github.com/gfx-rs/wgpu/pull/5101).
 - Add `first` and `either` sampling types for `@interpolate(flat, …)` in WGSL. By @ErichDonGubler in [#6181](https://github.com/gfx-rs/wgpu/pull/6181).
 - Support for more atomic ops in the SPIR-V frontend. By @schell in [#5824](https://github.com/gfx-rs/wgpu/pull/5824).
+- Support pipeline overrides in WGSL backend. By @cbbowen in [#6310](https://github.com/gfx-rs/wgpu/pull/6310).
 
 #### General
 

--- a/naga/src/proc/namer.rs
+++ b/naga/src/proc/namer.rs
@@ -8,6 +8,7 @@ const SEPARATOR: char = '_';
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub enum NameKey {
     Constant(Handle<crate::Constant>),
+    Override(Handle<crate::Override>),
     GlobalVariable(Handle<crate::GlobalVariable>),
     Type(Handle<crate::Type>),
     StructMember(Handle<crate::Type>, u32),

--- a/naga/tests/out/wgsl/overrides.wgsl
+++ b/naga/tests/out/wgsl/overrides.wgsl
@@ -1,0 +1,24 @@
+@id(0) override has_point_light: bool = true;
+@id(1200) override specular_param: f32 = 2.3f;
+@id(1300) override gain: f32;
+override width: f32 = 0f;
+override depth: f32;
+override height: f32 = (2f * depth);
+override inferred_f32_: f32 = 2.718f;
+
+var<private> gain_x_10_: f32 = (gain * 10f);
+var<private> store_override: f32;
+
+@compute @workgroup_size(1, 1, 1) 
+fn main() {
+    var t: f32 = (height * 5f);
+    var x: bool;
+    var gain_x_100_: f32;
+
+    let a = !(has_point_light);
+    x = a;
+    let _e7 = gain_x_10_;
+    gain_x_100_ = (_e7 * 10f);
+    store_override = gain;
+    return;
+}

--- a/naga/tests/snapshots.rs
+++ b/naga/tests/snapshots.rs
@@ -913,7 +913,8 @@ fn convert_wgsl() {
                 | Targets::SPIRV
                 | Targets::METAL
                 | Targets::HLSL
-                | Targets::GLSL,
+                | Targets::GLSL
+                | Targets::WGSL,
         ),
         (
             "overrides-atomicCompareExchangeWeak",


### PR DESCRIPTION
**Connections**
#4484

**Description**
The WGSL backend currently does not support pipeline overrides (i.e. `override foo: f32`). These are included in the [latest WGSL spec](https://www.w3.org/TR/WGSL/#override-declaration), this PR adds support for them by:
1. Generating appropriate `override` declarations in `wgsl::Writer`.
2. Handling `Override` expressions in `wgsl::Writer`.
3. Handling `Unary` and `Binary` constant expressions in `wgsl::Writer`.

This last step was necessary because the existing "overrides" snapshot test exercises the functionality, but it isn't currently implemented for the WGSL backend.

**Testing**
The first commit in this PR enables the existing "overrides" snapshot tests for the WGSL target which I verified fails. The following commits update the backend such that it passes and generates semantically equivalent WGSL to the input.

Ran:
```
cargo test --all-features
cargo xtask validate wgsl
```

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
