### PR TITLE
Move TextureDataOrder to wgpu-types

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1893,6 +1893,32 @@ bitflags::bitflags! {
     }
 }
 
+/// Order in which TextureData is laid out in memory.
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Hash)]
+pub enum TextureDataOrder {
+    /// The texture is laid out densely in memory as:
+    ///
+    /// ```text
+    /// Layer0Mip0 Layer0Mip1 Layer0Mip2
+    /// Layer1Mip0 Layer1Mip1 Layer1Mip2
+    /// Layer2Mip0 Layer2Mip1 Layer2Mip2
+    /// ````
+    ///
+    /// This is the layout used by dds files.
+    #[default]
+    LayerMajor,
+    /// The texture is laid out densely in memory as:
+    ///
+    /// ```text
+    /// Layer0Mip0 Layer1Mip0 Layer2Mip0
+    /// Layer0Mip1 Layer1Mip1 Layer2Mip1
+    /// Layer0Mip2 Layer1Mip2 Layer2Mip2
+    /// ```
+    ///
+    /// This is the layout used by ktx and ktx2 files.
+    MipMajor,
+}
+
 /// Dimensions of a particular texture view.
 ///
 /// Corresponds to [WebGPU `GPUTextureViewDimension`](

--- a/wgpu/src/util/device.rs
+++ b/wgpu/src/util/device.rs
@@ -1,3 +1,5 @@
+use wgt::TextureDataOrder;
+
 /// Describes a [Buffer](crate::Buffer) when allocating.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BufferInitDescriptor<'a> {
@@ -8,34 +10,6 @@ pub struct BufferInitDescriptor<'a> {
     /// Usages of a buffer. If the buffer is used in any way that isn't specified here, the operation
     /// will panic.
     pub usage: crate::BufferUsages,
-}
-
-/// Order in which TextureData is laid out in memory.
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Hash)]
-pub enum TextureDataOrder {
-    /// The texture is laid out densely in memory as:
-    ///
-    /// ```text
-    /// Layer0Mip0 Layer0Mip1 Layer0Mip2
-    /// Layer1Mip0 Layer1Mip1 Layer1Mip2
-    /// Layer2Mip0 Layer2Mip1 Layer2Mip2
-    /// ````
-    ///
-    /// This is the layout used by dds files.
-    ///
-    /// This was the previous behavior of [`DeviceExt::create_texture_with_data`].
-    #[default]
-    LayerMajor,
-    /// The texture is laid out densely in memory as:
-    ///
-    /// ```text
-    /// Layer0Mip0 Layer1Mip0 Layer2Mip0
-    /// Layer0Mip1 Layer1Mip1 Layer2Mip1
-    /// Layer0Mip2 Layer1Mip2 Layer2Mip2
-    /// ```
-    ///
-    /// This is the layout used by ktx and ktx2 files.
-    MipMajor,
 }
 
 /// Utility methods not meant to be in the main API.

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -16,10 +16,12 @@ use std::{
 };
 
 pub use belt::StagingBelt;
-pub use device::{BufferInitDescriptor, DeviceExt, TextureDataOrder};
+pub use device::{BufferInitDescriptor, DeviceExt};
 pub use encoder::RenderEncoder;
 pub use init::*;
-pub use wgt::{math::*, DispatchIndirectArgs, DrawIndexedIndirectArgs, DrawIndirectArgs};
+pub use wgt::{
+    math::*, DispatchIndirectArgs, DrawIndexedIndirectArgs, DrawIndirectArgs, TextureDataOrder,
+};
 
 /// Treat the given byte slice as a SPIR-V module.
 ///


### PR DESCRIPTION
**Connections**
For https://github.com/bevyengine/bevy/pull/16620

**Description**


**Testing**


<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
