### PR TITLE
[naga spv-out] Simplify `Writer::get_pointer_id`.

### DIFF
--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -386,7 +386,6 @@ impl<'w> BlockContext<'w> {
                             }
                         };
                         let (id, variable) = self.writer.promote_access_expression_to_variable(
-                            &self.ir_module.types,
                             result_type_id,
                             base_id,
                             base_ty,

--- a/naga/src/back/spv/index.rs
+++ b/naga/src/back/spv/index.rs
@@ -226,7 +226,7 @@ impl<'w> BlockContext<'w> {
                 let element_type_id = match self.ir_module.types[global.ty].inner {
                     crate::TypeInner::BindingArray { base, size: _ } => {
                         let class = map_storage_class(global.space);
-                        self.get_pointer_id(base, class)?
+                        self.get_pointer_id(base, class)
                     }
                     _ => return Err(Error::Validation("array length expression case-5")),
                 };

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -655,13 +655,8 @@ impl BlockContext<'_> {
             .get_constant_scalar(crate::Literal::I32(scope as _))
     }
 
-    fn get_pointer_id(
-        &mut self,
-        handle: Handle<crate::Type>,
-        class: spirv::StorageClass,
-    ) -> Result<Word, Error> {
-        self.writer
-            .get_pointer_id(&self.ir_module.types, handle, class)
+    fn get_pointer_id(&mut self, handle: Handle<crate::Type>, class: spirv::StorageClass) -> Word {
+        self.writer.get_pointer_id(handle, class)
     }
 }
 


### PR DESCRIPTION
Simplify the definition of `naga::back::spv::Writer::get_pointer_id` by using `get_type_id`'s ability to handle `LocalType::Pointer`.

This means that `get_pointer_id` is no longer fallible, and no longer needs a type arena. Simplify callers, as well as the `BlockContext::get_pointer_id` convenience function.
