### PR TITLE
[naga] Leave `Module` as the last thing in `naga/src/lib.rs`.

### DIFF
--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -2236,6 +2236,62 @@ pub struct SpecialTypes {
     pub predeclared_types: FastIndexMap<PredeclaredType, Handle<Type>>,
 }
 
+bitflags::bitflags! {
+    /// Ray flags used when casting rays.
+    /// Matching vulkan constants can be found in
+    /// https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/ray_common/ray_flags_section.txt
+    #[cfg_attr(feature = "serialize", derive(Serialize))]
+    #[cfg_attr(feature = "deserialize", derive(Deserialize))]
+    #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    pub struct RayFlag: u32 {
+        /// Force all intersections to be treated as opaque.
+        const FORCE_OPAQUE = 0x1;
+        /// Force all intersections to be treated as non-opaque.
+        const FORCE_NO_OPAQUE = 0x2;
+        /// Stop traversal after the first hit.
+        const TERMINATE_ON_FIRST_HIT = 0x4;
+        /// Don't execute the closest hit shader.
+        const SKIP_CLOSEST_HIT_SHADER = 0x8;
+        /// Cull back facing geometry.
+        const CULL_BACK_FACING = 0x10;
+        /// Cull front facing geometry.
+        const CULL_FRONT_FACING = 0x20;
+        /// Cull opaque geometry.
+        const CULL_OPAQUE = 0x40;
+        /// Cull non-opaque geometry.
+        const CULL_NO_OPAQUE = 0x80;
+        /// Skip triangular geometry.
+        const SKIP_TRIANGLES = 0x100;
+        /// Skip axis-aligned bounding boxes.
+        const SKIP_AABBS = 0x200;
+    }
+}
+
+/// Type of a ray query intersection.
+/// Matching vulkan constants can be found in
+/// <https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_ray_query.asciidoc>
+/// but the actual values are different for candidate intersections.
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum RayQueryIntersection {
+    /// No intersection found.
+    /// Matches `RayQueryCommittedIntersectionNoneKHR`.
+    #[default]
+    None = 0,
+    /// Intersecting with triangles.
+    /// Matches `RayQueryCommittedIntersectionTriangleKHR` and `RayQueryCandidateIntersectionTriangleKHR`.
+    Triangle = 1,
+    /// Intersecting with generated primitives.
+    /// Matches `RayQueryCommittedIntersectionGeneratedKHR`.
+    Generated = 2,
+    /// Intersecting with Axis Aligned Bounding Boxes.
+    /// Matches `RayQueryCandidateIntersectionAABBKHR`.
+    Aabb = 3,
+}
+
 /// Shader module.
 ///
 /// A module is a set of constants, global variables and functions, as well as
@@ -2294,60 +2350,4 @@ pub struct Module {
     /// See [`DiagnosticFilterNode`] for details on how the tree is represented and used in
     /// validation.
     pub diagnostic_filter_leaf: Option<Handle<DiagnosticFilterNode>>,
-}
-
-bitflags::bitflags! {
-    /// Ray flags used when casting rays.
-    /// Matching vulkan constants can be found in
-    /// https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/ray_common/ray_flags_section.txt
-    #[cfg_attr(feature = "serialize", derive(Serialize))]
-    #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-    #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    pub struct RayFlag: u32 {
-        /// Force all intersections to be treated as opaque.
-        const FORCE_OPAQUE = 0x1;
-        /// Force all intersections to be treated as non-opaque.
-        const FORCE_NO_OPAQUE = 0x2;
-        /// Stop traversal after the first hit.
-        const TERMINATE_ON_FIRST_HIT = 0x4;
-        /// Don't execute the closest hit shader.
-        const SKIP_CLOSEST_HIT_SHADER = 0x8;
-        /// Cull back facing geometry.
-        const CULL_BACK_FACING = 0x10;
-        /// Cull front facing geometry.
-        const CULL_FRONT_FACING = 0x20;
-        /// Cull opaque geometry.
-        const CULL_OPAQUE = 0x40;
-        /// Cull non-opaque geometry.
-        const CULL_NO_OPAQUE = 0x80;
-        /// Skip triangular geometry.
-        const SKIP_TRIANGLES = 0x100;
-        /// Skip axis-aligned bounding boxes.
-        const SKIP_AABBS = 0x200;
-    }
-}
-
-/// Type of a ray query intersection.
-/// Matching vulkan constants can be found in
-/// <https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_ray_query.asciidoc>
-/// but the actual values are different for candidate intersections.
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum RayQueryIntersection {
-    /// No intersection found.
-    /// Matches `RayQueryCommittedIntersectionNoneKHR`.
-    #[default]
-    None = 0,
-    /// Intersecting with triangles.
-    /// Matches `RayQueryCommittedIntersectionTriangleKHR` and `RayQueryCandidateIntersectionTriangleKHR`.
-    Triangle = 1,
-    /// Intersecting with generated primitives.
-    /// Matches `RayQueryCommittedIntersectionGeneratedKHR`.
-    Generated = 2,
-    /// Intersecting with Axis Aligned Bounding Boxes.
-    /// Matches `RayQueryCandidateIntersectionAABBKHR`.
-    Aabb = 3,
 }


### PR DESCRIPTION
Move the definitions of `RayFlag` and `RayQueryIntersection` above the definition of `Module`, so that `Module` remains the last definition in `lib.rs`. This is helpful for navigation.

This commit is purely code motion, and makes no changes to functionality.
