### PR TITLE
Allow `CAMetalLayer` images to be used as storage textures

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -344,7 +344,9 @@ impl crate::Adapter for super::Adapter {
             current_extent,
             usage: crate::TextureUses::COLOR_TARGET
                 | crate::TextureUses::COPY_SRC
-                | crate::TextureUses::COPY_DST,
+                | crate::TextureUses::COPY_DST
+                | crate::TextureUses::STORAGE_READ
+                | crate::TextureUses::STORAGE_READ_WRITE,
         })
     }
 


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
Problem: I want to use swap chain images in compute shaders, but I cannot do this since the Metal backend does not report the storage usage flags to be supported. When adding the necessary flags, I am able to write to the swap chain images from a compute shader.

The Metal backend already sets [framebufferOnly](https://developer.apple.com/documentation/quartzcore/cametallayer/1478168-framebufferonly) only if the usage is equivalent to `COLOR_TARGET`, see [here](https://github.com/gfx-rs/wgpu/blob/c22c062b54857e0598c0cccfb4d589406e1393b0/wgpu-hal/src/metal/surface.rs#L292), so no further changes seem to be necessary.

**Testing**
_Explain how this change is tested._

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
