### PR TITLE
WGSL: Add a skeleton for enable-extensions/`enable …;` that reports nice errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 - Support local `const` declarations in WGSL. By @sagudev in [#6156](https://github.com/gfx-rs/wgpu/pull/6156).
 - Implemented `const_assert` in WGSL. By @sagudev in [#6198](https://github.com/gfx-rs/wgpu/pull/6198).
 - Support polyfilling `inverse` in WGSL. By @chyyran in [#6385](https://github.com/gfx-rs/wgpu/pull/6385).
-- Add an internal skeleton for parsing `requires`, `enable`, and `diagnostic` directives that don't yet do anything besides emit nicer errors. By @ErichDonGubler in [#6352](https://github.com/gfx-rs/wgpu/pull/6352).
+- Add an internal skeleton for parsing `requires`, `enable`, and `diagnostic` directives that don't yet do anything besides emit nicer errors. By @ErichDonGubler in [#6352](https://github.com/gfx-rs/wgpu/pull/6352), [#6424](https://github.com/gfx-rs/wgpu/pull/6424).
 - Include error chain information as a message and notes in shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
 - Unify Naga CLI error output with the format of shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
 

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -1,3 +1,6 @@
+use crate::front::wgsl::parse::directive::enable_extension::{
+    EnableExtension, UnimplementedEnableExtension,
+};
 use crate::front::wgsl::parse::directive::{DirectiveKind, UnimplementedDirectiveKind};
 use crate::front::wgsl::parse::lexer::Token;
 use crate::front::wgsl::Scalar;
@@ -186,6 +189,7 @@ pub(crate) enum Error<'a> {
     UnknownType(Span),
     UnknownStorageFormat(Span),
     UnknownConservativeDepth(Span),
+    UnknownEnableExtension(Span, &'a str),
     SizeAttributeTooLow(Span, u32),
     AlignAttributeTooLow(Span, Alignment),
     NonPowerOfTwoAlignAttribute(Span),
@@ -274,6 +278,10 @@ pub(crate) enum Error<'a> {
     },
     DirectiveAfterFirstGlobalDecl {
         directive_span: Span,
+    },
+    EnableExtensionNotYetImplemented {
+        kind: UnimplementedEnableExtension,
+        span: Span,
     },
 }
 
@@ -524,6 +532,14 @@ impl<'a> Error<'a> {
                 message: format!("unknown type: '{}'", &source[bad_span]),
                 labels: vec![(bad_span, "unknown type".into())],
                 notes: vec![],
+            },
+            Error::UnknownEnableExtension(span, word) => ParseError {
+                message: format!("unknown enable-extension `{}`", word),
+                labels: vec![(span, "".into())],
+                notes: vec![
+                    "See available extensions at <https://www.w3.org/TR/WGSL/#enable-extension>."
+                        .into(),
+                ],
             },
             Error::SizeAttributeTooLow(bad_span, min_size) => ParseError {
                 message: format!("struct member size must be at least {min_size}"),
@@ -906,6 +922,28 @@ impl<'a> Error<'a> {
                     "maybe hoist this closer to the top of the shader module?"
                 )
                 .into()],
+            },
+            Error::EnableExtensionNotYetImplemented { kind, span } => ParseError {
+                message: format!(
+                    "the `{}` extension is not yet supported",
+                    EnableExtension::Unimplemented(kind).to_ident()
+                ),
+                labels: vec![(
+                    span,
+                    concat!(
+                        "this extension specifies standard functionality ",
+                        "which is not yet implemented in Naga"
+                    )
+                    .into(),
+                )],
+                notes: vec![format!(
+                    concat!(
+                        "Let Naga maintainers know that you ran into this at ",
+                        "<https://github.com/gfx-rs/wgpu/issues/{}>, ",
+                        "so they can prioritize it!"
+                    ),
+                    kind.tracking_issue_num()
+                )],
             },
         }
     }

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -112,6 +112,8 @@ impl std::error::Error for ParseError {
 pub enum ExpectedToken<'a> {
     Token(Token<'a>),
     Identifier,
+    AfterIdentListComma,
+    AfterIdentListArg,
     /// Expected: constant, parenthesized expression, identifier
     PrimaryExpression,
     /// Expected: assignment, increment/decrement expression
@@ -345,6 +347,12 @@ impl<'a> Error<'a> {
                     ExpectedToken::Type => "type".to_string(),
                     ExpectedToken::Variable => "variable access".to_string(),
                     ExpectedToken::Function => "function name".to_string(),
+                    ExpectedToken::AfterIdentListArg => {
+                        "next argument, trailing comma, or end of list (',' or ';')".to_string()
+                    }
+                    ExpectedToken::AfterIdentListComma => {
+                        "next argument or end of list (';')".to_string()
+                    }
                 };
                 ParseError {
                     message: format!(

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -283,6 +283,10 @@ pub(crate) enum Error<'a> {
         kind: UnimplementedEnableExtension,
         span: Span,
     },
+    EnableExtensionNotEnabled {
+        kind: EnableExtension,
+        span: Span,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -944,6 +948,33 @@ impl<'a> Error<'a> {
                     ),
                     kind.tracking_issue_num()
                 )],
+            },
+            Error::EnableExtensionNotEnabled { kind, span } => ParseError {
+                message: format!("`{}` enable extension is not enabled", kind.to_ident()),
+                labels: vec![(
+                    span,
+                    format!(
+                        concat!(
+                            "the `{}` enable extension is needed for this functionality, ",
+                            "but it is not currently enabled"
+                        ),
+                        kind.to_ident()
+                    )
+                    .into(),
+                )],
+                notes: if let EnableExtension::Unimplemented(kind) = kind {
+                    vec![format!(
+                        concat!(
+                            "This extension is not yet implemented. ",
+                            "Let Naga maintainers know that you ran into this at ",
+                            "<https://github.com/gfx-rs/wgpu/issues/{}>, ",
+                            "so they can prioritize it!"
+                        ),
+                        kind.tracking_issue_num()
+                    )]
+                } else {
+                    vec![]
+                },
             },
         }
     }

