### PR TITLE
Detect a common syntax error case for diagnostic_directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 
 - Show types of LHS and RHS in binary operation type mismatch errors. By @ErichDonGubler in [#6450](https://github.com/gfx-rs/wgpu/pull/6450).
 - The GLSL parser now uses less expressions for function calls. By @magcius in [#6604](https://github.com/gfx-rs/wgpu/pull/6604).
+- Add a note to help with a common syntax error case for global diagnostic filter directives. By @e-hat in [#6718](https://github.com/gfx-rs/wgpu/pull/6718)
 
 #### General
 

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -304,6 +304,7 @@ pub(crate) enum Error<'a> {
     },
     DiagnosticAttributeNotSupported {
         on_what_plural: &'static str,
+        intended_diagnostic_directive: bool,
         spans: Vec<Span>,
     },
 }
@@ -1082,6 +1083,7 @@ impl<'a> Error<'a> {
             },
             Error::DiagnosticAttributeNotSupported {
                 on_what_plural,
+                intended_diagnostic_directive,
                 ref spans,
             } => ParseError {
                 message: format!(
@@ -1098,7 +1100,15 @@ impl<'a> Error<'a> {
                         "some statements, and `switch`/`loop` bodies."
                     )
                     .into(),
-                    "These attributes are well-formed, you likely just need to move them.".into(),
+                    {
+                        if intended_diagnostic_directive {
+                            concat!("To declare a diagnostic filter that applies to the entire module, ", 
+                            "move this line to the top of the file and remove the `@` symbol.").into()
+                        } else {
+                            "These attributes are well-formed, you likely just need to move them."
+                                .into()
+                        }
+                    },
                 ],
             },
         }

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -1126,9 +1126,9 @@ impl<'a> Error<'a> {
                         {
                             if intended_diagnostic_directive {
                                 concat!(
-                                    "To declare a diagnostic filter that applies to the ",
-                                    "entire module, move this line to the top of the ",
-                                    "file and remove the `@` symbol."
+                                    "If you meant to declare a diagnostic filter that ",
+                                    "applies to the entire module, move this line to ",
+                                    "the top of the file and remove the `@` symbol."
                                 )
                                 .into()
                             } else {

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -1102,8 +1102,12 @@ impl<'a> Error<'a> {
                     .into(),
                     {
                         if intended_diagnostic_directive {
-                            concat!("To declare a diagnostic filter that applies to the entire module, ", 
-                            "move this line to the top of the file and remove the `@` symbol.").into()
+                            concat!(
+                                "To declare a diagnostic filter that applies to the ",
+                                "entire module, move this line to the top of the ",
+                                "file and remove the `@` symbol."
+                            )
+                            .into()
                         } else {
                             "These attributes are well-formed, you likely just need to move them."
                                 .into()

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -1132,7 +1132,10 @@ impl<'a> Error<'a> {
                                 )
                                 .into()
                             } else {
-                                "These attributes are well-formed, you likely just need to move them."
+                                concat!(
+                                    "These attributes are well-formed, ",
+                                    "you likely just need to move them."
+                                )
                                 .into()
                             }
                         },

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -2472,9 +2472,6 @@ impl Parser {
                 } else {
                     Err(Error::DiagnosticAttributeNotSupported {
                         on_what_plural,
-                        // In this case the user may have intended to create a global diagnostic filter directive,
-                        // so display a note to them suggesting the correct syntax.
-                        intended_diagnostic_directive: on_what_plural == "semicolons",
                         spans: filters.spans().collect(),
                     })
                 }

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -2472,6 +2472,9 @@ impl Parser {
                 } else {
                     Err(Error::DiagnosticAttributeNotSupported {
                         on_what_plural,
+                        // In this case the user may have intended to create a global diagnostic filter directive,
+                        // so display a note to them suggesting the correct syntax.
+                        intended_diagnostic_directive: on_what_plural == "semicolons",
                         spans: filters.spans().collect(),
                     })
                 }

--- a/naga/src/front/wgsl/tests.rs
+++ b/naga/src/front/wgsl/tests.rs
@@ -660,6 +660,27 @@ fn parse_missing_workgroup_size() {
 }
 
 mod diagnostic_filter {
+    use crate::front::wgsl::assert_parse_err;
+
+    #[test]
+    fn intended_global_directive() {
+        let shader = "@diagnostic(off, my.lint);";
+        assert_parse_err(
+            shader,
+            "\
+error: `@diagnostic(…)` attribute(s) on semicolons are not supported
+  ┌─ wgsl:1:1
+  │
+1 │ @diagnostic(off, my.lint);
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = note: `@diagnostic(…)` attributes are only permitted on `fn`s, some statements, and `switch`/`loop` bodies.
+  = note: To declare a diagnostic filter that applies to the entire module, move this line to the top of the file and remove the `@` symbol.
+
+"
+        );
+    }
+
     mod parse_sites_not_yet_supported {
         use crate::front::wgsl::assert_parse_err;
 
@@ -796,27 +817,5 @@ error: found conflicting `diagnostic(…)` rule(s)
 
 ");
         }
-    }
-
-    use crate::front::wgsl::assert_parse_err;
-    #[test]
-    fn intended_global_directive() {
-        let shader = "
-@diagnostic(off, my.lint);
-";
-        assert_parse_err(
-            shader,
-            "\
-error: `@diagnostic(…)` attribute(s) on semicolons are not supported
-  ┌─ wgsl:2:1
-  │
-2 │ @diagnostic(off, my.lint);
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^
-  │
-  = note: `@diagnostic(…)` attributes are only permitted on `fn`s, some statements, and `switch`/`loop` bodies.
-  = note: To declare a diagnostic filter that applies to the entire module, move this line to the top of the file and remove the `@` symbol.
-
-"
-        );
     }
 }

--- a/naga/src/front/wgsl/tests.rs
+++ b/naga/src/front/wgsl/tests.rs
@@ -797,4 +797,26 @@ error: found conflicting `diagnostic(…)` rule(s)
 ");
         }
     }
+
+    use crate::front::wgsl::assert_parse_err;
+    #[test]
+    fn intended_global_directive() {
+        let shader = "
+@diagnostic(off, my.lint);
+";
+        assert_parse_err(
+            shader,
+            "\
+error: `@diagnostic(…)` attribute(s) on semicolons are not supported
+  ┌─ wgsl:2:1
+  │
+2 │ @diagnostic(off, my.lint);
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = note: `@diagnostic(…)` attributes are only permitted on `fn`s, some statements, and `switch`/`loop` bodies.
+  = note: To declare a diagnostic filter that applies to the entire module, move this line to the top of the file and remove the `@` symbol.
+
+"
+        );
+    }
 }

