### PR TITLE
trivial fix typo in docs: `create_bind_group -> create_bind_group_layout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 
 - Removed some OpenGL and Vulkan references from `wgpu-types` documentation. Fixed Storage texel types in examples. By @Nelarius in [#6271](https://github.com/gfx-rs/wgpu/pull/6271)
 - Used `wgpu::include_wgsl!(…)` more in examples and tests. By @ErichDonGubler in [#6326](https://github.com/gfx-rs/wgpu/pull/6326).
+- Fix typo in docs (`create_bind_group -> create_bind_group_layout`) [#6404](https://github.com/gfx-rs/wgpu/pull/6404).
 
 ### Dependency Updates
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -6638,7 +6638,7 @@ pub enum BindingType {
         ///
         /// If this is `Some(size)`:
         ///
-        /// - When calling [`create_bind_group`], the resource at this bind point
+        /// - When calling [`create_bind_group_layout`], the resource at this bind point
         ///   must be a [`BindingResource::Buffer`] whose effective size is at
         ///   least `size`.
         ///


### PR DESCRIPTION


```rust
let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
            label: ...,
            entries: &[BindGroupLayoutEntry {
                binding: ...,
                visibility: ...,
                ty: BindingType::Buffer {
                    ty: ...,
                    has_dynamic_offset: ...,
                    min_binding_size: ...,  // Documentation of this field telling create_bind_group, not create_bind_group_layout
                },
                count: ...,
            }],
        });


```