### PR TITLE
[core] More vertex buffer validation

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2918,7 +2918,8 @@ impl Device {
             }
             let mut last_stride = 0;
             for attribute in vb_state.attributes.iter() {
-                if attribute.offset % attribute.format.size().min(4) != 0 {
+                let required_offset_alignment = attribute.format.size().min(4);
+                if attribute.offset % required_offset_alignment != 0 {
                     return Err(
                         pipeline::CreateRenderPipelineError::InvalidVertexAttributeOffset {
                             location: attribute.shader_location,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2929,7 +2929,7 @@ impl Device {
                 if attribute.shader_location >= self.limits.max_vertex_attributes {
                     return Err(
                         pipeline::CreateRenderPipelineError::TooManyVertexAttributes {
-                            given: total_attributes as u32,
+                            given: attribute.shader_location,
                             limit: self.limits.max_vertex_attributes,
                         },
                     );
@@ -2942,11 +2942,13 @@ impl Device {
                 vb_state.array_stride
             };
             if last_stride > max_stride {
-                return Err(pipeline::CreateRenderPipelineError::VertexStrideTooLarge {
-                    index: i as u32,
-                    given: last_stride as u32,
-                    limit: max_stride as u32,
-                });
+                return Err(
+                    pipeline::CreateRenderPipelineError::VertexAttributeStrideTooLarge {
+                        index: i as u32,
+                        given: last_stride as u32,
+                        limit: max_stride as u32,
+                    },
+                );
             }
             vertex_steps.push(pipeline::VertexStep {
                 stride: vb_state.array_stride,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2901,18 +2901,8 @@ impl Device {
         let mut shader_expects_dual_source_blending = false;
         let mut pipeline_expects_dual_source_blending = false;
         for (i, vb_state) in desc.vertex.buffers.iter().enumerate() {
-            let mut last_stride = 0;
-            for attribute in vb_state.attributes.iter() {
-                last_stride = last_stride.max(attribute.offset + attribute.format.size());
-            }
-            vertex_steps.push(pipeline::VertexStep {
-                stride: vb_state.array_stride,
-                last_stride,
-                mode: vb_state.step_mode,
-            });
-            if vb_state.attributes.is_empty() {
-                continue;
-            }
+            // https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-gpuvertexbufferlayout
+
             if vb_state.array_stride > self.limits.max_vertex_buffer_array_stride as u64 {
                 return Err(pipeline::CreateRenderPipelineError::VertexStrideTooLarge {
                     index: i as u32,
@@ -2925,6 +2915,46 @@ impl Device {
                     index: i as u32,
                     stride: vb_state.array_stride,
                 });
+            }
+            let mut last_stride = 0;
+            for attribute in vb_state.attributes.iter() {
+                if attribute.offset % attribute.format.size().min(4) != 0 {
+                    return Err(
+                        pipeline::CreateRenderPipelineError::InvalidVertexAttributeOffset {
+                            location: attribute.shader_location,
+                            offset: attribute.offset,
+                        },
+                    );
+                }
+                if attribute.shader_location >= self.limits.max_vertex_attributes {
+                    return Err(
+                        pipeline::CreateRenderPipelineError::TooManyVertexAttributes {
+                            given: total_attributes as u32,
+                            limit: self.limits.max_vertex_attributes,
+                        },
+                    );
+                }
+                last_stride = last_stride.max(attribute.offset + attribute.format.size());
+            }
+            let max_stride = if vb_state.array_stride == 0 {
+                self.limits.max_vertex_buffer_array_stride as u64
+            } else {
+                vb_state.array_stride
+            };
+            if last_stride > max_stride {
+                return Err(pipeline::CreateRenderPipelineError::VertexStrideTooLarge {
+                    index: i as u32,
+                    given: last_stride as u32,
+                    limit: max_stride as u32,
+                });
+            }
+            vertex_steps.push(pipeline::VertexStep {
+                stride: vb_state.array_stride,
+                last_stride,
+                mode: vb_state.step_mode,
+            });
+            if vb_state.attributes.is_empty() {
+                continue;
             }
             vertex_buffers.push(hal::VertexBufferLayout {
                 array_stride: vb_state.array_stride,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -475,8 +475,12 @@ pub enum CreateRenderPipelineError {
     TooManyVertexAttributes { given: u32, limit: u32 },
     #[error("Vertex buffer {index} stride {given} exceeds the limit {limit}")]
     VertexStrideTooLarge { index: u32, given: u32, limit: u32 },
-    #[error("Vertex buffer {index} attributes stride {given} exceeds the limit {limit}")]
-    VertexAttributeStrideTooLarge { index: u32, given: u32, limit: u32 },
+    #[error("Vertex attribute at location {location} stride {given} exceeds the limit {limit}")]
+    VertexAttributeStrideTooLarge {
+        location: wgt::ShaderLocation,
+        given: u32,
+        limit: u32,
+    },
     #[error("Vertex buffer {index} stride {stride} does not respect `VERTEX_STRIDE_ALIGNMENT`")]
     UnalignedVertexStride {
         index: u32,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -475,6 +475,8 @@ pub enum CreateRenderPipelineError {
     TooManyVertexAttributes { given: u32, limit: u32 },
     #[error("Vertex buffer {index} stride {given} exceeds the limit {limit}")]
     VertexStrideTooLarge { index: u32, given: u32, limit: u32 },
+    #[error("Vertex buffer {index} attributes stride {given} exceeds the limit {limit}")]
+    VertexAttributeStrideTooLarge { index: u32, given: u32, limit: u32 },
     #[error("Vertex buffer {index} stride {stride} does not respect `VERTEX_STRIDE_ALIGNMENT`")]
     UnalignedVertexStride {
         index: u32,


### PR DESCRIPTION
**Connections**
Fix #6799

**Testing**
[CTS run in servo](https://github.com/sagudev/servo/actions/runs/12452023550/job/34761648385):
```
OK /_webgpu/webgpu/cts.https.html?q=webgpu:api,validation,capability_checks,limits,maxVertexAttributes:createRenderPipeline,at_over:*

    PASS [expected FAIL] subtest: :limitTest="atDefault";testValueName="overLimit";async=false
    PASS [expected FAIL] subtest: :limitTest="atDefault";testValueName="overLimit";async=true
    PASS [expected FAIL] subtest: :limitTest="underDefault";testValueName="overLimit";async=false
    PASS [expected FAIL] subtest: :limitTest="underDefault";testValueName="overLimit";async=true
    PASS [expected FAIL] subtest: :limitTest="betweenDefaultAndMaximum";testValueName="overLimit";async=false
    PASS [expected FAIL] subtest: :limitTest="betweenDefaultAndMaximum";testValueName="overLimit";async=true
    PASS [expected FAIL] subtest: :limitTest="atMaximum";testValueName="overLimit";async=false
    PASS [expected FAIL] subtest: :limitTest="atMaximum";testValueName="overLimit";async=true
```

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
