### PR TITLE
Avoid creating the bind group for indirect validation if buffer size is 0

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -780,7 +780,10 @@ impl Device {
             let bind_group = indirect_validation
                 .create_src_bind_group(self.raw(), &self.limits, buffer_size, raw_buffer)
                 .map_err(resource::CreateBufferError::IndirectValidationBindGroup)?;
-            Ok(Snatchable::new(bind_group))
+            match bind_group {
+                Some(bind_group) => Ok(Snatchable::new(bind_group)),
+                None => Ok(Snatchable::empty()),
+            }
         } else {
             Ok(Snatchable::empty())
         }


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/wgpu/issues/6414.
