### PR TITLE
diag(naga): clarify `ImageStore` type mismatch cases

### DIFF
--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -137,8 +137,17 @@ pub enum FunctionError {
     LastCaseFallTrough,
     #[error("The pointer {0:?} doesn't relate to a valid destination for a store")]
     InvalidStorePointer(Handle<crate::Expression>),
-    #[error("The value {0:?} can not be stored")]
-    InvalidStoreValue(Handle<crate::Expression>),
+    #[error("Image store texture parameter type mismatch")]
+    InvalidStoreTexture {
+        actual: Handle<crate::Expression>,
+        actual_ty: crate::TypeInner,
+    },
+    #[error("Image store value parameter type mismatch")]
+    InvalidStoreValue {
+        actual: Handle<crate::Expression>,
+        actual_ty: crate::TypeInner,
+        expected_ty: crate::TypeInner,
+    },
     #[error("The type of {value:?} doesn't match the type stored in {pointer:?}")]
     InvalidStoreTypes {
         pointer: Handle<crate::Expression>,
@@ -1007,8 +1016,15 @@ impl super::Validator {
                     let value_ty = context.resolve_type(value, &self.valid_expression_set)?;
                     match *value_ty {
                         Ti::Image { .. } | Ti::Sampler { .. } => {
-                            return Err(FunctionError::InvalidStoreValue(value)
-                                .with_span_handle(value, context.expressions));
+                            return Err(FunctionError::InvalidStoreTexture {
+                                actual: value,
+                                actual_ty: value_ty.clone(),
+                            }
+                            .with_span_context((
+                                context.expressions.get_span(value),
+                                format!("this value is of type {value_ty:?}"),
+                            ))
+                            .with_span(span, "expects a texture argument"));
                         }
                         _ => {}
                     }
@@ -1165,9 +1181,22 @@ impl super::Validator {
 
                     // The value we're writing had better match the scalar type
                     // for `image`'s format.
-                    if *context.resolve_type(value, &self.valid_expression_set)? != value_ty {
-                        return Err(FunctionError::InvalidStoreValue(value)
-                            .with_span_handle(value, context.expressions));
+                    let actual_value_ty =
+                        context.resolve_type(value, &self.valid_expression_set)?;
+                    if actual_value_ty != &value_ty {
+                        return Err(FunctionError::InvalidStoreValue {
+                            actual: value,
+                            actual_ty: actual_value_ty.clone(),
+                            expected_ty: value_ty.clone(),
+                        }
+                        .with_span_context((
+                            context.expressions.get_span(value),
+                            format!("this value is of type {actual_value_ty:?}"),
+                        ))
+                        .with_span(
+                            span,
+                            format!("expects a value argument of type {value_ty:?}"),
+                        ));
                     }
                 }
                 S::Call {


### PR DESCRIPTION
Resolves <https://github.com/gfx-rs/wgpu/issues/6783> (I hope 🙏🏻).

- [ ] File follow-up to figure out why we don't have a direct argument span here.

Makes errors from source like this:

```wgsl
@group(0) @binding(0)
var input_texture: texture_depth_2d;
@group(0) @binding(1)
var input_sampler: sampler;
@group(0) @binding(2)
var output_texture: texture_storage_2d<r32float,write>;

@compute @workgroup_size(1, 1)
fn main() {
    let d: vec4<f32> = textureGather(input_texture, input_sampler, vec2f(0.0));
    let min_d = min(min(d[0], d[1]), min(d[2], d[3]));
    textureStore(output_texture, vec2u(1), min_d);
}
```

…which previously emitted an error like this:

```
error: Entry point main at Compute is invalid
   ┌─ in.wgsl:11:17
   │
11 │     let min_d = min(min(d[0], d[1]), min(d[2], d[3]));
   │                 ^^^ naga::Expression [11]
   │
   = The value [11] can not be stored
```

…to instead emit an error like this:

```
error: Entry point main at Compute is invalid
   ┌─ in.wgsl:11:17
   │
11 │     let min_d = min(min(d[0], d[1]), min(d[2], d[3]));
   │                 ^^^ this value is of type Scalar(Scalar { kind: Float, width: 4 })
12 │     textureStore(output_texture, vec2u(1), min_d);
   │     ^^^^^^^^^^^^ expects a value argument of type Vector { size: Quad, scalar: Scalar { kind: Float, width: 4 } }
   │
   = Image store value parameter type mismatch
```