### PR TITLE
Validate that at least one index must be specified in pass timestamp writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,10 +131,11 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Lower `QUERY_SET_MAX_QUERIES` (and enforced limits) from 8192 to 4096 to match WebGPU spec. By @ErichDonGubler in [#6525](https://github.com/gfx-rs/wgpu/pull/6525).
 - Allow non-filterable float on texture bindings never used with samplers when using a derived bind group layout. By @ErichDonGubler in [#6531](https://github.com/gfx-rs/wgpu/pull/6531/).
 - Replace potentially unsound usage of `PreHashedMap` with `FastHashMap`. By @jamienicol in [#6541](https://github.com/gfx-rs/wgpu/pull/6541).
-- Add missing validation for timestamp writes in compute and render passes. By @ErichDonGubler in [#6578](https://github.com/gfx-rs/wgpu/pull/6578).
+- Add missing validation for timestamp writes in compute and render passes. By @ErichDonGubler in [#6578](https://github.com/gfx-rs/wgpu/pull/6578), [#6583](https://github.com/gfx-rs/wgpu/pull/6583).
   - Check the status of the `TIMESTAMP_QUERY` feature before other validation.
   - Check that indices are in-bounds for the query set.
   - Check that begin and end indices are not equal.
+  - Check that at least one index is specified.
 - Reject destroyed buffers in query set resolution. By @ErichDonGubler in [#6579](https://github.com/gfx-rs/wgpu/pull/6579).
 
 #### Naga

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -354,6 +354,13 @@ impl Global {
                 }
             }
 
+            if beginning_of_pass_write_index
+                .or(end_of_pass_write_index)
+                .is_none()
+            {
+                return make_err(CommandEncoderError::TimestampWriteIndicesMissing, arc_desc);
+            }
+
             Some(ArcPassTimestampWrites {
                 query_set,
                 beginning_of_pass_write_index,

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -660,6 +660,8 @@ pub enum CommandEncoderError {
     TimestampWriteIndicesEqual { idx: u32 },
     #[error(transparent)]
     TimestampWritesInvalid(#[from] QueryUseError),
+    #[error("no begin or end indices were specified for pass timestamp writes, expected at least one to be set")]
+    TimestampWriteIndicesMissing,
 }
 
 impl Global {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1420,6 +1420,13 @@ impl Global {
                     }
                 }
 
+                if beginning_of_pass_write_index
+                    .or(end_of_pass_write_index)
+                    .is_none()
+                {
+                    return Err(CommandEncoderError::TimestampWriteIndicesMissing);
+                }
+
                 Some(ArcPassTimestampWrites {
                     query_set,
                     beginning_of_pass_write_index,


### PR DESCRIPTION
**Connections**

- Follow-up to testing #6578 and #6579.

**Description**

_**Recommended review experience is commit-by-commit. Each individual commit should pass CI!**_ 

**Testing**

- CTS: `webgpu:api,validation,encoding,beginComputePass:timestampWrites,query_index: beginningOfPassWriteIndex="_undef_";endOfPassWriteIndex="_undef_"`

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
