### PR TITLE
Add naga variants and stubs for r64uint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ By @bradwerth [#6216](https://github.com/gfx-rs/wgpu/pull/6216).
 - Add base support for parsing `requires`, `enable`, and `diagnostic` directives. No extensions or diagnostic filters are yet supported, but diagnostics have improved dramatically. By @ErichDonGubler in [#6352](https://github.com/gfx-rs/wgpu/pull/6352), [#6424](https://github.com/gfx-rs/wgpu/pull/6424), [#6437](https://github.com/gfx-rs/wgpu/pull/6437).
 - Include error chain information as a message and notes in shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
 - Unify Naga CLI error output with the format of shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
+- Add ImageAtomic enum variants and stubs. By @atlv24 in [#6459](https://github.com/gfx-rs/wgpu/pull/6459).
 
 #### General
 

--- a/naga/src/back/dot/mod.rs
+++ b/naga/src/back/dot/mod.rs
@@ -254,6 +254,19 @@ impl StatementGraph {
                     }
                     "Atomic"
                 }
+                S::ImageAtomic {
+                    image,
+                    coordinate,
+                    sample,
+                    fun: _,
+                    value,
+                } => {
+                    self.dependencies.push((id, image, "image"));
+                    self.dependencies.push((id, coordinate, "coordinate"));
+                    self.dependencies.push((id, sample, "sample"));
+                    self.dependencies.push((id, value, "value"));
+                    "ImageAtomic"
+                }
                 S::WorkGroupUniformLoad { pointer, result } => {
                     self.emits.push((id, result));
                     self.dependencies.push((id, pointer, "pointer"));

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -2469,6 +2469,18 @@ impl<'a, W: Write> Writer<'a, W> {
                 self.write_expr(value, ctx)?;
                 writeln!(self.out, ");")?;
             }
+            // Stores a value into an image.
+            Statement::ImageAtomic {
+                image: _,
+                coordinate: _,
+                sample: _,
+                fun: _,
+                value: _,
+            } => {
+                return Err(Error::Custom(
+                    "Image atomics are not implemented".to_string(),
+                ));
+            }
             Statement::RayQuery { .. } => unreachable!(),
             Statement::SubgroupBallot { result, predicate } => {
                 write!(self.out, "{level}")?;

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -2209,6 +2209,15 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
 
                 writeln!(self.out, ");")?;
             }
+            crate::Statement::ImageAtomic {
+                image: _,
+                coordinate: _,
+                sample: _,
+                fun: _,
+                value: _,
+            } => {
+                return Err(Error::Unimplemented("image atomics".to_string()));
+            }
             Statement::WorkGroupUniformLoad { pointer, result } => {
                 self.write_barrier(crate::Barrier::WORK_GROUP, level)?;
                 write!(self.out, "{level}")?;

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -3219,6 +3219,17 @@ impl<W: Write> Writer<W> {
                     // Done
                     writeln!(self.out, ";")?;
                 }
+                crate::Statement::ImageAtomic {
+                    image: _,
+                    coordinate: _,
+                    sample: _,
+                    fun: _,
+                    value: _,
+                } => {
+                    return Err(Error::UnsupportedCall(
+                        "Image atomics are not supported".into(),
+                    ));
+                }
                 crate::Statement::WorkGroupUniformLoad { pointer, result } => {
                     self.write_barrier(crate::Barrier::WORK_GROUP, level)?;
 

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -638,6 +638,18 @@ fn adjust_stmt(new_pos: &HandleVec<Expression, Handle<Expression>>, stmt: &mut S
                 | crate::AtomicFunction::Exchange { compare: None } => {}
             }
         }
+        Statement::ImageAtomic {
+            ref mut image,
+            ref mut coordinate,
+            ref mut sample,
+            fun: _,
+            ref mut value,
+        } => {
+            adjust(image);
+            adjust(coordinate);
+            adjust(sample);
+            adjust(value);
+        }
         Statement::WorkGroupUniformLoad {
             ref mut pointer,
             ref mut result,

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -2870,6 +2870,17 @@ impl<'w> BlockContext<'w> {
 
                     block.body.push(instruction);
                 }
+                Statement::ImageAtomic {
+                    image: _,
+                    coordinate: _,
+                    sample: _,
+                    fun: _,
+                    value: _,
+                } => {
+                    return Err(Error::FeatureNotImplemented(
+                        "Image atomics are not supported",
+                    ));
+                }
                 Statement::WorkGroupUniformLoad { pointer, result } => {
                     self.writer
                         .write_barrier(crate::Barrier::WORK_GROUP, &mut block);

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -791,7 +791,9 @@ impl<W: Write> Writer<W> {
                 fun: _,
                 value: _,
             } => {
-                unimplemented!("Image atomics are not yet supported");
+                return Err(Error::Unimplemented(
+                    "Image atomics are not yet supported".into(),
+                ));
             }
             Statement::WorkGroupUniformLoad { pointer, result } => {
                 write!(self.out, "{level}")?;

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -784,6 +784,15 @@ impl<W: Write> Writer<W> {
                 self.write_expr(module, value, func_ctx)?;
                 writeln!(self.out, ");")?
             }
+            Statement::ImageAtomic {
+                image: _,
+                coordinate: _,
+                sample: _,
+                fun: _,
+                value: _,
+            } => {
+                unimplemented!("Image atomics are not yet supported");
+            }
             Statement::WorkGroupUniformLoad { pointer, result } => {
                 write!(self.out, "{level}")?;
                 // TODO: Obey named expressions here.

--- a/naga/src/compact/statements.rs
+++ b/naga/src/compact/statements.rs
@@ -79,6 +79,18 @@ impl FunctionTracer<'_> {
                             self.expressions_used.insert(result);
                         }
                     }
+                    St::ImageAtomic {
+                        image,
+                        coordinate,
+                        sample,
+                        fun: _,
+                        value,
+                    } => {
+                        self.expressions_used.insert(image);
+                        self.expressions_used.insert(coordinate);
+                        self.expressions_used.insert(sample);
+                        self.expressions_used.insert(value);
+                    }
                     St::WorkGroupUniformLoad { pointer, result } => {
                         self.expressions_used.insert(pointer);
                         self.expressions_used.insert(result);
@@ -260,6 +272,18 @@ impl FunctionMap {
                         if let Some(ref mut result) = *result {
                             adjust(result);
                         }
+                    }
+                    St::ImageAtomic {
+                        ref mut image,
+                        ref mut coordinate,
+                        ref mut sample,
+                        fun: _,
+                        ref mut value,
+                    } => {
+                        adjust(image);
+                        adjust(coordinate);
+                        adjust(sample);
+                        adjust(value);
                     }
                     St::WorkGroupUniformLoad {
                         ref mut pointer,

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -4377,6 +4377,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                 | S::Store { .. }
                 | S::ImageStore { .. }
                 | S::Atomic { .. }
+                | S::ImageAtomic { .. }
                 | S::RayQuery { .. }
                 | S::SubgroupBallot { .. }
                 | S::SubgroupCollectiveOperation { .. }

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -1988,6 +1988,54 @@ pub enum Statement {
         /// [`SHADER_INT64_ATOMIC_ALL_OPS`]: crate::valid::Capabilities::SHADER_INT64_ATOMIC_ALL_OPS
         result: Option<Handle<Expression>>,
     },
+    /// Performs an atomic operation on a texel value of an image.
+    ///
+    /// Doing atomics on images with mipmaps is not supported, so there is no
+    /// `level` operand.
+    ///
+    /// This statement is a barrier for any operations on the corresponding
+    /// [`Expression::GlobalVariable`] for this image.
+    ImageAtomic {
+        /// The image to perform an atomic operation on. This must have type
+        /// [`Image`]. (This will necessarily be a [`GlobalVariable`] or
+        /// [`FunctionArgument`] expression, since no other expressions are
+        /// allowed to have that type.)
+        ///
+        /// [`Image`]: TypeInner::Image
+        /// [`GlobalVariable`]: Expression::GlobalVariable
+        /// [`FunctionArgument`]: Expression::FunctionArgument
+        image: Handle<Expression>,
+
+        /// The coordinate of the texel we wish to load. This must be a scalar
+        /// for [`D1`] images, a [`Bi`] vector for [`D2`] images, and a [`Tri`]
+        /// vector for [`D3`] images. (sample indices are supplied separately.)
+        /// Its component type must be [`Sint`].
+        ///
+        /// If this image is arrayed, [`D1`] images require a [`Bi`] vector and
+        /// [`D2`] images require a [`Tri`] vector.
+        ///
+        /// Explicit level-of-detail values are unsupported.
+        ///
+        /// [`D1`]: ImageDimension::D1
+        /// [`D2`]: ImageDimension::D2
+        /// [`D3`]: ImageDimension::D3
+        /// [`Bi`]: VectorSize::Bi
+        /// [`Tri`]: VectorSize::Tri
+        /// [`Sint`]: ScalarKind::Sint
+        coordinate: Handle<Expression>,
+
+        /// A sample index, for multisampled [`Sampled`] and [`Depth`] images.
+        ///
+        /// [`Sampled`]: ImageClass::Sampled
+        /// [`Depth`]: ImageClass::Depth
+        sample: Handle<Expression>,
+
+        /// The kind of atomic operation to perform on the texel.
+        fun: AtomicFunction,
+
+        // The value with which to perform the atomic operation.
+        value: Handle<Expression>,
+    },
     /// Load uniformly from a uniform pointer in the workgroup address space.
     ///
     /// Corresponds to the [`workgroupUniformLoad`](https://www.w3.org/TR/WGSL/#workgroupUniformLoad-builtin)

--- a/naga/src/proc/terminator.rs
+++ b/naga/src/proc/terminator.rs
@@ -36,6 +36,7 @@ pub fn ensure_block_returns(block: &mut crate::Block) {
             | S::Call { .. }
             | S::RayQuery { .. }
             | S::Atomic { .. }
+            | S::ImageAtomic { .. }
             | S::WorkGroupUniformLoad { .. }
             | S::SubgroupBallot { .. }
             | S::SubgroupCollectiveOperation { .. }

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -1022,6 +1022,19 @@ impl FunctionInfo {
                     }
                     FunctionUniformity::new()
                 }
+                S::ImageAtomic {
+                    image,
+                    coordinate,
+                    sample,
+                    fun: _,
+                    value,
+                } => {
+                    let _ = self.add_ref_impl(image, GlobalUse::WRITE);
+                    let _ = self.add_ref(coordinate);
+                    let _ = self.add_ref(sample);
+                    let _ = self.add_ref(value);
+                    FunctionUniformity::new()
+                }
                 S::RayQuery { query, ref fun } => {
                     let _ = self.add_ref(query);
                     if let crate::RayQueryFunction::Initialize {

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -65,6 +65,10 @@ pub enum ExpressionError {
     ExpectedSamplerType(Handle<crate::Type>),
     #[error("Unable to operate on image class {0:?}")]
     InvalidImageClass(crate::ImageClass),
+    #[error("Image atomics are not supported for storage format {0:?}")]
+    InvalidImageFormat(crate::StorageFormat),
+    #[error("Image atomics require read/write storage access, {0:?} is insufficient")]
+    InvalidImageStorageAccess(crate::StorageAccess),
     #[error("Derivatives can only be taken from scalar and vector floats")]
     InvalidDerivative,
     #[error("Image array index parameter is misplaced")]

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -146,6 +146,10 @@ pub enum FunctionError {
     },
     #[error("Image store parameters are invalid")]
     InvalidImageStore(#[source] ExpressionError),
+    #[error("Image atomic parameters are invalid")]
+    InvalidImageAtomic(#[source] ExpressionError),
+    #[error("Image atomic value is invalid")]
+    InvalidAtomicValue(Handle<crate::Expression>),
     #[error("Call to {function:?} is invalid")]
     InvalidCall {
         function: Handle<crate::Function>,
@@ -1135,6 +1139,18 @@ impl super::Validator {
                     result,
                 } => {
                     self.validate_atomic(pointer, fun, value, result, span, context)?;
+                }
+                S::ImageAtomic {
+                    image: _,
+                    coordinate: _,
+                    sample: _,
+                    fun: _,
+                    value: _,
+                } => {
+                    return Err(FunctionError::InvalidAtomic(AtomicError::MissingCapability(
+                        super::Capabilities::SHADER_INT64_ATOMIC_MIN_MAX,
+                    ))
+                    .with_span_static(span, "Image atomics are not implemented yet"))
                 }
                 S::WorkGroupUniformLoad { pointer, result } => {
                     stages &= super::ShaderStages::COMPUTE;

--- a/naga/src/valid/handles.rs
+++ b/naga/src/valid/handles.rs
@@ -536,6 +536,19 @@ impl super::Validator {
                 }
                 Ok(())
             }
+            crate::Statement::ImageAtomic {
+                image,
+                coordinate,
+                sample,
+                fun: _,
+                value,
+            } => {
+                validate_expr(image)?;
+                validate_expr(coordinate)?;
+                validate_expr(sample)?;
+                validate_expr(value)?;
+                Ok(())
+            }
             crate::Statement::WorkGroupUniformLoad { pointer, result } => {
                 validate_expr(pointer)?;
                 validate_expr(result)?;


### PR DESCRIPTION
**Connections**
commits pulled from https://github.com/gfx-rs/wgpu/pull/5537

**Description**
stubs for 64 bit image atomics

**Testing**
tests are in https://github.com/gfx-rs/wgpu/pull/5537

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
