### PR TITLE
[core] Use higher level LoadOp,StoreOp

### DIFF
--- a/player/tests/data/quad.ron
+++ b/player/tests/data/quad.ron
@@ -100,14 +100,13 @@
                     Some((
                         view: Id(0, 1),
                         resolve_target: None,
-                        load_op: clear,
-                        store_op: store,
-                        clear_value: (
+                        load_op: clear(Color(
                             r: 0,
                             g: 0,
                             b: 0,
                             a: 1,
-                        ),
+                        )),
+                        store_op: store,
                     )),
                 ],
                 target_depth_stencil: None,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -955,7 +955,7 @@ impl<'d> RenderPassInfo<'d> {
             let ds_aspects = view.desc.aspects();
 
             if !ds_aspects.contains(hal::FormatAspects::STENCIL)
-                || (at.stencil.load_op().discriminant() == at.depth.load_op().discriminant()
+                || (at.stencil.load_op().eq_variant(at.depth.load_op())
                     && at.stencil.store_op() == at.depth.store_op())
             {
                 Self::add_pass_texture_init_actions(

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4872,6 +4872,81 @@ impl PartialEq for DepthBiasState {
 
 impl Eq for DepthBiasState {}
 
+/// Operation to perform to the output attachment at the start of a render pass.
+///
+/// Corresponds to [WebGPU `GPULoadOp`](https://gpuweb.github.io/gpuweb/#enumdef-gpuloadop),
+/// plus the corresponding clearValue.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum LoadOp<V> {
+    /// Loads the specified value for this attachment into the render pass.
+    ///
+    /// On some GPU hardware (primarily mobile), "clear" is significantly cheaper
+    /// because it avoids loading data from main memory into tile-local memory.
+    ///
+    /// On other GPU hardware, there isn’t a significant difference.
+    ///
+    /// As a result, it is recommended to use "clear" rather than "load" in cases
+    /// where the initial value doesn’t matter
+    /// (e.g. the render target will be cleared using a skybox).
+    Clear(V),
+    /// Loads the existing value for this attachment into the render pass.
+    Load,
+}
+
+impl<V: Default> Default for LoadOp<V> {
+    fn default() -> Self {
+        Self::Clear(Default::default())
+    }
+}
+
+/// Operation to perform to the output attachment at the end of a render pass.
+///
+/// Corresponds to [WebGPU `GPUStoreOp`](https://gpuweb.github.io/gpuweb/#enumdef-gpustoreop).
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum StoreOp {
+    /// Stores the resulting value of the render pass for this attachment.
+    #[default]
+    Store,
+    /// Discards the resulting value of the render pass for this attachment.
+    ///
+    /// The attachment will be treated as uninitialized afterwards.
+    /// (If only either Depth or Stencil texture-aspects is set to `Discard`,
+    /// the respective other texture-aspect will be preserved.)
+    ///
+    /// This can be significantly faster on tile-based render hardware.
+    ///
+    /// Prefer this if the attachment is not read by subsequent passes.
+    Discard,
+}
+
+/// Pair of load and store operations for an attachment aspect.
+///
+/// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
+/// separate `loadOp` and `storeOp` fields are used instead.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Operations<V> {
+    /// How data should be read through this attachment.
+    pub load: LoadOp<V>,
+    /// Whether data will be written to through this attachment.
+    ///
+    /// Note that resolve textures (if specified) are always written to,
+    /// regardless of this setting.
+    pub store: StoreOp,
+}
+
+impl<V: Default> Default for Operations<V> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            load: LoadOp::<V>::default(),
+            store: StoreOp::default(),
+        }
+    }
+}
+
 /// Describes the depth/stencil state in a render pipeline.
 ///
 /// Corresponds to [WebGPU `GPUDepthStencilState`](

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4897,12 +4897,12 @@ pub enum LoadOp<V> {
 }
 
 impl<V> LoadOp<V> {
-    /// Returns discriminant of LoadOp (useful for operation only comparison)
-    pub fn discriminant(&self) -> u8 {
-        // SAFETY: Because `Self` is marked `repr(u8)`, its layout is a `repr(C)` `union`
-        // between `repr(C)` structs, each of which has the `u8` discriminant as its first
-        // field, so we can read the discriminant without offsetting the pointer.
-        unsafe { *<*const _>::from(self).cast::<u8>() }
+    /// Returns true if variants are same (ignoring clear value)
+    pub fn eq_variant<T>(&self, other: LoadOp<T>) -> bool {
+        matches!(
+            (self, other),
+            (LoadOp::Clear(_), LoadOp::Clear(_)) | (LoadOp::Load, LoadOp::Load)
+        )
     }
 }
 

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use crate::*;
+pub use wgt::{LoadOp, Operations, StoreOp};
 
 /// In-progress recording of a render pass: a list of render commands in a [`CommandEncoder`].
 ///
@@ -493,81 +494,6 @@ impl RenderPass<'_> {
     /// `begin_pipeline_statistics_query`. Pipeline statistics queries may not be nested.
     pub fn end_pipeline_statistics_query(&mut self) {
         self.inner.end_pipeline_statistics_query();
-    }
-}
-
-/// Operation to perform to the output attachment at the start of a render pass.
-///
-/// Corresponds to [WebGPU `GPULoadOp`](https://gpuweb.github.io/gpuweb/#enumdef-gpuloadop),
-/// plus the corresponding clearValue.
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum LoadOp<V> {
-    /// Loads the specified value for this attachment into the render pass.
-    ///
-    /// On some GPU hardware (primarily mobile), "clear" is significantly cheaper
-    /// because it avoids loading data from main memory into tile-local memory.
-    ///
-    /// On other GPU hardware, there isn’t a significant difference.
-    ///
-    /// As a result, it is recommended to use "clear" rather than "load" in cases
-    /// where the initial value doesn’t matter
-    /// (e.g. the render target will be cleared using a skybox).
-    Clear(V),
-    /// Loads the existing value for this attachment into the render pass.
-    Load,
-}
-
-impl<V: Default> Default for LoadOp<V> {
-    fn default() -> Self {
-        Self::Clear(Default::default())
-    }
-}
-
-/// Operation to perform to the output attachment at the end of a render pass.
-///
-/// Corresponds to [WebGPU `GPUStoreOp`](https://gpuweb.github.io/gpuweb/#enumdef-gpustoreop).
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum StoreOp {
-    /// Stores the resulting value of the render pass for this attachment.
-    #[default]
-    Store,
-    /// Discards the resulting value of the render pass for this attachment.
-    ///
-    /// The attachment will be treated as uninitialized afterwards.
-    /// (If only either Depth or Stencil texture-aspects is set to `Discard`,
-    /// the respective other texture-aspect will be preserved.)
-    ///
-    /// This can be significantly faster on tile-based render hardware.
-    ///
-    /// Prefer this if the attachment is not read by subsequent passes.
-    Discard,
-}
-
-/// Pair of load and store operations for an attachment aspect.
-///
-/// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
-/// separate `loadOp` and `storeOp` fields are used instead.
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Operations<V> {
-    /// How data should be read through this attachment.
-    pub load: LoadOp<V>,
-    /// Whether data will be written to through this attachment.
-    ///
-    /// Note that resolve textures (if specified) are always written to,
-    /// regardless of this setting.
-    pub store: StoreOp,
-}
-
-impl<V: Default> Default for Operations<V> {
-    #[inline]
-    fn default() -> Self {
-        Self {
-            load: LoadOp::<V>::default(),
-            store: StoreOp::default(),
-        }
     }
 }
 


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/pull/6753#discussion_r1886860187

