### PR TITLE
Expose `StagingBelt` allocation directly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Bottom level categories:
 
 - Added `Buffer` methods corresponding to `BufferSlice` methods, so you can skip creating a `BufferSlice` when it offers no benefit, and `BufferSlice::slice()` for sub-slicing a slice. By @kpreid in [#7123](https://github.com/gfx-rs/wgpu/pull/7123).
 
+- Add `util::StagingBelt::allocate()` so the staging belt can be used to write textures. By @kpreid in [#6900](https://github.com/gfx-rs/wgpu/pull/6900).
+
 #### Naga
 
 - Support @must_use attribute on function declarations. By @turbocrime in [#6801](https://github.com/gfx-rs/wgpu/pull/6801).

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -3,7 +3,7 @@ use crate::{
     BufferViewMut, CommandEncoder, Device, MapMode,
 };
 use std::fmt;
-use std::sync::{mpsc, Arc};
+use std::sync::mpsc;
 
 /// Efficiently performs many buffer writes by sharing and reusing temporary buffers.
 ///
@@ -146,12 +146,12 @@ impl StagingBelt {
             } else {
                 let size = self.chunk_size.max(size.get());
                 Chunk {
-                    buffer: Arc::new(device.create_buffer(&BufferDescriptor {
+                    buffer: device.create_buffer(&BufferDescriptor {
                         label: Some("(wgpu internal) StagingBelt staging buffer"),
                         size,
                         usage: BufferUsages::MAP_WRITE | BufferUsages::COPY_SRC,
                         mapped_at_creation: true,
-                    })),
+                    }),
                     size,
                     offset: 0,
                 }
@@ -230,7 +230,7 @@ impl fmt::Debug for StagingBelt {
 }
 
 struct Chunk {
-    buffer: Arc<Buffer>,
+    buffer: Buffer,
     size: BufferAddress,
     offset: BufferAddress,
 }

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -144,15 +144,13 @@ impl StagingBelt {
             {
                 self.free_chunks.swap_remove(index)
             } else {
-                let size = self.chunk_size.max(size.get());
                 Chunk {
                     buffer: device.create_buffer(&BufferDescriptor {
                         label: Some("(wgpu internal) StagingBelt staging buffer"),
-                        size,
+                        size: self.chunk_size.max(size.get()),
                         usage: BufferUsages::MAP_WRITE | BufferUsages::COPY_SRC,
                         mapped_at_creation: true,
                     }),
-                    size,
                     offset: 0,
                 }
             }
@@ -231,7 +229,6 @@ impl fmt::Debug for StagingBelt {
 
 struct Chunk {
     buffer: Buffer,
-    size: BufferAddress,
     offset: BufferAddress,
 }
 
@@ -240,14 +237,14 @@ impl Chunk {
         let alloc_start = align_to(self.offset, alignment);
         let alloc_end = alloc_start + size.get();
 
-        alloc_end <= self.size
+        alloc_end <= self.buffer.size()
     }
 
     fn allocate(&mut self, size: BufferSize, alignment: BufferAddress) -> BufferAddress {
         let alloc_start = align_to(self.offset, alignment);
         let alloc_end = alloc_start + size.get();
 
-        assert!(alloc_end <= self.size);
+        assert!(alloc_end <= self.buffer.size());
         self.offset = alloc_end;
         alloc_start
     }


### PR DESCRIPTION
**Connections**
* Can be seen as a partial implementation of #1444

**Description**
Added a method `StagingBelt::allocate()`. This allows using `StagingBelt` for copying to textures or any other operation where copying to an existing buffer is not the desired outcome.

One unfortunate feature of the API is that `allocate()` returns the entire buffer and an offset, so applications could accidentally touch parts of the belt buffer outside the intended allocation. It might make more sense to return `wgpu::BufferSlice`, but that struct cannot be used in operations like `copy_buffer_to_texture` and does not have getters, so it is not currently suitable for that purpose.

I also moved `Exclusive` into a module so that its unsafe-to-access field is properly private, and made various improvements to the `StagingBelt` documentation, such as acknowledging that `write_buffer_with()` exists.

**Testing**
I have manually tested the new function with my application which uses `StagingBelt` heavily. There are no unit-tests of `StagingBelt` and I did not add any.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
