### PR TITLE
[naga spv-out] Document and refactor `write_runtime_array_length`.

### DIFF
--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -200,10 +200,7 @@ impl<'w> BlockContext<'w> {
     fn is_intermediate(&self, expr_handle: Handle<crate::Expression>) -> bool {
         match self.ir_function.expressions[expr_handle] {
             crate::Expression::GlobalVariable(handle) => {
-                match self.ir_module.global_variables[handle].space {
-                    crate::AddressSpace::Handle => false,
-                    _ => true,
-                }
+                self.ir_module.global_variables[handle].space != crate::AddressSpace::Handle
             }
             crate::Expression::LocalVariable(_) => true,
             crate::Expression::FunctionArgument(index) => {

--- a/naga/src/back/spv/helpers.rs
+++ b/naga/src/back/spv/helpers.rs
@@ -85,7 +85,7 @@ impl crate::AddressSpace {
 
 /// Return true if the global requires a type decorated with `Block`.
 ///
-/// Vulkan spec v1.3 §15.6.2, "Descriptor Set Interface", says:
+/// In the Vulkan spec 1.3.296, the section [Descriptor Set Interface][dsi] says:
 ///
 /// > Variables identified with the `Uniform` storage class are used to
 /// > access transparent buffer backed resources. Such variables must
@@ -98,6 +98,8 @@ impl crate::AddressSpace {
 /// > -   laid out explicitly using the `Offset`, `ArrayStride`, and
 /// >     `MatrixStride` decorations as specified in §15.6.4, "Offset
 /// >     and Stride Assignment."
+///
+/// [dsi]: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-descset
 // See `back::spv::GlobalVariable::access_id` for details.
 pub fn global_needs_wrapper(ir_module: &crate::Module, var: &crate::GlobalVariable) -> bool {
     match var.space {


### PR DESCRIPTION
* Document and refactor `naga::back::spv::BlockContext::write_runtime_array_length`.

  Don't try to handle finding the length of a particular element of a `binding_array<array<T>>`. The SPIR-V backend doesn't wrap that type correctly anyway; #6333 changes the validator to forbid such types. Instead, assume that the elements of a `binding_array<T>` are always structs whose final members may be a runtime-sized array.

  Pull out consistency checks after the analysis of the array expression, so that we always carry out all the checks regardless of what path we took to produce the information.

* Update Vulkan spec section number, and provide link.

* Replace `match` with equivalent `!=`.
