### PR TITLE
Ensure we pick the right gpu card in the example backend

### DIFF
--- a/examples/src/framework.rs
+++ b/examples/src/framework.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use wgpu::{Instance, Surface};
+use wgpu::{Backends, Instance, Surface};
 use winit::{
     dpi::PhysicalSize,
     event::{Event, KeyEvent, StartCause, WindowEvent},
@@ -278,36 +278,63 @@ impl ExampleContext {
             gles_minor_version,
         });
         surface.pre_adapter(&instance, window);
-        let adapter = wgpu::util::initialize_adapter_from_env_or_default(&instance, surface.get())
-            .await
-            .expect("No suitable GPU adapters found on the system!");
+        // Get OS Environment WGPU_ADAPTER_NAME to select the adapter
+        let adapter = if std::env::var("WGPU_ADAPTER_NAME").is_ok() {
+            let adapter =
+                wgpu::util::initialize_adapter_from_env_or_default(&instance, surface.get())
+                    .await
+                    .expect("No suitable GPU adapters found on the system!");
 
-        let adapter_info = adapter.get_info();
-        log::info!("Using {} ({:?})", adapter_info.name, adapter_info.backend);
+            let adapter_info = adapter.get_info();
+            log::info!("Using {} ({:?})", adapter_info.name, adapter_info.backend);
 
-        let optional_features = E::optional_features();
-        let required_features = E::required_features();
-        let adapter_features = adapter.features();
-        assert!(
-            adapter_features.contains(required_features),
-            "Adapter does not support required features for this example: {:?}",
-            required_features - adapter_features
-        );
+            let optional_features = E::optional_features();
+            let required_features = E::required_features();
+            let adapter_features = adapter.features();
+            assert!(
+                adapter_features.contains(required_features),
+                "Adapter does not support required features for this example: {:?}",
+                required_features - adapter_features
+            );
 
-        let required_downlevel_capabilities = E::required_downlevel_capabilities();
-        let downlevel_capabilities = adapter.get_downlevel_capabilities();
-        assert!(
-            downlevel_capabilities.shader_model >= required_downlevel_capabilities.shader_model,
-            "Adapter does not support the minimum shader model required to run this example: {:?}",
-            required_downlevel_capabilities.shader_model
-        );
-        assert!(
-            downlevel_capabilities
-                .flags
-                .contains(required_downlevel_capabilities.flags),
-            "Adapter does not support the downlevel capabilities required to run this example: {:?}",
-            required_downlevel_capabilities.flags - downlevel_capabilities.flags
-        );
+            let required_downlevel_capabilities = E::required_downlevel_capabilities();
+            let downlevel_capabilities = adapter.get_downlevel_capabilities();
+            assert!(
+                downlevel_capabilities.shader_model >= required_downlevel_capabilities.shader_model,
+                "Adapter does not support the minimum shader model required to run this example: {:?}",
+                required_downlevel_capabilities.shader_model
+            );
+            assert!(
+                downlevel_capabilities
+                    .flags
+                    .contains(required_downlevel_capabilities.flags),
+                "Adapter does not support the downlevel capabilities required to run this example: {:?}",
+                required_downlevel_capabilities.flags - downlevel_capabilities.flags
+            );
+            adapter
+        } else {
+            let adapters = instance.enumerate_adapters(Backends::all());
+
+            let mut chosen_adapter = None;
+            for adapter in adapters {
+                if let Some(surface) = surface.get() {
+                    if !adapter.is_surface_supported(surface) {
+                        continue;
+                    }
+                }
+
+                let required_features = E::required_features();
+                let adapter_features = adapter.features();
+                if !adapter_features.contains(required_features) {
+                    continue;
+                } else {
+                    chosen_adapter = Some(adapter);
+                    break;
+                }
+            }
+
+            chosen_adapter.expect("No suitable GPU adapters found on the system!")
+        };
 
         // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the surface.
         let needed_limits = E::required_limits().using_resolution(adapter.limits());
