### PR TITLE
[naga spv-out] bounds-check runtime-sized array access correctly.

### DIFF
--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -1935,11 +1935,14 @@ impl<'w> BlockContext<'w> {
                 Ok(self.writer.get_constant_scalar(scalar))
             }
             BoundsCheckResult::Computed(computed_index_id) => Ok(computed_index_id),
-            BoundsCheckResult::Conditional(comparison_id) => {
-                self.extend_bounds_check_condition_chain(accumulated_checks, comparison_id, block);
+            BoundsCheckResult::Conditional {
+                condition_id: condition,
+                index_id: index,
+            } => {
+                self.extend_bounds_check_condition_chain(accumulated_checks, condition, block);
 
                 // Use the index from the `Access` expression unchanged.
-                Ok(self.cached[index])
+                Ok(index)
             }
         }
     }

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -1833,7 +1833,7 @@ impl<'w> BlockContext<'w> {
 
                     let index_id = match self.write_bounds_check(base, index, block)? {
                         BoundsCheckResult::KnownInBounds(known_index) => {
-                            // Even if the index is known, `OpAccessIndex`
+                            // Even if the index is known, `OpAccessChain`
                             // requires expression operands, not literals.
                             let scalar = crate::Literal::U32(known_index);
                             self.writer.get_constant_scalar(scalar)

--- a/naga/src/back/spv/index.rs
+++ b/naga/src/back/spv/index.rs
@@ -508,11 +508,10 @@ impl<'w> BlockContext<'w> {
     pub(super) fn write_bounds_check(
         &mut self,
         base: Handle<crate::Expression>,
-        index: Handle<crate::Expression>,
+        mut index: GuardedIndex,
         block: &mut Block,
     ) -> Result<BoundsCheckResult, Error> {
         // If the value of `index` is known at compile time, find it now.
-        let mut index = GuardedIndex::Expression(index);
         index.try_resolve_to_constant(self.ir_function, self.ir_module);
 
         let policy = self.writer.bounds_check_policies.choose_policy(
@@ -546,6 +545,7 @@ impl<'w> BlockContext<'w> {
         let result_type_id = self.get_expression_type_id(&self.fun_info[expr_handle].ty);
 
         let base_id = self.cached[base];
+        let index = GuardedIndex::Expression(index);
 
         let result_id = match self.write_bounds_check(base, index, block)? {
             BoundsCheckResult::KnownInBounds(known_index) => {

--- a/naga/src/back/spv/index.rs
+++ b/naga/src/back/spv/index.rs
@@ -7,13 +7,17 @@ use super::{
     selection::Selection,
     Block, BlockContext, Error, IdGenerator, Instruction, Word,
 };
-use crate::{arena::Handle, proc::BoundsCheckPolicy};
+use crate::{
+    arena::Handle,
+    proc::{index::GuardedIndex, BoundsCheckPolicy},
+};
 
 /// The results of performing a bounds check.
 ///
 /// On success, [`write_bounds_check`](BlockContext::write_bounds_check)
 /// returns a value of this type. The caller can assume that the right
 /// policy has been applied, and simply do what the variant says.
+#[derive(Debug)]
 pub(super) enum BoundsCheckResult {
     /// The index is statically known and in bounds, with the given value.
     KnownInBounds(u32),
@@ -40,6 +44,7 @@ pub(super) enum BoundsCheckResult {
 }
 
 /// A value that we either know at translation time, or need to compute at runtime.
+#[derive(Copy, Clone)]
 pub(super) enum MaybeKnown<T> {
     /// The value is known at shader translation time.
     Known(T),
@@ -329,33 +334,26 @@ impl<'w> BlockContext<'w> {
     pub(super) fn write_restricted_index(
         &mut self,
         sequence: Handle<crate::Expression>,
-        index: Handle<crate::Expression>,
+        index: GuardedIndex,
         block: &mut Block,
     ) -> Result<BoundsCheckResult, Error> {
-        let index_id = self.cached[index];
+        let max_index = self.write_sequence_max_index(sequence, block)?;
 
-        // Get the sequence's maximum valid index. Return early if we've already
-        // done the bounds check.
-        let max_index_id = match self.write_sequence_max_index(sequence, block)? {
-            MaybeKnown::Known(known_max_index) => {
-                if let Ok(known_index) = self
-                    .ir_module
-                    .to_ctx()
-                    .eval_expr_to_u32_from(index, &self.ir_function.expressions)
-                {
-                    // Both the index and length are known at compile time.
-                    //
-                    // In strict WGSL compliance mode, out-of-bounds indices cannot be
-                    // reported at shader translation time, and must be replaced with
-                    // in-bounds indices at run time. So we cannot assume that
-                    // validation ensured the index was in bounds. Restrict now.
-                    let restricted = std::cmp::min(known_index, known_max_index);
-                    return Ok(BoundsCheckResult::KnownInBounds(restricted));
-                }
+        // If both are known, we can compute the index to be used
+        // right now.
+        if let (GuardedIndex::Known(index), MaybeKnown::Known(max_index)) = (index, max_index) {
+            let restricted = std::cmp::min(index, max_index);
+            return Ok(BoundsCheckResult::KnownInBounds(restricted));
+        }
 
-                self.get_index_constant(known_max_index)
-            }
-            MaybeKnown::Computed(max_index_id) => max_index_id,
+        let index_id = match index {
+            GuardedIndex::Known(value) => self.get_index_constant(value),
+            GuardedIndex::Expression(expr) => self.cached[expr],
+        };
+
+        let max_index_id = match max_index {
+            MaybeKnown::Known(value) => self.get_index_constant(value),
+            MaybeKnown::Computed(id) => id,
         };
 
         // One or the other of the index or length is dynamic, so emit code for
@@ -393,48 +391,33 @@ impl<'w> BlockContext<'w> {
     fn write_index_comparison(
         &mut self,
         sequence: Handle<crate::Expression>,
-        index: Handle<crate::Expression>,
+        index: GuardedIndex,
         block: &mut Block,
     ) -> Result<BoundsCheckResult, Error> {
-        let index_id = self.cached[index];
+        let length = self.write_sequence_length(sequence, block)?;
 
-        // Get the sequence's length. Return early if we've already done the
-        // bounds check.
-        let length_id = match self.write_sequence_length(sequence, block)? {
-            MaybeKnown::Known(known_length) => {
-                if let Ok(known_index) = self
-                    .ir_module
-                    .to_ctx()
-                    .eval_expr_to_u32_from(index, &self.ir_function.expressions)
-                {
-                    // Both the index and length are known at compile time.
-                    //
-                    // It would be nice to assume that, since we are using the
-                    // `ReadZeroSkipWrite` policy, we are not in strict WGSL
-                    // compliance mode, and thus we can count on the validator to have
-                    // rejected any programs with known out-of-bounds indices, and
-                    // thus just return `KnownInBounds` here without actually
-                    // checking.
-                    //
-                    // But it's also reasonable to expect that bounds check policies
-                    // and error reporting policies should be able to vary
-                    // independently without introducing security holes. So, we should
-                    // support the case where bad indices do not cause validation
-                    // errors, and are handled via `ReadZeroSkipWrite`.
-                    //
-                    // In theory, when `known_index` is bad, we could return a new
-                    // `KnownOutOfBounds` variant here. But it's simpler just to fall
-                    // through and let the bounds check take place. The shader is
-                    // broken anyway, so it doesn't make sense to invest in emitting
-                    // the ideal code for it.
-                    if known_index < known_length {
-                        return Ok(BoundsCheckResult::KnownInBounds(known_index));
-                    }
-                }
-
-                self.get_index_constant(known_length)
+        // If both are known, we can decide whether the index is in
+        // bounds right now.
+        if let (GuardedIndex::Known(index), MaybeKnown::Known(length)) = (index, length) {
+            if index < length {
+                return Ok(BoundsCheckResult::KnownInBounds(index));
             }
-            MaybeKnown::Computed(length_id) => length_id,
+
+            // In theory, when `index` is bad, we could return a new
+            // `KnownOutOfBounds` variant here. But it's simpler just to fall
+            // through and let the bounds check take place. The shader is broken
+            // anyway, so it doesn't make sense to invest in emitting the ideal
+            // code for it.
+        }
+
+        let index_id = match index {
+            GuardedIndex::Known(value) => self.get_index_constant(value),
+            GuardedIndex::Expression(expr) => self.cached[expr],
+        };
+
+        let length_id = match length {
+            MaybeKnown::Known(value) => self.get_index_constant(value),
+            MaybeKnown::Computed(id) => id,
         };
 
         // Compare the index against the length.
@@ -519,6 +502,10 @@ impl<'w> BlockContext<'w> {
         index: Handle<crate::Expression>,
         block: &mut Block,
     ) -> Result<BoundsCheckResult, Error> {
+        // If the value of `index` is known at compile time, find it now.
+        let mut index = GuardedIndex::Expression(index);
+        index.try_resolve_to_constant(self.ir_function, self.ir_module);
+
         let policy = self.writer.bounds_check_policies.choose_policy(
             base,
             &self.ir_module.types,
@@ -530,7 +517,10 @@ impl<'w> BlockContext<'w> {
             BoundsCheckPolicy::ReadZeroSkipWrite => {
                 self.write_index_comparison(base, index, block)?
             }
-            BoundsCheckPolicy::Unchecked => BoundsCheckResult::Computed(self.cached[index]),
+            BoundsCheckPolicy::Unchecked => match index {
+                GuardedIndex::Known(value) => BoundsCheckResult::KnownInBounds(value),
+                GuardedIndex::Expression(expr) => BoundsCheckResult::Computed(self.cached[expr]),
+            },
         })
     }
 

--- a/naga/src/proc/index.rs
+++ b/naga/src/proc/index.rs
@@ -334,7 +334,11 @@ impl GuardedIndex {
     /// Make a `GuardedIndex::Known` from a `GuardedIndex::Expression` if possible.
     ///
     /// Return values that are already `Known` unchanged.
-    fn try_resolve_to_constant(&mut self, function: &crate::Function, module: &crate::Module) {
+    pub(crate) fn try_resolve_to_constant(
+        &mut self,
+        function: &crate::Function,
+        module: &crate::Module,
+    ) {
         if let GuardedIndex::Expression(expr) = *self {
             if let Ok(value) = module
                 .to_ctx()

--- a/naga/tests/in/bounds-check-restrict.wgsl
+++ b/naga/tests/in/bounds-check-restrict.wgsl
@@ -70,3 +70,11 @@ fn set_in_bounds(v: f32) {
    globals.v[3] = v;
    globals.m[2][3] = v;
 }
+
+fn index_dynamic_array_constant_index() -> f32 {
+   return globals.d[1000];
+}
+
+fn set_dynamic_array_constant_index(v: f32) {
+   globals.d[1000] = v;
+}

--- a/naga/tests/in/bounds-check-zero-atomic.wgsl
+++ b/naga/tests/in/bounds-check-zero-atomic.wgsl
@@ -36,3 +36,11 @@ fn exchange_atomic_dynamic_sized_array(i: i32) -> u32 {
    return atomicExchange(&globals.c[i], 1u);
 }
 
+fn fetch_add_atomic_dynamic_sized_array_static_index() -> u32 {
+   return atomicAdd(&globals.c[1000], 1u);
+}
+
+fn exchange_atomic_dynamic_sized_array_static_index() -> u32 {
+   return atomicExchange(&globals.c[1000], 1u);
+}
+

--- a/naga/tests/in/bounds-check-zero.wgsl
+++ b/naga/tests/in/bounds-check-zero.wgsl
@@ -70,3 +70,11 @@ fn set_in_bounds(v: f32) {
    globals.v[3] = v;
    globals.m[2][3] = v;
 }
+
+fn index_dynamic_array_constant_index() -> f32 {
+   return globals.d[1000];
+}
+
+fn set_dynamic_array_constant_index(v: f32) {
+   globals.d[1000] = v;
+}

--- a/naga/tests/out/msl/bounds-check-restrict.msl
+++ b/naga/tests/out/msl/bounds-check-restrict.msl
@@ -163,3 +163,20 @@ void set_in_bounds(
     globals.m[2].w = v_7;
     return;
 }
+
+float index_dynamic_array_constant_index(
+    device Globals const& globals,
+    constant _mslBufferSizes& _buffer_sizes
+) {
+    float _e3 = globals.d[metal::min(unsigned(1000), (_buffer_sizes.size0 - 112 - 4) / 4)];
+    return _e3;
+}
+
+void set_dynamic_array_constant_index(
+    float v_8,
+    device Globals& globals,
+    constant _mslBufferSizes& _buffer_sizes
+) {
+    globals.d[metal::min(unsigned(1000), (_buffer_sizes.size0 - 112 - 4) / 4)] = v_8;
+    return;
+}

--- a/naga/tests/out/msl/bounds-check-zero-atomic.msl
+++ b/naga/tests/out/msl/bounds-check-zero-atomic.msl
@@ -75,3 +75,19 @@ uint exchange_atomic_dynamic_sized_array(
     uint _e5 = uint(i_3) < 1 + (_buffer_sizes.size0 - 44 - 4) / 4 ? metal::atomic_exchange_explicit(&globals.c[i_3], 1u, metal::memory_order_relaxed) : DefaultConstructible();
     return _e5;
 }
+
+uint fetch_add_atomic_dynamic_sized_array_static_index(
+    device Globals& globals,
+    constant _mslBufferSizes& _buffer_sizes
+) {
+    uint _e4 = uint(1000) < 1 + (_buffer_sizes.size0 - 44 - 4) / 4 ? metal::atomic_fetch_add_explicit(&globals.c[1000], 1u, metal::memory_order_relaxed) : DefaultConstructible();
+    return _e4;
+}
+
+uint exchange_atomic_dynamic_sized_array_static_index(
+    device Globals& globals,
+    constant _mslBufferSizes& _buffer_sizes
+) {
+    uint _e4 = uint(1000) < 1 + (_buffer_sizes.size0 - 44 - 4) / 4 ? metal::atomic_exchange_explicit(&globals.c[1000], 1u, metal::memory_order_relaxed) : DefaultConstructible();
+    return _e4;
+}

--- a/naga/tests/out/msl/bounds-check-zero.msl
+++ b/naga/tests/out/msl/bounds-check-zero.msl
@@ -183,3 +183,22 @@ void set_in_bounds(
     globals.m[2].w = v_7;
     return;
 }
+
+float index_dynamic_array_constant_index(
+    device Globals const& globals,
+    constant _mslBufferSizes& _buffer_sizes
+) {
+    float _e3 = uint(1000) < 1 + (_buffer_sizes.size0 - 112 - 4) / 4 ? globals.d[1000] : DefaultConstructible();
+    return _e3;
+}
+
+void set_dynamic_array_constant_index(
+    float v_8,
+    device Globals& globals,
+    constant _mslBufferSizes& _buffer_sizes
+) {
+    if (uint(1000) < 1 + (_buffer_sizes.size0 - 112 - 4) / 4) {
+        globals.d[1000] = v_8;
+    }
+    return;
+}

--- a/naga/tests/out/spv/bounds-check-restrict.spvasm
+++ b/naga/tests/out/spv/bounds-check-restrict.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 163
+; Bound: 174
 OpCapability Shader
 OpCapability Linkage
 OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -52,6 +52,7 @@ OpDecorate %12 Binding 0
 %129 = OpTypeFunction %2 %11 %7
 %138 = OpTypeFunction %2 %11 %11 %3
 %158 = OpTypeFunction %2 %3
+%166 = OpConstant  %6  1000
 %16 = OpFunction  %3  None %17
 %15 = OpFunctionParameter  %11
 %14 = OpLabel
@@ -231,5 +232,22 @@ OpStore %160 %156
 OpStore %161 %156
 %162 = OpAccessChain  %43  %12 %62 %62 %35
 OpStore %162 %156
+OpReturn
+OpFunctionEnd
+%164 = OpFunction  %3  None %91
+%163 = OpLabel
+OpBranch %165
+%165 = OpLabel
+%167 = OpAccessChain  %20  %12 %35 %166
+%168 = OpLoad  %3  %167
+OpReturnValue %168
+OpFunctionEnd
+%171 = OpFunction  %2  None %158
+%170 = OpFunctionParameter  %3
+%169 = OpLabel
+OpBranch %172
+%172 = OpLabel
+%173 = OpAccessChain  %20  %12 %35 %166
+OpStore %173 %170
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/bounds-check-restrict.spvasm
+++ b/naga/tests/out/spv/bounds-check-restrict.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 174
+; Bound: 180
 OpCapability Shader
 OpCapability Linkage
 OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -52,7 +52,7 @@ OpDecorate %12 Binding 0
 %129 = OpTypeFunction %2 %11 %7
 %138 = OpTypeFunction %2 %11 %11 %3
 %158 = OpTypeFunction %2 %3
-%166 = OpConstant  %6  1000
+%168 = OpConstant  %6  1000
 %16 = OpFunction  %3  None %17
 %15 = OpFunctionParameter  %11
 %14 = OpLabel
@@ -238,16 +238,22 @@ OpFunctionEnd
 %163 = OpLabel
 OpBranch %165
 %165 = OpLabel
-%167 = OpAccessChain  %20  %12 %35 %166
-%168 = OpLoad  %3  %167
-OpReturnValue %168
+%166 = OpArrayLength  %6  %12 3
+%167 = OpISub  %6  %166 %32
+%169 = OpExtInst  %6  %1 UMin %168 %167
+%170 = OpAccessChain  %20  %12 %35 %169
+%171 = OpLoad  %3  %170
+OpReturnValue %171
 OpFunctionEnd
-%171 = OpFunction  %2  None %158
-%170 = OpFunctionParameter  %3
-%169 = OpLabel
-OpBranch %172
+%174 = OpFunction  %2  None %158
+%173 = OpFunctionParameter  %3
 %172 = OpLabel
-%173 = OpAccessChain  %20  %12 %35 %166
-OpStore %173 %170
+OpBranch %175
+%175 = OpLabel
+%176 = OpArrayLength  %6  %12 3
+%177 = OpISub  %6  %176 %32
+%178 = OpExtInst  %6  %1 UMin %168 %177
+%179 = OpAccessChain  %20  %12 %35 %178
+OpStore %179 %173
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/bounds-check-zero.spvasm
+++ b/naga/tests/out/spv/bounds-check-zero.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 200
+; Bound: 211
 OpCapability Shader
 OpCapability Linkage
 OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -56,6 +56,7 @@ OpDecorate %12 Binding 0
 %159 = OpTypeFunction %2 %11 %7
 %170 = OpTypeFunction %2 %11 %11 %3
 %195 = OpTypeFunction %2 %3
+%203 = OpConstant  %6  1000
 %16 = OpFunction  %3  None %17
 %15 = OpFunctionParameter  %11
 %14 = OpLabel
@@ -307,5 +308,22 @@ OpStore %197 %193
 OpStore %198 %193
 %199 = OpAccessChain  %48  %12 %76 %76 %37
 OpStore %199 %193
+OpReturn
+OpFunctionEnd
+%201 = OpFunction  %3  None %115
+%200 = OpLabel
+OpBranch %202
+%202 = OpLabel
+%204 = OpAccessChain  %20  %12 %37 %203
+%205 = OpLoad  %3  %204
+OpReturnValue %205
+OpFunctionEnd
+%208 = OpFunction  %2  None %195
+%207 = OpFunctionParameter  %3
+%206 = OpLabel
+OpBranch %209
+%209 = OpLabel
+%210 = OpAccessChain  %20  %12 %37 %203
+OpStore %210 %207
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/bounds-check-zero.spvasm
+++ b/naga/tests/out/spv/bounds-check-zero.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 211
+; Bound: 220
 OpCapability Shader
 OpCapability Linkage
 OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -56,7 +56,7 @@ OpDecorate %12 Binding 0
 %159 = OpTypeFunction %2 %11 %7
 %170 = OpTypeFunction %2 %11 %11 %3
 %195 = OpTypeFunction %2 %3
-%203 = OpConstant  %6  1000
+%204 = OpConstant  %6  1000
 %16 = OpFunction  %3  None %17
 %15 = OpFunctionParameter  %11
 %14 = OpLabel
@@ -314,16 +314,31 @@ OpFunctionEnd
 %200 = OpLabel
 OpBranch %202
 %202 = OpLabel
-%204 = OpAccessChain  %20  %12 %37 %203
-%205 = OpLoad  %3  %204
-OpReturnValue %205
+%203 = OpArrayLength  %6  %12 3
+%205 = OpULessThan  %22  %204 %203
+OpSelectionMerge %207 None
+OpBranchConditional %205 %208 %207
+%208 = OpLabel
+%206 = OpAccessChain  %20  %12 %37 %204
+%209 = OpLoad  %3  %206
+OpBranch %207
+%207 = OpLabel
+%210 = OpPhi  %3  %25 %202 %209 %208
+OpReturnValue %210
 OpFunctionEnd
-%208 = OpFunction  %2  None %195
-%207 = OpFunctionParameter  %3
-%206 = OpLabel
-OpBranch %209
-%209 = OpLabel
-%210 = OpAccessChain  %20  %12 %37 %203
-OpStore %210 %207
+%213 = OpFunction  %2  None %195
+%212 = OpFunctionParameter  %3
+%211 = OpLabel
+OpBranch %214
+%214 = OpLabel
+%215 = OpArrayLength  %6  %12 3
+%216 = OpULessThan  %22  %204 %215
+OpSelectionMerge %218 None
+OpBranchConditional %216 %219 %218
+%219 = OpLabel
+%217 = OpAccessChain  %20  %12 %37 %204
+OpStore %217 %212
+OpBranch %218
+%218 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/operators.spvasm
+++ b/naga/tests/out/spv/operators.spvasm
@@ -387,15 +387,15 @@ OpStore %302 %331
 %332 = OpLoad  %5  %302
 %333 = OpISub  %5  %332 %23
 OpStore %302 %333
-%335 = OpAccessChain  %334  %305 %23
+%335 = OpAccessChain  %334  %305 %122
 %336 = OpLoad  %5  %335
 %337 = OpIAdd  %5  %336 %23
-%338 = OpAccessChain  %334  %305 %23
+%338 = OpAccessChain  %334  %305 %122
 OpStore %338 %337
-%339 = OpAccessChain  %334  %305 %23
+%339 = OpAccessChain  %334  %305 %122
 %340 = OpLoad  %5  %339
 %341 = OpISub  %5  %340 %23
-%342 = OpAccessChain  %334  %305 %23
+%342 = OpAccessChain  %334  %305 %122
 OpStore %342 %341
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
Do not neglect to apply bounds checks to indexing operations on runtime-sized arrays, even when they are accessed via an `AccessIndex` instruction.

Before this commit, `BlockContext::write_expression_pointer` would not apply bounds checks to `OpAccessChain` indices provided by an `AccessIndex` instruction, apparently with the rationale that any out-of-bounds accesses should all have been reported by constant evaluation.

While it is true that the `index` operand of an `AccessIndex` expression is known at compile time, and that the WGSL constant evaluation rules require accesses that can be statically determined to be out-of-bounds to be shader creation or pipeline creation time errors, accesses to runtime-sized arrays don't follow this pattern: even if the index is known, the length with which it must be compared is not.

Fixes #4441.

-   [naga] Extend snapshot tests for bounds checks.
    
    Extend the snapshot tests for bounds checking to cover the case where a runtime-sized array is indexed by a constant.

-   [naga spv-out] Let `BoundsCheckResult` supply the index value.
    
    Let `BoundsCheckResult::Conditional` provide both the condition to check before carrying out the access, and the index to use for that access. The `Conditional` variant indicates that we generated a runtime bounds check, which implies we must have had a SPIR-V id for the index to pass to that check, so there's no reason not to provide that to the callers - especially if the bounds check code was able to reduce it to a known constant.
    
    At the moment, this is not much of a refactor, but later commits will use `GuardedIndex` in more places, at which point this will avoid a re-matching and assertion.

-   [naga spv-out] Abstract out `OpAccessChain` index production.
    
    Abstract the code from `write_expression_pointer` to handle one indexing operation out into its own function, `BlockContext::write_access_chain_index`.

-   [naga spv-out] Consolidate code to find index values.
    
    Let the SPIR-V backend use `GuardedIndex::try_resolve_to_constant`, rather than writing out its definition in `write_restricted_index` and `write_index_comparison`.
    
    Call `try_resolve_to_constant` in one place, in `write_bounds_check`, and simply pass the `GuardedIndex` into subroutines.
    
    Reduce `write_restricted_index` and `write_index_comparison` to case analysis and code generation.
    
    Note that this commit does have a benign effect on SPIR-V snapshot output for programs like this:
    
        let one_i = 1i;
        var vec0 = vec3<i32>();
        vec0[one_i] = 1;
    
    The value indexing `vec0` here is an `i32`, but after this commit, the operand to `OpAccessChain` becomes a `u32` constant (with the same value).
    
    This is because `write_bounds_check` now calls `try_resolve_to_constant` itself, rather than deferring this work to its callees, so it may return `BoundsCheckResult::KnownInBounds` even when the `Unchecked` policy is in force. This directs the caller, `write_expression_pointer`, to treat the `OpAccessChain` operand as a fresh `u32` constant, rather than simply passing through the original `i32` expression.

-   [naga spv-out] Abstract extending a bounds check condition chain.
    
    Introduce a new function, `BlockContext::extend_bounds_check_condition_chain`, which adds a new boolean condition to the chain of bounds checks guarding an `OpAccessChain` instruction.

-   [naga spv-out] Doc fix: typo

-   [naga spv-out] Abstract out non-uniform binding array access test.
    
    Introduce a new function, `BlockContext::is_nonuniform_binding_array_access`, which determines whether a given array access expression means that the `OpAccessChain` instruction must have a `NonUniform` decoration.
