### PR TITLE
[naga spv-out] Handle nested arrays when adding matrix decorations

### DIFF
--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -1800,12 +1800,13 @@ impl Writer {
             }
         }
 
-        // Matrices and arrays of matrices both require decorations,
-        // so "see through" an array to determine if they're needed.
-        let member_array_subty_inner = match arena[member.ty].inner {
-            crate::TypeInner::Array { base, .. } => &arena[base].inner,
-            ref other => other,
-        };
+        // Matrices and (potentially nested) arrays of matrices both require decorations,
+        // so "see through" any arrays to determine if they're needed.
+        let mut member_array_subty_inner = &arena[member.ty].inner;
+        while let crate::TypeInner::Array { base, .. } = *member_array_subty_inner {
+            member_array_subty_inner = &arena[base].inner;
+        }
+
         if let crate::TypeInner::Matrix {
             columns: _,
             rows,

--- a/naga/tests/out/spv/globals.spvasm
+++ b/naga/tests/out/spv/globals.spvasm
@@ -44,10 +44,14 @@ OpDecorate %45 DescriptorSet 0
 OpDecorate %45 Binding 6
 OpDecorate %46 Block
 OpMemberDecorate %46 0 Offset 0
+OpMemberDecorate %46 0 ColMajor
+OpMemberDecorate %46 0 MatrixStride 16
 OpDecorate %48 DescriptorSet 0
 OpDecorate %48 Binding 7
 OpDecorate %49 Block
 OpMemberDecorate %49 0 Offset 0
+OpMemberDecorate %49 0 ColMajor
+OpMemberDecorate %49 0 MatrixStride 8
 OpDecorate %116 BuiltIn LocalInvocationId
 %2 = OpTypeVoid
 %3 = OpTypeBool


### PR DESCRIPTION
**Connections**
Fixes #6307 

**Description**

Previously we only checked whether the outermost array's subtype was a Matrix when determining whether to add ColMajor and MatrixStride decorations, meaning arrays of arrays of matrices would not be decorated. This makes us keep looking until we find a non-array subtype.

**Testing**
`cargo xtask validate spv` now passes

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