--- a/naga/src/front/wgsl/tests.rs
+++ b/naga/src/front/wgsl/tests.rs
@@ -675,7 +675,7 @@ error: `@diagnostic(…)` attribute(s) on semicolons are not supported
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^
   │
   = note: `@diagnostic(…)` attributes are only permitted on `fn`s, some statements, and `switch`/`loop` bodies.
-  = note: To declare a diagnostic filter that applies to the entire module, move this line to the top of the file and remove the `@` symbol.
+  = note: If you meant to declare a diagnostic filter that applies to the entire module, move this line to the top of the file and remove the `@` symbol.
 
 "
         );


### PR DESCRIPTION
If the user has a `global_decl` of the form `@diagnostic(...);`, display a note suggesting they remove the `@` to create a global `diagnostic_directive`, which will apply the diagnostic filter to the entire module.

**Connections**
Addresses #6536.

**Description**
Sometimes the user will intend to declare a `diagnostic_directive` to apply a diagnostic filter to the entire module using the following incorrect syntax, i.e.:
```
@diagnostic(off, my.lint);
```
The `@` symbol is used to declare a scoped diagnostic attribute (`diagnostic_attr`) but not a global `diagnostic_directive`. This change adds a note to the error message in this case to use the correct syntax:
```
diagnostic(off, my.list);
```

**Testing**
Added a test `front::wgsl::tests::diagnostic_filter::intended_global_directive` that tests the case described above against the expected error message + notes.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.

Not sure about some steps in the checklist, maybe these checks are failing because of my local setup.  ~~Also not sure if this small change belongs in the changelog.~~ Thanks.
