### PR TITLE
Fix Issue 6467: Prevent MacOS crash on invalid workgroup size definition

### DIFF
--- a/tests/tests/regression/issue_6467.rs
+++ b/tests/tests/regression/issue_6467.rs
@@ -9,12 +9,14 @@ use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
 /// The following test should successfully do nothing on all platforms.
 #[gpu_test]
 static ZERO_WORKGROUP_SIZE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default()
-        .limits(wgpu::Limits::default()))
+    .parameters(TestParameters::default().limits(wgpu::Limits::default()))
     .run_async(|ctx| async move {
-        let module = ctx.device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: None,
-            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed("
+        let module = ctx
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: None,
+                source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
+                    "
                 @group(0)
                 @binding(0)
                 var<storage, read_write> vals: array<i32>;
@@ -24,22 +26,32 @@ static ZERO_WORKGROUP_SIZE: GpuTestConfiguration = GpuTestConfiguration::new()
                 fn main(@builtin(global_invocation_id) id: vec3u) {
                     vals[id.x] = vals[id.x] * i32(id.x);
                 }
-            ")),
-        });
-        let compute_pipeline = ctx.device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: None,
-            layout: None,
-            module: &module,
-            entry_point: Some("main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            cache: None,
-        });
-        let buffer = DeviceExt::create_buffer_init(&ctx.device, &wgpu::util::BufferInitDescriptor {
-            label: None,
-            contents: &[1, 1, 1, 1, 1, 1, 1, 1],
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
-        });
-        let mut encoder = ctx.device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None, });
+            ",
+                )),
+            });
+        let compute_pipeline =
+            ctx.device
+                .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                    label: None,
+                    layout: None,
+                    module: &module,
+                    entry_point: Some("main"),
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                    cache: None,
+                });
+        let buffer = DeviceExt::create_buffer_init(
+            &ctx.device,
+            &wgpu::util::BufferInitDescriptor {
+                label: None,
+                contents: &[1, 1, 1, 1, 1, 1, 1, 1],
+                usage: wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::COPY_SRC,
+            },
+        );
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         {
             let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
                 label: None,
@@ -61,4 +73,3 @@ static ZERO_WORKGROUP_SIZE: GpuTestConfiguration = GpuTestConfiguration::new()
         }
         ctx.queue.submit(Some(encoder.finish()));
     });
-

--- a/tests/tests/regression/issue_6467.rs
+++ b/tests/tests/regression/issue_6467.rs
@@ -1,0 +1,64 @@
+use wgpu::util::DeviceExt;
+use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
+
+/// Running a compute shader with one or more of the workgroup sizes set to 0 implies that no work
+/// should be done, and is a user error. Vulkan and DX12 accept this invalid input with grace, but
+/// Metal does not guard against this and eventually the machine will crash. Since this is a public
+/// API that may be given untrusted values in a browser, this must be protected again.
+///
+/// The following test should successfully do nothing on all platforms.
+#[gpu_test]
+static ZERO_WORKGROUP_SIZE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default()
+        .limits(wgpu::Limits::default()))
+    .run_async(|ctx| async move {
+        let module = ctx.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed("
+                @group(0)
+                @binding(0)
+                var<storage, read_write> vals: array<i32>;
+
+                @compute
+                @workgroup_size(1)
+                fn main(@builtin(global_invocation_id) id: vec3u) {
+                    vals[id.x] = vals[id.x] * i32(id.x);
+                }
+            ")),
+        });
+        let compute_pipeline = ctx.device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: None,
+            layout: None,
+            module: &module,
+            entry_point: Some("main"),
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+            cache: None,
+        });
+        let buffer = DeviceExt::create_buffer_init(&ctx.device, &wgpu::util::BufferInitDescriptor {
+            label: None,
+            contents: &[1, 1, 1, 1, 1, 1, 1, 1],
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
+        });
+        let mut encoder = ctx.device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None, });
+        {
+            let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: None,
+                timestamp_writes: None,
+            });
+            cpass.set_pipeline(&compute_pipeline);
+            let bind_group_layout = compute_pipeline.get_bind_group_layout(0);
+            let bind_group_entries = [wgpu::BindGroupEntry {
+                binding: 0,
+                resource: buffer.as_entire_binding(),
+            }];
+            let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &bind_group_layout,
+                entries: &bind_group_entries,
+            });
+            cpass.set_bind_group(0, &bind_group, &[]);
+            cpass.dispatch_workgroups(1, 0, 1);
+        }
+        ctx.queue.submit(Some(encoder.finish()));
+    });
+

--- a/tests/tests/root.rs
+++ b/tests/tests/root.rs
@@ -7,6 +7,7 @@ mod regression {
     mod issue_4514;
     mod issue_5553;
     mod issue_6317;
+    mod issue_6467;
 }
 
 mod bgra8unorm_storage;

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1240,13 +1240,15 @@ impl crate::CommandEncoder for super::CommandEncoder {
     }
 
     unsafe fn dispatch(&mut self, count: [u32; 3]) {
-        let encoder = self.state.compute.as_ref().unwrap();
-        let raw_count = metal::MTLSize {
-            width: count[0] as u64,
-            height: count[1] as u64,
-            depth: count[2] as u64,
-        };
-        encoder.dispatch_thread_groups(raw_count, self.state.raw_wg_size);
+        if count[0] > 0 && count[1] > 0 && count[2] > 0 {
+            let encoder = self.state.compute.as_ref().unwrap();
+            let raw_count = metal::MTLSize {
+                width: count[0] as u64,
+                height: count[1] as u64,
+                depth: count[2] as u64,
+            };
+            encoder.dispatch_thread_groups(raw_count, self.state.raw_wg_size);
+        }
     }
 
     unsafe fn dispatch_indirect(&mut self, buffer: &super::Buffer, offset: wgt::BufferAddress) {


### PR DESCRIPTION
**Connections**
This should resolve #6467 but I haven't yet been able to get the test suite working on the Mac Mini the problem is occurring on.

**Description**
If you make a mistake and define invalid workgroup dimensions (basically zero any of them), on Vulkan and DX12 it just ignores your compute shader, but on Metal it triggers a bug that eventually freezes the machine and causes a reboot.

**Testing**
I added a regression test, but something with the test harness is preventing it from running. Running the full test suite also causes a freeze and reboot. I am putting this up here in case your CI system is able to test this on a Mac and we can see if the same behavior shows up or not.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