**Description**
In f5bb3f7660c7a4b7e26b24534c9bf858b223afe7 I moved `Operations`, `LoadOp`, `StoreOp` for wgpu to wgt, so we can use those abstractions in 5542c3ca77ff06c6c8a96afce81107a25fbb8546 for `ResolvedPassChannel`. Then in fa4a5ed25634697618a96763fe19a9e4ff2dd8ad I moved `PassChannel` to also use `wgt::LoadOp`, `wgt::StoreOp`; thus removing old `LoadOp`/`StoreOp`. We still need somewhat `PassChannel` in core to be able to express all wrong stuff JS user can do, but when we do all validation we are back to wgpu's abstraction (which prevents all such misuses). It would be interesting future project to avoid some validation in core by passing those safer/strict types directly to core. In the future, hal could also start using higher abstraction for LoadOp.

Changes in servo needed for this PR: https://github.com/sagudev/servo/commit/612593105089689806cb84b450e29a5645eea19d (this will be useful for firefox).

**Testing**
No behaviour change is expected, [CTS run in servo](https://github.com/sagudev/servo/actions/runs/12443015962/job/34743455556) confirms that (note that CRASH in `webgpu:shader,execution,expression:*` are know problem in servo due to cyclic imports), there are also some existing tests covering this.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
