### PR TITLE
[naga spv-in] OpImageWrite allows input other than Vector4.

### DIFF
--- a/naga/src/front/spv/image.rs
+++ b/naga/src/front/spv/image.rs
@@ -319,22 +319,29 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
                 value,
                 size: crate::VectorSize::Quad,
             }),
-            crate::TypeInner::Vector { size, .. } => {
-                if size != crate::VectorSize::Quad {
-                    Some(crate::Expression::Swizzle {
-                        size: crate::VectorSize::Quad,
-                        vector: value,
-                        pattern: [
-                            crate::SwizzleComponent::X,
-                            crate::SwizzleComponent::Y,
-                            crate::SwizzleComponent::Y,
-                            crate::SwizzleComponent::Y,
-                        ],
-                    })
-                } else {
-                    None
-                }
-            }
+            crate::TypeInner::Vector { size, .. } => match size {
+                crate::VectorSize::Bi => Some(crate::Expression::Swizzle {
+                    size: crate::VectorSize::Quad,
+                    vector: value,
+                    pattern: [
+                        crate::SwizzleComponent::X,
+                        crate::SwizzleComponent::Y,
+                        crate::SwizzleComponent::Y,
+                        crate::SwizzleComponent::Y,
+                    ],
+                }),
+                crate::VectorSize::Tri => Some(crate::Expression::Swizzle {
+                    size: crate::VectorSize::Quad,
+                    vector: value,
+                    pattern: [
+                        crate::SwizzleComponent::X,
+                        crate::SwizzleComponent::Y,
+                        crate::SwizzleComponent::Z,
+                        crate::SwizzleComponent::Z,
+                    ],
+                }),
+                crate::VectorSize::Quad => None,
+            },
             _ => return Err(Error::InvalidVectorType(value_type)),
         };
 

--- a/naga/src/front/spv/image.rs
+++ b/naga/src/front/spv/image.rs
@@ -312,11 +312,64 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
         let value_lexp = self.lookup_expression.lookup(value_id)?;
         let value = self.get_expr_handle(value_id, value_lexp, ctx, emitter, block, body_idx);
 
+        // In hlsl etc, the write value may not be the vector 4.
+        let swizzled_value = match ctx.module.types[image_ty].inner {
+            crate::TypeInner::Image {
+                dim: _,
+                arrayed: _,
+                class: crate::ImageClass::Storage { format, access: _ },
+            } => match format {
+                crate::StorageFormat::Rg8Unorm
+                | crate::StorageFormat::Rg8Snorm
+                | crate::StorageFormat::Rg8Uint
+                | crate::StorageFormat::Rg8Sint
+                | crate::StorageFormat::Rg16Uint
+                | crate::StorageFormat::Rg16Sint
+                | crate::StorageFormat::Rg16Float
+                | crate::StorageFormat::Rg32Uint
+                | crate::StorageFormat::Rg32Sint
+                | crate::StorageFormat::Rg32Float => Some(crate::Expression::Swizzle {
+                    size: crate::VectorSize::Quad,
+                    vector: value,
+                    pattern: [
+                        crate::SwizzleComponent::X,
+                        crate::SwizzleComponent::Y,
+                        crate::SwizzleComponent::Y,
+                        crate::SwizzleComponent::Y,
+                    ],
+                }),
+
+                crate::StorageFormat::R8Unorm
+                | crate::StorageFormat::R8Snorm
+                | crate::StorageFormat::R8Uint
+                | crate::StorageFormat::R8Sint
+                | crate::StorageFormat::R16Uint
+                | crate::StorageFormat::R16Sint
+                | crate::StorageFormat::R16Float
+                | crate::StorageFormat::R32Uint
+                | crate::StorageFormat::R32Sint
+                | crate::StorageFormat::R32Float
+                | crate::StorageFormat::R16Unorm
+                | crate::StorageFormat::R16Snorm => Some(crate::Expression::Splat {
+                    value,
+                    size: crate::VectorSize::Quad,
+                }),
+                _ => None,
+            },
+            _ => None,
+        };
+
+        let value_patched = if let Some(s) = swizzled_value {
+            ctx.expressions.append(s, crate::Span::default())
+        } else {
+            value
+        };
+
         Ok(crate::Statement::ImageStore {
             image: image_lexp.handle,
             coordinate,
             array_index,
-            value,
+            value: value_patched,
         })
     }
 


