### PR TITLE
Remove `BufferUses::STORAGE_WRITE_ONLY`

### DIFF
--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -82,7 +82,7 @@ pub fn map_buffer_usage(usage: wgt::BufferUsages) -> hal::BufferUses {
         usage.contains(wgt::BufferUsages::UNIFORM),
     );
     u.set(
-        hal::BufferUses::STORAGE_READ_WRITE,
+        hal::BufferUses::STORAGE_READ_ONLY | hal::BufferUses::STORAGE_READ_WRITE,
         usage.contains(wgt::BufferUsages::STORAGE),
     );
     u.set(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -521,16 +521,7 @@ impl Device {
             self.require_downlevel_flags(wgt::DownlevelFlags::INDIRECT_EXECUTION)?;
             // We are going to be reading from it, internally;
             // when validating the content of the buffer
-            if !usage.intersects(
-                hal::BufferUses::STORAGE_READ_ONLY | hal::BufferUses::STORAGE_READ_WRITE,
-            ) {
-                if usage.contains(hal::BufferUses::STORAGE_WRITE_ONLY) {
-                    usage |= hal::BufferUses::STORAGE_READ_WRITE;
-                    usage &= !hal::BufferUses::STORAGE_WRITE_ONLY;
-                } else {
-                    usage |= hal::BufferUses::STORAGE_READ_ONLY;
-                }
-            }
+            usage |= hal::BufferUses::STORAGE_READ_ONLY | hal::BufferUses::STORAGE_READ_WRITE;
         }
 
         if desc.mapped_at_creation {

--- a/wgpu-hal/src/dx12/conv.rs
+++ b/wgpu-hal/src/dx12/conv.rs
@@ -128,7 +128,7 @@ pub fn map_buffer_usage_to_state(usage: crate::BufferUses) -> Direct3D12::D3D12_
     if usage.intersects(Bu::VERTEX | Bu::UNIFORM) {
         state |= Direct3D12::D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
     }
-    if usage.intersects(Bu::STORAGE_READ_WRITE | Bu::STORAGE_WRITE_ONLY) {
+    if usage.intersects(Bu::STORAGE_READ_WRITE) {
         state |= Direct3D12::D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
     } else if usage.intersects(Bu::STORAGE_READ_ONLY) {
         state |= Direct3D12::D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1225,9 +1225,7 @@ impl super::Queue {
                     flags |= glow::BUFFER_UPDATE_BARRIER_BIT;
                 }
                 if usage.intersects(
-                    crate::BufferUses::STORAGE_READ_ONLY
-                        | crate::BufferUses::STORAGE_WRITE_ONLY
-                        | crate::BufferUses::STORAGE_READ_WRITE,
+                    crate::BufferUses::STORAGE_READ_ONLY | crate::BufferUses::STORAGE_READ_WRITE,
                 ) {
                     flags |= glow::SHADER_STORAGE_BARRIER_BIT;
                 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1675,8 +1675,6 @@ bitflags::bitflags! {
         const UNIFORM = 1 << 6;
         /// A read-only storage buffer used in a bind group.
         const STORAGE_READ_ONLY = 1 << 7;
-        /// A write-only storage buffer used in a bind group.
-        const STORAGE_WRITE_ONLY = 1 << 8;
         /// A read-write buffer used in a bind group.
         const STORAGE_READ_WRITE = 1 << 8;
         /// The indirect or count buffer in a indirect draw or dispatch.

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -515,11 +515,9 @@ pub fn map_buffer_usage(usage: crate::BufferUses) -> vk::BufferUsageFlags {
     if usage.contains(crate::BufferUses::UNIFORM) {
         flags |= vk::BufferUsageFlags::UNIFORM_BUFFER;
     }
-    if usage.intersects(
-        crate::BufferUses::STORAGE_READ_ONLY
-            | crate::BufferUses::STORAGE_WRITE_ONLY
-            | crate::BufferUses::STORAGE_READ_WRITE,
-    ) {
+    if usage
+        .intersects(crate::BufferUses::STORAGE_READ_ONLY | crate::BufferUses::STORAGE_READ_WRITE)
+    {
         flags |= vk::BufferUsageFlags::STORAGE_BUFFER;
     }
     if usage.contains(crate::BufferUses::INDEX) {
@@ -573,17 +571,13 @@ pub fn map_buffer_usage_to_barrier(
         stages |= shader_stages;
         access |= vk::AccessFlags::UNIFORM_READ;
     }
-    if usage
-        .intersects(crate::BufferUses::STORAGE_READ_ONLY | crate::BufferUses::STORAGE_READ_WRITE)
-    {
+    if usage.intersects(crate::BufferUses::STORAGE_READ_ONLY) {
         stages |= shader_stages;
         access |= vk::AccessFlags::SHADER_READ;
     }
-    if usage
-        .intersects(crate::BufferUses::STORAGE_WRITE_ONLY | crate::BufferUses::STORAGE_READ_WRITE)
-    {
+    if usage.intersects(crate::BufferUses::STORAGE_READ_WRITE) {
         stages |= shader_stages;
-        access |= vk::AccessFlags::SHADER_WRITE;
+        access |= vk::AccessFlags::SHADER_READ | vk::AccessFlags::SHADER_WRITE;
     }
     if usage.contains(crate::BufferUses::INDEX) {
         stages |= vk::PipelineStageFlags::VERTEX_INPUT;


### PR DESCRIPTION
The spec doesn't have write-only storage buffers.

Follow-up to https://github.com/gfx-rs/wgpu/pull/6642.