### PR TITLE
[naga spv-out] Expand LocalType to permit pointers to matrices.

### DIFF
--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -3,8 +3,8 @@ Implementations for `BlockContext` methods.
 */
 
 use super::{
-    helpers, index::BoundsCheckResult, make_local, selection::Selection, Block, BlockContext,
-    Dimension, Error, Instruction, LocalType, LookupType, ResultMember, Writer, WriterFlags,
+    helpers, index::BoundsCheckResult, selection::Selection, Block, BlockContext, Dimension, Error,
+    Instruction, LocalType, LookupType, ResultMember, Writer, WriterFlags,
 };
 use crate::{arena::Handle, proc::TypeResolution, Statement};
 use spirv::Word;
@@ -1809,7 +1809,9 @@ impl<'w> BlockContext<'w> {
                 Some(ty) => ty,
                 None => LookupType::Handle(ty_handle),
             },
-            TypeResolution::Value(ref inner) => LookupType::Local(make_local(inner).unwrap()),
+            TypeResolution::Value(ref inner) => {
+                LookupType::Local(LocalType::from_inner(inner).unwrap())
+            }
         };
         let result_type_id = self.get_type_id(result_lookup_ty);
 

--- a/naga/src/back/spv/ray.rs
+++ b/naga/src/back/spv/ray.rs
@@ -2,7 +2,7 @@
 Generating SPIR-V for ray query operations.
 */
 
