### PR TITLE
Don't Run CI On Trunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["*"]
+    branches-ignore: ["trunk"]
     tags: [v0.*]
   pull_request:
   merge_group:

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -2,7 +2,7 @@ name: Shaders
 
 on:
   push:
-    branches: ["*"]
+    branches-ignore: ["trunk"]
     tags: [v0.*]
   pull_request:
   merge_group:


### PR DESCRIPTION
This should be handled by the new merge queue, making running directly on trunk a waste of resources.