### PR TITLE
Move buffer slice OOB check from panic in `wgpu` to validation error in `wgpu-core`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1209,6 +1209,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Set index type to NONE in `get_acceleration_structure_build_sizes`. By @Vecvec in [#6802](https://github.com/gfx-rs/wgpu/pull/6802).
 - Fix `wgpu-info` not showing dx12 adapters. By @wumpf in [#6844](https://github.com/gfx-rs/wgpu/pull/6844).
 - Use `transform_buffer_offset` when initialising `transform_buffer`. By @Vecvec in [#6864](https://github.com/gfx-rs/wgpu/pull/6864).
+- Move buffer slice OOB checks to be a validation error in `wgpu-core`, instead of a panic in `wgpu` only. By @ErichDonGubler in [#6493](https://github.com/gfx-rs/wgpu/pull/6493).
 
 #### naga
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -743,6 +743,17 @@ pub enum RenderPassErrorInner {
         end_count_offset: u64,
         count_buffer_size: u64,
     },
+    #[error(
+        "Requested indirect index buffer bytes {}..{} which overruns indirect buffer of size {}",
+        begin_offset,
+        end_offset,
+        buffer_size
+    )]
+    IndirectIndexBufferOverrun {
+        begin_offset: u64,
+        end_offset: u64,
+        buffer_size: u64,
+    },
     #[error(transparent)]
     ResourceUsageCompatibility(#[from] ResourceUsageCompatibilityError),
     #[error("Render bundle has incompatible targets, {0}")]
@@ -2403,6 +2414,21 @@ fn set_index_buffer(
         .binding(offset, size, state.pass.base.snatch_guard)
         .map_err(RenderCommandError::from)?;
     let end = offset + resolved_size;
+
+    let check_oob = |bound| {
+        if bound > buffer.size {
+            Err(RenderPassErrorInner::IndirectIndexBufferOverrun {
+                begin_offset: offset,
+                end_offset: end,
+                buffer_size: buffer.size,
+            })
+        } else {
+            Ok(())
+        }
+    };
+    check_oob(offset)?;
+    check_oob(end)?;
+
     state.index.update_buffer(offset..end, index_format);
 
     state.pass.base.buffer_memory_init_actions.extend(

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -311,7 +311,6 @@ impl Buffer {
     #[track_caller]
     pub fn slice<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferSlice<'_> {
         let (offset, size) = range_to_offset_size(bounds, self.size);
-        check_buffer_bounds(self.size, offset, size);
         BufferSlice {
             buffer: self,
             offset,
@@ -984,31 +983,6 @@ impl Drop for BufferViewMut {
     }
 }
 
-#[track_caller]
-fn check_buffer_bounds(
-    buffer_size: BufferAddress,
-    slice_offset: BufferAddress,
-    slice_size: BufferSize,
-) {
-    // A slice of length 0 is invalid, so the offset must not be equal to or greater than the buffer size.
-    if slice_offset >= buffer_size {
-        panic!(
-            "slice offset {} is out of range for buffer of size {}",
-            slice_offset, buffer_size
-        );
-    }
-
-    // Detect integer overflow.
-    let end = slice_offset.checked_add(slice_size.get());
-    if end.is_none_or(|end| end > buffer_size) {
-        panic!(
-            "slice offset {} size {} is out of range for buffer of size {}",
-            slice_offset, slice_size, buffer_size
-        );
-    }
-}
-
-#[track_caller]
 pub(crate) fn range_to_offset_size<S: RangeBounds<BufferAddress>>(
     bounds: S,
     whole_size: BufferAddress,
@@ -1030,9 +1004,7 @@ pub(crate) fn range_to_offset_size<S: RangeBounds<BufferAddress>>(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        check_buffer_bounds, range_overlaps, range_to_offset_size, BufferAddress, BufferSize,
-    };
+    use super::{range_overlaps, range_to_offset_size, BufferAddress, BufferSize};
 
     fn bs(value: BufferAddress) -> BufferSize {
         BufferSize::new(value).unwrap()
@@ -1060,27 +1032,6 @@ mod tests {
     #[should_panic = "buffer slices can not be empty"]
     fn range_to_offset_size_panics_for_unbounded_empty_range() {
         range_to_offset_size(..0, 100);
-    }
-
-    #[test]
-    fn check_buffer_bounds_works_for_end_in_range() {
-        check_buffer_bounds(200, 100, bs(50));
-        check_buffer_bounds(200, 100, bs(100));
-        check_buffer_bounds(u64::MAX, u64::MAX - 100, bs(100));
-        check_buffer_bounds(u64::MAX, 0, bs(u64::MAX));
-        check_buffer_bounds(u64::MAX, 1, bs(u64::MAX - 1));
-    }
-
-    #[test]
-    #[should_panic]
-    fn check_buffer_bounds_panics_for_end_over_size() {
-        check_buffer_bounds(200, 100, bs(101));
-    }
-
-    #[test]
-    #[should_panic]
-    fn check_buffer_bounds_panics_for_end_wraparound() {
-        check_buffer_bounds(u64::MAX, 1, bs(u64::MAX));
     }
 
     #[test]


### PR DESCRIPTION
**Connections**

Exercised by `webgpu:api,validation,encoding,cmds,render,setIndexBuffer:offset_and_size_oob:*`, which was disovered to be failing in Firefox in [this `webgpu-backlog1` run on a Windows debug build in `try:bed05e732fb557b6173872c508612399b6bc365e`](https://treeherder.mozilla.org/jobs?repo=try&tier=1%2C2%2C3&author=egubler%40mozilla.com&selectedTaskRun=enQluY6MT36HfWG8-NnjAw.0).

**Description**

`wgpu` implemented OOB checks on `BufferSlice` creation as a panic. However, it _should_ be implemented as a validation check in `wgpu-core`. So _fix it_. 😀

**Testing**

- Exercised by `webgpu:api,validation,encoding,cmds,render,setIndexBuffer:offset_and_size_oob:*` in Firefox.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
