### PR TITLE
Avoid cloning Arcs unnecessarily when iterating trackers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
   - Check that at least one index is specified.
 - Reject destroyed buffers in query set resolution. By @ErichDonGubler in [#6579](https://github.com/gfx-rs/wgpu/pull/6579).
 - Fix panic when dropping `Device` on some environments. By @Dinnerbone in [#6681](https://github.com/gfx-rs/wgpu/pull/6681).
+- Reduced the overhead of command buffer validation. By @nical in [#6721](https://github.com/gfx-rs/wgpu/pull/6721).
 
 #### Naga
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1568,8 +1568,7 @@ fn validate_command_buffer(
                     TextureInner::Native { .. } => false,
                     TextureInner::Surface { .. } => {
                         // Compare the Arcs by pointer as Textures don't implement Eq.
-                        submit_surface_textures_owned
-                            .insert(Arc::as_ptr(&texture), texture.clone());
+                        submit_surface_textures_owned.insert(Arc::as_ptr(texture), texture.clone());
 
                         true
                     }
@@ -1577,7 +1576,7 @@ fn validate_command_buffer(
                 if should_extend {
                     unsafe {
                         used_surface_textures
-                            .merge_single(&texture, None, hal::TextureUses::PRESENT)
+                            .merge_single(texture, None, hal::TextureUses::PRESENT)
                             .unwrap();
                     };
                 }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3637,12 +3637,12 @@ impl Device {
         // During these iterations, we discard all errors. We don't care!
         let trackers = self.trackers.lock();
         for buffer in trackers.buffers.used_resources() {
-            if let Some(buffer) = Weak::upgrade(&buffer) {
+            if let Some(buffer) = Weak::upgrade(buffer) {
                 let _ = buffer.destroy();
             }
         }
         for texture in trackers.textures.used_resources() {
-            if let Some(texture) = Weak::upgrade(&texture) {
+            if let Some(texture) = Weak::upgrade(texture) {
                 let _ = texture.destroy();
             }
         }

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -311,7 +311,7 @@ impl BufferTracker {
     }
 
     /// Returns a list of all buffers tracked.
-    pub fn used_resources(&self) -> impl Iterator<Item = Arc<Buffer>> + '_ {
+    pub fn used_resources(&self) -> impl Iterator<Item = &Arc<Buffer>> + '_ {
         self.metadata.owned_resources()
     }
 
@@ -559,7 +559,7 @@ impl DeviceBufferTracker {
     }
 
     /// Returns a list of all buffers tracked.
-    pub fn used_resources(&self) -> impl Iterator<Item = Weak<Buffer>> + '_ {
+    pub fn used_resources(&self) -> impl Iterator<Item = &Weak<Buffer>> + '_ {
         self.metadata.owned_resources()
     }
 

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -111,13 +111,13 @@ impl<T: Clone> ResourceMetadata<T> {
     }
 
     /// Returns an iterator over the resources owned by `self`.
-    pub(super) fn owned_resources(&self) -> impl Iterator<Item = T> + '_ {
+    pub(super) fn owned_resources(&self) -> impl Iterator<Item = &T> + '_ {
         if !self.owned.is_empty() {
             self.tracker_assert_in_bounds(self.owned.len() - 1)
         };
         iterate_bitvec_indices(&self.owned).map(move |index| {
             let resource = unsafe { self.resources.get_unchecked(index) };
-            resource.as_ref().unwrap().clone()
+            resource.as_ref().unwrap()
         })
     }
 

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -429,10 +429,9 @@ impl TextureTracker {
     }
 
     /// Returns a list of all textures tracked.
-    pub fn used_resources(&self) -> impl Iterator<Item = Arc<Texture>> + '_ {
+    pub fn used_resources(&self) -> impl Iterator<Item = &Arc<Texture>> + '_ {
         self.metadata.owned_resources()
     }
-
     /// Drain all currently pending transitions.
     pub fn drain_transitions<'a>(
         &'a mut self,
@@ -672,7 +671,7 @@ impl DeviceTextureTracker {
     }
 
     /// Returns a list of all textures tracked.
-    pub fn used_resources(&self) -> impl Iterator<Item = Weak<Texture>> + '_ {
+    pub fn used_resources(&self) -> impl Iterator<Item = &Weak<Texture>> + '_ {
         self.metadata.owned_resources()
     }
 


### PR DESCRIPTION
I noticed that in `validate_command_buffer` we spend a fair amount of CPU time cloning/dropping arcs while iterating trackers, just to peak into the contents of the buffer or textures (so we don't really need to hold on to the arcs and touch the reference counts).

This PR avoids that by iterating over references to the arcs instead of clones of the arcs.

I'm in a train and running low on battery so I can't properly record some numbers from the benchmarks right now, but when I ran them earlier I was seeing some non-trivial improvements   in the order of 10% for some benchmark).

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
