### PR TITLE
metal: fix query set result copies

### DIFF
--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -490,7 +490,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
             wgt::QueryType::Timestamp => {
                 encoder.resolve_counters(
                     set.counter_sample_buffer.as_ref().unwrap(),
-                    metal::NSRange::new(range.start as u64, range.end as u64),
+                    metal::NSRange::new(range.start as u64, (range.end - range.start) as u64),
                     &buffer.raw,
                     offset,
                 );


### PR DESCRIPTION
**Connections**
Just a drive-by fix

**Description**
The NSRange expects length, not end element. See https://github.com/gfx-rs/metal-rs/blob/9bbe74b1d3706e46ddf41bc8aad58ee74b0bf844/src/lib.rs#L51

**Testing**
Untested

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
