### PR TITLE
fix(const_eval): don't panic when a `vecN` constructor's arg. count is less than N

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Bottom level categories:
 #### Naga
 
 - Fix crash when a texture argument is missing. By @aedm in [#6486](https://github.com/gfx-rs/wgpu/pull/6486)
+- Emit an error in constant evaluation, rather than crash, in certain cases where `vecN` constructors have less than N arguments. By @ErichDonGubler in [#6508](https://github.com/gfx-rs/wgpu/pull/6508).
 
 #### General
 

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -137,8 +137,8 @@ macro_rules! gen_component_wise_extractor {
                             for idx in 0..(size as u8).into() {
                                 let group = component_groups
                                     .iter()
-                                    .map(|cs| cs[idx])
-                                    .collect::<ArrayVec<_, N>>()
+                                    .map(|cs| cs.get(idx).cloned().ok_or(err.clone()))
+                                    .collect::<Result<ArrayVec<_, N>, _>>()?
                                     .into_inner()
                                     .unwrap();
                                 new_components.push($ident(


### PR DESCRIPTION
**Connections**

- Fixes the crash noted in #6506.

**Description**

From my comment in the issue:

> … `component_wise_*` functions in the `const_eval` module presume that a `Compose` expression of a `Vector` of N elements (in the OP example, `vec4`) has N arguments in the IR.

Stop presuming this, and return an error gracefully if the condition is violated.

**Testing**

Tested manually.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