### PR DESCRIPTION
**Connections**
None

**Description**

Please excuse the use of machine translation (Google Translate).

It seems that an error (The value [~] can not be stored) occurs if a vector smaller than Vector4 is entered as the value of OpImageWrite.

However, according to the SPIR-V specification: https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpImageWrite

> Texel is the data to write. It must be a scalar or vector with component type the same as Sampled Type of the OpTypeImage (unless that Sampled Type is OpTypeVoid).

I think that even if a value other than Vector4 is entered, there is no problem as long as it matches the format of the target texture.

Looking at the error, it seems that it must be Vector4 in naga-ir, so I think that `naga::front::spv` needs to absorb that difference!

For now, I have created an implementation and made a PR.

The implementation is designed to insert an Expression that expands to Vector4 depending on the format of the texture to be written to.

However, this implementation has a flaw. It works fine for languages ​​that write Vector sizes that correspond to the destination, such as hlsl, but an error occurs if it is not...

If it is implemented correctly, I thought that it should be corrected by looking at the value to be written, not the format of the texture to be written, but I did not know how to implement it. (That is why this pull request is not mergeable, but a draft.)

So I hope this PR will explain the problem.

Finally, I will also include the minimum sample code (HLSL, SPIR-V) that causes this problem.

<details>
  <summary>Original japanese text</summary>
  
  機械翻訳(google translate)を使用していることをご容赦ください。

OpImageWrite の値として Vector4 より小さいベクターが入っているとエラー (The value [~] can not be stored) になるようです。

ですが、SPIR-V の仕様書によると: https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpImageWrite
> Texel is the data to write. It must be a scalar or vector with component type the same as Sampled Type of the OpTypeImage (unless that Sampled Type is OpTypeVoid).

と書かれており、Vector4 以外が入っていても対象となるテクスチャのフォーマットと適合していれば問題がないと私は思えます。

エラーを見るに naga-ir では Vector4 でないといけないようなので、 `naga::front::spv` がその差異を吸収する必要があると私は思います！

ひとまず、実装を作っては見たので PR を作りました。

実装としては、書き込み先のテクスチャのフォーマットに応じて Vector4 に拡張する Expression を差し込むようになっています。

ですが、この実装には欠陥があり hlsl などの書き込み先に対応した Vector サイズを書き込む言語の場合は問題がないですが、そうではない場合にかえってエラーが発生します ...

正しく実装するならば、書き込み先のテクスチャのフォーマットではなく、書き込む値の方を見て補正すべきだと私は思いましたが、私にそれを実装する方法がわかりませんでした。(このプルリクエストがマージできるものではなく、ドラフトにしている理由です。)

なので、この PR はその問題の説明になれば幸いです。

最後に、この問題が発生する最小の サンプルコード (HLSL,SPIR-V)も載せておきます。

</details>

<details>
  <summary>example shader code</summary>

example float2

```hlsl
cbuffer gv
{
    float2 RG;
}
RWTexture2D<float2> Tex;

[numthreads(32, 32, 1)] void CSMain(uint3 id : SV_DispatchThreadID)
{
    Tex[id.xy] = RG;
}
```

