### PR TITLE
[core] Allow depthClearValue to be empty

### DIFF
--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -163,7 +163,7 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
                 stencil: wgpu_core::command::PassChannel {
                     load_op: attachment.stencil_load_op,
                     store_op: attachment.stencil_store_op,
-                    clear_value: attachment.stencil_clear_value,
+                    clear_value: Some(attachment.stencil_clear_value),
                     read_only: attachment.stencil_read_only,
                 },
             });

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -157,7 +157,7 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
                 depth: wgpu_core::command::PassChannel {
                     load_op: attachment.depth_load_op,
                     store_op: attachment.depth_store_op,
-                    clear_value: attachment.depth_clear_value,
+                    clear_value: Some(attachment.depth_clear_value),
                     read_only: attachment.depth_read_only,
                 },
                 stencil: wgpu_core::command::PassChannel {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1489,11 +1489,14 @@ impl Global {
                         }
                     }
 
-                    let depth = PassChannel {
-                        load_op: depth_stencil_attachment.depth.load_op,
-                        store_op: depth_stencil_attachment.depth.store_op,
-                        read_only: depth_stencil_attachment.depth.read_only,
-                        clear_value: depth_stencil_attachment.depth.clear_value.unwrap_or_default()
+                    let depth = {
+                        let PassChannel { load_op, store_op, clear_value, read_only } = depth_stencil_attachment.depth;
+                        PassChannel {
+                            load_op,
+                            store_op,
+                            read_only,
+                            clear_value: clear_value.unwrap_or_default()
+                        }
                     };
 
                     Some(ArcRenderPassDepthStencilAttachment {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -650,10 +650,10 @@ pub enum AttachmentError {
     NoLoad,
     #[error("Attachment without store")]
     NoStore,
-    #[error("Clear value is not provided")]
+    #[error("LoadOp is `Clear` but no clear value was provided")]
     NoClearValue,
-    #[error("Clear value must be between 0.0 and 1.0, inclusive")]
-    ClearValueOutOfRange,
+    #[error("Clear value ({0}) must be between 0.0 and 1.0, inclusive")]
+    ClearValueOutOfRange(f32),
 }
 
 /// Error encountered when performing a render pass.
@@ -1482,7 +1482,7 @@ impl Global {
                     if depth_stencil_attachment.depth.load_op == Some(LoadOp::Clear) {
                         if let Some(clear_value) = depth_stencil_attachment.depth.clear_value {
                             if !(0.0..=1.0).contains(&clear_value) {
-                                return Err(CommandEncoderError::InvalidAttachment(AttachmentError::ClearValueOutOfRange));
+                                return Err(CommandEncoderError::InvalidAttachment(AttachmentError::ClearValueOutOfRange(clear_value)));
                             }
                         } else {
                             return Err(CommandEncoderError::InvalidAttachment(AttachmentError::NoClearValue));
@@ -1490,6 +1490,7 @@ impl Global {
                     }
 
                     let depth = {
+                        // We cannot update struct because of different generic
                         let PassChannel { load_op, store_op, clear_value, read_only } = depth_stencil_attachment.depth;
                         PassChannel {
                             load_op,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -411,11 +411,11 @@ fn map_load_op<V: Default>(op: LoadOp<V>) -> (wgc::command::LoadOp, V) {
     }
 }
 
-fn map_pass_channel<T: TryFrom<V> + Default, V: Copy + Default>(
-    ops: Option<&Operations<V>>,
-) -> wgc::command::PassChannel<T>
+fn map_pass_channel<T, V>(ops: Option<&Operations<V>>) -> wgc::command::PassChannel<T>
 where
-    <T as std::convert::TryFrom<V>>::Error: std::fmt::Debug,
+    T: TryFrom<V> + Default,
+    V: Copy + Default,
+    T::Error: std::fmt::Debug,
 {
     match ops {
         Some(&Operations { load, store }) => {


### PR DESCRIPTION
**Description**
Spec says that [depthClearValue](https://www.w3.org/TR/webgpu/#dom-gpurenderpassdepthstencilattachment-depthclearvalue) is optional, it must only be provided when loadOp is clear (or else raise validation error). To support this in browsers wgpu-core needs to accept depth.clear_value as option and do appropriate validation.

https://www.w3.org/TR/webgpu/#abstract-opdef-gpurenderpassdepthstencilattachment-gpurenderpassdepthstencilattachment-valid-usage:
> If this.[depthLoadOp](https://www.w3.org/TR/webgpu/#dom-gpurenderpassdepthstencilattachment-depthloadop) is ["clear"](https://www.w3.org/TR/webgpu/#dom-gpuloadop-clear), this.[depthClearValue](https://www.w3.org/TR/webgpu/#dom-gpurenderpassdepthstencilattachment-depthclearvalue) must [be provided](https://infra.spec.whatwg.org/#map-exists) and must be between 0.0 and 1.0, inclusive.

**Testing**
[CTS run in servo](https://github.com/sagudev/servo/actions/runs/12355696817/job/34487417853):
```
OK /_webgpu/webgpu/cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,depth_clear_value:*

    PASS [expected FAIL] subtest: :depthLoadOp="clear";depthClearValue="_undef_"
    PASS [expected FAIL] subtest: :depthLoadOp="clear";depthClearValue=-1
    PASS [expected FAIL] subtest: :depthLoadOp="clear";depthClearValue=1.5
```

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
