### PR TITLE
Static linking for DXC via mach-dxcompiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 
 - Return submission index in `map_async` and `on_submitted_work_done` to track down completion of async callbacks. By @eliemichel in [#6360](https://github.com/gfx-rs/wgpu/pull/6360).
 - Move raytracing alignments into HAL instead of in core. By @Vecvec in [#6563](https://github.com/gfx-rs/wgpu/pull/6563).
+- Allow for statically linking DXC rather than including separate `.dll` files. By @DouglasDwyer in [#6574](https://github.com/gfx-rs/wgpu/pull/6574).
 
 ### Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "mach-dxcompiler-rs"
-version = "0.1.0+2024.11.22-df583a3.1"
+version = "0.1.2+2024.11.22-df583a3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1adb8f5a21376264c903e4b6b0b5deb97236ccf8c49d9bd7e557bfe7d241388"
+checksum = "a30a333be477f592794a1c1c5739b1a64021ec0e5fb10a1bb5f0feab5b913f5f"
 
 [[package]]
 name = "malloc_buf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,12 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "mach-dxcompiler-rs"
-version = "2023.12.14+0b7073b.1"
+version = "0.1.0+2024.11.22-df583a3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7857414cb65eb5f03cf0365ac801f089fdbfbb0c47f3f257941eda735aebdf"
-dependencies = [
- "windows-core",
-]
+checksum = "f1adb8f5a21376264c903e4b6b0b5deb97236ccf8c49d9bd7e557bfe7d241388"
 
 [[package]]
 name = "malloc_buf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach-dxcompiler-rs"
+version = "2023.12.14+0b7073b.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7857414cb65eb5f03cf0365ac801f089fdbfbb0c47f3f257941eda735aebdf"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3692,6 +3701,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
+ "mach-dxcompiler-rs",
  "metal",
  "naga",
  "ndk-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ gpu-descriptor = "0.3"
 bit-set = "0.8"
 gpu-allocator = { version = "0.27", default-features = false }
 range-alloc = "0.1"
-mach-dxcompiler-rs = { version = "2023.12.14+0b7073b.1", default-features = false }
+mach-dxcompiler-rs = { version = "0.1.0", default-features = false }
 windows-core = { version = "0.58", default-features = false }
 
 # Gles dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ gpu-descriptor = "0.3"
 bit-set = "0.8"
 gpu-allocator = { version = "0.27", default-features = false }
 range-alloc = "0.1"
+mach-dxcompiler-rs = { version = "2023.12.14+0b7073b.1", default-features = false }
 windows-core = { version = "0.58", default-features = false }
 
 # Gles dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ gpu-descriptor = "0.3"
 bit-set = "0.8"
 gpu-allocator = { version = "0.27", default-features = false }
 range-alloc = "0.1"
-mach-dxcompiler-rs = { version = "0.1.0", default-features = false }
+mach-dxcompiler-rs = { version = "0.1.2", default-features = false }
 windows-core = { version = "0.58", default-features = false }
 
 # Gles dependencies

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ All testing and example infrastructure share the same set of environment variabl
 - `WGPU_ADAPTER_NAME` with a substring of the name of the adapter you want to use (ex. `1080` will match `NVIDIA GeForce 1080ti`).
 - `WGPU_BACKEND` with a comma-separated list of the backends you want to use (`vulkan`, `metal`, `dx12`, or `gl`).
 - `WGPU_POWER_PREF` with the power preference to choose when a specific adapter name isn't specified (`high`, `low` or `none`)
-- `WGPU_DX12_COMPILER` with the DX12 shader compiler you wish to use (`dxc` or `fxc`, note that `dxc` requires `dxil.dll` and `dxcompiler.dll` to be in the working directory otherwise it will fall back to `fxc`)
+- `WGPU_DX12_COMPILER` with the DX12 shader compiler you wish to use (`dxc`, `static-dxc`, or `fxc`). Note that `dxc` requires `dxil.dll` and `dxcompiler.dll` to be in the working directory, and `static-dxc` requires the `static-dxc` crate feature to be enabled. Otherwise, it will fall back to `fxc`.
 - `WGPU_GLES_MINOR_VERSION` with the minor OpenGL ES 3 version number to request (`0`, `1`, `2` or `automatic`).
 - `WGPU_ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER` with a boolean whether non-compliant drivers are enumerated (`0` for false, `1` for true).
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -91,8 +91,8 @@ dx12 = [
     "windows/Win32_System_Threading",
     "windows/Win32_UI_WindowsAndMessaging",
 ]
-## Enables the static DXC compiler using the `mach-dxcompiler-rs` crate.
-mach-dxcompiler-rs = ["dep:mach-dxcompiler-rs"]
+## Enables statically linking DXC.
+static-dxc = ["dep:mach-dxcompiler-rs"]
 renderdoc = ["dep:libloading", "dep:renderdoc-sys"]
 fragile-send-sync-non-atomic-wasm = ["wgt/fragile-send-sync-non-atomic-wasm"]
 # Panic when running into an out-of-memory error (for debugging purposes).

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -91,6 +91,8 @@ dx12 = [
     "windows/Win32_System_Threading",
     "windows/Win32_UI_WindowsAndMessaging",
 ]
+## Enables the static DXC compiler using the `mach-dxcompiler-rs` crate.
+mach-dxcompiler-rs = ["dep:mach-dxcompiler-rs"]
 renderdoc = ["dep:libloading", "dep:renderdoc-sys"]
 fragile-send-sync-non-atomic-wasm = ["wgt/fragile-send-sync-non-atomic-wasm"]
 # Panic when running into an out-of-memory error (for debugging purposes).
@@ -158,6 +160,7 @@ windows = { workspace = true, optional = true }
 bit-set = { workspace = true, optional = true }
 range-alloc = { workspace = true, optional = true }
 gpu-allocator = { workspace = true, optional = true }
+mach-dxcompiler-rs = { workspace = true, optional = true }
 # For core macros. This crate is also reexported as windows::core.
 windows-core = { workspace = true, optional = true }
 

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -239,7 +239,7 @@ impl<A: hal::Api> Example<A> {
         let instance_desc = hal::InstanceDescriptor {
             name: "example",
             flags: wgt::InstanceFlags::default(),
-            dx12_shader_compiler: wgt::Dx12Compiler::Dxc {
+            dx12_shader_compiler: wgt::Dx12Compiler::DynamicDxc {
                 dxil_path: None,
                 dxc_path: None,
             },

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -80,10 +80,22 @@ impl crate::Instance for super::Instance {
                 dxil_path,
                 dxc_path,
             } => {
-                let container = super::shader_compilation::get_dxc_container(dxc_path, dxil_path)
-                    .map_err(|e| {
-                    crate::InstanceError::with_source(String::from("Failed to load DXC"), e)
-                })?;
+                let container =
+                    super::shader_compilation::get_dynamic_dxc_container(dxc_path, dxil_path)
+                        .map_err(|e| {
+                            crate::InstanceError::with_source(String::from("Failed to load DXC"), e)
+                        })?;
+
+                container.map(Arc::new)
+            }
+            wgt::Dx12Compiler::MachDxc => {
+                let container =
+                    super::shader_compilation::get_mach_dxc_container().map_err(|e| {
+                        crate::InstanceError::with_source(
+                            String::from("Failed to load Mach DXC"),
+                            e,
+                        )
+                    })?;
 
                 container.map(Arc::new)
             }

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -76,23 +76,26 @@ impl crate::Instance for super::Instance {
 
         // Initialize DXC shader compiler
         let dxc_container = match desc.dx12_shader_compiler.clone() {
-            wgt::Dx12Compiler::Dxc {
+            wgt::Dx12Compiler::DynamicDxc {
                 dxil_path,
                 dxc_path,
             } => {
                 let container =
                     super::shader_compilation::get_dynamic_dxc_container(dxc_path, dxil_path)
                         .map_err(|e| {
-                            crate::InstanceError::with_source(String::from("Failed to load DXC"), e)
+                            crate::InstanceError::with_source(
+                                String::from("Failed to load dynamic DXC"),
+                                e,
+                            )
                         })?;
 
                 container.map(Arc::new)
             }
-            wgt::Dx12Compiler::MachDxc => {
+            wgt::Dx12Compiler::StaticDxc => {
                 let container =
-                    super::shader_compilation::get_mach_dxc_container().map_err(|e| {
+                    super::shader_compilation::get_static_dxc_container().map_err(|e| {
                         crate::InstanceError::with_source(
-                            String::from("Failed to load Mach DXC"),
+                            String::from("Failed to load static DXC"),
                             e,
                         )
                     })?;

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -198,9 +198,9 @@ pub(super) fn get_dynamic_dxc_container(
     }))
 }
 
-/// Creates a [`DxcContainer`] that delegates to the statically-linked `mach-dxcompiler` library.
-pub(super) fn get_mach_dxc_container() -> Result<Option<DxcContainer>, crate::DeviceError> {
-    #[cfg(feature = "mach-dxcompiler-rs")]
+/// Creates a [`DxcContainer`] that delegates to the statically-linked version of DXC.
+pub(super) fn get_static_dxc_container() -> Result<Option<DxcContainer>, crate::DeviceError> {
+    #[cfg(feature = "static-dxc")]
     {
         unsafe {
             let compiler = dxc_create_instance::<Dxc::IDxcCompiler3>(|clsid, iid, ppv| {
@@ -227,9 +227,9 @@ pub(super) fn get_mach_dxc_container() -> Result<Option<DxcContainer>, crate::De
             }))
         }
     }
-    #[cfg(not(feature = "mach-dxcompiler-rs"))]
+    #[cfg(not(feature = "static-dxc"))]
     {
-        panic!("Attempted to create a Mach DXC shader compiler, but the mach-dxcompiler-rs feature was not enabled")
+        panic!("Attempted to create a static DXC shader compiler, but the static-dxc feature was not enabled")
     }
 }
 

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -300,8 +300,11 @@ pub(super) fn compile_dxc(
         windows::core::w!("2018"), // Use HLSL 2018, Naga doesn't supported 2021 yet.
         windows::core::w!("-no-warnings"),
         Dxc::DXC_ARG_ENABLE_STRICTNESS,
-        Dxc::DXC_ARG_SKIP_VALIDATION, // Disable implicit validation to work around bugs when dxil.dll isn't in the local directory.
     ]);
+
+    if dxc_container.validator.is_some() {
+        compile_args.push(Dxc::DXC_ARG_SKIP_VALIDATION); // Disable implicit validation to work around bugs when dxil.dll isn't in the local directory.)
+    }
 
     if device
         .private_caps

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7401,6 +7401,9 @@ pub enum Dx12Compiler {
         /// Path to the `dxcompiler.dll` file, or path to the directory containing `dxcompiler.dll` file. Passing `None` will use standard platform specific dll loading rules.
         dxc_path: Option<PathBuf>,
     },
+    /// The statically-linked variant of Dxc, sourced from the [`mach-dxcompiler-rs`](https://crates.io/crates/mach-dxcompiler-rs) crate.
+    /// The `mach-dxcompiler-rs` feature is required to use this.
+    MachDxc,
 }
 
 /// Selects which OpenGL ES 3 minor version to request.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7395,15 +7395,15 @@ pub enum Dx12Compiler {
     /// Minimum supported version: [v1.5.2010](https://github.com/microsoft/DirectXShaderCompiler/releases/tag/v1.5.2010)
     ///
     /// It also requires WDDM 2.1 (Windows 10 version 1607).
-    Dxc {
+    DynamicDxc {
         /// Path to the `dxil.dll` file, or path to the directory containing `dxil.dll` file. Passing `None` will use standard platform specific dll loading rules.
         dxil_path: Option<PathBuf>,
         /// Path to the `dxcompiler.dll` file, or path to the directory containing `dxcompiler.dll` file. Passing `None` will use standard platform specific dll loading rules.
         dxc_path: Option<PathBuf>,
     },
-    /// The statically-linked variant of Dxc, sourced from the [`mach-dxcompiler-rs`](https://crates.io/crates/mach-dxcompiler-rs) crate.
-    /// The `mach-dxcompiler-rs` feature is required to use this.
-    MachDxc,
+    /// The statically-linked variant of Dxc.
+    /// The `static-dxc` feature is required to use this.
+    StaticDxc,
 }
 
 /// Selects which OpenGL ES 3 minor version to request.

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -73,6 +73,9 @@ glsl = ["naga/glsl-in", "wgc/glsl"]
 ## Enable accepting WGSL shaders as input.
 wgsl = ["wgc?/wgsl"]
 
+## Enables the static DXC compiler using the `mach-dxcompiler-rs` crate.
+mach-dxcompiler-rs = ["hal/mach-dxcompiler-rs"]
+
 ## Enable accepting naga IR shaders as input.
 naga-ir = ["dep:naga"]
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -73,9 +73,6 @@ glsl = ["naga/glsl-in", "wgc/glsl"]
 ## Enable accepting WGSL shaders as input.
 wgsl = ["wgc?/wgsl"]
 
-## Enables the static DXC compiler using the `mach-dxcompiler-rs` crate.
-mach-dxcompiler-rs = ["hal/mach-dxcompiler-rs"]
-
 ## Enable accepting naga IR shaders as input.
 naga-ir = ["dep:naga"]
 
@@ -119,6 +116,18 @@ fragile-send-sync-non-atomic-wasm = [
     "wgc/fragile-send-sync-non-atomic-wasm",
     "wgt/fragile-send-sync-non-atomic-wasm",
 ]
+
+
+#! ### External libraries
+# --------------------------------------------------------------------
+#! The following features facilitate integration with third-party supporting libraries.
+
+## Enables statically linking DXC.
+## Normally, to use the modern DXC shader compiler with WGPU, the final application
+## must be shipped alongside `dxcompiler.dll` and `dxil.dll` (which can be downloaded from Microsoft's GitHub).
+## This feature statically links a version of DXC so that no external binaries are required
+## to compile DX12 shaders.
+static-dxc = ["hal/static-dxc"]
 
 # wgpu-core is always available as an optional dependency, "wgc".
 # Whenever wgpu-core is selected, we want raw window handle support.

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -107,7 +107,7 @@ pub fn dx12_shader_compiler_from_env() -> Option<wgt::Dx12Compiler> {
             .map(str::to_lowercase)
             .as_deref()
         {
-            Ok("dxc") => wgt::Dx12Compiler::Dxc {
+            Ok("dxc") => wgt::Dx12Compiler::DynamicDxc {
                 dxil_path: None,
                 dxc_path: None,
             },

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -111,6 +111,8 @@ pub fn dx12_shader_compiler_from_env() -> Option<wgt::Dx12Compiler> {
                 dxil_path: None,
                 dxc_path: None,
             },
+            #[cfg(feature = "static-dxc")]
+            Ok("static-dxc") => wgt::Dx12Compiler::StaticDxc,
             Ok("fxc") => wgt::Dx12Compiler::Fxc,
             _ => return None,
         },


### PR DESCRIPTION
**Connections**
- resolves https://github.com/gfx-rs/wgpu/issues/6499
- https://github.com/gfx-rs/wgpu/issues/2719

**Description**
This PR adds support for statically linking the DXC binaries from [`mach-dxcompiler`](https://github.com/hexops/mach-dxcompiler). The `mach-dxcompiler` repo replaces Microsoft's DXC build system with Zig, which allows for building DXC as a static `.lib` file. I have created an upstream crate called [`mach-dxcompiler-rs`](https://crates.io/crates/mach-dxcompiler-rs) that handles downloading a prebuilt `mach-dxcompiler` binary and linking it into a Rust project (ideally, it would be built from source, but that was too complicated for my purposes - it can be added later if desired).

This PR adds a dependency on `mach-dxcompiler-rs`, gated behind the `mach-dxcompiler-rs` feature flag. When enabled, it allows for specifying `dx12_shader_compiler: Dx12Compiler::MachDxc` in the `InstanceDescriptor`. **This allows for using DXC in WGPU without having to ship any external `.dll`s alongside the main binary.**

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - (n/a) `--target wasm32-unknown-unknown`
  - (n/a) `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
