### PR TITLE
fix(naga-cli): allow output files with `--stdin-file-path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
-## New Features
+### New Features
 
-### Naga
+#### Naga
 
 - Parse `diagnostic(…)` directives, but don't implement any triggering rules yet. By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456).
+- Fix an issue where `naga` CLI would incorrectly skip the first positional argument when `--stdin-file-path` was specified. By @ErichDonGubler in [#6480](https://github.com/gfx-rs/wgpu/pull/6480).
 
 ## 23.0.0 (2024-10-25)
 


### PR DESCRIPTION
**Connections**

- Fixes #6474.

**Description**

Change file handling in non-`bulk-validation` cases to be based on an iterator, and use it to correctly treat `args.files`' first entry as an input or output path in response to `--stdin-file-path` being specified.

**Testing**

Ran things manually with `--stdin-file-path` and without. I encourage reviewers to do their own testing, since 

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
