### PR TITLE
Validate features and device mismatches in pass beginnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ Bottom level categories:
 
 - Change the `DropCallback` API to use `FnOnce` instead of `FnMut`. By @jerzywilczek in [#6482](https://github.com/gfx-rs/wgpu/pull/6482)
 
+### Bug Fixes
+
+#### General
+
+- Ensure that `Features::TIMESTAMP_QUERY` is set when using timestamp writes in render and compute passes. By @ErichDonGubler in [#6497](https://github.com/gfx-rs/wgpu/pull/6497).
+
 ## 23.0.0 (2024-10-25)
 
 ### Themes of this release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Bottom level categories:
 #### General
 
 - Ensure that `Features::TIMESTAMP_QUERY` is set when using timestamp writes in render and compute passes. By @ErichDonGubler in [#6497](https://github.com/gfx-rs/wgpu/pull/6497).
+- Check for device mismatches when beginning render and compute passes. By @ErichDonGubler in [#6497](https://github.com/gfx-rs/wgpu/pull/6497). 
 
 ## 23.0.0 (2024-10-25)
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -308,6 +308,14 @@ impl Global {
         };
 
         arc_desc.timestamp_writes = if let Some(tw) = desc.timestamp_writes {
+            let query_set = match hub.query_sets.get(tw.query_set).get() {
+                Ok(query_set) => query_set,
+                Err(e) => return make_err(e.into(), arc_desc),
+            };
+            match query_set.same_device(&cmd_buf.device) {
+                Ok(()) => (),
+                Err(e) => return make_err(e.into(), arc_desc),
+            }
             match cmd_buf
                 .device
                 .require_features(wgt::Features::TIMESTAMP_QUERY)
@@ -315,11 +323,6 @@ impl Global {
                 Ok(()) => (),
                 Err(e) => return make_err(e.into(), arc_desc),
             }
-
-            let query_set = match hub.query_sets.get(tw.query_set).get() {
-                Ok(query_set) => query_set,
-                Err(e) => return make_err(e.into(), arc_desc),
-            };
 
             Some(ArcPassTimestampWrites {
                 query_set,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -308,6 +308,14 @@ impl Global {
         };
 
         arc_desc.timestamp_writes = if let Some(tw) = desc.timestamp_writes {
+            match cmd_buf
+                .device
+                .require_features(wgt::Features::TIMESTAMP_QUERY)
+            {
+                Ok(()) => (),
+                Err(e) => return make_err(e.into(), arc_desc),
+            }
+
             let query_set = match hub.query_sets.get(tw.query_set).get() {
                 Ok(query_set) => query_set,
                 Err(e) => return make_err(e.into(), arc_desc),

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -26,7 +26,7 @@ pub use timestamp_writes::PassTimestampWrites;
 
 use self::memory_init::CommandBufferTextureMemoryActions;
 
-use crate::device::{Device, DeviceError};
+use crate::device::{Device, DeviceError, MissingFeatures};
 use crate::lock::{rank, Mutex};
 use crate::snatch::SnatchGuard;
 
@@ -642,6 +642,8 @@ pub enum CommandEncoderError {
     InvalidColorAttachment(#[from] ColorAttachmentError),
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
+    #[error(transparent)]
+    MissingFeatures(#[from] MissingFeatures),
 }
 
 impl Global {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1393,6 +1393,8 @@ impl Global {
                 };
 
             arc_desc.timestamp_writes = if let Some(tw) = desc.timestamp_writes {
+                device.require_features(wgt::Features::TIMESTAMP_QUERY)?;
+
                 let query_set = query_sets.get(tw.query_set).get()?;
 
                 Some(ArcPassTimestampWrites {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1358,9 +1358,11 @@ impl Global {
                 }) = color_attachment
                 {
                     let view = texture_views.get(*view_id).get()?;
+                    view.same_device(device)?;
 
                     let resolve_target = if let Some(resolve_target_id) = resolve_target {
                         let rt_arc = texture_views.get(*resolve_target_id).get()?;
+                        rt_arc.same_device(device)?;
 
                         Some(rt_arc)
                     } else {
@@ -1382,6 +1384,7 @@ impl Global {
             arc_desc.depth_stencil_attachment =
                 if let Some(depth_stencil_attachment) = desc.depth_stencil_attachment {
                     let view = texture_views.get(depth_stencil_attachment.view).get()?;
+                    view.same_device(device)?;
 
                     Some(ArcRenderPassDepthStencilAttachment {
                         view,
@@ -1393,9 +1396,10 @@ impl Global {
                 };
 
             arc_desc.timestamp_writes = if let Some(tw) = desc.timestamp_writes {
-                device.require_features(wgt::Features::TIMESTAMP_QUERY)?;
-
                 let query_set = query_sets.get(tw.query_set).get()?;
+                query_set.same_device(device)?;
+
+                device.require_features(wgt::Features::TIMESTAMP_QUERY)?;
 
                 Some(ArcPassTimestampWrites {
                     query_set,
@@ -1409,6 +1413,7 @@ impl Global {
             arc_desc.occlusion_query_set =
                 if let Some(occlusion_query_set) = desc.occlusion_query_set {
                     let query_set = query_sets.get(occlusion_query_set).get()?;
+                    query_set.same_device(device)?;
 
                     Some(query_set)
                 } else {


### PR DESCRIPTION
**Connections**

Found over the course of testing Firefox's query set implementation in [bug 1838729](https://bugzilla.mozilla.org/show_bug.cgi?id=1838729).

**Description**

\-

**Testing**

CTS coverage for these tests:

- `webgpu:api,validation,capability_checks,features,query_types:createQuerySet:*`
- `webgpu:api,validation,capability_checks,features,query_types:timestamp:*`
- `webgpu:api,validation,encoding,beginComputePass:timestamp_query_set,device_mismatch:*`
- `webgpu:api,validation,encoding,beginRenderPass:timestamp_query_set,device_mismatch:*`
- `webgpu:api,validation,encoding,beginRenderPass:occlusion_query_set,device_mismatch:*`

- [ ] Ensure that the above tests are changed by this validation.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
