### PR TITLE
Add actual sample type to `CreateBindGroupError::InvalidTextureSampleType` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 #### General
 
 - Make `Surface::as_hal` take an immutable reference to the surface. By @jerzywilczek in [#9999](https://github.com/gfx-rs/wgpu/pull/9999)
+- Add actual sample type to `CreateBindGroupError::InvalidTextureSampleType` error message. By @ErichDonGubler in [#6530](https://github.com/gfx-rs/wgpu/pull/6530).
 
 #### HAL
 

--- a/tests/tests/float32_filterable.rs
+++ b/tests/tests/float32_filterable.rs
@@ -64,9 +64,9 @@ static FLOAT32_FILTERABLE_WITHOUT_FEATURE: GpuTestConfiguration = GpuTestConfigu
                 create_texture_binding(device, wgpu::TextureFormat::R32Float, true);
             },
             Some(concat!(
-                "texture binding 0 expects sample type = float { filterable: true }, ",
-                "but given a view with format = r32float ",
-                "(sample type = float { filterable: false })"
+                "texture binding 0 expects sample type float { filterable: true }, ",
+                "but was given a view with format r32float ",
+                "(sample type float { filterable: false })"
             )),
         );
     });

--- a/tests/tests/float32_filterable.rs
+++ b/tests/tests/float32_filterable.rs
@@ -63,7 +63,11 @@ static FLOAT32_FILTERABLE_WITHOUT_FEATURE: GpuTestConfiguration = GpuTestConfigu
             || {
                 create_texture_binding(device, wgpu::TextureFormat::R32Float, true);
             },
-            Some("texture binding 0 expects sample type = float { filterable: true }, but given a view with format = r32float"),
+            Some(concat!(
+                "texture binding 0 expects sample type = float { filterable: true }, ",
+                "but given a view with format = r32float ",
+                "(sample type = float { filterable: false })"
+            )),
         );
     });
 

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -142,11 +142,18 @@ pub enum CreateBindGroupError {
         layout_multisampled: bool,
         view_samples: u32,
     },
-    #[error("Texture binding {binding} expects sample type = {layout_sample_type:?}, but given a view with format = {view_format:?}")]
+    #[error(
+        "Texture binding {} expects sample type = {:?}, but given a view with format = {:?} (sample type = {:?})",
+        binding,
+        layout_sample_type,
+        view_format,
+        view_sample_type
+    )]
     InvalidTextureSampleType {
         binding: u32,
         layout_sample_type: wgt::TextureSampleType,
         view_format: wgt::TextureFormat,
+        view_sample_type: wgt::TextureSampleType,
     },
     #[error("Texture binding {binding} expects dimension = {layout_dimension:?}, but given a view with dimension = {view_dimension:?}")]
     InvalidTextureDimension {

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -143,7 +143,7 @@ pub enum CreateBindGroupError {
         view_samples: u32,
     },
     #[error(
-        "Texture binding {} expects sample type = {:?}, but given a view with format = {:?} (sample type = {:?})",
+        "Texture binding {} expects sample type {:?}, but was given a view with format {:?} (sample type {:?})",
         binding,
         layout_sample_type,
         view_format,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2519,6 +2519,7 @@ impl Device {
                             binding,
                             layout_sample_type: sample_type,
                             view_format: view.desc.format,
+                            view_sample_type: compat_sample_type,
                         })
                     }
                 }


### PR DESCRIPTION
**Connections**

- Done while diagnosing https://github.com/gfx-rs/wgpu/issues/6527.

**Description**

\-

**Testing**

Tested that the output is more to my satisfaction. Is it to yours? 😀

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
