### PR TITLE
Emit unimplemented errors for several `@diagnostic(…)` attribute parse sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ There are some limitations to keep in mind with this new functionality:
 - Not all lints can be controlled with `diagnostic(…)` rules. In fact, only the `derivative_uniformity` triggering rule exists in the WGSL standard. That said, Naga contributors are excited to see how this level of control unlocks a new ecosystem of configurable diagnostics.
 - Finally, `diagnostic(…)` rules are not yet emitted in WGSL output. This means that `wgsl-in` → `wgsl-out` is currently a lossy process. We felt that it was important to unblock users who needed `diagnostic(…)` rules (i.e., <https://github.com/gfx-rs/wgpu/issues/3135>) before we took significant effort to fix this (tracked in <https://github.com/gfx-rs/wgpu/issues/6496>).
 
-By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148](https://github.com/gfx-rs/wgpu/pull/6148).
+By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148](https://github.com/gfx-rs/wgpu/pull/6148), [#6533](https://github.com/gfx-rs/wgpu/pull/6533).
 
 ### New Features
 

--- a/naga/src/diagnostic_filter.rs
+++ b/naga/src/diagnostic_filter.rs
@@ -27,22 +27,6 @@ pub enum Severity {
 }
 
 impl Severity {
-    const ERROR: &'static str = "error";
-    const WARNING: &'static str = "warning";
-    const INFO: &'static str = "info";
-    const OFF: &'static str = "off";
-
-    /// Convert from a sentinel word in WGSL into its associated [`Severity`], if possible.
-    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
-        Some(match s {
-            Self::ERROR => Self::Error,
-            Self::WARNING => Self::Warning,
-            Self::INFO => Self::Info,
-            Self::OFF => Self::Off,
-            _ => return None,
-        })
-    }
-
     /// Checks whether this severity is [`Self::Error`].
     ///
     /// Naga does not yet support diagnostic items at lesser severities than
@@ -79,23 +63,6 @@ pub enum FilterableTriggeringRule {
 }
 
 impl FilterableTriggeringRule {
-    const DERIVATIVE_UNIFORMITY: &'static str = "derivative_uniformity";
-
-    /// Convert from a sentinel word in WGSL into its associated [`FilterableTriggeringRule`], if possible.
-    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
-        Some(match s {
-            Self::DERIVATIVE_UNIFORMITY => Self::DerivativeUniformity,
-            _ => return None,
-        })
-    }
-
-    /// Maps this [`FilterableTriggeringRule`] into the sentinel word associated with it in WGSL.
-    pub const fn to_wgsl_ident(self) -> &'static str {
-        match self {
-            Self::DerivativeUniformity => Self::DERIVATIVE_UNIFORMITY,
-        }
-    }
-
     /// The default severity associated with this triggering rule.
     ///
     /// See <https://www.w3.org/TR/WGSL/#filterable-triggering-rules> for a table of default

--- a/naga/src/diagnostic_filter.rs
+++ b/naga/src/diagnostic_filter.rs
@@ -129,6 +129,18 @@ impl DiagnosticFilterMap {
         }
         Ok(())
     }
+
+    /// Were any rules specified?
+    pub(crate) fn is_empty(&self) -> bool {
+        let &Self(ref map) = self;
+        map.is_empty()
+    }
+
+    /// Returns the spans of all contained rules.
+    pub(crate) fn spans(&self) -> impl Iterator<Item = Span> + '_ {
+        let &Self(ref map) = self;
+        map.iter().map(|(_, &(_, span))| span)
+    }
 }
 
 #[cfg(feature = "wgsl-in")]

