### PR TITLE
[wgsl-in] Ensure textureSampleLevel's level argument is an integer for depth textures

### DIFF
--- a/naga/tests/in/image.wgsl
+++ b/naga/tests/in/image.wgsl
@@ -185,7 +185,9 @@ fn gather() -> @location(0) vec4<f32> {
 @fragment
 fn depth_no_comparison() -> @location(0) vec4<f32> {
     let tc = vec2<f32>(0.5);
+    let level = 1;
     let s2d = textureSample(image_2d_depth, sampler_reg, tc);
     let s2d_gather = textureGather(image_2d_depth, sampler_reg, tc);
-    return s2d + s2d_gather;
+    let s2d_level = textureSampleLevel(image_2d_depth, sampler_reg, tc, level);
+    return s2d + s2d_gather + s2d_level;
 }

--- a/naga/tests/out/hlsl/image.hlsl
+++ b/naga/tests/out/hlsl/image.hlsl
@@ -369,5 +369,6 @@ float4 depth_no_comparison() : SV_Target0
     float2 tc_3 = (0.5).xx;
     float s2d_1 = image_2d_depth.Sample(sampler_reg, tc_3);
     float4 s2d_gather = image_2d_depth.Gather(sampler_reg, tc_3);
-    return ((s2d_1).xxxx + s2d_gather);
+    float s2d_level = image_2d_depth.SampleLevel(sampler_reg, tc_3, 1);
+    return (((s2d_1).xxxx + s2d_gather) + (s2d_level).xxxx);
 }

--- a/naga/tests/out/msl/image.msl
+++ b/naga/tests/out/msl/image.msl
@@ -265,5 +265,6 @@ fragment depth_no_comparisonOutput depth_no_comparison(
     metal::float2 tc_3 = metal::float2(0.5);
     float s2d_1 = image_2d_depth.sample(sampler_reg, tc_3);
     metal::float4 s2d_gather = image_2d_depth.gather(sampler_reg, tc_3);
-    return depth_no_comparisonOutput { metal::float4(s2d_1) + s2d_gather };
+    float s2d_level = image_2d_depth.sample(sampler_reg, tc_3, metal::level(1));
+    return depth_no_comparisonOutput { (metal::float4(s2d_1) + s2d_gather) + metal::float4(s2d_level) };
 }

--- a/naga/tests/out/spv/image.spvasm
+++ b/naga/tests/out/spv/image.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 520
+; Bound: 526
 OpCapability Shader
 OpCapability Image1D
 OpCapability Sampled1D
@@ -687,8 +687,14 @@ OpBranch %512
 %515 = OpCompositeExtract  %7  %514 0
 %516 = OpSampledImage  %428  %511 %510
 %517 = OpImageGather  %23  %516 %280 %198
-%518 = OpCompositeConstruct  %23  %515 %515 %515 %515
-%519 = OpFAdd  %23  %518 %517
-OpStore %508 %519
+%518 = OpSampledImage  %428  %511 %510
+%520 = OpConvertSToF  %7  %29
+%519 = OpImageSampleExplicitLod  %23  %518 %280 Lod %520
+%521 = OpCompositeExtract  %7  %519 0
+%522 = OpCompositeConstruct  %23  %515 %515 %515 %515
+%523 = OpFAdd  %23  %522 %517
+%524 = OpCompositeConstruct  %23  %521 %521 %521 %521
+%525 = OpFAdd  %23  %523 %524
+OpStore %508 %525
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/image.wgsl
+++ b/naga/tests/out/wgsl/image.wgsl
@@ -235,5 +235,6 @@ fn depth_no_comparison() -> @location(0) vec4<f32> {
     const tc_3 = vec2(0.5f);
     let s2d_1 = textureSample(image_2d_depth, sampler_reg, tc_3);
     let s2d_gather = textureGather(image_2d_depth, sampler_reg, tc_3);
-    return (vec4(s2d_1) + s2d_gather);
+    let s2d_level = textureSampleLevel(image_2d_depth, sampler_reg, tc_3, 1i);
+    return ((vec4(s2d_1) + s2d_gather) + vec4(s2d_level));
 }


### PR DESCRIPTION
**Connections**
Fixes #4548 

**Description**
The [spec](https://www.w3.org/TR/WGSL/#texturesamplelevel) specifies that `textureSampleLevel()` takes an integer type as the `level` parameter for depth textures (and a float for non-depth textures). We currently accept a float for all texture types. This makes us require the correct type. As a result we now need to convert the value in the SPIR-V backend. For HLSL and MSL, `SampleLevel()` and `metal::level()` appear to implicitly convert the integer to floats just fine. And as far as I can tell we do not support non-_compare_ sampling of depth textures on GLSL?

**Testing**
Manual inspection of output shaders. Shader validation succeeds. Built gecko with change and verified relevant CTS tests (`webgpu:shader,validation,expression,call,builtin,textureSampleLevel:level_argument`) now pass.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
