### PR TITLE
fix(dxgi): DX12 exception handler lifetime based on device not adapter

### DIFF
--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -141,9 +141,6 @@ pub fn create_factory(
         if let Ok(Some(_)) = lib_dxgi.debug_interface1() {
             factory_flags |= Dxgi::DXGI_CREATE_FACTORY_DEBUG;
         }
-
-        // Intercept `OutputDebugString` calls
-        super::exception::register_exception_handler();
     }
 
     let factory4 = match lib_dxgi.create_factory4(factory_flags) {

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -37,6 +37,13 @@ impl super::Device {
         library: &Arc<D3D12Lib>,
         dxc_container: Option<Arc<shader_compilation::DxcContainer>>,
     ) -> Result<Self, crate::DeviceError> {
+        if private_caps
+            .instance_flags
+            .contains(wgt::InstanceFlags::VALIDATION)
+        {
+            auxil::dxgi::exception::register_exception_handler();
+        }
+
         let mem_allocator = super::suballocation::create_allocator_wrapper(&raw, memory_hints)?;
 
         let idle_fence: Direct3D12::ID3D12Fence = unsafe {

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -12,14 +12,6 @@ use windows::{
 use super::SurfaceTarget;
 use crate::{auxil, dx12::D3D12Lib};
 
-impl Drop for super::Instance {
-    fn drop(&mut self) {
-        if self.flags.contains(wgt::InstanceFlags::VALIDATION) {
-            auxil::dxgi::exception::unregister_exception_handler();
-        }
-    }
-}
-
 impl crate::Instance for super::Instance {
     type A = super::Api;
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -605,6 +605,13 @@ pub struct Device {
 impl Drop for Device {
     fn drop(&mut self) {
         self.rtv_pool.lock().free_handle(self.null_rtv_handle);
+        if self
+            .private_caps
+            .instance_flags
+            .contains(wgt::InstanceFlags::VALIDATION)
+        {
+            auxil::dxgi::exception::unregister_exception_handler();
+        }
     }
 }
 


### PR DESCRIPTION
**Connections**
Closes #4247 

**Description**
Instead of registering/unregistering the dxgi exception handler on the instance creation/drop. We instead use the device lifetime.
This fixes the issue where we get DX12 errors popping up on Vulkan hardware.

**Testing**
Locally this seems to fix the issue. I've manually ran a bunch of the benchmarks. Manually selecting backends is working as it was before, auto-selection no longer produces spurious error messages. However I'm not sure how to test to make sure that we're still getting the error messages when we want them. If theres a better way to test this I'm all ears!

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
