### PR TITLE
[wgpu] Revert changes to vendored copy of web-sys from #6377.

### DIFF
--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuSupportedLimits.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuSupportedLimits.rs
@@ -266,6 +266,17 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn max_vertex_buffer_array_stride(this: &GpuSupportedLimits) -> u32;
 
+    # [wasm_bindgen (structural , method , getter , js_class = "GPUSupportedLimits" , js_name = maxInterStageShaderComponents)]
+    #[doc = "Getter for the `maxInterStageShaderComponents` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUSupportedLimits/maxInterStageShaderComponents)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuSupportedLimits`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn max_inter_stage_shader_components(this: &GpuSupportedLimits) -> u32;
+
     # [wasm_bindgen (structural , method , getter , js_class = "GPUSupportedLimits" , js_name = maxInterStageShaderVariables)]
     #[doc = "Getter for the `maxInterStageShaderVariables` field of this object."]
     #[doc = ""]


### PR DESCRIPTION
Revert the changes to the vendored copy of web-sys's WebGPU bindings made in #6377. The only purpose of vendoring is to pin down our WebGPU JS bindings, not to allow local changes. And as it turns out, removing the `max_inter_stage_shader_components` accessor isn't necessary in order to fix #6290.
