### PR TITLE
[naga] Handle bitshifts for abstract lhs operands during const evaluation

### DIFF
--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1887,6 +1887,20 @@ impl<'a> ConstantEvaluator<'a> {
                             BinaryOperator::Modulo => a % b,
                             _ => return Err(ConstantEvaluatorError::InvalidBinaryOpArgs),
                         }),
+                        (Literal::AbstractInt(a), Literal::U32(b)) => {
+                            Literal::AbstractInt(match op {
+                                BinaryOperator::ShiftLeft => {
+                                    if (if a.is_negative() { !a } else { a }).leading_zeros() <= b {
+                                        return Err(ConstantEvaluatorError::Overflow(
+                                            "<<".to_string(),
+                                        ));
+                                    }
+                                    a.checked_shl(b).unwrap_or(0)
+                                }
+                                BinaryOperator::ShiftRight => a.checked_shr(b).unwrap_or(0),
+                                _ => return Err(ConstantEvaluatorError::InvalidBinaryOpArgs),
+                            })
+                        }
                         (Literal::AbstractInt(a), Literal::AbstractInt(b)) => {
                             Literal::AbstractInt(match op {
                                 BinaryOperator::Add => a.checked_add(b).ok_or_else(|| {

--- a/naga/tests/in/abstract-types-operators.wgsl
+++ b/naga/tests/in/abstract-types-operators.wgsl
@@ -24,6 +24,16 @@ const bitflip_uai: u32 = ~0xffffffff & (0x100000000 - 1);
 const least_i32: i32 = -2147483648;
 const least_f32: f32 = -3.40282347e+38;
 
+const shl_iaiai: i32 = 1 << 2;
+const shl_iai_u: i32 = 1 << 2u;
+const shl_uaiai: u32 = 1 << 2;
+const shl_uai_u: u32 = 1 << 2u;
+
+const shr_iaiai: i32 = 1 >> 2;
+const shr_iai_u: i32 = 1 >> 2u;
+const shr_uaiai: u32 = 1 >> 2;
+const shr_uai_u: u32 = 1 >> 2u;
+
 fn runtime_values() {
   var f: f32 = 42;
   var i: i32 = 43;

--- a/naga/tests/out/msl/abstract-types-operators.msl
+++ b/naga/tests/out/msl/abstract-types-operators.msl
@@ -28,6 +28,14 @@ constant uint bitflip_u_u = 0u;
 constant uint bitflip_uai = 0u;
 constant int least_i32_ = -2147483648;
 constant float least_f32_ = -340282350000000000000000000000000000000.0;
+constant int shl_iaiai = 4;
+constant int shl_iai_u = 4;
+constant uint shl_uaiai = 4u;
+constant uint shl_uai_u = 4u;
+constant int shr_iaiai = 0;
+constant int shr_iai_u = 0;
+constant uint shr_uaiai = 0u;
+constant uint shr_uai_u = 0u;
 constant int wgpu_4492_ = -2147483648;
 constant int wgpu_4492_2_ = -2147483648;
 

--- a/naga/tests/out/spv/abstract-types-operators.spvasm
+++ b/naga/tests/out/spv/abstract-types-operators.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 100
+; Bound: 103
 OpCapability Shader
 OpCapability Linkage
 %1 = OpExtInstImport "GLSL.std.450"
@@ -19,109 +19,112 @@ OpDecorate %6 ArrayStride 4
 %11 = OpConstant  %5  0
 %12 = OpConstant  %4  -2147483648
 %13 = OpConstant  %3  -3.4028235e38
-%15 = OpTypePointer Workgroup %6
-%14 = OpVariable  %15  Workgroup
-%18 = OpTypeFunction %2
-%19 = OpConstant  %3  42.0
-%20 = OpConstant  %4  43
-%21 = OpConstant  %5  44
-%22 = OpConstant  %3  1.0
-%23 = OpConstant  %3  2.0
-%24 = OpConstant  %4  1
-%25 = OpConstant  %4  2
-%26 = OpConstant  %5  1
-%27 = OpConstant  %5  2
-%29 = OpTypePointer Function %3
-%31 = OpTypePointer Function %4
-%33 = OpTypePointer Function %5
-%37 = OpConstantNull  %3
-%41 = OpConstantNull  %3
-%43 = OpConstantNull  %3
-%45 = OpConstantNull  %3
-%47 = OpConstantNull  %3
-%50 = OpConstantNull  %4
-%52 = OpConstantNull  %4
-%54 = OpConstantNull  %4
-%57 = OpConstantNull  %5
-%59 = OpConstantNull  %5
-%61 = OpConstantNull  %5
-%90 = OpConstant  %3  5.0
-%91 = OpConstant  %3  7.0
-%97 = OpTypePointer Workgroup %5
-%17 = OpFunction  %2  None %18
-%16 = OpLabel
-%60 = OpVariable  %33  Function %61
-%55 = OpVariable  %33  Function %10
-%49 = OpVariable  %31  Function %50
-%44 = OpVariable  %29  Function %45
-%39 = OpVariable  %29  Function %8
-%35 = OpVariable  %29  Function %8
-%30 = OpVariable  %31  Function %20
-%58 = OpVariable  %33  Function %59
-%53 = OpVariable  %31  Function %54
-%48 = OpVariable  %31  Function %9
-%42 = OpVariable  %29  Function %43
-%38 = OpVariable  %29  Function %8
-%34 = OpVariable  %29  Function %8
-%28 = OpVariable  %29  Function %19
-%56 = OpVariable  %33  Function %57
-%51 = OpVariable  %31  Function %52
-%46 = OpVariable  %29  Function %47
-%40 = OpVariable  %29  Function %41
-%36 = OpVariable  %29  Function %37
-%32 = OpVariable  %33  Function %21
-OpBranch %62
-%62 = OpLabel
-%63 = OpLoad  %3  %28
-%64 = OpFAdd  %3  %22 %63
-OpStore %36 %64
-%65 = OpLoad  %3  %28
-%66 = OpFAdd  %3  %22 %65
-OpStore %40 %66
-%67 = OpLoad  %3  %28
-%68 = OpFAdd  %3  %67 %23
-OpStore %42 %68
-%69 = OpLoad  %3  %28
-%70 = OpFAdd  %3  %69 %23
-OpStore %44 %70
-%71 = OpLoad  %3  %28
-%72 = OpLoad  %3  %28
-%73 = OpFAdd  %3  %71 %72
-OpStore %46 %73
-%74 = OpLoad  %4  %30
-%75 = OpIAdd  %4  %24 %74
-OpStore %49 %75
-%76 = OpLoad  %4  %30
-%77 = OpIAdd  %4  %76 %25
-OpStore %51 %77
-%78 = OpLoad  %4  %30
-%79 = OpLoad  %4  %30
-%80 = OpIAdd  %4  %78 %79
-OpStore %53 %80
-%81 = OpLoad  %5  %32
-%82 = OpIAdd  %5  %26 %81
-OpStore %56 %82
-%83 = OpLoad  %5  %32
-%84 = OpIAdd  %5  %83 %27
-OpStore %58 %84
-%85 = OpLoad  %5  %32
-%86 = OpLoad  %5  %32
-%87 = OpIAdd  %5  %85 %86
-OpStore %60 %87
+%14 = OpConstant  %4  4
+%15 = OpConstant  %5  4
+%16 = OpConstant  %4  0
+%18 = OpTypePointer Workgroup %6
+%17 = OpVariable  %18  Workgroup
+%21 = OpTypeFunction %2
+%22 = OpConstant  %3  42.0
+%23 = OpConstant  %4  43
+%24 = OpConstant  %5  44
+%25 = OpConstant  %3  1.0
+%26 = OpConstant  %3  2.0
+%27 = OpConstant  %4  1
+%28 = OpConstant  %4  2
+%29 = OpConstant  %5  1
+%30 = OpConstant  %5  2
+%32 = OpTypePointer Function %3
+%34 = OpTypePointer Function %4
+%36 = OpTypePointer Function %5
+%40 = OpConstantNull  %3
+%44 = OpConstantNull  %3
+%46 = OpConstantNull  %3
+%48 = OpConstantNull  %3
+%50 = OpConstantNull  %3
+%53 = OpConstantNull  %4
+%55 = OpConstantNull  %4
+%57 = OpConstantNull  %4
+%60 = OpConstantNull  %5
+%62 = OpConstantNull  %5
+%64 = OpConstantNull  %5
+%93 = OpConstant  %3  5.0
+%94 = OpConstant  %3  7.0
+%100 = OpTypePointer Workgroup %5
+%20 = OpFunction  %2  None %21
+%19 = OpLabel
+%63 = OpVariable  %36  Function %64
+%58 = OpVariable  %36  Function %10
+%52 = OpVariable  %34  Function %53
+%47 = OpVariable  %32  Function %48
+%42 = OpVariable  %32  Function %8
+%38 = OpVariable  %32  Function %8
+%33 = OpVariable  %34  Function %23
+%61 = OpVariable  %36  Function %62
+%56 = OpVariable  %34  Function %57
+%51 = OpVariable  %34  Function %9
+%45 = OpVariable  %32  Function %46
+%41 = OpVariable  %32  Function %8
+%37 = OpVariable  %32  Function %8
+%31 = OpVariable  %32  Function %22
+%59 = OpVariable  %36  Function %60
+%54 = OpVariable  %34  Function %55
+%49 = OpVariable  %32  Function %50
+%43 = OpVariable  %32  Function %44
+%39 = OpVariable  %32  Function %40
+%35 = OpVariable  %36  Function %24
+OpBranch %65
+%65 = OpLabel
+%66 = OpLoad  %3  %31
+%67 = OpFAdd  %3  %25 %66
+OpStore %39 %67
+%68 = OpLoad  %3  %31
+%69 = OpFAdd  %3  %25 %68
+OpStore %43 %69
+%70 = OpLoad  %3  %31
+%71 = OpFAdd  %3  %70 %26
+OpStore %45 %71
+%72 = OpLoad  %3  %31
+%73 = OpFAdd  %3  %72 %26
+OpStore %47 %73
+%74 = OpLoad  %3  %31
+%75 = OpLoad  %3  %31
+%76 = OpFAdd  %3  %74 %75
+OpStore %49 %76
+%77 = OpLoad  %4  %33
+%78 = OpIAdd  %4  %27 %77
+OpStore %52 %78
+%79 = OpLoad  %4  %33
+%80 = OpIAdd  %4  %79 %28
+OpStore %54 %80
+%81 = OpLoad  %4  %33
+%82 = OpLoad  %4  %33
+%83 = OpIAdd  %4  %81 %82
+OpStore %56 %83
+%84 = OpLoad  %5  %35
+%85 = OpIAdd  %5  %29 %84
+OpStore %59 %85
+%86 = OpLoad  %5  %35
+%87 = OpIAdd  %5  %86 %30
+OpStore %61 %87
+%88 = OpLoad  %5  %35
+%89 = OpLoad  %5  %35
+%90 = OpIAdd  %5  %88 %89
+OpStore %63 %90
 OpReturn
 OpFunctionEnd
-%89 = OpFunction  %2  None %18
-%88 = OpLabel
-OpBranch %92
-%92 = OpLabel
-OpReturn
-OpFunctionEnd
-%94 = OpFunction  %2  None %18
-%93 = OpLabel
+%92 = OpFunction  %2  None %21
+%91 = OpLabel
 OpBranch %95
 %95 = OpLabel
-%96 = OpISub  %4  %24 %24
-%98 = OpAccessChain  %97  %14 %96
-%99 = OpLoad  %5  %98
+OpReturn
+OpFunctionEnd
+%97 = OpFunction  %2  None %21
+%96 = OpLabel
+OpBranch %98
+%98 = OpLabel
+%99 = OpISub  %4  %27 %27
+%101 = OpAccessChain  %100  %17 %99
+%102 = OpLoad  %5  %101
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/abstract-types-operators.wgsl
+++ b/naga/tests/out/wgsl/abstract-types-operators.wgsl
@@ -19,6 +19,14 @@ const bitflip_u_u: u32 = 0u;
 const bitflip_uai: u32 = 0u;
 const least_i32_: i32 = i32(-2147483648);
 const least_f32_: f32 = -340282350000000000000000000000000000000f;
+const shl_iaiai: i32 = 4i;
+const shl_iai_u: i32 = 4i;
+const shl_uaiai: u32 = 4u;
+const shl_uai_u: u32 = 4u;
+const shr_iaiai: i32 = 0i;
+const shr_iai_u: i32 = 0i;
+const shr_uaiai: u32 = 0u;
+const shr_uai_u: u32 = 0u;
 const wgpu_4492_: i32 = i32(-2147483648);
 const wgpu_4492_2_: i32 = i32(-2147483648);
 


### PR DESCRIPTION
**Connections**
There's some discussion of this in #5085 but that's a larger issue

**Description**
Const evaluation currently doesn't handle the case where the LHS operand is an abstract int.

eg
```wgsl
let x = 1 << 1;
```

gives this error message: `error: failed to convert expression to a concrete type: Cannot cast scalar components of expression [4] Binary { op: ShiftLeft, left: [1], right: [3] } to type i32`

This is the same error message given when the lhs is abstract and the rhs operand is *not* constant therefore the expression cannot be const evaluated away, which is bug #5085. This patch will only fix the case where the rhs is constant.

The spec seems more tolerant of overflow in the abstract case than non-abstract, so this is not simply copying the existing implementation for an I32 left operand. I think I've got this right but would be good to have another pair of eyes on it.

**Testing**
Manual testing of shaders. Added simple cases to abstract-types-operators.wgsl

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