--- a/naga/src/front/wgsl/parse/ast.rs
+++ b/naga/src/front/wgsl/parse/ast.rs
@@ -1,3 +1,4 @@
+use crate::front::wgsl::parse::directive::enable_extension::EnableExtensions;
 use crate::front::wgsl::parse::number::Number;
 use crate::front::wgsl::Scalar;
 use crate::{Arena, FastIndexSet, Handle, Span};
@@ -5,6 +6,7 @@ use std::hash::Hash;
 
 #[derive(Debug, Default)]
 pub struct TranslationUnit<'a> {
+    pub enable_extensions: EnableExtensions,
     pub decls: Arena<GlobalDecl<'a>>,
     /// The common expressions arena for the entire translation unit.
     ///

--- a/naga/src/front/wgsl/parse/directive/enable_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/enable_extension.rs
@@ -1,0 +1,112 @@
+//! `enable …;` extensions in WGSL.
+//!
+//! The focal point of this module is the [`EnableExtension`] API.
+use crate::{front::wgsl::error::Error, Span};
+
+/// Tracks the status of every enable extension known to Naga.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EnableExtensions {}
+
+impl EnableExtensions {
+    pub(crate) const fn empty() -> Self {
+        Self {}
+    }
+
+    /// Add an enable extension to the set requested by a module.
+    #[allow(unreachable_code)]
+    pub(crate) fn add(&mut self, ext: ImplementedEnableExtension) {
+        let _field: &mut bool = match ext {};
+        *_field = true;
+    }
+
+    /// Query whether an enable extension tracked here has been requested.
+    #[allow(unused)]
+    pub(crate) const fn contains(&self, ext: ImplementedEnableExtension) -> bool {
+        match ext {}
+    }
+}
+
+impl Default for EnableExtensions {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// A shader language extension not guaranteed to be present in all environments.
+///
+/// WGSL spec.: <https://www.w3.org/TR/WGSL/#enable-extensions-sec>
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub enum EnableExtension {
+    #[allow(unused)]
+    Implemented(ImplementedEnableExtension),
+    Unimplemented(UnimplementedEnableExtension),
+}
+
+impl EnableExtension {
+    const F16: &'static str = "f16";
+    const CLIP_DISTANCES: &'static str = "clip_distances";
+    const DUAL_SOURCE_BLENDING: &'static str = "dual_source_blending";
+
+    /// Convert from a sentinel word in WGSL into its associated [`EnableExtension`], if possible.
+    pub(crate) fn from_ident(word: &str, span: Span) -> Result<Self, Error<'_>> {
+        Ok(match word {
+            Self::F16 => Self::Unimplemented(UnimplementedEnableExtension::F16),
+            Self::CLIP_DISTANCES => {
+                Self::Unimplemented(UnimplementedEnableExtension::ClipDistances)
+            }
+            Self::DUAL_SOURCE_BLENDING => {
+                Self::Unimplemented(UnimplementedEnableExtension::DualSourceBlending)
+            }
+            _ => return Err(Error::UnknownEnableExtension(span, word)),
+        })
+    }
+
+    /// Maps this [`EnableExtension`] into the sentinel word associated with it in WGSL.
+    pub const fn to_ident(self) -> &'static str {
+        match self {
+            Self::Implemented(kind) => match kind {},
+            Self::Unimplemented(kind) => match kind {
+                UnimplementedEnableExtension::F16 => Self::F16,
+                UnimplementedEnableExtension::ClipDistances => Self::CLIP_DISTANCES,
+                UnimplementedEnableExtension::DualSourceBlending => Self::DUAL_SOURCE_BLENDING,
+            },
+        }
+    }
+}
+
+/// A variant of [`EnableExtension::Implemented`].
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub enum ImplementedEnableExtension {}
+
+/// A variant of [`EnableExtension::Unimplemented`].
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub enum UnimplementedEnableExtension {
+    /// Enables `f16`/`half` primitive support in all shader languages.
+    ///
+    /// In the WGSL standard, this corresponds to [`enable f16;`].
+    ///
+    /// [`enable f16;`]: https://www.w3.org/TR/WGSL/#extension-f16
+    F16,
+    /// Enables the `clip_distances` variable in WGSL.
+    ///
+    /// In the WGSL standard, this corresponds to [`enable clip_distances;`].
+    ///
+    /// [`enable clip_distances;`]: https://www.w3.org/TR/WGSL/#extension-f16
+    ClipDistances,
+    /// Enables the `blend_src` attribute in WGSL.
+    ///
+    /// In the WGSL standard, this corresponds to [`enable dual_source_blending;`].
+    ///
+    /// [`enable dual_source_blending;`]: https://www.w3.org/TR/WGSL/#extension-f16
+    DualSourceBlending,
+}
+
+impl UnimplementedEnableExtension {
+    pub(crate) const fn tracking_issue_num(self) -> u16 {
+        match self {
+            Self::F16 => 4384,
+            Self::ClipDistances => 6236,
+            Self::DualSourceBlending => 6402,
+        }
+    }
+}

