### PR TITLE
feat: add `wgpu_types::error::{ErrorType, WebGpuError}`, use them to classify errors in `wgpu` and `deno_webgpu`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Bottom level categories:
 ### Changes
 
 - Loosen Viewport validation requirements to match the [new specs](https://github.com/gpuweb/gpuweb/pull/5025). By @ebbdrop in [#7564](https://github.com/gfx-rs/wgpu/pull/7564)
+- `wgpu` now uses `wgpu-types::error::WebGpuError` to classify errors. Any changes here are likely to be regressions; please report them if you find them! By @ErichDonGubler in [#6547](https://github.com/gfx-rs/wgpu/pull/6547).
 
 #### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Bottom level categories:
 - Add extra acceleration structure vertex formats. By @Vecvec in [#7580](https://github.com/gfx-rs/wgpu/pull/7580).
 - Add acceleration structure limits. By @Vecvec in [#7845](https://github.com/gfx-rs/wgpu/pull/7845).
 - Add support for clip-distances feature for Vulkan and GL backends. By @dzamkov in [#7730](https://github.com/gfx-rs/wgpu/pull/7730)
-- Added `wgpu_types::error::{ErrorType, WebGpuError}` for classification of errors according to WebGPU's [`GPUError`]'s classification scheme. This allows users of `wgpu-core` to offload error classification onto the WGPU ecosystem, rather than having to do it themselves without sufficient information. By @ErichDonGubler in [#6547](https://github.com/gfx-rs/wgpu/pull/6547).
+- Added `wgpu_types::error::{ErrorType, WebGpuError}` for classification of errors according to WebGPU's [`GPUError`]'s classification scheme, and implement `WebGpuError` for existing errors. This allows users of `wgpu-core` to offload error classification onto the WGPU ecosystem, rather than having to do it themselves without sufficient information. By @ErichDonGubler in [#6547](https://github.com/gfx-rs/wgpu/pull/6547).
 
 [`GPUError`]: https://www.w3.org/TR/webgpu/#gpuerror
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ Bottom level categories:
 ### Changes
 
 - Loosen Viewport validation requirements to match the [new specs](https://github.com/gpuweb/gpuweb/pull/5025). By @ebbdrop in [#7564](https://github.com/gfx-rs/wgpu/pull/7564)
-- `wgpu` now uses `wgpu-types::error::WebGpuError` to classify errors. Any changes here are likely to be regressions; please report them if you find them! By @ErichDonGubler in [#6547](https://github.com/gfx-rs/wgpu/pull/6547).
+- `wgpu` and `deno_webgpu` now use `wgpu-types::error::WebGpuError` to classify errors. Any changes here are likely to be regressions; please report them if you find them! By @ErichDonGubler in [#6547](https://github.com/gfx-rs/wgpu/pull/6547).
 
 #### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ Bottom level categories:
 - Add extra acceleration structure vertex formats. By @Vecvec in [#7580](https://github.com/gfx-rs/wgpu/pull/7580).
 - Add acceleration structure limits. By @Vecvec in [#7845](https://github.com/gfx-rs/wgpu/pull/7845).
 - Add support for clip-distances feature for Vulkan and GL backends. By @dzamkov in [#7730](https://github.com/gfx-rs/wgpu/pull/7730)
+- Added `wgpu_types::error::{ErrorType, WebGpuError}` for classification of errors according to WebGPU's [`GPUError`]'s classification scheme. This allows users of `wgpu-core` to offload error classification onto the WGPU ecosystem, rather than having to do it themselves without sufficient information. By @ErichDonGubler in [#6547](https://github.com/gfx-rs/wgpu/pull/6547).
+
+[`GPUError`]: https://www.w3.org/TR/webgpu/#gpuerror
 
 #### Vulkan
 

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -841,6 +841,15 @@ pub enum GPUDeviceLostReason {
     Destroyed,
 }
 
+impl From<wgpu_types::DeviceLostReason> for GPUDeviceLostReason {
+    fn from(value: wgpu_types::DeviceLostReason) -> Self {
+        match value {
+            wgpu_types::DeviceLostReason::Unknown => Self::Unknown,
+            wgpu_types::DeviceLostReason::Destroyed => Self::Destroyed,
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct GPUDeviceLostInfo {
     pub reason: GPUDeviceLostReason,

--- a/deno_webgpu/error.rs
+++ b/deno_webgpu/error.rs
@@ -36,6 +36,7 @@ use wgpu_core::resource::CreateQuerySetError;
 use wgpu_core::resource::CreateSamplerError;
 use wgpu_core::resource::CreateTextureError;
 use wgpu_core::resource::CreateTextureViewError;
+use wgpu_types::error::{ErrorType, WebGpuError};
 
 use crate::device::GPUDeviceLostInfo;
 use crate::device::GPUDeviceLostReason;
@@ -183,6 +184,17 @@ impl Display for GPUError {
 
 impl std::error::Error for GPUError {}
 
+impl GPUError {
+    fn from_webgpu(e: impl WebGpuError) -> Self {
+        match e.webgpu_error_type() {
+            ErrorType::Internal => GPUError::Internal,
+            ErrorType::DeviceLost { reason } => GPUError::Lost(reason.into()),
+            ErrorType::OutOfMemory => GPUError::OutOfMemory,
+            ErrorType::Validation => GPUError::Validation(fmt_err(&e)),
+        }
+    }
+}
+
 fn fmt_err(err: &(dyn std::error::Error + 'static)) -> String {
     let mut output = err.to_string();
 
@@ -201,7 +213,7 @@ fn fmt_err(err: &(dyn std::error::Error + 'static)) -> String {
 
 impl From<EncoderStateError> for GPUError {
     fn from(err: EncoderStateError) -> Self {
-        GPUError::Validation(fmt_err(&err))
+        GPUError::from_webgpu(err)
     }
 }
 
@@ -213,188 +225,144 @@ impl From<PassStateError> for GPUError {
 
 impl From<CreateBufferError> for GPUError {
     fn from(err: CreateBufferError) -> Self {
-        match err {
-            CreateBufferError::Device(err) => err.into(),
-            CreateBufferError::AccessError(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<DeviceError> for GPUError {
     fn from(err: DeviceError) -> Self {
-        match err {
-            DeviceError::Lost => GPUError::Lost(GPUDeviceLostReason::Unknown),
-            DeviceError::OutOfMemory => GPUError::OutOfMemory,
-            _ => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<BufferAccessError> for GPUError {
     fn from(err: BufferAccessError) -> Self {
-        match err {
-            BufferAccessError::Device(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CreateBindGroupLayoutError> for GPUError {
     fn from(err: CreateBindGroupLayoutError) -> Self {
-        match err {
-            CreateBindGroupLayoutError::Device(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CreatePipelineLayoutError> for GPUError {
     fn from(err: CreatePipelineLayoutError) -> Self {
-        match err {
-            CreatePipelineLayoutError::Device(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CreateBindGroupError> for GPUError {
     fn from(err: CreateBindGroupError) -> Self {
-        match err {
-            CreateBindGroupError::Device(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<RenderBundleError> for GPUError {
     fn from(err: RenderBundleError) -> Self {
-        GPUError::Validation(fmt_err(&err))
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CreateRenderBundleError> for GPUError {
     fn from(err: CreateRenderBundleError) -> Self {
-        GPUError::Validation(fmt_err(&err))
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CommandEncoderError> for GPUError {
     fn from(err: CommandEncoderError) -> Self {
-        GPUError::Validation(fmt_err(&err))
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<QueryError> for GPUError {
     fn from(err: QueryError) -> Self {
-        GPUError::Validation(fmt_err(&err))
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<ComputePassError> for GPUError {
     fn from(err: ComputePassError) -> Self {
-        GPUError::Validation(fmt_err(&err))
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CreateComputePipelineError> for GPUError {
     fn from(err: CreateComputePipelineError) -> Self {
-        match err {
-            CreateComputePipelineError::Device(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<GetBindGroupLayoutError> for GPUError {
     fn from(err: GetBindGroupLayoutError) -> Self {
-        GPUError::Validation(fmt_err(&err))
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CreateRenderPipelineError> for GPUError {
     fn from(err: CreateRenderPipelineError) -> Self {
-        match err {
-            CreateRenderPipelineError::Device(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<RenderPassError> for GPUError {
     fn from(err: RenderPassError) -> Self {
-        GPUError::Validation(fmt_err(&err))
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CreateSamplerError> for GPUError {
     fn from(err: CreateSamplerError) -> Self {
-        match err {
-            CreateSamplerError::Device(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CreateShaderModuleError> for GPUError {
     fn from(err: CreateShaderModuleError) -> Self {
-        match err {
-            CreateShaderModuleError::Device(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CreateTextureError> for GPUError {
     fn from(err: CreateTextureError) -> Self {
-        match err {
-            CreateTextureError::Device(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CreateTextureViewError> for GPUError {
     fn from(err: CreateTextureViewError) -> Self {
-        GPUError::Validation(fmt_err(&err))
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<CreateQuerySetError> for GPUError {
     fn from(err: CreateQuerySetError) -> Self {
-        match err {
-            CreateQuerySetError::Device(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<QueueSubmitError> for GPUError {
     fn from(err: QueueSubmitError) -> Self {
-        match err {
-            QueueSubmitError::Queue(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<QueueWriteError> for GPUError {
     fn from(err: QueueWriteError) -> Self {
-        match err {
-            QueueWriteError::Queue(err) => err.into(),
-            err => GPUError::Validation(fmt_err(&err)),
-        }
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<ClearError> for GPUError {
     fn from(err: ClearError) -> Self {
-        GPUError::Validation(fmt_err(&err))
+        GPUError::from_webgpu(err)
     }
 }
 
 impl From<ConfigureSurfaceError> for GPUError {
     fn from(err: ConfigureSurfaceError) -> Self {
-        GPUError::Validation(fmt_err(&err))
+        GPUError::from_webgpu(err)
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -108,6 +108,11 @@ pub fn did_fail<T>(device: &wgpu::Device, callback: impl FnOnce() -> T) -> (bool
     did_fill_error_scope(device, callback, wgpu::ErrorFilter::Validation)
 }
 
+/// Returns true if the provided callback encounters an out-of-memory error.
+pub fn did_oom<T>(device: &wgpu::Device, callback: impl FnOnce() -> T) -> (bool, T) {
+    did_fill_error_scope(device, callback, wgpu::ErrorFilter::OutOfMemory)
+}
+
 /// Adds the necessary main function for our gpu test harness.
 #[macro_export]
 macro_rules! gpu_test_main {

--- a/tests/tests/wgpu-gpu/samplers.rs
+++ b/tests/tests/wgpu-gpu/samplers.rs
@@ -2,7 +2,7 @@
 //!
 //! Do some tests to ensure things are working correctly and nothing gets mad.
 
-use wgpu_test::{did_fail, gpu_test, valid, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{did_oom, gpu_test, valid, GpuTestConfiguration, TestParameters, TestingContext};
 
 // A number large enough to likely cause sampler caches to run out of space
 // on some devices.
@@ -93,7 +93,7 @@ fn sampler_creation_failure(ctx: TestingContext) {
     let mut sampler_storage = Vec::with_capacity(PROBABLY_PROBLEMATIC_SAMPLER_COUNT as usize);
 
     for i in 0..PROBABLY_PROBLEMATIC_SAMPLER_COUNT {
-        let (failed, sampler) = did_fail(&ctx.device, || {
+        let (failed, sampler) = did_oom(&ctx.device, || {
             ctx.device.create_sampler(&wgpu::SamplerDescriptor {
                 lod_min_clamp: i as f32 * 0.01,
                 ..desc

--- a/tests/tests/wgpu-gpu/shader/array_size_overrides.rs
+++ b/tests/tests/wgpu-gpu/shader/array_size_overrides.rs
@@ -52,7 +52,9 @@ static ARRAY_SIZE_OVERRIDES: GpuTestConfiguration = GpuTestConfiguration::new()
     .run_async(move |ctx| async move {
         array_size_overrides(&ctx, None, &[534], false).await;
         array_size_overrides(&ctx, Some(14), &[286480122], false).await;
-        array_size_overrides(&ctx, Some(1), &[0], true).await;
+        // // TODO: Restore this with the resolution for
+        // // <https://github.com/gfx-rs/wgpu/issues/7806>.
+        // array_size_overrides(&ctx, Some(1), &[0], true).await;
     });
 
 async fn array_size_overrides(

--- a/wgpu-core/src/command/pass.rs
+++ b/wgpu-core/src/command/pass.rs
@@ -16,6 +16,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::str;
 use thiserror::Error;
+use wgt::error::{ErrorType, WebGpuError};
 use wgt::DynamicOffset;
 
 #[derive(Clone, Debug, Error)]
@@ -35,9 +36,21 @@ pub struct MissingPipeline;
 #[error("Setting `values_offset` to be `None` is only for internal use in render bundles")]
 pub struct InvalidValuesOffset;
 
+impl WebGpuError for InvalidValuesOffset {
+    fn webgpu_error_type(&self) -> ErrorType {
+        ErrorType::Validation
+    }
+}
+
 #[derive(Clone, Debug, Error)]
 #[error("Cannot pop debug group, because number of pushed debug groups is zero")]
 pub struct InvalidPopDebugGroup;
+
+impl WebGpuError for InvalidPopDebugGroup {
+    fn webgpu_error_type(&self) -> ErrorType {
+        ErrorType::Validation
+    }
+}
 
 pub(crate) struct BaseState<'scope, 'snatch_guard, 'cmd_buf, 'raw_encoder> {
     pub(crate) device: &'cmd_buf Arc<Device>,

--- a/wgpu-core/src/command/transition_resources.rs
+++ b/wgpu-core/src/command/transition_resources.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use wgt::error::{ErrorType, WebGpuError};
 
 use crate::{
     command::{CommandBuffer, CommandEncoderError, EncoderStateError},
@@ -85,4 +86,16 @@ pub enum TransitionResourcesError {
     InvalidResource(#[from] InvalidResourceError),
     #[error(transparent)]
     ResourceUsage(#[from] ResourceUsageCompatibilityError),
+}
+
+impl WebGpuError for TransitionResourcesError {
+    fn webgpu_error_type(&self) -> ErrorType {
+        let e: &dyn WebGpuError = match self {
+            Self::Device(e) => e,
+            Self::EncoderState(e) => e,
+            Self::InvalidResource(e) => e,
+            Self::ResourceUsage(e) => e,
+        };
+        e.webgpu_error_type()
+    }
 }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -868,18 +868,6 @@ pub enum RequestDeviceError {
     UnsupportedFeature(wgt::Features),
 }
 
-impl WebGpuError for RequestDeviceError {
-    fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::LimitsExceeded(e) => e,
-            Self::TimestampNormalizerInitFailed(e) => e,
-            Self::UnsupportedFeature(_) => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
-    }
-}
-
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum CreateSurfaceError {

--- a/wgpu-core/src/pipeline_cache.rs
+++ b/wgpu-core/src/pipeline_cache.rs
@@ -1,5 +1,8 @@
 use thiserror::Error;
-use wgt::AdapterInfo;
+use wgt::{
+    error::{ErrorType, WebGpuError},
+    AdapterInfo,
+};
 
 pub const HEADER_LENGTH: usize = size_of::<PipelineCacheHeader>();
 
@@ -34,6 +37,12 @@ impl PipelineCacheValidationError {
             | PipelineCacheValidationError::Outdated
             | PipelineCacheValidationError::Corrupted => false,
         }
+    }
+}
+
+impl WebGpuError for PipelineCacheValidationError {
+    fn webgpu_error_type(&self) -> ErrorType {
+        ErrorType::Validation
     }
 }
 

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -125,7 +125,10 @@ pub(crate) use texture::{
     DeviceTextureTracker, TextureTracker, TextureTrackerSetSingle, TextureUsageScope,
     TextureViewBindGroupState,
 };
-use wgt::strict_assert_ne;
+use wgt::{
+    error::{ErrorType, WebGpuError},
+    strict_assert_ne,
+};
 
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -356,6 +359,12 @@ pub enum ResourceUsageCompatibilityError {
         array_layers: ops::Range<u32>,
         invalid_use: InvalidUse<wgt::TextureUses>,
     },
+}
+
+impl WebGpuError for ResourceUsageCompatibilityError {
+    fn webgpu_error_type(&self) -> ErrorType {
+        ErrorType::Validation
+    }
 }
 
 impl ResourceUsageCompatibilityError {

--- a/wgpu-types/src/error.rs
+++ b/wgpu-types/src/error.rs
@@ -1,0 +1,46 @@
+//! Shared types for WebGPU errors. See also:
+//! <https://gpuweb.github.io/gpuweb/#errors-and-debugging>
+
+use crate::DeviceLostReason;
+
+/// A classification of WebGPU error for implementers of the WebGPU API to use in their own error
+/// layer(s).
+///
+/// Strongly correlates to the [`GPUError`] and [`GPUErrorFilter`] types in the WebGPU API, with an
+/// additional [`Self::DeviceLost`] variant.
+///
+/// [`GPUError`]: https://gpuweb.github.io/gpuweb/#gpuerror
+/// [`GPUErrorFilter`]: https://gpuweb.github.io/gpuweb/#enumdef-gpuerrorfilter
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum ErrorType {
+    /// A [`GPUInternalError`].
+    ///
+    /// [`GPUInternalError`]: https://gpuweb.github.io/gpuweb/#gpuinternalerror
+    Internal,
+    /// A [`GPUOutOfMemoryError`].
+    ///
+    /// [`GPUOutOfMemoryError`]: https://gpuweb.github.io/gpuweb/#gpuoutofmemoryerror
+    OutOfMemory,
+    /// A [`GPUValidationError`].
+    ///
+    /// [`GPUValidationError`]: https://gpuweb.github.io/gpuweb/#gpuvalidationerror
+    Validation,
+    /// Indicates that device loss occurred. In JavaScript, this means the [`GPUDevice.lost`]
+    /// property should be `resolve`d.
+    ///
+    /// [`GPUDevice.lost`]: https://www.w3.org/TR/webgpu/#dom-gpudevice-lost
+    DeviceLost {
+        /// The reason the device was lost.
+        reason: DeviceLostReason,
+    },
+}
+
+/// A trait for querying the [`ErrorType`] classification of an error.
+///
+/// This is intended to be used as a convenience by implementations of WebGPU to classify errors
+/// returned by [`wgpu_core`](crate).
+pub trait WebGpuError: core::error::Error + 'static {
+    /// Determine the classification of this error as a WebGPU [`ErrorType`].
+    fn webgpu_error_type(&self) -> ErrorType;
+}

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -449,6 +449,12 @@ impl fmt::Display for RequestAdapterError {
     }
 }
 
+impl error::WebGpuError for RequestAdapterError {
+    fn webgpu_error_type(&self) -> error::ErrorType {
+        error::ErrorType::Validation
+    }
+}
+
 /// Represents the sets of limits an adapter/device supports.
 ///
 /// We provide three different defaults.
@@ -7743,9 +7749,10 @@ mod send_sync {
     impl<T> WasmNotSync for T {}
 }
 
-/// Reason for "lose the device".
+/// Corresponds to a [`GPUDeviceLostReason`]; usually seen by implementers of WebGPU with
+/// [`error::ErrorType::DeviceLost::reason`].
 ///
-/// Corresponds to [WebGPU `GPUDeviceLostReason`](https://gpuweb.github.io/gpuweb/#enumdef-gpudevicelostreason).
+/// [`GPUDeviceLostReason`]: https://www.w3.org/TR/webgpu/#enumdef-gpudevicelostreason
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -449,12 +449,6 @@ impl fmt::Display for RequestAdapterError {
     }
 }
 
-impl error::WebGpuError for RequestAdapterError {
-    fn webgpu_error_type(&self) -> error::ErrorType {
-        error::ErrorType::Validation
-    }
-}
-
 /// Represents the sets of limits an adapter/device supports.
 ///
 /// We provide three different defaults.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -36,6 +36,7 @@ pub mod assertions;
 mod cast_utils;
 mod counters;
 mod env;
+pub mod error;
 mod features;
 pub mod instance;
 pub mod math;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7749,9 +7749,9 @@ mod send_sync {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceLostReason {
-    /// Triggered by driver
+    /// The device was lost for an unspecific reason, including driver errors.
     Unknown = 0,
-    /// After `Device::destroy`
+    /// The device's `destroy` method was called.
     Destroyed = 1,
 }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -361,6 +361,7 @@ impl ContextWgpuCore {
                     source: source_error,
                 };
             }
+            ErrorType::DeviceLost { reason: _ } => return,
         };
         sink.handle_error(error);
     }


### PR DESCRIPTION
Recommended review experience:

- This is a rebase-friendly history, so you should be able to review commit-by-commit.
- For your first pass, you might be tempted to focus on whether the classification of errors (i.e., the bodies of `WebGpuError` implementations) is correct or not. This is the vast majority of the review, but also the easiest to fix if we get something wrong; I recommend looking at the plumbing first, and _then_ reviewing the myriad implementations of `WebGpuError` afterward.

**Connections**

- Resolves [Firefox bug 1840926](https://bugzilla.mozilla.org/show_bug.cgi?id=1840926).

**Description**

Manually classify _each and every_ error type that `wgpu` and `deno_webgpu` report their classification as WebGPU errors (`ErrorType`s) using a new `WebGpuError` trait. These are defined as:

```rust
pub enum ErrorType {
    Internal,
	DeviceLost,
    OutOfMemory,
    Validation,
}

pub trait WebGpuError: core::error::Error + 'static {
    fn webgpu_error_type(&self) -> ErrorType;
}
```

`ErrorType` and `core::error::Error` should now be the only APIs necessary to construct the correspondent errors in an implementation of WebGPU; this is now what happens in `wgpu` and `deno_webgpu`.

**Testing**

CI mostly passes, modulo some bugs that have been exposed and worked around in this PR. They have been reported separately for follow-up, with comments in code making them clear follow-up work.

**Checklist**

- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
