### PR TITLE
Add visionos support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 
 - Return submission index in `map_async` and `on_submitted_work_done` to track down completion of async callbacks. By @eliemichel in [#6360](https://github.com/gfx-rs/wgpu/pull/6360).
 - Move raytracing alignments into HAL instead of in core. By @Vecvec in [#6563](https://github.com/gfx-rs/wgpu/pull/6563).
+- Add build support for Apple Vision Pro. By @guusw in [#6611](https://github.com/gfx-rs/wgpu/pull/6611).
 
 ### Changes
 

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -35,7 +35,7 @@ features = [
 ]
 
 # We want the wgpu-core Metal backend on macOS and iOS.
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.wgpu-core]
+[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos"))'.dependencies.wgpu-core]
 workspace = true
 features = ["metal"]
 

--- a/naga/build.rs
+++ b/naga/build.rs
@@ -3,7 +3,7 @@ fn main() {
         dot_out: { feature = "dot-out" },
         glsl_out: { feature = "glsl-out" },
         hlsl_out: { any(feature = "hlsl-out", all(target_os = "windows", feature = "hlsl-out-if-target-windows")) },
-        msl_out: { any(feature = "msl-out", all(any(target_os = "ios", target_os = "macos"), feature = "msl-out-if-target-apple")) },
+        msl_out: { any(feature = "msl-out", all(any(target_os = "ios", target_os = "visionos", target_os = "macos"), feature = "msl-out-if-target-apple")) },
         spv_out: { feature = "spv-out" },
         wgsl_out: { feature = "wgsl-out" },
     }

--- a/naga/fuzz/Cargo.toml
+++ b/naga/fuzz/Cargo.toml
@@ -9,11 +9,11 @@ license = "MIT OR Apache-2.0"
 [package.metadata]
 cargo-fuzz = true
 
-[target.'cfg(not(any(target_arch = "wasm32", target_os = "ios")))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))'.dependencies]
 arbitrary = { version = "1.3.2", features = ["derive"] }
 libfuzzer-sys = "0.4"
 
-[target.'cfg(not(any(target_arch = "wasm32", target_os = "ios")))'.dependencies.naga]
+[target.'cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))'.dependencies.naga]
 path = ".."
 version = "23.0.0"
 features = ["arbitrary", "spv-in", "wgsl-in", "glsl-in"]

--- a/naga/fuzz/fuzz_targets/glsl_parser.rs
+++ b/naga/fuzz/fuzz_targets/glsl_parser.rs
@@ -1,5 +1,5 @@
 #![no_main]
-#[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))]
 mod fuzz {
     use arbitrary::Arbitrary;
     use libfuzzer_sys::fuzz_target;

--- a/naga/fuzz/fuzz_targets/ir.rs
+++ b/naga/fuzz/fuzz_targets/ir.rs
@@ -1,5 +1,5 @@
 #![no_main]
-#[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))]
 mod fuzz {
     use libfuzzer_sys::fuzz_target;
 

--- a/naga/fuzz/fuzz_targets/spv_parser.rs
+++ b/naga/fuzz/fuzz_targets/spv_parser.rs
@@ -1,5 +1,5 @@
 #![no_main]
-#[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))]
 mod fuzz {
     use libfuzzer_sys::fuzz_target;
     use naga::front::spv::{Frontend, Options};

--- a/naga/fuzz/fuzz_targets/wgsl_parser.rs
+++ b/naga/fuzz/fuzz_targets/wgsl_parser.rs
@@ -1,5 +1,5 @@
 #![no_main]
-#[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))]
 mod fuzz {
     use libfuzzer_sys::fuzz_target;
     use naga::front::wgsl::Frontend;

--- a/naga/xtask/src/validate.rs
+++ b/naga/xtask/src/validate.rs
@@ -150,7 +150,7 @@ fn collect_validation_jobs(jobs: &mut Vec<Job>, cmd: ValidateSubcommand) -> anyh
                     | ValidateSubcommand::Spirv
                     | ValidateSubcommand::Glsl
                     | ValidateSubcommand::Dot => true,
-                    ValidateSubcommand::Metal => cfg!(any(target_os = "macos", target_os = "ios")),
+                    ValidateSubcommand::Metal => cfg!(any(target_os = "macos", target_os = "ios", target_os = "visionos")),
                     // The FXC compiler is only available on Windows.
                     //
                     // The DXC compiler can be built and run on any platform,

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -7,7 +7,7 @@ fn main() {
         webgl: { all(target_arch = "wasm32", not(target_os = "emscripten"), gles) },
         dx12: { all(target_os = "windows", feature = "dx12") },
         gles: { all(feature = "gles") },
-        metal: { all(any(target_os = "ios", target_os = "macos"), feature = "metal") },
+        metal: { all(any(target_os = "ios", target_os = "visionos", target_os = "macos"), feature = "metal") },
         vulkan: { all(not(target_arch = "wasm32"), feature = "vulkan") }
     }
 }

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(
     all(
         not(all(feature = "vulkan", not(target_arch = "wasm32"))),
-        not(all(feature = "metal", any(target_os = "macos", target_os = "ios"))),
+        not(all(feature = "metal", any(target_os = "macos", target_os = "ios", target_os = "visionos"))),
         not(all(feature = "dx12", windows)),
         not(feature = "gles"),
     ),

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -164,7 +164,7 @@ windows-core = { workspace = true, optional = true }
 # backend: Gles
 glutin_wgl_sys = { workspace = true, optional = true }
 
-[target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
+[target.'cfg(any(target_os="macos", target_os="ios", target_os="visionos"))'.dependencies]
 # backend: Metal
 block = { workspace = true, optional = true }
 
@@ -208,7 +208,7 @@ env_logger.workspace = true
 glam.workspace = true       # for ray-traced-triangle example
 winit.workspace = true      # for "halmark" example
 
-[target.'cfg(not(any(target_arch = "wasm32", target_os = "ios")))'.dev-dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))'.dev-dependencies]
 glutin-winit = { workspace = true, features = [
     "egl",
     "wgl",

--- a/wgpu-hal/build.rs
+++ b/wgpu-hal/build.rs
@@ -9,7 +9,7 @@ fn main() {
         Emscripten: { all(target_os = "emscripten", gles) },
         dx12: { all(target_os = "windows", feature = "dx12") },
         gles: { all(feature = "gles") },
-        metal: { all(any(target_os = "ios", target_os = "macos"), feature = "metal") },
+        metal: { all(any(target_os = "ios", target_os = "visionos", target_os = "macos"), feature = "metal") },
         vulkan: { all(not(target_arch = "wasm32"), feature = "vulkan") }
     }
 }

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -782,7 +782,7 @@ impl<A: hal::Api> Example<A> {
 
 cfg_if::cfg_if! {
     // Apple + Metal
-    if #[cfg(all(any(target_os = "macos", target_os = "ios"), feature = "metal"))] {
+    if #[cfg(all(any(target_os = "macos", target_os = "ios", target_os = "visionos"), feature = "metal"))] {
         type Api = hal::api::Metal;
     }
     // Wasm + Vulkan

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -10,7 +10,7 @@
 
 extern crate wgpu_hal as hal;
 
-#[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))]
 fn main() {
     use std::{ffi::CString, num::NonZeroU32};
 
@@ -256,7 +256,7 @@ fn main() {
 
 #[cfg(any(
     all(target_arch = "wasm32", not(target_os = "emscripten")),
-    target_os = "ios"
+    target_os = "ios", target_os = "visionos"
 ))]
 fn main() {
     eprintln!("This example is not supported on Windows and non-emscripten wasm32")
@@ -264,7 +264,7 @@ fn main() {
 
 #[cfg(not(any(
     all(target_arch = "wasm32", not(target_os = "emscripten")),
-    target_os = "ios"
+    target_os = "ios", target_os = "visionos"
 )))]
 fn fill_screen(exposed: &hal::ExposedAdapter<hal::api::Gles>, width: u32, height: u32) {
     use hal::{Adapter as _, CommandEncoder as _, Device as _, Queue as _};

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -1078,7 +1078,7 @@ impl<A: hal::Api> Example<A> {
 
 cfg_if::cfg_if! {
     // Apple + Metal
-    if #[cfg(all(any(target_os = "macos", target_os = "ios"), feature = "metal"))] {
+    if #[cfg(all(any(target_os = "macos", target_os = "ios", target_os = "visionos"), feature = "metal"))] {
         type Api = hal::api::Metal;
     }
     // Wasm + Vulkan

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -785,7 +785,7 @@ impl crate::Instance for Instance {
                     "libEGL.dll",
                 )
             }
-        } else if cfg!(any(target_os = "macos", target_os = "ios")) {
+        } else if cfg!(any(target_os = "macos", target_os = "ios", target_os = "visionos")) {
             unsafe {
                 khronos_egl::DynamicInstance::<khronos_egl::EGL1_4>::load_required_from_filename(
                     "libEGL.dylib",
@@ -1313,7 +1313,7 @@ impl crate::Surface for Surface {
                         let window_ptr = handle.ns_view.as_ptr();
                         #[cfg(target_os = "macos")]
                         let window_ptr = {
-                            use objc::{msg_send, runtime::Object, sel, sel_impl};
+                            use objc::{msg_send, runtime::Object, sel};
                             // ns_view always have a layer and don't need to verify that it exists.
                             let layer: *mut Object =
                                 msg_send![handle.ns_view.as_ptr().cast::<Object>(), layer];

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1,5 +1,5 @@
 use metal::{MTLFeatureSet, MTLGPUFamily, MTLLanguageVersion, MTLReadWriteTextureTier};
-use objc::{class, msg_send, sel, sel_impl};
+use objc::{class, msg_send, sel};
 use parking_lot::Mutex;
 use wgt::{AstcBlock, AstcChannel};
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -120,7 +120,7 @@ impl crate::Instance for Instance {
         window_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<Surface, crate::InstanceError> {
         match window_handle {
-            #[cfg(target_os = "ios")]
+            #[cfg(any(target_os = "ios", target_os = "visionos"))]
             raw_window_handle::RawWindowHandle::UiKit(handle) => {
                 Ok(unsafe { Surface::from_view(handle.ui_view.cast()) })
             }

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -16,7 +16,7 @@ use objc::{
     msg_send,
     rc::{autoreleasepool, StrongPtr},
     runtime::{Class, Object, Sel, BOOL, NO, YES},
-    sel, sel_impl,
+    sel
 };
 use parking_lot::{Mutex, RwLock};
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1005,7 +1005,7 @@ impl PhysicalDeviceProperties {
         }
 
         // Require `VK_KHR_portability_subset` on macOS/iOS
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos"))]
         extensions.push(khr::portability_subset::NAME);
 
         // Require `VK_EXT_texture_compression_astc_hdr` if the associated feature was requested

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -881,7 +881,7 @@ impl crate::Instance for super::Instance {
             {
                 self.create_surface_from_view(handle.ns_view)
             }
-            #[cfg(all(target_os = "ios", feature = "metal"))]
+            #[cfg(all(any(target_os = "ios", target_os = "visionos"), feature = "metal"))]
             (Rwh::UiKit(handle), _)
                 if self.shared.extensions.contains(&ext::metal_surface::NAME) =>
             {

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -138,7 +138,7 @@ features = ["indirect-validation"]
 
 # Enable `wgc` by default on macOS and iOS to allow the `metal` crate feature to
 # enable the Metal backend while being no-op on other targets.
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.wgc]
+[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos"))'.dependencies.wgc]
 workspace = true
 
 # We want the wgpu-core Direct3D backend and OpenGL (via WGL) on Windows.
@@ -147,12 +147,12 @@ workspace = true
 features = ["gles"]
 
 # We want the wgpu-core Vulkan backend on Unix (but not emscripten, macOS, iOS) and Windows.
-[target.'cfg(any(windows, all(unix, not(target_os = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
+[target.'cfg(any(windows, all(unix, not(target_os = "emscripten"), not(target_os = "ios"), not(target_os = "visionos"),  not(target_os = "macos"))))'.dependencies.wgc]
 workspace = true
 features = ["vulkan"]
 
 # We want the wgpu-core GLES backend on Unix (but not macOS, iOS).
-[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies.wgc]
+[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "visionos"), not(target_os = "macos")))'.dependencies.wgc]
 workspace = true
 features = ["gles"]
 
@@ -163,7 +163,7 @@ workspace = true
 [target.'cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))'.dependencies]
 hal = { workspace = true }
 
-[target.'cfg(all(not(target_arch = "wasm32"), unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
+[target.'cfg(all(not(target_arch = "wasm32"), unix, not(target_os = "ios"), not(target_os = "visionos"), not(target_os = "macos")))'.dependencies]
 hal = { workspace = true, features = ["renderdoc"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -10,7 +10,7 @@ fn main() {
             all(feature = "fragile-send-sync-non-atomic-wasm", not(target_feature = "atomics"))
         ) },
         dx12: { all(target_os = "windows", feature = "dx12") },
-        metal: { all(any(target_os = "ios", target_os = "macos"), feature = "metal") },
+        metal: { all(any(target_os = "ios", target_os = "visionos", target_os = "macos"), feature = "metal") },
         // This alias is _only_ if _we_ need naga in the wrapper. wgpu-core provides
         // its own re-export of naga, which can be used in other situations
         naga: { any(feature = "naga-ir", feature = "spirv", feature = "glsl") },


### PR DESCRIPTION
Add build support for VisionOS by adding the required feature checks. Note that vision is almost identical to iOS, except that the rust team decided to add a unique os feature "visionos"

Alternatives could be to check something like `#[all(target_vendor = "apple", not(target_os = "macos"))]`
to simplify all mobile devices, excluding desktop macos, let me know.

**NOTE**

A potential Issue it that the objc library does not have support for visionos and the library owned no longer seems to maintain the crate, we use a patched version in our project https://github.com/shards-lang/rust-objc/tree/shards-0.2.5
(based on this PR https://github.com/SSheldon/rust-objc/pull/123)

I'm not sure what the preferred solution here would be:
- Using a patched crate vendored under gfx-rs org git url?
- Using a vendored copy of objc?

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
