### PR TITLE
Remove stale references to `d3d12` bindings wrapper crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The repository hosts the following libraries:
 - [![Crates.io](https://img.shields.io/crates/v/wgpu-hal.svg?label=wgpu-hal)](https://crates.io/crates/wgpu-hal) [![docs.rs](https://docs.rs/wgpu-hal/badge.svg)](https://docs.rs/wgpu-hal/) - Internal unsafe GPU API abstraction layer.
 - [![Crates.io](https://img.shields.io/crates/v/wgpu-types.svg?label=wgpu-types)](https://crates.io/crates/wgpu-types) [![docs.rs](https://docs.rs/wgpu-types/badge.svg)](https://docs.rs/wgpu-types/) - Rust types shared between all crates.
 - [![Crates.io](https://img.shields.io/crates/v/naga.svg?label=naga)](https://crates.io/crates/naga) [![docs.rs](https://docs.rs/naga/badge.svg)](https://docs.rs/naga/) - Stand-alone shader translation library.
-- [![Crates.io](https://img.shields.io/crates/v/d3d12.svg?label=d3d12)](https://crates.io/crates/d3d12) [![docs.rs](https://docs.rs/d3d12/badge.svg)](https://docs.rs/d3d12/) - Collection of thin abstractions over d3d12.
 - [![Crates.io](https://img.shields.io/crates/v/deno_webgpu.svg?label=deno_webgpu)](https://crates.io/crates/deno_webgpu) - WebGPU implementation for the Deno JavaScript/TypeScript runtime
 
 The following binaries:
@@ -120,7 +119,7 @@ On Linux, you can point to them using `LD_LIBRARY_PATH` environment.
 
 Due to complex dependants, we have two MSRV policies:
 
-- `d3d12`, `naga`, `wgpu-core`, `wgpu-hal`, and `wgpu-types`'s MSRV is **1.76**, but may be lower than the rest of the workspace in the future.
+- `naga`, `wgpu-core`, `wgpu-hal`, and `wgpu-types`'s MSRV is **1.76**, but may be lower than the rest of the workspace in the future.
 - The rest of the workspace has an MSRV of **1.76** as well right now, but may be higher than above listed crates.
 
 It is enforced on CI (in "/.github/workflows/ci.yml") with the `CORE_MSRV` and `REPO_MSRV` variables.

--- a/wgpu-hal/README.md
+++ b/wgpu-hal/README.md
@@ -84,12 +84,12 @@ platform graphics APIs:
 
 - Metal on macOS, using the [`metal`] crate's bindings.
 
-- Direct3D 12 on Windows, using the [`d3d12`] crate's bindings.
+- Direct3D 12 on Windows, using the [`windows`] crate's bindings.
 
 [`ash`]: https://crates.io/crates/ash
 [MoltenVK]: https://github.com/KhronosGroup/MoltenVK
 [`metal`]: https://crates.io/crates/metal
-[`d3d12`]: https://crates.io/crates/d3d12
+[`windows`]: https://crates.io/crates/windows
 
 ## Secondary backends
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -82,12 +82,12 @@
 //!
 //! - Metal on macOS, using the [`metal`] crate's bindings.
 //!
-//! - Direct3D 12 on Windows, using the [`d3d12`] crate's bindings.
+//! - Direct3D 12 on Windows, using the [`windows`] crate's bindings.
 //!
 //! [`ash`]: https://crates.io/crates/ash
 //! [MoltenVK]: https://github.com/KhronosGroup/MoltenVK
 //! [`metal`]: https://crates.io/crates/metal
-//! [`d3d12`]: https://crates.io/crates/d3d12
+//! [`windows`]: https://crates.io/crates/windows
 //!
 //! ## Secondary backends
 //!


### PR DESCRIPTION
**Connections**
- #5956
- #6116
- #6154
- #6157

**Description**
While looking through some recent activity for the D3D12 crate, in particular a spelling fix for the crates.io link to `d3d12` (#6116), I realized that I completely forgot to remove these references to the now unused and removed `d3d12` crate in #5956.

**Testing**
N/A

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.

**Further work**

In addition the deprecation notice by #6157, merged to the `v22` branch, seems to have never been published to crates.io, hence the [proposed `d3d12-v22.1.1` tag](https://github.com/gfx-rs/wgpu/issues/6154#issuecomment-2308679255) has never materialized leaving the unpublished `repository` URL invalid.
(Furthermore I think the notice could have pointed users to the `windows` crate directly, in addition to referring them there via #5956)
