### PR TITLE
[naga] Remove redundant handle ordering check from validator.

### DIFF
--- a/naga/src/valid/type.rs
+++ b/naga/src/valid/type.rs
@@ -664,9 +664,6 @@ impl super::Validator {
                 )
             }
             Ti::BindingArray { base, size } => {
-                if base >= handle {
-                    return Err(TypeError::InvalidArrayBaseType(base));
-                }
                 let type_info_mask = match size {
                     crate::ArraySize::Constant(_) => TypeFlags::SIZED | TypeFlags::HOST_SHAREABLE,
                     crate::ArraySize::Dynamic => {


### PR DESCRIPTION
`Validator::validate_module_handles` already ensures that types refer only to other types appearing earlier in the arena than themselves, so this check in `Validator::validate_type` is redundant.
