### PR TITLE
[naga valid]: Clean up validation of `Statement::ImageStore`.

### DIFF
--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -1016,20 +1016,20 @@ impl super::Validator {
                         crate::Expression::GlobalVariable(var_handle) => {
                             &context.global_vars[var_handle]
                         }
-                        // We're looking at a binding index situation, so punch through the index and look at the global behind it.
+                        // The `image` operand is indexing into a binding array,
+                        // so punch through the `Access`* expression and look at
+                        // the global behind it.
                         crate::Expression::Access { base, .. }
                         | crate::Expression::AccessIndex { base, .. } => {
-                            match *context.get_expression(base) {
-                                crate::Expression::GlobalVariable(var_handle) => {
-                                    &context.global_vars[var_handle]
-                                }
-                                _ => {
-                                    return Err(FunctionError::InvalidImageStore(
-                                        ExpressionError::ExpectedGlobalVariable,
-                                    )
-                                    .with_span_handle(image, context.expressions))
-                                }
-                            }
+                            let crate::Expression::GlobalVariable(var_handle) =
+                                *context.get_expression(base)
+                            else {
+                                return Err(FunctionError::InvalidImageStore(
+                                    ExpressionError::ExpectedGlobalVariable,
+                                )
+                                .with_span_handle(image, context.expressions));
+                            };
+                            &context.global_vars[var_handle]
                         }
                         _ => {
                             return Err(FunctionError::InvalidImageStore(
@@ -1039,77 +1039,79 @@ impl super::Validator {
                         }
                     };
 
-                    // Punch through a binding array to get the underlying type
+                    // Punch through a binding array to get the underlying type.
                     let global_ty = match context.types[var.ty].inner {
                         Ti::BindingArray { base, .. } => &context.types[base].inner,
                         ref inner => inner,
                     };
 
-                    let value_ty = match *global_ty {
-                        Ti::Image {
-                            class,
-                            arrayed,
-                            dim,
-                        } => {
-                            match context
-                                .resolve_type(coordinate, &self.valid_expression_set)?
-                                .image_storage_coordinates()
-                            {
-                                Some(coord_dim) if coord_dim == dim => {}
-                                _ => {
-                                    return Err(FunctionError::InvalidImageStore(
-                                        ExpressionError::InvalidImageCoordinateType(
-                                            dim, coordinate,
-                                        ),
-                                    )
-                                    .with_span_handle(coordinate, context.expressions));
-                                }
-                            };
-                            if arrayed != array_index.is_some() {
-                                return Err(FunctionError::InvalidImageStore(
-                                    ExpressionError::InvalidImageArrayIndex,
-                                )
-                                .with_span_handle(coordinate, context.expressions));
-                            }
-                            if let Some(expr) = array_index {
-                                match *context.resolve_type(expr, &self.valid_expression_set)? {
-                                    Ti::Scalar(crate::Scalar {
-                                        kind: crate::ScalarKind::Sint | crate::ScalarKind::Uint,
-                                        width: _,
-                                    }) => {}
-                                    _ => {
-                                        return Err(FunctionError::InvalidImageStore(
-                                            ExpressionError::InvalidImageArrayIndexType(expr),
-                                        )
-                                        .with_span_handle(expr, context.expressions));
-                                    }
-                                }
-                            }
-                            match class {
-                                crate::ImageClass::Storage { format, .. } => {
-                                    crate::TypeInner::Vector {
-                                        size: crate::VectorSize::Quad,
-                                        scalar: format.into(),
-                                    }
-                                }
-                                _ => {
-                                    return Err(FunctionError::InvalidImageStore(
-                                        ExpressionError::InvalidImageClass(class),
-                                    )
-                                    .with_span_handle(image, context.expressions));
-                                }
-                            }
-                        }
-                        _ => {
-                            return Err(FunctionError::InvalidImageStore(
-                                ExpressionError::ExpectedImageType(var.ty),
-                            )
-                            .with_span()
-                            .with_handle(var.ty, context.types)
-                            .with_handle(image, context.expressions))
-                        }
+                    // The `image` operand must be an `Image`.
+                    let Ti::Image {
+                        class,
+                        arrayed,
+                        dim,
+                    } = *global_ty
+                    else {
+                        return Err(FunctionError::InvalidImageStore(
+                            ExpressionError::ExpectedImageType(var.ty),
+                        )
+                        .with_span()
+                        .with_handle(var.ty, context.types)
+                        .with_handle(image, context.expressions));
                     };
 
+                    // The `coordinate` operand must be a vector of the appropriate size.
+                    if !context
+                        .resolve_type(coordinate, &self.valid_expression_set)?
+                        .image_storage_coordinates()
+                        .is_some_and(|coord_dim| coord_dim == dim)
+                    {
+                        return Err(FunctionError::InvalidImageStore(
+                            ExpressionError::InvalidImageCoordinateType(dim, coordinate),
+                        )
+                        .with_span_handle(coordinate, context.expressions));
+                    }
+
+                    // The `array_index` operand should be present if and only if
+                    // the image itself is arrayed.
+                    if arrayed != array_index.is_some() {
+                        return Err(FunctionError::InvalidImageStore(
+                            ExpressionError::InvalidImageArrayIndex,
+                        )
+                        .with_span_handle(coordinate, context.expressions));
+                    }
+
+                    // If present, `array_index` must be a scalar integer type.
+                    if let Some(expr) = array_index {
+                        if !matches!(
+                            *context.resolve_type(expr, &self.valid_expression_set)?,
+                            Ti::Scalar(crate::Scalar {
+                                kind: crate::ScalarKind::Sint | crate::ScalarKind::Uint,
+                                width: _,
+                            })
+                        ) {
+                            return Err(FunctionError::InvalidImageStore(
+                                ExpressionError::InvalidImageArrayIndexType(expr),
+                            )
+                            .with_span_handle(expr, context.expressions));
+                        }
+                    }
+
+                    // It had better be a storage image, since we're writing to it.
+                    let crate::ImageClass::Storage { format, .. } = class else {
+                        return Err(FunctionError::InvalidImageStore(
+                            ExpressionError::InvalidImageClass(class),
+                        )
+                        .with_span_handle(image, context.expressions));
+                    };
+
+                    let value_ty = crate::TypeInner::Vector {
+                        size: crate::VectorSize::Quad,
+                        scalar: format.into(),
+                    };
+
+                    // The value we're writing had better match the scalar type
+                    // for `image`'s format.
                     if *context.resolve_type(value, &self.valid_expression_set)? != value_ty {
                         return Err(FunctionError::InvalidStoreValue(value)
                             .with_span_handle(value, context.expressions));

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -1060,6 +1060,14 @@ impl super::Validator {
                         .with_handle(image, context.expressions));
                     };
 
+                    // It had better be a storage image, since we're writing to it.
+                    let crate::ImageClass::Storage { format, .. } = class else {
+                        return Err(FunctionError::InvalidImageStore(
+                            ExpressionError::InvalidImageClass(class),
+                        )
+                        .with_span_handle(image, context.expressions));
+                    };
+
                     // The `coordinate` operand must be a vector of the appropriate size.
                     if !context
                         .resolve_type(coordinate, &self.valid_expression_set)?
@@ -1096,14 +1104,6 @@ impl super::Validator {
                             .with_span_handle(expr, context.expressions));
                         }
                     }
-
-                    // It had better be a storage image, since we're writing to it.
-                    let crate::ImageClass::Storage { format, .. } = class else {
-                        return Err(FunctionError::InvalidImageStore(
-                            ExpressionError::InvalidImageClass(class),
-                        )
-                        .with_span_handle(image, context.expressions));
-                    };
 
                     let value_ty = crate::TypeInner::Vector {
                         size: crate::VectorSize::Quad,


### PR DESCRIPTION
*   Ensure that the type we obtain for the `image` operand is correct:
    "see through" a binding array to its element type only when `image` is
    actually an `Access` or `AccessIndex` expression. (This changes the
    set of programs the validator will pass, but it turns out not to
    affect the set of WGSL programs that Naga will accept, since the WGSL
    front end is already checking the types of the `texture` arguments to
    `textureStore` function calls, in order to decide which overload
    applies.)
    Rename the variables to better reflect their values.

*   Move image class validation to a more natural spot.

*   Use `let-else` statements to keep the main flow of control at the
    left. Briefly describe the conditions we're testing.

