### PR TITLE
Ban Dynamic Offsets and Binding Arrays in the Same Bind Group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Bottom level categories:
 
 #### General
 
+- If you use Binding Arrays in a bind group, you may not use Dynamic Offset Buffers or Uniform Buffers in that bind group. By @cwfitzgerald in [#6811](https://github.com/gfx-rs/wgpu/pull/6811)
+
 ##### Refactored internal trace path parameter
 
 Refactored some functions to handle the internal trace path as a string to avoid possible issues with `no_std` support.
@@ -103,7 +105,6 @@ a soundness issue, the intent is to move an error from runtime to compile time. 
 #### Bindless (`binding_array`) Grew More Capabilities
 
 - DX12 now supports `PARTIALLY_BOUND_BINDING_ARRAY` on Resource Binding Tier 3 Hardware. This is most D3D12 hardware [D3D12 Feature Table] for more information on what hardware supports this feature. By @cwfitzgerald in [#6734](https://github.com/gfx-rs/wgpu/pull/6734).
-- Buffer Dynamic Offsets and Binding Arrays may not be used in the same bind group. By @cwfitzgerald in [#6811](https://github.com/gfx-rs/wgpu/pull/6811)
 
 [D3D12 Feature Table]: https://d3d12infodb.boolka.dev/FeatureTable.html
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ a soundness issue, the intent is to move an error from runtime to compile time. 
 #### Bindless (`binding_array`) Grew More Capabilities
 
 - DX12 now supports `PARTIALLY_BOUND_BINDING_ARRAY` on Resource Binding Tier 3 Hardware. This is most D3D12 hardware [D3D12 Feature Table] for more information on what hardware supports this feature. By @cwfitzgerald in [#6734](https://github.com/gfx-rs/wgpu/pull/6734).
+- Buffer Dynamic Offsets and Binding Arrays may not be used in the same bind group. By @cwfitzgerald in [#6811](https://github.com/gfx-rs/wgpu/pull/6811)
 
 [D3D12 Feature Table]: https://d3d12infodb.boolka.dev/FeatureTable.html
 

--- a/examples/src/texture_arrays/indexing.wgsl
+++ b/examples/src/texture_arrays/indexing.wgsl
@@ -35,7 +35,7 @@ struct Uniforms {
     index: u32,
 }
 
-@group(0) @binding(3)
+@group(1) @binding(0)
 var<uniform> uniforms: Uniforms;
 
 @fragment

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -42,8 +42,8 @@ pub fn fail<T>(
         assert!(
             lowered_actual.contains(&lowered_expected),
             concat!(
-                "expected validation error case-insensitively containing {:?}, ",
-                "but it was not present in actual error message:\n{:?}"
+                "expected validation error case-insensitively containing {}, ",
+                "but it was not present in actual error message:\n{}"
             ),
             expected_msg_substring,
             validation_error

--- a/tests/tests/binding_array/mod.rs
+++ b/tests/tests/binding_array/mod.rs
@@ -2,3 +2,4 @@ mod buffers;
 mod sampled_textures;
 mod samplers;
 mod storage_textures;
+mod validation;

--- a/tests/tests/binding_array/validation.rs
+++ b/tests/tests/binding_array/validation.rs
@@ -1,0 +1,92 @@
+use std::num::NonZeroU32;
+
+use wgpu::*;
+use wgpu_test::{
+    fail, gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext,
+};
+
+#[gpu_test]
+static VALIDATION: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(Features::TEXTURE_BINDING_ARRAY)
+            .limits(Limits {
+                max_dynamic_storage_buffers_per_pipeline_layout: 1,
+                ..Limits::downlevel_defaults()
+            })
+            .expect_fail(
+                // https://github.com/gfx-rs/wgpu/issues/6950
+                FailureCase::backend(Backends::VULKAN).validation_error("has not been destroyed"),
+            ),
+    )
+    .run_async(validation);
+
+async fn validation(ctx: TestingContext) {
+    // Check that you can't create a bind group with both dynamic offset and binding array
+    fail(
+        &ctx.device,
+        || {
+            ctx.device
+                .create_bind_group_layout(&BindGroupLayoutDescriptor {
+                    label: Some("Test1"),
+                    entries: &[
+                        BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: ShaderStages::FRAGMENT,
+                            ty: BindingType::Texture {
+                                sample_type: TextureSampleType::Float { filterable: false },
+                                view_dimension: TextureViewDimension::D2,
+                                multisampled: false,
+                            },
+                            count: Some(NonZeroU32::new(4).unwrap()),
+                        },
+                        BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: ShaderStages::FRAGMENT,
+                            ty: BindingType::Buffer {
+                                ty: BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: true,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                    ],
+                })
+        },
+        Some("binding array and a dynamically offset buffer"),
+    );
+
+    // Check that you can't create a bind group with both uniform buffer and binding array
+    fail(
+        &ctx.device,
+        || {
+            ctx.device
+                .create_bind_group_layout(&BindGroupLayoutDescriptor {
+                    label: Some("Test2"),
+                    entries: &[
+                        BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: ShaderStages::FRAGMENT,
+                            ty: BindingType::Texture {
+                                sample_type: TextureSampleType::Float { filterable: false },
+                                view_dimension: TextureViewDimension::D2,
+                                multisampled: false,
+                            },
+                            count: Some(NonZeroU32::new(4).unwrap()),
+                        },
+                        BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: ShaderStages::FRAGMENT,
+                            ty: BindingType::Buffer {
+                                ty: BufferBindingType::Uniform,
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                    ],
+                })
+        },
+        Some("binding array and a uniform buffer"),
+    );
+}

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -68,6 +68,8 @@ pub enum CreateBindGroupLayoutError {
     },
     #[error(transparent)]
     TooManyBindings(BindingTypeMaxCountError),
+    #[error("Bind groups may not contain both a binding array and a dynamically offset array")]
+    ContainsBothBindingArrayAndDynamicOffsetArray,
     #[error("Binding index {binding} is greater than the maximum number {maximum}")]
     InvalidBindingIndex { binding: u32, maximum: u32 },
     #[error("Invalid visibility {0:?}")]
@@ -319,6 +321,7 @@ pub(crate) struct BindingTypeMaxCountValidator {
     storage_textures: PerStageBindingTypeCounter,
     uniform_buffers: PerStageBindingTypeCounter,
     acceleration_structures: PerStageBindingTypeCounter,
+    has_bindless_array: bool,
 }
 
 impl BindingTypeMaxCountValidator {
@@ -357,6 +360,9 @@ impl BindingTypeMaxCountValidator {
             wgt::BindingType::AccelerationStructure => {
                 self.acceleration_structures.add(binding.visibility, count);
             }
+        }
+        if binding.count.is_some() {
+            self.has_bindless_array = true;
         }
     }
 
@@ -407,6 +413,19 @@ impl BindingTypeMaxCountValidator {
             limits.max_uniform_buffers_per_shader_stage,
             BindingTypeMaxCountErrorKind::UniformBuffers,
         )?;
+        Ok(())
+    }
+
+    /// Validate that the bind group layout does not contain both a binding array and a dynamic offset array.
+    ///
+    /// This allows us to use `UPDATE_AFTER_BIND` on vulkan for bindless arrays. Vulkan does not allow
+    /// `UPDATE_AFTER_BIND` on dynamic offset arrays. See <https://github.com/gfx-rs/wgpu/issues/6737>
+    pub(crate) fn validate_binding_arrays(&self) -> Result<(), CreateBindGroupLayoutError> {
+        let has_dynamic_offset_array =
+            self.dynamic_uniform_buffers > 0 || self.dynamic_storage_buffers > 0;
+        if self.has_bindless_array && has_dynamic_offset_array {
+            return Err(CreateBindGroupLayoutError::ContainsBothBindingArrayAndDynamicOffsetArray);
+        }
         Ok(())
     }
 }

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -68,8 +68,10 @@ pub enum CreateBindGroupLayoutError {
     },
     #[error(transparent)]
     TooManyBindings(BindingTypeMaxCountError),
-    #[error("Bind groups may not contain both a binding array and a dynamically offset array")]
+    #[error("Bind groups may not contain both a binding array and a dynamically offset buffer")]
     ContainsBothBindingArrayAndDynamicOffsetArray,
+    #[error("Bind groups may not contain both a binding array and a uniform buffer")]
+    ContainsBothBindingArrayAndUniformBuffer,
     #[error("Binding index {binding} is greater than the maximum number {maximum}")]
     InvalidBindingIndex { binding: u32, maximum: u32 },
     #[error("Invalid visibility {0:?}")]
@@ -423,8 +425,12 @@ impl BindingTypeMaxCountValidator {
     pub(crate) fn validate_binding_arrays(&self) -> Result<(), CreateBindGroupLayoutError> {
         let has_dynamic_offset_array =
             self.dynamic_uniform_buffers > 0 || self.dynamic_storage_buffers > 0;
+        let has_uniform_buffer = self.uniform_buffers.max().1 > 0;
         if self.has_bindless_array && has_dynamic_offset_array {
             return Err(CreateBindGroupLayoutError::ContainsBothBindingArrayAndDynamicOffsetArray);
+        }
+        if self.has_bindless_array && has_uniform_buffer {
+            return Err(CreateBindGroupLayoutError::ContainsBothBindingArrayAndUniformBuffer);
         }
         Ok(())
     }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1908,6 +1908,9 @@ impl Device {
             .validate(&self.limits)
             .map_err(binding_model::CreateBindGroupLayoutError::TooManyBindings)?;
 
+        // Validate that binding arrays don't conflict with dynamic offsets.
+        count_validator.validate_binding_arrays()?;
+
         let bgl = BindGroupLayout {
             raw: ManuallyDrop::new(raw),
             device: self.clone(),

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7127,8 +7127,9 @@ pub struct BindGroupLayoutEntry {
     /// - When `ty == BindingType::Sampler`, [`Features::TEXTURE_BINDING_ARRAY`] must be supported.
     /// - When `ty == BindingType::Buffer`, [`Features::BUFFER_BINDING_ARRAY`] must be supported.
     /// - When `ty == BindingType::Buffer` and `ty.ty == BufferBindingType::Storage`, [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] must be supported.
-    /// - When `ty == BindingTYpe::StorageTexture`, [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] must be supported.
+    /// - When `ty == BindingType::StorageTexture`, [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] must be supported.
     /// - When any binding in the group is an array, no `BindingType::Buffer` in the group may have `has_dynamic_offset == true`
+    /// - When any binding in the group is an array, no `BindingType::Buffer` in the group may have `ty.ty == BufferBindingType::Uniform`.
     ///
     #[cfg_attr(feature = "serde", serde(default))]
     pub count: Option<NonZeroU32>,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7113,17 +7113,23 @@ impl BindingType {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BindGroupLayoutEntry {
     /// Binding index. Must match shader index and be unique inside a BindGroupLayout. A binding
-    /// of index 1, would be described as `layout(set = 0, binding = 1) uniform` in shaders.
+    /// of index 1, would be described as `@group(0) @binding(1)` in shaders.
     pub binding: u32,
     /// Which shader stages can see this binding.
     pub visibility: ShaderStages,
     /// The type of the binding
     pub ty: BindingType,
-    /// If this value is Some, indicates this entry is an array. Array size must be 1 or greater.
+    /// If the binding is an array of multiple resources. Corresponds to `binding_array<T>` in the shader.
     ///
-    /// If this value is Some and `ty` is `BindingType::Texture`, [`Features::TEXTURE_BINDING_ARRAY`] must be supported.
+    /// When this is `Some` the following validation applies:
+    /// - Size must be of value 1 or greater.
+    /// - When `ty == BindingType::Texture`, [`Features::TEXTURE_BINDING_ARRAY`] must be supported.
+    /// - When `ty == BindingType::Sampler`, [`Features::TEXTURE_BINDING_ARRAY`] must be supported.
+    /// - When `ty == BindingType::Buffer`, [`Features::BUFFER_BINDING_ARRAY`] must be supported.
+    /// - When `ty == BindingType::Buffer` and `ty.ty == BufferBindingType::Storage`, [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] must be supported.
+    /// - When `ty == BindingTYpe::StorageTexture`, [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] must be supported.
+    /// - When any binding in the group is an array, no `BindingType::Buffer` in the group may have `has_dynamic_offset == true`
     ///
-    /// If this value is Some and `ty` is any other variant, bind group creation will fail.
     #[cfg_attr(feature = "serde", serde(default))]
     pub count: Option<NonZeroU32>,
 }


### PR DESCRIPTION
Closes #6736

We also need to ban uniform buffers and binding arrays.