### PR TITLE
Avoid breaking change: `set_bind_group` now takes  `Into<Option<...>>` rather than `Option<...>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,11 @@ By @teoxoy [#6134](https://github.com/gfx-rs/wgpu/pull/6134).
 #### `set_bind_group` now takes an `Option` for the bind group argument.
 
 https://gpuweb.github.io/gpuweb/#programmable-passes-bind-groups specifies that bindGroup
-is nullable. This change is the start of implementing this part of the spec. Callers that
-specify a `Some()` value should have unchanged behavior. Handling of `None` values still
+is nullable. This change is the start of implementing this part of the spec.
+Callers that specify a `Some()` value should have unchanged behavior. Handling of `None` values still
 needs to be implemented by backends.
+For convenience, the `set_bind_group` on compute/render passes & encoders takes `impl Into<Option<&BindGroup>>`,
+so most code should still work the same.
 
 By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 

--- a/benches/benches/computepass.rs
+++ b/benches/benches/computepass.rs
@@ -389,7 +389,7 @@ impl ComputepassState {
         let end_idx = start_idx + dispatch_per_pass;
         for dispatch_idx in start_idx..end_idx {
             compute_pass.set_pipeline(&self.pipeline);
-            compute_pass.set_bind_group(0, Some(&self.bind_groups[dispatch_idx]), &[]);
+            compute_pass.set_bind_group(0, &self.bind_groups[dispatch_idx], &[]);
             compute_pass.dispatch_workgroups(1, 1, 1);
         }
 

--- a/benches/benches/renderpass.rs
+++ b/benches/benches/renderpass.rs
@@ -367,7 +367,7 @@ impl RenderpassState {
         let end_idx = start_idx + draws_per_pass;
         for draw_idx in start_idx..end_idx {
             render_pass.set_pipeline(&self.pipeline);
-            render_pass.set_bind_group(0, Some(&self.bind_groups[draw_idx]), &[]);
+            render_pass.set_bind_group(0, &self.bind_groups[draw_idx], &[]);
             for i in 0..VERTEX_BUFFERS_PER_DRAW {
                 render_pass.set_vertex_buffer(
                     i as u32,

--- a/examples/src/boids/mod.rs
+++ b/examples/src/boids/mod.rs
@@ -292,7 +292,7 @@ impl crate::framework::Example for Example {
                 timestamp_writes: None,
             });
             cpass.set_pipeline(&self.compute_pipeline);
-            cpass.set_bind_group(0, Some(&self.particle_bind_groups[self.frame_num % 2]), &[]);
+            cpass.set_bind_group(0, &self.particle_bind_groups[self.frame_num % 2], &[]);
             cpass.dispatch_workgroups(self.work_group_count, 1, 1);
         }
         command_encoder.pop_debug_group();

--- a/examples/src/bunnymark/mod.rs
+++ b/examples/src/bunnymark/mod.rs
@@ -128,11 +128,11 @@ impl Example {
                 occlusion_query_set: None,
             });
             rpass.set_pipeline(&self.pipeline);
-            rpass.set_bind_group(0, Some(&self.global_group), &[]);
+            rpass.set_bind_group(0, &self.global_group, &[]);
             for i in 0..self.bunnies.len() {
                 let offset =
                     (i as wgpu::DynamicOffset) * (uniform_alignment as wgpu::DynamicOffset);
-                rpass.set_bind_group(1, Some(&self.local_group), &[offset]);
+                rpass.set_bind_group(1, &self.local_group, &[offset]);
                 rpass.draw(0..4, 0..1);
             }
         }

--- a/examples/src/conservative_raster/mod.rs
+++ b/examples/src/conservative_raster/mod.rs
@@ -296,7 +296,7 @@ impl crate::framework::Example for Example {
             });
 
             rpass.set_pipeline(&self.pipeline_upscale);
-            rpass.set_bind_group(0, Some(&self.bind_group_upscale), &[]);
+            rpass.set_bind_group(0, &self.bind_group_upscale, &[]);
             rpass.draw(0..3, 0..1);
 
             if let Some(pipeline_lines) = &self.pipeline_lines {

--- a/examples/src/cube/mod.rs
+++ b/examples/src/cube/mod.rs
@@ -358,7 +358,7 @@ impl crate::framework::Example for Example {
             });
             rpass.push_debug_group("Prepare data for draw.");
             rpass.set_pipeline(&self.pipeline);
-            rpass.set_bind_group(0, Some(&self.bind_group), &[]);
+            rpass.set_bind_group(0, &self.bind_group, &[]);
             rpass.set_index_buffer(self.index_buf.slice(..), wgpu::IndexFormat::Uint16);
             rpass.set_vertex_buffer(0, self.vertex_buf.slice(..));
             rpass.pop_debug_group();

--- a/examples/src/hello_compute/mod.rs
+++ b/examples/src/hello_compute/mod.rs
@@ -132,7 +132,7 @@ async fn execute_gpu_inner(
             timestamp_writes: None,
         });
         cpass.set_pipeline(&compute_pipeline);
-        cpass.set_bind_group(0, Some(&bind_group), &[]);
+        cpass.set_bind_group(0, &bind_group, &[]);
         cpass.insert_debug_marker("compute collatz iterations");
         cpass.dispatch_workgroups(numbers.len() as u32, 1, 1); // Number of cells to run, the (x,y,z) size of item being processed
     }

--- a/examples/src/hello_synchronization/mod.rs
+++ b/examples/src/hello_synchronization/mod.rs
@@ -125,7 +125,7 @@ async fn execute(
             timestamp_writes: None,
         });
         compute_pass.set_pipeline(&patient_pipeline);
-        compute_pass.set_bind_group(0, Some(&bind_group), &[]);
+        compute_pass.set_bind_group(0, &bind_group, &[]);
         compute_pass.dispatch_workgroups(local_patient_workgroup_results.len() as u32, 1, 1);
     }
     queue.submit(Some(command_encoder.finish()));
@@ -147,7 +147,7 @@ async fn execute(
             timestamp_writes: None,
         });
         compute_pass.set_pipeline(&hasty_pipeline);
-        compute_pass.set_bind_group(0, Some(&bind_group), &[]);
+        compute_pass.set_bind_group(0, &bind_group, &[]);
         compute_pass.dispatch_workgroups(local_patient_workgroup_results.len() as u32, 1, 1);
     }
     queue.submit(Some(command_encoder.finish()));

--- a/examples/src/hello_workgroups/mod.rs
+++ b/examples/src/hello_workgroups/mod.rs
@@ -124,7 +124,7 @@ async fn run() {
             timestamp_writes: None,
         });
         compute_pass.set_pipeline(&pipeline);
-        compute_pass.set_bind_group(0, Some(&bind_group), &[]);
+        compute_pass.set_bind_group(0, &bind_group, &[]);
         /* Note that since each workgroup will cover both arrays, we only need to
         cover the length of one array. */
         compute_pass.dispatch_workgroups(local_a.len() as u32, 1, 1);

--- a/examples/src/mipmap/mod.rs
+++ b/examples/src/mipmap/mod.rs
@@ -177,7 +177,7 @@ impl Example {
                 );
             }
             rpass.set_pipeline(&pipeline);
-            rpass.set_bind_group(0, Some(&bind_group), &[]);
+            rpass.set_bind_group(0, &bind_group, &[]);
             rpass.draw(0..3, 0..1);
             if let Some(ref query_sets) = query_sets {
                 rpass.write_timestamp(&query_sets.timestamp, timestamp_query_index_base + 1);
@@ -491,7 +491,7 @@ impl crate::framework::Example for Example {
                 occlusion_query_set: None,
             });
             rpass.set_pipeline(&self.draw_pipeline);
-            rpass.set_bind_group(0, Some(&self.bind_group), &[]);
+            rpass.set_bind_group(0, &self.bind_group, &[]);
             rpass.draw(0..4, 0..1);
         }
 

--- a/examples/src/repeated_compute/mod.rs
+++ b/examples/src/repeated_compute/mod.rs
@@ -59,7 +59,7 @@ async fn compute(local_buffer: &mut [u32], context: &WgpuContext) {
             timestamp_writes: None,
         });
         compute_pass.set_pipeline(&context.pipeline);
-        compute_pass.set_bind_group(0, Some(&context.bind_group), &[]);
+        compute_pass.set_bind_group(0, &context.bind_group, &[]);
         compute_pass.dispatch_workgroups(local_buffer.len() as u32, 1, 1);
     }
     // We finish the compute pass by dropping it.

--- a/examples/src/shadow/mod.rs
+++ b/examples/src/shadow/mod.rs
@@ -776,10 +776,10 @@ impl crate::framework::Example for Example {
                     occlusion_query_set: None,
                 });
                 pass.set_pipeline(&self.shadow_pass.pipeline);
-                pass.set_bind_group(0, Some(&self.shadow_pass.bind_group), &[]);
+                pass.set_bind_group(0, &self.shadow_pass.bind_group, &[]);
 
                 for entity in &self.entities {
-                    pass.set_bind_group(1, Some(&self.entity_bind_group), &[entity.uniform_offset]);
+                    pass.set_bind_group(1, &self.entity_bind_group, &[entity.uniform_offset]);
                     pass.set_index_buffer(entity.index_buf.slice(..), entity.index_format);
                     pass.set_vertex_buffer(0, entity.vertex_buf.slice(..));
                     pass.draw_indexed(0..entity.index_count as u32, 0, 0..1);
@@ -820,10 +820,10 @@ impl crate::framework::Example for Example {
                 occlusion_query_set: None,
             });
             pass.set_pipeline(&self.forward_pass.pipeline);
-            pass.set_bind_group(0, Some(&self.forward_pass.bind_group), &[]);
+            pass.set_bind_group(0, &self.forward_pass.bind_group, &[]);
 
             for entity in &self.entities {
-                pass.set_bind_group(1, Some(&self.entity_bind_group), &[entity.uniform_offset]);
+                pass.set_bind_group(1, &self.entity_bind_group, &[entity.uniform_offset]);
                 pass.set_index_buffer(entity.index_buf.slice(..), entity.index_format);
                 pass.set_vertex_buffer(0, entity.vertex_buf.slice(..));
                 pass.draw_indexed(0..entity.index_count as u32, 0, 0..1);

--- a/examples/src/skybox/mod.rs
+++ b/examples/src/skybox/mod.rs
@@ -448,7 +448,7 @@ impl crate::framework::Example for Example {
                 occlusion_query_set: None,
             });
 
-            rpass.set_bind_group(0, Some(&self.bind_group), &[]);
+            rpass.set_bind_group(0, &self.bind_group, &[]);
             rpass.set_pipeline(&self.entity_pipeline);
 
             for entity in self.entities.iter() {

--- a/examples/src/srgb_blend/mod.rs
+++ b/examples/src/srgb_blend/mod.rs
@@ -199,7 +199,7 @@ impl<const SRGB: bool> crate::framework::Example for Example<SRGB> {
             });
             rpass.push_debug_group("Prepare data for draw.");
             rpass.set_pipeline(&self.pipeline);
-            rpass.set_bind_group(0, Some(&self.bind_group), &[]);
+            rpass.set_bind_group(0, &self.bind_group, &[]);
             rpass.set_index_buffer(self.index_buf.slice(..), wgpu::IndexFormat::Uint16);
             rpass.set_vertex_buffer(0, self.vertex_buf.slice(..));
             rpass.pop_debug_group();

--- a/examples/src/storage_texture/mod.rs
+++ b/examples/src/storage_texture/mod.rs
@@ -114,7 +114,7 @@ async fn run(_path: Option<String>) {
             label: None,
             timestamp_writes: None,
         });
-        compute_pass.set_bind_group(0, Some(&bind_group), &[]);
+        compute_pass.set_bind_group(0, &bind_group, &[]);
         compute_pass.set_pipeline(&pipeline);
         compute_pass.dispatch_workgroups(TEXTURE_DIMS.0 as u32, TEXTURE_DIMS.1 as u32, 1);
     }

--- a/examples/src/texture_arrays/mod.rs
+++ b/examples/src/texture_arrays/mod.rs
@@ -391,12 +391,12 @@ impl crate::framework::Example for Example {
         rpass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
         rpass.set_index_buffer(self.index_buffer.slice(..), self.index_format);
         if self.uniform_workaround {
-            rpass.set_bind_group(0, Some(&self.bind_group), &[0]);
+            rpass.set_bind_group(0, &self.bind_group, &[0]);
             rpass.draw_indexed(0..6, 0, 0..1);
-            rpass.set_bind_group(0, Some(&self.bind_group), &[256]);
+            rpass.set_bind_group(0, &self.bind_group, &[256]);
             rpass.draw_indexed(6..12, 0, 0..1);
         } else {
-            rpass.set_bind_group(0, Some(&self.bind_group), &[0]);
+            rpass.set_bind_group(0, &self.bind_group, &[0]);
             rpass.draw_indexed(0..12, 0, 0..1);
         }
 

--- a/examples/src/timestamp_queries/mod.rs
+++ b/examples/src/timestamp_queries/mod.rs
@@ -321,7 +321,7 @@ fn compute_pass(
     });
     *next_unused_query += 2;
     cpass.set_pipeline(&compute_pipeline);
-    cpass.set_bind_group(0, Some(&bind_group), &[]);
+    cpass.set_bind_group(0, &bind_group, &[]);
     cpass.dispatch_workgroups(1, 1, 1);
     if device
         .features()

--- a/examples/src/water/mod.rs
+++ b/examples/src/water/mod.rs
@@ -624,7 +624,7 @@ impl crate::framework::Example for Example {
                     multiview: None,
                 });
             encoder.set_pipeline(&terrain_pipeline);
-            encoder.set_bind_group(0, Some(&terrain_flipped_bind_group), &[]);
+            encoder.set_bind_group(0, &terrain_flipped_bind_group, &[]);
             encoder.set_vertex_buffer(0, terrain_vertex_buf.slice(..));
             encoder.draw(0..terrain_vertices.len() as u32, 0..1);
             encoder.finish(&wgpu::RenderBundleDescriptor::default())
@@ -778,7 +778,7 @@ impl crate::framework::Example for Example {
                 occlusion_query_set: None,
             });
             rpass.set_pipeline(&self.terrain_pipeline);
-            rpass.set_bind_group(0, Some(&self.terrain_normal_bind_group), &[]);
+            rpass.set_bind_group(0, &self.terrain_normal_bind_group, &[]);
             rpass.set_vertex_buffer(0, self.terrain_vertex_buf.slice(..));
             rpass.draw(0..self.terrain_vertex_count as u32, 0..1);
         }
@@ -805,7 +805,7 @@ impl crate::framework::Example for Example {
             });
 
             rpass.set_pipeline(&self.water_pipeline);
-            rpass.set_bind_group(0, Some(&self.water_bind_group), &[]);
+            rpass.set_bind_group(0, &self.water_bind_group, &[]);
             rpass.set_vertex_buffer(0, self.water_vertex_buf.slice(..));
             rpass.draw(0..self.water_vertex_count as u32, 0..1);
         }

--- a/tests/src/image.rs
+++ b/tests/src/image.rs
@@ -376,7 +376,7 @@ fn copy_via_compute(
         let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor::default());
 
         pass.set_pipeline(&pipeline_copy);
-        pass.set_bind_group(0, Some(&bg), &[]);
+        pass.set_bind_group(0, &bg, &[]);
         pass.dispatch_workgroups(1, 1, 1);
     }
 

--- a/tests/tests/bgra8unorm_storage.rs
+++ b/tests/tests/bgra8unorm_storage.rs
@@ -110,7 +110,7 @@ static BGRA8_UNORM_STORAGE: GpuTestConfiguration = GpuTestConfiguration::new()
                 timestamp_writes: None,
             });
 
-            pass.set_bind_group(0, Some(&bg), &[]);
+            pass.set_bind_group(0, &bg, &[]);
             pass.set_pipeline(&pipeline);
             pass.dispatch_workgroups(256, 256, 1);
         }

--- a/tests/tests/bind_group_layout_dedup.rs
+++ b/tests/tests/bind_group_layout_dedup.rs
@@ -92,11 +92,11 @@ async fn bgl_dedupe(ctx: TestingContext) {
         timestamp_writes: None,
     });
 
-    pass.set_bind_group(0, Some(&bg_1b), &[]);
+    pass.set_bind_group(0, &bg_1b, &[]);
     pass.set_pipeline(&pipeline);
     pass.dispatch_workgroups(1, 1, 1);
 
-    pass.set_bind_group(0, Some(&bg_1a), &[]);
+    pass.set_bind_group(0, &bg_1a, &[]);
     pass.dispatch_workgroups(1, 1, 1);
 
     drop(pass);
@@ -179,7 +179,7 @@ fn bgl_dedupe_with_dropped_user_handle(ctx: TestingContext) {
         timestamp_writes: None,
     });
 
-    pass.set_bind_group(0, Some(&bg), &[]);
+    pass.set_bind_group(0, &bg, &[]);
     pass.set_pipeline(&pipeline);
     pass.dispatch_workgroups(1, 1, 1);
 
@@ -250,10 +250,10 @@ fn get_derived_bgl(ctx: TestingContext) {
 
     pass.set_pipeline(&pipeline);
 
-    pass.set_bind_group(0, Some(&bg1), &[]);
+    pass.set_bind_group(0, &bg1, &[]);
     pass.dispatch_workgroups(1, 1, 1);
 
-    pass.set_bind_group(0, Some(&bg2), &[]);
+    pass.set_bind_group(0, &bg2, &[]);
     pass.dispatch_workgroups(1, 1, 1);
 
     drop(pass);
@@ -313,7 +313,7 @@ fn separate_pipelines_have_incompatible_derived_bgls(ctx: TestingContext) {
     pass.set_pipeline(&pipeline1);
 
     // We use the wrong bind group for this pipeline here. This should fail.
-    pass.set_bind_group(0, Some(&bg2), &[]);
+    pass.set_bind_group(0, &bg2, &[]);
     pass.dispatch_workgroups(1, 1, 1);
 
     fail(
@@ -385,7 +385,7 @@ fn derived_bgls_incompatible_with_regular_bgls(ctx: TestingContext) {
 
     pass.set_pipeline(&pipeline);
 
-    pass.set_bind_group(0, Some(&bg), &[]);
+    pass.set_bind_group(0, &bg, &[]);
     pass.dispatch_workgroups(1, 1, 1);
 
     fail(
@@ -476,8 +476,8 @@ fn bgl_dedupe_derived(ctx: TestingContext) {
         timestamp_writes: None,
     });
     pass.set_pipeline(&pipeline);
-    pass.set_bind_group(0, Some(&bind_group_0), &[]);
-    pass.set_bind_group(1, Some(&bind_group_1), &[]);
+    pass.set_bind_group(0, &bind_group_0, &[]);
+    pass.set_bind_group(1, &bind_group_1, &[]);
     pass.dispatch_workgroups(1, 1, 1);
 
     drop(pass);

--- a/tests/tests/buffer.rs
+++ b/tests/tests/buffer.rs
@@ -328,7 +328,7 @@ static MINIMUM_BUFFER_BINDING_SIZE_DISPATCH: GpuTestConfiguration = GpuTestConfi
                     timestamp_writes: None,
                 });
 
-                pass.set_bind_group(0, Some(&bind_group), &[]);
+                pass.set_bind_group(0, &bind_group, &[]);
                 pass.set_pipeline(&pipeline);
                 pass.dispatch_workgroups(1, 1, 1);
 

--- a/tests/tests/compute_pass_ownership.rs
+++ b/tests/tests/compute_pass_ownership.rs
@@ -45,7 +45,7 @@ async fn compute_pass_resource_ownership(ctx: TestingContext) {
     {
         let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
         cpass.set_pipeline(&pipeline);
-        cpass.set_bind_group(0, Some(&bind_group), &[]);
+        cpass.set_bind_group(0, &bind_group, &[]);
         cpass.dispatch_workgroups_indirect(&indirect_buffer, 0);
 
         // Now drop all resources we set. Then do a device poll to make sure the resources are really not dropped too early, no matter what.
@@ -95,7 +95,7 @@ async fn compute_pass_query_set_ownership_pipeline_statistics(ctx: TestingContex
     {
         let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
         cpass.set_pipeline(&pipeline);
-        cpass.set_bind_group(0, Some(&bind_group), &[]);
+        cpass.set_bind_group(0, &bind_group, &[]);
         cpass.begin_pipeline_statistics_query(&query_set, 0);
         cpass.dispatch_workgroups(1, 1, 1);
         cpass.end_pipeline_statistics_query();
@@ -153,7 +153,7 @@ async fn compute_pass_query_set_ownership_timestamps(ctx: TestingContext) {
             }),
         });
         cpass.set_pipeline(&pipeline);
-        cpass.set_bind_group(0, Some(&bind_group), &[]);
+        cpass.set_bind_group(0, &bind_group, &[]);
         cpass.write_timestamp(&query_set_write_timestamp, 0);
         cpass.dispatch_workgroups(1, 1, 1);
 
@@ -203,7 +203,7 @@ async fn compute_pass_keep_encoder_alive(ctx: TestingContext) {
 
     // Record some draw commands.
     cpass.set_pipeline(&pipeline);
-    cpass.set_bind_group(0, Some(&bind_group), &[]);
+    cpass.set_bind_group(0, &bind_group, &[]);
     cpass.dispatch_workgroups_indirect(&indirect_buffer, 0);
 
     // Dropping the pass will still execute the pass, even though there's no way to submit it.

--- a/tests/tests/dispatch_workgroups_indirect.rs
+++ b/tests/tests/dispatch_workgroups_indirect.rs
@@ -82,7 +82,7 @@ static RESET_BIND_GROUPS: GpuTestConfiguration = GpuTestConfiguration::new()
             let mut compute_pass = encoder.begin_compute_pass(&Default::default());
             compute_pass.set_pipeline(&test_resources.pipeline);
             compute_pass.set_push_constants(0, &[0, 0, 0, 0]);
-            // compute_pass.set_bind_group(0, Some(&test_resources.bind_group), &[]);
+            // compute_pass.set_bind_group(0, &test_resources.bind_group, &[]);
             compute_pass.dispatch_workgroups_indirect(&indirect_buffer, 0);
         }
         ctx.queue.submit(Some(encoder.finish()));
@@ -124,7 +124,7 @@ static ZERO_SIZED_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new()
             let mut compute_pass = encoder.begin_compute_pass(&Default::default());
             compute_pass.set_pipeline(&test_resources.pipeline);
             compute_pass.set_push_constants(0, &[0, 0, 0, 0]);
-            compute_pass.set_bind_group(0, Some(&test_resources.bind_group), &[]);
+            compute_pass.set_bind_group(0, &test_resources.bind_group, &[]);
             compute_pass.dispatch_workgroups_indirect(&indirect_buffer, 0);
         }
         ctx.queue.submit(Some(encoder.finish()));
@@ -281,7 +281,7 @@ async fn run_test(ctx: &TestingContext, num_workgroups: &[u32; 3]) -> [u32; 3] {
             let mut compute_pass = encoder.begin_compute_pass(&Default::default());
             compute_pass.set_pipeline(&test_resources.pipeline);
             compute_pass.set_push_constants(0, &[0, 0, 0, 0]);
-            compute_pass.set_bind_group(0, Some(&test_resources.bind_group), &[]);
+            compute_pass.set_bind_group(0, &test_resources.bind_group, &[]);
             compute_pass.dispatch_workgroups_indirect(&indirect_buffer, indirect_offset);
         }
 

--- a/tests/tests/mem_leaks.rs
+++ b/tests/tests/mem_leaks.rs
@@ -194,7 +194,7 @@ async fn draw_test_with_reports(
     });
 
     rpass.set_pipeline(&pipeline);
-    rpass.set_bind_group(0, Some(&bg), &[]);
+    rpass.set_bind_group(0, &bg, &[]);
 
     let global_report = ctx.instance.generate_report().unwrap();
     let report = global_report.hub_report();

--- a/tests/tests/nv12_texture/mod.rs
+++ b/tests/tests/nv12_texture/mod.rs
@@ -115,7 +115,7 @@ static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfigurati
             occlusion_query_set: None,
         });
         rpass.set_pipeline(&pipeline);
-        rpass.set_bind_group(0, Some(&bind_group), &[]);
+        rpass.set_bind_group(0, &bind_group, &[]);
         rpass.draw(0..4, 0..1);
         drop(rpass);
         ctx.queue.submit(Some(encoder.finish()));

--- a/tests/tests/oob_indexing.rs
+++ b/tests/tests/oob_indexing.rs
@@ -22,7 +22,7 @@ static RESTRICT_WORKGROUP_PRIVATE_FUNCTION_LET: GpuTestConfiguration = GpuTestCo
         {
             let mut compute_pass = encoder.begin_compute_pass(&Default::default());
             compute_pass.set_pipeline(&test_resources.pipeline);
-            compute_pass.set_bind_group(0, Some(&test_resources.bind_group), &[]);
+            compute_pass.set_bind_group(0, &test_resources.bind_group, &[]);
             compute_pass.dispatch_workgroups(1, 1, 1);
         }
 

--- a/tests/tests/partially_bounded_arrays/mod.rs
+++ b/tests/tests/partially_bounded_arrays/mod.rs
@@ -87,7 +87,7 @@ static PARTIALLY_BOUNDED_ARRAY: GpuTestConfiguration = GpuTestConfiguration::new
                 timestamp_writes: None,
             });
             cpass.set_pipeline(&compute_pipeline);
-            cpass.set_bind_group(0, Some(&bind_group), &[]);
+            cpass.set_bind_group(0, &bind_group, &[]);
             cpass.dispatch_workgroups(1, 1, 1);
         }
 

--- a/tests/tests/poll.rs
+++ b/tests/tests/poll.rs
@@ -46,7 +46,7 @@ fn generate_dummy_work(ctx: &TestingContext) -> CommandBuffer {
         .create_command_encoder(&CommandEncoderDescriptor::default());
 
     let mut cpass = cmd_buf.begin_compute_pass(&ComputePassDescriptor::default());
-    cpass.set_bind_group(0, Some(&bind_group), &[]);
+    cpass.set_bind_group(0, &bind_group, &[]);
     drop(cpass);
 
     cmd_buf.finish()

--- a/tests/tests/push_constants.rs
+++ b/tests/tests/push_constants.rs
@@ -119,7 +119,7 @@ async fn partial_update_test(ctx: TestingContext) {
             timestamp_writes: None,
         });
         cpass.set_pipeline(&pipeline);
-        cpass.set_bind_group(0, Some(&bind_group), &[]);
+        cpass.set_bind_group(0, &bind_group, &[]);
 
         // -- Dispatch 0 --
 

--- a/tests/tests/regression/issue_3349.rs
+++ b/tests/tests/regression/issue_3349.rs
@@ -163,7 +163,7 @@ async fn multi_stage_data_binding_test(ctx: TestingContext) {
         });
 
         rpass.set_pipeline(&pipeline);
-        rpass.set_bind_group(0, Some(&bg), &[]);
+        rpass.set_bind_group(0, &bg, &[]);
         rpass.set_push_constants(
             wgpu::ShaderStages::VERTEX_FRAGMENT,
             0,

--- a/tests/tests/render_pass_ownership.rs
+++ b/tests/tests/render_pass_ownership.rs
@@ -87,7 +87,7 @@ async fn render_pass_resource_ownership(ctx: TestingContext) {
         drop(depth_stencil_view);
 
         rpass.set_pipeline(&pipeline);
-        rpass.set_bind_group(0, Some(&bind_group), &[]);
+        rpass.set_bind_group(0, &bind_group, &[]);
         rpass.set_vertex_buffer(0, vertex_buffer.slice(..));
         rpass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint32);
         rpass.begin_occlusion_query(0);
@@ -163,7 +163,7 @@ async fn render_pass_query_set_ownership_pipeline_statistics(ctx: TestingContext
             ..Default::default()
         });
         rpass.set_pipeline(&pipeline);
-        rpass.set_bind_group(0, Some(&bind_group), &[]);
+        rpass.set_bind_group(0, &bind_group, &[]);
         rpass.set_vertex_buffer(0, vertex_buffer.slice(..));
         rpass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint32);
         rpass.begin_pipeline_statistics_query(&query_set, 0);
@@ -242,7 +242,7 @@ async fn render_pass_query_set_ownership_timestamps(ctx: TestingContext) {
         rpass.write_timestamp(&query_set_write_timestamp, 0);
 
         rpass.set_pipeline(&pipeline);
-        rpass.set_bind_group(0, Some(&bind_group), &[]);
+        rpass.set_bind_group(0, &bind_group, &[]);
         rpass.set_vertex_buffer(0, vertex_buffer.slice(..));
         rpass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint32);
         rpass.draw(0..3, 0..1);
@@ -305,7 +305,7 @@ async fn render_pass_keep_encoder_alive(ctx: TestingContext) {
 
     // Record some a draw command.
     rpass.set_pipeline(&pipeline);
-    rpass.set_bind_group(0, Some(&bind_group), &[]);
+    rpass.set_bind_group(0, &bind_group, &[]);
     rpass.set_vertex_buffer(0, vertex_buffer.slice(..));
     rpass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint32);
     rpass.draw(0..3, 0..1);

--- a/tests/tests/shader/mod.rs
+++ b/tests/tests/shader/mod.rs
@@ -349,7 +349,7 @@ async fn shader_input_output_test(
             timestamp_writes: None,
         });
         cpass.set_pipeline(&pipeline);
-        cpass.set_bind_group(0, Some(&bg), &[]);
+        cpass.set_bind_group(0, &bg, &[]);
 
         if let InputStorageType::PushConstant = storage_type {
             cpass.set_push_constants(0, bytemuck::cast_slice(&test.input_values))

--- a/tests/tests/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/shader/zero_init_workgroup_mem.rs
@@ -119,7 +119,7 @@ static ZERO_INIT_WORKGROUP_MEMORY: GpuTestConfiguration = GpuTestConfiguration::
 
         cpass.set_pipeline(&pipeline_read);
         for i in 0..NR_OF_DISPATCHES {
-            cpass.set_bind_group(0, Some(&bg), &[i * BUFFER_BINDING_SIZE]);
+            cpass.set_bind_group(0, &bg, &[i * BUFFER_BINDING_SIZE]);
             cpass.dispatch_workgroups(DISPATCH_SIZE.0, DISPATCH_SIZE.1, DISPATCH_SIZE.2);
         }
         drop(cpass);

--- a/tests/tests/shader_view_format/mod.rs
+++ b/tests/tests/shader_view_format/mod.rs
@@ -148,7 +148,7 @@ async fn reinterpret(
         occlusion_query_set: None,
     });
     rpass.set_pipeline(&pipeline);
-    rpass.set_bind_group(0, Some(&bind_group), &[]);
+    rpass.set_bind_group(0, &bind_group, &[]);
     rpass.draw(0..3, 0..1);
     drop(rpass);
     ctx.queue.submit(Some(encoder.finish()));

--- a/tests/tests/subgroup_operations/mod.rs
+++ b/tests/tests/subgroup_operations/mod.rs
@@ -90,7 +90,7 @@ static SUBGROUP_OPERATIONS: GpuTestConfiguration = GpuTestConfiguration::new()
                 timestamp_writes: None,
             });
             cpass.set_pipeline(&compute_pipeline);
-            cpass.set_bind_group(0, Some(&bind_group), &[]);
+            cpass.set_bind_group(0, &bind_group, &[]);
             cpass.dispatch_workgroups(1, 1, 1);
         }
         ctx.queue.submit(Some(encoder.finish()));

--- a/tests/tests/vertex_formats/mod.rs
+++ b/tests/tests/vertex_formats/mod.rs
@@ -315,7 +315,7 @@ async fn vertex_formats_common(ctx: TestingContext, tests: &[Test<'_>]) {
 
         rpass.set_vertex_buffer(0, buffer_input.slice(..));
         rpass.set_pipeline(&pipeline);
-        rpass.set_bind_group(0, Some(&bg), &[]);
+        rpass.set_bind_group(0, &bg, &[]);
 
         // Draw three vertices and no instance, which is enough to generate the
         // checksums.

--- a/wgpu/src/api/compute_pass.rs
+++ b/wgpu/src/api/compute_pass.rs
@@ -45,13 +45,13 @@ impl<'encoder> ComputePass<'encoder> {
     /// If the bind group have dynamic offsets, provide them in the binding order.
     /// These offsets have to be aligned to [`Limits::min_uniform_buffer_offset_alignment`]
     /// or [`Limits::min_storage_buffer_offset_alignment`] appropriately.
-    pub fn set_bind_group(
+    pub fn set_bind_group<'a>(
         &mut self,
         index: u32,
-        bind_group: Option<&BindGroup>,
+        bind_group: impl Into<Option<&'a BindGroup>>,
         offsets: &[DynamicOffset],
     ) {
-        let bg = bind_group.map(|x| x.data.as_ref());
+        let bg = bind_group.into().map(|x| x.data.as_ref());
         DynContext::compute_pass_set_bind_group(
             &*self.inner.context,
             self.inner.data.as_mut(),

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -63,13 +63,13 @@ impl<'a> RenderBundleEncoder<'a> {
     /// in the active pipeline when any `draw()` function is called must match the layout of this bind group.
     ///
     /// If the bind group have dynamic offsets, provide them in the binding order.
-    pub fn set_bind_group(
+    pub fn set_bind_group<'b>(
         &mut self,
         index: u32,
-        bind_group: Option<&'a BindGroup>,
+        bind_group: impl Into<Option<&'a BindGroup>>,
         offsets: &[DynamicOffset],
     ) {
-        let bg = bind_group.map(|x| x.data.as_ref());
+        let bg = bind_group.into().map(|x| x.data.as_ref());
         DynContext::render_bundle_encoder_set_bind_group(
             &*self.parent.context,
             self.data.as_mut(),

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -74,13 +74,13 @@ impl<'encoder> RenderPass<'encoder> {
     /// or [`Limits::min_storage_buffer_offset_alignment`] appropriately.
     ///
     /// Subsequent draw calls’ shader executions will be able to access data in these bind groups.
-    pub fn set_bind_group(
+    pub fn set_bind_group<'a>(
         &mut self,
         index: u32,
-        bind_group: Option<&BindGroup>,
+        bind_group: impl Into<Option<&'a BindGroup>>,
         offsets: &[DynamicOffset],
     ) {
-        let bg = bind_group.map(|x| x.data.as_ref());
+        let bg = bind_group.into().map(|x| x.data.as_ref());
         DynContext::render_pass_set_bind_group(
             &*self.inner.context,
             self.inner.data.as_mut(),


### PR DESCRIPTION
**Connections**
* follow-up to https://github.com/gfx-rs/wgpu/pull/6216

**Description**
Avoids breaking everyone who calls `set_bind_group`.

Unfortunately, the `wgpu::utils::RenderEncoder` trait can't get this treatment because that would make it no longer be object safe.

**Testing**
it compiles!

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
