### PR TITLE
Make `Surface::as_hal` take an immutable reference to the surface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ Bottom level categories:
 
 ### Changes
 
+#### General
+
+- Make `Surface::as_hal` take an immutable reference to the surface. By @jerzywilczek in [#9999](https://github.com/gfx-rs/wgpu/pull/9999)
+
 #### HAL
 
 - Change the `DropCallback` API to use `FnOnce` instead of `FnMut`. By @jerzywilczek in [#6482](https://github.com/gfx-rs/wgpu/pull/6482)

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -159,7 +159,7 @@ impl Surface<'_> {
     /// - The raw handle obtained from the hal Surface must not be manually destroyed
     #[cfg(wgpu_core)]
     pub unsafe fn as_hal<A: wgc::hal_api::HalApi, F: FnOnce(Option<&A::Surface>) -> R, R>(
-        &mut self,
+        &self,
         hal_surface_callback: F,
     ) -> Option<R> {
         self.context


### PR DESCRIPTION
**Connections**
None

**Description**
`Surface::as_hal` right now takes a mutable reference to the surface. I don't understand why, and no documentation I found mentions why, so I propose to change that to take an immutable reference instead.

**Testing**
Everything still compiles and number of test passes doesn't change.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
  This fails on my PC
- [x] Run `cargo xtask test` to run tests.
129 tests fail on my PC, with or without the change
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
