### PR TITLE
Use more Rust features allowed under `REPO_MSRV`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4009,7 +4009,6 @@ dependencies = [
  "criterion",
  "naga",
  "nanorand",
- "once_cell",
  "pollster",
  "profiling",
  "rayon",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -43,7 +43,6 @@ naga = { workspace = true, features = [
     "wgsl-out",
 ] }
 nanorand.workspace = true
-once_cell.workspace = true
 pollster.workspace = true
 profiling.workspace = true
 rayon.workspace = true

--- a/benches/benches/bind_groups.rs
+++ b/benches/benches/bind_groups.rs
@@ -5,7 +5,7 @@ use std::{
 
 use criterion::{criterion_group, Criterion, Throughput};
 use nanorand::{Rng, WyRand};
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 use crate::DeviceState;
 
@@ -60,7 +60,7 @@ impl BindGroupState {
 }
 
 fn run_bench(ctx: &mut Criterion) {
-    let state = Lazy::new(BindGroupState::new);
+    let state = LazyLock::new(BindGroupState::new);
 
     if !state
         .device_state

--- a/benches/benches/computepass.rs
+++ b/benches/benches/computepass.rs
@@ -5,8 +5,8 @@ use std::{
 
 use criterion::{criterion_group, Criterion, Throughput};
 use nanorand::{Rng, WyRand};
-use once_cell::sync::Lazy;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use std::sync::LazyLock;
 
 use crate::DeviceState;
 
@@ -424,7 +424,7 @@ impl ComputepassState {
 }
 
 fn run_bench(ctx: &mut Criterion) {
-    let state = Lazy::new(ComputepassState::new);
+    let state = LazyLock::new(ComputepassState::new);
 
     let dispatch_count = dispatch_count();
     let dispatch_count_bindless = dispatch_count_bindless();
@@ -449,7 +449,7 @@ fn run_bench(ctx: &mut Criterion) {
             group.bench_function(
                 format!("{cpasses} computepasses x {dispatch_per_pass} dispatches ({label})"),
                 |b| {
-                    Lazy::force(&state);
+                    LazyLock::force(&state);
 
                     b.iter_custom(|iters| {
                         profiling::scope!("benchmark invocation");
@@ -498,7 +498,7 @@ fn run_bench(ctx: &mut Criterion) {
         group.bench_function(
             format!("{threads} threads x {dispatch_per_pass} dispatch"),
             |b| {
-                Lazy::force(&state);
+                LazyLock::force(&state);
 
                 b.iter_custom(|iters| {
                     profiling::scope!("benchmark invocation");
@@ -538,7 +538,7 @@ fn run_bench(ctx: &mut Criterion) {
     group.throughput(Throughput::Elements(dispatch_count_bindless as _));
 
     group.bench_function(format!("{dispatch_count_bindless} dispatch"), |b| {
-        Lazy::force(&state);
+        LazyLock::force(&state);
 
         b.iter_custom(|iters| {
             profiling::scope!("benchmark invocation");
@@ -579,7 +579,7 @@ fn run_bench(ctx: &mut Criterion) {
             texture_count + storage_texture_count + storage_buffer_count
         ),
         |b| {
-            Lazy::force(&state);
+            LazyLock::force(&state);
 
             b.iter(|| state.device_state.queue.submit([]));
         },

--- a/benches/benches/renderpass.rs
+++ b/benches/benches/renderpass.rs
@@ -5,8 +5,8 @@ use std::{
 
 use criterion::{criterion_group, Criterion, Throughput};
 use nanorand::{Rng, WyRand};
-use once_cell::sync::Lazy;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use std::sync::LazyLock;
 
 use crate::DeviceState;
 
@@ -427,7 +427,7 @@ impl RenderpassState {
 }
 
 fn run_bench(ctx: &mut Criterion) {
-    let state = Lazy::new(RenderpassState::new);
+    let state = LazyLock::new(RenderpassState::new);
 
     let draw_count = draw_count();
     let vertex_buffer_count = draw_count * VERTEX_BUFFERS_PER_DRAW;
@@ -450,7 +450,7 @@ fn run_bench(ctx: &mut Criterion) {
             group.bench_function(
                 format!("{rpasses} renderpasses x {draws_per_pass} draws ({label})"),
                 |b| {
-                    Lazy::force(&state);
+                    LazyLock::force(&state);
 
                     b.iter_custom(|iters| {
                         profiling::scope!("benchmark invocation");
@@ -502,7 +502,7 @@ fn run_bench(ctx: &mut Criterion) {
     for threads in [2, 4, 8] {
         let draws_per_pass = draw_count / threads;
         group.bench_function(format!("{threads} threads x {draws_per_pass} draws"), |b| {
-            Lazy::force(&state);
+            LazyLock::force(&state);
 
             b.iter_custom(|iters| {
                 profiling::scope!("benchmark invocation");
@@ -541,7 +541,7 @@ fn run_bench(ctx: &mut Criterion) {
     group.throughput(Throughput::Elements(draw_count as _));
 
     group.bench_function(format!("{draw_count} draws"), |b| {
-        Lazy::force(&state);
+        LazyLock::force(&state);
 
         b.iter_custom(|iters| {
             profiling::scope!("benchmark invocation");
@@ -577,7 +577,7 @@ fn run_bench(ctx: &mut Criterion) {
             texture_count + vertex_buffer_count
         ),
         |b| {
-            Lazy::force(&state);
+            LazyLock::force(&state);
 
             b.iter(|| state.device_state.queue.submit([]));
         },

--- a/benches/benches/resource_creation.rs
+++ b/benches/benches/resource_creation.rs
@@ -1,13 +1,13 @@
 use std::time::{Duration, Instant};
 
 use criterion::{criterion_group, Criterion, Throughput};
-use once_cell::sync::Lazy;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use std::sync::LazyLock;
 
 use crate::DeviceState;
 
 fn run_bench(ctx: &mut Criterion) {
-    let state = Lazy::new(DeviceState::new);
+    let state = LazyLock::new(DeviceState::new);
 
     const RESOURCES_TO_CREATE: usize = 8;
 
@@ -19,7 +19,7 @@ fn run_bench(ctx: &mut Criterion) {
         group.bench_function(
             format!("{threads} threads x {resources_per_thread} resource"),
             |b| {
-                Lazy::force(&state);
+                LazyLock::force(&state);
 
                 b.iter_custom(|iters| {
                     profiling::scope!("benchmark invocation");

--- a/examples/src/boids/mod.rs
+++ b/examples/src/boids/mod.rs
@@ -2,7 +2,6 @@
 // adapted from https://github.com/austinEng/webgpu-samples/blob/master/src/examples/computeBoids.ts
 
 use nanorand::{Rng, WyRand};
-use std::mem::size_of;
 use wgpu::util::DeviceExt;
 
 // number of boid particles to simulate

--- a/examples/src/bunnymark/mod.rs
+++ b/examples/src/bunnymark/mod.rs
@@ -1,6 +1,6 @@
 use bytemuck::{Pod, Zeroable};
 use nanorand::{Rng, WyRand};
-use std::{borrow::Cow, mem::size_of};
+use std::borrow::Cow;
 use wgpu::util::DeviceExt;
 use winit::{
     event::{ElementState, KeyEvent},

--- a/examples/src/cube/mod.rs
+++ b/examples/src/cube/mod.rs
@@ -1,5 +1,5 @@
 use bytemuck::{Pod, Zeroable};
-use std::{f32::consts, mem::size_of};
+use std::f32::consts;
 use wgpu::util::DeviceExt;
 
 #[repr(C)]

--- a/examples/src/framework.rs
+++ b/examples/src/framework.rs
@@ -362,8 +362,7 @@ async fn start<E: Example>(title: &str) {
     }
 
     log::info!("Entering event loop...");
-    // On native this is a result, but on wasm it's a unit type.
-    #[allow(clippy::let_unit_value)]
+    #[cfg_attr(target_arch = "wasm32", expect(clippy::let_unit_value))]
     let _ = (event_loop_function)(
         window_loop.event_loop,
         move |event: Event<()>, target: &EventLoopWindowTarget<()>| {

--- a/examples/src/hello/mod.rs
+++ b/examples/src/hello/mod.rs
@@ -1,6 +1,5 @@
 /// This example shows how to describe the adapter in use.
 async fn run() {
-    #[cfg_attr(target_arch = "wasm32", allow(unused_variables))]
     let adapter = {
         let instance = wgpu::Instance::default();
         #[cfg(not(target_arch = "wasm32"))]

--- a/examples/src/hello_compute/mod.rs
+++ b/examples/src/hello_compute/mod.rs
@@ -1,4 +1,4 @@
-use std::{mem::size_of_val, str::FromStr};
+use std::str::FromStr;
 use wgpu::util::DeviceExt;
 
 // Indicates a u32 overflow in an intermediate Collatz value

--- a/examples/src/hello_compute/mod.rs
+++ b/examples/src/hello_compute/mod.rs
@@ -4,7 +4,6 @@ use wgpu::util::DeviceExt;
 // Indicates a u32 overflow in an intermediate Collatz value
 const OVERFLOW: u32 = 0xffffffff;
 
-#[cfg_attr(test, allow(dead_code))]
 async fn run() {
     let numbers = if std::env::args().len() <= 2 {
         let default = vec![1, 2, 3, 4];
@@ -32,7 +31,6 @@ async fn run() {
     log::info!("Steps: [{}]", disp_steps.join(", "));
 }
 
-#[cfg_attr(test, allow(dead_code))]
 async fn execute_gpu(numbers: &[u32]) -> Option<Vec<u32>> {
     // Instantiates instance of WebGPU
     let instance = wgpu::Instance::default();

--- a/examples/src/hello_synchronization/mod.rs
+++ b/examples/src/hello_synchronization/mod.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of_val;
-
 const ARR_SIZE: usize = 128;
 
 struct ExecuteResults {

--- a/examples/src/hello_synchronization/mod.rs
+++ b/examples/src/hello_synchronization/mod.rs
@@ -2,11 +2,9 @@ const ARR_SIZE: usize = 128;
 
 struct ExecuteResults {
     patient_workgroup_results: Vec<u32>,
-    #[cfg_attr(test, allow(unused))]
     hasty_workgroup_results: Vec<u32>,
 }
 
-#[cfg_attr(test, allow(unused))]
 async fn run() {
     let instance = wgpu::Instance::default();
     let adapter = instance

--- a/examples/src/hello_triangle/mod.rs
+++ b/examples/src/hello_triangle/mod.rs
@@ -147,7 +147,10 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
 
 pub fn main() {
     let event_loop = EventLoop::new().unwrap();
-    #[allow(unused_mut)]
+    #[cfg_attr(
+        not(target_arch = "wasm32"),
+        expect(unused_mut, reason = "`wasm32` re-assigns to specify canvas")
+    )]
     let mut builder = winit::window::WindowBuilder::new();
     #[cfg(target_arch = "wasm32")]
     {

--- a/examples/src/hello_workgroups/mod.rs
+++ b/examples/src/hello_workgroups/mod.rs
@@ -7,8 +7,6 @@
 //!
 //! Only parts specific to this example will be commented.
 
-use std::mem::size_of_val;
-
 use wgpu::util::DeviceExt;
 
 async fn run() {

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::arc_with_non_send_sync)] // False positive on wasm
+#![warn(clippy::allow_attributes)]
 
 pub mod framework;
 pub mod utils;

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -1,9 +1,9 @@
 struct ExampleDesc {
     name: &'static str,
     function: fn(),
-    #[allow(dead_code)] // isn't used on native
+    #[cfg_attr(not(target_arch = "wasm32"), expect(dead_code))]
     webgl: bool,
-    #[allow(dead_code)] // isn't used on native
+    #[cfg_attr(not(target_arch = "wasm32"), expect(dead_code))]
     webgpu: bool,
 }
 

--- a/examples/src/mipmap/mod.rs
+++ b/examples/src/mipmap/mod.rs
@@ -1,5 +1,5 @@
 use bytemuck::{Pod, Zeroable};
-use std::{f32::consts, mem::size_of};
+use std::f32::consts;
 use wgpu::util::DeviceExt;
 
 const TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;

--- a/examples/src/msaa_line/mod.rs
+++ b/examples/src/msaa_line/mod.rs
@@ -7,7 +7,7 @@
 //! *   Set the primitive_topology to PrimitiveTopology::LineList.
 //! *   Vertices and Indices describe the two points that make up a line.
 
-use std::{iter, mem::size_of};
+use std::iter;
 
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;

--- a/examples/src/msaa_line/mod.rs
+++ b/examples/src/msaa_line/mod.rs
@@ -214,7 +214,7 @@ impl crate::framework::Example for Example {
         }
     }
 
-    #[allow(clippy::single_match)]
+    #[expect(clippy::single_match)]
     fn update(&mut self, event: winit::event::WindowEvent) {
         match event {
             WindowEvent::KeyboardInput {

--- a/examples/src/ray_cube_compute/mod.rs
+++ b/examples/src/ray_cube_compute/mod.rs
@@ -118,13 +118,17 @@ impl<F: Future<Output = Option<wgpu::Error>>> Future for ErrorFuture<F> {
     }
 }
 
-#[allow(dead_code)]
 struct Example {
     rt_target: wgpu::Texture,
+    #[expect(dead_code)]
     rt_view: wgpu::TextureView,
+    #[expect(dead_code)]
     sampler: wgpu::Sampler,
+    #[expect(dead_code)]
     uniform_buf: wgpu::Buffer,
+    #[expect(dead_code)]
     vertex_buf: wgpu::Buffer,
+    #[expect(dead_code)]
     index_buf: wgpu::Buffer,
     tlas_package: wgpu::TlasPackage,
     compute_pipeline: wgpu::ComputePipeline,

--- a/examples/src/repeated_compute/mod.rs
+++ b/examples/src/repeated_compute/mod.rs
@@ -5,8 +5,6 @@
 //! hello-compute example does not such as mapping buffers
 //! and why use the async channels.
 
-use std::mem::size_of_val;
-
 const OVERFLOW: u32 = 0xffffffff;
 
 async fn run() {

--- a/examples/src/shadow/mod.rs
+++ b/examples/src/shadow/mod.rs
@@ -1,4 +1,4 @@
-use std::{f32::consts, iter, mem::size_of, ops::Range, sync::Arc};
+use std::{f32::consts, iter, ops::Range, sync::Arc};
 
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::{align_to, DeviceExt};

--- a/examples/src/skybox/mod.rs
+++ b/examples/src/skybox/mod.rs
@@ -1,5 +1,5 @@
 use bytemuck::{Pod, Zeroable};
-use std::{f32::consts, mem::size_of};
+use std::f32::consts;
 use wgpu::{util::DeviceExt, AstcBlock, AstcChannel};
 
 const IMAGE_SIZE: u32 = 256;

--- a/examples/src/skybox/mod.rs
+++ b/examples/src/skybox/mod.rs
@@ -379,7 +379,7 @@ impl crate::framework::Example for Example {
         }
     }
 
-    #[allow(clippy::single_match)]
+    #[expect(clippy::single_match)]
     fn update(&mut self, event: winit::event::WindowEvent) {
         match event {
             winit::event::WindowEvent::CursorMoved { position, .. } => {

--- a/examples/src/srgb_blend/mod.rs
+++ b/examples/src/srgb_blend/mod.rs
@@ -1,5 +1,4 @@
 use bytemuck::{Pod, Zeroable};
-use std::mem::size_of;
 use wgpu::util::DeviceExt;
 
 #[repr(C)]

--- a/examples/src/stencil_triangles/mod.rs
+++ b/examples/src/stencil_triangles/mod.rs
@@ -1,5 +1,4 @@
 use bytemuck::{Pod, Zeroable};
-use std::mem::size_of;
 use wgpu::util::DeviceExt;
 
 #[repr(C)]

--- a/examples/src/storage_texture/mod.rs
+++ b/examples/src/storage_texture/mod.rs
@@ -14,8 +14,6 @@
 //! A lot of things aren't explained here via comments. See hello-compute and
 //! repeated-compute for code that is more thoroughly commented.
 
-use std::mem::size_of_val;
-
 #[cfg(not(target_arch = "wasm32"))]
 use crate::utils::output_image_native;
 #[cfg(target_arch = "wasm32")]

--- a/examples/src/texture_arrays/mod.rs
+++ b/examples/src/texture_arrays/mod.rs
@@ -1,8 +1,5 @@
 use bytemuck::{Pod, Zeroable};
-use std::{
-    mem::size_of,
-    num::{NonZeroU32, NonZeroU64},
-};
+use std::num::{NonZeroU32, NonZeroU64};
 use wgpu::util::DeviceExt;
 
 #[repr(C)]

--- a/examples/src/timestamp_queries/mod.rs
+++ b/examples/src/timestamp_queries/mod.rs
@@ -17,8 +17,6 @@
 //! The period, i.e. the unit of time, of the timestamps in wgpu is undetermined and needs to be queried with `wgpu::Queue::get_timestamp_period`
 //! in order to get comparable results.
 
-use std::mem::size_of;
-
 use wgpu::util::DeviceExt;
 
 struct Queries {

--- a/examples/src/timestamp_queries/mod.rs
+++ b/examples/src/timestamp_queries/mod.rs
@@ -47,7 +47,10 @@ impl QueryResults {
     // * compute end
     const NUM_QUERIES: u64 = 8;
 
-    #[allow(clippy::redundant_closure)] // False positive
+    #[expect(
+        clippy::redundant_closure,
+        reason = "false positive for `get_next_slot`, which needs to be used by reference"
+    )]
     fn from_raw_results(timestamps: Vec<u64>, timestamps_inside_passes: bool) -> Self {
         assert_eq!(timestamps.len(), Self::NUM_QUERIES as usize);
 

--- a/examples/src/timestamp_queries/mod.rs
+++ b/examples/src/timestamp_queries/mod.rs
@@ -75,7 +75,6 @@ impl QueryResults {
         }
     }
 
-    #[cfg_attr(test, allow(unused))]
     fn print(&self, queue: &wgpu::Queue) {
         let period = queue.get_timestamp_period();
         let elapsed_us = |start, end: u64| end.wrapping_sub(start) as f64 * period as f64 / 1000.0;
@@ -175,7 +174,6 @@ impl Queries {
     }
 }
 
-#[cfg_attr(test, allow(unused))]
 async fn run() {
     // Instantiates instance of wgpu
     let backends = wgpu::util::backend_bits_from_env().unwrap_or_default();

--- a/examples/src/uniform_values/mod.rs
+++ b/examples/src/uniform_values/mod.rs
@@ -16,7 +16,7 @@
 //! The usage of the uniform buffer within the shader itself is pretty self-explanatory given
 //! some understanding of WGSL.
 
-use std::{mem::size_of, sync::Arc};
+use std::sync::Arc;
 // We won't bring StorageBuffer into scope as that might be too easy to confuse
 // with actual GPU-allocated WGPU storage buffers.
 use encase::ShaderType;

--- a/examples/src/uniform_values/mod.rs
+++ b/examples/src/uniform_values/mod.rs
@@ -343,7 +343,10 @@ async fn run(event_loop: EventLoop<()>, window: Arc<Window>) {
 
 pub fn main() {
     let event_loop = EventLoop::new().unwrap();
-    #[allow(unused_mut)]
+    #[cfg_attr(
+        not(target_arch = "wasm32"),
+        expect(unused_mut, reason = "`wasm32` re-assigns to specify canvas")
+    )]
     let mut builder = winit::window::WindowBuilder::new()
         .with_title("Remember: Use U/D to change sample count!")
         .with_inner_size(winit::dpi::LogicalSize::new(900, 900));

--- a/examples/src/water/mod.rs
+++ b/examples/src/water/mod.rs
@@ -3,7 +3,7 @@ mod point_gen;
 use bytemuck::{Pod, Zeroable};
 use glam::Vec3;
 use nanorand::{Rng, WyRand};
-use std::{f32::consts, iter, mem::size_of};
+use std::{f32::consts, iter};
 use wgpu::util::DeviceExt;
 
 ///

--- a/examples/src/water/mod.rs
+++ b/examples/src/water/mod.rs
@@ -691,10 +691,10 @@ impl crate::framework::Example for Example {
         self.reflect_view = reflect_view;
     }
 
-    #[allow(clippy::eq_op)]
     fn render(&mut self, view: &wgpu::TextureView, device: &wgpu::Device, queue: &wgpu::Queue) {
         // Increment frame count regardless of if we draw.
         self.current_frame += 1;
+        #[expect(clippy::eq_op, reason = "keeping common divisor on all elements")]
         let back_color = wgpu::Color {
             r: 161.0 / 255.0,
             g: 246.0 / 255.0,

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -1,7 +1,7 @@
 //! This is a player library for WebGPU traces.
 
 #![cfg(not(target_arch = "wasm32"))]
-#![warn(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::allow_attributes, unsafe_op_in_unsafe_fn)]
 
 use wgc::device::trace;
 

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -14,7 +14,6 @@ use player::GlobalPlay;
 use std::{
     fs::{read_to_string, File},
     io::{Read, Seek, SeekFrom},
-    mem::size_of,
     path::{Path, PathBuf},
     slice,
 };

--- a/tests/tests/compute_pass_ownership.rs
+++ b/tests/tests/compute_pass_ownership.rs
@@ -1,7 +1,7 @@
 //! Tests that compute passes take ownership of resources that are associated with.
 //! I.e. once a resource is passed in to a compute pass, it can be dropped.
 
-use std::{mem::size_of, num::NonZeroU64};
+use std::num::NonZeroU64;
 
 use wgpu::util::DeviceExt as _;
 use wgpu_test::{gpu_test, valid, GpuTestConfiguration, TestParameters, TestingContext};

--- a/tests/tests/occlusion_query/mod.rs
+++ b/tests/tests/occlusion_query/mod.rs
@@ -1,4 +1,3 @@
-use std::mem::size_of;
 use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
 
 #[gpu_test]

--- a/tests/tests/render_pass_ownership.rs
+++ b/tests/tests/render_pass_ownership.rs
@@ -9,7 +9,7 @@
 //! * rpass.multi_draw_indirect_count
 //! * rpass.multi_draw_indexed_indirect_count
 //!
-use std::{mem::size_of, num::NonZeroU64};
+use std::num::NonZeroU64;
 
 use wgpu::util::DeviceExt as _;
 use wgpu_test::{gpu_test, valid, GpuTestConfiguration, TestParameters, TestingContext};

--- a/tests/tests/subgroup_operations/mod.rs
+++ b/tests/tests/subgroup_operations/mod.rs
@@ -1,4 +1,4 @@
-use std::{mem::size_of, num::NonZeroU64};
+use std::num::NonZeroU64;
 
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
 

--- a/tests/tests/vertex_formats/mod.rs
+++ b/tests/tests/vertex_formats/mod.rs
@@ -1,6 +1,6 @@
 //! Tests that vertex formats pass through to vertex shaders accurately.
 
-use std::{mem::size_of_val, num::NonZeroU64};
+use std::num::NonZeroU64;
 
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 

--- a/tests/tests/vertex_indices/mod.rs
+++ b/tests/tests/vertex_indices/mod.rs
@@ -3,7 +3,7 @@
 //! We need tests for these as the backends use various schemes to work around the lack
 //! of support for things like `gl_BaseInstance` in shaders.
 
-use std::{mem::size_of_val, num::NonZeroU64, ops::Range};
+use std::{num::NonZeroU64, ops::Range};
 
 use itertools::Itertools;
 use strum::IntoEnumIterator;

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -156,13 +156,21 @@ impl Blas {
 
 /// Context version of [BlasTriangleGeometry].
 pub struct ContextBlasTriangleGeometry<'a> {
+    #[expect(dead_code)]
     pub(crate) size: &'a BlasTriangleGeometrySizeDescriptor,
+    #[expect(dead_code)]
     pub(crate) vertex_buffer: &'a dispatch::DispatchBuffer,
+    #[expect(dead_code)]
     pub(crate) index_buffer: Option<&'a dispatch::DispatchBuffer>,
+    #[expect(dead_code)]
     pub(crate) transform_buffer: Option<&'a dispatch::DispatchBuffer>,
+    #[expect(dead_code)]
     pub(crate) first_vertex: u32,
+    #[expect(dead_code)]
     pub(crate) vertex_stride: wgt::BufferAddress,
+    #[expect(dead_code)]
     pub(crate) index_buffer_offset: Option<wgt::BufferAddress>,
+    #[expect(dead_code)]
     pub(crate) transform_buffer_offset: Option<wgt::BufferAddress>,
 }
 
@@ -174,6 +182,8 @@ pub enum ContextBlasGeometries<'a> {
 
 /// Context version see [BlasBuildEntry].
 pub struct ContextBlasBuildEntry<'a> {
+    #[expect(dead_code)]
     pub(crate) blas: &'a dispatch::DispatchBlas,
+    #[expect(dead_code)]
     pub(crate) geometries: ContextBlasGeometries<'a>,
 }

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -155,7 +155,6 @@ impl Blas {
 }
 
 /// Context version of [BlasTriangleGeometry].
-#[allow(dead_code)]
 pub struct ContextBlasTriangleGeometry<'a> {
     pub(crate) size: &'a BlasTriangleGeometrySizeDescriptor,
     pub(crate) vertex_buffer: &'a dispatch::DispatchBuffer,
@@ -174,7 +173,6 @@ pub enum ContextBlasGeometries<'a> {
 }
 
 /// Context version see [BlasBuildEntry].
-#[allow(dead_code)]
 pub struct ContextBlasBuildEntry<'a> {
     pub(crate) blas: &'a dispatch::DispatchBlas,
     pub(crate) geometries: ContextBlasGeometries<'a>,

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -127,7 +127,7 @@ impl Instance {
     ///
     /// If no backend feature for the active target platform is enabled,
     /// this method will panic, see [`Instance::enabled_backend_features()`].
-    #[allow(unreachable_code)]
+    #[allow(clippy::allow_attributes, unreachable_code)]
     pub fn new(_instance_desc: &InstanceDescriptor) -> Self {
         if Self::enabled_backend_features().is_empty() {
             panic!(

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -26,7 +26,14 @@ crate::cmp::impl_eq_ord_hash_proxy!(Queue => .inner);
 /// There is no analogue in the WebGPU specification.
 #[derive(Debug, Clone)]
 pub struct SubmissionIndex {
-    #[cfg_attr(not(native), allow(dead_code))]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            not(target_os = "emscripten"),
+            not(feature = "webgl"),
+        ),
+        expect(dead_code)
+    )]
     pub(crate) index: u64,
 }
 #[cfg(send_sync)]

--- a/wgpu/src/api/shader_module.rs
+++ b/wgpu/src/api/shader_module.rs
@@ -168,7 +168,7 @@ impl From<crate::naga::SourceLocation> for SourceLocation {
 ///
 /// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
 /// only WGSL source code strings are accepted.
-#[cfg_attr(feature = "naga-ir", allow(clippy::large_enum_variant))]
+#[cfg_attr(feature = "naga-ir", expect(clippy::large_enum_variant))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum ShaderSource<'a> {

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -346,7 +346,7 @@ pub(crate) enum CreateSurfaceErrorKind {
     Hal(wgc::instance::CreateSurfaceError),
 
     /// Error from WebGPU surface creation.
-    #[allow(dead_code)] // may be unused depending on target and features
+    #[cfg_attr(not(webgpu), expect(dead_code))]
     Web(String),
 
     /// Error when trying to get a [`DisplayHandle`] or a [`WindowHandle`] from

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2,6 +2,7 @@
 
 mod defined_non_null_js_value;
 mod ext_bindings;
+#[allow(clippy::allow_attributes)]
 mod webgpu_sys;
 
 use js_sys::Promise;

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -382,7 +382,7 @@ fn map_texture_copy_view(
 
 #[cfg_attr(
     any(not(target_arch = "wasm32"), target_os = "emscripten"),
-    allow(unused)
+    expect(unused)
 )]
 fn map_texture_tagged_copy_view(
     view: wgt::CopyExternalImageDestInfo<&api::Texture>,
@@ -859,7 +859,7 @@ impl dispatch::InstanceInterface for ContextWgpuCore {
             .copied()
             .fold(
                 crate::WgslLanguageFeatures::empty(),
-                #[allow(unreachable_code)]
+                #[expect(unreachable_code)]
                 |acc, wle| acc | match wle {},
             )
     }
@@ -963,7 +963,7 @@ impl dispatch::DeviceInterface for CoreDevice {
             feature = "wgsl",
             feature = "naga-ir"
         )),
-        allow(unreachable_code, unused)
+        expect(unused)
     )]
     fn create_shader_module(
         &self,

--- a/wgpu/src/cmp.rs
+++ b/wgpu/src/cmp.rs
@@ -65,7 +65,6 @@ macro_rules! impl_eq_ord_hash_proxy {
 /// ```ignore
 /// impl_eq_ord_hash_arc_address!(MyType => .field);
 /// ```
-#[cfg_attr(not(wgpu_core), allow(unused_macros))]
 macro_rules! impl_eq_ord_hash_arc_address {
     ($type:ty => $($access:tt)*) => {
         impl PartialEq for $type {
@@ -103,5 +102,4 @@ macro_rules! impl_eq_ord_hash_arc_address {
     };
 }
 
-#[cfg_attr(not(wgpu_core), allow(unused_imports))]
 pub(crate) use {impl_eq_ord_hash_arc_address, impl_eq_ord_hash_proxy};

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -575,7 +575,7 @@ macro_rules! dispatch_types_inner {
         impl $name {
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_core(&self) -> &<$wgpu_core_context as InterfaceTypes>::$subtype {
                 match self {
                     Self::Core(value) => value,
@@ -585,7 +585,7 @@ macro_rules! dispatch_types_inner {
 
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_core_opt(&self) -> Option<&<$wgpu_core_context as InterfaceTypes>::$subtype> {
                 match self {
                     Self::Core(value) => Some(value),
@@ -595,7 +595,7 @@ macro_rules! dispatch_types_inner {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_webgpu(&self) -> &<$webgpu_context as InterfaceTypes>::$subtype {
                 match self {
                     Self::WebGPU(value) => value,
@@ -605,7 +605,7 @@ macro_rules! dispatch_types_inner {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_webgpu_opt(&self) -> Option<&<$webgpu_context as InterfaceTypes>::$subtype> {
                 match self {
                     Self::WebGPU(value) => Some(value),
@@ -660,7 +660,7 @@ macro_rules! dispatch_types_inner {
         impl $name {
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_core(&self) -> &<$wgpu_core_context as InterfaceTypes>::$subtype {
                 match self {
                     Self::Core(value) => value,
@@ -670,7 +670,7 @@ macro_rules! dispatch_types_inner {
 
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_core_mut(&mut self) -> &mut <$wgpu_core_context as InterfaceTypes>::$subtype {
                 match self {
                     Self::Core(value) => value,
@@ -680,7 +680,7 @@ macro_rules! dispatch_types_inner {
 
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_core_opt(&self) -> Option<&<$wgpu_core_context as InterfaceTypes>::$subtype> {
                 match self {
                     Self::Core(value) => Some(value),
@@ -690,7 +690,7 @@ macro_rules! dispatch_types_inner {
 
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_core_mut_opt(
                 &mut self,
             ) -> Option<&mut <$wgpu_core_context as InterfaceTypes>::$subtype> {
@@ -702,7 +702,7 @@ macro_rules! dispatch_types_inner {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_webgpu(&self) -> &<$webgpu_context as InterfaceTypes>::$subtype {
                 match self {
                     Self::WebGPU(value) => value,
@@ -712,7 +712,7 @@ macro_rules! dispatch_types_inner {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_webgpu_mut(&mut self) -> &mut <$webgpu_context as InterfaceTypes>::$subtype {
                 match self {
                     Self::WebGPU(value) => value,
@@ -722,7 +722,7 @@ macro_rules! dispatch_types_inner {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_webgpu_opt(&self) -> Option<&<$webgpu_context as InterfaceTypes>::$subtype> {
                 match self {
                     Self::WebGPU(value) => Some(value),
@@ -732,7 +732,7 @@ macro_rules! dispatch_types_inner {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(unused)]
+            #[allow(clippy::allow_attributes, unused)]
             pub fn as_webgpu_mut_opt(
                 &mut self,
             ) -> Option<&mut <$webgpu_context as InterfaceTypes>::$subtype> {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -66,12 +66,12 @@ pub use wgt::{
     MAP_ALIGNMENT, PUSH_CONSTANT_ALIGNMENT, QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES,
     QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
 };
-#[allow(deprecated)]
+#[expect(deprecated)]
 pub use wgt::{ImageCopyBuffer, ImageCopyTexture, ImageCopyTextureTagged, ImageDataLayout};
 // wasm-only types, we try to keep as many types non-platform
 // specific, but these need to depend on web-sys.
 #[cfg(any(webgpu, webgl))]
-#[allow(deprecated)]
+#[expect(deprecated)]
 pub use wgt::ImageCopyExternalImage;
 #[cfg(any(webgpu, webgl))]
 pub use wgt::{CopyExternalImageSourceInfo, ExternalImageSource};

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -16,7 +16,12 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/gfx-rs/wgpu/trunk/logo.png")]
-#![warn(missing_docs, rust_2018_idioms, unsafe_op_in_unsafe_fn)]
+#![warn(
+    clippy::allow_attributes,
+    missing_docs,
+    rust_2018_idioms,
+    unsafe_op_in_unsafe_fn
+)]
 #![allow(clippy::arc_with_non_send_sync)]
 
 //

--- a/wgpu/src/macros.rs
+++ b/wgpu/src/macros.rs
@@ -32,8 +32,6 @@ macro_rules! vertex_attr_array {
 
 #[test]
 fn test_vertex_attr_array() {
-    use std::mem::size_of;
-
     let attrs = vertex_attr_array![0 => Float32x2, 3 => Uint16x4];
     // VertexAttribute does not support PartialEq, so we cannot test directly
     assert_eq!(attrs.len(), 2);

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -197,7 +197,6 @@ pub async fn is_browser_webgpu_supported() -> bool {
 ///
 /// If no backend feature for the active target platform is enabled,
 /// this method will panic, see [`Instance::enabled_backend_features()`].
-#[allow(unused_mut)]
 pub async fn new_instance_with_webgpu_detection(
     instance_desc: &wgt::InstanceDescriptor,
 ) -> crate::Instance {

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -9,11 +9,7 @@ mod encoder;
 mod init;
 
 use std::sync::Arc;
-use std::{
-    borrow::Cow,
-    mem::{align_of, size_of},
-    ptr::copy_nonoverlapping,
-};
+use std::{borrow::Cow, ptr::copy_nonoverlapping};
 
 pub use belt::StagingBelt;
 pub use device::{BufferInitDescriptor, DeviceExt};


### PR DESCRIPTION
A veritable grab bag of miscellaneous Rust features that we can now use for crates under `REPO_MSRV`:

* Removal of `std::mem` imports.
* Using `std::sync::LazyLock` instead of `once_cell::Lazy`.
* `#[expect(…)]` instead of `#[allow(…)]` (where I was able to make it work)