### PR TITLE
[core] Support optional ops in PassChannel

### DIFF
--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -155,22 +155,14 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
             Some(wgpu_core::command::RenderPassDepthStencilAttachment {
                 view: texture_view_resource.1,
                 depth: wgpu_core::command::PassChannel {
-                    load_op: attachment
-                        .depth_load_op
-                        .unwrap_or(wgpu_core::command::LoadOp::Load),
-                    store_op: attachment
-                        .depth_store_op
-                        .unwrap_or(wgpu_core::command::StoreOp::Store),
+                    load_op: attachment.depth_load_op,
+                    store_op: attachment.depth_store_op,
                     clear_value: attachment.depth_clear_value,
                     read_only: attachment.depth_read_only,
                 },
                 stencil: wgpu_core::command::PassChannel {
-                    load_op: attachment
-                        .stencil_load_op
-                        .unwrap_or(wgpu_core::command::LoadOp::Load),
-                    store_op: attachment
-                        .stencil_store_op
-                        .unwrap_or(wgpu_core::command::StoreOp::Store),
+                    load_op: attachment.stencil_load_op,
+                    store_op: attachment.stencil_store_op,
                     clear_value: attachment.stencil_clear_value,
                     read_only: attachment.stencil_read_only,
                 },

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -676,6 +676,8 @@ pub enum CommandEncoderError {
     #[error(transparent)]
     InvalidColorAttachment(#[from] ColorAttachmentError),
     #[error(transparent)]
+    InvalidAttachment(#[from] AttachmentError),
+    #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -418,15 +418,15 @@ fn map_pass_channel<V: Copy + Default>(
         Some(&Operations { load, store }) => {
             let (load_op, clear_value) = map_load_op(load);
             wgc::command::PassChannel {
-                load_op,
-                store_op: map_store_op(store),
+                load_op: Some(load_op),
+                store_op: Some(map_store_op(store)),
                 clear_value,
                 read_only: false,
             }
         }
         None => wgc::command::PassChannel {
-            load_op: wgc::command::LoadOp::Load,
-            store_op: wgc::command::StoreOp::Store,
+            load_op: None,
+            store_op: None,
             clear_value: V::default(),
             read_only: true,
         },


### PR DESCRIPTION
**Connections**
Fixes #6700

**Description**
When attachment is read only, ops must not be provided (else validation error should be raised). To support this `PassChannel` is generic over L and S, so we can use same struct for `LoadOp` or `Option<LoadOp>`. Now core users will pass `PassChannel<V, Option<LoadOp>, Option<StoreOp>>` that will be be resolved to `PassChannel<V, LoadOp, StoreOp>`, which is used same as before internally. While resolving we also do validation.

Changes needed in servo: https://github.com/sagudev/servo/commit/4aa142c83507b0d80009162f035e4dc5ecc29a6d.

**Testing**
CTS run in servo: https://github.com/gfx-rs/wgpu/pull/6716#issuecomment-2543034308 and existing test.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
