### PR TITLE
Track v23.0.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ Bottom level categories:
 
 ## Unreleased
 
+## 23.1.0 (2024-11-??)
+
+### Bug fixes
+
+#### Metal
+
+- Fix surface creation crashing on iOS. By @mockersf in [#6535](https://github.com/gfx-rs/wgpu/pull/6535)
+
 ## 23.0.0 (2024-10-25)
 
 ### Themes of this release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,10 @@ Bottom level categories:
 
 ## Unreleased
 
-## 23.0.1 (2024-11-24)
+## 23.0.1 (2024-11-25)
 
-This release includes `wgpu`, `wgpu-core` and `wgpu-hal`. All other crates remain at 23.0.0.
-Below changes were cherry-picked from 23.0.0.
+This release includes patches for `wgpu`, `wgpu-core` and `wgpu-hal`. All other crates remain at [23.0.0](https://github.com/gfx-rs/wgpu/releases/tag/v23.0.0).
+Below changes were cherry-picked from 24.0.0 development line.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
-## 23.1.0 (2024-11-??)
+## 23.0.1 (2024-11-24)
+
+This release includes `wgpu`, `wgpu-core` and `wgpu-hal`. All other crates remain at 23.0.0.
+Below changes were cherry-picked from 23.0.0.
 
 ### Bug fixes
-
 
 #### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ Bottom level categories:
 
 - Fix surface creation crashing on iOS. By @mockersf in [#6535](https://github.com/gfx-rs/wgpu/pull/6535)
 
+#### Vulkan
+
+- Fix surface capabilities being advertised when its query failed. By @wumpf in [#6510](https://github.com/gfx-rs/wgpu/pull/6510)
+
 ## 23.0.0 (2024-10-25)
 
 ### Themes of this release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ Bottom level categories:
 
 ### Bug fixes
 
+
+#### General
+
+- Fix Texture view leaks regression. By @xiaopengli89 in [#6576](https://github.com/gfx-rs/wgpu/pull/6576)
+
 #### Metal
 
 - Fix surface creation crashing on iOS. By @mockersf in [#6535](https://github.com/gfx-rs/wgpu/pull/6535)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,7 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock-analyzer"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "anyhow",
  "ron",
@@ -2271,7 +2271,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "player"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "env_logger",
  "log",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "arrayvec",
  "cfg_aliases",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-benchmark"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3605,7 +3605,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-examples"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-info"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-macros"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-test"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 homepage = "https://wgpu.rs/"
 repository = "https://github.com/gfx-rs/wgpu"
-version = "23.0.0"
+version = "23.0.1"
 authors = ["gfx-rs developers"]
 
 [workspace.dependencies.wgc]
 package = "wgpu-core"
 path = "./wgpu-core"
-version = "23.0.0"
+version = "23.0.1"
 
 [workspace.dependencies.wgt]
 package = "wgpu-types"
@@ -63,7 +63,7 @@ version = "23.0.0"
 [workspace.dependencies.hal]
 package = "wgpu-hal"
 path = "./wgpu-hal"
-version = "23.0.0"
+version = "23.0.1"
 
 [workspace.dependencies.naga]
 path = "./naga"
@@ -126,8 +126,8 @@ static_assertions = "1.1.0"
 strum = { version = "0.25.0", features = ["derive"] }
 tracy-client = "0.17"
 thiserror = "1.0.65"
-wgpu = { version = "23.0.0", path = "./wgpu", default-features = false }
-wgpu-core = { version = "23.0.0", path = "./wgpu-core" }
+wgpu = { version = "23.0.1", path = "./wgpu", default-features = false }
+wgpu-core = { version = "23.0.1", path = "./wgpu-core" }
 wgpu-macros = { version = "23.0.0", path = "./wgpu-macros" }
 wgpu-test = { version = "23.0.0", path = "./tests" }
 wgpu-types = { version = "23.0.0", path = "./wgpu-types" }

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-core"
-version = "23.0.0"
+version = "23.0.1"
 authors = ["gfx-rs developers"]
 edition = "2021"
 description = "WebGPU core logic on wgpu-hal"

--- a/wgpu-core/src/weak_vec.rs
+++ b/wgpu-core/src/weak_vec.rs
@@ -47,7 +47,7 @@ impl<T> WeakVec<T> {
         }
         if let Some(i) = self.empty_slots.pop() {
             self.inner[i] = Some(value);
-            self.scan_slots_on_next_push = false;
+            self.scan_slots_on_next_push = self.empty_slots.is_empty();
         } else {
             self.inner.push(Some(value));
             self.scan_slots_on_next_push = self.inner.len() == self.inner.capacity();

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-hal"
-version = "23.0.0"
+version = "23.0.1"
 authors = ["gfx-rs developers"]
 edition = "2021"
 description = "WebGPU hardware abstraction layer"

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -2254,7 +2254,8 @@ impl crate::Adapter for super::Adapter {
                 Ok(present_modes) => present_modes,
                 Err(e) => {
                     log::error!("get_physical_device_surface_present_modes: {}", e);
-                    Vec::new()
+                    // Per definition of `SurfaceCapabilities`, there must be at least one present mode.
+                    return None;
                 }
             }
         };
@@ -2269,7 +2270,8 @@ impl crate::Adapter for super::Adapter {
                 Ok(formats) => formats,
                 Err(e) => {
                     log::error!("get_physical_device_surface_formats: {}", e);
-                    Vec::new()
+                    // Per definition of `SurfaceCapabilities`, there must be at least one present format.
+                    return None;
                 }
             }
         };

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -702,10 +702,7 @@ impl crate::Context for ContextWgpuCore {
             .surface_get_capabilities(surface_data.id, *adapter_data)
         {
             Ok(caps) => caps,
-            Err(wgc::instance::GetSurfaceSupportError::Unsupported) => {
-                wgt::SurfaceCapabilities::default()
-            }
-            Err(err) => self.handle_error_fatal(err, "Surface::get_supported_formats"),
+            Err(_) => wgt::SurfaceCapabilities::default(),
         }
     }
 


### PR DESCRIPTION
**Don't merge**, this is just here to visualize the changes from v23.0.1 (or v23.1.0?) and have CI run on it.

Delete v23.0.0 branch again when this lands (but keep v23 branch), only created this for this comparison (the tag is enough, but doesn't allow me to create a draft pr)


Backported PRs so far:
* #6535
* #6576
* #6510

TODO:
* [x] @jimblandy can you please check whether we can backport the undefined-behavior-on-infinite-loop fixes for Metal? Bevy 0.15 would like to see those in (see https://discord.com/channels/691052431525675048/1295069829740499015/1310012906762403961) but I'm too removed to judge the risk (& actual changes) involved 
     * decided not to backport see https://matrix.to/#/!FZyQrssSlHEZqrYcOb:matrix.org/$XeH_dt3LDTytdPd29oj9AhDrCVWYcW4BxC-69UntmZ4
* [x] collect whatever else should be backported 
* [x] make sure no breaking changes are in there (run [cargo semvar checks](https://github.com/obi1kenobi/cargo-semver-checks))
* [x] Publish patch releases for...
    * `wgpu-core`
    * `wgpu-hal`
    * `wgpu`