### PR TITLE
fix(web)!: remove `maxInterStageShaderComponents` from vendored `web-sys`

### DIFF
--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -815,7 +815,6 @@ fn map_wgt_limits(limits: webgpu_sys::GpuSupportedLimits) -> wgt::Limits {
         max_vertex_buffer_array_stride: limits.max_vertex_buffer_array_stride(),
         min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment(),
         min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment(),
-        max_inter_stage_shader_components: limits.max_inter_stage_shader_components(),
         max_color_attachments: limits.max_color_attachments(),
         max_color_attachment_bytes_per_sample: limits.max_color_attachment_bytes_per_sample(),
         max_compute_workgroup_storage_size: limits.max_compute_workgroup_storage_size(),
@@ -829,6 +828,7 @@ fn map_wgt_limits(limits: webgpu_sys::GpuSupportedLimits) -> wgt::Limits {
         max_subgroup_size: wgt::Limits::default().max_subgroup_size,
         max_push_constant_size: wgt::Limits::default().max_push_constant_size,
         max_non_sampler_bindings: wgt::Limits::default().max_non_sampler_bindings,
+        max_inter_stage_shader_components: wgt::Limits::default().max_inter_stage_shader_components,
     }
 }
 
@@ -875,7 +875,6 @@ fn map_js_sys_limits(limits: &wgt::Limits) -> js_sys::Object {
         (maxBufferSize, max_buffer_size),
         (maxVertexAttributes, max_vertex_attributes),
         (maxVertexBufferArrayStride, max_vertex_buffer_array_stride),
-        (maxInterStageShaderComponents, max_inter_stage_shader_components),
         (maxComputeWorkgroupStorageSize, max_compute_workgroup_storage_size),
         (maxComputeInvocationsPerWorkgroup, max_compute_invocations_per_workgroup),
         (maxComputeWorkgroupSizeX, max_compute_workgroup_size_x),

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuSupportedLimits.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuSupportedLimits.rs
@@ -266,17 +266,6 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn max_vertex_buffer_array_stride(this: &GpuSupportedLimits) -> u32;
 
-    # [wasm_bindgen (structural , method , getter , js_class = "GPUSupportedLimits" , js_name = maxInterStageShaderComponents)]
-    #[doc = "Getter for the `maxInterStageShaderComponents` field of this object."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUSupportedLimits/maxInterStageShaderComponents)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `GpuSupportedLimits`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn max_inter_stage_shader_components(this: &GpuSupportedLimits) -> u32;
-
     # [wasm_bindgen (structural , method , getter , js_class = "GPUSupportedLimits" , js_name = maxInterStageShaderVariables)]
     #[doc = "Getter for the `maxInterStageShaderVariables` field of this object."]
     #[doc = ""]


### PR DESCRIPTION
**Connections**

Works around #6290. CC @daxpedda, who will likely be fielding a review in which I upstream this to `web-sys` eventually.

**Description**

\-

**Testing**

Tested locally that we are successfully working around the problem. Can be tested with `cargo xtask run-wasm` and opening the `hello_compute` example.

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
