### PR TITLE
Optimise GL fence checking by querying less

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 
 - Fix GL debug message callbacks not being properly cleaned up (causing UB). By @Imberflur in [#6114](https://github.com/gfx-rs/wgpu/pull/6114)
 - Fix calling `slice::from_raw_parts` with unaligned pointers in push constant handling. By @Imberflur in [#6341](https://github.com/gfx-rs/wgpu/pull/6341)
+- Optimise fence checking when `Queue::submit` is called many times per frame. By @dinnerbone in [#6427](https://github.com/gfx-rs/wgpu/pull/6427)
 
 #### WebGPU
 

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -8,6 +8,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use crate::AtomicFenceValue;
 use arrayvec::ArrayVec;
 use std::sync::atomic::Ordering;
 
@@ -1534,7 +1535,7 @@ impl crate::Device for super::Device {
     unsafe fn create_fence(&self) -> Result<super::Fence, crate::DeviceError> {
         self.counters.fences.add(1);
         Ok(super::Fence {
-            last_completed: 0,
+            last_completed: AtomicFenceValue::new(0),
             pending: Vec::new(),
         })
     }
@@ -1560,7 +1561,7 @@ impl crate::Device for super::Device {
         wait_value: crate::FenceValue,
         timeout_ms: u32,
     ) -> Result<bool, crate::DeviceError> {
-        if fence.last_completed < wait_value {
+        if fence.last_completed.load(Ordering::Relaxed) < wait_value {
             let gl = &self.shared.context.lock();
             let timeout_ns = if cfg!(any(webgl, Emscripten)) {
                 0
@@ -1572,19 +1573,25 @@ impl crate::Device for super::Device {
                 .iter()
                 .find(|&&(value, _)| value >= wait_value)
             {
-                return match unsafe {
+                let signalled = match unsafe {
                     gl.client_wait_sync(sync, glow::SYNC_FLUSH_COMMANDS_BIT, timeout_ns as i32)
                 } {
                     // for some reason firefox returns WAIT_FAILED, to investigate
                     #[cfg(any(webgl, Emscripten))]
                     glow::WAIT_FAILED => {
                         log::warn!("wait failed!");
-                        Ok(false)
+                        false
                     }
-                    glow::TIMEOUT_EXPIRED => Ok(false),
-                    glow::CONDITION_SATISFIED | glow::ALREADY_SIGNALED => Ok(true),
-                    _ => Err(crate::DeviceError::Lost),
+                    glow::TIMEOUT_EXPIRED => false,
+                    glow::CONDITION_SATISFIED | glow::ALREADY_SIGNALED => true,
+                    _ => return Err(crate::DeviceError::Lost),
                 };
+                if signalled {
+                    fence
+                        .last_completed
+                        .fetch_max(wait_value, Ordering::Relaxed);
+                }
+                return Ok(signalled);
             }
         }
         Ok(true)

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -120,7 +120,7 @@ use glow::HasContext;
 
 use naga::FastHashMap;
 use parking_lot::Mutex;
-use std::sync::atomic::{AtomicU32, AtomicU8};
+use std::sync::atomic::{AtomicU32, AtomicU8, Ordering};
 use std::{fmt, ops::Range, sync::Arc};
 
 #[derive(Clone, Debug)]
@@ -718,7 +718,7 @@ impl crate::DynQuerySet for QuerySet {}
 
 #[derive(Debug)]
 pub struct Fence {
-    last_completed: crate::FenceValue,
+    last_completed: crate::AtomicFenceValue,
     pending: Vec<(crate::FenceValue, glow::Fence)>,
 }
 
@@ -743,7 +743,7 @@ unsafe impl Sync for Fence {}
 
 impl Fence {
     fn get_latest(&self, gl: &glow::Context) -> crate::FenceValue {
-        let mut max_value = self.last_completed;
+        let mut max_value = self.last_completed.load(Ordering::Relaxed);
         for &(value, sync) in self.pending.iter() {
             if value <= max_value {
                 // We already know this was good, no need to check again
@@ -757,6 +757,10 @@ impl Fence {
                 break;
             }
         }
+
+        // Track the latest value, to save ourselves some querying later
+        self.last_completed.fetch_max(max_value, Ordering::Relaxed);
+
         max_value
     }
 
@@ -770,7 +774,6 @@ impl Fence {
             }
         }
         self.pending.retain(|&(value, _)| value > latest);
-        self.last_completed = latest;
     }
 }
 


### PR DESCRIPTION
**Connections**
This fixes https://github.com/gfx-rs/wgpu/issues/5179

**Description**
By keeping better track of which GL sync object last signalled, we can avoid repeatedly querying the status of them over and over. Additionally, bail early when encountering an unsignalled object as we know the remaining objects can't be signalled.

This has a noticable impact on performance when there are many `Queue::submit()`s per frame. For an extreme and contrived case, testing with the code below shows a reduction in frame time from 2 minutes to 2 seconds for me (with firefox, which seems to have a high cost of each sync check due to IPC)

_(It's likely we can apply the same optimisation to Vulkan's FencePool too, but, I doubt the cost is nearly as high there as WebGL.)_

**Testing**
Passes tests, and manually tested the impact by adding the following code to `hello_triangle`:
```rust
for _ in 0..1000 {
    let encoder = device.create_command_encoder(&Default::default());
    queue.submit(Some(encoder.finish()));
}
```

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