@@ -317,7 +344,8 @@ impl ExampleContext {
             .request_device(
                 &wgpu::DeviceDescriptor {
                     label: None,
-                    required_features: (optional_features & adapter_features) | required_features,
+                    required_features: (E::optional_features() & adapter.features())
+                        | E::required_features(),
                     required_limits: needed_limits,
                     memory_hints: wgpu::MemoryHints::MemoryUsage,
                 },

--- a/examples/src/framework.rs
+++ b/examples/src/framework.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use wgpu::{Backends, Instance, Surface};
+use wgpu::{Instance, Surface};
 use winit::{
     dpi::PhysicalSize,
     event::{Event, KeyEvent, StartCause, WindowEvent},
@@ -278,64 +278,14 @@ impl ExampleContext {
             gles_minor_version,
         });
         surface.pre_adapter(&instance, window);
-        // Get OS Environment WGPU_ADAPTER_NAME to select the adapter
-        let adapter = if std::env::var("WGPU_ADAPTER_NAME").is_ok() {
-            let adapter =
-                wgpu::util::initialize_adapter_from_env_or_default(&instance, surface.get())
-                    .await
-                    .expect("No suitable GPU adapters found on the system!");
 
-            let adapter_info = adapter.get_info();
-            log::info!("Using {} ({:?})", adapter_info.name, adapter_info.backend);
-
-            let optional_features = E::optional_features();
-            let required_features = E::required_features();
-            let adapter_features = adapter.features();
-            assert!(
-                adapter_features.contains(required_features),
-                "Adapter does not support required features for this example: {:?}",
-                required_features - adapter_features
-            );
-
-            let required_downlevel_capabilities = E::required_downlevel_capabilities();
-            let downlevel_capabilities = adapter.get_downlevel_capabilities();
-            assert!(
-                downlevel_capabilities.shader_model >= required_downlevel_capabilities.shader_model,
-                "Adapter does not support the minimum shader model required to run this example: {:?}",
-                required_downlevel_capabilities.shader_model
-            );
-            assert!(
-                downlevel_capabilities
-                    .flags
-                    .contains(required_downlevel_capabilities.flags),
-                "Adapter does not support the downlevel capabilities required to run this example: {:?}",
-                required_downlevel_capabilities.flags - downlevel_capabilities.flags
-            );
-            adapter
-        } else {
-            let adapters = instance.enumerate_adapters(Backends::all());
-
-            let mut chosen_adapter = None;
-            for adapter in adapters {
-                if let Some(surface) = surface.get() {
-                    if !adapter.is_surface_supported(surface) {
-                        continue;
-                    }
-                }
-
-                let required_features = E::required_features();
-                let adapter_features = adapter.features();
-                if !adapter_features.contains(required_features) {
-                    continue;
-                } else {
-                    chosen_adapter = Some(adapter);
-                    break;
-                }
-            }
-
-            chosen_adapter.expect("No suitable GPU adapters found on the system!")
-        };
-
+        let adapter = get_adapter_with_capabilities_or_from_env(
+            &instance,
+            &E::required_features(),
+            &E::required_downlevel_capabilities(),
+            &surface.get(),
+        )
+        .await;
         // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the surface.
         let needed_limits = E::required_limits().using_resolution(adapter.limits());
 
@@ -540,6 +490,8 @@ pub fn parse_url_query_string<'a>(query: &'a str, search_key: &str) -> Option<&'
 
 #[cfg(test)]
 pub use wgpu_test::image::ComparisonType;
+
+use crate::utils::get_adapter_with_capabilities_or_from_env;
 
 #[cfg(test)]
 #[derive(Clone)]

--- a/examples/src/utils.rs
+++ b/examples/src/utils.rs
@@ -158,6 +158,9 @@ fn create_output_image_element(document: &web_sys::Document) -> web_sys::HtmlIma
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+/// If the environment variable `WGPU_ADAPTER_NAME` is set, this function will attempt to
+/// initialize the adapter with that name. If it is not set, it will attempt to initialize
+/// the adapter which supports the required features.
 pub(crate) async fn get_adapter_with_capabilities_or_from_env(
     instance: &wgpu::Instance,
     required_features: &wgpu::Features,

--- a/examples/src/utils.rs
+++ b/examples/src/utils.rs
@@ -156,3 +156,102 @@ fn create_output_image_element(document: &web_sys::Document) -> web_sys::HtmlIma
     log::info!("Created new output target image: {:?}", &new_image);
     new_image
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) async fn get_adapter_with_capabilities_or_from_env(
+    instance: &wgpu::Instance,
+    required_features: &wgpu::Features,
+    required_downlevel_capabilities: &wgpu::DownlevelCapabilities,
+    surface: &Option<&wgpu::Surface<'_>>,
+) -> wgpu::Adapter {
+    use wgpu::Backends;
+    if std::env::var("WGPU_ADAPTER_NAME").is_ok() {
+        let adapter = wgpu::util::initialize_adapter_from_env_or_default(instance, *surface)
+            .await
+            .expect("No suitable GPU adapters found on the system!");
+
+        let adapter_info = adapter.get_info();
+        log::info!("Using {} ({:?})", adapter_info.name, adapter_info.backend);
+
+        let adapter_features = adapter.features();
+        assert!(
+            adapter_features.contains(*required_features),
+            "Adapter does not support required features for this example: {:?}",
+            *required_features - adapter_features
+        );
+
+        let downlevel_capabilities = adapter.get_downlevel_capabilities();
+        assert!(
+            downlevel_capabilities.shader_model >= required_downlevel_capabilities.shader_model,
+            "Adapter does not support the minimum shader model required to run this example: {:?}",
+            required_downlevel_capabilities.shader_model
+        );
+        assert!(
+                downlevel_capabilities
+                    .flags
+                    .contains(required_downlevel_capabilities.flags),
+                "Adapter does not support the downlevel capabilities required to run this example: {:?}",
+                required_downlevel_capabilities.flags - downlevel_capabilities.flags
+            );
+        adapter
+    } else {
+        let adapters = instance.enumerate_adapters(Backends::all());
+
+        let mut chosen_adapter = None;
+        for adapter in adapters {
+            if let Some(surface) = surface {
+                if !adapter.is_surface_supported(surface) {
+                    continue;
+                }
+            }
+
+            let required_features = *required_features;
+            let adapter_features = adapter.features();
+            if !adapter_features.contains(required_features) {
+                continue;
+            } else {
+                chosen_adapter = Some(adapter);
+                break;
+            }
+        }
+
+        chosen_adapter.expect("No suitable GPU adapters found on the system!")
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn get_adapter_with_capabilities_or_from_env(
+    instance: &wgpu::Instance,
+    required_features: &wgpu::Features,
+    required_downlevel_capabilities: &wgpu::DownlevelCapabilities,
+    surface: &Option<&wgpu::Surface<'_>>,
+) -> wgpu::Adapter {
+    let adapter = wgpu::util::initialize_adapter_from_env_or_default(instance, *surface)
+        .await
+        .expect("No suitable GPU adapters found on the system!");
+
+    let adapter_info = adapter.get_info();
+    log::info!("Using {} ({:?})", adapter_info.name, adapter_info.backend);
+
+    let adapter_features = adapter.features();
+    assert!(
+        adapter_features.contains(*required_features),
+        "Adapter does not support required features for this example: {:?}",
+        *required_features - adapter_features
+    );
+
+    let downlevel_capabilities = adapter.get_downlevel_capabilities();
+    assert!(
+        downlevel_capabilities.shader_model >= required_downlevel_capabilities.shader_model,
+        "Adapter does not support the minimum shader model required to run this example: {:?}",
+        required_downlevel_capabilities.shader_model
+    );
+    assert!(
+        downlevel_capabilities
+            .flags
+            .contains(required_downlevel_capabilities.flags),
+        "Adapter does not support the downlevel capabilities required to run this example: {:?}",
+        required_downlevel_capabilities.flags - downlevel_capabilities.flags
+    );
+    adapter
+}


### PR DESCRIPTION
**Connections**
fixes #6522 

**Description**
This is my first time contributing to this project, so it may be that I'm doing something wrong. Essentially, we retain the old behavior if we use the environment variable to select our gpu. Otherwise we first try to match required features prior to selecting an adapter.

**Testing**

Just run the example as done before.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
