### PR TITLE
Amend unknown bitflag contain check

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -496,9 +496,7 @@ impl Device {
             self.require_downlevel_flags(wgt::DownlevelFlags::UNRESTRICTED_INDEX_BUFFER)?;
         }
 
-        if desc.usage.is_empty()
-            || desc.usage | wgt::BufferUsages::all() != wgt::BufferUsages::all()
-        {
+        if desc.usage.is_empty() || desc.usage.bits() & !wgt::BufferUsages::all().bits() != 0 {
             return Err(resource::CreateBufferError::InvalidUsage(desc.usage));
         }
 
@@ -732,9 +730,7 @@ impl Device {
 
         self.check_is_valid()?;
 
-        if desc.usage.is_empty()
-            || desc.usage | wgt::TextureUsages::all() != wgt::TextureUsages::all()
-        {
+        if desc.usage.is_empty() || desc.usage.bits() & !wgt::TextureUsages::all().bits() != 0 {
             return Err(CreateTextureError::InvalidUsage(desc.usage));
         }
 
@@ -1806,7 +1802,7 @@ impl Device {
                     })?;
             }
 
-            if entry.visibility | wgt::ShaderStages::all() != wgt::ShaderStages::all() {
+            if entry.visibility.bits() & !wgt::ShaderStages::all().bits() != 0 {
                 return Err(
                     binding_model::CreateBindGroupLayoutError::InvalidVisibility(entry.visibility),
                 );
@@ -2971,7 +2967,7 @@ impl Device {
             if let Some(cs) = cs.as_ref() {
                 target_specified = true;
                 let error = 'error: {
-                    if cs.write_mask | wgt::ColorWrites::all() != wgt::ColorWrites::all() {
+                    if cs.write_mask.bits() & !wgt::ColorWrites::all().bits() != 0 {
                         break 'error Some(pipeline::ColorStateError::InvalidWriteMask(
                             cs.write_mask,
                         ));


### PR DESCRIPTION
**Connections**
I may have broken this in #6644 but im not fully certain. This should work and be clearer anyways.

**Description**
bitflag equality check may be truncating to known bits before comparing

**Testing**
intuition :|   im not sure if we have test coverage of these failure cases. we may want to add some, im not sure how to though.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
