### PR TITLE
Support extern context impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
+name = "custom-backend"
+version = "24.0.0"
+dependencies = [
+ "pollster",
+ "wgpu",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,6 +3082,20 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+dependencies = [
+ "pollster-macro",
+]
+
+[[package]]
+name = "pollster-macro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac5da421106a50887c5b51d20806867db377fbb86bacf478ee0500a912e0c113"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "portable-atomic"

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ be cloned out of the repository to serve as a starting point for your own projec
 |--------|-------------|-----------|
 | [hello compute](standalone/01_hello_compute/) | Simplest example and shows how to run a compute shader on a given set of input data and get the results back. | Native-Only |
 | [hello window](standalone/02_hello_window/) | Shows how to create a window and render into it. | Native-Only |
+| [custom backend](standalone/03_custom_backend/) | Shows how to implement and use custom wgpu context | Any |
 
 You can also use [`cargo-generate`](https://github.com/cargo-generate/cargo-generate) to easily use these as a basis for your own projects.
 

--- a/examples/standalone/03_custom_backend/Cargo.toml
+++ b/examples/standalone/03_custom_backend/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "custom-backend"
+description = "Example of creating and loading custom wgpu backend"
+edition.workspace = true
+rust-version.workspace = true
+keywords.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+
+[dependencies]
+wgpu = { workspace = true, features = ["custom"], default-features = false }
+pollster = { workspace = true, features = ["macro"] }
+
+[lints]
+workspace = true

--- a/examples/standalone/03_custom_backend/src/custom.rs
+++ b/examples/standalone/03_custom_backend/src/custom.rs
@@ -1,0 +1,346 @@
+#![allow(dead_code)]
+use std::pin::Pin;
+use std::sync::Arc;
+
+use wgpu::custom::{
+    AdapterInterface, DeviceInterface, DispatchAdapter, DispatchDevice, DispatchQueue,
+    DispatchShaderModule, DispatchSurface, InstanceInterface, QueueInterface, RequestAdapterFuture,
+    ShaderModuleInterface,
+};
+
+#[derive(Debug, Clone)]
+pub struct Counter(Arc<()>);
+
+impl Counter {
+    pub fn new() -> Self {
+        Self(Arc::new(()))
+    }
+
+    pub fn count(&self) -> usize {
+        Arc::strong_count(&self.0)
+    }
+}
+
+#[derive(Debug)]
+pub struct CustomInstance(pub Counter);
+
+impl InstanceInterface for CustomInstance {
+    fn new(__desc: &wgpu::InstanceDescriptor) -> Self
+    where
+        Self: Sized,
+    {
+        Self(Counter::new())
+    }
+
+    unsafe fn create_surface(
+        &self,
+        _target: wgpu::SurfaceTargetUnsafe,
+    ) -> Result<DispatchSurface, wgpu::CreateSurfaceError> {
+        unimplemented!()
+    }
+
+    fn request_adapter(
+        &self,
+        _options: &wgpu::RequestAdapterOptions<'_, '_>,
+    ) -> std::pin::Pin<Box<dyn RequestAdapterFuture>> {
+        Box::pin(std::future::ready(Some(DispatchAdapter::custom(
+            CustomAdapter(self.0.clone()),
+        ))))
+    }
+
+    fn poll_all_devices(&self, _force_wait: bool) -> bool {
+        unimplemented!()
+    }
+
+    fn wgsl_language_features(&self) -> wgpu::WgslLanguageFeatures {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug)]
+struct CustomAdapter(Counter);
+
+impl AdapterInterface for CustomAdapter {
+    fn request_device(
+        &self,
+        desc: &wgpu::DeviceDescriptor<'_>,
+        _trace_dir: Option<&std::path::Path>,
+    ) -> Pin<Box<dyn wgpu::custom::RequestDeviceFuture>> {
+        assert_eq!(desc.label, Some("device"));
+        let res: Result<_, wgpu::RequestDeviceError> = Ok((
+            DispatchDevice::custom(CustomDevice(self.0.clone())),
+            DispatchQueue::custom(CustomQueue(self.0.clone())),
+        ));
+        Box::pin(std::future::ready(res))
+    }
+
+    fn is_surface_supported(&self, _surface: &DispatchSurface) -> bool {
+        unimplemented!()
+    }
+
+    fn features(&self) -> wgpu::Features {
+        unimplemented!()
+    }
+
+    fn limits(&self) -> wgpu::Limits {
+        unimplemented!()
+    }
+
+    fn downlevel_capabilities(&self) -> wgpu::DownlevelCapabilities {
+        unimplemented!()
+    }
+
+    fn get_info(&self) -> wgpu::AdapterInfo {
+        unimplemented!()
+    }
+
+    fn get_texture_format_features(
+        &self,
+        _format: wgpu::TextureFormat,
+    ) -> wgpu::TextureFormatFeatures {
+        unimplemented!()
+    }
+
+    fn get_presentation_timestamp(&self) -> wgpu::PresentationTimestamp {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug)]
+struct CustomDevice(Counter);
+
+impl DeviceInterface for CustomDevice {
+    fn features(&self) -> wgpu::Features {
+        unimplemented!()
+    }
+
+    fn limits(&self) -> wgpu::Limits {
+        unimplemented!()
+    }
+
+    fn create_shader_module(
+        &self,
+        desc: wgpu::ShaderModuleDescriptor<'_>,
+        _shader_bound_checks: wgpu::ShaderRuntimeChecks,
+    ) -> DispatchShaderModule {
+        assert_eq!(desc.label, Some("shader"));
+        DispatchShaderModule::custom(CustomShaderModule(self.0.clone()))
+    }
+
+    unsafe fn create_shader_module_spirv(
+        &self,
+        _desc: &wgpu::ShaderModuleDescriptorSpirV<'_>,
+    ) -> DispatchShaderModule {
+        unimplemented!()
+    }
+
+    fn create_bind_group_layout(
+        &self,
+        _desc: &wgpu::BindGroupLayoutDescriptor<'_>,
+    ) -> wgpu::custom::DispatchBindGroupLayout {
+        unimplemented!()
+    }
+
+    fn create_bind_group(
+        &self,
+        _desc: &wgpu::BindGroupDescriptor<'_>,
+    ) -> wgpu::custom::DispatchBindGroup {
+        unimplemented!()
+    }
+
+    fn create_pipeline_layout(
+        &self,
+        _desc: &wgpu::PipelineLayoutDescriptor<'_>,
+    ) -> wgpu::custom::DispatchPipelineLayout {
+        unimplemented!()
+    }
+
+    fn create_render_pipeline(
+        &self,
+        _desc: &wgpu::RenderPipelineDescriptor<'_>,
+    ) -> wgpu::custom::DispatchRenderPipeline {
+        unimplemented!()
+    }
+
+    fn create_compute_pipeline(
+        &self,
+        _desc: &wgpu::ComputePipelineDescriptor<'_>,
+    ) -> wgpu::custom::DispatchComputePipeline {
+        unimplemented!()
+    }
+
+    unsafe fn create_pipeline_cache(
+        &self,
+        _desc: &wgpu::PipelineCacheDescriptor<'_>,
+    ) -> wgpu::custom::DispatchPipelineCache {
+        unimplemented!()
+    }
+
+    fn create_buffer(&self, _desc: &wgpu::BufferDescriptor<'_>) -> wgpu::custom::DispatchBuffer {
+        unimplemented!()
+    }
+
+    fn create_texture(&self, _desc: &wgpu::TextureDescriptor<'_>) -> wgpu::custom::DispatchTexture {
+        unimplemented!()
+    }
+
+    fn create_blas(
+        &self,
+        _desc: &wgpu::CreateBlasDescriptor<'_>,
+        _sizes: wgpu::BlasGeometrySizeDescriptors,
+    ) -> (Option<u64>, wgpu::custom::DispatchBlas) {
+        unimplemented!()
+    }
+
+    fn create_tlas(&self, _desc: &wgpu::CreateTlasDescriptor<'_>) -> wgpu::custom::DispatchTlas {
+        unimplemented!()
+    }
+
+    fn create_sampler(&self, _desc: &wgpu::SamplerDescriptor<'_>) -> wgpu::custom::DispatchSampler {
+        unimplemented!()
+    }
+
+    fn create_query_set(
+        &self,
+        _desc: &wgpu::QuerySetDescriptor<'_>,
+    ) -> wgpu::custom::DispatchQuerySet {
+        unimplemented!()
+    }
+
+    fn create_command_encoder(
+        &self,
+        _desc: &wgpu::CommandEncoderDescriptor<'_>,
+    ) -> wgpu::custom::DispatchCommandEncoder {
+        unimplemented!()
+    }
+
+    fn create_render_bundle_encoder(
+        &self,
+        _desc: &wgpu::RenderBundleEncoderDescriptor<'_>,
+    ) -> wgpu::custom::DispatchRenderBundleEncoder {
+        unimplemented!()
+    }
+
+    fn set_device_lost_callback(&self, _device_lost_callback: wgpu::custom::BoxDeviceLostCallback) {
+        unimplemented!()
+    }
+
+    fn on_uncaptured_error(&self, _handler: Box<dyn wgpu::UncapturedErrorHandler>) {
+        unimplemented!()
+    }
+
+    fn push_error_scope(&self, _filter: wgpu::ErrorFilter) {
+        unimplemented!()
+    }
+
+    fn pop_error_scope(&self) -> Pin<Box<dyn wgpu::custom::PopErrorScopeFuture>> {
+        unimplemented!()
+    }
+
+    fn start_capture(&self) {
+        unimplemented!()
+    }
+
+    fn stop_capture(&self) {
+        unimplemented!()
+    }
+
+    fn poll(&self, _maintain: wgpu::PollType) -> Result<wgpu::PollStatus, wgpu::PollError> {
+        unimplemented!()
+    }
+
+    fn get_internal_counters(&self) -> wgpu::InternalCounters {
+        unimplemented!()
+    }
+
+    fn generate_allocator_report(&self) -> Option<wgpu::AllocatorReport> {
+        unimplemented!()
+    }
+
+    fn destroy(&self) {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug)]
+struct CustomShaderModule(Counter);
+
+impl ShaderModuleInterface for CustomShaderModule {
+    fn get_compilation_info(&self) -> Pin<Box<dyn wgpu::custom::ShaderCompilationInfoFuture>> {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug)]
+struct CustomQueue(Counter);
+
+impl QueueInterface for CustomQueue {
+    fn write_buffer(
+        &self,
+        _buffer: &wgpu::custom::DispatchBuffer,
+        _offset: wgpu::BufferAddress,
+        _data: &[u8],
+    ) {
+        unimplemented!()
+    }
+
+    fn create_staging_buffer(
+        &self,
+        _size: wgpu::BufferSize,
+    ) -> Option<wgpu::custom::DispatchQueueWriteBuffer> {
+        unimplemented!()
+    }
+
+    fn validate_write_buffer(
+        &self,
+        _buffer: &wgpu::custom::DispatchBuffer,
+        _offset: wgpu::BufferAddress,
+        _size: wgpu::BufferSize,
+    ) -> Option<()> {
+        unimplemented!()
+    }
+
+    fn write_staging_buffer(
+        &self,
+        _buffer: &wgpu::custom::DispatchBuffer,
+        _offset: wgpu::BufferAddress,
+        _staging_buffer: &wgpu::custom::DispatchQueueWriteBuffer,
+    ) {
+        unimplemented!()
+    }
+
+    fn write_texture(
+        &self,
+        _texture: wgpu::TexelCopyTextureInfo<'_>,
+        _data: &[u8],
+        _data_layout: wgpu::TexelCopyBufferLayout,
+        _size: wgpu::Extent3d,
+    ) {
+        unimplemented!()
+    }
+
+    fn submit(
+        &self,
+        _command_buffers: &mut dyn Iterator<Item = wgpu::custom::DispatchCommandBuffer>,
+    ) -> u64 {
+        unimplemented!()
+    }
+
+    fn get_timestamp_period(&self) -> f32 {
+        unimplemented!()
+    }
+
+    fn on_submitted_work_done(&self, _callback: wgpu::custom::BoxSubmittedWorkDoneCallback) {
+        unimplemented!()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn copy_external_image_to_texture(
+        &self,
+        _source: &wgpu::CopyExternalImageSourceInfo,
+        _dest: wgpu::CopyExternalImageDestInfo<&wgpu::Texture>,
+        _size: wgpu::Extent3d,
+    ) {
+        unimplemented!()
+    }
+}

--- a/examples/standalone/03_custom_backend/src/main.rs
+++ b/examples/standalone/03_custom_backend/src/main.rs
@@ -1,0 +1,45 @@
+use std::marker::PhantomData;
+
+use custom::Counter;
+use wgpu::{DeviceDescriptor, RequestAdapterOptions};
+
+mod custom;
+
+#[pollster::main]
+async fn main() {
+    let counter = Counter::new();
+    {
+        let custom_instance = custom::CustomInstance(counter.clone());
+        // wrap custom instance into wgpu abstraction
+        let instance = wgpu::Instance::from_custom(custom_instance);
+        assert_eq!(counter.count(), 2);
+        // do work on instance (usually by passing it to other libs)
+
+        // here we will simulate a library and ensure that counter is incremented
+        let adapter = instance
+            .request_adapter(&RequestAdapterOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(counter.count(), 3);
+
+        let (device, _queue) = adapter
+            .request_device(
+                &DeviceDescriptor {
+                    label: Some("device"),
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(counter.count(), 5);
+
+        let _module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("shader"),
+            source: wgpu::ShaderSource::Dummy(PhantomData),
+        });
+
+        assert_eq!(counter.count(), 6);
+    }
+    assert_eq!(counter.count(), 1);
+}

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -82,6 +82,8 @@ noop = ["wgpu-core/noop"]
 #! it means that the item is only available when that backend is enabled _and_ the backend
 #! is supported on the current platform.
 
+custom = []
+
 #! ### Shading language support
 # --------------------------------------------------------------------
 #! These features enable support for that input language on all platforms.

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -45,6 +45,7 @@ fn main() {
         naga: { any(feature = "naga-ir", feature = "spirv", feature = "glsl") },
         // ⚠️ Keep in sync with target.cfg() definition in wgpu-hal/Cargo.toml and cfg_alias in `wgpu-hal` crate ⚠️
         static_dxc: { all(target_os = "windows", feature = "static-dxc", not(target_arch = "aarch64")) },
-        supports_64bit_atomics: { target_has_atomic = "64" }
+        supports_64bit_atomics: { target_has_atomic = "64" },
+        custom: {any(feature = "custom")}
     }
 }

--- a/wgpu/src/api/adapter.rs
+++ b/wgpu/src/api/adapter.rs
@@ -136,6 +136,14 @@ impl Adapter {
         }
     }
 
+    #[cfg(custom)]
+    /// Creates Adapter from custom implementation
+    pub fn from_custom<T: custom::AdapterInterface>(adapter: T) -> Self {
+        Self {
+            inner: dispatch::DispatchAdapter::custom(adapter),
+        }
+    }
+
     /// Returns whether this adapter may present to the passed surface.
     pub fn is_surface_supported(&self, surface: &Surface<'_>) -> bool {
         self.inner.is_surface_supported(&surface.inner)

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -34,6 +34,14 @@ pub type DeviceDescriptor<'a> = wgt::DeviceDescriptor<Label<'a>>;
 static_assertions::assert_impl_all!(DeviceDescriptor<'_>: Send, Sync);
 
 impl Device {
+    #[cfg(custom)]
+    /// Creates Device from custom implementation
+    pub fn from_custom<T: custom::DeviceInterface>(device: T) -> Self {
+        Self {
+            inner: dispatch::DispatchDevice::custom(device),
+        }
+    }
+
     /// Check for resource cleanups and mapping callbacks. Will block if [`PollType::Wait`] is passed.
     ///
     /// Return `true` if the queue is empty, or `false` if there are more queue

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -200,6 +200,14 @@ impl Instance {
         }
     }
 
+    #[cfg(custom)]
+    /// Creates instance from custom context implementation
+    pub fn from_custom<T: InstanceInterface>(instance: T) -> Self {
+        Self {
+            inner: dispatch::DispatchInstance::Custom(backend::custom::DynContext::new(instance)),
+        }
+    }
+
     /// Retrieves all available [`Adapter`]s that match the given [`Backends`].
     ///
     /// # Arguments

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -90,6 +90,14 @@ impl Drop for QueueWriteBufferView<'_> {
 }
 
 impl Queue {
+    #[cfg(custom)]
+    /// Creates Queue from custom implementation
+    pub fn from_custom<T: custom::QueueInterface>(queue: T) -> Self {
+        Self {
+            inner: dispatch::DispatchQueue::custom(queue),
+        }
+    }
+
     /// Schedule a data write into `buffer` starting at `offset`.
     ///
     /// This method fails if `data` overruns the size of `buffer` starting at `offset`.

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -57,6 +57,8 @@ impl<'a> RenderBundleEncoder<'a> {
             dispatch::DispatchRenderBundleEncoder::Core(b) => b.finish(desc),
             #[cfg(webgpu)]
             dispatch::DispatchRenderBundleEncoder::WebGPU(b) => b.finish(desc),
+            #[cfg(custom)]
+            dispatch::DispatchRenderBundleEncoder::Custom(_) => unimplemented!(),
         };
 
         RenderBundle { inner: bundle }

--- a/wgpu/src/backend/custom.rs
+++ b/wgpu/src/backend/custom.rs
@@ -1,0 +1,89 @@
+//! Provides wrappers custom backend implementations
+
+#![allow(ambiguous_wide_pointer_comparisons)]
+
+pub use crate::dispatch::*;
+
+use alloc::sync::Arc;
+
+macro_rules! dyn_type {
+    // cloning of arc forbidden
+    // but we still use it to provide Eq,Ord,Hash implementations
+    (pub mut struct $name:ident(dyn $interface:tt)) => {
+        #[derive(Debug)]
+        pub(crate) struct $name(Arc<dyn $interface>);
+        crate::cmp::impl_eq_ord_hash_arc_address!($name => .0);
+
+        impl $name {
+            pub(crate) fn new<T: $interface>(t: T) -> Self {
+                Self(Arc::new(t))
+            }
+        }
+
+        impl core::ops::Deref for $name {
+            type Target = dyn $interface;
+
+            #[inline]
+            fn deref(&self) -> &Self::Target {
+                self.0.as_ref()
+            }
+        }
+
+        impl core::ops::DerefMut for $name {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                Arc::get_mut(&mut self.0).expect("")
+            }
+        }
+    };
+    // cloning of arc is allowed
+    (pub ref struct $name:ident(dyn $interface:tt)) => {
+        #[derive(Debug, Clone)]
+        pub(crate) struct $name(Arc<dyn $interface>);
+        crate::cmp::impl_eq_ord_hash_arc_address!($name => .0);
+
+        impl $name {
+            pub(crate) fn new<T: $interface>(t: T) -> Self {
+                Self(Arc::new(t))
+            }
+        }
+
+        impl core::ops::Deref for $name {
+            type Target = dyn $interface;
+
+            #[inline]
+            fn deref(&self) -> &Self::Target {
+                self.0.as_ref()
+            }
+        }
+    };
+}
+
+dyn_type!(pub ref struct DynContext(dyn InstanceInterface));
+dyn_type!(pub ref struct DynAdapter(dyn AdapterInterface));
+dyn_type!(pub ref struct DynDevice(dyn DeviceInterface));
+dyn_type!(pub ref struct DynQueue(dyn QueueInterface));
+dyn_type!(pub ref struct DynShaderModule(dyn ShaderModuleInterface));
+dyn_type!(pub ref struct DynBindGroupLayout(dyn BindGroupLayoutInterface));
+dyn_type!(pub ref struct DynBindGroup(dyn BindGroupInterface));
+dyn_type!(pub ref struct DynTextureView(dyn TextureViewInterface));
+dyn_type!(pub ref struct DynSampler(dyn SamplerInterface));
+dyn_type!(pub ref struct DynBuffer(dyn BufferInterface));
+dyn_type!(pub ref struct DynTexture(dyn TextureInterface));
+dyn_type!(pub ref struct DynBlas(dyn BlasInterface));
+dyn_type!(pub ref struct DynTlas(dyn TlasInterface));
+dyn_type!(pub ref struct DynQuerySet(dyn QuerySetInterface));
+dyn_type!(pub ref struct DynPipelineLayout(dyn PipelineLayoutInterface));
+dyn_type!(pub ref struct DynRenderPipeline(dyn RenderPipelineInterface));
+dyn_type!(pub ref struct DynComputePipeline(dyn ComputePipelineInterface));
+dyn_type!(pub ref struct DynPipelineCache(dyn PipelineCacheInterface));
+dyn_type!(pub mut struct DynCommandEncoder(dyn CommandEncoderInterface));
+dyn_type!(pub mut struct DynComputePass(dyn ComputePassInterface));
+dyn_type!(pub mut struct DynRenderPass(dyn RenderPassInterface));
+dyn_type!(pub ref struct DynCommandBuffer(dyn CommandBufferInterface));
+dyn_type!(pub mut struct DynRenderBundleEncoder(dyn RenderBundleEncoderInterface));
+dyn_type!(pub ref struct DynRenderBundle(dyn RenderBundleInterface));
+dyn_type!(pub ref struct DynSurface(dyn SurfaceInterface));
+dyn_type!(pub ref struct DynSurfaceOutputDetail(dyn SurfaceOutputDetailInterface));
+dyn_type!(pub mut struct DynQueueWriteBuffer(dyn QueueWriteBufferInterface));
+dyn_type!(pub mut struct DynBufferMappedRange(dyn BufferMappedRangeInterface));

--- a/wgpu/src/backend/mod.rs
+++ b/wgpu/src/backend/mod.rs
@@ -8,3 +8,6 @@ pub mod wgpu_core;
 
 #[cfg(wgpu_core)]
 pub(crate) use wgpu_core::ContextWgpuCore;
+
+#[cfg(custom)]
+pub mod custom;

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -45,7 +45,7 @@ macro_rules! impl_send_sync {
     };
 }
 
-pub(crate) struct ContextWebGpu {
+pub struct ContextWebGpu {
     /// `None` if browser does not advertise support for WebGPU.
     gpu: Option<DefinedNonNullJsValue<webgpu_sys::Gpu>>,
     /// Unique identifier for this context.
@@ -1266,13 +1266,13 @@ pub struct WebTexture {
 }
 
 #[derive(Debug)]
-pub(crate) struct WebBlas {
+pub struct WebBlas {
     /// Unique identifier for this Blas.
     ident: crate::cmp::Identifier,
 }
 
 #[derive(Debug)]
-pub(crate) struct WebTlas {
+pub struct WebTlas {
     /// Unique identifier for this Blas.
     ident: crate::cmp::Identifier,
 }
@@ -1306,7 +1306,7 @@ pub struct WebComputePipeline {
 }
 
 #[derive(Debug)]
-pub(crate) struct WebPipelineCache {
+pub struct WebPipelineCache {
     /// Unique identifier for this PipelineCache.
     ident: crate::cmp::Identifier,
 }
@@ -1363,7 +1363,7 @@ pub struct WebSurface {
 }
 
 #[derive(Debug)]
-pub(crate) struct WebSurfaceOutputDetail {
+pub struct WebSurfaceOutputDetail {
     /// Unique identifier for this SurfaceOutputDetail.
     ident: crate::cmp::Identifier,
 }
@@ -1444,37 +1444,6 @@ crate::cmp::impl_eq_ord_hash_proxy!(WebSurface => .ident);
 crate::cmp::impl_eq_ord_hash_proxy!(WebSurfaceOutputDetail => .ident);
 crate::cmp::impl_eq_ord_hash_proxy!(WebQueueWriteBuffer => .ident);
 crate::cmp::impl_eq_ord_hash_proxy!(WebBufferMappedRange => .ident);
-
-impl dispatch::InterfaceTypes for ContextWebGpu {
-    type Instance = ContextWebGpu;
-    type Adapter = WebAdapter;
-    type Device = WebDevice;
-    type Queue = WebQueue;
-    type ShaderModule = WebShaderModule;
-    type BindGroupLayout = WebBindGroupLayout;
-    type BindGroup = WebBindGroup;
-    type TextureView = WebTextureView;
-    type Sampler = WebSampler;
-    type Buffer = WebBuffer;
-    type Texture = WebTexture;
-    type Blas = WebBlas;
-    type Tlas = WebTlas;
-    type QuerySet = WebQuerySet;
-    type PipelineLayout = WebPipelineLayout;
-    type RenderPipeline = WebRenderPipeline;
-    type ComputePipeline = WebComputePipeline;
-    type PipelineCache = WebPipelineCache;
-    type CommandEncoder = WebCommandEncoder;
-    type ComputePass = WebComputePassEncoder;
-    type RenderPass = WebRenderPassEncoder;
-    type CommandBuffer = WebCommandBuffer;
-    type RenderBundleEncoder = WebRenderBundleEncoder;
-    type RenderBundle = WebRenderBundle;
-    type Surface = WebSurface;
-    type SurfaceOutputDetail = WebSurfaceOutputDetail;
-    type QueueWriteBuffer = WebQueueWriteBuffer;
-    type BufferMappedRange = WebBufferMappedRange;
-}
 
 impl dispatch::InstanceInterface for ContextWebGpu {
     fn new(_desc: &crate::InstanceDescriptor) -> Self

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -17,7 +17,7 @@ use wgt::WasmNotSendSync;
 
 use crate::{
     api,
-    dispatch::{self, BufferMappedRangeInterface, InterfaceTypes},
+    dispatch::{self, BufferMappedRangeInterface},
     BindingResource, BufferBinding, BufferDescriptor, CompilationInfo, CompilationMessage,
     CompilationMessageType, ErrorSource, Features, Label, LoadOp, MapMode, Operations,
     ShaderSource, SurfaceTargetUnsafe, TextureDescriptor,
@@ -741,37 +741,6 @@ crate::cmp::impl_eq_ord_hash_proxy!(CoreSurface => .id);
 crate::cmp::impl_eq_ord_hash_proxy!(CoreSurfaceOutputDetail => .surface_id);
 crate::cmp::impl_eq_ord_hash_proxy!(CoreQueueWriteBuffer => .mapping.ptr);
 crate::cmp::impl_eq_ord_hash_proxy!(CoreBufferMappedRange => .ptr);
-
-impl InterfaceTypes for ContextWgpuCore {
-    type Instance = ContextWgpuCore;
-    type Adapter = CoreAdapter;
-    type Device = CoreDevice;
-    type Queue = CoreQueue;
-    type ShaderModule = CoreShaderModule;
-    type BindGroupLayout = CoreBindGroupLayout;
-    type BindGroup = CoreBindGroup;
-    type TextureView = CoreTextureView;
-    type Sampler = CoreSampler;
-    type Buffer = CoreBuffer;
-    type Texture = CoreTexture;
-    type Blas = CoreBlas;
-    type Tlas = CoreTlas;
-    type QuerySet = CoreQuerySet;
-    type PipelineLayout = CorePipelineLayout;
-    type RenderPipeline = CoreRenderPipeline;
-    type ComputePipeline = CoreComputePipeline;
-    type PipelineCache = CorePipelineCache;
-    type CommandEncoder = CoreCommandEncoder;
-    type ComputePass = CoreComputePass;
-    type RenderPass = CoreRenderPass;
-    type CommandBuffer = CoreCommandBuffer;
-    type RenderBundleEncoder = CoreRenderBundleEncoder;
-    type RenderBundle = CoreRenderBundle;
-    type Surface = CoreSurface;
-    type SurfaceOutputDetail = CoreSurfaceOutputDetail;
-    type QueueWriteBuffer = CoreQueueWriteBuffer;
-    type BufferMappedRange = CoreBufferMappedRange;
-}
 
 impl dispatch::InstanceInterface for ContextWgpuCore {
     fn new(desc: &wgt::InstanceDescriptor) -> Self

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -63,12 +63,15 @@ pub mod util;
 //
 //
 
+#[cfg(custom)]
+pub use backend::custom;
+
 pub use api::*;
 pub use wgt::{
-    AdapterInfo, AddressMode, AstcBlock, AstcChannel, Backend, BackendOptions, Backends,
-    BindGroupLayoutEntry, BindingType, BlendComponent, BlendFactor, BlendOperation, BlendState,
-    BufferAddress, BufferBindingType, BufferSize, BufferTransition, BufferUsages, BufferUses,
-    Color, ColorTargetState, ColorWrites, CommandBufferDescriptor, CompareFunction,
+    AdapterInfo, AddressMode, AllocatorReport, AstcBlock, AstcChannel, Backend, BackendOptions,
+    Backends, BindGroupLayoutEntry, BindingType, BlendComponent, BlendFactor, BlendOperation,
+    BlendState, BufferAddress, BufferBindingType, BufferSize, BufferTransition, BufferUsages,
+    BufferUses, Color, ColorTargetState, ColorWrites, CommandBufferDescriptor, CompareFunction,
     CompositeAlphaMode, CopyExternalImageDestInfo, CoreCounters, DepthBiasState, DepthStencilState,
     DeviceLostReason, DeviceType, DownlevelCapabilities, DownlevelFlags, DownlevelLimits,
     Dx12BackendOptions, Dx12Compiler, DxcShaderModel, DynamicOffset, Extent3d, Face, Features,


### PR DESCRIPTION
**Connections**
Based on https://github.com/gfx-rs/wgpu/pull/6619, fixes https://github.com/gfx-rs/wgpu/issues/6330

**Description**
This PR enables users of wgpu to provide custom Instance impl (and other wgpu types as all other types are derived from Instance->Adapter->Device), by adding `Custom` variant and custom backend that has dyn wrapper for all types: `struct DynDevice(Arc<dyn DeviceInterface>)`. I'm intermixing Custom with Dyn because I cannot really decide on name (`CustomDevice` is weird, but we already have Dyn* in wgpu-hal).
There are few rough sports:
- `RenderBundleEncoderInterface::finish` (other backends hacks around by not using dyn dispatch, but we can't: https://github.com/gfx-rs/wgpu/blob/b876b8c2816441bd53f4d787739db929f9da4dd4/wgpu/src/api/render_bundle_encoder.rs#L54-L60

**Testing**
There is wgpu-custom crate that showcases how one can create Custom wgpu types.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
