### PR TITLE
[d3d12] fix being able to use `dispatchWorkgroupsIndirect` without validation

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2612,10 +2612,17 @@ impl Device {
             .map(|bgl| bgl.raw())
             .collect::<ArrayVec<_, { hal::MAX_BIND_GROUPS }>>();
 
+        let additional_flags = if cfg!(feature = "indirect-validation") {
+            hal::PipelineLayoutFlags::INDIRECT_BUILTIN_UPDATE
+        } else {
+            hal::PipelineLayoutFlags::empty()
+        };
+
         let hal_desc = hal::PipelineLayoutDescriptor {
             label: desc.label.to_hal(self.instance_flags),
             flags: hal::PipelineLayoutFlags::FIRST_VERTEX_INSTANCE
-                | hal::PipelineLayoutFlags::NUM_WORK_GROUPS,
+                | hal::PipelineLayoutFlags::NUM_WORK_GROUPS
+                | additional_flags,
             bind_group_layouts: &raw_bind_group_layouts,
             push_constant_ranges: desc.push_constant_ranges.as_ref(),
         };

--- a/wgpu-core/src/indirect_validation.rs
+++ b/wgpu-core/src/indirect_validation.rs
@@ -180,7 +180,7 @@ impl IndirectValidation {
 
         let pipeline_layout_desc = hal::PipelineLayoutDescriptor {
             label: None,
-            flags: hal::PipelineLayoutFlags::FIRST_VERTEX_INSTANCE,
+            flags: hal::PipelineLayoutFlags::empty(),
             bind_group_layouts: &[
                 dst_bind_group_layout.as_ref(),
                 src_bind_group_layout.as_ref(),

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -1223,13 +1223,25 @@ impl crate::CommandEncoder for super::CommandEncoder {
     }
 
     unsafe fn dispatch_indirect(&mut self, buffer: &super::Buffer, offset: wgt::BufferAddress) {
-        self.update_root_elements();
+        if self
+            .pass
+            .layout
+            .special_constants
+            .as_ref()
+            .and_then(|sc| sc.indirect_cmd_signatures.as_ref())
+            .is_some()
+        {
+            self.update_root_elements();
+        } else {
+            self.prepare_dispatch([0; 3]);
+        }
+
         let cmd_signature = &self
             .pass
             .layout
             .special_constants
             .as_ref()
-            .map(|sc| &sc.cmd_signatures)
+            .and_then(|sc| sc.indirect_cmd_signatures.as_ref())
             .unwrap_or_else(|| &self.shared.cmd_signatures)
             .dispatch;
         unsafe {

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -946,7 +946,7 @@ unsafe impl Sync for PipelineLayoutShared {}
 #[derive(Debug, Clone)]
 struct PipelineLayoutSpecialConstants {
     root_index: RootIndex,
-    cmd_signatures: CommandSignatures,
+    indirect_cmd_signatures: Option<CommandSignatures>,
 }
 
 unsafe impl Send for PipelineLayoutSpecialConstants {}

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1513,10 +1513,15 @@ bitflags!(
     /// Pipeline layout creation flags.
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub struct PipelineLayoutFlags: u32 {
-        /// Include support for `first_vertex` / `first_instance` drawing.
+        /// D3D12: Add support for `first_vertex` and `first_instance` builtins
+        /// via push constants for direct execution.
         const FIRST_VERTEX_INSTANCE = 1 << 0;
-        /// Include support for num work groups builtin.
+        /// D3D12: Add support for `num_workgroups` builtins via push constants
+        /// for direct execution.
         const NUM_WORK_GROUPS = 1 << 1;
+        /// D3D12: Add support for the builtins that the other flags enable for
+        /// indirect execution.
+        const INDIRECT_BUILTIN_UPDATE = 1 << 2;
     }
 );
 


### PR DESCRIPTION
Follow-up to https://github.com/gfx-rs/wgpu/pull/5730 (which introduced the issue).

Trying to use `dispatchWorkgroupsIndirect` without the `indirect-validation` feature flag would result in:

```
Device creation failed: The parameter is incorrect. (0x80070057) 
```