### PR TITLE
Refine Multi-Draw-Indirect

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -484,10 +484,10 @@ impl RenderBundleEncoder {
                     )
                     .map_pass_err(scope)?;
                 }
-                RenderCommand::MultiDrawIndirect {
+                RenderCommand::DrawIndirect {
                     buffer_id,
                     offset,
-                    count: None,
+                    count: 1,
                     indexed,
                 } => {
                     let scope = PassErrorScope::Draw {
@@ -504,7 +504,7 @@ impl RenderBundleEncoder {
                     )
                     .map_pass_err(scope)?;
                 }
-                RenderCommand::MultiDrawIndirect { .. }
+                RenderCommand::DrawIndirect { .. }
                 | RenderCommand::MultiDrawIndirectCount { .. } => unimplemented!(),
                 RenderCommand::PushDebugGroup { color: _, len: _ } => unimplemented!(),
                 RenderCommand::InsertDebugMarker { color: _, len: _ } => unimplemented!(),
@@ -887,10 +887,10 @@ fn multi_draw_indirect(
 
     state.flush_vertices();
     state.flush_binds(used_bind_groups, dynamic_offsets);
-    state.commands.push(ArcRenderCommand::MultiDrawIndirect {
+    state.commands.push(ArcRenderCommand::DrawIndirect {
         buffer,
         offset,
-        count: None,
+        count: 1,
         indexed,
     });
     Ok(())
@@ -1101,25 +1101,25 @@ impl RenderBundle {
                         )
                     };
                 }
-                Cmd::MultiDrawIndirect {
+                Cmd::DrawIndirect {
                     buffer,
                     offset,
-                    count: None,
+                    count: 1,
                     indexed: false,
                 } => {
                     let buffer = buffer.try_raw(snatch_guard)?;
                     unsafe { raw.draw_indirect(buffer, *offset, 1) };
                 }
-                Cmd::MultiDrawIndirect {
+                Cmd::DrawIndirect {
                     buffer,
                     offset,
-                    count: None,
+                    count: 1,
                     indexed: true,
                 } => {
                     let buffer = buffer.try_raw(snatch_guard)?;
                     unsafe { raw.draw_indexed_indirect(buffer, *offset, 1) };
                 }
-                Cmd::MultiDrawIndirect { .. } | Cmd::MultiDrawIndirectCount { .. } => {
+                Cmd::DrawIndirect { .. } | Cmd::MultiDrawIndirectCount { .. } => {
                     return Err(ExecutionError::Unimplemented("multi-draw-indirect"))
                 }
                 Cmd::PushDebugGroup { .. } | Cmd::InsertDebugMarker { .. } | Cmd::PopDebugGroup => {
@@ -1727,10 +1727,10 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        bundle.base.commands.push(RenderCommand::MultiDrawIndirect {
+        bundle.base.commands.push(RenderCommand::DrawIndirect {
             buffer_id,
             offset,
-            count: None,
+            count: 1,
             indexed: false,
         });
     }
@@ -1740,10 +1740,10 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        bundle.base.commands.push(RenderCommand::MultiDrawIndirect {
+        bundle.base.commands.push(RenderCommand::DrawIndirect {
             buffer_id,
             offset,
-            count: None,
+            count: 1,
             indexed: true,
         });
     }

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use wgt::{BufferAddress, BufferSize, Color};
 
-use std::{num::NonZeroU32, sync::Arc};
+use std::sync::Arc;
 
 use super::{Rect, RenderBundle};
 
@@ -82,11 +82,10 @@ pub enum RenderCommand {
         base_vertex: i32,
         first_instance: u32,
     },
-    MultiDrawIndirect {
+    DrawIndirect {
         buffer_id: id::BufferId,
         offset: BufferAddress,
-        /// Count of `None` represents a non-multi call.
-        count: Option<NonZeroU32>,
+        count: u32,
         indexed: bool,
     },
     MultiDrawIndirectCount {
@@ -311,16 +310,16 @@ impl RenderCommand {
                             first_instance,
                         },
 
-                        RenderCommand::MultiDrawIndirect {
+                        RenderCommand::DrawIndirect {
                             buffer_id,
                             offset,
                             count,
                             indexed,
-                        } => ArcRenderCommand::MultiDrawIndirect {
+                        } => ArcRenderCommand::DrawIndirect {
                             buffer: buffers_guard.get(buffer_id).get().map_err(|e| {
                                 RenderPassError {
                                     scope: PassErrorScope::Draw {
-                                        kind: if count.is_some() {
+                                        kind: if count != 1 {
                                             DrawKind::MultiDrawIndirect
                                         } else {
                                             DrawKind::DrawIndirect
@@ -459,11 +458,10 @@ pub enum ArcRenderCommand {
         base_vertex: i32,
         first_instance: u32,
     },
-    MultiDrawIndirect {
+    DrawIndirect {
         buffer: Arc<Buffer>,
         offset: BufferAddress,
-        /// Count of `None` represents a non-multi call.
-        count: Option<NonZeroU32>,
+        count: u32,
         indexed: bool,
     },
     MultiDrawIndirectCount {

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -372,6 +372,8 @@ impl super::Adapter {
         } else {
             vertex_shader_storage_textures.min(fragment_shader_storage_textures)
         };
+        let indirect_execution =
+            supported((3, 1), (4, 3)) || extensions.contains("GL_ARB_multi_draw_indirect");
 
         let mut downlevel_flags = wgt::DownlevelFlags::empty()
             | wgt::DownlevelFlags::NON_POWER_OF_TWO_MIPMAPPED_TEXTURES
@@ -383,10 +385,7 @@ impl super::Adapter {
             wgt::DownlevelFlags::FRAGMENT_WRITABLE_STORAGE,
             max_storage_block_size != 0,
         );
-        downlevel_flags.set(
-            wgt::DownlevelFlags::INDIRECT_EXECUTION,
-            supported((3, 1), (4, 3)) || extensions.contains("GL_ARB_multi_draw_indirect"),
-        );
+        downlevel_flags.set(wgt::DownlevelFlags::INDIRECT_EXECUTION, indirect_execution);
         downlevel_flags.set(wgt::DownlevelFlags::BASE_VERTEX, supported((3, 2), (3, 2)));
         downlevel_flags.set(
             wgt::DownlevelFlags::INDEPENDENT_BLEND,
@@ -471,6 +470,8 @@ impl super::Adapter {
             wgt::Features::SHADER_EARLY_DEPTH_TEST,
             supported((3, 1), (4, 2)) || extensions.contains("GL_ARB_shader_image_load_store"),
         );
+        // We emulate MDI with a loop of draw calls.
+        features.set(wgt::Features::MULTI_DRAW_INDIRECT, indirect_execution);
         if extensions.contains("GL_ARB_timer_query") {
             features.set(wgt::Features::TIMESTAMP_QUERY, true);
             features.set(wgt::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS, true);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -638,12 +638,17 @@ bitflags::bitflags! {
         ///
         /// Allows multiple indirect calls to be dispatched from a single buffer.
         ///
-        /// Supported platforms:
+        /// Natively Supported Platforms:
         /// - DX12
         /// - Vulkan
-        /// - Metal on Apple3+ or Mac1+ (Emulated on top of `draw_indirect` and `draw_indexed_indirect`)
-        ///
-        /// This is a native only feature.
+        /// 
+        /// Emulated Platforms:
+        /// - Metal
+        /// - OpenGL
+        /// - WebGPU
+        /// 
+        /// Emulation is preformed by looping over the individual indirect draw calls in the backend. This is still significantly
+        /// faster than enulating it yourself, as wgpu only does draw call validation once.
         ///
         /// [`RenderPass::multi_draw_indirect`]: ../wgpu/struct.RenderPass.html#method.multi_draw_indirect
         /// [`RenderPass::multi_draw_indexed_indirect`]: ../wgpu/struct.RenderPass.html#method.multi_draw_indexed_indirect

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -641,12 +641,12 @@ bitflags::bitflags! {
         /// Natively Supported Platforms:
         /// - DX12
         /// - Vulkan
-        /// 
+        ///
         /// Emulated Platforms:
         /// - Metal
         /// - OpenGL
         /// - WebGPU
-        /// 
+        ///
         /// Emulation is preformed by looping over the individual indirect draw calls in the backend. This is still significantly
         /// faster than enulating it yourself, as wgpu only does draw call validation once.
         ///

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -784,7 +784,7 @@ const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 12] = [
 
 fn map_wgt_features(supported_features: webgpu_sys::GpuSupportedFeatures) -> wgt::Features {
     // We emulate MDI.
-    let mut features = wgpu::Features::MULTI_DRAW_INDIRECT;
+    let mut features = wgt::Features::MULTI_DRAW_INDIRECT;
     for (wgpu_feat, web_feat) in FEATURES_MAPPING {
         match wasm_bindgen::JsValue::from(web_feat).as_string() {
             Some(value) if supported_features.has(&value) => features |= wgpu_feat,

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -783,7 +783,8 @@ const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 12] = [
 ];
 
 fn map_wgt_features(supported_features: webgpu_sys::GpuSupportedFeatures) -> wgt::Features {
-    let mut features = wgt::Features::empty();
+    // We emulate MDI.
+    let mut features = wgpu::Features::MULTI_DRAW_INDIRECT;
     for (wgpu_feat, web_feat) in FEATURES_MAPPING {
         match wasm_bindgen::JsValue::from(web_feat).as_string() {
             Some(value) if supported_features.has(&value) => features |= wgpu_feat,


### PR DESCRIPTION
**Connections**

Closes #6854 

**Description**

This properly unifies validation for multi-draw indirect. It also properly exposes the fact that all backends emulate MDI if it is not available.

**Testing**

MDI doesn't have any real testing, but that's probably out of scope for this issue.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
