### PR TITLE
Add `device_unregister_device_lost_closure`

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2104,7 +2104,10 @@ impl Global {
 
     pub fn device_unregister_device_lost_closure(&self, device_id: DeviceId) {
         let device = self.hub.devices.get(device_id);
-        device.device_lost_closure.lock().take();
+        let closure = device.device_lost_closure.lock().take();
+        if let Some(closure) = closure {
+            closure.call(DeviceLostReason::ReplacedCallback, "".to_string());
+        }
     }
 
     pub fn device_destroy(&self, device_id: DeviceId) {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2102,6 +2102,11 @@ impl Global {
         }
     }
 
+    pub fn device_unregister_device_lost_closure(&self, device_id: DeviceId) {
+        let device = self.hub.devices.get(device_id);
+        device.device_lost_closure.lock().take();
+    }
+
     pub fn device_destroy(&self, device_id: DeviceId) {
         api_log!("Device::destroy {device_id:?}");
 


### PR DESCRIPTION
Firefox needs this to be able to unregister the callback prior to dropping its handle of the device.

Unblocks [Bug 1930751](https://bugzilla.mozilla.org/show_bug.cgi?id=1930751).