### PR TITLE
[wgpu] Move Arcs to dispatch

### DIFF
--- a/wgpu/src/api/bind_group.rs
+++ b/wgpu/src/api/bind_group.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::*;
 
 /// Handle to a binding group.
@@ -12,7 +10,7 @@ use crate::*;
 /// Corresponds to [WebGPU `GPUBindGroup`](https://gpuweb.github.io/gpuweb/#gpubindgroup).
 #[derive(Debug, Clone)]
 pub struct BindGroup {
-    pub(crate) inner: Arc<dispatch::DispatchBindGroup>,
+    pub(crate) inner: dispatch::DispatchBindGroup,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(BindGroup: Send, Sync);

--- a/wgpu/src/api/bind_group_layout.rs
+++ b/wgpu/src/api/bind_group_layout.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::*;
 
 /// Handle to a binding group layout.
@@ -15,7 +13,7 @@ use crate::*;
 /// https://gpuweb.github.io/gpuweb/#gpubindgrouplayout).
 #[derive(Debug, Clone)]
 pub struct BindGroupLayout {
-    pub(crate) inner: Arc<dispatch::DispatchBindGroupLayout>,
+    pub(crate) inner: dispatch::DispatchBindGroupLayout,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(BindGroupLayout: Send, Sync);

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -1,6 +1,5 @@
 use crate::dispatch;
 use crate::{Buffer, Label};
-use std::sync::Arc;
 use wgt::WasmNotSendSync;
 
 /// Descriptor for the size defining attributes of a triangle geometry, for a bottom level acceleration structure.
@@ -44,7 +43,7 @@ static_assertions::assert_impl_all!(CreateBlasDescriptor<'_>: Send, Sync);
 /// [TlasPackage]: crate::TlasPackage
 #[derive(Debug, Clone)]
 pub struct TlasInstance {
-    pub(crate) blas: Arc<dispatch::DispatchBlas>,
+    pub(crate) blas: dispatch::DispatchBlas,
     /// Affine transform matrix 3x4 (rows x columns, row major order).
     pub transform: [f32; 12],
     /// Custom index for the instance used inside the shader.
@@ -138,7 +137,7 @@ static_assertions::assert_impl_all!(BlasBuildEntry<'_>: WasmNotSendSync);
 /// [Tlas]: crate::Tlas
 pub struct Blas {
     pub(crate) handle: Option<u64>,
-    pub(crate) inner: Arc<dispatch::DispatchBlas>,
+    pub(crate) inner: dispatch::DispatchBlas,
 }
 static_assertions::assert_impl_all!(Blas: WasmNotSendSync);
 

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -8,15 +8,6 @@ use parking_lot::Mutex;
 
 use crate::*;
 
-#[derive(Debug, Clone)]
-pub(crate) struct BufferShared {
-    pub inner: dispatch::DispatchBuffer,
-    pub map_context: Arc<Mutex<MapContext>>,
-    pub size: wgt::BufferAddress,
-    pub usage: BufferUsages,
-    // Todo: missing map_state https://www.w3.org/TR/webgpu/#dom-gpubuffer-mapstate
-}
-
 /// Handle to a GPU-accessible buffer.
 ///
 /// Created with [`Device::create_buffer`] or
@@ -179,12 +170,16 @@ pub(crate) struct BufferShared {
 /// [`MAP_WRITE`]: BufferUsages::MAP_WRITE
 #[derive(Debug, Clone)]
 pub struct Buffer {
-    pub(crate) shared: BufferShared,
+    pub(crate) inner: dispatch::DispatchBuffer,
+    pub(crate) map_context: Arc<Mutex<MapContext>>,
+    pub(crate) size: wgt::BufferAddress,
+    pub(crate) usage: BufferUsages,
+    // Todo: missing map_state https://www.w3.org/TR/webgpu/#dom-gpubuffer-mapstate
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Buffer: Send, Sync);
 
-crate::cmp::impl_eq_ord_hash_proxy!(Buffer => .shared.inner);
+crate::cmp::impl_eq_ord_hash_proxy!(Buffer => .inner);
 
 impl Buffer {
     /// Return the binding view of the entire buffer.
@@ -212,7 +207,7 @@ impl Buffer {
         &self,
         hal_buffer_callback: F,
     ) -> R {
-        if let Some(buffer) = self.shared.inner.as_core_opt() {
+        if let Some(buffer) = self.inner.as_core_opt() {
             unsafe {
                 buffer
                     .context
@@ -239,7 +234,7 @@ impl Buffer {
     /// end of the buffer.
     pub fn slice<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferSlice<'_> {
         let (offset, size) = range_to_offset_size(bounds);
-        check_buffer_bounds(self.shared.size, offset, size);
+        check_buffer_bounds(self.size, offset, size);
         BufferSlice {
             buffer: self,
             offset,
@@ -249,27 +244,27 @@ impl Buffer {
 
     /// Flushes any pending write operations and unmaps the buffer from host memory.
     pub fn unmap(&self) {
-        self.shared.map_context.lock().reset();
-        self.shared.inner.unmap();
+        self.map_context.lock().reset();
+        self.inner.unmap();
     }
 
     /// Destroy the associated native resources as soon as possible.
     pub fn destroy(&self) {
-        self.shared.inner.destroy();
+        self.inner.destroy();
     }
 
     /// Returns the length of the buffer allocation in bytes.
     ///
     /// This is always equal to the `size` that was specified when creating the buffer.
     pub fn size(&self) -> BufferAddress {
-        self.shared.size
+        self.size
     }
 
     /// Returns the allowed usages for this `Buffer`.
     ///
     /// This is always equal to the `usage` that was specified when creating the buffer.
     pub fn usage(&self) -> BufferUsages {
-        self.shared.usage
+        self.usage
     }
 }
 
@@ -336,7 +331,7 @@ impl<'a> BufferSlice<'a> {
         mode: MapMode,
         callback: impl FnOnce(Result<(), BufferAsyncError>) + WasmNotSend + 'static,
     ) {
-        let mut mc = self.buffer.shared.map_context.lock();
+        let mut mc = self.buffer.map_context.lock();
         assert_eq!(mc.initial_range, 0..0, "Buffer is already mapped");
         let end = match self.size {
             Some(s) => self.offset + s.get(),
@@ -345,7 +340,6 @@ impl<'a> BufferSlice<'a> {
         mc.initial_range = self.offset..end;
 
         self.buffer
-            .shared
             .inner
             .map_async(mode, self.offset..end, Box::new(callback));
     }
@@ -365,13 +359,8 @@ impl<'a> BufferSlice<'a> {
     ///
     /// [mapped]: Buffer#mapping-buffers
     pub fn get_mapped_range(&self) -> BufferView<'a> {
-        let end = self
-            .buffer
-            .shared
-            .map_context
-            .lock()
-            .add(self.offset, self.size);
-        let range = self.buffer.shared.inner.get_mapped_range(self.offset..end);
+        let end = self.buffer.map_context.lock().add(self.offset, self.size);
+        let range = self.buffer.inner.get_mapped_range(self.offset..end);
         BufferView {
             slice: *self,
             inner: range,
@@ -388,15 +377,9 @@ impl<'a> BufferSlice<'a> {
     /// This is only available on WebGPU, on any other backends this will return `None`.
     #[cfg(webgpu)]
     pub fn get_mapped_range_as_array_buffer(&self) -> Option<js_sys::ArrayBuffer> {
-        let end = self
-            .buffer
-            .shared
-            .map_context
-            .lock()
-            .add(self.offset, self.size);
+        let end = self.buffer.map_context.lock().add(self.offset, self.size);
 
         self.buffer
-            .shared
             .inner
             .get_mapped_range_as_array_buffer(self.offset..end)
     }
@@ -416,17 +399,12 @@ impl<'a> BufferSlice<'a> {
     ///
     /// [mapped]: Buffer#mapping-buffers
     pub fn get_mapped_range_mut(&self) -> BufferViewMut<'a> {
-        let end = self
-            .buffer
-            .shared
-            .map_context
-            .lock()
-            .add(self.offset, self.size);
-        let range = self.buffer.shared.inner.get_mapped_range(self.offset..end);
+        let end = self.buffer.map_context.lock().add(self.offset, self.size);
+        let range = self.buffer.inner.get_mapped_range(self.offset..end);
         BufferViewMut {
             slice: *self,
             inner: range,
-            readable: self.buffer.shared.usage.contains(BufferUsages::MAP_READ),
+            readable: self.buffer.usage.contains(BufferUsages::MAP_READ),
         }
     }
 }
@@ -651,7 +629,6 @@ impl Drop for BufferView<'_> {
     fn drop(&mut self) {
         self.slice
             .buffer
-            .shared
             .map_context
             .lock()
             .remove(self.slice.offset, self.slice.size);
@@ -662,7 +639,6 @@ impl Drop for BufferViewMut<'_> {
     fn drop(&mut self) {
         self.slice
             .buffer
-            .shared
             .map_context
             .lock()
             .remove(self.slice.offset, self.slice.size);

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -8,10 +8,10 @@ use parking_lot::Mutex;
 
 use crate::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct BufferShared {
     pub inner: dispatch::DispatchBuffer,
-    pub map_context: Mutex<MapContext>,
+    pub map_context: Arc<Mutex<MapContext>>,
     pub size: wgt::BufferAddress,
     pub usage: BufferUsages,
     // Todo: missing map_state https://www.w3.org/TR/webgpu/#dom-gpubuffer-mapstate
@@ -179,7 +179,7 @@ pub(crate) struct BufferShared {
 /// [`MAP_WRITE`]: BufferUsages::MAP_WRITE
 #[derive(Debug, Clone)]
 pub struct Buffer {
-    pub(crate) shared: Arc<BufferShared>,
+    pub(crate) shared: BufferShared,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Buffer: Send, Sync);

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -183,8 +183,7 @@ impl CommandEncoder {
     /// - `CLEAR_TEXTURE` extension not enabled
     /// - Range is out of bounds
     pub fn clear_texture(&mut self, texture: &Texture, subresource_range: &ImageSubresourceRange) {
-        self.inner
-            .clear_texture(&texture.shared.inner, subresource_range);
+        self.inner.clear_texture(&texture.inner, subresource_range);
     }
 
     /// Clears buffer to zero.

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -122,9 +122,9 @@ impl CommandEncoder {
         copy_size: BufferAddress,
     ) {
         self.inner.copy_buffer_to_buffer(
-            &source.shared.inner,
+            &source.inner,
             source_offset,
-            &destination.shared.inner,
+            &destination.inner,
             destination_offset,
             copy_size,
         );
@@ -199,7 +199,7 @@ impl CommandEncoder {
         offset: BufferAddress,
         size: Option<BufferAddress>,
     ) {
-        self.inner.clear_buffer(&buffer.shared.inner, offset, size);
+        self.inner.clear_buffer(&buffer.inner, offset, size);
     }
 
     /// Inserts debug marker.
@@ -232,7 +232,7 @@ impl CommandEncoder {
             &query_set.inner,
             query_range.start,
             query_range.end - query_range.start,
-            &destination.shared.inner,
+            &destination.inner,
             destination_offset,
         );
     }

--- a/wgpu/src/api/compute_pass.rs
+++ b/wgpu/src/api/compute_pass.rs
@@ -52,7 +52,7 @@ impl ComputePass<'_> {
         Option<&'a BindGroup>: From<BG>,
     {
         let bg: Option<&BindGroup> = bind_group.into();
-        let bg = bg.map(|bg| &*bg.inner);
+        let bg = bg.map(|bg| &bg.inner);
         self.inner.set_bind_group(index, bg, offsets);
     }
 

--- a/wgpu/src/api/compute_pass.rs
+++ b/wgpu/src/api/compute_pass.rs
@@ -92,7 +92,7 @@ impl ComputePass<'_> {
         indirect_offset: BufferAddress,
     ) {
         self.inner
-            .dispatch_workgroups_indirect(&indirect_buffer.shared.inner, indirect_offset);
+            .dispatch_workgroups_indirect(&indirect_buffer.inner, indirect_offset);
     }
 }
 

--- a/wgpu/src/api/compute_pipeline.rs
+++ b/wgpu/src/api/compute_pipeline.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::*;
 
 /// Handle to a compute pipeline.
@@ -10,7 +8,7 @@ use crate::*;
 /// Corresponds to [WebGPU `GPUComputePipeline`](https://gpuweb.github.io/gpuweb/#compute-pipeline).
 #[derive(Debug, Clone)]
 pub struct ComputePipeline {
-    pub(crate) inner: Arc<dispatch::DispatchComputePipeline>,
+    pub(crate) inner: dispatch::DispatchComputePipeline,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(ComputePipeline: Send, Sync);
@@ -27,9 +25,7 @@ impl ComputePipeline {
     /// This method will raise a validation error if there is no bind group layout at `index`.
     pub fn get_bind_group_layout(&self, index: u32) -> BindGroupLayout {
         let bind_group = self.inner.get_bind_group_layout(index);
-        BindGroupLayout {
-            inner: Arc::new(bind_group),
-        }
+        BindGroupLayout { inner: bind_group }
     }
 }
 

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -215,12 +215,10 @@ impl Device {
         let buffer = self.inner.create_buffer(desc);
 
         Buffer {
-            shared: BufferShared {
-                inner: buffer,
-                map_context: Arc::new(Mutex::new(map_context)),
-                size: desc.size,
-                usage: desc.usage,
-            },
+            inner: buffer,
+            map_context: Arc::new(Mutex::new(map_context)),
+            size: desc.size,
+            usage: desc.usage,
         }
     }
 
@@ -302,12 +300,10 @@ impl Device {
         };
 
         Buffer {
-            shared: BufferShared {
-                inner: buffer.into(),
-                map_context: Arc::new(Mutex::new(map_context)),
-                size: desc.size,
-                usage: desc.usage,
-            },
+            inner: buffer.into(),
+            map_context: Arc::new(Mutex::new(map_context)),
+            size: desc.size,
+            usage: desc.usage,
         }
     }
 

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -215,12 +215,12 @@ impl Device {
         let buffer = self.inner.create_buffer(desc);
 
         Buffer {
-            shared: Arc::new(BufferShared {
+            shared: BufferShared {
                 inner: buffer,
-                map_context: Mutex::new(map_context),
+                map_context: Arc::new(Mutex::new(map_context)),
                 size: desc.size,
                 usage: desc.usage,
-            }),
+            },
         }
     }
 
@@ -232,14 +232,14 @@ impl Device {
         let texture = self.inner.create_texture(desc);
 
         Texture {
-            shared: Arc::new(TextureShared {
+            shared: TextureShared {
                 inner: texture,
                 descriptor: TextureDescriptor {
                     label: None,
                     view_formats: &[],
                     ..desc.clone()
                 },
-            }),
+            },
         }
     }
 
@@ -264,14 +264,14 @@ impl Device {
                 .create_texture_from_hal::<A>(hal_texture, core_device, desc)
         };
         Texture {
-            shared: Arc::new(TextureShared {
+            shared: TextureShared {
                 inner: texture.into(),
                 descriptor: TextureDescriptor {
                     label: None,
                     view_formats: &[],
                     ..desc.clone()
                 },
-            }),
+            },
         }
     }
 
@@ -302,12 +302,12 @@ impl Device {
         };
 
         Buffer {
-            shared: Arc::new(BufferShared {
+            shared: BufferShared {
                 inner: buffer.into(),
-                map_context: Mutex::new(map_context),
+                map_context: Arc::new(Mutex::new(map_context)),
                 size: desc.size,
                 usage: desc.usage,
-            }),
+            },
         }
     }
 

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -16,7 +16,7 @@ use crate::*;
 /// Corresponds to [WebGPU `GPUDevice`](https://gpuweb.github.io/gpuweb/#gpu-device).
 #[derive(Debug, Clone)]
 pub struct Device {
-    pub(crate) inner: Arc<dispatch::DispatchDevice>,
+    pub(crate) inner: dispatch::DispatchDevice,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Device: Send, Sync);
@@ -170,9 +170,7 @@ impl Device {
     #[must_use]
     pub fn create_bind_group(&self, desc: &BindGroupDescriptor<'_>) -> BindGroup {
         let group = self.inner.create_bind_group(desc);
-        BindGroup {
-            inner: Arc::new(group),
-        }
+        BindGroup { inner: group }
     }
 
     /// Creates a [`BindGroupLayout`].
@@ -182,36 +180,28 @@ impl Device {
         desc: &BindGroupLayoutDescriptor<'_>,
     ) -> BindGroupLayout {
         let layout = self.inner.create_bind_group_layout(desc);
-        BindGroupLayout {
-            inner: Arc::new(layout),
-        }
+        BindGroupLayout { inner: layout }
     }
 
     /// Creates a [`PipelineLayout`].
     #[must_use]
     pub fn create_pipeline_layout(&self, desc: &PipelineLayoutDescriptor<'_>) -> PipelineLayout {
         let layout = self.inner.create_pipeline_layout(desc);
-        PipelineLayout {
-            inner: Arc::new(layout),
-        }
+        PipelineLayout { inner: layout }
     }
 
     /// Creates a [`RenderPipeline`].
     #[must_use]
     pub fn create_render_pipeline(&self, desc: &RenderPipelineDescriptor<'_>) -> RenderPipeline {
         let pipeline = self.inner.create_render_pipeline(desc);
-        RenderPipeline {
-            inner: Arc::new(pipeline),
-        }
+        RenderPipeline { inner: pipeline }
     }
 
     /// Creates a [`ComputePipeline`].
     #[must_use]
     pub fn create_compute_pipeline(&self, desc: &ComputePipelineDescriptor<'_>) -> ComputePipeline {
         let pipeline = self.inner.create_compute_pipeline(desc);
-        ComputePipeline {
-            inner: Arc::new(pipeline),
-        }
+        ComputePipeline { inner: pipeline }
     }
 
     /// Creates a [`Buffer`].
@@ -327,18 +317,14 @@ impl Device {
     #[must_use]
     pub fn create_sampler(&self, desc: &SamplerDescriptor<'_>) -> Sampler {
         let sampler = self.inner.create_sampler(desc);
-        Sampler {
-            inner: Arc::new(sampler),
-        }
+        Sampler { inner: sampler }
     }
 
     /// Creates a new [`QuerySet`].
     #[must_use]
     pub fn create_query_set(&self, desc: &QuerySetDescriptor<'_>) -> QuerySet {
         let query_set = self.inner.create_query_set(desc);
-        QuerySet {
-            inner: Arc::new(query_set),
-        }
+        QuerySet { inner: query_set }
     }
 
     /// Set a callback for errors that are not handled in error scopes.
@@ -478,9 +464,7 @@ impl Device {
         desc: &PipelineCacheDescriptor<'_>,
     ) -> PipelineCache {
         let cache = unsafe { self.inner.create_pipeline_cache(desc) };
-        PipelineCache {
-            inner: Arc::new(cache),
-        }
+        PipelineCache { inner: cache }
     }
 }
 
@@ -511,7 +495,7 @@ impl Device {
         let (handle, blas) = self.inner.create_blas(desc, sizes);
 
         Blas {
-            inner: Arc::new(blas),
+            inner: blas,
             handle,
         }
     }

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -230,13 +230,11 @@ impl Device {
         let texture = self.inner.create_texture(desc);
 
         Texture {
-            shared: TextureShared {
-                inner: texture,
-                descriptor: TextureDescriptor {
-                    label: None,
-                    view_formats: &[],
-                    ..desc.clone()
-                },
+            inner: texture,
+            descriptor: TextureDescriptor {
+                label: None,
+                view_formats: &[],
+                ..desc.clone()
             },
         }
     }
@@ -262,13 +260,11 @@ impl Device {
                 .create_texture_from_hal::<A>(hal_texture, core_device, desc)
         };
         Texture {
-            shared: TextureShared {
-                inner: texture.into(),
-                descriptor: TextureDescriptor {
-                    label: None,
-                    view_formats: &[],
-                    ..desc.clone()
-                },
+            inner: texture.into(),
+            descriptor: TextureDescriptor {
+                label: None,
+                view_formats: &[],
+                ..desc.clone()
             },
         }
     }

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -2,7 +2,7 @@ use parking_lot::Mutex;
 
 use crate::{dispatch::InstanceInterface, *};
 
-use std::{future::Future, sync::Arc};
+use std::future::Future;
 
 /// Context for all other wgpu objects. Instance of wgpu.
 ///
@@ -14,7 +14,7 @@ use std::{future::Future, sync::Arc};
 /// Corresponds to [WebGPU `GPU`](https://gpuweb.github.io/gpuweb/#gpu-interface).
 #[derive(Debug, Clone)]
 pub struct Instance {
-    inner: Arc<dispatch::DispatchInstance>,
+    inner: dispatch::DispatchInstance,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Instance: Send, Sync);
@@ -131,7 +131,7 @@ impl Instance {
 
             if is_only_available_backend || (requested_webgpu && support_webgpu) {
                 return Self {
-                    inner: Arc::new(crate::backend::ContextWebGpu::new(_instance_desc).into()),
+                    inner: crate::backend::ContextWebGpu::new(_instance_desc).into(),
                 };
             }
         }
@@ -139,7 +139,7 @@ impl Instance {
         #[cfg(wgpu_core)]
         {
             return Self {
-                inner: Arc::new(crate::backend::ContextWgpuCore::new(_instance_desc).into()),
+                inner: crate::backend::ContextWgpuCore::new(_instance_desc).into(),
             };
         }
 
@@ -161,9 +161,7 @@ impl Instance {
     pub unsafe fn from_hal<A: wgc::hal_api::HalApi>(hal_instance: A::Instance) -> Self {
         Self {
             inner: unsafe {
-                Arc::new(
-                    crate::backend::ContextWgpuCore::from_hal_instance::<A>(hal_instance).into(),
-                )
+                crate::backend::ContextWgpuCore::from_hal_instance::<A>(hal_instance).into()
             },
         }
     }
@@ -198,7 +196,7 @@ impl Instance {
     pub unsafe fn from_core(core_instance: wgc::instance::Instance) -> Self {
         Self {
             inner: unsafe {
-                Arc::new(crate::backend::ContextWgpuCore::from_core_instance(core_instance).into())
+                crate::backend::ContextWgpuCore::from_core_instance(core_instance).into()
             },
         }
     }
@@ -222,9 +220,7 @@ impl Instance {
                     context: core_instance.clone(),
                     id: adapter,
                 };
-                crate::Adapter {
-                    inner: Arc::new(core.into()),
-                }
+                crate::Adapter { inner: core.into() }
             })
             .collect()
     }
@@ -241,11 +237,7 @@ impl Instance {
         options: &RequestAdapterOptions<'_, '_>,
     ) -> impl Future<Output = Option<Adapter>> + WasmNotSend {
         let future = self.inner.request_adapter(options);
-        async move {
-            future.await.map(|adapter| Adapter {
-                inner: Arc::new(adapter),
-            })
-        }
+        async move { future.await.map(|adapter| Adapter { inner: adapter }) }
     }
 
     /// Converts a wgpu-hal `ExposedAdapter` to a wgpu [`Adapter`].
@@ -265,9 +257,7 @@ impl Instance {
             id: adapter,
         };
 
-        Adapter {
-            inner: Arc::new(core.into()),
-        }
+        Adapter { inner: core.into() }
     }
 
     /// Creates a new surface targeting a given window/canvas/surface/etc..

--- a/wgpu/src/api/pipeline_cache.rs
+++ b/wgpu/src/api/pipeline_cache.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::*;
 
 /// Handle to a pipeline cache, which is used to accelerate
@@ -66,7 +64,7 @@ use crate::*;
 /// [renaming]: std::fs::rename
 #[derive(Debug, Clone)]
 pub struct PipelineCache {
-    pub(crate) inner: Arc<dispatch::DispatchPipelineCache>,
+    pub(crate) inner: dispatch::DispatchPipelineCache,
 }
 
 #[cfg(send_sync)]

--- a/wgpu/src/api/pipeline_layout.rs
+++ b/wgpu/src/api/pipeline_layout.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::*;
 
 /// Handle to a pipeline layout.
@@ -10,7 +8,7 @@ use crate::*;
 /// Corresponds to [WebGPU `GPUPipelineLayout`](https://gpuweb.github.io/gpuweb/#gpupipelinelayout).
 #[derive(Debug, Clone)]
 pub struct PipelineLayout {
-    pub(crate) inner: Arc<dispatch::DispatchPipelineLayout>,
+    pub(crate) inner: dispatch::DispatchPipelineLayout,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(PipelineLayout: Send, Sync);

--- a/wgpu/src/api/query_set.rs
+++ b/wgpu/src/api/query_set.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::*;
 
 /// Handle to a query set.
@@ -9,7 +7,7 @@ use crate::*;
 /// Corresponds to [WebGPU `GPUQuerySet`](https://gpuweb.github.io/gpuweb/#queryset).
 #[derive(Debug, Clone)]
 pub struct QuerySet {
-    pub(crate) inner: Arc<dispatch::DispatchQuerySet>,
+    pub(crate) inner: dispatch::DispatchQuerySet,
 }
 #[cfg(send_sync)]
 #[cfg(send_sync)]

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -1,7 +1,4 @@
-use std::{
-    ops::{Deref, DerefMut},
-    sync::Arc,
-};
+use std::ops::{Deref, DerefMut};
 
 use crate::*;
 
@@ -14,7 +11,7 @@ use crate::*;
 /// Corresponds to [WebGPU `GPUQueue`](https://gpuweb.github.io/gpuweb/#gpu-queue).
 #[derive(Debug, Clone)]
 pub struct Queue {
-    pub(crate) inner: Arc<dispatch::DispatchQueue>,
+    pub(crate) inner: dispatch::DispatchQueue,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Queue: Send, Sync);

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -77,7 +77,7 @@ impl Drop for QueueWriteBufferView<'_> {
     fn drop(&mut self) {
         self.queue
             .inner
-            .write_staging_buffer(&self.buffer.shared.inner, self.offset, &self.inner);
+            .write_staging_buffer(&self.buffer.inner, self.offset, &self.inner);
     }
 }
 
@@ -103,7 +103,7 @@ impl Queue {
     /// method avoids an intermediate copy and is often able to transfer data
     /// more efficiently than this one.
     pub fn write_buffer(&self, buffer: &Buffer, offset: BufferAddress, data: &[u8]) {
-        self.inner.write_buffer(&buffer.shared.inner, offset, data);
+        self.inner.write_buffer(&buffer.inner, offset, data);
     }
 
     /// Write to a buffer via a directly mapped staging buffer.
@@ -143,7 +143,7 @@ impl Queue {
     ) -> Option<QueueWriteBufferView<'a>> {
         profiling::scope!("Queue::write_buffer_with");
         self.inner
-            .validate_write_buffer(&buffer.shared.inner, offset, size)?;
+            .validate_write_buffer(&buffer.inner, offset, size)?;
         let staging_buffer = self.inner.create_staging_buffer(size)?;
         Some(QueueWriteBufferView {
             queue: self,

--- a/wgpu/src/api/render_bundle.rs
+++ b/wgpu/src/api/render_bundle.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::*;
 
 /// Pre-prepared reusable bundle of GPU operations.
@@ -13,7 +11,7 @@ use crate::*;
 /// Corresponds to [WebGPU `GPURenderBundle`](https://gpuweb.github.io/gpuweb/#render-bundle).
 #[derive(Debug, Clone)]
 pub struct RenderBundle {
-    pub(crate) inner: Arc<dispatch::DispatchRenderBundle>,
+    pub(crate) inner: dispatch::DispatchRenderBundle,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(RenderBundle: Send, Sync);

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::{marker::PhantomData, num::NonZeroU32, ops::Range};
 
 use crate::dispatch::RenderBundleEncoderInterface;
@@ -60,9 +59,7 @@ impl<'a> RenderBundleEncoder<'a> {
             dispatch::DispatchRenderBundleEncoder::WebGPU(b) => b.finish(desc),
         };
 
-        RenderBundle {
-            inner: Arc::new(bundle),
-        }
+        RenderBundle { inner: bundle }
     }
 
     /// Sets the active bind group for a given bind group index. The bind group layout
@@ -74,7 +71,7 @@ impl<'a> RenderBundleEncoder<'a> {
         Option<&'b BindGroup>: From<BG>,
     {
         let bg: Option<&'b BindGroup> = bind_group.into();
-        let bg = bg.map(|x| &*x.inner);
+        let bg = bg.map(|x| &x.inner);
         self.inner.set_bind_group(index, bg, offsets);
     }
 

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -88,7 +88,7 @@ impl<'a> RenderBundleEncoder<'a> {
     /// use `buffer` as the source index buffer.
     pub fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'a>, index_format: IndexFormat) {
         self.inner.set_index_buffer(
-            &buffer_slice.buffer.shared.inner,
+            &buffer_slice.buffer.inner,
             index_format,
             buffer_slice.offset,
             buffer_slice.size,
@@ -108,7 +108,7 @@ impl<'a> RenderBundleEncoder<'a> {
     pub fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'a>) {
         self.inner.set_vertex_buffer(
             slot,
-            &buffer_slice.buffer.shared.inner,
+            &buffer_slice.buffer.inner,
             buffer_slice.offset,
             buffer_slice.size,
         );
@@ -168,7 +168,7 @@ impl<'a> RenderBundleEncoder<'a> {
     /// The structure expected in `indirect_buffer` must conform to [`DrawIndirectArgs`](crate::util::DrawIndirectArgs).
     pub fn draw_indirect(&mut self, indirect_buffer: &'a Buffer, indirect_offset: BufferAddress) {
         self.inner
-            .draw_indirect(&indirect_buffer.shared.inner, indirect_offset);
+            .draw_indirect(&indirect_buffer.inner, indirect_offset);
     }
 
     /// Draws indexed primitives using the active index buffer and the active vertex buffers,
@@ -184,7 +184,7 @@ impl<'a> RenderBundleEncoder<'a> {
         indirect_offset: BufferAddress,
     ) {
         self.inner
-            .draw_indexed_indirect(&indirect_buffer.shared.inner, indirect_offset);
+            .draw_indexed_indirect(&indirect_buffer.inner, indirect_offset);
     }
 }
 

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -70,7 +70,7 @@ impl RenderPass<'_> {
         Option<&'a BindGroup>: From<BG>,
     {
         let bg: Option<&'a BindGroup> = bind_group.into();
-        let bg = bg.map(|bg| &*bg.inner);
+        let bg = bg.map(|bg| &bg.inner);
 
         self.inner.set_bind_group(index, bg, offsets);
     }
@@ -272,7 +272,7 @@ impl RenderPass<'_> {
         &mut self,
         render_bundles: I,
     ) {
-        let mut render_bundles = render_bundles.into_iter().map(|rb| &*rb.inner);
+        let mut render_bundles = render_bundles.into_iter().map(|rb| &rb.inner);
 
         self.inner.execute_bundles(&mut render_bundles);
     }

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -97,7 +97,7 @@ impl RenderPass<'_> {
     /// use `buffer` as the source index buffer.
     pub fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'_>, index_format: IndexFormat) {
         self.inner.set_index_buffer(
-            &buffer_slice.buffer.shared.inner,
+            &buffer_slice.buffer.inner,
             index_format,
             buffer_slice.offset,
             buffer_slice.size,
@@ -117,7 +117,7 @@ impl RenderPass<'_> {
     pub fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'_>) {
         self.inner.set_vertex_buffer(
             slot,
-            &buffer_slice.buffer.shared.inner,
+            &buffer_slice.buffer.inner,
             buffer_slice.offset,
             buffer_slice.size,
         );
@@ -237,7 +237,7 @@ impl RenderPass<'_> {
     /// See details on the individual flags for more information.
     pub fn draw_indirect(&mut self, indirect_buffer: &Buffer, indirect_offset: BufferAddress) {
         self.inner
-            .draw_indirect(&indirect_buffer.shared.inner, indirect_offset);
+            .draw_indirect(&indirect_buffer.inner, indirect_offset);
     }
 
     /// Draws indexed primitives using the active index buffer and the active vertex buffers,
@@ -260,7 +260,7 @@ impl RenderPass<'_> {
         indirect_offset: BufferAddress,
     ) {
         self.inner
-            .draw_indexed_indirect(&indirect_buffer.shared.inner, indirect_offset);
+            .draw_indexed_indirect(&indirect_buffer.inner, indirect_offset);
     }
 
     /// Execute a [render bundle][RenderBundle], which is a set of pre-recorded commands
@@ -297,7 +297,7 @@ impl RenderPass<'_> {
         count: u32,
     ) {
         self.inner
-            .multi_draw_indirect(&indirect_buffer.shared.inner, indirect_offset, count);
+            .multi_draw_indirect(&indirect_buffer.inner, indirect_offset, count);
     }
 
     /// Dispatches multiple draw calls from the active index buffer and the active vertex buffers,
@@ -317,11 +317,8 @@ impl RenderPass<'_> {
         indirect_offset: BufferAddress,
         count: u32,
     ) {
-        self.inner.multi_draw_indexed_indirect(
-            &indirect_buffer.shared.inner,
-            indirect_offset,
-            count,
-        );
+        self.inner
+            .multi_draw_indexed_indirect(&indirect_buffer.inner, indirect_offset, count);
     }
 }
 
@@ -358,9 +355,9 @@ impl RenderPass<'_> {
         max_count: u32,
     ) {
         self.inner.multi_draw_indirect_count(
-            &indirect_buffer.shared.inner,
+            &indirect_buffer.inner,
             indirect_offset,
-            &count_buffer.shared.inner,
+            &count_buffer.inner,
             count_offset,
             max_count,
         );
@@ -400,9 +397,9 @@ impl RenderPass<'_> {
         max_count: u32,
     ) {
         self.inner.multi_draw_indexed_indirect_count(
-            &indirect_buffer.shared.inner,
+            &indirect_buffer.inner,
             indirect_offset,
-            &count_buffer.shared.inner,
+            &count_buffer.inner,
             count_offset,
             max_count,
         );

--- a/wgpu/src/api/render_pipeline.rs
+++ b/wgpu/src/api/render_pipeline.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroU32, sync::Arc};
+use std::num::NonZeroU32;
 
 use crate::*;
 
@@ -10,7 +10,7 @@ use crate::*;
 /// Corresponds to [WebGPU `GPURenderPipeline`](https://gpuweb.github.io/gpuweb/#render-pipeline).
 #[derive(Debug, Clone)]
 pub struct RenderPipeline {
-    pub(crate) inner: Arc<dispatch::DispatchRenderPipeline>,
+    pub(crate) inner: dispatch::DispatchRenderPipeline,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(RenderPipeline: Send, Sync);
@@ -26,9 +26,7 @@ impl RenderPipeline {
     /// This method will raise a validation error if there is no bind group layout at `index`.
     pub fn get_bind_group_layout(&self, index: u32) -> BindGroupLayout {
         let layout = self.inner.get_bind_group_layout(index);
-        BindGroupLayout {
-            inner: Arc::new(layout),
-        }
+        BindGroupLayout { inner: layout }
     }
 }
 

--- a/wgpu/src/api/sampler.rs
+++ b/wgpu/src/api/sampler.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::*;
 
 /// Handle to a sampler.
@@ -13,7 +11,7 @@ use crate::*;
 /// Corresponds to [WebGPU `GPUSampler`](https://gpuweb.github.io/gpuweb/#sampler-interface).
 #[derive(Debug, Clone)]
 pub struct Sampler {
-    pub(crate) inner: Arc<dispatch::DispatchSampler>,
+    pub(crate) inner: dispatch::DispatchSampler,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Sampler: Send, Sync);

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt, sync::Arc};
+use std::{error, fmt};
 
 use parking_lot::Mutex;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
@@ -128,10 +128,10 @@ impl Surface<'_> {
         texture
             .map(|texture| SurfaceTexture {
                 texture: Texture {
-                    shared: Arc::new(TextureShared {
+                    shared: TextureShared {
                         inner: texture,
                         descriptor,
-                    }),
+                    },
                 },
                 suboptimal,
                 presented: false,

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -135,7 +135,7 @@ impl Surface<'_> {
                 },
                 suboptimal,
                 presented: false,
-                detail: Arc::new(detail),
+                detail,
             })
             .ok_or(SurfaceError::Lost)
     }

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -128,10 +128,8 @@ impl Surface<'_> {
         texture
             .map(|texture| SurfaceTexture {
                 texture: Texture {
-                    shared: TextureShared {
-                        inner: texture,
-                        descriptor,
-                    },
+                    inner: texture,
+                    descriptor,
                 },
                 suboptimal,
                 presented: false,

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt, sync::Arc, thread};
+use std::{error, fmt, thread};
 
 use crate::*;
 
@@ -16,7 +16,7 @@ pub struct SurfaceTexture {
     /// but should be recreated for maximum performance.
     pub suboptimal: bool,
     pub(crate) presented: bool,
-    pub(crate) detail: Arc<dispatch::DispatchSurfaceOutputDetail>,
+    pub(crate) detail: dispatch::DispatchSurfaceOutputDetail,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(SurfaceTexture: Send, Sync);

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -21,7 +21,7 @@ pub struct SurfaceTexture {
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(SurfaceTexture: Send, Sync);
 
-crate::cmp::impl_eq_ord_hash_proxy!(SurfaceTexture => .texture.shared.inner);
+crate::cmp::impl_eq_ord_hash_proxy!(SurfaceTexture => .texture.inner);
 
 impl SurfaceTexture {
     /// Schedule this texture to be presented on the owning surface.

--- a/wgpu/src/api/texture.rs
+++ b/wgpu/src/api/texture.rs
@@ -1,11 +1,5 @@
 use crate::*;
 
-#[derive(Debug, Clone)]
-pub(crate) struct TextureShared {
-    pub(crate) inner: dispatch::DispatchTexture,
-    pub(crate) descriptor: TextureDescriptor<'static>,
-}
-
 /// Handle to a texture on the GPU.
 ///
 /// It can be created with [`Device::create_texture`].
@@ -13,12 +7,13 @@ pub(crate) struct TextureShared {
 /// Corresponds to [WebGPU `GPUTexture`](https://gpuweb.github.io/gpuweb/#texture-interface).
 #[derive(Debug, Clone)]
 pub struct Texture {
-    pub(crate) shared: TextureShared,
+    pub(crate) inner: dispatch::DispatchTexture,
+    pub(crate) descriptor: TextureDescriptor<'static>,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Texture: Send, Sync);
 
-crate::cmp::impl_eq_ord_hash_proxy!(Texture => .shared.inner);
+crate::cmp::impl_eq_ord_hash_proxy!(Texture => .inner);
 
 impl Texture {
     /// Returns the inner hal Texture using a callback. The hal texture will be `None` if the
@@ -32,7 +27,7 @@ impl Texture {
         &self,
         hal_texture_callback: F,
     ) -> R {
-        if let Some(tex) = self.shared.inner.as_core_opt() {
+        if let Some(tex) = self.inner.as_core_opt() {
             unsafe {
                 tex.context
                     .texture_as_hal::<A, F, R>(tex, hal_texture_callback)
@@ -44,14 +39,14 @@ impl Texture {
 
     /// Creates a view of this texture.
     pub fn create_view(&self, desc: &TextureViewDescriptor<'_>) -> TextureView {
-        let view = self.shared.inner.create_view(desc);
+        let view = self.inner.create_view(desc);
 
         TextureView { inner: view }
     }
 
     /// Destroy the associated native resources as soon as possible.
     pub fn destroy(&self) {
-        self.shared.inner.destroy();
+        self.inner.destroy();
     }
 
     /// Make an `TexelCopyTextureInfo` representing the whole texture.
@@ -68,63 +63,63 @@ impl Texture {
     ///
     /// This is always equal to the `size` that was specified when creating the texture.
     pub fn size(&self) -> Extent3d {
-        self.shared.descriptor.size
+        self.descriptor.size
     }
 
     /// Returns the width of this `Texture`.
     ///
     /// This is always equal to the `size.width` that was specified when creating the texture.
     pub fn width(&self) -> u32 {
-        self.shared.descriptor.size.width
+        self.descriptor.size.width
     }
 
     /// Returns the height of this `Texture`.
     ///
     /// This is always equal to the `size.height` that was specified when creating the texture.
     pub fn height(&self) -> u32 {
-        self.shared.descriptor.size.height
+        self.descriptor.size.height
     }
 
     /// Returns the depth or layer count of this `Texture`.
     ///
     /// This is always equal to the `size.depth_or_array_layers` that was specified when creating the texture.
     pub fn depth_or_array_layers(&self) -> u32 {
-        self.shared.descriptor.size.depth_or_array_layers
+        self.descriptor.size.depth_or_array_layers
     }
 
     /// Returns the mip_level_count of this `Texture`.
     ///
     /// This is always equal to the `mip_level_count` that was specified when creating the texture.
     pub fn mip_level_count(&self) -> u32 {
-        self.shared.descriptor.mip_level_count
+        self.descriptor.mip_level_count
     }
 
     /// Returns the sample_count of this `Texture`.
     ///
     /// This is always equal to the `sample_count` that was specified when creating the texture.
     pub fn sample_count(&self) -> u32 {
-        self.shared.descriptor.sample_count
+        self.descriptor.sample_count
     }
 
     /// Returns the dimension of this `Texture`.
     ///
     /// This is always equal to the `dimension` that was specified when creating the texture.
     pub fn dimension(&self) -> TextureDimension {
-        self.shared.descriptor.dimension
+        self.descriptor.dimension
     }
 
     /// Returns the format of this `Texture`.
     ///
     /// This is always equal to the `format` that was specified when creating the texture.
     pub fn format(&self) -> TextureFormat {
-        self.shared.descriptor.format
+        self.descriptor.format
     }
 
     /// Returns the allowed usages of this `Texture`.
     ///
     /// This is always equal to the `usage` that was specified when creating the texture.
     pub fn usage(&self) -> TextureUsages {
-        self.shared.descriptor.usage
+        self.descriptor.usage
     }
 }
 

--- a/wgpu/src/api/texture.rs
+++ b/wgpu/src/api/texture.rs
@@ -1,8 +1,6 @@
-use std::sync::Arc;
-
 use crate::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct TextureShared {
     pub(crate) inner: dispatch::DispatchTexture,
     pub(crate) descriptor: TextureDescriptor<'static>,
@@ -15,7 +13,7 @@ pub(crate) struct TextureShared {
 /// Corresponds to [WebGPU `GPUTexture`](https://gpuweb.github.io/gpuweb/#texture-interface).
 #[derive(Debug, Clone)]
 pub struct Texture {
-    pub(crate) shared: Arc<TextureShared>,
+    pub(crate) shared: TextureShared,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Texture: Send, Sync);

--- a/wgpu/src/api/texture.rs
+++ b/wgpu/src/api/texture.rs
@@ -48,9 +48,7 @@ impl Texture {
     pub fn create_view(&self, desc: &TextureViewDescriptor<'_>) -> TextureView {
         let view = self.shared.inner.create_view(desc);
 
-        TextureView {
-            inner: Arc::new(view),
-        }
+        TextureView { inner: view }
     }
 
     /// Destroy the associated native resources as soon as possible.

--- a/wgpu/src/api/texture_view.rs
+++ b/wgpu/src/api/texture_view.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::*;
 
 /// Handle to a texture view.
@@ -10,7 +8,7 @@ use crate::*;
 /// Corresponds to [WebGPU `GPUTextureView`](https://gpuweb.github.io/gpuweb/#gputextureview).
 #[derive(Debug, Clone)]
 pub struct TextureView {
-    pub(crate) inner: Arc<dispatch::DispatchTextureView>,
+    pub(crate) inner: dispatch::DispatchTextureView,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(TextureView: Send, Sync);

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -649,7 +649,7 @@ fn map_buffer_copy_view(
 fn map_texture_copy_view(
     view: crate::TexelCopyTextureInfo<'_>,
 ) -> webgpu_sys::GpuTexelCopyTextureInfo {
-    let texture = view.texture.shared.inner.as_webgpu();
+    let texture = view.texture.inner.as_webgpu();
     let mapped = webgpu_sys::GpuTexelCopyTextureInfo::new(&texture.inner);
     mapped.set_mip_level(view.mip_level);
     mapped.set_origin(&map_origin_3d(view.origin));
@@ -659,7 +659,7 @@ fn map_texture_copy_view(
 fn map_tagged_texture_copy_view(
     view: wgt::CopyExternalImageDestInfo<&crate::api::Texture>,
 ) -> webgpu_sys::GpuCopyExternalImageDestInfo {
-    let texture = view.texture.shared.inner.as_webgpu();
+    let texture = view.texture.inner.as_webgpu();
     let mapped = webgpu_sys::GpuCopyExternalImageDestInfo::new(&texture.inner);
     mapped.set_mip_level(view.mip_level);
     mapped.set_origin(&map_origin_3d(view.origin));
@@ -1938,7 +1938,7 @@ impl dispatch::DeviceInterface for WebDevice {
                         offset,
                         size,
                     }) => {
-                        let buffer = buffer.shared.inner.as_webgpu();
+                        let buffer = buffer.inner.as_webgpu();
                         let mapped_buffer_binding =
                             webgpu_sys::GpuBufferBinding::new(&buffer.inner);
                         mapped_buffer_binding.set_offset(offset as f64);

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -634,7 +634,7 @@ fn map_texture_view_dimension(
 fn map_buffer_copy_view(
     view: crate::TexelCopyBufferInfo<'_>,
 ) -> webgpu_sys::GpuTexelCopyBufferInfo {
-    let buffer = view.buffer.shared.inner.as_webgpu();
+    let buffer = view.buffer.inner.as_webgpu();
     let mapped = webgpu_sys::GpuTexelCopyBufferInfo::new(&buffer.inner);
     if let Some(bytes_per_row) = view.layout.bytes_per_row {
         mapped.set_bytes_per_row(bytes_per_row);

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -373,7 +373,7 @@ fn map_texture_copy_view(
     view: crate::TexelCopyTextureInfo<'_>,
 ) -> wgc::command::TexelCopyTextureInfo {
     wgc::command::TexelCopyTextureInfo {
-        texture: view.texture.shared.inner.as_core().id,
+        texture: view.texture.inner.as_core().id,
         mip_level: view.mip_level,
         origin: view.origin,
         aspect: view.aspect,
@@ -388,7 +388,7 @@ fn map_texture_tagged_copy_view(
     view: wgt::CopyExternalImageDestInfo<&api::Texture>,
 ) -> wgc::command::CopyExternalImageDestInfo {
     wgc::command::CopyExternalImageDestInfo {
-        texture: view.texture.shared.inner.as_core().id,
+        texture: view.texture.inner.as_core().id,
         mip_level: view.mip_level,
         origin: view.origin,
         aspect: view.aspect,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -364,7 +364,7 @@ impl ContextWgpuCore {
 
 fn map_buffer_copy_view(view: crate::TexelCopyBufferInfo<'_>) -> wgc::command::TexelCopyBufferInfo {
     wgc::command::TexelCopyBufferInfo {
-        buffer: view.buffer.shared.inner.as_core().id,
+        buffer: view.buffer.inner.as_core().id,
         layout: view.layout,
     }
 }
@@ -1106,7 +1106,7 @@ impl dispatch::DeviceInterface for CoreDevice {
             for entry in desc.entries.iter() {
                 if let BindingResource::BufferArray(array) = entry.resource {
                     arrayed_buffer_bindings.extend(array.iter().map(|binding| bm::BufferBinding {
-                        buffer_id: binding.buffer.shared.inner.as_core().id,
+                        buffer_id: binding.buffer.inner.as_core().id,
                         offset: binding.offset,
                         size: binding.size,
                     }));
@@ -1126,7 +1126,7 @@ impl dispatch::DeviceInterface for CoreDevice {
                         offset,
                         size,
                     }) => bm::BindingResource::Buffer(bm::BufferBinding {
-                        buffer_id: buffer.shared.inner.as_core().id,
+                        buffer_id: buffer.inner.as_core().id,
                         offset,
                         size,
                     }),
@@ -2438,11 +2438,9 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
                 crate::BlasGeometries::TriangleGeometries(ref triangle_geometries) => {
                     let iter = triangle_geometries.iter().map(|tg| {
                         wgc::ray_tracing::BlasTriangleGeometry {
-                            vertex_buffer: tg.vertex_buffer.shared.inner.as_core().id,
-                            index_buffer: tg.index_buffer.map(|buf| buf.shared.inner.as_core().id),
-                            transform_buffer: tg
-                                .transform_buffer
-                                .map(|buf| buf.shared.inner.as_core().id),
+                            vertex_buffer: tg.vertex_buffer.inner.as_core().id,
+                            index_buffer: tg.index_buffer.map(|buf| buf.inner.as_core().id),
+                            transform_buffer: tg.transform_buffer.map(|buf| buf.inner.as_core().id),
                             size: tg.size,
                             transform_buffer_offset: tg.transform_buffer_offset,
                             first_vertex: tg.first_vertex,
@@ -2462,7 +2460,7 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
         let tlas = tlas.into_iter().map(|e: &crate::TlasBuildEntry<'a>| {
             wgc::ray_tracing::TlasBuildEntry {
                 tlas_id: e.tlas.shared.inner.as_core().id,
-                instance_buffer_id: e.instance_buffer.shared.inner.as_core().id,
+                instance_buffer_id: e.instance_buffer.inner.as_core().id,
                 instance_count: e.instance_count,
             }
         });
@@ -2490,11 +2488,9 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
                 crate::BlasGeometries::TriangleGeometries(ref triangle_geometries) => {
                     let iter = triangle_geometries.iter().map(|tg| {
                         wgc::ray_tracing::BlasTriangleGeometry {
-                            vertex_buffer: tg.vertex_buffer.shared.inner.as_core().id,
-                            index_buffer: tg.index_buffer.map(|buf| buf.shared.inner.as_core().id),
-                            transform_buffer: tg
-                                .transform_buffer
-                                .map(|buf| buf.shared.inner.as_core().id),
+                            vertex_buffer: tg.vertex_buffer.inner.as_core().id,
+                            index_buffer: tg.index_buffer.map(|buf| buf.inner.as_core().id),
+                            transform_buffer: tg.transform_buffer.map(|buf| buf.inner.as_core().id),
                             size: tg.size,
                             transform_buffer_offset: tg.transform_buffer_offset,
                             first_vertex: tg.first_vertex,

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -101,7 +101,7 @@ impl DownloadBuffer {
     ) {
         let size = match buffer.size {
             Some(size) => size.into(),
-            None => buffer.buffer.shared.map_context.lock().total_size - buffer.offset,
+            None => buffer.buffer.map_context.lock().total_size - buffer.offset,
         };
 
         let download = Arc::new(device.create_buffer(&super::BufferDescriptor {
@@ -126,7 +126,7 @@ impl DownloadBuffer {
                     return;
                 }
 
-                let mapped_range = download.shared.inner.get_mapped_range(0..size);
+                let mapped_range = download.inner.get_mapped_range(0..size);
                 callback(Ok(Self {
                     _gpu_buffer: download,
                     mapped_range,


### PR DESCRIPTION
**Connections**
Fixes #6848, builds on #6665

**Description**
Moving Arcs one level lower into dispatch enum. Reviewable per commit.

**Testing**
Existing tests

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
