### PR TITLE
Only Initialize a Single Backend in Tests

### DIFF
--- a/tests/src/report.rs
+++ b/tests/src/report.rs
@@ -25,8 +25,8 @@ impl GpuReport {
 /// A single report of the capabilities of an Adapter.
 ///
 /// Must be synchronized with the definition on wgpu-info/src/report.rs.
-#[derive(Deserialize)]
-pub(crate) struct AdapterReport {
+#[derive(Deserialize, Clone)]
+pub struct AdapterReport {
     pub info: AdapterInfo,
     pub features: Features,
     pub limits: Limits,

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -24,14 +24,14 @@ pub struct TestingContext {
     pub queue: Queue,
 }
 
-/// Execute the given test configuration with the given adapter index.
+/// Execute the given test configuration with the given adapter report.
 ///
 /// If test_info is specified, will use the information whether to skip the test.
 /// If it is not, we'll create the test info from the adapter itself.
 pub async fn execute_test(
+    adapter_report: Option<&AdapterReport>,
     config: GpuTestConfiguration,
     test_info: Option<TestInfo>,
-    adapter_index: usize,
 ) {
     // If we get information externally, skip based on that information before we do anything.
     if let Some(TestInfo { skip: true, .. }) = test_info {
@@ -43,7 +43,7 @@ pub async fn execute_test(
     let _test_guard = isolation::OneTestPerProcessGuard::new();
 
     let (instance, adapter, _surface_guard) =
-        initialize_adapter(adapter_index, config.params.force_fxc).await;
+        initialize_adapter(adapter_report, config.params.force_fxc).await;
 
     let adapter_info = adapter.get_info();
     let adapter_downlevel_capabilities = adapter.get_downlevel_capabilities();

--- a/tests/tests/create_surface_error.rs
+++ b/tests/tests/create_surface_error.rs
@@ -6,7 +6,7 @@
 #[wasm_bindgen_test::wasm_bindgen_test]
 fn canvas_get_context_returned_null() {
     // Not using the normal testing infrastructure because that goes straight to creating the canvas for us.
-    let instance = wgpu_test::initialize_instance(false);
+    let instance = wgpu_test::initialize_instance(wgpu::Backends::GL, false);
     // Create canvas
     let canvas = wgpu_test::initialize_html_canvas();
 

--- a/tests/tests/create_surface_error.rs
+++ b/tests/tests/create_surface_error.rs
@@ -6,7 +6,7 @@
 #[wasm_bindgen_test::wasm_bindgen_test]
 fn canvas_get_context_returned_null() {
     // Not using the normal testing infrastructure because that goes straight to creating the canvas for us.
-    let instance = wgpu_test::initialize_instance(wgpu::Backends::GL, false);
+    let instance = wgpu_test::initialize_instance(wgpu::Backends::all(), false);
     // Create canvas
     let canvas = wgpu_test::initialize_html_canvas();
 

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -87,7 +87,7 @@ static REQUEST_DEVICE_ERROR_MESSAGE_NATIVE: GpuTestConfiguration =
 async fn request_device_error_message() {
     // Not using initialize_test() because that doesn't let us catch the error
     // nor .await anything
-    let (_instance, adapter, _surface_guard) = wgpu_test::initialize_adapter(0, false).await;
+    let (_instance, adapter, _surface_guard) = wgpu_test::initialize_adapter(None, false).await;
 
     let device_error = adapter
         .request_device(

--- a/wgpu-macros/src/lib.rs
+++ b/wgpu-macros/src/lib.rs
@@ -37,7 +37,7 @@ pub fn gpu_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
             // Allow any type that can be converted to a GpuTestConfiguration
             let test_config = ::wgpu_test::GpuTestConfiguration::from(#expr).name_from_init_function_typename::<S>(#ident_lower);
 
-            ::wgpu_test::execute_test(test_config, None, 0).await;
+            ::wgpu_test::execute_test(None, test_config, None).await;
         }
     }
     .into()


### PR DESCRIPTION
Changes tests from matching on a strict adapter index to matching on the full adpater info.

This lets us only initialize the backends that are needed to find that particular adapter, providing massive speed gains, and allows `WGPU_BACKEND` to work again. 

This brings the test suite from 130s to 100s on my machine.

If I limit to only the vulkan backend, it brings the vulkan tests from 55s -> 35s. 

Pretty snazzy.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
