### PR TITLE
Fix unaligned slice::from_raw_parts in gles push contant handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 #### GLES / OpenGL
 
 - Fix GL debug message callbacks not being properly cleaned up (causing UB). By @Imberflur in [#6114](https://github.com/gfx-rs/wgpu/pull/6114)
+- Fix calling `slice::from_raw_parts` with unaligned pointers in push constant handling. By @Imberflur in [#6341](https://github.com/gfx-rs/wgpu/pull/6341)
 
 #### WebGPU
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,6 +3681,7 @@ dependencies = [
  "bit-set",
  "bitflags 2.6.0",
  "block",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "core-graphics-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ arrayvec = "0.7"
 bincode = "1"
 bit-vec = "0.8"
 bitflags = "2.6"
-bytemuck = { version = "1.18", features = ["derive"] }
+bytemuck = { version = "1.18" }
 cfg_aliases = "0.1"
 cfg-if = "1"
 criterion = "0.5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,7 +29,7 @@ webgl = ["wgpu/webgl"]
 webgpu = ["wgpu/webgpu"]
 
 [dependencies]
-bytemuck.workspace = true
+bytemuck = { workspace = true, features = ["derive"] }
 cfg-if.workspace = true
 encase = { workspace = true, features = ["glam"] }
 flume.workspace = true

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -56,6 +56,7 @@ vulkan = [
 ]
 gles = [
     "naga/glsl-out",
+    "dep:bytemuck",
     "dep:glow",
     "dep:glutin_wgl_sys",
     "dep:khronos-egl",
@@ -126,6 +127,7 @@ rustc-hash.workspace = true
 log.workspace = true
 
 # backend: Gles
+bytemuck = { workspace = true, optional = true }
 glow = { workspace = true, optional = true }
 
 [dependencies.wgt]


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/6327

**Description**

Fixes calling `slice::from_raw_parts` with an unaligned pointer by using `bytemuck::pod_read_unaligned` instead (which copies the value to the stack). I assume this is fine for values of the sizes used in push constants. If it seems useful to try to avoid this, then the push constants need to be stored aligned instead (actually looking at this, it would probably be easy to make `CommandBuffer::add_push_constant_data` include some padding to align the data).

This adds a new dependency on `bytemuck` in `wgpu-hal`. I don't know whether adding this is acceptable (e.g. for firefox).

**Testing**

I updated to a recent rustc nightly (`rustc 1.83.0-nightly (2bd1e894e 2024-09-26)`) and used `rustup override set nightly` followed by `cargo xtask test` on a linux system where the gles backend is present.

Before the fix I saw panics from new debug assertions in `slice::from_raw_parts` with these tests:
* `wgpu_test::regression::issue_3349::multi_stage_data_binding`
* `wgpu_test::shader::struct_layout::push_constant_input`

After the fix these test no longer panic.

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
