### PR TITLE
[naga] resolve the size of override-sized arrays in backends

### DIFF
--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -502,6 +502,8 @@ pub enum Error {
     /// [`crate::Sampling::First`] is unsupported.
     #[error("`{:?}` sampling is unsupported", crate::Sampling::First)]
     FirstSamplingNotSupported,
+    #[error(transparent)]
+    ResolveArraySizeError(#[from] proc::ResolveArraySizeError),
 }
 
 /// Binary operation with a different logic on the GLSL side.
@@ -976,13 +978,12 @@ impl<'a, W: Write> Writer<'a, W> {
         write!(self.out, "[")?;
 
         // Write the array size
-        // Writes nothing if `ArraySize::Dynamic`
-        match size {
-            crate::ArraySize::Constant(size) => {
+        // Writes nothing if `ResolvedSize::Runtime`
+        match size.resolve(self.module.to_ctx())? {
+            proc::ResolvedSize::Constant(size) => {
                 write!(self.out, "{size}")?;
             }
-            crate::ArraySize::Pending(_) => unreachable!(),
-            crate::ArraySize::Dynamic => (),
+            proc::ResolvedSize::Runtime => (),
         }
 
         write!(self.out, "]")?;
@@ -4519,13 +4520,9 @@ impl<'a, W: Write> Writer<'a, W> {
                 write!(self.out, ")")?;
             }
             TypeInner::Array { base, size, .. } => {
-                let count = match size
-                    .to_indexable_length(self.module)
-                    .expect("Bad array size")
-                {
-                    proc::IndexableLength::Known(count) => count,
-                    proc::IndexableLength::Pending => unreachable!(),
-                    proc::IndexableLength::Dynamic => return Ok(()),
+                let count = match size.resolve(self.module.to_ctx())? {
+                    proc::ResolvedSize::Constant(size) => size,
+                    proc::ResolvedSize::Runtime => return Ok(()),
                 };
                 self.write_type(base)?;
                 self.write_array_size(base, size)?;

--- a/naga/src/back/hlsl/conv.rs
+++ b/naga/src/back/hlsl/conv.rs
@@ -53,7 +53,7 @@ impl crate::TypeInner {
         }
     }
 
-    pub(super) fn size_hlsl(&self, gctx: crate::proc::GlobalCtx) -> u32 {
+    pub(super) fn size_hlsl(&self, gctx: crate::proc::GlobalCtx) -> Result<u32, Error> {
         match *self {
             Self::Matrix {
                 columns,
@@ -62,19 +62,18 @@ impl crate::TypeInner {
             } => {
                 let stride = Alignment::from(rows) * scalar.width as u32;
                 let last_row_size = rows as u32 * scalar.width as u32;
-                ((columns as u32 - 1) * stride) + last_row_size
+                Ok(((columns as u32 - 1) * stride) + last_row_size)
             }
             Self::Array { base, size, stride } => {
-                let count = match size {
-                    crate::ArraySize::Constant(size) => size.get(),
-                    // A dynamically-sized array has to have at least one element
-                    crate::ArraySize::Pending(_) => unreachable!(),
-                    crate::ArraySize::Dynamic => 1,
+                let count = match size.resolve(gctx)? {
+                    crate::proc::ResolvedSize::Constant(size) => size,
+                    // A runtime-sized array has to have at least one element
+                    crate::proc::ResolvedSize::Runtime => 1,
                 };
-                let last_el_size = gctx.types[base].inner.size_hlsl(gctx);
-                ((count - 1) * stride) + last_el_size
+                let last_el_size = gctx.types[base].inner.size_hlsl(gctx)?;
+                Ok(((count - 1) * stride) + last_el_size)
             }
-            _ => self.size(gctx),
+            _ => Ok(self.size(gctx)),
         }
     }
 

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -349,6 +349,8 @@ pub enum Error {
     Custom(String),
     #[error("overrides should not be present at this stage")]
     Override,
+    #[error(transparent)]
+    ResolveArraySizeError(#[from] proc::ResolveArraySizeError),
 }
 
 #[derive(Default)]

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -1090,12 +1090,11 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
     ) -> BackendResult {
         write!(self.out, "[")?;
 
-        match size {
-            crate::ArraySize::Constant(size) => {
+        match size.resolve(module.to_ctx())? {
+            proc::ResolvedSize::Constant(size) => {
                 write!(self.out, "{size}")?;
             }
-            crate::ArraySize::Pending(_) => unreachable!(),
-            crate::ArraySize::Dynamic => unreachable!(),
+            proc::ResolvedSize::Runtime => unreachable!(),
         }
 
         write!(self.out, "]")?;
@@ -1140,7 +1139,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 }
             }
             let ty_inner = &module.types[member.ty].inner;
-            last_offset = member.offset + ty_inner.size_hlsl(module.to_ctx());
+            last_offset = member.offset + ty_inner.size_hlsl(module.to_ctx())?;
 
             // The indentation is only for readability
             write!(self.out, "{}", back::INDENT)?;
@@ -2851,7 +2850,6 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                             index::IndexableLength::Known(limit) => {
                                 write!(self.out, "{}u", limit - 1)?;
                             }
-                            index::IndexableLength::Pending => unreachable!(),
                             index::IndexableLength::Dynamic => unreachable!(),
                         }
                         write!(self.out, ")")?;

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -150,6 +150,8 @@ pub enum Error {
     Override,
     #[error("bitcasting to {0:?} is not supported")]
     UnsupportedBitCast(crate::TypeInner),
+    #[error(transparent)]
+    ResolveArraySizeError(#[from] crate::proc::ResolveArraySizeError),
 }
 
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -2,8 +2,7 @@ use super::{sampler as sm, Error, LocationMode, Options, PipelineOptions, Transl
 use crate::{
     arena::{Handle, HandleSet},
     back::{self, Baked},
-    proc::index,
-    proc::{self, NameKey, TypeResolution},
+    proc::{self, index, NameKey, TypeResolution},
     valid, FastHashMap, FastHashSet,
 };
 #[cfg(test)]
@@ -2555,7 +2554,6 @@ impl<W: Write> Writer<W> {
                     self.out.write_str(") < ")?;
                     match length {
                         index::IndexableLength::Known(value) => write!(self.out, "{value}")?,
-                        index::IndexableLength::Pending => unreachable!(),
                         index::IndexableLength::Dynamic => {
                             let global =
                                 context.function.originating_global(base).ok_or_else(|| {
@@ -2692,7 +2690,7 @@ impl<W: Write> Writer<W> {
     ) -> BackendResult {
         let accessing_wrapped_array = match *base_ty {
             crate::TypeInner::Array {
-                size: crate::ArraySize::Constant(_),
+                size: crate::ArraySize::Constant(_) | crate::ArraySize::Pending(_),
                 ..
             } => true,
             _ => false,
@@ -2720,7 +2718,6 @@ impl<W: Write> Writer<W> {
                 index::IndexableLength::Known(limit) => {
                     write!(self.out, "{}u", limit - 1)?;
                 }
-                index::IndexableLength::Pending => unreachable!(),
                 index::IndexableLength::Dynamic => {
                     let global = context.function.originating_global(base).ok_or_else(|| {
                         Error::GenericValidation("Could not find originating global".into())
@@ -3911,8 +3908,8 @@ impl<W: Write> Writer<W> {
                         first_time: false,
                     };
 
-                    match size {
-                        crate::ArraySize::Constant(size) => {
+                    match size.resolve(module.to_ctx())? {
+                        proc::ResolvedSize::Constant(size) => {
                             writeln!(self.out, "struct {name} {{")?;
                             writeln!(
                                 self.out,
@@ -3924,10 +3921,7 @@ impl<W: Write> Writer<W> {
                             )?;
                             writeln!(self.out, "}};")?;
                         }
-                        crate::ArraySize::Pending(_) => {
-                            unreachable!()
-                        }
-                        crate::ArraySize::Dynamic => {
+                        proc::ResolvedSize::Runtime => {
                             writeln!(self.out, "typedef {base_name} {name}[1];")?;
                         }
                     }
@@ -6321,11 +6315,9 @@ mod workgroup_mem_init {
                         writeln!(self.out, ", 0, {NAMESPACE}::memory_order_relaxed);")?;
                     }
                     crate::TypeInner::Array { base, size, .. } => {
-                        let count = match size.to_indexable_length(module).expect("Bad array size")
-                        {
-                            proc::IndexableLength::Known(count) => count,
-                            proc::IndexableLength::Pending => unreachable!(),
-                            proc::IndexableLength::Dynamic => unreachable!(),
+                        let count = match size.resolve(module.to_ctx())? {
+                            proc::ResolvedSize::Constant(size) => size,
+                            proc::ResolvedSize::Runtime => unreachable!(),
                         };
 
                         access_stack.enter_array(|access_stack, array_depth| {

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -4,7 +4,7 @@ use crate::{
     proc::{ConstantEvaluator, ConstantEvaluatorError, Emitter},
     valid::{Capabilities, ModuleInfo, ValidationError, ValidationFlags, Validator},
     Arena, Block, Constant, Expression, Function, Handle, Literal, Module, Override, Range, Scalar,
-    Span, Statement, TypeInner, WithSpan,
+    Span, Statement, Type, TypeInner, UniqueArena, WithSpan,
 };
 use std::{borrow::Cow, collections::HashSet, mem};
 use thiserror::Error;
@@ -29,19 +29,29 @@ pub enum PipelineConstantError {
     NegativeWorkgroupSize,
 }
 
-/// Replace all overrides in `module` with constants.
+/// Replace all overrides in `module` with fully-evaluated constant expressions.
 ///
-/// If no changes are needed, this just returns `Cow::Borrowed`
-/// references to `module` and `module_info`. Otherwise, it clones
-/// `module`, edits its [`global_expressions`] arena to contain only
-/// fully-evaluated expressions, and returns `Cow::Owned` values
-/// holding the simplified module and its validation results.
+/// Given `pipeline_constants`, providing values for all overrides in
+/// `module`:
 ///
-/// In either case, the module returned has an empty `overrides`
-/// arena, and the `global_expressions` arena contains only
-/// fully-evaluated expressions.
+/// - Replace all [`Override`] expressions with fully-evaluated
+///   constant expressions.
 ///
-/// [`global_expressions`]: Module::global_expressions
+/// - Replace all [`Override`][paso] array sizes with [`Expression`]
+///   array sizes, referring to fully-evaluated constant expressions.
+///
+/// - Empty out the `module.overrides` arena.
+///
+/// Although the above is described in terms of changes to `module`'s
+/// contents, this function only actually has shared access to
+/// `module`. When changes are needed, this function clones `module`
+/// and returns a [`Cow::Owned`] value. If no changes are needed, this
+/// function returns a [`Cow::Borrowed`] value that just passes along
+/// the original reference.
+///
+/// [`Override`]: Expression::Override
+/// [paso]: crate::PendingArraySize::Override
+/// [`Expression`]: crate::PendingArraySize::Expression
 pub fn process_overrides<'a>(
     module: &'a Module,
     module_info: &'a ModuleInfo,
@@ -51,6 +61,7 @@ pub fn process_overrides<'a>(
         return Ok((Cow::Borrowed(module), Cow::Borrowed(module_info)));
     }
 
+    let original_module_types = &module.types;
     let mut module = module.clone();
 
     // A map from override handles to the handles of the constants
@@ -196,7 +207,12 @@ pub fn process_overrides<'a>(
     }
     module.entry_points = entry_points;
 
-    process_pending(&mut module, &override_map, &adjusted_global_expressions)?;
+    process_pending(
+        &mut module,
+        original_module_types,
+        &override_map,
+        &adjusted_global_expressions,
+    );
 
     // Now that we've rewritten all the expressions, we need to
     // recompute their types and other metadata. For the time being,
@@ -209,60 +225,55 @@ pub fn process_overrides<'a>(
 
 fn process_pending(
     module: &mut Module,
+    original_module_types: &UniqueArena<Type>,
     override_map: &HandleVec<Override, Handle<Constant>>,
     adjusted_global_expressions: &HandleVec<Expression, Handle<Expression>>,
-) -> Result<(), PipelineConstantError> {
-    for (handle, ty) in module.types.clone().iter() {
+) {
+    for (handle, ty) in original_module_types.iter() {
         if let TypeInner::Array {
             base,
             size: crate::ArraySize::Pending(size),
             stride,
         } = ty.inner
         {
-            let expr = match size {
+            match size {
                 crate::PendingArraySize::Expression(size_expr) => {
-                    adjusted_global_expressions[size_expr]
+                    let expr = adjusted_global_expressions[size_expr];
+                    if expr != size_expr {
+                        module.types.replace(
+                            handle,
+                            Type {
+                                name: ty.name.clone(),
+                                inner: TypeInner::Array {
+                                    base,
+                                    size: crate::ArraySize::Pending(
+                                        crate::PendingArraySize::Expression(expr),
+                                    ),
+                                    stride,
+                                },
+                            },
+                        );
+                    }
                 }
                 crate::PendingArraySize::Override(size_override) => {
-                    module.constants[override_map[size_override]].init
+                    let expr = module.constants[override_map[size_override]].init;
+                    module.types.replace(
+                        handle,
+                        Type {
+                            name: ty.name.clone(),
+                            inner: TypeInner::Array {
+                                base,
+                                size: crate::ArraySize::Pending(
+                                    crate::PendingArraySize::Expression(expr),
+                                ),
+                                stride,
+                            },
+                        },
+                    );
                 }
             };
-            let value = module
-                .to_ctx()
-                .eval_expr_to_u32(expr)
-                .map(|n| {
-                    if n == 0 {
-                        Err(PipelineConstantError::ValidationError(
-                            WithSpan::new(ValidationError::ArraySizeError { handle: expr })
-                                .with_span(
-                                    module.global_expressions.get_span(expr),
-                                    "evaluated to zero",
-                                ),
-                        ))
-                    } else {
-                        Ok(std::num::NonZeroU32::new(n).unwrap())
-                    }
-                })
-                .map_err(|_| {
-                    PipelineConstantError::ValidationError(
-                        WithSpan::new(ValidationError::ArraySizeError { handle: expr })
-                            .with_span(module.global_expressions.get_span(expr), "negative"),
-                    )
-                })??;
-            module.types.replace(
-                handle,
-                crate::Type {
-                    name: None,
-                    inner: TypeInner::Array {
-                        base,
-                        size: crate::ArraySize::Constant(value),
-                        stride,
-                    },
-                },
-            );
         }
     }
-    Ok(())
 }
 
 fn process_workgroup_size_override(

--- a/naga/src/back/spv/index.rs
+++ b/naga/src/back/spv/index.rs
@@ -267,12 +267,11 @@ impl BlockContext<'_> {
         block: &mut Block,
     ) -> Result<MaybeKnown<u32>, Error> {
         let sequence_ty = self.fun_info[sequence].ty.inner_with(&self.ir_module.types);
-        match sequence_ty.indexable_length(self.ir_module) {
+        match sequence_ty
+            .indexable_length(self.ir_module, crate::ArraySize::indexable_length_resolved)
+        {
             Ok(crate::proc::IndexableLength::Known(known_length)) => {
                 Ok(MaybeKnown::Known(known_length))
-            }
-            Ok(crate::proc::IndexableLength::Pending) => {
-                unreachable!()
             }
             Ok(crate::proc::IndexableLength::Dynamic) => {
                 let length_id = self.write_runtime_array_length(sequence, block)?;

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -73,6 +73,8 @@ pub enum Error {
     Validation(&'static str),
     #[error("overrides should not be present at this stage")]
     Override,
+    #[error(transparent)]
+    ResolveArraySizeError(#[from] crate::proc::ResolveArraySizeError),
 }
 
 #[derive(Default)]

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -942,10 +942,10 @@ impl Writer {
 
     fn write_type_declaration_arena(
         &mut self,
-        arena: &UniqueArena<crate::Type>,
+        module: &crate::Module,
         handle: Handle<crate::Type>,
     ) -> Result<Word, Error> {
-        let ty = &arena[handle];
+        let ty = &module.types[handle];
         // If it's a type that needs SPIR-V capabilities, request them now.
         // This needs to happen regardless of the LocalType lookup succeeding,
         // because some types which map to the same LocalType have different
@@ -978,24 +978,26 @@ impl Writer {
                     self.decorate(id, Decoration::ArrayStride, &[stride]);
 
                     let type_id = self.get_type_id(LookupType::Handle(base));
-                    match size {
-                        crate::ArraySize::Constant(length) => {
-                            let length_id = self.get_index_constant(length.get());
+                    match size.resolve(module.to_ctx())? {
+                        crate::proc::ResolvedSize::Constant(length) => {
+                            let length_id = self.get_index_constant(length);
                             Instruction::type_array(id, type_id, length_id)
                         }
-                        crate::ArraySize::Pending(_) => unreachable!(),
-                        crate::ArraySize::Dynamic => Instruction::type_runtime_array(id, type_id),
+                        crate::proc::ResolvedSize::Runtime => {
+                            Instruction::type_runtime_array(id, type_id)
+                        }
                     }
                 }
                 crate::TypeInner::BindingArray { base, size } => {
                     let type_id = self.get_type_id(LookupType::Handle(base));
-                    match size {
-                        crate::ArraySize::Constant(length) => {
-                            let length_id = self.get_index_constant(length.get());
+                    match size.resolve(module.to_ctx())? {
+                        crate::proc::ResolvedSize::Constant(length) => {
+                            let length_id = self.get_index_constant(length);
                             Instruction::type_array(id, type_id, length_id)
                         }
-                        crate::ArraySize::Pending(_) => unreachable!(),
-                        crate::ArraySize::Dynamic => Instruction::type_runtime_array(id, type_id),
+                        crate::proc::ResolvedSize::Runtime => {
+                            Instruction::type_runtime_array(id, type_id)
+                        }
                     }
                 }
                 crate::TypeInner::Struct {
@@ -1005,7 +1007,7 @@ impl Writer {
                     let mut has_runtime_array = false;
                     let mut member_ids = Vec::with_capacity(members.len());
                     for (index, member) in members.iter().enumerate() {
-                        let member_ty = &arena[member.ty];
+                        let member_ty = &module.types[member.ty];
                         match member_ty.inner {
                             crate::TypeInner::Array {
                                 base: _,
@@ -1016,7 +1018,7 @@ impl Writer {
                             }
                             _ => (),
                         }
-                        self.decorate_struct_member(id, index, member, arena)?;
+                        self.decorate_struct_member(id, index, member, &module.types)?;
                         let member_id = self.get_type_id(LookupType::Handle(member.ty));
                         member_ids.push(member_id);
                     }
@@ -1954,7 +1956,7 @@ impl Writer {
 
         // write all types
         for (handle, _) in ir_module.types.iter() {
-            self.write_type_declaration_arena(&ir_module.types, handle)?;
+            self.write_type_declaration_arena(ir_module, handle)?;
         }
 
         // write all const-expressions as constants

--- a/naga/src/proc/index.rs
+++ b/naga/src/proc/index.rs
@@ -315,7 +315,9 @@ pub fn access_needs_check(
     // Unwrap safety: `Err` here indicates unindexable base types and invalid
     // length constants, but `access_needs_check` is only used by back ends, so
     // validation should have caught those problems.
-    let length = base_inner.indexable_length(module).unwrap();
+    let length = base_inner
+        .indexable_length(module, crate::ArraySize::indexable_length_resolved)
+        .unwrap();
     index.try_resolve_to_constant(expressions, module);
     if let (&GuardedIndex::Known(index), &IndexableLength::Known(length)) = (&index, &length) {
         if index < length {
@@ -357,8 +359,8 @@ impl GuardedIndex {
 pub enum IndexableLengthError {
     #[error("Type is not indexable, and has no length (validation error)")]
     TypeNotIndexable,
-    #[error("Array length constant {0:?} is invalid")]
-    InvalidArrayLength(Handle<crate::Expression>),
+    #[error(transparent)]
+    ResolveArraySizeError(#[from] super::ResolveArraySizeError),
 }
 
 impl crate::TypeInner {
@@ -376,13 +378,17 @@ impl crate::TypeInner {
     pub fn indexable_length(
         &self,
         module: &crate::Module,
+        array_size_indexable_length: fn(
+            crate::ArraySize,
+            &crate::Module,
+        ) -> Result<IndexableLength, IndexableLengthError>,
     ) -> Result<IndexableLength, IndexableLengthError> {
         use crate::TypeInner as Ti;
         let known_length = match *self {
             Ti::Vector { size, .. } => size as _,
             Ti::Matrix { columns, .. } => columns as _,
             Ti::Array { size, .. } | Ti::BindingArray { size, .. } => {
-                return size.to_indexable_length(module);
+                return array_size_indexable_length(size, module);
             }
             Ti::ValuePointer {
                 size: Some(size), ..
@@ -396,7 +402,7 @@ impl crate::TypeInner {
                     Ti::Vector { size, .. } => size as _,
                     Ti::Matrix { columns, .. } => columns as _,
                     Ti::Array { size, .. } | Ti::BindingArray { size, .. } => {
-                        return size.to_indexable_length(module)
+                        return array_size_indexable_length(size, module);
                     }
                     _ => return Err(IndexableLengthError::TypeNotIndexable),
                 }
@@ -416,21 +422,31 @@ pub enum IndexableLength {
     /// Values of this type always have the given number of elements.
     Known(u32),
 
-    Pending,
-
     /// The number of elements is determined at runtime.
     Dynamic,
 }
 
 impl crate::ArraySize {
-    pub const fn to_indexable_length(
+    /// This function should be used by validators that allow overrides
+    pub const fn indexable_length(
         self,
         _module: &crate::Module,
     ) -> Result<IndexableLength, IndexableLengthError> {
         Ok(match self {
             Self::Constant(length) => IndexableLength::Known(length.get()),
-            Self::Pending(_) => IndexableLength::Pending,
+            Self::Pending(_) => IndexableLength::Dynamic,
             Self::Dynamic => IndexableLength::Dynamic,
         })
+    }
+
+    /// This function should be used by backends and validators that reject overrides
+    pub fn indexable_length_resolved(
+        self,
+        module: &crate::Module,
+    ) -> Result<IndexableLength, IndexableLengthError> {
+        match self.resolve(module.to_ctx())? {
+            super::ResolvedSize::Constant(length) => Ok(IndexableLength::Known(length)),
+            super::ResolvedSize::Runtime => Ok(IndexableLength::Dynamic),
+        }
     }
 }

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -18,6 +18,7 @@ pub use index::{BoundsCheckPolicies, BoundsCheckPolicy, IndexableLength, Indexab
 pub use layouter::{Alignment, LayoutError, LayoutErrorInner, Layouter, TypeLayout};
 pub use namer::{EntryPointIndex, NameKey, Namer};
 pub use terminator::ensure_block_returns;
+use thiserror::Error;
 pub use typifier::{ResolveContext, ResolveError, TypeResolution};
 
 impl From<super::StorageFormat> for super::Scalar {
@@ -284,7 +285,7 @@ impl super::TypeInner {
     }
 
     /// Get the size of this type.
-    pub fn size(&self, _gctx: GlobalCtx) -> u32 {
+    pub fn size(&self, gctx: GlobalCtx) -> u32 {
         match *self {
             Self::Scalar(scalar) | Self::Atomic(scalar) => scalar.width as u32,
             Self::Vector { size, scalar } => size as u32 * scalar.width as u32,
@@ -302,9 +303,15 @@ impl super::TypeInner {
             } => {
                 let count = match size {
                     super::ArraySize::Constant(count) => count.get(),
-                    // any struct member or array element needing a size at pipeline-creation time
-                    // must have a creation-fixed footprint
-                    super::ArraySize::Pending(_) => 0,
+                    super::ArraySize::Pending(pending_size) => {
+                        let expr = match pending_size {
+                            crate::PendingArraySize::Expression(handle) => handle,
+                            // any struct member or array element needing a size at pipeline-creation time
+                            // must have a creation-fixed footprint
+                            crate::PendingArraySize::Override(_) => return 0,
+                        };
+                        gctx.eval_expr_to_u32(expr).unwrap_or_default()
+                    }
                     // A dynamically-sized array has to have at least one element
                     super::ArraySize::Dynamic => 1,
                 };
@@ -733,6 +740,56 @@ impl GlobalCtx<'_> {
                 get(*self, self.constants[c].init, self.global_expressions)
             }
             _ => get(*self, handle, arena),
+        }
+    }
+}
+
+pub enum ResolvedSize {
+    Constant(u32),
+    Runtime,
+}
+
+#[derive(Error, Debug, Clone, Copy, PartialEq)]
+pub enum ResolveArraySizeError {
+    #[error("array element count must be positive (> 0)")]
+    ExpectedPositiveArrayLength,
+}
+
+impl crate::ArraySize {
+    /// Return the number of elements that `size` represents, if known at code generation time.
+    ///
+    /// This must only be called after `back::pipeline_constants::process_overrides`, or on modules
+    /// that contain no overrides.
+    ///
+    /// # Panics
+    ///
+    /// - If `module` contains arrays with a pending size of [`crate::PendingArraySize::Override`]
+    /// - If `module` contains override expressions
+    pub fn resolve(&self, gctx: GlobalCtx) -> Result<ResolvedSize, ResolveArraySizeError> {
+        match *self {
+            crate::ArraySize::Constant(length) => Ok(ResolvedSize::Constant(length.get())),
+            crate::ArraySize::Pending(pending_size) => {
+                let expr = match pending_size {
+                    crate::PendingArraySize::Expression(handle) => handle,
+                    crate::PendingArraySize::Override(_) => {
+                        unreachable!("PendingArraySize::Override variants must have been replaced with PendingArraySize::Expression variants");
+                    }
+                };
+
+                let length = gctx.eval_expr_to_u32(expr).map_err(|err| match err {
+                    U32EvalError::NonConst => {
+                        unreachable!("non-const expression in global_expressions arena");
+                    }
+                    U32EvalError::Negative => ResolveArraySizeError::ExpectedPositiveArrayLength,
+                })?;
+
+                if length == 0 {
+                    return Err(ResolveArraySizeError::ExpectedPositiveArrayLength);
+                }
+
+                Ok(ResolvedSize::Constant(length))
+            }
+            crate::ArraySize::Dynamic => Ok(ResolvedSize::Runtime),
         }
     }
 }

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -280,10 +280,16 @@ impl super::Validator {
                     }
                 }
 
+                let array_size_indexable_length = if self.allow_overrides {
+                    crate::ArraySize::indexable_length
+                } else {
+                    crate::ArraySize::indexable_length_resolved
+                };
+
                 // If we know both the length and the index, we can do the
                 // bounds check now.
                 if let crate::proc::IndexableLength::Known(known_length) =
-                    base_type.indexable_length(module)?
+                    base_type.indexable_length(module, array_size_indexable_length)?
                 {
                     match module
                         .to_ctx()

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -345,8 +345,6 @@ pub enum ValidationError {
         handle: Handle<crate::Expression>,
         source: ConstExpressionError,
     },
-    #[error("Array size expression {handle:?} is not strictly positive")]
-    ArraySizeError { handle: Handle<crate::Expression> },
     #[error("Constant {handle:?} '{name}' is invalid")]
     Constant {
         handle: Handle<crate::Constant>,
@@ -616,6 +614,7 @@ impl Validator {
                 .into_boxed_slice(),
         };
 
+        let mut array_override_expr_set = HandleSet::new();
         for (handle, ty) in module.types.iter() {
             let ty_info = self
                 .validate_type(handle, module.to_ctx())
@@ -627,18 +626,32 @@ impl Validator {
                     }
                     .with_span_handle(handle, &module.types)
                 })?;
-            if !self.allow_overrides {
-                if let crate::TypeInner::Array {
-                    size: crate::ArraySize::Pending(_),
-                    ..
-                } = ty.inner
-                {
-                    return Err((ValidationError::Type {
-                        handle,
-                        name: ty.name.clone().unwrap_or_default(),
-                        source: TypeError::UnresolvedOverride(handle),
-                    })
-                    .with_span_handle(handle, &module.types));
+            if let crate::TypeInner::Array {
+                size: crate::ArraySize::Pending(pending_size),
+                ..
+            } = ty.inner
+            {
+                match pending_size {
+                    crate::PendingArraySize::Expression(expr) => {
+                        if !array_override_expr_set.insert(expr) {
+                            return Err((ValidationError::Type {
+                                handle,
+                                name: ty.name.clone().unwrap_or_default(),
+                                source: TypeError::NonUniqueOverrideExpressionForArray(handle),
+                            })
+                            .with_span_handle(handle, &module.types));
+                        }
+                    }
+                    crate::PendingArraySize::Override(_) => {
+                        if !self.allow_overrides {
+                            return Err((ValidationError::Type {
+                                handle,
+                                name: ty.name.clone().unwrap_or_default(),
+                                source: TypeError::UnresolvedOverride(handle),
+                            })
+                            .with_span_handle(handle, &module.types));
+                        }
+                    }
                 }
             }
             mod_info.type_flags.push(ty_info.flags);

--- a/naga/src/valid/type.rs
+++ b/naga/src/valid/type.rs
@@ -150,6 +150,8 @@ pub enum TypeError {
         "The base handle {0:?} has an override-expression that didn't get resolved to a constant"
     )]
     UnresolvedOverride(Handle<crate::Type>),
+    #[error("Array {0:?} has a non-unique handle to an override-expression")]
+    NonUniqueOverrideExpressionForArray(Handle<crate::Type>),
 }
 
 #[derive(Clone, Debug, thiserror::Error)]

--- a/tests/tests/shader/array_size_overrides.rs
+++ b/tests/tests/shader/array_size_overrides.rs
@@ -11,6 +11,13 @@ const SHADER: &str = r#"
     @group(0) @binding(0)
     var<storage, read_write> output: array<u32>;
 
+    // When `n` is overridden to 14 above, it will generate the type `array<u32, 14 - 2>` which
+    // already exists in the program because of variable declaration. Ensures naga does not panic
+    // when this happens.
+    //
+    // See https://github.com/gfx-rs/wgpu/issues/6722 for more info.
+    var<workgroup> testing: array<u32, 12>;
+
     @compute @workgroup_size(1) fn main() {
         // 1d spiral
         for (var i = 0; i < n - 2; i++) {


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/6722
Closes https://github.com/gfx-rs/wgpu/pull/6746

**Description**
Implements Jim's suggestion of resolving the size of override-sized arrays in backends so that we don't have to rebuild the types arena when processing overrides.

**Testing**
The new and existing tests passed.