### PR TITLE
Skip AMD GPUs from RT Tests

### DIFF
--- a/tests/tests/ray_tracing/as_build.rs
+++ b/tests/tests/ray_tracing/as_build.rs
@@ -4,7 +4,9 @@ use wgpu::{
     util::{BufferInitDescriptor, DeviceExt},
     *,
 };
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    fail, gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext,
+};
 
 struct AsBuildContext {
     vertices: Buffer,
@@ -86,7 +88,9 @@ static UNBUILT_BLAS: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
+            // https://github.com/gfx-rs/wgpu/issues/6727
+            .skip(FailureCase::adapter("AMD")),
     )
     .run_sync(unbuilt_blas);
 
@@ -114,7 +118,9 @@ static OUT_OF_ORDER_AS_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
+            // https://github.com/gfx-rs/wgpu/issues/6727
+            .skip(FailureCase::adapter("AMD")),
     )
     .run_sync(out_of_order_as_build);
 
@@ -184,10 +190,16 @@ fn out_of_order_as_build(ctx: TestingContext) {
 
 #[gpu_test]
 static OUT_OF_ORDER_AS_BUILD_USE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().test_features_limits().features(
-        wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
-            | wgpu::Features::EXPERIMENTAL_RAY_QUERY,
-    ))
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .features(
+                wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
+                    | wgpu::Features::EXPERIMENTAL_RAY_QUERY,
+            )
+            // https://github.com/gfx-rs/wgpu/issues/6727
+            .skip(FailureCase::adapter("AMD")),
+    )
     .run_sync(out_of_order_as_build_use);
 
 fn out_of_order_as_build_use(ctx: TestingContext) {

--- a/tests/tests/ray_tracing/as_use_after_free.rs
+++ b/tests/tests/ray_tracing/as_use_after_free.rs
@@ -10,7 +10,7 @@ use wgpu::{
     Maintain, TlasInstance, TlasPackage, VertexFormat,
 };
 use wgpu_macros::gpu_test;
-use wgpu_test::{GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
 
 fn required_features() -> wgpu::Features {
     wgpu::Features::EXPERIMENTAL_RAY_QUERY
@@ -147,6 +147,8 @@ static ACCELERATION_STRUCTURE_USE_AFTER_FREE: GpuTestConfiguration = GpuTestConf
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(required_features()),
+            .features(required_features())
+            // https://github.com/gfx-rs/wgpu/issues/6727
+            .skip(FailureCase::adapter("AMD")),
     )
     .run_sync(acceleration_structure_use_after_free);

--- a/tests/tests/ray_tracing/scene/mod.rs
+++ b/tests/tests/ray_tracing/scene/mod.rs
@@ -1,6 +1,6 @@
 use std::{iter, mem};
 
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
 
 use wgpu::util::DeviceExt;
 
@@ -103,7 +103,9 @@ static ACCELERATION_STRUCTURE_BUILD_NO_INDEX: GpuTestConfiguration = GpuTestConf
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
+            // https://github.com/gfx-rs/wgpu/issues/6727
+            .skip(FailureCase::adapter("AMD")),
     )
     .run_sync(|ctx| {
         acceleration_structure_build(&ctx, false);
@@ -114,7 +116,9 @@ static ACCELERATION_STRUCTURE_BUILD_WITH_INDEX: GpuTestConfiguration = GpuTestCo
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
+            // https://github.com/gfx-rs/wgpu/issues/6727
+            .skip(FailureCase::adapter("AMD")),
     )
     .run_sync(|ctx| {
         acceleration_structure_build(&ctx, true);


### PR DESCRIPTION
Mitigate #6727 when running locally.