### PR TITLE
Adapter docs tell how to create

### DIFF
--- a/wgpu/src/api/adapter.rs
+++ b/wgpu/src/api/adapter.rs
@@ -5,6 +5,9 @@ use crate::*;
 
 /// Handle to a physical graphics and/or compute device.
 ///
+/// Adapters can be created using [`Instance::request_adapter`]
+/// or other [`Instance`] methods.
+///
 /// Adapters can be used to open a connection to the corresponding [`Device`]
 /// on the host system by using [`Adapter::request_device`].
 ///


### PR DESCRIPTION
This is a trivial change to the documentation.

I haven't used WGPU for awhile and forgot how to create an Adapter. I eventually figured it out, but the doc changes in this PR would have helped me.