### PR TITLE
[naga] In compaction, fix array lengths as part of type adjustment.

### DIFF
--- a/naga/src/compact/mod.rs
+++ b/naga/src/compact/mod.rs
@@ -216,30 +216,6 @@ pub fn compact(module: &mut crate::Module) {
         }
     }
 
-    for (handle, ty) in module.types.clone().iter() {
-        if let crate::TypeInner::Array {
-            base,
-            size: crate::ArraySize::Pending(crate::PendingArraySize::Expression(mut size_expr)),
-            stride,
-        } = ty.inner
-        {
-            module_map.global_expressions.adjust(&mut size_expr);
-            module.types.replace(
-                handle,
-                crate::Type {
-                    name: None,
-                    inner: crate::TypeInner::Array {
-                        base,
-                        size: crate::ArraySize::Pending(crate::PendingArraySize::Expression(
-                            size_expr,
-                        )),
-                        stride,
-                    },
-                },
-            );
-        }
-    }
-
     // Temporary storage to help us reuse allocations of existing
     // named expression tables.
     let mut reused_named_expressions = crate::NamedExpressions::default();

--- a/naga/src/compact/types.rs
+++ b/naga/src/compact/types.rs
@@ -82,9 +82,17 @@ impl ModuleMap {
             } => adjust(base),
             Ti::Array {
                 ref mut base,
-                size: _,
+                ref mut size,
                 stride: _,
-            } => adjust(base),
+            } => {
+                adjust(base);
+                if let crate::ArraySize::Pending(crate::PendingArraySize::Expression(
+                    ref mut size_expr,
+                )) = *size
+                {
+                    self.global_expressions.adjust(size_expr);
+                }
+            }
             Ti::Struct {
                 ref mut members,
                 span: _,


### PR DESCRIPTION
Adjust the `Handle<Expression>` values that appear in `TypeInner::Array` via `PendingArraySize::Expression` as part of the normal type adjustment process in `ModuleMap::adjust_type`, rather than cloning the type arena so we can iterate over it and call `UniqueArena::replace`.

Fixes #6789.
