### PR TITLE
Dx12 HAL texture: expose raw resource

### DIFF
--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -777,6 +777,12 @@ pub struct Texture {
     allocation: Option<suballocation::AllocationWrapper>,
 }
 
+impl Texture {
+    pub unsafe fn raw_resource(&self) -> &Direct3D12::ID3D12Resource {
+        &self.resource
+    }
+}
+
 impl crate::DynTexture for Texture {}
 impl crate::DynSurfaceTexture for Texture {}
 


### PR DESCRIPTION
**Description**
In project I'm working on we want to temporarily use wgpu textures directly with dx12. Vulkan seems to have analogous access: https://github.com/gfx-rs/wgpu/blob/trunk/wgpu-hal/src/vulkan/mod.rs#L798
Device and Queue are available in similar fashion: https://github.com/gfx-rs/wgpu/blob/trunk/wgpu-hal/src/dx12/device.rs#L352

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
