### PR TITLE
test(naga): add coverage for `diagnostic` directive parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,62 @@ Bottom level categories:
 
 ## Unreleased
 
+## Major changes
+
+### The `diagnostic(…);` directive is now supported in WGSL
+
+Naga now parses `diagnostic(…);` directives according to the WGSL spec. This allows users to control certain lints, similar to Rust's `allow`, `warn`, and `deny` attributes. For example, in standard WGSL (but, notably, not Naga yet—see <https://github.com/gfx-rs/wgpu/issues/4369>) this snippet would emit a uniformity error:
+
+```wgsl
+@group(0) @binding(0) var s : sampler;
+@group(0) @binding(2) var tex : texture_2d<f32>;
+@group(1) @binding(0) var<storage, read> ro_buffer : array<f32, 4>;
+
+@fragment
+fn main(@builtin(position) p : vec4f) -> @location(0) vec4f {
+  if ro_buffer[0] == 0 {
+    // Emits a derivative uniformity error during validation.
+    return textureSample(tex, s, vec2(0.,0.));
+  }
+
+  return vec4f(0.);
+}
+```
+
+…but we can now silence it with the `off` severity level, like so:
+
+```wgsl
+// Disable the diagnosic with this…
+diagnostic(off, derivative_uniformity);
+
+@group(0) @binding(0) var s : sampler;
+@group(0) @binding(2) var tex : texture_2d<f32>;
+@group(1) @binding(0) var<storage, read> ro_buffer : array<f32, 4>;
+
+@fragment
+fn main(@builtin(position) p : vec4f) -> @location(0) vec4f {
+  if ro_buffer[0] == 0 {
+    // Look ma, no error!
+    return textureSample(tex, s, vec2(0.,0.));
+  }
+
+  return vec4f(0.);
+}
+```
+
+There are some limitations to keep in mind with this new functionality:
+
+- We do not yet support `diagnostic(…)` rules in attribute position (i.e., `@diagnostic(…) fn my_func { … }`). This is being tracked in <https://github.com/gfx-rs/wgpu/issues/5320>. We expect that rules in `fn` attribute position will be relaxed shortly (see <https://github.com/gfx-rs/wgpu/pull/6353>), but the prioritization for statement positions is unclear. If you are blocked by not being able to parse `diagnostic(…)` rules in statement positions, please let us know in that issue, so we can determine how to prioritize it!
+- Standard WGSL specifies `error`, `warning`, `info`, and `off` severity levels. These are all technically usable now! A caveat, though: warning- and info-level are only emitted to `stderr` via the `log` façade, rather than being reported through a `Result::Err` in Naga or the `CompilationInfo` interface in `wgpu{,-core}`. This will require breaking changes in Naga to fix, and is being tracked by <https://github.com/gfx-rs/wgpu/issues/6458>.
+- Not all lints can be controlled with `diagnostic(…)` rules. In fact, only the `derivative_uniformity` triggering rule exists in the WGSL standard. That said, Naga contributors are excited to see how this level of control unlocks a new ecosystem of configurable diagnostics.
+- Finally, `diagnostic(…)` rules are not yet emitted in WGSL output. This means that `wgsl-in` → `wgsl-out` is currently a lossy process. We felt that it was important to unblock users who needed `diagnostic(…)` rules (i.e., <https://github.com/gfx-rs/wgpu/issues/3135>) before we took significant effort to fix this (tracked in <https://github.com/gfx-rs/wgpu/issues/6496>).
+
+By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148](https://github.com/gfx-rs/wgpu/pull/6148).
+
 ### New Features
 
 #### Naga
 
-- Parse `diagnostic(…)` directives, but don't implement any triggering rules yet. By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456).
 - Fix an issue where `naga` CLI would incorrectly skip the first positional argument when `--stdin-file-path` was specified. By @ErichDonGubler in [#6480](https://github.com/gfx-rs/wgpu/pull/6480).
 - Fix textureNumLevels in the GLSL backend. By @magcius in [#6483](https://github.com/gfx-rs/wgpu/pull/6483).
 

--- a/naga/src/diagnostic_filter.rs
+++ b/naga/src/diagnostic_filter.rs
@@ -84,13 +84,6 @@ impl FilterableTriggeringRule {
             Self::DerivativeUniformity => Self::DERIVATIVE_UNIFORMITY,
         }
     }
-
-    #[cfg(feature = "wgsl-in")]
-    pub(crate) const fn tracking_issue_num(self) -> u16 {
-        match self {
-            FilterableTriggeringRule::DerivativeUniformity => 5320,
-        }
-    }
 }
 
 /// A filter that modifies how diagnostics are emitted for shaders.

--- a/naga/src/diagnostic_filter.rs
+++ b/naga/src/diagnostic_filter.rs
@@ -48,7 +48,6 @@ impl Severity {
     /// Naga does not yet support diagnostic items at lesser severities than
     /// [`Severity::Error`]. When this is implemented, this method should be deleted, and the
     /// severity should be used directly for reporting diagnostics.
-    #[cfg(feature = "wgsl-in")]
     pub(crate) fn report_diag<E>(
         self,
         err: E,
@@ -101,7 +100,6 @@ impl FilterableTriggeringRule {
     ///
     /// See <https://www.w3.org/TR/WGSL/#filterable-triggering-rules> for a table of default
     /// severities.
-    #[allow(dead_code)]
     pub(crate) const fn default_severity(self) -> Severity {
         match self {
             FilterableTriggeringRule::DerivativeUniformity => Severity::Error,
@@ -227,7 +225,6 @@ impl DiagnosticFilterNode {
     /// is found, return the value of [`FilterableTriggeringRule::default_severity`].
     ///
     /// When `triggering_rule` is not applicable to this node, its parent is consulted recursively.
-    #[allow(dead_code)]
     pub(crate) fn search(
         node: Option<Handle<Self>>,
         arena: &Arena<Self>,

--- a/naga/src/diagnostic_filter.rs
+++ b/naga/src/diagnostic_filter.rs
@@ -18,7 +18,7 @@ impl Severity {
     const OFF: &'static str = "off";
 
     /// Convert from a sentinel word in WGSL into its associated [`Severity`], if possible.
-    pub fn from_ident(s: &str) -> Option<Self> {
+    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
         Some(match s {
             Self::ERROR => Self::Error,
             Self::WARNING => Self::Warning,
@@ -65,7 +65,7 @@ impl FilterableTriggeringRule {
     const DERIVATIVE_UNIFORMITY: &'static str = "derivative_uniformity";
 
     /// Convert from a sentinel word in WGSL into its associated [`FilterableTriggeringRule`], if possible.
-    pub fn from_ident(s: &str) -> Option<Self> {
+    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
         Some(match s {
             Self::DERIVATIVE_UNIFORMITY => Self::DerivativeUniformity,
             _ => return None,
@@ -73,7 +73,7 @@ impl FilterableTriggeringRule {
     }
 
     /// Maps this [`FilterableTriggeringRule`] into the sentinel word associated with it in WGSL.
-    pub const fn to_ident(self) -> &'static str {
+    pub const fn to_wgsl_ident(self) -> &'static str {
         match self {
             Self::DerivativeUniformity => Self::DERIVATIVE_UNIFORMITY,
         }

--- a/naga/src/diagnostic_filter.rs
+++ b/naga/src/diagnostic_filter.rs
@@ -12,22 +12,6 @@ pub enum Severity {
 }
 
 impl Severity {
-    const ERROR: &'static str = "error";
-    const WARNING: &'static str = "warning";
-    const INFO: &'static str = "info";
-    const OFF: &'static str = "off";
-
-    /// Convert from a sentinel word in WGSL into its associated [`Severity`], if possible.
-    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
-        Some(match s {
-            Self::ERROR => Self::Error,
-            Self::WARNING => Self::Warning,
-            Self::INFO => Self::Info,
-            Self::OFF => Self::Off,
-            _ => return None,
-        })
-    }
-
     /// Checks whether this severity is [`Self::Error`].
     ///
     /// Naga does not yet support diagnostic items at lesser severities than
@@ -59,32 +43,6 @@ impl Severity {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum FilterableTriggeringRule {
     DerivativeUniformity,
-}
-
-impl FilterableTriggeringRule {
-    const DERIVATIVE_UNIFORMITY: &'static str = "derivative_uniformity";
-
-    /// Convert from a sentinel word in WGSL into its associated [`FilterableTriggeringRule`], if possible.
-    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
-        Some(match s {
-            Self::DERIVATIVE_UNIFORMITY => Self::DerivativeUniformity,
-            _ => return None,
-        })
-    }
-
-    /// Maps this [`FilterableTriggeringRule`] into the sentinel word associated with it in WGSL.
-    pub const fn to_wgsl_ident(self) -> &'static str {
-        match self {
-            Self::DerivativeUniformity => Self::DERIVATIVE_UNIFORMITY,
-        }
-    }
-
-    #[cfg(feature = "wgsl-in")]
-    pub(crate) const fn tracking_issue_num(self) -> u16 {
-        match self {
-            FilterableTriggeringRule::DerivativeUniformity => 5320,
-        }
-    }
 }
 
 /// A filter that modifies how diagnostics are emitted for shaders.

--- a/naga/src/diagnostic_filter.rs
+++ b/naga/src/diagnostic_filter.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(test, derive(strum::EnumIter))]
 pub enum Severity {
     Off,
     Info,
@@ -27,6 +28,17 @@ pub enum Severity {
 }
 
 impl Severity {
+    /// Maps this [`Severity`] into the sentinel word associated with it in WGSL.
+    #[cfg(test)]
+    pub const fn to_ident(self) -> &'static str {
+        match self {
+            Self::Error => Self::ERROR,
+            Self::Warning => Self::WARNING,
+            Self::Info => Self::INFO,
+            Self::Off => Self::OFF,
+        }
+    }
+
     /// Checks whether this severity is [`Self::Error`].
     ///
     /// Naga does not yet support diagnostic items at lesser severities than
@@ -58,6 +70,7 @@ impl Severity {
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(test, derive(strum::EnumIter))]
 pub enum FilterableTriggeringRule {
     DerivativeUniformity,
 }

--- a/naga/src/front/wgsl/diagnostic_filter.rs
+++ b/naga/src/front/wgsl/diagnostic_filter.rs
@@ -1,0 +1,44 @@
+use crate::diagnostic_filter::{FilterableTriggeringRule, Severity};
+
+impl Severity {
+    const ERROR: &'static str = "error";
+    const WARNING: &'static str = "warning";
+    const INFO: &'static str = "info";
+    const OFF: &'static str = "off";
+
+    /// Convert from a sentinel word in WGSL into its associated [`Severity`], if possible.
+    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
+        Some(match s {
+            Self::ERROR => Self::Error,
+            Self::WARNING => Self::Warning,
+            Self::INFO => Self::Info,
+            Self::OFF => Self::Off,
+            _ => return None,
+        })
+    }
+}
+
+impl FilterableTriggeringRule {
+    const DERIVATIVE_UNIFORMITY: &'static str = "derivative_uniformity";
+
+    /// Convert from a sentinel word in WGSL into its associated [`FilterableTriggeringRule`], if possible.
+    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
+        Some(match s {
+            Self::DERIVATIVE_UNIFORMITY => Self::DerivativeUniformity,
+            _ => return None,
+        })
+    }
+
+    /// Maps this [`FilterableTriggeringRule`] into the sentinel word associated with it in WGSL.
+    pub const fn to_wgsl_ident(self) -> &'static str {
+        match self {
+            Self::DerivativeUniformity => Self::DERIVATIVE_UNIFORMITY,
+        }
+    }
+
+    pub(crate) const fn tracking_issue_num(self) -> u16 {
+        match self {
+            FilterableTriggeringRule::DerivativeUniformity => 5320,
+        }
+    }
+}

--- a/naga/src/front/wgsl/diagnostic_filter.rs
+++ b/naga/src/front/wgsl/diagnostic_filter.rs
@@ -36,3 +36,74 @@ impl FilterableTriggeringRule {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::diagnostic_filter::{FilterableTriggeringRule, Severity};
+    use crate::front::wgsl::assert_parse_err;
+
+    use itertools::Itertools as _;
+    use strum::IntoEnumIterator as _;
+
+    #[test]
+    fn basic() {}
+
+    #[test]
+    fn malformed() {
+        assert_parse_err("directive;", snapshot);
+        assert_parse_err("directive(off, asdf;", snapshot);
+        assert_parse_err("directive();", snapshot);
+    }
+
+    #[test]
+    fn severities() {}
+
+    #[test]
+    fn invalid_severity() {}
+
+    #[test]
+    fn triggering_rules() {}
+
+    #[test]
+    fn invalid_triggering_rule() {
+        #[derive(Debug, Clone)]
+        enum Rule {
+            Valid(FilterableTriggeringRule),
+            Invalid,
+        }
+
+        #[derive(Debug, Clone)]
+        enum Sev {
+            Valid(Severity),
+            Invalid,
+        }
+
+        let cases = {
+            let invalid_sev_cases = FilterableTriggeringRule::iter()
+                .map(Rule::Valid)
+                .cartesian_product([Sev::Invalid]);
+            let invalid_rule_cases = [Rule::Invalid]
+                .into_iter()
+                .cartesian_product(Severity::iter().map(Sev::Valid));
+            invalid_sev_cases.chain(invalid_rule_cases)
+        };
+
+        for (rule, severity) in cases {
+            let rule = match rule {
+                Rule::Valid(rule) => rule.to_wgsl_ident(),
+                Rule::Invalid => "totes_invalid_rule",
+            };
+            let severity = match severity {
+                Sev::Valid(severity) => severity.to_ident(),
+                Sev::Invalid => "totes_invalid_severity",
+            };
+            let shader = format!("diagnostic({severity},{rule});");
+            let expected_msg = format!(
+                "\
+"
+            );
+
+            assert_parse_err(&shader, &expected_msg);
+        }
+    }
+}

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -296,10 +296,6 @@ pub(crate) enum Error<'a> {
         severity_control_name_span: Span,
     },
     DiagnosticDuplicateTriggeringRule(ConflictingDiagnosticRuleError),
-    DiagnosticNotYetImplemented {
-        triggering_rule: FilterableTriggeringRule,
-        span: Span,
-    },
 }
 
 impl<'a> From<ConflictingDiagnosticRuleError> for Error<'a> {
@@ -1047,24 +1043,6 @@ impl<'a> Error<'a> {
                     .into()],
                 }
             }
-            Error::DiagnosticNotYetImplemented {
-                triggering_rule,
-                span,
-            } => ParseError {
-                message: format!(
-                    "the `{}` diagnostic filter is not yet supported",
-                    triggering_rule.to_ident()
-                ),
-                labels: vec![(span, "".into())],
-                notes: vec![format!(
-                    concat!(
-                        "Let Naga maintainers know that you ran into this at ",
-                        "<https://github.com/gfx-rs/wgpu/issues/{}>, ",
-                        "so they can prioritize it!"
-                    ),
-                    triggering_rule.tracking_issue_num()
-                )],
-            },
         }
     }
 }

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -1023,7 +1023,7 @@ impl<'a> Error<'a> {
             } => ParseError {
                 message: format!(
                     "the `{}` diagnostic filter is not yet supported",
-                    triggering_rule.to_ident()
+                    triggering_rule.to_wgsl_ident()
                 ),
                 labels: vec![(span, "".into())],
                 notes: vec![format!(

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1244,7 +1244,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             .arguments
             .iter()
             .enumerate()
-            .map(|(i, arg)| {
+            .map(|(i, arg)| -> Result<_, Error<'_>> {
                 let ty = self.resolve_ast_type(arg.ty, ctx)?;
                 let expr = expressions
                     .append(crate::Expression::FunctionArgument(i as u32), arg.name.span);
@@ -1263,7 +1263,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
         let result = f
             .result
             .as_ref()
-            .map(|res| {
+            .map(|res| -> Result<_, Error<'_>> {
                 let ty = self.resolve_ast_type(res.ty, ctx)?;
                 Ok(crate::FunctionResult {
                     ty,

--- a/naga/src/front/wgsl/mod.rs
+++ b/naga/src/front/wgsl/mod.rs
@@ -4,6 +4,7 @@ Frontend for [WGSL][wgsl] (WebGPU Shading Language).
 [wgsl]: https://gpuweb.github.io/gpuweb/wgsl.html
 */
 
+mod diagnostic_filter;
 mod error;
 mod index;
 mod lower;

--- a/naga/src/front/wgsl/parse/ast.rs
+++ b/naga/src/front/wgsl/parse/ast.rs
@@ -1,3 +1,4 @@
+use crate::diagnostic_filter::DiagnosticFilterNode;
 use crate::front::wgsl::parse::directive::enable_extension::EnableExtensions;
 use crate::front::wgsl::parse::number::Number;
 use crate::front::wgsl::Scalar;
@@ -26,6 +27,17 @@ pub struct TranslationUnit<'a> {
     /// These are referred to by `Handle<ast::Type<'a>>` values.
     /// User-defined types are referred to by name until lowering.
     pub types: Arena<Type<'a>>,
+
+    /// Arena for all diagnostic filter rules parsed in this module, including those in functions.
+    ///
+    /// See [`DiagnosticFilterNode`] for details on how the tree is represented and used in
+    /// validation.
+    pub diagnostic_filters: Arena<DiagnosticFilterNode>,
+    /// The leaf of all `diagnostic(…)` directives in this module.
+    ///
+    /// See [`DiagnosticFilterNode`] for details on how the tree is represented and used in
+    /// validation.
+    pub diagnostic_filter_leaf: Option<Handle<DiagnosticFilterNode>>,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -2631,11 +2631,10 @@ impl Parser {
         lexer.expect(Token::Paren('('))?;
 
         let (severity_control_name, severity_control_name_span) = lexer.next_ident_with_span()?;
-        let new_severity = diagnostic_filter::Severity::from_ident(severity_control_name).ok_or(
-            Error::DiagnosticInvalidSeverity {
+        let new_severity = diagnostic_filter::Severity::from_wgsl_ident(severity_control_name)
+            .ok_or(Error::DiagnosticInvalidSeverity {
                 severity_control_name_span,
-            },
-        )?;
+            })?;
 
         lexer.expect(Token::Separator(','))?;
 
@@ -2652,7 +2651,7 @@ impl Parser {
 
         let filter = diagnostic_rule_name
             .and_then(|name| {
-                FilterableTriggeringRule::from_ident(name)
+                FilterableTriggeringRule::from_wgsl_ident(name)
                     .map(Ok)
                     .or_else(|| {
                         diagnostic_filter::Severity::Warning

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -2534,13 +2534,8 @@ impl Parser {
                 match kind {
                     DirectiveKind::Diagnostic => {
                         if let Some(diagnostic_filter) = self.diagnostic_filter(&mut lexer)? {
-                            let triggering_rule = diagnostic_filter.triggering_rule;
                             let span = self.peek_rule_span(&lexer);
                             diagnostic_filters.add(diagnostic_filter, span)?;
-                            Err(Error::DiagnosticNotYetImplemented {
-                                triggering_rule,
-                                span,
-                            })?;
                         }
                         lexer.expect(Token::Separator(';'))?;
                     }

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -1907,10 +1907,8 @@ impl Parser {
                         let _ = lexer.next();
                         let mut body = ast::Block::default();
 
-                        let (condition, span) = lexer.capture_span(|lexer| {
-                            let condition = self.general_expression(lexer, ctx)?;
-                            Ok(condition)
-                        })?;
+                        let (condition, span) =
+                            lexer.capture_span(|lexer| self.general_expression(lexer, ctx))?;
                         let mut reject = ast::Block::default();
                         reject.stmts.push(ast::Statement {
                             kind: ast::StatementKind::Break,
@@ -1966,11 +1964,12 @@ impl Parser {
 
                         let mut body = ast::Block::default();
                         if !lexer.skip(Token::Separator(';')) {
-                            let (condition, span) = lexer.capture_span(|lexer| {
-                                let condition = self.general_expression(lexer, ctx)?;
-                                lexer.expect(Token::Separator(';'))?;
-                                Ok(condition)
-                            })?;
+                            let (condition, span) =
+                                lexer.capture_span(|lexer| -> Result<_, Error<'_>> {
+                                    let condition = self.general_expression(lexer, ctx)?;
+                                    lexer.expect(Token::Separator(';'))?;
+                                    Ok(condition)
+                                })?;
                             let mut reject = ast::Block::default();
                             reject.stmts.push(ast::Statement {
                                 kind: ast::StatementKind::Break,

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -1,4 +1,6 @@
-use crate::diagnostic_filter::{self, DiagnosticFilter, FilterableTriggeringRule};
+use crate::diagnostic_filter::{
+    self, DiagnosticFilter, DiagnosticFilterMap, FilterableTriggeringRule,
+};
 use crate::front::wgsl::error::{Error, ExpectedToken};
 use crate::front::wgsl::parse::directive::enable_extension::{
     EnableExtension, EnableExtensions, UnimplementedEnableExtension,
@@ -2522,6 +2524,7 @@ impl Parser {
         let mut lexer = Lexer::new(source);
         let mut tu = ast::TranslationUnit::default();
         let mut enable_extensions = EnableExtensions::empty();
+        let mut diagnostic_filters = DiagnosticFilterMap::new();
 
         // Parse directives.
         while let Ok((ident, _directive_ident_span)) = lexer.peek_ident_with_span() {
@@ -2533,6 +2536,7 @@ impl Parser {
                         if let Some(diagnostic_filter) = self.diagnostic_filter(&mut lexer)? {
                             let triggering_rule = diagnostic_filter.triggering_rule;
                             let span = self.peek_rule_span(&lexer);
+                            diagnostic_filters.add(diagnostic_filter, span)?;
                             Err(Error::DiagnosticNotYetImplemented {
                                 triggering_rule,
                                 span,

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -269,6 +269,7 @@ pub use crate::arena::{Arena, Handle, Range, UniqueArena};
 pub use crate::span::{SourceLocation, Span, SpanContext, WithSpan};
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
+use diagnostic_filter::DiagnosticFilterNode;
 #[cfg(feature = "deserialize")]
 use serde::Deserialize;
 #[cfg(feature = "serialize")]
@@ -2271,4 +2272,17 @@ pub struct Module {
     pub functions: Arena<Function>,
     /// Entry points.
     pub entry_points: Vec<EntryPoint>,
+    /// Arena for all diagnostic filter rules parsed in this module, including those in functions
+    /// and statements.
+    ///
+    /// This arena contains elements of a _tree_ of diagnostic filter rules. When nodes are built
+    /// by a front-end, they refer to a parent scope
+    pub diagnostic_filters: Arena<DiagnosticFilterNode>,
+    /// The leaf of all diagnostic filter rules tree parsed from directives in this module.
+    ///
+    /// In WGSL, this corresponds to `diagnostic(…);` directives.
+    ///
+    /// See [`DiagnosticFilterNode`] for details on how the tree is represented and used in
+    /// validation.
+    pub diagnostic_filter_leaf: Option<Handle<DiagnosticFilterNode>>,
 }

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -6,6 +6,7 @@
 //! - expression reference counts
 
 use super::{ExpressionError, FunctionError, ModuleInfo, ShaderStages, ValidationFlags};
+use crate::diagnostic_filter::DiagnosticFilterNode;
 use crate::span::{AddSpan as _, WithSpan};
 use crate::{
     arena::{Arena, Handle},
@@ -289,6 +290,13 @@ pub struct FunctionInfo {
 
     /// Indicates that the function is using dual source blending.
     pub dual_source_blending: bool,
+
+    /// The leaf of all module-wide diagnostic filter rules tree parsed from directives in this
+    /// module.
+    ///
+    /// See [`DiagnosticFilterNode`] for details on how the tree is represented and used in
+    /// validation.
+    diagnostic_filter_leaf: Option<Handle<DiagnosticFilterNode>>,
 }
 
 impl FunctionInfo {
@@ -820,12 +828,14 @@ impl FunctionInfo {
     /// Returns a `NonUniformControlFlow` error if any of the expressions in the block
     /// require uniformity, but the current flow is non-uniform.
     #[allow(clippy::or_fun_call)]
+    #[allow(clippy::only_used_in_recursion)]
     fn process_block(
         &mut self,
         statements: &crate::Block,
         other_functions: &[FunctionInfo],
         mut disruptor: Option<UniformityDisruptor>,
         expression_arena: &Arena<crate::Expression>,
+        diagnostic_filter_arena: &Arena<DiagnosticFilterNode>,
     ) -> Result<FunctionUniformity, WithSpan<FunctionError>> {
         use crate::Statement as S;
 
@@ -901,9 +911,13 @@ impl FunctionInfo {
                         exit: ExitFlags::empty(),
                     }
                 }
-                S::Block(ref b) => {
-                    self.process_block(b, other_functions, disruptor, expression_arena)?
-                }
+                S::Block(ref b) => self.process_block(
+                    b,
+                    other_functions,
+                    disruptor,
+                    expression_arena,
+                    diagnostic_filter_arena,
+                )?,
                 S::If {
                     condition,
                     ref accept,
@@ -917,12 +931,14 @@ impl FunctionInfo {
                         other_functions,
                         branch_disruptor,
                         expression_arena,
+                        diagnostic_filter_arena,
                     )?;
                     let reject_uniformity = self.process_block(
                         reject,
                         other_functions,
                         branch_disruptor,
                         expression_arena,
+                        diagnostic_filter_arena,
                     )?;
                     accept_uniformity | reject_uniformity
                 }
@@ -941,6 +957,7 @@ impl FunctionInfo {
                             other_functions,
                             case_disruptor,
                             expression_arena,
+                            diagnostic_filter_arena,
                         )?;
                         case_disruptor = if case.fall_through {
                             case_disruptor.or(case_uniformity.exit_disruptor())
@@ -956,14 +973,20 @@ impl FunctionInfo {
                     ref continuing,
                     break_if,
                 } => {
-                    let body_uniformity =
-                        self.process_block(body, other_functions, disruptor, expression_arena)?;
+                    let body_uniformity = self.process_block(
+                        body,
+                        other_functions,
+                        disruptor,
+                        expression_arena,
+                        diagnostic_filter_arena,
+                    )?;
                     let continuing_disruptor = disruptor.or(body_uniformity.exit_disruptor());
                     let continuing_uniformity = self.process_block(
                         continuing,
                         other_functions,
                         continuing_disruptor,
                         expression_arena,
+                        diagnostic_filter_arena,
                     )?;
                     if let Some(expr) = break_if {
                         let _ = self.add_ref(expr);
@@ -1117,6 +1140,7 @@ impl ModuleInfo {
             expressions: vec![ExpressionInfo::new(); fun.expressions.len()].into_boxed_slice(),
             sampling: crate::FastHashSet::default(),
             dual_source_blending: false,
+            diagnostic_filter_leaf: module.diagnostic_filter_leaf,
         };
         let resolve_context =
             ResolveContext::with_locals(module, &fun.local_variables, &fun.arguments);
@@ -1140,7 +1164,13 @@ impl ModuleInfo {
             }
         }
 
-        let uniformity = info.process_block(&fun.body, &self.functions, None, &fun.expressions)?;
+        let uniformity = info.process_block(
+            &fun.body,
+            &self.functions,
+            None,
+            &fun.expressions,
+            &module.diagnostic_filters,
+        )?;
         info.uniformity = uniformity.result;
         info.may_kill = uniformity.exit.contains(ExitFlags::MAY_KILL);
 
@@ -1230,6 +1260,7 @@ fn uniform_control_flow() {
         expressions: vec![ExpressionInfo::new(); expressions.len()].into_boxed_slice(),
         sampling: crate::FastHashSet::default(),
         dual_source_blending: false,
+        diagnostic_filter_leaf: None,
     };
     let resolve_context = ResolveContext {
         constants: &Arena::new(),
@@ -1276,7 +1307,8 @@ fn uniform_control_flow() {
             &vec![stmt_emit1, stmt_if_uniform].into(),
             &[],
             None,
-            &expressions
+            &expressions,
+            &Arena::new(),
         ),
         Ok(FunctionUniformity {
             result: Uniformity {
@@ -1308,6 +1340,7 @@ fn uniform_control_flow() {
             &[],
             None,
             &expressions,
+            &Arena::new(),
         );
         if DISABLE_UNIFORMITY_REQ_FOR_FRAGMENT_STAGE {
             assert_eq!(info[derivative_expr].ref_count, 2);
@@ -1335,7 +1368,8 @@ fn uniform_control_flow() {
             &vec![stmt_emit3, stmt_return_non_uniform].into(),
             &[],
             Some(UniformityDisruptor::Return),
-            &expressions
+            &expressions,
+            &Arena::new(),
         ),
         Ok(FunctionUniformity {
             result: Uniformity {
@@ -1362,7 +1396,8 @@ fn uniform_control_flow() {
             &vec![stmt_emit4, stmt_assign, stmt_kill, stmt_return_pointer].into(),
             &[],
             Some(UniformityDisruptor::Discard),
-            &expressions
+            &expressions,
+            &Arena::new(),
         ),
         Ok(FunctionUniformity {
             result: Uniformity {

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -6,7 +6,7 @@
 //! - expression reference counts
 
 use super::{ExpressionError, FunctionError, ModuleInfo, ShaderStages, ValidationFlags};
-use crate::diagnostic_filter::DiagnosticFilterNode;
+use crate::diagnostic_filter::{DiagnosticFilterNode, FilterableTriggeringRule};
 use crate::span::{AddSpan as _, WithSpan};
 use crate::{
     arena::{Arena, Handle},
@@ -828,7 +828,6 @@ impl FunctionInfo {
     /// Returns a `NonUniformControlFlow` error if any of the expressions in the block
     /// require uniformity, but the current flow is non-uniform.
     #[allow(clippy::or_fun_call)]
-    #[allow(clippy::only_used_in_recursion)]
     fn process_block(
         &mut self,
         statements: &crate::Block,
@@ -852,8 +851,21 @@ impl FunctionInfo {
                             && !req.is_empty()
                         {
                             if let Some(cause) = disruptor {
-                                return Err(FunctionError::NonUniformControlFlow(req, expr, cause)
-                                    .with_span_handle(expr, expression_arena));
+                                let severity = DiagnosticFilterNode::search(
+                                    self.diagnostic_filter_leaf,
+                                    diagnostic_filter_arena,
+                                    FilterableTriggeringRule::DerivativeUniformity,
+                                );
+                                severity.report_diag(
+                                    FunctionError::NonUniformControlFlow(req, expr, cause)
+                                        .with_span_handle(expr, expression_arena),
+                                    // TODO: Yes, this isn't contextualized with source, because
+                                    // the user is supposed to render what would normally be an
+                                    // error here. Once we actually support warning-level
+                                    // diagnostic items, then we won't need this non-compliant hack:
+                                    // <https://github.com/gfx-rs/wgpu/issues/6458>
+                                    |e, level| log::log!(level, "{e}"),
+                                )?;
                             }
                         }
                         requirements |= req;

--- a/naga/src/valid/handles.rs
+++ b/naga/src/valid/handles.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     arena::{BadHandle, BadRangeError},
+    diagnostic_filter::DiagnosticFilterNode,
     Handle,
 };
 
@@ -39,6 +40,8 @@ impl super::Validator {
             ref types,
             ref special_types,
             ref global_expressions,
+            ref diagnostic_filters,
+            ref diagnostic_filter_leaf,
         } = module;
 
         // NOTE: Types being first is important. All other forms of validation depend on this.
@@ -178,6 +181,19 @@ impl super::Validator {
         }
         if let Some(ty) = special_types.ray_intersection {
             validate_type(ty)?;
+        }
+
+        {
+            for (handle, _node) in diagnostic_filters.iter() {
+                handle.check_valid_for(diagnostic_filters)?;
+                let DiagnosticFilterNode { inner: _, parent } = diagnostic_filters[handle];
+                if let Some(handle) = parent {
+                    handle.check_valid_for(diagnostic_filters)?;
+                }
+            }
+            if let Some(handle) = *diagnostic_filter_leaf {
+                handle.check_valid_for(diagnostic_filters)?;
+            }
         }
 
         Ok(())

--- a/naga/tests/out/analysis/access.info.ron
+++ b/naga/tests/out/analysis/access.info.ron
@@ -1191,6 +1191,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2516,6 +2517,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2555,6 +2557,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2603,6 +2606,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2645,6 +2649,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2738,6 +2743,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2789,6 +2795,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2843,6 +2850,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2894,6 +2902,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2948,6 +2957,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
     ],
     entry_points: [
@@ -3623,6 +3633,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -4074,6 +4085,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -4194,6 +4206,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -4257,6 +4270,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
     ],
     const_expression_types: [

--- a/naga/tests/out/analysis/collatz.info.ron
+++ b/naga/tests/out/analysis/collatz.info.ron
@@ -274,6 +274,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
     ],
     entry_points: [
@@ -428,6 +429,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
     ],
     const_expression_types: [],

--- a/naga/tests/out/analysis/overrides.info.ron
+++ b/naga/tests/out/analysis/overrides.info.ron
@@ -163,6 +163,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
     ],
     const_expression_types: [

--- a/naga/tests/out/analysis/shadow.info.ron
+++ b/naga/tests/out/analysis/shadow.info.ron
@@ -412,6 +412,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -1571,6 +1572,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
     ],
     entry_points: [
@@ -1664,6 +1666,7 @@
             ],
             sampling: [],
             dual_source_blending: false,
+            diagnostic_filter_leaf: None,
         ),
     ],
     const_expression_types: [

--- a/naga/tests/out/ir/access.compact.ron
+++ b/naga/tests/out/ir/access.compact.ron
@@ -2476,4 +2476,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/access.ron
+++ b/naga/tests/out/ir/access.ron
@@ -2476,4 +2476,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/atomic_i_increment.compact.ron
+++ b/naga/tests/out/ir/atomic_i_increment.compact.ron
@@ -279,4 +279,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/atomic_i_increment.ron
+++ b/naga/tests/out/ir/atomic_i_increment.ron
@@ -304,4 +304,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/collatz.compact.ron
+++ b/naga/tests/out/ir/collatz.compact.ron
@@ -330,4 +330,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/collatz.ron
+++ b/naga/tests/out/ir/collatz.ron
@@ -330,4 +330,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/const_assert.compact.ron
+++ b/naga/tests/out/ir/const_assert.compact.ron
@@ -51,4 +51,6 @@
         ),
     ],
     entry_points: [],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/const_assert.ron
+++ b/naga/tests/out/ir/const_assert.ron
@@ -51,4 +51,6 @@
         ),
     ],
     entry_points: [],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/fetch_depth.compact.ron
+++ b/naga/tests/out/ir/fetch_depth.compact.ron
@@ -192,4 +192,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/fetch_depth.ron
+++ b/naga/tests/out/ir/fetch_depth.ron
@@ -262,4 +262,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/index-by-value.compact.ron
+++ b/naga/tests/out/ir/index-by-value.compact.ron
@@ -369,4 +369,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/index-by-value.ron
+++ b/naga/tests/out/ir/index-by-value.ron
@@ -369,4 +369,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/local-const.compact.ron
+++ b/naga/tests/out/ir/local-const.compact.ron
@@ -136,4 +136,6 @@
         ),
     ],
     entry_points: [],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/local-const.ron
+++ b/naga/tests/out/ir/local-const.ron
@@ -136,4 +136,6 @@
         ),
     ],
     entry_points: [],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/overrides-atomicCompareExchangeWeak.compact.ron
+++ b/naga/tests/out/ir/overrides-atomicCompareExchangeWeak.compact.ron
@@ -125,4 +125,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/overrides-atomicCompareExchangeWeak.ron
+++ b/naga/tests/out/ir/overrides-atomicCompareExchangeWeak.ron
@@ -125,4 +125,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/overrides-ray-query.compact.ron
+++ b/naga/tests/out/ir/overrides-ray-query.compact.ron
@@ -256,4 +256,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/overrides-ray-query.ron
+++ b/naga/tests/out/ir/overrides-ray-query.ron
@@ -256,4 +256,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/overrides.compact.ron
+++ b/naga/tests/out/ir/overrides.compact.ron
@@ -196,4 +196,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/overrides.ron
+++ b/naga/tests/out/ir/overrides.ron
@@ -196,4 +196,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/shadow.compact.ron
+++ b/naga/tests/out/ir/shadow.compact.ron
@@ -1026,4 +1026,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/shadow.ron
+++ b/naga/tests/out/ir/shadow.ron
@@ -1304,4 +1304,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/spec-constants.compact.ron
+++ b/naga/tests/out/ir/spec-constants.compact.ron
@@ -609,4 +609,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )

--- a/naga/tests/out/ir/spec-constants.ron
+++ b/naga/tests/out/ir/spec-constants.ron
@@ -715,4 +715,6 @@
             ),
         ),
     ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
 )


### PR DESCRIPTION
Tests `diagnostic` parsing added in #6456.

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
