### PR TITLE
fix: Read environment variable configs in hello_triangle example

### DIFF
--- a/examples/src/framework.rs
+++ b/examples/src/framework.rs
@@ -268,16 +268,7 @@ impl ExampleContext {
     async fn init_async<E: Example>(surface: &mut SurfaceWrapper, window: Arc<Window>) -> Self {
         log::info!("Initializing wgpu...");
 
-        let backends = wgpu::util::backend_bits_from_env().unwrap_or_default();
-        let dx12_shader_compiler = wgpu::util::dx12_shader_compiler_from_env().unwrap_or_default();
-        let gles_minor_version = wgpu::util::gles_minor_version_from_env().unwrap_or_default();
-
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends,
-            flags: wgpu::InstanceFlags::from_build_config().with_env(),
-            dx12_shader_compiler,
-            gles_minor_version,
-        });
+        let instance = wgpu::Instance::new(wgpu::util::instance_descriptor_from_env());
         surface.pre_adapter(&instance, window);
 
         let adapter = get_adapter_with_capabilities_or_from_env(

--- a/examples/src/hello_triangle/mod.rs
+++ b/examples/src/hello_triangle/mod.rs
@@ -10,7 +10,17 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
     size.width = size.width.max(1);
     size.height = size.height.max(1);
 
-    let instance = wgpu::Instance::default();
+    // Configure instance using `WGPU_BACKEND`, `WGPU_DX12_COMPILER` and `WGPU_GLES_MINOR_VERSION` environment variables. (or use default if environment variables not set)
+    let backends = wgpu::util::backend_bits_from_env().unwrap_or_default();
+    let dx12_shader_compiler = wgpu::util::dx12_shader_compiler_from_env().unwrap_or_default();
+    let gles_minor_version = wgpu::util::gles_minor_version_from_env().unwrap_or_default();
+
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends,
+        flags: wgpu::InstanceFlags::from_build_config().with_env(),
+        dx12_shader_compiler,
+        gles_minor_version,
+    });
 
     let surface = instance.create_surface(&window).unwrap();
     let adapter = instance

--- a/examples/src/hello_triangle/mod.rs
+++ b/examples/src/hello_triangle/mod.rs
@@ -10,17 +10,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
     size.width = size.width.max(1);
     size.height = size.height.max(1);
 
-    // Configure instance using `WGPU_BACKEND`, `WGPU_DX12_COMPILER` and `WGPU_GLES_MINOR_VERSION` environment variables. (or use default if environment variables not set)
-    let backends = wgpu::util::backend_bits_from_env().unwrap_or_default();
-    let dx12_shader_compiler = wgpu::util::dx12_shader_compiler_from_env().unwrap_or_default();
-    let gles_minor_version = wgpu::util::gles_minor_version_from_env().unwrap_or_default();
-
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-        backends,
-        flags: wgpu::InstanceFlags::from_build_config().with_env(),
-        dx12_shader_compiler,
-        gles_minor_version,
-    });
+    let instance = wgpu::Instance::new(wgpu::util::instance_descriptor_from_env());
 
     let surface = instance.create_surface(&window).unwrap();
     let adapter = instance

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -146,12 +146,12 @@ pub fn gles_minor_version_from_env() -> Option<wgt::Gles3MinorVersion> {
 /// - WGPU_GLES_MINOR_VERSION
 /// If variables are missing, falls back to default or build config values
 pub fn instance_descriptor_from_env() -> wgt::InstanceDescriptor {
-    return wgt::InstanceDescriptor {
+    wgt::InstanceDescriptor {
         backends: backend_bits_from_env().unwrap_or_default(),
         flags: wgt::InstanceFlags::from_build_config().with_env(),
         dx12_shader_compiler: dx12_shader_compiler_from_env().unwrap_or_default(),
         gles_minor_version: gles_minor_version_from_env().unwrap_or_default(),
-    };
+    }
 }
 
 /// Determines whether the [`Backends::BROWSER_WEBGPU`] backend is supported.

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -138,6 +138,22 @@ pub fn gles_minor_version_from_env() -> Option<wgt::Gles3MinorVersion> {
     )
 }
 
+/// Get an instance descriptor from the following environment variables
+/// - WGPU_BACKEND
+/// - WGPU_DEBUG
+/// - WGPU_VALIDATION
+/// - WGPU_DX12_COMPILER
+/// - WGPU_GLES_MINOR_VERSION
+/// If variables are missing, falls back to default or build config values
+pub fn instance_descriptor_from_env() -> wgt::InstanceDescriptor {
+    return wgt::InstanceDescriptor {
+        backends: backend_bits_from_env().unwrap_or_default(),
+        flags: wgt::InstanceFlags::from_build_config().with_env(),
+        dx12_shader_compiler: dx12_shader_compiler_from_env().unwrap_or_default(),
+        gles_minor_version: gles_minor_version_from_env().unwrap_or_default(),
+    };
+}
+
 /// Determines whether the [`Backends::BROWSER_WEBGPU`] backend is supported.
 ///
 /// The result can only be true if this is called from the main thread or a dedicated worker.


### PR DESCRIPTION
**Connections**
The hello_triangle doesn't support switching backends, leading to confusing errors like this one: https://github.com/gfx-rs/wgpu/issues/4247

**Description**
This adds support for the WGPU_* environment variables to the hello_triangle example, so that backend-specific issues can more quickly be narrowed down and fixes.

**Testing**
I've tested this manually, not sure if there is a better procedure for automatically testing these things

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
