### PR TITLE
[wgpu-core] simplify callbacks

### DIFF
--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -108,7 +108,7 @@ pub async fn op_webgpu_buffer_get_map_async(
                         2 => wgpu_core::device::HostMap::Write,
                         _ => unreachable!(),
                     },
-                    callback: Some(wgpu_core::resource::BufferMapCallback::from_rust(callback)),
+                    callback: Some(callback),
                 },
             )
             .err();

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -144,9 +144,7 @@ impl Test<'_> {
                     Some(expect.data.len() as u64),
                     wgc::resource::BufferMapOperation {
                         host: wgc::device::HostMap::Read,
-                        callback: Some(wgc::resource::BufferMapCallback::from_rust(Box::new(
-                            map_callback,
-                        ))),
+                        callback: Some(Box::new(map_callback)),
                     },
                 )
                 .unwrap();

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2083,7 +2083,7 @@ impl Global {
         self.hub.devices.remove(device_id);
     }
 
-    /// This closure will be called exactly once during "lose the device".
+    /// `device_lost_closure` might never be called.
     pub fn device_set_device_lost_closure(
         &self,
         device_id: DeviceId,
@@ -2144,6 +2144,7 @@ impl Global {
         self.hub.queues.remove(queue_id);
     }
 
+    /// `op.callback` is guaranteed to be called.
     pub fn buffer_map_async(
         &self,
         buffer_id: id::BufferId,

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2170,7 +2170,7 @@ impl Global {
             Ok(submission_index) => Ok(submission_index),
             Err((mut operation, err)) => {
                 if let Some(callback) = operation.callback.take() {
-                    callback.call(Err(err.clone()));
+                    callback(Err(err.clone()));
                 }
                 log::error!("Buffer::map_async error: {err}");
                 Err(err)

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2097,11 +2097,6 @@ impl Global {
             .replace(device_lost_closure);
     }
 
-    pub fn device_unregister_device_lost_closure(&self, device_id: DeviceId) {
-        let device = self.hub.devices.get(device_id);
-        device.device_lost_closure.lock().take();
-    }
-
     pub fn device_destroy(&self, device_id: DeviceId) {
         api_log!("Device::destroy {device_id:?}");
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     command::{self, CommandBuffer},
     conv,
-    device::{bgl, life::WaitIdleError, DeviceError, DeviceLostClosure, DeviceLostReason},
+    device::{bgl, life::WaitIdleError, DeviceError, DeviceLostClosure},
     global::Global,
     hal_api::HalApi,
     id::{self, AdapterId, DeviceId, QueueId, SurfaceId},
@@ -2083,8 +2083,7 @@ impl Global {
         self.hub.devices.remove(device_id);
     }
 
-    // This closure will be called exactly once during "lose the device",
-    // or when it is replaced.
+    /// This closure will be called exactly once during "lose the device".
     pub fn device_set_device_lost_closure(
         &self,
         device_id: DeviceId,
@@ -2092,22 +2091,15 @@ impl Global {
     ) {
         let device = self.hub.devices.get(device_id);
 
-        let old_device_lost_closure = device
+        device
             .device_lost_closure
             .lock()
             .replace(device_lost_closure);
-
-        if let Some(old_device_lost_closure) = old_device_lost_closure {
-            old_device_lost_closure.call(DeviceLostReason::ReplacedCallback, "".to_string());
-        }
     }
 
     pub fn device_unregister_device_lost_closure(&self, device_id: DeviceId) {
         let device = self.hub.devices.get(device_id);
-        let closure = device.device_lost_closure.lock().take();
-        if let Some(closure) = closure {
-            closure.call(DeviceLostReason::ReplacedCallback, "".to_string());
-        }
+        device.device_lost_closure.lock().take();
     }
 
     pub fn device_destroy(&self, device_id: DeviceId) {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -191,9 +191,9 @@ impl UserClosures {
 }
 
 #[cfg(send_sync)]
-pub type DeviceLostCallback = Box<dyn Fn(DeviceLostReason, String) + Send + 'static>;
+pub type DeviceLostCallback = Box<dyn FnOnce(DeviceLostReason, String) + Send + 'static>;
 #[cfg(not(send_sync))]
-pub type DeviceLostCallback = Box<dyn Fn(DeviceLostReason, String) + 'static>;
+pub type DeviceLostCallback = Box<dyn FnOnce(DeviceLostReason, String) + 'static>;
 
 pub struct DeviceLostClosureRust {
     pub callback: DeviceLostCallback,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -12,7 +12,6 @@ use crate::{
 
 use arrayvec::ArrayVec;
 use smallvec::SmallVec;
-use std::os::raw::c_char;
 use thiserror::Error;
 use wgt::{BufferAddress, DeviceLostReason, TextureFormat};
 
@@ -183,81 +182,20 @@ impl UserClosures {
             closure();
         }
         for invocation in self.device_lost_invocations {
-            invocation
-                .closure
-                .call(invocation.reason, invocation.message);
+            (invocation.closure)(invocation.reason, invocation.message);
         }
     }
 }
 
 #[cfg(send_sync)]
-pub type DeviceLostCallback = Box<dyn FnOnce(DeviceLostReason, String) + Send + 'static>;
+pub type DeviceLostClosure = Box<dyn FnOnce(DeviceLostReason, String) + Send + 'static>;
 #[cfg(not(send_sync))]
-pub type DeviceLostCallback = Box<dyn FnOnce(DeviceLostReason, String) + 'static>;
-
-pub struct DeviceLostClosureRust {
-    pub callback: DeviceLostCallback,
-}
-
-#[repr(C)]
-pub struct DeviceLostClosureC {
-    pub callback: unsafe extern "C" fn(user_data: *mut u8, reason: u8, message: *const c_char),
-    pub user_data: *mut u8,
-}
-
-#[cfg(send_sync)]
-unsafe impl Send for DeviceLostClosureC {}
-
-pub struct DeviceLostClosure {
-    // We wrap this so creating the enum in the C variant can be unsafe,
-    // allowing our call function to be safe.
-    inner: DeviceLostClosureInner,
-}
+pub type DeviceLostClosure = Box<dyn FnOnce(DeviceLostReason, String) + 'static>;
 
 pub struct DeviceLostInvocation {
     closure: DeviceLostClosure,
     reason: DeviceLostReason,
     message: String,
-}
-
-enum DeviceLostClosureInner {
-    Rust { inner: DeviceLostClosureRust },
-    C { inner: DeviceLostClosureC },
-}
-
-impl DeviceLostClosure {
-    pub fn from_rust(callback: DeviceLostCallback) -> Self {
-        let inner = DeviceLostClosureRust { callback };
-        Self {
-            inner: DeviceLostClosureInner::Rust { inner },
-        }
-    }
-
-    /// # Safety
-    ///
-    /// - The callback pointer must be valid to call with the provided `user_data`
-    ///   pointer.
-    ///
-    /// - Both pointers must point to `'static` data, as the callback may happen at
-    ///   an unspecified time.
-    pub unsafe fn from_c(inner: DeviceLostClosureC) -> Self {
-        Self {
-            inner: DeviceLostClosureInner::C { inner },
-        }
-    }
-
-    pub(crate) fn call(self, reason: DeviceLostReason, message: String) {
-        match self.inner {
-            DeviceLostClosureInner::Rust { inner } => (inner.callback)(reason, message),
-            // SAFETY: the contract of the call to from_c says that this unsafe is sound.
-            DeviceLostClosureInner::C { inner } => unsafe {
-                // Ensure message is structured as a null-terminated C string. It only
-                // needs to live as long as the callback invocation.
-                let message = std::ffi::CString::new(message).unwrap();
-                (inner.callback)(inner.user_data, reason as u8, message.as_ptr())
-            },
-        }
-    }
 }
 
 pub(crate) fn map_buffer(

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -176,7 +176,7 @@ impl UserClosures {
         // a on_submitted_work_done callback to be fired before the on_submitted_work_done callback.
         for (mut operation, status) in self.mappings {
             if let Some(callback) = operation.callback.take() {
-                callback.call(status);
+                callback(status);
             }
         }
         for closure in self.submissions {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -180,7 +180,7 @@ impl UserClosures {
             }
         }
         for closure in self.submissions {
-            closure.call();
+            closure();
         }
         for invocation in self.device_lost_invocations {
             invocation

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1396,6 +1396,7 @@ impl Queue {
         unsafe { self.raw().get_timestamp_period() }
     }
 
+    /// `closure` is guaranteed to be called.
     pub fn on_submitted_work_done(
         &self,
         closure: SubmittedWorkDoneClosure,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -149,10 +149,6 @@ impl Drop for Device {
     fn drop(&mut self) {
         resource_log!("Drop {}", self.error_ident());
 
-        if let Some(closure) = self.device_lost_closure.lock().take() {
-            closure.call(DeviceLostReason::Dropped, String::from("Device dropped."));
-        }
-
         // SAFETY: We are in the Drop impl and we don't use self.zero_buffer anymore after this point.
         let zero_buffer = unsafe { ManuallyDrop::take(&mut self.zero_buffer) };
         // SAFETY: We are in the Drop impl and we don't use self.fence anymore after this point.

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3600,7 +3600,7 @@ impl Device {
 
         // 1) Resolve the GPUDevice device.lost promise.
         if let Some(device_lost_closure) = self.device_lost_closure.lock().take() {
-            device_lost_closure.call(DeviceLostReason::Unknown, message.to_string());
+            device_lost_closure(DeviceLostReason::Unknown, message.to_string());
         }
 
         // 2) Complete any outstanding mapAsync() steps.

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -188,36 +188,6 @@ macro_rules! impl_trackable {
     };
 }
 
-/// The status code provided to the buffer mapping callback.
-///
-/// This is very similar to `BufferAccessResult`, except that this is FFI-friendly.
-#[repr(C)]
-#[derive(Debug)]
-pub enum BufferMapAsyncStatus {
-    /// The Buffer is successfully mapped, `get_mapped_range` can be called.
-    ///
-    /// All other variants of this enum represent failures to map the buffer.
-    Success,
-    /// The buffer is already mapped.
-    ///
-    /// While this is treated as an error, it does not prevent mapped range from being accessed.
-    AlreadyMapped,
-    /// Mapping was already requested.
-    MapAlreadyPending,
-    /// An unknown error.
-    Error,
-    /// The context is Lost.
-    ContextLost,
-    /// The buffer is in an invalid state.
-    Invalid,
-    /// The range isn't fully contained in the buffer.
-    InvalidRange,
-    /// The range isn't properly aligned.
-    InvalidAlignment,
-    /// Incompatible usage flags.
-    InvalidUsageFlags,
-}
-
 #[derive(Debug)]
 pub(crate) enum BufferMapState {
     /// Mapped at creation.
@@ -239,105 +209,23 @@ unsafe impl Send for BufferMapState {}
 #[cfg(send_sync)]
 unsafe impl Sync for BufferMapState {}
 
-#[repr(C)]
-pub struct BufferMapCallbackC {
-    pub callback: unsafe extern "C" fn(status: BufferMapAsyncStatus, user_data: *mut u8),
-    pub user_data: *mut u8,
-}
-
 #[cfg(send_sync)]
-unsafe impl Send for BufferMapCallbackC {}
-
-#[derive(Debug)]
-pub struct BufferMapCallback {
-    // We wrap this so creating the enum in the C variant can be unsafe,
-    // allowing our call function to be safe.
-    inner: BufferMapCallbackInner,
-}
-
-#[cfg(send_sync)]
-type BufferMapCallbackCallback = Box<dyn FnOnce(BufferAccessResult) + Send + 'static>;
+pub type BufferMapCallback = Box<dyn FnOnce(BufferAccessResult) + Send + 'static>;
 #[cfg(not(send_sync))]
-type BufferMapCallbackCallback = Box<dyn FnOnce(BufferAccessResult) + 'static>;
+pub type BufferMapCallback = Box<dyn FnOnce(BufferAccessResult) + 'static>;
 
-enum BufferMapCallbackInner {
-    Rust { callback: BufferMapCallbackCallback },
-    C { inner: BufferMapCallbackC },
-}
-
-impl Debug for BufferMapCallbackInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            BufferMapCallbackInner::Rust { callback: _ } => f.debug_struct("Rust").finish(),
-            BufferMapCallbackInner::C { inner: _ } => f.debug_struct("C").finish(),
-        }
-    }
-}
-
-impl BufferMapCallback {
-    pub fn from_rust(callback: BufferMapCallbackCallback) -> Self {
-        Self {
-            inner: BufferMapCallbackInner::Rust { callback },
-        }
-    }
-
-    /// # Safety
-    ///
-    /// - The callback pointer must be valid to call with the provided user_data
-    ///   pointer.
-    ///
-    /// - Both pointers must point to valid memory until the callback is
-    ///   invoked, which may happen at an unspecified time.
-    pub unsafe fn from_c(inner: BufferMapCallbackC) -> Self {
-        Self {
-            inner: BufferMapCallbackInner::C { inner },
-        }
-    }
-
-    pub(crate) fn call(self, result: BufferAccessResult) {
-        match self.inner {
-            BufferMapCallbackInner::Rust { callback } => {
-                callback(result);
-            }
-            // SAFETY: the contract of the call to from_c says that this unsafe is sound.
-            BufferMapCallbackInner::C { inner } => unsafe {
-                let status = match result {
-                    Ok(_) => BufferMapAsyncStatus::Success,
-                    Err(BufferAccessError::Device(_)) => BufferMapAsyncStatus::ContextLost,
-                    Err(BufferAccessError::InvalidResource(_))
-                    | Err(BufferAccessError::DestroyedResource(_)) => BufferMapAsyncStatus::Invalid,
-                    Err(BufferAccessError::AlreadyMapped) => BufferMapAsyncStatus::AlreadyMapped,
-                    Err(BufferAccessError::MapAlreadyPending) => {
-                        BufferMapAsyncStatus::MapAlreadyPending
-                    }
-                    Err(BufferAccessError::MissingBufferUsage(_)) => {
-                        BufferMapAsyncStatus::InvalidUsageFlags
-                    }
-                    Err(BufferAccessError::UnalignedRange)
-                    | Err(BufferAccessError::UnalignedRangeSize { .. })
-                    | Err(BufferAccessError::UnalignedOffset { .. }) => {
-                        BufferMapAsyncStatus::InvalidAlignment
-                    }
-                    Err(BufferAccessError::OutOfBoundsUnderrun { .. })
-                    | Err(BufferAccessError::OutOfBoundsOverrun { .. })
-                    | Err(BufferAccessError::NegativeRange { .. }) => {
-                        BufferMapAsyncStatus::InvalidRange
-                    }
-                    Err(BufferAccessError::Failed)
-                    | Err(BufferAccessError::NotMapped)
-                    | Err(BufferAccessError::MapAborted) => BufferMapAsyncStatus::Error,
-                };
-
-                (inner.callback)(status, inner.user_data);
-            },
-        }
-    }
-}
-
-#[derive(Debug)]
 pub struct BufferMapOperation {
     pub host: HostMap,
     pub callback: Option<BufferMapCallback>,
+}
+
+impl Debug for BufferMapOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BufferMapOperation")
+            .field("host", &self.host)
+            .field("callback", &self.callback.as_ref().map(|_| "?"))
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Error)]
@@ -637,7 +525,7 @@ impl Buffer {
             // We can safely unwrap below since we just set the `map_state` to `BufferMapState::Waiting`.
             let (mut operation, status) = self.map(&device.snatchable_lock.read()).unwrap();
             if let Some(callback) = operation.callback.take() {
-                callback.call(status);
+                callback(status);
             }
             0
         };
@@ -711,7 +599,7 @@ impl Buffer {
             buffer_id,
         )? {
             if let Some(callback) = operation.callback.take() {
-                callback.call(status);
+                callback(status);
             }
         }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7673,18 +7673,4 @@ pub enum DeviceLostReason {
     Unknown = 0,
     /// After Device::destroy
     Destroyed = 1,
-    /// After Device::drop
-    ///
-    /// WebGPU does not invoke the device lost callback when the device is
-    /// dropped to prevent garbage collection from being observable. In wgpu,
-    /// we invoke the callback on drop to help with managing memory owned by
-    /// the callback.
-    Dropped = 2,
-    /// After replacing the device_lost_callback
-    ///
-    /// WebGPU does not have a concept of a device lost callback, but wgpu
-    /// does. wgpu guarantees that any supplied callback will be invoked
-    /// exactly once before it is dropped, which helps with managing the
-    /// memory owned by the callback.
-    ReplacedCallback = 3,
 }

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1406,12 +1406,10 @@ impl crate::Context for ContextWgpuCore {
                 MapMode::Read => wgc::device::HostMap::Read,
                 MapMode::Write => wgc::device::HostMap::Write,
             },
-            callback: Some(wgc::resource::BufferMapCallback::from_rust(Box::new(
-                |status| {
-                    let res = status.map_err(|_| crate::BufferAsyncError);
-                    callback(res);
-                },
-            ))),
+            callback: Some(Box::new(|status| {
+                let res = status.map_err(|_| crate::BufferAsyncError);
+                callback(res);
+            })),
         };
 
         match self.0.buffer_map_async(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -24,7 +24,7 @@ use std::{
     sync::Arc,
 };
 use wgc::error::ContextErrorSource;
-use wgc::{command::bundle_ffi::*, device::DeviceLostClosure, pipeline::CreateShaderModuleError};
+use wgc::{command::bundle_ffi::*, pipeline::CreateShaderModuleError};
 use wgt::WasmNotSendSync;
 
 pub struct ContextWgpuCore(wgc::global::Global);
@@ -1352,9 +1352,8 @@ impl crate::Context for ContextWgpuCore {
         device_data: &Self::DeviceData,
         device_lost_callback: crate::context::DeviceLostCallback,
     ) {
-        let device_lost_closure = DeviceLostClosure::from_rust(device_lost_callback);
         self.0
-            .device_set_device_lost_closure(device_data.id, device_lost_closure);
+            .device_set_device_lost_closure(device_data.id, device_lost_callback);
     }
     fn device_destroy(&self, device_data: &Self::DeviceData) {
         self.0.device_destroy(device_data.id);

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2105,8 +2105,7 @@ impl crate::Context for ContextWgpuCore {
         queue_data: &Self::QueueData,
         callback: crate::context::SubmittedWorkDoneCallback,
     ) {
-        let closure = wgc::device::queue::SubmittedWorkDoneClosure::from_rust(callback);
-        self.0.queue_on_submitted_work_done(queue_data.id, closure);
+        self.0.queue_on_submitted_work_done(queue_data.id, callback);
     }
 
     fn device_start_capture(&self, device_data: &Self::DeviceData) {

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -777,9 +777,9 @@ pub type SubmittedWorkDoneCallback = Box<dyn FnOnce() + Send + 'static>;
 #[cfg(not(send_sync))]
 pub type SubmittedWorkDoneCallback = Box<dyn FnOnce() + 'static>;
 #[cfg(send_sync)]
-pub type DeviceLostCallback = Box<dyn Fn(DeviceLostReason, String) + Send + 'static>;
+pub type DeviceLostCallback = Box<dyn FnOnce(DeviceLostReason, String) + Send + 'static>;
 #[cfg(not(send_sync))]
-pub type DeviceLostCallback = Box<dyn Fn(DeviceLostReason, String) + 'static>;
+pub type DeviceLostCallback = Box<dyn FnOnce(DeviceLostReason, String) + 'static>;
 
 /// An object safe variant of [`Context`] implemented by all types that implement [`Context`].
 pub(crate) trait DynContext: Debug + WasmNotSendSync {


### PR DESCRIPTION
Follow-up to https://github.com/gfx-rs/wgpu/pull/6588.

At a high-level:
- it removes C variants of closures as users of `wgpu-core` already use the rust variants (incuding `wgpu-native`).
- removes the `device_unregister_device_lost_closure` as users of the API that have cleanup work to do can just implement `Drop` for state passed into the closure