### PR TITLE
don't set autoresizing mask on ios as that's not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,10 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 
 - Fix surface capabilities being advertised when its query failed. By @wumpf in [#6510](https://github.com/gfx-rs/wgpu/pull/6510)
 
+### Metal
+
+- Fix surface creation crashing on iOS. By @mockersf in [#6535](https://github.com/gfx-rs/wgpu/pull/6535)
+
 
 ## 23.0.0 (2024-10-25)
 

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -207,23 +207,26 @@ impl super::Surface {
             let new_layer: *mut Object = msg_send![class!(CAMetalLayer), new];
             let () = msg_send![root_layer, addSublayer: new_layer];
 
-            // Automatically resize the sublayer's frame to match the
-            // superlayer's bounds.
-            //
-            // Note that there is a somewhat hidden design decision in this:
-            // We define the `width` and `height` in `configure` to control
-            // the `drawableSize` of the layer, while `bounds` and `frame` are
-            // outside of the user's direct control - instead, though, they
-            // can control the size of the view (or root layer), and get the
-            // desired effect that way.
-            //
-            // We _could_ also let `configure` set the `bounds` size, however
-            // that would be inconsistent with using the root layer directly
-            // (as we may do, see above).
-            let width_sizable = 1 << 1; // kCALayerWidthSizable
-            let height_sizable = 1 << 4; // kCALayerHeightSizable
-            let mask: c_uint = width_sizable | height_sizable;
-            let () = msg_send![new_layer, setAutoresizingMask: mask];
+            #[cfg(not(target_os = "ios"))]
+            {
+                // Automatically resize the sublayer's frame to match the
+                // superlayer's bounds.
+                //
+                // Note that there is a somewhat hidden design decision in this:
+                // We define the `width` and `height` in `configure` to control
+                // the `drawableSize` of the layer, while `bounds` and `frame` are
+                // outside of the user's direct control - instead, though, they
+                // can control the size of the view (or root layer), and get the
+                // desired effect that way.
+                //
+                // We _could_ also let `configure` set the `bounds` size, however
+                // that would be inconsistent with using the root layer directly
+                // (as we may do, see above).
+                let width_sizable = 1 << 1; // kCALayerWidthSizable
+                let height_sizable = 1 << 4; // kCALayerHeightSizable
+                let mask: c_uint = width_sizable | height_sizable;
+                let () = msg_send![new_layer, setAutoresizingMask: mask];
+            }
 
             // Specify the relative size that the auto resizing mask above
             // will keep (i.e. tell it to fill out its superlayer).

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::let_unit_value)] // `let () =` being used to constrain result type
 
-use std::ffi::c_uint;
 use std::mem::ManuallyDrop;
 use std::ptr::NonNull;
 use std::sync::Once;
@@ -224,7 +223,7 @@ impl super::Surface {
                 // (as we may do, see above).
                 let width_sizable = 1 << 1; // kCALayerWidthSizable
                 let height_sizable = 1 << 4; // kCALayerHeightSizable
-                let mask: c_uint = width_sizable | height_sizable;
+                let mask: std::ffi::c_uint = width_sizable | height_sizable;
                 let () = msg_send![new_layer, setAutoresizingMask: mask];
             }
 

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -206,7 +206,7 @@ impl super::Surface {
             let new_layer: *mut Object = msg_send![class!(CAMetalLayer), new];
             let () = msg_send![root_layer, addSublayer: new_layer];
 
-            #[cfg(not(target_os = "ios"))]
+            #[cfg(target_os = "macos")]
             {
                 // Automatically resize the sublayer's frame to match the
                 // superlayer's bounds.


### PR DESCRIPTION
**Connections**
https://github.com/bevyengine/bevy/issues/16363

**Description**
After updating to wgpu 23, Bevy crashes on iOS with `fatal runtime error: Rust cannot catch foreign exceptions`

This started with https://github.com/gfx-rs/wgpu/pull/6107

By adding logging between all lines of code in the `get_metal_layer`, it came from
https://github.com/gfx-rs/wgpu/blob/ae6c6fbea4ee9dff911961512f128cfbfadb02b9/wgpu-hal/src/metal/surface.rs#L226

new_layer is a `CAMetalLayer` which is available on iOS https://developer.apple.com/documentation/quartzcore/cametallayer
but `autoresizingMask ` is only available on macOS https://developer.apple.com/documentation/quartzcore/calayer/1410877-autoresizingmask

this PR stops setting the `autoresizingMask` on iOS

**Testing**

I tested the same fix on the 23 tag with Bevy and it works

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
