### PR TITLE
Unify validation error presentation in Naga CLI and WebGPU compilation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 - Support polyfilling `inverse` in WGSL. By @chyyran in [#6385](https://github.com/gfx-rs/wgpu/pull/6385).
 - Add an internal skeleton for parsing `requires`, `enable`, and `diagnostic` directives that don't yet do anything besides emit nicer errors. By @ErichDonGubler in [#6352](https://github.com/gfx-rs/wgpu/pull/6352).
 - Include error chain information as a message and notes in shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
+- Unify Naga CLI error output with the format of shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
 
 #### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 - Implemented `const_assert` in WGSL. By @sagudev in [#6198](https://github.com/gfx-rs/wgpu/pull/6198).
 - Support polyfilling `inverse` in WGSL. By @chyyran in [#6385](https://github.com/gfx-rs/wgpu/pull/6385).
 - Add an internal skeleton for parsing `requires`, `enable`, and `diagnostic` directives that don't yet do anything besides emit nicer errors. By @ErichDonGubler in [#6352](https://github.com/gfx-rs/wgpu/pull/6352).
+- Include error chain information as a message and notes in shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
 
 #### General
 

--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -516,7 +516,7 @@ fn run() -> anyhow::Result<()> {
             // Validation failure is not fatal. Just report the error.
             if let Some(input) = &input_text {
                 let filename = input_path.file_name().and_then(std::ffi::OsStr::to_str);
-                emit_annotated_error(&error, filename.unwrap_or("input"), input);
+                error.emit_to_stderr_with_path(input, filename.unwrap_or("input"));
             } else {
                 print_err(&error);
             }
@@ -545,7 +545,7 @@ fn run() -> anyhow::Result<()> {
                     eprintln!("Error validating compacted module:");
                     if let Some(input) = &input_text {
                         let filename = input_path.file_name().and_then(std::ffi::OsStr::to_str);
-                        emit_annotated_error(&error, filename.unwrap_or("input"), input);
+                        error.emit_to_stderr_with_path(input, filename.unwrap_or("input"));
                     } else {
                         print_err(&error);
                     }
@@ -871,7 +871,7 @@ fn bulk_validate(args: Args, params: &Parameters) -> anyhow::Result<()> {
             eprintln!("Error validating {input_path}:");
             if let Some(input) = &input_text {
                 let filename = path.file_name().and_then(std::ffi::OsStr::to_str);
-                emit_annotated_error(&error, filename.unwrap_or("input"), input);
+                error.emit_to_stderr_with_path(input, filename.unwrap_or("input"));
             } else {
                 print_err(&error);
             }
@@ -896,8 +896,4 @@ fn bulk_validate(args: Args, params: &Parameters) -> anyhow::Result<()> {
 }
 
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
-use naga::{FastHashMap, WithSpan};
-
-pub fn emit_annotated_error<E: Error>(ann_err: &WithSpan<E>, filename: &str, source: &str) {
-    ann_err.emit_to_stderr_with_path(source, filename);
-}
+use naga::FastHashMap;

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -239,7 +239,7 @@ impl<E> WithSpan<E> {
         Some(self.spans[0].0.location(source))
     }
 
-    fn diagnostic(&self) -> codespan_reporting::diagnostic::Diagnostic<()>
+    pub(crate) fn diagnostic(&self) -> codespan_reporting::diagnostic::Diagnostic<()>
     where
         E: Error,
     {


### PR DESCRIPTION
**Connections**

- Supersedes <https://github.com/gfx-rs/wgpu/pull/3731>.
- One step on the path towards <https://github.com/gfx-rs/wgpu/issues/4494>.

**Description**

This PR changes the format of validation errors emitted by `naga` CLI and the compilation message API in WebGPU. It changes the presentation of the error in this shader:

```wgsl
fn sdfRect(samplePosition: vec2f, halfSize: vec2f) -> f32 {
    let componentWiseEdgeDistance = abs(samplePosition) - halfSize;
    let outsideDistance = length(max(componentWiseEdgeDistance, vec2f(0)));
    let insideDistance = min(max(componentWiseEdgeDistance.x, componentWiseEdgeDistance.y), 0);
    return outsideDistance + insideDistance;
}
```

…which is reported like this in Naga CLI:

```
error:
  ┌─ in.wgsl:1:1
  │
1 │ ╭ fn sdfRect(samplePosition: vec2f, halfSize: vec2f) -> f32 {
2 │ │     let componentWiseEdgeDistance = abs(samplePosition) - halfSize;
3 │ │     let outsideDistance = length(max(componentWiseEdgeDistance, vec2f(0)));
4 │ │     let insideDistance = min(max(componentWiseEdgeDistance.x, componentWiseEdgeDistance.y), 0);
  │ │                          ^^^ naga::Expression [12]
5 │ │     return outsideDistance + insideDistance;
  │ ╰────────────────────────────────────────────^ naga::Function [0]

Function [0] 'sdfRect' is invalid:
        Expression [12] is invalid
        Argument [1] to Min as expression [11] has an invalid type.
```


…and, particularly badly and motivating this PR, like this in consumers of the compilation message API in WebGPU:

```
Shader validation error: 
  ┌─ in.wgsl:1:1
  │  
1 │ ╭ fn sdfRect(samplePosition: vec2f, halfSize: vec2f) -> f32 {
2 │ │     let componentWiseEdgeDistance = abs(samplePosition) - halfSize;
3 │ │     let outsideDistance = length(max(componentWiseEdgeDistance, vec2f(0)));
4 │ │     let insideDistance = min(max(componentWiseEdgeDistance.x, componentWiseEdgeDistance.y), 0);
  │ │                          ^^^ naga::Expression [12]
5 │ │     return outsideDistance + insideDistance;
  │ ╰────────────────────────────────────────────^ naga::Function [0]
```

…to this in both contexts:

```
error: Function [0] 'sdfRect' is invalid
  ┌─ in.wgsl:1:1
  │
1 │ ╭ fn sdfRect(samplePosition: vec2f, halfSize: vec2f) -> f32 {
2 │ │     let componentWiseEdgeDistance = abs(samplePosition) - halfSize;
3 │ │     let outsideDistance = length(max(componentWiseEdgeDistance, vec2f(0)));
4 │ │     let insideDistance = min(max(componentWiseEdgeDistance.x, componentWiseEdgeDistance.y), 0);
  │ │                          ^^^ naga::Expression [12]
5 │ │     return outsideDistance + insideDistance;
  │ ╰────────────────────────────────────────────^ naga::Function [0]
  │
  = Expression [12] is invalid
  = Argument [1] to Min as expression [11] has an invalid type.
```

**Testing**

I have validated the output of this myself, as is hopefully demonstrated. No tests appeared to need to be updated. If we want snapshot coverage for Naga CLI's output, or our WebGPU API's compilation message items, I believe we should file a follow-up issue to address it.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
