### PR TITLE
fix(core): validate `dst_buffer` isn't destroyed when resolving query sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,8 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Lower `QUERY_SET_MAX_QUERIES` (and enforced limits) from 8192 to 4096 to match WebGPU spec. By @ErichDonGubler in [#6525](https://github.com/gfx-rs/wgpu/pull/6525).
 - Allow non-filterable float on texture bindings never used with samplers when using a derived bind group layout. By @ErichDonGubler in [#6531](https://github.com/gfx-rs/wgpu/pull/6531/).
 - Replace potentially unsound usage of `PreHashedMap` with `FastHashMap`. By @jamienicol in [#6541](https://github.com/gfx-rs/wgpu/pull/6541).
+- Add missing validation for timestamp writes in compute and render passes. By @ErichDonGubler in [#6578](https://github.com/gfx-rs/wgpu/pull/6578).
+  - Check the status of the `TIMESTAMP_QUERY` feature before other validation.
 
 #### Naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Add missing validation for timestamp writes in compute and render passes. By @ErichDonGubler in [#6578](https://github.com/gfx-rs/wgpu/pull/6578).
   - Check the status of the `TIMESTAMP_QUERY` feature before other validation.
   - Check that indices are in-bounds for the query set.
+  - Check that begin and end indices are not equal.
 
 #### Naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
   - Check the status of the `TIMESTAMP_QUERY` feature before other validation.
   - Check that indices are in-bounds for the query set.
   - Check that begin and end indices are not equal.
+- Reject destroyed buffers in query set resolution. By @ErichDonGubler in [#6579](https://github.com/gfx-rs/wgpu/pull/6579).
 
 #### Naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Replace potentially unsound usage of `PreHashedMap` with `FastHashMap`. By @jamienicol in [#6541](https://github.com/gfx-rs/wgpu/pull/6541).
 - Add missing validation for timestamp writes in compute and render passes. By @ErichDonGubler in [#6578](https://github.com/gfx-rs/wgpu/pull/6578).
   - Check the status of the `TIMESTAMP_QUERY` feature before other validation.
+  - Check that indices are in-bounds for the query set.
 
 #### Naga
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -345,6 +345,15 @@ impl Global {
                 }
             }
 
+            if let Some((begin, end)) = beginning_of_pass_write_index.zip(end_of_pass_write_index) {
+                if begin == end {
+                    return make_err(
+                        CommandEncoderError::TimestampWriteIndicesEqual { idx: begin },
+                        arc_desc,
+                    );
+                }
+            }
+
             Some(ArcPassTimestampWrites {
                 query_set,
                 beginning_of_pass_write_index,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -335,6 +335,16 @@ impl Global {
                 Err(e) => return make_err(e.into(), arc_desc),
             }
 
+            for idx in [beginning_of_pass_write_index, end_of_pass_write_index]
+                .into_iter()
+                .flatten()
+            {
+                match query_set.validate_query(SimplifiedQueryType::Timestamp, idx, None) {
+                    Ok(()) => (),
+                    Err(e) => return make_err(e.into(), arc_desc),
+                }
+            }
+
             Some(ArcPassTimestampWrites {
                 query_set,
                 beginning_of_pass_write_index,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -309,18 +309,20 @@ impl Global {
         };
 
         arc_desc.timestamp_writes = if let Some(tw) = desc.timestamp_writes {
-            let query_set = match hub.query_sets.get(tw.query_set).get() {
-                Ok(query_set) => query_set,
-                Err(e) => return make_err(e.into(), arc_desc),
-            };
-            match query_set.same_device(&cmd_buf.device) {
-                Ok(()) => (),
-                Err(e) => return make_err(e.into(), arc_desc),
-            }
             match cmd_buf
                 .device
                 .require_features(wgt::Features::TIMESTAMP_QUERY)
             {
+                Ok(()) => (),
+                Err(e) => return make_err(e.into(), arc_desc),
+            }
+
+            let query_set = match hub.query_sets.get(tw.query_set).get() {
+                Ok(query_set) => query_set,
+                Err(e) => return make_err(e.into(), arc_desc),
+            };
+
+            match query_set.same_device(&cmd_buf.device) {
                 Ok(()) => (),
                 Err(e) => return make_err(e.into(), arc_desc),
             }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -654,6 +654,8 @@ pub enum CommandEncoderError {
     InvalidResource(#[from] InvalidResourceError),
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
+    #[error(transparent)]
+    TimestampWritesInvalid(#[from] QueryUseError),
 }
 
 impl Global {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -654,6 +654,10 @@ pub enum CommandEncoderError {
     InvalidResource(#[from] InvalidResourceError),
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
+    #[error(
+        "begin and end indices of pass timestamp writes are both set to {idx}, which is not allowed"
+    )]
+    TimestampWriteIndicesEqual { idx: u32 },
     #[error(transparent)]
     TimestampWritesInvalid(#[from] QueryUseError),
 }

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -160,7 +160,7 @@ pub enum ResolveError {
 }
 
 impl QuerySet {
-    fn validate_query(
+    pub(crate) fn validate_query(
         self: &Arc<Self>,
         query_type: SimplifiedQueryType,
         query_index: u32,

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -387,12 +387,13 @@ impl Global {
 
         dst_buffer.same_device_as(cmd_buf.as_ref())?;
 
+        let snatch_guard = dst_buffer.device.snatchable_lock.read();
+        dst_buffer.check_destroyed(&snatch_guard)?;
+
         let dst_pending = cmd_buf_data
             .trackers
             .buffers
             .set_single(&dst_buffer, hal::BufferUses::COPY_DST);
-
-        let snatch_guard = dst_buffer.device.snatchable_lock.read();
 
         let dst_barrier = dst_pending.map(|pending| pending.into_hal(&dst_buffer, &snatch_guard));
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1,6 +1,7 @@
 use crate::binding_model::BindGroup;
 use crate::command::{
     validate_and_begin_occlusion_query, validate_and_begin_pipeline_statistics_query,
+    SimplifiedQueryType,
 };
 use crate::init_tracker::BufferInitTrackerAction;
 use crate::pipeline::RenderPipeline;
@@ -1403,6 +1404,13 @@ impl Global {
                 device.require_features(wgt::Features::TIMESTAMP_QUERY)?;
 
                 query_set.same_device(device)?;
+
+                for idx in [beginning_of_pass_write_index, end_of_pass_write_index]
+                    .into_iter()
+                    .flatten()
+                {
+                    query_set.validate_query(SimplifiedQueryType::Timestamp, idx, None)?;
+                }
 
                 Some(ArcPassTimestampWrites {
                     query_set,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1412,6 +1412,14 @@ impl Global {
                     query_set.validate_query(SimplifiedQueryType::Timestamp, idx, None)?;
                 }
 
+                if let Some((begin, end)) =
+                    beginning_of_pass_write_index.zip(end_of_pass_write_index)
+                {
+                    if begin == end {
+                        return Err(CommandEncoderError::TimestampWriteIndicesEqual { idx: begin });
+                    }
+                }
+
                 Some(ArcPassTimestampWrites {
                     query_set,
                     beginning_of_pass_write_index,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1393,9 +1393,10 @@ impl Global {
 
             arc_desc.timestamp_writes = if let Some(tw) = desc.timestamp_writes {
                 let query_set = query_sets.get(tw.query_set).get()?;
-                query_set.same_device(device)?;
 
                 device.require_features(wgt::Features::TIMESTAMP_QUERY)?;
+
+                query_set.same_device(device)?;
 
                 Some(ArcPassTimestampWrites {
                     query_set,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1392,7 +1392,13 @@ impl Global {
                 };
 
             arc_desc.timestamp_writes = if let Some(tw) = desc.timestamp_writes {
-                let query_set = query_sets.get(tw.query_set).get()?;
+                let &PassTimestampWrites {
+                    query_set,
+                    beginning_of_pass_write_index,
+                    end_of_pass_write_index,
+                } = tw;
+
+                let query_set = query_sets.get(query_set).get()?;
 
                 device.require_features(wgt::Features::TIMESTAMP_QUERY)?;
 
@@ -1400,8 +1406,8 @@ impl Global {
 
                 Some(ArcPassTimestampWrites {
                     query_set,
-                    beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
-                    end_of_pass_write_index: tw.end_of_pass_write_index,
+                    beginning_of_pass_write_index,
+                    end_of_pass_write_index,
                 })
             } else {
                 None


### PR DESCRIPTION
**Connections**

- [Firefox bug 1931929](https://bugzilla.mozilla.org/show_bug.cgi?id=1931929)

**Description**

We should be checking that the buffer query that query sets will be resolved into are, in fact, not destroyed. Do it!

**Testing**

- CTS: `webgpu:api,validation,encoding,beginComputePass:timestampWrites,invalid_query_set:querySetState="invalid"`
- In-tree coverage has been punted to #6578.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
