### PR TITLE
Improve lifetime management of command encoders and buffers

### DIFF
--- a/wgpu-core/src/command/allocator.rs
+++ b/wgpu-core/src/command/allocator.rs
@@ -1,5 +1,3 @@
-use crate::resource_log;
-
 use crate::lock::{rank, Mutex};
 
 /// A pool of free [`wgpu_hal::CommandEncoder`]s, owned by a `Device`.
@@ -48,18 +46,5 @@ impl CommandAllocator {
     pub(crate) fn release_encoder(&self, encoder: Box<dyn hal::DynCommandEncoder>) {
         let mut free_encoders = self.free_encoders.lock();
         free_encoders.push(encoder);
-    }
-
-    /// Free the pool of command encoders.
-    ///
-    /// This is only called when the `Device` is dropped.
-    pub(crate) fn dispose(&self, device: &dyn hal::DynDevice) {
-        let mut free_encoders = self.free_encoders.lock();
-        resource_log!("CommandAllocator::dispose encoders {}", free_encoders.len());
-        for cmd_encoder in free_encoders.drain(..) {
-            unsafe {
-                device.destroy_command_encoder(cmd_encoder);
-            }
-        }
     }
 }

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -91,8 +91,8 @@ impl Global {
         let cmd_buf = hub
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.try_get()?;
-        cmd_buf_data.check_recording()?;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {
@@ -174,8 +174,8 @@ impl Global {
         let cmd_buf = hub
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.try_get()?;
-        cmd_buf_data.check_recording()?;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -92,7 +92,8 @@ impl Global {
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.record()?;
+        let mut cmd_buf_data_guard = cmd_buf_data.record()?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {
@@ -138,6 +139,8 @@ impl Global {
 
         if offset == end_offset {
             log::trace!("Ignoring fill_buffer of size 0");
+
+            cmd_buf_data_guard.mark_successful();
             return Ok(());
         }
 
@@ -157,6 +160,8 @@ impl Global {
             cmd_buf_raw.transition_buffers(dst_barrier.as_slice());
             cmd_buf_raw.clear_buffer(dst_raw, offset..end_offset);
         }
+
+        cmd_buf_data_guard.mark_successful();
         Ok(())
     }
 
@@ -175,7 +180,8 @@ impl Global {
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.record()?;
+        let mut cmd_buf_data_guard = cmd_buf_data.record()?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {
@@ -243,7 +249,10 @@ impl Global {
             &device.alignments,
             device.zero_buffer.as_ref(),
             &snatch_guard,
-        )
+        )?;
+
+        cmd_buf_data_guard.mark_successful();
+        Ok(())
     }
 }
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -8,8 +8,8 @@ use crate::{
         end_pipeline_statistics_query,
         memory_init::{fixup_discarded_surfaces, SurfacesInDiscardState},
         validate_and_begin_pipeline_statistics_query, ArcPassTimestampWrites, BasePass,
-        BindGroupStateChange, CommandBuffer, CommandEncoderError, CommandEncoderStatus, MapPassErr,
-        PassErrorScope, PassTimestampWrites, QueryUseError, StateChange,
+        BindGroupStateChange, CommandBuffer, CommandEncoderError, MapPassErr, PassErrorScope,
+        PassTimestampWrites, QueryUseError, StateChange,
     },
     device::{Device, DeviceError, MissingDownlevelFlags, MissingFeatures},
     global::Global,
@@ -30,8 +30,7 @@ use wgt::{BufferAddress, DynamicOffset};
 
 use super::{bind::BinderError, memory_init::CommandBufferTextureMemoryActions};
 use crate::ray_tracing::TlasAction;
-use std::sync::Arc;
-use std::{fmt, mem::size_of, str};
+use std::{fmt, mem::size_of, str, sync::Arc};
 
 pub struct ComputePass {
     /// All pass data & records is stored here.
@@ -282,7 +281,9 @@ impl Global {
     /// If creation fails, an invalid pass is returned.
     /// Any operation on an invalid pass will return an error.
     ///
-    /// If successful, puts the encoder into the [`CommandEncoderStatus::Locked`] state.
+    /// If successful, puts the encoder into the [`Locked`] state.
+    ///
+    /// [`Locked`]: crate::command::CommandEncoderStatus::Locked
     pub fn command_encoder_create_compute_pass(
         &self,
         encoder_id: id::CommandEncoderId,
@@ -299,11 +300,7 @@ impl Global {
 
         let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
 
-        match cmd_buf
-            .try_get()
-            .map_err(|e| e.into())
-            .and_then(|mut cmd_buf_data| cmd_buf_data.lock_encoder())
-        {
+        match cmd_buf.data.lock().lock_encoder() {
             Ok(_) => {}
             Err(e) => return make_err(e, arc_desc),
         };
@@ -340,7 +337,8 @@ impl Global {
                 .hub
                 .command_buffers
                 .get(encoder_id.into_command_buffer_id());
-            let mut cmd_buf_data = cmd_buf.try_get().map_pass_err(pass_scope)?;
+            let mut cmd_buf_data = cmd_buf.data.lock();
+            let cmd_buf_data = cmd_buf_data.get_inner().map_pass_err(pass_scope)?;
 
             if let Some(ref mut list) = cmd_buf_data.commands {
                 list.push(crate::device::trace::Command::RunComputePass {
@@ -408,19 +406,16 @@ impl Global {
         let device = &cmd_buf.device;
         device.check_is_valid().map_pass_err(pass_scope)?;
 
-        let mut cmd_buf_data = cmd_buf.try_get().map_pass_err(pass_scope)?;
-        cmd_buf_data.unlock_encoder().map_pass_err(pass_scope)?;
-        let cmd_buf_data = &mut *cmd_buf_data;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let mut cmd_buf_data_guard = cmd_buf_data.unlock_encoder().map_pass_err(pass_scope)?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         let encoder = &mut cmd_buf_data.encoder;
-        let status = &mut cmd_buf_data.status;
 
         // We automatically keep extending command buffers over time, and because
         // we want to insert a command buffer _before_ what we're about to record,
         // we need to make sure to close the previous one.
         encoder.close(&cmd_buf.device).map_pass_err(pass_scope)?;
-        // will be reset to true if recording is done without errors
-        *status = CommandEncoderStatus::Error;
         let raw_encoder = encoder.open(&cmd_buf.device).map_pass_err(pass_scope)?;
 
         let mut state = State {
@@ -590,10 +585,6 @@ impl Global {
             state.raw_encoder.end_compute_pass();
         }
 
-        // We've successfully recorded the compute pass, bring the
-        // command buffer out of the error state.
-        *status = CommandEncoderStatus::Recording;
-
         let State {
             snatch_guard,
             tracker,
@@ -626,6 +617,7 @@ impl Global {
         encoder
             .close_and_swap(&cmd_buf.device)
             .map_pass_err(pass_scope)?;
+        cmd_buf_data_guard.mark_successful();
 
         Ok(())
     }

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -216,7 +216,7 @@ impl BakedCommands {
             let raw_buf = buffer.try_raw(snatch_guard)?;
 
             unsafe {
-                self.encoder.transition_buffers(
+                self.encoder.raw.transition_buffers(
                     transition
                         .map(|pending| pending.into_hal(&buffer, snatch_guard))
                         .as_slice(),
@@ -240,7 +240,7 @@ impl BakedCommands {
                 );
 
                 unsafe {
-                    self.encoder.clear_buffer(raw_buf, range.clone());
+                    self.encoder.raw.clear_buffer(raw_buf, range.clone());
                 }
             }
         }
@@ -293,7 +293,7 @@ impl BakedCommands {
                 let clear_result = clear_texture(
                     &texture_use.texture,
                     range,
-                    self.encoder.as_mut(),
+                    self.encoder.raw.as_mut(),
                     &mut device_tracker.textures,
                     &device.alignments,
                     device.zero_buffer.as_ref(),

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -388,13 +388,10 @@ impl CommandBufferMutable {
         }
     }
 
-    pub(crate) fn destroy(mut self, device: &Device) {
+    pub(crate) fn destroy(mut self) {
         self.encoder.discard();
         unsafe {
             self.encoder.raw.reset_all(self.encoder.list);
-        }
-        unsafe {
-            device.raw().destroy_command_encoder(self.encoder.raw);
         }
     }
 }
@@ -436,7 +433,7 @@ impl Drop for CommandBuffer {
     fn drop(&mut self) {
         resource_log!("Drop {}", self.error_ident());
         if let Some(data) = self.data.lock().take() {
-            data.destroy(&self.device);
+            data.destroy();
         }
     }
 }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -13,6 +13,7 @@ mod render_command;
 mod timestamp_writes;
 mod transfer;
 
+use std::mem::{self, ManuallyDrop};
 use std::sync::Arc;
 
 pub(crate) use self::clear::clear_texture;
@@ -47,7 +48,6 @@ use crate::device::trace::Command as TraceCommand;
 const PUSH_CONSTANT_CLEAR_ARRAY: &[u32] = &[0_u32; 64];
 
 /// The current state of a [`CommandBuffer`].
-#[derive(Debug)]
 pub(crate) enum CommandEncoderStatus {
     /// Ready to record commands. An encoder's initial state.
     ///
@@ -60,7 +60,7 @@ pub(crate) enum CommandEncoderStatus {
     ///
     /// [`command_encoder_clear_buffer`]: Global::command_encoder_clear_buffer
     /// [`compute_pass_end`]: Global::compute_pass_end
-    Recording,
+    Recording(CommandBufferMutable),
 
     /// Locked by a render or compute pass.
     ///
@@ -68,9 +68,9 @@ pub(crate) enum CommandEncoderStatus {
     /// and exited when the pass is ended.
     ///
     /// As long as the command encoder is locked, any command building operation on it will fail
-    /// and put the encoder into the [`CommandEncoderStatus::Error`] state.
+    /// and put the encoder into the [`Self::Error`] state.
     /// See <https://www.w3.org/TR/webgpu/#encoder-state-locked>
-    Locked,
+    Locked(CommandBufferMutable),
 
     /// Command recording is complete, and the buffer is ready for submission.
     ///
@@ -79,19 +79,145 @@ pub(crate) enum CommandEncoderStatus {
     ///
     /// [`Global::queue_submit`] drops command buffers unless they are
     /// in this state.
-    Finished,
+    Finished(CommandBufferMutable),
 
     /// An error occurred while recording a compute or render pass.
     ///
     /// When a `CommandEncoder` is left in this state, we have also
     /// returned an error result from the function that encountered
     /// the problem. Future attempts to use the encoder (for example,
-    /// calls to [`CommandBufferMutable::check_recording`]) will also return
-    /// errors.
-    ///
-    /// Calling [`Global::command_encoder_finish`] in this state
-    /// discards the command buffer under construction.
+    /// calls to [`Self::record`]) will also return errors.
     Error,
+}
+
+impl CommandEncoderStatus {
+    /// Checks that the encoder is in the [`Self::Recording`] state.
+    pub(crate) fn record(&mut self) -> Result<&mut CommandBufferMutable, CommandEncoderError> {
+        match self {
+            Self::Recording(inner) => Ok(inner),
+            Self::Locked(_) => {
+                *self = Self::Error;
+                Err(CommandEncoderError::Locked)
+            }
+            Self::Finished(_) => Err(CommandEncoderError::NotRecording),
+            Self::Error => Err(CommandEncoderError::Invalid),
+        }
+    }
+
+    #[cfg(feature = "trace")]
+    fn get_inner(&mut self) -> Result<&mut CommandBufferMutable, CommandEncoderError> {
+        match self {
+            Self::Locked(inner) | Self::Finished(inner) | Self::Recording(inner) => Ok(inner),
+            Self::Error => Err(CommandEncoderError::Invalid),
+        }
+    }
+
+    /// Locks the encoder by putting it in the [`Self::Locked`] state.
+    ///
+    /// Call [`Self::unlock_encoder`] to put the [`CommandBuffer`] back into the [`Self::Recording`] state.
+    fn lock_encoder(&mut self) -> Result<(), CommandEncoderError> {
+        match mem::replace(self, Self::Error) {
+            Self::Recording(inner) => {
+                *self = Self::Locked(inner);
+                Ok(())
+            }
+            Self::Finished(inner) => {
+                *self = Self::Finished(inner);
+                Err(CommandEncoderError::NotRecording)
+            }
+            Self::Locked(_) => Err(CommandEncoderError::Locked),
+            Self::Error => Err(CommandEncoderError::Invalid),
+        }
+    }
+
+    /// Unlocks the [`CommandBuffer`] and puts it back into the [`Self::Recording`] state.
+    ///
+    /// This function is the unlocking counterpart to [`Self::lock_encoder`].
+    ///
+    /// It is only valid to call this function if the encoder is in the [`Self::Locked`] state.
+    fn unlock_encoder(&mut self) -> Result<RecordingGuard<'_>, CommandEncoderError> {
+        match mem::replace(self, Self::Error) {
+            Self::Locked(inner) => {
+                *self = Self::Recording(inner);
+                Ok(RecordingGuard { inner: self })
+            }
+            Self::Finished(inner) => {
+                *self = Self::Finished(inner);
+                Err(CommandEncoderError::NotRecording)
+            }
+            Self::Recording(_) => Err(CommandEncoderError::Invalid),
+            Self::Error => Err(CommandEncoderError::Invalid),
+        }
+    }
+
+    fn finish(&mut self, device: &Device) -> Result<(), CommandEncoderError> {
+        match mem::replace(self, Self::Error) {
+            Self::Recording(mut inner) => {
+                if let Err(e) = inner.encoder.close(device) {
+                    Err(e.into())
+                } else {
+                    *self = Self::Finished(inner);
+                    // Note: if we want to stop tracking the swapchain texture view,
+                    // this is the place to do it.
+                    Ok(())
+                }
+            }
+            Self::Finished(inner) => {
+                *self = Self::Finished(inner);
+                Err(CommandEncoderError::NotRecording)
+            }
+            Self::Locked(_) => Err(CommandEncoderError::Locked),
+            Self::Error => Err(CommandEncoderError::Invalid),
+        }
+    }
+}
+
+/// A guard to enforce error reporting, for a [`CommandBuffer`] in the [`Recording`] state.
+///
+/// An [`RecordingGuard`] holds a mutable reference to a [`CommandEncoderStatus`] that
+/// has been verified to be in the [`Recording`] state. The [`RecordingGuard`] dereferences
+/// mutably to the [`CommandBufferMutable`] that the status holds.
+///
+/// Dropping an [`RecordingGuard`] sets the [`CommandBuffer`]'s state to
+/// [`CommandEncoderStatus::Error`]. If your use of the guard was
+/// successful, call its [`mark_successful`] method to dispose of it.
+///
+/// [`Recording`]: CommandEncoderStatus::Recording
+/// [`mark_successful`]: Self::mark_successful
+pub(crate) struct RecordingGuard<'a> {
+    inner: &'a mut CommandEncoderStatus,
+}
+
+impl<'a> RecordingGuard<'a> {
+    pub(crate) fn mark_successful(self) {
+        mem::forget(self)
+    }
+}
+
+impl<'a> Drop for RecordingGuard<'a> {
+    fn drop(&mut self) {
+        *self.inner = CommandEncoderStatus::Error;
+    }
+}
+
+impl<'a> std::ops::Deref for RecordingGuard<'a> {
+    type Target = CommandBufferMutable;
+
+    fn deref(&self) -> &Self::Target {
+        match &*self.inner {
+            CommandEncoderStatus::Recording(command_buffer_mutable) => command_buffer_mutable,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<'a> std::ops::DerefMut for RecordingGuard<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self.inner {
+            CommandEncoderStatus::Recording(command_buffer_mutable) => command_buffer_mutable,
+            _ => unreachable!(),
+        }
+    }
 }
 
 /// A raw [`CommandEncoder`][rce], and the raw [`CommandBuffer`][rcb]s built from it.
@@ -122,7 +248,7 @@ pub(crate) struct CommandEncoder {
     ///
     /// [`CommandEncoder`]: hal::Api::CommandEncoder
     /// [`CommandAllocator`]: crate::command::CommandAllocator
-    pub(crate) raw: Box<dyn hal::DynCommandEncoder>,
+    pub(crate) raw: ManuallyDrop<Box<dyn hal::DynCommandEncoder>>,
 
     /// All the raw command buffers for our owning [`CommandBuffer`], in
     /// submission order.
@@ -136,6 +262,8 @@ pub(crate) struct CommandEncoder {
     /// [CE::ra]: hal::CommandEncoder::reset_all
     /// [`wgpu_hal::CommandEncoder`]: hal::CommandEncoder
     pub(crate) list: Vec<Box<dyn hal::DynCommandBuffer>>,
+
+    pub(crate) device: Arc<Device>,
 
     /// True if `raw` is in the "recording" state.
     ///
@@ -206,16 +334,6 @@ impl CommandEncoder {
         Ok(())
     }
 
-    /// Discard the command buffer under construction, if any.
-    ///
-    /// The underlying hal encoder is closed, if it was recording.
-    pub(crate) fn discard(&mut self) {
-        if self.is_open {
-            self.is_open = false;
-            unsafe { self.raw.discard_encoding() };
-        }
-    }
-
     /// Begin recording a new command buffer, if we haven't already.
     ///
     /// The underlying hal encoder is put in the "recording" state.
@@ -245,6 +363,20 @@ impl CommandEncoder {
     }
 }
 
+impl Drop for CommandEncoder {
+    fn drop(&mut self) {
+        if self.is_open {
+            unsafe { self.raw.discard_encoding() };
+        }
+        unsafe {
+            self.raw.reset_all(mem::take(&mut self.list));
+        }
+        // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
+        let raw = unsafe { ManuallyDrop::take(&mut self.raw) };
+        self.device.command_allocator.release_encoder(raw);
+    }
+}
+
 /// Look at the documentation for [`CommandBufferMutable`] for an explanation of
 /// the fields in this struct. This is the "built" counterpart to that type.
 pub(crate) struct BakedCommands {
@@ -261,9 +393,6 @@ pub struct CommandBufferMutable {
     ///
     /// [`wgpu_hal::Api::CommandBuffer`]: hal::Api::CommandBuffer
     pub(crate) encoder: CommandEncoder,
-
-    /// The current state of this command buffer's encoder.
-    status: CommandEncoderStatus,
 
     /// All the resources that the commands recorded so far have referred to.
     pub(crate) trackers: Tracker,
@@ -297,99 +426,12 @@ impl CommandBufferMutable {
         Ok((encoder, tracker))
     }
 
-    fn lock_encoder_impl(&mut self, lock: bool) -> Result<(), CommandEncoderError> {
-        match self.status {
-            CommandEncoderStatus::Recording => {
-                if lock {
-                    self.status = CommandEncoderStatus::Locked;
-                }
-                Ok(())
-            }
-            CommandEncoderStatus::Locked => {
-                // Any operation on a locked encoder is required to put it into the invalid/error state.
-                // See https://www.w3.org/TR/webgpu/#encoder-state-locked
-                self.encoder.discard();
-                self.status = CommandEncoderStatus::Error;
-                Err(CommandEncoderError::Locked)
-            }
-            CommandEncoderStatus::Finished => Err(CommandEncoderError::NotRecording),
-            CommandEncoderStatus::Error => Err(CommandEncoderError::Invalid),
-        }
-    }
-
-    /// Checks that the encoder is in the [`CommandEncoderStatus::Recording`] state.
-    fn check_recording(&mut self) -> Result<(), CommandEncoderError> {
-        self.lock_encoder_impl(false)
-    }
-
-    /// Locks the encoder by putting it in the [`CommandEncoderStatus::Locked`] state.
-    ///
-    /// Call [`CommandBufferMutable::unlock_encoder`] to put the [`CommandBuffer`] back into the [`CommandEncoderStatus::Recording`] state.
-    fn lock_encoder(&mut self) -> Result<(), CommandEncoderError> {
-        self.lock_encoder_impl(true)
-    }
-
-    /// Unlocks the [`CommandBuffer`] and puts it back into the [`CommandEncoderStatus::Recording`] state.
-    ///
-    /// This function is the counterpart to [`CommandBufferMutable::lock_encoder`].
-    /// It is only valid to call this function if the encoder is in the [`CommandEncoderStatus::Locked`] state.
-    fn unlock_encoder(&mut self) -> Result<(), CommandEncoderError> {
-        match self.status {
-            CommandEncoderStatus::Recording => Err(CommandEncoderError::Invalid),
-            CommandEncoderStatus::Locked => {
-                self.status = CommandEncoderStatus::Recording;
-                Ok(())
-            }
-            CommandEncoderStatus::Finished => Err(CommandEncoderError::Invalid),
-            CommandEncoderStatus::Error => Err(CommandEncoderError::Invalid),
-        }
-    }
-
-    pub fn check_finished(&self) -> Result<(), CommandEncoderError> {
-        match self.status {
-            CommandEncoderStatus::Finished => Ok(()),
-            _ => Err(CommandEncoderError::Invalid),
-        }
-    }
-
-    pub(crate) fn finish(&mut self, device: &Device) -> Result<(), CommandEncoderError> {
-        match self.status {
-            CommandEncoderStatus::Recording => {
-                if let Err(e) = self.encoder.close(device) {
-                    Err(e.into())
-                } else {
-                    self.status = CommandEncoderStatus::Finished;
-                    // Note: if we want to stop tracking the swapchain texture view,
-                    // this is the place to do it.
-                    Ok(())
-                }
-            }
-            CommandEncoderStatus::Locked => {
-                self.encoder.discard();
-                self.status = CommandEncoderStatus::Error;
-                Err(CommandEncoderError::Locked)
-            }
-            CommandEncoderStatus::Finished => Err(CommandEncoderError::NotRecording),
-            CommandEncoderStatus::Error => {
-                self.encoder.discard();
-                Err(CommandEncoderError::Invalid)
-            }
-        }
-    }
-
     pub(crate) fn into_baked_commands(self) -> BakedCommands {
         BakedCommands {
             encoder: self.encoder,
             trackers: self.trackers,
             buffer_memory_init_actions: self.buffer_memory_init_actions,
             texture_memory_actions: self.texture_memory_actions,
-        }
-    }
-
-    pub(crate) fn destroy(mut self) {
-        self.encoder.discard();
-        unsafe {
-            self.encoder.raw.reset_all(self.encoder.list);
         }
     }
 }
@@ -424,15 +466,12 @@ pub struct CommandBuffer {
     /// When this is submitted, dropped, or destroyed, its contents are
     /// extracted into a [`BakedCommands`] by
     /// [`CommandBufferMutable::into_baked_commands`].
-    pub(crate) data: Mutex<Option<CommandBufferMutable>>,
+    pub(crate) data: Mutex<CommandEncoderStatus>,
 }
 
 impl Drop for CommandBuffer {
     fn drop(&mut self) {
         resource_log!("Drop {}", self.error_ident());
-        if let Some(data) = self.data.lock().take() {
-            data.destroy();
-        }
     }
 }
 
@@ -448,14 +487,14 @@ impl CommandBuffer {
             label: label.to_string(),
             data: Mutex::new(
                 rank::COMMAND_BUFFER_DATA,
-                Some(CommandBufferMutable {
+                CommandEncoderStatus::Recording(CommandBufferMutable {
                     encoder: CommandEncoder {
-                        raw: encoder,
-                        is_open: false,
+                        raw: ManuallyDrop::new(encoder),
                         list: Vec::new(),
+                        device: device.clone(),
+                        is_open: false,
                         hal_label: label.to_hal(device.instance_flags).map(str::to_owned),
                     },
-                    status: CommandEncoderStatus::Recording,
                     trackers: Tracker::new(),
                     buffer_memory_init_actions: Default::default(),
                     texture_memory_actions: Default::default(),
@@ -478,7 +517,7 @@ impl CommandBuffer {
             device: device.clone(),
             support_clear_texture: device.features.contains(wgt::Features::CLEAR_TEXTURE),
             label: label.to_string(),
-            data: Mutex::new(rank::COMMAND_BUFFER_DATA, None),
+            data: Mutex::new(rank::COMMAND_BUFFER_DATA, CommandEncoderStatus::Error),
         }
     }
 
@@ -560,19 +599,14 @@ impl CommandBuffer {
 }
 
 impl CommandBuffer {
-    pub fn try_get<'a>(
-        &'a self,
-    ) -> Result<parking_lot::MappedMutexGuard<'a, CommandBufferMutable>, InvalidResourceError> {
-        let g = self.data.lock();
-        crate::lock::MutexGuard::try_map(g, |data| data.as_mut())
-            .map_err(|_| InvalidResourceError(self.error_ident()))
-    }
-
-    pub fn try_take<'a>(&'a self) -> Result<CommandBufferMutable, InvalidResourceError> {
-        self.data
-            .lock()
-            .take()
-            .ok_or_else(|| InvalidResourceError(self.error_ident()))
+    pub fn take_finished<'a>(&'a self) -> Result<CommandBufferMutable, InvalidResourceError> {
+        let status = mem::replace(&mut *self.data.lock(), CommandEncoderStatus::Error);
+        match status {
+            CommandEncoderStatus::Finished(command_buffer_mutable) => Ok(command_buffer_mutable),
+            CommandEncoderStatus::Recording(_)
+            | CommandEncoderStatus::Locked(_)
+            | CommandEncoderStatus::Error => Err(InvalidResourceError(self.error_ident())),
+        }
     }
 }
 
@@ -672,11 +706,7 @@ impl Global {
 
         let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
 
-        let error = match cmd_buf
-            .try_get()
-            .map_err(|e| e.into())
-            .and_then(|mut cmd_buf_data| cmd_buf_data.finish(&cmd_buf.device))
-        {
+        let error = match cmd_buf.data.lock().finish(&cmd_buf.device) {
             Ok(_) => None,
             Err(e) => Some(e),
         };
@@ -695,8 +725,8 @@ impl Global {
         let hub = &self.hub;
 
         let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.try_get()?;
-        cmd_buf_data.check_recording()?;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {
@@ -727,8 +757,8 @@ impl Global {
         let hub = &self.hub;
 
         let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.try_get()?;
-        cmd_buf_data.check_recording()?;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {
@@ -758,8 +788,8 @@ impl Global {
         let hub = &self.hub;
 
         let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.try_get()?;
-        cmd_buf_data.check_recording()?;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -122,7 +122,7 @@ pub(crate) struct CommandEncoder {
     ///
     /// [`CommandEncoder`]: hal::Api::CommandEncoder
     /// [`CommandAllocator`]: crate::command::CommandAllocator
-    raw: Box<dyn hal::DynCommandEncoder>,
+    pub(crate) raw: Box<dyn hal::DynCommandEncoder>,
 
     /// All the raw command buffers for our owning [`CommandBuffer`], in
     /// submission order.
@@ -135,7 +135,7 @@ pub(crate) struct CommandEncoder {
     ///
     /// [CE::ra]: hal::CommandEncoder::reset_all
     /// [`wgpu_hal::CommandEncoder`]: hal::CommandEncoder
-    list: Vec<Box<dyn hal::DynCommandBuffer>>,
+    pub(crate) list: Vec<Box<dyn hal::DynCommandBuffer>>,
 
     /// True if `raw` is in the "recording" state.
     ///
@@ -143,9 +143,9 @@ pub(crate) struct CommandEncoder {
     /// details on the states `raw` can be in.
     ///
     /// [`wgpu_hal::CommandEncoder`]: hal::CommandEncoder
-    is_open: bool,
+    pub(crate) is_open: bool,
 
-    hal_label: Option<String>,
+    pub(crate) hal_label: Option<String>,
 }
 
 //TODO: handle errors better
@@ -248,8 +248,7 @@ impl CommandEncoder {
 /// Look at the documentation for [`CommandBufferMutable`] for an explanation of
 /// the fields in this struct. This is the "built" counterpart to that type.
 pub(crate) struct BakedCommands {
-    pub(crate) encoder: Box<dyn hal::DynCommandEncoder>,
-    pub(crate) list: Vec<Box<dyn hal::DynCommandBuffer>>,
+    pub(crate) encoder: CommandEncoder,
     pub(crate) trackers: Tracker,
     buffer_memory_init_actions: Vec<BufferInitTrackerAction>,
     texture_memory_actions: CommandBufferTextureMemoryActions,
@@ -380,8 +379,7 @@ impl CommandBufferMutable {
 
     pub(crate) fn into_baked_commands(self) -> BakedCommands {
         BakedCommands {
-            encoder: self.encoder.raw,
-            list: self.encoder.list,
+            encoder: self.encoder,
             trackers: self.trackers,
             buffer_memory_init_actions: self.buffer_memory_init_actions,
             texture_memory_actions: self.texture_memory_actions,

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -321,8 +321,8 @@ impl Global {
         let cmd_buf = hub
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.try_get()?;
-        cmd_buf_data.check_recording()?;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         cmd_buf
             .device
@@ -361,8 +361,8 @@ impl Global {
         let cmd_buf = hub
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.try_get()?;
-        cmd_buf_data.check_recording()?;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -322,7 +322,8 @@ impl Global {
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.record()?;
+        let mut cmd_buf_data_guard = cmd_buf_data.record()?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         cmd_buf
             .device
@@ -344,6 +345,7 @@ impl Global {
 
         cmd_buf_data.trackers.query_sets.insert_single(query_set);
 
+        cmd_buf_data_guard.mark_successful();
         Ok(())
     }
 
@@ -362,7 +364,8 @@ impl Global {
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.record()?;
+        let mut cmd_buf_data_guard = cmd_buf_data.record()?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         #[cfg(feature = "trace")]
         if let Some(ref mut list) = cmd_buf_data.commands {
@@ -458,6 +461,7 @@ impl Global {
 
         cmd_buf_data.trackers.query_sets.insert_single(query_set);
 
+        cmd_buf_data_guard.mark_successful();
         Ok(())
     }
 }

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -126,7 +126,7 @@ impl Global {
         #[cfg(feature = "trace")]
         let trace_tlas: Vec<TlasBuildEntry> = tlas_iter.collect();
         #[cfg(feature = "trace")]
-        if let Some(ref mut list) = cmd_buf.data.lock().as_mut().unwrap().commands {
+        if let Some(ref mut list) = cmd_buf.data.lock().get_inner()?.commands {
             list.push(
                 crate::device::trace::Command::BuildAccelerationStructuresUnsafeTlas {
                     blas: trace_blas.clone(),
@@ -170,7 +170,7 @@ impl Global {
         let mut scratch_buffer_blas_size = 0;
         let mut blas_storage = Vec::new();
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         iter_blas(
             blas_iter,
@@ -435,7 +435,7 @@ impl Global {
             .collect();
 
         #[cfg(feature = "trace")]
-        if let Some(ref mut list) = cmd_buf.data.lock().as_mut().unwrap().commands {
+        if let Some(ref mut list) = cmd_buf.data.lock().get_inner()?.commands {
             list.push(crate::device::trace::Command::BuildAccelerationStructures {
                 blas: trace_blas.clone(),
                 tlas: trace_tlas.clone(),
@@ -486,7 +486,7 @@ impl Global {
         let mut scratch_buffer_blas_size = 0;
         let mut blas_storage = Vec::new();
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.as_mut().unwrap();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         iter_blas(
             blas_iter,

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -170,7 +170,8 @@ impl Global {
         let mut scratch_buffer_blas_size = 0;
         let mut blas_storage = Vec::new();
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.record()?;
+        let mut cmd_buf_data_guard = cmd_buf_data.record()?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         iter_blas(
             blas_iter,
@@ -276,7 +277,10 @@ impl Global {
 
         let scratch_size =
             match wgt::BufferSize::new(max(scratch_buffer_blas_size, scratch_buffer_tlas_size)) {
-                None => return Ok(()),
+                None => {
+                    cmd_buf_data_guard.mark_successful();
+                    return Ok(());
+                }
                 Some(size) => size,
             };
 
@@ -353,6 +357,7 @@ impl Global {
                 .consume_temp(TempResource::ScratchBuffer(scratch_buffer));
         }
 
+        cmd_buf_data_guard.mark_successful();
         Ok(())
     }
 
@@ -486,7 +491,8 @@ impl Global {
         let mut scratch_buffer_blas_size = 0;
         let mut blas_storage = Vec::new();
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.record()?;
+        let mut cmd_buf_data_guard = cmd_buf_data.record()?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         iter_blas(
             blas_iter,
@@ -611,7 +617,10 @@ impl Global {
         let scratch_size =
             match wgt::BufferSize::new(max(scratch_buffer_blas_size, scratch_buffer_tlas_size)) {
                 // if the size is zero there is nothing to build
-                None => return Ok(()),
+                None => {
+                    cmd_buf_data_guard.mark_successful();
+                    return Ok(());
+                }
                 Some(size) => size,
             };
 
@@ -763,6 +772,7 @@ impl Global {
                 .consume_temp(TempResource::ScratchBuffer(scratch_buffer));
         }
 
+        cmd_buf_data_guard.mark_successful();
         Ok(())
     }
 }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -14,8 +14,8 @@ use crate::{
         end_occlusion_query, end_pipeline_statistics_query,
         memory_init::{fixup_discarded_surfaces, SurfacesInDiscardState},
         ArcPassTimestampWrites, BasePass, BindGroupStateChange, CommandBuffer, CommandEncoderError,
-        CommandEncoderStatus, DrawError, ExecutionError, MapPassErr, PassErrorScope,
-        PassTimestampWrites, QueryUseError, RenderCommandError, StateChange,
+        DrawError, ExecutionError, MapPassErr, PassErrorScope, PassTimestampWrites, QueryUseError,
+        RenderCommandError, StateChange,
     },
     device::{
         AttachmentData, Device, DeviceError, MissingDownlevelFlags, MissingFeatures,
@@ -45,8 +45,7 @@ use serde::Deserialize;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
-use std::sync::Arc;
-use std::{borrow::Cow, fmt, iter, mem::size_of, num::NonZeroU32, ops::Range, str};
+use std::{borrow::Cow, fmt, iter, mem::size_of, num::NonZeroU32, ops::Range, str, sync::Arc};
 
 use super::render_command::ArcRenderCommand;
 use super::{
@@ -1321,7 +1320,9 @@ impl Global {
     /// If creation fails, an invalid pass is returned.
     /// Any operation on an invalid pass will return an error.
     ///
-    /// If successful, puts the encoder into the [`CommandEncoderStatus::Locked`] state.
+    /// If successful, puts the encoder into the [`Locked`] state.
+    ///
+    /// [`Locked`]: crate::command::CommandEncoderStatus::Locked
     pub fn command_encoder_create_render_pass(
         &self,
         encoder_id: id::CommandEncoderId,
@@ -1422,11 +1423,7 @@ impl Global {
 
         let cmd_buf = hub.command_buffers.get(encoder_id.into_command_buffer_id());
 
-        match cmd_buf
-            .try_get()
-            .map_err(|e| e.into())
-            .and_then(|mut cmd_buf_data| cmd_buf_data.lock_encoder())
-        {
+        match cmd_buf.data.lock().lock_encoder() {
             Ok(_) => {}
             Err(e) => return make_err(e, arc_desc),
         };
@@ -1457,7 +1454,8 @@ impl Global {
                 .hub
                 .command_buffers
                 .get(encoder_id.into_command_buffer_id());
-            let mut cmd_buf_data = cmd_buf.try_get().map_pass_err(pass_scope)?;
+            let mut cmd_buf_data = cmd_buf.data.lock();
+            let cmd_buf_data = cmd_buf_data.get_inner().map_pass_err(pass_scope)?;
 
             if let Some(ref mut list) = cmd_buf_data.commands {
                 list.push(crate::device::trace::Command::RunRenderPass {
@@ -1532,9 +1530,9 @@ impl Global {
             base.label.as_deref().unwrap_or("")
         );
 
-        let mut cmd_buf_data = cmd_buf.try_get().map_pass_err(pass_scope)?;
-        cmd_buf_data.unlock_encoder().map_pass_err(pass_scope)?;
-        let cmd_buf_data = &mut *cmd_buf_data;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let mut cmd_buf_data_guard = cmd_buf_data.unlock_encoder().map_pass_err(pass_scope)?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         let device = &cmd_buf.device;
         let snatch_guard = &device.snatchable_lock.read();
@@ -1545,7 +1543,6 @@ impl Global {
             device.check_is_valid().map_pass_err(pass_scope)?;
 
             let encoder = &mut cmd_buf_data.encoder;
-            let status = &mut cmd_buf_data.status;
             let tracker = &mut cmd_buf_data.trackers;
             let buffer_memory_init_actions = &mut cmd_buf_data.buffer_memory_init_actions;
             let texture_memory_actions = &mut cmd_buf_data.texture_memory_actions;
@@ -1555,8 +1552,6 @@ impl Global {
             // we want to insert a command buffer _before_ what we're about to record,
             // we need to make sure to close the previous one.
             encoder.close(&cmd_buf.device).map_pass_err(pass_scope)?;
-            // We will reset this to `Recording` if we succeed, acts as a fail-safe.
-            *status = CommandEncoderStatus::Error;
             encoder
                 .open_pass(hal_label, &cmd_buf.device)
                 .map_pass_err(pass_scope)?;
@@ -1867,7 +1862,6 @@ impl Global {
         };
 
         let encoder = &mut cmd_buf_data.encoder;
-        let status = &mut cmd_buf_data.status;
         let tracker = &mut cmd_buf_data.trackers;
 
         {
@@ -1886,10 +1880,10 @@ impl Global {
             CommandBuffer::insert_barriers_from_scope(transit, tracker, &scope, snatch_guard);
         }
 
-        *status = CommandEncoderStatus::Recording;
         encoder
             .close_and_swap(&cmd_buf.device)
             .map_pass_err(pass_scope)?;
+        cmd_buf_data_guard.mark_successful();
 
         Ok(())
     }

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -550,7 +550,8 @@ impl Global {
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.record()?;
+        let mut cmd_buf_data_guard = cmd_buf_data.record()?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         let device = &cmd_buf.device;
         device.check_is_valid()?;
@@ -652,6 +653,7 @@ impl Global {
 
         if size == 0 {
             log::trace!("Ignoring copy_buffer_to_buffer of size 0");
+            cmd_buf_data_guard.mark_successful();
             return Ok(());
         }
 
@@ -685,6 +687,8 @@ impl Global {
             cmd_buf_raw.transition_buffers(&barriers);
             cmd_buf_raw.copy_buffer_to_buffer(src_raw, dst_raw, &[region]);
         }
+
+        cmd_buf_data_guard.mark_successful();
         Ok(())
     }
 
@@ -708,7 +712,8 @@ impl Global {
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.record()?;
+        let mut cmd_buf_data_guard = cmd_buf_data.record()?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         let device = &cmd_buf.device;
         device.check_is_valid()?;
@@ -724,6 +729,7 @@ impl Global {
 
         if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
             log::trace!("Ignoring copy_buffer_to_texture of size 0");
+            cmd_buf_data_guard.mark_successful();
             return Ok(());
         }
 
@@ -838,6 +844,8 @@ impl Global {
             cmd_buf_raw.transition_buffers(src_barrier.as_slice());
             cmd_buf_raw.copy_buffer_to_texture(src_raw, dst_raw, &regions);
         }
+
+        cmd_buf_data_guard.mark_successful();
         Ok(())
     }
 
@@ -861,7 +869,8 @@ impl Global {
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.record()?;
+        let mut cmd_buf_data_guard = cmd_buf_data.record()?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         let device = &cmd_buf.device;
         device.check_is_valid()?;
@@ -877,6 +886,7 @@ impl Global {
 
         if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
             log::trace!("Ignoring copy_texture_to_buffer of size 0");
+            cmd_buf_data_guard.mark_successful();
             return Ok(());
         }
 
@@ -1005,6 +1015,8 @@ impl Global {
                 &regions,
             );
         }
+
+        cmd_buf_data_guard.mark_successful();
         Ok(())
     }
 
@@ -1028,7 +1040,8 @@ impl Global {
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.record()?;
+        let mut cmd_buf_data_guard = cmd_buf_data.record()?;
+        let cmd_buf_data = &mut *cmd_buf_data_guard;
 
         let device = &cmd_buf.device;
         device.check_is_valid()?;
@@ -1046,6 +1059,7 @@ impl Global {
 
         if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
             log::trace!("Ignoring copy_texture_to_texture of size 0");
+            cmd_buf_data_guard.mark_successful();
             return Ok(());
         }
 
@@ -1165,6 +1179,7 @@ impl Global {
             );
         }
 
+        cmd_buf_data_guard.mark_successful();
         Ok(())
     }
 }

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -549,8 +549,8 @@ impl Global {
         let cmd_buf = hub
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.try_get()?;
-        cmd_buf_data.check_recording()?;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         let device = &cmd_buf.device;
         device.check_is_valid()?;
@@ -707,8 +707,8 @@ impl Global {
         let cmd_buf = hub
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.try_get()?;
-        cmd_buf_data.check_recording()?;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         let device = &cmd_buf.device;
         device.check_is_valid()?;
@@ -746,7 +746,7 @@ impl Global {
         // have an easier time inserting "immediate-inits" that may be required
         // by prior discards in rare cases.
         handle_dst_texture_init(
-            &mut cmd_buf_data,
+            cmd_buf_data,
             device,
             destination,
             copy_size,
@@ -860,14 +860,14 @@ impl Global {
         let cmd_buf = hub
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.try_get()?;
-        cmd_buf_data.check_recording()?;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         let device = &cmd_buf.device;
         device.check_is_valid()?;
 
         #[cfg(feature = "trace")]
-        if let Some(ref mut list) = cmd_buf_data.commands {
+        if let Some(list) = cmd_buf_data.commands.as_mut() {
             list.push(TraceCommand::CopyTextureToBuffer {
                 src: *source,
                 dst: *destination,
@@ -895,7 +895,7 @@ impl Global {
         // have an easier time inserting "immediate-inits" that may be required
         // by prior discards in rare cases.
         handle_src_texture_init(
-            &mut cmd_buf_data,
+            cmd_buf_data,
             device,
             source,
             copy_size,
@@ -1027,8 +1027,8 @@ impl Global {
         let cmd_buf = hub
             .command_buffers
             .get(command_encoder_id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.try_get()?;
-        cmd_buf_data.check_recording()?;
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record()?;
 
         let device = &cmd_buf.device;
         device.check_is_valid()?;
@@ -1092,7 +1092,7 @@ impl Global {
         // have an easier time inserting "immediate-inits" that may be required
         // by prior discards in rare cases.
         handle_src_texture_init(
-            &mut cmd_buf_data,
+            cmd_buf_data,
             device,
             source,
             copy_size,
@@ -1100,7 +1100,7 @@ impl Global {
             &snatch_guard,
         )?;
         handle_dst_texture_init(
-            &mut cmd_buf_data,
+            cmd_buf_data,
             device,
             destination,
             copy_size,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3535,9 +3535,7 @@ impl Device {
                 .map_err(|e| self.handle_hal_error(e))?;
             drop(fence);
             if let Some(queue) = self.get_queue() {
-                let closures = queue
-                    .lock_life()
-                    .triage_submissions(submission_index, &self.command_allocator);
+                let closures = queue.lock_life().triage_submissions(submission_index);
                 assert!(
                     closures.is_empty(),
                     "wait_for_submit is not expected to work with closures"

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -153,7 +153,6 @@ impl Drop for Device {
         let zero_buffer = unsafe { ManuallyDrop::take(&mut self.zero_buffer) };
         // SAFETY: We are in the Drop impl and we don't use self.fence anymore after this point.
         let fence = unsafe { ManuallyDrop::take(&mut self.fence.write()) };
-        self.command_allocator.dispose(self.raw.as_ref());
         #[cfg(feature = "indirect-validation")]
         self.indirect_validation
             .take()

--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -78,15 +78,6 @@ impl<T> Mutex<T> {
     }
 }
 
-impl<'a, T> MutexGuard<'a, T> {
-    pub fn try_map<U: ?Sized, F>(s: Self, f: F) -> Result<parking_lot::MappedMutexGuard<'a, U>, ()>
-    where
-        F: FnOnce(&mut T) -> Option<&mut U>,
-    {
-        parking_lot::MutexGuard::try_map(s.inner, f).map_err(|_| ())
-    }
-}
-
 impl<'a, T> std::ops::Deref for MutexGuard<'a, T> {
     type Target = T;
 

--- a/wgpu-core/src/lock/vanilla.rs
+++ b/wgpu-core/src/lock/vanilla.rs
@@ -30,15 +30,6 @@ impl<T> Mutex<T> {
     }
 }
 
-impl<'a, T> MutexGuard<'a, T> {
-    pub fn try_map<U: ?Sized, F>(s: Self, f: F) -> Result<parking_lot::MappedMutexGuard<'a, U>, ()>
-    where
-        F: FnOnce(&mut T) -> Option<&mut U>,
-    {
-        parking_lot::MutexGuard::try_map(s.0, f).map_err(|_| ())
-    }
-}
-
 impl<'a, T> std::ops::Deref for MutexGuard<'a, T> {
     type Target = T;
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1369,15 +1369,17 @@ impl Global {
 
         let cmd_buf = hub.command_buffers.get(id.into_command_buffer_id());
         let mut cmd_buf_data = cmd_buf.data.lock();
-        let cmd_buf_data = cmd_buf_data.record();
+        let cmd_buf_data_guard = cmd_buf_data.record();
 
-        if let Ok(cmd_buf_data) = cmd_buf_data {
-            let cmd_buf_raw = cmd_buf_data
+        if let Ok(mut cmd_buf_data_guard) = cmd_buf_data_guard {
+            let cmd_buf_raw = cmd_buf_data_guard
                 .encoder
                 .open(&cmd_buf.device)
                 .ok()
                 .and_then(|encoder| encoder.as_any_mut().downcast_mut());
-            hal_command_encoder_callback(cmd_buf_raw)
+            let ret = hal_command_encoder_callback(cmd_buf_raw);
+            cmd_buf_data_guard.mark_successful();
+            ret
         } else {
             hal_command_encoder_callback(None)
         }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1368,9 +1368,10 @@ impl Global {
         let hub = &self.hub;
 
         let cmd_buf = hub.command_buffers.get(id.into_command_buffer_id());
-        let cmd_buf_data = cmd_buf.try_get();
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        let cmd_buf_data = cmd_buf_data.record();
 
-        if let Ok(mut cmd_buf_data) = cmd_buf_data {
+        if let Ok(cmd_buf_data) = cmd_buf_data {
             let cmd_buf_raw = cmd_buf_data
                 .encoder
                 .open(&cmd_buf.device)

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -559,7 +559,7 @@ impl<A: hal::Api> Example<A> {
 
             for mut ctx in self.contexts {
                 ctx.wait_and_clear(&self.device);
-                self.device.destroy_command_encoder(ctx.encoder);
+                drop(ctx.encoder);
                 self.device.destroy_fence(ctx.fence);
             }
 

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -1046,7 +1046,7 @@ impl<A: hal::Api> Example<A> {
 
             for mut ctx in self.contexts {
                 ctx.wait_and_clear(&self.device);
-                self.device.destroy_command_encoder(ctx.encoder);
+                drop(ctx.encoder);
                 self.device.destroy_fence(ctx.fence);
             }
 

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -64,6 +64,7 @@ impl Drop for super::CommandEncoder {
     fn drop(&mut self) {
         use crate::CommandEncoder;
         unsafe { self.discard_encoding() }
+        self.counters.command_encoders.sub(1);
     }
 }
 

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -746,11 +746,8 @@ impl crate::Device for super::Device {
             pass: super::PassState::new(),
             temp: super::Temp::default(),
             end_of_pass_timer_query: None,
+            counters: Arc::clone(&self.counters),
         })
-    }
-
-    unsafe fn destroy_command_encoder(&self, _encoder: super::CommandEncoder) {
-        self.counters.command_encoders.sub(1);
     }
 
     unsafe fn create_bind_group_layout(
@@ -1908,7 +1905,7 @@ impl crate::Device for super::Device {
     }
 
     fn get_internal_counters(&self) -> wgt::HalCounters {
-        self.counters.clone()
+        self.counters.as_ref().clone()
     }
 
     fn generate_allocator_report(&self) -> Option<wgt::AllocatorReport> {

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -599,7 +599,7 @@ pub struct Device {
     null_rtv_handle: descriptor::Handle,
     mem_allocator: Mutex<suballocation::GpuAllocatorWrapper>,
     dxc_container: Option<Arc<shader_compilation::DxcContainer>>,
-    counters: wgt::HalCounters,
+    counters: Arc<wgt::HalCounters>,
 }
 
 impl Drop for Device {
@@ -722,6 +722,8 @@ pub struct CommandEncoder {
     /// If set, the end of the next render/compute pass will write a timestamp at
     /// the given pool & location.
     end_of_pass_timer_query: Option<(Direct3D12::ID3D12QueryHeap, u32)>,
+
+    counters: Arc<wgt::HalCounters>,
 }
 
 unsafe impl Send for CommandEncoder {}

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -58,7 +58,6 @@ pub trait DynDevice: DynResource {
         &self,
         desc: &CommandEncoderDescriptor<dyn DynQueue>,
     ) -> Result<Box<dyn DynCommandEncoder>, DeviceError>;
-    unsafe fn destroy_command_encoder(&self, pool: Box<dyn DynCommandEncoder>);
 
     unsafe fn create_bind_group_layout(
         &self,
@@ -266,10 +265,6 @@ impl<D: Device + DynResource> DynDevice for D {
         };
         unsafe { D::create_command_encoder(self, &desc) }
             .map(|b| -> Box<dyn DynCommandEncoder> { Box::new(b) })
-    }
-
-    unsafe fn destroy_command_encoder(&self, encoder: Box<dyn DynCommandEncoder>) {
-        unsafe { D::destroy_command_encoder(self, encoder.unbox()) };
     }
 
     unsafe fn create_bind_group_layout(

--- a/wgpu-hal/src/empty.rs
+++ b/wgpu-hal/src/empty.rs
@@ -206,7 +206,6 @@ impl crate::Device for Context {
     ) -> DeviceResult<Encoder> {
         Ok(Encoder)
     }
-    unsafe fn destroy_command_encoder(&self, encoder: Encoder) {}
 
     unsafe fn create_bind_group_layout(
         &self,

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -99,6 +99,7 @@ impl Drop for super::CommandEncoder {
     fn drop(&mut self) {
         use crate::CommandEncoder;
         unsafe { self.discard_encoding() }
+        self.counters.command_encoders.sub(1);
     }
 }
 

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1116,11 +1116,8 @@ impl crate::Device for super::Device {
             cmd_buffer: super::CommandBuffer::default(),
             state: Default::default(),
             private_caps: self.shared.private_caps,
+            counters: Arc::clone(&self.counters),
         })
-    }
-
-    unsafe fn destroy_command_encoder(&self, _encoder: super::CommandEncoder) {
-        self.counters.command_encoders.sub(1);
     }
 
     unsafe fn create_bind_group_layout(
@@ -1638,7 +1635,7 @@ impl crate::Device for super::Device {
     }
 
     fn get_internal_counters(&self) -> wgt::HalCounters {
-        self.counters.clone()
+        self.counters.as_ref().clone()
     }
 }
 

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -292,7 +292,7 @@ pub struct Device {
     main_vao: glow::VertexArray,
     #[cfg(all(native, feature = "renderdoc"))]
     render_doc: crate::auxil::renderdoc::RenderDoc,
-    counters: wgt::HalCounters,
+    counters: Arc<wgt::HalCounters>,
 }
 
 impl Drop for Device {
@@ -1081,6 +1081,7 @@ pub struct CommandEncoder {
     cmd_buffer: CommandBuffer,
     state: command::State,
     private_caps: PrivateCapabilities,
+    counters: Arc<wgt::HalCounters>,
 }
 
 impl fmt::Debug for CommandEncoder {

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -842,7 +842,6 @@ pub trait Device: WasmNotSendSync {
         &self,
         desc: &CommandEncoderDescriptor<<Self::A as Api>::Queue>,
     ) -> Result<<Self::A as Api>::CommandEncoder, DeviceError>;
-    unsafe fn destroy_command_encoder(&self, pool: <Self::A as Api>::CommandEncoder);
 
     /// Creates a bind group layout.
     unsafe fn create_bind_group_layout(
@@ -1109,8 +1108,6 @@ pub trait Queue: WasmNotSendSync {
 ///
 /// - A `CommandBuffer` must not outlive the `CommandEncoder` that
 ///   built it.
-///
-/// - A `CommandEncoder` must not outlive its `Device`.
 ///
 /// It is the user's responsibility to meet this requirements. This
 /// allows `CommandEncoder` implementations to keep their state

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1295,5 +1295,6 @@ impl Drop for super::CommandEncoder {
         unsafe {
             self.discard_encoding();
         }
+        self.counters.command_encoders.sub(1);
     }
 }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -585,11 +585,8 @@ impl crate::Device for super::Device {
             raw_cmd_buf: None,
             state: super::CommandState::default(),
             temp: super::Temp::default(),
+            counters: Arc::clone(&self.counters),
         })
-    }
-
-    unsafe fn destroy_command_encoder(&self, _encoder: super::CommandEncoder) {
-        self.counters.command_encoders.sub(1);
     }
 
     unsafe fn create_bind_group_layout(
@@ -1438,6 +1435,6 @@ impl crate::Device for super::Device {
     }
 
     fn get_internal_counters(&self) -> wgt::HalCounters {
-        self.counters.clone()
+        self.counters.as_ref().clone()
     }
 }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -356,7 +356,7 @@ impl Queue {
 pub struct Device {
     shared: Arc<AdapterShared>,
     features: wgt::Features,
-    counters: wgt::HalCounters,
+    counters: Arc<wgt::HalCounters>,
 }
 
 pub struct Surface {
@@ -910,6 +910,7 @@ pub struct CommandEncoder {
     raw_cmd_buf: Option<metal::CommandBuffer>,
     state: CommandState,
     temp: Temp,
+    counters: Arc<wgt::HalCounters>,
 }
 
 impl fmt::Debug for CommandEncoder {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1373,18 +1373,8 @@ impl crate::Device for super::Device {
             discarded: Vec::new(),
             rpass_debug_marker_active: false,
             end_of_pass_timer_query: None,
+            counters: Arc::clone(&self.counters),
         })
-    }
-    unsafe fn destroy_command_encoder(&self, cmd_encoder: super::CommandEncoder) {
-        unsafe {
-            // `vkDestroyCommandPool` also frees any command buffers allocated
-            // from that pool, so there's no need to explicitly call
-            // `vkFreeCommandBuffers` on `cmd_encoder`'s `free` and `discarded`
-            // fields.
-            self.shared.raw.destroy_command_pool(cmd_encoder.raw, None);
-        }
-
-        self.counters.command_encoders.sub(1);
     }
 
     unsafe fn create_bind_group_layout(
@@ -2556,7 +2546,7 @@ impl crate::Device for super::Device {
             .memory_allocations
             .set(self.shared.memory_allocations_counter.read());
 
-        self.counters.clone()
+        self.counters.as_ref().clone()
     }
 
     fn tlas_instance_to_bytes(&self, instance: TlasInstance) -> Vec<u8> {


### PR DESCRIPTION
This PR improves the lifetime management of command encoders (it's now automatic on drop, no more manual destruction), it also removes duplicate invalidity state from command encodes and with the last commit, we now invalidate the command encoder if there have been any errors while recording (per spec).