### PR TITLE
Add Pipeline Overrides for `workgroup_size`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Implement `quantizeToF16()` for WGSL frontend, and WGSL, SPIR-V, HLSL, MSL, and GLSL backends. By @jamienicol in [#6519](https://github.com/gfx-rs/wgpu/pull/6519).
 - Add support for GLSL `usampler*` and `isampler*`. By @DavidPeicho in [#6513](https://github.com/gfx-rs/wgpu/pull/6513).
 - Expose Ray Query flags as constants in WGSL. Implement candidate intersections. By @kvark in [#5429](https://github.com/gfx-rs/wgpu/pull/5429)
+- Allow for override-expressions in `workgroup_size`. By @KentSlaney in [#6635](https://github.com/gfx-rs/wgpu/pull/6635).
 
 #### General
 

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -25,7 +25,7 @@ pub enum PipelineConstantError {
     ConstantEvaluatorError(#[from] ConstantEvaluatorError),
     #[error(transparent)]
     ValidationError(#[from] WithSpan<ValidationError>),
-    #[error("workgroup_size was overridden to a negative value")]
+    #[error("workgroup_size overridde isn't strictly positive")]
     NegativeWorkgroupSize,
 }
 
@@ -218,29 +218,17 @@ fn process_workgroup_size_override(
                     match *overridden {
                         None => Ok(()),
                         Some(h) => {
-                            let c = module.constants[override_map[h]].init;
-                            let n = &module.global_expressions[c];
-                            match *n {
-                                crate::Expression::Literal(literal) => {
-                                    ep.workgroup_size[i] = match literal {
-                                        crate::Literal::U32(m) => m,
-                                        crate::Literal::I32(m) => {
-                                            if m < 0 {
-                                                Err(PipelineConstantError::NegativeWorkgroupSize)?;
-                                                unreachable!();
-                                            } else {
-                                                m as u32
-                                            }
-                                        }
-                                        _ => {
-                                            unreachable!();
-                                        }
-                                    };
-                                }
-                                _ => {
-                                    unreachable!();
-                                }
-                            }
+                            ep.workgroup_size[i] = module
+                                .to_ctx()
+                                .eval_expr_to_u32(module.constants[override_map[h]].init)
+                                .map(|n| {
+                                    if n == 0 {
+                                        Err(PipelineConstantError::NegativeWorkgroupSize)
+                                    } else {
+                                        Ok(n)
+                                    }
+                                })
+                                .map_err(|_| PipelineConstantError::NegativeWorkgroupSize)??;
                             Ok(())
                         }
                     }

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -208,28 +208,28 @@ pub fn process_overrides<'a>(
 fn process_workgroup_size_override(
     module: &mut Module,
     override_map: &HandleVec<Override, Handle<Constant>>,
-    ep: &mut crate::EntryPoint
+    ep: &mut crate::EntryPoint,
 ) -> Result<(), PipelineConstantError> {
     match ep.workgroup_size_overrides {
         None => {}
         Some(overrides) => {
             overrides.iter().enumerate().try_for_each(
                 |(i, overridden)| -> Result<(), PipelineConstantError> {
-                    match overridden {
+                    match *overridden {
                         None => Ok(()),
                         Some(h) => {
-                            let c = module.constants[override_map[*h]].init;
+                            let c = module.constants[override_map[h]].init;
                             let n = &module.global_expressions[c];
-                            match n {
+                            match *n {
                                 crate::Expression::Literal(literal) => {
                                     ep.workgroup_size[i] = match literal {
-                                        crate::Literal::U32(m) => (*m).into(),
+                                        crate::Literal::U32(m) => m,
                                         crate::Literal::I32(m) => {
-                                            if *m < 0 {
+                                            if m < 0 {
                                                 Err(PipelineConstantError::NegativeWorkgroupSize)?;
                                                 unreachable!();
                                             } else {
-                                                *m as u32
+                                                m as u32
                                             }
                                         }
                                         _ => {
@@ -244,7 +244,7 @@ fn process_workgroup_size_override(
                             Ok(())
                         }
                     }
-                }
+                },
             )?;
         }
     }

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -192,7 +192,7 @@ pub fn process_overrides<'a>(
     let mut entry_points = mem::take(&mut module.entry_points);
     for ep in entry_points.iter_mut() {
         process_function(&mut module, &override_map, &mut ep.function)?;
-        process_workgroup_size_override(&mut module, &override_map, ep)?;
+        process_workgroup_size_override(&mut module, &adjusted_global_expressions, ep)?;
     }
     module.entry_points = entry_points;
 
@@ -207,7 +207,7 @@ pub fn process_overrides<'a>(
 
 fn process_workgroup_size_override(
     module: &mut Module,
-    override_map: &HandleVec<Override, Handle<Constant>>,
+    adjusted_global_expressions: &HandleVec<Expression, Handle<Expression>>,
     ep: &mut crate::EntryPoint,
 ) -> Result<(), PipelineConstantError> {
     match ep.workgroup_size_overrides {
@@ -220,7 +220,7 @@ fn process_workgroup_size_override(
                         Some(h) => {
                             ep.workgroup_size[i] = module
                                 .to_ctx()
-                                .eval_expr_to_u32(module.constants[override_map[h]].init)
+                                .eval_expr_to_u32(adjusted_global_expressions[h])
                                 .map(|n| {
                                     if n == 0 {
                                         Err(PipelineConstantError::NegativeWorkgroupSize)

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -25,7 +25,7 @@ pub enum PipelineConstantError {
     ConstantEvaluatorError(#[from] ConstantEvaluatorError),
     #[error(transparent)]
     ValidationError(#[from] WithSpan<ValidationError>),
-    #[error("workgroup_size overridde isn't strictly positive")]
+    #[error("workgroup_size override isn't strictly positive")]
     NegativeWorkgroupSize,
 }
 
@@ -234,6 +234,7 @@ fn process_workgroup_size_override(
                     }
                 },
             )?;
+            ep.workgroup_size_overrides = None;
         }
     }
     Ok(())

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -25,6 +25,8 @@ pub enum PipelineConstantError {
     ConstantEvaluatorError(#[from] ConstantEvaluatorError),
     #[error(transparent)]
     ValidationError(#[from] WithSpan<ValidationError>),
+    #[error("workgroup_size was overridden to a negative value")]
+    NegativeWorkgroupSize,
 }
 
 /// Replace all overrides in `module` with constants.
@@ -190,6 +192,7 @@ pub fn process_overrides<'a>(
     let mut entry_points = mem::take(&mut module.entry_points);
     for ep in entry_points.iter_mut() {
         process_function(&mut module, &override_map, &mut ep.function)?;
+        process_workgroup_size_override(&mut module, &override_map, ep)?;
     }
     module.entry_points = entry_points;
 
@@ -200,6 +203,52 @@ pub fn process_overrides<'a>(
     let module_info = validator.validate_no_overrides(&module)?;
 
     Ok((Cow::Owned(module), Cow::Owned(module_info)))
+}
+
+fn process_workgroup_size_override(
+    module: &mut Module,
+    override_map: &HandleVec<Override, Handle<Constant>>,
+    ep: &mut crate::EntryPoint
+) -> Result<(), PipelineConstantError> {
+    match ep.workgroup_size_overrides {
+        None => {}
+        Some(overrides) => {
+            overrides.iter().enumerate().try_for_each(
+                |(i, overridden)| -> Result<(), PipelineConstantError> {
+                    match overridden {
+                        None => Ok(()),
+                        Some(h) => {
+                            let c = module.constants[override_map[*h]].init;
+                            let n = &module.global_expressions[c];
+                            match n {
+                                crate::Expression::Literal(literal) => {
+                                    ep.workgroup_size[i] = match literal {
+                                        crate::Literal::U32(m) => (*m).into(),
+                                        crate::Literal::I32(m) => {
+                                            if *m < 0 {
+                                                Err(PipelineConstantError::NegativeWorkgroupSize)?;
+                                                unreachable!();
+                                            } else {
+                                                *m as u32
+                                            }
+                                        }
+                                        _ => {
+                                            unreachable!();
+                                        }
+                                    };
+                                }
+                                _ => {
+                                    unreachable!();
+                                }
+                            }
+                            Ok(())
+                        }
+                    }
+                }
+            )?;
+        }
+    }
+    Ok(())
 }
 
 /// Add a [`Constant`] to `module` for the override `old_h`.

--- a/naga/src/compact/mod.rs
+++ b/naga/src/compact/mod.rs
@@ -63,6 +63,14 @@ pub fn compact(module: &mut crate::Module) {
         }
     }
 
+    for e in module.entry_points.iter() {
+        if let Some(sizes) = e.workgroup_size_overrides {
+            for size in sizes.iter().filter_map(|x| *x) {
+                module_tracer.global_expressions_used.insert(size);
+            }
+        }
+    }
+
     // We assume that all functions are used.
     //
     // Observe which types, constant expressions, constants, and
@@ -173,6 +181,18 @@ pub fn compact(module: &mut crate::Module) {
         module_map.types.adjust(&mut override_.ty);
         if let Some(init) = override_.init.as_mut() {
             module_map.global_expressions.adjust(init);
+        }
+    }
+
+    // Adjust workgroup_size_overrides
+    log::trace!("adjusting workgroup_size_overrides");
+    for e in module.entry_points.iter_mut() {
+        if let Some(sizes) = e.workgroup_size_overrides.as_mut() {
+            for size in sizes.iter_mut() {
+                if let Some(expr) = size.as_mut() {
+                    module_map.global_expressions.adjust(expr);
+                }
+            }
         }
     }
 

--- a/naga/src/front/glsl/functions.rs
+++ b/naga/src/front/glsl/functions.rs
@@ -1366,6 +1366,7 @@ impl Frontend {
             early_depth_test: Some(crate::EarlyDepthTest { conservative: None })
                 .filter(|_| self.meta.early_fragment_tests),
             workgroup_size: self.meta.workgroup_size,
+            workgroup_size_overrides: None,
             function: Function {
                 arguments,
                 expressions,

--- a/naga/src/front/spv/function.rs
+++ b/naga/src/front/spv/function.rs
@@ -569,6 +569,7 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
             stage: ep.stage,
             early_depth_test: ep.early_depth_test,
             workgroup_size: ep.workgroup_size,
+            workgroup_size_overrides: None,
             function,
         });
 

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1325,13 +1325,12 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                 if let Err(Error::ConstantEvaluatorError(ref ty, _)) = err {
                                     match **ty {
                                         crate::proc::ConstantEvaluatorError::OverrideExpr => {
-                                            workgroup_size_overrides_out[i] = Some(
-                                                self.workgroup_size_override(
+                                            workgroup_size_overrides_out[i] =
+                                                Some(self.workgroup_size_override(
                                                     size_expr,
                                                     &mut ctx.as_override(),
                                                     i,
-                                                )?
-                                            );
+                                                )?);
                                         }
                                         _ => {
                                             err?;
@@ -1390,9 +1389,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     span,
                 )
             }),
-            _ => {
-                Err(Error::ExpectedConstExprConcreteIntegerScalar(span))
-            }
+            _ => Err(Error::ExpectedConstExprConcreteIntegerScalar(span)),
         }
     }
 

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1329,7 +1329,6 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                                 Some(self.workgroup_size_override(
                                                     size_expr,
                                                     &mut ctx.as_override(),
-                                                    i,
                                                 )?);
                                         }
                                         _ => {
@@ -1372,23 +1371,11 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
         &mut self,
         size_expr: Handle<ast::Expression<'source>>,
         ctx: &mut ExpressionContext<'source, '_, '_>,
-        i: usize,
-    ) -> Result<Handle<crate::Override>, Error<'source>> {
+    ) -> Result<Handle<crate::Expression>, Error<'source>> {
         let span = ctx.ast_expressions.get_span(size_expr);
         let expr = self.expression(size_expr, ctx)?;
-        let ty = ctx.register_type(expr)?;
-        match ctx.module.types[ty].inner.scalar_kind().ok_or(0) {
-            Ok(crate::ScalarKind::Sint) | Ok(crate::ScalarKind::Uint) => Ok({
-                ctx.module.overrides.append(
-                    crate::Override {
-                        name: Some(format!("__workgroup_size_{}", i)),
-                        id: None,
-                        ty,
-                        init: Some(expr),
-                    },
-                    span,
-                )
-            }),
+        match resolve_inner!(ctx, expr).scalar_kind().ok_or(0) {
+            Ok(crate::ScalarKind::Sint) | Ok(crate::ScalarKind::Uint) => Ok(expr),
             _ => Err(Error::ExpectedConstExprConcreteIntegerScalar(span)),
         }
     }

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1311,30 +1311,88 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             .collect();
 
         if let Some(ref entry) = f.entry_point {
-            let workgroup_size = if let Some(workgroup_size) = entry.workgroup_size {
+            let workgroup_size_info = if let Some(workgroup_size) = entry.workgroup_size {
                 // TODO: replace with try_map once stabilized
                 let mut workgroup_size_out = [1; 3];
+                let mut workgroup_size_overrides_out = [None; 3];
                 for (i, size) in workgroup_size.into_iter().enumerate() {
                     if let Some(size_expr) = size {
-                        workgroup_size_out[i] = self.const_u32(size_expr, &mut ctx.as_const())?.0;
+                        match self.const_u32(size_expr, &mut ctx.as_const()) {
+                            Ok(value) => {
+                                workgroup_size_out[i] = value.0;
+                            }
+                            err => {
+                                if let Err(Error::ConstantEvaluatorError(ref ty, _)) = err {
+                                    match **ty {
+                                        crate::proc::ConstantEvaluatorError::OverrideExpr => {
+                                            workgroup_size_overrides_out[i] = Some(
+                                                self.workgroup_size_override(
+                                                    size_expr,
+                                                    &mut ctx.as_override(),
+                                                    i,
+                                                )?
+                                            );
+                                        }
+                                        _ => {
+                                            err?;
+                                        }
+                                    }
+                                } else {
+                                    err?;
+                                }
+                            }
+                        }
                     }
                 }
-                workgroup_size_out
+                if workgroup_size_overrides_out.iter().all(|x| x.is_none()) {
+                    (workgroup_size_out, None)
+                } else {
+                    (workgroup_size_out, Some(workgroup_size_overrides_out))
+                }
             } else {
-                [0; 3]
+                ([0; 3], None)
             };
 
+            let (workgroup_size, workgroup_size_overrides) = workgroup_size_info;
             ctx.module.entry_points.push(crate::EntryPoint {
                 name: f.name.name.to_string(),
                 stage: entry.stage,
                 early_depth_test: entry.early_depth_test,
                 workgroup_size,
+                workgroup_size_overrides,
                 function,
             });
             Ok(LoweredGlobalDecl::EntryPoint)
         } else {
             let handle = ctx.module.functions.append(function, span);
             Ok(LoweredGlobalDecl::Function(handle))
+        }
+    }
+
+    fn workgroup_size_override(
+        &mut self,
+        size_expr: Handle<ast::Expression<'source>>,
+        ctx: &mut ExpressionContext<'source, '_, '_>,
+        i: usize,
+    ) -> Result<Handle<crate::Override>, Error<'source>> {
+        let span = ctx.ast_expressions.get_span(size_expr);
+        let expr = self.expression(size_expr, ctx)?;
+        let ty = ctx.register_type(expr)?;
+        match ctx.module.types[ty].inner.scalar_kind().ok_or(0) {
+            Ok(crate::ScalarKind::Sint) | Ok(crate::ScalarKind::Uint) => Ok({
+                ctx.module.overrides.append(
+                    crate::Override {
+                        name: Some(format!("__workgroup_size_{}", i)),
+                        id: None,
+                        ty,
+                        init: Some(expr),
+                    },
+                    span,
+                )
+            }),
+            _ => {
+                Err(Error::ExpectedConstExprConcreteIntegerScalar(span))
+            }
         }
     }
 

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -2186,7 +2186,7 @@ pub struct EntryPoint {
     pub early_depth_test: Option<EarlyDepthTest>,
     /// Workgroup size for compute stages
     pub workgroup_size: [u32; 3],
-    /// Override expressions for workgroup size
+    /// Override expressions in the global_expressions arena for workgroup size
     pub workgroup_size_overrides: Option<[Option<Handle<Override>>; 3]>,
     /// The entrance function.
     pub function: Function,

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -2186,7 +2186,7 @@ pub struct EntryPoint {
     pub early_depth_test: Option<EarlyDepthTest>,
     /// Workgroup size for compute stages
     pub workgroup_size: [u32; 3],
-    /// Override expressions for workgroup size
+    /// Override expressions for workgroup size in the global_expressions arena
     pub workgroup_size_overrides: Option<[Option<Handle<Expression>>; 3]>,
     /// The entrance function.
     pub function: Function,

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -2186,6 +2186,8 @@ pub struct EntryPoint {
     pub early_depth_test: Option<EarlyDepthTest>,
     /// Workgroup size for compute stages
     pub workgroup_size: [u32; 3],
+    /// Override expressions for workgroup size
+    pub workgroup_size_overrides: Option<[Option<Handle<Override>>; 3]>,
     /// The entrance function.
     pub function: Function,
 }

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -2187,7 +2187,7 @@ pub struct EntryPoint {
     /// Workgroup size for compute stages
     pub workgroup_size: [u32; 3],
     /// Override expressions for workgroup size
-    pub workgroup_size_overrides: Option<[Option<Handle<Override>>; 3]>,
+    pub workgroup_size_overrides: Option<[Option<Handle<Expression>>; 3]>,
     /// The entrance function.
     pub function: Function,
 }

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -2186,7 +2186,7 @@ pub struct EntryPoint {
     pub early_depth_test: Option<EarlyDepthTest>,
     /// Workgroup size for compute stages
     pub workgroup_size: [u32; 3],
-    /// Override expressions in the global_expressions arena for workgroup size
+    /// Override expressions for workgroup size
     pub workgroup_size_overrides: Option<[Option<Handle<Override>>; 3]>,
     /// The entrance function.
     pub function: Function,

--- a/naga/src/valid/handles.rs
+++ b/naga/src/valid/handles.rs
@@ -176,8 +176,8 @@ impl super::Validator {
         for entry_point in entry_points.iter() {
             validate_function(None, &entry_point.function)?;
             if let Some(sizes) = entry_point.workgroup_size_overrides {
-                for size in sizes.iter().filter(|x| x.is_some()) {
-                    Self::validate_override_handle(size.unwrap(), overrides)?;
+                for size in sizes.iter().filter_map(|x| *x) {
+                    validate_const_expr(size)?;
                 }
             }
         }

--- a/naga/src/valid/handles.rs
+++ b/naga/src/valid/handles.rs
@@ -175,6 +175,11 @@ impl super::Validator {
 
         for entry_point in entry_points.iter() {
             validate_function(None, &entry_point.function)?;
+            if let Some(sizes) = entry_point.workgroup_size_overrides {
+                for size in sizes.iter().filter(|x| x.is_some()) {
+                    Self::validate_override_handle(size.unwrap(), overrides)?;
+                }
+            }
         }
 
         for (function_handle, function) in functions.iter() {

--- a/naga/tests/out/ir/access.compact.ron
+++ b/naga/tests/out/ir/access.compact.ron
@@ -1854,6 +1854,7 @@
             stage: Vertex,
             early_depth_test: None,
             workgroup_size: (0, 0, 0),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("foo_vert"),
                 arguments: [
@@ -2156,6 +2157,7 @@
             stage: Fragment,
             early_depth_test: None,
             workgroup_size: (0, 0, 0),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("foo_frag"),
                 arguments: [],
@@ -2348,6 +2350,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("assign_through_ptr"),
                 arguments: [],
@@ -2430,6 +2433,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("assign_to_ptr_components"),
                 arguments: [],

--- a/naga/tests/out/ir/access.ron
+++ b/naga/tests/out/ir/access.ron
@@ -1854,6 +1854,7 @@
             stage: Vertex,
             early_depth_test: None,
             workgroup_size: (0, 0, 0),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("foo_vert"),
                 arguments: [
@@ -2156,6 +2157,7 @@
             stage: Fragment,
             early_depth_test: None,
             workgroup_size: (0, 0, 0),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("foo_frag"),
                 arguments: [],
@@ -2348,6 +2350,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("assign_through_ptr"),
                 arguments: [],
@@ -2430,6 +2433,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("assign_to_ptr_components"),
                 arguments: [],

--- a/naga/tests/out/ir/atomic_i_increment.compact.ron
+++ b/naga/tests/out/ir/atomic_i_increment.compact.ron
@@ -263,6 +263,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (32, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("stage::test_atomic_i_increment_wrap"),
                 arguments: [],

--- a/naga/tests/out/ir/atomic_i_increment.ron
+++ b/naga/tests/out/ir/atomic_i_increment.ron
@@ -288,6 +288,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (32, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("stage::test_atomic_i_increment_wrap"),
                 arguments: [],

--- a/naga/tests/out/ir/collatz.compact.ron
+++ b/naga/tests/out/ir/collatz.compact.ron
@@ -257,6 +257,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("main"),
                 arguments: [

--- a/naga/tests/out/ir/collatz.ron
+++ b/naga/tests/out/ir/collatz.ron
@@ -257,6 +257,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("main"),
                 arguments: [

--- a/naga/tests/out/ir/fetch_depth.compact.ron
+++ b/naga/tests/out/ir/fetch_depth.compact.ron
@@ -176,6 +176,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (32, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("cull::fetch_depth_wrap"),
                 arguments: [],

--- a/naga/tests/out/ir/fetch_depth.ron
+++ b/naga/tests/out/ir/fetch_depth.ron
@@ -246,6 +246,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (32, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("cull::fetch_depth_wrap"),
                 arguments: [],

--- a/naga/tests/out/ir/index-by-value.compact.ron
+++ b/naga/tests/out/ir/index-by-value.compact.ron
@@ -300,6 +300,7 @@
             stage: Vertex,
             early_depth_test: None,
             workgroup_size: (0, 0, 0),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("index_let_array_1d"),
                 arguments: [

--- a/naga/tests/out/ir/index-by-value.ron
+++ b/naga/tests/out/ir/index-by-value.ron
@@ -300,6 +300,7 @@
             stage: Vertex,
             early_depth_test: None,
             workgroup_size: (0, 0, 0),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("index_let_array_1d"),
                 arguments: [

--- a/naga/tests/out/ir/overrides-atomicCompareExchangeWeak.compact.ron
+++ b/naga/tests/out/ir/overrides-atomicCompareExchangeWeak.compact.ron
@@ -85,6 +85,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("f"),
                 arguments: [],

--- a/naga/tests/out/ir/overrides-atomicCompareExchangeWeak.ron
+++ b/naga/tests/out/ir/overrides-atomicCompareExchangeWeak.ron
@@ -85,6 +85,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("f"),
                 arguments: [],

--- a/naga/tests/out/ir/overrides-ray-query.compact.ron
+++ b/naga/tests/out/ir/overrides-ray-query.compact.ron
@@ -111,6 +111,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("main"),
                 arguments: [],

--- a/naga/tests/out/ir/overrides-ray-query.ron
+++ b/naga/tests/out/ir/overrides-ray-query.ron
@@ -111,6 +111,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("main"),
                 arguments: [],

--- a/naga/tests/out/ir/overrides.compact.ron
+++ b/naga/tests/out/ir/overrides.compact.ron
@@ -108,6 +108,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("main"),
                 arguments: [],

--- a/naga/tests/out/ir/overrides.ron
+++ b/naga/tests/out/ir/overrides.ron
@@ -108,6 +108,7 @@
             stage: Compute,
             early_depth_test: None,
             workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("main"),
                 arguments: [],

--- a/naga/tests/out/ir/shadow.compact.ron
+++ b/naga/tests/out/ir/shadow.compact.ron
@@ -958,6 +958,7 @@
             stage: Fragment,
             early_depth_test: None,
             workgroup_size: (0, 0, 0),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("fs_main_wrap"),
                 arguments: [

--- a/naga/tests/out/ir/shadow.ron
+++ b/naga/tests/out/ir/shadow.ron
@@ -1236,6 +1236,7 @@
             stage: Fragment,
             early_depth_test: None,
             workgroup_size: (0, 0, 0),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("fs_main_wrap"),
                 arguments: [

--- a/naga/tests/out/ir/spec-constants.compact.ron
+++ b/naga/tests/out/ir/spec-constants.compact.ron
@@ -495,6 +495,7 @@
             stage: Vertex,
             early_depth_test: None,
             workgroup_size: (0, 0, 0),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("main_wrap"),
                 arguments: [

--- a/naga/tests/out/ir/spec-constants.ron
+++ b/naga/tests/out/ir/spec-constants.ron
@@ -601,6 +601,7 @@
             stage: Vertex,
             early_depth_test: None,
             workgroup_size: (0, 0, 0),
+            workgroup_size_overrides: None,
             function: (
                 name: Some("main_wrap"),
                 arguments: [

--- a/tests/tests/shader/mod.rs
+++ b/tests/tests/shader/mod.rs
@@ -19,6 +19,7 @@ pub mod compilation_messages;
 pub mod data_builtins;
 pub mod numeric_builtins;
 pub mod struct_layout;
+pub mod workgroup_size_overrides;
 pub mod zero_init_workgroup_mem;
 
 #[derive(Clone, Copy, PartialEq)]

--- a/tests/tests/shader/workgroup_size_overrides.rs
+++ b/tests/tests/shader/workgroup_size_overrides.rs
@@ -1,0 +1,103 @@
+use std::mem::size_of_val;
+use wgpu::util::DeviceExt;
+use wgpu::{BufferDescriptor, BufferUsages, Maintain, MapMode};
+use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+
+const SHADER: &str = r#"
+    override n = 3;
+
+    @group(0) @binding(0)
+    var<storage, read_write> output: array<u32>;
+
+    @compute @workgroup_size(n - 2)
+    fn main(@builtin(local_invocation_index) lii: u32) {
+        output[lii] = lii + 2;
+    }
+"#;
+
+#[gpu_test]
+static WORKGROUP_SIZE_OVERRIDES: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().limits(wgpu::Limits::default()))
+    .run_async(move |ctx| async move {
+        workgroup_size_overrides(&ctx, 0, &[2, 0, 0]).await;
+        workgroup_size_overrides(&ctx, 4, &[2, 3, 0]).await;
+        // Expected to fail during pipeline creation:
+        //workgroup_size_overrides(&ctx, 1, &[0, 0, 0]).await;
+    });
+
+async fn workgroup_size_overrides(ctx: &TestingContext, n: u32, out: &[u32]) {
+    let module = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(SHADER)),
+        });
+    let pipeline_options = wgpu::PipelineCompilationOptions {
+        constants: &[("n".to_owned(), n.into())].into(),
+        ..Default::default()
+    };
+    let compute_pipeline = ctx
+        .device
+        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: None,
+            layout: None,
+            module: &module,
+            entry_point: Some("main"),
+            compilation_options: if n == 0 {
+                wgpu::PipelineCompilationOptions::default()
+            } else {
+                pipeline_options
+            },
+            cache: None,
+        });
+    let init: &[u32] = &[0, 0, 0];
+    let init_size: u64 = size_of_val(init).try_into().unwrap();
+    let buffer = DeviceExt::create_buffer_init(
+        &ctx.device,
+        &wgpu::util::BufferInitDescriptor {
+            label: None,
+            contents: bytemuck::cast_slice(init),
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
+        },
+    );
+    let mapping_buffer = ctx.device.create_buffer(&BufferDescriptor {
+        label: Some("mapping buffer"),
+        size: init_size,
+        usage: BufferUsages::COPY_DST | BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    {
+        let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: None,
+            timestamp_writes: None,
+        });
+        cpass.set_pipeline(&compute_pipeline);
+        let bind_group_layout = compute_pipeline.get_bind_group_layout(0);
+        let bind_group_entries = [wgpu::BindGroupEntry {
+            binding: 0,
+            resource: buffer.as_entire_binding(),
+        }];
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &bind_group_layout,
+            entries: &bind_group_entries,
+        });
+        cpass.set_bind_group(0, &bind_group, &[]);
+        cpass.dispatch_workgroups(1, 1, 1);
+    }
+    encoder.copy_buffer_to_buffer(&buffer, 0, &mapping_buffer, 0, init_size);
+    ctx.queue.submit(Some(encoder.finish()));
+
+    mapping_buffer.slice(..).map_async(MapMode::Read, |_| ());
+    ctx.async_poll(Maintain::wait()).await.panic_on_timeout();
+
+    let mapped = mapping_buffer.slice(..).get_mapped_range();
+
+    let typed: &[u32] = bytemuck::cast_slice(&mapped);
+    assert_eq!(typed, out);
+}

--- a/tests/tests/shader/workgroup_size_overrides.rs
+++ b/tests/tests/shader/workgroup_size_overrides.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of_val;
 use wgpu::util::DeviceExt;
 use wgpu::{BufferDescriptor, BufferUsages, Maintain, MapMode};
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
 const SHADER: &str = r#"
     override n = 3;
@@ -19,13 +19,18 @@ const SHADER: &str = r#"
 static WORKGROUP_SIZE_OVERRIDES: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default().limits(wgpu::Limits::default()))
     .run_async(move |ctx| async move {
-        workgroup_size_overrides(&ctx, 0, &[2, 0, 0]).await;
-        workgroup_size_overrides(&ctx, 4, &[2, 3, 0]).await;
-        // Expected to fail during pipeline creation:
-        //workgroup_size_overrides(&ctx, 1, &[0, 0, 0]).await;
+        workgroup_size_overrides(&ctx, false, 0, &[2, 0, 0], false).await;
+        workgroup_size_overrides(&ctx,  true, 4, &[2, 3, 0], false).await;
+        workgroup_size_overrides(&ctx,  true, 1, &[0, 0, 0],  true).await;
     });
 
-async fn workgroup_size_overrides(ctx: &TestingContext, n: u32, out: &[u32]) {
+async fn workgroup_size_overrides(
+    ctx: &TestingContext,
+    use_override: bool,
+    n: u32,
+    out: &[u32],
+    should_fail: bool,
+) {
     let module = ctx
         .device
         .create_shader_module(wgpu::ShaderModuleDescriptor {
@@ -36,20 +41,28 @@ async fn workgroup_size_overrides(ctx: &TestingContext, n: u32, out: &[u32]) {
         constants: &[("n".to_owned(), n.into())].into(),
         ..Default::default()
     };
-    let compute_pipeline = ctx
-        .device
-        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: None,
-            layout: None,
-            module: &module,
-            entry_point: Some("main"),
-            compilation_options: if n == 0 {
-                wgpu::PipelineCompilationOptions::default()
-            } else {
-                pipeline_options
-            },
-            cache: None,
-        });
+    let compute_pipeline = fail_if(
+        &ctx.device,
+        should_fail,
+        || {
+            ctx.device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: None,
+                layout: None,
+                module: &module,
+                entry_point: Some("main"),
+                compilation_options: if use_override {
+                    pipeline_options
+                } else {
+                    wgpu::PipelineCompilationOptions::default()
+                },
+                cache: None,
+            })
+        },
+        None
+    );
+    if should_fail {
+        return;
+    }
     let init: &[u32] = &[0, 0, 0];
     let init_size: u64 = size_of_val(init).try_into().unwrap();
     let buffer = DeviceExt::create_buffer_init(

--- a/tests/tests/shader/workgroup_size_overrides.rs
+++ b/tests/tests/shader/workgroup_size_overrides.rs
@@ -19,15 +19,14 @@ const SHADER: &str = r#"
 static WORKGROUP_SIZE_OVERRIDES: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default().limits(wgpu::Limits::default()))
     .run_async(move |ctx| async move {
-        workgroup_size_overrides(&ctx, false, 0, &[2, 0, 0], false).await;
-        workgroup_size_overrides(&ctx, true, 4, &[2, 3, 0], false).await;
-        workgroup_size_overrides(&ctx, true, 1, &[0, 0, 0], true).await;
+        workgroup_size_overrides(&ctx, None, &[2, 0, 0], false).await;
+        workgroup_size_overrides(&ctx, Some(4), &[2, 3, 0], false).await;
+        workgroup_size_overrides(&ctx, Some(1), &[0, 0, 0], true).await;
     });
 
 async fn workgroup_size_overrides(
     ctx: &TestingContext,
-    use_override: bool,
-    n: u32,
+    n: Option<u32>,
     out: &[u32],
     should_fail: bool,
 ) {
@@ -38,7 +37,7 @@ async fn workgroup_size_overrides(
             source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(SHADER)),
         });
     let pipeline_options = wgpu::PipelineCompilationOptions {
-        constants: &[("n".to_owned(), n.into())].into(),
+        constants: &[("n".to_owned(), n.unwrap_or(0).into())].into(),
         ..Default::default()
     };
     let compute_pipeline = fail_if(
@@ -51,7 +50,7 @@ async fn workgroup_size_overrides(
                     layout: None,
                     module: &module,
                     entry_point: Some("main"),
-                    compilation_options: if use_override {
+                    compilation_options: if n.is_some() {
                         pipeline_options
                     } else {
                         wgpu::PipelineCompilationOptions::default()

--- a/tests/tests/shader/workgroup_size_overrides.rs
+++ b/tests/tests/shader/workgroup_size_overrides.rs
@@ -5,14 +5,13 @@ use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, TestParameters, Testing
 
 const SHADER: &str = r#"
     override n = 3;
-    const m = 2u;
 
     @group(0) @binding(0)
     var<storage, read_write> output: array<u32>;
 
     @compute @workgroup_size(n - 2)
     fn main(@builtin(local_invocation_index) lii: u32) {
-        output[lii] = lii + m;
+        output[lii] = lii + 2;
     }
 "#;
 

--- a/tests/tests/shader/workgroup_size_overrides.rs
+++ b/tests/tests/shader/workgroup_size_overrides.rs
@@ -20,8 +20,8 @@ static WORKGROUP_SIZE_OVERRIDES: GpuTestConfiguration = GpuTestConfiguration::ne
     .parameters(TestParameters::default().limits(wgpu::Limits::default()))
     .run_async(move |ctx| async move {
         workgroup_size_overrides(&ctx, false, 0, &[2, 0, 0], false).await;
-        workgroup_size_overrides(&ctx,  true, 4, &[2, 3, 0], false).await;
-        workgroup_size_overrides(&ctx,  true, 1, &[0, 0, 0],  true).await;
+        workgroup_size_overrides(&ctx, true, 4, &[2, 3, 0], false).await;
+        workgroup_size_overrides(&ctx, true, 1, &[0, 0, 0], true).await;
     });
 
 async fn workgroup_size_overrides(
@@ -45,20 +45,21 @@ async fn workgroup_size_overrides(
         &ctx.device,
         should_fail,
         || {
-            ctx.device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-                label: None,
-                layout: None,
-                module: &module,
-                entry_point: Some("main"),
-                compilation_options: if use_override {
-                    pipeline_options
-                } else {
-                    wgpu::PipelineCompilationOptions::default()
-                },
-                cache: None,
-            })
+            ctx.device
+                .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                    label: None,
+                    layout: None,
+                    module: &module,
+                    entry_point: Some("main"),
+                    compilation_options: if use_override {
+                        pipeline_options
+                    } else {
+                        wgpu::PipelineCompilationOptions::default()
+                    },
+                    cache: None,
+                })
         },
-        None
+        None,
     );
     if should_fail {
         return;

--- a/tests/tests/shader/workgroup_size_overrides.rs
+++ b/tests/tests/shader/workgroup_size_overrides.rs
@@ -5,13 +5,14 @@ use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, TestParameters, Testing
 
 const SHADER: &str = r#"
     override n = 3;
+    const m = 2u;
 
     @group(0) @binding(0)
     var<storage, read_write> output: array<u32>;
 
     @compute @workgroup_size(n - 2)
     fn main(@builtin(local_invocation_index) lii: u32) {
-        output[lii] = lii + 2;
+        output[lii] = lii + m;
     }
 "#;
 


### PR DESCRIPTION
**Connections**
resolves #4450 

**Description**
The WebGPU spec allows for pipeline overrides of `workgroup_size`. This is achieved by adding a `workgroup_size_overrides` field to `crate::EntryPoint` and registering any override expressions in `workgroup_size` as an override with the name `__workgroup_size_{[012]}` since identifiers [aren't allowed](https://www.w3.org/TR/WGSL/#identifiers) to start with two underscores in a row. From there, they are resolved to constants with the other overrides and any `Some` fields in `workgroup_size_overrides` replace the corresponding `workgroup_size`.

**Testing**
This change adds an integration test via `wgpu_test`, which checks that the workgroup size equals the initialization value by default and that it changes with pipeline overrides.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] ~`--target wasm32-unknown-unknown`~
  - [ ] ~`--target wasm32-unknown-emscripten`~
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
