### PR TITLE
Add a way to notify with Queue::submit() to Vulkan's vk::Semaphore allocated outside of wgpu

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1982,6 +1982,7 @@ impl super::Adapter {
             device: Arc::clone(&shared),
             family_index,
             relay_semaphores: Mutex::new(relay_semaphores),
+            signal_semaphores: Mutex::new((Vec::new(), Vec::new())),
         };
 
         let mem_allocator = {


### PR DESCRIPTION
**Connections**
Fixes #6812

**Description**
The following changes are done.
* Add Global::queue_as_hal() for accessing hal queue.
* Add Queue::add_signal_semahore() for adding signal semaphore to Queue, the semaphore is submitted by next Queue::submit().
* Add Queue::raw_device(&self). It could be used to allocate vk::Semaphore. 

