### PR TITLE
[naga/wgsl-out] allow user-provided polyfills of `inverse` and `outer` 

### DIFF
--- a/naga/src/back/wgsl/mod.rs
+++ b/naga/src/back/wgsl/mod.rs
@@ -8,6 +8,7 @@ mod writer;
 
 use thiserror::Error;
 
+pub use writer::PolyfillOverload;
 pub use writer::{Writer, WriterFlags};
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
**Connections**
* https://github.com/gfx-rs/wgpu/issues/4330
* https://github.com/gpuweb/gpuweb/issues/4115
* https://github.com/gfx-rs/naga/issues/893

**Description**
`inverse` and `outer` are not currently supported by WGSL and might never be. However this leaves shaders that do need these functions fundamentally incompatible with WGSL unless they get polyfilled.

This provides an escape hatch for the user to provide their own polyfill for this function. The user is responsible for appending valid WGSL code to the output source that implements these polyfills.

Validation is unaffected because validation treats `inverse` and `outer` as normal `MathFunction`s. Providing an invalid polyfill or not appending the implementations is user error.

If something like this is desireable to have in naga, I wouldn't mind looking into similar functionality for msl-out as well.

**Testing**
I'm not sure how to utilize the existing test harness to test this, but I'm using something like this right now. Proper tests should be added before moving forward with this but I'll need some pointers on how or where to write these tests.

```rust
fn write_wgsl(module: &Module, info: &ModuleInfo) -> Result<String, ShaderCompileError> {
  let mut polyfills: naga::FastHashMap<_, _> = Default::default();
  polyfills.insert(
          PolyfillOverload::Inverse {
                    dimension: VectorSize::Quad,
                    width: 4,
                },
                String::from("inverse_4"),
   );

   let mut writer = naga::back::wgsl::Writer::new_with_polyfills(
            String::new(),
            WriterFlags::empty(),
            polyfills,
   );
   writer.write(module, info)?;
   let output = writer.finish();
   Ok(output)
}
```

<!-- 
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