-use super::{Block, BlockContext, Instruction, LocalType, LookupType};
+use super::{Block, BlockContext, Instruction, LocalType, LookupType, NumericType};
 use crate::arena::Handle;
 
 impl<'w> BlockContext<'w> {
@@ -22,11 +22,9 @@ impl<'w> BlockContext<'w> {
                 let desc_id = self.cached[descriptor];
                 let acc_struct_id = self.get_handle_id(acceleration_structure);
 
-                let flag_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
-                    vector_size: None,
-                    scalar: crate::Scalar::U32,
-                    pointer_space: None,
-                }));
+                let flag_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
+                    NumericType::Scalar(crate::Scalar::U32),
+                )));
                 let ray_flags_id = self.gen_id();
                 block.body.push(Instruction::composite_extract(
                     flag_type_id,
@@ -42,11 +40,9 @@ impl<'w> BlockContext<'w> {
                     &[1],
                 ));
 
-                let scalar_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
-                    vector_size: None,
-                    scalar: crate::Scalar::F32,
-                    pointer_space: None,
-                }));
+                let scalar_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
+                    NumericType::Scalar(crate::Scalar::F32),
+                )));
                 let tmin_id = self.gen_id();
                 block.body.push(Instruction::composite_extract(
                     scalar_type_id,
@@ -62,11 +58,11 @@ impl<'w> BlockContext<'w> {
                     &[3],
                 ));
 
-                let vector_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
-                    vector_size: Some(crate::VectorSize::Tri),
-                    scalar: crate::Scalar::F32,
-                    pointer_space: None,
-                }));
+                let vector_type_id =
+                    self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Vector {
+                        size: crate::VectorSize::Tri,
+                        scalar: crate::Scalar::F32,
+                    })));
                 let ray_origin_id = self.gen_id();
                 block.body.push(Instruction::composite_extract(
                     vector_type_id,
@@ -116,11 +112,9 @@ impl<'w> BlockContext<'w> {
             spirv::RayQueryIntersection::RayQueryCommittedIntersectionKHR as _,
         ));
 
-        let flag_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
-            vector_size: None,
-            scalar: crate::Scalar::U32,
-            pointer_space: None,
-        }));
+        let flag_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
+            NumericType::Scalar(crate::Scalar::U32),
+        )));
         let kind_id = self.gen_id();
         block.body.push(Instruction::ray_query_get_intersection(
             spirv::Op::RayQueryGetIntersectionTypeKHR,
@@ -170,11 +164,9 @@ impl<'w> BlockContext<'w> {
             intersection_id,
         ));
 
-        let scalar_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
-            vector_size: None,
-            scalar: crate::Scalar::F32,
-            pointer_space: None,
-        }));
+        let scalar_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
+            NumericType::Scalar(crate::Scalar::F32),
+        )));
         let t_id = self.gen_id();
         block.body.push(Instruction::ray_query_get_intersection(
             spirv::Op::RayQueryGetIntersectionTKHR,
@@ -184,11 +176,11 @@ impl<'w> BlockContext<'w> {
             intersection_id,
         ));
 
-        let barycentrics_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
-            vector_size: Some(crate::VectorSize::Bi),
-            scalar: crate::Scalar::F32,
-            pointer_space: None,
-        }));
+        let barycentrics_type_id =
+            self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Vector {
+                size: crate::VectorSize::Bi,
+                scalar: crate::Scalar::F32,
+            })));
         let barycentrics_id = self.gen_id();
         block.body.push(Instruction::ray_query_get_intersection(
             spirv::Op::RayQueryGetIntersectionBarycentricsKHR,
@@ -198,11 +190,9 @@ impl<'w> BlockContext<'w> {
             intersection_id,
         ));
 
-        let bool_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
-            vector_size: None,
-            scalar: crate::Scalar::BOOL,
-            pointer_space: None,
-        }));
+        let bool_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
+            NumericType::Scalar(crate::Scalar::BOOL),
+        )));
         let front_face_id = self.gen_id();
         block.body.push(Instruction::ray_query_get_intersection(
             spirv::Op::RayQueryGetIntersectionFrontFaceKHR,
@@ -212,11 +202,12 @@ impl<'w> BlockContext<'w> {
             intersection_id,
         ));
 
-        let transform_type_id = self.get_type_id(LookupType::Local(LocalType::Matrix {
-            columns: crate::VectorSize::Quad,
-            rows: crate::VectorSize::Tri,
-            width: 4,
-        }));
+        let transform_type_id =
+            self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Matrix {
+                columns: crate::VectorSize::Quad,
+                rows: crate::VectorSize::Tri,
+                scalar: crate::Scalar::F32,
+            })));
         let object_to_world_id = self.gen_id();
         block.body.push(Instruction::ray_query_get_intersection(
             spirv::Op::RayQueryGetIntersectionObjectToWorldKHR,

--- a/naga/src/back/spv/subgroup.rs
+++ b/naga/src/back/spv/subgroup.rs
@@ -1,4 +1,4 @@
-use super::{Block, BlockContext, Error, Instruction};
+use super::{Block, BlockContext, Error, Instruction, NumericType};
 use crate::{
     arena::Handle,
     back::spv::{LocalType, LookupType},
@@ -16,11 +16,11 @@ impl<'w> BlockContext<'w> {
             "GroupNonUniformBallot",
             &[spirv::Capability::GroupNonUniformBallot],
         )?;
-        let vec4_u32_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
-            vector_size: Some(crate::VectorSize::Quad),
-            scalar: crate::Scalar::U32,
-            pointer_space: None,
-        }));
+        let vec4_u32_type_id =
+            self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Vector {
+                size: crate::VectorSize::Quad,
+                scalar: crate::Scalar::U32,
+            })));
         let exec_scope_id = self.get_index_constant(spirv::Scope::Subgroup as u32);
         let predicate = if let Some(predicate) = *predicate {
             self.cached[predicate]

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -1,10 +1,10 @@
 use super::{
     block::DebugInfoInner,
     helpers::{contains_builtin, global_needs_wrapper, map_storage_class},
-    make_local, Block, BlockContext, CachedConstant, CachedExpressions, DebugInfo,
-    EntryPointContext, Error, Function, FunctionArgument, GlobalVariable, IdGenerator, Instruction,
-    LocalType, LocalVariable, LogicalLayout, LookupFunctionType, LookupType, Options,
-    PhysicalLayout, PipelineOptions, ResultMember, Writer, WriterFlags, BITS_PER_BYTE,
+    Block, BlockContext, CachedConstant, CachedExpressions, DebugInfo, EntryPointContext, Error,
+    Function, FunctionArgument, GlobalVariable, IdGenerator, Instruction, LocalType, LocalVariable,
+    LogicalLayout, LookupFunctionType, LookupType, Options, PhysicalLayout, PipelineOptions,
+    ResultMember, Writer, WriterFlags, BITS_PER_BYTE,
 };
 use crate::{
     arena::{Handle, HandleVec, UniqueArena},
@@ -254,7 +254,9 @@ impl Writer {
     pub(super) fn get_expression_lookup_type(&mut self, tr: &TypeResolution) -> LookupType {
         match *tr {
             TypeResolution::Handle(ty_handle) => LookupType::Handle(ty_handle),
-            TypeResolution::Value(ref inner) => LookupType::Local(make_local(inner).unwrap()),
+            TypeResolution::Value(ref inner) => {
+                LookupType::Local(LocalType::from_inner(inner).unwrap())
+            }
         }
     }
 
@@ -1025,7 +1027,7 @@ impl Writer {
         // because some types which map to the same LocalType have different
         // capability requirements. See https://github.com/gfx-rs/wgpu/issues/5569
         self.request_type_capabilities(&ty.inner)?;
-        let id = if let Some(local) = make_local(&ty.inner) {
+        let id = if let Some(local) = LocalType::from_inner(&ty.inner) {
             // This type can be represented as a `LocalType`, so check if we've
             // already written an instruction for it. If not, do so now, with
             // `write_type_declaration_local`.


### PR DESCRIPTION
In `back::spv`:

- Factor out the numeric variants of `LocalType` into a new enum, `NumericType`.

- Split the `Value` variant into `Numeric` and `LocalPointer` variants, and let `LocalPointer` point to any numeric type, including matrices.

  In subsequent PRs, we'll need to spill matrices out into temporary local variables. This means we'll need to generate SPIR-V pointer-to-matrix types, so `LocalType` needs to be able to represent that.

- Rename `make_local` to `LocalType::from_inner`.

  Change the free function `back::spv::make_local` into an associated function `LocalType::from_inner`.