--- a/naga/src/front/wgsl/parse/lexer.rs
+++ b/naga/src/front/wgsl/parse/lexer.rs
@@ -1,5 +1,6 @@
 use super::{number::consume_number, Error, ExpectedToken};
 use crate::front::wgsl::error::NumberError;
+use crate::front::wgsl::parse::directive::enable_extension::EnableExtensions;
 use crate::front::wgsl::parse::{conv, Number};
 use crate::front::wgsl::Scalar;
 use crate::Span;
@@ -204,6 +205,8 @@ pub(in crate::front::wgsl) struct Lexer<'a> {
     pub(in crate::front::wgsl) source: &'a str,
     // The byte offset of the end of the last non-trivia token.
     last_end_offset: usize,
+    #[allow(dead_code)]
+    pub(in crate::front::wgsl) enable_extensions: EnableExtensions,
 }
 
 impl<'a> Lexer<'a> {
@@ -212,6 +215,7 @@ impl<'a> Lexer<'a> {
             input,
             source: input,
             last_end_offset: 0,
+            enable_extensions: EnableExtensions::empty(),
         }
     }
 

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -1,5 +1,7 @@
 use crate::front::wgsl::error::{Error, ExpectedToken};
-use crate::front::wgsl::parse::directive::enable_extension::{EnableExtension, EnableExtensions};
+use crate::front::wgsl::parse::directive::enable_extension::{
+    EnableExtension, EnableExtensions, UnimplementedEnableExtension,
+};
 use crate::front::wgsl::parse::directive::DirectiveKind;
 use crate::front::wgsl::parse::lexer::{Lexer, Token};
 use crate::front::wgsl::parse::number::Number;
@@ -667,7 +669,15 @@ impl Parser {
             }
             (Token::Number(res), span) => {
                 let _ = lexer.next();
-                let num = res.map_err(|err| Error::BadNumber(span, err))?;
+                let num = res.map_err(|err| match err {
+                    super::error::NumberError::UnimplementedF16 => {
+                        Error::EnableExtensionNotEnabled {
+                            kind: EnableExtension::Unimplemented(UnimplementedEnableExtension::F16),
+                            span,
+                        }
+                    }
+                    err => Error::BadNumber(span, err),
+                })?;
                 ast::Expression::Literal(ast::Literal::Number(num))
             }
             (Token::Word("RAY_FLAG_NONE"), _) => {


### PR DESCRIPTION
**Connections**

- Based on <https://github.com/gfx-rs/wgpu/pull/6352>.
- Paves the way for #5701, #6236, and #6402.

**Description**

This PR is much like #6352, but for the `enable` directive; it unblocks work on `enable` extensions in WGSL by serving as a foundation on which to build individual extension functionality. It does the following:

1. Build on #6352 by parsing an `enable` extension list after we encounter an `enable` in the directive parse path keyword, instead of emitting an unimplemented directive error.
2. Create an `enum` modeling all known extensions, including standard-but-unimplemented ones.
3. Add nice diagnostics for known and unknown extensions. If a known, but unimplemented, extension is requested, provide a hint that points users towards the appropriate Naga issue, so they can let us know they were blocked.

Note that this PR does not actually implement any extensions yet—see also the `UnimplementedEnableExtension::tracking_issue_num` method added in this PR for references to follow-up work for those.

**Testing**

- This functionality is exercised in #5701.
- More exhaustive tests will be added in <https://github.com/gfx-rs/wgpu/pull/6444>. 

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
