### PR TITLE
fix(core): handle HAL errors from query set creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ Bottom level categories:
 
 ### Bug Fixes
 
+#### General
+
+- Handle query set creation as an internal error that loses the `Device`, rather than panicking. By @ErichDonGubler in [#6505](https://github.com/gfx-rs/wgpu/pull/6505).
+
 #### Naga
 
 - Fix crash when a texture argument is missing. By @aedm in [#6486](https://github.com/gfx-rs/wgpu/pull/6486)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Bottom level categories:
 
 #### General
 
-- Handle query set creation as an internal error that loses the `Device`, rather than panicking. By @ErichDonGubler in [#6505](https://github.com/gfx-rs/wgpu/pull/6505).
+- Handle query set creation failure as an internal error that loses the `Device`, rather than panicking. By @ErichDonGubler in [#6505](https://github.com/gfx-rs/wgpu/pull/6505).
 
 #### Naga
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3605,7 +3605,8 @@ impl Device {
 
         let hal_desc = desc.map_label(|label| label.to_hal(self.instance_flags));
 
-        let raw = unsafe { self.raw().create_query_set(&hal_desc).unwrap() };
+        let raw = unsafe { self.raw().create_query_set(&hal_desc) }
+            .map_err(|e| self.handle_hal_error(e))?;
 
         let query_set = QuerySet {
             raw: ManuallyDrop::new(raw),


### PR DESCRIPTION
**Connections**

- Makes #6504 less severe.

**Description**

When query set creation fails, return an internal error and lose the device, rather than panic.

**Testing**

\-

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
