### PR TITLE
feat(naga-cli)!: init. logger to `INFO` by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "bincode",
  "codespan-reporting",
  "env_logger",
+ "log",
  "naga",
 ]
 

--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -23,6 +23,7 @@ codespan-reporting.workspace = true
 env_logger.workspace = true
 argh.workspace = true
 anyhow.workspace = true
+log.workspace = true
 
 [dependencies.naga]
 version = "22.0.0"

--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -375,7 +375,10 @@ impl fmt::Display for CliError {
 impl std::error::Error for CliError {}
 
 fn run() -> anyhow::Result<()> {
-    env_logger::init();
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
+        .init();
 
     // Parse commandline arguments
     let args: Args = argh::from_env();


### PR DESCRIPTION
**Connections**

- Discovered over the course of testing #6456, which needs to emit a warning.

**Description**

Many of Naga's internals print to `stderr` with `eprintln!(…)`. I'm sure that part of the reason is to avoid. I'm _also_ sure that users are missing vital information when Naga CLI doesn't emit warnings by default; how else would they become aware of them, if not being emitted by default?

**Testing**
_Explain how this change is tested._

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
