### PR TITLE
Add minor ray tracing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,10 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Fix crash when a texture argument is missing. By @aedm in [#6486](https://github.com/gfx-rs/wgpu/pull/6486)
 - Emit an error in constant evaluation, rather than crash, in certain cases where `vecN` constructors have less than N arguments. By @ErichDonGubler in [#6508](https://github.com/gfx-rs/wgpu/pull/6508).
 
+### Testing
+
+- Tests the early returns in the acceleration structure build calls with empty calls. By @Vecvec in [#6651](https://github.com/gfx-rs/wgpu/pull/6651).
+
 ## 23.0.1 (2024-11-25)
 
 This release includes patches for `wgpu`, `wgpu-core` and `wgpu-hal`. All other crates remain at [23.0.0](https://github.com/gfx-rs/wgpu/releases/tag/v23.0.0).

--- a/tests/tests/ray_tracing/as_build.rs
+++ b/tests/tests/ray_tracing/as_build.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use std::{iter, mem};
 
 use wgpu::{
     util::{BufferInitDescriptor, DeviceExt},
@@ -282,4 +282,32 @@ fn out_of_order_as_build_use(ctx: TestingContext) {
         },
         None,
     );
+}
+
+#[gpu_test]
+static EMPTY_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().test_features_limits().features(
+        wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE,
+    ))
+    .run_sync(empty_build);
+fn empty_build(ctx: TestingContext) {
+    let mut encoder_safe = ctx
+        .device
+        .create_command_encoder(&CommandEncoderDescriptor {
+            label: Some("BLAS 1"),
+        });
+
+    encoder_safe.build_acceleration_structures(iter::empty(), iter::empty());
+
+    let mut encoder_unsafe = ctx
+        .device
+        .create_command_encoder(&CommandEncoderDescriptor {
+            label: Some("BLAS 1"),
+        });
+
+    // # SAFETY:
+    // we don't actually do anything so all the requirements are satisfied
+    unsafe { encoder_unsafe.build_acceleration_structures_unsafe_tlas(iter::empty(), iter::empty()); }
+
+    ctx.queue.submit([encoder_safe.finish(), encoder_unsafe.finish()]);
 }

--- a/tests/tests/ray_tracing/as_build.rs
+++ b/tests/tests/ray_tracing/as_build.rs
@@ -286,9 +286,11 @@ fn out_of_order_as_build_use(ctx: TestingContext) {
 
 #[gpu_test]
 static EMPTY_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().test_features_limits().features(
-        wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE,
-    ))
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE),
+    )
     .run_sync(empty_build);
 fn empty_build(ctx: TestingContext) {
     let mut encoder_safe = ctx
@@ -307,7 +309,10 @@ fn empty_build(ctx: TestingContext) {
 
     // # SAFETY:
     // we don't actually do anything so all the requirements are satisfied
-    unsafe { encoder_unsafe.build_acceleration_structures_unsafe_tlas(iter::empty(), iter::empty()); }
+    unsafe {
+        encoder_unsafe.build_acceleration_structures_unsafe_tlas(iter::empty(), iter::empty());
+    }
 
-    ctx.queue.submit([encoder_safe.finish(), encoder_unsafe.finish()]);
+    ctx.queue
+        .submit([encoder_safe.finish(), encoder_unsafe.finish()]);
 }


### PR DESCRIPTION
**Connections**
fixes #6646 

**Description**
adds tests the early returns by calling the functions with empty iterators.

**Testing**
This adds a new test that passes

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - `--target wasm32-unknown-unknown` N/A
  - `--target wasm32-unknown-emscripten` N/A
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
