### PR TITLE
Explicitly enable dx12 & metal features on `wgpu-info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Fix panic when dropping `Device` on some environments. By @Dinnerbone in [#6681](https://github.com/gfx-rs/wgpu/pull/6681).
 - Reduced the overhead of command buffer validation. By @nical in [#6721](https://github.com/gfx-rs/wgpu/pull/6721).
 - Set index type to NONE in `get_acceleration_structure_build_sizes`. By @Vecvec in [#6802](https://github.com/gfx-rs/wgpu/pull/6802).
+- Fix `wgpu-info` not showing dx12 adapters. By @wumpf in [#6844](https://github.com/gfx-rs/wgpu/pull/6844).
 
 #### Naga
 

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -16,4 +16,4 @@ env_logger.workspace = true
 pico-args.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-wgpu = { workspace = true, features = ["serde", "static-dxc"] }
+wgpu = { workspace = true, features = ["serde", "dx12", "metal", "static-dxc"] }


### PR DESCRIPTION
**Connections**

* https://github.com/gfx-rs/wgpu/pull/6782

**Description**

We didn't show dx12 adapters on wgpu-info anymore 😬 

**Testing**
Run `cargo run -p wgpu-info`

Before: Dx12  doesn't show up
After: Dx12 shows up

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
