### PR TITLE
WGSL: add base support for `requires` that reports nice errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 - Support local `const` declarations in WGSL. By @sagudev in [#6156](https://github.com/gfx-rs/wgpu/pull/6156).
 - Implemented `const_assert` in WGSL. By @sagudev in [#6198](https://github.com/gfx-rs/wgpu/pull/6198).
 - Support polyfilling `inverse` in WGSL. By @chyyran in [#6385](https://github.com/gfx-rs/wgpu/pull/6385).
-- Add an internal skeleton for parsing `requires`, `enable`, and `diagnostic` directives that don't yet do anything besides emit nicer errors. By @ErichDonGubler in [#6352](https://github.com/gfx-rs/wgpu/pull/6352), [#6424](https://github.com/gfx-rs/wgpu/pull/6424), [#6437](https://github.com/gfx-rs/wgpu/pull/6437).
+- Add base support for parsing `requires`, `enable`, and `diagnostic` directives. No extensions or diagnostic filters are yet supported, but diagnostics have improved dramatically. By @ErichDonGubler in [#6352](https://github.com/gfx-rs/wgpu/pull/6352), [#6424](https://github.com/gfx-rs/wgpu/pull/6424), [#6437](https://github.com/gfx-rs/wgpu/pull/6437).
 - Include error chain information as a message and notes in shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
 - Unify Naga CLI error output with the format of shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 - Support local `const` declarations in WGSL. By @sagudev in [#6156](https://github.com/gfx-rs/wgpu/pull/6156).
 - Implemented `const_assert` in WGSL. By @sagudev in [#6198](https://github.com/gfx-rs/wgpu/pull/6198).
 - Support polyfilling `inverse` in WGSL. By @chyyran in [#6385](https://github.com/gfx-rs/wgpu/pull/6385).
-- Add an internal skeleton for parsing `requires`, `enable`, and `diagnostic` directives that don't yet do anything besides emit nicer errors. By @ErichDonGubler in [#6352](https://github.com/gfx-rs/wgpu/pull/6352), [#6424](https://github.com/gfx-rs/wgpu/pull/6424).
+- Add an internal skeleton for parsing `requires`, `enable`, and `diagnostic` directives that don't yet do anything besides emit nicer errors. By @ErichDonGubler in [#6352](https://github.com/gfx-rs/wgpu/pull/6352), [#6424](https://github.com/gfx-rs/wgpu/pull/6424), [#6437](https://github.com/gfx-rs/wgpu/pull/6437).
 - Include error chain information as a message and notes in shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
 - Unify Naga CLI error output with the format of shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
 

--- a/naga/src/front/wgsl/parse/directive/language_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/language_extension.rs
@@ -1,0 +1,85 @@
+//! `requires …;` extensions in WGSL.
+//!
+//! The focal point of this module is the [`LanguageExtension`] API.
+
+/// A language extension not guaranteed to be present in all environments.
+///
+/// WGSL spec.: <https://www.w3.org/TR/WGSL/#language-extensions-sec>
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum LanguageExtension {
+    #[allow(unused)]
+    Implemented(ImplementedLanguageExtension),
+    Unimplemented(UnimplementedLanguageExtension),
+}
+
+impl LanguageExtension {
+    const READONLY_AND_READWRITE_STORAGE_TEXTURES: &'static str =
+        "readonly_and_readwrite_storage_textures";
+    const PACKED4X8_INTEGER_DOT_PRODUCT: &'static str = "packed_4x8_integer_dot_product";
+    const UNRESTRICTED_POINTER_PARAMETERS: &'static str = "unrestricted_pointer_parameters";
+    const POINTER_COMPOSITE_ACCESS: &'static str = "pointer_composite_access";
+
+    /// Convert from a sentinel word in WGSL into its associated [`LanguageExtension`], if possible.
+    pub fn from_ident(s: &str) -> Option<Self> {
+        Some(match s {
+            Self::READONLY_AND_READWRITE_STORAGE_TEXTURES => Self::Unimplemented(
+                UnimplementedLanguageExtension::ReadOnlyAndReadWriteStorageTextures,
+            ),
+            Self::PACKED4X8_INTEGER_DOT_PRODUCT => {
+                Self::Unimplemented(UnimplementedLanguageExtension::Packed4x8IntegerDotProduct)
+            }
+            Self::UNRESTRICTED_POINTER_PARAMETERS => {
+                Self::Unimplemented(UnimplementedLanguageExtension::UnrestrictedPointerParameters)
+            }
+            Self::POINTER_COMPOSITE_ACCESS => {
+                Self::Unimplemented(UnimplementedLanguageExtension::PointerCompositeAccess)
+            }
+            _ => return None,
+        })
+    }
+
+    /// Maps this [`LanguageExtension`] into the sentinel word associated with it in WGSL.
+    pub const fn to_ident(self) -> &'static str {
+        match self {
+            Self::Implemented(kind) => match kind {},
+            Self::Unimplemented(kind) => match kind {
+                UnimplementedLanguageExtension::ReadOnlyAndReadWriteStorageTextures => {
+                    Self::READONLY_AND_READWRITE_STORAGE_TEXTURES
+                }
+                UnimplementedLanguageExtension::Packed4x8IntegerDotProduct => {
+                    Self::PACKED4X8_INTEGER_DOT_PRODUCT
+                }
+                UnimplementedLanguageExtension::UnrestrictedPointerParameters => {
+                    Self::UNRESTRICTED_POINTER_PARAMETERS
+                }
+                UnimplementedLanguageExtension::PointerCompositeAccess => {
+                    Self::POINTER_COMPOSITE_ACCESS
+                }
+            },
+        }
+    }
+}
+
+/// A variant of [`LanguageExtension::Implemented`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum ImplementedLanguageExtension {}
+
+/// A variant of [`LanguageExtension::Unimplemented`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum UnimplementedLanguageExtension {
+    ReadOnlyAndReadWriteStorageTextures,
+    Packed4x8IntegerDotProduct,
+    UnrestrictedPointerParameters,
+    PointerCompositeAccess,
+}
+
+impl UnimplementedLanguageExtension {
+    pub(crate) const fn tracking_issue_num(self) -> u16 {
+        match self {
+            Self::ReadOnlyAndReadWriteStorageTextures => 6204,
+            Self::Packed4x8IntegerDotProduct => 6445,
+            Self::UnrestrictedPointerParameters => 5158,
+            Self::PointerCompositeAccess => 6192,
+        }
+    }
+}


### PR DESCRIPTION
**Connections**

- Resolves #6350.

**Description**

\-

**Testing**

- I've manually tested this to my satisfaction.
- Tests will be added in a follow-up PR for the most impactful coverage. Exhaustive coverage is left for WebGPU CTS.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
