### PR TITLE
 WGSL: Add a skeleton for diagnostic filter rules/`diagnostic(…)`; that reports nice errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+## New Features
+
+### Naga
+
+- Parse `diagnostic(…)` directives, but don't implement any triggering rules yet. By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456).
+
 ## 23.0.0 (2024-10-25)
 
 ### Themes of this release

--- a/naga/src/diagnostic_filter.rs
+++ b/naga/src/diagnostic_filter.rs
@@ -1,0 +1,97 @@
+//! [`DiagnosticFilter`]s and supporting functionality.
+
+/// A severity set on a [`DiagnosticFilter`].
+///
+/// <https://www.w3.org/TR/WGSL/#diagnostic-severity>
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Severity {
+    Off,
+    Info,
+    Warning,
+    Error,
+}
+
+impl Severity {
+    const ERROR: &'static str = "error";
+    const WARNING: &'static str = "warning";
+    const INFO: &'static str = "info";
+    const OFF: &'static str = "off";
+
+    /// Convert from a sentinel word in WGSL into its associated [`Severity`], if possible.
+    pub fn from_ident(s: &str) -> Option<Self> {
+        Some(match s {
+            Self::ERROR => Self::Error,
+            Self::WARNING => Self::Warning,
+            Self::INFO => Self::Info,
+            Self::OFF => Self::Off,
+            _ => return None,
+        })
+    }
+
+    /// Checks whether this severity is [`Self::Error`].
+    ///
+    /// Naga does not yet support diagnostic items at lesser severities than
+    /// [`Severity::Error`]. When this is implemented, this method should be deleted, and the
+    /// severity should be used directly for reporting diagnostics.
+    #[cfg(feature = "wgsl-in")]
+    pub(crate) fn report_diag<E>(
+        self,
+        err: E,
+        log_handler: impl FnOnce(E, log::Level),
+    ) -> Result<(), E> {
+        let log_level = match self {
+            Severity::Off => return Ok(()),
+
+            // NOTE: These severities are not yet reported.
+            Severity::Info => log::Level::Info,
+            Severity::Warning => log::Level::Warn,
+
+            Severity::Error => return Err(err),
+        };
+        log_handler(err, log_level);
+        Ok(())
+    }
+}
+
+/// A filterable triggering rule in a [`DiagnosticFilter`].
+///
+/// <https://www.w3.org/TR/WGSL/#filterable-triggering-rules>
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum FilterableTriggeringRule {
+    DerivativeUniformity,
+}
+
+impl FilterableTriggeringRule {
+    const DERIVATIVE_UNIFORMITY: &'static str = "derivative_uniformity";
+
+    /// Convert from a sentinel word in WGSL into its associated [`FilterableTriggeringRule`], if possible.
+    pub fn from_ident(s: &str) -> Option<Self> {
+        Some(match s {
+            Self::DERIVATIVE_UNIFORMITY => Self::DerivativeUniformity,
+            _ => return None,
+        })
+    }
+
+    /// Maps this [`FilterableTriggeringRule`] into the sentinel word associated with it in WGSL.
+    pub const fn to_ident(self) -> &'static str {
+        match self {
+            Self::DerivativeUniformity => Self::DERIVATIVE_UNIFORMITY,
+        }
+    }
+
+    #[cfg(feature = "wgsl-in")]
+    pub(crate) const fn tracking_issue_num(self) -> u16 {
+        match self {
+            FilterableTriggeringRule::DerivativeUniformity => 5320,
+        }
+    }
+}
+
+/// A filter that modifies how diagnostics are emitted for shaders.
+///
+/// <https://www.w3.org/TR/WGSL/#diagnostic-filter>
+#[derive(Clone, Debug)]
+pub struct DiagnosticFilter {
+    pub new_severity: Severity,
+    pub triggering_rule: FilterableTriggeringRule,
+}

