### PR TITLE
Update `cfg_aliases` in order to fix  unexpected cfg condition warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "cgl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,7 +1331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746"
 dependencies = [
  "bitflags 2.6.0",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "cgl",
  "core-foundation",
  "dispatch",
@@ -1347,7 +1353,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "glutin",
  "raw-window-handle 0.5.2",
  "winit",
@@ -1875,7 +1881,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.6.0",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "codespan-reporting",
  "diff",
  "env_logger",
@@ -3578,7 +3584,7 @@ name = "wgpu"
 version = "22.0.0"
 dependencies = [
  "arrayvec",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "document-features",
  "js-sys",
  "log",
@@ -3622,7 +3628,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.6.0",
  "bytemuck",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "document-features",
  "indexmap",
  "log",
@@ -3682,7 +3688,7 @@ dependencies = [
  "bitflags 2.6.0",
  "block",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "core-graphics-types",
  "env_logger",
  "glam",
@@ -4122,7 +4128,7 @@ dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
  "calloop",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "core-foundation",
  "core-graphics",
  "cursor-icon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ bincode = "1"
 bit-vec = "0.8"
 bitflags = "2.6"
 bytemuck = { version = "1.18", features = ["derive"] }
-cfg_aliases = "0.1"
+cfg_aliases = "0.2.1"
 cfg-if = "1"
 criterion = "0.5"
 codespan-reporting = "0.11"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -29,6 +29,11 @@ targets = [
 # Cargo machete can't check build.rs dependencies. See https://github.com/bnjbvr/cargo-machete/issues/100
 ignored = ["cfg_aliases"]
 
+[lints.rust]
+# The `wgpu_validate_locks` config is supposed to be set via `RUSTFLAGS='--cfg wgpu_validate_locks'`
+# If set, `wgpu-core` uses the [`ranked`] module's locks. We hope to make this the default for debug builds soon.
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(wgpu_validate_locks)'] }
+
 [lib]
 
 [features]


### PR DESCRIPTION
**Connections**
* fixes https://github.com/gfx-rs/wgpu/issues/6347

**Description**
(title)

**Testing**
run `cargo clippy` with deleted rust-toolchain.toml file
-> Turns out we do have one condition that needs to be ignored, `wgpu_validate_locks` (cc: @jimblandy )

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
