### PR TITLE
Roll back once_cell to 1.19.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,12 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -2340,12 +2337,6 @@ name = "pollster"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
-
-[[package]]
-name = "portable-atomic"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "pp-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ nanorand = { version = "0.7", default-features = false, features = ["wyrand"] }
 noise = { version = "0.8", git = "https://github.com/Razaekel/noise-rs.git", rev = "c6942d4fb70af26db4441edcf41f90fa115333f2" }
 nv-flip = "0.1"
 obj = "0.10"
-once_cell = "1.20.1"
+once_cell = "1.19.0"
 parking_lot = "0.12.1"
 pico-args = { version = "0.5.0", features = [
     "eq-separator",


### PR DESCRIPTION
Roll back `wgpu`'s dependencies on `once_cell` from 1.20.1 to 1.19.0.

Version 1.20.1 of `once_cell` added a more complex conditional dependency on `portable-atomic`, which causes `cargo metadata` to incorrectly list `portable-atomic` as a dependency even though the given `once_cell` features are not enabled.

The Firefox source tree uses `cargo vet` to enforce supply-chain auditing. Since `cargo vet` depends on `cargo metadata` to tell it what crates are going to be included in the tree, the extraneous dependency above adds `portable-atomic` to the set of sources we must audit. Since `portable-atomic` is roughly [edit] 28kloc, we would like to avoid this.

Nothing in `wgpu` actually needs `once_cell` 1.20; it was upgraded by Dependabot. So the simplest workaround for the moment is to roll back the version.
