### PR TITLE
Add `no_std` support to `wgpu-types`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,29 +91,34 @@ jobs:
           - name: Windows x86_64
             os: windows-2022
             target: x86_64-pc-windows-msvc
+            tier: 1
             kind: native
 
           # Windows
           - name: Windows aarch64
             os: windows-2022
             target: aarch64-pc-windows-msvc
+            tier: 2
             kind: native
 
           # MacOS
           - name: MacOS x86_64
             os: macos-14
             target: x86_64-apple-darwin
+            tier: 1
             kind: native
 
           - name: MacOS aarch64
             os: macos-14
             target: aarch64-apple-darwin
+            tier: 1
             kind: native
 
           # IOS
           - name: IOS aarch64
             os: macos-14
             target: aarch64-apple-ios
+            tier: 2
             kind: native
 
           # VisionOS
@@ -121,35 +126,40 @@ jobs:
             os: macos-14
             target: aarch64-apple-visionos
             kind: wgpu-only
-            toolchain: nightly
+            tier: 3
             extra-flags: -Zbuild-std
 
           # Linux
           - name: Linux x86_64
             os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+            tier: 1
             kind: native
 
           - name: Linux aarch64
             os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
+            tier: 1
             kind: native
 
           # Android
           - name: Android aarch64
             os: ubuntu-22.04
             target: aarch64-linux-android
+            tier: 2
             kind: native
 
           # WebGPU/WebGL
           - name: WebAssembly
             os: ubuntu-22.04
             target: wasm32-unknown-unknown
+            tier: 2
             kind: web
 
           - name: Emscripten
             os: ubuntu-22.04
             target: wasm32-unknown-emscripten
+            tier: 2
             kind: wgpu-only
           
           # TODO: Uncomment once web-sys updates past 0.3.76
@@ -157,16 +167,17 @@ jobs:
           # - name: WebAssembly Core 1.0
           #   os: ubuntu-22.04
           #   target: wasm32v1-none
-          #   kind: no-std
-          #   toolchain: nightly
+          #   tier: 2
+          #   kind: no_std
           
           # Bare-metal x86-64
           # TODO: Remove once web-sys updates past 0.3.76
           # Included while wasm32v1-none is failing to ensure `no_std` does not regress
-          - name: no-std x86_64
+          - name: no_std x86_64
             os: ubuntu-22.04
             target: x86_64-unknown-none
-            kind: no-std
+            tier: 2
+            kind: no_std
 
     name: Clippy ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -175,8 +186,8 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v4
 
-      - name: Install Toolchain (Repo MSRV)
-        if: matrix.toolchain != 'nightly'
+      - name: Install Toolchain (Repo MSRV - Tier 1 or 2)
+        if: matrix.tier == 1 || matrix.tier == 2
         run: |
           rustup toolchain install ${{ env.REPO_MSRV }} --no-self-update --profile=minimal --component clippy
           rustup target add ${{ matrix.target }} --toolchain ${{ env.REPO_MSRV }}
@@ -194,8 +205,8 @@ jobs:
       #
       # RUSTC_BOOTSTRAP=1 is how the rust project builds itself when bootstrapping the compiler, so while not "stable"
       # it has been around for many years and don't anticipate it going away any time soon.
-      - name: Install Toolchain (Repo MSRV - Pseudo Nightly)
-        if: matrix.toolchain == 'nightly'
+      - name: Install Toolchain (Repo MSRV - Tier 3)
+        if: matrix.tier == 3
         run: |
           rustup toolchain install ${{ env.REPO_MSRV }} --no-self-update --profile=minimal --component clippy,rust-src
           echo "RUSTC_BOOTSTRAP=1" >> "$GITHUB_ENV"
@@ -265,7 +276,7 @@ jobs:
         
       # Building for no_std platforms where every feature is enabled except "std".
       - name: check no_std
-        if: matrix.kind == 'no-std'
+        if: matrix.kind == 'no_std'
         shell: bash
         run: |
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
             kind: wgpu-only
           
           # TODO: Uncomment once web-sys updates past 0.3.76
+          # See https://github.com/rustwasm/wasm-bindgen/pull/4378 for details
           # - name: WebAssembly Core 1.0
           #   os: ubuntu-22.04
           #   target: wasm32v1-none
@@ -160,6 +161,8 @@ jobs:
           #   toolchain: nightly
           
           # Bare-metal x86-64
+          # TODO: Remove once web-sys updates past 0.3.76
+          # Included while wasm32v1-none is failing to ensure `no_std` does not regress
           - name: Bare-metal x86_64
             os: ubuntu-22.04
             target: x86_64-unknown-none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           # Bare-metal x86-64
           # TODO: Remove once web-sys updates past 0.3.76
           # Included while wasm32v1-none is failing to ensure `no_std` does not regress
-          - name: Bare-metal x86_64
+          - name: no-std x86_64
             os: ubuntu-22.04
             target: x86_64-unknown-none
             kind: no-std

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,6 @@ jobs:
             os: ubuntu-22.04
             target: x86_64-unknown-none
             kind: no-std
-            toolchain: nightly
 
     name: Clippy ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
         
       # Building for no_std platforms where every feature is enabled except "std".
       - name: check no_std
-        if: matrix.kind == 'no_std'
+        if: matrix.kind == 'no-std'
         shell: bash
         run: |
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,16 +152,19 @@ jobs:
             target: wasm32-unknown-emscripten
             kind: wgpu-only
           
-          - name: WebAssembly Core 1.0
-            os: ubuntu-22.04
-            target: wasm32v1-none
-            kind: no-std
+          # TODO: Uncomment once web-sys updates past 0.3.76
+          # - name: WebAssembly Core 1.0
+          #   os: ubuntu-22.04
+          #   target: wasm32v1-none
+          #   kind: no-std
+          #   toolchain: nightly
           
           # Bare-metal x86-64
           - name: Bare-metal x86_64
             os: ubuntu-22.04
             target: x86_64-unknown-none
             kind: no-std
+            toolchain: nightly
 
     name: Clippy ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,17 @@ jobs:
             os: ubuntu-22.04
             target: wasm32-unknown-emscripten
             kind: wgpu-only
