### PR TITLE
Add usage to TextureViewDescriptor

### DIFF
--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -8,7 +8,6 @@ use deno_core::ResourceId;
 use serde::Deserialize;
 use std::borrow::Cow;
 use std::rc::Rc;
-use wgpu_types::TextureUsages;
 
 use super::error::WebGpuResult;
 pub(crate) struct WebGpuTexture {
@@ -116,7 +115,7 @@ pub fn op_webgpu_create_texture_view(
         format: args.format,
         dimension: args.dimension,
         range: args.range,
-        usage: TextureUsages::FROM_PARENT, // FIXME: Actually obtain from parent
+        usage: None, // FIXME: Actually obtain from parent
     };
 
     gfx_put!(instance.texture_create_view(

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -115,7 +115,7 @@ pub fn op_webgpu_create_texture_view(
         format: args.format,
         dimension: args.dimension,
         range: args.range,
-        usage: None, // FIXME: Actually obtain from parent
+        usage: None, // FIXME: Obtain actual value from desc
     };
 
     gfx_put!(instance.texture_create_view(

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -8,6 +8,7 @@ use deno_core::ResourceId;
 use serde::Deserialize;
 use std::borrow::Cow;
 use std::rc::Rc;
+use wgpu_types::TextureUsages;
 
 use super::error::WebGpuResult;
 pub(crate) struct WebGpuTexture {
@@ -115,6 +116,7 @@ pub fn op_webgpu_create_texture_view(
         format: args.format,
         dimension: args.dimension,
         range: args.range,
+        usage: TextureUsages::FROM_PARENT, // FIXME: Actually obtain from parent
     };
 
     gfx_put!(instance.texture_create_view(

--- a/examples/src/mipmap/mod.rs
+++ b/examples/src/mipmap/mod.rs
@@ -1,6 +1,7 @@
 use bytemuck::{Pod, Zeroable};
 use std::{f32::consts, mem::size_of};
 use wgpu::util::DeviceExt;
+use wgpu::TextureUsages;
 
 const TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
 const MIP_LEVEL_COUNT: u32 = 10;
@@ -127,6 +128,7 @@ impl Example {
                     label: Some("mip"),
                     format: None,
                     dimension: None,
+                    usage: TextureUsages::FROM_PARENT,
                     aspect: wgpu::TextureAspect::All,
                     base_mip_level: mip,
                     mip_level_count: Some(1),

--- a/examples/src/mipmap/mod.rs
+++ b/examples/src/mipmap/mod.rs
@@ -1,7 +1,6 @@
 use bytemuck::{Pod, Zeroable};
 use std::{f32::consts, mem::size_of};
 use wgpu::util::DeviceExt;
-use wgpu::TextureUsages;
 
 const TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
 const MIP_LEVEL_COUNT: u32 = 10;
@@ -128,7 +127,7 @@ impl Example {
                     label: Some("mip"),
                     format: None,
                     dimension: None,
-                    usage: TextureUsages::FROM_PARENT,
+                    usage: None,
                     aspect: wgpu::TextureAspect::All,
                     base_mip_level: mip,
                     mip_level_count: Some(1),

--- a/examples/src/multiple_render_targets/mod.rs
+++ b/examples/src/multiple_render_targets/mod.rs
@@ -69,6 +69,7 @@ impl MultiTargetRenderer {
             label: Some("view"),
             format: None,
             dimension: Some(wgpu::TextureViewDimension::D2),
+            usage: None,
             aspect: wgpu::TextureAspect::All,
             base_mip_level: 0,
             mip_level_count: None,

--- a/examples/src/ray_cube_compute/mod.rs
+++ b/examples/src/ray_cube_compute/mod.rs
@@ -177,7 +177,7 @@ impl crate::framework::Example for Example {
             label: None,
             format: Some(wgpu::TextureFormat::Rgba8Unorm),
             dimension: Some(wgpu::TextureViewDimension::D2),
-            usage: wgpu::TextureUsages::FROM_PARENT,
+            usage: None,
             aspect: wgpu::TextureAspect::All,
             base_mip_level: 0,
             mip_level_count: None,

--- a/examples/src/ray_cube_compute/mod.rs
+++ b/examples/src/ray_cube_compute/mod.rs
@@ -177,6 +177,7 @@ impl crate::framework::Example for Example {
             label: None,
             format: Some(wgpu::TextureFormat::Rgba8Unorm),
             dimension: Some(wgpu::TextureViewDimension::D2),
+            usage: wgpu::TextureUsages::FROM_PARENT,
             aspect: wgpu::TextureAspect::All,
             base_mip_level: 0,
             mip_level_count: None,

--- a/examples/src/shadow/mod.rs
+++ b/examples/src/shadow/mod.rs
@@ -393,7 +393,7 @@ impl crate::framework::Example for Example {
                     label: Some("shadow"),
                     format: None,
                     dimension: Some(wgpu::TextureViewDimension::D2),
-                    usage: wgpu::TextureUsages::FROM_PARENT,
+                    usage: None,
                     aspect: wgpu::TextureAspect::All,
                     base_mip_level: 0,
                     mip_level_count: None,

--- a/examples/src/shadow/mod.rs
+++ b/examples/src/shadow/mod.rs
@@ -393,6 +393,7 @@ impl crate::framework::Example for Example {
                     label: Some("shadow"),
                     format: None,
                     dimension: Some(wgpu::TextureViewDimension::D2),
+                    usage: wgpu::TextureUsages::FROM_PARENT,
                     aspect: wgpu::TextureAspect::All,
                     base_mip_level: 0,
                     mip_level_count: None,

--- a/tests/tests/bgra8unorm_storage.rs
+++ b/tests/tests/bgra8unorm_storage.rs
@@ -44,6 +44,7 @@ static BGRA8_UNORM_STORAGE: GpuTestConfiguration = GpuTestConfiguration::new()
             label: None,
             format: None,
             dimension: None,
+            usage: wgpu::TextureUsages::FROM_PARENT,
             aspect: wgpu::TextureAspect::All,
             base_mip_level: 0,
             base_array_layer: 0,

--- a/tests/tests/bgra8unorm_storage.rs
+++ b/tests/tests/bgra8unorm_storage.rs
@@ -44,7 +44,7 @@ static BGRA8_UNORM_STORAGE: GpuTestConfiguration = GpuTestConfiguration::new()
             label: None,
             format: None,
             dimension: None,
-            usage: wgpu::TextureUsages::FROM_PARENT,
+            usage: None,
             aspect: wgpu::TextureAspect::All,
             base_mip_level: 0,
             base_array_layer: 0,

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -688,6 +688,7 @@ static DIFFERENT_BGL_ORDER_BW_SHADER_AND_API: GpuTestConfiguration = GpuTestConf
             label: None,
             format: None,
             dimension: None,
+            usage: wgpu::TextureUsages::FROM_PARENT,
             aspect: wgt::TextureAspect::All,
             base_mip_level: 0,
             mip_level_count: None,

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -688,7 +688,7 @@ static DIFFERENT_BGL_ORDER_BW_SHADER_AND_API: GpuTestConfiguration = GpuTestConf
             label: None,
             format: None,
             dimension: None,
-            usage: wgpu::TextureUsages::FROM_PARENT,
+            usage: None,
             aspect: wgt::TextureAspect::All,
             base_mip_level: 0,
             mip_level_count: None,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1086,15 +1086,18 @@ impl Device {
                         .saturating_sub(desc.range.base_array_layer),
                 });
 
-        let resolved_usage = if desc.usage == wgt::TextureUsages::FROM_PARENT {
-            texture.desc.usage
-        } else if texture.desc.usage.contains(desc.usage) {
-            desc.usage
-        } else {
-            return Err(resource::CreateTextureViewError::InvalidTextureViewUsage {
-                view: desc.usage,
-                texture: texture.desc.usage,
-            });
+        let resolved_usage = {
+            let usage = desc.usage.unwrap_or(wgt::TextureUsages::empty());
+            if usage.is_empty() {
+                texture.desc.usage
+            } else if texture.desc.usage.contains(usage) {
+                usage
+            } else {
+                return Err(resource::CreateTextureViewError::InvalidTextureViewUsage {
+                    view: usage,
+                    texture: texture.desc.usage,
+                });
+            }
         };
 
         // validate TextureViewDescriptor

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1100,6 +1100,25 @@ impl Device {
             }
         };
 
+        let allowed_format_usages = resolved_format
+            .guaranteed_format_features(self.features)
+            .allowed_usages;
+        if resolved_usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT)
+            && !allowed_format_usages.contains(wgt::TextureUsages::RENDER_ATTACHMENT)
+        {
+            return Err(
+                resource::CreateTextureViewError::TextureViewFormatNotRenderable(resolved_format),
+            );
+        }
+
+        if resolved_usage.contains(wgt::TextureUsages::STORAGE_BINDING)
+            && !allowed_format_usages.contains(wgt::TextureUsages::STORAGE_BINDING)
+        {
+            return Err(
+                resource::CreateTextureViewError::TextureViewFormatNotStorage(resolved_format),
+            );
+        }
+
         // validate TextureViewDescriptor
 
         let aspects = hal::FormatAspects::new(texture.desc.format, desc.range.aspect);

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1086,7 +1086,7 @@ impl Device {
                         .saturating_sub(desc.range.base_array_layer),
                 });
 
-        let resolved_usage = if desc.usage.is_empty() {
+        let resolved_usage = if desc.usage == wgt::TextureUsages::FROM_PARENT {
             texture.desc.usage
         } else if texture.desc.usage.contains(desc.usage) {
             desc.usage

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1100,8 +1100,8 @@ impl Device {
             }
         };
 
-        let allowed_format_usages = resolved_format
-            .guaranteed_format_features(self.features)
+        let allowed_format_usages = self
+            .describe_format_features(resolved_format)?
             .allowed_usages;
         if resolved_usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT)
             && !allowed_format_usages.contains(wgt::TextureUsages::RENDER_ATTACHMENT)

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1552,6 +1552,9 @@ pub struct TextureViewDescriptor<'a> {
     /// - For 2D textures it must be one of `D2`, `D2Array`, `Cube`, or `CubeArray`.
     /// - For 3D textures it must be `D3`.
     pub dimension: Option<wgt::TextureViewDimension>,
+    /// The allowed usage(s) for the texture view. Must be a subset of the usage flags of the texture.
+    /// If 0, defaults to the full set of usage flags of the texture.
+    pub usage: wgt::TextureUsages,
     /// Range within the texture that is accessible via this view.
     pub range: wgt::ImageSubresourceRange,
 }
@@ -1644,6 +1647,11 @@ pub enum CreateTextureViewError {
     InvalidTextureViewDimension {
         view: wgt::TextureViewDimension,
         texture: wgt::TextureDimension,
+    },
+    #[error("Invalid texture view usage `{view:?}` with texture of usage `{texture:?}`")]
+    InvalidTextureViewUsage {
+        view: wgt::TextureUsages,
+        texture: wgt::TextureUsages,
     },
     #[error("Invalid texture view dimension `{0:?}` of a multisampled texture")]
     InvalidMultisampledTextureViewDimension(wgt::TextureViewDimension),

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1554,8 +1554,8 @@ pub struct TextureViewDescriptor<'a> {
     /// - For 3D textures it must be `D3`.
     pub dimension: Option<wgt::TextureViewDimension>,
     /// The allowed usage(s) for the texture view. Must be a subset of the usage flags of the texture.
-    /// If 0, defaults to the full set of usage flags of the texture.
-    pub usage: wgt::TextureUsages,
+    /// If not provided, defaults to the full set of usage flags of the texture.
+    pub usage: Option<wgt::TextureUsages>,
     /// Range within the texture that is accessible via this view.
     pub range: wgt::ImageSubresourceRange,
 }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1060,6 +1060,7 @@ impl Texture {
             bind_groups: Mutex::new(rank::TEXTURE_BIND_GROUPS, WeakVec::new()),
         }
     }
+
     /// Checks that the given texture usage contains the required texture usage,
     /// returns an error otherwise.
     pub(crate) fn check_usage(
@@ -1563,6 +1564,7 @@ pub struct TextureViewDescriptor<'a> {
 pub(crate) struct HalTextureViewDescriptor {
     pub texture_format: wgt::TextureFormat,
     pub format: wgt::TextureFormat,
+    pub usage: wgt::TextureUsages,
     pub dimension: wgt::TextureViewDimension,
     pub range: wgt::ImageSubresourceRange,
 }
@@ -1633,6 +1635,23 @@ impl TextureView {
             .get(guard)
             .map(|it| it.as_ref())
             .ok_or_else(|| DestroyedResourceError(self.error_ident()))
+    }
+
+    /// Checks that the given texture usage contains the required texture usage,
+    /// returns an error otherwise.
+    pub(crate) fn check_usage(
+        &self,
+        expected: wgt::TextureUsages,
+    ) -> Result<(), MissingTextureUsageError> {
+        if self.desc.usage.contains(expected) {
+            Ok(())
+        } else {
+            Err(MissingTextureUsageError {
+                res: self.error_ident(),
+                actual: self.desc.usage,
+                expected,
+            })
+        }
     }
 }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1667,6 +1667,10 @@ pub enum CreateTextureViewError {
         view: wgt::TextureViewDimension,
         texture: wgt::TextureDimension,
     },
+    #[error("Texture view format `{0:?}` is not renderable")]
+    TextureViewFormatNotRenderable(wgt::TextureFormat),
+    #[error("Texture view format `{0:?}` is not storage bindable")]
+    TextureViewFormatNotStorage(wgt::TextureFormat),
     #[error("Invalid texture view usage `{view:?}` with texture of usage `{texture:?}`")]
     InvalidTextureViewUsage {
         view: wgt::TextureUsages,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1711,6 +1711,8 @@ pub enum CreateTextureViewError {
     },
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
+    #[error(transparent)]
+    MissingFeatures(#[from] MissingFeatures),
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -5540,8 +5540,10 @@ bitflags::bitflags! {
     #[repr(transparent)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[cfg_attr(feature = "serde", serde(transparent))]
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
     pub struct TextureUsages: u32 {
+        /// For use in texture views, expands to the full set of usage flags of the texture
+        const FROM_PARENT = 0;
         /// Allows a texture to be the source in a [`CommandEncoder::copy_texture_to_buffer`] or
         /// [`CommandEncoder::copy_texture_to_texture`] operation.
         const COPY_SRC = 1 << 0;
@@ -6102,6 +6104,9 @@ pub struct TextureViewDescriptor<L> {
     /// The dimension of the texture view. For 1D textures, this must be `D1`. For 2D textures it must be one of
     /// `D2`, `D2Array`, `Cube`, and `CubeArray`. For 3D textures it must be `D3`
     pub dimension: Option<TextureViewDimension>,
+    /// The allowed usage(s) for the texture view. Must be a subset of the usage flags of the texture.
+    /// If 0, defaults to the full set of usage flags of the texture.
+    pub usage: TextureUsages,
     /// Aspect of the texture. Color textures must be [`TextureAspect::All`].
     pub aspect: TextureAspect,
     /// Base mip level.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -5540,10 +5540,8 @@ bitflags::bitflags! {
     #[repr(transparent)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[cfg_attr(feature = "serde", serde(transparent))]
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub struct TextureUsages: u32 {
-        /// For use in texture views, expands to the full set of usage flags of the texture
-        const FROM_PARENT = 0;
         /// Allows a texture to be the source in a [`CommandEncoder::copy_texture_to_buffer`] or
         /// [`CommandEncoder::copy_texture_to_texture`] operation.
         const COPY_SRC = 1 << 0;
@@ -6105,8 +6103,8 @@ pub struct TextureViewDescriptor<L> {
     /// `D2`, `D2Array`, `Cube`, and `CubeArray`. For 3D textures it must be `D3`
     pub dimension: Option<TextureViewDimension>,
     /// The allowed usage(s) for the texture view. Must be a subset of the usage flags of the texture.
-    /// If 0, defaults to the full set of usage flags of the texture.
-    pub usage: TextureUsages,
+    /// If not provided, defaults to the full set of usage flags of the texture.
+    pub usage: Option<TextureUsages>,
     /// Aspect of the texture. Color textures must be [`TextureAspect::All`].
     pub aspect: TextureAspect,
     /// Base mip level.

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2683,6 +2683,7 @@ impl dispatch::TextureInterface for WebTexture {
         if let Some(label) = desc.label {
             mapped.set_label(label);
         }
+        mapped.set_usage(desc.usage.unwrap_or(wgt::TextureUsages::empty()).bits());
 
         let view = self.inner.create_view_with_descriptor(&mapped).unwrap();
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1967,6 +1967,7 @@ impl dispatch::TextureInterface for CoreTexture {
             label: desc.label.map(Borrowed),
             format: desc.format,
             dimension: desc.dimension,
+            usage: desc.usage,
             range: wgt::ImageSubresourceRange {
                 aspect: desc.aspect,
                 base_mip_level: desc.base_mip_level,


### PR DESCRIPTION
**Description**
Spec says that we should obtain usage via TextureViewDescriptor: https://www.w3.org/TR/webgpu/#dom-gputextureviewdescriptor-usage, although by default it's is the same as in parent.

**Testing**
CTS run in servo: https://github.com/gfx-rs/wgpu/pull/6755#issuecomment-2547798268

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