```spirv
; SPIR-V
; Version: 1.0
; Generator: Google spiregg; 0
; Bound: 26
; Schema: 0
               OpCapability Shader
               OpCapability StorageImageExtendedFormats
               OpMemoryModel Logical GLSL450
               OpEntryPoint GLCompute %CSMain "CSMain" %gl_GlobalInvocationID
               OpExecutionMode %CSMain LocalSize 32 32 1
               OpSource HLSL 600
               OpName %type_gv "type.gv"
               OpMemberName %type_gv 0 "RG"
               OpName %gv "gv"
               OpName %type_2d_image "type.2d.image"
               OpName %Tex "Tex"
               OpName %CSMain "CSMain"
               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
               OpDecorate %gv DescriptorSet 0
               OpDecorate %gv Binding 0
               OpDecorate %Tex DescriptorSet 0
               OpDecorate %Tex Binding 1
               OpMemberDecorate %type_gv 0 Offset 0
               OpDecorate %type_gv Block
        %int = OpTypeInt 32 1
      %int_0 = OpConstant %int 0
      %float = OpTypeFloat 32
    %v2float = OpTypeVector %float 2
    %type_gv = OpTypeStruct %v2float
%_ptr_Uniform_type_gv = OpTypePointer Uniform %type_gv
%type_2d_image = OpTypeImage %float 2D 2 0 0 2 Rg32f
%_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
       %uint = OpTypeInt 32 0
     %v3uint = OpTypeVector %uint 3
%_ptr_Input_v3uint = OpTypePointer Input %v3uint
       %void = OpTypeVoid
         %17 = OpTypeFunction %void
%_ptr_Uniform_v2float = OpTypePointer Uniform %v2float
     %v2uint = OpTypeVector %uint 2
         %gv = OpVariable %_ptr_Uniform_type_gv Uniform
        %Tex = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
     %CSMain = OpFunction %void None %17
         %20 = OpLabel
         %21 = OpLoad %v3uint %gl_GlobalInvocationID
         %22 = OpAccessChain %_ptr_Uniform_v2float %gv %int_0
         %23 = OpLoad %v2float %22
         %24 = OpVectorShuffle %v2uint %21 %21 0 1
         %25 = OpLoad %type_2d_image %Tex
               OpImageWrite %25 %24 %23 None
               OpReturn
               OpFunctionEnd
```

example float

```hlsl
cbuffer gv
{
    float R;
}
RWTexture2D<float> Tex;

[numthreads(32, 32, 1)] void CSMain(uint3 id : SV_DispatchThreadID)
{
    Tex[id.xy] = R;
}
```

```spirv
; SPIR-V
; Version: 1.0
; Generator: Google spiregg; 0
; Bound: 25
; Schema: 0
               OpCapability Shader
               OpMemoryModel Logical GLSL450
               OpEntryPoint GLCompute %CSMain "CSMain" %gl_GlobalInvocationID
               OpExecutionMode %CSMain LocalSize 32 32 1
               OpSource HLSL 600
               OpName %type_gv "type.gv"
               OpMemberName %type_gv 0 "R"
               OpName %gv "gv"
               OpName %type_2d_image "type.2d.image"
               OpName %Tex "Tex"
               OpName %CSMain "CSMain"
               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
               OpDecorate %gv DescriptorSet 0
               OpDecorate %gv Binding 0
               OpDecorate %Tex DescriptorSet 0
               OpDecorate %Tex Binding 1
               OpMemberDecorate %type_gv 0 Offset 0
               OpDecorate %type_gv Block
        %int = OpTypeInt 32 1
      %int_0 = OpConstant %int 0
      %float = OpTypeFloat 32
    %type_gv = OpTypeStruct %float
%_ptr_Uniform_type_gv = OpTypePointer Uniform %type_gv
%type_2d_image = OpTypeImage %float 2D 2 0 0 2 R32f
%_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
       %uint = OpTypeInt 32 0
     %v3uint = OpTypeVector %uint 3
%_ptr_Input_v3uint = OpTypePointer Input %v3uint
       %void = OpTypeVoid
         %16 = OpTypeFunction %void
%_ptr_Uniform_float = OpTypePointer Uniform %float
     %v2uint = OpTypeVector %uint 2
         %gv = OpVariable %_ptr_Uniform_type_gv Uniform
        %Tex = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
     %CSMain = OpFunction %void None %16
         %19 = OpLabel
         %20 = OpLoad %v3uint %gl_GlobalInvocationID
         %21 = OpAccessChain %_ptr_Uniform_float %gv %int_0
         %22 = OpLoad %float %21
         %23 = OpVectorShuffle %v2uint %20 %20 0 1
         %24 = OpLoad %type_2d_image %Tex
               OpImageWrite %24 %23 %22 None
               OpReturn
               OpFunctionEnd
```
</details>

**Testing**
I've provided example shader code so you should be able to create your own tests based on that.
(Is this the right answer...? Sorry if I'm wrong.)

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