+          
+          - name: WebAssembly Core 1.0
+            os: ubuntu-22.04
+            target: wasm32v1-none
+            kind: no-std
+          
+          # Bare-metal x86-64
+          - name: Bare-metal x86_64
+            os: ubuntu-22.04
+            target: x86_64-unknown-none
+            kind: no-std
 
     name: Clippy ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -246,6 +257,19 @@ jobs:
           # Check with all features.
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-hal --all-features
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu --all-features
+        
+      # Building for no_std platforms where every feature is enabled except "std".
+      - name: check no_std
+        if: matrix.kind == 'no_std'
+        shell: bash
+        run: |
+          set -e
+
+          # check with no features
+          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features
+
+          # Check with all features except "std".
+          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features --features strict_asserts,fragile-send-sync-non-atomic-wasm,serde,counters
 
       # Building for native platforms with standard tests.
       - name: check native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@ By @wumpf in [#6849](https://github.com/gfx-rs/wgpu/pull/6849).
 - `DeviceType` and `AdapterInfo` now impl `Hash` by @cwfitzgerald in [#6868](https://github.com/gfx-rs/wgpu/pull/6868)
 - Add build support for Apple Vision Pro. By @guusw in [#6611](https://github.com/gfx-rs/wgpu/pull/6611).
 - Add `wgsl_language_features` for obtaining available WGSL language feature by @sagudev in [#6814](https://github.com/gfx-rs/wgpu/pull/6814)
+- Add `no_std` support to `wgpu-types`. By @bushrat011899 in [#6892](https://github.com/gfx-rs/wgpu/pull/6892).
 
 ##### Vulkan
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ ron = "0.8"
 # rustc-hash 2.0 is a completely different hasher with different performance characteristics
 serde_json = "1.0.134"
 rustc-hash = "1"
-serde = "1"
+serde = { version = "1", default-features = false }
 smallvec = "1"
 static_assertions = "1.1.0"
 strum = { version = "0.26.0", features = ["derive"] }
@@ -173,11 +173,11 @@ windows = { version = "0.58", default-features = false }
 # wasm32 dependencies
 console_error_panic_hook = "0.1.7"
 console_log = "1"
-js-sys = "0.3.70"
+js-sys = { version = "0.3.70", default-features = false }
 wasm-bindgen = "0.2.97"
 wasm-bindgen-futures = "0.4.45"
 wasm-bindgen-test = "0.3"
-web-sys = "0.3.74"
+web-sys = { version = "0.3.74", default-features = false }
 web-time = "0.2.4"
 
 # deno dependencies

--- a/lock-analyzer/Cargo.toml
+++ b/lock-analyzer/Cargo.toml
@@ -16,4 +16,4 @@ anyhow.workspace = true
 
 [dependencies.serde]
 workspace = true
-features = ["serde_derive"]
+features = ["default", "serde_derive"]

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -78,7 +78,10 @@ log = "0.4"
 strum.workspace = true
 spirv = { version = "0.3", optional = true }
 thiserror.workspace = true
-serde = { version = "1.0.217", features = ["derive"], optional = true }
+serde = { version = "1.0.217", features = [
+    "default",
+    "derive",
+], optional = true }
 # Hold on updating to 0.7 until https://github.com/petgraph/petgraph/pull/714 is on crates.io
 petgraph = { version = "0.6", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
@@ -101,5 +104,5 @@ hlsl-snapshots = { path = "./hlsl-snapshots" }
 # incompatible with our tests because we do a syntactic diff and not a semantic one.
 ron = "0.8.0"
 rspirv = { version = "0.11", git = "https://github.com/gfx-rs/rspirv", rev = "b969f175d5663258b4891e44b76c1544da9661ab" }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["default", "derive"] }
 spirv = { version = "0.3", features = ["deserialize"] }

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -127,7 +127,7 @@ profiling = { workspace = true, default-features = false }
 raw-window-handle = { workspace = true, optional = true }
 ron = { workspace = true, optional = true }
 rustc-hash.workspace = true
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["default", "derive"], optional = true }
 smallvec.workspace = true
 thiserror.workspace = true
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -188,12 +188,13 @@ core-graphics-types.workspace = true
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
 wasm-bindgen.workspace = true
 web-sys = { workspace = true, features = [
+    "default",
     "Window",
     "HtmlCanvasElement",
     "WebGl2RenderingContext",
     "OffscreenCanvas",
 ] }
-js-sys.workspace = true
+js-sys = { workspace = true, features = ["default"] }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -240,8 +240,8 @@ impl<A: hal::Api> Example<A> {
             name: "example",
             flags: wgt::InstanceFlags::default(),
             dx12_shader_compiler: wgt::Dx12Compiler::DynamicDxc {
-                dxc_path: std::path::PathBuf::from("dxcompiler.dll"),
-                dxil_path: std::path::PathBuf::from("dxil.dll"),
+                dxc_path: "dxcompiler.dll".to_string(),
+                dxil_path: "dxil.dll".to_string(),
             },
             gles_minor_version: wgt::Gles3MinorVersion::default(),
         };

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -72,14 +72,13 @@ impl crate::Instance for super::Instance {
                 dxil_path,
                 dxc_path,
             } => {
-                let container =
-                    super::shader_compilation::get_dynamic_dxc_container(dxc_path, dxil_path)
-                        .map_err(|e| {
-                            crate::InstanceError::with_source(
-                                String::from("Failed to load dynamic DXC"),
-                                e,
-                            )
-                        })?;
+                let container = super::shader_compilation::get_dynamic_dxc_container(
+                    dxc_path.into(),
+                    dxil_path.into(),
+                )
+                .map_err(|e| {
+                    crate::InstanceError::with_source(String::from("Failed to load dynamic DXC"), e)
+                })?;
 
                 Some(Arc::new(container))
             }

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -14,6 +14,6 @@ anyhow.workspace = true
 bitflags.workspace = true
 env_logger.workspace = true
 pico-args.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["default"] }
 serde_json.workspace = true
 wgpu = { workspace = true, features = ["serde", "dx12", "metal", "static-dxc"] }

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -28,6 +28,9 @@ targets = [
 [lib]
 
 [features]
+default = ["std"]
+std = ["alloc", "js-sys/std", "web-sys/std"]
+alloc = ["serde?/alloc"]
 strict_asserts = []
 fragile-send-sync-non-atomic-wasm = []
 serde = ["dep:serde"]
@@ -39,11 +42,13 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
 
 [dependencies]
 bitflags = { workspace = true, features = ["serde"] }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, default-features = false, features = [
+    "derive",
+], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys.workspace = true
-web-sys = { workspace = true, features = [
+js-sys = { workspace = true, default-features = false }
+web-sys = { workspace = true, default-features = false, features = [
     "ImageBitmap",
     "ImageData",
     "HtmlImageElement",
@@ -56,3 +61,8 @@ web-sys = { workspace = true, features = [
 [dev-dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+
+[lints.clippy]
+std_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+alloc_instead_of_core = "warn"

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -29,8 +29,7 @@ targets = [
 
 [features]
 default = ["std"]
-std = ["alloc", "js-sys/std", "web-sys/std"]
-alloc = ["serde?/alloc"]
+std = ["js-sys/std", "web-sys/std"]
 strict_asserts = []
 fragile-send-sync-non-atomic-wasm = []
 serde = ["dep:serde"]
@@ -43,6 +42,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
 [dependencies]
 bitflags = { workspace = true, features = ["serde"] }
 serde = { workspace = true, default-features = false, features = [
+    "alloc",
     "derive",
 ], optional = true }
 

--- a/wgpu-types/src/assertions.rs
+++ b/wgpu-types/src/assertions.rs
@@ -11,7 +11,7 @@
 //! `wgpu-core`'s `"strict_asserts"` feature enables that validation
 //! in both debug and release builds.
 
-/// This is equivalent to [`std::assert`] if the `strict_asserts` feature is activated, otherwise equal to [`std::debug_assert`].
+/// This is equivalent to [`core::assert`] if the `strict_asserts` feature is activated, otherwise equal to [`core::debug_assert`].
 #[cfg(feature = "strict_asserts")]
 #[macro_export]
 macro_rules! strict_assert {
@@ -20,7 +20,7 @@ macro_rules! strict_assert {
     }
 }
 
-/// This is equivalent to [`std::assert_eq`] if the `strict_asserts` feature is activated, otherwise equal to [`std::debug_assert_eq`].
+/// This is equivalent to [`core::assert_eq`] if the `strict_asserts` feature is activated, otherwise equal to [`core::debug_assert_eq`].
 #[cfg(feature = "strict_asserts")]
 #[macro_export]
 macro_rules! strict_assert_eq {
@@ -29,7 +29,7 @@ macro_rules! strict_assert_eq {
     }
 }
 
-/// This is equivalent to [`std::assert_ne`] if the `strict_asserts` feature is activated, otherwise equal to [`std::debug_assert_ne`].
+/// This is equivalent to [`core::assert_ne`] if the `strict_asserts` feature is activated, otherwise equal to [`core::debug_assert_ne`].
 #[cfg(feature = "strict_asserts")]
 #[macro_export]
 macro_rules! strict_assert_ne {
@@ -38,7 +38,7 @@ macro_rules! strict_assert_ne {
     }
 }
 
-/// This is equivalent to [`std::assert`] if the `strict_asserts` feature is activated, otherwise equal to [`std::debug_assert`]
+/// This is equivalent to [`core::assert`] if the `strict_asserts` feature is activated, otherwise equal to [`core::debug_assert`]
 #[cfg(not(feature = "strict_asserts"))]
 #[macro_export]
 macro_rules! strict_assert {
@@ -47,7 +47,7 @@ macro_rules! strict_assert {
     };
 }
 
-/// This is equivalent to [`std::assert_eq`] if the `strict_asserts` feature is activated, otherwise equal to [`std::debug_assert_eq`]
+/// This is equivalent to [`core::assert_eq`] if the `strict_asserts` feature is activated, otherwise equal to [`core::debug_assert_eq`]
 #[cfg(not(feature = "strict_asserts"))]
 #[macro_export]
 macro_rules! strict_assert_eq {
@@ -56,7 +56,7 @@ macro_rules! strict_assert_eq {
     };
 }
 
-/// This is equivalent to [`std::assert_ne`] if the `strict_asserts` feature is activated, otherwise equal to [`std::debug_assert_ne`]
+/// This is equivalent to [`core::assert_ne`] if the `strict_asserts` feature is activated, otherwise equal to [`core::debug_assert_ne`]
 #[cfg(not(feature = "strict_asserts"))]
 #[macro_export]
 macro_rules! strict_assert_ne {

--- a/wgpu-types/src/counters.rs
+++ b/wgpu-types/src/counters.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "counters")]
-use std::sync::atomic::{AtomicIsize, Ordering};
-use std::{fmt, ops::Range};
+use core::sync::atomic::{AtomicIsize, Ordering};
+use core::{fmt, ops::Range};
+
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec::Vec};
 
 /// An internal counter for debugging purposes
 ///
@@ -95,8 +98,8 @@ impl Default for InternalCounter {
     }
 }
 
-impl std::fmt::Debug for InternalCounter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for InternalCounter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.read().fmt(f)
     }
 }
@@ -145,6 +148,7 @@ pub struct InternalCounters {
 }
 
 /// Describes an allocation in the [`AllocatorReport`].
+#[cfg(feature = "alloc")]
 #[derive(Clone)]
 pub struct AllocationReport {
     /// The name provided to the `allocate()` function.
@@ -166,6 +170,7 @@ pub struct MemoryBlockReport {
 }
 
 /// A report that can be generated for informational purposes using `Allocator::generate_report()`.
+#[cfg(feature = "alloc")]
 #[derive(Clone)]
 pub struct AllocatorReport {
     /// All live allocations, sub-allocated from memory blocks.
@@ -178,6 +183,7 @@ pub struct AllocatorReport {
     pub total_reserved_bytes: u64,
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Debug for AllocationReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = if !self.name.is_empty() {
@@ -189,10 +195,11 @@ impl fmt::Debug for AllocationReport {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Debug for AllocatorReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut allocations = self.allocations.clone();
-        allocations.sort_by_key(|alloc| std::cmp::Reverse(alloc.size));
+        allocations.sort_by_key(|alloc| core::cmp::Reverse(alloc.size));
 
         let max_num_allocations_to_print = f.precision().unwrap_or(usize::MAX);
         allocations.truncate(max_num_allocations_to_print);
@@ -200,7 +207,7 @@ impl fmt::Debug for AllocatorReport {
         f.debug_struct("AllocatorReport")
             .field(
                 "summary",
-                &std::format_args!(
+                &core::format_args!(
                     "{} / {}",
                     FmtBytes(self.total_allocated_bytes),
                     FmtBytes(self.total_reserved_bytes)
@@ -213,6 +220,10 @@ impl fmt::Debug for AllocatorReport {
     }
 }
 
+#[cfg_attr(
+    not(feature = "alloc"),
+    expect(dead_code, reason = "only required with alloc feature")
+)]
 struct FmtBytes(u64);
 
 impl fmt::Display for FmtBytes {

--- a/wgpu-types/src/counters.rs
+++ b/wgpu-types/src/counters.rs
@@ -1,9 +1,7 @@
+use alloc::{string::String, vec::Vec};
 #[cfg(feature = "counters")]
 use core::sync::atomic::{AtomicIsize, Ordering};
 use core::{fmt, ops::Range};
-
-#[cfg(feature = "alloc")]
-use alloc::{string::String, vec::Vec};
 
 /// An internal counter for debugging purposes
 ///
@@ -148,7 +146,6 @@ pub struct InternalCounters {
 }
 
 /// Describes an allocation in the [`AllocatorReport`].
-#[cfg(feature = "alloc")]
 #[derive(Clone)]
 pub struct AllocationReport {
     /// The name provided to the `allocate()` function.
@@ -170,7 +167,6 @@ pub struct MemoryBlockReport {
 }
 
 /// A report that can be generated for informational purposes using `Allocator::generate_report()`.
-#[cfg(feature = "alloc")]
 #[derive(Clone)]
 pub struct AllocatorReport {
     /// All live allocations, sub-allocated from memory blocks.
@@ -183,7 +179,6 @@ pub struct AllocatorReport {
     pub total_reserved_bytes: u64,
 }
 
-#[cfg(feature = "alloc")]
 impl fmt::Debug for AllocationReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = if !self.name.is_empty() {
@@ -195,7 +190,6 @@ impl fmt::Debug for AllocationReport {
     }
 }
 
-#[cfg(feature = "alloc")]
 impl fmt::Debug for AllocatorReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut allocations = self.allocations.clone();
@@ -220,10 +214,6 @@ impl fmt::Debug for AllocatorReport {
     }
 }
 
-#[cfg_attr(
-    not(feature = "alloc"),
-    expect(dead_code, reason = "only required with alloc feature")
-)]
 struct FmtBytes(u64);
 
 impl fmt::Display for FmtBytes {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -23,7 +23,10 @@ use core::{
 };
 
 #[cfg(any(feature = "serde", test))]
-use serde::{Deserialize, Serialize};
+use {
+    alloc::format,
+    serde::{Deserialize, Serialize},
+};
 
 pub mod assertions;
 mod counters;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -15,13 +15,15 @@ extern crate std;
 extern crate alloc;
 
 use alloc::{string::String, vec, vec::Vec};
-use core::hash::{Hash, Hasher};
-use core::mem::size_of;
-use core::{num::NonZeroU32, ops::Range};
+use core::{
+    hash::{Hash, Hasher},
+    mem::size_of,
+    num::NonZeroU32,
+    ops::Range,
+};
+
 #[cfg(any(feature = "serde", test))]
-use serde::Deserialize;
-#[cfg(any(feature = "serde", test))]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use std::path::PathBuf;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2846,57 +2846,6 @@ pub enum TextureFormat {
 }
 
 #[cfg(any(feature = "serde", test))]
-const fn astc_texture_format_to_str(block: AstcBlock, channel: AstcChannel) -> &'static str {
-    use AstcBlock::*;
-    use AstcChannel::*;
-
-    match (block, channel) {
-        (B4x4, Unorm) => "astc-4x4-unorm",
-        (B5x4, Unorm) => "astc-5x4-unorm",
-        (B5x5, Unorm) => "astc-5x5-unorm",
-        (B6x5, Unorm) => "astc-6x5-unorm",
-        (B6x6, Unorm) => "astc-6x6-unorm",
-        (B8x5, Unorm) => "astc-8x5-unorm",
-        (B8x6, Unorm) => "astc-8x6-unorm",
-        (B8x8, Unorm) => "astc-8x8-unorm",
-        (B10x5, Unorm) => "astc-10x5-unorm",
-        (B10x6, Unorm) => "astc-10x6-unorm",
-        (B10x8, Unorm) => "astc-10x8-unorm",
-        (B10x10, Unorm) => "astc-10x10-unorm",
-        (B12x10, Unorm) => "astc-12x10-unorm",
-        (B12x12, Unorm) => "astc-12x12-unorm",
-        (B4x4, UnormSrgb) => "astc-4x4-unorm-srgb",
-        (B5x4, UnormSrgb) => "astc-5x4-unorm-srgb",
-        (B5x5, UnormSrgb) => "astc-5x5-unorm-srgb",
-        (B6x5, UnormSrgb) => "astc-6x5-unorm-srgb",
-        (B6x6, UnormSrgb) => "astc-6x6-unorm-srgb",
-        (B8x5, UnormSrgb) => "astc-8x5-unorm-srgb",
-        (B8x6, UnormSrgb) => "astc-8x6-unorm-srgb",
-        (B8x8, UnormSrgb) => "astc-8x8-unorm-srgb",
-        (B10x5, UnormSrgb) => "astc-10x5-unorm-srgb",
-        (B10x6, UnormSrgb) => "astc-10x6-unorm-srgb",
-        (B10x8, UnormSrgb) => "astc-10x8-unorm-srgb",
-        (B10x10, UnormSrgb) => "astc-10x10-unorm-srgb",
-        (B12x10, UnormSrgb) => "astc-12x10-unorm-srgb",
-        (B12x12, UnormSrgb) => "astc-12x12-unorm-srgb",
-        (B4x4, Hdr) => "astc-4x4-hdr",
-        (B5x4, Hdr) => "astc-5x4-hdr",
-        (B5x5, Hdr) => "astc-5x5-hdr",
-        (B6x5, Hdr) => "astc-6x5-hdr",
-        (B6x6, Hdr) => "astc-6x6-hdr",
-        (B8x5, Hdr) => "astc-8x5-hdr",
-        (B8x6, Hdr) => "astc-8x6-hdr",
-        (B8x8, Hdr) => "astc-8x8-hdr",
-        (B10x5, Hdr) => "astc-10x5-hdr",
-        (B10x6, Hdr) => "astc-10x6-hdr",
-        (B10x8, Hdr) => "astc-10x8-hdr",
-        (B10x10, Hdr) => "astc-10x10-hdr",
-        (B12x10, Hdr) => "astc-12x10-hdr",
-        (B12x12, Hdr) => "astc-12x12-hdr",
-    }
-}
-
-#[cfg(any(feature = "serde", test))]
 impl<'de> Deserialize<'de> for TextureFormat {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -3041,6 +2990,7 @@ impl Serialize for TextureFormat {
     where
         S: serde::Serializer,
     {
+        let s: String;
         let name = match *self {
             TextureFormat::R8Unorm => "r8unorm",
             TextureFormat::R8Snorm => "r8snorm",
@@ -3116,7 +3066,33 @@ impl Serialize for TextureFormat {
             TextureFormat::EacR11Snorm => "eac-r11snorm",
             TextureFormat::EacRg11Unorm => "eac-rg11unorm",
             TextureFormat::EacRg11Snorm => "eac-rg11snorm",
-            TextureFormat::Astc { block, channel } => astc_texture_format_to_str(block, channel),
+            TextureFormat::Astc { block, channel } => {
+                let block = match block {
+                    AstcBlock::B4x4 => "4x4",
+                    AstcBlock::B5x4 => "5x4",
+                    AstcBlock::B5x5 => "5x5",
+                    AstcBlock::B6x5 => "6x5",
+                    AstcBlock::B6x6 => "6x6",
+                    AstcBlock::B8x5 => "8x5",
+                    AstcBlock::B8x6 => "8x6",
+                    AstcBlock::B8x8 => "8x8",
+                    AstcBlock::B10x5 => "10x5",
+                    AstcBlock::B10x6 => "10x6",
+                    AstcBlock::B10x8 => "10x8",
+                    AstcBlock::B10x10 => "10x10",
+                    AstcBlock::B12x10 => "12x10",
+                    AstcBlock::B12x12 => "12x12",
+                };
+
+                let channel = match channel {
+                    AstcChannel::Unorm => "unorm",
+                    AstcChannel::UnormSrgb => "unorm-srgb",
+                    AstcChannel::Hdr => "hdr",
+                };
+
+                s = format!("astc-{block}-{channel}");
+                &s
+            }
         };
         serializer.serialize_str(name)
     }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4149,8 +4149,11 @@ impl TextureFormat {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn texture_format_serialize() {
+    use alloc::string::ToString;
+
     assert_eq!(
         serde_json::to_string(&TextureFormat::R8Unorm).unwrap(),
         "\"r8unorm\"".to_string()

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7,15 +7,30 @@
     clippy::match_like_matches_macro,
 )]
 #![warn(clippy::ptr_as_ptr, missing_docs, unsafe_op_in_unsafe_fn)]
+#![no_std]
 
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+use core::hash::{Hash, Hasher};
+use core::mem::size_of;
+use core::{num::NonZeroU32, ops::Range};
 #[cfg(any(feature = "serde", test))]
 use serde::Deserialize;
 #[cfg(any(feature = "serde", test))]
 use serde::Serialize;
-use std::hash::{Hash, Hasher};
-use std::mem::size_of;
+
+#[cfg(feature = "std")]
 use std::path::PathBuf;
-use std::{num::NonZeroU32, ops::Range};
+
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec, vec::Vec};
+
+#[cfg(all(feature = "alloc", feature = "serde"))]
+use alloc::format;
 
 pub mod assertions;
 mod counters;
@@ -26,7 +41,7 @@ pub use counters::*;
 /// Integral type used for buffer offsets.
 pub type BufferAddress = u64;
 /// Integral type used for buffer slice sizes.
-pub type BufferSize = std::num::NonZeroU64;
+pub type BufferSize = core::num::NonZeroU64;
 /// Integral type used for binding locations in shaders.
 pub type ShaderLocation = u32;
 /// Integral type used for dynamic bind group offsets.
@@ -88,8 +103,8 @@ impl Backend {
     }
 }
 
-impl std::fmt::Display for Backend {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Backend {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(self.to_str())
     }
 }
@@ -985,6 +1000,7 @@ impl Features {
     }
 
     /// Vertex formats allowed for creating and building BLASes
+    #[cfg(feature = "alloc")]
     #[must_use]
     pub fn allowed_vertex_formats_for_blas(&self) -> Vec<VertexFormat> {
         let mut formats = Vec::new();
@@ -1076,6 +1092,7 @@ impl InstanceFlags {
     /// The environment variables are named after the flags prefixed with "WGPU_". For example:
     /// - WGPU_DEBUG
     /// - WGPU_VALIDATION
+    #[cfg(feature = "std")]
     #[must_use]
     pub fn with_env(mut self) -> Self {
         fn env(key: &str) -> Option<bool> {
@@ -1479,7 +1496,7 @@ impl Limits {
         fatal: bool,
         mut fail_fn: impl FnMut(&'static str, u64, u64),
     ) {
-        use std::cmp::Ordering;
+        use core::cmp::Ordering;
 
         macro_rules! compare {
             ($name:ident, $ordering:ident) => {
@@ -1790,6 +1807,7 @@ pub enum DeviceType {
 //TODO: convert `vendor` and `device` to `u32`
 
 /// Information about an adapter.
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AdapterInfo {
@@ -2433,6 +2451,7 @@ impl TextureFormatFeatureFlags {
 
     /// A `Vec` of supported sample counts.
     #[must_use]
+    #[cfg(feature = "alloc")]
     pub fn supported_sample_counts(&self) -> Vec<u32> {
         let all_possible_sample_counts: [u32; 5] = [1, 2, 4, 8, 16];
         all_possible_sample_counts
@@ -2836,6 +2855,57 @@ pub enum TextureFormat {
 }
 
 #[cfg(any(feature = "serde", test))]
+const fn astc_texture_format_to_str(block: AstcBlock, channel: AstcChannel) -> &'static str {
+    use AstcBlock::*;
+    use AstcChannel::*;
+
+    match (block, channel) {
+        (B4x4, Unorm) => "astc-4x4-unorm",
+        (B5x4, Unorm) => "astc-5x4-unorm",
+        (B5x5, Unorm) => "astc-5x5-unorm",
+        (B6x5, Unorm) => "astc-6x5-unorm",
+        (B6x6, Unorm) => "astc-6x6-unorm",
+        (B8x5, Unorm) => "astc-8x5-unorm",
+        (B8x6, Unorm) => "astc-8x6-unorm",
+        (B8x8, Unorm) => "astc-8x8-unorm",
+        (B10x5, Unorm) => "astc-10x5-unorm",
+        (B10x6, Unorm) => "astc-10x6-unorm",
+        (B10x8, Unorm) => "astc-10x8-unorm",
+        (B10x10, Unorm) => "astc-10x10-unorm",
+        (B12x10, Unorm) => "astc-12x10-unorm",
+        (B12x12, Unorm) => "astc-12x12-unorm",
+        (B4x4, UnormSrgb) => "astc-4x4-unorm-srgb",
+        (B5x4, UnormSrgb) => "astc-5x4-unorm-srgb",
+        (B5x5, UnormSrgb) => "astc-5x5-unorm-srgb",
+        (B6x5, UnormSrgb) => "astc-6x5-unorm-srgb",
+        (B6x6, UnormSrgb) => "astc-6x6-unorm-srgb",
+        (B8x5, UnormSrgb) => "astc-8x5-unorm-srgb",
+        (B8x6, UnormSrgb) => "astc-8x6-unorm-srgb",
+        (B8x8, UnormSrgb) => "astc-8x8-unorm-srgb",
+        (B10x5, UnormSrgb) => "astc-10x5-unorm-srgb",
+        (B10x6, UnormSrgb) => "astc-10x6-unorm-srgb",
+        (B10x8, UnormSrgb) => "astc-10x8-unorm-srgb",
+        (B10x10, UnormSrgb) => "astc-10x10-unorm-srgb",
+        (B12x10, UnormSrgb) => "astc-12x10-unorm-srgb",
+        (B12x12, UnormSrgb) => "astc-12x12-unorm-srgb",
+        (B4x4, Hdr) => "astc-4x4-hdr",
+        (B5x4, Hdr) => "astc-5x4-hdr",
+        (B5x5, Hdr) => "astc-5x5-hdr",
+        (B6x5, Hdr) => "astc-6x5-hdr",
+        (B6x6, Hdr) => "astc-6x6-hdr",
+        (B8x5, Hdr) => "astc-8x5-hdr",
+        (B8x6, Hdr) => "astc-8x6-hdr",
+        (B8x8, Hdr) => "astc-8x8-hdr",
+        (B10x5, Hdr) => "astc-10x5-hdr",
+        (B10x6, Hdr) => "astc-10x6-hdr",
+        (B10x8, Hdr) => "astc-10x8-hdr",
+        (B10x10, Hdr) => "astc-10x10-hdr",
+        (B12x10, Hdr) => "astc-12x10-hdr",
+        (B12x12, Hdr) => "astc-12x12-hdr",
+    }
+}
+
+#[cfg(any(feature = "serde", test))]
 impl<'de> Deserialize<'de> for TextureFormat {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -2848,7 +2918,7 @@ impl<'de> Deserialize<'de> for TextureFormat {
         impl de::Visitor<'_> for TextureFormatVisitor {
             type Value = TextureFormat;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 formatter.write_str("a valid texture format")
             }
 
@@ -2980,7 +3050,6 @@ impl Serialize for TextureFormat {
     where
         S: serde::Serializer,
     {
-        let s: String;
         let name = match *self {
             TextureFormat::R8Unorm => "r8unorm",
             TextureFormat::R8Snorm => "r8snorm",
@@ -3056,33 +3125,7 @@ impl Serialize for TextureFormat {
             TextureFormat::EacR11Snorm => "eac-r11snorm",
             TextureFormat::EacRg11Unorm => "eac-rg11unorm",
             TextureFormat::EacRg11Snorm => "eac-rg11snorm",
-            TextureFormat::Astc { block, channel } => {
-                let block = match block {
-                    AstcBlock::B4x4 => "4x4",
-                    AstcBlock::B5x4 => "5x4",
-                    AstcBlock::B5x5 => "5x5",
-                    AstcBlock::B6x5 => "6x5",
-                    AstcBlock::B6x6 => "6x6",
-                    AstcBlock::B8x5 => "8x5",
-                    AstcBlock::B8x6 => "8x6",
-                    AstcBlock::B8x8 => "8x8",
-                    AstcBlock::B10x5 => "10x5",
-                    AstcBlock::B10x6 => "10x6",
-                    AstcBlock::B10x8 => "10x8",
-                    AstcBlock::B10x10 => "10x10",
-                    AstcBlock::B12x10 => "12x10",
-                    AstcBlock::B12x12 => "12x12",
-                };
-
-                let channel = match channel {
-                    AstcChannel::Unorm => "unorm",
-                    AstcChannel::UnormSrgb => "unorm-srgb",
-                    AstcChannel::Hdr => "hdr",
-                };
-
-                s = format!("astc-{block}-{channel}");
-                &s
-            }
+            TextureFormat::Astc { block, channel } => astc_texture_format_to_str(block, channel),
         };
         serializer.serialize_str(name)
     }
@@ -5684,6 +5727,7 @@ bitflags::bitflags! {
 }
 
 /// Defines the capabilities of a given surface and adapter.
+#[cfg(feature = "alloc")]
 #[derive(Debug)]
 pub struct SurfaceCapabilities {
     /// List of supported formats to use with the given adapter. The first format in the vector is preferred.
@@ -5704,6 +5748,7 @@ pub struct SurfaceCapabilities {
     pub usages: TextureUsages,
 }
 
+#[cfg(feature = "alloc")]
 impl Default for SurfaceCapabilities {
     fn default() -> Self {
         Self {
@@ -5961,8 +6006,8 @@ impl Origin2d {
     }
 }
 
-impl std::fmt::Debug for Origin2d {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Origin2d {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         (self.x, self.y).fmt(f)
     }
 }
@@ -6004,8 +6049,8 @@ impl Default for Origin3d {
     }
 }
 
-impl std::fmt::Debug for Origin3d {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Origin3d {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         (self.x, self.y, self.z).fmt(f)
     }
 }
@@ -6028,8 +6073,8 @@ pub struct Extent3d {
     pub depth_or_array_layers: u32,
 }
 
-impl std::fmt::Debug for Extent3d {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Extent3d {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         (self.width, self.height, self.depth_or_array_layers).fmt(f)
     }
 }
@@ -7546,8 +7591,8 @@ impl DrawIndirectArgs {
     #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         unsafe {
-            std::mem::transmute(std::slice::from_raw_parts(
-                std::ptr::from_ref(self).cast::<u8>(),
+            core::mem::transmute(core::slice::from_raw_parts(
+                core::ptr::from_ref(self).cast::<u8>(),
                 size_of::<Self>(),
             ))
         }
@@ -7577,8 +7622,8 @@ impl DrawIndexedIndirectArgs {
     #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         unsafe {
-            std::mem::transmute(std::slice::from_raw_parts(
-                std::ptr::from_ref(self).cast::<u8>(),
+            core::mem::transmute(core::slice::from_raw_parts(
+                core::ptr::from_ref(self).cast::<u8>(),
                 size_of::<Self>(),
             ))
         }
@@ -7602,8 +7647,8 @@ impl DispatchIndirectArgs {
     #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         unsafe {
-            std::mem::transmute(std::slice::from_raw_parts(
-                std::ptr::from_ref(self).cast::<u8>(),
+            core::mem::transmute(core::slice::from_raw_parts(
+                core::ptr::from_ref(self).cast::<u8>(),
                 size_of::<Self>(),
             ))
         }
@@ -7688,6 +7733,7 @@ impl Default for ShaderRuntimeChecks {
 ///
 /// `wgpu::utils::init::dx12_shader_compiler_from_env` can be used to set the compiler
 /// from the `WGPU_DX12_SHADER_COMPILER` environment variable, but this should only be used for testing.
+#[cfg(feature = "std")]
 #[derive(Clone, Debug, Default)]
 pub enum Dx12Compiler {
     /// The Fxc compiler (default) is old, slow and unmaintained.
@@ -7736,6 +7782,7 @@ pub enum Gles3MinorVersion {
 }
 
 /// Options for creating an instance.
+#[cfg(feature = "std")]
 #[derive(Clone, Debug)]
 pub struct InstanceDescriptor {
     /// Which `Backends` to enable.
@@ -7748,6 +7795,7 @@ pub struct InstanceDescriptor {
     pub gles_minor_version: Gles3MinorVersion,
 }
 
+#[cfg(feature = "std")]
 impl Default for InstanceDescriptor {
     fn default() -> Self {
         Self {
@@ -7779,6 +7827,7 @@ pub struct BlasTriangleGeometrySizeDescriptor {
     pub flags: AccelerationStructureGeometryFlags,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Descriptor for all size defining attributes of all geometries inside a bottom level acceleration structure.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -12,9 +12,9 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 
+use alloc::{string::String, vec, vec::Vec};
 use core::hash::{Hash, Hasher};
 use core::mem::size_of;
 use core::{num::NonZeroU32, ops::Range};
@@ -25,9 +25,6 @@ use serde::Serialize;
 
 #[cfg(feature = "std")]
 use std::path::PathBuf;
-
-#[cfg(feature = "alloc")]
-use alloc::{string::String, vec, vec::Vec};
 
 pub mod assertions;
 mod counters;
@@ -997,7 +994,6 @@ impl Features {
     }
 
     /// Vertex formats allowed for creating and building BLASes
-    #[cfg(feature = "alloc")]
     #[must_use]
     pub fn allowed_vertex_formats_for_blas(&self) -> Vec<VertexFormat> {
         let mut formats = Vec::new();
@@ -1804,7 +1800,6 @@ pub enum DeviceType {
 //TODO: convert `vendor` and `device` to `u32`
 
 /// Information about an adapter.
-#[cfg(feature = "alloc")]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AdapterInfo {
@@ -2448,7 +2443,6 @@ impl TextureFormatFeatureFlags {
 
     /// A `Vec` of supported sample counts.
     #[must_use]
-    #[cfg(feature = "alloc")]
     pub fn supported_sample_counts(&self) -> Vec<u32> {
         let all_possible_sample_counts: [u32; 5] = [1, 2, 4, 8, 16];
         all_possible_sample_counts
@@ -4149,7 +4143,6 @@ impl TextureFormat {
     }
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn texture_format_serialize() {
     use alloc::string::ToString;
@@ -5727,7 +5720,6 @@ bitflags::bitflags! {
 }
 
 /// Defines the capabilities of a given surface and adapter.
-#[cfg(feature = "alloc")]
 #[derive(Debug)]
 pub struct SurfaceCapabilities {
     /// List of supported formats to use with the given adapter. The first format in the vector is preferred.
@@ -5748,7 +5740,6 @@ pub struct SurfaceCapabilities {
     pub usages: TextureUsages,
 }
 
-#[cfg(feature = "alloc")]
 impl Default for SurfaceCapabilities {
     fn default() -> Self {
         Self {
@@ -7266,7 +7257,7 @@ impl ExternalImageSource {
 }
 
 #[cfg(target_arch = "wasm32")]
-impl std::ops::Deref for ExternalImageSource {
+impl core::ops::Deref for ExternalImageSource {
     type Target = js_sys::Object;
 
     fn deref(&self) -> &Self::Target {
@@ -7827,7 +7818,6 @@ pub struct BlasTriangleGeometrySizeDescriptor {
     pub flags: AccelerationStructureGeometryFlags,
 }
 
-#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Descriptor for all size defining attributes of all geometries inside a bottom level acceleration structure.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1084,14 +1084,18 @@ impl InstanceFlags {
     /// The environment variables are named after the flags prefixed with "WGPU_". For example:
     /// - WGPU_DEBUG
     /// - WGPU_VALIDATION
-    #[cfg(feature = "std")]
     #[must_use]
     pub fn with_env(mut self) -> Self {
-        fn env(key: &str) -> Option<bool> {
-            std::env::var(key).ok().map(|s| match s.as_str() {
+        fn env(_key: &str) -> Option<bool> {
+            #[cfg(feature = "std")]
+            return std::env::var(_key).ok().map(|s| match s.as_str() {
                 "0" => false,
                 _ => true,
-            })
+            });
+
+            // Without access to std, environment variables are considered unset
+            #[cfg(not(feature = "std"))]
+            return None;
         }
 
         if let Some(bit) = env("WGPU_VALIDATION") {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -29,9 +29,6 @@ use std::path::PathBuf;
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec, vec::Vec};
 
-#[cfg(all(feature = "alloc", feature = "serde"))]
-use alloc::format;
-
 pub mod assertions;
 mod counters;
 pub mod math;

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -25,9 +25,6 @@ use core::{
 #[cfg(any(feature = "serde", test))]
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "std")]
-use std::path::PathBuf;
-
 pub mod assertions;
 mod counters;
 pub mod math;
@@ -7702,7 +7699,6 @@ impl Default for ShaderRuntimeChecks {
 ///
 /// `wgpu::utils::init::dx12_shader_compiler_from_env` can be used to set the compiler
 /// from the `WGPU_DX12_SHADER_COMPILER` environment variable, but this should only be used for testing.
-#[cfg(feature = "std")]
 #[derive(Clone, Debug, Default)]
 pub enum Dx12Compiler {
     /// The Fxc compiler (default) is old, slow and unmaintained.
@@ -7720,9 +7716,9 @@ pub enum Dx12Compiler {
     /// It also requires WDDM 2.1 (Windows 10 version 1607).
     DynamicDxc {
         /// Path to `dxcompiler.dll`.
-        dxc_path: PathBuf,
+        dxc_path: String,
         /// Path to `dxil.dll`.
-        dxil_path: PathBuf,
+        dxil_path: String,
     },
     /// The statically-linked variant of Dxc.
     ///
@@ -7751,7 +7747,6 @@ pub enum Gles3MinorVersion {
 }
 
 /// Options for creating an instance.
-#[cfg(feature = "std")]
 #[derive(Clone, Debug)]
 pub struct InstanceDescriptor {
     /// Which `Backends` to enable.
@@ -7764,7 +7759,6 @@ pub struct InstanceDescriptor {
     pub gles_minor_version: Gles3MinorVersion,
 }
 
-#[cfg(feature = "std")]
 impl Default for InstanceDescriptor {
     fn default() -> Self {
         Self {

--- a/wgpu-types/src/math.rs
+++ b/wgpu-types/src/math.rs
@@ -1,6 +1,6 @@
 //! Utilitary math functions.
 
-use std::ops::{Add, Rem, Sub};
+use core::ops::{Add, Rem, Sub};
 
 ///
 /// Aligns a `value` to an `alignment`.

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -193,7 +193,7 @@ log.workspace = true
 parking_lot.workspace = true
 profiling.workspace = true
 raw-window-handle = { workspace = true, features = ["std"] }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["default", "derive"], optional = true }
 smallvec.workspace = true
 static_assertions.workspace = true
 
@@ -211,6 +211,7 @@ features = ["wgsl-in"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { workspace = true, features = [
+    "default",
     "Document",
     "Navigator",
     "Node",
@@ -227,6 +228,6 @@ web-sys = { workspace = true, features = [
     "EventTarget",
 ] }
 wasm-bindgen.workspace = true
-js-sys.workspace = true
+js-sys = { workspace = true, features = ["default"] }
 wasm-bindgen-futures.workspace = true
 parking_lot.workspace = true

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -108,8 +108,8 @@ pub fn dx12_shader_compiler_from_env() -> Option<wgt::Dx12Compiler> {
             .as_deref()
         {
             Ok("dxc") => wgt::Dx12Compiler::DynamicDxc {
-                dxc_path: std::path::PathBuf::from("dxcompiler.dll"),
-                dxil_path: std::path::PathBuf::from("dxil.dll"),
+                dxc_path: "dxcompiler.dll".to_string(),
+                dxil_path: "dxil.dll".to_string(),
             },
             #[cfg(static_dxc)]
             Ok("static-dxc") => wgt::Dx12Compiler::StaticDxc,


### PR DESCRIPTION
**Connections**
- Contributes to #6826

**Description**
For a possible `no_std` version of `wgpu` (as requested in the above issue), a good first step would be for the already slim `wgpu-types` crate to be `no_std` compatible. This is what this PR accomplishes.

First, I disabled default features on the crates `wgpu-types` relies on (disabling their respective `std` features). As these dependencies are managed through the workspace, they had to be disabled there, requiring re-enabling `default` in the adjacent crates.

Next, I added `std` and `default` features to `wgpu-types`. This ensures users who do not care about `no_std` compatibility have minimal friction when using this crate. I also added the following lints to `wgpu-types`:

```toml
[lints.clippy]
std_instead_of_core = "warn"
std_instead_of_alloc = "warn"
alloc_instead_of_core = "warn"
```

These are very helpful when working on a crate with features for `std` and `alloc`, since they will inform you if you're being overly restrictive on how you import items which are re-exported.

Next, I added the following to the `lib.rs` file:

```rust
#![no_std]

#[cfg(feature = "std")]
extern crate std;

extern crate alloc;
```

By being unconditionally `no_std` and optionally including `std` through a feature, this crate will always use the `core` implicit prelude instead of switching between `core` and `std` based on the `std` feature. This was a headache in Bevy's `no_std` efforts.

Finally, I added appropriate feature gates where required, and tweaked one particular method for serializing `Astc` texture formats ~~to ensure the `serde` feature didn't require the `alloc` one. There's nothing wrong with requiring `alloc` for `serde`, but it was a minor change to decouple these two features.~~ ~~Change isn't required but I've already written it, and it does avoid allocation, so it's marginally more performant.~~ Reverted.

**Testing**
Tested through compiling `wgpu-types` using the following commands:
```bash
cargo check -p wgpu-types --no-default-features --target x86_64-unknown-none
cargo check -p wgpu-types --no-default-features --target x86_64-unknown-none --features strict_asserts,fragile-send-sync-non-atomic-wasm,serde,counters
```

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.

**Notes**

~~I have made the assumption that conditional `alloc` may provide utility to this crate, but that may be faulty. It could be removed and the `extern crate alloc` line could always be included.~~
