### PR TITLE
[naga] Implement binding_array function arguments

### DIFF
--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -264,6 +264,7 @@ impl crate::TypeInner {
             crate::TypeInner::Image { .. }
             | crate::TypeInner::Sampler { .. }
             | crate::TypeInner::AccelerationStructure { .. } => true,
+            crate::TypeInner::BindingArray { .. } => true,
             _ => false,
         }
     }

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -493,6 +493,7 @@ impl CachedExpressions {
         self.ids.resize(length, 0);
     }
 }
+
 impl ops::Index<Handle<crate::Expression>> for CachedExpressions {
     type Output = Word;
     fn index(&self, h: Handle<crate::Expression>) -> &Word {
@@ -689,6 +690,10 @@ struct BlockContext<'w> {
     /// SPIR-V ids for expressions we've evaluated.
     cached: CachedExpressions,
 
+    /// The pointers of the cached expressions' SPIR-V ids from [`Block::Context::cached`].
+    /// Only used when loaded opaque types need to be passed to a function call.
+    function_arg_ids: crate::FastIndexMap<Word, Word>,
+
     /// The `Writer`'s temporary vector, for convenience.
     temp_list: Vec<Word>,
 
@@ -761,6 +766,11 @@ pub struct Writer {
     // Cached expressions are only meaningful within a BlockContext, but we
     // retain the table here between functions to save heap allocations.
     saved_cached: CachedExpressions,
+
+    // Maps the expression ids from `saved_cached` to the pointer id they were loaded from.
+    // Only used when opaque types need to be passed to a function call.
+    // This goes alongside `saved_cached`, so it too is only meaningful within a BlockContext.
+    function_arg_ids: crate::FastIndexMap<Word, Word>,
 
     gl450_ext_inst_id: Word,
 

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -690,7 +690,7 @@ struct BlockContext<'w> {
     /// SPIR-V ids for expressions we've evaluated.
     cached: CachedExpressions,
 
-    /// The pointers of the cached expressions' SPIR-V ids from [`Block::Context::cached`].
+    /// The pointers of the cached expressions' SPIR-V ids from [`BlockContext::cached`].
     /// Only used when loaded opaque types need to be passed to a function call.
     function_arg_ids: crate::FastIndexMap<Word, Word>,
 

--- a/naga/src/back/spv/recyclable.rs
+++ b/naga/src/back/spv/recyclable.rs
@@ -59,6 +59,13 @@ impl<K, S: Clone> Recyclable for indexmap::IndexSet<K, S> {
     }
 }
 
+impl<K, V, S: Clone> Recyclable for indexmap::IndexMap<K, V, S> {
+    fn recycle(mut self) -> Self {
+        self.clear();
+        self
+    }
+}
+
 impl<K: Ord, V> Recyclable for std::collections::BTreeMap<K, V> {
     fn recycle(mut self) -> Self {
         self.clear();

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -79,6 +79,7 @@ impl Writer {
             global_variables: HandleVec::new(),
             binding_map: options.binding_map.clone(),
             saved_cached: CachedExpressions::default(),
+            function_arg_ids: crate::FastIndexMap::default(),
             gl450_ext_inst_id,
             temp_list: Vec::new(),
         })
@@ -130,6 +131,7 @@ impl Writer {
             cached_constants: take(&mut self.cached_constants).recycle(),
             global_variables: take(&mut self.global_variables).recycle(),
             saved_cached: take(&mut self.saved_cached).recycle(),
+            function_arg_ids: take(&mut self.function_arg_ids).recycle(),
             temp_list: take(&mut self.temp_list).recycle(),
         };
 
@@ -585,6 +587,7 @@ impl Writer {
             function: &mut function,
             // Re-use the cached expression table from prior functions.
             cached: std::mem::take(&mut self.saved_cached),
+            function_arg_ids: std::mem::take(&mut self.function_arg_ids),
 
             // Steal the Writer's temp list for a bit.
             temp_list: std::mem::take(&mut self.temp_list),

--- a/naga/src/front/spv/image.rs
+++ b/naga/src/front/spv/image.rs
@@ -592,6 +592,12 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
                     }
                 }
 
+                crate::Expression::FunctionArgument(i) => {
+                    match ctx.type_arena[ctx.arguments[i as usize].ty].inner {
+                        crate::TypeInner::BindingArray { base, .. } => base,
+                        _ => return Err(Error::InvalidGlobalVar(ctx.expressions[base].clone())),
+                    }
+                }
                 ref other => return Err(Error::InvalidGlobalVar(other.clone())),
             },
 
@@ -610,6 +616,9 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
             crate::Expression::Access { base, .. } => match ctx.expressions[base] {
                 crate::Expression::GlobalVariable(handle) => {
                     *self.handle_sampling.get_mut(&handle).unwrap() |= sampling_bit;
+                }
+                crate::Expression::FunctionArgument(i) => {
+                    ctx.parameter_sampling[i as usize] |= sampling_bit;
                 }
 
                 ref other => return Err(Error::InvalidGlobalVar(other.clone())),

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -4406,6 +4406,17 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                             crate::Expression::FunctionArgument(i) => {
                                 fun_parameter_sampling[i as usize] |= flags;
                             }
+                            crate::Expression::Access { base, .. } => match expressions[base] {
+                                crate::Expression::GlobalVariable(handle) => {
+                                    if let Some(sampling) = self.handle_sampling.get_mut(&handle) {
+                                        *sampling |= flags
+                                    }
+                                }
+                                crate::Expression::FunctionArgument(i) => {
+                                    fun_parameter_sampling[i as usize] |= flags;
+                                }
+                                ref other => return Err(Error::InvalidGlobalVar(other.clone())),
+                            },
                             ref other => return Err(Error::InvalidGlobalVar(other.clone())),
                         }
                     }

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -844,9 +844,6 @@ pub enum TypeInner {
     /// a binding array of samplers yields a [`Sampler`], indexing a pointer to the
     /// binding array of storage buffers produces a pointer to the storage struct.
     ///
-    /// Unlike textures and samplers, binding arrays are not [`ARGUMENT`], so
-    /// they cannot be passed as arguments to functions.
-    ///
     /// Naga's WGSL front end supports binding arrays with the type syntax
     /// `binding_array<T, N>`.
     ///
@@ -858,7 +855,6 @@ pub enum TypeInner {
     /// [`SamplerArray`]: https://docs.rs/wgpu/latest/wgpu/enum.BindingResource.html#variant.SamplerArray
     /// [`BufferArray`]: https://docs.rs/wgpu/latest/wgpu/enum.BindingResource.html#variant.BufferArray
     /// [`DATA`]: crate::valid::TypeFlags::DATA
-    /// [`ARGUMENT`]: crate::valid::TypeFlags::ARGUMENT
     /// [naga#1864]: https://github.com/gfx-rs/naga/issues/1864
     BindingArray { base: Handle<Type>, size: ArraySize },
 }

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -212,6 +212,7 @@ impl GlobalOrArgument {
             crate::Expression::Access { base, .. }
             | crate::Expression::AccessIndex { base, .. } => match expression_arena[base] {
                 crate::Expression::GlobalVariable(var) => GlobalOrArgument::Global(var),
+                crate::Expression::FunctionArgument(i) => GlobalOrArgument::Argument(i),
                 _ => return Err(ExpressionError::ExpectedGlobalOrArgument),
             },
             _ => return Err(ExpressionError::ExpectedGlobalOrArgument),

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -373,6 +373,7 @@ impl super::Validator {
                             .flags
                             .contains(TypeFlags::SIZED | TypeFlags::DATA) => {}
                     Ti::ValuePointer { .. } => {}
+                    Ti::BindingArray { .. } => {}
                     ref other => {
                         log::error!("Loading {:?}", other);
                         return Err(ExpressionError::InvalidPointerType(pointer));
@@ -1671,6 +1672,14 @@ impl super::Validator {
                 match function.expressions[base] {
                     Ex::GlobalVariable(var_handle) => {
                         let array_ty = module.global_variables[var_handle].ty;
+
+                        match module.types[array_ty].inner {
+                            crate::TypeInner::BindingArray { base, .. } => Ok(base),
+                            _ => Err(ExpressionError::ExpectedBindingArrayType(array_ty)),
+                        }
+                    }
+                    Ex::FunctionArgument(i) => {
+                        let array_ty = function.arguments[i as usize].ty;
 
                         match module.types[array_ty].inner {
                             crate::TypeInner::BindingArray { base, .. } => Ok(base),

--- a/naga/src/valid/type.rs
+++ b/naga/src/valid/type.rs
@@ -665,10 +665,12 @@ impl super::Validator {
             }
             Ti::BindingArray { base, size } => {
                 let type_info_mask = match size {
-                    crate::ArraySize::Constant(_) => TypeFlags::SIZED | TypeFlags::HOST_SHAREABLE,
+                    crate::ArraySize::Constant(_) => {
+                        TypeFlags::SIZED | TypeFlags::HOST_SHAREABLE | TypeFlags::ARGUMENT
+                    }
                     crate::ArraySize::Dynamic => {
                         // Final type is non-sized
-                        TypeFlags::HOST_SHAREABLE
+                        TypeFlags::HOST_SHAREABLE | TypeFlags::ARGUMENT
                     }
                 };
                 let base_info = &self.types[base.index()];


### PR DESCRIPTION
**Connections**
Fixes both cases described in #4857.
Also related to #6283.

**Description**
There are two cases addressed here:

1. Allowing binding arrays to appear as function arguments by implementing various missing branches that this case triggers.
2. Fix issue where `OpFunctionCall` uses the value of an opaque type loaded via `OpAccessChain` + `OpLoad` is used as the argument when only the pointer to that opaque type is valid. This is implemented by keeping track of the pointer id of a loaded variable when `OpAccessChain` is called.

I'm not two happy with the 2nd fix because it uses an extra map for a relatively obscure edge case. Hopefully, there is a function that does the equivalent.

**Testing**
To test these changes, I ran the following shaders through naga multiple times (`SPV => spirv-val => WGSL => SPV => spirv-val => WGSL => SPV => spirv-val`).

The cases described in the WGPU issue above:
https://shader-playground.timjones.io/8a6382938dcc19b6d86bb569a93f1872
https://shader-playground.timjones.io/e37907fe8b30779a53201ef5ba4e1809

The issue I am running into:
https://shader-playground.timjones.io/656df9d61201d86379fe5c6f6b04d43a
(For this shader, the assumption is that `SPV_EXT_descriptor_indexing` is removed after every translation.)

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
