### PR TITLE
[naga wgsl-in] Disallow named component expression for matrix types

### DIFF
--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -2060,11 +2060,9 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
                         lowered_base.map(|base| crate::Expression::AccessIndex { base, index })
                     }
-                    crate::TypeInner::Vector { .. } | crate::TypeInner::Matrix { .. } => {
+                    crate::TypeInner::Vector { .. } => {
                         match Components::new(field.name, field.span)? {
                             Components::Swizzle { size, pattern } => {
-                                // Swizzles aren't allowed on matrices, but
-                                // validation will catch that.
                                 Typed::Plain(crate::Expression::Swizzle {
                                     size,
                                     vector: ctx.apply_load_rule(lowered_base)?,

--- a/naga/src/front/wgsl/tests.rs
+++ b/naga/src/front/wgsl/tests.rs
@@ -399,6 +399,14 @@ fn parse_postfix() {
     }",
     )
     .unwrap();
+
+    let err = parse_str(
+        "fn foo() {
+        let v = mat4x4<f32>().x;
+    }",
+    )
+    .unwrap_err();
+    assert_eq!(err.message(), "invalid field accessor `x`");
 }
 
 #[test]

--- a/naga/tests/in/shadow.wgsl
+++ b/naga/tests/in/shadow.wgsl
@@ -37,7 +37,7 @@ fn vs_main(
     let w = u_entity.world;
     let world_pos = u_entity.world * vec4<f32>(position);
     var out: VertexOutput;
-    out.world_normal = mat3x3<f32>(w.x.xyz, w.y.xyz, w.z.xyz) * vec3<f32>(normal.xyz);
+    out.world_normal = mat3x3<f32>(w[0].xyz, w[1].xyz, w[2].xyz) * vec3<f32>(normal.xyz);
     out.world_position = world_pos;
     out.proj_position = u_globals.view_proj * world_pos;
     return out;

--- a/naga/tests/in/skybox.wgsl
+++ b/naga/tests/in/skybox.wgsl
@@ -22,7 +22,7 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
         1.0,
     );
 
-    let inv_model_view = transpose(mat3x3<f32>(r_data.view.x.xyz, r_data.view.y.xyz, r_data.view.z.xyz));
+    let inv_model_view = transpose(mat3x3<f32>(r_data.view[0].xyz, r_data.view[1].xyz, r_data.view[2].xyz));
     let unprojected = r_data.proj_inv * pos;
     return VertexOutput(pos, inv_model_view * unprojected.xyz);
 }

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -1238,8 +1238,8 @@ fn pointer_type_equivalence() {
 
             fn g() {
                var m: mat2x2<f32>;
-               let pv: ptr<function, vec2<f32>> = &m.x;
-               let pf: ptr<function, f32> = &m.x.x;
+               let pv: ptr<function, vec2<f32>> = &m[0];
+               let pf: ptr<function, f32> = &m[0].x;
 
                f(pv, pf);
             }


### PR DESCRIPTION
**Connections**
Fixes #5496

**Description**
The WGSL spec only allows named component expressions when the base type is a vector or a structure, so this patch removes support for it for matrices. Additionally tests which used this for matrices have been updated to use indexing expressions instead, and a test has been added to ensure a named component expression on a matrix results in an error.

**Testing**
Added a test to ensure the bad code errors during parsing

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
