### PR TITLE
chore: satisfy `clippy::manual_c_str_literals`

### DIFF
--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -30,8 +30,7 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5671
         // Versions 1.3.240 through 1.3.250 return a spurious error here if
         // the debug range start and end appear in different command buffers.
-        const KHRONOS_VALIDATION_LAYER: &CStr =
-            unsafe { CStr::from_bytes_with_nul_unchecked(b"Khronos Validation Layer\0") };
+        const KHRONOS_VALIDATION_LAYER: &CStr = c"Khronos Validation Layer";
         if let Some(layer_properties) = user_data.validation_layer_properties.as_ref() {
             if layer_properties.layer_description.as_ref() == KHRONOS_VALIDATION_LAYER
                 && layer_properties.layer_spec_version >= vk::make_api_version(0, 1, 3, 240)
@@ -599,7 +598,7 @@ impl crate::Instance for super::Instance {
         let app_info = vk::ApplicationInfo::default()
             .application_name(app_name.as_c_str())
             .application_version(1)
-            .engine_name(CStr::from_bytes_with_nul(b"wgpu-hal\0").unwrap())
+            .engine_name(c"wgpu-hal")
             .engine_version(2)
             .api_version(
                 // Vulkan 1.0 doesn't like anything but 1.0 passed in here...
@@ -641,8 +640,7 @@ impl crate::Instance for super::Instance {
                 .find(|inst_layer| inst_layer.layer_name_as_c_str() == Ok(name))
         }
 
-        let validation_layer_name =
-            CStr::from_bytes_with_nul(b"VK_LAYER_KHRONOS_validation\0").unwrap();
+        let validation_layer_name = c"VK_LAYER_KHRONOS_validation";
         let validation_layer_properties = find_layer(&instance_layers, validation_layer_name);
 
         // Determine if VK_EXT_validation_features is available, so we can enable
@@ -666,10 +664,10 @@ impl crate::Instance for super::Instance {
             .intersects(wgt::InstanceFlags::GPU_BASED_VALIDATION)
             && validation_features_are_enabled;
 
-        let nv_optimus_layer = CStr::from_bytes_with_nul(b"VK_LAYER_NV_optimus\0").unwrap();
+        let nv_optimus_layer = c"VK_LAYER_NV_optimus";
         let has_nv_optimus = find_layer(&instance_layers, nv_optimus_layer).is_some();
 
-        let obs_layer = CStr::from_bytes_with_nul(b"VK_LAYER_OBS_HOOK\0").unwrap();
+        let obs_layer = c"VK_LAYER_OBS_HOOK";
         let has_obs_layer = find_layer(&instance_layers, obs_layer).is_some();
 
         let mut layers: Vec<&'static CStr> = Vec::new();


### PR DESCRIPTION
This was previously an `allow`-by-default warning in Clippy's `pedantic` group, but with Rust 1.83 it was promoted to a `warn`-by-default member of its `complexity` group.