### PR TITLE
Inline PassChannel into ColorAttachment

### DIFF
--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -133,12 +133,9 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
                 Some(wgpu_core::command::RenderPassColorAttachment {
                     view: texture_view_resource.1,
                     resolve_target,
-                    channel: wgpu_core::command::PassChannel {
-                        load_op: at.load_op,
-                        store_op: at.store_op,
-                        clear_value: at.clear_value.unwrap_or_default(),
-                        read_only: false,
-                    },
+                    load_op: at.load_op,
+                    store_op: at.store_op,
+                    clear_value: at.clear_value.unwrap_or_default(),
                 })
             } else {
                 None

--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -100,16 +100,13 @@
                     Some((
                         view: Id(0, 1),
                         resolve_target: None,
-                        channel: (
-                            load_op: clear,
-                            store_op: store,
-                            clear_value: (
-                                r: 0,
-                                g: 0,
-                                b: 0,
-                                a: 1,
-                            ),
-                            read_only: false,
+                        load_op: clear,
+                        store_op: store,
+                        clear_value: (
+                            r: 0,
+                            g: 0,
+                            b: 0,
+                            a: 1,
                         ),
                     )),
                 ],

--- a/player/tests/data/zero-init-texture-rendertarget.ron
+++ b/player/tests/data/zero-init-texture-rendertarget.ron
@@ -50,13 +50,10 @@
                     Some((
                         view: Id(0, 1),
                         resolve_target: None,
-                        channel: (
-                            load_op: load,
-                            store_op: store,
-                            clear_value: (
-                                r: 1, g: 1, b: 1, a: 1,
-                            ),
-                            read_only: false,
+                        load_op: load,
+                        store_op: store,
+                        clear_value: (
+                            r: 1, g: 1, b: 1, a: 1,
                         ),
                     )),
                 ],


### PR DESCRIPTION
**Connections**
In preparation for https://github.com/gfx-rs/wgpu/issues/6700

**Description**
ColorAttachments requires load/store ops and does not use read_only field at all, while in depth/stencil attachment ops are optional and read_only must be true if ops not provided. So sharing those fields as PassCannel only makes sense for depth/stencil attachment.

**Testing**
Safe refactoring because we are in Rust, also there are tests that cover color attachments (water example).

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
