### PR TITLE
Improve binding error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 
 - Make `Surface::as_hal` take an immutable reference to the surface. By @jerzywilczek in [#9999](https://github.com/gfx-rs/wgpu/pull/9999)
 - Add actual sample type to `CreateBindGroupError::InvalidTextureSampleType` error message. By @ErichDonGubler in [#6530](https://github.com/gfx-rs/wgpu/pull/6530).
+- Improve binding error to give a clearer message when there is a mismatch between resource binding as it is in the shader and as it is in the binding layout. By @eliemichel in [#6553](https://github.com/gfx-rs/wgpu/pull/6553).
 
 #### HAL
 

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -140,8 +140,13 @@ pub enum BindingError {
     Missing,
     #[error("Visibility flags don't include the shader stage")]
     Invisible,
-    #[error("Type on the shader side does not match the pipeline binding")]
-    WrongType,
+    #[error(
+        "Type on the shader side ({shader:?}) does not match the pipeline binding ({binding:?})"
+    )]
+    WrongType {
+        binding: BindingType,
+        shader: ResourceType,
+    },
     #[error("Storage class {binding:?} doesn't match the shader {shader:?}")]
     WrongAddressSpace {
         binding: naga::AddressSpace,
@@ -378,7 +383,12 @@ impl Resource {
                         }
                         min_binding_size
                     }
-                    _ => return Err(BindingError::WrongType),
+                    _ => {
+                        return Err(BindingError::WrongType {
+                            binding: entry.ty,
+                            shader: self.ty,
+                        })
+                    }
                 };
                 match min_size {
                     Some(non_zero) if non_zero < size => {
@@ -396,7 +406,12 @@ impl Resource {
                         return Err(BindingError::WrongSamplerComparison);
                     }
                 }
-                _ => return Err(BindingError::WrongType),
+                _ => {
+                    return Err(BindingError::WrongType {
+                        binding: entry.ty,
+                        shader: self.ty,
+                    })
+                }
             },
             ResourceType::Texture {
                 dim,
@@ -478,7 +493,12 @@ impl Resource {
                             access: naga_access,
                         }
                     }
-                    _ => return Err(BindingError::WrongType),
+                    _ => {
+                        return Err(BindingError::WrongType {
+                            binding: entry.ty,
+                            shader: self.ty,
+                        })
+                    }
                 };
                 if class != expected_class {
                     return Err(BindingError::WrongTextureClass {
@@ -504,7 +524,12 @@ impl Resource {
                     naga::AddressSpace::Storage { access } => wgt::BufferBindingType::Storage {
                         read_only: access == naga::StorageAccess::LOAD,
                     },
-                    _ => return Err(BindingError::WrongType),
+                    _ => {
+                        return Err(BindingError::WrongType {
+                            binding: entry.ty,
+                            shader: self.ty,
+                        })
+                    }
                 },
                 has_dynamic_offset: false,
                 min_binding_size: Some(size),

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -20,6 +20,33 @@ enum ResourceType {
     AccelerationStructure,
 }
 
+#[derive(Clone, Debug)]
+pub enum BindingTypeName {
+    Buffer,
+    Texture,
+    Sampler,
+    AccelerationStructure,
+}
+
+fn map_resource_to_type_name(ty: &ResourceType) -> BindingTypeName {
+    match ty {
+        ResourceType::Buffer{ .. } => BindingTypeName::Buffer,
+        ResourceType::Texture{ .. } => BindingTypeName::Texture,
+        ResourceType::Sampler{ .. } => BindingTypeName::Sampler,
+        ResourceType::AccelerationStructure{ .. } => BindingTypeName::AccelerationStructure,
+    }
+}
+
+fn map_binding_to_type_name(ty: &BindingType) -> BindingTypeName {
+    match ty {
+        BindingType::Buffer{ .. } => BindingTypeName::Buffer,
+        BindingType::Texture{ .. } => BindingTypeName::Texture,
+        BindingType::StorageTexture{ .. } => BindingTypeName::Texture,
+        BindingType::Sampler{ .. } => BindingTypeName::Sampler,
+        BindingType::AccelerationStructure{ .. } => BindingTypeName::AccelerationStructure,
+    }
+}
+
 #[derive(Debug)]
 struct Resource {
     #[allow(unused)]
@@ -140,17 +167,19 @@ pub enum BindingError {
     Missing,
     #[error("Visibility flags don't include the shader stage")]
     Invisible,
-    #[error(
-        "Type on the shader side ({shader:?}) does not match the pipeline binding ({binding:?})"
-    )]
+    #[error("Type on the shader side ({shader:?}) does not match the pipeline binding ({binding:?})")]
     WrongType {
-        binding: BindingType,
-        shader: ResourceType,
+        binding: BindingTypeName,
+        shader: BindingTypeName,
     },
     #[error("Storage class {binding:?} doesn't match the shader {shader:?}")]
     WrongAddressSpace {
         binding: naga::AddressSpace,
         shader: naga::AddressSpace,
+    },
+    #[error("Address space {space:?} is not a valid Buffer address space")]
+    WrongBufferAddressSpace {
+        space: naga::AddressSpace,
     },
     #[error("Buffer structure size {buffer_size}, added to one element of an unbound array, if it's the last field, ended up greater than the given `min_binding_size`, which is {min_binding_size}")]
     WrongBufferSize {
@@ -385,8 +414,8 @@ impl Resource {
                     }
                     _ => {
                         return Err(BindingError::WrongType {
-                            binding: entry.ty,
-                            shader: self.ty,
+                            binding: map_binding_to_type_name(&entry.ty),
+                            shader: map_resource_to_type_name(&self.ty),
                         })
                     }
                 };
@@ -408,8 +437,8 @@ impl Resource {
                 }
                 _ => {
                     return Err(BindingError::WrongType {
-                        binding: entry.ty,
-                        shader: self.ty,
+                        binding: map_binding_to_type_name(&entry.ty),
+                        shader: map_resource_to_type_name(&self.ty),
                     })
                 }
             },
@@ -495,8 +524,8 @@ impl Resource {
                     }
                     _ => {
                         return Err(BindingError::WrongType {
-                            binding: entry.ty,
-                            shader: self.ty,
+                            binding: map_binding_to_type_name(&entry.ty),
+                            shader: map_resource_to_type_name(&self.ty),
                         })
                     }
                 };
@@ -507,7 +536,15 @@ impl Resource {
                     });
                 }
             }
