### PR TITLE
Unbreak `rustfmt` in some places

### DIFF
--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -14,7 +14,10 @@ use thiserror::Error;
 pub enum PipelineConstantError {
     #[error("Missing value for pipeline-overridable constant with identifier string: '{0}'")]
     MissingValue(String),
-    #[error("Source f64 value needs to be finite (NaNs and Inifinites are not allowed) for number destinations")]
+    #[error(
+        "Source f64 value needs to be finite ({}) for number destinations",
+        "NaNs and Inifinites are not allowed"
+    )]
     SrcNeedsToBeFinite,
     #[error("Source f64 value doesn't fit in destination")]
     DstRangeTooSmall,

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -630,7 +630,8 @@ impl<'a> Context<'a> {
                             frontend.errors.push(Error {
                                 kind: ErrorKind::SemanticError(
                                     format!(
-                                        "Cannot apply operation to {left_inner:?} and {right_inner:?}"
+                                        "Cannot apply operation to {:?} and {:?}",
+                                        left_inner, right_inner
                                     )
                                     .into(),
                                 ),
@@ -828,7 +829,8 @@ impl<'a> Context<'a> {
                             frontend.errors.push(Error {
                                 kind: ErrorKind::SemanticError(
                                     format!(
-                                        "Cannot apply operation to {left_inner:?} and {right_inner:?}"
+                                        "Cannot apply operation to {:?} and {:?}",
+                                        left_inner, right_inner
                                     )
                                     .into(),
                                 ),
@@ -908,7 +910,8 @@ impl<'a> Context<'a> {
                             frontend.errors.push(Error {
                                 kind: ErrorKind::SemanticError(
                                     format!(
-                                        "Cannot apply operation to {left_inner:?} and {right_inner:?}"
+                                        "Cannot apply operation to {:?} and {:?}",
+                                        left_inner, right_inner
                                     )
                                     .into(),
                                 ),

--- a/naga/src/front/glsl/functions.rs
+++ b/naga/src/front/glsl/functions.rs
@@ -634,7 +634,8 @@ impl Frontend {
                         self.errors.push(Error {
                             kind: ErrorKind::SemanticError(
                                 format!(
-                                    "'{name}': image needs {overload_access:?} access but only {call_access:?} was provided"
+                                    "'{}': image needs {:?} access but only {:?} was provided",
+                                    name, overload_access, call_access
                                 )
                                 .into(),
                             ),

--- a/naga/src/front/glsl/parser/expressions.rs
+++ b/naga/src/front/glsl/parser/expressions.rs
@@ -38,7 +38,13 @@ impl<'source> ParsingContext<'source> {
             TokenValue::FloatConstant(float) => {
                 if float.width != 32 {
                     frontend.errors.push(Error {
-                        kind: ErrorKind::SemanticError("Unsupported floating-point value (expected single-precision floating-point number)".into()),
+                        kind: ErrorKind::SemanticError(
+                            concat!(
+                                "Unsupported floating-point value ",
+                                "(expected single-precision floating-point number)"
+                            )
+                            .into(),
+                        ),
                         meta: token.meta,
                     });
                 }

--- a/naga/src/front/glsl/variables.rs
+++ b/naga/src/front/glsl/variables.rs
@@ -294,14 +294,17 @@ impl Frontend {
                             .any(|i| components[i..].contains(&components[i - 1]));
                         if not_unique {
                             self.errors.push(Error {
-                                kind:
-                                ErrorKind::SemanticError(
-                                format!(
-                                    "swizzle cannot have duplicate components in left-hand-side expression for \"{name:?}\""
-                                )
-                                .into(),
-                            ),
-                                meta ,
+                                kind: ErrorKind::SemanticError(
+                                    format!(
+                                        concat!(
+                                            "swizzle cannot have duplicate components in ",
+                                            "left-hand-side expression for \"{:?}\""
+                                        ),
+                                        name
+                                    )
+                                    .into(),
+                                ),
+                                meta,
                             })
                         }
                     }

--- a/naga/src/front/spv/error.rs
+++ b/naga/src/front/spv/error.rs
@@ -47,7 +47,13 @@ pub enum Error {
     UnsupportedBinaryOperator(spirv::Word),
     #[error("Naga supports OpTypeRuntimeArray in the StorageBuffer storage class only")]
     UnsupportedRuntimeArrayStorageClass,
-    #[error("unsupported matrix stride {stride} for a {columns}x{rows} matrix with scalar width={width}")]
+    #[error(
+        "unsupported matrix stride {} for a {}x{} matrix with scalar width={}",
+        stride,
+        columns,
+        rows,
+        width
+    )]
     UnsupportedMatrixStride {
         stride: u32,
         columns: u8,

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -298,32 +298,42 @@ impl<'a> Error<'a> {
         match *self {
             Error::Unexpected(unexpected_span, expected) => {
                 let expected_str = match expected {
-                    ExpectedToken::Token(token) => {
-                        match token {
-                            Token::Separator(c) => format!("'{c}'"),
-                            Token::Paren(c) => format!("'{c}'"),
-                            Token::Attribute => "@".to_string(),
-                            Token::Number(_) => "number".to_string(),
-                            Token::Word(s) => s.to_string(),
-                            Token::Operation(c) => format!("operation ('{c}')"),
-                            Token::LogicalOperation(c) => format!("logical operation ('{c}')"),
-                            Token::ShiftOperation(c) => format!("bitshift ('{c}{c}')"),
-                            Token::AssignmentOperation(c) if c=='<' || c=='>' => format!("bitshift ('{c}{c}=')"),
-                            Token::AssignmentOperation(c) => format!("operation ('{c}=')"),
-                            Token::IncrementOperation => "increment operation".to_string(),
-                            Token::DecrementOperation => "decrement operation".to_string(),
-                            Token::Arrow => "->".to_string(),
-                            Token::Unknown(c) => format!("unknown ('{c}')"),
-                            Token::Trivia => "trivia".to_string(),
-                            Token::End => "end".to_string(),
+                    ExpectedToken::Token(token) => match token {
+                        Token::Separator(c) => format!("'{c}'"),
+                        Token::Paren(c) => format!("'{c}'"),
+                        Token::Attribute => "@".to_string(),
+                        Token::Number(_) => "number".to_string(),
+                        Token::Word(s) => s.to_string(),
+                        Token::Operation(c) => format!("operation ('{c}')"),
+                        Token::LogicalOperation(c) => format!("logical operation ('{c}')"),
+                        Token::ShiftOperation(c) => format!("bitshift ('{c}{c}')"),
+                        Token::AssignmentOperation(c) if c == '<' || c == '>' => {
+                            format!("bitshift ('{c}{c}=')")
                         }
-                    }
+                        Token::AssignmentOperation(c) => format!("operation ('{c}=')"),
+                        Token::IncrementOperation => "increment operation".to_string(),
+                        Token::DecrementOperation => "decrement operation".to_string(),
+                        Token::Arrow => "->".to_string(),
+                        Token::Unknown(c) => format!("unknown ('{c}')"),
+                        Token::Trivia => "trivia".to_string(),
+                        Token::End => "end".to_string(),
+                    },
                     ExpectedToken::Identifier => "identifier".to_string(),
                     ExpectedToken::PrimaryExpression => "expression".to_string(),
                     ExpectedToken::Assignment => "assignment or increment/decrement".to_string(),
-                    ExpectedToken::SwitchItem => "switch item ('case' or 'default') or a closing curly bracket to signify the end of the switch statement ('}')".to_string(),
-                    ExpectedToken::WorkgroupSizeSeparator => "workgroup size separator (',') or a closing parenthesis".to_string(),
-                    ExpectedToken::GlobalItem => "global item ('struct', 'const', 'var', 'alias', ';', 'fn') or the end of the file".to_string(),
+                    ExpectedToken::SwitchItem => concat!(
+                        "switch item ('case' or 'default') or a closing curly bracket ",
+                        "to signify the end of the switch statement ('}')"
+                    )
+                    .to_string(),
+                    ExpectedToken::WorkgroupSizeSeparator => {
+                        "workgroup size separator (',') or a closing parenthesis".to_string()
+                    }
+                    ExpectedToken::GlobalItem => concat!(
+                        "global item ('struct', 'const', 'var', 'alias', ';', 'fn') ",
+                        "or the end of the file"
+                    )
+                    .to_string(),
                     ExpectedToken::Type => "type".to_string(),
                     ExpectedToken::Variable => "variable access".to_string(),
                     ExpectedToken::Function => "function name".to_string(),
@@ -384,9 +394,11 @@ impl<'a> Error<'a> {
                 notes: vec![],
             },
             Error::BadIncrDecrReferenceType(span) => ParseError {
-                message:
-                    "increment/decrement operation requires reference type to be one of i32 or u32"
-                        .to_string(),
+                message: concat!(
+                    "increment/decrement operation requires ",
+                    "reference type to be one of i32 or u32"
+                )
+                .to_string(),
                 labels: vec![(span, "must be a reference type of i32 or u32".into())],
                 notes: vec![],
             },
@@ -527,25 +539,24 @@ impl<'a> Error<'a> {
                 labels: vec![(span, "type can't be inferred".into())],
                 notes: vec![],
             },
-            Error::InitializationTypeMismatch { name, ref expected, ref got } => {
-                ParseError {
-                    message: format!(
-                        "the type of `{}` is expected to be `{}`, but got `{}`",
-                        &source[name], expected, got,
-                    ),
-                    labels: vec![(
-                        name,
-                        format!("definition of `{}`", &source[name]).into(),
-                    )],
-                    notes: vec![],
-                }
-            }
+            Error::InitializationTypeMismatch {
+                name,
+                ref expected,
+                ref got,
+            } => ParseError {
+                message: format!(
+                    "the type of `{}` is expected to be `{}`, but got `{}`",
+                    &source[name], expected, got,
+                ),
+                labels: vec![(name, format!("definition of `{}`", &source[name]).into())],
+                notes: vec![],
+            },
             Error::DeclMissingTypeAndInit(name_span) => ParseError {
-                message: format!("declaration of `{}` needs a type specifier or initializer", &source[name_span]),
-                labels: vec![(
-                    name_span,
-                    "needs a type specifier or initializer".into(),
-                )],
+                message: format!(
+                    "declaration of `{}` needs a type specifier or initializer",
+                    &source[name_span]
+                ),
+                labels: vec![(name_span, "needs a type specifier or initializer".into())],
                 notes: vec![],
             },
             Error::MissingAttribute(name, name_span) => ParseError {
@@ -725,7 +736,11 @@ impl<'a> Error<'a> {
                 notes: vec![message.into()],
             },
             Error::ExpectedConstExprConcreteIntegerScalar(span) => ParseError {
-                message: "must be a const-expression that resolves to a concrete integer scalar (u32 or i32)".to_string(),
+                message: concat!(
+                    "must be a const-expression that ",
+                    "resolves to a concrete integer scalar (u32 or i32)"
+                )
+                .to_string(),
                 labels: vec![(span, "must resolve to u32 or i32".into())],
                 notes: vec![],
             },
@@ -754,9 +769,17 @@ impl<'a> Error<'a> {
             },
             Error::AutoConversion(ref error) => {
                 // destructuring ensures all fields are handled
-                let AutoConversionError { dest_span, ref dest_type, source_span, ref source_type } = **error;
+                let AutoConversionError {
+                    dest_span,
+                    ref dest_type,
+                    source_span,
+                    ref source_type,
+                } = **error;
                 ParseError {
-                    message: format!("automatic conversions cannot convert `{source_type}` to `{dest_type}`"),
+                    message: format!(
+                        "automatic conversions cannot convert `{}` to `{}`",
+                        source_type, dest_type
+                    ),
                     labels: vec![
                         (
                             dest_span,
@@ -765,72 +788,77 @@ impl<'a> Error<'a> {
                         (
                             source_span,
                             format!("this expression has type {source_type}").into(),
-                        )
+                        ),
                     ],
                     notes: vec![],
                 }
-            },
+            }
             Error::AutoConversionLeafScalar(ref error) => {
-                let AutoConversionLeafScalarError { dest_span, ref dest_scalar, source_span, ref source_type } = **error;
+                let AutoConversionLeafScalarError {
+                    dest_span,
+                    ref dest_scalar,
+                    source_span,
+                    ref source_type,
+                } = **error;
                 ParseError {
-                    message: format!("automatic conversions cannot convert elements of `{source_type}` to `{dest_scalar}`"),
+                    message: format!(
+                        "automatic conversions cannot convert elements of `{}` to `{}`",
+                        source_type, dest_scalar
+                    ),
                     labels: vec![
                         (
                             dest_span,
-                            format!("a value with elements of type {dest_scalar} is required here").into(),
+                            format!(
+                                "a value with elements of type {} is required here",
+                                dest_scalar
+                            )
+                            .into(),
                         ),
                         (
                             source_span,
                             format!("this expression has type {source_type}").into(),
-                        )
+                        ),
                     ],
                     notes: vec![],
                 }
-            },
+            }
             Error::ConcretizationFailed(ref error) => {
-                let ConcretizationFailedError { expr_span, ref expr_type, ref scalar, ref inner } = **error;
+                let ConcretizationFailedError {
+                    expr_span,
+                    ref expr_type,
+                    ref scalar,
+                    ref inner,
+                } = **error;
                 ParseError {
                     message: format!("failed to convert expression to a concrete type: {inner}"),
-                    labels: vec![
-                        (
-                            expr_span,
-                            format!("this expression has type {expr_type}").into(),
-                        )
-                    ],
-                    notes: vec![
-                        format!("the expression should have been converted to have {} scalar type", scalar),
-                    ]
+                    labels: vec![(
+                        expr_span,
+                        format!("this expression has type {expr_type}").into(),
+                    )],
+                    notes: vec![format!(
+                        "the expression should have been converted to have {} scalar type",
+                        scalar
+                    )],
                 }
-            },
+            }
             Error::ExceededLimitForNestedBraces { span, limit } => ParseError {
                 message: "brace nesting limit reached".into(),
                 labels: vec![(span, "limit reached at this brace".into())],
-                notes: vec![
-                    format!("nesting limit is currently set to {limit}"),
-                ],
+                notes: vec![format!("nesting limit is currently set to {limit}")],
             },
             Error::PipelineConstantIDValue(span) => ParseError {
                 message: "pipeline constant ID must be between 0 and 65535 inclusive".to_string(),
-                labels: vec![(
-                    span,
-                    "must be between 0 and 65535 inclusive".into(),
-                )],
+                labels: vec![(span, "must be between 0 and 65535 inclusive".into())],
                 notes: vec![],
             },
             Error::NotBool(span) => ParseError {
                 message: "must be a const-expression that resolves to a bool".to_string(),
-                labels: vec![(
-                    span,
-                    "must resolve to bool".into(),
-                )],
+                labels: vec![(span, "must resolve to bool".into())],
                 notes: vec![],
             },
             Error::ConstAssertFailed(span) => ParseError {
                 message: "const_assert failure".to_string(),
-                labels: vec![(
-                    span,
-                    "evaluates to false".into(),
-                )],
+                labels: vec![(span, "evaluates to false".into())],
                 notes: vec![],
             },
         }

--- a/naga/src/proc/typifier.rs
+++ b/naga/src/proc/typifier.rs
@@ -631,41 +631,37 @@ impl<'a> ResolveContext<'a> {
                 use crate::MathFunction as Mf;
                 let res_arg = past(arg)?;
                 match fun {
-                    // comparison
-                    Mf::Abs |
-                    Mf::Min |
-                    Mf::Max |
-                    Mf::Clamp |
-                    Mf::Saturate |
-                    // trigonometry
-                    Mf::Cos |
-                    Mf::Cosh |
-                    Mf::Sin |
-                    Mf::Sinh |
-                    Mf::Tan |
-                    Mf::Tanh |
-                    Mf::Acos |
-                    Mf::Asin |
-                    Mf::Atan |
-                    Mf::Atan2 |
-                    Mf::Asinh |
-                    Mf::Acosh |
-                    Mf::Atanh |
-                    Mf::Radians |
-                    Mf::Degrees |
-                    // decomposition
-                    Mf::Ceil |
-                    Mf::Floor |
-                    Mf::Round |
-                    Mf::Fract |
-                    Mf::Trunc |
-                    Mf::Ldexp |
-                    // exponent
-                    Mf::Exp |
-                    Mf::Exp2 |
-                    Mf::Log |
-                    Mf::Log2 |
-                    Mf::Pow => res_arg.clone(),
+                    Mf::Abs
+                    | Mf::Min
+                    | Mf::Max
+                    | Mf::Clamp
+                    | Mf::Saturate
+                    | Mf::Cos
+                    | Mf::Cosh
+                    | Mf::Sin
+                    | Mf::Sinh
+                    | Mf::Tan
+                    | Mf::Tanh
+                    | Mf::Acos
+                    | Mf::Asin
+                    | Mf::Atan
+                    | Mf::Atan2
+                    | Mf::Asinh
+                    | Mf::Acosh
+                    | Mf::Atanh
+                    | Mf::Radians
+                    | Mf::Degrees
+                    | Mf::Ceil
+                    | Mf::Floor
+                    | Mf::Round
+                    | Mf::Fract
+                    | Mf::Trunc
+                    | Mf::Ldexp
+                    | Mf::Exp
+                    | Mf::Exp2
+                    | Mf::Log
+                    | Mf::Log2
+                    | Mf::Pow => res_arg.clone(),
                     Mf::Modf | Mf::Frexp => {
                         let (size, width) = match res_arg.inner_with(types) {
                             &Ti::Scalar(crate::Scalar {
@@ -673,77 +669,81 @@ impl<'a> ResolveContext<'a> {
                                 width,
                             }) => (None, width),
                             &Ti::Vector {
-                                scalar: crate::Scalar {
-                                    kind: crate::ScalarKind::Float,
-                                    width,
-                                },
+                                scalar:
+                                    crate::Scalar {
+                                        kind: crate::ScalarKind::Float,
+                                        width,
+                                    },
                                 size,
                             } => (Some(size), width),
-                            ref other =>
-                                return Err(ResolveError::IncompatibleOperands(format!("{fun:?}({other:?}, _)")))
+                            ref other => {
+                                return Err(ResolveError::IncompatibleOperands(format!(
+                                    "{fun:?}({other:?}, _)"
+                                )))
+                            }
                         };
                         let result = self
-                        .special_types
-                        .predeclared_types
-                        .get(&if fun == Mf::Modf {
-                            crate::PredeclaredType::ModfResult { size, width }
-                    } else {
-                            crate::PredeclaredType::FrexpResult { size, width }
-                    })
-                        .ok_or(ResolveError::MissingSpecialType)?;
+                            .special_types
+                            .predeclared_types
+                            .get(&if fun == Mf::Modf {
+                                crate::PredeclaredType::ModfResult { size, width }
+                            } else {
+                                crate::PredeclaredType::FrexpResult { size, width }
+                            })
+                            .ok_or(ResolveError::MissingSpecialType)?;
                         TypeResolution::Handle(*result)
-                    },
-                    // geometry
+                    }
                     Mf::Dot => match *res_arg.inner_with(types) {
-                        Ti::Vector {
-                            size: _,
-                            scalar,
-                        } => TypeResolution::Value(Ti::Scalar(scalar)),
-                        ref other =>
-                            return Err(ResolveError::IncompatibleOperands(
-                                format!("{fun:?}({other:?}, _)")
-                            )),
+                        Ti::Vector { size: _, scalar } => TypeResolution::Value(Ti::Scalar(scalar)),
+                        ref other => {
+                            return Err(ResolveError::IncompatibleOperands(format!(
+                                "{fun:?}({other:?}, _)"
+                            )))
+                        }
                     },
                     Mf::Outer => {
-                        let arg1 = arg1.ok_or_else(|| ResolveError::IncompatibleOperands(
-                            format!("{fun:?}(_, None)")
-                        ))?;
+                        let arg1 = arg1.ok_or_else(|| {
+                            ResolveError::IncompatibleOperands(format!("{fun:?}(_, None)"))
+                        })?;
                         match (res_arg.inner_with(types), past(arg1)?.inner_with(types)) {
                             (
-                                &Ti::Vector { size: columns, scalar },
-                                &Ti::Vector{ size: rows, .. }
+                                &Ti::Vector {
+                                    size: columns,
+                                    scalar,
+                                },
+                                &Ti::Vector { size: rows, .. },
                             ) => TypeResolution::Value(Ti::Matrix {
                                 columns,
                                 rows,
                                 scalar,
                             }),
-                            (left, right) =>
-                                return Err(ResolveError::IncompatibleOperands(
-                                    format!("{fun:?}({left:?}, {right:?})")
-                                )),
+                            (left, right) => {
+                                return Err(ResolveError::IncompatibleOperands(format!(
+                                    "{fun:?}({left:?}, {right:?})"
+                                )))
+                            }
+                        }
+                    }
+                    Mf::Cross => res_arg.clone(),
+                    Mf::Distance | Mf::Length => match *res_arg.inner_with(types) {
+                        Ti::Scalar(scalar) | Ti::Vector { scalar, size: _ } => {
+                            TypeResolution::Value(Ti::Scalar(scalar))
+                        }
+                        ref other => {
+                            return Err(ResolveError::IncompatibleOperands(format!(
+                                "{fun:?}({other:?})"
+                            )))
                         }
                     },
-                    Mf::Cross => res_arg.clone(),
-                    Mf::Distance |
-                    Mf::Length => match *res_arg.inner_with(types) {
-                        Ti::Scalar(scalar) |
-                        Ti::Vector {scalar,size:_} => TypeResolution::Value(Ti::Scalar(scalar)),
-                        ref other => return Err(ResolveError::IncompatibleOperands(
-                                format!("{fun:?}({other:?})")
-                            )),
-                    },
-                    Mf::Normalize |
-                    Mf::FaceForward |
-                    Mf::Reflect |
-                    Mf::Refract => res_arg.clone(),
+                    Mf::Normalize | Mf::FaceForward | Mf::Reflect | Mf::Refract => res_arg.clone(),
                     // computational
-                    Mf::Sign |
-                    Mf::Fma |
-                    Mf::Mix |
-                    Mf::Step |
-                    Mf::SmoothStep |
-                    Mf::Sqrt |
-                    Mf::InverseSqrt => res_arg.clone(),
+                    Mf::Sign
+                    | Mf::Fma
+                    | Mf::Mix
+                    | Mf::Step
+                    | Mf::SmoothStep
+                    | Mf::Sqrt
+                    | Mf::InverseSqrt => res_arg.clone(),
                     Mf::Transpose => match *res_arg.inner_with(types) {
                         Ti::Matrix {
                             columns,
@@ -754,9 +754,11 @@ impl<'a> ResolveContext<'a> {
                             rows: columns,
                             scalar,
                         }),
-                        ref other => return Err(ResolveError::IncompatibleOperands(
-                            format!("{fun:?}({other:?})")
-                        )),
+                        ref other => {
+                            return Err(ResolveError::IncompatibleOperands(format!(
+                                "{fun:?}({other:?})"
+                            )))
+                        }
                     },
                     Mf::Inverse => match *res_arg.inner_with(types) {
                         Ti::Matrix {
@@ -768,70 +770,75 @@ impl<'a> ResolveContext<'a> {
                             rows,
                             scalar,
                         }),
-                        ref other => return Err(ResolveError::IncompatibleOperands(
-                            format!("{fun:?}({other:?})")
-                        )),
+                        ref other => {
+                            return Err(ResolveError::IncompatibleOperands(format!(
+                                "{fun:?}({other:?})"
+                            )))
+                        }
                     },
                     Mf::Determinant => match *res_arg.inner_with(types) {
-                        Ti::Matrix {
-                            scalar,
-                            ..
-                        } => TypeResolution::Value(Ti::Scalar(scalar)),
-                        ref other => return Err(ResolveError::IncompatibleOperands(
-                            format!("{fun:?}({other:?})")
-                        )),
+                        Ti::Matrix { scalar, .. } => TypeResolution::Value(Ti::Scalar(scalar)),
+                        ref other => {
+                            return Err(ResolveError::IncompatibleOperands(format!(
+                                "{fun:?}({other:?})"
+                            )))
+                        }
                     },
                     // bits
-                    Mf::CountTrailingZeros |
-                    Mf::CountLeadingZeros |
-                    Mf::CountOneBits |
-                    Mf::ReverseBits |
-                    Mf::ExtractBits |
-                    Mf::InsertBits |
-                    Mf::FirstTrailingBit |
-                    Mf::FirstLeadingBit => match *res_arg.inner_with(types)  {
-                        Ti::Scalar(scalar @ crate::Scalar {
-                            kind: crate::ScalarKind::Sint | crate::ScalarKind::Uint,
-                            ..
-                        }) => TypeResolution::Value(Ti::Scalar(scalar)),
-                        Ti::Vector {
-                            size,
-                            scalar: scalar @ crate::Scalar {
+                    Mf::CountTrailingZeros
+                    | Mf::CountLeadingZeros
+                    | Mf::CountOneBits
+                    | Mf::ReverseBits
+                    | Mf::ExtractBits
+                    | Mf::InsertBits
+                    | Mf::FirstTrailingBit
+                    | Mf::FirstLeadingBit => match *res_arg.inner_with(types) {
+                        Ti::Scalar(
+                            scalar @ crate::Scalar {
                                 kind: crate::ScalarKind::Sint | crate::ScalarKind::Uint,
                                 ..
-                            }
+                            },
+                        ) => TypeResolution::Value(Ti::Scalar(scalar)),
+                        Ti::Vector {
+                            size,
+                            scalar:
+                                scalar @ crate::Scalar {
+                                    kind: crate::ScalarKind::Sint | crate::ScalarKind::Uint,
+                                    ..
+                                },
                         } => TypeResolution::Value(Ti::Vector { size, scalar }),
-                        ref other => return Err(ResolveError::IncompatibleOperands(
-                                format!("{fun:?}({other:?})")
-                            )),
+                        ref other => {
+                            return Err(ResolveError::IncompatibleOperands(format!(
+                                "{fun:?}({other:?})"
+                            )))
+                        }
                     },
                     // data packing
-                    Mf::Pack4x8snorm |
-                    Mf::Pack4x8unorm |
-                    Mf::Pack2x16snorm |
-                    Mf::Pack2x16unorm |
-                    Mf::Pack2x16float |
-                    Mf::Pack4xI8 |
-                    Mf::Pack4xU8 => TypeResolution::Value(Ti::Scalar(crate::Scalar::U32)),
+                    Mf::Pack4x8snorm
+                    | Mf::Pack4x8unorm
+                    | Mf::Pack2x16snorm
+                    | Mf::Pack2x16unorm
+                    | Mf::Pack2x16float
+                    | Mf::Pack4xI8
+                    | Mf::Pack4xU8 => TypeResolution::Value(Ti::Scalar(crate::Scalar::U32)),
                     // data unpacking
-                    Mf::Unpack4x8snorm |
-                    Mf::Unpack4x8unorm => TypeResolution::Value(Ti::Vector {
+                    Mf::Unpack4x8snorm | Mf::Unpack4x8unorm => TypeResolution::Value(Ti::Vector {
                         size: crate::VectorSize::Quad,
-                        scalar: crate::Scalar::F32
+                        scalar: crate::Scalar::F32,
                     }),
-                    Mf::Unpack2x16snorm |
-                    Mf::Unpack2x16unorm |
-                    Mf::Unpack2x16float => TypeResolution::Value(Ti::Vector {
-                        size: crate::VectorSize::Bi,
-                        scalar: crate::Scalar::F32
-                    }),
+                    Mf::Unpack2x16snorm | Mf::Unpack2x16unorm | Mf::Unpack2x16float => {
+                        TypeResolution::Value(Ti::Vector {
+                            size: crate::VectorSize::Bi,
+                            scalar: crate::Scalar::F32,
+                        })
+                    }
                     Mf::Unpack4xI8 => TypeResolution::Value(Ti::Vector {
                         size: crate::VectorSize::Quad,
-                        scalar: crate::Scalar::I32
+                        scalar: crate::Scalar::I32,
                     }),
                     Mf::Unpack4xU8 => TypeResolution::Value(Ti::Vector {
                         size: crate::VectorSize::Quad,
-                        scalar: crate::Scalar::U32
+                        scalar: crate::Scalar::U32,
                     }),
                 }
             }

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -11,6 +11,7 @@ pub struct Span {
 
 impl Span {
     pub const UNDEFINED: Self = Self { start: 0, end: 0 };
+
     /// Creates a new `Span` from a range of byte indices
     ///
     /// Note: end is exclusive, it doesn't belong to the `Span`

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -124,7 +124,12 @@ impl AccelerationStructureInstance {
         &mut self,
         shader_binding_table_record_offset: u32,
     ) {
-        debug_assert!(shader_binding_table_record_offset <= Self::MAX_U24, "shader_binding_table_record_offset uses more than 24 bits! {shader_binding_table_record_offset} > {}", Self::MAX_U24);
+        debug_assert!(
+            shader_binding_table_record_offset <= Self::MAX_U24,
+            "shader_binding_table_record_offset uses more than 24 bits! {} > {}",
+            shader_binding_table_record_offset,
+            Self::MAX_U24
+        );
         self.shader_binding_table_record_offset_and_flags = (shader_binding_table_record_offset
             & Self::LOW_24_MASK)
             | (self.shader_binding_table_record_offset_and_flags & !Self::LOW_24_MASK)
@@ -151,7 +156,9 @@ impl AccelerationStructureInstance {
         );
         debug_assert!(
             shader_binding_table_record_offset <= Self::MAX_U24,
-            "shader_binding_table_record_offset uses more than 24 bits! {shader_binding_table_record_offset} > {}", Self::MAX_U24
+            "shader_binding_table_record_offset uses more than 24 bits! {} > {}",
+            shader_binding_table_record_offset,
+            Self::MAX_U24
         );
         AccelerationStructureInstance {
             transform: Self::affine_to_rows(transform),

--- a/wgpu-hal/src/auxil/renderdoc.rs
+++ b/wgpu-hal/src/auxil/renderdoc.rs
@@ -74,7 +74,8 @@ impl RenderDoc {
                 Err(e) => {
                     return RenderDoc::NotAvailable {
                         reason: format!(
-                            "Unable to get RENDERDOC_GetAPI from renderdoc library '{renderdoc_filename}': {e:?}"
+                            "Unable to get RENDERDOC_GetAPI from renderdoc library '{}': {e:?}",
+                            renderdoc_filename
                         ),
                     }
                 }
@@ -89,7 +90,8 @@ impl RenderDoc {
             },
             return_value => RenderDoc::NotAvailable {
                 reason: format!(
-                    "Unable to get API from renderdoc library '{renderdoc_filename}': {return_value}"
+                    "Unable to get API from renderdoc library '{}': {}",
+                    renderdoc_filename, return_value
                 ),
             },
         }

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -457,11 +457,24 @@ impl Texture {
         };
 
         log::error!(
-            "wgpu-hal heuristics assumed that the view dimension will be equal to `{got}` rather than `{view_dimension:?}`.\n{}\n{}\n{}\n{}",
-            "`D2` textures with `depth_or_array_layers == 1` are assumed to have view dimension `D2`",
-            "`D2` textures with `depth_or_array_layers > 1` are assumed to have view dimension `D2Array`",
-            "`D2` textures with `depth_or_array_layers == 6` are assumed to have view dimension `Cube`",
-            "`D2` textures with `depth_or_array_layers > 6 && depth_or_array_layers % 6 == 0` are assumed to have view dimension `CubeArray`",
+            concat!(
+                "wgpu-hal heuristics assumed that ",
+                "the view dimension will be equal to `{}` rather than `{:?}`.\n",
+                "`D2` textures with ",
+                "`depth_or_array_layers == 1` ",
+                "are assumed to have view dimension `D2`\n",
+                "`D2` textures with ",
+                "`depth_or_array_layers > 1` ",
+                "are assumed to have view dimension `D2Array`\n",
+                "`D2` textures with ",
+                "`depth_or_array_layers == 6` ",
+                "are assumed to have view dimension `Cube`\n",
+                "`D2` textures with ",
+                "`depth_or_array_layers > 6 && depth_or_array_layers % 6 == 0` ",
+                "are assumed to have view dimension `CubeArray`\n",
+            ),
+            got,
+            view_dimension,
         );
     }
 }

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -64,9 +64,10 @@ impl Instance {
                 // “not supported” could include “insufficient GPU resources” or “the GPU process
                 // previously crashed”. So, we must return it as an `Err` since it could occur
                 // for circumstances outside the application author's control.
-                return Err(crate::InstanceError::new(String::from(
-                    "canvas.getContext() returned null; webgl2 not available or canvas already in use"
-                )));
+                return Err(crate::InstanceError::new(String::from(concat!(
+                    "canvas.getContext() returned null; ",
+                    "webgl2 not available or canvas already in use"
+                ))));
             }
             Err(js_error) => {
                 // <https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-getcontext>

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -745,7 +745,12 @@ impl crate::Instance for super::Instance {
                     Ok(sdk_ver) => sdk_ver,
                     Err(err) => {
                         log::error!(
-                            "Couldn't parse Android's ro.build.version.sdk system property ({val}): {err}"
+                            concat!(
+                                "Couldn't parse Android's ",
+                                "ro.build.version.sdk system property ({}): {}",
+                            ),
+                            val,
+                            err,
                         );
                         0
                     }
@@ -931,7 +936,10 @@ impl crate::Instance for super::Instance {
                         if version < (21, 2) {
                             // See https://gitlab.freedesktop.org/mesa/mesa/-/issues/4688
                             log::warn!(
-                                "Disabling presentation on '{}' (id {:?}) due to NV Optimus and Intel Mesa < v21.2",
+                                concat!(
+                                    "Disabling presentation on '{}' (id {:?}) ",
+                                    "due to NV Optimus and Intel Mesa < v21.2"
+                                ),
                                 exposed.info.name,
                                 exposed.adapter.raw
                             );

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -418,7 +418,13 @@ impl Surface {
             swapchain.next_present_time = Some(present_timing);
         } else {
             // Ideally we'd use something like `device.required_features` here, but that's in `wgpu-core`, which we are a dependency of
-            panic!("Tried to set display timing properties without the corresponding feature ({features:?}) enabled.");
+            panic!(
+                concat!(
+                    "Tried to set display timing properties ",
+                    "without the corresponding feature ({:?}) enabled."
+                ),
+                features
+            );
         }
     }
 }


### PR DESCRIPTION
**Connections**

Discovered during #6148.

**Description**

Hunks of Rust source from <https://github.com/gfx-rs/wgpu/pull/6316> and prior have some lines with string literals that are so long that `rustfmt` refuses to reformat both the literal and surrounding runs of expressions. Fix this, and keep chugging with delicious `rustfmt`'d code.

**Testing**

Still green in CI, still good!

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ Definitely not necessary.
