### PR TITLE
[naga] change i32 arithmetic operations to use `wrapping_` instead of `checked_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,6 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Add support for OpAtomicCompareExchange in SPIR-V frontend. By @schell in [#6590](https://github.com/gfx-rs/wgpu/pull/6590).
 - Implement type inference for abstract arguments to user-defined functions. By @jamienicol in [#6577](https://github.com/gfx-rs/wgpu/pull/6577).
 - Allow for override-expressions in array sizes. By @KentSlaney in [#6654](https://github.com/gfx-rs/wgpu/pull/6654).
-- Change multiplication between two i32 variables to wrap on overflow to match WGSL spec. By @matthew-wong1 in [#6835](https://github.com/gfx-rs/wgpu/pull/6835)
 
 #### General
 
@@ -158,6 +157,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Show types of LHS and RHS in binary operation type mismatch errors. By @ErichDonGubler in [#6450](https://github.com/gfx-rs/wgpu/pull/6450).
 - The GLSL parser now uses less expressions for function calls. By @magcius in [#6604](https://github.com/gfx-rs/wgpu/pull/6604).
 - Add a note to help with a common syntax error case for global diagnostic filter directives. By @e-hat in [#6718](https://github.com/gfx-rs/wgpu/pull/6718)
+- Change multiplication between two i32 variables to wrap on overflow to match WGSL spec. By @matthew-wong1 in [#6835](https://github.com/gfx-rs/wgpu/pull/6835).
 
 #### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Add support for OpAtomicCompareExchange in SPIR-V frontend. By @schell in [#6590](https://github.com/gfx-rs/wgpu/pull/6590).
 - Implement type inference for abstract arguments to user-defined functions. By @jamienicol in [#6577](https://github.com/gfx-rs/wgpu/pull/6577).
 - Allow for override-expressions in array sizes. By @KentSlaney in [#6654](https://github.com/gfx-rs/wgpu/pull/6654).
+- Change multiplication between two i32 variables to wrap on overflow to match WGSL spec. By @matthew-wong1 [#6835](https://github.com/gfx-rs/wgpu/pull/6835)
 
 #### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Show types of LHS and RHS in binary operation type mismatch errors. By @ErichDonGubler in [#6450](https://github.com/gfx-rs/wgpu/pull/6450).
 - The GLSL parser now uses less expressions for function calls. By @magcius in [#6604](https://github.com/gfx-rs/wgpu/pull/6604).
 - Add a note to help with a common syntax error case for global diagnostic filter directives. By @e-hat in [#6718](https://github.com/gfx-rs/wgpu/pull/6718)
-- Change multiplication between two i32 variables to wrap on overflow to match WGSL spec. By @matthew-wong1 in [#6835](https://github.com/gfx-rs/wgpu/pull/6835).
+- Change arithmetic operations between two i32 variables to wrap on overflow to match WGSL spec. By @matthew-wong1 in [#6835](https://github.com/gfx-rs/wgpu/pull/6835).
 
 #### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Add support for OpAtomicCompareExchange in SPIR-V frontend. By @schell in [#6590](https://github.com/gfx-rs/wgpu/pull/6590).
 - Implement type inference for abstract arguments to user-defined functions. By @jamienicol in [#6577](https://github.com/gfx-rs/wgpu/pull/6577).
 - Allow for override-expressions in array sizes. By @KentSlaney in [#6654](https://github.com/gfx-rs/wgpu/pull/6654).
-- Change multiplication between two i32 variables to wrap on overflow to match WGSL spec. By @matthew-wong1 [#6835](https://github.com/gfx-rs/wgpu/pull/6835)
+- Change multiplication between two i32 variables to wrap on overflow to match WGSL spec. By @matthew-wong1 in [#6835](https://github.com/gfx-rs/wgpu/pull/6835)
 
 #### General
 

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1808,27 +1808,23 @@ impl<'a> ConstantEvaluator<'a> {
 
                     _ => match (left_value, right_value) {
                         (Literal::I32(a), Literal::I32(b)) => Literal::I32(match op {
-                            BinaryOperator::Add => a.checked_add(b).ok_or_else(|| {
-                                ConstantEvaluatorError::Overflow("addition".into())
-                            })?,
-                            BinaryOperator::Subtract => a.checked_sub(b).ok_or_else(|| {
-                                ConstantEvaluatorError::Overflow("subtraction".into())
-                            })?,
+                            BinaryOperator::Add => a.wrapping_add(b),
+                            BinaryOperator::Subtract => a.wrapping_sub(b),
                             BinaryOperator::Multiply => a.wrapping_mul(b),
-                            BinaryOperator::Divide => a.checked_div(b).ok_or_else(|| {
+                            BinaryOperator::Divide => {
                                 if b == 0 {
-                                    ConstantEvaluatorError::DivisionByZero
+                                    return Err(ConstantEvaluatorError::DivisionByZero);
                                 } else {
-                                    ConstantEvaluatorError::Overflow("division".into())
+                                    a.wrapping_div(b)
                                 }
-                            })?,
-                            BinaryOperator::Modulo => a.checked_rem(b).ok_or_else(|| {
+                            }
+                            BinaryOperator::Modulo => {
                                 if b == 0 {
-                                    ConstantEvaluatorError::RemainderByZero
+                                    return Err(ConstantEvaluatorError::RemainderByZero);
                                 } else {
-                                    ConstantEvaluatorError::Overflow("remainder".into())
+                                    a.wrapping_rem(b)
                                 }
-                            })?,
+                            }
                             BinaryOperator::And => a & b,
                             BinaryOperator::ExclusiveOr => a ^ b,
                             BinaryOperator::InclusiveOr => a | b,

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1814,9 +1814,7 @@ impl<'a> ConstantEvaluator<'a> {
                             BinaryOperator::Subtract => a.checked_sub(b).ok_or_else(|| {
                                 ConstantEvaluatorError::Overflow("subtraction".into())
                             })?,
-                            BinaryOperator::Multiply => a.checked_mul(b).ok_or_else(|| {
-                                ConstantEvaluatorError::Overflow("multiplication".into())
-                            })?,
+                            BinaryOperator::Multiply => a.wrapping_mul(b),
                             BinaryOperator::Divide => a.checked_div(b).ok_or_else(|| {
                                 if b == 0 {
                                     ConstantEvaluatorError::DivisionByZero


### PR DESCRIPTION
**Connections**
Fixes #6023 

**Description**
For arithmetic operations between two variables of type `i32`, if an overflow occurs, it is meant to wrap instead of throw an error according to the WGSL spec ("Expressions on concrete integer types that overflow produce a result that is modulo 2<sup>bitwidth</sup>")

**Testing**
Compiled the original program detailed in #6023 (and variations for other arithemtic operations) that threw the overflow error (now overflow error free) 

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.