-            ResourceType::AccelerationStructure => (),
+            ResourceType::AccelerationStructure => match entry.ty {
+                BindingType::AccelerationStructure => (),
+                _ => {
+                    return Err(BindingError::WrongType {
+                        binding: map_binding_to_type_name(&entry.ty),
+                        shader: map_resource_to_type_name(&self.ty),
+                    })
+                }
+            },
         };
 
         Ok(())
@@ -525,9 +562,8 @@ impl Resource {
                         read_only: access == naga::StorageAccess::LOAD,
                     },
                     _ => {
-                        return Err(BindingError::WrongType {
-                            binding: entry.ty,
-                            shader: self.ty,
+                        return Err(BindingError::WrongBufferAddressSpace {
+                            space: self.class,
                         })
                     }
                 },

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -28,22 +28,26 @@ pub enum BindingTypeName {
     AccelerationStructure,
 }
 
-fn map_resource_to_type_name(ty: &ResourceType) -> BindingTypeName {
-    match ty {
-        ResourceType::Buffer { .. } => BindingTypeName::Buffer,
-        ResourceType::Texture { .. } => BindingTypeName::Texture,
-        ResourceType::Sampler { .. } => BindingTypeName::Sampler,
-        ResourceType::AccelerationStructure { .. } => BindingTypeName::AccelerationStructure,
+impl From<&ResourceType> for BindingTypeName {
+    fn from(ty: &ResourceType) -> BindingTypeName {
+        match ty {
+            ResourceType::Buffer { .. } => BindingTypeName::Buffer,
+            ResourceType::Texture { .. } => BindingTypeName::Texture,
+            ResourceType::Sampler { .. } => BindingTypeName::Sampler,
+            ResourceType::AccelerationStructure { .. } => BindingTypeName::AccelerationStructure,
+        }
     }
 }
 
-fn map_binding_to_type_name(ty: &BindingType) -> BindingTypeName {
-    match ty {
-        BindingType::Buffer { .. } => BindingTypeName::Buffer,
-        BindingType::Texture { .. } => BindingTypeName::Texture,
-        BindingType::StorageTexture { .. } => BindingTypeName::Texture,
-        BindingType::Sampler { .. } => BindingTypeName::Sampler,
-        BindingType::AccelerationStructure { .. } => BindingTypeName::AccelerationStructure,
+impl From<&BindingType> for BindingTypeName {
+    fn from(ty: &BindingType) -> BindingTypeName {
+        match ty {
+            BindingType::Buffer { .. } => BindingTypeName::Buffer,
+            BindingType::Texture { .. } => BindingTypeName::Texture,
+            BindingType::StorageTexture { .. } => BindingTypeName::Texture,
+            BindingType::Sampler { .. } => BindingTypeName::Sampler,
+            BindingType::AccelerationStructure { .. } => BindingTypeName::AccelerationStructure,
+        }
     }
 }
 
@@ -414,8 +418,8 @@ impl Resource {
                     }
                     _ => {
                         return Err(BindingError::WrongType {
-                            binding: map_binding_to_type_name(&entry.ty),
-                            shader: map_resource_to_type_name(&self.ty),
+                            binding: (&entry.ty).into(),
+                            shader: (&self.ty).into(),
                         })
                     }
                 };
@@ -437,8 +441,8 @@ impl Resource {
                 }
                 _ => {
                     return Err(BindingError::WrongType {
-                        binding: map_binding_to_type_name(&entry.ty),
-                        shader: map_resource_to_type_name(&self.ty),
+                        binding: (&entry.ty).into(),
+                        shader: (&self.ty).into(),
                     })
                 }
             },
@@ -524,8 +528,8 @@ impl Resource {
                     }
                     _ => {
                         return Err(BindingError::WrongType {
-                            binding: map_binding_to_type_name(&entry.ty),
-                            shader: map_resource_to_type_name(&self.ty),
+                            binding: (&entry.ty).into(),
+                            shader: (&self.ty).into(),
                         })
                     }
                 };
@@ -540,8 +544,8 @@ impl Resource {
                 BindingType::AccelerationStructure => (),
                 _ => {
                     return Err(BindingError::WrongType {
-                        binding: map_binding_to_type_name(&entry.ty),
-                        shader: map_resource_to_type_name(&self.ty),
+                        binding: (&entry.ty).into(),
+                        shader: (&self.ty).into(),
                     })
                 }
             },

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -30,20 +30,20 @@ pub enum BindingTypeName {
 
 fn map_resource_to_type_name(ty: &ResourceType) -> BindingTypeName {
     match ty {
-        ResourceType::Buffer{ .. } => BindingTypeName::Buffer,
-        ResourceType::Texture{ .. } => BindingTypeName::Texture,
-        ResourceType::Sampler{ .. } => BindingTypeName::Sampler,
-        ResourceType::AccelerationStructure{ .. } => BindingTypeName::AccelerationStructure,
+        ResourceType::Buffer { .. } => BindingTypeName::Buffer,
+        ResourceType::Texture { .. } => BindingTypeName::Texture,
+        ResourceType::Sampler { .. } => BindingTypeName::Sampler,
+        ResourceType::AccelerationStructure { .. } => BindingTypeName::AccelerationStructure,
     }
 }
 
 fn map_binding_to_type_name(ty: &BindingType) -> BindingTypeName {
     match ty {
-        BindingType::Buffer{ .. } => BindingTypeName::Buffer,
-        BindingType::Texture{ .. } => BindingTypeName::Texture,
-        BindingType::StorageTexture{ .. } => BindingTypeName::Texture,
-        BindingType::Sampler{ .. } => BindingTypeName::Sampler,
-        BindingType::AccelerationStructure{ .. } => BindingTypeName::AccelerationStructure,
+        BindingType::Buffer { .. } => BindingTypeName::Buffer,
+        BindingType::Texture { .. } => BindingTypeName::Texture,
+        BindingType::StorageTexture { .. } => BindingTypeName::Texture,
+        BindingType::Sampler { .. } => BindingTypeName::Sampler,
+        BindingType::AccelerationStructure { .. } => BindingTypeName::AccelerationStructure,
     }
 }
 
@@ -167,7 +167,9 @@ pub enum BindingError {
     Missing,
     #[error("Visibility flags don't include the shader stage")]
     Invisible,
-    #[error("Type on the shader side ({shader:?}) does not match the pipeline binding ({binding:?})")]
+    #[error(
+        "Type on the shader side ({shader:?}) does not match the pipeline binding ({binding:?})"
+    )]
     WrongType {
         binding: BindingTypeName,
         shader: BindingTypeName,
@@ -178,9 +180,7 @@ pub enum BindingError {
         shader: naga::AddressSpace,
     },
     #[error("Address space {space:?} is not a valid Buffer address space")]
-    WrongBufferAddressSpace {
-        space: naga::AddressSpace,
-    },
+    WrongBufferAddressSpace { space: naga::AddressSpace },
     #[error("Buffer structure size {buffer_size}, added to one element of an unbound array, if it's the last field, ended up greater than the given `min_binding_size`, which is {min_binding_size}")]
     WrongBufferSize {
         buffer_size: wgt::BufferSize,
@@ -561,11 +561,7 @@ impl Resource {
                     naga::AddressSpace::Storage { access } => wgt::BufferBindingType::Storage {
                         read_only: access == naga::StorageAccess::LOAD,
                     },
-                    _ => {
-                        return Err(BindingError::WrongBufferAddressSpace {
-                            space: self.class,
-                        })
-                    }
+                    _ => return Err(BindingError::WrongBufferAddressSpace { space: self.class }),
                 },
                 has_dynamic_offset: false,
                 min_binding_size: Some(size),


### PR DESCRIPTION
**Description**
Error messages in case of a mismatch between resource binding as it is in the shader and as it is in the binding layout only say "there is a mismatch" without precising what binding type was found where. This improves the error message.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
