### PR TITLE
[naga] Permit only structs as binding array elements.

### DIFF
--- a/naga/src/valid/type.rs
+++ b/naga/src/valid/type.rs
@@ -680,7 +680,6 @@ impl super::Validator {
                     // Currently Naga only supports binding arrays of structs for non-handle types.
                     match gctx.types[base].inner {
                         crate::TypeInner::Struct { .. } => {}
-                        crate::TypeInner::Array { .. } => {}
                         _ => return Err(TypeError::BindingArrayBaseTypeNotStruct(base)),
                     };
                 }


### PR DESCRIPTION
Require `T` to be a struct in `binding_array<T, ...>`; do not permit arrays.

In #5428, the validator was changed to accept binding array types that the SPIR-V backend couldn't properly emit. Specifically, the validator was changed to accept `binding_array<array<T>>`, but the SPIR-V backend wasn't changed to wrap the binding array elements in a SPIR-V struct type, as Vulkan requires. So the type would be accepted by the validator, and then rejected by the backend.
