### PR TITLE
Fix Test Failure on AMD GL

### DIFF
--- a/tests/tests/regression/issue_6467.rs
+++ b/tests/tests/regression/issue_6467.rs
@@ -1,14 +1,14 @@
 use wgpu::util::DeviceExt;
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
 
-/// Running a compute shader with one or more of the workgroup sizes set to 0 implies that no work
+/// Running a compute shader with a total workgroup count of zero implies that no work
 /// should be done, and is a user error. Vulkan and DX12 accept this invalid input with grace, but
-/// Metal does not guard against this and eventually the machine will crash. Since this is a public
-/// API that may be given untrusted values in a browser, this must be protected again.
+/// Metal and some OpenGL drivers do not guard against this and eventually the machine will crash.
+/// Since this is a public  API that may be given untrusted values in a browser, this must be protected again.
 ///
 /// The following test should successfully do nothing on all platforms.
 #[gpu_test]
-static ZERO_WORKGROUP_SIZE: GpuTestConfiguration = GpuTestConfiguration::new()
+static ZERO_WORKGROUP_COUNT: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default().limits(wgpu::Limits::default()))
     .run_async(|ctx| async move {
         let module = ctx

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -1177,6 +1177,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
     }
 
     unsafe fn dispatch(&mut self, count: [u32; 3]) {
+        // Empty dispatches are invalid in OpenGL, but valid in WebGPU.
+        if count.iter().any(|&c| c == 0) {
+            return;
+        }
         self.cmd_buffer.commands.push(C::Dispatch(count));
     }
     unsafe fn dispatch_indirect(&mut self, buffer: &super::Buffer, offset: wgt::BufferAddress) {


### PR DESCRIPTION
**Connections**

#6467 also applies to AMD GL. Add the check for OpenGL as well.

**Description**

I changed the wording from workgroup _size_ to workgroup _count_.
