### PR TITLE
[wgpu-hal] Change the `DropCallback` API to use `FnOnce` instead of `FnMut`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ Bottom level categories:
 
 - Parse `diagnostic(…)` directives, but don't implement any triggering rules yet. By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456).
 
+### Changes
+
+#### HAL
+
+- Change the `DropCallback` API to use `FnOnce` instead of `FnMut`. By @jerzywilczek in [#6482](https://github.com/gfx-rs/wgpu/pull/6482)
+
 ## 23.0.0 (2024-10-25)
 
 ### Themes of this release


### PR DESCRIPTION
**Connections**
This refines the change I made in #6164 

**Description**
I initially made the `DropCallback` API use `FnMut`. This seemed like a good choice at the time, since we only get `&mut self` access to the `DropGuard` in its `Drop` implementation. After some time it became apparent to me that at least a part of the users of this API will want to supply a closure which just holds some kind of a reference-counted wrapper around the corresponding resource that would drop it when called, thus freeing the resource. With the current API they have to do weird stuff to achieve this behavior, because `FnMut` cannot consume its captures:

```rs
let mut vulkan_device_clone: Option<Arc<VulkanDevice>> = Some(vulkan_device.clone());
let wgpu_device = unsafe {
    wgpu_adapter.adapter.device_from_raw(
        ...
        Some(Box::new(move || { vulkan_device_clone.take(); })),
        ...
    )?
};
``` 

With this change they could consume the capture:

```rs
let vulkan_device_clone: Arc<VulkanDevice> = vulkan_device.clone();
let wgpu_device = unsafe {
    wgpu_adapter.adapter.device_from_raw(
        ...
        Some(Box::new(move || { vulkan_device_clone; })),
        ...
    )?
};
// or more explicitly:
let wgpu_device = unsafe {
    wgpu_adapter.adapter.device_from_raw(
        ...
        Some(Box::new(move || { drop(vulkan_device_clone); })),
        ...
    )?
};
``` 

This seems a lot more intuitive.

**Testing**
 Things still compile and there is no difference in test passes.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
  This just fails
- [x] Run `cargo xtask test` to run tests.
129 tests fail on my machine, with or without the changes
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