--- a/naga/src/diagnostic_filter.rs
+++ b/naga/src/diagnostic_filter.rs
@@ -33,7 +33,7 @@ impl Severity {
     const OFF: &'static str = "off";
 
     /// Convert from a sentinel word in WGSL into its associated [`Severity`], if possible.
-    pub fn from_ident(s: &str) -> Option<Self> {
+    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
         Some(match s {
             Self::ERROR => Self::Error,
             Self::WARNING => Self::Warning,
@@ -82,7 +82,7 @@ impl FilterableTriggeringRule {
     const DERIVATIVE_UNIFORMITY: &'static str = "derivative_uniformity";
 
     /// Convert from a sentinel word in WGSL into its associated [`FilterableTriggeringRule`], if possible.
-    pub fn from_ident(s: &str) -> Option<Self> {
+    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
         Some(match s {
             Self::DERIVATIVE_UNIFORMITY => Self::DerivativeUniformity,
             _ => return None,
@@ -90,7 +90,7 @@ impl FilterableTriggeringRule {
     }
 
     /// Maps this [`FilterableTriggeringRule`] into the sentinel word associated with it in WGSL.
-    pub const fn to_ident(self) -> &'static str {
+    pub const fn to_wgsl_ident(self) -> &'static str {
         match self {
             Self::DerivativeUniformity => Self::DERIVATIVE_UNIFORMITY,
         }

--- a/naga/src/front/wgsl/diagnostic_filter.rs
+++ b/naga/src/front/wgsl/diagnostic_filter.rs
@@ -1,0 +1,38 @@
+use crate::diagnostic_filter::{FilterableTriggeringRule, Severity};
+
+impl Severity {
+    const ERROR: &'static str = "error";
+    const WARNING: &'static str = "warning";
+    const INFO: &'static str = "info";
+    const OFF: &'static str = "off";
+
+    /// Convert from a sentinel word in WGSL into its associated [`Severity`], if possible.
+    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
+        Some(match s {
+            Self::ERROR => Self::Error,
+            Self::WARNING => Self::Warning,
+            Self::INFO => Self::Info,
+            Self::OFF => Self::Off,
+            _ => return None,
+        })
+    }
+}
+
+impl FilterableTriggeringRule {
+    const DERIVATIVE_UNIFORMITY: &'static str = "derivative_uniformity";
+
+    /// Convert from a sentinel word in WGSL into its associated [`FilterableTriggeringRule`], if possible.
+    pub fn from_wgsl_ident(s: &str) -> Option<Self> {
+        Some(match s {
+            Self::DERIVATIVE_UNIFORMITY => Self::DerivativeUniformity,
+            _ => return None,
+        })
+    }
+
+    /// Maps this [`FilterableTriggeringRule`] into the sentinel word associated with it in WGSL.
+    pub const fn to_wgsl_ident(self) -> &'static str {
+        match self {
+            Self::DerivativeUniformity => Self::DERIVATIVE_UNIFORMITY,
+        }
+    }
+}

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -1028,7 +1028,7 @@ impl<'a> Error<'a> {
                 ParseError {
                     message: format!(
                         "found conflicting `diagnostic(…)` rule(s) for `{}`",
-                        triggering_rule.to_ident()
+                        triggering_rule.to_wgsl_ident()
                     ),
                     labels: vec![
                         (first_span, "first rule".into()),

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -136,6 +136,8 @@ pub enum ExpectedToken<'a> {
     Variable,
     /// Access of a function
     Function,
+    /// The `diagnostic` identifier of the `@diagnostic(…)` attribute.
+    DiagnosticAttribute,
 }
 
 #[derive(Clone, Copy, Debug, Error, PartialEq)]
@@ -387,6 +389,9 @@ impl<'a> Error<'a> {
                     }
                     ExpectedToken::AfterIdentListComma => {
                         "next argument or end of list (';')".to_string()
+                    }
+                    ExpectedToken::DiagnosticAttribute => {
+                        "the 'diagnostic' attribute identifier".to_string()
                     }
                 };
                 ParseError {

--- a/naga/src/front/wgsl/mod.rs
+++ b/naga/src/front/wgsl/mod.rs
@@ -4,6 +4,7 @@ Frontend for [WGSL][wgsl] (WebGPU Shading Language).
 [wgsl]: https://gpuweb.github.io/gpuweb/wgsl.html
 */
 
+mod diagnostic_filter;
 mod error;
 mod index;
 mod lower;

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -2631,11 +2631,10 @@ impl Parser {
         lexer.expect(Token::Paren('('))?;
 
         let (severity_control_name, severity_control_name_span) = lexer.next_ident_with_span()?;
-        let new_severity = diagnostic_filter::Severity::from_ident(severity_control_name).ok_or(
-            Error::DiagnosticInvalidSeverity {
+        let new_severity = diagnostic_filter::Severity::from_wgsl_ident(severity_control_name)
+            .ok_or(Error::DiagnosticInvalidSeverity {
                 severity_control_name_span,
-            },
-        )?;
+            })?;
 
         lexer.expect(Token::Separator(','))?;
 
@@ -2652,7 +2651,7 @@ impl Parser {
 
         let filter = diagnostic_rule_name
             .and_then(|name| {
-                FilterableTriggeringRule::from_ident(name)
+                FilterableTriggeringRule::from_wgsl_ident(name)
                     .map(Ok)
                     .or_else(|| {
                         diagnostic_filter::Severity::Warning

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -2327,33 +2327,34 @@ impl Parser {
 
         self.push_rule_span(Rule::Attribute, lexer);
         while lexer.skip(Token::Attribute) {
-            match lexer.next_ident_with_span()? {
-                ("binding", name_span) => {
+            let (name, name_span) = lexer.next_ident_with_span()?;
+            match name {
+                "binding" => {
                     lexer.expect(Token::Paren('('))?;
                     bind_index.set(self.general_expression(lexer, &mut ctx)?, name_span)?;
                     lexer.expect(Token::Paren(')'))?;
                 }
-                ("group", name_span) => {
+                "group" => {
                     lexer.expect(Token::Paren('('))?;
                     bind_group.set(self.general_expression(lexer, &mut ctx)?, name_span)?;
                     lexer.expect(Token::Paren(')'))?;
                 }
-                ("id", name_span) => {
+                "id" => {
                     lexer.expect(Token::Paren('('))?;
                     id.set(self.general_expression(lexer, &mut ctx)?, name_span)?;
                     lexer.expect(Token::Paren(')'))?;
                 }
-                ("vertex", name_span) => {
+                "vertex" => {
                     stage.set(ShaderStage::Vertex, name_span)?;
                 }
-                ("fragment", name_span) => {
+                "fragment" => {
                     stage.set(ShaderStage::Fragment, name_span)?;
                 }
-                ("compute", name_span) => {
+                "compute" => {
                     stage.set(ShaderStage::Compute, name_span)?;
                     compute_span = name_span;
                 }
-                ("workgroup_size", name_span) => {
+                "workgroup_size" => {
                     lexer.expect(Token::Paren('('))?;
                     let mut new_workgroup_size = [None; 3];
                     for (i, size) in new_workgroup_size.iter_mut().enumerate() {
@@ -2371,7 +2372,7 @@ impl Parser {
                     }
                     workgroup_size.set(new_workgroup_size, name_span)?;
                 }
-                ("early_depth_test", name_span) => {
+                "early_depth_test" => {
                     let conservative = if lexer.skip(Token::Paren('(')) {
                         let (ident, ident_span) = lexer.next_ident_with_span()?;
                         let value = conv::map_conservative_depth(ident, ident_span)?;
@@ -2382,7 +2383,7 @@ impl Parser {
                     };
                     early_depth_test.set(crate::EarlyDepthTest { conservative }, name_span)?;
                 }
-                (_, word_span) => return Err(Error::UnknownAttribute(word_span)),
+                _ => return Err(Error::UnknownAttribute(name_span)),
             }
         }
 


### PR DESCRIPTION
**Connections**

- Hard dependency and based on <https://github.com/gfx-rs/wgpu/pull/6503>.

**Description**

\-

**Testing**

- I've tested this manually, and plan on following up with actual test coverage in a separate PR.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
