### PR TITLE
Bump version & update changelog following 23.0.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,14 +144,24 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Fix crash when a texture argument is missing. By @aedm in [#6486](https://github.com/gfx-rs/wgpu/pull/6486)
 - Emit an error in constant evaluation, rather than crash, in certain cases where `vecN` constructors have less than N arguments. By @ErichDonGubler in [#6508](https://github.com/gfx-rs/wgpu/pull/6508).
 
-#### Vulkan
+## 23.0.1 (2024-11-25)
 
-- Fix surface capabilities being advertised when its query failed. By @wumpf in [#6510](https://github.com/gfx-rs/wgpu/pull/6510)
+This release includes patches for `wgpu`, `wgpu-core` and `wgpu-hal`. All other crates remain at [23.0.0](https://github.com/gfx-rs/wgpu/releases/tag/v23.0.0).
+Below changes were cherry-picked from 24.0.0 development line.
 
-### Metal
+### Bug fixes
+
+#### General
+
+- Fix Texture view leaks regression. By @xiaopengli89 in [#6576](https://github.com/gfx-rs/wgpu/pull/6576)
+
+#### Metal
 
 - Fix surface creation crashing on iOS. By @mockersf in [#6535](https://github.com/gfx-rs/wgpu/pull/6535)
 
+#### Vulkan
+
+- Fix surface capabilities being advertised when its query failed. By @wumpf in [#6510](https://github.com/gfx-rs/wgpu/pull/6510)
 
 ## 23.0.0 (2024-10-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,14 +329,9 @@ By @MarijnS95 in [#6006](https://github.com/gfx-rs/wgpu/pull/6006).
 #### General
 
 - If GL context creation fails retry with GLES. By @Rapdorian in [#5996](https://github.com/gfx-rs/wgpu/pull/5996).
-- Fix profiling with `tracy`. By @waywardmonkeys in [#5988](https://github.com/gfx-rs/wgpu/pull/5988).
-- As a workaround for [issue #4905](https://github.com/gfx-rs/wgpu/issues/4905), `wgpu-core` is undocumented unless `--cfg wgpu_core_doc` feature is enabled. By @kpreid in [#5987](https://github.com/gfx-rs/wgpu/pull/5987).
 - Bump MSRV for `d3d12`/`naga`/`wgpu-core`/`wgpu-hal`/`wgpu-types`' to 1.76. By @wumpf in [#6003](https://github.com/gfx-rs/wgpu/pull/6003).
 - Print requested and supported usages on `UnsupportedUsage` error. By @VladasZ in [#6007](https://github.com/gfx-rs/wgpu/pull/6007).
-- Fix function for checking bind compatibility to error instead of panic. By @sagudev [#6012](https://github.com/gfx-rs/wgpu/pull/6012).
 - Deduplicate bind group layouts that are created from pipelines with "auto" layouts. By @teoxoy [#6049](https://github.com/gfx-rs/wgpu/pull/6049).
-- Fix crash when dropping the surface after the device. By @wumpf in [#6052](https://github.com/gfx-rs/wgpu/pull/6052).
-- Fix error message that is thrown in create_render_pass to no longer say `compute_pass`. By @matthew-wong1 [#6041](https://github.com/gfx-rs/wgpu/pull/6041).
 - Document `wgpu_hal` bounds-checking promises, and adapt `wgpu_core`'s lazy initialization logic to the slightly weaker-than-expected guarantees. By @jimblandy in [#6201](https://github.com/gfx-rs/wgpu/pull/6201).
 - Raise validation error instead of panicking in `{Render,Compute}Pipeline::get_bind_group_layout` on native / WebGL. By @bgr360 in [#6280](https://github.com/gfx-rs/wgpu/pull/6280).
 - **BREAKING**: Remove the last exposed C symbols in project, located in `wgpu_core::render::bundle::bundle_ffi`, to allow multiple versions of WGPU to compile together. By @ErichDonGubler in [#6272](https://github.com/gfx-rs/wgpu/pull/6272).
@@ -403,6 +398,27 @@ By @MarijnS95 in [#6006](https://github.com/gfx-rs/wgpu/pull/6006).
 #### HAL
 
 - Update `parking_lot` to `0.12`. By @mahkoh in [#6287](https://github.com/gfx-rs/wgpu/pull/6287).
+
+## v22.1.0 (2024-07-17)
+
+This release includes `wgpu`, `wgpu-core` and `naga`. All other crates remain at 22.0.0.
+
+### Added
+
+#### Naga
+
+- Added back implementations of PartialEq for more IR types. By @teoxoy in [#6045](https://github.com/gfx-rs/wgpu/pull/6045)
+
+### Bug Fixes
+
+#### General
+
+- Fix profiling with `tracy`. By @waywardmonkeys in [#5988](https://github.com/gfx-rs/wgpu/pull/5988)
+- Fix function for checking bind compatibility to error instead of panic. By @sagudev [#6012](https://github.com/gfx-rs/wgpu/pull/6012)
+- Fix crash when dropping the surface after the device. By @wumpf in [#6052](https://github.com/gfx-rs/wgpu/pull/6052)
+- Fix length of copy in `queue_write_texture`. By @teoxoy in [#6009](https://github.com/gfx-rs/wgpu/pull/6009)
+- Fix error message that is thrown in create_render_pass to no longer say `compute_pass`. By @matthew-wong1 [#6041](https://github.com/gfx-rs/wgpu/pull/6041)
+- As a workaround for [issue #4905](https://github.com/gfx-rs/wgpu/issues/4905), `wgpu-core` is undocumented unless `--cfg wgpu_core_doc` feature is enabled. By @kpreid in [#5987](https://github.com/gfx-rs/wgpu/pull/5987)
 
 ## 22.0.0 (2024-07-17)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,7 +1742,7 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock-analyzer"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "anyhow",
  "ron",
@@ -2275,7 +2275,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "player"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "env_logger",
  "log",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "arrayvec",
  "cfg_aliases",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-benchmark"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-examples"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-info"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-macros"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-test"
-version = "23.0.0"
+version = "23.0.1"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 homepage = "https://wgpu.rs/"
 repository = "https://github.com/gfx-rs/wgpu"
-version = "23.0.0"
+version = "23.0.1"
 authors = ["gfx-rs developers"]
 
 [workspace.dependencies.wgc]
 package = "wgpu-core"
 path = "./wgpu-core"
-version = "23.0.0"
+version = "23.0.1"
 
 [workspace.dependencies.wgt]
 package = "wgpu-types"
@@ -63,7 +63,7 @@ version = "23.0.0"
 [workspace.dependencies.hal]
 package = "wgpu-hal"
 path = "./wgpu-hal"
-version = "23.0.0"
+version = "23.0.1"
 
 [workspace.dependencies.naga]
 path = "./naga"
@@ -126,8 +126,8 @@ static_assertions = "1.1.0"
 strum = { version = "0.25.0", features = ["derive"] }
 tracy-client = "0.17"
 thiserror = "1.0.69"
-wgpu = { version = "23.0.0", path = "./wgpu", default-features = false }
-wgpu-core = { version = "23.0.0", path = "./wgpu-core" }
+wgpu = { version = "23.0.1", path = "./wgpu", default-features = false }
+wgpu-core = { version = "23.0.1", path = "./wgpu-core" }
 wgpu-macros = { version = "23.0.0", path = "./wgpu-macros" }
 wgpu-test = { version = "23.0.0", path = "./tests" }
 wgpu-types = { version = "23.0.0", path = "./wgpu-types" }

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-core"
-version = "23.0.0"
+version = "23.0.1"
 authors = ["gfx-rs developers"]
 edition = "2021"
 description = "WebGPU core logic on wgpu-hal"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-hal"
-version = "23.0.0"
+version = "23.0.1"
 authors = ["gfx-rs developers"]
 edition = "2021"
 description = "WebGPU hardware abstraction layer"


### PR DESCRIPTION
**Connections**

* Follow-up to https://github.com/gfx-rs/wgpu/pull/6598

**Description**

* cherry-pick version bump
* cherry-pick changelog addition for v23.0.1 and remove pr lines from v24/unreleased line
* cherry-pick changelog additions for v22.1.0 and remove pr lines from v23 patch
     * todo: update in published release as well 

**Testing**

n/a

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
