### PR TITLE
Add a skeleton for directives that reports nice errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 - Support local `const` declarations in WGSL. By @sagudev in [#6156](https://github.com/gfx-rs/wgpu/pull/6156).
 - Implemented `const_assert` in WGSL. By @sagudev in [#6198](https://github.com/gfx-rs/wgpu/pull/6198).
 - Support polyfilling `inverse` in WGSL. By @chyyran in [#6385](https://github.com/gfx-rs/wgpu/pull/6385).
+- Add an internal skeleton for parsing `requires`, `enable`, and `diagnostic` directives that don't yet do anything besides emit nicer errors. By @ErichDonGubler in [#6352](https://github.com/gfx-rs/wgpu/pull/6352).
 
 #### General
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,6 +1897,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "spirv 0.3.0+sdk-1.3.268.0",
+ "strum",
  "termcolor",
  "thiserror",
  "unicode-xid",

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -101,3 +101,4 @@ ron = "0.8.0"
 rspirv = { version = "0.11", git = "https://github.com/gfx-rs/rspirv", rev = "b969f175d5663258b4891e44b76c1544da9661ab" }
 serde = { workspace = true, features = ["derive"] }
 spirv = { version = "0.3", features = ["deserialize"] }
+strum.workspace = true

--- a/naga/src/front/wgsl/mod.rs
+++ b/naga/src/front/wgsl/mod.rs
@@ -58,3 +58,21 @@ impl Frontend {
 pub fn parse_str(source: &str) -> Result<crate::Module, ParseError> {
     Frontend::new().parse(source)
 }
+
+#[cfg(test)]
+#[track_caller]
+pub fn assert_parse_err(input: &str, snapshot: &str) {
+    let output = parse_str(input)
+        .expect_err("expected parser error")
+        .emit_to_string(input);
+    if output != snapshot {
+        for diff in diff::lines(snapshot, &output) {
+            match diff {
+                diff::Result::Left(l) => println!("-{l}"),
+                diff::Result::Both(l, _) => println!(" {l}"),
+                diff::Result::Right(r) => println!("+{r}"),
+            }
+        }
+        panic!("Error snapshot failed");
+    }
+}

--- a/naga/src/front/wgsl/parse/directive.rs
+++ b/naga/src/front/wgsl/parse/directive.rs
@@ -1,0 +1,179 @@
+//! WGSL directives. The focal point of this API is [`DirectiveKind`].
+//!
+//! See also <https://www.w3.org/TR/WGSL/#directives>.
+
+/// A parsed sentinel word indicating the type of directive to be parsed next.
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub enum DirectiveKind {
+    Unimplemented(UnimplementedDirectiveKind),
+}
+
+impl DirectiveKind {
+    const DIAGNOSTIC: &'static str = "diagnostic";
+    const ENABLE: &'static str = "enable";
+    const REQUIRES: &'static str = "requires";
+
+    /// Convert from a sentinel word in WGSL into its associated [`DirectiveKind`], if possible.
+    pub fn from_ident(s: &str) -> Option<Self> {
+        Some(match s {
+            Self::DIAGNOSTIC => Self::Unimplemented(UnimplementedDirectiveKind::Diagnostic),
+            Self::ENABLE => Self::Unimplemented(UnimplementedDirectiveKind::Enable),
+            Self::REQUIRES => Self::Unimplemented(UnimplementedDirectiveKind::Requires),
+            _ => return None,
+        })
+    }
+
+    /// Maps this [`DirectiveKind`] into the sentinel word associated with it in WGSL.
+    pub const fn to_ident(self) -> &'static str {
+        match self {
+            Self::Unimplemented(kind) => match kind {
+                UnimplementedDirectiveKind::Diagnostic => Self::DIAGNOSTIC,
+                UnimplementedDirectiveKind::Enable => Self::ENABLE,
+                UnimplementedDirectiveKind::Requires => Self::REQUIRES,
+            },
+        }
+    }
+
+    #[cfg(test)]
+    fn iter() -> impl Iterator<Item = Self> {
+        use strum::IntoEnumIterator;
+
+        UnimplementedDirectiveKind::iter().map(Self::Unimplemented)
+    }
+}
+
+/// A [`DirectiveKind`] that is not yet implemented. See [`DirectiveKind::Unimplemented`].
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+#[cfg_attr(test, derive(strum::EnumIter))]
+pub enum UnimplementedDirectiveKind {
+    Diagnostic,
+    Enable,
+    Requires,
+}
+
+impl UnimplementedDirectiveKind {
+    pub const fn tracking_issue_num(self) -> u16 {
+        match self {
+            Self::Diagnostic => 5320,
+            Self::Requires => 6350,
+            Self::Enable => 5476,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use strum::IntoEnumIterator;
+
+    use crate::front::wgsl::assert_parse_err;
+
+    use super::{DirectiveKind, UnimplementedDirectiveKind};
+
+    #[test]
+    fn unimplemented_directives() {
+        for unsupported_shader in UnimplementedDirectiveKind::iter() {
+            let shader;
+            let expected_msg;
+            match unsupported_shader {
+                UnimplementedDirectiveKind::Diagnostic => {
+                    shader = "diagnostic(off,derivative_uniformity);";
+                    expected_msg = "\
+error: `diagnostic` is not yet implemented
+  ┌─ wgsl:1:1
+  │
+1 │ diagnostic(off,derivative_uniformity);
+  │ ^^^^^^^^^^ this global directive is standard, but not yet implemented
+  │
+  = note: Let Naga maintainers know that you ran into this at <https://github.com/gfx-rs/wgpu/issues/5320>, so they can prioritize it!
+
+";
+                }
+                UnimplementedDirectiveKind::Enable => {
+                    shader = "enable f16;";
+                    expected_msg = "\
+error: `enable` is not yet implemented
+  ┌─ wgsl:1:1
+  │
+1 │ enable f16;
+  │ ^^^^^^ this global directive is standard, but not yet implemented
+  │
+  = note: Let Naga maintainers know that you ran into this at <https://github.com/gfx-rs/wgpu/issues/5476>, so they can prioritize it!
+
+";
+                }
+                UnimplementedDirectiveKind::Requires => {
+                    shader = "requires readonly_and_readwrite_storage_textures";
+                    expected_msg = "\
+error: `requires` is not yet implemented
+  ┌─ wgsl:1:1
+  │
+1 │ requires readonly_and_readwrite_storage_textures
+  │ ^^^^^^^^ this global directive is standard, but not yet implemented
+  │
+  = note: Let Naga maintainers know that you ran into this at <https://github.com/gfx-rs/wgpu/issues/6350>, so they can prioritize it!
+
+";
+                }
+            };
+
+            assert_parse_err(shader, expected_msg);
+        }
+    }
+
+    #[test]
+    fn directive_after_global_decl() {
+        for unsupported_shader in DirectiveKind::iter() {
+            let directive;
+            let expected_msg;
+            match unsupported_shader {
+                DirectiveKind::Unimplemented(UnimplementedDirectiveKind::Diagnostic) => {
+                    directive = "diagnostic(off,derivative_uniformity)";
+                    expected_msg = "\
+error: expected global declaration, but found a global directive
+  ┌─ wgsl:2:1
+  │
+2 │ diagnostic(off,derivative_uniformity);
+  │ ^^^^^^^^^^ written after first global declaration
+  │
+  = note: global directives are only allowed before global declarations; maybe hoist this closer to the top of the shader module?
+
+";
+                }
+                DirectiveKind::Unimplemented(UnimplementedDirectiveKind::Enable) => {
+                    directive = "enable f16";
+                    expected_msg = "\
+error: expected global declaration, but found a global directive
+  ┌─ wgsl:2:1
+  │
+2 │ enable f16;
+  │ ^^^^^^ written after first global declaration
+  │
+  = note: global directives are only allowed before global declarations; maybe hoist this closer to the top of the shader module?
+
+";
+                }
+                DirectiveKind::Unimplemented(UnimplementedDirectiveKind::Requires) => {
+                    directive = "requires readonly_and_readwrite_storage_textures";
+                    expected_msg = "\
+error: expected global declaration, but found a global directive
+  ┌─ wgsl:2:1
+  │
+2 │ requires readonly_and_readwrite_storage_textures;
+  │ ^^^^^^^^ written after first global declaration
+  │
+  = note: global directives are only allowed before global declarations; maybe hoist this closer to the top of the shader module?
+
+";
+                }
+            }
+
+            let shader = format!(
+                "\
+@group(0) @binding(0) var<storage> thing: i32;
+{directive};
+"
+            );
+            assert_parse_err(&shader, expected_msg);
+        }
+    }
+}

--- a/naga/src/front/wgsl/parse/lexer.rs
+++ b/naga/src/front/wgsl/parse/lexer.rs
@@ -350,27 +350,43 @@ impl<'a> Lexer<'a> {
         &mut self,
     ) -> Result<(&'a str, Span), Error<'a>> {
         match self.next() {
-            (Token::Word("_"), span) => Err(Error::InvalidIdentifierUnderscore(span)),
-            (Token::Word(word), span) if word.starts_with("__") => {
-                Err(Error::ReservedIdentifierPrefix(span))
-            }
-            (Token::Word(word), span) => Ok((word, span)),
+            (Token::Word(word), span) => Self::word_as_ident_with_span(word, span),
             other => Err(Error::Unexpected(other.1, ExpectedToken::Identifier)),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(in crate::front::wgsl) fn peek_ident_with_span(
+        &mut self,
+    ) -> Result<(&'a str, Span), Error<'a>> {
+        match self.peek() {
+            (Token::Word(word), span) => Self::word_as_ident_with_span(word, span),
+            other => Err(Error::Unexpected(other.1, ExpectedToken::Identifier)),
+        }
+    }
+
+    fn word_as_ident_with_span(word: &'a str, span: Span) -> Result<(&'a str, Span), Error<'a>> {
+        match word {
+            "_" => Err(Error::InvalidIdentifierUnderscore(span)),
+            word if word.starts_with("__") => Err(Error::ReservedIdentifierPrefix(span)),
+            word => Ok((word, span)),
         }
     }
 
     pub(in crate::front::wgsl) fn next_ident(
         &mut self,
     ) -> Result<super::ast::Ident<'a>, Error<'a>> {
-        let ident = self
-            .next_ident_with_span()
-            .map(|(name, span)| super::ast::Ident { name, span })?;
+        self.next_ident_with_span()
+            .and_then(|(word, span)| Self::word_as_ident(word, span))
+            .map(|(name, span)| super::ast::Ident { name, span })
+    }
 
-        if crate::keywords::wgsl::RESERVED.contains(&ident.name) {
-            return Err(Error::ReservedKeyword(ident.span));
+    fn word_as_ident(word: &'a str, span: Span) -> Result<(&'a str, Span), Error<'a>> {
+        if crate::keywords::wgsl::RESERVED.contains(&word) {
+            Err(Error::ReservedKeyword(span))
+        } else {
+            Ok((word, span))
         }
-
-        Ok(ident)
     }
 
     /// Parses a generic scalar type, for example `<f32>`.

--- a/naga/src/front/wgsl/parse/lexer.rs
+++ b/naga/src/front/wgsl/parse/lexer.rs
@@ -355,7 +355,6 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    #[allow(dead_code)]
     pub(in crate::front::wgsl) fn peek_ident_with_span(
         &mut self,
     ) -> Result<(&'a str, Span), Error<'a>> {


### PR DESCRIPTION
**Connections**

Dependency of #6148.

May conflict with changes in #5701. If this merges first, I'll resolve conflicts there.

Lays groundwork for:

* #5476 (see also <https://github.com/gfx-rs/wgpu/pull/5701>)
* #6148
* #6350

**Description**

**Recommended review experience is commit-by-commit. Each individual commit should pass CI!**

There's not a parse path for _any_ directives, let alone what I'm working on with the `diagnostic(…)` directive in #6148. It turns out that adding the starting point with some diagnostics is enough code that a PR checkpoint sounds wise. As a bonus, this can also serve as the base for a full solution to <https://github.com/gfx-rs/wgpu/issues/5476> and <https://github.com/gfx-rs/wgpu/issues/6350>.

**Testing**

Tests will be added before this PR comes out of draft, to ensure that the error cases added here are covered.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
