### PR TITLE
[wgpu-core] Make `CommandEncoder.is_open` accurate

### DIFF
--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -155,7 +155,7 @@ impl Global {
 
         // actual hal barrier & operation
         let dst_barrier = dst_pending.map(|pending| pending.into_hal(&dst_buffer, &snatch_guard));
-        let cmd_buf_raw = cmd_buf_data.encoder.open(&cmd_buf.device)?;
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
         unsafe {
             cmd_buf_raw.transition_buffers(dst_barrier.as_slice());
             cmd_buf_raw.clear_buffer(dst_raw, offset..end_offset);
@@ -235,7 +235,7 @@ impl Global {
 
         let device = &cmd_buf.device;
         device.check_is_valid()?;
-        let (encoder, tracker) = cmd_buf_data.open_encoder_and_tracker(&cmd_buf.device)?;
+        let (encoder, tracker) = cmd_buf_data.open_encoder_and_tracker()?;
 
         let snatch_guard = device.snatchable_lock.read();
         clear_texture(

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -416,7 +416,9 @@ impl Global {
         // we want to insert a command buffer _before_ what we're about to record,
         // we need to make sure to close the previous one.
         encoder.close(&cmd_buf.device).map_pass_err(pass_scope)?;
-        let raw_encoder = encoder.open(&cmd_buf.device).map_pass_err(pass_scope)?;
+        let raw_encoder = encoder
+            .open_pass(base.label.as_deref(), &cmd_buf.device)
+            .map_pass_err(pass_scope)?;
 
         let mut state = State {
             binder: Binder::new(),
@@ -599,7 +601,9 @@ impl Global {
         // Create a new command buffer, which we will insert _before_ the body of the compute pass.
         //
         // Use that buffer to insert barriers and clear discarded images.
-        let transit = encoder.open(&cmd_buf.device).map_pass_err(pass_scope)?;
+        let transit = encoder
+            .open_pass(Some("(wgpu internal) Pre Pass"), &cmd_buf.device)
+            .map_pass_err(pass_scope)?;
         fixup_discarded_surfaces(
             pending_discard_init_fixups.into_iter(),
             transit,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -415,7 +415,9 @@ impl Global {
         // We automatically keep extending command buffers over time, and because
         // we want to insert a command buffer _before_ what we're about to record,
         // we need to make sure to close the previous one.
-        encoder.close(&cmd_buf.device).map_pass_err(pass_scope)?;
+        encoder
+            .close_if_open(&cmd_buf.device)
+            .map_pass_err(pass_scope)?;
         let raw_encoder = encoder
             .open_pass(base.label.as_deref(), &cmd_buf.device)
             .map_pass_err(pass_scope)?;

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -415,11 +415,9 @@ impl Global {
         // We automatically keep extending command buffers over time, and because
         // we want to insert a command buffer _before_ what we're about to record,
         // we need to make sure to close the previous one.
-        encoder
-            .close_if_open(&cmd_buf.device)
-            .map_pass_err(pass_scope)?;
+        encoder.close_if_open().map_pass_err(pass_scope)?;
         let raw_encoder = encoder
-            .open_pass(base.label.as_deref(), &cmd_buf.device)
+            .open_pass(base.label.as_deref())
             .map_pass_err(pass_scope)?;
 
         let mut state = State {
@@ -598,13 +596,13 @@ impl Global {
         } = state;
 
         // Stop the current command buffer.
-        encoder.close(&cmd_buf.device).map_pass_err(pass_scope)?;
+        encoder.close().map_pass_err(pass_scope)?;
 
         // Create a new command buffer, which we will insert _before_ the body of the compute pass.
         //
         // Use that buffer to insert barriers and clear discarded images.
         let transit = encoder
-            .open_pass(Some("(wgpu internal) Pre Pass"), &cmd_buf.device)
+            .open_pass(Some("(wgpu internal) Pre Pass"))
             .map_pass_err(pass_scope)?;
         fixup_discarded_surfaces(
             pending_discard_init_fixups.into_iter(),
@@ -620,9 +618,7 @@ impl Global {
             &snatch_guard,
         );
         // Close the command buffer, and swap it with the previous.
-        encoder
-            .close_and_swap(&cmd_buf.device)
-            .map_pass_err(pass_scope)?;
+        encoder.close_and_swap().map_pass_err(pass_scope)?;
         cmd_buf_data_guard.mark_successful();
 
         Ok(())

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -379,13 +379,13 @@ impl CommandEncoder {
         &mut self,
         label: Option<&str>,
         device: &Device,
-    ) -> Result<(), DeviceError> {
+    ) -> Result<&mut dyn hal::DynCommandEncoder, DeviceError> {
         self.is_open = true;
 
         let hal_label = hal_label(label, device.instance_flags);
         unsafe { self.raw.begin_encoding(hal_label) }.map_err(|e| device.handle_hal_error(e))?;
 
-        Ok(())
+        Ok(self.raw.as_mut())
     }
 }
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -37,8 +37,8 @@ use crate::ray_tracing::{BlasAction, TlasAction};
 use crate::resource::{Fallible, InvalidResourceError, Labeled, ParentDevice as _, QuerySet};
 use crate::storage::Storage;
 use crate::track::{DeviceTracker, Tracker, UsageScope};
-use crate::LabelHelpers;
 use crate::{api_log, global::Global, id, resource_log, Label};
+use crate::{hal_label, LabelHelpers};
 
 use thiserror::Error;
 
@@ -377,10 +377,12 @@ impl CommandEncoder {
     /// The underlying hal encoder is put in the "recording" state.
     pub(crate) fn open_pass(
         &mut self,
-        hal_label: Option<&str>,
+        label: Option<&str>,
         device: &Device,
     ) -> Result<(), DeviceError> {
         self.is_open = true;
+
+        let hal_label = hal_label(label, device.instance_flags);
         unsafe { self.raw.begin_encoding(hal_label) }.map_err(|e| device.handle_hal_error(e))?;
 
         Ok(())

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -276,7 +276,6 @@ pub(crate) struct CommandEncoder {
     pub(crate) hal_label: Option<String>,
 }
 
-//TODO: handle errors better
 impl CommandEncoder {
     /// Finish the current command buffer and insert it just before
     /// the last element in [`self.list`][l].

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -395,11 +395,16 @@ impl CommandEncoder {
     /// its own label.
     ///
     /// The underlying hal encoder is put in the "recording" state.
+    ///
+    /// # Panics
+    ///
+    /// - If the encoder is already open.
     pub(crate) fn open_pass(
         &mut self,
         label: Option<&str>,
         device: &Device,
     ) -> Result<&mut dyn hal::DynCommandEncoder, DeviceError> {
+        assert!(!self.is_open);
         self.is_open = true;
 
         let hal_label = hal_label(label, device.instance_flags);

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -337,7 +337,7 @@ impl Global {
             });
         }
 
-        let raw_encoder = cmd_buf_data.encoder.open(&cmd_buf.device)?;
+        let raw_encoder = cmd_buf_data.encoder.open()?;
 
         let query_set = hub.query_sets.get(query_set_id).get()?;
 
@@ -447,7 +447,7 @@ impl Global {
         );
 
         let raw_dst_buffer = dst_buffer.try_raw(&snatch_guard)?;
-        let raw_encoder = cmd_buf_data.encoder.open(&cmd_buf.device)?;
+        let raw_encoder = cmd_buf_data.encoder.open()?;
         unsafe {
             raw_encoder.transition_buffers(dst_barrier.as_slice());
             raw_encoder.copy_query_results(

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -322,7 +322,7 @@ impl Global {
         let blas_present = !blas_storage.is_empty();
         let tlas_present = !tlas_storage.is_empty();
 
-        let cmd_buf_raw = cmd_buf_data.encoder.open(device)?;
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
 
         let mut descriptors = Vec::new();
 
@@ -674,7 +674,7 @@ impl Global {
         let blas_present = !blas_storage.is_empty();
         let tlas_present = !tlas_storage.is_empty();
 
-        let cmd_buf_raw = cmd_buf_data.encoder.open(device)?;
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
 
         let mut descriptors = Vec::new();
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1663,7 +1663,9 @@ impl Global {
             // We automatically keep extending command buffers over time, and because
             // we want to insert a command buffer _before_ what we're about to record,
             // we need to make sure to close the previous one.
-            encoder.close(&cmd_buf.device).map_pass_err(pass_scope)?;
+            encoder
+                .close_if_open(&cmd_buf.device)
+                .map_pass_err(pass_scope)?;
             encoder
                 .open_pass(base.label.as_deref(), &cmd_buf.device)
                 .map_pass_err(pass_scope)?;

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1977,7 +1977,9 @@ impl Global {
         let tracker = &mut cmd_buf_data.trackers;
 
         {
-            let transit = encoder.open(&cmd_buf.device).map_pass_err(pass_scope)?;
+            let transit = encoder
+                .open_pass(Some("(wgpu internal) Pre Pass"), &cmd_buf.device)
+                .map_pass_err(pass_scope)?;
 
             fixup_discarded_surfaces(
                 pending_discard_init_fixups.into_iter(),

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1651,8 +1651,6 @@ impl Global {
         let device = &cmd_buf.device;
         let snatch_guard = &device.snatchable_lock.read();
 
-        let hal_label = hal_label(base.label.as_deref(), device.instance_flags);
-
         let (scope, pending_discard_init_fixups) = {
             device.check_is_valid().map_pass_err(pass_scope)?;
 
@@ -1667,12 +1665,12 @@ impl Global {
             // we need to make sure to close the previous one.
             encoder.close(&cmd_buf.device).map_pass_err(pass_scope)?;
             encoder
-                .open_pass(hal_label, &cmd_buf.device)
+                .open_pass(base.label.as_deref(), &cmd_buf.device)
                 .map_pass_err(pass_scope)?;
 
             let info = RenderPassInfo::start(
                 device,
-                hal_label,
+                hal_label(base.label.as_deref(), device.instance_flags),
                 pass.color_attachments.take(),
                 pass.depth_stencil_attachment.take(),
                 pass.timestamp_writes.take(),

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -444,7 +444,7 @@ fn handle_texture_init(
 
     // In rare cases we may need to insert an init operation immediately onto the command buffer.
     if !immediate_inits.is_empty() {
-        let cmd_buf_raw = cmd_buf_data.encoder.open(device)?;
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
         for init in immediate_inits {
             clear_texture(
                 &init.texture,
@@ -678,7 +678,7 @@ impl Global {
             dst_offset: destination_offset,
             size: wgt::BufferSize::new(size).unwrap(),
         };
-        let cmd_buf_raw = cmd_buf_data.encoder.open(&cmd_buf.device)?;
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
         let barriers = src_barrier
             .into_iter()
             .chain(dst_barrier)
@@ -838,7 +838,7 @@ impl Global {
             })
             .collect::<Vec<_>>();
 
-        let cmd_buf_raw = cmd_buf_data.encoder.open(&cmd_buf.device)?;
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
         unsafe {
             cmd_buf_raw.transition_textures(&dst_barrier);
             cmd_buf_raw.transition_buffers(src_barrier.as_slice());
@@ -1004,7 +1004,7 @@ impl Global {
                 }
             })
             .collect::<Vec<_>>();
-        let cmd_buf_raw = cmd_buf_data.encoder.open(&cmd_buf.device)?;
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
         unsafe {
             cmd_buf_raw.transition_buffers(dst_barrier.as_slice());
             cmd_buf_raw.transition_textures(&src_barrier);
@@ -1168,7 +1168,7 @@ impl Global {
                 }
             })
             .collect::<Vec<_>>();
-        let cmd_buf_raw = cmd_buf_data.encoder.open(&cmd_buf.device)?;
+        let cmd_buf_raw = cmd_buf_data.encoder.open()?;
         unsafe {
             cmd_buf_raw.transition_textures(&barriers);
             cmd_buf_raw.copy_texture_to_texture(

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1164,10 +1164,7 @@ impl Queue {
                         };
 
                         // execute resource transitions
-                        if let Err(e) = baked
-                            .encoder
-                            .open_pass(Some("(wgpu internal) Transit"), &self.device)
-                        {
+                        if let Err(e) = baked.encoder.open_pass(Some("(wgpu internal) Transit")) {
                             break 'error Err(e.into());
                         }
 
@@ -1194,7 +1191,7 @@ impl Queue {
                             &snatch_guard,
                         );
 
-                        if let Err(e) = baked.encoder.close_and_push_front(&self.device) {
+                        if let Err(e) = baked.encoder.close_and_push_front() {
                             break 'error Err(e.into());
                         }
 
@@ -1202,9 +1199,7 @@ impl Queue {
                         // Note: we could technically do it after all of the command buffers,
                         // but here we have a command encoder by hand, so it's easier to use it.
                         if !used_surface_textures.is_empty() {
-                            if let Err(e) = baked
-                                .encoder
-                                .open_pass(Some("(wgpu internal) Present"), &self.device)
+                            if let Err(e) = baked.encoder.open_pass(Some("(wgpu internal) Present"))
                             {
                                 break 'error Err(e.into());
                             }
@@ -1218,7 +1213,7 @@ impl Queue {
                             unsafe {
                                 baked.encoder.raw.transition_textures(&texture_barriers);
                             };
-                            if let Err(e) = baked.encoder.close(&self.device) {
+                            if let Err(e) = baked.encoder.close() {
                                 break 'error Err(e.into());
                             }
                             used_surface_textures = track::TextureUsageScope::default();

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -11,7 +11,6 @@ use crate::{
     device::{DeviceError, WaitIdleError},
     get_lowest_common_denom,
     global::Global,
-    hal_label,
     id::{self, QueueId},
     init_tracker::{has_copy_partial_init_tracker_coverage, TextureInitRange},
     lock::{rank, Mutex, MutexGuard, RwLockWriteGuard},
@@ -1165,10 +1164,10 @@ impl Queue {
                         };
 
                         // execute resource transitions
-                        if let Err(e) = baked.encoder.open_pass(
-                            hal_label(Some("(wgpu internal) Transit"), self.device.instance_flags),
-                            &self.device,
-                        ) {
+                        if let Err(e) = baked
+                            .encoder
+                            .open_pass(Some("(wgpu internal) Transit"), &self.device)
+                        {
                             break 'error Err(e.into());
                         }
 
@@ -1203,13 +1202,10 @@ impl Queue {
                         // Note: we could technically do it after all of the command buffers,
                         // but here we have a command encoder by hand, so it's easier to use it.
                         if !used_surface_textures.is_empty() {
-                            if let Err(e) = baked.encoder.open_pass(
-                                hal_label(
-                                    Some("(wgpu internal) Present"),
-                                    self.device.instance_flags,
-                                ),
-                                &self.device,
-                            ) {
+                            if let Err(e) = baked
+                                .encoder
+                                .open_pass(Some("(wgpu internal) Present"), &self.device)
+                            {
                                 break 'error Err(e.into());
                             }
                             let texture_barriers = trackers

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1381,7 +1381,7 @@ impl Global {
         if let Ok(mut cmd_buf_data_guard) = cmd_buf_data_guard {
             let cmd_buf_raw = cmd_buf_data_guard
                 .encoder
-                .open(&cmd_buf.device)
+                .open()
                 .ok()
                 .and_then(|encoder| encoder.as_any_mut().downcast_mut());
             let ret = hal_command_encoder_callback(cmd_buf_raw);


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/6795.

**Description**
See https://github.com/gfx-rs/wgpu/issues/6795
This also makes the methods more fail-proof by panicking if we misuse the API.
The last commit is cleanup.

**Testing**
Existing tests & made sure that the tests from [Bug 1937600](https://bugzilla.mozilla.org/show_bug.cgi?id=1937600) work now.
