### PR TITLE
[naga] Remove vestigial `false`.

### DIFF
--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -258,7 +258,7 @@ impl super::Validator {
                     | Ti::Array { .. }
                     | Ti::Pointer { .. }
                     | Ti::ValuePointer { size: Some(_), .. }
-                    | Ti::BindingArray { .. } => {},
+                    | Ti::BindingArray { .. } => {}
                     ref other => {
                         log::error!("Indexing of {:?}", other);
                         return Err(ExpressionError::InvalidBaseType(base));

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -258,7 +258,7 @@ impl super::Validator {
                     | Ti::Array { .. }
                     | Ti::Pointer { .. }
                     | Ti::ValuePointer { size: Some(_), .. }
-                    | Ti::BindingArray { .. } => false,
+                    | Ti::BindingArray { .. } => {},
                     ref other => {
                         log::error!("Indexing of {:?}", other);
                         return Err(ExpressionError::InvalidBaseType(base));


### PR DESCRIPTION
When we implemented dynamic indexing of matrices in #6390, we stopped needing to recognize types that could only be indexed by a constant expression. However, we accidentally left a `false` in the `match` expression, even though it's no longer used. Replace that with a `{}` for clarity.
