### PR TITLE
Improve Snapshot Test Configuration Deserialization

### DIFF
--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -258,6 +258,7 @@ bitflags::bitflags! {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "deserialize", serde(default))]
 pub struct Options {
     /// The GLSL version to be used.
     pub version: Version,

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -193,6 +193,7 @@ pub enum EntryPointError {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "deserialize", serde(default))]
 pub struct Options {
     /// The hlsl shader model to be used
     pub shader_model: ShaderModel,

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -195,6 +195,7 @@ enum LocationMode {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "deserialize", serde(default))]
 pub struct Options {
     /// (Major, Minor) target version of the Metal Shading Language.
     pub lang_version: (u8, u8),
@@ -207,7 +208,6 @@ pub struct Options {
     /// Don't panic on missing bindings, instead generate invalid MSL.
     pub fake_missing_bindings: bool,
     /// Bounds checking policies.
-    #[cfg_attr(feature = "deserialize", serde(default))]
     pub bounds_check_policies: index::BoundsCheckPolicies,
     /// Should workgroup variables be zero initialized (by polyfilling)?
     pub zero_initialize_workgroup_memory: bool,
@@ -341,6 +341,7 @@ pub struct VertexBufferMapping {
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "deserialize", serde(default))]
 pub struct PipelineOptions {
     /// Allow `BuiltIn::PointSize` and inject it if doesn't exist.
     ///

--- a/naga/src/proc/index.rs
+++ b/naga/src/proc/index.rs
@@ -64,10 +64,10 @@ pub enum BoundsCheckPolicy {
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "deserialize", serde(default))]
 pub struct BoundsCheckPolicies {
     /// How should the generated code handle array, vector, or matrix indices
     /// that are out of range?
-    #[cfg_attr(feature = "deserialize", serde(default))]
     pub index: BoundsCheckPolicy,
 
     /// How should the generated code handle array, vector, or matrix indices
@@ -103,7 +103,6 @@ pub struct BoundsCheckPolicies {
     /// [`AccessIndex`]: crate::Expression::AccessIndex
     /// [`Storage`]: crate::AddressSpace::Storage
     /// [`Uniform`]: crate::AddressSpace::Uniform
-    #[cfg_attr(feature = "deserialize", serde(default))]
     pub buffer: BoundsCheckPolicy,
 
     /// How should the generated code handle image texel loads that are out
@@ -119,11 +118,9 @@ pub struct BoundsCheckPolicies {
     /// [`ImageLoad`]: crate::Expression::ImageLoad
     /// [`ImageStore`]: crate::Statement::ImageStore
     /// [`ReadZeroSkipWrite`]: BoundsCheckPolicy::ReadZeroSkipWrite
-    #[cfg_attr(feature = "deserialize", serde(default))]
     pub image_load: BoundsCheckPolicy,
 
     /// How should the generated code handle binding array indexes that are out of bounds.
-    #[cfg_attr(feature = "deserialize", serde(default))]
     pub binding_array: BoundsCheckPolicy,
 }
 

--- a/naga/tests/snapshots.rs
+++ b/naga/tests/snapshots.rs
@@ -39,61 +39,60 @@ impl Default for SpvOutVersion {
 }
 
 #[derive(Default, serde::Deserialize)]
+#[serde(default)]
 struct SpirvOutParameters {
     version: SpvOutVersion,
-    #[serde(default)]
     capabilities: naga::FastHashSet<spirv::Capability>,
-    #[serde(default)]
     debug: bool,
-    #[serde(default)]
     adjust_coordinate_space: bool,
-    #[serde(default)]
     force_point_size: bool,
-    #[serde(default)]
     clamp_frag_depth: bool,
-    #[serde(default)]
     separate_entry_points: bool,
-    #[serde(default)]
     #[cfg(all(feature = "deserialize", spv_out))]
     binding_map: naga::back::spv::BindingMap,
 }
 
 #[derive(Default, serde::Deserialize)]
+#[serde(default)]
 struct WgslOutParameters {
-    #[serde(default)]
     explicit_types: bool,
 }
 
 #[derive(Default, serde::Deserialize)]
+#[serde(default)]
 struct Parameters {
-    #[serde(default)]
+    // -- GOD MODE --
     god_mode: bool,
-    #[cfg(feature = "deserialize")]
-    #[serde(default)]
-    bounds_check_policies: naga::proc::BoundsCheckPolicies,
-    #[serde(default)]
+
+    // -- SPIR-V options --
     spv: SpirvOutParameters,
+
+    // -- MSL options --
     #[cfg(all(feature = "deserialize", msl_out))]
-    #[serde(default)]
     msl: naga::back::msl::Options,
     #[cfg(all(feature = "deserialize", msl_out))]
     #[serde(default)]
     msl_pipeline: naga::back::msl::PipelineOptions,
+
+    // -- GLSL options --
     #[cfg(all(feature = "deserialize", glsl_out))]
-    #[serde(default)]
     glsl: naga::back::glsl::Options,
-    #[serde(default)]
     glsl_exclude_list: naga::FastHashSet<String>,
-    #[cfg(all(feature = "deserialize", hlsl_out))]
-    #[serde(default)]
-    hlsl: naga::back::hlsl::Options,
-    #[serde(default)]
-    wgsl: WgslOutParameters,
     #[cfg(all(feature = "deserialize", glsl_out))]
-    #[serde(default)]
     glsl_multiview: Option<std::num::NonZeroU32>,
+
+    // -- HLSL options --
+    #[cfg(all(feature = "deserialize", hlsl_out))]
+    hlsl: naga::back::hlsl::Options,
+
+    // -- WGSL options --
+    wgsl: WgslOutParameters,
+
+    // -- General options --
+    #[cfg(feature = "deserialize")]
+    bounds_check_policies: naga::proc::BoundsCheckPolicies,
+
     #[cfg(all(feature = "deserialize", any(hlsl_out, msl_out, spv_out, glsl_out)))]
-    #[serde(default)]
     pipeline_constants: naga::back::PipelineConstants,
 }
 


### PR DESCRIPTION
Small improvement I noticed. By putting the default on the struct instead of the individual members, you no longer need to specify default on every single member. 

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