--- a/naga/src/front/wgsl/parse/directive.rs
+++ b/naga/src/front/wgsl/parse/directive.rs
@@ -8,6 +8,8 @@ pub(crate) mod language_extension;
 /// A parsed sentinel word indicating the type of directive to be parsed next.
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub(crate) enum DirectiveKind {
+    /// A [`crate::diagnostic_filter`].
+    Diagnostic,
     /// An [`enable_extension`].
     Enable,
     /// A [`language_extension`].
@@ -23,7 +25,7 @@ impl DirectiveKind {
     /// Convert from a sentinel word in WGSL into its associated [`DirectiveKind`], if possible.
     pub fn from_ident(s: &str) -> Option<Self> {
         Some(match s {
-            Self::DIAGNOSTIC => Self::Unimplemented(UnimplementedDirectiveKind::Diagnostic),
+            Self::DIAGNOSTIC => Self::Diagnostic,
             Self::ENABLE => Self::Enable,
             Self::REQUIRES => Self::Requires,
             _ => return None,
@@ -33,11 +35,10 @@ impl DirectiveKind {
     /// Maps this [`DirectiveKind`] into the sentinel word associated with it in WGSL.
     pub const fn to_ident(self) -> &'static str {
         match self {
+            Self::Diagnostic => Self::DIAGNOSTIC,
             Self::Enable => Self::ENABLE,
             Self::Requires => Self::REQUIRES,
-            Self::Unimplemented(kind) => match kind {
-                UnimplementedDirectiveKind::Diagnostic => Self::DIAGNOSTIC,
-            },
+            Self::Unimplemented(kind) => match kind {},
         }
     }
 
@@ -45,7 +46,7 @@ impl DirectiveKind {
     fn iter() -> impl Iterator<Item = Self> {
         use strum::IntoEnumIterator;
 
-        [Self::Enable, Self::Requires]
+        [Self::Diagnostic, Self::Enable, Self::Requires]
             .into_iter()
             .chain(UnimplementedDirectiveKind::iter().map(Self::Unimplemented))
     }
@@ -54,15 +55,25 @@ impl DirectiveKind {
 /// A [`DirectiveKind`] that is not yet implemented. See [`DirectiveKind::Unimplemented`].
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(test, derive(strum::EnumIter))]
-pub(crate) enum UnimplementedDirectiveKind {
-    Diagnostic,
-}
+pub(crate) enum UnimplementedDirectiveKind {}
 
 impl UnimplementedDirectiveKind {
     pub const fn tracking_issue_num(self) -> u16 {
-        match self {
-            Self::Diagnostic => 5320,
-        }
+        match self {}
+    }
+}
+
+impl crate::diagnostic_filter::Severity {
+    #[cfg(feature = "wgsl-in")]
+    pub(crate) fn report_wgsl_parse_diag<'a>(
+        self,
+        err: crate::front::wgsl::error::Error<'a>,
+        source: &str,
+    ) -> Result<(), crate::front::wgsl::error::Error<'a>> {
+        self.report_diag(err, |e, level| {
+            let e = e.as_parse_error(source);
+            log::log!(level, "{}", e.emit_to_string(source));
+        })
     }
 }
 
@@ -75,25 +86,12 @@ mod test {
     use super::{DirectiveKind, UnimplementedDirectiveKind};
 
     #[test]
+    #[allow(clippy::never_loop, unreachable_code, unused_variables)]
     fn unimplemented_directives() {
         for unsupported_shader in UnimplementedDirectiveKind::iter() {
             let shader;
             let expected_msg;
-            match unsupported_shader {
-                UnimplementedDirectiveKind::Diagnostic => {
-                    shader = "diagnostic(off,derivative_uniformity);";
-                    expected_msg = "\
-error: the `diagnostic` directive is not yet implemented
-  ┌─ wgsl:1:1
-  │
-1 │ diagnostic(off,derivative_uniformity);
-  │ ^^^^^^^^^^ this global directive is standard, but not yet implemented
-  │
-  = note: Let Naga maintainers know that you ran into this at <https://github.com/gfx-rs/wgpu/issues/5320>, so they can prioritize it!
-
-";
-                }
-            };
+            match unsupported_shader {};
 
             assert_parse_err(shader, expected_msg);
         }
@@ -105,7 +103,7 @@ error: the `diagnostic` directive is not yet implemented
             let directive;
             let expected_msg;
             match unsupported_shader {
-                DirectiveKind::Unimplemented(UnimplementedDirectiveKind::Diagnostic) => {
+                DirectiveKind::Diagnostic => {
                     directive = "diagnostic(off,derivative_uniformity)";
                     expected_msg = "\
 error: expected global declaration, but found a global directive
@@ -144,6 +142,7 @@ error: expected global declaration, but found a global directive
 
 ";
                 }
+                DirectiveKind::Unimplemented(kind) => match kind {},
             }
 
             let shader = format!(

--- a/naga/src/front/wgsl/parse/directive.rs
+++ b/naga/src/front/wgsl/parse/directive.rs
@@ -45,7 +45,9 @@ impl DirectiveKind {
     fn iter() -> impl Iterator<Item = Self> {
         use strum::IntoEnumIterator;
 
-        UnimplementedDirectiveKind::iter().map(Self::Unimplemented)
+        [Self::Enable, Self::Requires]
+            .into_iter()
+            .chain(UnimplementedDirectiveKind::iter().map(Self::Unimplemented))
     }
 }
 

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -255,6 +255,7 @@ pub mod back;
 mod block;
 #[cfg(feature = "compact")]
 pub mod compact;
+pub mod diagnostic_filter;
 pub mod error;
 pub mod front;
 pub mod keywords;


### PR DESCRIPTION
**Connections**

- Part of #5320.
- Unblocks #6148.

**Description**

_**Recommended review experience is commit-by-commit. Each individual commit should pass CI!**_ 

Finishes building out a parsing skeleton for all directives (see also #6352, #6424, #6350). Paves the way for us to actually track diagnostic filters, and apply them.

**Testing**

Testing has been done manually to @ErichDonGubler's satisfaction. Test coverage for this parsing will be added in #6457.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
