### PR TITLE
chore: satisfy `clippy::unnecessary_map_or`

### DIFF
--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -5128,7 +5128,7 @@ template <typename A>
                             AttributeMappingResolved {
                                 ty_name: ty_name.to_string(),
                                 dimension: ty_name.vertex_input_dimension(),
-                                ty_is_int: ty_name.scalar().map_or(false, scalar_is_int),
+                                ty_is_int: ty_name.scalar().is_some_and(scalar_is_int),
                                 name: name.to_string(),
                             },
                         );

--- a/naga/src/front/glsl/functions.rs
+++ b/naga/src/front/glsl/functions.rs
@@ -140,7 +140,7 @@ impl Frontend {
                 )?
             }
             TypeInner::Vector { size, scalar } => {
-                if vector_size.map_or(true, |s| s != size) {
+                if vector_size != Some(size) {
                     value = ctx.vector_resize(size, value, expr_meta)?;
                 }
 

--- a/naga/src/front/glsl/parser/declarations.rs
+++ b/naga/src/front/glsl/parser/declarations.rs
@@ -186,7 +186,7 @@ impl ParsingContext<'_> {
         // Consume any leading comma, e.g. this is valid: `float, a=1;`
         if self
             .peek(frontend)
-            .map_or(false, |t| t.value == TokenValue::Comma)
+            .is_some_and(|t| t.value == TokenValue::Comma)
         {
             self.next(frontend);
         }

--- a/naga/src/front/glsl/parser/functions.rs
+++ b/naga/src/front/glsl/parser/functions.rs
@@ -15,7 +15,7 @@ use crate::{
 
 impl ParsingContext<'_> {
     pub fn peek_parameter_qualifier(&mut self, frontend: &mut Frontend) -> bool {
-        self.peek(frontend).map_or(false, |t| match t.value {
+        self.peek(frontend).is_some_and(|t| match t.value {
             TokenValue::In | TokenValue::Out | TokenValue::InOut | TokenValue::Const => true,
             _ => false,
         })

--- a/naga/src/front/glsl/parser/types.rs
+++ b/naga/src/front/glsl/parser/types.rs
@@ -147,7 +147,7 @@ impl ParsingContext<'_> {
     }
 
     pub fn peek_type_qualifier(&mut self, frontend: &mut Frontend) -> bool {
-        self.peek(frontend).map_or(false, |t| match t.value {
+        self.peek(frontend).is_some_and(|t| match t.value {
             TokenValue::Invariant
             | TokenValue::Interpolation(_)
             | TokenValue::Sampling(_)
@@ -379,7 +379,7 @@ impl ParsingContext<'_> {
     }
 
     pub fn peek_type_name(&mut self, frontend: &mut Frontend) -> bool {
-        self.peek(frontend).map_or(false, |t| match t.value {
+        self.peek(frontend).is_some_and(|t| match t.value {
             TokenValue::TypeName(_) | TokenValue::Void => true,
             TokenValue::Struct => true,
             TokenValue::Identifier(ref ident) => frontend.lookup_type.contains_key(ident),

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -5371,7 +5371,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
         let parent_decor = self.future_decor.remove(&id);
         let is_storage_buffer = parent_decor
             .as_ref()
-            .map_or(false, |decor| decor.storage_buffer);
+            .is_some_and(|decor| decor.storage_buffer);
 
         self.layouter.update(module.to_ctx()).unwrap();
 

--- a/tests/tests/dispatch_workgroups_indirect.rs
+++ b/tests/tests/dispatch_workgroups_indirect.rs
@@ -88,7 +88,7 @@ static RESET_BIND_GROUPS: GpuTestConfiguration = GpuTestConfiguration::new()
         ctx.queue.submit(Some(encoder.finish()));
 
         let error = pollster::block_on(ctx.device.pop_error_scope());
-        assert!(error.map_or(false, |error| {
+        assert!(error.is_some_and(|error| {
             format!("{error}").contains("The current set ComputePipeline with '' label expects a BindGroup to be set at index 0")
         }));
     });
@@ -130,7 +130,7 @@ static ZERO_SIZED_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new()
         ctx.queue.submit(Some(encoder.finish()));
 
         let error = pollster::block_on(ctx.device.pop_error_scope());
-        assert!(error.map_or(false, |error| {
+        assert!(error.is_some_and(|error| {
             format!("{error}").contains(
                 "Indirect buffer uses bytes 0..12 which overruns indirect buffer of size 0",
             )

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2644,7 +2644,7 @@ impl Device {
     ) -> Result<Arc<binding_model::PipelineLayout>, pipeline::ImplicitLayoutError> {
         while derived_group_layouts
             .last()
-            .map_or(false, |map| map.is_empty())
+            .is_some_and(|map| map.is_empty())
         {
             derived_group_layouts.pop();
         }

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -192,7 +192,7 @@ impl super::CommandEncoder {
             if dirty_textures & (1 << texture_index) != 0
                 || slot
                     .sampler_index
-                    .map_or(false, |si| dirty_samplers & (1 << si) != 0)
+                    .is_some_and(|si| dirty_samplers & (1 << si) != 0)
             {
                 let sampler = slot
                     .sampler_index

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1498,7 +1498,7 @@ impl super::Instance {
                 Some(features) => features.imageless_framebuffer == vk::TRUE,
                 None => phd_features
                     .imageless_framebuffer
-                    .map_or(false, |ext| ext.imageless_framebuffer != 0),
+                    .is_some_and(|ext| ext.imageless_framebuffer != 0),
             },
             image_view_usage: phd_capabilities.device_api_version >= vk::API_VERSION_1_1
                 || phd_capabilities.supports_extension(khr::maintenance2::NAME),
@@ -1506,7 +1506,7 @@ impl super::Instance {
                 Some(features) => features.timeline_semaphore == vk::TRUE,
                 None => phd_features
                     .timeline_semaphore
-                    .map_or(false, |ext| ext.timeline_semaphore != 0),
+                    .is_some_and(|ext| ext.timeline_semaphore != 0),
             },
             texture_d24: supports_format(
                 &self.shared.raw,
@@ -1537,7 +1537,7 @@ impl super::Instance {
                 Some(ref f) => f.robust_image_access2 != 0,
                 None => phd_features
                     .image_robustness
-                    .map_or(false, |ext| ext.robust_image_access != 0),
+                    .is_some_and(|ext| ext.robust_image_access != 0),
             },
             robust_buffer_access2: phd_features
                 .robustness2
@@ -1551,9 +1551,7 @@ impl super::Instance {
                 .unwrap_or_default(),
             zero_initialize_workgroup_memory: phd_features
                 .zero_initialize_workgroup_memory
-                .map_or(false, |ext| {
-                    ext.shader_zero_initialize_workgroup_memory == vk::TRUE
-                }),
+                .is_some_and(|ext| ext.shader_zero_initialize_workgroup_memory == vk::TRUE),
             image_format_list: phd_capabilities.device_api_version >= vk::API_VERSION_1_2
                 || phd_capabilities.supports_extension(khr::image_format_list::NAME),
             #[cfg(windows)]

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -156,9 +156,7 @@ pub async fn is_browser_webgpu_supported() -> bool {
         let adapter_promise = gpu.request_adapter();
         wasm_bindgen_futures::JsFuture::from(adapter_promise)
             .await
-            .map_or(false, |adapter| {
-                !adapter.is_undefined() && !adapter.is_null()
-            })
+            .is_ok_and(|adapter| !adapter.is_undefined() && !adapter.is_null())
     }
     #[cfg(not(webgpu))]
     {


### PR DESCRIPTION
Started firing in Rust 1.84.